### PR TITLE
Add .env config file to reduce cmd line toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Fabrik configuration
+# Copy this file to .env and fill in your values.
+# Make sure .env is listed in .gitignore (Fabrik will refuse to start otherwise).
+
+# Required: GitHub token with repo and project access
+FABRIK_TOKEN=ghp_your_token_here
+# GITHUB_TOKEN is also accepted for backward compatibility
+
+# Required: GitHub repository owner
+FABRIK_OWNER=your-org-or-username
+
+# Required: GitHub repository name
+FABRIK_REPO=your-repo
+
+# Required: GitHub project number
+FABRIK_PROJECT_NUMBER=1
+
+# Required: Your GitHub username (only process issues assigned to this user)
+FABRIK_USER=your-github-username

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,15 @@ FABRIK_PROJECT_NUMBER=1
 
 # Required: Your GitHub username (only process issues assigned to this user)
 FABRIK_USER=your-github-username
+
+# Optional: Directory containing stage YAML configs (default: ./stages)
+# FABRIK_STAGES=./stages
+
+# Optional: Auto-advance issues through stages without waiting for human input (default: false)
+# FABRIK_YOLO=false
+
+# Optional: Polling interval in seconds (default: 30)
+# FABRIK_POLL=30
+
+# Optional: Maximum concurrent issue workers (default: 5)
+# FABRIK_MAX_CONCURRENT=5

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .history/*
 .claude/
 .fabrik/
+.env
 stages/mystages/
 fabrik
 *.exe

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ are user input, and the board columns define the workflow.
 # Build
 go build -o fabrik .
 
-# Set up your GitHub token
-export GITHUB_TOKEN=ghp_...
+# Create your .env file from the example
+cp .env.example .env
+# Edit .env with your GitHub token and repo details
+# Make sure .env is in your .gitignore (Fabrik enforces this)
 
 # Copy and customize stage configs
 cp -r stages/examples stages/mystages
 
-# Run
-./fabrik \
-  --owner your-org \
-  --repo your-repo \
-  --project 1 \
-  --user your-github-username \
-  --stages ./stages/mystages
+# Run (all config comes from .env — no flags needed)
+./fabrik
+
+# Or override specific values with flags
+./fabrik --stages ./stages/mystages --yolo
 ```
 
 ### Development
@@ -109,6 +109,25 @@ completion:
   value: ""               # Type-specific (label name, approval keyword)
 auto_advance: false       # Override global yolo setting for this stage
 ```
+
+## Configuration
+
+Fabrik loads configuration from a `.env` file in the current working directory.
+See [`.env.example`](.env.example) for all supported keys.
+
+| Key | Description |
+|-----|-------------|
+| `FABRIK_TOKEN` | GitHub token (preferred) |
+| `GITHUB_TOKEN` | GitHub token (backward-compatible fallback) |
+| `FABRIK_OWNER` | GitHub repo owner |
+| `FABRIK_REPO` | GitHub repo name |
+| `FABRIK_PROJECT_NUMBER` | GitHub project number |
+| `FABRIK_USER` | Your GitHub username |
+
+**Safety:** If a `.env` file exists but is not listed in `.gitignore`, Fabrik will
+refuse to start with a fatal error to prevent accidental token leaks.
+
+Command-line flags take precedence over `.env` values.
 
 ## Flags
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/verveguy/fabrik/config"
 	"github.com/verveguy/fabrik/engine"
@@ -73,7 +74,8 @@ func Execute() error {
 	}
 	if !cfg.Yolo {
 		if v := os.Getenv("FABRIK_YOLO"); v != "" {
-			cfg.Yolo = v == "true" || v == "1" || v == "yes"
+			lv := strings.ToLower(v)
+			cfg.Yolo = lv == "true" || lv == "1" || lv == "yes"
 		}
 	}
 	if cfg.PollSeconds == 30 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,11 +56,34 @@ func Execute() error {
 	}
 	if cfg.ProjectNum == 0 {
 		if v := os.Getenv("FABRIK_PROJECT_NUMBER"); v != "" {
-			fmt.Sscanf(v, "%d", &cfg.ProjectNum)
+			n, err := strconv.Atoi(v)
+			if err != nil || n <= 0 {
+				return fmt.Errorf("FABRIK_PROJECT_NUMBER=%q is invalid (must be a positive integer)", v)
+			}
+			cfg.ProjectNum = n
 		}
 	}
 	if cfg.User == "" {
 		cfg.User = os.Getenv("FABRIK_USER")
+	}
+	if cfg.StagesDir == "./stages" {
+		if v := os.Getenv("FABRIK_STAGES"); v != "" {
+			cfg.StagesDir = v
+		}
+	}
+	if !cfg.Yolo {
+		if v := os.Getenv("FABRIK_YOLO"); v != "" {
+			cfg.Yolo = v == "true" || v == "1" || v == "yes"
+		}
+	}
+	if cfg.PollSeconds == 30 {
+		if v := os.Getenv("FABRIK_POLL"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.PollSeconds = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_POLL=%q is invalid (must be a positive integer); using default %d\n", v, cfg.PollSeconds)
+			}
+		}
 	}
 
 	// Max concurrent from env, default 5

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/verveguy/fabrik/config"
 	"github.com/verveguy/fabrik/engine"
 	"github.com/verveguy/fabrik/stages"
 )
@@ -34,23 +35,44 @@ func Execute() error {
 
 	flag.Parse()
 
-	// Token from env if not provided
+	// Load .env file if present (fatal if .env exists but not in .gitignore)
+	if err := config.LoadDotenv(); err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+
+	// Token: flag > FABRIK_TOKEN > GITHUB_TOKEN
 	if cfg.Token == "" {
-		cfg.Token = os.Getenv("GITHUB_TOKEN")
+		cfg.Token = config.Token()
+	}
+
+	// Allow env vars (from .env or shell) to fill in missing flags
+	if cfg.Owner == "" {
+		cfg.Owner = os.Getenv("FABRIK_OWNER")
+	}
+	if cfg.Repo == "" {
+		cfg.Repo = os.Getenv("FABRIK_REPO")
+	}
+	if cfg.ProjectNum == 0 {
+		if v := os.Getenv("FABRIK_PROJECT_NUMBER"); v != "" {
+			fmt.Sscanf(v, "%d", &cfg.ProjectNum)
+		}
+	}
+	if cfg.User == "" {
+		cfg.User = os.Getenv("FABRIK_USER")
 	}
 
 	if cfg.Owner == "" || cfg.Repo == "" || cfg.ProjectNum == 0 {
 		fmt.Fprintf(os.Stderr, "Usage: fabrik --owner OWNER --repo REPO --project NUM [options]\n\n")
 		flag.PrintDefaults()
-		return fmt.Errorf("missing required flags: --owner, --repo, --project")
+		return fmt.Errorf("missing required config: owner, repo, project (use flags or .env file)")
 	}
 
 	if cfg.Token == "" {
-		return fmt.Errorf("GitHub token required: use --token or set GITHUB_TOKEN env var")
+		return fmt.Errorf("GitHub token required: use --token, FABRIK_TOKEN, or GITHUB_TOKEN")
 	}
 
 	if cfg.User == "" {
-		return fmt.Errorf("--user is required (your GitHub username)")
+		return fmt.Errorf("user is required: use --user flag or FABRIK_USER in .env")
 	}
 
 	// Load stage configurations

--- a/config/config.go
+++ b/config/config.go
@@ -24,8 +24,9 @@ func LoadDotenv() error {
 }
 
 // isInGitignore checks whether the given filename is covered by an entry in .gitignore.
-// It accepts any non-comment, non-negation line that contains filename as a substring
-// (e.g. ".env", "**/.env", ".env*" all match ".env").
+// It accepts lines where filename appears at the end of the pattern or is followed only
+// by a glob wildcard (*) or path separator (/), so that ".envrc" or ".env.example" in
+// .gitignore do NOT falsely match ".env".
 func isInGitignore(filename string) bool {
 	f, err := os.Open(".gitignore")
 	if err != nil {
@@ -39,9 +40,17 @@ func isInGitignore(filename string) bool {
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
 			continue
 		}
-		if strings.Contains(line, filename) {
-			return true
+		idx := strings.Index(line, filename)
+		if idx < 0 {
+			continue
 		}
+		// Reject if the match is embedded inside a longer filename component,
+		// e.g. ".envrc" or ".env.example" must not match ".env".
+		rest := line[idx+len(filename):]
+		if rest != "" && rest[0] != '/' && rest[0] != '*' {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,9 @@ func LoadDotenv() error {
 	return godotenv.Load(".env")
 }
 
-// isInGitignore checks whether the given filename appears as an entry in .gitignore.
+// isInGitignore checks whether the given filename is covered by an entry in .gitignore.
+// It accepts any non-comment, non-negation line that contains filename as a substring
+// (e.g. ".env", "**/.env", ".env*" all match ".env").
 func isInGitignore(filename string) bool {
 	f, err := os.Open(".gitignore")
 	if err != nil {
@@ -34,7 +36,10 @@ func isInGitignore(filename string) bool {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == filename {
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		if strings.Contains(line, filename) {
 			return true
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+)
+
+// LoadDotenv loads .env from CWD if it exists, and verifies it is listed in .gitignore.
+// Returns nil if no .env file is present.
+func LoadDotenv() error {
+	if _, err := os.Stat(".env"); os.IsNotExist(err) {
+		return nil
+	}
+
+	if !isInGitignore(".env") {
+		return fmt.Errorf(".env file found but not listed in .gitignore — add '.env' to .gitignore to prevent accidental token leaks")
+	}
+
+	return godotenv.Load(".env")
+}
+
+// isInGitignore checks whether the given filename appears as an entry in .gitignore.
+func isInGitignore(filename string) bool {
+	f, err := os.Open(".gitignore")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == filename {
+			return true
+		}
+	}
+	return false
+}
+
+// Token returns the GitHub token, preferring FABRIK_TOKEN over GITHUB_TOKEN.
+func Token() string {
+	if t := os.Getenv("FABRIK_TOKEN"); t != "" {
+		return t
+	}
+	return os.Getenv("GITHUB_TOKEN")
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,16 @@ func TestIsInGitignore_Commented(t *testing.T) {
 	}
 }
 
+func TestIsInGitignore_SimilarName(t *testing.T) {
+	dir := t.TempDir()
+	// .envrc and .env.example should NOT match ".env"
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".envrc\n.env.example\n"), 0644)
+	chdir(t, dir)
+	if isInGitignore(".env") {
+		t.Error(".envrc / .env.example entries must not falsely match .env")
+	}
+}
+
 func TestIsInGitignore_Absent(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.log\nnode_modules/\n"), 0644)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// chdir changes to dir for the duration of the test, restoring the original on cleanup.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+}
+
+func TestIsInGitignore_Present(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".env\n"), 0644)
+	chdir(t, dir)
+	if !isInGitignore(".env") {
+		t.Error("expected .env to be found in .gitignore")
+	}
+}
+
+func TestIsInGitignore_GlobPattern(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("**/.env\n"), 0644)
+	chdir(t, dir)
+	if !isInGitignore(".env") {
+		t.Error("expected **/.env pattern to match .env")
+	}
+}
+
+func TestIsInGitignore_Commented(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("# .env\n"), 0644)
+	chdir(t, dir)
+	if isInGitignore(".env") {
+		t.Error("commented-out .env should not count as ignored")
+	}
+}
+
+func TestIsInGitignore_Absent(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.log\nnode_modules/\n"), 0644)
+	chdir(t, dir)
+	if isInGitignore(".env") {
+		t.Error("expected .env not to be found in .gitignore")
+	}
+}
+
+func TestIsInGitignore_NoGitignoreFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if isInGitignore(".env") {
+		t.Error("expected false when .gitignore does not exist")
+	}
+}
+
+func TestLoadDotenv_NoEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := LoadDotenv(); err != nil {
+		t.Errorf("expected nil when no .env file, got: %v", err)
+	}
+}
+
+func TestLoadDotenv_EnvNotInGitignore(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("FABRIK_OWNER=test\n"), 0600)
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.log\n"), 0644)
+	chdir(t, dir)
+	if err := LoadDotenv(); err == nil {
+		t.Error("expected fatal error when .env is not in .gitignore")
+	}
+}
+
+func TestLoadDotenv_Success(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("FABRIK_OWNER=myorg\n"), 0600)
+	os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".env\n"), 0644)
+	chdir(t, dir)
+	os.Unsetenv("FABRIK_OWNER")
+	t.Cleanup(func() { os.Unsetenv("FABRIK_OWNER") })
+	if err := LoadDotenv(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("FABRIK_OWNER"); got != "myorg" {
+		t.Errorf("expected FABRIK_OWNER=myorg, got %q", got)
+	}
+}
+
+func TestToken_FabrikTokenPreferred(t *testing.T) {
+	t.Setenv("FABRIK_TOKEN", "fabrik-tok")
+	t.Setenv("GITHUB_TOKEN", "github-tok")
+	if got := Token(); got != "fabrik-tok" {
+		t.Errorf("expected FABRIK_TOKEN to win, got %q", got)
+	}
+}
+
+func TestToken_FallbackToGitHubToken(t *testing.T) {
+	t.Setenv("FABRIK_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "github-tok")
+	if got := Token(); got != "github-tok" {
+		t.Errorf("expected GITHUB_TOKEN fallback, got %q", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/verveguy/fabrik
 go 1.26.1
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary
- Adds `.env` file support using `joho/godotenv` to load config from CWD
- All required settings (`FABRIK_TOKEN`, `FABRIK_OWNER`, `FABRIK_REPO`, `FABRIK_PROJECT_NUMBER`, `FABRIK_USER`) can be specified via env vars instead of flags
- Enforces `.gitignore` safety check — fatal error if `.env` exists but is not gitignored
- Preserves backward compatibility with `GITHUB_TOKEN` env var
- Includes `.env.example` and updated README documentation

## Test plan
- [ ] Verify `fabrik` starts with only a `.env` file (no flags)
- [ ] Verify flags override `.env` values
- [ ] Verify fatal error when `.env` exists but not in `.gitignore`
- [ ] Verify `GITHUB_TOKEN` still works as fallback
- [ ] Verify graceful behavior when no `.env` file exists

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)