### PR TITLE
Support comment processing on Pull Requests

### DIFF
--- a/engine/claude.go
+++ b/engine/claude.go
@@ -219,7 +219,7 @@ New comments have been posted on this pull request. These may include:
 
 Your job is to:
 1. Read and understand the new comments in context of the current PR description and code changes.
-2. Make any requested code changes and push them to the PR branch.
+2. Make any requested code changes in the checked-out worktree/issue branch, following the existing fabrik workflow.
 3. Update the PR description as needed to reflect the current state of the changes.
 4. Respond to review feedback by addressing the concerns raised.
 5. If comments from automated review bots suggest improvements, evaluate and apply them where appropriate.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -144,21 +144,30 @@ func buildPrompt(stage *stages.Stage, issue gh.ProjectItem) string {
 	return b.String()
 }
 
-func buildCommentReviewPrompt(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment) string {
+func buildCommentReviewPrompt(stage *stages.Stage, item gh.ProjectItem, comments []gh.Comment) string {
 	var b strings.Builder
 
 	// Use stage-specific comment prompt if available, otherwise default
 	if stage.CommentPrompt != "" {
 		b.WriteString(stage.CommentPrompt)
+	} else if item.IsPR {
+		b.WriteString(defaultPRCommentPrompt())
 	} else {
 		b.WriteString(defaultCommentPrompt(stage.Name))
 	}
 
 	b.WriteString("\n\n---\n\n")
-	b.WriteString(fmt.Sprintf("# Issue #%d: %s\n\n", issue.Number, issue.Title))
-	b.WriteString(fmt.Sprintf("URL: %s\n\n", issue.URL))
-	b.WriteString("## Current Issue Body\n\n")
-	b.WriteString(issue.Body)
+
+	if item.IsPR {
+		b.WriteString(fmt.Sprintf("# PR #%d: %s\n\n", item.Number, item.Title))
+		b.WriteString(fmt.Sprintf("URL: %s\n\n", item.URL))
+		b.WriteString("## Current PR Description\n\n")
+	} else {
+		b.WriteString(fmt.Sprintf("# Issue #%d: %s\n\n", item.Number, item.Title))
+		b.WriteString(fmt.Sprintf("URL: %s\n\n", item.URL))
+		b.WriteString("## Current Issue Body\n\n")
+	}
+	b.WriteString(item.Body)
 	b.WriteString("\n\n")
 
 	b.WriteString("## New Comments to Process\n\n")
@@ -168,12 +177,25 @@ func buildCommentReviewPrompt(stage *stages.Stage, issue gh.ProjectItem, comment
 
 	b.WriteString("---\n\n")
 	b.WriteString("First, perform any actions requested in the comments using available tools.\n")
-	b.WriteString("Then, if the issue body needs updating, output the complete updated issue body between these exact markers:\n\n")
+	if item.IsPR {
+		b.WriteString("Then, if the PR description needs updating, output the complete updated PR description between these exact markers:\n\n")
+	} else {
+		b.WriteString("Then, if the issue body needs updating, output the complete updated issue body between these exact markers:\n\n")
+	}
 	b.WriteString("FABRIK_ISSUE_UPDATE_BEGIN\n")
-	b.WriteString("(the full updated issue body goes here)\n")
+	if item.IsPR {
+		b.WriteString("(the full updated PR description goes here)\n")
+	} else {
+		b.WriteString("(the full updated issue body goes here)\n")
+	}
 	b.WriteString("FABRIK_ISSUE_UPDATE_END\n\n")
-	b.WriteString("Include the ENTIRE issue body in your update, not just the changed parts.\n")
-	b.WriteString("If no issue body changes are needed, you may omit the markers.\n")
+	if item.IsPR {
+		b.WriteString("Include the ENTIRE PR description in your update, not just the changed parts.\n")
+		b.WriteString("If no PR description changes are needed, you may omit the markers.\n")
+	} else {
+		b.WriteString("Include the ENTIRE issue body in your update, not just the changed parts.\n")
+		b.WriteString("If no issue body changes are needed, you may omit the markers.\n")
+	}
 
 	return b.String()
 }
@@ -186,6 +208,23 @@ The user has posted new comments on this issue. Your job is to:
 3. If comments provide information, corrections, or answers to questions, incorporate them into the issue body.
 4. Preserve all existing content that is still valid.
 5. Maintain the structure and formatting of the issue body.`, stageName)
+}
+
+func defaultPRCommentPrompt() string {
+	return `You are a PR comment review agent.
+New comments have been posted on this pull request. These may include:
+- Review feedback from humans or automated bots (e.g., GitHub Copilot, Gemini code review)
+- Requests for code changes or clarifications
+- Suggestions for improving the PR description
+
+Your job is to:
+1. Read and understand the new comments in context of the current PR description and code changes.
+2. Make any requested code changes and push them to the PR branch.
+3. Update the PR description as needed to reflect the current state of the changes.
+4. Respond to review feedback by addressing the concerns raised.
+5. If comments from automated review bots suggest improvements, evaluate and apply them where appropriate.
+6. Preserve all existing PR description content that is still valid.
+7. Maintain the structure and formatting of the PR description.`
 }
 
 // extractBetweenMarkers extracts content between a BEGIN/END marker pair.
@@ -211,7 +250,7 @@ func extractBetweenMarkers(output, beginMarker, endMarker string) string {
 	return strings.TrimSpace(body)
 }
 
-// extractUpdatedBody parses the updated issue body from Claude's output.
+// extractUpdatedBody parses the updated issue/PR body from Claude's output.
 func extractUpdatedBody(output string) string {
 	return extractBetweenMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 }

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -204,7 +204,7 @@ func defaultCommentPrompt(stageName string) string {
 	return fmt.Sprintf(`You are a comment review agent for the "%s" stage.
 The user has posted new comments on this issue. Your job is to:
 1. Read and understand the new comments in context of the current issue body.
-2. If comments request actions (e.g., linking a PR, running a command, making code changes), perform those actions using available tools.
+2. If comments request actions (e.g., linking a pull request, running a command, making code changes), perform those actions using available tools.
 3. If comments provide information, corrections, or answers to questions, incorporate them into the issue body.
 4. Preserve all existing content that is still valid.
 5. Maintain the structure and formatting of the issue body.`, stageName)

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -1,0 +1,135 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+func TestBuildCommentReviewPrompt_Issue(t *testing.T) {
+	stage := &stages.Stage{Name: "Research"}
+	item := gh.ProjectItem{
+		Number: 42,
+		Title:  "Test Issue",
+		URL:    "https://github.com/org/repo/issues/42",
+		Body:   "Issue body content",
+	}
+	comments := []gh.Comment{
+		{Author: "alice", Body: "looks good", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+
+	prompt := buildCommentReviewPrompt(stage, item, comments)
+
+	if !strings.Contains(prompt, "# Issue #42: Test Issue") {
+		t.Error("expected issue header in prompt")
+	}
+	if !strings.Contains(prompt, "## Current Issue Body") {
+		t.Error("expected 'Current Issue Body' section")
+	}
+	if !strings.Contains(prompt, "updated issue body") {
+		t.Error("expected issue-specific marker instructions")
+	}
+	if strings.Contains(prompt, "PR") {
+		t.Error("should not contain PR terminology for issues")
+	}
+}
+
+func TestBuildCommentReviewPrompt_PR(t *testing.T) {
+	stage := &stages.Stage{Name: "Review"}
+	item := gh.ProjectItem{
+		Number: 7,
+		Title:  "Fix bug",
+		URL:    "https://github.com/org/repo/pull/7",
+		Body:   "PR description",
+		IsPR:   true,
+	}
+	comments := []gh.Comment{
+		{Author: "bot", Body: "suggestion: use const", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+
+	prompt := buildCommentReviewPrompt(stage, item, comments)
+
+	if !strings.Contains(prompt, "# PR #7: Fix bug") {
+		t.Error("expected PR header in prompt")
+	}
+	if !strings.Contains(prompt, "## Current PR Description") {
+		t.Error("expected 'Current PR Description' section")
+	}
+	if !strings.Contains(prompt, "updated PR description") {
+		t.Error("expected PR-specific marker instructions")
+	}
+	if !strings.Contains(prompt, "FABRIK_ISSUE_UPDATE_BEGIN") {
+		t.Error("expected consistent FABRIK_ISSUE_UPDATE markers for PRs")
+	}
+}
+
+func TestBuildCommentReviewPrompt_CustomCommentPrompt(t *testing.T) {
+	stage := &stages.Stage{Name: "Review", CommentPrompt: "Custom prompt text"}
+	item := gh.ProjectItem{
+		Number: 7,
+		Title:  "Fix bug",
+		IsPR:   true,
+	}
+	comments := []gh.Comment{
+		{Author: "user", Body: "hello", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+	}
+
+	prompt := buildCommentReviewPrompt(stage, item, comments)
+
+	if !strings.Contains(prompt, "Custom prompt text") {
+		t.Error("expected custom comment prompt to be used")
+	}
+	if strings.Contains(prompt, "PR comment review agent") {
+		t.Error("should use custom prompt, not default PR prompt")
+	}
+}
+
+func TestDefaultPRCommentPrompt(t *testing.T) {
+	prompt := defaultPRCommentPrompt()
+
+	if !strings.Contains(prompt, "PR comment review agent") {
+		t.Error("expected PR-specific agent description")
+	}
+	if !strings.Contains(prompt, "code changes") {
+		t.Error("expected mention of code changes")
+	}
+	if !strings.Contains(prompt, "review feedback") {
+		t.Error("expected mention of review feedback")
+	}
+}
+
+func TestExtractUpdatedBody(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "normal extraction",
+			input:  "Some preamble\nFABRIK_ISSUE_UPDATE_BEGIN\nUpdated body here\nFABRIK_ISSUE_UPDATE_END\nSome epilogue",
+			expect: "Updated body here",
+		},
+		{
+			name:   "no markers",
+			input:  "Just some output without markers",
+			expect: "",
+		},
+		{
+			name:   "only begin marker",
+			input:  "FABRIK_ISSUE_UPDATE_BEGIN\nBody without end",
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractUpdatedBody(tt.input)
+			if got != tt.expect {
+				t.Errorf("extractUpdatedBody() = %q, want %q", got, tt.expect)
+			}
+		})
+	}
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -162,6 +162,11 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem) error 
 		return e.processComments(board, item, stage, newComments)
 	}
 
+	// PRs only support comment processing — skip stage invocation
+	if item.IsPR {
+		return nil
+	}
+
 	// Check for stage completion label — already done
 	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 	for _, label := range item.Labels {

--- a/github/project.go
+++ b/github/project.go
@@ -87,6 +87,12 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
                   }
                   body
                   createdAt
+                  reactionGroups {
+                    content
+                    reactors {
+                      totalCount
+                    }
+                  }
                 }
               }
             }
@@ -110,18 +116,18 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
 					ID    string `json:"id"`
 					Items struct {
 						Nodes []struct {
-							ID                 string `json:"id"`
-							FieldValueByName   *struct {
+							ID               string `json:"id"`
+							FieldValueByName *struct {
 								Name string `json:"name"`
 							} `json:"fieldValueByName"`
 							Content struct {
 								Typename string `json:"__typename"`
 								ID       string `json:"id"`
 								Number   int    `json:"number"`
-								Title string `json:"title"`
-								Body  string `json:"body"`
-								URL   string `json:"url"`
-								Author *struct {
+								Title    string `json:"title"`
+								Body     string `json:"body"`
+								URL      string `json:"url"`
+								Author   *struct {
 									Login string `json:"login"`
 								} `json:"author"`
 								Labels struct {

--- a/github/project.go
+++ b/github/project.go
@@ -118,9 +118,9 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
 								Typename string `json:"__typename"`
 								ID       string `json:"id"`
 								Number   int    `json:"number"`
-								Title  string `json:"title"`
-								Body   string `json:"body"`
-								URL    string `json:"url"`
+								Title string `json:"title"`
+								Body  string `json:"body"`
+								URL   string `json:"url"`
 								Author *struct {
 									Login string `json:"login"`
 								} `json:"author"`
@@ -169,7 +169,7 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
 	}
 
 	for _, node := range proj.Items.Nodes {
-		// Skip items without content (e.g. draft issues)
+		// Skip items whose content was not returned (empty content ID, e.g. draft issues)
 		if node.Content.ID == "" {
 			continue
 		}

--- a/github/project.go
+++ b/github/project.go
@@ -21,6 +21,7 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
             }
           }
           content {
+            __typename
             ... on Issue {
               id
               number
@@ -58,6 +59,37 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
                 }
               }
             }
+            ... on PullRequest {
+              id
+              number
+              title
+              body
+              url
+              author {
+                login
+              }
+              labels(first: 20) {
+                nodes {
+                  name
+                }
+              }
+              assignees(first: 10) {
+                nodes {
+                  login
+                }
+              }
+              comments(first: 50) {
+                nodes {
+                  id
+                  databaseId
+                  author {
+                    login
+                  }
+                  body
+                  createdAt
+                }
+              }
+            }
           }
         }
       }
@@ -83,8 +115,9 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
 								Name string `json:"name"`
 							} `json:"fieldValueByName"`
 							Content struct {
-								ID     string `json:"id"`
-								Number int    `json:"number"`
+								Typename string `json:"__typename"`
+								ID       string `json:"id"`
+								Number   int    `json:"number"`
 								Title  string `json:"title"`
 								Body   string `json:"body"`
 								URL    string `json:"url"`
@@ -136,7 +169,7 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
 	}
 
 	for _, node := range proj.Items.Nodes {
-		// Skip non-issue items (draft issues, PRs)
+		// Skip items without content (e.g. draft issues)
 		if node.Content.ID == "" {
 			continue
 		}
@@ -148,6 +181,7 @@ query($owner: String!, $repo: String!, $projectNum: Int!) {
 			Title:  node.Content.Title,
 			Body:   node.Content.Body,
 			URL:    node.Content.URL,
+			IsPR:   node.Content.Typename == "PullRequest",
 		}
 
 		if node.FieldValueByName != nil {

--- a/github/types.go
+++ b/github/types.go
@@ -8,7 +8,7 @@ type ProjectBoard struct {
 	Items     []ProjectItem
 }
 
-// ProjectItem represents an issue card on the project board.
+// ProjectItem represents an issue or pull request card on the project board.
 type ProjectItem struct {
 	ID        string
 	ItemID    string // The project item ID (needed for mutations)
@@ -17,6 +17,7 @@ type ProjectItem struct {
 	Body      string
 	Status    string // The column/status on the board
 	URL       string
+	IsPR      bool   // True if this item is a Pull Request (vs an Issue)
 	Labels    []string
 	Assignees []string
 	Comments  []Comment

--- a/github/types.go
+++ b/github/types.go
@@ -17,7 +17,7 @@ type ProjectItem struct {
 	Body      string
 	Status    string // The column/status on the board
 	URL       string
-	IsPR      bool   // True if this item is a Pull Request (vs an Issue)
+	IsPR      bool // True if this item is a Pull Request (vs an Issue)
 	Labels    []string
 	Assignees []string
 	Comments  []Comment


### PR DESCRIPTION
## Summary

- Add `... on PullRequest` fragment to the `FetchProjectBoard` GraphQL query so PR items on the project board are no longer silently skipped
- PR-backed items get a dedicated comment prompt oriented around code review, bot feedback, and pushing changes to the PR branch
- Stage processing is skipped for PR items since PRs don't have stages in the current model

Closes #9

## Changes

- `github/types.go`: add `IsPR` bool to `ProjectItem`
- `github/project.go`: add `__typename` + `... on PullRequest` fragment, set `IsPR` when parsing
- `engine/claude.go`: add `defaultPRCommentPrompt()`, branch `buildCommentReviewPrompt` on `IsPR` for prompt and terminology
- `engine/engine.go`: skip stage invocation for PR items after comments
- `engine/claude_test.go`: tests for PR vs Issue prompt building

## Test plan

- [ ] Run `go test ./...` to verify all tests pass
- [ ] Verify PR items on a project board are fetched and have `IsPR=true`
- [ ] Verify comments on PR items trigger the PR-specific comment prompt
- [ ] Verify stage processing is skipped for PR items

🤖 Generated with [Claude Code](https://claude.com/claude-code)