### PR TITLE
Prefix log lines with issue number for concurrent workers

### DIFF
--- a/engine/claude.go
+++ b/engine/claude.go
@@ -86,7 +86,7 @@ func buildClaudeArgs(stage *stages.Stage, issueNumber int, resume bool, modelOve
 }
 
 func runClaude(args []string, workDir string, issueNumber int, label string) (string, bool, error) {
-	fmt.Printf("  [claude] invoking for issue #%d (%s) in %s\n", issueNumber, label, workDir)
+	logf(issueNumber, "claude", "invoking (%s) in %s\n", label, workDir)
 
 	cmd := exec.Command("claude", args...)
 	cmd.Dir = workDir

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -122,7 +122,7 @@ func (e *Engine) poll() error {
 			defer wg.Done()
 			defer func() { <-sem }()
 			if err := e.processItem(board, item, &worked); err != nil {
-				fmt.Printf("  [error] issue #%d: %v\n", item.Number, err)
+				logf(item.Number, "error", "%v\n", err)
 			}
 		}()
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -147,7 +147,7 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 	otherLockPrefix := "fabrik:locked:"
 	for _, label := range item.Labels {
 		if strings.HasPrefix(label, otherLockPrefix) && label != lockLabel {
-			fmt.Printf("  [skip] issue #%d locked by another user\n", item.Number)
+			logf(item.Number, "skip", "locked by another user\n")
 			return nil
 		}
 	}
@@ -155,7 +155,7 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 	// Skip if currently being edited
 	for _, label := range item.Labels {
 		if label == "fabrik:editing" {
-			fmt.Printf("  [skip] issue #%d is being edited\n", item.Number)
+			logf(item.Number, "skip", "is being edited\n")
 			return nil
 		}
 	}
@@ -200,15 +200,15 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 		if time.Since(lastAttempt) < cooldown {
 			return nil
 		}
-		fmt.Printf("  [retry] cooldown expired for issue #%d stage %q, retrying\n", item.Number, stage.Name)
+		logf(item.Number, "retry", "cooldown expired for stage %q, retrying\n", stage.Name)
 	}
 
 	atomic.AddInt32(worked, 1)
-	fmt.Printf("\n[process] issue #%d %q — stage: %s\n", item.Number, item.Title, stage.Name)
+	logf(item.Number, "process", "%q — stage: %s\n", item.Title, stage.Name)
 
 	// Acquire lock
 	if err := e.client.AddLabelToIssue(e.cfg.Owner, e.cfg.Repo, item.Number, lockLabel); err != nil {
-		fmt.Printf("  [warn] could not add lock label: %v\n", err)
+		logf(item.Number, "warn", "could not add lock label: %v\n", err)
 	}
 
 	// Ensure worktree exists for this issue
@@ -219,13 +219,13 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 	}
 
 	// Invoke Claude Code in the issue's worktree
-	modelOverride := extractModelOverride(item.Labels)
+	modelOverride := extractModelOverride(item.Number, item.Labels)
 	if modelOverride != "" {
-		fmt.Printf("  [model] using model override %q for issue #%d\n", modelOverride, item.Number)
+		logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
 	output, completed, err := InvokeClaude(stage, item, false, workDir, modelOverride)
 	if err != nil {
-		fmt.Printf("  [warn] claude invocation issue: %v\n", err)
+		logf(item.Number, "warn", "claude invocation issue: %v\n", err)
 	}
 
 	// Post Claude's output
@@ -235,7 +235,7 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 		} else {
 			comment := formatOutputComment(stage.Name, output)
 			if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
-				fmt.Printf("  [warn] could not post comment: %v\n", err)
+				logf(item.Number, "warn", "could not post comment: %v\n", err)
 			}
 		}
 	}
@@ -251,7 +251,7 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 		e.handleStageComplete(board, item, stage)
 	} else {
 		cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
-		fmt.Printf("  [wait] stage %q did not complete for issue #%d — will retry after %v\n", stage.Name, item.Number, cooldown)
+		logf(item.Number, "wait", "stage %q did not complete — will retry after %v\n", stage.Name, cooldown)
 	}
 
 	return nil
@@ -260,13 +260,13 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 // processComments handles new user comments on an issue.
 // Flow: 👀 reactions → editing label → invoke Claude → perform actions / update issue body → remove editing label → 🚀 reactions
 func (e *Engine) processComments(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment) error {
-	fmt.Printf("\n[comments] processing %d new comment(s) on issue #%d — stage: %s\n",
-		len(comments), item.Number, stage.Name)
+	logf(item.Number, "comments", "processing %d new comment(s) — stage: %s\n",
+		len(comments), stage.Name)
 
 	// Step 1: React with 👀 to all new comments
 	for _, c := range comments {
 		if err := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, c.DatabaseID, "eyes"); err != nil {
-			fmt.Printf("  [warn] could not add 👀 to comment %s: %v\n", c.ID, err)
+			logf(item.Number, "warn", "could not add 👀 to comment %s: %v\n", c.ID, err)
 		}
 	}
 
@@ -284,29 +284,29 @@ func (e *Engine) processComments(board *gh.ProjectBoard, item gh.ProjectItem, st
 	}
 
 	// Step 4: Invoke Claude with the comment review prompt
-	modelOverride := extractModelOverride(item.Labels)
+	modelOverride := extractModelOverride(item.Number, item.Labels)
 	if modelOverride != "" {
-		fmt.Printf("  [model] using model override %q for issue #%d\n", modelOverride, item.Number)
+		logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
 	output, _, err := InvokeClaudeForComments(stage, item, comments, workDir, modelOverride)
 	if err != nil {
-		fmt.Printf("  [warn] claude comment review issue: %v\n", err)
+		logf(item.Number, "warn", "claude comment review issue: %v\n", err)
 		e.removeEditingLabel(item.Number)
 		return err
 	}
 
 	// Step 5: Parse the updated issue body from Claude's output and apply it
 	if updatedBody := extractUpdatedBody(output); updatedBody != "" {
-		fmt.Printf("  [edit] updating issue #%d body\n", item.Number)
+		logf(item.Number, "edit", "updating issue body\n")
 		if err := e.client.UpdateIssueBody(e.cfg.Owner, e.cfg.Repo, item.Number, updatedBody); err != nil {
-			fmt.Printf("  [warn] could not update issue body: %v\n", err)
+			logf(item.Number, "warn", "could not update issue body: %v\n", err)
 		}
 	} else {
 		// No body update — post output as a comment instead
 		if output != "" {
 			comment := formatOutputComment(stage.Name+" (comment review)", output)
 			if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
-				fmt.Printf("  [warn] could not post comment: %v\n", err)
+				logf(item.Number, "warn", "could not post comment: %v\n", err)
 			}
 		}
 	}
@@ -317,14 +317,14 @@ func (e *Engine) processComments(board *gh.ProjectBoard, item gh.ProjectItem, st
 	// Step 7: React with 🚀 to all processed comments
 	for _, c := range comments {
 		if err := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, c.DatabaseID, "rocket"); err != nil {
-			fmt.Printf("  [warn] could not add 🚀 to comment %s: %v\n", c.ID, err)
+			logf(item.Number, "warn", "could not add 🚀 to comment %s: %v\n", c.ID, err)
 		}
 	}
 
 	// Mark comments as processed only after everything succeeded
 	e.markCommentsProcessed(item, comments)
 
-	fmt.Printf("  [done] comment processing complete for issue #%d\n", item.Number)
+	logf(item.Number, "done", "comment processing complete\n")
 	return nil
 }
 
@@ -342,45 +342,45 @@ func (e *Engine) markCommentsProcessed(item gh.ProjectItem, comments []gh.Commen
 func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output string) {
 	prNumber, err := e.client.FindPRForIssue(e.cfg.Owner, e.cfg.Repo, item.Number)
 	if err != nil {
-		fmt.Printf("  [warn] could not find PR for issue #%d: %v\n", item.Number, err)
+		logf(item.Number, "warn", "could not find PR: %v\n", err)
 	}
 
 	if prNumber > 0 {
 		// Post detailed output on the PR
 		comment := formatOutputComment(stageName, output)
 		if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, prNumber, comment); err != nil {
-			fmt.Printf("  [warn] could not post to PR #%d: %v\n", prNumber, err)
+			logf(item.Number, "warn", "could not post to PR #%d: %v\n", prNumber, err)
 		} else {
-			fmt.Printf("  [post] detailed %s output posted to PR #%d\n", stageName, prNumber)
+			logf(item.Number, "post", "detailed %s output posted to PR #%d\n", stageName, prNumber)
 		}
 
 		// Post brief summary on the issue
 		summary := formatPRSummaryComment(stageName, prNumber, output)
 		if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, summary); err != nil {
-			fmt.Printf("  [warn] could not post summary to issue #%d: %v\n", item.Number, err)
+			logf(item.Number, "warn", "could not post summary: %v\n", err)
 		}
 	} else {
 		// No PR found — fall back to posting on the issue
-		fmt.Printf("  [warn] no open PR found for issue #%d, posting on issue instead\n", item.Number)
+		logf(item.Number, "warn", "no open PR found, posting on issue instead\n")
 		comment := formatOutputComment(stageName, output)
 		if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
-			fmt.Printf("  [warn] could not post comment: %v\n", err)
+			logf(item.Number, "warn", "could not post comment: %v\n", err)
 		}
 	}
 }
 
 func (e *Engine) removeEditingLabel(issueNumber int) {
 	if err := e.client.RemoveLabelFromIssue(e.cfg.Owner, e.cfg.Repo, issueNumber, "fabrik:editing"); err != nil {
-		fmt.Printf("  [warn] could not remove editing label: %v\n", err)
+		logf(issueNumber, "warn", "could not remove editing label: %v\n", err)
 	}
 }
 
 func (e *Engine) handleStageComplete(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
-	fmt.Printf("  [done] stage %q complete for issue #%d\n", stage.Name, item.Number)
+	logf(item.Number, "done", "stage %q complete\n", stage.Name)
 
 	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 	if err := e.client.AddLabelToIssue(e.cfg.Owner, e.cfg.Repo, item.Number, completeLabel); err != nil {
-		fmt.Printf("  [warn] could not add completion label: %v\n", err)
+		logf(item.Number, "warn", "could not add completion label: %v\n", err)
 	}
 
 	shouldAdvance := e.cfg.Yolo
@@ -390,10 +390,10 @@ func (e *Engine) handleStageComplete(board *gh.ProjectBoard, item gh.ProjectItem
 
 	if shouldAdvance {
 		if err := e.advanceToNextStage(board, item, stage); err != nil {
-			fmt.Printf("  [warn] could not advance: %v\n", err)
+			logf(item.Number, "warn", "could not advance: %v\n", err)
 		}
 	} else {
-		fmt.Printf("  [wait] waiting for human to advance issue #%d\n", item.Number)
+		logf(item.Number, "wait", "waiting for human to advance\n")
 	}
 }
 
@@ -427,7 +427,7 @@ func (e *Engine) findNewComments(item gh.ProjectItem) []gh.Comment {
 func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem, currentStage *stages.Stage) error {
 	next := stages.NextStage(e.cfg.Stages, currentStage.Name)
 	if next == nil {
-		fmt.Printf("  [info] issue #%d has completed all stages\n", item.Number)
+		logf(item.Number, "info", "completed all stages\n")
 		return nil
 	}
 
@@ -441,7 +441,7 @@ func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem,
 			next.Name, mapKeys(e.statusField.Options))
 	}
 
-	fmt.Printf("  [advance] moving issue #%d to stage %q\n", item.Number, next.Name)
+	logf(item.Number, "advance", "moving to stage %q\n", next.Name)
 	return e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID)
 }
 
@@ -464,7 +464,7 @@ func formatPRSummaryComment(stageName string, prNumber int, output string) strin
 // extractModelOverride scans item labels for the first "model:<name>" label and returns <name>.
 // If multiple model labels exist, it uses the first and logs a warning.
 // Returns "" if no model label is found.
-func extractModelOverride(labels []string) string {
+func extractModelOverride(issueNumber int, labels []string) string {
 	const prefix = "model:"
 	var found string
 	for _, label := range labels {
@@ -476,11 +476,16 @@ func extractModelOverride(labels []string) string {
 			if found == "" {
 				found = name
 			} else {
-				fmt.Printf("  [warn] multiple model: labels found, using %q (ignoring %q)\n", found, name)
+				logf(issueNumber, "warn", "multiple model: labels found, using %q (ignoring %q)\n", found, name)
 			}
 		}
 	}
 	return found
+}
+
+func logf(issueNumber int, tag, format string, args ...any) {
+	prefix := fmt.Sprintf("[#%d %s] ", issueNumber, tag)
+	fmt.Printf(prefix+format, args...)
 }
 
 func mapKeys(m map[string]string) []string {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -151,7 +151,8 @@ func TestConcurrentItemDispatch(t *testing.T) {
 			}
 			mu.Unlock()
 
-			if err := e.processItem(board, item); err != nil {
+			var worked int32
+			if err := e.processItem(board, item, &worked); err != nil {
 				t.Errorf("processItem error for issue #%d: %v", item.Number, err)
 			}
 

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -39,13 +39,13 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string) (s
 		if out, cmdErr := cmd.CombinedOutput(); cmdErr == nil {
 			if strings.TrimSpace(string(out)) == branch {
 				// Worktree exists and is on the right branch — update from origin
-				wm.updateWorktreeFromMain(wtDir, baseBranch)
+				wm.updateWorktreeFromMain(wtDir, baseBranch, issueNumber)
 				return wtDir, nil
 			}
 		}
 		// Directory exists but git can't identify it — still usable, don't destroy it
 		// The directory might have uncommitted work from a killed Claude session
-		fmt.Printf("  [worktree] directory exists for issue #%d but branch check failed, using as-is\n", issueNumber)
+		logf(issueNumber, "worktree", "directory exists but branch check failed, using as-is\n")
 		return wtDir, nil
 	}
 
@@ -75,7 +75,7 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string) (s
 		return "", fmt.Errorf("creating worktree: %s: %w", string(out), err)
 	}
 
-	fmt.Printf("  [worktree] created %s for issue #%d\n", wtDir, issueNumber)
+	logf(issueNumber, "worktree", "created %s\n", wtDir)
 	return wtDir, nil
 }
 
@@ -99,7 +99,7 @@ func (wm *WorktreeManager) CleanupWorktree(issueNumber int, deleteBranch bool) e
 		}
 	}
 
-	fmt.Printf("  [worktree] cleaned up for issue #%d\n", issueNumber)
+	logf(issueNumber, "worktree", "cleaned up\n")
 	return nil
 }
 
@@ -127,12 +127,12 @@ func (wm *WorktreeManager) branchExists(branch string) bool {
 // updateWorktreeFromMain fetches latest origin and merges main into the worktree branch.
 // This ensures stages always start from an up-to-date base.
 // Errors are non-fatal — the worktree is still usable, just potentially behind.
-func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string) {
+func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string, issueNumber int) {
 	// Check for uncommitted changes — skip update if dirty
 	statusCmd := exec.Command("git", "status", "--porcelain")
 	statusCmd.Dir = wtDir
 	if out, err := statusCmd.Output(); err == nil && len(strings.TrimSpace(string(out))) > 0 {
-		fmt.Printf("  [worktree] has uncommitted changes, skipping update from main\n")
+		logf(issueNumber, "worktree", "has uncommitted changes, skipping update from main\n")
 		return
 	}
 
@@ -140,7 +140,7 @@ func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string) {
 	cmd := exec.Command("git", "fetch", "origin", baseBranch)
 	cmd.Dir = wtDir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		fmt.Printf("  [worktree] warn: could not fetch origin: %s\n", strings.TrimSpace(string(out)))
+		logf(issueNumber, "worktree", "warn: could not fetch origin: %s\n", strings.TrimSpace(string(out)))
 		return
 	}
 
@@ -151,17 +151,17 @@ func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string) {
 		outStr := strings.TrimSpace(string(out))
 		// If merge conflicts, abort and let Claude handle it during the stage
 		if strings.Contains(outStr, "CONFLICT") || strings.Contains(outStr, "Automatic merge failed") {
-			fmt.Printf("  [worktree] merge conflicts detected, aborting merge — Claude will resolve during stage\n")
+			logf(issueNumber, "worktree", "merge conflicts detected, aborting merge — Claude will resolve during stage\n")
 			abort := exec.Command("git", "merge", "--abort")
 			abort.Dir = wtDir
 			_ = abort.Run()
 		} else {
-			fmt.Printf("  [worktree] warn: could not merge origin/%s: %s\n", baseBranch, outStr)
+			logf(issueNumber, "worktree", "warn: could not merge origin/%s: %s\n", baseBranch, outStr)
 		}
 		return
 	}
 
-	fmt.Printf("  [worktree] updated from origin/%s\n", baseBranch)
+	logf(issueNumber, "worktree", "updated from origin/%s\n", baseBranch)
 }
 
 // Prune removes stale worktree registrations from git.


### PR DESCRIPTION
## Summary

- Prefixes all log lines emitted during item processing with the issue number (e.g. `[#22 worktree]`, `[#22 claude]`)
- Updates `engine/engine.go` and `engine/worktree.go` to pass and use issue number in log output
- Makes interleaved log output from concurrent workers much easier to follow

Closes #22

## Test plan

- [ ] Run fabrik with multiple concurrent workers and confirm log lines are prefixed with the correct issue number
- [ ] Verify no log lines within `processItem`/`processComments` are missing the issue prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)