### PR TITLE
Improve the Implement workflow with engine-managed PR lifecycle

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -218,6 +218,11 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 		return fmt.Errorf("setting up worktree: %w", err)
 	}
 
+	// Pre-stage: create a draft PR if requested and none exists yet
+	if stage.CreateDraftPR {
+		e.ensureDraftPR(item, baseBranch)
+	}
+
 	// Invoke Claude Code in the issue's worktree
 	modelOverride := extractModelOverride(item.Labels)
 	if modelOverride != "" {
@@ -248,6 +253,10 @@ func (e *Engine) processItem(board *gh.ProjectBoard, item gh.ProjectItem, worked
 	}()
 
 	if completed {
+		// Post-stage: push branch and mark PR ready if requested
+		if stage.MarkPRReadyOnComplete {
+			e.markPRReady(item)
+		}
 		e.handleStageComplete(board, item, stage)
 	} else {
 		cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
@@ -336,6 +345,59 @@ func (e *Engine) markCommentsProcessed(item gh.ProjectItem, comments []gh.Commen
 		key := fmt.Sprintf("%d-comment-%s", item.Number, c.ID)
 		e.processedSet[key] = time.Now()
 	}
+}
+
+// ensureDraftPR pushes the issue branch and creates a draft PR if one doesn't exist yet.
+// Idempotent: skips creation if FindPRForIssue finds an existing PR.
+func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) {
+	// Push the branch so GitHub can create a PR against it
+	if err := e.worktrees.PushBranch(item.Number); err != nil {
+		fmt.Printf("  [warn] could not push branch for issue #%d: %v\n", item.Number, err)
+		return
+	}
+
+	// Check if a PR already exists
+	prNumber, err := e.client.FindPRForIssue(e.cfg.Owner, e.cfg.Repo, item.Number)
+	if err != nil {
+		fmt.Printf("  [warn] could not check for existing PR for issue #%d: %v\n", item.Number, err)
+		return
+	}
+	if prNumber > 0 {
+		fmt.Printf("  [pr] draft PR #%d already exists for issue #%d, skipping creation\n", prNumber, item.Number)
+		return
+	}
+
+	head := fmt.Sprintf("fabrik/issue-%d", item.Number)
+	prNum, err := e.client.CreateDraftPR(e.cfg.Owner, e.cfg.Repo, item.Title, head, baseBranch, item.Number)
+	if err != nil {
+		fmt.Printf("  [warn] could not create draft PR for issue #%d: %v\n", item.Number, err)
+		return
+	}
+	fmt.Printf("  [pr] created draft PR #%d for issue #%d\n", prNum, item.Number)
+}
+
+// markPRReady pushes the issue branch and transitions its PR from draft to ready-for-review.
+func (e *Engine) markPRReady(item gh.ProjectItem) {
+	if err := e.worktrees.PushBranch(item.Number); err != nil {
+		fmt.Printf("  [warn] could not push branch for issue #%d: %v\n", item.Number, err)
+		// Don't return — still try to mark ready if push is a no-op (already up to date)
+	}
+
+	prNumber, err := e.client.FindPRForIssue(e.cfg.Owner, e.cfg.Repo, item.Number)
+	if err != nil {
+		fmt.Printf("  [warn] could not find PR for issue #%d: %v\n", item.Number, err)
+		return
+	}
+	if prNumber == 0 {
+		fmt.Printf("  [warn] no open PR found for issue #%d, cannot mark ready\n", item.Number)
+		return
+	}
+
+	if err := e.client.MarkPRReady(e.cfg.Owner, e.cfg.Repo, prNumber); err != nil {
+		fmt.Printf("  [warn] could not mark PR #%d ready: %v\n", prNumber, err)
+		return
+	}
+	fmt.Printf("  [pr] marked PR #%d ready-for-review for issue #%d\n", prNumber, item.Number)
 }
 
 // postOutputToPR posts detailed output on the linked PR and a brief summary on the issue.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -378,6 +378,8 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) {
 }
 
 // markPRReady pushes the issue branch and transitions its PR from draft to ready-for-review.
+// If no PR exists yet (e.g., ensureDraftPR failed earlier because there were no commits),
+// it attempts to create one before marking it ready.
 func (e *Engine) markPRReady(item gh.ProjectItem) {
 	if err := e.worktrees.PushBranch(item.Number); err != nil {
 		fmt.Printf("  [warn] could not push branch for issue #%d: %v\n", item.Number, err)
@@ -390,8 +392,16 @@ func (e *Engine) markPRReady(item gh.ProjectItem) {
 		return
 	}
 	if prNumber == 0 {
-		fmt.Printf("  [warn] no open PR found for issue #%d, cannot mark ready\n", item.Number)
-		return
+		// No PR yet — ensureDraftPR may have failed earlier (e.g., branch had no commits).
+		// Now that commits exist and the branch is pushed, try to create the PR.
+		baseBranch := e.worktrees.DefaultBaseBranch()
+		head := fmt.Sprintf("fabrik/issue-%d", item.Number)
+		prNumber, err = e.client.CreateDraftPR(e.cfg.Owner, e.cfg.Repo, item.Title, head, baseBranch, item.Number)
+		if err != nil {
+			fmt.Printf("  [warn] could not create PR for issue #%d: %v\n", item.Number, err)
+			return
+		}
+		fmt.Printf("  [pr] created PR #%d for issue #%d\n", prNumber, item.Number)
 	}
 
 	if err := e.client.MarkPRReady(e.cfg.Owner, e.cfg.Repo, prNumber); err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -348,15 +348,10 @@ func (e *Engine) markCommentsProcessed(item gh.ProjectItem, comments []gh.Commen
 }
 
 // ensureDraftPR pushes the issue branch and creates a draft PR if one doesn't exist yet.
-// Idempotent: skips creation if FindPRForIssue finds an existing PR.
+// Idempotent: checks for an existing PR first; only pushes and creates if none found.
 func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) {
-	// Push the branch so GitHub can create a PR against it
-	if err := e.worktrees.PushBranch(item.Number); err != nil {
-		fmt.Printf("  [warn] could not push branch for issue #%d: %v\n", item.Number, err)
-		return
-	}
-
-	// Check if a PR already exists
+	// Check for an existing PR first — avoids pushing on retries and handles
+	// the case where a push fails but a PR already exists from a prior run.
 	prNumber, err := e.client.FindPRForIssue(e.cfg.Owner, e.cfg.Repo, item.Number)
 	if err != nil {
 		fmt.Printf("  [warn] could not check for existing PR for issue #%d: %v\n", item.Number, err)
@@ -364,6 +359,12 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) {
 	}
 	if prNumber > 0 {
 		fmt.Printf("  [pr] draft PR #%d already exists for issue #%d, skipping creation\n", prNumber, item.Number)
+		return
+	}
+
+	// No PR exists — push the branch so GitHub can create a PR against it
+	if err := e.worktrees.PushBranch(item.Number); err != nil {
+		fmt.Printf("  [warn] could not push branch for issue #%d: %v\n", item.Number, err)
 		return
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -151,7 +151,8 @@ func TestConcurrentItemDispatch(t *testing.T) {
 			}
 			mu.Unlock()
 
-			if err := e.processItem(board, item); err != nil {
+			var worked int32
+			if err := e.processItem(board, item, &worked); err != nil {
 				t.Errorf("processItem error for issue #%d: %v", item.Number, err)
 			}
 

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -79,6 +79,21 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string) (s
 	return wtDir, nil
 }
 
+// PushBranch pushes the issue's worktree branch to origin.
+// Uses -u to set upstream tracking on the first push.
+// Errors are non-fatal (e.g., no commits yet) — the caller decides how to handle them.
+func (wm *WorktreeManager) PushBranch(issueNumber int) error {
+	wtDir := wm.worktreeDir(issueNumber)
+	branch := wm.branchName(issueNumber)
+	cmd := exec.Command("git", "push", "-u", "origin", branch)
+	cmd.Dir = wtDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("pushing branch %s: %s: %w", branch, strings.TrimSpace(string(out)), err)
+	}
+	fmt.Printf("  [worktree] pushed %s to origin\n", branch)
+	return nil
+}
+
 // CleanupWorktree removes the worktree and optionally the branch for an issue.
 func (wm *WorktreeManager) CleanupWorktree(issueNumber int, deleteBranch bool) error {
 	wtDir := wm.worktreeDir(issueNumber)

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -81,8 +81,12 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string) (s
 
 // PushBranch pushes the issue's worktree branch to origin.
 // Uses -u to set upstream tracking on the first push.
+// Serialized with mu because git push -u writes upstream tracking to .git/config,
+// which is not safe to update concurrently across workers.
 // Errors are non-fatal (e.g., no commits yet) — the caller decides how to handle them.
 func (wm *WorktreeManager) PushBranch(issueNumber int) error {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
 	wtDir := wm.worktreeDir(issueNumber)
 	branch := wm.branchName(issueNumber)
 	cmd := exec.Command("git", "push", "-u", "origin", branch)

--- a/github/mutations.go
+++ b/github/mutations.go
@@ -136,6 +136,35 @@ func (c *Client) RemoveLabelFromIssue(owner, repo string, issueNumber int, label
 	return c.restDelete(url)
 }
 
+// CreateDraftPR creates a draft pull request for the given issue branch.
+// Returns the PR number. Callers should first call FindPRForIssue to avoid duplicates.
+func (c *Client) CreateDraftPR(owner, repo, title, head, base string, issueNumber int) (int, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls", owner, repo)
+	body := map[string]interface{}{
+		"title": title,
+		"head":  head,
+		"base":  base,
+		"body":  fmt.Sprintf("Closes #%d", issueNumber),
+		"draft": true,
+	}
+	var result struct {
+		Number int `json:"number"`
+	}
+	if err := c.restPostWithResponse(apiURL, body, &result); err != nil {
+		return 0, fmt.Errorf("creating draft PR: %w", err)
+	}
+	return result.Number, nil
+}
+
+// MarkPRReady transitions a draft PR to ready-for-review.
+func (c *Client) MarkPRReady(owner, repo string, prNumber int) error {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%d", owner, repo, prNumber)
+	body := map[string]interface{}{
+		"draft": false,
+	}
+	return c.restPatch(apiURL, body)
+}
+
 // FindPRForIssue finds the open PR associated with an issue by looking for
 // a PR whose head branch matches the fabrik/issue-N convention.
 // Returns the PR number, or 0 if no matching PR is found.

--- a/github/mutations.go
+++ b/github/mutations.go
@@ -157,12 +157,53 @@ func (c *Client) CreateDraftPR(owner, repo, title, head, base string, issueNumbe
 }
 
 // MarkPRReady transitions a draft PR to ready-for-review.
+// Uses the GraphQL markPullRequestReadyForReview mutation, which is the supported
+// path — REST PATCH does not reliably support draft→ready transitions.
 func (c *Client) MarkPRReady(owner, repo string, prNumber int) error {
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%d", owner, repo, prNumber)
-	body := map[string]interface{}{
-		"draft": false,
+	// Fetch the PR node ID (required for the GraphQL mutation)
+	fetchQuery := `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}`
+	fetchVars := map[string]interface{}{
+		"owner":  owner,
+		"repo":   repo,
+		"number": prNumber,
 	}
-	return c.restPatch(apiURL, body)
+	var fetchResult struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ID string `json:"id"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
+		return fmt.Errorf("fetching PR node ID: %w", err)
+	}
+	nodeID := fetchResult.Data.Repository.PullRequest.ID
+	if nodeID == "" {
+		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	}
+
+	mutation := `
+mutation($prId: ID!) {
+  markPullRequestReadyForReview(input: { pullRequestId: $prId }) {
+    pullRequest {
+      id
+    }
+  }
+}`
+	mutVars := map[string]interface{}{
+		"prId": nodeID,
+	}
+	var mutResult struct{}
+	return c.graphqlRequest(mutation, mutVars, &mutResult)
 }
 
 // FindPRForIssue finds the open PR associated with an issue by looking for

--- a/github/rest.go
+++ b/github/rest.go
@@ -73,6 +73,35 @@ func (c *Client) restPost(url string, body interface{}) error {
 	return c.restRequest("POST", url, body)
 }
 
+// restPostWithResponse POSTs and decodes the response body into the provided target.
+func (c *Client) restPostWithResponse(url string, body interface{}, target interface{}) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
 func (c *Client) restPatch(url string, body interface{}) error {
 	return c.restRequest("PATCH", url, body)
 }

--- a/github/rest.go
+++ b/github/rest.go
@@ -99,7 +99,10 @@ func (c *Client) restPostWithResponse(url string, body interface{}, target inter
 		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	return json.NewDecoder(resp.Body).Decode(target)
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) restPatch(url string, body interface{}) error {

--- a/stages/examples/implement.yaml
+++ b/stages/examples/implement.yaml
@@ -19,7 +19,6 @@ prompt: |
 model: sonnet
 max_turns: 50
 create_draft_pr: true
-mark_pr_ready_on_complete: true
 post_to_pr: true
 completion:
   type: claude

--- a/stages/examples/implement.yaml
+++ b/stages/examples/implement.yaml
@@ -10,15 +10,16 @@ prompt: |
      This preserves progress if the session is interrupted.
   4. Write tests for any new functionality.
   5. Ensure the code compiles and tests pass.
-  6. Push your commits to the remote branch.
-  7. Create a draft PR using: gh pr create --draft --title "..." --body "Closes #N"
-     The body MUST include "Closes #N" (where N is the issue number) so that
-     the PR is linked to the issue. This linking is how Fabrik discovers PR
-     comments.
+  6. Push your commits to the remote branch regularly (after each commit or set
+     of related commits) so progress is visible on the draft PR.
+  7. Before signaling completion, ensure all changes are committed and pushed.
 
   Work methodically through the task checklist. When all tasks are complete
   and tests pass, signal completion.
 model: sonnet
 max_turns: 50
+create_draft_pr: true
+mark_pr_ready_on_complete: true
+post_to_pr: true
 completion:
   type: claude

--- a/stages/examples/review.yaml
+++ b/stages/examples/review.yaml
@@ -17,14 +17,16 @@ prompt: |
      Commit after each fix, not all at once.
   9. Re-review your fixes to make sure they are correct.
 
-  The engine will push the branch and the PR is already marked ready-for-review
-  by the time Review runs — you do not need to push or open a PR.
+  When Review completes, the engine will push your branch and mark the PR
+  ready-for-review, triggering external review bots. You do not need to push
+  or open a PR manually.
 
   If the implementation is clean (or you fixed all issues), signal completion.
   If you cannot fix an issue (e.g., it requires a design decision), list it
   clearly and do NOT signal completion.
 model: sonnet
 max_turns: 30
+mark_pr_ready_on_complete: true
 post_to_pr: true
 completion:
   type: claude

--- a/stages/examples/review.yaml
+++ b/stages/examples/review.yaml
@@ -16,7 +16,9 @@ prompt: |
   8. Fix any issues you identified — update the code and commit your changes.
      Commit after each fix, not all at once.
   9. Re-review your fixes to make sure they are correct.
-  10. Push your changes to the PR branch.
+
+  The engine will push the branch and the PR is already marked ready-for-review
+  by the time Review runs — you do not need to push or open a PR.
 
   If the implementation is clean (or you fixed all issues), signal completion.
   If you cannot fix an issue (e.g., it requires a design decision), list it

--- a/stages/stages.go
+++ b/stages/stages.go
@@ -41,8 +41,8 @@ type Stage struct {
 	PostToPR bool `yaml:"post_to_pr,omitempty"`
 
 	// CreateDraftPR causes the engine to push the branch and create a draft PR
-	// (linked to the issue) before invoking Claude. Idempotent — skipped if a PR
-	// already exists for the issue branch.
+	// (linked to the issue) before invoking Claude. Idempotent with respect to
+	// open PRs — skipped if an open PR already exists for the issue branch.
 	CreateDraftPR bool `yaml:"create_draft_pr,omitempty"`
 
 	// MarkPRReadyOnComplete causes the engine to push the branch and mark the PR

--- a/stages/stages.go
+++ b/stages/stages.go
@@ -40,6 +40,16 @@ type Stage struct {
 	// A brief summary is still posted on the issue.
 	PostToPR bool `yaml:"post_to_pr,omitempty"`
 
+	// CreateDraftPR causes the engine to push the branch and create a draft PR
+	// (linked to the issue) before invoking Claude. Idempotent — skipped if a PR
+	// already exists for the issue branch.
+	CreateDraftPR bool `yaml:"create_draft_pr,omitempty"`
+
+	// MarkPRReadyOnComplete causes the engine to push the branch and mark the PR
+	// as ready-for-review after the stage signals completion. This transitions
+	// the draft PR and triggers external review bots.
+	MarkPRReadyOnComplete bool `yaml:"mark_pr_ready_on_complete,omitempty"`
+
 	// AutoAdvance overrides the global yolo setting for this specific stage.
 	// nil means use the global setting.
 	AutoAdvance *bool `yaml:"auto_advance,omitempty"`


### PR DESCRIPTION
## Summary

- Add `CreateDraftPR` and `MarkPRReady` GitHub API methods to `github/mutations.go`
- Wire engine-managed PR lifecycle into `engine/engine.go`: create draft PR at start of Implement stage, push and mark ready after Review
- Update Implement and Review stage prompts to reflect engine-owned PR lifecycle and encourage regular commits

## Test plan

- [ ] Run Fabrik against a test issue through the Implement stage — verify a draft PR is created automatically at stage start
- [ ] Verify regular commits are made during implementation
- [ ] Run through Review stage — verify PR is automatically marked ready for review and external bots are triggered
- [ ] Confirm stage prompt changes don't break session continuity

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)