### PR TITLE
Fix README Go version and sanitize session file stage names

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ See [adrs/](adrs/) for documented decisions and their rationale.
 
 ## Requirements
 
-- Go 1.21+
+- Go 1.26.1+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
 - GitHub personal access token with `repo` and `project` scopes
 - A GitHub Project (v2) with board columns matching your stage names

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -20,8 +20,9 @@ func SessionDir(issueNumber int) string {
 }
 
 // sessionFile returns the path to the session ID file for a given issue+stage.
+// stageName is sanitized via filepath.Base to prevent path traversal.
 func sessionFile(issueNumber int, stageName string) string {
-	return filepath.Join(SessionDir(issueNumber), stageName+".session")
+	return filepath.Join(SessionDir(issueNumber), filepath.Base(stageName)+".session")
 }
 
 // InvokeClaude runs Claude Code with the given stage configuration and issue context.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -20,9 +20,15 @@ func SessionDir(issueNumber int) string {
 }
 
 // sessionFile returns the path to the session ID file for a given issue+stage.
-// stageName is sanitized via filepath.Base to prevent path traversal.
+// stageName is sanitized to prevent path traversal: filepath.Base strips directory
+// components, and an additional check rejects names that are empty, ".", or the
+// path separator (e.g. filepath.Base("/") == "/"), falling back to "default".
 func sessionFile(issueNumber int, stageName string) string {
-	return filepath.Join(SessionDir(issueNumber), filepath.Base(stageName)+".session")
+	base := filepath.Base(stageName)
+	if base == "" || base == "." || base == "/" || base == string(filepath.Separator) {
+		base = "default"
+	}
+	return filepath.Join(SessionDir(issueNumber), base+".session")
 }
 
 // InvokeClaude runs Claude Code with the given stage configuration and issue context.


### PR DESCRIPTION
## Summary

- Update README "Go 1.21+" to "Go 1.26.1+" to match `go.mod`
- Apply `filepath.Base(stageName)` in `sessionFile` to strip path traversal components (e.g. `../../etc/passwd` → `passwd`)

## Test plan

- [ ] Verify `go.mod` says `go 1.26.1` and README now matches
- [ ] Verify `sessionFile("Research")` returns expected path; `sessionFile("../../evil")` returns a safe filename
- [ ] Build passes: `go build ./...`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)