### PR TITLE
Capture Claude session logs for observability

### DIFF
--- a/engine/claude.go
+++ b/engine/claude.go
@@ -90,7 +90,9 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 	prompt := buildCommentReviewPrompt(stage, issue, comments)
 	args := buildClaudeArgs(stage, issue.Number, true, modelOverride) // resume existing session
 
-	return runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review")
+	output, stats, completed, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review")
+	stats.MaxTurns = stage.MaxTurns
+	return output, stats, completed, err
 }
 
 func buildClaudeArgs(stage *stages.Stage, issueNumber int, resume bool, modelOverride string) []string {

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -136,8 +136,8 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 		logf(issueNumber, "warn", "could not set log dir permissions: %v\n", err)
 	} else {
 		safeLabel := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-").Replace(label)
-		ts := time.Now().UTC().Format("20060102-150405")
-		logPath := filepath.Join(logDir, fmt.Sprintf("%s-%s.log", safeLabel, ts))
+		now := time.Now().UTC()
+		logPath := filepath.Join(logDir, fmt.Sprintf("%s-%s-%d.log", safeLabel, now.Format("20060102-150405"), now.UnixNano()))
 		if logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600); err != nil {
 			logf(issueNumber, "warn", "could not create log file %s: %v\n", logPath, err)
 		} else {

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -342,7 +342,7 @@ Your job is to:
 // formatStatsFooter returns a one-line stats summary suitable for appending to a comment.
 // Returns empty string when no stats are available (e.g. JSON parse fallback).
 func formatStatsFooter(stats ClaudeStats, completed bool) string {
-	if stats.TurnsUsed == 0 && stats.InputTokens == 0 {
+	if stats.TurnsUsed == 0 && stats.InputTokens == 0 && stats.OutputTokens == 0 {
 		return ""
 	}
 	var completion string

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -1,18 +1,29 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
+
+// ClaudeStats holds usage statistics from a Claude invocation.
+type ClaudeStats struct {
+	TurnsUsed    int
+	MaxTurns     int
+	InputTokens  int
+	OutputTokens int
+}
 
 var stageCompleteRE = regexp.MustCompile(`(?m)^FABRIK_STAGE_COMPLETE\r?$`)
 
@@ -20,6 +31,12 @@ var stageCompleteRE = regexp.MustCompile(`(?m)^FABRIK_STAGE_COMPLETE\r?$`)
 func SessionDir(issueNumber int) string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".fabrik", "sessions", fmt.Sprintf("issue-%d", issueNumber))
+}
+
+// LogDir returns the directory where Claude session logs are stored for an issue.
+func LogDir(issueNumber int) string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".fabrik", "logs", fmt.Sprintf("issue-%d", issueNumber))
 }
 
 // sessionFile returns the path to the session ID file for a given issue+stage.
@@ -37,36 +54,37 @@ func sessionFile(issueNumber int, stageName string) string {
 // InvokeClaude runs Claude Code with the given stage configuration and issue context.
 // workDir is the directory Claude should run in (typically a git worktree).
 // modelOverride, if non-empty, replaces the stage's configured model.
-// It returns Claude's output and whether Claude indicated completion.
-func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+// It returns Claude's output, usage stats, and whether Claude indicated completion.
+func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
 	sessDir := SessionDir(issue.Number)
 	if err := os.MkdirAll(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("creating session dir: %w", err)
+		return "", ClaudeStats{}, false, fmt.Errorf("creating session dir: %w", err)
 	}
 	if err := os.Chmod(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("setting session dir permissions: %w", err)
+		return "", ClaudeStats{}, false, fmt.Errorf("setting session dir permissions: %w", err)
 	}
 
 	prompt := buildPrompt(stage, issue, newComments)
 	args := buildClaudeArgs(stage, issue.Number, resume, modelOverride)
 
-	output, _, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name)
+	output, stats, _, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name)
+	stats.MaxTurns = stage.MaxTurns
 	if err != nil {
-		return output, false, err
+		return output, stats, false, err
 	}
-	return output, checkCompletion(stage, output), nil
+	return output, stats, checkCompletion(stage, output), nil
 }
 
 // InvokeClaudeForComments runs Claude Code with a comment-review prompt.
 // It uses the stage's CommentPrompt if defined, otherwise a default.
 // modelOverride, if non-empty, replaces the stage's configured model.
-func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (string, bool, error) {
+func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
 	sessDir := SessionDir(issue.Number)
 	if err := os.MkdirAll(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("creating session dir: %w", err)
+		return "", ClaudeStats{}, false, fmt.Errorf("creating session dir: %w", err)
 	}
 	if err := os.Chmod(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("setting session dir permissions: %w", err)
+		return "", ClaudeStats{}, false, fmt.Errorf("setting session dir permissions: %w", err)
 	}
 
 	prompt := buildCommentReviewPrompt(stage, issue, comments)
@@ -77,7 +95,7 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 
 func buildClaudeArgs(stage *stages.Stage, issueNumber int, resume bool, modelOverride string) []string {
 	args := []string{
-		"--print",
+		"--output-format", "json",
 		"--verbose",
 	}
 
@@ -106,30 +124,80 @@ func buildClaudeArgs(stage *stages.Stage, issueNumber int, resume bool, modelOve
 	return args
 }
 
-func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string) (string, bool, error) {
+func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string) (string, ClaudeStats, bool, error) {
 	logf(issueNumber, "claude", "invoking (%s) in %s\n", label, workDir)
+
+	// Set up stderr tee to a timestamped log file.
+	var stderrWriter io.Writer = os.Stderr
+	logDir := LogDir(issueNumber)
+	if err := os.MkdirAll(logDir, 0700); err != nil {
+		logf(issueNumber, "warn", "could not create log dir: %v\n", err)
+	} else if err := os.Chmod(logDir, 0700); err != nil {
+		logf(issueNumber, "warn", "could not set log dir permissions: %v\n", err)
+	} else {
+		safeLabel := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-").Replace(label)
+		ts := time.Now().UTC().Format("20060102-150405")
+		logPath := filepath.Join(logDir, fmt.Sprintf("%s-%s.log", safeLabel, ts))
+		if logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600); err != nil {
+			logf(issueNumber, "warn", "could not create log file %s: %v\n", logPath, err)
+		} else {
+			defer logFile.Close()
+			stderrWriter = io.MultiWriter(os.Stderr, logFile)
+		}
+	}
 
 	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Dir = workDir
 	cmd.Stdin = strings.NewReader(prompt)
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = stderrWriter
 
-	output, err := cmd.Output()
-	if err != nil {
-		return string(output), false, fmt.Errorf("claude exited with error: %w", err)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	runErr := cmd.Run()
+	rawOutput := stdout.Bytes()
+
+	// Parse JSON envelope from --output-format json.
+	var envelope struct {
+		Result    string `json:"result"`
+		SessionID string `json:"session_id"`
+		NumTurns  int    `json:"num_turns"`
+		Usage     struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
 	}
 
-	result := string(output)
-
-	// Try to save session ID for future resumption
-	// Use the base stage name (strip "-comment-review" suffix) for session continuity
+	var stats ClaudeStats
+	var result string
 	baseName := strings.TrimSuffix(label, "-comment-review")
-	saveSessionID(sessionFile(issueNumber, baseName), result)
 
-	// Simple marker check — callers with the stage use checkCompletion for robustness.
+	if jsonErr := json.Unmarshal(bytes.TrimSpace(rawOutput), &envelope); jsonErr == nil {
+		result = envelope.Result
+		stats.TurnsUsed = envelope.NumTurns
+		stats.InputTokens = envelope.Usage.InputTokens
+		stats.OutputTokens = envelope.Usage.OutputTokens
+		if envelope.SessionID != "" {
+			sessPath := sessionFile(issueNumber, baseName)
+			if err := os.WriteFile(sessPath, []byte(envelope.SessionID), 0600); err != nil {
+				logf(issueNumber, "warn", "could not save session id: %v\n", err)
+			} else {
+				_ = os.Chmod(sessPath, 0600)
+			}
+		}
+	} else {
+		// Fallback: treat raw stdout as plain text and use legacy session ID scan.
+		logf(issueNumber, "warn", "JSON parse failed (%v); falling back to raw output\n", jsonErr)
+		result = string(rawOutput)
+		saveSessionID(sessionFile(issueNumber, baseName), result)
+	}
+
+	if runErr != nil {
+		return result, stats, false, fmt.Errorf("claude exited with error: %w", runErr)
+	}
+
 	completed := stageCompleteRE.MatchString(result)
-
-	return result, completed, nil
+	return result, stats, completed, nil
 }
 
 // checkCompletion returns true if Claude's output indicates the stage is complete.
@@ -269,6 +337,24 @@ Your job is to:
 5. If comments from automated review bots suggest improvements, evaluate and apply them where appropriate.
 6. Preserve all existing PR description content that is still valid.
 7. Maintain the structure and formatting of the PR description.`
+}
+
+// formatStatsFooter returns a one-line stats summary suitable for appending to a comment.
+// Returns empty string when no stats are available (e.g. JSON parse fallback).
+func formatStatsFooter(stats ClaudeStats, completed bool) string {
+	if stats.TurnsUsed == 0 && stats.InputTokens == 0 {
+		return ""
+	}
+	var completion string
+	if !completed {
+		completion = " Stage incomplete."
+	}
+	if stats.MaxTurns > 0 {
+		return fmt.Sprintf("\n\n---\nUsed %d/%d turns, %dk input / %dk output tokens.%s",
+			stats.TurnsUsed, stats.MaxTurns, stats.InputTokens/1000, stats.OutputTokens/1000, completion)
+	}
+	return fmt.Sprintf("\n\n---\nUsed %d turns, %dk input / %dk output tokens.%s",
+		stats.TurnsUsed, stats.InputTokens/1000, stats.OutputTokens/1000, completion)
 }
 
 // extractBetweenMarkers extracts content between a BEGIN/END marker pair.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -176,8 +176,10 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	var result string
 	baseName := strings.TrimSuffix(label, "-comment-review")
 
-	text, sessionID, turns, _, inputTokens, outputTokens := parseClaudeJSON(bytes.TrimSpace(rawOutput))
-	if text != "" {
+	ok, text, sessionID, turns, _, inputTokens, outputTokens := parseClaudeJSON(bytes.TrimSpace(rawOutput))
+	if ok {
+		// JSON parsed successfully — use the result field (may be empty for error responses
+		// like max_turns, which have no "result" field; that's correct, not raw JSON).
 		result = text
 		stats.TurnsUsed = turns
 		stats.InputTokens = inputTokens
@@ -388,14 +390,15 @@ func extractSummary(output string) string {
 }
 
 // parseClaudeJSON parses the JSON output from claude --output-format json.
-// Returns the text result, session ID, turn count, cost, input tokens, and output tokens.
+// Returns ok=true if the JSON was successfully parsed (regardless of whether
+// the result field is populated — error responses like max_turns have no result).
 // Returns empty strings/zero values if parsing fails.
-func parseClaudeJSON(output []byte) (text, sessionID string, turns int, cost float64, inputTokens, outputTokens int) {
+func parseClaudeJSON(output []byte) (ok bool, text, sessionID string, turns int, cost float64, inputTokens, outputTokens int) {
 	var resp claudeResponse
 	if err := json.Unmarshal(output, &resp); err != nil {
-		return "", "", 0, 0, 0, 0
+		return false, "", "", 0, 0, 0, 0
 	}
-	return resp.Result, resp.SessionID, resp.NumTurns, resp.CostUSD, resp.Usage.InputTokens, resp.Usage.OutputTokens
+	return true, resp.Result, resp.SessionID, resp.NumTurns, resp.CostUSD, resp.Usage.InputTokens, resp.Usage.OutputTokens
 }
 
 // saveSessionIDDirect saves a known session ID to disk for future resumption.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -181,8 +181,6 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 			sessPath := sessionFile(issueNumber, baseName)
 			if err := os.WriteFile(sessPath, []byte(envelope.SessionID), 0600); err != nil {
 				logf(issueNumber, "warn", "could not save session id: %v\n", err)
-			} else {
-				_ = os.Chmod(sessPath, 0600)
 			}
 		}
 	} else {

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -337,6 +337,7 @@ printf '%s\n' '{"result":"stage output\nFABRIK_STAGE_COMPLETE\n","session_id":"s
 	}
 	issue := gh.ProjectItem{Number: 77, Title: "Test JSON"}
 	defer os.RemoveAll(SessionDir(77))
+	defer os.RemoveAll(LogDir(77))
 
 	output, stats, completed, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
 	if err != nil {
@@ -412,6 +413,7 @@ echo "real invoker output"
 		t.Errorf("output = %q", output)
 	}
 	os.RemoveAll(SessionDir(80))
+	os.RemoveAll(LogDir(80))
 }
 
 func TestInvokeClaude_FakeBinary(t *testing.T) {
@@ -466,6 +468,7 @@ printf '%s\n' '{"result":"Claude output for test\nFABRIK_STAGE_COMPLETE\n","sess
 	}
 	// Cleanup
 	os.RemoveAll(SessionDir(42))
+	os.RemoveAll(LogDir(42))
 }
 
 func TestInvokeClaude_WithResume(t *testing.T) {
@@ -501,6 +504,7 @@ echo "NO RESUME"
 	os.MkdirAll(sessDir, 0700)
 	os.WriteFile(sessionFile(99, "Plan"), []byte("sess_existing"), 0600)
 	defer os.RemoveAll(sessDir)
+	defer os.RemoveAll(LogDir(99))
 
 	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, true, workDir, "")
 	if err != nil {
@@ -559,6 +563,7 @@ echo "args: $@"
 		t.Error("expected --allowedTools in args")
 	}
 	os.RemoveAll(SessionDir(50))
+	os.RemoveAll(LogDir(50))
 }
 
 func TestInvokeClaude_WithModelOverride(t *testing.T) {
@@ -592,6 +597,7 @@ echo "args: $@"
 		t.Error("expected model override 'opus' in args")
 	}
 	os.RemoveAll(SessionDir(51))
+	os.RemoveAll(LogDir(51))
 }
 
 func TestInvokeClaude_BinaryError(t *testing.T) {
@@ -624,6 +630,7 @@ exit 1
 		t.Errorf("expected partial output, got: %q", output)
 	}
 	os.RemoveAll(SessionDir(60))
+	os.RemoveAll(LogDir(60))
 }
 
 func TestInvokeClaude_WithComments(t *testing.T) {
@@ -658,6 +665,7 @@ cat | grep -o "New Comments" && echo "HAS_COMMENTS" || echo "NO_COMMENTS"
 		t.Errorf("expected comments in prompt, output: %q", output)
 	}
 	os.RemoveAll(SessionDir(70))
+	os.RemoveAll(LogDir(70))
 }
 
 func TestBuildCommentReviewPrompt_Issue(t *testing.T) {

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -281,6 +281,13 @@ func TestFormatStatsFooter(t *testing.T) {
 			wantEmpty: false,
 			wantSubs:  []string{"5k input"},
 		},
+		{
+			name:      "only output tokens",
+			stats:     ClaudeStats{OutputTokens: 2000},
+			completed: true,
+			wantEmpty: false,
+			wantSubs:  []string{"2k output"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -265,7 +265,7 @@ echo "real invoker output"
 	}
 	issue := gh.ProjectItem{Number: 80, Title: "T"}
 
-	output, _, err := invoker.Invoke(context.Background(), stage, issue, nil, false, t.TempDir(), "")
+	output, _, _, err := invoker.Invoke(context.Background(), stage, issue, nil, false, t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -307,7 +307,7 @@ echo "FABRIK_STAGE_COMPLETE"
 		URL:    "https://example.com",
 	}
 
-	output, completed, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	output, _, completed, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -365,7 +365,7 @@ echo "NO RESUME"
 	os.WriteFile(sessionFile(99, "Plan"), []byte("sess_existing"), 0600)
 	defer os.RemoveAll(sessDir)
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, true, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, true, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -404,7 +404,7 @@ echo "args: $@"
 	}
 	issue := gh.ProjectItem{Number: 50, Title: "T"}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -446,7 +446,7 @@ echo "args: $@"
 	}
 	issue := gh.ProjectItem{Number: 51, Title: "T"}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "opus")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "opus")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -479,7 +479,7 @@ exit 1
 	}
 	issue := gh.ProjectItem{Number: 60, Title: "T"}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
 	if err == nil {
 		t.Fatal("expected error for failing binary")
 	}
@@ -513,7 +513,7 @@ cat | grep -o "New Comments" && echo "HAS_COMMENTS" || echo "NO_COMMENTS"
 		{Author: "user", Body: "Fix this", CreatedAt: time.Now()},
 	}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, comments, false, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, comments, false, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -196,7 +196,10 @@ func TestSaveSessionIDDirect_Empty(t *testing.T) {
 
 func TestParseClaudeJSON(t *testing.T) {
 	input := []byte(`{"result":"hello","session_id":"sess_xyz","num_turns":5,"total_cost_usd":0.01,"usage":{"input_tokens":100,"output_tokens":50}}`)
-	text, sessionID, turns, cost, inputTokens, outputTokens := parseClaudeJSON(input)
+	ok, text, sessionID, turns, cost, inputTokens, outputTokens := parseClaudeJSON(input)
+	if !ok {
+		t.Error("expected ok=true for valid JSON")
+	}
 	if text != "hello" {
 		t.Errorf("text = %q, want hello", text)
 	}
@@ -218,9 +221,34 @@ func TestParseClaudeJSON(t *testing.T) {
 }
 
 func TestParseClaudeJSON_Invalid(t *testing.T) {
-	text, sessionID, turns, cost, inputTokens, outputTokens := parseClaudeJSON([]byte("not json"))
+	ok, text, sessionID, turns, cost, inputTokens, outputTokens := parseClaudeJSON([]byte("not json"))
+	if ok {
+		t.Error("expected ok=false for invalid JSON")
+	}
 	if text != "" || sessionID != "" || turns != 0 || cost != 0 || inputTokens != 0 || outputTokens != 0 {
 		t.Errorf("expected zero values for invalid JSON, got text=%q sessionID=%q turns=%d cost=%f inputTokens=%d outputTokens=%d", text, sessionID, turns, cost, inputTokens, outputTokens)
+	}
+}
+
+func TestParseClaudeJSON_MaxTurnsError(t *testing.T) {
+	// When Claude hits max_turns, the JSON has no "result" field.
+	// parseClaudeJSON must return ok=true with empty text (not fail to parse).
+	input := []byte(`{"type":"result","subtype":"error_max_turns","is_error":true,"num_turns":30,"usage":{"input_tokens":1000,"output_tokens":500},"errors":["Reached maximum number of turns (30)"]}`)
+	ok, text, _, turns, _, inputTokens, outputTokens := parseClaudeJSON(input)
+	if !ok {
+		t.Error("expected ok=true: valid JSON should parse even without a result field")
+	}
+	if text != "" {
+		t.Errorf("text = %q, want empty string for error response", text)
+	}
+	if turns != 30 {
+		t.Errorf("turns = %d, want 30", turns)
+	}
+	if inputTokens != 1000 {
+		t.Errorf("inputTokens = %d, want 1000", inputTokens)
+	}
+	if outputTokens != 500 {
+		t.Errorf("outputTokens = %d, want 500", outputTokens)
 	}
 }
 

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -232,6 +232,136 @@ func TestSessionDir(t *testing.T) {
 	}
 }
 
+func TestLogDir(t *testing.T) {
+	dir := LogDir(42)
+	if !strings.Contains(dir, "issue-42") {
+		t.Errorf("LogDir(42) = %q, expected to contain issue-42", dir)
+	}
+	if !strings.Contains(dir, ".fabrik/logs") {
+		t.Errorf("LogDir(42) = %q, expected to contain .fabrik/logs", dir)
+	}
+}
+
+func TestFormatStatsFooter(t *testing.T) {
+	tests := []struct {
+		name      string
+		stats     ClaudeStats
+		completed bool
+		wantEmpty bool
+		wantSubs  []string
+	}{
+		{
+			name:      "zero stats returns empty",
+			stats:     ClaudeStats{},
+			completed: true,
+			wantEmpty: true,
+		},
+		{
+			name:      "with turns and tokens, completed",
+			stats:     ClaudeStats{TurnsUsed: 15, MaxTurns: 30, InputTokens: 47000, OutputTokens: 8000},
+			completed: true,
+			wantSubs:  []string{"15/30 turns", "47k input", "8k output"},
+		},
+		{
+			name:      "with turns and tokens, incomplete",
+			stats:     ClaudeStats{TurnsUsed: 30, MaxTurns: 30, InputTokens: 47000, OutputTokens: 8000},
+			completed: false,
+			wantSubs:  []string{"30/30 turns", "Stage incomplete."},
+		},
+		{
+			name:      "no max turns",
+			stats:     ClaudeStats{TurnsUsed: 10, InputTokens: 5000, OutputTokens: 1000},
+			completed: true,
+			wantSubs:  []string{"10 turns", "5k input", "1k output"},
+		},
+		{
+			name:      "only input tokens",
+			stats:     ClaudeStats{InputTokens: 5000},
+			completed: true,
+			wantEmpty: false,
+			wantSubs:  []string{"5k input"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatStatsFooter(tt.stats, tt.completed)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty footer, got %q", got)
+				}
+				return
+			}
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(got, sub) {
+					t.Errorf("footer %q missing %q", got, sub)
+				}
+			}
+		})
+	}
+}
+
+func TestInvokeClaude_JSONOutput(t *testing.T) {
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	// Output a valid JSON envelope as --output-format json would.
+	// Use a Python heredoc-style approach to avoid shell escaping issues with
+	// embedded newlines in JSON string values.
+	script := `#!/bin/sh
+cat >/dev/null
+python3 -c "import json,sys; sys.stdout.write(json.dumps({'result':'stage output\nFABRIK_STAGE_COMPLETE\n','session_id':'sess_json123','num_turns':12,'usage':{'input_tokens':5000,'output_tokens':1000}}))"
+`
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "Research",
+		Prompt:     "Do research",
+		MaxTurns:   30,
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 77, Title: "Test JSON"}
+	defer os.RemoveAll(SessionDir(77))
+
+	output, stats, completed, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	if err != nil {
+		t.Fatalf("InvokeClaude: %v", err)
+	}
+	if !strings.Contains(output, "stage output") {
+		t.Errorf("output = %q, expected to contain 'stage output'", output)
+	}
+	if !completed {
+		t.Error("expected completed=true")
+	}
+	if stats.TurnsUsed != 12 {
+		t.Errorf("TurnsUsed = %d, want 12", stats.TurnsUsed)
+	}
+	if stats.MaxTurns != 30 {
+		t.Errorf("MaxTurns = %d, want 30", stats.MaxTurns)
+	}
+	if stats.InputTokens != 5000 {
+		t.Errorf("InputTokens = %d, want 5000", stats.InputTokens)
+	}
+	if stats.OutputTokens != 1000 {
+		t.Errorf("OutputTokens = %d, want 1000", stats.OutputTokens)
+	}
+
+	// Check session file was saved from JSON
+	data, err := os.ReadFile(sessionFile(77, "Research"))
+	if err != nil {
+		t.Fatalf("reading session file: %v", err)
+	}
+	if string(data) != "sess_json123" {
+		t.Errorf("session = %q, want sess_json123", string(data))
+	}
+}
+
 func TestSessionFile(t *testing.T) {
 	path := sessionFile(42, "Research")
 	if !strings.HasSuffix(path, "Research.session") {

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -91,7 +91,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	} else {
 		// No body update — post output as a comment instead
 		if output != "" {
-			comment := formatOutputComment(stage.Name+" (comment review)", output, branch, commit, timestamp)
+			comment := formatOutputComment(stage.Name+" (comment review)", output, "", branch, commit, timestamp)
 			if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
 				logf(item.Number, "warn", "could not post comment: %v\n", err)
 			}

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -68,7 +68,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if modelOverride != "" {
 		logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
-	output, _, err := InvokeClaudeForComments(ctx, stage, item, comments, workDir, modelOverride)
+	output, _, _, err := InvokeClaudeForComments(ctx, stage, item, comments, workDir, modelOverride)
 	if err != nil {
 		e.removeEditingLabel(item.Number)
 		if ctx.Err() != nil {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1385,8 +1385,8 @@ func TestProcessItem_EscalatesAtMaxRetries(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "partial output", false, nil // never completes
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "partial output", ClaudeStats{}, false, nil // never completes
 		},
 	}
 
@@ -1469,8 +1469,8 @@ func TestProcessItem_ResetsOnUnpause(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "output", ClaudeStats{}, false, nil
 		},
 	}
 
@@ -1535,8 +1535,8 @@ func TestProcessItem_UnlimitedWhenMaxRetriesZero(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "output", ClaudeStats{}, false, nil
 		},
 	}
 
@@ -1589,8 +1589,8 @@ func TestProcessItem_ClearsRetryCountOnCompletion(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", true, nil // stage completes successfully
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "output", ClaudeStats{}, true, nil // stage completes successfully
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -341,7 +341,7 @@ func TestAdvanceToNextStage_MissingOption(t *testing.T) {
 }
 
 func TestFormatOutputComment(t *testing.T) {
-	comment := formatOutputComment("Research", "Hello world", "main", "abc12345", "2026-04-01 14:30 UTC")
+	comment := formatOutputComment("Research", "Hello world", "", "main", "abc12345", "2026-04-01 14:30 UTC")
 	if !strings.Contains(comment, "🏭 **Fabrik — stage: Research**") {
 		t.Errorf("comment = %q", comment)
 	}
@@ -355,12 +355,25 @@ func TestFormatOutputComment(t *testing.T) {
 
 func TestFormatOutputComment_Truncation(t *testing.T) {
 	longOutput := strings.Repeat("x", 70000)
-	comment := formatOutputComment("Test", longOutput, "main", "abc12345", "2026-04-01 14:30 UTC")
+	comment := formatOutputComment("Test", longOutput, "", "main", "abc12345", "2026-04-01 14:30 UTC")
 	if len(comment) > 61000 {
 		t.Errorf("comment should be truncated, len = %d", len(comment))
 	}
 	if !strings.Contains(comment, "... (truncated)") {
 		t.Error("truncated comment missing truncation notice")
+	}
+}
+
+func TestFormatOutputComment_FooterSurvivesTruncation(t *testing.T) {
+	// Output exceeds the limit; footer must appear after the truncation notice, not be cut off.
+	longOutput := strings.Repeat("x", 65000)
+	footer := "\n\n---\nUsed 30/30 turns, 47k input / 8k output tokens. Stage incomplete."
+	comment := formatOutputComment("Test", longOutput, footer, "main", "abc12345", "2026-04-01 14:30 UTC")
+	if !strings.Contains(comment, "... (truncated)") {
+		t.Error("expected truncation notice")
+	}
+	if !strings.Contains(comment, "30/30 turns") {
+		t.Error("stats footer must appear after truncation, not be cut off")
 	}
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -154,8 +154,8 @@ func TestItemNeedsWork_SkipsPausedWithNewComments(t *testing.T) {
 func TestProcessItem_AllowsOwnLock(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "output", ClaudeStats{}, false, nil
 		},
 	}
 	eng := testEngine(client, claude)
@@ -507,8 +507,8 @@ func TestProcessItem_FullHappyPath(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Claude output here", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "Claude output here", ClaudeStats{}, false, nil
 		},
 	}
 
@@ -582,8 +582,8 @@ func TestProcessItem_CompletionWithAutoAdvance(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Done\nFABRIK_STAGE_COMPLETE", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "Done\nFABRIK_STAGE_COMPLETE", ClaudeStats{}, true, nil
 		},
 	}
 
@@ -660,8 +660,8 @@ func TestProcessItem_CompletionNoAutoAdvance(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Done", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "Done", ClaudeStats{}, true, nil
 		},
 	}
 
@@ -701,8 +701,8 @@ func TestProcessItem_StageAutoAdvanceOverride(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Done", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "Done", ClaudeStats{}, true, nil
 		},
 	}
 
@@ -751,8 +751,8 @@ func TestProcessItem_EmptyOutput(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "", ClaudeStats{}, false, nil
 		},
 	}
 
@@ -782,11 +782,11 @@ func TestProcessItem_ClaudeError(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
 			// Simulate a start failure: binary not found (*exec.Error)
 			cmd := exec.Command("this-binary-does-not-exist-fabrik-test")
 			_, startErr := cmd.Output()
-			return "partial output", false, startErr
+			return "partial output", ClaudeStats{}, false, startErr
 		},
 	}
 
@@ -826,11 +826,11 @@ func TestProcessItem_ClaudeExitError(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
 			// Simulate Claude running and exiting non-zero (wrapped *exec.ExitError)
 			cmd := exec.Command("git", "definitely-invalid-arg")
 			runErr := cmd.Run()
-			return "some output", false, fmt.Errorf("claude exited with error: %w", runErr)
+			return "some output", ClaudeStats{}, false, fmt.Errorf("claude exited with error: %w", runErr)
 		},
 	}
 
@@ -864,8 +864,8 @@ func TestProcessItem_ResumeOnReprocess(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "output", ClaudeStats{}, false, nil
 		},
 	}
 
@@ -1022,8 +1022,8 @@ func TestProcessItem_LabelAndCommentErrors(t *testing.T) {
 		},
 	}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "output", ClaudeStats{}, true, nil
 		},
 	}
 
@@ -1057,8 +1057,8 @@ func TestPoll_ProcessItemError(t *testing.T) {
 		},
 	}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
+			return "", ClaudeStats{}, false, nil
 		},
 	}
 

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -25,12 +25,12 @@ type GitHubClient interface {
 
 // ClaudeInvoker defines the interface for invoking Claude Code.
 type ClaudeInvoker interface {
-	Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (output string, completed bool, err error)
+	Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (output string, stats ClaudeStats, completed bool, err error)
 }
 
 // RealClaudeInvoker wraps the existing InvokeClaude function.
 type RealClaudeInvoker struct{}
 
-func (r *RealClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+func (r *RealClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
 	return InvokeClaude(ctx, stage, issue, newComments, resume, workDir, modelOverride)
 }

--- a/engine/item.go
+++ b/engine/item.go
@@ -262,11 +262,11 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 	// Post Claude's output
 	if output != "" {
-		displayOutput := output + formatStatsFooter(stats, completed)
+		footer := formatStatsFooter(stats, completed)
 		if stage.PostToPR {
-			e.postOutputToPR(item, stage.Name, displayOutput, branch, commit, timestamp)
+			e.postOutputToPR(item, stage.Name, output, footer, branch, commit, timestamp)
 		} else {
-			comment := formatOutputComment(stage.Name, displayOutput, branch, commit, timestamp)
+			comment := formatOutputComment(stage.Name, output, footer, branch, commit, timestamp)
 			if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
 				logf(item.Number, "warn", "could not post comment: %v\n", err)
 			}

--- a/engine/item.go
+++ b/engine/item.go
@@ -228,7 +228,16 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
 	resume := attempted // resume session if we've processed this before
-	output, completed, err := e.claude.Invoke(ctx, stage, item, nil, resume, workDir, modelOverride)
+	output, stats, completed, err := e.claude.Invoke(ctx, stage, item, nil, resume, workDir, modelOverride)
+	if stats.TurnsUsed > 0 || stats.InputTokens > 0 {
+		if stats.MaxTurns > 0 {
+			logf(item.Number, "stats", "used %d/%d turns, %dk input / %dk output tokens\n",
+				stats.TurnsUsed, stats.MaxTurns, stats.InputTokens/1000, stats.OutputTokens/1000)
+		} else {
+			logf(item.Number, "stats", "used %d turns, %dk input / %dk output tokens\n",
+				stats.TurnsUsed, stats.InputTokens/1000, stats.OutputTokens/1000)
+		}
+	}
 
 	// Restore any stashed changes now that the read-only stage has finished.
 	if stashed {
@@ -253,10 +262,11 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 	// Post Claude's output
 	if output != "" {
+		displayOutput := output + formatStatsFooter(stats, completed)
 		if stage.PostToPR {
-			e.postOutputToPR(item, stage.Name, output, branch, commit, timestamp)
+			e.postOutputToPR(item, stage.Name, displayOutput, branch, commit, timestamp)
 		} else {
-			comment := formatOutputComment(stage.Name, output, branch, commit, timestamp)
+			comment := formatOutputComment(stage.Name, displayOutput, branch, commit, timestamp)
 			if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
 				logf(item.Number, "warn", "could not post comment: %v\n", err)
 			}

--- a/engine/item.go
+++ b/engine/item.go
@@ -229,7 +229,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	}
 	resume := attempted // resume session if we've processed this before
 	output, stats, completed, err := e.claude.Invoke(ctx, stage, item, nil, resume, workDir, modelOverride)
-	if stats.TurnsUsed > 0 || stats.InputTokens > 0 {
+	if stats.TurnsUsed > 0 || stats.InputTokens > 0 || stats.OutputTokens > 0 {
 		if stats.MaxTurns > 0 {
 			logf(item.Number, "stats", "used %d/%d turns, %dk input / %dk output tokens\n",
 				stats.TurnsUsed, stats.MaxTurns, stats.InputTokens/1000, stats.OutputTokens/1000)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -117,7 +117,7 @@ func (m *mockGitHubClient) MarkPRReady(owner, repo string, prNumber int) error {
 
 // mockClaudeInvoker implements ClaudeInvoker for testing.
 type mockClaudeInvoker struct {
-	invokeFn func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error)
+	invokeFn func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error)
 	calls    []claudeInvokeCall
 }
 
@@ -129,10 +129,10 @@ type claudeInvokeCall struct {
 	modelOverride string
 }
 
-func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, ClaudeStats, bool, error) {
 	m.calls = append(m.calls, claudeInvokeCall{stage.Name, issue.Number, resume, workDir, modelOverride})
 	if m.invokeFn != nil {
 		return m.invokeFn(stage, issue, newComments, resume, workDir, modelOverride)
 	}
-	return "mock output", false, nil
+	return "mock output", ClaudeStats{}, false, nil
 }

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -97,7 +97,7 @@ func (e *Engine) markPRReady(item gh.ProjectItem, knownPR int) {
 }
 
 // postOutputToPR posts detailed output on the linked PR and a brief summary on the issue.
-func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, branch, commit, timestamp string) {
+func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, branch, commit, timestamp string) {
 	prNumber, err := e.client.FindPRForIssue(e.cfg.Owner, e.cfg.Repo, item.Number)
 	if err != nil {
 		logf(item.Number, "warn", "could not find PR: %v\n", err)
@@ -105,7 +105,7 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, branch, 
 
 	if prNumber > 0 {
 		// Post detailed output on the PR
-		comment := formatOutputComment(stageName, output, branch, commit, timestamp)
+		comment := formatOutputComment(stageName, output, footer, branch, commit, timestamp)
 		if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, prNumber, comment); err != nil {
 			logf(item.Number, "warn", "could not post to PR #%d: %v\n", prNumber, err)
 		} else {
@@ -120,20 +120,22 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, branch, 
 	} else {
 		// No PR found — fall back to posting on the issue
 		logf(item.Number, "warn", "no open PR found, posting on issue instead\n")
-		comment := formatOutputComment(stageName, output, branch, commit, timestamp)
+		comment := formatOutputComment(stageName, output, footer, branch, commit, timestamp)
 		if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
 			logf(item.Number, "warn", "could not post comment: %v\n", err)
 		}
 	}
 }
 
-func formatOutputComment(stageName, output, branch, commit, timestamp string) string {
+// formatOutputComment formats Claude's output as a GitHub comment.
+// footer is appended after any truncation so it is never cut off.
+func formatOutputComment(stageName, output, footer, branch, commit, timestamp string) string {
 	const maxLen = 60000
 	if len(output) > maxLen {
 		output = output[:maxLen] + "\n\n... (truncated)"
 	}
 	meta := fmt.Sprintf("*branch: %s | commit: %s | %s*", branch, commit, timestamp)
-	return fmt.Sprintf("🏭 **Fabrik — stage: %s**\n%s\n\n%s", stageName, meta, output)
+	return fmt.Sprintf("🏭 **Fabrik — stage: %s**\n%s\n\n%s%s", stageName, meta, output, footer)
 }
 
 func formatPRSummaryComment(stageName string, prNumber int, output, branch, commit, timestamp string) string {


### PR DESCRIPTION
## Summary
- Adds `ClaudeStats` struct (turns used, token counts) returned alongside existing Claude invocation results
- Switches to `--output-format json` for structured output including turn count and token usage
- Tees stderr to a timestamped log file via `io.MultiWriter` for session observability

## Test plan
- [ ] Run `go build ./...` to verify compilation
- [ ] Run `go test -race ./...` to verify all tests pass
- [ ] Verify log files are created at `~/.fabrik/logs/issue-N/<stage>-<timestamp>.log`
- [ ] Verify turn/token summary appears in stage comments

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)