### PR TITLE
feat: move stages to .fabrik/stages and add fabrik init subcommand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,9 @@ FABRIK_PROJECT_NUMBER=1
 # Required: Your GitHub username (only process issues assigned to this user)
 FABRIK_USER=your-github-username
 
-# Optional: Directory containing stage YAML configs (default: ./stages)
-# FABRIK_STAGES=./stages
+# Optional: Directory containing stage YAML configs (default: ./.fabrik/stages)
+# Run `fabrik init` to create .fabrik/stages/ with the default stage YAMLs.
+# FABRIK_STAGES=./.fabrik/stages
 
 # Optional: Auto-advance issues through stages without waiting for human input (default: false)
 # FABRIK_YOLO=false

--- a/.fabrik/stages/implement.yaml
+++ b/.fabrik/stages/implement.yaml
@@ -1,0 +1,29 @@
+name: Implement
+order: 3
+prompt: |
+  You are an implementation agent. Given the issue spec and plan:
+  1. First, check for any uncommitted changes in the worktree (git status).
+     If there are existing changes, review them — they may be partial work
+     from a previous session. Assess what's already done and continue from there.
+  2. Implement the changes described in the plan, working through tasks in order.
+  3. After completing each task, update the issue body to check off the
+     corresponding checkbox (change "- [ ]" to "- [x]") using:
+     gh issue edit <number> --body "..."
+     This provides real-time progress visibility on the issue.
+  4. Commit frequently — after each logical unit of work, not just at the end.
+     This preserves progress if the session is interrupted.
+  5. Write tests for any new functionality.
+  6. Ensure the code compiles and tests pass.
+  7. Push your commits to the remote branch regularly (after each commit or set
+     of related commits) so progress is visible on the draft PR.
+  8. Before signaling completion, ensure all changes are committed and pushed.
+
+  Work methodically through the task checklist. When all tasks are complete
+  and tests pass, signal completion.
+model: sonnet
+max_turns: 50
+create_draft_pr: true
+mark_pr_ready_on_complete: true
+post_to_pr: true
+completion:
+  type: claude

--- a/.fabrik/stages/plan.yaml
+++ b/.fabrik/stages/plan.yaml
@@ -1,0 +1,39 @@
+name: Plan
+order: 2
+prompt: |
+  You are a planning agent. Given the issue spec and research findings:
+  1. Propose a concrete implementation approach with trade-offs considered.
+  2. Break the work into an ordered task checklist using GitHub markdown checkboxes:
+     - [ ] Task one
+     - [ ] Task two
+     These checkboxes will be checked off during implementation to track progress.
+  3. Identify key design decisions and get them documented.
+  4. Note any dependencies, risks, or things that need human input.
+
+  Update the issue body with your plan. The task checklist MUST use markdown
+  checkbox format (- [ ] task) so progress can be tracked during implementation.
+
+  When the plan is complete, all tasks are identified, and the approach is clear,
+  signal completion.
+model: sonnet
+max_turns: 50
+read_only: true
+allowed_tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(git log)
+  - Bash(git diff)
+  - WebSearch
+  - WebFetch
+comment_prompt: |
+  You are reviewing user comments on a Plan-stage issue.
+  The user has provided feedback on the proposed plan.
+  Update the issue body to reflect their input:
+  1. Adjust the implementation approach based on feedback.
+  2. Update the task checklist if tasks were added, removed, or reordered.
+     Always use markdown checkbox format (- [ ] task).
+  3. Revise design decisions based on the user's preferences.
+  4. Keep the issue body well-structured and complete.
+completion:
+  type: claude

--- a/.fabrik/stages/research.yaml
+++ b/.fabrik/stages/research.yaml
@@ -1,0 +1,32 @@
+name: Research
+order: 1
+prompt: |
+  You are a research agent. Your job is to analyze the issue spec below and:
+  1. Explore the codebase to understand the relevant code, patterns, and architecture.
+  2. Identify all files, modules, and dependencies that are relevant to this issue.
+  3. Clarify any ambiguities by listing questions as a checklist.
+  4. Summarize your findings: what exists today, what needs to change, and any risks.
+
+  When you have a thorough understanding of the problem space and all questions
+  are resolved, signal completion.
+model: sonnet
+max_turns: 50
+read_only: true
+allowed_tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(git log)
+  - Bash(git diff)
+  - WebSearch
+  - WebFetch
+comment_prompt: |
+  You are reviewing user comments on a Research-stage issue.
+  The user has answered questions or provided clarifications from the research phase.
+  Incorporate their answers into the issue body:
+  1. Remove resolved questions from any checklist.
+  2. Update the research summary with the new information.
+  3. Add any new findings or constraints mentioned in the comments.
+  4. Keep the issue body well-structured and complete.
+completion:
+  type: claude

--- a/.fabrik/stages/review.yaml
+++ b/.fabrik/stages/review.yaml
@@ -1,0 +1,30 @@
+name: Review
+order: 4
+prompt: |
+  You are a code review and fix agent. Your job is to review the implementation
+  and fix any issues you find:
+  1. First, check for any uncommitted changes in the worktree (git status).
+     If there are existing changes, review them — they may be partial work
+     from a previous session. Commit or incorporate them before proceeding.
+  2. Rebase the branch onto the latest main to ensure it is up to date.
+     Resolve any merge conflicts.
+  3. Check for PR review feedback from external bots (Copilot, Gemini, etc.)
+     using: gh pr view <number> --comments
+     Address any valid feedback — fix the code issues they identified.
+  4. Perform your own review: check for correctness, edge cases, bugs,
+     security issues, test coverage, and code style consistency.
+  5. List your findings clearly.
+  6. Fix any issues you identified — update the code and commit your changes.
+     Commit after each fix, not all at once.
+  7. Re-review your fixes to make sure they are correct.
+  8. Push your changes to the PR branch.
+
+  If the implementation is clean (or you fixed all issues), signal completion.
+  If you cannot fix an issue (e.g., it requires a design decision), list it
+  clearly and do NOT signal completion.
+model: sonnet
+max_turns: 30
+post_to_pr: true
+mark_pr_ready_on_complete: true
+completion:
+  type: claude

--- a/.fabrik/stages/validate.yaml
+++ b/.fabrik/stages/validate.yaml
@@ -1,0 +1,21 @@
+name: Validate
+order: 5
+prompt: |
+  You are a validation agent. Your job is to verify the implementation is complete and correct:
+  1. First, check for any uncommitted changes in the worktree (git status).
+     If there are existing changes, commit them before proceeding.
+  2. Rebase the branch onto the latest main to ensure you're testing against
+     the current codebase. Resolve any merge conflicts.
+  3. Run the full test suite and confirm everything passes.
+  4. Verify the original issue requirements are met — check each acceptance criterion.
+  5. Test edge cases and error paths.
+  6. Confirm the changes don't break existing functionality.
+  7. Push your changes (rebase + any fixes) to the remote branch.
+
+  If validation passes, signal completion.
+  If any issues are found, describe them clearly and do NOT signal completion.
+model: sonnet
+max_turns: 50
+post_to_pr: true
+completion:
+  type: claude

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,8 @@
 !.claude/rules/
 !.claude/skills/
 !.claude/agents/
-.fabrik/
+.fabrik/worktrees/
 .env
-stages/mystages/
 fabrik
 *.exe
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,10 @@ go vet ./...             # Lint
 - `github/rest.go` — HTTP helpers
 - `github/types.go` — Shared data types (ProjectItem, Comment, ReactionGroup)
 - `stages/stages.go` — YAML stage config loading
-- `stages/examples/` — Default stage configs (committed)
-- `stages/mystages/` — User-customized stages (gitignored)
+- `stages/examples/` — Default stage YAML sources, embedded in binary via `//go:embed`
+- `stages/embed.go` — Exposes embedded default stages as `stages.DefaultStages`
+- `cmd/init.go` — `fabrik init` subcommand; extracts embedded YAMLs to `.fabrik/stages/`
+- `.fabrik/stages/` — Live stage configs for this project (tracked in git)
 
 ## Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ cp ./stages/mystages/*.yaml .fabrik/stages/
 
 ## Documentation
 
-- [User Guide](docs/USER_GUIDE.md) — full configuration reference, workflow patterns, stage details, labels, and troubleshooting
+- [User Guide](docs/USER_GUIDE.md) — full configuration reference for the pre-v0.2 `./stages` workflow (see "Quick Start" and "Migration from `./stages`" above for the current `./.fabrik/stages` default), workflow patterns, stage details, labels, and troubleshooting
 
 ## Architecture Decision Records
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ cp .env.example .env
 # Edit .env with your GitHub token and repo details
 # Make sure .env is in your .gitignore (Fabrik enforces this)
 
-# Copy and customize stage configs
-cp -r stages/examples stages/mystages
+# Initialize stage configs in .fabrik/stages/
+./fabrik init
 
 # Run (all config comes from .env — no flags needed)
 ./fabrik
 
 # Or override specific values with flags
-./fabrik --stages ./stages/mystages --yolo
+./fabrik --stages ./.fabrik/stages --yolo
 ```
 
 ### Development
@@ -159,7 +159,7 @@ Command-line flags take precedence over `.env` values.
 | `--project` | GitHub project number | required |
 | `--user` | Your GitHub username | required |
 | `--token` | GitHub token | `$GITHUB_TOKEN` |
-| `--stages` | Stage configs directory | `./stages` |
+| `--stages` | Stage configs directory | `./.fabrik/stages` |
 | `--yolo` | Auto-advance through stages | `false` |
 | `--auto-upgrade` | Self-upgrade from origin/main when idle | `false` |
 | `--poll` | Poll interval in seconds | `30` |
@@ -203,6 +203,16 @@ The human's role is product manager: file issues, answer questions when the
 Research stage surfaces them, drag cards across the board, and occasionally
 comment "please process PR feedback" when Copilot has opinions. The factory
 does the rest.
+
+## Migration from `./stages`
+
+If you used Fabrik before `v0.2`, your stage configs were in `./stages/mystages/`.
+
+```bash
+mkdir -p .fabrik/stages
+cp ./stages/mystages/*.yaml .fabrik/stages/
+# Or set FABRIK_STAGES=./stages/mystages in your .env to keep the old path
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -206,12 +206,17 @@ does the rest.
 
 ## Migration from `./stages`
 
-If you used Fabrik before `v0.2`, your stage configs were in `./stages/mystages/`.
+If you used Fabrik before `v0.2`, your stage configs were in `./stages` (the old default)
+or `./stages/mystages/` if you used that convention.
 
 ```bash
 mkdir -p .fabrik/stages
+# If you used the default ./stages path:
+cp ./stages/*.yaml .fabrik/stages/
+# If you used ./stages/mystages/:
 cp ./stages/mystages/*.yaml .fabrik/stages/
-# Or set FABRIK_STAGES=./stages/mystages in your .env to keep the old path
+# Or keep the old path by setting FABRIK_STAGES in your .env:
+# FABRIK_STAGES=./stages
 ```
 
 ## Documentation

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/verveguy/fabrik/stages"
+)
+
+// runInit implements the `fabrik init` subcommand.
+// It extracts the embedded default stage YAML files into .fabrik/stages/.
+// Existing files are skipped unless --force is passed.
+func runInit(args []string) error {
+	fs_ := flag.NewFlagSet("init", flag.ContinueOnError)
+	force := fs_.Bool("force", false, "Overwrite existing stage files")
+	if err := fs_.Parse(args); err != nil {
+		return err
+	}
+
+	destDir := ".fabrik/stages"
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("creating %s: %w", destDir, err)
+	}
+
+	entries, err := fs.ReadDir(stages.DefaultStages, "examples")
+	if err != nil {
+		return fmt.Errorf("reading embedded stages: %w", err)
+	}
+
+	wrote := 0
+	skipped := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		destPath := filepath.Join(destDir, entry.Name())
+		if !*force {
+			if _, err := os.Stat(destPath); err == nil {
+				skipped++
+				fmt.Printf("  skip   %s (already exists; use --force to overwrite)\n", destPath)
+				continue
+			}
+		}
+		data, err := stages.DefaultStages.ReadFile(filepath.Join("examples", entry.Name()))
+		if err != nil {
+			return fmt.Errorf("reading embedded %s: %w", entry.Name(), err)
+		}
+		if err := os.WriteFile(destPath, data, 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", destPath, err)
+		}
+		wrote++
+		fmt.Printf("  write  %s\n", destPath)
+	}
+
+	fmt.Printf("fabrik init: wrote %d file(s), skipped %d file(s)\n", wrote, skipped)
+	fmt.Printf("Stage configs are in %s — edit them to customize your pipeline.\n", destDir)
+	return nil
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/verveguy/fabrik/stages"
@@ -38,13 +40,15 @@ func runInit(args []string) error {
 		}
 		destPath := filepath.Join(destDir, entry.Name())
 		if !*force {
-			if _, err := os.Stat(destPath); err == nil {
+			if _, statErr := os.Stat(destPath); statErr == nil {
 				skipped++
 				fmt.Printf("  skip   %s (already exists; use --force to overwrite)\n", destPath)
 				continue
+			} else if !errors.Is(statErr, fs.ErrNotExist) {
+				return fmt.Errorf("checking %s: %w", destPath, statErr)
 			}
 		}
-		data, err := stages.DefaultStages.ReadFile(filepath.Join("examples", entry.Name()))
+		data, err := stages.DefaultStages.ReadFile(path.Join("examples", entry.Name()))
 		if err != nil {
 			return fmt.Errorf("reading embedded %s: %w", entry.Name(), err)
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,9 +16,9 @@ import (
 // It extracts the embedded default stage YAML files into .fabrik/stages/.
 // Existing files are skipped unless --force is passed.
 func runInit(args []string) error {
-	fs_ := flag.NewFlagSet("init", flag.ContinueOnError)
-	force := fs_.Bool("force", false, "Overwrite existing stage files")
-	if err := fs_.Parse(args); err != nil {
+	fset := flag.NewFlagSet("init", flag.ContinueOnError)
+	force := fset.Bool("force", false, "Overwrite existing stage files")
+	if err := fset.Parse(args); err != nil {
 		return err
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,9 @@ func runInit(args []string) error {
 	if err := fset.Parse(args); err != nil {
 		return err
 	}
+	if fset.NArg() != 0 {
+		return fmt.Errorf("init: unexpected positional arguments: %v", fset.Args())
+	}
 
 	destDir := ".fabrik/stages"
 	if err := os.MkdirAll(destDir, 0755); err != nil {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -160,6 +160,12 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 	}
 }
 
+func TestRunInit_RejectsPositionalArgs(t *testing.T) {
+	if err := runInit([]string{"unexpected"}); err == nil {
+		t.Fatal("expected error for unexpected positional argument, got nil")
+	}
+}
+
 func TestRunInit_IdempotentDestDir(t *testing.T) {
 	dir := t.TempDir()
 	orig, err := os.Getwd()

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/verveguy/fabrik/stages"
 )
 
 func TestRunInit_WritesFiles(t *testing.T) {
@@ -25,19 +28,43 @@ func TestRunInit_WritesFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadDir: %v", err)
 	}
-	if len(entries) == 0 {
-		t.Fatal("expected files in .fabrik/stages, got none")
+
+	// Count embedded source files to verify all were written.
+	embedded, err := fs.ReadDir(stages.DefaultStages, "examples")
+	if err != nil {
+		t.Fatalf("reading embedded stages: %v", err)
 	}
+	embeddedFiles := 0
+	for _, e := range embedded {
+		if !e.IsDir() {
+			embeddedFiles++
+		}
+	}
+	writtenFiles := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			writtenFiles++
+		}
+	}
+	if writtenFiles != embeddedFiles {
+		t.Fatalf("expected %d file(s) written, got %d", embeddedFiles, writtenFiles)
+	}
+
+	// Verify each written file matches the embedded source exactly.
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, ".fabrik", "stages", e.Name()))
+		written, err := os.ReadFile(filepath.Join(dir, ".fabrik", "stages", e.Name()))
 		if err != nil {
 			t.Fatalf("reading written file %s: %v", e.Name(), err)
 		}
-		if len(data) == 0 {
-			t.Errorf("file %s is empty", e.Name())
+		source, err := stages.DefaultStages.ReadFile("examples/" + e.Name())
+		if err != nil {
+			t.Fatalf("reading embedded source %s: %v", e.Name(), err)
+		}
+		if string(written) != string(source) {
+			t.Errorf("file %s: content mismatch", e.Name())
 		}
 	}
 }
@@ -60,7 +87,10 @@ func TestRunInit_SkipsExistingFiles(t *testing.T) {
 
 	// Overwrite one file with sentinel content.
 	stagesDir := filepath.Join(dir, ".fabrik", "stages")
-	entries, _ := os.ReadDir(stagesDir)
+	entries, err := os.ReadDir(stagesDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
 	if len(entries) == 0 {
 		t.Fatal("no files written by first init")
 	}
@@ -101,7 +131,10 @@ func TestRunInit_ForceOverwrites(t *testing.T) {
 	}
 
 	stagesDir := filepath.Join(dir, ".fabrik", "stages")
-	entries, _ := os.ReadDir(stagesDir)
+	entries, err := os.ReadDir(stagesDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
 	if len(entries) == 0 {
 		t.Fatal("no files written by first init")
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunInit_WritesFiles(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint
+
+	if err := runInit([]string{}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dir, ".fabrik", "stages"))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected files in .fabrik/stages, got none")
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, ".fabrik", "stages", e.Name()))
+		if err != nil {
+			t.Fatalf("reading written file %s: %v", e.Name(), err)
+		}
+		if len(data) == 0 {
+			t.Errorf("file %s is empty", e.Name())
+		}
+	}
+}
+
+func TestRunInit_SkipsExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint
+
+	// First init — writes all files.
+	if err := runInit([]string{}); err != nil {
+		t.Fatalf("first runInit: %v", err)
+	}
+
+	// Overwrite one file with sentinel content.
+	stagesDir := filepath.Join(dir, ".fabrik", "stages")
+	entries, _ := os.ReadDir(stagesDir)
+	if len(entries) == 0 {
+		t.Fatal("no files written by first init")
+	}
+	sentinel := []byte("sentinel content")
+	targetPath := filepath.Join(stagesDir, entries[0].Name())
+	if err := os.WriteFile(targetPath, sentinel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second init — should skip the existing file.
+	if err := runInit([]string{}); err != nil {
+		t.Fatalf("second runInit: %v", err)
+	}
+
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(sentinel) {
+		t.Errorf("existing file was overwritten; want sentinel, got %q", string(got))
+	}
+}
+
+func TestRunInit_ForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint
+
+	// First init.
+	if err := runInit([]string{}); err != nil {
+		t.Fatalf("first runInit: %v", err)
+	}
+
+	stagesDir := filepath.Join(dir, ".fabrik", "stages")
+	entries, _ := os.ReadDir(stagesDir)
+	if len(entries) == 0 {
+		t.Fatal("no files written by first init")
+	}
+
+	// Overwrite one file with sentinel.
+	sentinel := []byte("sentinel content")
+	targetPath := filepath.Join(stagesDir, entries[0].Name())
+	if err := os.WriteFile(targetPath, sentinel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second init with --force — should overwrite.
+	if err := runInit([]string{"--force"}); err != nil {
+		t.Fatalf("force runInit: %v", err)
+	}
+
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) == string(sentinel) {
+		t.Error("--force did not overwrite existing file")
+	}
+}
+
+func TestRunInit_IdempotentDestDir(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint
+
+	// Running init twice should not error even if .fabrik/stages already exists.
+	if err := runInit([]string{}); err != nil {
+		t.Fatalf("first runInit: %v", err)
+	}
+	if err := runInit([]string{}); err != nil {
+		t.Fatalf("second runInit: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,11 @@ type Config struct {
 }
 
 func Execute() error {
+	// Dispatch subcommands before flag parsing so they get their own flag sets.
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		return runInit(os.Args[2:])
+	}
+
 	cfg := &Config{}
 
 	flag.StringVar(&cfg.Owner, "owner", "", "GitHub repository owner")
@@ -39,7 +44,7 @@ func Execute() error {
 	flag.IntVar(&cfg.ProjectNum, "project", 0, "GitHub project number")
 	flag.StringVar(&cfg.User, "user", "", "GitHub username (only process changes by this user)")
 	flag.StringVar(&cfg.Token, "token", "", "GitHub token (or set GITHUB_TOKEN env var)")
-	flag.StringVar(&cfg.StagesDir, "stages", "./stages", "Directory containing stage YAML configs")
+	flag.StringVar(&cfg.StagesDir, "stages", "./.fabrik/stages", "Directory containing stage YAML configs")
 	flag.BoolVar(&cfg.Yolo, "yolo", false, "Auto-advance issues through stages without waiting for human input")
 	flag.BoolVar(&cfg.AutoUpgrade, "auto-upgrade", false, "When idle, check for new commits on origin/main and self-upgrade (for fabrik developing itself)")
 	flag.IntVar(&cfg.PollSeconds, "poll", 30, "Polling interval in seconds")
@@ -76,7 +81,7 @@ func Execute() error {
 	if cfg.User == "" {
 		cfg.User = os.Getenv("FABRIK_USER")
 	}
-	if cfg.StagesDir == "./stages" {
+	if cfg.StagesDir == "./.fabrik/stages" {
 		if v := os.Getenv("FABRIK_STAGES"); v != "" {
 			cfg.StagesDir = v
 		}

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -336,9 +336,29 @@ func parseClaudeJSON(output []byte) (text, sessionID string, turns int, cost flo
 	return resp.Result, resp.SessionID, resp.NumTurns, resp.CostUSD
 }
 
+// saveSessionID scans output lines for a JSON object containing session_id and
+// saves it to path. Used when the session ID must be extracted from raw output.
+func saveSessionID(path, output string) {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.Contains(line, "session_id") {
+			continue
+		}
+		var resp claudeResponse
+		if err := json.Unmarshal([]byte(line), &resp); err == nil && resp.SessionID != "" {
+			saveSessionIDDirect(path, resp.SessionID)
+			return
+		}
+	}
+}
+
 // saveSessionIDDirect saves a known session ID to disk for future resumption.
 func saveSessionIDDirect(path, sessionID string) {
 	if sessionID == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to create session dir %s: %v\n", filepath.Dir(path), err)
 		return
 	}
 	if err := os.WriteFile(path, []byte(sessionID), 0600); err != nil {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -508,7 +508,7 @@ func TestProcessItem_FullHappyPath(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
 		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Claude output here", false, nil
+			return "Claude output here\nFABRIK_STAGE_COMPLETE\n", true, nil
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"os"
 
@@ -9,6 +11,9 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/stages/embed.go
+++ b/stages/embed.go
@@ -1,0 +1,9 @@
+package stages
+
+import "embed"
+
+// DefaultStages holds the embedded default stage YAML files from examples/.
+// These are extracted by `fabrik init` into .fabrik/stages/ for new projects.
+//
+//go:embed examples/*.yaml
+var DefaultStages embed.FS


### PR DESCRIPTION
## Summary

- Moves the default stages directory from `./stages` to `./.fabrik/stages` so all Fabrik artifacts live under `.fabrik/`
- Embeds default stage YAMLs into the binary via `//go:embed` so the binary is self-contained
- Adds `fabrik init` subcommand that extracts embedded stages into `.fabrik/stages/` (skips existing files; `--force` to overwrite)
- Updates `.gitignore` to track `.fabrik/stages/` while still ignoring `.fabrik/worktrees/`
- Updates `README.md`, `CLAUDE.md`, and `.env.example` to reflect new defaults
- Adds tests for `runInit()` including re-run safety and `--force` behavior

## Migration

Existing users with `./stages` setups can either:
- Run `fabrik init` in their project directory, or
- Set `FABRIK_STAGES=./stages` to keep the old path

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)