### PR TITLE
feat: log token consumption per poll cycle

### DIFF
--- a/engine/claude.go
+++ b/engine/claude.go
@@ -16,6 +16,26 @@ import (
 
 var stageCompleteRE = regexp.MustCompile(`(?m)^FABRIK_STAGE_COMPLETE\r?$`)
 
+// TokenUsage holds token consumption data from a single Claude invocation.
+type TokenUsage struct {
+	InputTokens          int
+	OutputTokens         int
+	CacheCreationTokens  int
+	CacheReadTokens      int
+	CostUSD              float64
+}
+
+// add returns a new TokenUsage that is the sum of t and other.
+func (t TokenUsage) add(other TokenUsage) TokenUsage {
+	return TokenUsage{
+		InputTokens:         t.InputTokens + other.InputTokens,
+		OutputTokens:        t.OutputTokens + other.OutputTokens,
+		CacheCreationTokens: t.CacheCreationTokens + other.CacheCreationTokens,
+		CacheReadTokens:     t.CacheReadTokens + other.CacheReadTokens,
+		CostUSD:             t.CostUSD + other.CostUSD,
+	}
+}
+
 // SessionDir returns the directory where Claude sessions are cached for an issue.
 func SessionDir(issueNumber int) string {
 	home, _ := os.UserHomeDir()
@@ -37,36 +57,36 @@ func sessionFile(issueNumber int, stageName string) string {
 // InvokeClaude runs Claude Code with the given stage configuration and issue context.
 // workDir is the directory Claude should run in (typically a git worktree).
 // modelOverride, if non-empty, replaces the stage's configured model.
-// It returns Claude's output and whether Claude indicated completion.
-func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+// It returns Claude's output, whether Claude indicated completion, and token usage.
+func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 	sessDir := SessionDir(issue.Number)
 	if err := os.MkdirAll(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("creating session dir: %w", err)
+		return "", false, TokenUsage{}, fmt.Errorf("creating session dir: %w", err)
 	}
 	if err := os.Chmod(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("setting session dir permissions: %w", err)
+		return "", false, TokenUsage{}, fmt.Errorf("setting session dir permissions: %w", err)
 	}
 
 	prompt := buildPrompt(stage, issue, newComments)
 	args := buildClaudeArgs(stage, issue.Number, resume, modelOverride)
 
-	output, _, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name)
+	output, _, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name)
 	if err != nil {
-		return output, false, err
+		return output, false, usage, err
 	}
-	return output, checkCompletion(stage, output), nil
+	return output, checkCompletion(stage, output), usage, nil
 }
 
 // InvokeClaudeForComments runs Claude Code with a comment-review prompt.
 // It uses the stage's CommentPrompt if defined, otherwise a default.
 // modelOverride, if non-empty, replaces the stage's configured model.
-func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (string, bool, error) {
+func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 	sessDir := SessionDir(issue.Number)
 	if err := os.MkdirAll(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("creating session dir: %w", err)
+		return "", false, TokenUsage{}, fmt.Errorf("creating session dir: %w", err)
 	}
 	if err := os.Chmod(sessDir, 0700); err != nil {
-		return "", false, fmt.Errorf("setting session dir permissions: %w", err)
+		return "", false, TokenUsage{}, fmt.Errorf("setting session dir permissions: %w", err)
 	}
 
 	prompt := buildCommentReviewPrompt(stage, issue, comments)
@@ -106,7 +126,7 @@ func buildClaudeArgs(stage *stages.Stage, issueNumber int, resume bool, modelOve
 	return args
 }
 
-func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string) (string, bool, error) {
+func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string) (string, bool, TokenUsage, error) {
 	logf(issueNumber, "claude", "invoking (%s) in %s\n", label, workDir)
 
 	cmd := exec.CommandContext(ctx, "claude", args...)
@@ -116,20 +136,20 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 
 	output, err := cmd.Output()
 	if err != nil {
-		return string(output), false, fmt.Errorf("claude exited with error: %w", err)
+		return string(output), false, TokenUsage{}, fmt.Errorf("claude exited with error: %w", err)
 	}
 
 	result := string(output)
 
-	// Try to save session ID for future resumption
+	// Try to save session ID and extract token usage from metadata line
 	// Use the base stage name (strip "-comment-review" suffix) for session continuity
 	baseName := strings.TrimSuffix(label, "-comment-review")
-	saveSessionID(sessionFile(issueNumber, baseName), result)
+	usage := extractMetadata(sessionFile(issueNumber, baseName), result)
 
 	// Simple marker check — callers with the stage use checkCompletion for robustness.
 	completed := stageCompleteRE.MatchString(result)
 
-	return result, completed, nil
+	return result, completed, usage, nil
 }
 
 // checkCompletion returns true if Claude's output indicates the stage is complete.
@@ -304,24 +324,42 @@ func extractSummary(output string) string {
 	return extractBetweenMarkers(output, "FABRIK_SUMMARY_BEGIN", "FABRIK_SUMMARY_END")
 }
 
-// saveSessionID attempts to extract a session ID from Claude's output.
-func saveSessionID(path string, output string) {
+// extractMetadata extracts the session ID and token usage from Claude's output.
+// It saves the session ID to path for future resumption, and returns token usage.
+// Missing fields produce zero values (graceful degradation if output format changes).
+func extractMetadata(path string, output string) TokenUsage {
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "{") && strings.Contains(line, "session_id") {
-			var meta struct {
-				SessionID string `json:"session_id"`
-			}
-			if err := json.Unmarshal([]byte(line), &meta); err == nil && meta.SessionID != "" {
-				if err := os.WriteFile(path, []byte(meta.SessionID), 0600); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: failed to save session id to %s: %v\n", path, err)
-					return
-				}
-				if err := os.Chmod(path, 0600); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: failed to set permissions on session file %s: %v\n", path, err)
-				}
-				return
+		if !strings.HasPrefix(line, "{") || !strings.Contains(line, "session_id") {
+			continue
+		}
+		var meta struct {
+			SessionID string `json:"session_id"`
+			CostUSD   float64 `json:"total_cost_usd"`
+			Usage     struct {
+				InputTokens         int `json:"input_tokens"`
+				OutputTokens        int `json:"output_tokens"`
+				CacheCreationTokens int `json:"cache_creation_input_tokens"`
+				CacheReadTokens     int `json:"cache_read_input_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(line), &meta); err != nil {
+			continue
+		}
+		if meta.SessionID != "" {
+			if err := os.WriteFile(path, []byte(meta.SessionID), 0600); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to save session id to %s: %v\n", path, err)
+			} else if err := os.Chmod(path, 0600); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to set permissions on session file %s: %v\n", path, err)
 			}
 		}
+		return TokenUsage{
+			InputTokens:         meta.Usage.InputTokens,
+			OutputTokens:        meta.Usage.OutputTokens,
+			CacheCreationTokens: meta.Usage.CacheCreationTokens,
+			CacheReadTokens:     meta.Usage.CacheReadTokens,
+			CostUSD:             meta.CostUSD,
+		}
 	}
+	return TokenUsage{}
 }

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -133,12 +133,15 @@ type claudeResponse struct {
 	NumTurns  int     `json:"num_turns"`
 	CostUSD   float64 `json:"total_cost_usd"`
 	IsError   bool    `json:"is_error"`
-	Usage     struct {
-		InputTokens         int `json:"input_tokens"`
-		OutputTokens        int `json:"output_tokens"`
-		CacheCreationTokens int `json:"cache_creation_input_tokens"`
-		CacheReadTokens     int `json:"cache_read_input_tokens"`
-	} `json:"usage"`
+	// ModelUsage contains per-model accumulated token counts for the full session.
+	// These are more accurate than the top-level "usage" field, which reflects only
+	// the last API call rather than the entire multi-turn session.
+	ModelUsage map[string]struct {
+		InputTokens         int `json:"inputTokens"`
+		OutputTokens        int `json:"outputTokens"`
+		CacheCreationTokens int `json:"cacheCreationInputTokens"`
+		CacheReadTokens     int `json:"cacheReadInputTokens"`
+	} `json:"modelUsage"`
 }
 
 func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string) (string, bool, TokenUsage, error) {
@@ -363,14 +366,17 @@ func parseClaudeJSON(output []byte) (claudeResponse, bool) {
 }
 
 // tokenUsageFromResponse converts a claudeResponse to TokenUsage.
+// Token counts are summed across all models in ModelUsage for accuracy;
+// CostUSD comes from the top-level total_cost_usd field.
 func tokenUsageFromResponse(resp claudeResponse) TokenUsage {
-	return TokenUsage{
-		InputTokens:         resp.Usage.InputTokens,
-		OutputTokens:        resp.Usage.OutputTokens,
-		CacheCreationTokens: resp.Usage.CacheCreationTokens,
-		CacheReadTokens:     resp.Usage.CacheReadTokens,
-		CostUSD:             resp.CostUSD,
+	usage := TokenUsage{CostUSD: resp.CostUSD}
+	for _, m := range resp.ModelUsage {
+		usage.InputTokens += m.InputTokens
+		usage.OutputTokens += m.OutputTokens
+		usage.CacheCreationTokens += m.CacheCreationTokens
+		usage.CacheReadTokens += m.CacheReadTokens
 	}
+	return usage
 }
 
 // saveSessionIDDirect saves a known session ID to disk for future resumption.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -167,12 +167,12 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 
 	resp, ok := parseClaudeJSON(output)
 	text := resp.Result
+	usage := tokenUsageFromResponse(resp)
 	if !ok {
 		text = string(output)
+	} else {
+		logf(issueNumber, "claude", "completed in %d turns, $%.4f\n", resp.NumTurns, resp.CostUSD)
 	}
-
-	usage := tokenUsageFromResponse(resp)
-	logf(issueNumber, "claude", "completed in %d turns, $%.4f\n", resp.NumTurns, resp.CostUSD)
 
 	// Save session ID for future resumption
 	baseName := strings.TrimSuffix(label, "-comment-review")

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -221,6 +221,49 @@ func TestTokenUsageFromResponse_MultiModel(t *testing.T) {
 	}
 }
 
+func TestTokenUsageAdd(t *testing.T) {
+	a := TokenUsage{InputTokens: 10, OutputTokens: 5, CacheCreationTokens: 2, CacheReadTokens: 3, CostUSD: 0.001}
+	b := TokenUsage{InputTokens: 20, OutputTokens: 15, CacheCreationTokens: 8, CacheReadTokens: 7, CostUSD: 0.002}
+	got := a.add(b)
+	if got.InputTokens != 30 {
+		t.Errorf("InputTokens = %d, want 30", got.InputTokens)
+	}
+	if got.OutputTokens != 20 {
+		t.Errorf("OutputTokens = %d, want 20", got.OutputTokens)
+	}
+	if got.CacheCreationTokens != 10 {
+		t.Errorf("CacheCreationTokens = %d, want 10", got.CacheCreationTokens)
+	}
+	if got.CacheReadTokens != 10 {
+		t.Errorf("CacheReadTokens = %d, want 10", got.CacheReadTokens)
+	}
+	if diff := got.CostUSD - 0.003; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("CostUSD = %f, want ~0.003", got.CostUSD)
+	}
+	// Adding zero value leaves original unchanged
+	zero := TokenUsage{}
+	if a.add(zero) != a {
+		t.Error("adding zero TokenUsage should return original")
+	}
+}
+
+func TestTokenUsageFromResponse_NoModelUsage(t *testing.T) {
+	// When modelUsage is absent (older CLI or error response), token counts are zero
+	// but CostUSD is still populated from the top-level field.
+	output := []byte(`{"result":"hello","session_id":"s","total_cost_usd":0.005}`)
+	resp, ok := parseClaudeJSON(output)
+	if !ok {
+		t.Fatal("expected successful parse")
+	}
+	usage := tokenUsageFromResponse(resp)
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.CacheCreationTokens != 0 || usage.CacheReadTokens != 0 {
+		t.Errorf("expected zero token counts when modelUsage absent, got %+v", usage)
+	}
+	if diff := usage.CostUSD - 0.005; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("CostUSD = %f, want ~0.005", usage.CostUSD)
+	}
+}
+
 func TestParseClaudeJSON_InvalidJSON(t *testing.T) {
 	_, ok := parseClaudeJSON([]byte(`not json at all`))
 	if ok {

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -163,7 +163,7 @@ func TestCheckCompletion_UnsupportedTypes(t *testing.T) {
 }
 
 func TestParseClaudeJSON_ValidJSON(t *testing.T) {
-	output := []byte(`{"result":"hello world","session_id":"sess_abc123","num_turns":5,"total_cost_usd":0.0042,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}}`)
+	output := []byte(`{"result":"hello world","session_id":"sess_abc123","num_turns":5,"total_cost_usd":0.0042,"modelUsage":{"claude-sonnet-4-6":{"inputTokens":100,"outputTokens":50,"cacheCreationInputTokens":10,"cacheReadInputTokens":5}}}`)
 
 	resp, ok := parseClaudeJSON(output)
 	if !ok {

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -162,15 +162,15 @@ func TestCheckCompletion_UnsupportedTypes(t *testing.T) {
 	}
 }
 
-func TestSaveSessionID_ValidJSON(t *testing.T) {
+func TestExtractMetadata_ValidJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.session")
 
 	output := `Some output text
-{"session_id":"sess_abc123","other":"data"}
+{"session_id":"sess_abc123","total_cost_usd":0.0042,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}}
 More output`
 
-	saveSessionID(path, output)
+	usage := extractMetadata(path, output)
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -185,40 +185,64 @@ More output`
 	} else if perm := info.Mode().Perm(); perm != 0600 {
 		t.Errorf("session file mode = %04o, want 0600", perm)
 	}
+
+	if usage.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100", usage.InputTokens)
+	}
+	if usage.OutputTokens != 50 {
+		t.Errorf("OutputTokens = %d, want 50", usage.OutputTokens)
+	}
+	if usage.CacheCreationTokens != 10 {
+		t.Errorf("CacheCreationTokens = %d, want 10", usage.CacheCreationTokens)
+	}
+	if usage.CacheReadTokens != 5 {
+		t.Errorf("CacheReadTokens = %d, want 5", usage.CacheReadTokens)
+	}
+	if usage.CostUSD != 0.0042 {
+		t.Errorf("CostUSD = %f, want 0.0042", usage.CostUSD)
+	}
 }
 
-func TestSaveSessionID_NoSessionID(t *testing.T) {
+func TestExtractMetadata_NoSessionID(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.session")
 
-	saveSessionID(path, "just plain output\nno json here\n")
+	usage := extractMetadata(path, "just plain output\nno json here\n")
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("session file should not exist when no session ID found")
 	}
+	if usage.CostUSD != 0 || usage.InputTokens != 0 {
+		t.Error("expected zero TokenUsage for output with no metadata")
+	}
 }
 
-func TestSaveSessionID_InvalidJSON(t *testing.T) {
+func TestExtractMetadata_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.session")
 
-	output := `{not valid json but has session_id}`
-	saveSessionID(path, output)
+	usage := extractMetadata(path, `{not valid json but has session_id}`)
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("session file should not exist for invalid JSON")
 	}
+	if usage.CostUSD != 0 {
+		t.Error("expected zero CostUSD for invalid JSON")
+	}
 }
 
-func TestSaveSessionID_EmptySessionID(t *testing.T) {
+func TestExtractMetadata_EmptySessionID(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.session")
 
-	output := `{"session_id":""}`
-	saveSessionID(path, output)
+	usage := extractMetadata(path, `{"session_id":"","total_cost_usd":0.01,"usage":{"input_tokens":5}}`)
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("session file should not exist for empty session_id")
+	}
+	// Token data should still be returned even without session ID
+	if usage.InputTokens != 5 {
+		t.Errorf("InputTokens = %d, want 5", usage.InputTokens)
 	}
 }
 
@@ -265,7 +289,7 @@ echo "real invoker output"
 	}
 	issue := gh.ProjectItem{Number: 80, Title: "T"}
 
-	output, _, err := invoker.Invoke(context.Background(), stage, issue, nil, false, t.TempDir(), "")
+	output, _, _, err := invoker.Invoke(context.Background(), stage, issue, nil, false, t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -307,7 +331,7 @@ echo "FABRIK_STAGE_COMPLETE"
 		URL:    "https://example.com",
 	}
 
-	output, completed, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	output, completed, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -365,7 +389,7 @@ echo "NO RESUME"
 	os.WriteFile(sessionFile(99, "Plan"), []byte("sess_existing"), 0600)
 	defer os.RemoveAll(sessDir)
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, true, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil,true, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -404,7 +428,7 @@ echo "args: $@"
 	}
 	issue := gh.ProjectItem{Number: 50, Title: "T"}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil,false, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -446,7 +470,7 @@ echo "args: $@"
 	}
 	issue := gh.ProjectItem{Number: 51, Title: "T"}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "opus")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil,false, workDir, "opus")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}
@@ -479,7 +503,7 @@ exit 1
 	}
 	issue := gh.ProjectItem{Number: 60, Title: "T"}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil,false, workDir, "")
 	if err == nil {
 		t.Fatal("expected error for failing binary")
 	}
@@ -513,7 +537,7 @@ cat | grep -o "New Comments" && echo "HAS_COMMENTS" || echo "NO_COMMENTS"
 		{Author: "user", Body: "Fix this", CreatedAt: time.Now()},
 	}
 
-	output, _, err := InvokeClaude(context.Background(), stage, issue, comments, false, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, comments, false, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -192,8 +192,8 @@ func TestParseClaudeJSON_ValidJSON(t *testing.T) {
 	if usage.CacheReadTokens != 5 {
 		t.Errorf("CacheReadTokens = %d, want 5", usage.CacheReadTokens)
 	}
-	if usage.CostUSD != 0.0042 {
-		t.Errorf("CostUSD = %f, want 0.0042", usage.CostUSD)
+	if diff := usage.CostUSD - 0.0042; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("CostUSD = %f, want ~0.0042", usage.CostUSD)
 	}
 }
 
@@ -378,7 +378,7 @@ echo "NO RESUME"
 	os.WriteFile(sessionFile(99, "Plan"), []byte("sess_existing"), 0600)
 	defer os.RemoveAll(sessDir)
 
-	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil,true, workDir, "")
+	output, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, true, workDir, "")
 	if err != nil {
 		t.Fatalf("InvokeClaude: %v", err)
 	}

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -68,7 +68,12 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if modelOverride != "" {
 		logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
-	output, _, err := InvokeClaudeForComments(ctx, stage, item, comments, workDir, modelOverride)
+	output, _, usage, err := InvokeClaudeForComments(ctx, stage, item, comments, workDir, modelOverride)
+	func() {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		e.totalTokens = e.totalTokens.add(usage)
+	}()
 	if err != nil {
 		e.removeEditingLabel(item.Number)
 		if ctx.Err() != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -34,6 +34,7 @@ type Engine struct {
 	mu           sync.Mutex
 	processedSet map[string]time.Time // track what we've processed: "issue#-commentID" -> timestamp
 	lockedIssues map[int]bool         // issues that have had fabrik:locked added and not yet released
+	totalTokens  TokenUsage           // accumulated token usage since process start
 	idleCount    int                  // consecutive idle polls; triggers self-upgrade at threshold
 	sem          chan struct{}        // semaphore bounding concurrent workers across poll cycles
 	wg           sync.WaitGroup       // tracks in-flight workers for graceful shutdown

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,6 +36,7 @@ type Engine struct {
 	processedSet       map[string]time.Time // track what we've processed: "issue#-commentID" -> timestamp
 	lockedIssues       map[int]bool         // issues that have had fabrik:locked added and not yet released
 	totalTokens        TokenUsage           // accumulated token usage since process start
+	lastReportedCost   float64              // cost at last [stats] report; skip repeat prints when unchanged
 	retryCount         map[string]int       // key: "<issueNum>-<stageName>", value: failed attempt count
 	pausedDueToRetries map[string]bool      // key: "<issueNum>-<stageName>", true if engine paused this issue
 	idleCount          int                  // consecutive idle polls; triggers self-upgrade at threshold

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -155,8 +155,8 @@ func TestItemNeedsWork_SkipsPausedWithNewComments(t *testing.T) {
 func TestProcessItem_AllowsOwnLock(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "output", false, TokenUsage{}, nil
 		},
 	}
 	eng := testEngine(client, claude)
@@ -508,8 +508,8 @@ func TestProcessItem_FullHappyPath(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Claude output here\nFABRIK_STAGE_COMPLETE\n", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "Claude output here\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
 		},
 	}
 
@@ -583,8 +583,8 @@ func TestProcessItem_CompletionWithAutoAdvance(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Done\nFABRIK_STAGE_COMPLETE", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "Done\nFABRIK_STAGE_COMPLETE", true, TokenUsage{}, nil
 		},
 	}
 
@@ -661,8 +661,8 @@ func TestProcessItem_CompletionNoAutoAdvance(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Done", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "Done", true, TokenUsage{}, nil
 		},
 	}
 
@@ -702,8 +702,8 @@ func TestProcessItem_StageAutoAdvanceOverride(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "Done", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "Done", true, TokenUsage{}, nil
 		},
 	}
 
@@ -752,8 +752,8 @@ func TestProcessItem_EmptyOutput(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "", false, TokenUsage{}, nil
 		},
 	}
 
@@ -783,11 +783,11 @@ func TestProcessItem_ClaudeError(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 			// Simulate a start failure: binary not found (*exec.Error)
 			cmd := exec.Command("this-binary-does-not-exist-fabrik-test")
 			_, startErr := cmd.Output()
-			return "partial output", false, startErr
+			return "partial output", false, TokenUsage{}, startErr
 		},
 	}
 
@@ -827,11 +827,11 @@ func TestProcessItem_ClaudeExitError(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 			// Simulate Claude running and exiting non-zero (wrapped *exec.ExitError)
 			cmd := exec.Command("git", "definitely-invalid-arg")
 			runErr := cmd.Run()
-			return "some output", false, fmt.Errorf("claude exited with error: %w", runErr)
+			return "some output", false, TokenUsage{}, fmt.Errorf("claude exited with error: %w", runErr)
 		},
 	}
 
@@ -865,8 +865,8 @@ func TestProcessItem_ResumeOnReprocess(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "output", false, TokenUsage{}, nil
 		},
 	}
 
@@ -1061,8 +1061,8 @@ func TestProcessItem_LabelAndCommentErrors(t *testing.T) {
 		},
 	}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", true, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "output", true, TokenUsage{}, nil
 		},
 	}
 
@@ -1096,8 +1096,8 @@ func TestPoll_ProcessItemError(t *testing.T) {
 		},
 	}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "", false, TokenUsage{}, nil
 		},
 	}
 
@@ -1424,8 +1424,8 @@ func TestProcessItem_EscalatesAtMaxRetries(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "partial output", false, nil // never completes
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{}, nil // never completes
 		},
 	}
 
@@ -1512,8 +1512,8 @@ func TestProcessItem_ResetsOnUnpause(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "output", false, TokenUsage{}, nil
 		},
 	}
 
@@ -1580,8 +1580,8 @@ func TestProcessItem_UnlimitedWhenMaxRetriesZero(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", false, nil
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "output", false, TokenUsage{}, nil
 		},
 	}
 
@@ -1636,8 +1636,8 @@ func TestProcessItem_ClearsRetryCountOnCompletion(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
-		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
-			return "output", true, nil // stage completes successfully
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "output", true, TokenUsage{}, nil // stage completes successfully
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -576,6 +576,52 @@ func TestProcessItem_FullHappyPath(t *testing.T) {
 	}
 }
 
+func TestProcessItem_AccumulatesTokenUsage(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	want := TokenUsage{InputTokens: 100, OutputTokens: 50, CacheCreationTokens: 10, CacheReadTokens: 5, CostUSD: 0.0042}
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+			return "FABRIK_STAGE_COMPLETE", true, want, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "o", Repo: "r", User: "u", Token: "t", Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 200, Title: "Token Test", Status: "Research", ItemID: "PVTI_200"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	eng.mu.Lock()
+	got := eng.totalTokens
+	eng.mu.Unlock()
+
+	if got.InputTokens != want.InputTokens {
+		t.Errorf("totalTokens.InputTokens = %d, want %d", got.InputTokens, want.InputTokens)
+	}
+	if got.OutputTokens != want.OutputTokens {
+		t.Errorf("totalTokens.OutputTokens = %d, want %d", got.OutputTokens, want.OutputTokens)
+	}
+	if got.CacheCreationTokens != want.CacheCreationTokens {
+		t.Errorf("totalTokens.CacheCreationTokens = %d, want %d", got.CacheCreationTokens, want.CacheCreationTokens)
+	}
+	if got.CacheReadTokens != want.CacheReadTokens {
+		t.Errorf("totalTokens.CacheReadTokens = %d, want %d", got.CacheReadTokens, want.CacheReadTokens)
+	}
+	if diff := got.CostUSD - want.CostUSD; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("totalTokens.CostUSD = %f, want ~%f", got.CostUSD, want.CostUSD)
+	}
+}
+
 func TestProcessItem_CompletionWithAutoAdvance(t *testing.T) {
 	skipIfNoGit(t)
 	repoDir := initBareRepo(t)

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -25,12 +25,12 @@ type GitHubClient interface {
 
 // ClaudeInvoker defines the interface for invoking Claude Code.
 type ClaudeInvoker interface {
-	Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (output string, completed bool, err error)
+	Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (output string, completed bool, usage TokenUsage, err error)
 }
 
 // RealClaudeInvoker wraps the existing InvokeClaude function.
 type RealClaudeInvoker struct{}
 
-func (r *RealClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+func (r *RealClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 	return InvokeClaude(ctx, stage, issue, newComments, resume, workDir, modelOverride)
 }

--- a/engine/item.go
+++ b/engine/item.go
@@ -205,7 +205,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
 	resume := attempted // resume session if we've processed this before
-	output, completed, err := e.claude.Invoke(ctx, stage, item, nil, resume, workDir, modelOverride)
+	output, completed, usage, err := e.claude.Invoke(ctx, stage, item, nil, resume, workDir, modelOverride)
+	func() {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		e.totalTokens = e.totalTokens.add(usage)
+	}()
 
 	// Restore any stashed changes now that the read-only stage has finished.
 	if stashed {

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -129,10 +129,11 @@ type claudeInvokeCall struct {
 	modelOverride string
 }
 
-func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error) {
+func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 	m.calls = append(m.calls, claudeInvokeCall{stage.Name, issue.Number, resume, workDir, modelOverride})
 	if m.invokeFn != nil {
-		return m.invokeFn(stage, issue, newComments, resume, workDir, modelOverride)
+		output, completed, err := m.invokeFn(stage, issue, newComments, resume, workDir, modelOverride)
+		return output, completed, TokenUsage{}, err
 	}
-	return "mock output", false, nil
+	return "mock output", false, TokenUsage{}, nil
 }

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -133,7 +133,7 @@ func (m *mockGitHubClient) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStat
 
 // mockClaudeInvoker implements ClaudeInvoker for testing.
 type mockClaudeInvoker struct {
-	invokeFn func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, error)
+	invokeFn func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error)
 	calls    []claudeInvokeCall
 }
 
@@ -148,8 +148,7 @@ type claudeInvokeCall struct {
 func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
 	m.calls = append(m.calls, claudeInvokeCall{stage.Name, issue.Number, resume, workDir, modelOverride})
 	if m.invokeFn != nil {
-		output, completed, err := m.invokeFn(stage, issue, newComments, resume, workDir, modelOverride)
-		return output, completed, TokenUsage{}, err
+		return m.invokeFn(stage, issue, newComments, resume, workDir, modelOverride)
 	}
 	return "mock output", false, TokenUsage{}, nil
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -167,6 +167,15 @@ func (e *Engine) poll(ctx context.Context) error {
 	}
 doneDispatching:
 
+	// Report cumulative token consumption when non-zero.
+	e.mu.Lock()
+	tokens := e.totalTokens
+	e.mu.Unlock()
+	if tokens.CostUSD > 0 {
+		fmt.Printf("[stats] cost: $%.4f | in: %d | out: %d | cache_read: %d | cache_write: %d\n",
+			tokens.CostUSD, tokens.InputTokens, tokens.OutputTokens, tokens.CacheReadTokens, tokens.CacheCreationTokens)
+	}
+
 	if dispatched == 0 {
 		// Check whether any workers from a previous poll cycle are still running.
 		// If so, the engine is not truly idle — auto-upgrade must not run because

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -186,11 +186,16 @@ func (e *Engine) poll(ctx context.Context) error {
 	}
 doneDispatching:
 
-	// Report cumulative token consumption when non-zero.
+	// Report cumulative token consumption only when new cost has accrued since
+	// the last print, to avoid repeated log noise on idle polls.
 	e.mu.Lock()
 	tokens := e.totalTokens
+	newCost := tokens.CostUSD > e.lastReportedCost
+	if newCost {
+		e.lastReportedCost = tokens.CostUSD
+	}
 	e.mu.Unlock()
-	if tokens.CostUSD > 0 {
+	if newCost {
 		fmt.Printf("[stats] cost: $%.4f | in: %d | out: %d | cache_read: %d | cache_write: %d\n",
 			tokens.CostUSD, tokens.InputTokens, tokens.OutputTokens, tokens.CacheReadTokens, tokens.CacheCreationTokens)
 	}


### PR DESCRIPTION
## Summary

- Adds `TokenUsage` struct to track input/output/cache tokens and cost per Claude invocation
- Extracts token data from Claude's `--verbose` JSON metadata output
- Accumulates totals in the Engine, protected by `e.mu`
- Reports a `[stats]` summary line each poll cycle when cost is non-zero

Closes #83

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)