### PR TITLE
Add context files and stage comment rewriting (#99)

### DIFF
--- a/adrs/011-context-files.md
+++ b/adrs/011-context-files.md
@@ -1,0 +1,48 @@
+# ADR 011: Context Files as Claude Context Delivery Mechanism
+
+## Status
+
+Accepted
+
+## Context
+
+Fabrik invokes Claude for each pipeline stage by building a prompt that includes the issue body, prior comments, and stage instructions. As issues accumulate discussion — user answers, prior stage outputs, comment processing results — the inline prompt grows large and increasingly redundant.
+
+There is also a blind-spot problem: when a user answers a question via a comment, `processComments` adds a rocket reaction and incorporates the answer. But when the stage re-invokes via `processItem`, `buildPrompt` only includes *new* (un-rocketed) comments. The user's answer is invisible to Claude because it was already processed.
+
+## Decision
+
+Before each Claude invocation (both stage runs and comment processing), Fabrik writes context files to `.fabrik/` in the worktree:
+
+- `.fabrik/issue.md` — the issue body (the spec); always written
+- `.fabrik/stage-{Name}.md` — the body of the most recent Fabrik stage comment for each relevant stage
+- `.fabrik/pr-description.md` — the linked PR's description, for `post_to_pr` stage invocations only
+
+**Scoping rules:**
+- For stage invocations: write context for stages with `Order < currentStage.Order` (prior stages only). This supports rewinding — if an issue goes back to Plan, Claude only sees Specify and Research context.
+- For comment processing: write context for all stages including the current one. Claude needs the current stage comment to build upon.
+
+**Ordering:** Context files are written after any `git stash push -u` operation (for read-only stages) so they are present when Claude runs but not captured in the stash.
+
+**Git exclusion:** `.fabrik/` is excluded from git tracking via `.git/info/exclude` (per-worktree, not `.gitignore`). This is written idempotently on every `EnsureWorktree` call.
+
+**Error handling:** Context file write failures are non-fatal. Claude can still run without the files; the engine logs a warning and continues.
+
+**Phased rollout:** Context files are shipped and validated first. Removing the inline fallback from `buildPrompt` / `buildCommentReviewPrompt` is deferred to a follow-up issue — confirm Claude reads the files reliably before removing the inline content.
+
+## Alternatives Considered
+
+**Stuffing everything into the inline prompt:** The current approach. Works but wastes tokens, grows unboundedly, and creates the processed-comment blind-spot described above.
+
+**Passing content as tool definitions or system messages:** More complex to implement and no advantage over files that Claude can simply read with the Read tool.
+
+**Removing inline context immediately:** Risky without validation. Files are a new mechanism; Claude's reliability in reading them should be confirmed before the fallback is removed.
+
+## Consequences
+
+- Claude can read prior stage outputs on demand without the engine predicting what it needs.
+- The processed-comment blind-spot is eliminated: processed comments' effects are reflected in `.fabrik/stage-{Name}.md`, so stage retries see the incorporated answer.
+- Context file content is always fresh (overwritten before each invocation) — no stale data risk.
+- The inline prompt still contains the issue body and prior discussion during the transition period.
+- Stage skills must instruct Claude to read `.fabrik/issue.md` and `.fabrik/stage-{Name}.md` at the start of each stage.
+- Future contributors must keep `writeContextFiles` in sync with `formatOutputComment` in `engine/pr.go` (the header format used to identify stage comments).

--- a/adrs/012-stage-comment-living-document.md
+++ b/adrs/012-stage-comment-living-document.md
@@ -1,0 +1,45 @@
+# ADR 012: Stage Comment as Living Document
+
+## Status
+
+Accepted
+
+## Context
+
+When a user comments on an issue during a stage (e.g., answering a Specify-stage question), Fabrik's `processComments` invokes Claude to incorporate the input and posts the result as a new comment. This created two problems:
+
+1. **Thread noise:** Each comment processing run adds a new comment to the issue. An issue with multiple rounds of user interaction accumulates a long comment thread of near-duplicate stage outputs.
+
+2. **Identity confusion:** The "comment review" comment uses a variant header (`🏭 **Fabrik — stage: Research (comment review)**`) that is distinct from the stage's own output comment. This makes it harder to answer "what is the current Research output?" — you have to look at both.
+
+## Decision
+
+When `processComments` completes, instead of always posting a new comment:
+
+1. `findStageComment()` scans `item.Comments` for the most recent comment whose body starts with `🏭 **Fabrik — stage: {stageName}**` (the base stage name, no variant suffix).
+2. If found: call `UpdateComment()` to replace its body with Claude's new output.
+3. If not found: call `AddComment()` to create a new comment using the base stage name header.
+
+The `(comment review)` variant header is retired. Comment processing output is now the stage's authoritative output — it updates the same comment, under the same header.
+
+**Exceptions:**
+- `post_to_pr` stages: skip the rewrite and post new comment processing output on the issue as a new comment. The stage output lives on the PR; rewriting a PR comment from an issue comment flow adds complexity for unclear benefit.
+- Empty output: if Claude produces no output, no comment is created or updated.
+
+**No acknowledgement comment:** The rocket reaction (🚀) on the user's comment is sufficient signal that input was processed. Acknowledgement comments add noise to the thread, which this ADR is trying to reduce.
+
+## Alternatives Considered
+
+**Always post a new comment:** The previous behavior. Simple but noisy. Abandoned because it creates a growing thread of near-duplicate outputs.
+
+**Keep the `(comment review)` variant header:** Preserves backward compatibility with existing comments but requires `findStageComment` to handle both variants, adds complexity, and perpetuates the identity confusion.
+
+**Delete old comment and post new one:** Technically equivalent to rewriting, but deletion + creation creates two events in the GitHub API and a brief gap where no comment exists. Update-in-place is cleaner.
+
+## Consequences
+
+- The issue comment thread stays clean: each stage has at most one living output comment.
+- The stage comment becomes the authoritative, up-to-date output regardless of whether it was last touched by a stage run or comment processing.
+- Existing `(comment review)` comments in live issues will not be matched by `findStageComment` (different header prefix). The first post-deploy comment processing run creates a new base-name comment alongside the old variant. The old one stays as historical record; the new one becomes the living document going forward.
+- `findStageComment` must stay in sync with `formatOutputComment` in `engine/pr.go`. Both live in the engine package; `findStageComment` is in `engine/context.go` with a comment noting the coupling.
+- `UpdateComment` is a new method on `GitHubClient` backed by `PATCH /repos/{owner}/{repo}/issues/comments/{id}`.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -410,6 +410,10 @@ func buildCommentReviewPrompt(stage *stages.Stage, item gh.ProjectItem, comments
 	}
 
 	b.WriteString("---\n\n")
+	b.WriteString("Context files are available in `.fabrik/` in your working directory:\n")
+	b.WriteString("- `.fabrik/issue.md` — the issue body (spec)\n")
+	b.WriteString("- `.fabrik/stage-{Name}.md` — the current stage output (e.g. `.fabrik/stage-Specify.md`) and prior stage outputs\n")
+	b.WriteString("\n")
 	b.WriteString("First, perform any actions requested in the comments using available tools.\n")
 	if item.IsPR {
 		b.WriteString("Then, if the PR description needs updating, output the complete updated PR description between these exact markers:\n\n")

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -348,6 +348,13 @@ func buildPrompt(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Com
 	}
 
 	b.WriteString("---\n\n")
+	b.WriteString("Context files are available in `.fabrik/` in your working directory:\n")
+	b.WriteString("- `.fabrik/issue.md` — the issue body (spec)\n")
+	b.WriteString("- `.fabrik/stage-{Name}.md` — output from prior stages (e.g. `.fabrik/stage-Research.md`)\n")
+	if stage.PostToPR {
+		b.WriteString("- `.fabrik/pr-description.md` — the linked PR description\n")
+	}
+	b.WriteString("\n")
 	if stage.PostToPR {
 		b.WriteString("Your detailed output will be posted on the PR. Provide a brief summary (2-4 sentences)\n")
 		b.WriteString("for the issue between these markers:\n\n")

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -63,6 +63,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		return fmt.Errorf("setting up worktree: %w", err)
 	}
 
+	// Write context files (all stages including current) before Claude runs.
+	e.writeContextFiles(item, stage, workDir, true)
+
 	// Step 4: Invoke Claude with the comment review prompt
 	modelOverride := e.extractModelOverride(item.Number, item.Labels)
 	if modelOverride != "" {
@@ -90,26 +93,44 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	// Capture git metadata for the comment header
 	branch, commit, timestamp := captureGitMeta(workDir)
 
-	// Step 5: Parse the updated issue body from Claude's output and apply it
+	// Step 5: Strip FABRIK_ISSUE_UPDATE block from output, then update issue body if present.
 	if updatedBody := extractUpdatedBody(output); updatedBody != "" {
 		e.logf(item.Number, "edit", "updating issue body\n")
 		if err := e.client.UpdateIssueBody(e.cfg.Owner, e.cfg.Repo, item.Number, updatedBody); err != nil {
 			e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
 		}
-	} else {
-		// No body update — post output as a comment instead
-		if output != "" {
+		output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
+	}
+
+	// Step 6: Rewrite or create the stage comment (unless post_to_pr).
+	// For post_to_pr stages the stage output lives on the PR; comment processing
+	// output on such stages is posted as a new comment on the issue as before.
+	if output != "" {
+		if stage.PostToPR {
 			comment := formatOutputComment(stage.Name+" (comment review)", output, "", branch, commit, timestamp)
 			if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, comment); err != nil {
 				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
 			}
+		} else {
+			existing := findStageComment(item.Comments, stage.Name)
+			stageComment := formatOutputComment(stage.Name, output, "", branch, commit, timestamp)
+			if existing != nil {
+				e.logf(item.Number, "edit", "rewriting stage comment for %s\n", stage.Name)
+				if err := e.client.UpdateComment(e.cfg.Owner, e.cfg.Repo, existing.DatabaseID, stageComment); err != nil {
+					e.logf(item.Number, "warn", "could not update stage comment: %v\n", err)
+				}
+			} else {
+				if err := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, stageComment); err != nil {
+					e.logf(item.Number, "warn", "could not post stage comment: %v\n", err)
+				}
+			}
 		}
 	}
 
-	// Step 6: Remove editing label
+	// Step 7: Remove editing label
 	e.removeEditingLabel(item.Number)
 
-	// Step 7: React with 🚀 to all processed comments
+	// Step 8: React with 🚀 to all processed comments
 	for _, c := range comments {
 		if err := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, c.DatabaseID, "rocket"); err != nil {
 			e.logf(item.Number, "warn", "could not add 🚀 to comment %s: %v\n", c.ID, err)

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -71,10 +71,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if modelOverride != "" {
 		e.logf(item.Number, "model", "using model override %q\n", modelOverride)
 	}
-	output, _, usage, err := InvokeClaudeForComments(ctx, stage, item, comments, workDir, modelOverride)
-	if e.cfg.DebugOutput {
-		saveDebugLog(item.Number, stage.Name+"-comment-review", output)
-	}
+	output, _, usage, err := e.claude.InvokeForComments(ctx, stage, item, comments, workDir, modelOverride)
 	func() {
 		e.mu.Lock()
 		defer e.mu.Unlock()

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -1,0 +1,219 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// testEngineWithRepo creates an engine using a real git repo for worktree operations.
+func testEngineWithRepo(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
+	t.Helper()
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+	return NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		client,
+		claude,
+		wm,
+	)
+}
+
+func TestProcessComments_CreatesNewStageComment(t *testing.T) {
+	skipIfNoGit(t)
+
+	var addCommentBody string
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
+			addCommentBody = body
+			return nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir, modelOverride string) (string, bool, TokenUsage, error) {
+			return "Claude's response to comment", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{
+		Number:   10,
+		Body:     "spec",
+		Comments: []gh.Comment{}, // no existing stage comment
+	}
+	userComments := []gh.Comment{
+		{ID: "C_1", DatabaseID: 101, Author: "testuser", Body: "please research X"},
+	}
+
+	err := eng.processComments(context.Background(), board, item, stage, userComments)
+	if err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	// Should use AddComment (no existing stage comment to rewrite)
+	if addCommentBody == "" {
+		t.Fatal("expected AddComment to be called")
+	}
+	if len(client.updateCommentCalls) > 0 {
+		t.Error("should not call UpdateComment when no existing stage comment")
+	}
+	// The posted comment should use the base stage name header
+	if !strings.Contains(addCommentBody, "🏭 **Fabrik — stage: Research**") {
+		t.Errorf("posted comment should use base stage name header, got: %q", addCommentBody[:min(100, len(addCommentBody))])
+	}
+}
+
+func TestProcessComments_RewritesExistingStageComment(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir, modelOverride string) (string, bool, TokenUsage, error) {
+			return "updated research output", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{
+		Number: 11,
+		Body:   "spec",
+		Comments: []gh.Comment{
+			// Existing stage comment to be rewritten
+			{ID: "C_existing", DatabaseID: 200, Author: "fabrik-bot",
+				Body: "🏭 **Fabrik — stage: Research**\nold research output"},
+		},
+	}
+	userComments := []gh.Comment{
+		{ID: "C_user", DatabaseID: 201, Author: "testuser", Body: "please update research"},
+	}
+
+	err := eng.processComments(context.Background(), board, item, stage, userComments)
+	if err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	// Should use UpdateComment (existing stage comment found)
+	if len(client.updateCommentCalls) == 0 {
+		t.Fatal("expected UpdateComment to be called")
+	}
+	call := client.updateCommentCalls[0]
+	if call.commentID != 200 {
+		t.Errorf("UpdateComment called with commentID=%d, want 200", call.commentID)
+	}
+	if !strings.Contains(call.body, "updated research output") {
+		t.Errorf("updated body should contain new output, got: %q", call.body[:min(100, len(call.body))])
+	}
+	// Should not AddComment (since we rewrote existing)
+	if len(client.addCommentCalls) > 0 {
+		t.Error("should not AddComment when existing stage comment was found and rewritten")
+	}
+}
+
+func TestProcessComments_PostToPR_AlwaysAddsNewComment(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir, modelOverride string) (string, bool, TokenUsage, error) {
+			return "review comment output", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	// PostToPR stage — should not rewrite, should always add new comment
+	stage := &stages.Stage{Name: "Review", Order: 4, PostToPR: true}
+	item := gh.ProjectItem{
+		Number: 12,
+		Body:   "spec",
+		Comments: []gh.Comment{
+			// Even with an existing stage comment, post_to_pr should not rewrite
+			{ID: "C_existing", DatabaseID: 300, Author: "fabrik-bot",
+				Body: "🏭 **Fabrik — stage: Review**\nold review output"},
+		},
+	}
+	userComments := []gh.Comment{
+		{ID: "C_user", DatabaseID: 301, Author: "testuser", Body: "please re-review"},
+	}
+
+	err := eng.processComments(context.Background(), board, item, stage, userComments)
+	if err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	// Should AddComment, not UpdateComment, for post_to_pr stages
+	if len(client.addCommentCalls) == 0 {
+		t.Fatal("expected AddComment to be called for post_to_pr stage")
+	}
+	if len(client.updateCommentCalls) > 0 {
+		t.Error("should not UpdateComment for post_to_pr stage")
+	}
+}
+
+func TestProcessComments_UpdatesIssueBodyOnMarker(t *testing.T) {
+	skipIfNoGit(t)
+
+	var updatedBody string
+	client := &mockGitHubClient{
+		updateIssueBodyFn: func(owner, repo string, issueNumber int, body string) error {
+			updatedBody = body
+			return nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir, modelOverride string) (string, bool, TokenUsage, error) {
+			output := "FABRIK_ISSUE_UPDATE_BEGIN\nnew issue body\nFABRIK_ISSUE_UPDATE_END\nstage comment content"
+			return output, false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{
+		Number: 13,
+		Body:   "old spec",
+	}
+	userComments := []gh.Comment{
+		{ID: "C_u", DatabaseID: 400, Author: "testuser", Body: "update please"},
+	}
+
+	err := eng.processComments(context.Background(), board, item, stage, userComments)
+	if err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	// Issue body should be updated
+	if updatedBody != "new issue body" {
+		t.Errorf("updatedBody = %q, want %q", updatedBody, "new issue body")
+	}
+
+	// Stage comment should be posted with FABRIK_ISSUE_UPDATE stripped
+	if len(client.addCommentCalls) > 0 {
+		body := client.addCommentCalls[0].body
+		if strings.Contains(body, "FABRIK_ISSUE_UPDATE") {
+			t.Error("FABRIK_ISSUE_UPDATE block should be stripped from stage comment")
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/engine/context.go
+++ b/engine/context.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// findStageComment returns the most recent comment in item.Comments whose body
+// starts with the Fabrik stage header for the given stage name. Returns nil if
+// no match is found.
+//
+// NOTE: The header prefix matched here must stay in sync with formatOutputComment
+// in engine/pr.go. If that format ever changes, update this function too.
+func findStageComment(comments []gh.Comment, stageName string) *gh.Comment {
+	prefix := fmt.Sprintf("🏭 **Fabrik — stage: %s**", stageName)
+	var found *gh.Comment
+	for i := range comments {
+		if strings.HasPrefix(comments[i].Body, prefix) {
+			found = &comments[i]
+		}
+	}
+	return found
+}
+
+// writeContextFiles writes context files to .fabrik/ in the worktree so Claude
+// can read them on demand without relying solely on inline prompt content.
+//
+// Files written:
+//   - .fabrik/issue.md — the issue body (always)
+//   - .fabrik/stage-{Name}.md — body of the most recent Fabrik comment for each stage
+//   - .fabrik/pr-description.md — linked PR body, for post_to_pr stage invocations only
+//
+// For stage invocations (isCommentProcessing=false): writes context for stages
+// with Order strictly less than currentStage.Order (prior stages only).
+// For comment processing (isCommentProcessing=true): writes context for all stages
+// including the current one.
+//
+// Errors are non-fatal — Claude can still run without the files; log and continue.
+func (e *Engine) writeContextFiles(item gh.ProjectItem, currentStage *stages.Stage, workDir string, isCommentProcessing bool) {
+	fabrikDir := filepath.Join(workDir, ".fabrik")
+	if err := os.MkdirAll(fabrikDir, 0755); err != nil {
+		e.logf(item.Number, "warn", "could not create .fabrik dir: %v\n", err)
+		return
+	}
+
+	// Always write the issue body.
+	if err := os.WriteFile(filepath.Join(fabrikDir, "issue.md"), []byte(item.Body), 0644); err != nil {
+		e.logf(item.Number, "warn", "could not write .fabrik/issue.md: %v\n", err)
+	}
+
+	// Write context files for each stage that has a comment.
+	for _, stage := range e.cfg.Stages {
+		// For stage invocations, only include prior stages (Order < current).
+		// For comment processing, include all stages including current.
+		if !isCommentProcessing && stage.Order >= currentStage.Order {
+			continue
+		}
+		comment := findStageComment(item.Comments, stage.Name)
+		if comment == nil {
+			continue
+		}
+		filename := fmt.Sprintf("stage-%s.md", stage.Name)
+		if err := os.WriteFile(filepath.Join(fabrikDir, filename), []byte(comment.Body), 0644); err != nil {
+			e.logf(item.Number, "warn", "could not write .fabrik/%s: %v\n", filename, err)
+		}
+	}
+
+	// Write PR description for post_to_pr stage invocations.
+	if !isCommentProcessing && currentStage.PostToPR {
+		prNumber, err := e.client.FindPRForIssue(e.cfg.Owner, e.cfg.Repo, item.Number)
+		if err != nil || prNumber == 0 {
+			return
+		}
+		prBody, err := e.client.GetIssueBody(e.cfg.Owner, e.cfg.Repo, prNumber)
+		if err != nil {
+			e.logf(item.Number, "warn", "could not fetch PR body for context file: %v\n", err)
+			return
+		}
+		if err := os.WriteFile(filepath.Join(fabrikDir, "pr-description.md"), []byte(prBody), 0644); err != nil {
+			e.logf(item.Number, "warn", "could not write .fabrik/pr-description.md: %v\n", err)
+		}
+	}
+}

--- a/engine/context.go
+++ b/engine/context.go
@@ -64,7 +64,14 @@ func (e *Engine) writeContextFiles(item gh.ProjectItem, currentStage *stages.Sta
 		if comment == nil {
 			continue
 		}
-		filename := fmt.Sprintf("stage-%s.md", stage.Name)
+		// Sanitize stage name: reject names with path separators to prevent
+		// context files from being written outside .fabrik/.
+		safeName := stage.Name
+		if strings.ContainsAny(safeName, "/\\") {
+			e.logf(item.Number, "warn", "stage name %q contains path separator, skipping context file\n", safeName)
+			continue
+		}
+		filename := fmt.Sprintf("stage-%s.md", safeName)
 		if err := os.WriteFile(filepath.Join(fabrikDir, filename), []byte(comment.Body), 0644); err != nil {
 			e.logf(item.Number, "warn", "could not write .fabrik/%s: %v\n", filename, err)
 		}

--- a/engine/context_test.go
+++ b/engine/context_test.go
@@ -1,0 +1,204 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+func TestFindStageComment_NoComments(t *testing.T) {
+	result := findStageComment(nil, "Research")
+	if result != nil {
+		t.Errorf("expected nil for empty comments, got %+v", result)
+	}
+}
+
+func TestFindStageComment_NoMatch(t *testing.T) {
+	comments := []gh.Comment{
+		{Body: "some user comment"},
+		{Body: "🏭 **Fabrik — stage: Plan**\nsome content"},
+	}
+	result := findStageComment(comments, "Research")
+	if result != nil {
+		t.Errorf("expected nil for no matching stage, got %+v", result)
+	}
+}
+
+func TestFindStageComment_ExactMatch(t *testing.T) {
+	comments := []gh.Comment{
+		{Body: "🏭 **Fabrik — stage: Research**\nresearch output", DatabaseID: 42},
+	}
+	result := findStageComment(comments, "Research")
+	if result == nil {
+		t.Fatal("expected match, got nil")
+	}
+	if result.DatabaseID != 42 {
+		t.Errorf("DatabaseID = %d, want 42", result.DatabaseID)
+	}
+}
+
+func TestFindStageComment_ReturnsLast(t *testing.T) {
+	// Multiple comments matching the same stage — should return the last one.
+	comments := []gh.Comment{
+		{Body: "🏭 **Fabrik — stage: Research**\nfirst run", DatabaseID: 1},
+		{Body: "🏭 **Fabrik — stage: Research**\nsecond run", DatabaseID: 2},
+	}
+	result := findStageComment(comments, "Research")
+	if result == nil {
+		t.Fatal("expected match, got nil")
+	}
+	if result.DatabaseID != 2 {
+		t.Errorf("DatabaseID = %d, want 2 (last match)", result.DatabaseID)
+	}
+}
+
+func TestFindStageComment_DoesNotMatchVariant(t *testing.T) {
+	// "(comment review)" variant should not match base stage name.
+	comments := []gh.Comment{
+		{Body: "🏭 **Fabrik — stage: Research (comment review)**\ncomment review output", DatabaseID: 99},
+	}
+	result := findStageComment(comments, "Research")
+	if result != nil {
+		t.Errorf("expected nil (variant should not match base), got DatabaseID=%d", result.DatabaseID)
+	}
+}
+
+func TestFindStageComment_MatchesAmongMixed(t *testing.T) {
+	comments := []gh.Comment{
+		{Body: "user comment"},
+		{Body: "🏭 **Fabrik — stage: Plan**\nplan output", DatabaseID: 10},
+		{Body: "🏭 **Fabrik — stage: Research**\nresearch output", DatabaseID: 20},
+		{Body: "another user comment"},
+	}
+	result := findStageComment(comments, "Research")
+	if result == nil {
+		t.Fatal("expected match")
+	}
+	if result.DatabaseID != 20 {
+		t.Errorf("DatabaseID = %d, want 20", result.DatabaseID)
+	}
+}
+
+func TestWriteContextFiles_IssueAlwaysWritten(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(client, claude)
+	eng.cfg.Stages = []*stages.Stage{
+		{Name: "Research", Order: 1},
+		{Name: "Plan", Order: 2},
+	}
+
+	workDir := t.TempDir()
+	item := gh.ProjectItem{
+		Number: 42,
+		Body:   "# My Issue\n\nSpec content here.",
+	}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.writeContextFiles(item, stage, workDir, false)
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".fabrik", "issue.md"))
+	if err != nil {
+		t.Fatalf("issue.md not written: %v", err)
+	}
+	if string(data) != item.Body {
+		t.Errorf("issue.md content = %q, want %q", string(data), item.Body)
+	}
+}
+
+func TestWriteContextFiles_PriorStagesOnly(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(client, claude)
+	eng.cfg.Stages = []*stages.Stage{
+		{Name: "Research", Order: 1},
+		{Name: "Plan", Order: 2},
+		{Name: "Implement", Order: 3},
+	}
+
+	workDir := t.TempDir()
+	item := gh.ProjectItem{
+		Number: 5,
+		Body:   "spec",
+		Comments: []gh.Comment{
+			{Body: "🏭 **Fabrik — stage: Research**\nresearch out", DatabaseID: 1},
+			{Body: "🏭 **Fabrik — stage: Plan**\nplan out", DatabaseID: 2},
+		},
+	}
+	// Current stage is Plan (Order=2): only Research (Order=1) should be written.
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.writeContextFiles(item, stage, workDir, false)
+
+	// Research should be written (Order 1 < 2)
+	if _, err := os.ReadFile(filepath.Join(workDir, ".fabrik", "stage-Research.md")); err != nil {
+		t.Errorf("stage-Research.md should be written for prior stage: %v", err)
+	}
+
+	// Plan should NOT be written (Order 2 == current, not strictly less)
+	if _, err := os.ReadFile(filepath.Join(workDir, ".fabrik", "stage-Plan.md")); err == nil {
+		t.Error("stage-Plan.md should not be written (current stage, not prior)")
+	}
+}
+
+func TestWriteContextFiles_CommentProcessingIncludesCurrent(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(client, claude)
+	eng.cfg.Stages = []*stages.Stage{
+		{Name: "Research", Order: 1},
+		{Name: "Plan", Order: 2},
+	}
+
+	workDir := t.TempDir()
+	item := gh.ProjectItem{
+		Number: 7,
+		Body:   "spec",
+		Comments: []gh.Comment{
+			{Body: "🏭 **Fabrik — stage: Research**\nresearch out", DatabaseID: 1},
+			{Body: "🏭 **Fabrik — stage: Plan**\nplan out", DatabaseID: 2},
+		},
+	}
+	// Comment processing for Plan — should include Plan itself.
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.writeContextFiles(item, stage, workDir, true)
+
+	for _, name := range []string{"stage-Research.md", "stage-Plan.md"} {
+		if _, err := os.ReadFile(filepath.Join(workDir, ".fabrik", name)); err != nil {
+			t.Errorf("%s should be written for comment processing: %v", name, err)
+		}
+	}
+}
+
+func TestWriteContextFiles_SkipsStagesWithNoComment(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(client, claude)
+	eng.cfg.Stages = []*stages.Stage{
+		{Name: "Research", Order: 1},
+		{Name: "Plan", Order: 2},
+	}
+
+	workDir := t.TempDir()
+	item := gh.ProjectItem{
+		Number:   8,
+		Body:     "spec",
+		Comments: []gh.Comment{}, // no stage comments
+	}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.writeContextFiles(item, stage, workDir, false)
+
+	// No stage-Research.md since there's no matching comment.
+	if _, err := os.ReadFile(filepath.Join(workDir, ".fabrik", "stage-Research.md")); err == nil {
+		t.Error("stage-Research.md should not exist when there is no matching comment")
+	}
+	// But issue.md should still exist.
+	if _, err := os.ReadFile(filepath.Join(workDir, ".fabrik", "issue.md")); err != nil {
+		t.Errorf("issue.md should always be written: %v", err)
+	}
+}

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -29,6 +29,7 @@ type GitHubClient interface {
 // ClaudeInvoker defines the interface for invoking Claude Code.
 type ClaudeInvoker interface {
 	Invoke(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, modelOverride string) (output string, completed bool, usage TokenUsage, err error)
+	InvokeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (output string, completed bool, usage TokenUsage, err error)
 }
 
 // RealClaudeInvoker wraps the existing InvokeClaude function.
@@ -40,6 +41,14 @@ func (r *RealClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, iss
 	output, completed, usage, err := InvokeClaude(ctx, stage, issue, newComments, resume, workDir, modelOverride)
 	if r.DebugOutput {
 		saveDebugLog(issue.Number, stage.Name, output)
+	}
+	return output, completed, usage, err
+}
+
+func (r *RealClaudeInvoker) InvokeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+	output, completed, usage, err := InvokeClaudeForComments(ctx, stage, issue, comments, workDir, modelOverride)
+	if r.DebugOutput {
+		saveDebugLog(issue.Number, stage.Name+"-comment-review", output)
 	}
 	return output, completed, usage, err
 }

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -16,6 +16,7 @@ type GitHubClient interface {
 	RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error
 	AddComment(owner, repo string, issueNumber int, body string) error
 	AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error
+	UpdateComment(owner, repo string, commentDatabaseID int, body string) error
 	UpdateIssueBody(owner, repo string, issueNumber int, body string) error
 	UpdateProjectItemStatus(projectID, itemID, statusFieldID, statusOptionID string) error
 	GetIssueBody(owner, repo string, issueNumber int) (string, error)

--- a/engine/item.go
+++ b/engine/item.go
@@ -400,6 +400,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		}
 	}
 
+	// Write context files after any stash so they are present for Claude but
+	// not captured in the stash. Errors are non-fatal.
+	e.writeContextFiles(item, stage, workDir, false)
+
 	// Invoke Claude Code in the issue's worktree
 	modelOverride := e.extractModelOverride(item.Number, item.Labels)
 	if modelOverride != "" {

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -16,6 +16,7 @@ type mockGitHubClient struct {
 	removeLabelFromIssueFn    func(owner, repo string, issueNumber int, labelName string) error
 	addCommentFn              func(owner, repo string, issueNumber int, body string) error
 	updateCommentFn           func(owner, repo string, commentDatabaseID int, body string) error
+	updateIssueBodyFn         func(owner, repo string, issueNumber int, body string) error
 	updateProjectItemStatusFn func(projectID, itemID, statusFieldID, statusOptionID string) error
 	rateLimitStatsFn          func() (gh.RateLimitStats, gh.RateLimitStats)
 
@@ -113,6 +114,9 @@ func (m *mockGitHubClient) UpdateComment(owner, repo string, commentDatabaseID i
 }
 
 func (m *mockGitHubClient) UpdateIssueBody(owner, repo string, issueNumber int, body string) error {
+	if m.updateIssueBodyFn != nil {
+		return m.updateIssueBodyFn(owner, repo, issueNumber, body)
+	}
 	return nil
 }
 
@@ -167,4 +171,11 @@ func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, iss
 		return m.invokeFn(stage, issue, newComments, resume, workDir, modelOverride)
 	}
 	return "mock output", false, TokenUsage{}, nil
+}
+
+func (m *mockClaudeInvoker) InvokeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, modelOverride string) (string, bool, TokenUsage, error) {
+	if m.invokeFn != nil {
+		return m.invokeFn(stage, issue, comments, false, workDir, modelOverride)
+	}
+	return "mock comment output", false, TokenUsage{}, nil
 }

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -15,14 +15,16 @@ type mockGitHubClient struct {
 	addLabelToIssueFn         func(owner, repo string, issueNumber int, labelName string) error
 	removeLabelFromIssueFn    func(owner, repo string, issueNumber int, labelName string) error
 	addCommentFn              func(owner, repo string, issueNumber int, body string) error
+	updateCommentFn           func(owner, repo string, commentDatabaseID int, body string) error
 	updateProjectItemStatusFn func(projectID, itemID, statusFieldID, statusOptionID string) error
 	rateLimitStatsFn          func() (gh.RateLimitStats, gh.RateLimitStats)
 
 	// Track calls
-	addLabelCalls     []addLabelCall
-	removeLabelCalls  []removeLabelCall
-	addCommentCalls   []addCommentCall
-	updateStatusCalls []updateStatusCall
+	addLabelCalls      []addLabelCall
+	removeLabelCalls   []removeLabelCall
+	addCommentCalls    []addCommentCall
+	updateCommentCalls []updateCommentCall
+	updateStatusCalls  []updateStatusCall
 }
 
 type addLabelCall struct {
@@ -40,6 +42,12 @@ type removeLabelCall struct {
 type addCommentCall struct {
 	owner, repo string
 	issueNumber int
+	body        string
+}
+
+type updateCommentCall struct {
+	owner, repo string
+	commentID   int
 	body        string
 }
 
@@ -93,6 +101,14 @@ func (m *mockGitHubClient) AddComment(owner, repo string, issueNumber int, body 
 }
 
 func (m *mockGitHubClient) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	return nil
+}
+
+func (m *mockGitHubClient) UpdateComment(owner, repo string, commentDatabaseID int, body string) error {
+	if m.updateCommentFn != nil {
+		return m.updateCommentFn(owner, repo, commentDatabaseID, body)
+	}
+	m.updateCommentCalls = append(m.updateCommentCalls, updateCommentCall{owner, repo, commentDatabaseID, body})
 	return nil
 }
 

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -65,6 +65,7 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string, sk
 		// Directory exists but git can't identify it — still usable, don't destroy it
 		// The directory might have uncommitted work from a killed Claude session
 		wm.logf(issueNumber, "worktree", "directory exists but branch check failed, using as-is\n")
+		wm.writeGitExclude(wtDir, issueNumber)
 		return wtDir, nil
 	}
 

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -58,6 +58,7 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string, sk
 				if !skipUpdate {
 					wm.updateWorktreeFromMain(wtDir, baseBranch, issueNumber)
 				}
+				wm.writeGitExclude(wtDir, issueNumber)
 				return wtDir, nil
 			}
 		}
@@ -94,6 +95,7 @@ func (wm *WorktreeManager) EnsureWorktree(issueNumber int, baseBranch string, sk
 	}
 
 	wm.logf(issueNumber, "worktree", "created %s\n", wtDir)
+	wm.writeGitExclude(wtDir, issueNumber)
 	return wtDir, nil
 }
 
@@ -210,6 +212,47 @@ func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string, issu
 	}
 
 	wm.logf(issueNumber, "worktree", "rebased onto origin/%s\n", baseBranch)
+}
+
+// writeGitExclude writes `.fabrik/` to the per-worktree git exclude file so
+// context files never get accidentally staged or committed. This is idempotent —
+// safe to call on every EnsureWorktree invocation.
+//
+// In a linked worktree, `.git` is a file pointing to the per-worktree git dir
+// (e.g. <main>/.git/worktrees/issue-N/). `git rev-parse --git-dir` returns
+// that absolute path, so we append `info/exclude` to it.
+func (wm *WorktreeManager) writeGitExclude(wtDir string, issueNumber int) {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = wtDir
+	out, err := cmd.Output()
+	if err != nil {
+		wm.logf(issueNumber, "warn", "could not determine git-dir for exclude setup: %v\n", err)
+		return
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtDir, gitDir)
+	}
+	infoDir := filepath.Join(gitDir, "info")
+	if err := os.MkdirAll(infoDir, 0755); err != nil {
+		wm.logf(issueNumber, "warn", "could not create git info dir: %v\n", err)
+		return
+	}
+	excludePath := filepath.Join(infoDir, "exclude")
+	const entry = ".fabrik/\n"
+	existing, _ := os.ReadFile(excludePath)
+	if strings.Contains(string(existing), ".fabrik/") {
+		return // already present
+	}
+	f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		wm.logf(issueNumber, "warn", "could not open git exclude file: %v\n", err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.WriteString(entry); err != nil {
+		wm.logf(issueNumber, "warn", "could not write git exclude entry: %v\n", err)
+	}
 }
 
 // Prune removes stale worktree registrations from git.

--- a/github/comments.go
+++ b/github/comments.go
@@ -20,6 +20,15 @@ func (c *Client) AddCommentReaction(owner, repo string, commentDatabaseID int, c
 	return c.restPost(apiURL, payload)
 }
 
+// UpdateComment replaces the body of an existing issue comment.
+func (c *Client) UpdateComment(owner, repo string, commentDatabaseID int, body string) error {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", c.baseURL, owner, repo, commentDatabaseID)
+	payload := map[string]interface{}{
+		"body": body,
+	}
+	return c.restPatch(apiURL, payload)
+}
+
 // UpdateIssueBody updates the body of an issue.
 func (c *Client) UpdateIssueBody(owner, repo string, issueNumber int, body string) error {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.baseURL, owner, repo, issueNumber)

--- a/github/mutations_test.go
+++ b/github/mutations_test.go
@@ -241,3 +241,39 @@ func TestEnsureLabel(t *testing.T) {
 		t.Fatalf("ensureLabel: %v", err)
 	}
 }
+
+func TestUpdateComment_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/repos/owner/repo/issues/comments/99") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["body"] != "updated body" {
+			t.Errorf("body = %v", body["body"])
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if err := c.UpdateComment("owner", "repo", 99, "updated body"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+}
+
+func TestUpdateComment_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"not found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if err := c.UpdateComment("owner", "repo", 99, "body"); err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}

--- a/plugin/fabrik-plugin/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-implement/SKILL.md
@@ -12,18 +12,27 @@ Produce a clean, tested, committed implementation that follows the plan and is r
 
 ## Before You Start
 
+### Read context files
+
+The engine has written context files to `.fabrik/` in your working directory:
+- `.fabrik/issue.md` — the issue body (the spec); understand what you're building
+- `.fabrik/stage-Plan.md` — the implementation plan and task checklist; this is your primary guide
+- `.fabrik/stage-Research.md` — the research findings, if present
+
+Read these files before looking at the code. The task checklist in `.fabrik/stage-Plan.md` is the authoritative source of truth — not the issue body.
+
 ### Check for existing work
 
 Always start with `git status`. There may be:
 - **Uncommitted changes** from a previous interrupted session — review them, decide if they're useful, commit or discard
 - **Prior commits** on the branch — check `git log` to see what's already been done
-- **Checked-off tasks** in the issue body — don't redo completed work
+- **Checked-off tasks** in the Plan stage comment — don't redo completed work
 
-If resuming, pick up where the previous session left off. Read the commit history and task checklist to understand what's done.
+If resuming, pick up where the previous session left off. Read the commit history and the task checklist in `.fabrik/stage-Plan.md` to understand what's done.
 
 ### Understand the plan
 
-Read the issue body thoroughly. The plan section contains:
+Read `.fabrik/stage-Plan.md` thoroughly. The plan contains:
 - The implementation approach and key decisions (follow them, don't redesign)
 - The task checklist (work through it in order)
 - File changes (the plan tells you what to modify)
@@ -40,7 +49,7 @@ Work through tasks in the order listed. For each task:
 3. Write or update tests
 4. Commit with a clear message describing what was done
 5. Push to remote
-6. Check off the task in the issue body using `gh issue edit`
+6. Check off the task in the Plan stage comment (see below)
 
 ### Commit frequently
 
@@ -65,11 +74,36 @@ Push after each commit or small group of related commits. The remote branch is t
 
 ### Update task progress
 
-After completing each task, update the issue body to check it off:
+After completing each task, check it off in the **Plan stage comment** — not the issue body. The issue body is the spec (owned by Specify); task tracking lives in the Plan stage comment.
+
+First, find the Plan stage comment's database ID:
 ```bash
-gh issue edit <number> --body "..."
+gh issue view <number> --json comments \
+  --jq '.comments[] | select(.body | startswith("🏭 **Fabrik — stage: Plan**")) | .databaseId' \
+  | tail -1
 ```
-Change `- [ ] Task` to `- [x] Task`. This provides real-time visibility.
+
+Then update the comment body with the task checked off:
+```bash
+# Get current body and update the checkbox
+COMMENT_ID=<id from above>
+CURRENT_BODY=$(gh api /repos/{owner}/{repo}/issues/comments/$COMMENT_ID --jq '.body')
+# Edit CURRENT_BODY: change "- [ ] Task N" to "- [x] Task N"
+gh api -X PATCH /repos/{owner}/{repo}/issues/comments/$COMMENT_ID \
+  -f body="$UPDATED_BODY"
+```
+
+If no Plan stage comment exists (Plan was never run or comment was deleted), skip task tracking gracefully — don't fail.
+
+### Write a reviewer-oriented PR description
+
+When creating the draft PR, write a PR description for a human reviewer — not a copy of the plan. The description should cover:
+1. **What the PR does** — a concise summary of the feature or fix
+2. **Key changes** — the most significant code changes (files, interfaces, behaviors)
+3. **How to test** — steps a reviewer can take to verify the change works
+4. **Closing reference**: `Closes #N`
+
+This is not a task checklist. It is not the plan. It is a summary for someone reviewing the diff who may not have read the issue.
 
 ### Write tests
 

--- a/plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md
@@ -10,6 +10,15 @@ You are the Plan agent in the Fabrik SDLC pipeline. Your job is to design a conc
 
 Produce an implementation plan that is specific enough to follow mechanically, but flexible enough to accommodate discoveries during implementation.
 
+## Before You Start
+
+Read the context files the engine has written to `.fabrik/` in your working directory:
+- `.fabrik/issue.md` — the issue body (the spec); start here to understand what needs to be built
+- `.fabrik/stage-Specify.md` — the Specify stage output, if present
+- `.fabrik/stage-Research.md` — the research findings; this is your primary input for planning
+
+These files are always fresher than the inline prompt. Read them before designing the approach.
+
 ## What You Do
 
 ### Design the approach

--- a/plugin/fabrik-plugin/skills/fabrik-research/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-research/SKILL.md
@@ -10,6 +10,14 @@ You are the Research agent in the Fabrik SDLC pipeline. Your job is to deeply un
 
 Produce a thorough technical analysis that a planner could use to design an implementation approach without needing to re-read the codebase.
 
+## Before You Start
+
+Read the context files the engine has written to `.fabrik/` in your working directory:
+- `.fabrik/issue.md` — the issue body (the spec); start here to understand the feature
+- `.fabrik/stage-Specify.md` — the Specify stage output, if present
+
+These files are always fresher than what appears in the inline prompt. Read them before exploring the codebase.
+
 ## What You Do
 
 ### Explore the codebase

--- a/plugin/fabrik-plugin/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-review/SKILL.md
@@ -12,6 +12,17 @@ Produce a clean, well-tested PR that a human reviewer can approve with confidenc
 
 ## Before You Start
 
+### Read context files
+
+The engine has written context files to `.fabrik/` in your working directory:
+- `.fabrik/issue.md` — the issue body (spec and task checklist)
+- `.fabrik/stage-Research.md` — the research findings, if present
+- `.fabrik/stage-Plan.md` — the implementation plan and task checklist
+- `.fabrik/stage-Implement.md` — the Implement stage output, if present
+- `.fabrik/pr-description.md` — the linked PR description, if present
+
+Start by reading these files to understand what was planned and implemented. Use the task checklist in `.fabrik/stage-Plan.md` to verify all tasks were completed.
+
 ### Check worktree state
 
 1. `git status` — commit or incorporate any uncommitted changes from prior sessions

--- a/plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md
@@ -6,6 +6,14 @@ description: Use when operating as the Fabrik Specify comment reviewer. This ski
 
 You are the comment reviewer for the Specify stage. The user has answered one or more questions about the issue spec. Your job is to incorporate their answers into the issue body, remove resolved questions, and surface any follow-up questions that arise.
 
+## Before You Start
+
+Read the context files the engine has written to `.fabrik/` in your working directory:
+- `.fabrik/issue.md` — the current issue body (the evolving spec)
+- `.fabrik/stage-Specify.md` — the current Specify stage output; this is the living document you are building upon
+
+The content in `.fabrik/stage-Specify.md` is the most recent authoritative state of the Specify stage output. Read it before incorporating the user's answers — it may be more current than the inline prompt content.
+
 ## What You Do
 
 ### Incorporate answers

--- a/plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md
@@ -12,6 +12,17 @@ Confirm with high confidence that the PR is ready to merge. If it's not, clearly
 
 ## Before You Start
 
+### Read context files
+
+The engine has written context files to `.fabrik/` in your working directory:
+- `.fabrik/issue.md` — the issue body (the original spec); use this to verify requirements
+- `.fabrik/stage-Plan.md` — the task checklist; verify all tasks were completed
+- `.fabrik/stage-Implement.md` — the implementation summary, if present
+- `.fabrik/stage-Review.md` — the review findings, if present
+- `.fabrik/pr-description.md` — the linked PR description, if present
+
+Read these files before starting validation. The spec in `.fabrik/issue.md` is your ground truth for requirements verification.
+
 1. `git status` — commit any uncommitted changes
 2. Rebase onto latest main:
    ```bash


### PR DESCRIPTION
## Summary

- Writes `.fabrik/issue.md` and `.fabrik/stage-{Name}.md` context files before each Claude invocation so Claude can read prior stage outputs on demand instead of relying solely on inline prompt content
- Rewrites existing stage comments in-place during comment processing (instead of creating new comments), keeping the issue thread clean with each stage comment as a living document
- Adds `UpdateComment` API to patch existing issue comments via `PATCH /repos/{owner}/{repo}/issues/comments/{id}`

## Key Changes

- **`engine/context.go`**: New file with `findStageComment` (finds last matching stage comment by header prefix) and `writeContextFiles` (writes `.fabrik/` context files before each invocation)
- **`engine/worktree.go`**: Writes `.git/info/exclude` via `git rev-parse --git-dir` to keep `.fabrik/` untracked per-worktree
- **`engine/comments.go`**: `processComments` now always rewrites/creates the base stage comment (not `post_to_pr` stages); removes the old "post only if no body update" conditional
- **`engine/item.go`**: Calls `writeContextFiles` after stash, before Claude invocation
- **`github/comments.go`** + **`engine/interfaces.go`**: `UpdateComment` implementation and interface method
- **Plugin skills**: All stage skills (research, plan, implement, review, validate) updated to read context files; `fabrik-implement` skill updated to track tasks in Plan stage comment via `gh api PATCH`; `fabrik-specify-comment` updated to read `.fabrik/stage-Specify.md`
- **ADRs 011 and 012**: Document context files mechanism and stage comment as living document

## How to Test

1. Run `go test -race ./...` — all tests pass
2. Run `go vet ./...` — clean
3. Start fabrik on a test issue and observe `.fabrik/issue.md` and `.fabrik/stage-*.md` files appear in the worktree before Claude runs
4. Post a comment on a stage that has existing output — verify the existing stage comment is updated in-place rather than a new one created

Closes #99