### PR TITLE
Use tea.ExecProcess to launch fabrik watch and claude resume from TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ to prevent accidental token leaks.
 | `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` for debugging | `false` |
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides installed plugin) | `""` |
-| `--terminal` | Terminal emulator for log viewer (`terminal`, `iterm2`, `ghostty`, `kitty`, `alacritty`, `warp`) | `""` |
 
 ## Subcommands
 

--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -109,15 +109,6 @@ func TestExecute_EnvYolo(t *testing.T) {
 	executeAndStop(t)
 }
 
-func TestExecute_EnvTerminal(t *testing.T) {
-	dir, stagesDir := setupValidStages(t)
-	chdirTest(t, dir)
-	resetFlags()
-	t.Setenv("FABRIK_TERMINAL", "iterm2")
-	t.Setenv("GITHUB_TOKEN", "tok")
-	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
-	executeAndStop(t)
-}
 
 func TestExecute_EnvMaxRetries_Valid(t *testing.T) {
 	dir, stagesDir := setupValidStages(t)

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -344,29 +344,6 @@ func TestRunStreamFilter_MalformedJSON(t *testing.T) {
 
 // ── root.go helpers ───────────────────────────────────────────────────────────
 
-func TestDetectTerminalFromEnv(t *testing.T) {
-	cases := []struct {
-		env  string
-		want string
-	}{
-		{"Apple_Terminal", "terminal"},
-		{"iTerm.app", "iterm2"},
-		{"ghostty", "ghostty"},
-		{"WarpTerminal", "warp"},
-		{"alacritty", "alacritty"},
-		{"unknown", ""},
-		{"", ""},
-	}
-	for _, tc := range cases {
-		os.Setenv("TERM_PROGRAM", tc.env)
-		got := detectTerminalFromEnv()
-		if got != tc.want {
-			t.Errorf("TERM_PROGRAM=%q: got %q, want %q", tc.env, got, tc.want)
-		}
-	}
-	os.Unsetenv("TERM_PROGRAM")
-}
-
 func TestBuildProjectInfo_HomeRelative(t *testing.T) {
 	dir := t.TempDir()
 	chdirTest(t, dir)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,6 @@ type Config struct {
 	MaxRetries    int
 	DebugOutput   bool
 	PluginDir     string
-	Terminal      string
 }
 
 func Execute() error {
@@ -82,7 +81,6 @@ func Execute() error {
 	flag.IntVar(&cfg.MaxRetries, "max-retries", 3, "Max failed stage attempts before pausing the issue (0 = unlimited)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
 	flag.StringVar(&cfg.PluginDir, "plugin-dir", "", "Path to Fabrik plugin directory (for development; overrides installed plugin)")
-	flag.StringVar(&cfg.Terminal, "terminal", "", "Terminal emulator to use for log viewer (terminal, iterm2, ghostty, kitty, alacritty, warp)")
 
 	flag.Parse()
 
@@ -238,15 +236,6 @@ func Execute() error {
 			cfg.DebugOutput = true
 		}
 	}
-	if cfg.Terminal == "" {
-		if v := os.Getenv("FABRIK_TERMINAL"); v != "" {
-			cfg.Terminal = v
-		} else if pc.Terminal != "" {
-			cfg.Terminal = pc.Terminal
-		} else {
-			cfg.Terminal = detectTerminalFromEnv()
-		}
-	}
 	if cfg.PluginDir == "" {
 		if v := os.Getenv("FABRIK_PLUGIN_DIR"); v != "" {
 			cfg.PluginDir = v
@@ -344,29 +333,9 @@ func Execute() error {
 	// When TUI is enabled (and we have a real terminal), run the bubbletea
 	// TUI. Otherwise fall through to plain-text mode.
 	if useTUI {
-		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.Terminal, cfg.PluginDir)
+		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.PluginDir)
 	}
 	return eng.Run()
-}
-
-// detectTerminalFromEnv maps the TERM_PROGRAM environment variable to a Fabrik
-// terminal identifier. Returns "" if TERM_PROGRAM is not set or not recognized,
-// causing openTerminalCmd to fall back to the platform default.
-func detectTerminalFromEnv() string {
-	switch os.Getenv("TERM_PROGRAM") {
-	case "Apple_Terminal":
-		return "terminal"
-	case "iTerm.app":
-		return "iterm2"
-	case "ghostty":
-		return "ghostty"
-	case "WarpTerminal":
-		return "warp"
-	case "alacritty":
-		return "alacritty"
-	default:
-		return ""
-	}
 }
 
 // buildProjectInfo assembles the TUI footer metadata from the active config.
@@ -398,11 +367,11 @@ func buildProjectInfo(cfg *Config, pc config.ProjectConfig) tui.ProjectInfo {
 // runTUI wires the event channel, starts the bubbletea program, and runs the
 // engine. The engine handles SIGINT itself; bubbletea uses WithoutSignalHandler
 // so it doesn't interfere. When the engine exits, the TUI is quit.
-func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, terminal string, pluginDir string) error {
+func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir string) error {
 	events := make(chan tui.Event, 256)
 	eng.SetEvents(events)
 
-	tuiModel := tui.New(pollSeconds, info, terminal, pluginDir)
+	tuiModel := tui.New(pollSeconds, info, pluginDir)
 	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
 
 	// Forward events from the engine's channel into bubbletea.

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,6 @@ type ProjectConfig struct {
 	Yolo          bool   `yaml:"yolo"`
 	AutoUpgrade   bool   `yaml:"auto_upgrade"`
 	TUI           *bool  `yaml:"tui"`
-	Terminal      string `yaml:"terminal"`
 	DebugOutput   bool   `yaml:"debug_output"`
 	Version       string `yaml:"version"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -136,7 +136,6 @@ max_retries: 5
 yolo: true
 auto_upgrade: true
 tui: true
-terminal: iTerm.app
 debug_output: true
 version: "2.0.0"
 `
@@ -175,9 +174,6 @@ version: "2.0.0"
 	}
 	if pc.TUI == nil || !*pc.TUI {
 		t.Error("tui: want true")
-	}
-	if pc.Terminal != "iTerm.app" {
-		t.Errorf("terminal: want iTerm.app, got %q", pc.Terminal)
 	}
 	if !pc.DebugOutput {
 		t.Error("debug_output: want true")

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -196,11 +196,6 @@ user: your-github-username
 # Disable the interactive TUI dashboard (enabled by default when a real terminal is detected).
 # tui: false
 
-# Terminal app for the TUI log viewer. Valid values: terminal, iterm2, ghostty,
-# kitty, alacritty, warp. Auto-detected from TERM_PROGRAM env var if not set.
-# Note: kitty has no TERM_PROGRAM auto-detection -- set this explicitly for kitty.
-# terminal: ""
-
 # Save raw Claude output to .fabrik/debug/ for diagnosing unexpected behavior
 # or prompt issues. Files are named by issue number and stage.
 # debug_output: false
@@ -266,7 +261,6 @@ FABRIK_USER=my-personal-username
 | `FABRIK_MAX_RETRIES` | `max_retries` | Max retries before pausing (0 = unlimited) | `3` |
 | `FABRIK_AUTO_UPGRADE` | `auto_upgrade` | Self-upgrade when idle (`true`/`1`/`yes`) | `false` |
 | `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
-| `FABRIK_TERMINAL` | `terminal` | Terminal app for TUI log viewer (`terminal`, `iterm2`, `ghostty`, `kitty`, `alacritty`, `warp`). Auto-detected from `TERM_PROGRAM` if not set. | `""` |
 | `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
 | `FABRIK_DEBUG_OUTPUT` | `debug_output` | Save raw Claude output for debugging | `false` |
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -266,42 +266,6 @@ FABRIK_USER=my-personal-username
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
 
-### Terminal Auto-Detection
-
-The `terminal:` setting (and its `--terminal` flag / `FABRIK_TERMINAL` env var) controls
-which terminal app the TUI opens for the log viewer. Valid values:
-
-| Value | Terminal |
-|-------|----------|
-| `terminal` | macOS Terminal.app (default on macOS) |
-| `iterm2` | iTerm2 (macOS only; uses AppleScript) |
-| `ghostty` | Ghostty (macOS: `open -na Ghostty.app`; Linux: `ghostty -e`) |
-| `kitty` | kitty (cross-platform: `kitty sh -c ...`) |
-| `alacritty` | Alacritty (cross-platform: `alacritty -e sh -c ...`) |
-| `warp` | Warp (macOS only; opens app without a command) |
-
-**Auto-detection from `TERM_PROGRAM`:**
-
-When `terminal:` is unset (or `""`), Fabrik reads the `TERM_PROGRAM` environment variable:
-
-| `TERM_PROGRAM` value | Detected terminal |
-|----------------------|-------------------|
-| `Apple_Terminal` | `terminal` |
-| `iTerm.app` | `iterm2` |
-| `ghostty` | `ghostty` |
-| `WarpTerminal` | `warp` |
-| `alacritty` | `alacritty` |
-| *(anything else)* | platform default |
-
-**kitty** has no `TERM_PROGRAM` entry — set `terminal: kitty` explicitly in `config.yaml`.
-
-**Platform notes:**
-- `warp` — macOS only; Warp cannot be launched with a specific command, so only the
-  app opens (the user navigates to the log manually).
-- `iterm2` — macOS only (uses AppleScript); Linux falls back to the platform default.
-- `ghostty` — macOS uses `open -na Ghostty.app --args ...`; Linux uses `ghostty -e`.
-- Linux fallback tries `gnome-terminal`, then `xterm`, then `konsole` in order.
-
 ### Stage YAML Reference
 
 Each stage is a YAML file in your stages directory. The filename is arbitrary; the

--- a/tui/model.go
+++ b/tui/model.go
@@ -744,32 +744,6 @@ func (m Model) sortedActiveKeys() []string {
 	return keys
 }
 
-// logDirForJob returns the log directory for an active job.
-func logDirForJob(job *activeJob) string {
-	return logDirForIssue(job.Repo, job.IssueNumber)
-}
-
-// logDirForHistory returns the log directory for a history entry.
-func logDirForHistory(h HistoryEntry) string {
-	return logDirForIssue(h.Repo, h.IssueNumber)
-}
-
-// logDirForIssue returns the log directory for an issue.
-// Uses the repo-namespaced path (~/.fabrik/logs/<owner>-<repo>/issue-N/) when
-// repo is non-empty, otherwise the flat path (~/.fabrik/logs/issue-N/).
-func logDirForIssue(repo string, issueNumber int) string {
-	home := homeDir()
-	issuePart := fmt.Sprintf("issue-%d", issueNumber)
-
-	if repo != "" {
-		repoPart := strings.ReplaceAll(repo, "/", "-")
-		return filepath.Join(home, ".fabrik", "logs", repoPart, issuePart)
-	}
-
-	return filepath.Join(home, ".fabrik", "logs", issuePart)
-}
-
-
 // tuiReadSessionID reads the Claude session ID for a given repo, issue and stage.
 // The path logic mirrors engine.ReadSessionID — keep in sync if either changes.
 func tuiReadSessionID(repo string, issueNumber int, stageName string) string {
@@ -803,12 +777,6 @@ func fmtDuration(d time.Duration) string {
 	m := int(d.Minutes())
 	s := int(d.Seconds()) % 60
 	return fmt.Sprintf("%d:%02d", m, s)
-}
-
-// homeDir returns the user's home directory.
-func homeDir() string {
-	h, _ := os.UserHomeDir()
-	return h
 }
 
 // openWatchInlineCmd returns a tea.Cmd that suspends the TUI and launches

--- a/tui/model.go
+++ b/tui/model.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -53,6 +53,12 @@ func activeJobKey(repo string, issueNumber int) string {
 	}
 	return fmt.Sprintf("#%d", issueNumber)
 }
+
+// watchExitMsg is returned by tea.ExecProcess when the fabrik watch subprocess exits.
+type watchExitMsg struct{ Err error }
+
+// claudeResumeFinishedMsg is returned by tea.ExecProcess when the claude --resume subprocess exits.
+type claudeResumeFinishedMsg struct{ Err error }
 
 // pane identifies which TUI section has focus.
 type pane int
@@ -108,10 +114,13 @@ type Model struct {
 	// statusLine shows the latest poll-level log message in the header
 	statusLine string
 
-	// terminal is the resolved terminal emulator identifier (e.g. "terminal",
-	// "iterm2", "ghostty", "kitty", "alacritty", "warp"). Empty string means
-	// use the platform default.
-	terminal string
+	// statusMsg is a transient user-facing message shown in the header instead
+	// of statusLine. It is cleared on each TickEvent so it disappears after ~1s.
+	statusMsg string
+
+	// detailPanel controls whether the inline detail panel is shown between the
+	// active and history sections in View().
+	detailPanel bool
 
 	// selection state
 	focusPane    pane
@@ -139,9 +148,8 @@ var (
 // New creates an initial TUI model.
 // pollSeconds is the configured polling interval.
 // info provides project metadata displayed in the footer.
-// terminal is the resolved terminal emulator identifier; empty string uses the platform default.
 // pluginDir is the Fabrik plugin directory passed to claude --plugin-dir (may be empty).
-func New(pollSeconds int, info ProjectInfo, terminal string, pluginDir string) Model {
+func New(pollSeconds int, info ProjectInfo, pluginDir string) Model {
 	vp := viewport.New(80, 10)
 	return Model{
 		projectInfo:    info,
@@ -152,7 +160,6 @@ func New(pollSeconds int, info ProjectInfo, terminal string, pluginDir string) M
 		historyVP:      vp,
 		spinnerFrames:  []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
 		now:            time.Now(),
-		terminal:       terminal,
 		pluginDir:      pluginDir,
 	}
 }
@@ -217,6 +224,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.confirmClear = false
 				return m, nil
 			}
+			if m.detailPanel {
+				m.detailPanel = false
+				return m, nil
+			}
 
 		case "tab":
 			if m.focusPane == paneActive {
@@ -254,42 +265,56 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
-		case "enter", "l":
-			// Open latest log file for selected job (active or history pane)
+		case "l":
+			// Launch fabrik watch <issueNumber> inline via tea.ExecProcess.
+			// Suspends the TUI until the user exits watch with q.
 			if m.focusPane == paneActive {
 				keys := m.sortedActiveKeys()
 				if m.activeIdx < len(keys) {
 					if job, ok := m.active[keys[m.activeIdx]]; ok {
-						logDir := logDirForJob(job)
-						return m, m.openLogViewerCmd(logDir)
+						return m, openWatchInlineCmd(job.IssueNumber, job.Repo)
 					}
 				}
 			} else if m.focusPane == paneHistory && len(m.history) > 0 {
 				realIdx := len(m.history) - 1 - m.histIdx
 				if realIdx >= 0 && realIdx < len(m.history) {
 					h := m.history[realIdx]
-					logDir := logDirForHistory(h)
-					return m, m.openLogViewerCmd(logDir)
+					return m, openWatchInlineCmd(h.IssueNumber, h.Repo)
 				}
 			}
 			return m, nil
 
+		case "enter":
+			// Toggle the inline detail panel.
+			m.detailPanel = !m.detailPanel
+			return m, nil
+
 		case "r":
-			// Active pane: open log viewer (active sessions must not be interrupted)
-			// History pane: open interactive resume session in the issue's worktree
+			// Active pane: show status message — active sessions must not be interrupted.
+			// History pane: resume an interactive Claude session in the issue's worktree,
+			// but only when the issue is not currently active.
 			if m.focusPane == paneActive {
 				keys := m.sortedActiveKeys()
 				if m.activeIdx < len(keys) {
-					if job, ok := m.active[keys[m.activeIdx]]; ok {
-						logDir := logDirForJob(job)
-						return m, m.openLogViewerCmd(logDir)
-					}
+					m.statusMsg = "stage in progress — use l to watch"
 				}
+				return m, nil
 			} else if m.focusPane == paneHistory && len(m.history) > 0 {
 				realIdx := len(m.history) - 1 - m.histIdx
 				if realIdx >= 0 && realIdx < len(m.history) {
 					h := m.history[realIdx]
-					return m, m.openResumeCmd(h.Repo, h.IssueNumber, h.StageName, h.StageModel)
+					if m.isActiveIssue(h) {
+						m.statusMsg = "stage in progress — use l to watch"
+						return m, nil
+					}
+					// Check worktree exists before launching resume.
+					cwd, _ := os.Getwd()
+					worktreePath := worktreePathForIssue(cwd, h.Repo, h.IssueNumber)
+					if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+						m.statusMsg = fmt.Sprintf("no worktree for #%d", h.IssueNumber)
+						return m, nil
+					}
+					return m, m.openResumeInlineCmd(h.Repo, h.IssueNumber, h.StageName, h.StageModel, worktreePath)
 				}
 			}
 			return m, nil
@@ -306,9 +331,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateHistoryViewport(false)
 		return m, nil
 
+	case watchExitMsg:
+		// fabrik watch subprocess exited — nothing to do (TUI resumes automatically).
+		return m, nil
+
+	case claudeResumeFinishedMsg:
+		// claude --resume subprocess exited — nothing to do (TUI resumes automatically).
+		return m, nil
+
 	case TickEvent:
 		m.now = ev.At
 		m.spinnerIdx = (m.spinnerIdx + 1) % len(m.spinnerFrames)
+		m.statusMsg = "" // clear transient status message each tick
 		return m, tickCmd()
 
 	case PollStartedEvent:
@@ -481,6 +515,13 @@ func (m Model) View() string {
 	// ── In-Progress pane ──
 	sections = append(sections, m.viewActive())
 
+	// ── Detail panel (toggled by enter) ──
+	if m.detailPanel {
+		if detail := m.viewDetail(); detail != "" {
+			sections = append(sections, detail)
+		}
+	}
+
 	// ── History pane ──
 	sections = append(sections, m.viewHistory())
 
@@ -505,9 +546,15 @@ func (m Model) viewHeader() string {
 	}
 	timerStr := dimStyle.Render(timer)
 
+	// statusMsg is transient (cleared each tick); it takes priority over statusLine.
+	displayStatus := m.statusMsg
+	if displayStatus == "" {
+		displayStatus = m.statusLine
+	}
+
 	status := ""
-	if m.statusLine != "" {
-		status = "  " + dimStyle.Render(m.statusLine)
+	if displayStatus != "" {
+		status = "  " + dimStyle.Render(displayStatus)
 	}
 
 	// title + status on left, timer on right, single line
@@ -520,8 +567,8 @@ func (m Model) viewHeader() string {
 		//   " " + title + "  " + dimStyle(s+"…") + gap + timerStr
 		// where "  " (2 chars) is the prefix and "…" (1 char) is the suffix → 3 chars overhead.
 		maxStatus := max(available-lipgloss.Width(title)-timerWidth-3, 0)
-		if maxStatus > 0 && m.statusLine != "" {
-			s := m.statusLine
+		if maxStatus > 0 && displayStatus != "" {
+			s := displayStatus
 			// Shrink using display width (lipgloss.Width strips ANSI), matching viewFooter pattern.
 			for lipgloss.Width(s) > maxStatus {
 				runes := []rune(s)
@@ -612,7 +659,7 @@ func (m Model) viewActive() string {
 
 	hint := ""
 	if m.focusPane == paneActive && len(m.active) > 0 {
-		hint = dimStyle.Render("  [r/enter/l]ogs  [tab] history")
+		hint = dimStyle.Render("  [l] watch  [enter] details  [tab] history")
 	}
 	content := title + hint + "\n" + strings.Join(lines, "\n")
 	return borderStyle.Width(m.width - 4).Render(content)
@@ -628,7 +675,7 @@ func (m Model) viewHistory() string {
 	if m.confirmClear {
 		hint = failStyle.Render("  Clear all history? [C]onfirm / [n]o")
 	} else if m.focusPane == paneHistory && len(m.history) > 0 {
-		hint = dimStyle.Render("  [r]esume  [l]ogs  [c]lear entry  [C]lear all  [tab] in-progress")
+		hint = dimStyle.Render("  [r]esume  [l] watch  [enter] details  [c]lear  [C]lear all  [tab] in-progress")
 	}
 	content := title + hint + "\n" + m.historyVP.View()
 	return borderStyle.Width(m.width - 4).Render(content)
@@ -722,51 +769,6 @@ func logDirForIssue(repo string, issueNumber int) string {
 	return filepath.Join(home, ".fabrik", "logs", issuePart)
 }
 
-// openLogViewerCmd returns a tea.Cmd that opens a terminal showing the most
-// recent log file in the given directory, piped through the stream filter
-// for human-readable output.
-func (m Model) openLogViewerCmd(logDir string) tea.Cmd {
-	if _, err := os.Stat(logDir); err != nil {
-		return nil
-	}
-	entries, err := os.ReadDir(logDir)
-	if err != nil || len(entries) == 0 {
-		return nil
-	}
-	// Sort by modification time (most recent last) — filenames sort
-	// alphabetically by stage name, not by time.
-	sort.Slice(entries, func(i, j int) bool {
-		fi, _ := entries[i].Info()
-		fj, _ := entries[j].Info()
-		if fi == nil || fj == nil {
-			return entries[i].Name() < entries[j].Name()
-		}
-		return fi.ModTime().Before(fj.ModTime())
-	})
-	latest := entries[len(entries)-1].Name()
-
-	// Resolve fabrik binary for the stream filter
-	fabrikBin, err := os.Executable()
-	if err != nil {
-		fabrikBin = "fabrik"
-	}
-
-	// For JSON files, pipe through the stream filter; for other files, use less.
-	// Pass as a single string — openTerminalCmd sends it to Terminal.app's do script.
-	// Shell-quote path components so directories or binaries with spaces work correctly.
-	if strings.HasSuffix(latest, ".json") {
-		return m.openTerminalCmd(fmt.Sprintf(
-			"cd %s && cat %s | %s _stream-filter | less -R",
-			shellQuote(logDir), shellQuote(latest), shellQuote(fabrikBin)))
-	}
-	return m.openTerminalCmd(fmt.Sprintf("cd %s && less +F %s", shellQuote(logDir), shellQuote(latest)))
-}
-
-// shellQuote wraps s in single quotes and escapes any embedded single quotes,
-// making it safe to embed in a shell command string.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
 
 // tuiReadSessionID reads the Claude session ID for a given repo, issue and stage.
 // The path logic mirrors engine.ReadSessionID — keep in sync if either changes.
@@ -791,41 +793,6 @@ func tuiReadSessionID(repo string, issueNumber int, stageName string) string {
 	return strings.TrimSpace(string(data))
 }
 
-// openResumeCmd returns a tea.Cmd that opens a new terminal window running an
-// interactive Claude session in the issue's worktree. If a session file exists
-// for the given stage, --resume <id> is passed; otherwise a fresh session starts.
-// If the worktree directory does not exist, an error terminal window is opened.
-func (m Model) openResumeCmd(repo string, issueNumber int, stageName, stageModel string) tea.Cmd {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil
-	}
-	worktreeDir := filepath.Join(cwd, ".fabrik", "worktrees", fmt.Sprintf("issue-%d", issueNumber))
-	if _, statErr := os.Stat(worktreeDir); statErr != nil {
-		if os.IsNotExist(statErr) {
-			return m.openTerminalCmd(fmt.Sprintf("echo 'Worktree for issue #%d not found (%s). The issue has not been processed yet.' && read", issueNumber, worktreeDir))
-		}
-		return m.openTerminalCmd(fmt.Sprintf("echo 'Failed to access worktree for issue #%d (%s): %v' && read", issueNumber, worktreeDir, statErr))
-	}
-
-	// Build the command with properly shell-quoted arguments to handle paths
-	// with spaces or shell metacharacters.
-	parts := []string{"claude"}
-	sessionID := tuiReadSessionID(repo, issueNumber, stageName)
-	if sessionID != "" {
-		parts = append(parts, "--resume", shellQuote(sessionID))
-	}
-	if stageModel != "" {
-		parts = append(parts, "--model", shellQuote(stageModel))
-	}
-	if m.pluginDir != "" {
-		parts = append(parts, "--plugin-dir", shellQuote(m.pluginDir))
-	}
-
-	// Build: cd <worktreeDir> && claude [--resume <id>] [--model <m>] [--plugin-dir <d>]
-	cmdStr := fmt.Sprintf("cd %s && %s", shellQuote(worktreeDir), strings.Join(parts, " "))
-	return m.openTerminalCmd(cmdStr)
-}
 
 // fmtDuration formats a duration as MM:SS.
 func fmtDuration(d time.Duration) string {
@@ -844,95 +811,137 @@ func homeDir() string {
 	return h
 }
 
-// openTerminalCmd returns a tea.Cmd that opens a new terminal window running
-// cmdStr as a shell command. It dispatches to the terminal specified by
-// m.terminal; an empty string or unknown ID falls back to the platform default.
-func (m Model) openTerminalCmd(cmdStr string) tea.Cmd {
-	return func() tea.Msg {
-		var cmd *exec.Cmd
-
-		switch m.terminal {
-		case "iterm2":
-			// iTerm2 v3+ AppleScript API; macOS only. Fall back to Linux default on other platforms.
-			if runtime.GOOS == "darwin" {
-				script := fmt.Sprintf(`tell application "iTerm"
-	activate
-	create window with default profile command "%s"
-end tell`, strings.ReplaceAll(cmdStr, `"`, `\"`))
-				cmd = exec.Command("osascript", "-e", script)
-			} else {
-				cmd = linuxFallbackTerminal(cmdStr)
-			}
-
-		case "ghostty":
-			if runtime.GOOS == "darwin" {
-				// Ghostty binary cannot launch the GUI directly on macOS; use open.
-				cmd = exec.Command("open", "-na", "Ghostty.app", "--args", "-e", "sh", "-c", cmdStr)
-			} else {
-				cmd = exec.Command("ghostty", "-e", "sh", "-c", cmdStr)
-			}
-
-		case "kitty":
-			cmd = exec.Command("kitty", "sh", "-c", cmdStr)
-
-		case "alacritty":
-			cmd = exec.Command("alacritty", "-e", "sh", "-c", cmdStr)
-
-		case "warp":
-			// Warp does not support passing a command via -e; macOS only.
-			if runtime.GOOS == "darwin" {
-				fmt.Fprintf(os.Stderr, "[warn] Warp terminal does not support opening with a command; log viewer unavailable\n")
-				cmd = exec.Command("open", "-a", "Warp")
-			} else {
-				cmd = linuxFallbackTerminal(cmdStr)
-			}
-
-		case "terminal", "":
-			// Terminal.app on macOS or platform default on Linux.
-			if runtime.GOOS == "darwin" {
-				script := fmt.Sprintf(`tell application "Terminal"
-activate
-do script "%s"
-end tell`, strings.ReplaceAll(cmdStr, `"`, `\"`))
-				cmd = exec.Command("osascript", "-e", script)
-			} else {
-				cmd = linuxFallbackTerminal(cmdStr)
-			}
-
-		default:
-			// Unknown terminal ID — warn and fall through to platform default.
-			fmt.Fprintf(os.Stderr, "[warn] unknown terminal %q; falling back to platform default\n", m.terminal)
-			if runtime.GOOS == "darwin" {
-				script := fmt.Sprintf(`tell application "Terminal"
-activate
-do script "%s"
-end tell`, strings.ReplaceAll(cmdStr, `"`, `\"`))
-				cmd = exec.Command("osascript", "-e", script)
-			} else {
-				cmd = linuxFallbackTerminal(cmdStr)
-			}
-		}
-
-		if cmd == nil {
-			return nil
-		}
-		if err := cmd.Start(); err != nil {
-			fmt.Fprintf(os.Stderr, "[warn] failed to launch terminal %q: %v\n", m.terminal, err)
-		}
-		return nil
+// openWatchInlineCmd returns a tea.Cmd that suspends the TUI and launches
+// "fabrik watch <issueNumber>" in the current terminal via tea.ExecProcess.
+// The TUI is restored automatically when the user exits watch with q.
+// In multi-repo mode, --owner and --repo flags are passed explicitly so the
+// child process watches the correct repository.
+func openWatchInlineCmd(issueNumber int, repo string) tea.Cmd {
+	fabrikBin, err := os.Executable()
+	if err != nil {
+		fabrikBin = "fabrik"
 	}
+	args := []string{"watch"}
+	if repo != "" {
+		parts := strings.SplitN(repo, "/", 2)
+		if len(parts) == 2 {
+			args = append(args, "--owner", parts[0], "--repo", parts[1])
+		}
+	}
+	args = append(args, strconv.Itoa(issueNumber))
+	cmd := exec.Command(fabrikBin, args...)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return watchExitMsg{Err: err}
+	})
 }
 
-// linuxFallbackTerminal returns an *exec.Cmd for the first available terminal
-// emulator found in PATH (gnome-terminal, xterm, konsole). Returns nil if none found.
-func linuxFallbackTerminal(cmdStr string) *exec.Cmd {
-	for _, term := range []string{"gnome-terminal", "xterm", "konsole"} {
-		if _, err := exec.LookPath(term); err == nil {
-			if term == "gnome-terminal" {
-				return exec.Command(term, "--", "sh", "-c", cmdStr)
+// openResumeInlineCmd returns a tea.Cmd that suspends the TUI and launches an
+// interactive Claude session in the issue's worktree via tea.ExecProcess.
+// worktreePath must already be verified to exist by the caller.
+// If a session file exists for the given stage, --resume <id> is passed;
+// otherwise a fresh session starts.
+func (m Model) openResumeInlineCmd(repo string, issueNumber int, stageName, stageModel, worktreePath string) tea.Cmd {
+	args := []string{}
+	sessionID := tuiReadSessionID(repo, issueNumber, stageName)
+	if sessionID != "" {
+		args = append(args, "--resume", sessionID)
+	}
+	if stageModel != "" {
+		args = append(args, "--model", stageModel)
+	}
+	if m.pluginDir != "" {
+		args = append(args, "--plugin-dir", m.pluginDir)
+	}
+	cmd := exec.Command("claude", args...)
+	cmd.Dir = worktreePath
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return claudeResumeFinishedMsg{Err: err}
+	})
+}
+
+// worktreePathForIssue returns the absolute path to the issue's git worktree.
+// In single-repo mode: <rootDir>/.fabrik/worktrees/issue-N
+// In multi-repo mode:  <rootDir>/.fabrik/worktrees/<owner>-<repo>/issue-N
+func worktreePathForIssue(rootDir, repo string, issueNumber int) string {
+	issuePart := fmt.Sprintf("issue-%d", issueNumber)
+	if repo != "" {
+		repoPart := strings.ReplaceAll(repo, "/", "-")
+		return filepath.Join(rootDir, ".fabrik", "worktrees", repoPart, issuePart)
+	}
+	return filepath.Join(rootDir, ".fabrik", "worktrees", issuePart)
+}
+
+// isActiveIssue reports whether the history entry's issue is currently being
+// processed (present in the active jobs map). Works correctly in multi-repo mode.
+func (m Model) isActiveIssue(h HistoryEntry) bool {
+	key := activeJobKey(h.Repo, h.IssueNumber)
+	_, ok := m.active[key]
+	return ok
+}
+
+// viewDetail renders an inline detail panel for the currently selected item.
+// Active pane: shows in-flight job metadata.
+// History pane: shows completed job metadata.
+// Returns an empty string when there is nothing to display.
+func (m Model) viewDetail() string {
+	var lines []string
+
+	if m.focusPane == paneActive {
+		keys := m.sortedActiveKeys()
+		if m.activeIdx < len(keys) {
+			if job, ok := m.active[keys[m.activeIdx]]; ok {
+				elapsed := fmtDuration(m.now.Sub(job.StartedAt))
+				lines = append(lines, fmt.Sprintf("Issue:   #%d", job.IssueNumber))
+				if job.Title != "" {
+					lines = append(lines, fmt.Sprintf("Title:   %s", job.Title))
+				}
+				lines = append(lines, fmt.Sprintf("Stage:   %s", job.StageName))
+				lines = append(lines, fmt.Sprintf("Elapsed: %s", elapsed))
 			}
-			return exec.Command(term, "-e", "sh", "-c", cmdStr)
+		}
+	} else if m.focusPane == paneHistory && len(m.history) > 0 {
+		realIdx := len(m.history) - 1 - m.histIdx
+		if realIdx >= 0 && realIdx < len(m.history) {
+			h := m.history[realIdx]
+			statusStr := "success"
+			if !h.Success {
+				statusStr = "error"
+			} else if h.BlockedOnInput {
+				statusStr = "awaiting input"
+			} else if !h.Completed {
+				statusStr = "incomplete"
+			}
+			lines = append(lines, fmt.Sprintf("Issue:    #%d", h.IssueNumber))
+			if h.Title != "" {
+				lines = append(lines, fmt.Sprintf("Title:    %s", h.Title))
+			}
+			lines = append(lines, fmt.Sprintf("Stage:    %s", h.StageName))
+			if h.StageModel != "" {
+				lines = append(lines, fmt.Sprintf("Model:    %s", h.StageModel))
+			}
+			lines = append(lines, fmt.Sprintf("Status:   %s", statusStr))
+			lines = append(lines, fmt.Sprintf("Duration: %s", fmtDuration(h.Duration)))
+			if h.TurnsUsed > 0 {
+				if h.MaxTurns > 0 {
+					lines = append(lines, fmt.Sprintf("Turns:    %d/%d", h.TurnsUsed, h.MaxTurns))
+				} else {
+					lines = append(lines, fmt.Sprintf("Turns:    %d", h.TurnsUsed))
+				}
+			}
+			if h.CostUSD > 0 {
+				lines = append(lines, fmt.Sprintf("Cost:     $%.4f", h.CostUSD))
+			}
+			if !h.CompletedAt.IsZero() {
+				lines = append(lines, fmt.Sprintf("At:       %s", h.CompletedAt.Format("2006-01-02 15:04:05")))
+			}
 		}
 	}
-	return nil
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	titleLine := dimStyle.Render("Detail") + "  " + dimStyle.Render("[esc] close")
+	content := titleLine + "\n" + strings.Join(lines, "\n")
+	return borderStyle.Width(m.width - 4).Render(content)
 }

--- a/tui/model.go
+++ b/tui/model.go
@@ -219,7 +219,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
-		case "n", "N", "escape":
+		case "n", "N", "esc":
 			if m.confirmClear {
 				m.confirmClear = false
 				return m, nil

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -73,7 +73,7 @@ func TestActiveHeight(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	if m.pollInterval != 30*time.Second {
 		t.Errorf("pollInterval = %v, want 30s", m.pollInterval)
 	}
@@ -89,7 +89,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestUpdate_TickEvent(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	initial := m.spinnerIdx
@@ -111,7 +111,7 @@ func TestUpdate_TickEvent(t *testing.T) {
 
 func TestUpdate_JobStartedAndCompleted(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	start := time.Now()
 
 	// JobStartedEvent adds to active
@@ -152,7 +152,7 @@ func TestUpdate_JobStartedAndCompleted(t *testing.T) {
 }
 
 func TestUpdate_LogEvent_UpdatesActiveJob(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	key7 := activeJobKey("", 7)
 	m.active[key7] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
 	m.activeNumToKey[7] = key7
@@ -174,7 +174,7 @@ func TestUpdate_LogEvent_UpdatesActiveJob(t *testing.T) {
 
 func TestUpdate_LogEvent_UnknownIssue(t *testing.T) {
 	// LogEvent for an issue not in active map should not panic
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	next, _ := m.Update(LogEvent{IssueNumber: 999, Tag: "warn", Message: "something\n"})
 	nm := next.(Model)
 	if _, ok := nm.active[activeJobKey("", 999)]; ok {
@@ -183,7 +183,7 @@ func TestUpdate_LogEvent_UnknownIssue(t *testing.T) {
 }
 
 func TestUpdate_PollStartedAndCompleted(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	before := time.Now()
 
 	next, _ := m.Update(PollStartedEvent{Owner: "o", Repo: "r", Project: 1})
@@ -200,7 +200,7 @@ func TestUpdate_PollStartedAndCompleted(t *testing.T) {
 }
 
 func TestUpdate_QuitKey(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	if cmd == nil {
 		t.Error("expected quit cmd from 'q' key")
@@ -212,24 +212,26 @@ func TestUpdate_QuitKey(t *testing.T) {
 	}
 }
 
-func TestUpdate_RKey_ActivePane_AliasesLogViewer(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+func TestUpdate_RKey_ActivePane_SetsStatusMsg(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
 	m.focusPane = paneActive
 	key7 := activeJobKey("", 7)
 	m.active[key7] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
 	m.activeNumToKey[7] = key7
 
-	// r on an active pane item delegates to the log viewer (same as enter/l).
-	// openLogViewerCmd returns nil when the log dir is empty, so we just verify
-	// the key is handled (no panic) and the model is returned.
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
-	if _, ok := next.(Model); !ok {
-		t.Error("expected Model returned from Update with r key in active pane")
+	// r on an active pane item sets statusMsg and returns no cmd.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if cmd != nil {
+		t.Error("expected nil cmd from r key in active pane")
+	}
+	nm := next.(Model)
+	if nm.statusMsg == "" {
+		t.Error("expected statusMsg to be set after r key in active pane")
 	}
 }
 
 func TestUpdate_RKey_ActivePane_NoJobs_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.focusPane = paneActive
 	// No active jobs: r is a no-op
 
@@ -239,24 +241,51 @@ func TestUpdate_RKey_ActivePane_NoJobs_NoOp(t *testing.T) {
 	}
 }
 
-func TestUpdate_RKey_HistoryPane_WithEntry(t *testing.T) {
+func TestUpdate_RKey_HistoryPane_WithEntry_MissingWorktree(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	// Chdir to a temp dir so worktree path won't accidentally exist.
+	t.Chdir(t.TempDir())
+	m := New(30, ProjectInfo{}, "")
 	m.focusPane = paneHistory
 	m.history = []HistoryEntry{
 		{IssueNumber: 42, StageName: "Research", StageModel: "sonnet", Success: true},
 	}
 
-	// r on a history entry calls openResumeCmd — non-nil cmd returned
-	// (openResumeCmd returns an error-message terminal cmd when worktree is missing)
+	// r on a history entry when worktree is missing: nil cmd, statusMsg set.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if cmd != nil {
+		t.Error("expected nil cmd when worktree is missing")
+	}
+	nm := next.(Model)
+	if nm.statusMsg == "" {
+		t.Error("expected statusMsg to be set when worktree is missing")
+	}
+}
+
+func TestUpdate_RKey_HistoryPane_WithWorktree(t *testing.T) {
+	redirectHistory(t)
+	// Create a temp project dir with the worktree directory.
+	dir := t.TempDir()
+	worktree := filepath.Join(dir, ".fabrik", "worktrees", "issue-42")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	m := New(30, ProjectInfo{}, "")
+	m.focusPane = paneHistory
+	m.history = []HistoryEntry{
+		{IssueNumber: 42, StageName: "Research", StageModel: "sonnet", Success: true},
+	}
+
+	// r on a history entry with worktree present: returns non-nil tea.ExecProcess cmd.
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
 	if cmd == nil {
-		t.Error("expected non-nil cmd from r key with history entry")
+		t.Error("expected non-nil cmd (tea.ExecProcess) from r key with worktree present")
 	}
 }
 
 func TestUpdate_RKey_HistoryPane_NoEntries_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.focusPane = paneHistory
 	m.history = nil
 
@@ -266,26 +295,9 @@ func TestUpdate_RKey_HistoryPane_NoEntries_NoOp(t *testing.T) {
 	}
 }
 
-func TestShellQuote(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"simple", "'simple'"},
-		{"path/with spaces/dir", "'path/with spaces/dir'"},
-		{"it's a test", "'it'\\''s a test'"},
-		{"", "''"},
-	}
-	for _, tt := range tests {
-		got := shellQuote(tt.input)
-		if got != tt.want {
-			t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
 
 func TestView_BeforeWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	// Before width is set, View should return a loading placeholder without panicking
 	v := m.View()
 	if !strings.Contains(v, "Loading") {
@@ -294,7 +306,7 @@ func TestView_BeforeWindowSize(t *testing.T) {
 }
 
 func TestView_AfterWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{Repo: "owner/repo", CWD: "~/myproject"}, "", "")
+	m := New(30, ProjectInfo{Repo: "owner/repo", CWD: "~/myproject"}, "")
 	m.width = 80
 	m.height = 24
 	m.nextPollAt = time.Now().Add(30 * time.Second)
@@ -322,7 +334,7 @@ func TestView_AfterWindowSize(t *testing.T) {
 
 func TestNew_StoresProjectInfo(t *testing.T) {
 	info := ProjectInfo{CWD: "~/foo", Repo: "org/bar", Version: "1.2.3"}
-	m := New(30, info, "", "")
+	m := New(30, info, "")
 	if m.projectInfo != info {
 		t.Errorf("projectInfo = %+v, want %+v", m.projectInfo, info)
 	}
@@ -335,7 +347,7 @@ func TestFooterHeight(t *testing.T) {
 }
 
 func TestViewFooter_Content(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp", Version: "2.0.0"}, "", "")
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp", Version: "2.0.0"}, "")
 	m.width = 120
 	footer := m.viewFooter()
 
@@ -347,7 +359,7 @@ func TestViewFooter_Content(t *testing.T) {
 }
 
 func TestViewFooter_NoVersion(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp"}, "", "")
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp"}, "")
 	m.width = 120
 	footer := m.viewFooter()
 
@@ -365,7 +377,7 @@ func TestViewFooter_Truncation(t *testing.T) {
 		CWD:     "~/very/long/path/to/a/deeply/nested/project/directory",
 		Repo:    "some-long-org/some-long-repo-name",
 		Version: "99.99.99",
-	}, "", "")
+	}, "")
 	m.width = 30
 	footer := m.viewFooter()
 
@@ -380,28 +392,6 @@ func TestViewFooter_Truncation(t *testing.T) {
 	}
 }
 
-// TestOpenTerminalCmd_UnknownID verifies that an unknown terminal ID does not
-// panic and returns a non-nil tea.Cmd (the fallback path runs).
-// The returned Cmd is intentionally not executed — doing so may launch GUI
-// processes (osascript, terminal emulators) during go test.
-func TestOpenTerminalCmd_UnknownID(t *testing.T) {
-	m := New(30, ProjectInfo{}, "totally_unknown_terminal", "")
-	cmd := m.openTerminalCmd("echo hello")
-	if cmd == nil {
-		t.Error("expected non-nil tea.Cmd for unknown terminal ID")
-	}
-}
-
-// TestOpenTerminalCmd_KnownIDs verifies that known terminal IDs return non-nil Cmds.
-func TestOpenTerminalCmd_KnownIDs(t *testing.T) {
-	for _, id := range []string{"terminal", "iterm2", "ghostty", "kitty", "alacritty", "warp", ""} {
-		m := New(30, ProjectInfo{}, id, "")
-		cmd := m.openTerminalCmd("echo hello")
-		if cmd == nil {
-			t.Errorf("terminal %q: expected non-nil tea.Cmd", id)
-		}
-	}
-}
 
 // TestLayoutHeightInvariant verifies that the total rendered height of View()
 // equals m.height for various numbers of active jobs. This ensures the header
@@ -414,7 +404,7 @@ func TestLayoutHeightInvariant(t *testing.T) {
 
 	for _, n := range []int{0, 1, 7, 8, 15} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", "")
+			m := New(30, ProjectInfo{}, "")
 			// Add n active jobs.
 			now := time.Now()
 			for i := 0; i < n; i++ {
@@ -461,7 +451,7 @@ func TestLayoutHeightInvariant_SmallTerminal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("h=%d,n=%d", tc.termHeight, tc.nActive), func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", "")
+			m := New(30, ProjectInfo{}, "")
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -481,7 +471,7 @@ func TestLayoutHeightInvariant_SmallTerminal(t *testing.T) {
 // TestViewHeader_TimerAlwaysVisible verifies that when the status message is
 // long enough to trigger truncation, the timer string still appears in the output.
 func TestViewHeader_TimerAlwaysVisible(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 60
 	m.nextPollAt = time.Now().Add(90 * time.Second)
 
@@ -514,7 +504,7 @@ func TestViewHeader_WidthNeverExceedsTerminal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", "")
+			m := New(30, ProjectInfo{}, "")
 			m.width = tc.width
 			m.nextPollAt = time.Now().Add(90 * time.Second)
 			m.statusLine = tc.statusLine
@@ -529,20 +519,10 @@ func TestViewHeader_WidthNeverExceedsTerminal(t *testing.T) {
 	}
 }
 
-// TestDetectTerminalFromEnv is in the cmd package; here we just verify the
-// terminal field is stored on the model correctly.
-func TestNew_TerminalStored(t *testing.T) {
-	for _, id := range []string{"", "ghostty", "iterm2"} {
-		m := New(30, ProjectInfo{}, id, "")
-		if m.terminal != id {
-			t.Errorf("New(30, ProjectInfo{}, %q, \"\"): got terminal=%q, want %q", id, m.terminal, id)
-		}
-	}
-}
 
 // TestInit verifies Init returns a non-nil cmd (the initial tick).
 func TestInit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	cmd := m.Init()
 	if cmd == nil {
 		t.Error("Init() should return a non-nil cmd")
@@ -591,7 +571,7 @@ func TestLoadHistory_RoundTrip(t *testing.T) {
 
 // TestUpdate_TabKey_SwitchesPanes verifies tab toggles focus between panes.
 func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	if m.focusPane != paneActive {
@@ -615,7 +595,7 @@ func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
 // TestUpdate_JK_HistoryPane verifies j/k navigation in the history pane.
 func TestUpdate_JK_HistoryPane(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -647,7 +627,7 @@ func TestUpdate_JK_HistoryPane(t *testing.T) {
 
 // TestUpdate_JK_ActivePane verifies j/k navigation in the active pane.
 func TestUpdate_JK_ActivePane(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.active[activeJobKey("", 1)] = &activeJob{StageName: "Research", StartedAt: time.Now()}
 	m.active[activeJobKey("", 2)] = &activeJob{StageName: "Plan", StartedAt: time.Now()}
 
@@ -666,7 +646,7 @@ func TestUpdate_JK_ActivePane(t *testing.T) {
 // TestUpdate_CKey_DeletesHistoryEntry verifies c removes the selected entry.
 func TestUpdate_CKey_DeletesHistoryEntry(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -687,7 +667,7 @@ func TestUpdate_CKey_DeletesHistoryEntry(t *testing.T) {
 
 // TestUpdate_CKey_EmptyHistory_NoOp verifies c is a no-op with no history.
 func TestUpdate_CKey_EmptyHistory_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.focusPane = paneHistory
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
 	if cmd != nil {
@@ -699,7 +679,7 @@ func TestUpdate_CKey_EmptyHistory_NoOp(t *testing.T) {
 // viewport area scrolls the YOffset down, and navigating back up scrolls it up.
 func TestUpdate_ScrollToVisible(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -758,7 +738,7 @@ func TestUpdate_ScrollToVisible(t *testing.T) {
 // resets the viewport to the top regardless of the current selection position.
 func TestUpdate_JobCompletedScrollsToTop(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -792,7 +772,7 @@ func TestUpdate_JobCompletedScrollsToTop(t *testing.T) {
 // TestUpdate_CapitalC_ClearAll verifies two C presses clear all history.
 func TestUpdate_CapitalC_ClearAll(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -822,7 +802,7 @@ func TestUpdate_CapitalC_ClearAll(t *testing.T) {
 
 // TestUpdate_QuitDuringConfirmClear_Cancels verifies q cancels confirmClear state.
 func TestUpdate_QuitDuringConfirmClear_Cancels(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.confirmClear = true
 	m.focusPane = paneHistory
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
@@ -837,7 +817,7 @@ func TestUpdate_QuitDuringConfirmClear_Cancels(t *testing.T) {
 
 // TestUpdate_NKey_CancelsConfirmClear verifies n cancels the clear confirmation.
 func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.confirmClear = true
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
 	nm := next.(Model)
@@ -849,7 +829,7 @@ func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
 // TestUpdate_EnterL_HistoryPane_NoLogDir verifies enter returns nil when log dir is missing.
 func TestUpdate_EnterL_HistoryPane_NoLogDir(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -862,22 +842,35 @@ func TestUpdate_EnterL_HistoryPane_NoLogDir(t *testing.T) {
 	}
 }
 
-// TestUpdate_EnterL_ActivePane_NoLogDir verifies enter in active pane returns nil when log dir missing.
-func TestUpdate_EnterL_ActivePane_NoLogDir(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+// TestUpdate_EnterKey_ActivePane_TogglesDetailPanel verifies enter in active pane toggles the detail panel.
+func TestUpdate_EnterKey_ActivePane_TogglesDetailPanel(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneActive
 	m.active[activeJobKey("", 99999)] = &activeJob{StageName: "Research", StartedAt: time.Now()}
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// First enter: panel opens.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	nm := next.(Model)
 	if cmd != nil {
-		t.Error("expected nil cmd from enter when log dir doesn't exist")
+		t.Error("enter key should return nil cmd (no subprocess)")
+	}
+	if !nm.detailPanel {
+		t.Error("expected detailPanel=true after first enter")
+	}
+
+	// Second enter: panel closes.
+	next2, _ := nm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	nm2 := next2.(Model)
+	if nm2.detailPanel {
+		t.Error("expected detailPanel=false after second enter")
 	}
 }
 
 // TestUpdate_LogEvent_IssueZero_StatusLine verifies poll-level log events update statusLine.
 func TestUpdate_LogEvent_IssueZero_StatusLine(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	next, _ := m.Update(LogEvent{IssueNumber: 0, Tag: "poll", Message: "polling now\n"})
@@ -895,48 +888,23 @@ func TestTuiReadSessionID_NotFound(t *testing.T) {
 	}
 }
 
-// TestOpenLogViewerCmd_WithLogFile verifies a non-nil cmd is returned for a dir with log files.
-func TestOpenLogViewerCmd_WithLogFile(t *testing.T) {
-	logDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(logDir, "research.log"), []byte("log content"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	m := New(30, ProjectInfo{}, "", "")
-	cmd := m.openLogViewerCmd(logDir)
-	if cmd == nil {
-		t.Error("expected non-nil cmd for dir with log files")
-	}
-	// Do NOT execute cmd — it would launch a terminal.
-}
+// TestUpdate_LKey_Returns_WatchCmd verifies the l key returns a non-nil tea.ExecProcess cmd.
+func TestUpdate_LKey_Returns_WatchCmd(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.focusPane = paneActive
+	m.active[activeJobKey("", 7)] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
+	m.activeNumToKey[7] = activeJobKey("", 7)
 
-// TestOpenLogViewerCmd_WithJSONFile verifies JSON log files use stream-filter pipe.
-func TestOpenLogViewerCmd_WithJSONFile(t *testing.T) {
-	logDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(logDir, "research.json"), []byte(`{"type":"log"}`), 0600); err != nil {
-		t.Fatal(err)
-	}
-	m := New(30, ProjectInfo{}, "", "")
-	cmd := m.openLogViewerCmd(logDir)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
 	if cmd == nil {
-		t.Error("expected non-nil cmd for .json log file")
-	}
-	// Do NOT execute cmd — it would launch a terminal.
-}
-
-// TestOpenLogViewerCmd_EmptyDir verifies nil cmd for an empty log directory.
-func TestOpenLogViewerCmd_EmptyDir(t *testing.T) {
-	logDir := t.TempDir()
-	m := New(30, ProjectInfo{}, "", "")
-	cmd := m.openLogViewerCmd(logDir)
-	if cmd != nil {
-		t.Error("expected nil cmd for empty log dir")
+		t.Error("expected non-nil cmd (tea.ExecProcess) from l key with active job")
 	}
 }
 
 // TestViewHistory_ConfirmClear verifies the confirmation prompt is shown.
 func TestViewHistory_ConfirmClear(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -950,7 +918,7 @@ func TestViewHistory_ConfirmClear(t *testing.T) {
 
 // TestViewActive_IsComment verifies the 💬 emoji appears for comment jobs.
 func TestViewActive_IsComment(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.active[activeJobKey("", 5)] = &activeJob{StageName: "Implement", IsComment: true, StartedAt: time.Now()}
@@ -963,7 +931,7 @@ func TestViewActive_IsComment(t *testing.T) {
 // TestViewHistory_IsComment verifies the 💬 emoji appears for comment history entries.
 func TestViewHistory_IsComment(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.height = 24
 	m.history = []HistoryEntry{{IssueNumber: 5, StageName: "Implement", IsComment: true, Success: true}}
@@ -977,7 +945,7 @@ func TestViewHistory_IsComment(t *testing.T) {
 
 // TestViewHeader_WithStatusLine verifies statusLine content appears in the header.
 func TestViewHeader_WithStatusLine(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 80
 	m.statusLine = "some status"
 	header := m.viewHeader()
@@ -988,7 +956,7 @@ func TestViewHeader_WithStatusLine(t *testing.T) {
 
 // TestViewHeader_StatusLineTruncation verifies narrow headers truncate statusLine without panic.
 func TestViewHeader_StatusLineTruncation(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", "")
+	m := New(30, ProjectInfo{}, "")
 	m.width = 25
 	m.statusLine = "a very very very very very very long status message"
 	header := m.viewHeader()
@@ -998,27 +966,25 @@ func TestViewHeader_StatusLineTruncation(t *testing.T) {
 	}
 }
 
-// TestOpenResumeCmd_WorktreeExists verifies a non-nil cmd is returned when the worktree exists.
-func TestOpenResumeCmd_WorktreeExists(t *testing.T) {
-	tmpDir := t.TempDir()
-	issueNum := 42
-	worktreeDir := filepath.Join(tmpDir, ".fabrik", "worktrees", fmt.Sprintf("issue-%d", issueNum))
-	if err := os.MkdirAll(worktreeDir, 0700); err != nil {
-		t.Fatal(err)
+// TestUpdate_RKey_HistoryPane_ActiveIssue_SetsStatusMsg verifies that r on a history entry
+// for an issue that is currently active shows a status message and returns no cmd.
+func TestUpdate_RKey_HistoryPane_ActiveIssue_SetsStatusMsg(t *testing.T) {
+	redirectHistory(t)
+	m := New(30, ProjectInfo{}, "")
+	m.focusPane = paneHistory
+	// Add issue 42 to both active map and history.
+	key42 := activeJobKey("", 42)
+	m.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
+	m.history = []HistoryEntry{
+		{IssueNumber: 42, StageName: "Research", Success: true},
 	}
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(oldWd) //nolint:errcheck
 
-	m := New(30, ProjectInfo{}, "", "")
-	cmd := m.openResumeCmd("", issueNum, "Research", "sonnet")
-	if cmd == nil {
-		t.Error("expected non-nil cmd when worktree exists")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if cmd != nil {
+		t.Error("expected nil cmd when issue is active")
 	}
-	// Do NOT execute cmd — it would launch a terminal.
+	nm := next.(Model)
+	if nm.statusMsg == "" {
+		t.Error("expected statusMsg to be set when issue is actively running")
+	}
 }

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -826,8 +826,8 @@ func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
 	}
 }
 
-// TestUpdate_EnterL_HistoryPane_NoLogDir verifies enter returns nil when log dir is missing.
-func TestUpdate_EnterL_HistoryPane_NoLogDir(t *testing.T) {
+// TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel verifies enter in history pane toggles the detail panel.
+func TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel(t *testing.T) {
 	redirectHistory(t)
 	m := New(30, ProjectInfo{}, "")
 	m.width = 80
@@ -836,9 +836,29 @@ func TestUpdate_EnterL_HistoryPane_NoLogDir(t *testing.T) {
 	m.history = []HistoryEntry{
 		{IssueNumber: 99999, StageName: "Research"},
 	}
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	// enter toggles detail panel — no subprocess launched.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd != nil {
-		t.Error("expected nil cmd from enter when log dir doesn't exist")
+		t.Error("enter key should return nil cmd (no subprocess)")
+	}
+	nm := next.(Model)
+	if !nm.detailPanel {
+		t.Error("expected detailPanel=true after enter in history pane")
+	}
+}
+
+// TestUpdate_EscapeKey_ClosesDetailPanel verifies escape closes the detail panel.
+func TestUpdate_EscapeKey_ClosesDetailPanel(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.detailPanel = true
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Error("escape key should return nil cmd")
+	}
+	nm := next.(Model)
+	if nm.detailPanel {
+		t.Error("expected detailPanel=false after escape key")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces the fragile "open new terminal window" approach with `tea.ExecProcess` for the main TUI's `l` and `r` keys, suspending the TUI inline and restoring it when the subprocess exits.
- Adds an inline detail panel (`enter` key) that shows per-issue metadata without suspending the TUI.
- Removes all terminal-emulator detection and launch code (`--terminal` flag, `FABRIK_TERMINAL` env var, `terminal:` config key).

## Key Changes

**`tui/model.go`**
- `New()` signature: removed `terminal string` parameter (breaking change for callers)
- New `openWatchInlineCmd(issueNumber, repo)`: resolves `fabrikBin` via `os.Executable()`, passes `--owner`/`--repo` for multi-repo, returns `tea.ExecProcess`
- New `openResumeInlineCmd(...)`: replaces `openResumeCmd`; fixes multi-repo worktree path bug; uses `tea.ExecProcess` returning `claudeResumeFinishedMsg`
- New `viewDetail()`: inline detail panel rendered between active and history sections
- New `isActiveIssue(h)`: guards `r` key in history pane against active issues
- `statusMsg string` field: transient header message cleared on each tick
- Removed: `openTerminalCmd`, `linuxFallbackTerminal`, `shellQuote`, `openLogViewerCmd`, `openResumeCmd`

**`cmd/root.go`** — Removed `Config.Terminal`, `--terminal` flag, `FABRIK_TERMINAL` env var, `detectTerminalFromEnv()`, `terminal` param from `runTUI()`

**`config/config.go`** — Removed `Terminal string yaml:"terminal"` from `ProjectConfig`

**Docs** — Removed `--terminal` flag row from README, removed `FABRIK_TERMINAL` env var row and Terminal Auto-Detection section from USER_GUIDE.md

> **Breaking config change**: `terminal:` in `.fabrik/config.yaml` is silently ignored after this change (Go YAML unmarshaling ignores unknown fields). Users who set this field should remove it.

## How to Test

1. Run `fabrik` with a real project board
2. In the TUI active pane, press `l` — the TUI should suspend and `fabrik watch <N>` should run in the same terminal; press `q` to return to the TUI
3. In the history pane, press `r` on a non-active issue with a worktree — the TUI should suspend and `claude --resume` should run in the issue's worktree
4. Press `r` on an active issue (appears in both active and history panes) — a status message should appear in the header briefly
5. Press `enter` in either pane — an inline detail panel should appear; press `enter` or `esc` to close it
6. Verify `fabrik --terminal iterm2` produces an error (flag removed)

Closes #193