### PR TITLE
feat(mouse): add mouse support to main TUI and fabrik watch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -372,7 +372,7 @@ func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir
 	eng.SetEvents(events)
 
 	tuiModel := tui.New(pollSeconds, info, pluginDir)
-	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
+	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler(), tea.WithMouseCellMotion())
 
 	// Forward events from the engine's channel into bubbletea.
 	go func() {

--- a/tui/model.go
+++ b/tui/model.go
@@ -128,6 +128,11 @@ type Model struct {
 	histIdx      int  // index into history (0 = newest)
 	confirmClear bool // true when waiting for Y/N on clear-all
 	confirmQuit  bool // true when waiting for q/n on quit-with-active-jobs
+
+	// mouse double-click detection
+	lastClickAt time.Time
+	lastClickX  int
+	lastClickY  int
 }
 
 var (
@@ -441,9 +446,105 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+
+	case tea.MouseMsg:
+		return m.handleMouse(ev)
 	}
 
 	return m, nil
+}
+
+// handleMouse processes a tea.MouseMsg: forwards all mouse events to the history
+// viewport (which handles wheel scroll internally), then performs hit-testing for
+// left-click events to update selection state and detect double-clicks.
+func (m Model) handleMouse(ev tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// Forward all mouse events to the history viewport so wheel-scroll works.
+	var cmd tea.Cmd
+	m.historyVP, cmd = m.historyVP.Update(ev)
+
+	if ev.Button != tea.MouseButtonLeft || ev.Action != tea.MouseActionPress {
+		return m, cmd
+	}
+
+	// Compute layout Y positions for hit-testing.
+	nActive := len(m.active)
+	activeH := activeHeight(nActive)
+
+	// histTopY: Y where the history pane border starts.
+	// Active pane occupies Y=1..activeH (inclusive). Detail panel may follow.
+	histTopY := 1 + activeH
+	if m.detailPanel {
+		if detail := m.viewDetail(); detail != "" {
+			histTopY += strings.Count(detail, "\n") + 1
+		}
+	}
+
+	clickY := ev.Y
+
+	// Detect double-click: same cell within 300ms.
+	isDoubleClick := time.Since(m.lastClickAt) < 300*time.Millisecond &&
+		ev.X == m.lastClickX && ev.Y == m.lastClickY
+	m.lastClickAt = time.Now()
+	m.lastClickX = ev.X
+	m.lastClickY = ev.Y
+
+	switch {
+	case clickY >= 1 && clickY <= activeH:
+		// Click anywhere in the active pane (borders, title, or content rows).
+		m.focusPane = paneActive
+
+		// Content rows start at Y=3 (border-top at Y=1, title at Y=2).
+		// Border-bottom is at Y=activeH; don't treat it as a row selection.
+		if clickY >= 3 && clickY < activeH {
+			keys := m.sortedActiveKeys()
+			nKeys := len(keys)
+			maxLines := activeH - 3
+			start := 0
+			if nKeys > maxLines && maxLines > 0 {
+				start = m.activeIdx - maxLines/2
+				if start < 0 {
+					start = 0
+				}
+				if start+maxLines > nKeys {
+					start = max(nKeys-maxLines, 0)
+				}
+			}
+			visibleRow := clickY - 3
+			actualIdx := start + visibleRow
+			if actualIdx >= 0 && actualIdx < nKeys {
+				m.activeIdx = actualIdx
+				if isDoubleClick {
+					if job, ok := m.active[keys[actualIdx]]; ok {
+						return m, openWatchInlineCmd(job.IssueNumber, job.Repo)
+					}
+				}
+			}
+		}
+
+	case clickY >= histTopY && clickY <= histTopY+1:
+		// Click on history pane border-top or title row → switch focus.
+		m.focusPane = paneHistory
+		m.updateHistoryViewport(false)
+
+	case clickY >= histTopY+2:
+		// Click on history viewport content.
+		visibleRow := clickY - (histTopY + 2)
+		newHistIdx := visibleRow + m.historyVP.YOffset
+		if newHistIdx >= 0 && newHistIdx < len(m.history) {
+			m.focusPane = paneHistory
+			m.histIdx = newHistIdx
+			m.updateHistoryViewport(false)
+			if isDoubleClick {
+				realIdx := len(m.history) - 1 - m.histIdx
+				if realIdx >= 0 && realIdx < len(m.history) {
+					h := m.history[realIdx]
+					return m, openWatchInlineCmd(h.IssueNumber, h.Repo)
+				}
+			}
+		}
+	}
+
+	return m, cmd
 }
 
 // updateHistoryViewport rebuilds the viewport content from the history slice.

--- a/tui/model.go
+++ b/tui/model.go
@@ -500,6 +500,7 @@ func (m Model) handleMouse(ev tea.MouseMsg) (tea.Model, tea.Cmd) {
 			nKeys := len(keys)
 			maxLines := activeH - 3
 			start := 0
+			hasEllipsis := false
 			if nKeys > maxLines && maxLines > 0 {
 				start = m.activeIdx - maxLines/2
 				if start < 0 {
@@ -508,8 +509,18 @@ func (m Model) handleMouse(ev tea.MouseMsg) (tea.Model, tea.Cmd) {
 				if start+maxLines > nKeys {
 					start = max(nKeys-maxLines, 0)
 				}
+				// Mirror viewActive(): when ellipsis is shown, the last content
+				// row is the ellipsis indicator and must not be treated as a job.
+				if start > 0 || start+maxLines < nKeys {
+					maxLines--
+					hasEllipsis = true
+				}
 			}
 			visibleRow := clickY - 3
+			if hasEllipsis && visibleRow == maxLines {
+				// Clicked the "… N more" ellipsis row; focus the pane but don't select a job.
+				break
+			}
 			actualIdx := start + visibleRow
 			if actualIdx >= 0 && actualIdx < nKeys {
 				m.activeIdx = actualIdx

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -1125,3 +1125,231 @@ func TestViewHistory_ConfirmQuit(t *testing.T) {
 		t.Errorf("expected job count in viewHistory confirmation, got: %q", view)
 	}
 }
+
+// --- Mouse tests ---
+
+// mouseLeftPress returns a tea.MouseMsg for a left button press at (x, y).
+func mouseLeftPress(x, y int) tea.MouseMsg {
+	return tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, X: x, Y: y}
+}
+
+// TestHandleMouse_ClickActivePaneTitle verifies a click on the active pane title
+// area (Y=2) switches focus to the active pane.
+func TestHandleMouse_ClickActivePaneTitle(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.focusPane = paneHistory // start on history
+
+	next, cmd := m.Update(mouseLeftPress(10, 2))
+	nm := next.(Model)
+	if nm.focusPane != paneActive {
+		t.Errorf("focusPane = %v, want paneActive after clicking title row Y=2", nm.focusPane)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from clicking active pane title")
+	}
+}
+
+// TestHandleMouse_ClickActivePaneBorderTop verifies a click on Y=1 (active pane
+// border top) also switches focus to the active pane.
+func TestHandleMouse_ClickActivePaneBorderTop(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.focusPane = paneHistory
+
+	next, _ := m.Update(mouseLeftPress(5, 1))
+	nm := next.(Model)
+	if nm.focusPane != paneActive {
+		t.Errorf("focusPane = %v, want paneActive after clicking Y=1", nm.focusPane)
+	}
+}
+
+// TestHandleMouse_ClickActiveRow_SelectsRow verifies clicking on a row in the
+// active pane content area selects that row and switches focus.
+func TestHandleMouse_ClickActiveRow_SelectsRow(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.focusPane = paneHistory
+	// Add two active jobs so row clicks are meaningful.
+	m.active[activeJobKey("", 1)] = &activeJob{IssueNumber: 1, StageName: "Research", StartedAt: time.Now()}
+	m.active[activeJobKey("", 2)] = &activeJob{IssueNumber: 2, StageName: "Plan", StartedAt: time.Now()}
+
+	// With 2 active jobs, activeHeight(2)=5. Row 0 is at Y=3, row 1 is at Y=4.
+	// Click Y=3 → select row 0.
+	next, cmd := m.Update(mouseLeftPress(5, 3))
+	nm := next.(Model)
+	if nm.focusPane != paneActive {
+		t.Errorf("focusPane = %v, want paneActive", nm.focusPane)
+	}
+	if nm.activeIdx != 0 {
+		t.Errorf("activeIdx = %d, want 0 after clicking row Y=3", nm.activeIdx)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd (single click, not double-click)")
+	}
+
+	// Click Y=4 → select row 1.
+	next2, _ := m.Update(mouseLeftPress(5, 4))
+	nm2 := next2.(Model)
+	if nm2.activeIdx != 1 {
+		t.Errorf("activeIdx = %d, want 1 after clicking row Y=4", nm2.activeIdx)
+	}
+}
+
+// TestHandleMouse_DoubleClickActiveRow_OpensWatch verifies that a double-click on
+// an active pane row returns a non-nil cmd (tea.ExecProcess for fabrik watch).
+func TestHandleMouse_DoubleClickActiveRow_OpensWatch(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.active[activeJobKey("", 7)] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
+
+	// First click: single click, no cmd.
+	next, cmd := m.Update(mouseLeftPress(5, 3))
+	if cmd != nil {
+		t.Error("first click should not open watch")
+	}
+	nm := next.(Model)
+
+	// Second click at the same position within 300ms: double-click.
+	nm.lastClickAt = time.Now() // ensure it's within the threshold
+	next2, cmd2 := nm.Update(mouseLeftPress(5, 3))
+	_ = next2
+	if cmd2 == nil {
+		t.Error("expected non-nil cmd (tea.ExecProcess) from double-click on active row")
+	}
+}
+
+// TestHandleMouse_ClickHistoryTitle_SwitchesFocus verifies clicking the history
+// pane title row switches focus to the history pane.
+func TestHandleMouse_ClickHistoryTitle_SwitchesFocus(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.focusPane = paneActive
+
+	// With no active jobs, activeHeight(0)=4. Active pane: Y=1..4.
+	// histTopY = 1 + 4 = 5. histTitle at Y=6.
+	histTopY := 1 + activeHeight(0)
+	histTitleY := histTopY + 1
+
+	next, _ := m.Update(mouseLeftPress(5, histTitleY))
+	nm := next.(Model)
+	if nm.focusPane != paneHistory {
+		t.Errorf("focusPane = %v, want paneHistory after clicking history title Y=%d", nm.focusPane, histTitleY)
+	}
+}
+
+// TestHandleMouse_ClickHistoryRow_SelectsEntry verifies clicking on a history
+// viewport row selects that entry.
+func TestHandleMouse_ClickHistoryRow_SelectsEntry(t *testing.T) {
+	redirectHistory(t)
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.focusPane = paneActive
+	m.history = []HistoryEntry{
+		{IssueNumber: 1, StageName: "Research", Success: true},
+		{IssueNumber: 2, StageName: "Plan", Success: true},
+		{IssueNumber: 3, StageName: "Implement", Success: true},
+	}
+	m.updateHistoryViewport(false)
+
+	// histTopY = 1 + activeHeight(0) = 5. Viewport content starts at Y=7.
+	histTopY := 1 + activeHeight(0)
+	histContentStart := histTopY + 2
+
+	// Click the first viewport row → histIdx=0.
+	next, cmd := m.Update(mouseLeftPress(10, histContentStart))
+	nm := next.(Model)
+	if nm.focusPane != paneHistory {
+		t.Errorf("focusPane = %v, want paneHistory", nm.focusPane)
+	}
+	if nm.histIdx != 0 {
+		t.Errorf("histIdx = %d, want 0 after clicking first history row", nm.histIdx)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd from single history row click")
+	}
+
+	// Click the second viewport row → histIdx=1.
+	next2, _ := m.Update(mouseLeftPress(10, histContentStart+1))
+	nm2 := next2.(Model)
+	if nm2.histIdx != 1 {
+		t.Errorf("histIdx = %d, want 1 after clicking second history row", nm2.histIdx)
+	}
+}
+
+// TestHandleMouse_DoubleClickHistoryRow_OpensWatch verifies that a double-click on
+// a history row returns a non-nil cmd.
+func TestHandleMouse_DoubleClickHistoryRow_OpensWatch(t *testing.T) {
+	redirectHistory(t)
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.history = []HistoryEntry{
+		{IssueNumber: 42, StageName: "Research", Success: true},
+	}
+	m.updateHistoryViewport(false)
+
+	histTopY := 1 + activeHeight(0)
+	histContentStart := histTopY + 2
+
+	// First click at history row.
+	next, cmd := m.Update(mouseLeftPress(10, histContentStart))
+	if cmd != nil {
+		t.Error("first click should not open watch")
+	}
+	nm := next.(Model)
+
+	// Second click immediately (simulate double-click).
+	nm.lastClickAt = time.Now()
+	next2, cmd2 := nm.Update(mouseLeftPress(10, histContentStart))
+	_ = next2
+	if cmd2 == nil {
+		t.Error("expected non-nil cmd from double-click on history row")
+	}
+}
+
+// TestHandleMouse_NonLeftClick_NoStateChange verifies that non-left-click mouse
+// events (e.g. right click, motion) do not change selection state.
+func TestHandleMouse_NonLeftClick_NoStateChange(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	m.focusPane = paneActive
+
+	// Right button press: should not change focus or selection.
+	rightClick := tea.MouseMsg{Button: tea.MouseButtonRight, Action: tea.MouseActionPress, X: 5, Y: 3}
+	next, _ := m.Update(rightClick)
+	nm := next.(Model)
+	if nm.focusPane != paneActive {
+		t.Error("right-click should not change focus pane")
+	}
+
+	// Release event: no state change.
+	release := tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionRelease, X: 5, Y: 2}
+	next2, _ := m.Update(release)
+	nm2 := next2.(Model)
+	if nm2.focusPane != paneActive {
+		t.Error("mouse release should not change focus pane")
+	}
+}
+
+// TestHandleMouse_ClickOutOfBounds_NoStateChange verifies clicks outside the
+// known pane regions do not crash or change state unexpectedly.
+func TestHandleMouse_ClickOutOfBounds_NoStateChange(t *testing.T) {
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+
+	// Click at Y=0 (header) should not crash or change focus.
+	next, _ := m.Update(mouseLeftPress(5, 0))
+	nm := next.(Model)
+	if nm.focusPane != paneActive {
+		t.Error("click on header should not change focus pane from initial paneActive")
+	}
+}

--- a/watch/model.go
+++ b/watch/model.go
@@ -352,11 +352,63 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case StatusMsgMsg:
 		m.statusMsg = ev.Text
 		return m, nil
+
+	case tea.MouseMsg:
+		// Left click on the tab bar → switch tab.
+		if ev.Button == tea.MouseButtonLeft && ev.Action == tea.MouseActionPress && len(m.stageTabs) > 0 {
+			// Tab bar Y: header(Y=0) + labels?(Y=1) + prLine + tabBar
+			tabBarY := 2 // no labels: header(0) + prLine(1) + tabBar(2)
+			if len(m.github.labels) > 0 {
+				tabBarY = 3 // header(0) + labels(1) + prLine(2) + tabBar(3)
+			}
+			if ev.Y == tabBarY {
+				if idx := m.tabClickIdx(ev.X); idx >= 0 {
+					m.selectedTabIdx = idx
+					m.switchToTab(idx)
+					return m, nil
+				}
+			}
+		}
+		// All other mouse events (wheel, etc.) pass to the viewport.
+		var cmd tea.Cmd
+		m.vp, cmd = m.vp.Update(ev)
+		return m, cmd
 	}
 
 	var cmd tea.Cmd
 	m.vp, cmd = m.vp.Update(msg)
 	return m, cmd
+}
+
+// tabClickIdx returns the index of the tab whose rendered X range contains clickX,
+// or -1 if no tab was hit. The tab rendering must match tabBar() exactly.
+func (m WatchModel) tabClickIdx(clickX int) int {
+	x := 0
+	for i, t := range m.stageTabs {
+		label := t.Label
+		if t.IsLive {
+			label = "● " + label
+		}
+		tab := fmt.Sprintf("[ %s ]", label)
+		isSelected := i == m.selectedTabIdx
+		var style lipgloss.Style
+		switch {
+		case t.IsLive && isSelected:
+			style = activeSectionStyle
+		case t.IsLive:
+			style = activeStyle
+		case isSelected:
+			style = sectionStyle
+		default:
+			style = dimStyle
+		}
+		w := lipgloss.Width(style.Render(tab))
+		if clickX >= x && clickX < x+w {
+			return i
+		}
+		x += w + 1 // 1 for the space separator between tabs
+	}
+	return -1
 }
 
 // fetchGitHub refreshes GitHub state synchronously. For a TUI this runs on the

--- a/watch/model.go
+++ b/watch/model.go
@@ -213,7 +213,7 @@ func (m WatchModel) Init() tea.Cmd {
 // Run runs the bubbletea program with the WatchModel.
 // It injects p.Send into the log follower goroutines before starting.
 func Run(m WatchModel) error {
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	// Start background goroutines that send messages via p.Send.
 	StartLogFollower(m.logDir, func(msg tea.Msg) { p.Send(msg) }, m.done)

--- a/watch/mouse_test.go
+++ b/watch/mouse_test.go
@@ -1,0 +1,229 @@
+package watch
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestTabClickIdx_NoTabs verifies -1 is returned when there are no tabs.
+func TestTabClickIdx_NoTabs(t *testing.T) {
+	m := WatchModel{}
+	if got := m.tabClickIdx(0); got != -1 {
+		t.Errorf("tabClickIdx with no tabs = %d, want -1", got)
+	}
+}
+
+// TestTabClickIdx_SingleTab verifies clicking within the tab's X range returns 0.
+func TestTabClickIdx_SingleTab(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{{Label: "Research", IsLive: false}},
+	}
+	// Tab renders as "[ Research ]" styled with dimStyle. Width should be > 0.
+	// Click at X=0 (start of tab) should hit the tab.
+	if got := m.tabClickIdx(0); got != 0 {
+		t.Errorf("tabClickIdx(0) with single tab = %d, want 0", got)
+	}
+}
+
+// TestTabClickIdx_BeyondAllTabs verifies -1 is returned when clicking past the
+// last tab's X boundary.
+func TestTabClickIdx_BeyondAllTabs(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{{Label: "Research", IsLive: false}},
+	}
+	// Click far to the right: should return -1.
+	if got := m.tabClickIdx(10000); got != -1 {
+		t.Errorf("tabClickIdx(10000) = %d, want -1", got)
+	}
+}
+
+// TestTabClickIdx_SecondTab verifies clicking in the second tab's X range returns 1.
+func TestTabClickIdx_SecondTab(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{
+			{Label: "Research", IsLive: false},
+			{Label: "Plan", IsLive: false},
+		},
+	}
+	// First tab: "[ Research ]" → measure its width, then skip the separator.
+	// We use a large X to ensure we're past the first tab.
+	// Find where the second tab starts by measuring the first.
+	firstRendered := dimStyle.Render("[ Research ]")
+	firstW := len([]rune(firstRendered)) // rough width — lipgloss.Width more accurate but this is a test
+	// Use tabClickIdx to probe: click 1 past first tab + 1 separator.
+	// Instead, rely on tabClickIdx for the actual width computation.
+	//
+	// A simpler approach: click somewhere and verify we get the right tab or -1.
+	// We know first tab starts at X=0. Test that X=0 gives tab 0.
+	if got := m.tabClickIdx(0); got != 0 {
+		t.Errorf("tabClickIdx(0) = %d, want 0 (first tab)", got)
+	}
+	_ = firstRendered
+	_ = firstW
+
+	// Find boundary: walk X until we get 1 (second tab).
+	found := -1
+	for x := 0; x < 80; x++ {
+		if m.tabClickIdx(x) == 1 {
+			found = x
+			break
+		}
+	}
+	if found == -1 {
+		t.Error("could not find X that hits the second tab")
+	}
+}
+
+// TestTabClickIdx_LiveTab verifies live tab (with ● prefix) is clickable.
+func TestTabClickIdx_LiveTab(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{
+			{Label: "Implement", IsLive: true},
+		},
+		selectedTabIdx: 0,
+	}
+	// Live tab renders as "[ ● Implement ]". Should still be clickable at X=0.
+	if got := m.tabClickIdx(0); got != 0 {
+		t.Errorf("tabClickIdx(0) with live tab = %d, want 0", got)
+	}
+}
+
+// TestUpdate_MouseMsg_TabClick verifies a left click at the tab bar Y switches
+// the selected tab.
+func TestUpdate_MouseMsg_TabClick(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{
+			{Label: "Research", IsLive: false},
+			{Label: "Plan", IsLive: false},
+		},
+		selectedTabIdx: 0,
+	}
+	m.width = 80
+	m.height = 24
+
+	// With no labels: tabBarY = 2.
+	tabBarY := 2
+
+	// Find X that hits the second tab.
+	secondTabX := -1
+	for x := 0; x < 80; x++ {
+		if m.tabClickIdx(x) == 1 {
+			secondTabX = x
+			break
+		}
+	}
+	if secondTabX == -1 {
+		t.Fatal("could not find X position for second tab")
+	}
+
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      secondTabX,
+		Y:      tabBarY,
+	}
+	next, _ := m.Update(click)
+	nm := next.(WatchModel)
+	if nm.selectedTabIdx != 1 {
+		t.Errorf("selectedTabIdx = %d, want 1 after clicking second tab", nm.selectedTabIdx)
+	}
+}
+
+// TestUpdate_MouseMsg_TabClick_WithLabels verifies the tab bar Y offset is
+// correctly computed when labels are present (tabBarY = 3 instead of 2).
+func TestUpdate_MouseMsg_TabClick_WithLabels(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{
+			{Label: "Research", IsLive: false},
+			{Label: "Plan", IsLive: false},
+		},
+		selectedTabIdx: 0,
+	}
+	m.width = 80
+	m.height = 24
+	m.github.labels = []string{"stage:Research:complete"}
+
+	// With labels: tabBarY = 3.
+	tabBarY := 3
+
+	// Find X that hits the second tab.
+	secondTabX := -1
+	for x := 0; x < 80; x++ {
+		if m.tabClickIdx(x) == 1 {
+			secondTabX = x
+			break
+		}
+	}
+	if secondTabX == -1 {
+		t.Fatal("could not find X position for second tab")
+	}
+
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      secondTabX,
+		Y:      tabBarY,
+	}
+	next, _ := m.Update(click)
+	nm := next.(WatchModel)
+	if nm.selectedTabIdx != 1 {
+		t.Errorf("selectedTabIdx = %d, want 1 after clicking second tab with labels", nm.selectedTabIdx)
+	}
+}
+
+// TestUpdate_MouseMsg_WrongY_NoTabSwitch verifies that a left click at the wrong
+// Y coordinate does not switch the selected tab.
+func TestUpdate_MouseMsg_WrongY_NoTabSwitch(t *testing.T) {
+	m := WatchModel{
+		stageTabs: []stageTab{
+			{Label: "Research", IsLive: false},
+			{Label: "Plan", IsLive: false},
+		},
+		selectedTabIdx: 0,
+	}
+	m.width = 80
+	m.height = 24
+
+	// Find X that hits the second tab.
+	secondTabX := -1
+	for x := 0; x < 80; x++ {
+		if m.tabClickIdx(x) == 1 {
+			secondTabX = x
+			break
+		}
+	}
+	if secondTabX == -1 {
+		t.Fatal("could not find X position for second tab")
+	}
+
+	// Click at Y=5 (not the tab bar).
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      secondTabX,
+		Y:      5,
+	}
+	next, _ := m.Update(click)
+	nm := next.(WatchModel)
+	if nm.selectedTabIdx != 0 {
+		t.Errorf("selectedTabIdx = %d, want 0 (unchanged) after clicking wrong Y", nm.selectedTabIdx)
+	}
+}
+
+// TestUpdate_MouseMsg_NoTabs_NoOp verifies that a left click when there are no
+// tabs does not panic and returns without changing state.
+func TestUpdate_MouseMsg_NoTabs_NoOp(t *testing.T) {
+	m := WatchModel{}
+	m.width = 80
+	m.height = 24
+
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      5,
+		Y:      2,
+	}
+	next, _ := m.Update(click)
+	_ = next.(WatchModel) // should not panic
+}


### PR DESCRIPTION
## Summary

- Enable `tea.WithMouseCellMotion()` in both TUI programs (main dashboard and `fabrik watch`)
- Handle `tea.MouseMsg` in `tui.Model.Update()` for click-to-select rows, pane title focus switching, and double-click-to-watch
- Handle `tea.MouseMsg` in `watch.WatchModel.Update()` for click-to-switch-tab; mouse wheel scrolling works automatically via the existing viewport fall-through

## Key Changes

**`cmd/root.go`**: Add `tea.WithMouseCellMotion()` to the main TUI `tea.NewProgram` call.

**`watch/model.go`**:
- Add `tea.WithMouseCellMotion()` to `Run()`
- `case tea.MouseMsg` in `Update()`: intercepts left clicks on the tab bar (hit-tests X position via `tabClickIdx()`); all other mouse events pass through to `m.vp.Update()` for viewport wheel scrolling
- `tabClickIdx()`: walks tab rendered widths using `lipgloss.Width()` to find which tab was clicked

**`tui/model.go`**:
- Add `lastClickAt/X/Y` fields for double-click detection (300ms threshold, same cell)
- `case tea.MouseMsg` dispatches to `handleMouse()`
- `handleMouse()`: forwards all mouse events to `historyVP` (wheel scroll), then hit-tests left clicks:
  - Y=1..activeH → active pane focus; Y=3..activeH-1 → select row; double-click → `openWatchInlineCmd()`
  - Y=histTopY..histTopY+1 → history pane focus; Y=histTopY+2+ → select history row; double-click → `openWatchInlineCmd()`
  - `histTopY` is computed at click time from `activeHeight(len(m.active))` plus optional detail panel height

## How to Test

1. Run `fabrik` in a project directory — the main dashboard now responds to mouse clicks
2. Click a row in **In Progress** to select it; keyboard navigation continues from the new selection
3. Click the **History** pane title to focus it; click a history row to select it
4. Double-click any row (same position, <300ms) to open `fabrik watch` inline for that issue
5. Scroll the history viewport with the mouse wheel
6. Run `fabrik watch <N>` — click stage tabs to switch between log views; scroll with mouse wheel

Closes #197