### PR TITLE
fabrik watch picks wrong 'live' log file due to lexicographic filename sort

### DIFF
--- a/watch/logfollow.go
+++ b/watch/logfollow.go
@@ -45,6 +45,23 @@ func isAllDigits(s string) bool {
 	return true
 }
 
+// logTimestampSuffix returns the timestamp portion of a log filename:
+// <yyyyMMdd>-<HHmmss>-<nanos>.log — everything from the first 8-digit
+// all-numeric segment onward. Because timestamps are zero-padded with fixed
+// widths, lexicographic comparison of this suffix gives correct chronological
+// ordering regardless of the stage label prefix. Falls back to name unchanged
+// if no 8-digit segment is found (e.g. malformed filenames).
+func logTimestampSuffix(name string) string {
+	base := strings.TrimSuffix(name, ".log")
+	parts := strings.Split(base, "-")
+	for i, p := range parts {
+		if len(p) == 8 && isAllDigits(p) {
+			return strings.Join(parts[i:], "-") + ".log"
+		}
+	}
+	return name
+}
+
 // buildStageTabs scans logDir, groups .log files by stage label, picks the
 // newest log per label, and sorts by pipeline order (stageOrder map). Logs
 // whose label matches "<ParentStage>-comment-review" are grouped under the
@@ -96,12 +113,12 @@ func buildStageTabs(logDir string, stageOrder map[string]int) []stageTab {
 		parent := strings.TrimSuffix(label, "-comment-review")
 		if _, known := stageOrder[parent]; known {
 			// Merge under parent: keep whichever filename is newer.
-			if filename > effectiveNewest[parent] {
+			if logTimestampSuffix(filename) > logTimestampSuffix(effectiveNewest[parent]) {
 				effectiveNewest[parent] = filename
 			}
 		} else {
 			// Unknown parent — keep as its own tab.
-			if existing, ok := effectiveNewest[label]; !ok || filename > existing {
+			if existing, ok := effectiveNewest[label]; !ok || logTimestampSuffix(filename) > logTimestampSuffix(existing) {
 				effectiveNewest[label] = filename
 			}
 		}
@@ -138,9 +155,15 @@ func buildStageTabs(logDir string, stageOrder map[string]int) []stageTab {
 	tabs := append(knownTabs, unknownTabs...)
 
 	// Find the globally newest log file across all tabs and mark it as IsLive.
+	// Compare by timestamp suffix only (not full filename) so that a stage label
+	// like "Specify" (alphabetically > "Research") cannot beat a chronologically
+	// newer "Research" log.
 	newestFile := ""
+	newestSuffix := ""
 	for _, t := range tabs {
-		if base := filepath.Base(t.LogPath); base > newestFile {
+		base := filepath.Base(t.LogPath)
+		if suffix := logTimestampSuffix(base); suffix > newestSuffix {
+			newestSuffix = suffix
 			newestFile = base
 		}
 	}
@@ -203,10 +226,12 @@ func newestLogFile(logDir string) string {
 	if len(logs) == 0 {
 		return ""
 	}
-	// Sort by name (which is <label>-<timestamp>-<nanos>.log); lexicographic
-	// order gives us chronological order since timestamps are zero-padded.
+	// Sort by timestamp suffix only (not full filename) so that a stage label
+	// prefix cannot distort chronological ordering. Within a single label the
+	// sort is still correct, and across labels the timestamp alone determines
+	// which file is newest.
 	sort.Slice(logs, func(i, j int) bool {
-		return logs[i].Name() < logs[j].Name()
+		return logTimestampSuffix(logs[i].Name()) < logTimestampSuffix(logs[j].Name())
 	})
 	return filepath.Join(logDir, logs[len(logs)-1].Name())
 }

--- a/watch/logfollow_test.go
+++ b/watch/logfollow_test.go
@@ -134,3 +134,57 @@ func TestBuildStageTabs_EmptyDir(t *testing.T) {
 		t.Errorf("want 0 tabs for empty dir, got %d", len(tabs))
 	}
 }
+
+// TestBuildStageTabs_IsLive_ByTimestampNotLabel is a regression test for the
+// bug where an alphabetically-later stage label (e.g. "Specify" > "Research")
+// would be wrongly selected as IsLive even when its log has an older timestamp.
+// After the fix, the Research tab (newer timestamp) must be IsLive.
+func TestBuildStageTabs_IsLive_ByTimestampNotLabel(t *testing.T) {
+	dir := t.TempDir()
+	// Specify log is older (09:41); Research log is newer (17:04).
+	// "Specify-..." > "Research-..." lexicographically ('S' > 'R'),
+	// so without the fix Specify would wrongly win.
+	writeLog(t, dir, "Specify-20260407-094159-000000000.log")
+	writeLog(t, dir, "Research-20260407-170451-000000000.log")
+
+	stageOrder := map[string]int{
+		"Research": 1,
+		"Specify":  2,
+	}
+	tabs := buildStageTabs(dir, stageOrder)
+
+	if len(tabs) != 2 {
+		t.Fatalf("want 2 tabs, got %d", len(tabs))
+	}
+	// Pipeline order: Research(1) first, Specify(2) second.
+	if tabs[0].Label != "Research" {
+		t.Errorf("tab[0] want Research, got %s", tabs[0].Label)
+	}
+	if tabs[1].Label != "Specify" {
+		t.Errorf("tab[1] want Specify, got %s", tabs[1].Label)
+	}
+	// Research has the newer timestamp — it must be IsLive.
+	if !tabs[0].IsLive {
+		t.Error("Research tab should be IsLive (newer timestamp), not Specify")
+	}
+	if tabs[1].IsLive {
+		t.Error("Specify tab should not be IsLive (older timestamp)")
+	}
+}
+
+// TestNewestLogFile_ByTimestampNotLabel is a regression test for the bug where
+// newestLogFile would return the alphabetically-last filename regardless of
+// timestamp, so "Specify-..." would beat "Research-..." even when Research is newer.
+// After the fix, newestLogFile must return the Research log (newer timestamp).
+func TestNewestLogFile_ByTimestampNotLabel(t *testing.T) {
+	dir := t.TempDir()
+	// Specify log is older (09:00); Research log is newer (10:00).
+	writeLog(t, dir, "Specify-20260101-090000-000000000.log")
+	writeLog(t, dir, "Research-20260101-100000-000000000.log")
+
+	got := newestLogFile(dir)
+	want := filepath.Join(dir, "Research-20260101-100000-000000000.log")
+	if got != want {
+		t.Errorf("newestLogFile: want %s, got %s", filepath.Base(want), filepath.Base(got))
+	}
+}


### PR DESCRIPTION
Closes #225