### PR TITLE
Write poll log to disk in TUI mode for forensics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .fabrik/worktrees/
 .fabrik/repos/
 .fabrik/fabrik.lock
+.fabrik/fabrik.log
 .fabrik/debug/
 .fabrik/history.json
 */.fabrik/history.json

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -70,6 +70,8 @@ type Engine struct {
 	inFlight           sync.Map              // key: issueKey string, value: bool (isPR)
 	cloneInFlight      sync.Map              // key: "owner/repo" string, value: *cloneCall; per-repo bare-clone coordination
 	events             chan tui.Event        // nil in tests / plain-text mode; TUI goroutine consumes
+	logFile            *os.File             // persistent log file at .fabrik/fabrik.log; nil if not opened
+	logMu              sync.Mutex           // serializes concurrent writes to logFile
 }
 
 func New(cfg Config) (*Engine, error) {
@@ -256,15 +258,26 @@ func (e *Engine) logf(issueNumber int, tag, format string, args ...any) {
 		case e.events <- tui.LogEvent{IssueNumber: issueNumber, Tag: tag, Message: msg}:
 		default:
 		}
-		return
-	}
-	// Plain-text mode: clear any transient status line before printing.
-	pollStatusClear()
-	if issueNumber == 0 {
-		fmt.Printf("[%s] %s", tag, msg)
 	} else {
-		fmt.Printf("[#%d %s] %s", issueNumber, tag, msg)
+		// Plain-text mode: clear any transient status line before printing.
+		pollStatusClear()
+		if issueNumber == 0 {
+			fmt.Printf("[%s] %s", tag, msg)
+		} else {
+			fmt.Printf("[#%d %s] %s", issueNumber, tag, msg)
+		}
 	}
+	// Write to persistent log file in both TUI and plain-text modes.
+	e.logMu.Lock()
+	if e.logFile != nil {
+		ts := time.Now().UTC().Format(time.RFC3339)
+		if issueNumber == 0 {
+			fmt.Fprintf(e.logFile, "%s [%s] %s", ts, tag, msg)
+		} else {
+			fmt.Fprintf(e.logFile, "%s [#%d %s] %s", ts, issueNumber, tag, msg)
+		}
+	}
+	e.logMu.Unlock()
 }
 
 func mapKeys(m map[string]string) []string {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -41,17 +41,26 @@ var isTTY = func() bool {
 // event channel.
 var tuiMode bool
 
+// pollLogFile is the persistent log file handle, set in Engine.Run() and used
+// by pollStatus to write timestamped lines. Nil when no log file is open (tests).
+var pollLogFile *os.File
+
 // lastStatusLen tracks the length of the last overwritten status line so we
 // can clear any leftover characters when the next line is shorter.
 var lastStatusLen int
 
 // pollStatus prints a transient status line that overwrites itself on a TTY.
 // On non-TTY output it prints a normal line. No-op in TUI mode.
+// Always writes a timestamped line to the persistent log file when one is open.
 func pollStatus(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if pollLogFile != nil {
+		ts := time.Now().UTC().Format(time.RFC3339)
+		fmt.Fprintf(pollLogFile, "%s [poll] %s\n", ts, msg)
+	}
 	if tuiMode {
 		return
 	}
-	msg := fmt.Sprintf(format, args...)
 	if isTTY {
 		// Pad with spaces to clear any leftover characters from the previous line.
 		pad := ""
@@ -96,6 +105,21 @@ func (e *Engine) Run() error {
 	lockFile.Truncate(0)
 	lockFile.Seek(0, 0)
 	fmt.Fprintf(lockFile, "%d\n", os.Getpid())
+
+	// Open the persistent poll log file. Truncated on each startup so the file
+	// always reflects the current run only. Non-fatal if the open fails.
+	logPath := filepath.Join(e.fabrikDir, ".fabrik", "fabrik.log")
+	if lf, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600); err != nil {
+		fmt.Printf("warning: could not open log file %s: %v\n", logPath, err)
+	} else {
+		e.logFile = lf
+		pollLogFile = lf
+		defer func() {
+			e.logFile = nil
+			pollLogFile = nil
+			lf.Close()
+		}()
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/engine/poll_status_test.go
+++ b/engine/poll_status_test.go
@@ -8,11 +8,14 @@ import (
 func TestPollStatus_NonTTY(t *testing.T) {
 	orig := isTTY
 	origTUI := tuiMode
+	origLog := pollLogFile
 	isTTY = false
 	tuiMode = false
+	pollLogFile = nil
 	defer func() {
 		isTTY = orig
 		tuiMode = origTUI
+		pollLogFile = origLog
 	}()
 	// Should not panic
 	pollStatus("polling %s", "test")
@@ -23,11 +26,14 @@ func TestPollStatus_NonTTY(t *testing.T) {
 func TestPollStatus_TTY(t *testing.T) {
 	origTTY := isTTY
 	origTUI := tuiMode
+	origLog := pollLogFile
 	isTTY = true
 	tuiMode = false
+	pollLogFile = nil
 	defer func() {
 		isTTY = origTTY
 		tuiMode = origTUI
+		pollLogFile = origLog
 		lastStatusLen = 0
 	}()
 	// Should not panic; output goes to stdout with \r prefix
@@ -40,8 +46,13 @@ func TestPollStatus_TTY(t *testing.T) {
 // TestPollStatus_TuiMode_IsNoop verifies that pollStatus is a no-op in TUI mode.
 func TestPollStatus_TuiMode_IsNoop(t *testing.T) {
 	orig := tuiMode
+	origLog := pollLogFile
 	tuiMode = true
-	defer func() { tuiMode = orig }()
+	pollLogFile = nil
+	defer func() {
+		tuiMode = orig
+		pollLogFile = origLog
+	}()
 	// Should not panic or output anything
 	pollStatus("this should not appear")
 	pollStatusClear()


### PR DESCRIPTION
## Summary

- Adds `.fabrik/fabrik.log`, a persistent log file written on every Fabrik run (truncated on startup)
- Every `e.logf()` call writes a timestamped RFC3339 line to the file in addition to the TUI event channel or stdout
- Every `pollStatus()` call writes a `[poll]`-tagged line to the file, even in TUI mode where these are otherwise ephemeral

## Key Changes

- `engine/engine.go`: Added `logFile *os.File` and `logMu sync.Mutex` to `Engine` struct; updated `logf` to write to the log file (nil-guarded, mutex-protected for concurrent workers)
- `engine/poll.go`: Added `var pollLogFile *os.File`; opens `.fabrik/fabrik.log` in `Run()` immediately after the lock file is acquired (non-fatal if open fails); updated `pollStatus` to write timestamped lines before the TUI/TTY branches
- `engine/poll_status_test.go`: Save/restore `pollLogFile` in all three tests (set nil to disable file writes in tests)

## How to Test

1. Run `fabrik` normally — check that `.fabrik/fabrik.log` appears and grows with timestamped lines
2. Stop and restart — verify the file is truncated (only current-run lines present)
3. Run with `--notui` — same file should appear with both `logf` and `pollStatus` output
4. Verify that if `.fabrik/` is not writable, Fabrik starts with a warning instead of failing

Closes #307