### PR TITLE
TUI footer: show project board title with OSC 8 hyperlink

### DIFF
--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -357,9 +357,6 @@ func TestBuildProjectInfo_HomeRelative(t *testing.T) {
 	cfg := &Config{Owner: "acme", Repo: "myrepo"}
 	info := buildProjectInfo(cfg, config.ProjectConfig{})
 
-	if info.Repo != "acme/myrepo" {
-		t.Errorf("Repo = %q, want %q", info.Repo, "acme/myrepo")
-	}
 	// CWD should not be empty
 	if info.CWD == "" {
 		t.Error("CWD should not be empty")
@@ -405,9 +402,6 @@ func TestBuildProjectInfo_RepoFormat(t *testing.T) {
 	chdirTest(t, dir)
 	cfg := &Config{Owner: "org", Repo: "repo"}
 	info := buildProjectInfo(cfg, config.ProjectConfig{Version: "v1.2.3"})
-	if info.Repo != "org/repo" {
-		t.Errorf("Repo = %q, want org/repo", info.Repo)
-	}
 	if info.Version != "v1.2.3" {
 		t.Errorf("Version = %q, want v1.2.3", info.Version)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -380,7 +380,6 @@ func buildProjectInfo(cfg *Config, pc config.ProjectConfig) tui.ProjectInfo {
 
 	return tui.ProjectInfo{
 		CWD:           cwdDisplay,
-		Repo:          cfg.Owner + "/" + cfg.Repo,
 		Version:       version,
 		FabrikVersion: Version,
 	}

--- a/engine/startup.go
+++ b/engine/startup.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/verveguy/fabrik/tui"
 )
 
 // checkStageColumnAlignment validates that every configured non-cleanup stage
@@ -28,6 +30,16 @@ func (e *Engine) checkStageColumnAlignment(ctx context.Context) error {
 	if board.ProjectID == "" {
 		e.logf(0, "startup", "warning: project board has no ID — skipping startup check\n")
 		return nil
+	}
+
+	// Emit project metadata to the TUI so the footer can display the board title.
+	if board.Title != "" {
+		ownerSegment := "orgs"
+		if board.OwnerType == "user" {
+			ownerSegment = "users"
+		}
+		boardURL := fmt.Sprintf("https://github.com/%s/%s/projects/%d", ownerSegment, e.cfg.Owner, e.cfg.ProjectNum)
+		e.emitStructural(tui.ProjectMetaEvent{BoardTitle: board.Title, BoardURL: boardURL})
 	}
 
 	sf, err := e.client.FetchStatusField(board.ProjectID)

--- a/github/fetch_board_test.go
+++ b/github/fetch_board_test.go
@@ -13,7 +13,8 @@ func TestFetchProjectBoard_Success(t *testing.T) {
 			"data": map[string]interface{}{
 				"user": map[string]interface{}{
 					"projectV2": map[string]interface{}{
-						"id": "PVT_123",
+						"id":    "PVT_123",
+						"title": "My Board",
 						"items": map[string]interface{}{
 							"nodes": []interface{}{
 								map[string]interface{}{
@@ -61,6 +62,12 @@ func TestFetchProjectBoard_Success(t *testing.T) {
 
 	if board.ProjectID != "PVT_123" {
 		t.Errorf("ProjectID = %q", board.ProjectID)
+	}
+	if board.Title != "My Board" {
+		t.Errorf("Title = %q, want %q", board.Title, "My Board")
+	}
+	if board.OwnerType != "user" {
+		t.Errorf("OwnerType = %q, want %q", board.OwnerType, "user")
 	}
 	if len(board.Items) != 1 {
 		t.Fatalf("items count = %d, want 1", len(board.Items))

--- a/github/project.go
+++ b/github/project.go
@@ -90,7 +90,8 @@ func (c *Client) fetchProjectBoard(owner, repo string, projectNum int, ownerType
 query($owner: String!, $projectNum: Int!, $cursor: String) {
   %s(login: $owner) {
     projectV2(number: $projectNum) {
-      id`, ownerType) + `
+      id
+      title`, ownerType) + `
       items(first: 100, after: $cursor) {
         pageInfo {
           hasNextPage
@@ -148,6 +149,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 }`
 
 	var projectID string
+	var projectTitle string
 	var allNodes []itemNode
 
 	// Paginate over items.
@@ -165,6 +167,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 			Data map[string]struct {
 				ProjectV2 struct {
 					ID    string `json:"id"`
+					Title string `json:"title"`
 					Items struct {
 						PageInfo struct {
 							HasNextPage bool   `json:"hasNextPage"`
@@ -187,6 +190,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 		proj := ownerData.ProjectV2
 		if projectID == "" {
 			projectID = proj.ID
+			projectTitle = proj.Title
 		}
 		allNodes = append(allNodes, proj.Items.Nodes...)
 
@@ -199,7 +203,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 		cursor = proj.Items.PageInfo.EndCursor
 	}
 
-	board := &ProjectBoard{ProjectID: projectID}
+	board := &ProjectBoard{ProjectID: projectID, Title: projectTitle, OwnerType: ownerType}
 
 	for _, node := range allNodes {
 		// Skip items whose content was not returned (empty content ID, e.g. draft issues)

--- a/github/types.go
+++ b/github/types.go
@@ -14,6 +14,8 @@ type RateLimitStats struct {
 // ProjectBoard represents the full state of a GitHub Project (v2) board.
 type ProjectBoard struct {
 	ProjectID string
+	Title     string // display name of the project board (from projectV2.title)
+	OwnerType string // "organization" or "user", resolved by FetchProjectBoard
 	Items     []ProjectItem
 }
 

--- a/tui/events.go
+++ b/tui/events.go
@@ -91,3 +91,12 @@ type TickEvent struct {
 }
 
 func (TickEvent) tuiEvent() {}
+
+// ProjectMetaEvent is emitted once after the startup board fetch succeeds.
+// It delivers the project board title and URL to the TUI for display in the footer.
+type ProjectMetaEvent struct {
+	BoardTitle string // display name of the GitHub Project board
+	BoardURL   string // https://github.com/{orgs|users}/{owner}/projects/{num}
+}
+
+func (ProjectMetaEvent) tuiEvent() {}

--- a/tui/model.go
+++ b/tui/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // HistoryEntry records a completed job for the history pane.
@@ -80,7 +81,8 @@ const (
 // ProjectInfo holds display metadata about the monitored project shown in the footer.
 type ProjectInfo struct {
 	CWD           string // display-ready CWD (home-relative or absolute)
-	Repo          string // "owner/repo"
+	BoardTitle    string // GitHub Project board title; empty until startup board fetch succeeds
+	BoardURL      string // https://github.com/{orgs|users}/{owner}/projects/{num}
 	Version       string // optional version or module name of the monitored project; empty if unknown
 	FabrikVersion string // fabrik binary version (e.g. "v1.2.3" or "dev(abc1234)")
 }
@@ -167,6 +169,30 @@ var (
 	activeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	selectedStyle = lipgloss.NewStyle().Background(lipgloss.Color("238"))
 )
+
+// supportsOSC8 returns true when the terminal is known to support OSC 8 hyperlinks.
+// Detection uses environment variables because no universal runtime query exists.
+func supportsOSC8() bool {
+	prog := strings.ToLower(os.Getenv("TERM_PROGRAM"))
+	switch prog {
+	case "iterm.app", "ghostty", "wezterm", "kitty":
+		return true
+	}
+	if strings.Contains(strings.ToLower(os.Getenv("TERM")), "kitty") {
+		return true
+	}
+	return false
+}
+
+// applyOSC8 wraps the first occurrence of title in plain with an OSC 8 hyperlink
+// pointing to boardURL. If title or boardURL is empty, or if the terminal does not
+// support OSC 8, plain is returned unchanged.
+func applyOSC8(plain, title, boardURL string) string {
+	if title == "" || boardURL == "" || !supportsOSC8() {
+		return plain
+	}
+	return strings.Replace(plain, title, termenv.Hyperlink(boardURL, title), 1)
+}
 
 // New creates an initial TUI model.
 // pollSeconds is the configured polling interval.
@@ -403,6 +429,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.spinnerIdx = (m.spinnerIdx + 1) % len(m.spinnerFrames)
 		m.statusMsg = "" // clear transient status message each tick
 		return m, tickCmd()
+
+	case ProjectMetaEvent:
+		m.projectInfo.BoardTitle = ev.BoardTitle
+		m.projectInfo.BoardURL = ev.BoardURL
+		return m, nil
 
 	case PollStartedEvent:
 		m.nextPollAt = time.Now().Add(m.pollInterval)
@@ -933,13 +964,13 @@ func (m Model) viewHistory() string {
 }
 
 func (m Model) viewFooter() string {
-	// Assemble left side: CWD · owner/repo [· version]
+	// Assemble left side: CWD [· BoardTitle] [· version]
 	parts := []string{}
 	if m.projectInfo.CWD != "" {
 		parts = append(parts, m.projectInfo.CWD)
 	}
-	if m.projectInfo.Repo != "" {
-		parts = append(parts, m.projectInfo.Repo)
+	if m.projectInfo.BoardTitle != "" {
+		parts = append(parts, m.projectInfo.BoardTitle)
 	}
 	if m.projectInfo.Version != "" {
 		parts = append(parts, m.projectInfo.Version)
@@ -971,13 +1002,13 @@ func (m Model) viewFooter() string {
 
 	if rightStr == "" {
 		// No right side — original single-side logic.
-		footer := dimStyle.Render(leftPlain)
+		footer := dimStyle.Render(applyOSC8(leftPlain, m.projectInfo.BoardTitle, m.projectInfo.BoardURL))
 		if lipgloss.Width(footer) > maxWidth {
 			runes := []rune(leftPlain)
 			for len(runes) > 0 && lipgloss.Width(dimStyle.Render(string(runes)+"…")) > maxWidth {
 				runes = runes[:len(runes)-1]
 			}
-			footer = dimStyle.Render(string(runes) + "…")
+			footer = dimStyle.Render(applyOSC8(string(runes)+"…", m.projectInfo.BoardTitle, m.projectInfo.BoardURL))
 		}
 		return footer
 	}
@@ -985,7 +1016,7 @@ func (m Model) viewFooter() string {
 	// Two-sided layout: left + gap + right.
 	// Right side is always preserved; left is truncated when space is tight.
 	rightWidth := lipgloss.Width(rightStr)
-	leftRendered := dimStyle.Render(leftPlain)
+	leftRendered := dimStyle.Render(applyOSC8(leftPlain, m.projectInfo.BoardTitle, m.projectInfo.BoardURL))
 	gap := maxWidth - lipgloss.Width(leftRendered) - rightWidth
 	if gap < 1 {
 		// Left must be truncated to make room for the right side.
@@ -1004,7 +1035,7 @@ func (m Model) viewFooter() string {
 			if len(runes) == 0 {
 				leftRendered = ""
 			} else {
-				leftRendered = dimStyle.Render(string(runes) + "…")
+				leftRendered = dimStyle.Render(applyOSC8(string(runes)+"…", m.projectInfo.BoardTitle, m.projectInfo.BoardURL))
 			}
 		}
 		gap = maxWidth - lipgloss.Width(leftRendered) - rightWidth

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -360,24 +360,24 @@ func TestViewFooter_Content(t *testing.T) {
 }
 
 func TestViewFooter_NoVersion(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp"}, "")
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "")
 	m.width = 120
 	footer := m.viewFooter()
 
 	if !strings.Contains(footer, "~/projects/myapp") {
 		t.Error("footer missing CWD when version is absent")
 	}
-	if !strings.Contains(footer, "org/myapp") {
-		t.Error("footer missing repo when version is absent")
+	if !strings.Contains(footer, "My Board") {
+		t.Error("footer missing board title when version is absent")
 	}
 }
 
 func TestViewFooter_Truncation(t *testing.T) {
 	// Use a narrow terminal to force truncation.
 	m := New(30, ProjectInfo{
-		CWD:     "~/very/long/path/to/a/deeply/nested/project/directory",
-		Repo:    "some-long-org/some-long-repo-name",
-		Version: "99.99.99",
+		CWD:        "~/very/long/path/to/a/deeply/nested/project/directory",
+		BoardTitle: "Some Long Board Name For Truncation Test",
+		Version:    "99.99.99",
 	}, "")
 	m.width = 30
 	footer := m.viewFooter()
@@ -396,7 +396,7 @@ func TestViewFooter_Truncation(t *testing.T) {
 // TestViewFooter_RateLimitHidden verifies that the rate limit section is omitted
 // when no stats have been received (Limit==0).
 func TestViewFooter_RateLimitHidden(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp"}, "")
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "")
 	m.width = 120
 	// graphqlStats is zero-value (Limit==0) by default.
 	footer := m.viewFooter()
@@ -415,7 +415,7 @@ func TestViewFooter_RateLimitHidden(t *testing.T) {
 // TestViewFooter_RateLimitShown verifies the rate limit section appears once
 // graphqlStats is populated, and contains the fraction and countdown.
 func TestViewFooter_RateLimitShown(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp"}, "")
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "")
 	m.width = 120
 	m.now = time.Now()
 	m.graphqlStats = RateLimitStats{
@@ -455,7 +455,7 @@ func TestViewFooter_RateLimitColors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{CWD: "~", Repo: "org/repo"}, "")
+			m := New(30, ProjectInfo{CWD: "~", BoardTitle: "My Board"}, "")
 			m.width = 120
 			m.now = now
 			m.graphqlStats = RateLimitStats{
@@ -477,9 +477,9 @@ func TestViewFooter_RateLimitColors(t *testing.T) {
 func TestViewFooter_TruncationWithRateLimit(t *testing.T) {
 	now := time.Now()
 	m := New(30, ProjectInfo{
-		CWD:     "~/very/long/path/to/a/deeply/nested/project/directory",
-		Repo:    "some-long-org/some-long-repo-name",
-		Version: "99.99.99",
+		CWD:        "~/very/long/path/to/a/deeply/nested/project/directory",
+		BoardTitle: "Some Long Board Name For Truncation Test",
+		Version:    "99.99.99",
 	}, "")
 	m.width = 40
 	m.now = now
@@ -503,6 +503,63 @@ func TestViewFooter_TruncationWithRateLimit(t *testing.T) {
 	// Left side must be truncated (too long to fit with right side).
 	if !strings.Contains(plain, "…") {
 		t.Errorf("expected left-side truncation ellipsis; got: %q", plain)
+	}
+}
+
+// TestViewFooter_OSC8Hyperlink verifies that the board title is wrapped in an
+// OSC 8 hyperlink when the terminal reports OSC 8 support.
+func TestViewFooter_OSC8Hyperlink(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "ghostty")
+	m := New(30, ProjectInfo{
+		CWD:        "~",
+		BoardTitle: "My Board",
+		BoardURL:   "https://github.com/orgs/acme/projects/1",
+	}, "")
+	m.width = 120
+	footer := m.viewFooter()
+
+	if !strings.Contains(footer, "My Board") {
+		t.Errorf("footer missing board title; got: %q", footer)
+	}
+	if !strings.Contains(footer, "https://github.com/orgs/acme/projects/1") {
+		t.Errorf("footer missing OSC 8 hyperlink URL; got: %q", footer)
+	}
+}
+
+// TestViewFooter_PlainTextNoOSC8 verifies that the board title is rendered as
+// plain text (no URL) when the terminal does not support OSC 8.
+func TestViewFooter_PlainTextNoOSC8(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("TERM", "")
+	m := New(30, ProjectInfo{
+		CWD:        "~",
+		BoardTitle: "My Board",
+		BoardURL:   "https://github.com/orgs/acme/projects/1",
+	}, "")
+	m.width = 120
+	footer := m.viewFooter()
+
+	if !strings.Contains(footer, "My Board") {
+		t.Errorf("footer missing board title; got: %q", footer)
+	}
+	if strings.Contains(footer, "https://github.com/orgs/acme/projects/1") {
+		t.Errorf("footer should not contain hyperlink URL in non-OSC8 terminal; got: %q", footer)
+	}
+}
+
+// TestViewFooter_NoTitleSlot verifies that no separator dot is shown when
+// BoardTitle is empty (footer is just CWD with no board title slot).
+func TestViewFooter_NoTitleSlot(t *testing.T) {
+	m := New(30, ProjectInfo{CWD: "~/project"}, "")
+	m.width = 120
+	footer := m.viewFooter()
+	plain := ansi.Strip(footer)
+
+	if !strings.Contains(plain, "~/project") {
+		t.Errorf("footer missing CWD; got: %q", plain)
+	}
+	if strings.Contains(plain, "·") {
+		t.Errorf("footer should not contain separator when board title is absent; got: %q", plain)
 	}
 }
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -307,7 +307,7 @@ func TestView_BeforeWindowSize(t *testing.T) {
 }
 
 func TestView_AfterWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{Repo: "owner/repo", CWD: "~/myproject"}, "")
+	m := New(30, ProjectInfo{BoardTitle: "Acme PM", CWD: "~/myproject"}, "")
 	m.width = 80
 	m.height = 24
 	m.nextPollAt = time.Now().Add(30 * time.Second)
@@ -325,8 +325,8 @@ func TestView_AfterWindowSize(t *testing.T) {
 	if !strings.Contains(v, "History") {
 		t.Error("should show History pane")
 	}
-	if !strings.Contains(v, "owner/repo") {
-		t.Error("footer should contain repo")
+	if !strings.Contains(v, "Acme PM") {
+		t.Error("footer should contain board title")
 	}
 	if !strings.Contains(v, "~/myproject") {
 		t.Error("footer should contain CWD")
@@ -334,7 +334,7 @@ func TestView_AfterWindowSize(t *testing.T) {
 }
 
 func TestNew_StoresProjectInfo(t *testing.T) {
-	info := ProjectInfo{CWD: "~/foo", Repo: "org/bar", Version: "1.2.3"}
+	info := ProjectInfo{CWD: "~/foo", BoardTitle: "Acme Board", Version: "1.2.3"}
 	m := New(30, info, "")
 	if m.projectInfo != info {
 		t.Errorf("projectInfo = %+v, want %+v", m.projectInfo, info)
@@ -348,11 +348,11 @@ func TestFooterHeight(t *testing.T) {
 }
 
 func TestViewFooter_Content(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", Repo: "org/myapp", Version: "2.0.0"}, "")
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board", Version: "2.0.0"}, "")
 	m.width = 120
 	footer := m.viewFooter()
 
-	for _, want := range []string{"~/projects/myapp", "org/myapp", "2.0.0"} {
+	for _, want := range []string{"~/projects/myapp", "My Board", "2.0.0"} {
 		if !strings.Contains(footer, want) {
 			t.Errorf("viewFooter() missing %q; got: %q", want, footer)
 		}


### PR DESCRIPTION
## Summary

- Replaces the `owner/repo` slot in the TUI footer with the GitHub Project board title (e.g. "Fabrik PM"), fetched from the existing startup GraphQL board query
- In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), the title renders as a clickable link to the board URL
- Before the startup board fetch succeeds, the footer shows just `CWD [· version]` with no title slot

## Key changes

- `github/types.go` + `project.go`: `ProjectBoard` gains `Title` and `OwnerType` fields; `title` added to the GraphQL query
- `tui/events.go`: new `ProjectMetaEvent{BoardTitle, BoardURL}` event type
- `tui/model.go`: `ProjectInfo.Repo` removed; `BoardTitle`/`BoardURL` added; `supportsOSC8()` checks `$TERM_PROGRAM`/`$TERM`; `applyOSC8()` wraps title with `termenv.Hyperlink` when supported; `viewFooter` updated; `Update` handles `ProjectMetaEvent`
- `engine/startup.go`: emits `ProjectMetaEvent` after successful startup board fetch
- `cmd/root.go`: `buildProjectInfo` no longer sets `Repo`

## How to test

1. Run `fabrik` in Ghostty, iTerm2, WezTerm, or Kitty — the footer should show the project board title as a clickable link
2. Run in Apple Terminal or other non-OSC8 terminals — the footer shows the plain board title without a hyperlink
3. On startup before board fetch completes, verify no `·` separator appears when there's no title yet

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)