### PR TITLE
docs: update USER_GUIDE, README, and index.md for v0.0.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ to prevent accidental token leaks.
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` for debugging | `false` |
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides installed plugin) | `""` |
 
+> **Releases:** New releases are announced in the [shadoworg/fabrik Discussions "Announcements" category](https://github.com/shadoworg/fabrik/discussions/categories/announcements) after each successful release.
+
 ## Subcommands
 
 | Command | Description |
@@ -266,6 +268,7 @@ Fabrik uses labels to track state:
 | `stage:<name>:in_progress` | Stage is actively running |
 | `stage:<name>:failed` | Stage hit max retries and was paused |
 | `model:<name>` | Use this model for the issue (e.g. `model:opus` overrides the stage YAML default) |
+| `effort:<level>` | Override thinking effort for this issue only — valid values: `low`, `medium`, `high`, `max`; precedence: `max > high > medium > low`. Complements `model:` label. |
 | `fabrik:yolo` | Force auto-advance even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes |
 | `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` to Claude Code for this issue only; use when an issue needs to write to paths not covered by `.claude/settings.json` (e.g. `.claude/skills/`). **Caution:** bypasses the permission system. |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -923,6 +923,8 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 
 ### Fabrik-Managed Labels
 
+> Fabrik auto-seeds all managed labels on the configured repository at startup — creating them with their descriptions and colors if they do not already exist, so the GitHub UI shows meaningful hover text.
+
 | Label | Purpose |
 |-------|---------|
 | `fabrik:locked:<user>` | Issue being processed by this user's instance |
@@ -985,7 +987,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `C` | Clear all history (with confirmation) |
 | `q` | Quit |
 
-In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), issue numbers (`#NNN`) in the In Progress and History panes are clickable links that open the corresponding GitHub issue in your browser. The project board title in the footer is also a clickable link. Use keyboard navigation for selection and scrolling.
+In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), issue numbers (`#NNN`) in the In Progress and History panes are hyperlinks. **Cmd+click** (macOS) or **Ctrl+click** (Linux) on a `#NNN` to open the corresponding GitHub issue in your browser; **Cmd+click** / **Ctrl+click** the board title in the footer to open the project board. Use keyboard navigation for selection and scrolling.
 
 ### What's Displayed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -235,7 +235,7 @@ description: >-
           <code>l</code> to open <code>fabrik watch</code> for the selected issue
           (live log streaming, stage tabs, CI/PR status), <code>enter</code> to
           toggle an inline detail panel, <code>r</code> to resume a Claude session
-          from history, and <code>q</code> to quit. Mouse support enabled by default.
+          from history, and <code>q</code> to quit. In supported terminals (Ghostty, iTerm2, WezTerm, Kitty), <strong>Cmd+click</strong> (macOS) or <strong>Ctrl+click</strong> (Linux) on issue numbers to open them in your browser, or on the board title in the footer to open the project board.
         </div>
       </div>
       <div class="feature-card">
@@ -416,7 +416,7 @@ echo '.env' >> .gitignore
         <span class="link-icon">⭐</span>
         <div>
           <div class="link-title">GitHub Repository</div>
-          <div class="link-desc">Releases, discussions, and community skills</div>
+          <div class="link-desc">Releases (with announcements in GitHub Discussions), issue tracker, and community skills</div>
         </div>
       </a>
       <a href="{{ '/USER_GUIDE' | relative_url }}" class="link-card">


### PR DESCRIPTION
## Summary

- Documents four v0.0.34 user-facing changes across `docs/USER_GUIDE.md`, `README.md`, and `docs/index.md`
- No code changes — purely additive documentation edits plus one stale-sentence fix

## Key changes

**`docs/USER_GUIDE.md`**
- §7 TUI Dashboard: replaces generic "clickable links" with explicit **Cmd+click** (macOS) / **Ctrl+click** (Linux) activation gesture for OSC 8 hyperlinks on issue numbers and the board title in the footer
- §6 Labels Reference: adds a blockquote preamble to the Fabrik-Managed Labels table stating that Fabrik auto-seeds all managed labels at startup with descriptions and colors

**`README.md`**
- Labels table: adds `effort:<level>` row (valid values, precedence, complements `model:` label)
- Flags table footer: adds a blockquote pointing to the Discussions "Announcements" category for release news

**`docs/index.md`**
- Terminal UI feature card: replaces the now-incorrect "Mouse support enabled by default." sentence with an explanation of Cmd+click / Ctrl+click to open issues and the project board
- GitHub Repository link card: makes the Discussions reference explicit ("with announcements in GitHub Discussions")

## How to test

1. Read each modified section and confirm it matches the v0.0.34 release notes
2. Verify "Mouse support enabled by default." no longer appears anywhere in `docs/index.md` (`grep "Mouse support" docs/index.md` should return nothing)
3. Verify `effort:<level>` appears in `README.md` Labels table
4. `go build .` should succeed unchanged (no Go files modified)

Closes #347