### PR TITLE
TUI: add '?' help panel with keybindings and label reference

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -985,6 +985,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `n` / `N` | Cancel quit or clear-all confirmation dialogs |
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
+| `?` | Toggle help panel (keybindings and labels reference) |
 | `q` | Quit |
 
 In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), issue numbers (`#NNN`) in the In Progress and History panes are hyperlinks. **Cmd+click** (macOS) or **Ctrl+click** (Linux) on a `#NNN` to open the corresponding GitHub issue in your browser; **Cmd+click** / **Ctrl+click** the board title in the footer to open the project board. Use keyboard navigation for selection and scrolling.

--- a/tui/help.go
+++ b/tui/help.go
@@ -1,0 +1,133 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// helpContent holds all keybindings and labels documentation shown in the help panel.
+// All lines must be ≤ 72 visible characters to avoid wrapping at standard terminal widths.
+//
+// NOTE: keep in sync with docs/USER_GUIDE.md §6 (Labels Reference) and §7 (TUI
+// Dashboard Keyboard Shortcuts). Update both locations when adding or changing entries.
+var helpContent = strings.TrimSpace(`
+KEYBOARD SHORTCUTS
+
+  Navigation
+    tab        Switch focus: In Progress <-> History
+    ↑/↓  k/j  Navigate items in the focused pane
+    enter      Toggle inline detail panel
+    esc        Close open panels; or triggers quit confirmation
+    n / N      Cancel quit or clear-all confirmation
+
+  Active Jobs (In Progress pane)
+    l          Open fabrik watch for selected issue (live output)
+    r          (disabled) Stage in progress — use l to watch
+
+  History pane
+    l          View log for selected history entry
+    r          Resume Claude session for selected history entry
+    c          Delete selected history entry
+    C          Clear all history (with confirmation)
+
+  Global
+    ?          Toggle this help panel
+    q          Quit
+    ctrl+c     Force quit
+
+─────────────────────────────────────────────────────────
+
+LABELS REFERENCE
+
+  Engine-managed state
+    fabrik:locked:<user>   Issue being processed by this user's instance
+    fabrik:editing         Issue body being updated (comment processing)
+    fabrik:paused          Processing paused (max retries exceeded)
+    fabrik:awaiting-input  Stage paused waiting for user input
+    fabrik:awaiting-review Waiting for PR reviewers to submit
+    fabrik:blocked         Waiting for blocking issues to close
+
+  Stage state
+    stage:<name>:in_progress  Stage actively running
+    stage:<name>:complete     Stage completed successfully
+    stage:<name>:failed       Stage hit max retries
+
+  Automation modes
+    fabrik:yolo    Auto-advance; auto-merge PR on Validate complete
+    fabrik:cruise  Auto-advance through all stages, no auto-merge
+
+  Per-issue overrides (user-set)
+    model:<name>        Override Claude model (e.g. opus, sonnet)
+    effort:<level>      Override thinking effort (low/medium/high/max)
+    fabrik:paused       Manually pause (add to pause, remove to resume)
+    fabrik:unrestricted Skip permissions check (use with caution)
+
+  Other
+    fabrik:sub-issue  Plan-created sub-issues; never decomposed further
+`) + "\n"
+
+// HelpPanelComponent renders a scrollable help overlay with keybindings
+// and label reference. It follows the DetailPanelComponent pattern:
+// value-type component with pointer-receiver setters and Height() returning
+// 0 when not visible.
+type HelpPanelComponent struct {
+	vp        viewport.Model
+	visible   bool
+	lastWidth int
+}
+
+// Update is a no-op. Scrolling is handled by forwarding key events from
+// the root model directly to vp.
+func (h HelpPanelComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	return h, nil
+}
+
+// View renders the help panel. Returns an empty string when not visible.
+func (h HelpPanelComponent) View(width int) string {
+	if !h.visible {
+		return ""
+	}
+	titleLine := dimStyle.Render("Help") + "  " + dimStyle.Render("[?/esc] close")
+	content := titleLine + "\n" + h.vp.View()
+	return borderStyle.Width(width - 4).Render(content)
+}
+
+// Height returns the total rendered height by measuring the actual rendered view.
+// Returns 0 when not visible. Uses the same approach as DetailPanelComponent to
+// correctly account for any line wrapping inside the border.
+func (h HelpPanelComponent) Height() int {
+	if !h.visible {
+		return 0
+	}
+	w := h.lastWidth
+	if w == 0 {
+		w = 80
+	}
+	view := h.View(w)
+	if view == "" {
+		return 0
+	}
+	return strings.Count(view, "\n") + 1
+}
+
+// SetVisible controls whether the help panel is shown.
+func (h *HelpPanelComponent) SetVisible(v bool) {
+	h.visible = v
+}
+
+// SetLayout sizes the internal viewport to fit within targetHeight terminal rows.
+// The viewport height is targetHeight - 3 (subtracting 1 title and 2 border lines).
+func (h *HelpPanelComponent) SetLayout(width, targetHeight int) {
+	vpH := max(targetHeight-3, 1)
+	innerWidth := max(width-4, 20) // -4 for border+padding
+	h.vp = viewport.New(innerWidth, vpH)
+	h.vp.SetContent(helpContent)
+	h.lastWidth = width
+}
+
+// ScrollToTop scrolls the viewport to the top.
+func (h *HelpPanelComponent) ScrollToTop() {
+	h.vp.GotoTop()
+}

--- a/tui/help.go
+++ b/tui/help.go
@@ -19,7 +19,7 @@ KEYBOARD SHORTCUTS
     tab        Switch focus: In Progress <-> History
     ↑/↓  k/j  Navigate items in the focused pane
     enter      Toggle inline detail panel
-    esc        Close open panels; or triggers quit confirmation
+    esc        Close open panels; with none open, triggers quit confirmation
     n / N      Cancel quit or clear-all confirmation
 
   Active Jobs (In Progress pane)
@@ -44,7 +44,7 @@ LABELS REFERENCE
   Engine-managed state
     fabrik:locked:<user>   Issue being processed by this user's instance
     fabrik:editing         Issue body being updated (comment processing)
-    fabrik:paused          Processing paused (max retries exceeded)
+    fabrik:paused          Processing paused (max retries exceeded or manual)
     fabrik:awaiting-input  Stage paused waiting for user input
     fabrik:awaiting-review Waiting for PR reviewers to submit
     fabrik:blocked         Waiting for blocking issues to close
@@ -61,7 +61,7 @@ LABELS REFERENCE
   Per-issue overrides (user-set)
     model:<name>        Override Claude model (e.g. opus, sonnet)
     effort:<level>      Override thinking effort (low/medium/high/max)
-    fabrik:paused       Manually pause (add to pause, remove to resume)
+    fabrik:paused       Manually pause (same label; add to pause, remove to resume)
     fabrik:unrestricted Skip permissions check (use with caution)
 
   Other
@@ -119,11 +119,17 @@ func (h *HelpPanelComponent) SetVisible(v bool) {
 
 // SetLayout sizes the internal viewport to fit within targetHeight terminal rows.
 // The viewport height is targetHeight - 3 (subtracting 1 title and 2 border lines).
+// On resize the existing scroll offset is preserved so an open panel stays in place.
 func (h *HelpPanelComponent) SetLayout(width, targetHeight int) {
 	vpH := max(targetHeight-3, 1)
-	innerWidth := max(width-4, 20) // -4 for border+padding
-	h.vp = viewport.New(innerWidth, vpH)
-	h.vp.SetContent(helpContent)
+	innerWidth := max(width-6, 20) // -6 for border+padding, matching other bordered components
+	if h.vp.Width == 0 && h.vp.Height == 0 {
+		h.vp = viewport.New(innerWidth, vpH)
+		h.vp.SetContent(helpContent)
+	} else {
+		h.vp.Width = innerWidth
+		h.vp.Height = vpH
+	}
 	h.lastWidth = width
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -418,11 +418,14 @@ func (m *Model) updateLayout(scrollToTop bool) {
 	helpH := 0
 	if m.helpPanel {
 		helpTarget := max(totalAvail-minHistoryRows, 5)
+		if helpTarget > totalAvail {
+			helpTarget = max(totalAvail, 0)
+		}
 		m.help.SetLayout(m.width, helpTarget)
 		helpH = m.help.Height()
 	}
 
-	availableHistoryH := totalAvail - helpH
+	availableHistoryH := max(totalAvail-helpH, 0)
 	m.history.SetLayout(m.width, availableHistoryH, m.confirmQuit, m.active.ActiveCount())
 	if scrollToTop {
 		m.history.ScrollToTop()

--- a/tui/model.go
+++ b/tui/model.go
@@ -91,6 +91,7 @@ type Model struct {
 	focusPane   pane
 	confirmQuit bool
 	detailPanel bool
+	helpPanel   bool
 
 	// plugin directory
 	pluginDir string
@@ -100,9 +101,14 @@ type Model struct {
 	active  ActivePaneComponent
 	history HistoryPaneComponent
 	detail  DetailPanelComponent
+	help    HelpPanelComponent
 	footer  FooterComponent
 
 }
+
+// minHistoryRows is the minimum number of rows reserved for the history pane
+// when the help panel is open, ensuring history always renders.
+const minHistoryRows = 5
 
 // New creates an initial TUI model.
 // pollSeconds is the configured polling interval.
@@ -156,9 +162,35 @@ func tickCmd() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch ev := msg.(type) {
 	case tea.KeyMsg:
+		// When help panel is open, suppress most keybindings.
+		// Scroll keys are forwarded to the help viewport; ctrl+c still quits.
+		if m.helpPanel {
+			switch ev.String() {
+			case "ctrl+c":
+				return m, tea.Quit
+			case "?", "esc":
+				m.helpPanel = false
+				m.help.SetVisible(false)
+				m.updateLayout(false)
+				return m, nil
+			default:
+				var cmd tea.Cmd
+				m.help.vp, cmd = m.help.vp.Update(msg)
+				return m, cmd
+			}
+		}
+
 		switch ev.String() {
 		case "ctrl+c":
 			return m, tea.Quit
+
+		case "?":
+			m.helpPanel = true
+			m.detailPanel = false
+			m.help.SetVisible(true)
+			m.updateLayout(false)
+			m.help.ScrollToTop()
+			return m, nil
 
 		case "q":
 			if m.history.ConfirmClear() {
@@ -373,7 +405,7 @@ func (m *Model) syncFocus() {
 	m.history.SetFocused(m.focusPane == paneHistory)
 }
 
-// updateLayout recomputes the history viewport dimensions and content.
+// updateLayout recomputes the history and help viewport dimensions and content.
 func (m *Model) updateLayout(scrollToTop bool) {
 	activeH := m.active.Height()
 	detailH := 0
@@ -381,8 +413,17 @@ func (m *Model) updateLayout(scrollToTop bool) {
 		m.prepareDetailItem()
 		detailH = m.detail.Height()
 	}
-	availableHeight := m.height - m.header.Height() - activeH - detailH - m.footer.Height()
-	m.history.SetLayout(m.width, availableHeight, m.confirmQuit, m.active.ActiveCount())
+	totalAvail := m.height - m.header.Height() - activeH - detailH - m.footer.Height()
+
+	helpH := 0
+	if m.helpPanel {
+		helpTarget := max(totalAvail-minHistoryRows, 5)
+		m.help.SetLayout(m.width, helpTarget)
+		helpH = m.help.Height()
+	}
+
+	availableHistoryH := totalAvail - helpH
+	m.history.SetLayout(m.width, availableHistoryH, m.confirmQuit, m.active.ActiveCount())
 	if scrollToTop {
 		m.history.ScrollToTop()
 	} else {
@@ -441,6 +482,12 @@ func (m Model) View() string {
 		m.prepareDetailItem()
 		if detail := m.detail.View(m.width); detail != "" {
 			sections = append(sections, detail)
+		}
+	}
+
+	if m.helpPanel {
+		if help := m.help.View(m.width); help != "" {
+			sections = append(sections, help)
 		}
 	}
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -457,3 +457,151 @@ func TestTuiEventMethods(t *testing.T) {
 	JobCompletedEvent{}.tuiEvent()
 	TickEvent{}.tuiEvent()
 }
+
+// TestHelpPanelToggle verifies that pressing ? opens the help panel, pressing ?
+// or esc closes it, and opening help closes the detail panel.
+func TestHelpPanelToggle(t *testing.T) {
+	redirectHistory(t)
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+
+	// Pressing ? opens help panel.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+	nm := next.(Model)
+	if cmd != nil {
+		t.Error("expected nil cmd from ? key")
+	}
+	if !nm.helpPanel {
+		t.Error("expected helpPanel=true after ? key")
+	}
+
+	// Pressing ? again closes help panel.
+	next2, _ := nm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+	nm2 := next2.(Model)
+	if nm2.helpPanel {
+		t.Error("expected helpPanel=false after second ? key")
+	}
+
+	// Pressing esc while help is open closes help panel.
+	next3, _ := nm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	nm3 := next3.(Model)
+	if nm3.helpPanel {
+		t.Error("expected helpPanel=false after esc while help open")
+	}
+
+	// Pressing ? while detail panel is open closes detail and opens help.
+	m2 := New(30, ProjectInfo{}, "")
+	m2.width = 80
+	m2.height = 24
+	m2.detailPanel = true
+	next4, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+	nm4 := next4.(Model)
+	if !nm4.helpPanel {
+		t.Error("expected helpPanel=true after ? with detail open")
+	}
+	if nm4.detailPanel {
+		t.Error("expected detailPanel=false after ? with detail open")
+	}
+}
+
+// TestHelpPanelSuppressKeys verifies that when the help panel is open, keys that
+// would normally change model state (tab, enter, r, l) are suppressed.
+func TestHelpPanelSuppressKeys(t *testing.T) {
+	redirectHistory(t)
+	m := New(30, ProjectInfo{}, "")
+	m.width = 80
+	m.height = 24
+	// Open help panel.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+	m = next.(Model)
+	if !m.helpPanel {
+		t.Fatal("precondition: help panel should be open")
+	}
+
+	initialFocusPane := m.focusPane
+	initialDetailPanel := m.detailPanel
+
+	// tab should not switch panes.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	nm := next.(Model)
+	if nm.focusPane != initialFocusPane {
+		t.Error("tab should be suppressed while help is open (focusPane changed)")
+	}
+
+	// enter should not toggle detail panel.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	nm = next.(Model)
+	if nm.detailPanel != initialDetailPanel {
+		t.Error("enter should be suppressed while help is open (detailPanel changed)")
+	}
+
+	// r should be suppressed (nil cmd, no status message change).
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	nm = next.(Model)
+	if nm.focusPane != initialFocusPane {
+		t.Error("r should be suppressed while help is open (focusPane changed)")
+	}
+
+	// q should be suppressed (no quit).
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd != nil {
+		// The viewport Update forwards q to the viewport which returns nil cmd.
+		// If somehow a quit cmd is returned, that's a bug.
+		msg := cmd()
+		if _, ok := msg.(tea.QuitMsg); ok {
+			t.Error("q should be suppressed while help is open (got quit cmd)")
+		}
+	}
+}
+
+// TestLayoutHeightInvariant_WithHelp verifies that the total rendered height of View()
+// equals m.height when the help panel is open at a standard terminal size.
+func TestLayoutHeightInvariant_WithHelp(t *testing.T) {
+	redirectHistory(t)
+
+	const termWidth = 80
+	const termHeight = 24
+
+	cases := []struct {
+		name    string
+		nActive int
+		focused pane
+		nHist   int
+	}{
+		{"active_focus_no_history", 0, paneActive, 0},
+		{"active_focus_with_history", 0, paneActive, 3},
+		{"history_focus_with_history", 0, paneHistory, 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(30, ProjectInfo{}, "")
+			now := time.Now()
+			for i := 0; i < tc.nActive; i++ {
+				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
+			}
+			for i := 0; i < tc.nHist; i++ {
+				m.history.history = append(m.history.history, HistoryEntry{IssueNumber: i + 1, StageName: "Research", Success: true, Completed: true})
+			}
+			m.focusPane = tc.focused
+			m.syncFocus()
+
+			// Apply window size first.
+			next, _ := m.Update(tea.WindowSizeMsg{Width: termWidth, Height: termHeight})
+			m = next.(Model)
+
+			// Open help panel.
+			next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+			m = next.(Model)
+			if !m.helpPanel {
+				t.Fatal("precondition: help panel should be open")
+			}
+
+			got := lipgloss.Height(m.View())
+			if got != termHeight {
+				t.Errorf("%s: View() height with help = %d, want %d", tc.name, got, termHeight)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `?` key to the main TUI dashboard that toggles a scrollable help panel. The panel shows all current keybindings grouped by context and a reference for all Fabrik-managed labels grouped by category.

- Pressing `?` opens the panel and suppresses all other keybindings (except scroll keys and `ctrl+c`)
- `?` or `esc` dismisses the panel
- Opening help closes any open detail panel (only one overlay at a time)
- Content scrolls via `viewport.Model` when it exceeds available height

## Key Changes

- **`tui/help.go`** (new): `HelpPanelComponent` struct following the `DetailPanelComponent` pattern with a `viewport.Model` for scrolling; `helpContent` var with all keybindings and labels in one place (with sync comment pointing to `docs/USER_GUIDE.md §6`)
- **`tui/model.go`**: `helpPanel bool` + `help HelpPanelComponent` fields on `Model`; `?` key handler in `Update()`; help height accounted for in `updateLayout()`; help panel rendered between detail and history in `View()`
- **`tui/model_test.go`**: `TestHelpPanelToggle`, `TestHelpPanelSuppressKeys`, `TestLayoutHeightInvariant_WithHelp`
- **`docs/USER_GUIDE.md`**: `?` row added to the keyboard shortcuts table in section 7

## How to Test

1. Run `fabrik` (or `go run . ...`)
2. Press `?` — help panel appears above history, showing keybindings and labels
3. Press `↑/↓` or `j/k` — help content scrolls
4. Press `?` again or `esc` — panel closes, normal bindings resume
5. Open detail panel with `enter`, then press `?` — detail closes, help opens
6. Run `go test -race ./tui/...` — all tests pass

Closes #343