### PR TITLE
feat: detect fine-grained PAT and enrich 401/403 error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,5 +365,7 @@ See [adrs/](adrs/) for documented decisions and their rationale.
 
 - Go 1.26.1+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
-- GitHub personal access token with `repo` and `project` scopes
+- GitHub **classic** personal access token (`ghp_...`) with `repo`, `project`, and `workflow` scopes
+  - Fine-grained tokens (`github_pat_...`) are **not supported** — GitHub Projects v2 GraphQL requires a classic PAT
+  - Create one at: https://github.com/settings/tokens (select "Tokens (classic)")
 - A GitHub Project (v2) with board columns matching your stage names

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -264,6 +264,10 @@ func Execute() error {
 		return fmt.Errorf("GitHub token required: use --token, FABRIK_TOKEN, or GITHUB_TOKEN")
 	}
 
+	if strings.HasPrefix(cfg.Token, "github_pat_") {
+		fmt.Fprintf(os.Stderr, "[warn] Fine-grained personal access tokens (github_pat_...) do not support GitHub Projects v2 GraphQL. Switch to a classic personal access token with 'repo', 'project', and 'workflow' scopes. See: https://github.com/settings/tokens\n")
+	}
+
 	if cfg.User == "" {
 		return fmt.Errorf("user is required: use --user flag or FABRIK_USER in .env")
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -292,4 +294,38 @@ func TestExecute_ConfigTUIFalse(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "tok")
 	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
 	executeAndStop(t)
+}
+
+// TestExecute_FineGrainedTokenWarning verifies that a token prefixed with
+// "github_pat_" causes a warning to be written to stderr before any API calls.
+// The test does not use t.Parallel() to avoid races on os.Stderr.
+func TestExecute_FineGrainedTokenWarning(t *testing.T) {
+	// Redirect os.Stderr to a pipe so we can capture the warning.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	resetFlags()
+	// Provide a fine-grained token but omit --user so Execute fails early.
+	// The warning must be logged before the user-check error is returned.
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--token", "github_pat_testtoken"}
+
+	Execute() //nolint:errcheck — we only care about the stderr output
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stderr pipe: %v", err)
+	}
+
+	if !strings.Contains(string(output), "Fine-grained personal access tokens") {
+		t.Errorf("expected fine-grained PAT warning on stderr, got: %q", string(output))
+	}
+	if !strings.Contains(string(output), "classic personal access token") {
+		t.Errorf("expected classic PAT guidance on stderr, got: %q", string(output))
+	}
 }

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -33,7 +33,9 @@ For details on the internal stage lifecycle, see [Stage Lifecycle](stage-lifecyc
 
 - Go 1.26.1+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
-- GitHub personal access token with `repo` and `project` scopes
+- GitHub **classic** personal access token (`ghp_...`) with `repo`, `project`, and `workflow` scopes
+  - Fine-grained tokens (`github_pat_...`) are **not supported** — GitHub Projects v2 GraphQL requires a classic PAT
+  - Create one at: https://github.com/settings/tokens (select "Tokens (classic)")
 - A GitHub Project (v2) with board columns matching your stage names
 
 
@@ -100,6 +102,9 @@ GitHub token to a gitignored `.env` file:
 
 ```
 # .env (gitignored — keep secrets here)
+# Use a CLASSIC personal access token (ghp_...) — not a fine-grained token (github_pat_...)
+# Required scopes: repo, project, workflow
+# Create at: https://github.com/settings/tokens (select "Tokens (classic)")
 FABRIK_TOKEN=ghp_...
 ```
 
@@ -300,7 +305,8 @@ Keep only secrets here. Fabrik refuses to start if `.env` exists but is not giti
 
 ```
 # .env (gitignored)
-FABRIK_TOKEN=ghp_...         # Preferred token env var
+# Classic personal access token (ghp_...) required — see https://github.com/settings/tokens
+FABRIK_TOKEN=ghp_...         # Preferred token env var (needs repo, project, workflow scopes)
 GITHUB_TOKEN=ghp_...         # Fallback token env var
 ```
 
@@ -333,8 +339,8 @@ FABRIK_USER=my-personal-username
 
 | Variable | `config.yaml` key | Description | Default |
 |----------|-------------------|-------------|---------|
-| `FABRIK_TOKEN` | *(secrets only)* | GitHub personal access token (preferred) | required |
-| `GITHUB_TOKEN` | *(secrets only)* | GitHub personal access token (fallback) | required |
+| `FABRIK_TOKEN` | *(secrets only)* | GitHub **classic** personal access token (`ghp_...`) with `repo`, `project`, `workflow` scopes (preferred) | required |
+| `GITHUB_TOKEN` | *(secrets only)* | GitHub **classic** personal access token (`ghp_...`) — fallback when `FABRIK_TOKEN` is unset | required |
 | `FABRIK_OWNER` | `owner` | GitHub repo owner | -- |
 | `FABRIK_REPO` | `repo` | GitHub repo name; optional — omitting enables multi-repo mode (all repos on the board) | -- |
 | `FABRIK_PROJECT_NUMBER` | `project` | GitHub Project (v2) number | -- |
@@ -1122,6 +1128,19 @@ Typical cost is ~5–30 points per poll depending on active items, well within t
 ---
 
 ## 9. Troubleshooting
+
+### GitHub API Returns 401 or "Fine-Grained Token" Warning
+
+Fabrik requires a **classic** personal access token (`ghp_...`). Fine-grained tokens (`github_pat_...`) are **not supported** because GitHub Projects v2 GraphQL — which Fabrik uses for status updates and board queries — is not available to fine-grained PATs.
+
+**Symptoms:**
+- Startup warning: `[warn] Fine-grained personal access tokens (github_pat_...) do not support GitHub Projects v2 GraphQL...`
+- Error on first API call: `GitHub API returned 401: ... If you used a fine-grained access token...`
+
+**Fix:**
+1. Go to https://github.com/settings/tokens and select **"Tokens (classic)"**
+2. Generate a new token with scopes: `repo`, `project`, `workflow`
+3. Update `FABRIK_TOKEN` in your `.env` file with the new `ghp_...` token
 
 ### Startup Board Validation Failure
 

--- a/github/client.go
+++ b/github/client.go
@@ -110,7 +110,7 @@ func (c *Client) graphqlRequest(query string, variables map[string]interface{}, 
 	}
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	// Check for GraphQL errors

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -69,6 +69,60 @@ func TestGraphqlRequest_HTTPError(t *testing.T) {
 	}
 }
 
+func TestGraphqlRequest_401ContainsHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"message":"Requires authentication"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	var result struct{}
+	err := c.graphqlRequest("{ test }", nil, &result)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !containsStr(err.Error(), "classic personal access token") {
+		t.Errorf("GraphQL 401 error missing auth hint, got: %q", err.Error())
+	}
+}
+
+func TestGraphqlRequest_403ContainsHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`{"message":"Forbidden"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	var result struct{}
+	err := c.graphqlRequest("{ test }", nil, &result)
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !containsStr(err.Error(), "classic personal access token") {
+		t.Errorf("GraphQL 403 error missing auth hint, got: %q", err.Error())
+	}
+}
+
+func TestGraphqlRequest_500NoHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`Internal Server Error`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	var result struct{}
+	err := c.graphqlRequest("{ test }", nil, &result)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if containsStr(err.Error(), "classic personal access token") {
+		t.Errorf("GraphQL 500 error should not contain auth hint, got: %q", err.Error())
+	}
+}
+
 func TestGraphqlRequest_GraphQLError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/github/rest.go
+++ b/github/rest.go
@@ -33,6 +33,17 @@ var ErrUnprocessableEntity = errors.New("unprocessable entity")
 // detect unsupported operations (e.g. rebase merge not allowed by repo policy).
 var ErrMethodNotAllowed = errors.New("method not allowed")
 
+// authErrorHint returns an actionable hint string for 401/403 HTTP errors and
+// an empty string for all other status codes. The hint advises users to switch
+// to a classic personal access token, which is required for GitHub Projects v2
+// GraphQL operations that fine-grained tokens do not support.
+func authErrorHint(statusCode int) string {
+	if statusCode == 401 || statusCode == 403 {
+		return " If you used a fine-grained access token (github_pat_...), switch to a classic personal access token with 'repo', 'project', and 'workflow' scopes. See: https://github.com/settings/tokens"
+	}
+	return ""
+}
+
 func (c *Client) restRequest(method, url string, body interface{}) error {
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
@@ -63,7 +74,7 @@ func (c *Client) restRequest(method, url string, body interface{}) error {
 		case 422:
 			return fmt.Errorf("GitHub API returned 422: %s: %w", string(respBody), ErrUnprocessableEntity)
 		}
-		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	return nil
@@ -90,7 +101,7 @@ func (c *Client) restGetJSON(url string, result interface{}) error {
 		if resp.StatusCode == 404 {
 			return fmt.Errorf("GitHub API returned 404: %s: %w", string(respBody), ErrNotFound)
 		}
-		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)
@@ -121,7 +132,7 @@ func (c *Client) restGet(url string) (*SearchResult, error) {
 
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	var result SearchResult
@@ -160,7 +171,7 @@ func (c *Client) restPostWithResponse(url string, body interface{}, target inter
 
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
@@ -204,7 +215,7 @@ func (c *Client) restPutWithResponse(url string, body interface{}, target interf
 		case 422:
 			return fmt.Errorf("GitHub API returned 422: %s: %w", string(respBody), ErrUnprocessableEntity)
 		}
-		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
@@ -234,7 +245,7 @@ func (c *Client) restDelete(url string) error {
 		if resp.StatusCode == 404 {
 			return fmt.Errorf("GitHub API returned 404: %s: %w", string(respBody), ErrNotFound)
 		}
-		return fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
 	}
 
 	return nil

--- a/github/rest_test.go
+++ b/github/rest_test.go
@@ -132,3 +132,96 @@ func TestRestPost_NoRateLimitHeaders(t *testing.T) {
 		t.Errorf("rest.Limit = %d, want 0 when headers absent", rest.Limit)
 	}
 }
+
+func TestAuthErrorHint_401ContainsHint(t *testing.T) {
+	hint := authErrorHint(401)
+	if hint == "" {
+		t.Fatal("expected non-empty hint for 401")
+	}
+	if !containsStr(hint, "classic personal access token") {
+		t.Errorf("hint for 401 missing expected text, got: %q", hint)
+	}
+}
+
+func TestAuthErrorHint_403ContainsHint(t *testing.T) {
+	hint := authErrorHint(403)
+	if hint == "" {
+		t.Fatal("expected non-empty hint for 403")
+	}
+	if !containsStr(hint, "classic personal access token") {
+		t.Errorf("hint for 403 missing expected text, got: %q", hint)
+	}
+}
+
+func TestAuthErrorHint_500NoHint(t *testing.T) {
+	if hint := authErrorHint(500); hint != "" {
+		t.Errorf("expected empty hint for 500, got: %q", hint)
+	}
+}
+
+func TestAuthErrorHint_404NoHint(t *testing.T) {
+	if hint := authErrorHint(404); hint != "" {
+		t.Errorf("expected empty hint for 404, got: %q", hint)
+	}
+}
+
+func TestRestPost_401ContainsHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"message":"Requires authentication"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	err := c.restPost(srv.URL+"/test", map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !containsStr(err.Error(), "classic personal access token") {
+		t.Errorf("401 error missing auth hint, got: %q", err.Error())
+	}
+}
+
+func TestRestPost_403ContainsHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`{"message":"Forbidden"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	err := c.restPost(srv.URL+"/test", map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !containsStr(err.Error(), "classic personal access token") {
+		t.Errorf("403 error missing auth hint, got: %q", err.Error())
+	}
+}
+
+func TestRestPost_500NoHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`Internal Server Error`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	err := c.restPost(srv.URL+"/test", map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if containsStr(err.Error(), "classic personal access token") {
+		t.Errorf("500 error should not contain auth hint, got: %q", err.Error())
+	}
+}
+
+// containsStr reports whether substr is found in s.
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds startup warning when a fine-grained token (`github_pat_...`) is detected — non-fatal, since the prefix check is a heuristic
- Enriches all GitHub API 401/403 error messages with an actionable hint directing users to switch to a classic PAT with `repo`, `project`, and `workflow` scopes
- Updates `README.md` and `docs/USER_GUIDE.md` to explicitly require a classic PAT, document all three required scopes, and add a Troubleshooting entry for the fine-grained token failure case

## Key Changes

- **`github/rest.go`**: New `authErrorHint(statusCode int) string` helper; applied to all six REST HTTP error paths
- **`github/client.go`**: `authErrorHint` applied to the `graphqlRequest` HTTP 401/403 path (the most common failure point when using a fine-grained token against Projects v2 GraphQL)
- **`cmd/root.go`**: `strings.HasPrefix(cfg.Token, "github_pat_")` guard after the empty-token check; logs to stderr before any API call is made
- **`github/rest_test.go`**, **`github/client_test.go`**, **`cmd/root_test.go`**: New tests for the helper, enriched error text on 401/403, absence of hint on 500, and stderr capture of the startup warning

## How to Test

1. Set `FABRIK_TOKEN=github_pat_anything` and start Fabrik — verify the `[warn]` line appears on stderr immediately, before any API call
2. Use a mock server returning 401 or 403 — verify the error message contains "classic personal access token" guidance
3. Verify a 500 error does **not** contain the auth hint
4. Run `go test ./...` — all tests pass

Closes #354