### PR TITLE
reviewCycleCount should be per-stage, not per-issue

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -445,7 +445,7 @@ After the review gate clears (Path 2), if there are unresolved PR review thread 
 
 1. `buildReviewThreadComments()` collects inline comments from unresolved review threads that haven't been processed (no ROCKET reaction, not in `processedSet`)
 2. **inFlight guard:** If a reinvoke goroutine from a previous poll cycle is still running, the entire reinvoke path is skipped (including cycle-limit checks)
-3. **Cycle limit check:** `reviewCycleCount[iKey]` is compared against `MaxReviewCycles` (default 5)
+3. **Cycle limit check:** `reviewCycleCount[stageKey]` is compared against `MaxReviewCycles` (default 5)
    - If exceeded: `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
    - If not exceeded: increment count, dispatch reinvoke
 4. `dispatchReviewReinvoke()` spawns an async goroutine:
@@ -541,7 +541,7 @@ Closed issues are normally skipped by `itemMayNeedWork()` and `itemNeedsWork()`.
 | Cooldown timer | `processedSet[stageKey]` | None | Lost — item retried immediately |
 | Retry count | `retryCount[stageKey]` | None | Lost — retries restart from 0 |
 | Paused-due-to-retries | `pausedDueToRetries[stageKey]` | `fabrik:paused` + `stage:<X>:failed` | Labels survive; in-memory flag lost but `processItem()` detects the failed label directly |
-| Review cycle count | `reviewCycleCount[iKey]` | None | Lost — cycle count restarts from 0 |
+| Review cycle count | `reviewCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
 | Comment processed | `processedSet[key]` | ROCKET (🚀) reaction | Reaction survives restart; in-memory dedup is defense-in-depth |
 | Lock tracking | `lockedIssues[iKey]` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
 | Last updatedAt | `lastUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -61,7 +61,7 @@ type Engine struct {
 	lastReportedCost     float64               // cost at last [stats] report; skip repeat prints when unchanged
 	retryCount           map[string]int        // key: "owner/repo#N-stageName", value: failed attempt count
 	pausedDueToRetries   map[string]bool       // key: "owner/repo#N-stageName", true if engine paused this issue
-	reviewCycleCount     map[string]int        // key: issueKey; review re-invocation cycle count per issue
+	reviewCycleCount     map[string]int        // key: "owner/repo#N-stageName"; review re-invocation cycle count per stage
 	lastUsage            map[string]TokenUsage // key: issueKey; per-issue token usage from last processItem (for TUI)
 	lastCompleted        map[string]bool       // key: issueKey; per-issue stage completion from last processItem (for TUI)
 	lastBlocked          map[string]bool       // key: issueKey; per-issue blocked-on-input from last processItem (for TUI)

--- a/engine/item.go
+++ b/engine/item.go
@@ -859,8 +859,8 @@ func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	e.mu.Lock()
 	delete(e.retryCount, stageKey)
 	delete(e.pausedDueToRetries, stageKey)
-	delete(e.processedSet, stageKey) // clear cooldown so the stage retries immediately
-	delete(e.reviewCycleCount, iKey) // reset review cycle counter on unpause
+	delete(e.processedSet, stageKey)    // clear cooldown so the stage retries immediately
+	delete(e.reviewCycleCount, stageKey) // reset review cycle counter on unpause
 	e.mu.Unlock()
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -649,6 +649,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			// have nothing to address; fall through to advance as normal.
 			if syntheticComments := e.buildReviewThreadComments(item); len(syntheticComments) > 0 {
 				iKey := issueKey(item, e.defaultRepo())
+				stageKey := iKey + "-" + stage.Name
 				// Guard: if a goroutine from a previous poll cycle is still
 				// running dispatchReviewReinvoke for this item, skip the entire
 				// reinvoke path — including cycle-limit checks — to avoid
@@ -660,14 +661,14 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 					continue
 				}
 				e.mu.Lock()
-				cycleCount := e.reviewCycleCount[iKey]
+				cycleCount := e.reviewCycleCount[stageKey]
 				maxCycles := e.cfg.MaxReviewCycles
 				e.mu.Unlock()
 				if cycleCount >= maxCycles {
 					e.pauseForReviewCycleLimit(board, item, stage, cycleCount, maxCycles)
 				} else {
 					e.mu.Lock()
-					e.reviewCycleCount[iKey]++
+					e.reviewCycleCount[stageKey]++
 					e.mu.Unlock()
 					e.dispatchReviewReinvoke(ctx, board, item, stage)
 					advancedItems[issueKey(item, e.defaultRepo())] = true

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -448,19 +448,37 @@ func TestReviewCycleCount_PerStageNotPerIssue(t *testing.T) {
 	}
 	eng := testEngineWithStages(client, stgs)
 	iKey := "owner/repo#10"
+	reviewStageKey := iKey + "-Review"
+	validateStageKey := iKey + "-Validate"
 
 	// Simulate Review consuming 3 cycles out of 5.
 	eng.mu.Lock()
-	eng.reviewCycleCount[iKey+"-Review"] = 3
+	eng.reviewCycleCount[reviewStageKey] = 3
+	_, validateExistsBefore := eng.reviewCycleCount[validateStageKey]
 	eng.mu.Unlock()
 
-	// Validate stage must have an independent budget: its counter is still 0.
+	// Before Validate "runs", it must not even have a stage-specific entry yet —
+	// proving Review's counter did not bleed into Validate's key.
+	if validateExistsBefore {
+		t.Fatalf("Validate reviewCycleCount entry already exists before Validate runs; want no entry")
+	}
+
+	// Simulate Validate consuming one cycle and verify it uses its own counter
+	// without disturbing Review's existing count.
 	eng.mu.Lock()
-	validateCount := eng.reviewCycleCount[iKey+"-Validate"]
+	eng.reviewCycleCount[validateStageKey]++
+	reviewCount := eng.reviewCycleCount[reviewStageKey]
+	validateCount, validateExistsAfter := eng.reviewCycleCount[validateStageKey]
 	eng.mu.Unlock()
 
-	if validateCount != 0 {
-		t.Errorf("Validate reviewCycleCount = %d; want 0 (must be independent of Review cycles)", validateCount)
+	if reviewCount != 3 {
+		t.Errorf("Review reviewCycleCount = %d after Validate increment; want 3", reviewCount)
+	}
+	if !validateExistsAfter {
+		t.Fatalf("Validate reviewCycleCount entry missing after Validate increment; want stage-specific entry")
+	}
+	if validateCount != 1 {
+		t.Errorf("Validate reviewCycleCount = %d; want 1 (must be independent of Review cycles)", validateCount)
 	}
 }
 

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -366,8 +366,9 @@ func TestCatchUpLoop_InFlightGuard(t *testing.T) {
 	eng.wg.Wait()
 
 	// reviewCycleCount must remain 0 — the inFlight guard must prevent the dispatch.
+	stageKey := iKey + "-Implement" // item.Status == "Implement"
 	eng.mu.Lock()
-	count := eng.reviewCycleCount[iKey]
+	count := eng.reviewCycleCount[stageKey]
 	eng.mu.Unlock()
 	if count != 0 {
 		t.Errorf("reviewCycleCount = %d; want 0 (dispatch must be suppressed when in-flight)", count)
@@ -434,6 +435,75 @@ func TestPauseForReviewCycleLimit(t *testing.T) {
 	// Should have posted a comment mentioning the cycle count
 	if len(client.addCommentCalls) != 1 {
 		t.Fatalf("expected 1 comment, got %d", len(client.addCommentCalls))
+	}
+}
+
+// (i1) reviewCycleCount is per-stage: cycles consumed by one stage do not
+// reduce the budget for a different stage on the same issue.
+func TestReviewCycleCount_PerStageNotPerIssue(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := []*stages.Stage{
+		{Name: "Review", Order: 1, Prompt: "review"},
+		{Name: "Validate", Order: 2, Prompt: "validate"},
+	}
+	eng := testEngineWithStages(client, stgs)
+	iKey := "owner/repo#10"
+
+	// Simulate Review consuming 3 cycles out of 5.
+	eng.mu.Lock()
+	eng.reviewCycleCount[iKey+"-Review"] = 3
+	eng.mu.Unlock()
+
+	// Validate stage must have an independent budget: its counter is still 0.
+	eng.mu.Lock()
+	validateCount := eng.reviewCycleCount[iKey+"-Validate"]
+	eng.mu.Unlock()
+
+	if validateCount != 0 {
+		t.Errorf("Validate reviewCycleCount = %d; want 0 (must be independent of Review cycles)", validateCount)
+	}
+}
+
+// (i2) clearFailedStage resets only the paused stage's reviewCycleCount; a
+// different stage's counter on the same issue is unaffected.
+func TestClearFailedStage_ReviewCycleCount_ResetsOnlyCurrentStage(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := []*stages.Stage{
+		{Name: "Review", Order: 1, Prompt: "review", WaitForReviews: boolPtr(true)},
+		{Name: "Validate", Order: 2, Prompt: "validate", WaitForReviews: boolPtr(true)},
+	}
+	eng := testEngineWithStages(client, stgs)
+	item := gh.ProjectItem{
+		Number: 10,
+		Repo:   "owner/repo",
+		Labels: []string{"stage:Review:failed", "fabrik:paused"},
+	}
+	iKey := "owner/repo#10"
+	reviewStageKey := iKey + "-Review"
+	validateStageKey := iKey + "-Validate"
+
+	// Simulate both stages having consumed cycles (Review hit limit; Validate consumed 2).
+	eng.mu.Lock()
+	eng.reviewCycleCount[reviewStageKey] = 5
+	eng.reviewCycleCount[validateStageKey] = 2
+	eng.mu.Unlock()
+
+	// User manually unpauses Review.
+	reviewStage := &stages.Stage{Name: "Review", Order: 1}
+	eng.clearFailedStage(item, reviewStage)
+
+	// Review's counter must be reset to 0.
+	eng.mu.Lock()
+	afterReview := eng.reviewCycleCount[reviewStageKey]
+	afterValidate := eng.reviewCycleCount[validateStageKey]
+	eng.mu.Unlock()
+
+	if afterReview != 0 {
+		t.Errorf("Review reviewCycleCount = %d after clearFailedStage; want 0", afterReview)
+	}
+	// Validate's counter must be untouched — it has an independent budget.
+	if afterValidate != 2 {
+		t.Errorf("Validate reviewCycleCount = %d after clearing Review; want 2 (independent)", afterValidate)
 	}
 }
 


### PR DESCRIPTION
## Summary

Change `reviewCycleCount` to be keyed by `iKey + "-" + stage.Name` (the same `stageKey` convention used by `processedSet`, `retryCount`, and `pausedDueToRetries`) so each stage gets its own independent reinvocation budget.

## Problem

`Engine.reviewCycleCount` is a `map[string]int` keyed by issue key (`iKey`), not by stage. The counter is incremented in `engine/poll.go` when `dispatchReviewReinvoke` is scheduled, and checked against `cfg.MaxReviewCycles` before each reinvocation.

Because the key is per-issue, reinvoke cycles consumed during the Review stage leave fewer available cycles for the Validate stage on the same issue. If `MaxReviewCycles=5` and Review burns 3 cycles addressing Copilot feedback, Validate only has 2 cycles before `pauseForReviewCycleLimit` fires — even though Review's feedback is entirely unrelated to Validate's.

`clearFailedStage` (in `engine/item.go`) does reset `reviewCycleCount[iKey]` when a user manually unpauses after a cycle-limit pause, so the counter resets at that point. But during a healthy Review → Validate progression without user intervention, the budget is unintentionally shared across stages.

All other per-issue-per-stage tracking maps (`processedSet`, `retryCount`, `pausedDueToRetries`) use a composite `stageKey` (`iKey + "-" + stage.Name`). `reviewCycleCount` is the sole outlier.

This was surfaced in `docs/state-machine.md` §9.5 during a state-machine review and flagged as as-built behavior of questionable correctness. Both Review and Validate default to `wait_for_reviews: true`, so this affects every issue that goes through the pipeline with any review activity.

Discovered while writing up #392 (process PR review thread comments outside of yolo/cruise catch-up).

## Approach

(Populated by Implement)

## Verification

Changed `reviewCycleCount` to use `stageKey` (`iKey + "-" + stage.Name`) instead of `iKey` across all four read/write/delete sites in `engine/poll.go` and `engine/item.go`, bringing it in line with `retryCount`, `pausedDueToRetries`, and `processedSet`. Updated the field comment in `engine/engine.go` and two references in `docs/state-machine.md` (§6.2 and §7.5). Updated `TestCatchUpLoop_InFlightGuard` and added two new tests (`TestReviewCycleCount_PerStageNotPerIssue`, `TestClearFailedStage_ReviewCycleCount_ResetsOnlyCurrentStage`) to verify per-stage isolation; all tests pass with `-race`.

---

Closes #393