### PR TITLE
Process PR review thread comments outside of yolo/cruise catch-up

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -214,9 +214,9 @@ Nine distinct event types drive state transitions:
 
 ### 2.9 Review Reinvoke
 
-**Trigger:** The catch-up loop detects unresolved PR review thread comments after the review gate clears.
+**Trigger:** The catch-up loop Phase 1 detects unresolved PR review thread comments on any `stage:<X>:complete` item — regardless of whether the item has `fabrik:yolo`, `fabrik:cruise`, or any `auto_advance` config. Phase 1 runs unconditionally; only Phase 2 (stage advancement) is gated on those labels.
 
-**Code path:** `poll()` catch-up loop → `buildReviewThreadComments()` → cycle limit check → `dispatchReviewReinvoke()` → async goroutine → `processComments()` with synthetic comments
+**Code path:** `poll()` catch-up loop Phase 1 → `buildReviewThreadComments()` → cycle limit check → `dispatchReviewReinvoke()` → async goroutine → `processComments()` with synthetic comments
 
 **Distinct from regular comment processing because:**
 - Uses synthetic comments derived from PR review threads (`LinkedPRReviewThreadComments`), not issue comments
@@ -443,18 +443,27 @@ The review gate has two paths that handle different timing scenarios:
 
 ### 6.2 Review Reinvoke Mechanics
 
-After the review gate clears (Path 2), if there are unresolved PR review thread comments with actionable content:
+The catch-up loop in `poll()` is split into two phases for every `stage:<X>:complete` non-paused non-cleanup item:
 
-1. `buildReviewThreadComments()` collects inline comments from unresolved review threads that haven't been processed (no ROCKET reaction, not in `processedSet`)
-2. **inFlight guard:** If a reinvoke goroutine from a previous poll cycle is still running, the entire reinvoke path is skipped (including cycle-limit checks)
-3. **Cycle limit check:** `reviewCycleCount[stageKey]` is compared against `MaxReviewCycles` (default 5)
+**Phase 1 — unconditional (all items, regardless of yolo/cruise/auto_advance):**
+1. `checkDependencies()` — if blocked, skip
+2. `checkReviewGate()` — if awaiting reviewers, skip; if timed out, pause
+3. `buildReviewThreadComments()` collects inline comments from unresolved review threads (no ROCKET reaction, not in `processedSet`)
+4. **inFlight guard:** If a reinvoke goroutine from a previous poll cycle is still running, the entire reinvoke path is skipped (including cycle-limit checks)
+5. **Cycle limit check:** `reviewCycleCount[stageKey]` is compared against `MaxReviewCycles` (default 5)
    - If exceeded: `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
-   - If not exceeded: increment count, dispatch reinvoke
-4. `dispatchReviewReinvoke()` spawns an async goroutine:
-   - Marks item in `inFlight` (prevents double-dispatch by dispatch loop)
-   - Acquires semaphore slot (respects `MaxConcurrent`)
-   - Calls `processComments()` with the synthetic review comments
-   - On exit: releases semaphore, clears `inFlight`
+   - If not exceeded: increment count, dispatch reinvoke via `dispatchReviewReinvoke()`:
+     - Marks item in `inFlight` (prevents double-dispatch)
+     - Acquires semaphore slot (respects `MaxConcurrent`)
+     - Calls `processComments()` with the synthetic review comments asynchronously
+     - On exit: releases semaphore, clears `inFlight`
+
+**Phase 2 — gated (yolo/cruise/auto_advance only):**
+- Only runs when no unresolved review threads remain (Phase 1 `continue`s on reinvoke)
+- Gated on: `e.cfg.Yolo` OR `fabrik:yolo` label OR `fabrik:cruise` label OR stage `auto_advance: true`
+- Runs `attemptMergeOnValidate()` (yolo only), skips if unprocessed comments exist, then calls `advanceToNextStage()`
+
+**processComments widening:** `processComments()` itself also merges any unresolved `LinkedPRReviewThreadComments` at entry, before Step 1. This closes the race where a user nudge arrives before the catch-up loop Phase 1 fires — the review thread comments are addressed in the same invocation as the nudge comment.
 
 **Review thread resolution:** Step 10 of `processComments()` resolves addressed review threads via `ResolveReviewThread()` after adding ROCKET reactions.
 
@@ -467,7 +476,7 @@ After the review gate clears (Path 2), if there are unresolved PR review thread 
 | Dispatch | Synchronous in `processItem()` | Async goroutine via `dispatchReviewReinvoke()` |
 | Cycle limits | None | `MaxReviewCycles` (default 5) |
 | Timeout | None | Integrated with `ReviewWaitTimeout` |
-| Thread resolution | No | Yes — resolves review threads after processing |
+| Thread resolution | Yes — `processComments()` merges unresolved `LinkedPRReviewThreadComments` at entry, so a user nudge resolves threads in the same invocation | Yes — resolves review threads after processing |
 | inFlight guard | Uses dispatch loop's `inFlight` check | Has its own `inFlight` check in catch-up loop |
 
 ### 6.4 Decompose Path
@@ -721,7 +730,12 @@ stateDiagram-v2
 stateDiagram-v2
     direction TB
 
-    StageComplete --> CheckReviewGate : Catch-up loop (Path 2)
+    StageComplete --> CheckDependencies : Catch-up loop Phase 1\n(unconditional — all items)
+    CheckDependencies --> Blocked : Has open blockers
+    CheckDependencies --> CheckReviewGate : No blockers
+
+    Blocked --> CheckDependencies : Next poll tick
+
     CheckReviewGate --> WaitingForReviewers : Outstanding reviewers
     CheckReviewGate --> TimedOut : Timeout elapsed
     CheckReviewGate --> GateCleared : All reviewers submitted
@@ -732,7 +746,7 @@ stateDiagram-v2
     note right of PausedForTimeout : fabrik:paused\nfabrik:awaiting-input
 
     GateCleared --> CheckThreads : buildReviewThreadComments()
-    CheckThreads --> Advance : No unresolved threads
+    CheckThreads --> Phase2 : No unresolved threads → Phase 2
     CheckThreads --> CheckInFlight : Unresolved threads exist
 
     CheckInFlight --> SkipReinvoke : Already in-flight
@@ -744,9 +758,13 @@ stateDiagram-v2
     CheckCycleLimit --> DispatchReinvoke : cycleCount < MaxReviewCycles
     DispatchReinvoke --> ProcessComments : Async goroutine
     ProcessComments --> CheckReviewGate : Next poll (if new reviews arrive)
-    ProcessComments --> Advance : Stage complete after addressing feedback
+    ProcessComments --> Phase2 : Stage complete after addressing feedback
 
     SkipReinvoke --> CheckReviewGate : Next poll tick
+
+    Phase2 --> Advance : yolo/cruise/auto_advance gate passes
+    Phase2 --> Idle : Gate not met — no advancement
+    note right of Idle : Item stays in stage:X:complete\nuntil user advances manually\nor adds yolo/cruise label
 ```
 
 ---
@@ -762,10 +780,19 @@ Stage advancement can occur through two code paths:
 | **Review data** | Stale (just ran MarkPRReady) | Fresh (from FetchItemDetails) |
 | **Review gate** | Optimistic: applies `fabrik:awaiting-review`, returns | Real: calls `checkReviewGate()`, evaluates timeout |
 | **Label freshness** | Re-fetched (handles mid-run yolo/cruise) | Already fresh from deep fetch |
-| **Merge at Validate** | `attemptMergeOnValidate()` called directly | `attemptMergeOnValidate()` called from catch-up |
-| **Advancement** | `advanceToNextStage()` if should advance and no gate | `advanceToNextStage()` after gate evaluation |
+| **Merge at Validate** | `attemptMergeOnValidate()` called directly | `attemptMergeOnValidate()` called from catch-up (yolo only) |
+| **Advancement** | `advanceToNextStage()` if should advance and no gate | `advanceToNextStage()` after Phase 2 gate (yolo/cruise/auto_advance) |
 
 **Label re-fetch in Path 1:** At `stages.go:55`, `handleStageComplete()` calls `FetchLabels()` to pick up changes made while the stage was running (e.g., `fabrik:yolo` added mid-run). This ensures the advancement decision uses current label state, not the stale snapshot from dispatch time.
+
+**Path 2 is split into two phases:**
+
+| Phase | Gate | What it does |
+|-------|------|--------------|
+| **Phase 1** | Unconditional (all `stage:<X>:complete` non-paused non-cleanup items) | `checkDependencies()` → `checkReviewGate()` → `buildReviewThreadComments()` / `dispatchReviewReinvoke()` |
+| **Phase 2** | `fabrik:yolo` (cfg or label) OR `fabrik:cruise` label OR stage `auto_advance: true` | `attemptMergeOnValidate()` (yolo only) → `findNewComments()` deferral → `advanceToNextStage()` |
+
+Phase 1 ensures inline PR review thread comments (from Copilot, Gemini, or human reviewers) are addressed on **all** issues, not just yolo/cruise ones. Phase 2 keeps stage advancement gated as before. Items that pass Phase 1 (review reinvoke dispatched) skip Phase 2 on that poll cycle and are re-evaluated on the next poll.
 
 ## Appendix B: Guard Evaluation in `itemMayNeedWork()` (Shallow Pre-Filter)
 

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -37,11 +37,40 @@ func (e *Engine) findNewComments(item gh.ProjectItem) []gh.Comment {
 // processComments handles new user comments on an issue.
 // Flow: 👀 reactions → editing label → invoke Claude → perform actions / update issue body → remove editing label → 🚀 reactions
 func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment) error {
-	e.logf(item.Number, "comments", "processing %d new comment(s) — stage: %s\n",
-		len(comments), stage.Name)
-
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	iKey := issueKey(item, e.defaultRepo())
+
+	// Merge any unresolved PR review thread comments into the working slice.
+	// This ensures that when a user nudge arrives (e.g. "please address Copilot
+	// feedback"), the review thread comments are processed alongside the
+	// conversation comment without requiring a separate dispatchReviewReinvoke
+	// cycle. For non-PR-backed items LinkedPRReviewThreadComments is empty, so
+	// this is a no-op. For dispatchReviewReinvoke call sites the synthetic
+	// comments were already filtered by buildReviewThreadComments, so the merge
+	// adds nothing (ID dedup prevents duplicates).
+	if len(item.LinkedPRReviewThreadComments) > 0 {
+		existingIDs := make(map[string]bool, len(comments))
+		for _, c := range comments {
+			existingIDs[c.ID] = true
+		}
+		e.mu.Lock()
+		for _, c := range item.LinkedPRReviewThreadComments {
+			if existingIDs[c.ID] {
+				continue
+			}
+			if c.HasReaction("ROCKET") {
+				continue
+			}
+			if _, seen := e.processedSet[iKey+"-comment-"+c.ID]; seen {
+				continue
+			}
+			comments = append(comments, c)
+		}
+		e.mu.Unlock()
+	}
+
+	e.logf(item.Number, "comments", "processing %d new comment(s) — stage: %s\n",
+		len(comments), stage.Name)
 
 	// Step 1: React with 👀 to all new comments. PR review thread (inline)
 	// comments use a different REST endpoint than issue comments.

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -42,14 +42,22 @@ type mockGitHubClient struct {
 	archiveProjectItemCalls []archiveProjectItemCall
 
 	// Track calls — access under mu when accessed from concurrent goroutines.
-	addLabelCalls      []addLabelCall
-	removeLabelCalls   []removeLabelCall
-	addCommentCalls    []addCommentCall
-	updateCommentCalls []updateCommentCall
-	updateStatusCalls  []updateStatusCall
-	mergePRCalls       []mergePRCall
-	markPRReadyCalls   []markPRReadyCall
-	createDraftPRCalls []createDraftPRCall
+	addLabelCalls                    []addLabelCall
+	removeLabelCalls                 []removeLabelCall
+	addCommentCalls                  []addCommentCall
+	updateCommentCalls               []updateCommentCall
+	updateStatusCalls                []updateStatusCall
+	mergePRCalls                     []mergePRCall
+	markPRReadyCalls                 []markPRReadyCall
+	createDraftPRCalls               []createDraftPRCall
+	resolveReviewThreadCalls         []string
+	addPRReviewCommentReactionCalls  []prReviewCommentReactionCall
+}
+
+type prReviewCommentReactionCall struct {
+	owner, repo string
+	commentID   int
+	content     string
 }
 
 type fetchLabelAppliedAtCall struct {
@@ -172,10 +180,16 @@ func (m *mockGitHubClient) AddCommentReaction(owner, repo string, commentDatabas
 }
 
 func (m *mockGitHubClient) AddPRReviewCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	m.mu.Lock()
+	m.addPRReviewCommentReactionCalls = append(m.addPRReviewCommentReactionCalls, prReviewCommentReactionCall{owner, repo, commentDatabaseID, content})
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *mockGitHubClient) ResolveReviewThread(threadID string) error {
+	m.mu.Lock()
+	m.resolveReviewThreadCalls = append(m.resolveReviewThreadCalls, threadID)
+	m.mu.Unlock()
 	return nil
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -692,9 +692,10 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		}
 
 		if stage.Name == "Validate" {
-			// cruise stops here: skip merge and advancement, leave for human.
-			isCruiseOnly := !e.cfg.Yolo && !hasYoloLabel(item) && hasCruiseLabel(item)
-			if isCruiseOnly {
+			// auto-merge is yolo-only — matches handleStageComplete gating.
+			// cruise and auto_advance:true both stop here without merging.
+			yoloActive := e.cfg.Yolo || hasYoloLabel(item)
+			if !yoloActive {
 				continue
 			}
 			if err := e.attemptMergeOnValidate(item); err != nil {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -597,13 +597,17 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		e.logf(0, "poll", "deep-fetched details for %d item(s)\n", deepFetched)
 	}
 
-	// Catch-up: auto-advance items that have fabrik:yolo or fabrik:cruise +
-	// stage complete but are still sitting in the completed stage's column.
-	// Operates only on deepFetchCandidates so the full label set is available.
+	// Catch-up loop: operates only on deepFetchCandidates so the full label set is available.
+	//
+	// Phase 1 (unconditional): for every non-paused, non-cleanup item with a
+	// stage:<X>:complete label, run dependency check, review gate, and review
+	// reinvoke regardless of yolo/cruise/auto_advance. This ensures inline PR
+	// review thread comments (Copilot, Gemini, human inline) are addressed on
+	// all issues, not just yolo/cruise ones.
+	//
+	// Phase 2 (gated): stage advancement, gated on yolo/cruise/auto_advance.
 	for _, item := range deepFetchCandidates {
-		if !e.cfg.Yolo && !hasYoloLabel(item) && !hasCruiseLabel(item) {
-			continue
-		}
+		// Skip paused items in both phases.
 		isPaused := false
 		for _, l := range item.Labels {
 			if l == "fabrik:paused" {
@@ -618,11 +622,6 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		if stage == nil || stage.CleanupWorktree {
 			continue
 		}
-		// cruise and yolo both override auto_advance:false on individual stages.
-		isAutoAdvance := hasYoloLabel(item) || hasCruiseLabel(item)
-		if !isAutoAdvance && stage.AutoAdvance != nil && !*stage.AutoAdvance {
-			continue
-		}
 		completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 		hasComplete := false
 		for _, l := range item.Labels {
@@ -631,74 +630,90 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 				break
 			}
 		}
-		if hasComplete {
-			if e.checkDependencies(board, item, stage) {
-				continue // blocked; checkDependencies handled label + comment
-			}
-			blocked, timedOut := e.checkReviewGate(board, item, stage)
-			if blocked {
-				continue // awaiting reviewers; checkReviewGate handled label
-			}
-			if timedOut {
-				e.pauseForReviewTimeout(board, item, stage)
-				continue
-			}
-			// Gate cleared naturally — if reviews with actionable body text were
-			// submitted, re-invoke the stage agent to address the feedback before
-			// advancing. Reviews with empty bodies (e.g. APPROVED with no comment)
-			// have nothing to address; fall through to advance as normal.
-			if syntheticComments := e.buildReviewThreadComments(item); len(syntheticComments) > 0 {
-				iKey := issueKey(item, e.defaultRepo())
-				stageKey := iKey + "-" + stage.Name
-				// Guard: if a goroutine from a previous poll cycle is still
-				// running dispatchReviewReinvoke for this item, skip the entire
-				// reinvoke path — including cycle-limit checks — to avoid
-				// pausing an item while valid work is still in progress. The
-				// goroutine clears inFlight when it exits; the next poll will
-				// re-evaluate.
-				if _, ok := e.inFlight.Load(iKey); ok {
-					e.logf(item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
-					continue
-				}
-				e.mu.Lock()
-				cycleCount := e.reviewCycleCount[stageKey]
-				maxCycles := e.cfg.MaxReviewCycles
-				e.mu.Unlock()
-				if cycleCount >= maxCycles {
-					e.pauseForReviewCycleLimit(board, item, stage, cycleCount, maxCycles)
-				} else {
-					e.mu.Lock()
-					e.reviewCycleCount[stageKey]++
-					e.mu.Unlock()
-					e.dispatchReviewReinvoke(ctx, board, item, stage)
-					advancedItems[issueKey(item, e.defaultRepo())] = true
-				}
-				continue
-			}
-			if stage.Name == "Validate" {
-				// cruise stops here: skip merge and advancement, leave for human.
-				isCruiseOnly := !e.cfg.Yolo && !hasYoloLabel(item) && hasCruiseLabel(item)
-				if isCruiseOnly {
-					continue
-				}
-				if err := e.attemptMergeOnValidate(item); err != nil {
-					e.logf(item.Number, "warn", "PR not merged during catch-up: %v\n", err)
-					continue
-				}
-			}
-			if newComments := e.findNewComments(item); len(newComments) > 0 {
-				e.logf(item.Number, "advance", "auto-advance catch-up: skipping advance for stage %q — %d unprocessed comment(s) pending\n", stage.Name, len(newComments))
-				continue
-			}
-			e.logf(item.Number, "advance", "auto-advance catch-up: stage %q already complete, advancing\n", stage.Name)
-			if err := e.advanceToNextStage(board, item, stage); err != nil {
-				e.logf(item.Number, "warn", "could not advance: %v\n", err)
-			}
-			// Mark as advanced so the defer doesn't re-cache the old updatedAt.
-			// Board column moves don't bump updatedAt, so re-caching would
-			// make the item look "unchanged" on the next poll.
-			advancedItems[issueKey(item, e.defaultRepo())] = true
+		if !hasComplete {
+			continue
 		}
+
+		// Phase 1: unconditional dependency check, review gate, and review reinvoke.
+		if e.checkDependencies(board, item, stage) {
+			continue // blocked; checkDependencies handled label + comment
+		}
+		blocked, timedOut := e.checkReviewGate(board, item, stage)
+		if blocked {
+			continue // awaiting reviewers; checkReviewGate handled label
+		}
+		if timedOut {
+			e.pauseForReviewTimeout(board, item, stage)
+			continue
+		}
+		// Gate cleared naturally — if reviews with actionable body text were
+		// submitted, re-invoke the stage agent to address the feedback before
+		// advancing. Reviews with empty bodies (e.g. APPROVED with no comment)
+		// have nothing to address; fall through to Phase 2.
+		if syntheticComments := e.buildReviewThreadComments(item); len(syntheticComments) > 0 {
+			iKey := issueKey(item, e.defaultRepo())
+			stageKey := iKey + "-" + stage.Name
+			// Guard: if a goroutine from a previous poll cycle is still
+			// running dispatchReviewReinvoke for this item, skip the entire
+			// reinvoke path — including cycle-limit checks — to avoid
+			// pausing an item while valid work is still in progress. The
+			// goroutine clears inFlight when it exits; the next poll will
+			// re-evaluate.
+			if _, ok := e.inFlight.Load(iKey); ok {
+				e.logf(item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
+				continue
+			}
+			e.mu.Lock()
+			cycleCount := e.reviewCycleCount[stageKey]
+			maxCycles := e.cfg.MaxReviewCycles
+			e.mu.Unlock()
+			if cycleCount >= maxCycles {
+				e.pauseForReviewCycleLimit(board, item, stage, cycleCount, maxCycles)
+			} else {
+				e.mu.Lock()
+				e.reviewCycleCount[stageKey]++
+				e.mu.Unlock()
+				e.dispatchReviewReinvoke(ctx, board, item, stage)
+				advancedItems[issueKey(item, e.defaultRepo())] = true
+			}
+			continue
+		}
+
+		// Phase 2: gated stage advancement.
+		// Gate: yolo (cfg or label), cruise label, or stage-level auto_advance:true.
+		isAutoAdvance := hasYoloLabel(item) || hasCruiseLabel(item)
+		if !e.cfg.Yolo && !isAutoAdvance && !(stage.AutoAdvance != nil && *stage.AutoAdvance) {
+			continue
+		}
+		// cruise and yolo labels override auto_advance:false on individual stages;
+		// cfg.Yolo alone does not (allows per-stage opt-out to be respected).
+		if !isAutoAdvance && stage.AutoAdvance != nil && !*stage.AutoAdvance {
+			continue
+		}
+
+		if stage.Name == "Validate" {
+			// cruise stops here: skip merge and advancement, leave for human.
+			isCruiseOnly := !e.cfg.Yolo && !hasYoloLabel(item) && hasCruiseLabel(item)
+			if isCruiseOnly {
+				continue
+			}
+			if err := e.attemptMergeOnValidate(item); err != nil {
+				e.logf(item.Number, "warn", "PR not merged during catch-up: %v\n", err)
+				continue
+			}
+		}
+		if newComments := e.findNewComments(item); len(newComments) > 0 {
+			e.logf(item.Number, "advance", "auto-advance catch-up: skipping advance for stage %q — %d unprocessed comment(s) pending\n", stage.Name, len(newComments))
+			continue
+		}
+		e.logf(item.Number, "advance", "auto-advance catch-up: stage %q already complete, advancing\n", stage.Name)
+		if err := e.advanceToNextStage(board, item, stage); err != nil {
+			e.logf(item.Number, "warn", "could not advance: %v\n", err)
+		}
+		// Mark as advanced so the defer doesn't re-cache the old updatedAt.
+		// Board column moves don't bump updatedAt, so re-caching would
+		// make the item look "unchanged" on the next poll.
+		advancedItems[issueKey(item, e.defaultRepo())] = true
 	}
 
 	var dispatched int

--- a/engine/review_phase_test.go
+++ b/engine/review_phase_test.go
@@ -1,0 +1,269 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// TestCatchUpLoop_NonYolo_ReviewReinvoke_Fires verifies that Phase 1 of the
+// catch-up loop dispatches dispatchReviewReinvoke even when the item has no
+// fabrik:yolo or fabrik:cruise label. This is the core behavior added by
+// issue #392: inline PR review thread comments must be addressed on all issues,
+// not just yolo/cruise ones.
+func TestCatchUpLoop_NonYolo_ReviewReinvoke_Fires(t *testing.T) {
+	threadComment := gh.Comment{
+		ID:             "PRRC_nonyolo_1",
+		DatabaseID:     301,
+		Author:         "copilot",
+		Body:           "Please fix the error handling.",
+		ReviewThreadID: "RT_nonyolo_1",
+	}
+
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{
+				ProjectID: "PVT_1",
+				Items: []gh.ProjectItem{
+					{
+						Number: 55,
+						ItemID: "PVTI_55",
+						Status: "Implement",
+						Repo:   "owner/repo",
+						// No yolo or cruise label — this is a normal issue
+						Labels: []string{"stage:Implement:complete"},
+					},
+				},
+			}, nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRReviewThreadComments = []gh.Comment{threadComment}
+			return nil
+		},
+	}
+
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(client, stgs)
+	eng.cfg.MaxReviewCycles = 5
+
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	eng.wg.Wait()
+
+	// reviewCycleCount should be 1 — dispatchReviewReinvoke was dispatched.
+	// Key is stageKey ("owner/repo#N-stageName"), not iKey, for per-stage isolation.
+	stageKey := "owner/repo#55-Implement"
+	eng.mu.Lock()
+	count := eng.reviewCycleCount[stageKey]
+	eng.mu.Unlock()
+	if count != 1 {
+		t.Errorf("reviewCycleCount = %d; want 1 (reinvoke must fire for non-yolo items with unresolved review threads)", count)
+	}
+
+	// No stage advancement should have occurred (Phase 2 is gated on yolo/cruise).
+	client.mu.Lock()
+	statusCalls := len(client.updateStatusCalls)
+	client.mu.Unlock()
+	if statusCalls != 0 {
+		t.Errorf("updateStatusCalls = %d; want 0 (non-yolo items must not auto-advance)", statusCalls)
+	}
+}
+
+// TestCatchUpLoop_NonYolo_NoThreads_NoAdvance verifies that a non-yolo item
+// with stage:X:complete but no unresolved review thread comments does NOT
+// auto-advance. Phase 2 advancement remains gated on yolo/cruise/auto_advance.
+func TestCatchUpLoop_NonYolo_NoThreads_NoAdvance(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{
+				ProjectID: "PVT_1",
+				Items: []gh.ProjectItem{
+					{
+						Number: 56,
+						ItemID: "PVTI_56",
+						Status: "Implement",
+						Repo:   "owner/repo",
+						// No yolo or cruise label, no review threads
+						Labels: []string{"stage:Implement:complete"},
+					},
+				},
+			}, nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			// No review thread comments — nothing to reinvoke or advance.
+			item.LinkedPRReviewThreadComments = nil
+			return nil
+		},
+	}
+
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(client, stgs)
+
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	eng.wg.Wait()
+
+	// No advancement and no reinvoke cycle.
+	client.mu.Lock()
+	statusCalls := len(client.updateStatusCalls)
+	client.mu.Unlock()
+	if statusCalls != 0 {
+		t.Errorf("updateStatusCalls = %d; want 0 (non-yolo items must not auto-advance)", statusCalls)
+	}
+	eng.mu.Lock()
+	count := eng.reviewCycleCount["owner/repo#56-Implement"]
+	eng.mu.Unlock()
+	if count != 0 {
+		t.Errorf("reviewCycleCount = %d; want 0 (no review threads, no reinvoke)", count)
+	}
+}
+
+// TestProcessComments_MergesReviewThreadComments verifies that processComments
+// automatically merges unresolved PR review thread comments from
+// item.LinkedPRReviewThreadComments into the working slice. This closes the
+// race where a user nudge arrives before the catch-up loop Phase 1 fires —
+// the review thread comments are addressed in the same invocation, receive 🚀
+// reactions, and have their threads resolved.
+func TestProcessComments_MergesReviewThreadComments(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "Addressed the review feedback.", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Implement", Order: 1}
+
+	// Item has a linked PR review thread comment that is unresolved.
+	reviewThreadComment := gh.Comment{
+		ID:             "PRRC_merge_1",
+		DatabaseID:     401,
+		Author:         "copilot",
+		Body:           "Please add error handling here.",
+		ReviewThreadID: "RT_merge_1",
+	}
+	item := gh.ProjectItem{
+		Number: 20,
+		Repo:   "owner/repo",
+		Body:   "spec",
+		LinkedPRReviewThreadComments: []gh.Comment{reviewThreadComment},
+	}
+
+	// User nudge — just a conversation comment, NOT the review thread comment.
+	userComment := gh.Comment{
+		ID:         "IC_nudge_1",
+		DatabaseID: 402,
+		Author:     "user",
+		Body:       "Please address the Copilot feedback.",
+	}
+
+	err := eng.processComments(context.Background(), board, item, stage, []gh.Comment{userComment})
+	if err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	// ResolveReviewThread must have been called for the review thread.
+	client.mu.Lock()
+	resolvedThreads := make([]string, len(client.resolveReviewThreadCalls))
+	copy(resolvedThreads, client.resolveReviewThreadCalls)
+	client.mu.Unlock()
+
+	found := false
+	for _, tid := range resolvedThreads {
+		if tid == "RT_merge_1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ResolveReviewThread to be called for RT_merge_1; got calls: %v", resolvedThreads)
+	}
+
+	// The ROCKET reaction must have been added to the review thread comment.
+	client.mu.Lock()
+	rocketCalls := make([]prReviewCommentReactionCall, len(client.addPRReviewCommentReactionCalls))
+	copy(rocketCalls, client.addPRReviewCommentReactionCalls)
+	client.mu.Unlock()
+
+	rocketFound := false
+	for _, rc := range rocketCalls {
+		if rc.commentID == 401 && rc.content == "rocket" {
+			rocketFound = true
+			break
+		}
+	}
+	if !rocketFound {
+		t.Errorf("expected ROCKET reaction to be added to review comment 401; reaction calls: %v", rocketCalls)
+	}
+}
+
+// TestCatchUpLoop_YoloIssue_ReviewReinvoke_StillFires verifies that Phase 1
+// review reinvoke continues to work correctly for yolo-labeled items
+// (regression guard for the existing TestCatchUpLoop_InFlightGuard behavior).
+func TestCatchUpLoop_YoloIssue_ReviewReinvoke_StillFires(t *testing.T) {
+	threadComment := gh.Comment{
+		ID:             "PRRC_yolo_1",
+		DatabaseID:     501,
+		Author:         "copilot",
+		Body:           "Fix this.",
+		ReviewThreadID: "RT_yolo_1",
+	}
+
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{
+				ProjectID: "PVT_1",
+				Items: []gh.ProjectItem{
+					{
+						Number: 57,
+						ItemID: "PVTI_57",
+						Status: "Implement",
+						Repo:   "owner/repo",
+						Labels: []string{"stage:Implement:complete", "fabrik:yolo"},
+					},
+				},
+			}, nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRReviewThreadComments = []gh.Comment{threadComment}
+			return nil
+		},
+	}
+
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(client, stgs)
+	eng.cfg.MaxReviewCycles = 5
+
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	eng.wg.Wait()
+
+	stageKey := "owner/repo#57-Implement"
+	eng.mu.Lock()
+	count := eng.reviewCycleCount[stageKey]
+	eng.mu.Unlock()
+	if count != 1 {
+		t.Errorf("reviewCycleCount = %d; want 1 (yolo items must still trigger review reinvoke)", count)
+	}
+}

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -12,11 +12,11 @@ import (
 )
 
 // checkReviewGate inspects item.LinkedPRReviewRequests and determines whether
-// auto-advance is gated by outstanding PR reviewer requests.
+// the review gate is blocking review reinvoke or stage advancement.
 //
-// This function is only called from the catch-up path (Path 2) in poll.go,
+// This function is only called from the catch-up loop (Phase 1) in poll.go,
 // where item.LinkedPRReviewRequests contains fresh data from FetchItemDetails.
-// Path 1 (handleStageComplete) always applies fabrik:awaiting-review directly
+// handleStageComplete (Path 1) always applies fabrik:awaiting-review directly
 // because reviewer assignment happens after MarkPRReady, so data would be stale.
 //
 // Returns (blocked, timedOut):


### PR DESCRIPTION
## Summary

Split the catch-up loop in `engine/poll.go` into two phases: Phase 1 (review reinvoke — runs unconditionally for all `stage:<X>:complete` items that are not paused/cleanup/dependency-blocked) and Phase 2 (stage advancement — gated on yolo/cruise/`auto_advance: true` as today). Additionally, widen `processComments` to merge any unresolved PR review thread comments into the input slice when processing user comments on PR-backed items, closing the race where a user nudge arrives before the catch-up fires.

## Problem

Inline PR review comments (Copilot, Gemini, human inline comments) are only addressed by Fabrik when `fabrik:yolo` or `fabrik:cruise` is set on the issue. This is because `dispatchReviewReinvoke` lives under the yolo/cruise gate at `engine/poll.go:603`:

```go
if !e.cfg.Yolo && !hasYoloLabel(item) && !hasCruiseLabel(item) {
    continue
}
```

On normal (human-driven) issues, the consequences are:

- Inline review thread comments never receive 👀 or 🚀 reactions
- Review threads are never auto-resolved (`ResolveReviewThread` lives in `processComments` step 10 and only runs for comments that were passed in)
- `buildReviewThreadComments` / `dispatchReviewReinvoke` never fires
- When the user nudges manually (e.g. posting "please address copilot feedback" on the PR conversation), `processComments` runs with only that conversation comment in its `comments` slice. Claude may read the inline threads via worktree context and act on them, but the threads themselves stay unresolved and un-reacted. On the next poll cycle, the same unresolved threads re-surface — Claude re-addresses them. This is the "duplicate comment processing" loop.

Observed on PRs #386 and #388: conversation comments posted by the human have 👀+🚀, but every single Copilot inline review thread comment has zero reactions.

This is a design gap, not just a doc gap. `docs/state-machine.md` §6.2 treats review reinvoke as the mechanism for addressing inline reviewer feedback, but the mechanism is silently gated on yolo/cruise.

## Approach

(Populated by Implement)

## Verification

Split the catch-up loop in `engine/poll.go` into Phase 1 (unconditional review reinvoke for all `stage:<X>:complete` items, regardless of yolo/cruise) and Phase 2 (gated stage advancement, unchanged). Widened `processComments` in `engine/comments.go` to automatically merge unresolved `LinkedPRReviewThreadComments` at entry, so a user nudge processes inline review threads in the same invocation. Added four tests covering non-yolo reinvoke firing, processComments merging with thread resolution, non-advance guard, and a yolo regression guard. Updated `docs/state-machine.md` §2.9, §6.2, §6.3, §10.3, and Appendix A to document the Phase 1/Phase 2 split.

---

Closes #392