### PR TITLE
Name docs/state-machine.md and docs/stage-lifecycle.md as canonical docs in Fabrik's CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,17 @@ effort_level: max               # Claude Code thinking effort: low, medium, high
   - `fabrik:unrestricted` — passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk`; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set (e.g. non-standard toolchains). **Caution:** removes all tool restrictions.
   - `base:<branch>` — set by user to override the worktree base branch for this issue; Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default; must be set before Research; multiple `base:` labels use the first and logs a warning; if the branch does not exist on the remote, Fabrik falls back to the default and posts a comment
 
+## Canonical Documentation
+
+These files are the authoritative as-built specifications for Fabrik's engine behavior. They must be kept in sync with the code — any PR that changes behavior in the areas they cover must update the corresponding doc in the same change set.
+
+- **`docs/state-machine.md`** — As-built specification for: engine state transitions, label semantics, `FABRIK_*` marker handling, comment processing lifecycle, review gate and review reinvoke, PR lifecycle coupling, and guard/filter behavior in `itemMayNeedWork` / `itemNeedsWork`.
+- **`docs/stage-lifecycle.md`** — As-built specification for the per-invocation lifecycle: what happens before, during, and after a single Claude invocation (context files, worktree setup, Claude invocation, output handling).
+
+These are **as-built docs** — they describe what the engine currently does. They are distinct from `adrs/*.md`, which record architectural decisions and design rationale, not current state. Do not put state-machine content into ADRs or vice versa.
+
+PRs introducing new as-built behavioral docs should also add an entry here.
+
 ## Startup Board Validation
 
 On every startup, Fabrik fetches the project board and compares stage names to board columns. If any non-cleanup stage is missing from the board, Fabrik exits with a detailed error message listing the mismatched names. Extra board columns (without a matching stage) produce a warning but don't block startup. This catches mismatches between stage YAML config and the GitHub Project board configuration early.


### PR DESCRIPTION
## Summary

Add a "Canonical Documentation" section to Fabrik's root `CLAUDE.md` — placed after "Important Conventions" and before "Common Issues" — that names `docs/state-machine.md` and `docs/stage-lifecycle.md` as authoritative as-built docs and specifies when changes to them are required. This lets the generic research/plan skills pick these docs up naturally via the existing project-repo scan, without embedding Fabrik-specific paths in project-agnostic skill text.

## Problem

Fabrik's generic research/plan skills (see sibling issue #395) scan the project repo for canonical documentation when assessing doc-impact. That mechanism works for any project, but it relies on the project's own conventions — typically surfaced through its root `CLAUDE.md` — to signal which docs matter.

Fabrik's own `CLAUDE.md` currently documents architecture, key patterns, stage config, and conventions, but it does **not** name `docs/state-machine.md` or `docs/stage-lifecycle.md` as canonical as-built documents that must be kept in sync with engine behavior changes. As a result, engine-internal changes (new markers, changed state transitions, changed label semantics, changed review gating, changed PR lifecycle behavior) can land in code without updating those docs. We've already seen this pattern: #392, #393, and #394 each had to have state-machine.md update requirements added manually.

`docs/state-machine.md`'s preamble explicitly says it is the "As-built specification" — its value is only preserved if every engine-behavior-changing PR updates it in the same change set.

## Approach

### Approach

Single insertion into the repo root `CLAUDE.md` — add a `## Canonical Documentation` section immediately after line 134 (end of `## Important Conventions`) and before line 135 (`## Startup Board Validation`). This placement keeps policy content together and satisfies the "after Important Conventions, before Common Issues" requirement from R1.

The section covers all eight requirements in ~15 lines. No cross-reference to #395 is included because that issue has not yet landed (per R6, the cross-reference is conditional).

No ADR is needed — this is an additive documentation change with no architectural decision, interface, or behavioral constraint that a new contributor would need to discover without reading the code.

No user-facing behavior changes — this is purely an authoring guide for contributors.

### New/Modified Files

| File | Change |
|------|--------|
| `CLAUDE.md` (repo root) | Insert `## Canonical Documentation` section after line 134 |

### Key Decisions

- **Placement before `## Startup Board Validation`**: The spec says "after Important Conventions, before Common Issues" without specifying relative to `## Startup Board Validation`. Placing the new section immediately after Important Conventions groups policy/convention content together (Important Conventions → Canonical Documentation → Startup Board Validation → Common Issues), which is more coherent than inserting it between Startup Board Validation and Common Issues.

- **No #395 cross-reference**: Research confirmed #395 has not landed. Per R6, the cross-reference is omitted. The section is fully standalone.

- **No ADR**: The change is additive documentation with no structural or behavioral implications. No future contributor needs to discover a decision here that isn't obvious from reading CLAUDE.md.

### Task Checklist

- [ ] Task 1: Insert `## Canonical Documentation` section into `CLAUDE.md` after the `## Important Conventions` block (after line 134, before `## Startup Board Validation`)

  Content to insert (satisfies R1–R8, ~15 lines):
  ```markdown

## Verification

Added a `## Canonical Documentation` section to the repo root `CLAUDE.md` immediately after `## Important Conventions` and before `## Startup Board Validation`. The section names `docs/state-machine.md` and `docs/stage-lifecycle.md` as authoritative as-built specifications, requires PRs touching covered engine behavior to update the corresponding doc in the same change set, distinguishes these from `adrs/*.md` (architectural decisions, not current state), and notes that new as-built docs should be added here. The section is 11 lines, committed in a single push to `fabrik/issue-396`.

---

Closes #396