### PR TITLE
Prohibit direct gh comment posting from stages with post_to_pr: true

### DIFF
--- a/plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md
@@ -61,3 +61,8 @@ Do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Implement returns c
 - **Do not skip compilation and test verification** before committing
 - **Do not make unrelated changes** while applying the requested fix
 - **Do not leave uncommitted changes** — always commit and push before returning
+- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
+
+  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
+
+  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.

--- a/plugin/fabrik-plugin/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-implement/SKILL.md
@@ -144,6 +144,11 @@ Before signaling completion:
 - **Do not add features not in the plan** — no scope creep
 - **Do not leave the branch in a broken state** — every push should compile and pass tests
 - **Do not defer documentation** — if the change is user-facing, update the docs in the same PR. A doc update that gets "tracked as a follow-up" is a doc update that never happens.
+- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
+
+  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
+
+  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.
 
 ## Engine Context
 

--- a/plugin/fabrik-plugin/skills/fabrik-review-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-review-comment/SKILL.md
@@ -87,3 +87,8 @@ Do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Review returns cont
 - **Do not leave uncommitted changes** — always commit and push before returning
 - **Do not re-run the full review** — focus on the specific findings the user addressed
 - **Do not make unrelated changes** while applying fixes
+- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
+
+  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
+
+  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.

--- a/plugin/fabrik-plugin/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-review/SKILL.md
@@ -122,7 +122,7 @@ git push
 
 ## Output
 
-Your detailed findings and fixes are posted on the PR (when `post_to_pr: true`). A brief summary is posted on the issue.
+The engine captures your stdout and posts it on the PR (when `post_to_pr: true`). A brief summary is posted on the issue.
 
 ### PR comment structure
 
@@ -158,6 +158,11 @@ FABRIK_SUMMARY_END
 - **Do not add features** — review what's there, not what could be there
 - **Do not nitpick style** unless it violates project conventions
 - **Do not approve if something is wrong** — if you can't fix an issue, do NOT signal completion. Describe the blocker clearly.
+- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
+
+  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
+
+  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.
 
 ## Engine Context
 

--- a/plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md
@@ -60,3 +60,8 @@ When in doubt, do not signal completion — let the user be explicit.
 - **Do not apply fixes beyond what the user requested** — minimal targeted changes only
 - **Do not leave uncommitted changes** — always commit and push before returning
 - **Do not re-run the full validation suite** unless the user specifically requests it — focus on the checks relevant to their feedback
+- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
+
+  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
+
+  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.

--- a/plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md
@@ -147,6 +147,14 @@ If you find major issues (wrong architecture, missing feature, design flaw):
 - Report it clearly
 - Do NOT signal completion
 
+## What You Do NOT Do
+
+- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
+
+  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
+
+  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.
+
 ## Engine Context
 
 **Before you run**: Worktree exists with implementation + review commits.


### PR DESCRIPTION
## Summary

Update the six affected stage skills to explicitly prohibit direct comment posting via `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a GitHub comment on the issue or linked PR. Claude's output must flow to stdout only; Fabrik's engine is the single posting point, ensuring every stage-output comment carries the correct `🏭 **Fabrik — stage: <Name>**` header.

## Problem

Claude invocations in stages with `post_to_pr: true` (Review, Validate, Implement on some configs) can post comments directly to the PR or issue via `gh pr comment` / `gh issue comment`, bypassing Fabrik's engine-side comment posting. When this happens, two comments end up on the PR for the same stage output:

1. Claude's direct post — no `🏭 **Fabrik` header.
2. The engine's `formatOutputComment`-wrapped post — proper header.

On the next poll, `findNewComments` treats the first (header-less) comment as a new user comment because it doesn't match the `🏭 **Fabrik` prefix check at `engine/comments.go:25`. The engine then fires comment processing on it, invoking Claude again to "respond" to its own review. A self-review loop.

Observed on verveguy/liminis PR #614 (Fabrik issue #609). The Claude session log contains the direct `gh pr comment 614 --body ...` invocation. Both comments show up under the runner account `verveguy`, posted 6 seconds apart — the second is Fabrik's wrapped copy.

The skill's current language at `plugin/fabrik-plugin/skills/fabrik-review/SKILL.md:125` — "Your detailed findings and fixes are posted on the PR (when `post_to_pr: true`)" — reads ambiguously. It can be taken to mean "the engine posts them for you" or "you post them yourself." Claude took the latter interpretation. The default allowed-tools list includes `Bash(gh:*)`, so the action was permitted.

Same risk applies to any skill running in a stage with `post_to_pr: true` — at minimum Review, Validate, and any custom Implement configuration. The corresponding `*-comment` skills (which run during comment processing) have the same hazard.

## Approach

### Approach

This is a pure instructional change to six SKILL.md files — no Go code, no tests, no ADRs. The spec provides the exact wording (R4) and the research confirms the exact placement for each file. The implementation is mechanical: add the specified prohibition text to `## What You Do NOT Do` in five files, create that section in the sixth (`fabrik-validate`), and fix one ambiguous line in `fabrik-review`.

One `fabrik-validate/SKILL.md` requires a new `## What You Do NOT Do` section — all other files already have it. The insertion point is between `## Fixing Issues` and `## Engine Context`, consistent with the structure of sibling skills.

No ADR is warranted — this is a wording clarification to internal agent instructions, not an architectural decision that constrains future contributors in a non-obvious way.

No user-facing documentation is affected — these SKILL.md files are internal agent instructions, not CLI docs or user guides.

### New/Modified Files

| File | Change |
|------|--------|
| `plugin/fabrik-plugin/skills/fabrik-review/SKILL.md` | Fix ambiguous line 125; add prohibition to `## What You Do NOT Do` |
| `plugin/fabrik-plugin/skills/fabrik-review-comment/SKILL.md` | Add prohibition to `## What You Do NOT Do` |
| `plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md` | Create `## What You Do NOT Do` section between `## Fixing Issues` and `## Engine Context`; add prohibition |
| `plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md` | Add prohibition to `## What You Do NOT Do` |
| `plugin/fabrik-plugin/skills/fabrik-implement/SKILL.md` | Add prohibition to `## What You Do NOT Do` |
| `plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md` | Add prohibition to `## What You Do NOT Do` |

### Key Decisions

- **Exact R4 wording verbatim**: The spec mandates exact wording. No paraphrasing. The `<Name>` placeholder appears literally in all six files.
- **New section in `fabrik-validate`**: Between `## Fixing Issues` and `## Engine Context`, matching the pattern of sibling skills that have `## What You Do NOT Do` before `## Engine Context`.
- **Append to existing sections**: For the five files that already have `## What You Do NOT Do`, the prohibition text is appended as a new bullet block at the end of that section — after the existing bullets. This preserves existing content and makes the addition easy to diff.
- **Single commit for all six files**: The change is cohesive (one prohibition, six files) and trivially safe. A single commit is cleaner than splitting across files.

### Task Checklist

- [ ] Task 1: Fix ambiguous line in `fabrik-review/SKILL.md` — change "Your detailed findings and fixes are posted on the PR (when `post_to_pr: true`)" to "The engine captures your stdout and posts it on the PR (when `post_to_pr: true`)" at line 125.
- [ ] Task 2: Append the R4 prohibition block to `## What You Do NOT Do` in `fabrik-review/SKILL.md` (currently ends at line 161).
- [ ] Task 3: Append the R4 prohibition block to `## What You Do NOT Do` in `fabrik-review-comment/SKILL.md` (currently ends at line 90).
- [ ] Task 4: Create `## What You Do NOT Do` section in `fabrik-validate/SKILL.md` between `## Fixing Issues` and `## Engine Context`; add the R4 prohibition block as its sole content.
- [ ] Task 5: Append the R4 prohibition block to `## What You Do NOT Do` in `fabrik-validate-comment/SKILL.md` (currently ends at line 63).
- [ ] Task 6: Append the R4 prohibition block to `## What You Do NOT Do` in `fabrik-implement/SKILL.md` (currently ends at line 147).
- [ ] Task 7: Append the R4 prohibition block to `## What You Do NOT Do` in `fabrik-implement-comment/SKILL.md` (currently ends at line 64).
- [ ] Task 8: Commit all six files with message: `docs: prohibit direct gh comment posting in post_to_pr stage skills`

### Prohibition Block (verbatim for all six files)

The following block should be appended (or placed as the sole content in the new `fabrik-validate` section):

```markdown
- **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).

  Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.

  **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.
```

### Risks

- None identified. All files exist, all target sections are confirmed by research. The `fabrik-validate` section creation is additive. Line numbers from research are approximate — implementer should search for the surrounding text anchors rather than relying on exact line numbers.

---
Used 5/50 turns, 3k input / 2k output tokens.

## Verification

Added explicit prohibition against direct `gh pr comment`/`gh issue comment`/`gh pr review` posting to all six `post_to_pr` stage skills (fabrik-review, fabrik-review-comment, fabrik-validate, fabrik-validate-comment, fabrik-implement, fabrik-implement-comment). Also created a new `## What You Do NOT Do` section in `fabrik-validate/SKILL.md` (it had none) and fixed the ambiguous "Your detailed findings…are posted on the PR" line in `fabrik-review/SKILL.md`. All changes committed and pushed in a single commit (`3ddcd32`).

---

Closes #397