### PR TITLE
Harden research/plan skills to enforce state-machine.md and engineering doc sync

### DIFF
--- a/plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md
@@ -52,7 +52,7 @@ Tasks should be:
 
 Include testing tasks alongside the code they test, not as a separate phase at the end.
 
-If the feature is user-facing, identify which docs need updating — check the Research findings for a "Documentation Impact" section if present; if absent, scan the repo for user-facing docs (e.g., `docs/USER_GUIDE.md`, `README.md`, `docs/index.md`). Include doc update tasks alongside the implementation tasks they document, not as a separate phase at the end; reference the spec's Problem/Summary and requirements as source material so Implement has concrete content guidance. If the feature has no user-facing impact (no new commands, flags, workflows, config options, or output behaviors visible to users), state that explicitly in the plan so the Implement agent doesn't wonder whether documentation updates were overlooked.
+Identify which docs need updating — check the Research findings for a "Documentation Impact" section if present; if absent, scan the repo for both user-facing docs (e.g., `README.md`, user guides, config references) and as-built engineering docs (e.g., architecture specs, state machines, protocol docs, internal API references). Include doc update tasks alongside the implementation tasks they document, not as a separate phase at the end; reference the spec's Problem/Summary and requirements as source material so Implement has concrete content guidance. If neither user-facing nor engineering docs require updating, state that explicitly in the plan so the Implement agent doesn't wonder whether documentation updates were overlooked.
 
 ### Document key decisions
 
@@ -203,3 +203,4 @@ Before signaling completion, verify:
 - [ ] The plan is grounded in the research findings
 - [ ] An implementer could follow this plan without making design decisions
 - [ ] Testing is integrated into the task list, not deferred
+- [ ] Documentation impact is reflected in the plan, covering both user-facing and engineering/as-built docs as applicable


### PR DESCRIPTION
## Summary

Update the plan skill to broaden the doc-impact framing to cover both user-facing docs and as-built engineering docs (architecture specs, state machines, protocol docs, internal API references) — whatever the project has. Review the research skill to ensure its doc-impact assessment section reads as project-agnostic. Review comment-skill variants for the same gap.

## Problem

Research and Plan skills already have machinery to track documentation impact — `fabrik-research/SKILL.md:52-62` produces a "Documentation Impact" section, and `fabrik-plan/SKILL.md:55` consumes it. However, a gap in framing lets internal changes slip past the doc-sync check:

### Gap: The "user-facing" framing excludes engineering docs

`fabrik-plan/SKILL.md:55` starts with *"If the feature is user-facing, identify which docs need updating..."*. Changes to internal behavior (new markers, new label semantics, changed state transitions, changed comment-processing lifecycle, changed review-gate behavior) are *not* user-facing but absolutely do need documentation updates in as-built engineering docs. The current framing gives agents implicit license to skip doc updates for purely internal work — on any project Fabrik automates.

### Why this matters

Most non-trivial projects have engineering docs (architecture specs, state machines, protocol specs, internal API references) that aren't user-facing but must stay in sync with the code they describe. The "user-facing" gate is too narrow: it excludes a whole class of documentation that agents should be prompted to consider.

A Fabrik-specific concern (naming `docs/state-machine.md` as a canonical doc) is tracked separately and handled via `CLAUDE.md` in the Fabrik repo — the right venue for project-scoped doc-sync discipline.

## Approach

### Approach

Two targeted edits to `plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md`:

1. **R2 (line 55):** Replace the conditional "If the feature is user-facing..." paragraph with an unconditional paragraph that covers both user-facing docs and as-built engineering docs, while preserving all existing scanning guidance and the "state explicitly if no impact" fallback pattern.

2. **R4 (lines 199–205, Quality Checklist):** Append one bullet item that mirrors the broadened doc-impact framing from R2.

The research confirmed `fabrik-research/SKILL.md` lines 52–62 are already project-agnostic and the research criteria list is out of scope — no changes needed there. Comment skills (`fabrik-research-comment`, `fabrik-plan-comment`) have no doc-impact machinery — no changes needed there either.

### New/Modified Files

| File | Change |
|------|--------|
| `plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md` | R2: replace line-55 paragraph to broaden doc-impact framing; R4: add one Quality Checklist item |

### Key Decisions

- **Unconditional framing, not conditional on engineering docs existing:** The spec resolved Q1 as "unconditional" — always scan for both doc types and state explicitly if neither applies. This removes the discretion gap entirely and matches the existing "state explicitly" fallback pattern already in the skill.
- **Preserve, don't restructure:** The paragraph at line 55 does multiple things (trigger, scanning guidance, fallback). The edit replaces only the conditional trigger and widens the scan scope — the surrounding text is left intact. This satisfies the "surgical changes only" constraint.
- **No ADR warranted:** The decision is fully captured in the updated skill text itself. No novel constraint that future contributors would need to discover outside the code.

### Task Checklist

- [ ] Edit `plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md` line 55: replace "If the feature is user-facing, identify which docs need updating — check the Research findings for a "Documentation Impact" section if present; if absent, scan the repo for user-facing docs (e.g., `docs/USER_GUIDE.md`, `README.md`, `docs/index.md`). Include doc update tasks alongside the implementation tasks they document, not as a separate phase at the end; reference the spec's Problem/Summary and requirements as source material so Implement has concrete content guidance. If the feature has no user-facing impact (no new commands, flags, workflows, config options, or output behaviors visible to users), state that explicitly in the plan so the Implement agent doesn't wonder whether documentation updates were overlooked." with the new unconditional paragraph (see Exact Edit below).
- [ ] Edit `plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md` Quality Checklist (after the last existing bullet, currently "Testing is integrated into the task list, not deferred"): append `- [ ] Documentation impact is reflected in the plan, covering both user-facing and engineering/as-built docs as applicable`.

#### Exact Edit — R2 (line 55 replacement paragraph)

Replace the current paragraph with:

> Identify which docs need updating — check the Research findings for a "Documentation Impact" section if present; if absent, scan the repo for both user-facing docs (e.g., `README.md`, user guides, config references) and as-built engineering docs (e.g., architecture specs, state machines, protocol docs, internal API references). Include doc update tasks alongside the implementation tasks they document, not as a separate phase at the end; reference the spec's Problem/Summary and requirements as source material so Implement has concrete content guidance. If neither user-facing nor engineering docs require updating, state that explicitly in the plan so the Implement agent doesn't wonder whether documentation updates were overlooked.

This preserves: "check Research findings first, then scan the repo", "include tasks alongside implementation tasks", "reference spec as source material", and "state explicitly if no impact" — while removing the "user-facing" conditional gate and broadening scope to both doc types.

### Documentation Impact

This change is to the plugin skill prompt text itself — no user-facing CLI behavior changes (no new commands, flags, config options, or output formats). No engineering docs (architecture specs, state machines) describe how skill SKILL.md text is structured, so neither doc type requires updating. The change is its own documentation artifact.

### Risks

- **Low.** Two text edits in one markdown file; no Go code, interfaces, or tests involved.
- **Key risk:** accidentally dropping the "state explicitly if neither applies" fallback when editing line 55. The exact replacement paragraph above preserves this explicitly — Implement should confirm the fallback sentence is present in the final edit.

---
Used 6/50 turns, 4k input / 2k output tokens.

## Verification

Updated `plugin/fabrik-plugin/skills/fabrik-plan/SKILL.md` with two targeted changes: (1) replaced the "If the feature is user-facing..." conditional gate on doc-impact guidance with an unconditional paragraph that covers both user-facing docs and as-built engineering docs, preserving all existing scanning and fallback language; (2) added a matching Quality Checklist item requiring documentation impact to be reflected in the plan for both doc types. No other files were changed — all scope boundaries from the spec were observed.

---

Closes #395