### PR TITLE
Auto-react with rocket on engine-posted comments as secondary dedup signal

### DIFF
--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -48,8 +48,8 @@ func (m *testGitHubUpgradeClient) AddLabelToIssue(owner, repo string, issueNumbe
 func (m *testGitHubUpgradeClient) RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error {
 	return nil
 }
-func (m *testGitHubUpgradeClient) AddComment(owner, repo string, issueNumber int, body string) error {
-	return nil
+func (m *testGitHubUpgradeClient) AddComment(owner, repo string, issueNumber int, body string) (int, error) {
+	return 0, nil
 }
 func (m *testGitHubUpgradeClient) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
 	return nil

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -335,11 +335,17 @@ When new comments are detected on an issue (or synthetic review comments on a PR
 
 ### 4.1 Comment Detection
 
-`findNewComments()` filters `item.Comments` to find unprocessed comments:
+`findNewComments()` filters `item.Comments` to find unprocessed comments using three independent dedup signals:
 
-1. Skip comments already in `processedSet` (in-memory, session-scoped)
-2. Skip comments with body starting with `🏭 **Fabrik` (engine-generated output)
-3. Skip comments with a ROCKET (🚀) reaction (durable cross-restart marker)
+1. **In-memory `processedSet`** (session-scoped) — skip comments whose key is already present. Fast but lost on restart.
+2. **`🏭 **Fabrik` body prefix** (engine-authored output convention) — skip comments whose body starts with this header. Durable but requires the header to be present.
+3. **🚀 ROCKET reaction** (durable, cross-restart) — skip comments that already have a rocket reaction. Applied to user comments by `processComments` step 10 after processing; **also applied by the engine to every comment it posts** immediately after `AddComment` succeeds.
+
+Any single signal catching the comment is sufficient to skip it. The three signals are orthogonal — any two can fail independently without triggering the self-review loop.
+
+**Dedup coverage by comment type:**
+- **Engine-authored comments**: carry signals (2) and (3) — the `🏭 **Fabrik` prefix (when formatted via `formatOutputComment`) and a 🚀 reaction added by the engine at post time.
+- **User comments**: carry signals (1) and (3) after processing — the `processedSet` entry added during `processComments`, and the 🚀 reaction added at step 10.
 
 > **Invariant:** every engine-emitted `AddComment` call must start with `🏭 **Fabrik — <context>**`. This is an engine-wide convention enforced by `TestAddCommentCompliance` in `engine/compliance_test.go`, not just a detection heuristic.
 

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -173,8 +173,10 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if output != "" {
 		if stage.PostToPR {
 			comment := formatOutputComment(stage.Name+" (comment review)", output, "", branch, commit, mainSHA, timestamp)
-			if err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+			if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
+			} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 			}
 		} else {
 			existing := findStageComment(item.Comments, stage.Name)
@@ -185,8 +187,10 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 					e.logf(item.Number, "warn", "could not update stage comment: %v\n", err)
 				}
 			} else {
-				if err := e.client.AddComment(owner, repo, item.Number, stageComment); err != nil {
+				if dbID, err := e.client.AddComment(owner, repo, item.Number, stageComment); err != nil {
 					e.logf(item.Number, "warn", "could not post stage comment: %v\n", err)
+				} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 				}
 			}
 		}

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -217,3 +217,81 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// TestFindNewComments_SkipsRocketReactedComment verifies that findNewComments
+// skips a comment that has a 🚀 reaction even if the body lacks the Fabrik header.
+// This is the defense-in-depth dedup signal for engine-authored comments.
+func TestFindNewComments_SkipsRocketReactedComment(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 20,
+		Comments: []gh.Comment{
+			{
+				ID:         "C_rocketed",
+				DatabaseID: 500,
+				Author:     "fabrik-bot",
+				Body:       "Waiting for dependencies to close: #100", // no 🏭 header
+				Reactions:  []gh.ReactionGroup{{Content: "ROCKET", Count: 1}},
+			},
+		},
+	}
+
+	newComments := eng.findNewComments(item)
+	if len(newComments) != 0 {
+		t.Errorf("expected 0 new comments (should skip rocket-reacted), got %d", len(newComments))
+	}
+}
+
+// TestAddComment_ReactsWithRocket verifies that processComments adds a 🚀 reaction
+// to every comment it posts via AddComment, using the returned database ID.
+func TestAddComment_ReactsWithRocket(t *testing.T) {
+	skipIfNoGit(t)
+
+	const postedCommentID = 99
+
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return postedCommentID, nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "some output from Claude", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{
+		Number:   21,
+		Body:     "spec",
+		Comments: []gh.Comment{}, // no existing stage comment → will call AddComment
+	}
+	userComments := []gh.Comment{
+		{ID: "C_user", DatabaseID: 600, Author: "testuser", Body: "please do research"},
+	}
+
+	err := eng.processComments(context.Background(), board, item, stage, userComments)
+	if err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	// AddComment should have been called and produced a reaction call
+	if len(client.addCommentCalls) == 0 {
+		t.Fatal("expected AddComment to be called")
+	}
+
+	// Verify AddCommentReaction was called with the returned comment ID and "rocket"
+	var rocketFound bool
+	for _, rc := range client.addCommentReactionCalls {
+		if rc.commentDatabaseID == postedCommentID && rc.content == "rocket" {
+			rocketFound = true
+			break
+		}
+	}
+	if !rocketFound {
+		t.Errorf("expected AddCommentReaction(_, _, %d, %q) to be called; got calls: %+v",
+			postedCommentID, "rocket", client.addCommentReactionCalls)
+	}
+}

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -34,9 +34,9 @@ func TestProcessComments_CreatesNewStageComment(t *testing.T) {
 
 	var addCommentBody string
 	client := &mockGitHubClient{
-		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
 			addCommentBody = body
-			return nil
+			return 0, nil
 		},
 	}
 	claude := &mockClaudeInvoker{

--- a/engine/dependencies.go
+++ b/engine/dependencies.go
@@ -78,8 +78,10 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 	}
 	if !alreadyBlocked {
 		comment := fmt.Sprintf("🏭 **Fabrik — blocked on dependencies**\n\nWaiting for the following issues to close: %s", strings.Join(waitingFor, ", "))
-		if err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post blocked comment: %v\n", err)
+		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 		}
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:blocked"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:blocked label: %v\n", err)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -365,8 +365,10 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 		e.cloneInFlight.Delete(nameWithOwner)
 
 		msg := fmt.Sprintf("🏭 **Fabrik — cannot clone repo**\n\nFailed to clone `%s/%s`:\n```\n%v\n```\nHuman intervention required. Fix the clone issue and remove `fabrik:paused` to retry.", owner, repo, err)
-		if commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
+		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
 			e.logf(item.Number, "warn", "could not post clone-failure comment: %v\n", commentErr)
+		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 		}
 		if labelErr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); labelErr != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", labelErr)

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -16,7 +16,7 @@ type GitHubClient interface {
 	FetchLabels(owner, repo string, issueNumber int) ([]string, error)
 	AddLabelToIssue(owner, repo string, issueNumber int, labelName string) error
 	RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error
-	AddComment(owner, repo string, issueNumber int, body string) error
+	AddComment(owner, repo string, issueNumber int, body string) (int, error)
 	AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error
 	AddPRReviewCommentReaction(owner, repo string, commentDatabaseID int, content string) error
 	ResolveReviewThread(threadID string) error

--- a/engine/item.go
+++ b/engine/item.go
@@ -675,8 +675,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			e.postOutputToPR(item, stage.Name, postOutput, footer, branch, commit, mainSHA, timestamp)
 		} else {
 			comment := formatOutputComment(stage.Name, postOutput, footer, branch, commit, mainSHA, timestamp)
-			if err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+			if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
+			} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 			}
 		}
 	}
@@ -713,8 +715,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	if claudeRan && err == nil && strings.TrimSpace(output) == "" {
 		e.logf(item.Number, "warn", "stage %q ran without error but produced no output\n", stage.Name)
 		warnComment := fmt.Sprintf("🏭 **Fabrik — empty stage output**\n\nStage **%s** ran without error but produced no output.", stage.Name)
-		if commentErr := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, warnComment); commentErr != nil {
+		if dbID, commentErr := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, warnComment); commentErr != nil {
 			e.logf(item.Number, "warn", "could not post empty-output warning: %v\n", commentErr)
+		} else if reactErr := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 		}
 	}
 
@@ -831,8 +835,10 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 		"🏭 **Fabrik — stage failed**\n\nStage **%s** failed to complete after %d attempt(s). The issue has been paused (`fabrik:paused`).\n\nTo retry: investigate the failure, make any needed fixes, then remove the `fabrik:paused` label.",
 		stage.Name, e.cfg.MaxRetries,
 	)
-	if err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 		e.logf(item.Number, "warn", "could not post escalation comment: %v\n", err)
+	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 	}
 
 	stageKey := issueKey(item, e.defaultRepo()) + "-" + stage.Name
@@ -1005,8 +1011,10 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 	warnKey := fmt.Sprintf("%s/%s#%d:%s", owner, repo, item.Number, candidate)
 	if _, alreadyWarned := e.baseBranchWarnedSet.LoadOrStore(warnKey, true); !alreadyWarned {
 		body := fmt.Sprintf("🏭 **Fabrik — base branch not found**\n\nFabrik could not find branch `%s` on the remote (from `base:%s` label). Falling back to the repository default branch.", candidate, candidate)
-		if err := e.client.AddComment(owner, repo, item.Number, body); err != nil {
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, body); err != nil {
 			e.logf(item.Number, "warn", "could not post base branch fallback comment: %v\n", err)
+		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 		}
 	}
 	return wm.DefaultBaseBranch()

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -21,7 +21,8 @@ type mockGitHubClient struct {
 	fetchStatusFieldFn        func(projectID string) (*gh.StatusField, error)
 	addLabelToIssueFn         func(owner, repo string, issueNumber int, labelName string) error
 	removeLabelFromIssueFn    func(owner, repo string, issueNumber int, labelName string) error
-	addCommentFn              func(owner, repo string, issueNumber int, body string) error
+	addCommentFn              func(owner, repo string, issueNumber int, body string) (int, error)
+	addCommentReactionFn      func(owner, repo string, commentDatabaseID int, content string) error
 	updateCommentFn           func(owner, repo string, commentDatabaseID int, body string) error
 	updateIssueBodyFn         func(owner, repo string, issueNumber int, body string) error
 	updateProjectItemStatusFn func(projectID, itemID, statusFieldID, statusOptionID string) error
@@ -42,16 +43,17 @@ type mockGitHubClient struct {
 	archiveProjectItemCalls []archiveProjectItemCall
 
 	// Track calls — access under mu when accessed from concurrent goroutines.
-	addLabelCalls                    []addLabelCall
-	removeLabelCalls                 []removeLabelCall
-	addCommentCalls                  []addCommentCall
-	updateCommentCalls               []updateCommentCall
-	updateStatusCalls                []updateStatusCall
-	mergePRCalls                     []mergePRCall
-	markPRReadyCalls                 []markPRReadyCall
-	createDraftPRCalls               []createDraftPRCall
-	resolveReviewThreadCalls         []string
-	addPRReviewCommentReactionCalls  []prReviewCommentReactionCall
+	addLabelCalls                   []addLabelCall
+	removeLabelCalls                []removeLabelCall
+	addCommentCalls                 []addCommentCall
+	addCommentReactionCalls         []addCommentReactionCall
+	updateCommentCalls              []updateCommentCall
+	updateStatusCalls               []updateStatusCall
+	mergePRCalls                    []mergePRCall
+	markPRReadyCalls                []markPRReadyCall
+	createDraftPRCalls              []createDraftPRCall
+	resolveReviewThreadCalls        []string
+	addPRReviewCommentReactionCalls []prReviewCommentReactionCall
 }
 
 type prReviewCommentReactionCall struct {
@@ -110,6 +112,12 @@ type updateCommentCall struct {
 	body        string
 }
 
+type addCommentReactionCall struct {
+	owner, repo       string
+	commentDatabaseID int
+	content           string
+}
+
 type updateStatusCall struct {
 	projectID, itemID, fieldID, optionID string
 }
@@ -164,7 +172,7 @@ func (m *mockGitHubClient) RemoveLabelFromIssue(owner, repo string, issueNumber 
 	return nil
 }
 
-func (m *mockGitHubClient) AddComment(owner, repo string, issueNumber int, body string) error {
+func (m *mockGitHubClient) AddComment(owner, repo string, issueNumber int, body string) (int, error) {
 	m.mu.Lock()
 	m.addCommentCalls = append(m.addCommentCalls, addCommentCall{owner, repo, issueNumber, body})
 	fn := m.addCommentFn
@@ -172,10 +180,17 @@ func (m *mockGitHubClient) AddComment(owner, repo string, issueNumber int, body 
 	if fn != nil {
 		return fn(owner, repo, issueNumber, body)
 	}
-	return nil
+	return 0, nil
 }
 
 func (m *mockGitHubClient) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	m.mu.Lock()
+	m.addCommentReactionCalls = append(m.addCommentReactionCalls, addCommentReactionCall{owner, repo, commentDatabaseID, content})
+	fn := m.addCommentReactionFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, commentDatabaseID, content)
+	}
 	return nil
 }
 

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -169,23 +169,30 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 	if prNumber > 0 {
 		// Post detailed output on the PR
 		comment := formatOutputComment(stageName, output, footer, branch, commit, mainSHA, timestamp)
-		if err := e.client.AddComment(owner, repo, prNumber, comment); err != nil {
+		if dbID, err := e.client.AddComment(owner, repo, prNumber, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post to PR #%d: %v\n", prNumber, err)
 		} else {
 			e.logf(item.Number, "post", "detailed %s output posted to PR #%d\n", stageName, prNumber)
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 
 		// Post brief summary on the issue
 		summary := formatPRSummaryComment(stageName, prNumber, output, branch, commit, mainSHA, timestamp)
-		if err := e.client.AddComment(owner, repo, item.Number, summary); err != nil {
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, summary); err != nil {
 			e.logf(item.Number, "warn", "could not post summary: %v\n", err)
+		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 		}
 	} else {
 		// No PR found — fall back to posting on the issue
 		e.logf(item.Number, "warn", "no open PR found, posting on issue instead\n")
 		comment := formatOutputComment(stageName, output, footer, branch, commit, mainSHA, timestamp)
-		if err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post comment: %v\n", err)
+		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 		}
 	}
 }

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -179,8 +179,8 @@ func TestPostOutputToPR_AddCommentErrors_LogsWarnings(t *testing.T) {
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
 			return 30, nil
 		},
-		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
-			return errors.New("post error") // all AddComment calls fail
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, errors.New("post error") // all AddComment calls fail
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
@@ -196,9 +196,9 @@ func TestPostOutputToPR_NoPR_FallsBackToIssue(t *testing.T) {
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
 			return 0, nil // no PR
 		},
-		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
 			addCommentCalls = append(addCommentCalls, addCommentCall{owner, repo, issueNumber, body})
-			return nil
+			return 0, nil
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -121,9 +121,9 @@ func TestPostOutputToPR_WithPR_PostsToPRAndIssue(t *testing.T) {
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
 			return 20, nil
 		},
-		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
 			addCommentCalls = append(addCommentCalls, addCommentCall{owner, repo, issueNumber, body})
-			return nil
+			return 0, nil
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
@@ -158,9 +158,9 @@ func TestPostOutputToPR_FindPRError_FallsBackToIssue(t *testing.T) {
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
 			return 0, errors.New("api error") // error + 0 PR number
 		},
-		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
 			addCommentIssues = append(addCommentIssues, issueNumber)
-			return nil
+			return 0, nil
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})

--- a/engine/process_item_test.go
+++ b/engine/process_item_test.go
@@ -616,8 +616,8 @@ func TestProcessItem_LabelAndCommentErrors(t *testing.T) {
 		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
 			return fmt.Errorf("label error")
 		},
-		addCommentFn: func(owner, repo string, issueNumber int, body string) error {
-			return fmt.Errorf("comment error")
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, fmt.Errorf("comment error")
 		},
 	}
 	claude := &mockClaudeInvoker{

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -150,8 +150,10 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 			"Fabrik has paused this issue. Please check the PR for pending reviews, address any issues, and then remove the `fabrik:paused` label to resume.",
 		stage.Name,
 	)
-	if err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post review timeout comment: %v\n", err)
+	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
@@ -257,8 +259,10 @@ func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.Projec
 			"remove the `fabrik:paused` label to resume.",
 		stage.Name, cycleCount, maxCycles,
 	)
-	if err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post review cycle limit comment: %v\n", err)
+	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -145,8 +145,10 @@ func (e *Engine) attemptMergeOnValidate(item gh.ProjectItem) error {
 	if err := e.client.MergePR(owner, repo, prNumber); err != nil {
 		if errors.Is(err, gh.ErrNotMergeable) {
 			msg := fmt.Sprintf("🏭 **Fabrik — auto-merge skipped**\n\nAuto-merge skipped: PR #%d is not mergeable (GitHub reports a merge conflict or the mergeable status is not yet computed). Please resolve any conflicts and merge manually.", prNumber)
-			if cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
+			if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
 				e.logf(item.Number, "warn", "could not post unmergeable comment: %v\n", cerr)
+			} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 			}
 			if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); lerr != nil {
 				e.logf(item.Number, "warn", "could not add fabrik:paused label: %v\n", lerr)

--- a/github/comments.go
+++ b/github/comments.go
@@ -2,13 +2,19 @@ package github
 
 import "fmt"
 
-// AddComment posts a comment on an issue.
-func (c *Client) AddComment(owner, repo string, issueNumber int, body string) error {
+// AddComment posts a comment on an issue and returns the comment's database ID.
+func (c *Client) AddComment(owner, repo string, issueNumber int, body string) (int, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.baseURL, owner, repo, issueNumber)
 	payload := map[string]interface{}{
 		"body": body,
 	}
-	return c.restPost(apiURL, payload)
+	var resp struct {
+		ID int `json:"id"`
+	}
+	if err := c.restPostWithResponse(apiURL, payload, &resp); err != nil {
+		return 0, err
+	}
+	return resp.ID, nil
 }
 
 // AddCommentReaction adds a reaction to an issue comment (or issue-level PR

--- a/github/comments.go
+++ b/github/comments.go
@@ -14,6 +14,9 @@ func (c *Client) AddComment(owner, repo string, issueNumber int, body string) (i
 	if err := c.restPostWithResponse(apiURL, payload, &resp); err != nil {
 		return 0, err
 	}
+	if resp.ID <= 0 {
+		return 0, fmt.Errorf("github: add comment response missing valid id")
+	}
 	return resp.ID, nil
 }
 

--- a/github/mutations_test.go
+++ b/github/mutations_test.go
@@ -47,6 +47,20 @@ func TestAddComment_Error(t *testing.T) {
 	}
 }
 
+func TestAddComment_MissingID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		w.Write([]byte(`{}`)) // valid JSON but no "id" field
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if _, err := c.AddComment("owner", "repo", 42, "test"); err == nil {
+		t.Fatal("expected error when response omits id")
+	}
+}
+
 func TestAddLabelToIssue_Success(t *testing.T) {
 	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/github/mutations_test.go
+++ b/github/mutations_test.go
@@ -18,13 +18,19 @@ func TestAddComment_Success(t *testing.T) {
 		if body["body"] != "Hello world" {
 			t.Errorf("body = %v", body["body"])
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(201)
+		w.Write([]byte(`{"id": 12345}`))
 	}))
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token", srv.URL)
-	if err := c.AddComment("owner", "repo", 42, "Hello world"); err != nil {
+	id, err := c.AddComment("owner", "repo", 42, "Hello world")
+	if err != nil {
 		t.Fatalf("AddComment: %v", err)
+	}
+	if id != 12345 {
+		t.Errorf("expected id=12345, got %d", id)
 	}
 }
 
@@ -36,7 +42,7 @@ func TestAddComment_Error(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token", srv.URL)
-	if err := c.AddComment("owner", "repo", 42, "test"); err == nil {
+	if _, err := c.AddComment("owner", "repo", 42, "test"); err == nil {
 		t.Fatal("expected error for 403 response")
 	}
 }


### PR DESCRIPTION
## Summary

As a defense-in-depth measure independent of header discipline and skill-level prohibitions, have the engine automatically add a 🚀 reaction to every comment it posts, immediately after the `AddComment` call succeeds. This creates a second, orthogonal dedup signal: even if the header is missing (bug), the rocket reaction catches the comment on the next poll.

Combined with the sibling issues (consistent header + skill-level prohibition), this produces three independent lines of defense. Any two can fail without triggering the loop.

## Problem

`findNewComments` (`engine/comments.go:13-35`) uses two signals to skip Fabrik-generated comments:

1. `strings.HasPrefix(c.Body, "🏭 **Fabrik")` — the header convention.
2. `c.HasReaction("ROCKET")` — set on user comments after they've been processed by `processComments`.

Both signals can fail:

- **Signal 1** breaks if the engine posts a comment without the header (see sibling issue on consistent-header-prefix) OR if Claude posts a comment directly via `gh pr comment` (see sibling issue on skill-level prohibition).
- **Signal 2** only covers user-authored comments — engine-authored comments don't have 🚀 reactions, because the engine posts them and never "processes" them.

A header-less engine comment therefore falls through both signals and gets processed as a new user comment on the next poll, producing the self-review loop observed on verveguy/liminis PR #614.

## Approach

### Approach

The implementation has two interlocked parts:

**Part 1 — `github` package**: Change `AddComment` from `restPost` (discards response body) to `restPostWithResponse`, decoding `{"id": N}` from the 201 response. Return `(int, error)` so callers receive the comment's database ID.

**Part 2 — `engine` package**: At every one of the 14 `AddComment` call sites, capture the returned `dbID` and add a non-fatal 🚀 reaction immediately after a successful post. The pattern is a simple `else if` on the existing error check — no new function, no new helper. Reaction failures log-and-continue per R3.

The `UpdateComment` path in `processComments` does **not** get a reaction call — the comment was already reacted to when first created.

No new exported types are needed in the `github` package. The decode struct for the response is a local anonymous struct.

### New/Modified Files

| File | Change |
|------|--------|
| `github/comments.go` | `AddComment` returns `(int, error)` via `restPostWithResponse`; decode `id` field |
| `engine/interfaces.go` | `GitHubClient.AddComment` signature → `(int, error)` |
| `engine/mocks_test.go` | `addCommentFn` type + `AddComment` method → `(int, error)` |
| `cmd/cmd_extra_test.go` | `testGitHubUpgradeClient.AddComment` → `(int, error)` |
| `engine/item.go` | 4 call sites: capture `dbID`, add 🚀 reaction |
| `engine/comments.go` | 2 `AddComment` call sites: capture `dbID`, add 🚀 reaction (not on `UpdateComment` path) |
| `engine/pr.go` | 3 call sites: capture `dbID`, add 🚀 reaction |
| `engine/engine.go` | 1 call site: capture `dbID`, add 🚀 reaction |
| `engine/reviews.go` | 2 call sites: capture `dbID`, add 🚀 reaction |
| `engine/dependencies.go` | 1 call site: capture `dbID`, add 🚀 reaction |
| `engine/stages.go` | 1 call site: capture `dbID`, add 🚀 reaction |
| `engine/comments_test.go` | All `addCommentFn` closures → return `(int, error)` |
| `engine/pr_test.go` | All `addCommentFn` closures → return `(int, error)` |
| `github/mutations_test.go` | `TestAddComment_Success`: server returns `{"id": 12345}`, verify ID; `TestAddComment_Error`: handle `(int, error)` return |
| `engine/comments_test.go` or new `_test.go` | New tests per R6 |
| `docs/state-machine.md` | §4.1 Comment Detection — three-signal dedup model |

### Key Decisions

- **Signature change vs. sibling method**: `AddComment` returns `(int, error)` rather than introducing a parallel `AddCommentWithID`. The 14 call sites are bounded and churn is caught by the compiler. A sibling method would let future callers silently skip the defense. Decided in spec.

- **Failure handling**: Reaction failures are log-and-continue. If `AddComment` returns an error, `dbID` is `0` and the reaction call is skipped (the `else if` pattern enforces this). No guard for zero-ID is needed — `AddComment` success always yields a non-zero GitHub ID.

- **`processComments` UpdateComment path**: The `UpdateComment` branch (line 154-157) does **not** get a reaction — the comment already has one from when it was first created via `AddComment`.

- **`pr.go:172`** already has an `else` block logging success. The reaction call goes *inside* that `else` block rather than chained `else if`, preserving the existing success log.

- **No new ADR**: ADR 009 already establishes the 🚀 reaction as the durable dedup signal. This change extends the pattern to engine-authored comments; it doesn't introduce a new architectural pattern. The `docs/state-machine.md` update (R7) provides the operational documentation.

### Task Checklist

- [ ] **Task 1** — `github/comments.go`: Change `AddComment` to return `(int, error)`. Switch from `restPost` to `restPostWithResponse` with a local `struct{ ID int \`json:"id"\` }{}` decode target. Return `(resp.ID, nil)` on success.
- [ ] **Task 2** — `engine/interfaces.go`: Update `GitHubClient.AddComment` signature from `error` to `(int, error)` (line 19).
- [ ] **Task 3** — `engine/mocks_test.go`: Change `addCommentFn` field type to `func(owner, repo string, issueNumber int, body string) (int, error)`. Update `AddComment` method to return `(int, error)`, with `(0, nil)` as the no-fn default.
- [ ] **Task 4** — `cmd/cmd_extra_test.go`: Update `testGitHubUpgradeClient.AddComment` to return `(int, error)` — `return 0, nil`.
- [ ] **Task 5** — `engine/item.go` (4 sites at lines 678, 716, 834, 1008): At each site, restructure the call to capture `dbID`, then add `else if reactErr := e.client.AddCommentReaction(..., dbID, "rocket"); reactErr != nil { e.logf(..., "warn", ...) }`.
- [ ] **Task 6** — `engine/comments.go` (2 `AddComment` sites at lines 147 and 159): Same pattern. Apply only to the two `AddComment` paths; leave the `UpdateComment` path (line 155) untouched.
- [ ] **Task 7** — `engine/pr.go` (3 sites at lines 172, 180, 187): At line 172 (which already has an `else` logging success), place the reaction call inside the existing `else` block. At lines 180 and 187, use the standard `else if` pattern.
- [ ] **Task 8** — Remaining 5 sites: `engine/engine.go:368`, `engine/reviews.go:153`, `engine/reviews.go:260`, `engine/dependencies.go:81`, `engine/stages.go:148` — apply the standard `else if` reaction pattern at each.
- [ ] **Task 9** — `engine/comments_test.go` and `engine/pr_test.go`: Update every `addCommentFn` closure to return `(int, error)` — typically `return 0, nil` for no-op mocks or `return 0, someError` for error cases. Keep existing capture logic (e.g., `addCommentBody = body`) intact, just change the return type.
- [ ] **Task 10** — `github/mutations_test.go`: Update `TestAddComment_Success` server handler to write `{"id": 12345}` in its 201 response. Update the call to `_, err := c.AddComment(...)` and verify the returned ID is non-zero. Update `TestAddComment_Error` to `_, err := c.AddComment(...)`.
- [ ] **Task 11** — New unit tests (add to `engine/comments_test.go` or a new `engine/reaction_test.go`):
  - `TestFindNewComments_SkipsRocketReactedComment`: construct an item with a comment that has `HasReaction("ROCKET") == true` and a body that does NOT start with `🏭 **Fabrik`; verify `findNewComments` returns an empty slice.
  - `TestAddComment_ReactsWithRocket`: set up a `mockGitHubClient` where `addCommentFn` returns `(99, nil)` and track `AddCommentReaction` calls; run one of the engine paths that calls `AddComment` (e.g., `processComments` with a stage that has no existing comment); verify `AddCommentReaction` was called with ID `99` and content `"rocket"`.
- [ ] **Task 12** — `docs/state-machine.md` §4.1: Rewrite the three-item list to document the three-signal dedup model: (a) `🏭 **Fabrik` body prefix (engine-authored output convention), (b) 🚀 reaction — applied to user comments after `processComments` and **also applied by the engine to every comment it posts**, (c) in-memory `processedSet` (session-scoped). Add a note that engine-authored comments carry signals (a) and (b); user comments carry (b) and (c) after processing.
- [ ] **Task 13** — Verify: `go build -o fabrik . && go test -race ./... && go vet ./...` — all must pass.

### Risks

- **Broad test churn**: The signature change propagates to every `addCommentFn` closure in every test. Missing even one yields a compile error, which is preferable to a silent skip — the build check catches it exhaustively.

- **`processComments` `AddComment` paths require careful scoping**: Lines 147 and 159 are inside an `if stage.PostToPR { } else { ... }` block. The `UpdateComment` at line 155 is in the `else` branch's inner `if existing != nil`. Only the `AddComment` at line 159 (the `else` of `existing != nil`) and line 147 (the `PostToPR` path) need reaction calls. The `UpdateComment` at line 155 must not.

- **`pr.go:172` existing `else` block**: The reaction must be added inside the existing `else` block (not as a new `else if`), otherwise the success log message at line 175 is lost.

- **GraphQL propagation lag**: The 🚀 reaction is fire-and-forget. If it doesn't appear in the next GraphQL poll for a comment that also has the `🏭 **Fabrik` prefix, the prefix check still catches it. The race window is bounded by the poll interval and acceptable per spec.

---
Used 26/50 turns, 5k input / 11k output tokens.

## Verification

Implemented auto-rocket-reaction on all engine-posted comments. Changed `AddComment` from returning `error` to `(int, error)` (returning the created comment's database ID), updated the `GitHubClient` interface, and wired the rocket reaction at all 14 engine call sites using a non-fatal `else if` pattern. Added `TestFindNewComments_SkipsRocketReactedComment` and `TestAddComment_ReactsWithRocket`, updated the github mutations test to verify the returned ID, and documented the three-signal dedup model in `docs/state-machine.md` §4.1. All tests pass with `go test -race ./...`.

---

Closes #399