### PR TITLE
Post Fabrik-marked summary on PR and issue after review-feedback processing

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -360,7 +360,7 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
 | 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Only applied if `update_issue_body: true` |
 | 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_SUMMARY_BEGIN/END |
-| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one |
+| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
 | 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |
 | 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
 | 11 | If FABRIK_STAGE_COMPLETE was detected: handle completion | `handleStageComplete()` | Same completion flow as a normal stage invocation (advance, PR ops, etc.) |
@@ -473,6 +473,8 @@ The catch-up loop in `poll()` is split into two phases for every `stage:<X>:comp
 
 **Review thread resolution:** Step 10 of `processComments()` resolves addressed review threads via `ResolveReviewThread()` after adding ROCKET reactions.
 
+**PR summary comment:** Step 8b of `processComments()` posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR when the invocation is a review-reinvoke (all-`ReviewThreadID` batch) and `output != ""`. The comment includes Claude's cleaned output plus a machine-generated per-thread footer listing `path:line — resolved` for each unique `ReviewThreadID` in the input batch (deduped; line resolved from `Comment.Line` with `OriginalLine` fallback). This gives reviewers a visible record in the PR timeline that their inline feedback was addressed.
+
 ### 6.3 Review Reinvoke vs Regular Comment Processing
 
 | Aspect | Regular Comments | Review Reinvoke |
@@ -483,6 +485,7 @@ The catch-up loop in `poll()` is split into two phases for every `stage:<X>:comp
 | Cycle limits | None | `MaxReviewCycles` (default 5) |
 | Timeout | None | Integrated with `ReviewWaitTimeout` |
 | Thread resolution | Yes — `processComments()` merges unresolved `LinkedPRReviewThreadComments` at entry, so a user nudge resolves threads in the same invocation | Yes — resolves review threads after processing |
+| PR summary posting | None | Posts `"<StageName> (review feedback addressed)"` on the linked PR with per-thread footer (one `path:line — resolved` bullet per unique `ReviewThreadID`); skipped when `output == ""` or no linked PR |
 | inFlight guard | Uses dispatch loop's `inFlight` check | Has its own `inFlight` check in catch-up loop |
 
 ### 6.4 Decompose Path

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -209,7 +209,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		} else if prNumber > 0 {
 			threads := buildThreadEntries(comments)
 			prComment := formatReviewFeedbackComment(stage.Name, output, branch, commit, mainSHA, timestamp, threads, len(comments))
-			if err := e.client.AddComment(owner, repo, prNumber, prComment); err != nil {
+			if _, err := e.client.AddComment(owner, repo, prNumber, prComment); err != nil {
 				e.logf(item.Number, "warn", "could not post review feedback summary to PR #%d: %v\n", prNumber, err)
 			} else {
 				e.logf(item.Number, "post", "review feedback summary posted to PR #%d (%d thread(s))\n", prNumber, len(threads))

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -196,6 +196,29 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		}
 	}
 
+	// Step 8b: When this is a review-reinvoke (all comments are PR inline review
+	// thread comments), also post a Fabrik-marked summary on the linked PR so
+	// reviewers can see at a glance that their feedback was addressed. The
+	// existing issue comment from Step 8 is unchanged (R4). Gate: output != ""
+	// and a linked PR exists. No post_to_pr check — linked-PR existence is the
+	// only gate (R5).
+	if isReviewReinvoke(comments) && output != "" {
+		prNumber, prErr := e.client.FindPRForIssue(owner, repo, item.Number)
+		if prErr != nil {
+			e.logf(item.Number, "warn", "review reinvoke: could not find PR for issue: %v\n", prErr)
+		} else if prNumber > 0 {
+			threads := buildThreadEntries(comments)
+			prComment := formatReviewFeedbackComment(stage.Name, output, branch, commit, mainSHA, timestamp, threads, len(comments))
+			if err := e.client.AddComment(owner, repo, prNumber, prComment); err != nil {
+				e.logf(item.Number, "warn", "could not post review feedback summary to PR #%d: %v\n", prNumber, err)
+			} else {
+				e.logf(item.Number, "post", "review feedback summary posted to PR #%d (%d thread(s))\n", prNumber, len(threads))
+			}
+		} else {
+			e.logf(item.Number, "warn", "review reinvoke: no linked PR found — skipping PR summary comment\n")
+		}
+	}
+
 	// Step 9: Remove editing label
 	e.removeEditingLabel(owner, repo, item.Number)
 
@@ -255,6 +278,21 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	}
 
 	return nil
+}
+
+// isReviewReinvoke reports whether this processComments invocation originated
+// from a review-reinvoke dispatch (i.e., all comments are PR inline review
+// thread comments). Returns false for an empty slice.
+func isReviewReinvoke(comments []gh.Comment) bool {
+	if len(comments) == 0 {
+		return false
+	}
+	for _, c := range comments {
+		if c.ReviewThreadID == "" {
+			return false
+		}
+	}
+	return true
 }
 
 // markCommentsSeenByStage adds a rocket reaction to any user comments that were

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -295,3 +295,44 @@ func TestAddComment_ReactsWithRocket(t *testing.T) {
 			postedCommentID, "rocket", client.addCommentReactionCalls)
 	}
 }
+
+// ── isReviewReinvoke ──────────────────────────────────────────────────────────
+
+func TestIsReviewReinvoke_AllReviewThreadIDs_ReturnsTrue(t *testing.T) {
+	comments := []gh.Comment{
+		{ID: "C_1", ReviewThreadID: "RT_abc"},
+		{ID: "C_2", ReviewThreadID: "RT_def"},
+	}
+	if !isReviewReinvoke(comments) {
+		t.Error("expected true when all comments have ReviewThreadID")
+	}
+}
+
+func TestIsReviewReinvoke_MixedComments_ReturnsFalse(t *testing.T) {
+	comments := []gh.Comment{
+		{ID: "C_1", ReviewThreadID: "RT_abc"},
+		{ID: "C_2", ReviewThreadID: ""},
+	}
+	if isReviewReinvoke(comments) {
+		t.Error("expected false for mixed batch (some without ReviewThreadID)")
+	}
+}
+
+func TestIsReviewReinvoke_NoReviewThreadIDs_ReturnsFalse(t *testing.T) {
+	comments := []gh.Comment{
+		{ID: "C_1", ReviewThreadID: ""},
+		{ID: "C_2", ReviewThreadID: ""},
+	}
+	if isReviewReinvoke(comments) {
+		t.Error("expected false when no comments have ReviewThreadID")
+	}
+}
+
+func TestIsReviewReinvoke_EmptySlice_ReturnsFalse(t *testing.T) {
+	if isReviewReinvoke(nil) {
+		t.Error("expected false for nil slice")
+	}
+	if isReviewReinvoke([]gh.Comment{}) {
+		t.Error("expected false for empty slice")
+	}
+}

--- a/engine/compliance_test.go
+++ b/engine/compliance_test.go
@@ -88,7 +88,7 @@ func checkAddCommentBody(t *testing.T, fset *token.FileSet, body *ast.BlockStmt)
 			if !isCompliantAddCommentArg(bodyArg, assigns) {
 				pos := fset.Position(v.Pos())
 				t.Errorf(
-					"non-compliant AddComment body at %s:%d — body must start with %q or go through formatOutputComment/formatPRSummaryComment",
+					"non-compliant AddComment body at %s:%d — body must start with %q or go through formatOutputComment/formatPRSummaryComment/formatReviewFeedbackComment",
 					pos.Filename, pos.Line, "🏭 **Fabrik",
 				)
 			}
@@ -165,12 +165,13 @@ func isCompliantRHS(expr ast.Expr) bool {
 }
 
 // isCompliantCallExpr returns true for formatOutputComment, formatPRSummaryComment,
-// or fmt.Sprintf whose first argument is a Fabrik-header literal (or a string
-// concatenation expression whose leftmost literal is a Fabrik-header literal).
+// formatReviewFeedbackComment, or fmt.Sprintf whose first argument is a
+// Fabrik-header literal (or a string concatenation expression whose leftmost
+// literal is a Fabrik-header literal).
 func isCompliantCallExpr(call *ast.CallExpr) bool {
 	switch fn := call.Fun.(type) {
 	case *ast.Ident:
-		return fn.Name == "formatOutputComment" || fn.Name == "formatPRSummaryComment"
+		return fn.Name == "formatOutputComment" || fn.Name == "formatPRSummaryComment" || fn.Name == "formatReviewFeedbackComment"
 	case *ast.SelectorExpr:
 		// fmt.Sprintf("🏭 **Fabrik...", ...) — the first arg may be a plain literal
 		// or a binary string concatenation expression ("..." + "...").

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -279,10 +279,14 @@ func formatReviewFeedbackComment(stageName, output, branch, commit, mainSHA, tim
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("🏭 **Fabrik — stage: %s**\n%s\n\n%s\n\n---\n**Threads addressed:**\n", title, meta, output))
 	for _, e := range threads {
+		displayPath := e.Path
+		if displayPath == "" {
+			displayPath = "(unknown path)"
+		}
 		if e.Line > 0 {
-			sb.WriteString(fmt.Sprintf("- `%s:%d` — resolved\n", e.Path, e.Line))
+			sb.WriteString(fmt.Sprintf("- `%s:%d` — resolved\n", displayPath, e.Line))
 		} else {
-			sb.WriteString(fmt.Sprintf("- `%s` — resolved\n", e.Path))
+			sb.WriteString(fmt.Sprintf("- `%s` — resolved\n", displayPath))
 		}
 	}
 	sb.WriteString(fmt.Sprintf("\nResolved %d review thread(s) across %d comment(s).", len(threads), totalComments))

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -229,3 +229,62 @@ func formatMetaLine(branch, commit, mainSHA, timestamp string) string {
 	}
 	return fmt.Sprintf("*branch: %s | commit: %s | %s*", branch, commit, timestamp)
 }
+
+// reviewThreadEntry holds the resolved location data for a single PR review thread.
+// Line is already resolved: Comment.Line if nonzero, else Comment.OriginalLine.
+// A zero Line means no line number was available.
+type reviewThreadEntry struct {
+	Path string
+	Line int
+}
+
+// buildThreadEntries constructs a deduplicated list of reviewThreadEntry values
+// from the input comments. One entry per unique ReviewThreadID; first occurrence
+// wins. Line is resolved from Comment.Line (nonzero) or Comment.OriginalLine.
+func buildThreadEntries(comments []gh.Comment) []reviewThreadEntry {
+	seen := make(map[string]bool)
+	var entries []reviewThreadEntry
+	for _, c := range comments {
+		if c.ReviewThreadID == "" {
+			continue
+		}
+		if seen[c.ReviewThreadID] {
+			continue
+		}
+		seen[c.ReviewThreadID] = true
+		line := c.Line
+		if line == 0 {
+			line = c.OriginalLine
+		}
+		entries = append(entries, reviewThreadEntry{Path: c.Path, Line: line})
+	}
+	return entries
+}
+
+// formatReviewFeedbackComment formats a Fabrik-marked comment for posting on a
+// linked PR after review-reinvoke processing completes. It includes:
+//   - a header line identifying the stage and action
+//   - standard metadata (branch, commit, main SHA, timestamp)
+//   - Claude's cleaned output (truncated at 60k)
+//   - a per-thread footer listing each addressed thread by path:line
+//   - a summary line with thread and comment counts
+func formatReviewFeedbackComment(stageName, output, branch, commit, mainSHA, timestamp string, threads []reviewThreadEntry, totalComments int) string {
+	const maxLen = 60000
+	if len(output) > maxLen {
+		output = output[:maxLen] + "\n\n... (truncated)"
+	}
+	meta := formatMetaLine(branch, commit, mainSHA, timestamp)
+	title := stageName + " (review feedback addressed)"
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("🏭 **Fabrik — stage: %s**\n%s\n\n%s\n\n---\n**Threads addressed:**\n", title, meta, output))
+	for _, e := range threads {
+		if e.Line > 0 {
+			sb.WriteString(fmt.Sprintf("- `%s:%d` — resolved\n", e.Path, e.Line))
+		} else {
+			sb.WriteString(fmt.Sprintf("- `%s` — resolved\n", e.Path))
+		}
+	}
+	sb.WriteString(fmt.Sprintf("\nResolved %d review thread(s) across %d comment(s).", len(threads), totalComments))
+	return sb.String()
+}

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -434,6 +434,126 @@ func TestEnsureDraftPR_NewPR_MissingContextFiles_UsesPlaceholders(t *testing.T) 
 	}
 }
 
+// ── buildThreadEntries ────────────────────────────────────────────────────────
+
+func TestBuildThreadEntries_DedupsByReviewThreadID(t *testing.T) {
+	comments := []gh.Comment{
+		{ReviewThreadID: "RT_1", Path: "engine/foo.go", Line: 42},
+		{ReviewThreadID: "RT_1", Path: "engine/foo.go", Line: 43}, // duplicate thread
+		{ReviewThreadID: "RT_2", Path: "engine/bar.go", Line: 10},
+	}
+	entries := buildThreadEntries(comments)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (deduped), got %d", len(entries))
+	}
+	if entries[0].Path != "engine/foo.go" || entries[0].Line != 42 {
+		t.Errorf("entry[0] = {%q, %d}, want {engine/foo.go, 42}", entries[0].Path, entries[0].Line)
+	}
+	if entries[1].Path != "engine/bar.go" || entries[1].Line != 10 {
+		t.Errorf("entry[1] = {%q, %d}, want {engine/bar.go, 10}", entries[1].Path, entries[1].Line)
+	}
+}
+
+func TestBuildThreadEntries_FallsBackToOriginalLine(t *testing.T) {
+	comments := []gh.Comment{
+		{ReviewThreadID: "RT_1", Path: "engine/foo.go", Line: 0, OriginalLine: 55},
+	}
+	entries := buildThreadEntries(comments)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Line != 55 {
+		t.Errorf("expected Line=55 (from OriginalLine fallback), got %d", entries[0].Line)
+	}
+}
+
+func TestBuildThreadEntries_ZeroLineWhenBothZero(t *testing.T) {
+	comments := []gh.Comment{
+		{ReviewThreadID: "RT_1", Path: "engine/foo.go", Line: 0, OriginalLine: 0},
+	}
+	entries := buildThreadEntries(comments)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Line != 0 {
+		t.Errorf("expected Line=0 when both Line and OriginalLine are zero, got %d", entries[0].Line)
+	}
+}
+
+func TestBuildThreadEntries_SkipsNonReviewComments(t *testing.T) {
+	comments := []gh.Comment{
+		{ReviewThreadID: "", Path: "", Line: 0},          // regular issue comment
+		{ReviewThreadID: "RT_1", Path: "x.go", Line: 1}, // review thread comment
+	}
+	entries := buildThreadEntries(comments)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (skipping non-review comment), got %d", len(entries))
+	}
+}
+
+// ── formatReviewFeedbackComment ───────────────────────────────────────────────
+
+func TestFormatReviewFeedbackComment_HeaderContainsTitle(t *testing.T) {
+	threads := []reviewThreadEntry{{Path: "engine/foo.go", Line: 42}}
+	result := formatReviewFeedbackComment("Review", "Claude output", "branch", "abc123", "main123", "2024-01-01", threads, 3)
+
+	if !strings.Contains(result, "🏭 **Fabrik — stage: Review (review feedback addressed)**") {
+		t.Errorf("header not found in:\n%s", result)
+	}
+}
+
+func TestFormatReviewFeedbackComment_FooterSection(t *testing.T) {
+	threads := []reviewThreadEntry{{Path: "engine/foo.go", Line: 42}}
+	result := formatReviewFeedbackComment("Review", "output", "branch", "c", "m", "ts", threads, 3)
+
+	if !strings.Contains(result, "**Threads addressed:**") {
+		t.Errorf("missing 'Threads addressed:' section in:\n%s", result)
+	}
+}
+
+func TestFormatReviewFeedbackComment_ThreadBulletWithLine(t *testing.T) {
+	threads := []reviewThreadEntry{{Path: "engine/foo.go", Line: 42}}
+	result := formatReviewFeedbackComment("Review", "output", "b", "c", "m", "ts", threads, 1)
+
+	if !strings.Contains(result, "`engine/foo.go:42` — resolved") {
+		t.Errorf("expected path:line bullet, got:\n%s", result)
+	}
+}
+
+func TestFormatReviewFeedbackComment_ThreadBulletWithoutLine(t *testing.T) {
+	threads := []reviewThreadEntry{{Path: "engine/bar.go", Line: 0}}
+	result := formatReviewFeedbackComment("Review", "output", "b", "c", "m", "ts", threads, 1)
+
+	if !strings.Contains(result, "`engine/bar.go` — resolved") {
+		t.Errorf("expected path-only bullet, got:\n%s", result)
+	}
+	if strings.Contains(result, "engine/bar.go:0") {
+		t.Error("zero line number must not appear as :0 in the bullet")
+	}
+}
+
+func TestFormatReviewFeedbackComment_SummaryLine(t *testing.T) {
+	threads := []reviewThreadEntry{
+		{Path: "a.go", Line: 1},
+		{Path: "b.go", Line: 2},
+	}
+	result := formatReviewFeedbackComment("Review", "output", "b", "c", "m", "ts", threads, 5)
+
+	if !strings.Contains(result, "Resolved 2 review thread(s) across 5 comment(s).") {
+		t.Errorf("expected summary line, got:\n%s", result)
+	}
+}
+
+func TestFormatReviewFeedbackComment_TruncatesLongOutput(t *testing.T) {
+	long := strings.Repeat("x", 70000)
+	threads := []reviewThreadEntry{{Path: "a.go", Line: 1}}
+	result := formatReviewFeedbackComment("Review", long, "b", "c", "m", "ts", threads, 1)
+
+	if !strings.Contains(result, "... (truncated)") {
+		t.Error("expected truncation marker for output > 60000 chars")
+	}
+}
+
 // ── processItem Verification update integration test ─────────────────────────
 
 func TestProcessItem_ImplementStage_UpdatesVerificationOnComplete(t *testing.T) {

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -544,6 +544,15 @@ func TestFormatReviewFeedbackComment_SummaryLine(t *testing.T) {
 	}
 }
 
+func TestFormatReviewFeedbackComment_EmptyPathFallback(t *testing.T) {
+	threads := []reviewThreadEntry{{Path: "", Line: 0}}
+	result := formatReviewFeedbackComment("Review", "output", "b", "c", "m", "ts", threads, 1)
+
+	if !strings.Contains(result, "`(unknown path)` — resolved") {
+		t.Errorf("expected (unknown path) fallback bullet, got:\n%s", result)
+	}
+}
+
 func TestFormatReviewFeedbackComment_TruncatesLongOutput(t *testing.T) {
 	long := strings.Repeat("x", 70000)
 	threads := []reviewThreadEntry{{Path: "a.go", Line: 1}}


### PR DESCRIPTION
## Summary

After `processComments` finishes addressing synthetic review-thread comments (i.e., the call originated from `dispatchReviewReinvoke`), also post a Fabrik-marked summary comment on the **PR** conversation. The existing issue comment behavior is unchanged. This gives reviewers — human and bot — a clear record that their feedback was acted on, visible in the PR timeline where they're looking.

## Problem

When Fabrik re-invokes a stage to address PR review thread comments (via `dispatchReviewReinvoke` → `processComments` with synthetic comments), the inline comments get 👀 and 🚀 reactions and their threads are resolved. That's great — but there's no visible summary anywhere on the PR saying "Fabrik addressed these reviewer comments", so a human reading the PR conversation can't confirm at a glance that the feedback was dealt with.

Current behavior (`engine/comments.go` Step 8):

- For `post_to_pr: true` stages (Review, Validate), `processComments` posts a comment titled `"<StageName> (comment review)"` on the **issue**, not the PR.
- The PR conversation gets nothing. Review threads go from unresolved → resolved via `ResolveReviewThread`, but that's silent from the perspective of a human scanning the PR timeline.

## Approach

### Approach

This is a focused, additive change entirely within the engine package. No new files are needed — all code goes into existing files. The detection of "review-reinvoke" (R8) is a simple predicate on the input `comments` slice. The PR comment is posted in a new Step 8b inside `processComments()`, guarded by the predicate and a non-empty output check. Two new formatting helpers go in `engine/pr.go`, one detection helper goes in `engine/comments.go`, and three documentation sections are updated.

No ADR is warranted — all design decisions are directly specified in the issue (detection predicate, PR-existence gate, footer format, dedup strategy). None of these constrain future contributors in non-obvious ways.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/pr.go` | Add `reviewThreadEntry` struct, `buildThreadEntries()`, `formatReviewFeedbackComment()` |
| `engine/comments.go` | Add `isReviewReinvoke()` helper; add Step 8b inside `processComments()` |
| `engine/pr_test.go` | Add tests for `buildThreadEntries` and `formatReviewFeedbackComment` |
| `engine/comments_test.go` | Add tests for `isReviewReinvoke` |
| `docs/state-machine.md` | Update §4.2 Step 8, §6.2, §6.3 |

### Key Decisions

- **`isReviewReinvoke` lives in `engine/comments.go`** — it's a local predicate used only by `processComments`; no need to export it.
- **`reviewThreadEntry`, `buildThreadEntries`, `formatReviewFeedbackComment` live in `engine/pr.go`** — PR formatting helpers already live there; these follow the same pattern as `formatOutputComment`.
- **Thread entry dedup uses first-occurrence ordering** — `buildThreadEntries` iterates `comments` in order and takes the first comment per `ReviewThreadID`. This preserves natural ordering (which matches how reviewers will scan the footer).
- **`isReviewReinvoke` returns false for empty slice** — an empty batch is never a reinvoke; defensive against future callers.
- **Step 8b is placed after the existing Step 8 block** — the issue comment is posted first (unchanged behavior R4), then the PR comment is attempted. Both are independent; a failure posting one does not prevent the other.
- **`FindPRForIssue` is called inside `processComments`** — a new API call per reinvoke, but low-cost and bounded (one per reinvoke cycle). No caching needed.

### Task Checklist

- [ ] **Task 1:** Add `reviewThreadEntry` struct and `buildThreadEntries()` to `engine/pr.go` — `reviewThreadEntry{Path, Line}` where `Line` is already resolved (use `Comment.Line` if nonzero, else `Comment.OriginalLine`); dedup by `ReviewThreadID`, first occurrence wins
- [ ] **Task 2:** Add `formatReviewFeedbackComment(stageName, output, branch, commit, mainSHA, timestamp string, threads []reviewThreadEntry, totalComments int) string` to `engine/pr.go` — header `🏭 **Fabrik — stage: <StageName> (review feedback addressed)**`, standard metadata line, output (with 60k truncation), per-thread footer (`` `path:line` — resolved `` or `` `path` — resolved `` when Line is 0), summary line `Resolved N review thread(s) across N comment(s).`
- [ ] **Task 3:** Add `isReviewReinvoke(comments []gh.Comment) bool` to `engine/comments.go` — returns false for empty slice; returns true iff every comment has `ReviewThreadID != ""`
- [ ] **Task 4:** Insert Step 8b into `processComments()` in `engine/comments.go` — after the existing `if output != ""` block; guarded by `isReviewReinvoke(comments) && output != ""`; call `FindPRForIssue`, then `buildThreadEntries`, then `formatReviewFeedbackComment`, then `AddComment(owner, repo, prNumber, ...)` on success; log warning and skip if no PR or FindPRForIssue errors
- [ ] **Task 5:** Add unit tests for `isReviewReinvoke` in `engine/comments_test.go` — cases: all-ReviewThreadID → true; mixed → false; none → false; empty → false
- [ ] **Task 6:** Add unit tests for `buildThreadEntries` and `formatReviewFeedbackComment` in `engine/pr_test.go` — `buildThreadEntries`: dedup by ReviewThreadID; Line fallback to OriginalLine; zero-Line entry included with omitted line number. `formatReviewFeedbackComment`: header contains `(review feedback addressed)`; footer has `Threads addressed:` section; per-thread bullet with path:line; zero-line bullet omits line number; summary line contains thread count and comment count
- [ ] **Task 7:** Update `docs/state-machine.md` §4.2 Step 8 to describe the reinvoke branch: all-ReviewThreadID batch → also posts Fabrik-marked summary on linked PR titled `"<StageName> (review feedback addressed)"` with per-thread footer; gated on linked-PR existence; skipped when `output == ""`
- [ ] **Task 8:** Update `docs/state-machine.md` §6.2 with a new bullet: PR summary comment as visible artifact — posted on linked PR with per-thread footer listing path:line for each resolved thread, alongside the existing thread-resolution bullet
- [ ] **Task 9:** Update `docs/state-machine.md` §6.3 comparison table with new row: `PR summary posting` — Regular Comments → None; Review Reinvoke → Posts `"<StageName> (review feedback addressed)"` on linked PR with per-thread footer

### Risks

- **`FindPRForIssue` error handling**: the code already follows the engine pattern — log a warning, skip silently. No risk of breaking existing behavior.
- **Empty `threads` slice**: If `buildThreadEntries` returns empty (e.g., all comments have empty `Path`), the footer renders with no bullets. This is correct — the summary line still says `Resolved 0 review thread(s) across N comment(s).` In practice GitHub always provides `Path` for inline review comments.
- **`output != ""` guard ordering**: Step 8b uses its own `output != ""` guard independent of Step 8. Both guards are consistent with R6. No issue — they read the same variable.
- **#392 dependency**: If #392 ships first, the review-reinvoke path runs for all issues (not just yolo/cruise). This implementation is additive and doesn't conflict — it can ship before or after #392 independently.
- **Test coverage for the integrated path** (`processComments` with review comments posting to PR): not required by spec (unit tests on helpers are sufficient) and would require significant mock wiring. The existing `processComments` integration tests cover the comment-processing path; the PR post is covered by the helper unit tests.

## Verification

Added review-reinvoke PR summary posting in 3 commits: `isReviewReinvoke()` detects all-ReviewThreadID batches; `buildThreadEntries()` and `formatReviewFeedbackComment()` build a Fabrik-marked comment with per-thread footer; Step 8b in `processComments()` posts it to the linked PR. Fourteen unit tests added; compliance checker updated to recognize the new formatter; `docs/state-machine.md` §4.2 Step 8, §6.2, and §6.3 updated.

---

Closes #394