### PR TITLE
Update docs for v0.0.39

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ also rebases onto the configured base branch and resolves merge conflicts before
 keeping the PR branch clean.
 
 The Review and Validate stages ship with `wait_for_reviews: true` enabled by
-default. When this option is set and auto-advance is active, Fabrik uses a
-three-phase reviewer gate:
+default. When this option is set, Fabrik uses a three-phase reviewer gate
+(re-invocation fires unconditionally; auto-advancement to the next stage still
+requires auto-advance to be active):
 
 1. **Always-gate:** On stage completion, Fabrik adds `fabrik:awaiting-review`
    and holds auto-advance until all requested reviewers submit.
@@ -129,6 +130,8 @@ three-phase reviewer gate:
    round. Reviews with no inline thread comments—including reviews with only
    top-level review text (for example, bot approvals or summary-only
    comments)—do not trigger re-invocation, and the issue advances normally.
+   After each re-invocation cycle, Fabrik posts a PR summary comment with a
+   per-thread footer listing how each inline review thread was addressed.
 
 > **Configuration:** `--max-review-cycles` / `FABRIK_MAX_REVIEW_CYCLES` (default `5`)
 > caps the number of re-invocation cycles per session. `--review-wait-timeout` /
@@ -400,6 +403,7 @@ cp ./stages/mystages/*.yaml .fabrik/stages/
 ## Documentation
 
 - [User Guide](docs/USER_GUIDE.md) — full configuration reference for the pre-v0.2 `./stages` workflow (see "Quick Start" and "Migration from `./stages`" above for the current `./.fabrik/stages` default), workflow patterns, stage details, labels, and troubleshooting
+- [State Machine](docs/state-machine.md) — authoritative spec for engine state transitions, label semantics, and review gate behavior
 - [Troubleshooting](docs/USER_GUIDE.md#10-troubleshooting) — common issues: plugin conflicts, PID lock, merge conflicts, max turns, and more
 
 ## Architecture Decision Records

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -601,11 +601,11 @@ The Implement stage creates a **draft PR** linked to the issue when `create_draf
 | `## Summary` | Extracted from the issue spec (`.fabrik-context/issue.md`) |
 | `## Problem` | Extracted from the issue spec (`.fabrik-context/issue.md`) |
 | `## Approach` | Extracted from the Plan stage output (`.fabrik-context/stage-Plan.md`); falls back to a placeholder if absent |
-| `## Verification` | Placeholder text, auto-replaced by the stage summary on completion |
+| `## Verification` | Placeholder text, auto-replaced by an extracted stage summary when available |
 
 The `Closes #N` footer in the PR body links the PR to the issue so Fabrik can discover PR comments via GraphQL.
 
-**Verification auto-update**: When a `post_to_pr` stage completes and includes a `FABRIK_SUMMARY` in its output, Fabrik replaces the `## Verification` section of the PR body with that summary. This keeps the PR description current as each stage contributes its findings.
+**Verification auto-update**: For draft PRs created with `create_draft_pr: true`, Fabrik updates the `## Verification` section only when it can extract a summary block delimited by `FABRIK_SUMMARY_BEGIN` and `FABRIK_SUMMARY_END` from stage output. This keeps the PR description current when a stage provides a structured summary for PR-body updates.
 
 ### Retry and Escalation
 
@@ -796,7 +796,7 @@ The "Threads addressed" footer lists each inline thread by file path and line nu
 To prevent infinite loops (e.g., a bot that always posts new reviews after every push), Fabrik caps the number of re-invocation cycles per issue per stage per engine session. When the limit is reached with reviewers still pending, Fabrik pauses the issue with `fabrik:awaiting-input` and posts a comment explaining the situation.
 
 ```bash
-FABRIK_MAX_REVIEW_CYCLES=3  # Limit to 3 re-invocation cycles per issue (default: 5)
+FABRIK_MAX_REVIEW_CYCLES=3  # Limit to 3 re-invocation cycles per issue per stage (default: 5)
 # or equivalently:
 fabrik --max-review-cycles=3
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -10,6 +10,7 @@ This guide covers everything you need to set up, configure, and use Fabrik effec
 
 For a quick overview see the [README](../README.md).
 For details on the internal stage lifecycle, see [Stage Lifecycle](stage-lifecycle.md).
+For the authoritative engine state-machine spec (label semantics, review gate transitions, marker handling), see [State Machine](state-machine.md).
 
 ---
 
@@ -163,6 +164,8 @@ or `poll:` in `config.yaml`).
 | 5–10 min | 2× | 60s |
 | 10–20 min | 4× | 120s |
 | 20+ min | max (5 minutes) | 300s |
+
+**Rate-limit backoff**: When Fabrik detects GraphQL API quota pressure, the same interval infrastructure adds a separate rate-limit component. This component is capped at `10 × configured poll interval` (300s at the default 30s base; 600s at 60s base) — there is no separate 5-minute ceiling for the rate-limit contributor. The effective poll interval is `max(idle interval, rate-limit interval)`, so whichever is larger governs at any given moment.
 
 Move an issue to `Specify` on the board to start processing it.
 
@@ -467,13 +470,15 @@ auto_advance: false       # Optional. Per-stage override for the global yolo set
 cleanup_worktree: false   # Optional. Removes the issue worktree instead of invoking Claude.
                           #   Use for terminal stages (e.g., Done) where no further work
                           #   is needed on the branch.
-wait_for_reviews: false   # Optional. When true and auto-advance is active, Fabrik waits for
-                          #   all requested PR reviewers to submit, then re-invokes the stage
-                          #   agent via the comment-processing path to address the feedback.
-                          #   This loop repeats until no reviewers are pending (up to
-                          #   FABRIK_MAX_REVIEW_CYCLES cycles). On timeout or cycle limit,
-                          #   Fabrik pauses with fabrik:awaiting-input instead of advancing.
-                          #   See §10 Pending Reviewer Gate for full details.
+wait_for_reviews: false   # Optional. When true, Fabrik waits for all requested PR reviewers
+                          #   to submit and re-invokes the stage agent via the comment-processing
+                          #   path to address submitted inline feedback. Re-invocation is
+                          #   unconditional — it fires regardless of the auto-advance setting.
+                          #   Auto-advancement to the next stage after re-invocation still requires
+                          #   auto-advance to be active. This loop repeats until no reviewers are
+                          #   pending (up to FABRIK_MAX_REVIEW_CYCLES cycles). On timeout or cycle
+                          #   limit, Fabrik pauses with fabrik:awaiting-input instead of advancing.
+                          #   See §3 Pending Reviewer Gate for full details.
 allowed_tools:            # Optional. REPLACES the default tool set — not additive. When set,
   - Read                  #   only these tools are allowed; the default list is not added.
   - Grep                  #   When omitted, Fabrik uses a comprehensive default covering common
@@ -566,6 +571,8 @@ When you post a comment:
 
 The rocket reaction is durable -- on restart, Fabrik skips comments that already have it.
 
+Engine-posted comments are identified by **two dedup signals**: the `🏭 **Fabrik` header (primary) and the 🚀 rocket reaction (secondary). Both categories are skipped when scanning for new user comments to process.
+
 ### Reaction Flow
 
 | Reaction | Meaning |
@@ -585,9 +592,20 @@ You do not need to babysit the pipeline. The intended human role is:
 
 ### Draft PR Workflow
 
-The Implement stage creates a **draft PR** linked to the issue. This gives you a place
-to review incrementally. The Review stage then rebases, reviews, fixes, and pushes --
-turning the draft into a review-ready PR.
+The Implement stage creates a **draft PR** linked to the issue when `create_draft_pr: true` is set (the default for Implement). This gives you a place to review incrementally. The Review stage then rebases, reviews, fixes, and pushes — turning the draft into a review-ready PR.
+
+**PR body seeding**: When the draft PR is created, Fabrik seeds the PR body from context files already written in the worktree:
+
+| Section | Source |
+|---------|--------|
+| `## Summary` | Extracted from the issue spec (`.fabrik-context/issue.md`) |
+| `## Problem` | Extracted from the issue spec (`.fabrik-context/issue.md`) |
+| `## Approach` | Extracted from the Plan stage output (`.fabrik-context/stage-Plan.md`); falls back to a placeholder if absent |
+| `## Verification` | Placeholder text, auto-replaced by the stage summary on completion |
+
+The `Closes #N` footer in the PR body links the PR to the issue so Fabrik can discover PR comments via GraphQL.
+
+**Verification auto-update**: When a `post_to_pr` stage completes and includes a `FABRIK_SUMMARY` in its output, Fabrik replaces the `## Verification` section of the PR body with that summary. This keeps the PR description current as each stage contributes its findings.
 
 ### Retry and Escalation
 
@@ -709,7 +727,9 @@ Sub-issues (those labeled `fabrik:sub-issue`) are **never decomposed further**. 
 
 ### Pending Reviewer Gate
 
-When a stage has `wait_for_reviews: true` set and auto-advance is active (global `yolo: true`, per-stage `auto_advance: true`, or the `fabrik:yolo` label on the issue), Fabrik waits for all requested PR reviewers to submit their reviews, then re-invokes the stage agent to address the feedback before advancing.
+When a stage has `wait_for_reviews: true` set, Fabrik waits for all requested PR reviewers to submit their reviews, then re-invokes the stage agent to address any submitted inline feedback. **Re-invocation is unconditional** — it fires for any issue with submitted inline review thread comments, regardless of whether auto-advance is active. Auto-advancement to the next stage after re-invocation still requires auto-advance to be active (global `yolo: true`, per-stage `auto_advance: true`, or the `fabrik:yolo` label on the issue).
+
+For the authoritative spec on label lifecycle and gate transitions, see [State Machine](state-machine.md).
 
 The Review and Validate stages ship with `wait_for_reviews: true` enabled by default.
 
@@ -724,7 +744,7 @@ wait_for_reviews: true
 ...
 ```
 
-The gate only fires when auto-advance is active. If you're manually dragging cards through the board, the gate has no effect — you control the timing.
+The reviewer wait and re-invocation cycle fire unconditionally — they activate whenever `wait_for_reviews: true` and inline review feedback is present, regardless of whether auto-advance is active. If you're manually dragging cards through the board, re-invocation still happens; the issue will not advance automatically after the cycle completes — you still move the card manually.
 
 #### Label Lifecycle
 
@@ -741,7 +761,7 @@ The gate uses a three-phase design:
 
 1. **Phase 1 (always-gate):** On stage completion, Fabrik immediately adds `fabrik:awaiting-review` and skips auto-advance. This fires even before reviewer assignments propagate.
 2. **Phase 2 (gate evaluation):** On subsequent poll cycles, Fabrik re-fetches the PR with fresh GraphQL data and evaluates whether all requested reviewers have submitted. If still pending → wait. If timed out → pause with `fabrik:awaiting-input`.
-3. **Phase 3 (re-invocation):** When the gate clears with submitted reviews present, Fabrik re-invokes the stage agent via the comment-processing skill (`comment_skill`) with the unresolved inline review thread comments as input. Top-level PR review bodies are not included, so a review that only contains general feedback without inline thread comments does not provide re-invocation input. Each inline thread comment is enriched with its **file path** and, when available, **line number** and **raw diff-hunk context** (line number and hunk may be absent for file-level or outdated comments) so the agent understands where in the code the reviewer's feedback applies. The agent addresses the feedback, commits, and signals `FABRIK_STAGE_COMPLETE`. This re-applies `fabrik:awaiting-review` and the cycle repeats from Phase 2 until no reviewers are pending.
+3. **Phase 3 (re-invocation):** When the gate clears with submitted reviews present, Fabrik re-invokes the stage agent via the comment-processing skill (`comment_skill`) with the unresolved inline review thread comments as input. Top-level PR review bodies are not included, so a review that only contains general feedback without inline thread comments does not provide re-invocation input. Each inline thread comment is enriched with its **file path** and, when available, **line number** and **raw diff-hunk context** (line number and hunk may be absent for file-level or outdated comments) so the agent understands where in the code the reviewer's feedback applies. The agent addresses the feedback, commits, and signals `FABRIK_STAGE_COMPLETE`. This re-applies `fabrik:awaiting-review` and the cycle repeats from Phase 2 until no reviewers are pending. **As of v0.0.39, re-invocation is unconditional** — it fires for any issue with `wait_for_reviews: true` and submitted inline feedback, regardless of whether auto-advance is active.
 
 This means there is always at least one extra poll cycle delay after stage completion — typically 30 seconds.
 
@@ -751,9 +771,29 @@ If a submitted-review batch leaves no unresolved inline PR review thread comment
 
 This prevents spurious re-invocation cycles when reviews contain no actionable inline thread feedback for the agent to address.
 
+#### PR Summary Comment
+
+After each re-invocation cycle, Fabrik posts a summary comment on the **linked PR** (not the issue) with the following format:
+
+```
+🏭 **Fabrik — stage: {StageName} (review feedback addressed)**
+*branch: {branch} | commit: {sha} | main: {mainSHA} | {timestamp}*
+
+{Claude output}
+
+---
+**Threads addressed:**
+- `path/to/file.go:42` — resolved
+- `other/file.go` — resolved
+
+Resolved N review thread(s) across M comment(s).
+```
+
+The "Threads addressed" footer lists each inline thread by file path and line number (when available); file-level or outdated threads show only the file path. This comment is posted only when Claude produces output and a linked PR is found. It carries the `🏭 **Fabrik` header so it is not reprocessed as user input on subsequent polls.
+
 #### Cycle Limit
 
-To prevent infinite loops (e.g., a bot that always posts new reviews after every push), Fabrik caps the number of re-invocation cycles per issue per engine session. When the limit is reached with reviewers still pending, Fabrik pauses the issue with `fabrik:awaiting-input` and posts a comment explaining the situation.
+To prevent infinite loops (e.g., a bot that always posts new reviews after every push), Fabrik caps the number of re-invocation cycles per issue per stage per engine session. When the limit is reached with reviewers still pending, Fabrik pauses the issue with `fabrik:awaiting-input` and posts a comment explaining the situation.
 
 ```bash
 FABRIK_MAX_REVIEW_CYCLES=3  # Limit to 3 re-invocation cycles per issue (default: 5)
@@ -1031,6 +1071,8 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 
 ## 6. Labels Reference
 
+> For the authoritative label lifecycle spec — when each label is added, cleared, and what transitions it guards — see [State Machine](state-machine.md).
+
 ### Fabrik-Managed Labels
 
 > Fabrik auto-seeds all managed labels on the configured repository at startup — creating them with their descriptions and colors if they do not already exist, so the GitHub UI shows meaningful hover text.
@@ -1041,7 +1083,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:editing` | Issue body being updated (comment processing) |
 | `fabrik:paused` | Processing paused (max retries exceeded or manual) |
 | `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user |
-| `fabrik:awaiting-review` | Issue waiting for all requested PR reviewers to submit; set when `wait_for_reviews: true` stage completes with auto-advance active; cleared when all reviewers submit (then re-invocation fires) or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
+| `fabrik:awaiting-review` | Issue waiting for all requested PR reviewers to submit; set when a `wait_for_reviews: true` stage completes; cleared when all reviewers submit (then re-invocation fires unconditionally) or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
 | `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; added and removed automatically by the engine (Fabrik creates this label on first use — no pre-creation needed) |
 | `stage:<name>:in_progress` | Stage actively running |
 | `stage:<name>:complete` | Stage completed successfully |
@@ -1149,7 +1191,7 @@ In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), is
 
 ### What's Displayed
 
-**In Progress**: Issue number, stage name, elapsed time, issue title, latest status message.
+**In Progress**: Issue number, stage name, elapsed time, issue title, latest status message. Review-reinvoke jobs appear here alongside regular stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time, just like a normal stage invocation.
 
 **History**: Issue number, stage name, success/fail icon, duration, timestamp, turns used,
 cost, and issue title. Status icons:

--- a/docs/index.md
+++ b/docs/index.md
@@ -282,10 +282,12 @@ description: >-
           Set <code>wait_for_reviews: true</code> on a stage and Fabrik uses
           a three-phase gate: (1) immediately apply <code>fabrik:awaiting-review</code>
           on completion, (2) poll until all requested reviewers submit, (3)
-          re-invoke the stage agent to address any unresolved inline PR review
-          thread comments before advancing. Reviews with only top-level text
-          (e.g., bot approvals or summary-only comments) skip re-invocation.
-          Controlled by <code>--review-wait-timeout</code> /
+          unconditionally re-invoke the stage agent to address any unresolved
+          inline PR review thread comments — regardless of whether auto-advance
+          is active. Reviews with only top-level text (e.g., bot approvals or
+          summary-only comments) skip re-invocation. Auto-advancement to the
+          next stage after re-invocation still requires auto-advance to be
+          active. Controlled by <code>--review-wait-timeout</code> /
           <code>FABRIK_REVIEW_WAIT_TIMEOUT</code> (default 15
           min per cycle) and <code>--max-review-cycles</code> /
           <code>FABRIK_MAX_REVIEW_CYCLES</code> (default 5
@@ -439,6 +441,13 @@ echo '.env' >> .gitignore
         <div>
           <div class="link-title">Stage Lifecycle</div>
           <div class="link-desc">Engine internals, markers, context files, and comment processing</div>
+        </div>
+      </a>
+      <a href="{{ '/state-machine' | relative_url }}" class="link-card">
+        <span class="link-icon">🔄</span>
+        <div>
+          <div class="link-title">State Machine</div>
+          <div class="link-desc">Authoritative spec for engine state transitions, label semantics, and review gate behavior</div>
         </div>
       </a>
       <a href="{{ '/USER_GUIDE#10-troubleshooting' | relative_url }}" class="link-card">


### PR DESCRIPTION
## Summary

Update the user-facing documentation (USER_GUIDE, README, marketing page) to accurately reflect v0.0.39 behavior. Add cross-references to `docs/state-machine.md` from the user docs. Ensure all configuration references, behavior descriptions, and examples are current.

## Problem

v0.0.39 shipped several user-visible behavior changes — most significantly the split of review-feedback processing into unconditional reinvoke (Phase 1) and gated advancement (Phase 2), PR body seeding from context files, the 🏭 Fabrik header on all engine comments, unified idle/rate-limit backoff, and PR summary comments after review reinvoke. The existing docs describe the pre-v0.0.39 behavior and need to be updated before users encounter inconsistencies between what the docs say and what Fabrik actually does.

Additionally, `docs/state-machine.md` (shipped in #383, cross-referenced in CLAUDE.md) is not yet cross-referenced from `USER_GUIDE.md`, `README.md`, or `docs/index.md`, even though those docs contain substantial label-semantics and review-handling content that the state machine spec now supersedes.

## Approach

### Approach

This is a pure documentation task — no code changes. All three files (`docs/USER_GUIDE.md`, `README.md`, `docs/index.md`) require targeted edits in specific sections. The approach is to make all edits to each file in a single commit per file, ordered USER_GUIDE first (largest set of changes), then README, then docs/index.md.

**Key decisions:**

1. **Review gate framing**: Preserve the existing Phase 1/2/3 terminology (handleStageComplete / gate evaluation / re-invocation). The "Phase 1 unconditional / Phase 2 gated" language in v0.0.39 code comments refers to the catch-up loop partitioning and should not be surfaced directly in user docs — it would create a naming collision. Instead, add a clear note that Phase 3 (re-invocation) is now unconditional.

2. **Rate-limit backoff format**: Add a descriptive note below the existing idle backoff table rather than replacing or merging it. The idle table is still accurate; only the rate-limit behavior is new and needs a prose addition.

3. **PR body seeding placement**: Expand the existing "Draft PR Workflow" subsection (§3, line 586) with a concrete description of the 4-section PR body template and Verification auto-update. Keep it as an extension of that subsection, not a new top-level section.

4. **PR summary comment**: Add as a new `#### PR Summary Comment` subsection directly after the `#### No Inline-Thread Feedback Skip` subsection, before `#### Cycle Limit`.

5. **No ADR warranted**: All changes are documentation corrections. No architectural decisions are being made.

---

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | 10 targeted edits across §1, §3, §6, §8 |
| `README.md` | 3 targeted edits in Review and Fix and Documentation sections |
| `docs/index.md` | 2 targeted edits in Pending Reviewer Gate card and Resources section |

---

### Key Decisions

- **Preserve Phase 1/2/3 terminology**: USER_GUIDE and README already use this numbering for the review gate mechanism (handleStageComplete / poll evaluation / re-invocation). The v0.0.39 catch-up loop refactoring uses "Phase 1 unconditional / Phase 2 gated" for a different level of abstraction. Surfacing the internal partition terminology in user docs would create confusion. Instead, add one sentence to the existing Phase 3 description: "As of v0.0.39, re-invocation (Phase 3) is unconditional — it fires for any issue with `wait_for_reviews: true` and submitted inline feedback, regardless of whether auto-advance is active."

- **`wait_for_reviews:` YAML comment (line 470)**: The inline comment says "When true and auto-advance is active, Fabrik waits for..." — this is stale. Update it to match the unconditional behavior.

- **`fabrik:awaiting-review` label description (line 1044)**: Currently says "set when `wait_for_reviews: true` stage completes with auto-advance active" — update to remove "with auto-advance active" since the label is now set unconditionally.

- **Rate-limit backoff cap**: Document as `10 × configured poll interval` (not a fixed number) since the multiplier is 10× and the base is user-configured. At the default 30s this equals 300s; at 60s base it reaches 600s. Do not expose the internal `rateLimitBackoffThreshold` (20% remaining) constant.

---

### Task Checklist

- [ ] **Task 1 — USER_GUIDE §1: Update idle backoff section (line 158–165)**
  Add a sentence after the idle backoff table (after the "20+ min" row) clarifying rate-limit backoff: the same interval infrastructure also handles GraphQL rate-limit pressure; when near the rate limit, the effective interval can reach up to `10 × configured poll interval` independently of idle duration; the two contributors are combined as `max(idle, rate-limit)`. Note there is no hard 5-minute cap specific to rate-limit backoff.

- [ ] **Task 2 — USER_GUIDE §3: Update Pending Reviewer Gate intro (line 712)**
  Replace "When a stage has `wait_for_reviews: true` set and auto-advance is active (global `yolo: true`, per-stage `auto_advance: true`, or the `fabrik:yolo` label on the issue), Fabrik waits for all requested PR reviewers to submit their reviews, then re-invokes the stage agent to address the feedback before advancing." with a version that separates re-invocation (unconditional) from auto-advancement (gated): re-invocation fires for any issue with `wait_for_reviews: true` and submitted inline feedback; auto-advancement to the next stage still requires auto-advance to be active.

- [ ] **Task 3 — USER_GUIDE §3: Update "gate only fires when auto-advance is active" sentence (line 727)**
  Replace "The gate only fires when auto-advance is active. If you're manually dragging cards through the board, the gate has no effect — you control the timing." with a more precise statement: the reviewer wait and re-invocation fire unconditionally; if auto-advance is not active, the issue will not advance automatically after re-invocation completes — you still move the card manually.

- [ ] **Task 4 — USER_GUIDE §3: Update Three-Phase Mechanism, Phase 3 entry (line 744)**
  Add one sentence to Phase 3 noting that as of v0.0.39, re-invocation is unconditional — it fires for any issue with submitted inline review feedback, regardless of whether auto-advance is active.

- [ ] **Task 5 — USER_GUIDE §3: Add PR Summary Comment subsection**
  After the `#### No Inline-Thread Feedback Skip` subsection (before `#### Cycle Limit` at line 754), insert a new `#### PR Summary Comment` subsection explaining: after each re-invocation cycle, Fabrik posts a summary comment on the linked PR (not the issue) containing the Claude output and a "Threads addressed" footer listing each inline thread by file path and line number (when available), concluding with "Resolved N review thread(s) across M comment(s)." The comment header reads `🏭 **Fabrik — stage: {StageName} (review feedback addressed)**`. It is posted only when there is Claude output and a linked PR exists.

- [ ] **Task 6 — USER_GUIDE §3: Update Cycle Limit subsection (line 756)**
  Change "per issue per engine session" to "per issue per stage per engine session" in the cycle count description.

- [ ] **Task 7 — USER_GUIDE §3: Update Steering with Comments — comment dedup (lines 566–567)**
  After "The rocket reaction is durable -- on restart, Fabrik skips comments that already have it.", add a note that engine-posted comments are identified by two signals: the `🏭 **Fabrik` header (primary) and the 🚀 rocket reaction (secondary). Both categories are skipped when processing new comments.

- [ ] **Task 8 — USER_GUIDE §3: Expand Draft PR Workflow subsection (line 586–590)**
  Expand the one-paragraph "Draft PR Workflow" subsection to document PR body seeding: when `create_draft_pr: true`, Fabrik seeds the PR body from context files at creation time — `## Summary` and `## Problem` from the issue spec; `## Approach` from the Plan stage output (or a placeholder if absent); `## Verification` as a placeholder auto-replaced by the stage summary when a `post_to_pr` stage completes with a `FABRIK_SUMMARY`. The `Closes #N` footer links the PR to the issue.

- [ ] **Task 9 — USER_GUIDE §6: Update `fabrik:awaiting-review` label description (line 1044)**
  Update label description to remove "with auto-advance active" — the label is now set unconditionally when a `wait_for_reviews: true` stage completes.

- [ ] **Task 10 — USER_GUIDE §8: Add review-reinvoke note to TUI section (around line 1105)**
  Add a note that review-reinvoke jobs appear in the In Progress panel alongside stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time.

- [ ] **Task 11 — USER_GUIDE: Add cross-references to `docs/state-machine.md`**
  Add three cross-references:
  1. Introduction (line 12): add "For the authoritative state-machine spec see [State Machine](state-machine.md)." alongside the existing stage-lifecycle reference.
  2. §3 Pending Reviewer Gate intro: add a trailing sentence directing readers to `docs/state-machine.md` for full label/gate spec.
  3. §6 Labels intro: add a note that `docs/state-machine.md` is the authoritative reference for label lifecycle.

- [ ] **Task 12 — USER_GUIDE: Fix `wait_for_reviews:` YAML comment (line 470)**
  Update the inline YAML comment to remove "and auto-advance is active" from the `wait_for_reviews` description, reflecting the v0.0.39 unconditional re-invocation behavior.

- [ ] **Task 13 — README.md: Update Review and Fix — Phase 3 description (lines 126–131)**
  Remove "and auto-advance is active" from the re-invocation step. Add a bullet or trailing note that a PR summary comment with per-thread footers is posted to the linked PR after each re-invocation cycle.

- [ ] **Task 14 — README.md: Update Review and Fix intro (line 118)**
  Change "When this option is set and auto-advance is active, Fabrik uses a three-phase reviewer gate:" to remove the "and auto-advance is active" conditional — the three-phase gate now runs unconditionally when `wait_for_reviews: true`; auto-advance only controls whether the issue advances after the cycle completes.

- [ ] **Task 15 — README.md: Add `docs/state-machine.md` to Documentation section (lines 400–403)**
  Add a bullet: `- [State Machine](docs/state-machine.md) — authoritative spec for engine state transitions, label semantics, and review gate behavior`.

- [ ] **Task 16 — docs/index.md: Update Pending Reviewer Gate feature card (lines 282–294)**
  Remove or qualify "when auto-advance is active" from the re-invocation description in the feature card. The card should convey that re-invocation fires unconditionally when inline feedback is present; auto-advancement is a separate concern.

- [ ] **Task 17 — docs/index.md: Add state-machine.md link card to Resources section (after line 443)**
  After the Stage Lifecycle link card, add a new link card for `docs/state-machine.md` with title "State Machine" and description "Authoritative spec for engine state transitions, label semantics, and review gate behavior".

- [ ] **Task 18 — Commit all `docs/USER_GUIDE.md` changes**

- [ ] **Task 19 — Commit all `README.md` changes**

- [ ] **Task 20 — Commit all `docs/index.md` changes**

---

### Risks

- **Phase 1/2/3 terminology collision**: The USER_GUIDE and README currently use "Phase 1/2/3" for the review gate mechanism (handleStageComplete / evaluation / re-invocation). v0.0.39 code comments use "Phase 1/2" for the catch-up loop partition. Implementation must update the description of Phase 3 (re-invocation is now unconditional) without importing the catch-up loop partition terminology — that would create a four-phase naming conflict.

- **YAML inline comment is documentation too**: The `wait_for_reviews` YAML comment (Task 12) is in the configuration example block in USER_GUIDE. Missing this would leave a stale description in a visible user-facing location.

- **PR body section name exactness**: User docs must match the 4-section PR body template exactly: `## Summary`, `## Problem`, `## Approach`, `## Verification`. These names are case-insensitive in the code but user docs should use the canonical casing.

---
Used 21/50 turns, 6k input / 7k output tokens.

## Verification

Updated `docs/USER_GUIDE.md`, `README.md`, and `docs/index.md` to reflect v0.0.39 behavior changes across 3 commits. Key updates: unconditional Phase 3 review reinvoke (removed the "auto-advance active" gate requirement everywhere), new PR Summary Comment subsection in USER_GUIDE, PR body seeding documentation (4-section template + Verification auto-update), rate-limit backoff note (10× cap, no 5-min ceiling), dual dedup signal clarification (🏭 header + 🚀 rocket), per-stage cycle count fix, and cross-references to `docs/state-machine.md` in the intro, §3, §6, and the Resources section of the marketing page.

---

Closes #408