### PR TITLE
Update docs for v0.0.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Fabrik uses labels to track state:
 | `fabrik:paused` | Issue is skipped entirely — no stage processing or comment processing occurs |
 | `fabrik:awaiting-input` | Stage is paused waiting for user input; auto-clears when a new comment from the configured user (`--user`) is received |
 | `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; managed automatically by the engine |
-| `fabrik:awaiting-review` | Set by the engine when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding and at least one review has been submitted (the dual condition catches bot reviewers like Copilot and Gemini that self-trigger via webhook without appearing in the formal reviewer list), or when the reviewer-wait timeout elapses as a fallback (`--review-wait-timeout` / `FABRIK_REVIEW_WAIT_TIMEOUT`) |
+| `fabrik:awaiting-review` | Applied optimistically by the engine whenever a `wait_for_reviews: true` stage completes (reviewer request data may still be stale at that moment); removed when no requested reviewers are outstanding and at least one review has been submitted (the dual condition catches bot reviewers like Copilot and Gemini that self-trigger via webhook without appearing in the formal reviewer list), or when the reviewer-wait timeout elapses as a fallback (`--review-wait-timeout` / `FABRIK_REVIEW_WAIT_TIMEOUT`), at which point the issue is paused with `fabrik:awaiting-input` |
 | `stage:<name>:complete` | Stage has been completed |
 | `stage:<name>:in_progress` | Stage is actively running |
 | `stage:<name>:failed` | Stage hit max retries and was paused |

--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ default. When this option is set, Fabrik uses a three-phase reviewer gate
 requires auto-advance to be active):
 
 1. **Always-gate:** On stage completion, Fabrik adds `fabrik:awaiting-review`
-   and holds auto-advance until all requested reviewers submit.
-2. **Gate evaluation:** On each subsequent poll, Fabrik checks whether all
-   reviewers have submitted. If reviewers are still pending and the per-cycle
-   timeout expires, the issue pauses with `fabrik:awaiting-input`.
-3. **Re-invocation:** When all reviewers submit and there are unresolved PR
+   and holds auto-advance until the gate clears.
+2. **Gate evaluation:** On each subsequent poll, Fabrik checks the dual
+   condition: no requested reviewers are outstanding **and** at least one
+   review has been submitted (this catches bot reviewers like Copilot and
+   Gemini that self-trigger via webhook without appearing in the formal
+   reviewer list). If the condition isn't met and the per-cycle timeout
+   expires, the issue pauses with `fabrik:awaiting-input`.
+3. **Re-invocation:** When the gate clears and there are unresolved PR
    review thread comments, Fabrik re-invokes the stage agent to address that
    inline feedback and push a new commit, then waits for the next review
    round. Reviews with no inline thread comments—including reviews with only

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Fabrik uses labels to track state:
 | `fabrik:paused` | Issue is skipped entirely — no stage processing or comment processing occurs |
 | `fabrik:awaiting-input` | Stage is paused waiting for user input; auto-clears when a new comment from the configured user (`--user`) is received |
 | `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; managed automatically by the engine |
-| `fabrik:awaiting-review` | Set by the engine when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when all reviewers submit (approve, request changes, or comment) or the configured reviewer-wait timeout elapses (`--review-wait-timeout` / `FABRIK_REVIEW_WAIT_TIMEOUT`) |
+| `fabrik:awaiting-review` | Set by the engine when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding and at least one review has been submitted (the dual condition catches bot reviewers like Copilot and Gemini that self-trigger via webhook without appearing in the formal reviewer list), or when the reviewer-wait timeout elapses as a fallback (`--review-wait-timeout` / `FABRIK_REVIEW_WAIT_TIMEOUT`) |
 | `stage:<name>:complete` | Stage has been completed |
 | `stage:<name>:in_progress` | Stage is actively running |
 | `stage:<name>:failed` | Stage hit max retries and was paused |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1083,7 +1083,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:editing` | Issue body being updated (comment processing) |
 | `fabrik:paused` | Processing paused (max retries exceeded or manual) |
 | `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user |
-| `fabrik:awaiting-review` | Issue waiting for all requested PR reviewers to submit; set when a `wait_for_reviews: true` stage completes; cleared when all reviewers submit (then re-invocation fires unconditionally) or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
+| `fabrik:awaiting-review` | Set when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding **and** at least one review has been submitted (then re-invocation fires unconditionally), or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
 | `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; added and removed automatically by the engine (Fabrik creates this label on first use — no pre-creation needed) |
 | `stage:<name>:in_progress` | Stage actively running |
 | `stage:<name>:complete` | Stage completed successfully |
@@ -1175,7 +1175,7 @@ Pressing `?` opens an overlay that displays all keybindings and a labels referen
 | `fabrik:cruise` | Auto-advance through all stages without auto-merging the PR |
 | `fabrik:paused` | Issue processing is paused |
 | `fabrik:awaiting-input` | Stage is blocked waiting for user input |
-| `fabrik:awaiting-review` | Stage completed; waiting for outstanding PR reviewer requests; clears when all reviewers submit, then re-invokes the stage agent to address feedback |
+| `fabrik:awaiting-review` | Stage completed; waiting for outstanding PR reviewer requests; clears when no requested reviewers are outstanding and at least one review has been submitted, then re-invokes the stage agent to address feedback |
 | `fabrik:locked:<user>` | Issue is locked for editing by the specified user |
 | `stage:<name>:in_progress` | Named stage is currently running |
 | `stage:<name>:complete` | Named stage completed successfully |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -751,7 +751,7 @@ The reviewer wait and re-invocation cycle fire unconditionally — they activate
 When the gate is active, Fabrik adds the `fabrik:awaiting-review` label to the issue. This label:
 
 - Makes the wait state visible on the project board
-- Is cleared automatically when all requested reviewers submit (approve, request changes, or comment)
+- Is cleared automatically when no requested reviewers are outstanding **and** at least one review has been submitted — this dual condition catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without ever appearing in the formal requested-reviewer list
 - Triggers a re-invocation of the stage agent (via the comment-processing path) to address the submitted review feedback
 - After re-invocation, if new reviewers are assigned (e.g. bots triggered by a fresh push), the label is re-applied and the cycle continues
 
@@ -760,7 +760,7 @@ When the gate is active, Fabrik adds the `fabrik:awaiting-review` label to the i
 The gate uses a three-phase design:
 
 1. **Phase 1 (always-gate):** On stage completion, Fabrik immediately adds `fabrik:awaiting-review` and skips auto-advance. This fires even before reviewer assignments propagate.
-2. **Phase 2 (gate evaluation):** On subsequent poll cycles, Fabrik re-fetches the PR with fresh GraphQL data and evaluates whether all requested reviewers have submitted. If still pending → wait. If timed out → pause with `fabrik:awaiting-input`.
+2. **Phase 2 (gate evaluation):** On subsequent poll cycles, Fabrik re-fetches the PR with fresh GraphQL data and evaluates the dual condition: the gate clears only when no requested reviewers are outstanding **and** at least one review has been submitted. Requiring at least one review (not just an empty pending list) is what catches bot reviewers like Copilot and Gemini that self-trigger via webhook without ever appearing in the formal requested-reviewer list — if only the pending list were checked, the gate would race through while bots were still processing. If still pending → wait. If timed out → pause with `fabrik:awaiting-input`.
 3. **Phase 3 (re-invocation):** When the gate clears with submitted reviews present, Fabrik re-invokes the stage agent via the comment-processing skill (`comment_skill`) with the unresolved inline review thread comments as input. Top-level PR review bodies are not included, so a review that only contains general feedback without inline thread comments does not provide re-invocation input. Each inline thread comment is enriched with its **file path** and, when available, **line number** and **raw diff-hunk context** (line number and hunk may be absent for file-level or outdated comments) so the agent understands where in the code the reviewer's feedback applies. The agent addresses the feedback, commits, and signals `FABRIK_STAGE_COMPLETE`. This re-applies `fabrik:awaiting-review` and the cycle repeats from Phase 2 until no reviewers are pending. **As of v0.0.39, re-invocation is unconditional** — it fires for any issue with `wait_for_reviews: true` and submitted inline feedback, regardless of whether auto-advance is active.
 
 This means there is always at least one extra poll cycle delay after stage completion — typically 30 seconds.
@@ -805,7 +805,7 @@ The cycle count resets on engine restart.
 
 #### Timeout Configuration
 
-`FABRIK_REVIEW_WAIT_TIMEOUT` sets the per-cycle timeout in minutes. If reviewers don't submit within the timeout, Fabrik **pauses** the issue with `fabrik:awaiting-input` (rather than auto-advancing) so a human can investigate.
+`FABRIK_REVIEW_WAIT_TIMEOUT` sets the per-cycle timeout in minutes. If reviewers don't submit within the timeout, Fabrik **pauses** the issue with `fabrik:awaiting-input` (rather than auto-advancing) so a human can investigate. This timeout also acts as the fallback when no reviews ever arrive — for example, if all bot reviewers fail to post — since the dual-condition gate requires at least one submitted review and would otherwise wait indefinitely.
 
 ```bash
 FABRIK_REVIEW_WAIT_TIMEOUT=30  # Wait up to 30 minutes per cycle for reviewers (default: 15)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -424,7 +424,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
 | `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
 | `FABRIK_DEBUG_OUTPUT` | `debug_output` | Save raw Claude output for debugging | `false` |
-| `FABRIK_REVIEW_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait per review cycle for all requested PR reviewers to submit before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 15) | `15` |
+| `FABRIK_REVIEW_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait per review cycle at the review gate (whether waiting for requested reviewers to submit or for at least one review to exist) before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 15) | `15` |
 | `FABRIK_MAX_REVIEW_CYCLES` | *(no config.yaml key)* | Maximum number of review re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
@@ -751,7 +751,7 @@ The reviewer wait and re-invocation cycle fire unconditionally — they activate
 When the gate is active, Fabrik adds the `fabrik:awaiting-review` label to the issue. This label:
 
 - Makes the wait state visible on the project board
-- Is cleared automatically when no requested reviewers are outstanding **and** at least one review has been submitted — this dual condition catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without ever appearing in the formal requested-reviewer list
+- Is cleared automatically either when no requested reviewers are outstanding **and** at least one review has been submitted — this dual condition catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without ever appearing in the formal requested-reviewer list — **or** when the review-wait timeout expires and Fabrik removes the label before pausing with `fabrik:awaiting-input`
 - Triggers a re-invocation of the stage agent (via the comment-processing path) to address the submitted review feedback
 - After re-invocation, if new reviewers are assigned (e.g. bots triggered by a fresh push), the label is re-applied and the cycle continues
 
@@ -761,7 +761,7 @@ The gate uses a three-phase design:
 
 1. **Phase 1 (always-gate):** On stage completion, Fabrik immediately adds `fabrik:awaiting-review` and skips auto-advance. This fires even before reviewer assignments propagate.
 2. **Phase 2 (gate evaluation):** On subsequent poll cycles, Fabrik re-fetches the PR with fresh GraphQL data and evaluates the dual condition: the gate clears only when no requested reviewers are outstanding **and** at least one review has been submitted. Requiring at least one review (not just an empty pending list) is what catches bot reviewers like Copilot and Gemini that self-trigger via webhook without ever appearing in the formal requested-reviewer list — if only the pending list were checked, the gate would race through while bots were still processing. If still pending → wait. If timed out → pause with `fabrik:awaiting-input`.
-3. **Phase 3 (re-invocation):** When the gate clears with submitted reviews present, Fabrik re-invokes the stage agent via the comment-processing skill (`comment_skill`) with the unresolved inline review thread comments as input. Top-level PR review bodies are not included, so a review that only contains general feedback without inline thread comments does not provide re-invocation input. Each inline thread comment is enriched with its **file path** and, when available, **line number** and **raw diff-hunk context** (line number and hunk may be absent for file-level or outdated comments) so the agent understands where in the code the reviewer's feedback applies. The agent addresses the feedback, commits, and signals `FABRIK_STAGE_COMPLETE`. This re-applies `fabrik:awaiting-review` and the cycle repeats from Phase 2 until no reviewers are pending. **As of v0.0.39, re-invocation is unconditional** — it fires for any issue with `wait_for_reviews: true` and submitted inline feedback, regardless of whether auto-advance is active.
+3. **Phase 3 (re-invocation):** When the gate clears with submitted reviews present, Fabrik re-invokes the stage agent via the comment-processing skill (`comment_skill`) with the unresolved inline review thread comments as input. Top-level PR review bodies are not included, so a review that only contains general feedback without inline thread comments does not provide re-invocation input. Each inline thread comment is enriched with its **file path** and, when available, **line number** and **raw diff-hunk context** (line number and hunk may be absent for file-level or outdated comments) so the agent understands where in the code the reviewer's feedback applies. The agent addresses the feedback, commits, and signals `FABRIK_STAGE_COMPLETE`. This re-applies `fabrik:awaiting-review`, and the cycle returns to Phase 2 until the gate clears again under the same dual condition — no requested reviewers outstanding **and** at least one review submitted — or, if that does not happen before the wait limit, Fabrik falls back to `fabrik:awaiting-input`. **As of v0.0.39, re-invocation is unconditional** — it fires for any issue with `wait_for_reviews: true` and submitted inline feedback, regardless of whether auto-advance is active.
 
 This means there is always at least one extra poll cycle delay after stage completion — typically 30 seconds.
 
@@ -805,7 +805,7 @@ The cycle count resets on engine restart.
 
 #### Timeout Configuration
 
-`FABRIK_REVIEW_WAIT_TIMEOUT` sets the per-cycle timeout in minutes. If reviewers don't submit within the timeout, Fabrik **pauses** the issue with `fabrik:awaiting-input` (rather than auto-advancing) so a human can investigate. This timeout also acts as the fallback when no reviews ever arrive — for example, if all bot reviewers fail to post — since the dual-condition gate requires at least one submitted review and would otherwise wait indefinitely.
+`FABRIK_REVIEW_WAIT_TIMEOUT` sets the per-cycle timeout in minutes for the review gate. If the gate is still waiting within the timeout — whether for requested reviewers to submit or simply for at least one review to exist — Fabrik **pauses** the issue with `fabrik:awaiting-input` (rather than auto-advancing) so a human can investigate. This timeout also acts as the fallback when no reviews ever arrive — for example, if all bot reviewers fail to post — since the dual-condition gate requires at least one submitted review and would otherwise wait indefinitely.
 
 ```bash
 FABRIK_REVIEW_WAIT_TIMEOUT=30  # Wait up to 30 minutes per cycle for reviewers (default: 15)


### PR DESCRIPTION
## Summary

Update USER_GUIDE.md and README.md to reflect the v0.0.42 behavior. The skills (`fabrik-implement`, `fabrik-review`, `fabrik-validate`) already contain the per-test timeout guidance — no skill changes are needed. The primary change is updating the `wait_for_reviews` documentation to describe the new dual-condition gate-clearing logic and its effect on bot reviewers.

## Problem

Two behavior changes shipped in v0.0.42 are not reflected in USER_GUIDE.md or README.md:

1. **Review gate dual-condition:** `checkReviewGate` previously cleared when `LinkedPRReviewRequests` was empty. Bot reviewers (Copilot, Gemini) self-trigger via webhooks and never appear in the formal requested-reviewer list, so with `fabrik:yolo` active, the gate raced through Validate → merge → Done while bots were still processing. The gate now requires **both** conditions: `LinkedPRReviewRequests` empty **and** `LinkedPRReviews` non-empty. The existing `ReviewWaitTimeout` (default 15 min) serves as the fallback when no reviews ever arrive.

2. **Per-test timeout requirement:** A hanging pytest suite with no timeout flag kept a Claude CLI process alive for 39+ minutes, burning three full Review runs before manual intervention. The Implement, Review, and Validate skills now require per-test timeouts (e.g., `pytest --timeout=60`, `go test -timeout 5m`, `jest --testTimeout=30000`).

## Approach

### Approach

Targeted text edits to four locations across two files. No code, no tests, no YAML changes. The authoritative language comes from `docs/state-machine.md §6.1` (already accurate), adapted for a user-facing audience. All edit targets were pinpointed by Research.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Three edits: Label Lifecycle bullet (line 754), Phase 2 description (line 763), Timeout Configuration section (line 808) |
| `README.md` | One edit: `fabrik:awaiting-review` label table row (line 305) |

### Key Decisions

- **USER_GUIDE.md language**: Use user-facing prose ("no requested reviewers are outstanding AND at least one review has been submitted") rather than the raw `len()` conditions from `state-machine.md`. The state-machine doc is the machine-level spec; USER_GUIDE.md is the operator guide — different registers.
- **README.md row**: Keep it brief (single sentence) with a pointer to USER_GUIDE.md for detail, consistent with the terse style of the surrounding label table rows.
- **No ADRs warranted**: This is a documentation catch-up for already-shipped behavior. No new architectural decisions are being made.
- **No decomposition**: Four small text edits to two files, well within a single Implement cycle.

### Task Checklist

- [ ] Task 1: Update `docs/USER_GUIDE.md` Label Lifecycle bullet (line 754) — replace "Is cleared automatically when all requested reviewers submit (approve, request changes, or comment)" with the dual-condition description: cleared when all requested reviewers have submitted **and** at least one review has been received; note this catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without appearing in the formal reviewer list
- [ ] Task 2: Update `docs/USER_GUIDE.md` Phase 2 description (line 763) — replace "evaluates whether all requested reviewers have submitted" with the dual-condition evaluation: gate clears only when no requested reviewers are outstanding AND at least one review has been submitted; add explanation that this catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without appearing in the formal requested-reviewer list
- [ ] Task 3: Update `docs/USER_GUIDE.md` Timeout Configuration section (line 808) — add a sentence after the existing description stating that `FABRIK_REVIEW_WAIT_TIMEOUT` also serves as the fallback when no reviews ever arrive (e.g., all bots fail to post), not only when reviewers don't submit within the window
- [ ] Task 4: Update `README.md` `fabrik:awaiting-review` label row (line 305) — replace "cleared when all reviewers submit (approve, request changes, or comment) or the configured reviewer-wait timeout elapses" with dual-condition language: cleared when no requested reviewers are outstanding and at least one review has been submitted, or when the reviewer-wait timeout elapses (fallback if no reviews arrive)
- [ ] Task 5: Commit all changes on `fabrik/issue-414` branch with a message referencing the v0.0.42 dual-condition gate behavior

### Risks

- **Line number drift**: The research-identified line numbers (754, 763, 808, 305) are approximate. Implementer must verify the exact old string before replacing; using the `Edit` tool with the exact old string avoids mismatch.
- No other risks — documentation-only change with no behavioral impact.

---
Used 7/50 turns, 2k input / 2k output tokens.

## Verification

Updated `docs/USER_GUIDE.md` (three locations: Label Lifecycle bullet, Phase 2 description, Timeout Configuration section) and `README.md` (`fabrik:awaiting-review` label row) to reflect the v0.0.42 dual-condition review gate behavior: the gate now clears only when no requested reviewers are outstanding AND at least one review has been submitted. The new language explains that this dual condition catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without appearing in the formal reviewer list, and that `FABRIK_REVIEW_WAIT_TIMEOUT` serves as the fallback when no reviews ever arrive.

---

Closes #414