### PR TITLE
Update existing PR's base branch when base:<branch> label changes mid-pipeline

### DIFF
--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -69,6 +69,12 @@ func (m *testGitHubUpgradeClient) GetIssueBody(owner, repo string, issueNumber i
 func (m *testGitHubUpgradeClient) FindPRForIssue(owner, repo string, issueNumber int) (int, error) {
 	return 0, nil
 }
+func (m *testGitHubUpgradeClient) GetPRBase(owner, repo string, prNumber int) (string, error) {
+	return "", nil
+}
+func (m *testGitHubUpgradeClient) UpdatePRBase(owner, repo string, prNumber int, newBase string) error {
+	return nil
+}
 func (m *testGitHubUpgradeClient) CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
 	return 0, nil
 }

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -68,7 +68,7 @@ These labels do not define distinct states but influence transition behavior:
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
 | `model:<name>` | Selects a specific model for this issue (e.g., `model:opus`) |
 | `effort:<level>` | Overrides stage effort level (`low`, `medium`, `high`, `max`); highest wins |
-| `base:<branch>` | Overrides worktree base branch; must exist on remote |
+| `base:<branch>` | Overrides worktree base branch; falls back to default if not on remote; updates PR base if PR exists |
 | `fabrik:sub-issue` | Informational; marks issue as created by decomposition |
 
 ### 1.3 Reachable States by Board Column

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -121,7 +121,7 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:unrestricted` | User (manual) | Any time | User (manual) | Any time | Passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` |
 | `model:<name>` | User (manual) | Any time | User (manual) | Any time | Selects Claude model; first label wins if multiple present |
 | `effort:<level>` | User (manual) | Any time | User (manual) | Any time | Overrides stage effort level; highest-ranked wins if multiple present |
-| `base:<branch>` | User (manual) | Before Research (recommended) | User (manual) | Any time | Overrides worktree base branch; falls back to default if branch not found on remote |
+| `base:<branch>` | User (manual) | Before Research (recommended) | User (manual) | Any time | Overrides worktree base branch; falls back to default if branch not found on remote; if a PR exists, its base branch is updated to match on each stage invocation |
 | `fabrik:sub-issue` | Plan stage (via Claude) | During decomposition | N/A | N/A | Informational — marks sub-issues created by decomposition |
 
 ---

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -108,6 +108,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		return fmt.Errorf("setting up worktree for %s/%s: %w", owner, repo, err)
 	}
 
+	// If a PR exists and its base branch doesn't match the resolved base, update it.
+	e.syncPRBase(item, baseBranch)
+
 	// Write context files (all stages including current) before Claude runs.
 	e.writeContextFiles(item, stage, workDir, true)
 

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -26,6 +26,8 @@ type GitHubClient interface {
 	ArchiveProjectItem(projectID, itemID string) error
 	GetIssueBody(owner, repo string, issueNumber int) (string, error)
 	FindPRForIssue(owner, repo string, issueNumber int) (int, error)
+	GetPRBase(owner, repo string, prNumber int) (string, error)
+	UpdatePRBase(owner, repo string, prNumber int, newBase string) error
 	CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error)
 	MarkPRReady(owner, repo string, prNumber int) error
 	MergePR(owner, repo string, prNumber int) error

--- a/engine/item.go
+++ b/engine/item.go
@@ -562,6 +562,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		return fmt.Errorf("setting up worktree for %s/%s: %w", owner, repo, err)
 	}
 
+	// If a PR exists and its base branch doesn't match the resolved base, update it.
+	e.syncPRBase(item, baseBranch)
+
 	// If this is a read-only stage, stash any unexpected dirty state (including
 	// untracked files) before invocation so the stage sees a clean worktree, and
 	// restore it afterward.

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -27,6 +27,8 @@ type mockGitHubClient struct {
 	updateIssueBodyFn         func(owner, repo string, issueNumber int, body string) error
 	updateProjectItemStatusFn func(projectID, itemID, statusFieldID, statusOptionID string) error
 	findPRForIssueFn          func(owner, repo string, issueNumber int) (int, error)
+	getPRBaseFn               func(owner, repo string, prNumber int) (string, error)
+	updatePRBaseFn            func(owner, repo string, prNumber int, newBase string) error
 	mergePRFn                 func(owner, repo string, prNumber int) error
 	rateLimitStatsFn          func() (gh.RateLimitStats, gh.RateLimitStats)
 	getIssueBodyFn            func(owner, repo string, issueNumber int) (string, error)
@@ -43,6 +45,8 @@ type mockGitHubClient struct {
 	archiveProjectItemCalls []archiveProjectItemCall
 
 	// Track calls — access under mu when accessed from concurrent goroutines.
+	getPRBaseCalls                  []getPRBaseCall
+	updatePRBaseCalls               []updatePRBaseCall
 	addLabelCalls                   []addLabelCall
 	removeLabelCalls                []removeLabelCall
 	addCommentCalls                 []addCommentCall
@@ -81,6 +85,17 @@ type createDraftPRCall struct {
 	owner, repo, title, head, base string
 	body                           string
 	issueNumber                    int
+}
+
+type getPRBaseCall struct {
+	owner, repo string
+	prNumber    int
+}
+
+type updatePRBaseCall struct {
+	owner, repo string
+	prNumber    int
+	newBase     string
 }
 
 type mergePRCall struct {
@@ -250,6 +265,28 @@ func (m *mockGitHubClient) FindPRForIssue(owner, repo string, issueNumber int) (
 		return fn(owner, repo, issueNumber)
 	}
 	return 0, nil
+}
+
+func (m *mockGitHubClient) GetPRBase(owner, repo string, prNumber int) (string, error) {
+	m.mu.Lock()
+	m.getPRBaseCalls = append(m.getPRBaseCalls, getPRBaseCall{owner, repo, prNumber})
+	fn := m.getPRBaseFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber)
+	}
+	return "", nil
+}
+
+func (m *mockGitHubClient) UpdatePRBase(owner, repo string, prNumber int, newBase string) error {
+	m.mu.Lock()
+	m.updatePRBaseCalls = append(m.updatePRBaseCalls, updatePRBaseCall{owner, repo, prNumber, newBase})
+	fn := m.updatePRBaseFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber, newBase)
+	}
+	return nil
 }
 
 func (m *mockGitHubClient) MergePR(owner, repo string, prNumber int) error {

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -48,6 +48,40 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) int {
 	return prNum
 }
 
+// syncPRBase checks whether the open PR for this issue has the expected base branch and
+// updates it via the GitHub API if not. All errors are non-fatal: a warning is logged
+// and the stage continues regardless.
+//
+// Insertion point: called after EnsureWorktree succeeds (baseBranch is resolved and the
+// worktree lock is held) but before Claude is invoked.
+func (e *Engine) syncPRBase(item gh.ProjectItem, baseBranch string) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	prNumber, err := e.client.FindPRForIssue(owner, repo, item.Number)
+	if err != nil {
+		e.logf(item.Number, "warn", "syncPRBase: could not find PR: %v\n", err)
+		return
+	}
+	if prNumber == 0 {
+		return // no PR yet — nothing to sync
+	}
+
+	currentBase, err := e.client.GetPRBase(owner, repo, prNumber)
+	if err != nil {
+		e.logf(item.Number, "warn", "syncPRBase: could not fetch PR #%d base: %v\n", prNumber, err)
+		return
+	}
+	if currentBase == baseBranch {
+		return // already correct
+	}
+
+	if err := e.client.UpdatePRBase(owner, repo, prNumber, baseBranch); err != nil {
+		e.logf(item.Number, "warn", "syncPRBase: could not update PR #%d base %q → %q: %v\n", prNumber, currentBase, baseBranch, err)
+		return
+	}
+	e.logf(item.Number, "pr", "updated PR #%d base: %s → %s\n", prNumber, currentBase, baseBranch)
+}
+
 // buildSeedBody reads .fabrik-context/issue.md and .fabrik-context/stage-Plan.md from
 // workDir and constructs the structured PR seed body. File read errors are non-fatal:
 // missing files produce empty strings which buildPRSeedBody handles with placeholders.

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -563,6 +563,95 @@ func TestFormatReviewFeedbackComment_TruncatesLongOutput(t *testing.T) {
 	}
 }
 
+// ── syncPRBase ────────────────────────────────────────────────────────────────
+
+func TestSyncPRBase_NoPR_NoUpdateAttempted(t *testing.T) {
+	client := &mockGitHubClient{
+		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
+			return 0, nil // no PR
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{Number: 1}
+
+	eng.syncPRBase(item, "main") // must not panic or call UpdatePRBase
+
+	if len(client.updatePRBaseCalls) != 0 {
+		t.Errorf("UpdatePRBase should not be called when no PR exists, got %d calls", len(client.updatePRBaseCalls))
+	}
+	if len(client.getPRBaseCalls) != 0 {
+		t.Errorf("GetPRBase should not be called when no PR exists, got %d calls", len(client.getPRBaseCalls))
+	}
+}
+
+func TestSyncPRBase_MatchingBase_NoUpdateAttempted(t *testing.T) {
+	client := &mockGitHubClient{
+		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
+			return 42, nil
+		},
+		getPRBaseFn: func(owner, repo string, prNumber int) (string, error) {
+			return "main", nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{Number: 1}
+
+	eng.syncPRBase(item, "main") // base matches — no update
+
+	if len(client.updatePRBaseCalls) != 0 {
+		t.Errorf("UpdatePRBase should not be called when base already matches, got %d calls", len(client.updatePRBaseCalls))
+	}
+}
+
+func TestSyncPRBase_MismatchedBase_UpdatesExactlyOnce(t *testing.T) {
+	client := &mockGitHubClient{
+		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
+			return 42, nil
+		},
+		getPRBaseFn: func(owner, repo string, prNumber int) (string, error) {
+			return "main", nil // current base
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{Number: 1}
+
+	eng.syncPRBase(item, "feature/foo") // desired base differs
+
+	if len(client.updatePRBaseCalls) != 1 {
+		t.Fatalf("expected exactly 1 UpdatePRBase call, got %d", len(client.updatePRBaseCalls))
+	}
+	got := client.updatePRBaseCalls[0]
+	if got.prNumber != 42 {
+		t.Errorf("UpdatePRBase called with PR #%d, want 42", got.prNumber)
+	}
+	if got.newBase != "feature/foo" {
+		t.Errorf("UpdatePRBase called with base %q, want %q", got.newBase, "feature/foo")
+	}
+}
+
+func TestSyncPRBase_UpdateError_StageContinues(t *testing.T) {
+	client := &mockGitHubClient{
+		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
+			return 42, nil
+		},
+		getPRBaseFn: func(owner, repo string, prNumber int) (string, error) {
+			return "main", nil
+		},
+		updatePRBaseFn: func(owner, repo string, prNumber int, newBase string) error {
+			return errors.New("github: unprocessable entity")
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{Number: 1}
+
+	// syncPRBase must not propagate the error — caller sees no return value
+	eng.syncPRBase(item, "feature/bar")
+
+	if len(client.updatePRBaseCalls) != 1 {
+		t.Fatalf("expected 1 UpdatePRBase attempt even on error, got %d", len(client.updatePRBaseCalls))
+	}
+}
+
 // ── processItem Verification update integration test ─────────────────────────
 
 func TestProcessItem_ImplementStage_UpdatesVerificationOnComplete(t *testing.T) {

--- a/github/prs.go
+++ b/github/prs.go
@@ -196,6 +196,33 @@ func (c *Client) FindPRForIssue(owner, repo string, issueNumber int) (int, error
 	return resp.Items[0].Number, nil
 }
 
+// GetPRBase fetches the current base branch reference of an open pull request.
+// Returns the base branch name (e.g. "main" or "feature/foo"), or an error if
+// the API call fails.
+func (c *Client) GetPRBase(owner, repo string, prNumber int) (string, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
+	var raw struct {
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		return "", fmt.Errorf("fetching PR #%d base: %w", prNumber, err)
+	}
+	return raw.Base.Ref, nil
+}
+
+// UpdatePRBase changes the base branch of an open pull request via the GitHub REST API.
+// GitHub accepts base-branch changes on open PRs; the PR may become unmergeable if
+// the head and new base have diverged, but the API call itself succeeds.
+func (c *Client) UpdatePRBase(owner, repo string, prNumber int, newBase string) error {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
+	if err := c.restPatch(apiURL, map[string]interface{}{"base": newBase}); err != nil {
+		return fmt.Errorf("updating PR #%d base to %q: %w", prNumber, newBase, err)
+	}
+	return nil
+}
+
 // MergePR merges the pull request identified by prNumber. It first checks
 // GitHub's mergeable status: if null (not yet computed) or false, it returns
 // ErrNotMergeable. It attempts a rebase merge first; if the repository does

--- a/github/prs_test.go
+++ b/github/prs_test.go
@@ -296,3 +296,84 @@ func TestFetchLinkedPR_NotFound(t *testing.T) {
 		t.Errorf("expected nil PR for empty response, got %+v", pr)
 	}
 }
+
+func TestGetPRBase_DecodesBaseRef(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/pulls/42" {
+			t.Errorf("path = %s, want /repos/owner/repo/pulls/42", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"base": map[string]string{"ref": "feature/foo"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	base, err := c.GetPRBase("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("GetPRBase: %v", err)
+	}
+	if base != "feature/foo" {
+		t.Errorf("base = %q, want %q", base, "feature/foo")
+	}
+}
+
+func TestGetPRBase_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, err := c.GetPRBase("owner", "repo", 999)
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestUpdatePRBase_SendsPatchWithBase(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(map[string]interface{}{"number": 42})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if err := c.UpdatePRBase("owner", "repo", 42, "feature/bar"); err != nil {
+		t.Fatalf("UpdatePRBase: %v", err)
+	}
+	if gotMethod != "PATCH" {
+		t.Errorf("method = %s, want PATCH", gotMethod)
+	}
+	if gotPath != "/repos/owner/repo/pulls/42" {
+		t.Errorf("path = %s, want /repos/owner/repo/pulls/42", gotPath)
+	}
+	if gotBody["base"] != "feature/bar" {
+		t.Errorf("body[base] = %v, want %q", gotBody["base"], "feature/bar")
+	}
+}
+
+func TestUpdatePRBase_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+		w.Write([]byte(`{"message":"Validation Failed"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	err := c.UpdatePRBase("owner", "repo", 42, "nonexistent-branch")
+	if err == nil {
+		t.Fatal("expected error for 422 response")
+	}
+}


### PR DESCRIPTION
## Summary

At each stage invocation that calls `baseBranchForItem`, if a PR exists for the issue and its current base branch differs from the resolved base, update the PR's base via the GitHub REST API.

## Problem

The `base:<branch>` label override is honored on every stage invocation (via `baseBranchForItem`), so a label change takes effect for future stage runs. However, **once a PR has been created** (by Implement via `ensureDraftPR`), Fabrik does not retroactively change the PR's base branch if the `base:` label is later added or modified.

GitHub's `PATCH /repos/{owner}/{repo}/pulls/{prNumber}` endpoint accepts a `base` field, but Fabrik never calls it after PR creation. So a `base:` label applied after Implement has run leaves the PR targeting the old base, even though:
- The worktree now rebases against the new base on each update
- New commits on the issue branch assume the new base
- `updateWorktreeFromMain` and review/validate logic use the new base

The result is a mismatch: the PR target is stale, possibly causing merge conflicts, wrong-base review diffs, or (like verveguy/graphiti#28 → PR #29) a merge to the wrong branch that skips GitHub's `Closes #N` auto-close.

## Approach

### Approach

Add two new REST methods (`GetPRBase` and `UpdatePRBase`) to `github/prs.go`, register them in the `GitHubClient` interface, and add a new `syncPRBase` engine helper in `engine/pr.go` that orchestrates the fetch-compare-update flow. Call `syncPRBase` at the two call sites in `processItem` and `processComments` after `EnsureWorktree` succeeds (the worktree is ready, the lock is held, and `baseBranch` is resolved).

`syncPRBase` calls `FindPRForIssue` fresh — no attempt to pass a locally-known `prNumber`. Research confirms `FindPRForIssue` is already called 3–4 times per stage invocation with no caching, so one additional call is entirely consistent. Passing a local `prNumber` from `ensureDraftPR` would require plumbing return values across call sites that don't currently surface them, and is not worth the complexity.

No new files are needed. No ADR is warranted — this is a narrow, self-evident propagation of existing label state to the PR object, fully consistent with ADR 002 (labels as truth source) and ADR 003 (polling model).

### New/Modified Files

| File | Change |
|------|--------|
| `github/prs.go` | Add `GetPRBase` and `UpdatePRBase` methods |
| `engine/interfaces.go` | Add `GetPRBase` and `UpdatePRBase` to `GitHubClient` interface |
| `engine/mocks_test.go` | Add `getPRBaseFn`, `updatePRBaseFn`, call tracking structs/slices, and mock method implementations |
| `engine/pr.go` | Add `syncPRBase` engine helper method |
| `engine/item.go` | Call `syncPRBase` after `EnsureWorktree` in `processItem` |
| `engine/comments.go` | Call `syncPRBase` after `EnsureWorktree` in `processComments` |
| `engine/pr_test.go` | Add regression tests for R6 cases (or existing test file if one covers PR helpers) |
| `docs/state-machine.md` | Update `base:<branch>` row (line 124) |

### Key Decisions

- **`syncPRBase` lives in `engine/pr.go`**: All PR-related engine helpers (`ensureDraftPR`, `markPRReady`, `postOutputToPR`) live there. This groups like concerns and keeps `item.go` / `comments.go` call sites clean single-line calls.

- **Call `FindPRForIssue` fresh inside `syncPRBase`**: Reusing a locally-known `prNumber` would require surfacing the return value through `ensureDraftPR` (which currently returns nothing), threading it back through the call stack in `processItem`, and then conditionally passing it to `syncPRBase`. The research confirms no in-memory cache exists, and the existing pattern is to call `FindPRForIssue` per-need. A fresh call is simpler and consistent.

- **Insertion point after `EnsureWorktree`, before `writeContextFiles`**: The worktree is ready and the lock is confirmed held at this point in both `processItem` and `processComments`. There is no benefit to inserting earlier (before the worktree is guaranteed ready) or later (after Claude is invoked). The spec says "after `baseBranchForItem` resolves" — both insertion points satisfy this.

- **`syncPRBase` returns nothing**: All errors are non-fatal (R5). The method logs warnings and returns, so there is nothing for callers to check. Returning an error would tempt callers to propagate it, which would violate R5.

- **No ADR**: This feature is a direct, narrow propagation of a label value to a PR field. The design is self-evident from the function name, the log format, and the alignment with the existing polling model. Future contributors do not need architectural context beyond what the code and existing ADRs already provide.

### Task Checklist

- [ ] **Task 1**: Add `GetPRBase(owner, repo string, prNumber int) (string, error)` to `github/prs.go` — calls `GET /repos/{owner}/{repo}/pulls/{prNumber}` via `restGetJSON`, decodes only `base.ref`
- [ ] **Task 2**: Add `UpdatePRBase(owner, repo string, prNumber int, newBase string) error` to `github/prs.go` — calls `PATCH /repos/{owner}/{repo}/pulls/{prNumber}` via `restPatch` with `{"base": newBase}`
- [ ] **Task 3**: Add `GetPRBase` and `UpdatePRBase` signatures to `GitHubClient` interface in `engine/interfaces.go`
- [ ] **Task 4**: Add `getPRBaseFn`/`updatePRBaseFn` function fields, `getPRBaseCalls`/`updatePRBaseCalls` tracking slices with their call structs, and the two mock method implementations to `engine/mocks_test.go`
- [ ] **Task 5**: Add `(e *Engine) syncPRBase(item gh.ProjectItem, baseBranch string)` to `engine/pr.go` — calls `FindPRForIssue`; if 0, returns; calls `GetPRBase`; if bases match, returns; calls `UpdatePRBase`; logs `[#N pr] updated PR #M base: <old> → <new>` on success or a warning on error
- [ ] **Task 6**: Call `e.syncPRBase(item, baseBranch)` in `engine/item.go` `processItem`, after `EnsureWorktree` succeeds and before `writeContextFiles` (around line 563)
- [ ] **Task 7**: Call `e.syncPRBase(item, baseBranch)` in `engine/comments.go` `processComments`, after `EnsureWorktree` succeeds and before `writeContextFiles` (around line 109)
- [ ] **Task 8**: Add regression tests covering all four R6 cases: no PR → no update; PR with matching base → no update; PR with mismatched base → `UpdatePRBase` called exactly once; `UpdatePRBase` error → stage continues with warning logged
- [ ] **Task 9**: Update `docs/state-machine.md` line 124 — extend the `base:<branch>` row's Effect column to note: "Overrides worktree base branch; falls back to default if branch not found on remote; if a PR exists, its base branch is updated to match on each stage invocation"

### Risks

- **Search API lag on fresh PRs**: `FindPRForIssue` may return 0 immediately after Implement creates a PR. `syncPRBase` silently skips the update in this case, which is correct — the PR was just created with the right base. No mitigation needed.
- **422 on `UpdatePRBase`**: Possible if the remote branch is deleted between `baseBranchForItem`'s validation and the PATCH call. The non-fatal warning path handles this per R5.
- **Concurrent calls are idempotent**: Two Fabrik instances calling `UpdatePRBase` simultaneously (prevented in practice by the lock label) would each PATCH the same value — the second is a no-op. No mitigation needed.

---
Used 11/50 turns, 5k input / 3k output tokens.

## Verification

Implemented PR base branch sync for mid-pipeline `base:<branch>` label changes. Added `GetPRBase` and `UpdatePRBase` REST methods to `github/prs.go`, registered them in the `GitHubClient` interface and mock, and added a `syncPRBase` engine helper in `engine/pr.go` that detects and corrects base branch mismatches before each stage invocation. All four R6 regression test cases pass, and `docs/state-machine.md` was updated to document the new behavior.

---

Closes #416