### PR TITLE
Gate auto-merge on CI/CD status and add CI-fix workflow to Review and Validate

### DIFF
--- a/.fabrik/stages/validate.yaml
+++ b/.fabrik/stages/validate.yaml
@@ -6,5 +6,6 @@ model: sonnet
 max_turns: 50
 post_to_pr: true
 wait_for_reviews: true
+wait_for_ci: true
 completion:
   type: claude

--- a/adrs/027-ci-gate-and-fix-reinvoke.md
+++ b/adrs/027-ci-gate-and-fix-reinvoke.md
@@ -1,0 +1,100 @@
+# ADR 027: CI Gate and CI-Fix Re-invocation Loop
+
+**Status**: Accepted  
+**Date**: 2026-04-16
+
+## Context
+
+Fabrik's yolo/cruise auto-advance paths could silently merge or advance issues whose PR CI was broken. The Review and Validate stages lacked any mechanism to:
+
+1. Block auto-merge when CI checks are failing on the PR head.
+2. Re-invoke the stage agent to fix CI failures before advancing.
+
+The review gate (ADR 026) established the pattern for re-invocation loops. The CI gate mirrors this pattern.
+
+## Decision
+
+Implement a two-pronged CI gate controlled by `wait_for_ci: true` in the stage YAML.
+
+### Prong 1 — Merge Guard (`attemptMergeOnValidate`)
+
+The `yolo` auto-merge path already called `MergePR` directly. A CI gate is embedded directly in `attemptMergeOnValidate`:
+
+- Fetch the PR's head SHA via `FetchLinkedPR` (REST — avoids extending the existing large GraphQL query).
+- Fetch check runs via `FetchCheckRuns`.
+- **R5**: No check runs → gate clears (repo has no CI).
+- **R4**: All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge.
+- **R3**: Any check failed → add `fabrik:awaiting-ci`; return error (caller logs and skips advance).
+- **R2**: Any check pending → track start time in `ciMergePendingSince`; return error (no label added — R10c).
+- **R6**: Pending elapsed ≥ `CIWaitTimeout` (default 30 min) → post comment; add `fabrik:paused` + `fabrik:awaiting-input`; return error.
+
+The `ciMergePendingSince` map is keyed by `issueKey` (owner/repo#N). It tracks the first time a pending-CI observation is made for a given issue, so the timeout starts from when pending was first seen, not from when the issue was advanced.
+
+### Prong 2 — Catch-up Loop CI Gate and Fix-Reinvoke
+
+For stages with `wait_for_ci: true`, `handleStageComplete` uses **Approach A**:
+- Add the `stage:<X>:complete` label immediately.
+- Skip `attemptMergeOnValidate` (for Validate+yolo).
+- Return without advancing; the catch-up loop handles the CI gate.
+
+The catch-up loop Phase 1 (`poll()`) now calls `checkCIGate(board, item, stage)` after the review gate:
+
+- `(false, false, false)` — gate clear; fall through to Phase 2 (advancement/merge).
+- `(true, false, false)` — CI still pending; skip to next item. **`fabrik:awaiting-ci` is NOT applied (R10c)** — label churn from transient pending states would produce noise and mislead users. The item's `fabrik:awaiting-ci` label presence triggers `itemMayNeedWork` to bypass the `updatedAt` cache, ensuring re-evaluation on every poll.
+- `(true, true, false)` — CI failed; `fabrik:awaiting-ci` applied (idempotent); dispatch `dispatchCIFixReinvoke` or pause if cycle limit exceeded.
+- `(false, false, true)` — Timeout: `fabrik:awaiting-ci` already present ≥ `CIWaitTimeout` (checked via `FetchLabelAppliedAt`); pause with `fabrik:paused` + `fabrik:awaiting-input`.
+
+### Timeout Strategy: Two Different Approaches
+
+The two prongs use different timeout strategies due to their different lifecycles:
+
+- **Prong 1** (merge guard): Uses an in-memory `ciMergePendingSince` map. Acceptable because merge-guard state is transient — if the engine restarts, it simply re-evaluates CI on the next poll.
+- **Prong 2** (catch-up loop): Uses `FetchLabelAppliedAt` on `fabrik:awaiting-ci`. The label is durable across restarts. `FetchLabelAppliedAt` makes a REST API call, but only when CI has already failed and the label is present — a rare, high-signal path.
+
+### CI-Fix Re-invocation
+
+When `checkCIGate` returns `ciFailure=true`, the catch-up loop mirrors `dispatchReviewReinvoke` exactly:
+
+1. Guard: if a goroutine from a previous poll is still in-flight for this item, skip dispatch.
+2. Cycle check: if `ciFixCycleCount[stageKey] >= MaxCiFixCycles` (default 5), pause with `pauseForCIFixCycleLimit`.
+3. Otherwise: increment cycle count, call `dispatchCIFixReinvoke`.
+
+`dispatchCIFixReinvoke` spawns a goroutine that:
+- Marks `inFlight`; acquires semaphore; calls `ensureRepoReady`.
+- Calls `buildCIFixComment` to construct a synthetic `gh.Comment` (DatabaseID: 0) with a structured CI failure report comparing PR failures against base-branch failures (to classify NEW REGRESSION vs pre-existing).
+- Calls `processComments` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if not set).
+- Emits `JobStarted`/`JobCompleted` TUI events.
+
+The `DatabaseID: 0` guard (already in place from ADR 026) skips 👀 and 🚀 reactions for synthetic comments.
+
+The stage agent should fix NEW REGRESSION failures, commit, push, and **not** emit `FABRIK_STAGE_COMPLETE` — the engine re-evaluates CI on the next poll and advances once all checks pass.
+
+### YAML Defaults
+
+`wait_for_ci: true` is added to `stages/examples/validate.yaml` and `.fabrik/stages/validate.yaml`. The `WaitForCI *bool` field uses nil-means-false semantics. Only Validate has `wait_for_ci: true` in the defaults; other stages opt in explicitly.
+
+### `itemMayNeedWork` Cache Bypass
+
+Items with `fabrik:awaiting-ci` bypass the `updatedAt` cache in `itemMayNeedWork` — same as `fabrik:blocked`. CI results change independently of the issue's GitHub `updatedAt`, so without this bypass, items would be skipped once their `updatedAt` settles.
+
+## Alternatives Considered
+
+### Approach B: Check CI in `handleStageComplete` Before Adding Completion Label
+
+Gate in `handleStageComplete`: poll CI, return early (without adding completion label) if CI is pending or failed.
+
+Rejected because:
+- `handleStageComplete` runs synchronously in the worker goroutine, which holds the semaphore. Polling CI repeatedly in a semaphore-held goroutine starves other workers.
+- The catch-up loop already evaluates per-item state at the right cadence. Deferring to it (Approach A) is architecturally consistent with how `wait_for_reviews` works.
+
+### Extending the GraphQL Query for Head SHA
+
+Adding `pullRequest { headRefOid }` to the board GraphQL query would avoid a separate REST call for the head SHA.
+
+Rejected because the existing query is already large. The head SHA is only needed on CI-gate paths (stages with `wait_for_ci: true`, which is a subset of all items). A targeted REST call via `FetchLinkedPR` has lower cost for the common case (no CI gate).
+
+### A Single Timeout Strategy for Both Prongs
+
+Using `FetchLabelAppliedAt` for the merge guard (Prong 1) would make both prongs consistent. Rejected because the merge guard runs in a frequently-called hot path (every poll, for every yolo Validate item). `FetchLabelAppliedAt` is a REST call and would add latency for every merge attempt when CI is pending.
+
+Using `ciMergePendingSince` for the catch-up loop (Prong 2) would require persisting the map across restarts to avoid losing timeout context. The label-based approach is naturally durable with no extra machinery.

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -69,6 +69,12 @@ func (m *testGitHubUpgradeClient) GetIssueBody(owner, repo string, issueNumber i
 func (m *testGitHubUpgradeClient) FindPRForIssue(owner, repo string, issueNumber int) (int, error) {
 	return 0, nil
 }
+func (m *testGitHubUpgradeClient) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	return nil, nil
+}
+func (m *testGitHubUpgradeClient) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	return nil, nil
+}
 func (m *testGitHubUpgradeClient) GetPRBase(owner, repo string, prNumber int) (string, error) {
 	return "", nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,8 @@ type Config struct {
 	MaxRetries        int
 	ReviewWaitTimeout int // minutes; 0 means use default (15)
 	MaxReviewCycles   int // 0 means use default (5)
+	CIWaitTimeout     int // minutes; 0 means use default (30)
+	MaxCiFixCycles    int // 0 means use default (5)
 	DebugOutput       bool
 	PluginDir         string
 }
@@ -109,6 +111,8 @@ func Execute() error {
 	flag.IntVar(&cfg.MaxRetries, "max-retries", 3, "Max failed stage attempts before pausing the issue (0 = unlimited)")
 	flag.IntVar(&cfg.ReviewWaitTimeout, "review-wait-timeout", 0, "Maximum time in minutes to wait for PR reviewers before advancing (0 = use default of 15; also FABRIK_REVIEW_WAIT_TIMEOUT)")
 	flag.IntVar(&cfg.MaxReviewCycles, "max-review-cycles", 0, "Maximum number of review-and-fix cycles per issue (0 = use default of 5; also FABRIK_MAX_REVIEW_CYCLES)")
+	flag.IntVar(&cfg.CIWaitTimeout, "ci-wait-timeout", 0, "Maximum time in minutes to wait for CI in the merge guard before pausing (0 = use default of 30; also FABRIK_CI_WAIT_TIMEOUT)")
+	flag.IntVar(&cfg.MaxCiFixCycles, "max-ci-fix-cycles", 0, "Maximum number of CI-fix cycles per issue before pausing (0 = use default of 5; also FABRIK_MAX_CI_FIX_CYCLES)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
 	flag.StringVar(&cfg.PluginDir, "plugin-dir", "", "Path to Fabrik plugin directory (for development; overrides installed plugin)")
 
@@ -274,6 +278,24 @@ func Execute() error {
 			}
 		}
 	}
+	if !explicitFlags["ci-wait-timeout"] {
+		if v := os.Getenv("FABRIK_CI_WAIT_TIMEOUT"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.CIWaitTimeout = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_CI_WAIT_TIMEOUT=%q is invalid (must be a positive integer of minutes); using default 30\n", v)
+			}
+		}
+	}
+	if !explicitFlags["max-ci-fix-cycles"] {
+		if v := os.Getenv("FABRIK_MAX_CI_FIX_CYCLES"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.MaxCiFixCycles = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_CI_FIX_CYCLES=%q is invalid (must be a positive integer); using default 5\n", v)
+			}
+		}
+	}
 	if !cfg.AutoUpgrade {
 		if v := os.Getenv("FABRIK_AUTO_UPGRADE"); v != "" {
 			lv := strings.ToLower(v)
@@ -392,6 +414,8 @@ func Execute() error {
 		MaxRetries:        cfg.MaxRetries,
 		ReviewWaitTimeout: reviewWaitTimeout(cfg.ReviewWaitTimeout),
 		MaxReviewCycles:   maxReviewCycles(cfg.MaxReviewCycles),
+		CIWaitTimeout:     ciWaitTimeout(cfg.CIWaitTimeout),
+		MaxCiFixCycles:    maxCiFixCycles(cfg.MaxCiFixCycles),
 		DebugOutput:       cfg.DebugOutput,
 		PluginDir:         cfg.PluginDir,
 		Stages:            stageCfgs,
@@ -423,6 +447,24 @@ func reviewWaitTimeout(minutes int) time.Duration {
 // maxReviewCycles returns the configured MaxReviewCycles value, defaulting to 5
 // when n is 0 (unset).
 func maxReviewCycles(n int) int {
+	if n <= 0 {
+		return 5
+	}
+	return n
+}
+
+// ciWaitTimeout converts a CIWaitTimeout config value (minutes) to a
+// time.Duration. When minutes is 0 (unset), the default of 30 minutes is used.
+func ciWaitTimeout(minutes int) time.Duration {
+	if minutes <= 0 {
+		return 30 * time.Minute
+	}
+	return time.Duration(minutes) * time.Minute
+}
+
+// maxCiFixCycles returns the configured MaxCiFixCycles value, defaulting to 5
+// when n is 0 (unset).
+func maxCiFixCycles(n int) int {
 	if n <= 0 {
 		return 5
 	}

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -403,6 +403,8 @@ FABRIK_USER=my-personal-username
 | `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
 | `--review-wait-timeout` | Minutes to wait for all requested PR reviewers before advancing (0 = use default of 15; also `FABRIK_REVIEW_WAIT_TIMEOUT`) | `0` (15 min) |
 | `--max-review-cycles` | Maximum number of review-and-fix cycles per issue (0 = use default of 5; also `FABRIK_MAX_REVIEW_CYCLES`) | `0` (5 cycles) |
+| `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
+| `--max-ci-fix-cycles` | Maximum number of CI-fix re-invocation cycles per issue (0 = use default of 5; also `FABRIK_MAX_CI_FIX_CYCLES`) | `0` (5 cycles) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
 
 ### Environment Variables
@@ -426,6 +428,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_DEBUG_OUTPUT` | `debug_output` | Save raw Claude output for debugging | `false` |
 | `FABRIK_REVIEW_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait per review cycle at the review gate (whether waiting for requested reviewers to submit or for at least one review to exist) before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 15) | `15` |
 | `FABRIK_MAX_REVIEW_CYCLES` | *(no config.yaml key)* | Maximum number of review re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
+| `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |
+| `FABRIK_MAX_CI_FIX_CYCLES` | *(no config.yaml key)* | Maximum number of CI-fix re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
 
@@ -479,6 +483,17 @@ wait_for_reviews: false   # Optional. When true, Fabrik waits for all requested 
                           #   pending (up to FABRIK_MAX_REVIEW_CYCLES cycles). On timeout or cycle
                           #   limit, Fabrik pauses with fabrik:awaiting-input instead of advancing.
                           #   See §3 Pending Reviewer Gate for full details.
+wait_for_ci: false        # Optional. When true, Fabrik gates auto-advance (and auto-merge for
+                          #   Validate+yolo) on CI checks passing on the PR head. On CI failure,
+                          #   Fabrik adds `fabrik:awaiting-ci` and re-invokes the stage agent via
+                          #   ci_fix_skill (falls back to comment_skill) with a structured report
+                          #   classifying each failed check as NEW REGRESSION or pre-existing.
+                          #   Re-invocation repeats up to FABRIK_MAX_CI_FIX_CYCLES times. On CI
+                          #   timeout or cycle limit, Fabrik pauses with fabrik:awaiting-input.
+                          #   Enabled by default on the Validate stage.
+                          #   See §3 CI Gate and CI-Fix Workflow for full details.
+ci_fix_skill:             # Optional. Plugin skill name for CI-fix re-invocations (the synthetic
+                          #   CI failure report comment). Defaults to comment_skill if unset.
 allowed_tools:            # Optional. REPLACES the default tool set — not additive. When set,
   - Read                  #   only these tools are allowed; the default list is not added.
   - Grep                  #   When omitted, Fabrik uses a comprehensive default covering common
@@ -816,6 +831,126 @@ fabrik --review-wait-timeout=30
 #### Restart Persistence
 
 The timeout is based on the timestamp of when the `fabrik:awaiting-review` label was added to the issue, which is stored in GitHub's event history. If Fabrik restarts while waiting, it recalculates the remaining wait time from the label timestamp rather than resetting the clock. The cycle count is in-memory and resets on restart.
+
+---
+
+### CI Gate and CI-Fix Workflow
+
+When a stage has `wait_for_ci: true` set, Fabrik gates auto-advance (and auto-merge for Validate+yolo) on CI checks passing on the PR head. If checks fail, Fabrik re-invokes the stage agent with a structured failure report so it can fix the regression and push again. **Re-invocation is unconditional** — it fires for any issue with `wait_for_ci: true` and a failing CI check, regardless of whether auto-advance is active.
+
+For the authoritative spec on label lifecycle and gate transitions, see [State Machine](state-machine.md).
+
+The Validate stage ships with `wait_for_ci: true` enabled by default.
+
+#### Enabling the Gate
+
+Add `wait_for_ci: true` to the relevant stage YAML:
+
+```yaml
+name: Validate
+order: 5
+wait_for_ci: true
+...
+```
+
+CI checks are only evaluated on the **PR head SHA** — Fabrik makes two REST calls per poll: one to get the head SHA via the linked PR, and one to fetch the check runs. If no check runs exist (the repo has no CI), the gate clears immediately.
+
+#### Label Lifecycle
+
+When CI fails, Fabrik adds the `fabrik:awaiting-ci` label to the issue. This label:
+
+- Makes the CI-blocked state visible on the project board
+- Is **only applied on confirmed failure** — while checks are still running (pending/queued), no label is applied to avoid label churn for transient states
+- Is cleared automatically when all CI checks pass; or when the CI wait timeout elapses (removed before pausing with `fabrik:awaiting-input`)
+- Triggers the `itemMayNeedWork` cache bypass — CI results change independently of the issue's GitHub `updatedAt`, so items with `fabrik:awaiting-ci` bypass the staleness cache and are re-evaluated on every poll
+
+#### The CI-Fix Report
+
+When CI fails and Fabrik re-invokes the stage agent, it passes a synthetic CI failure comment with the following structure:
+
+```
+🏭 **Fabrik — CI Fix Required**
+
+CI checks failed on the PR head. Fix **NEW REGRESSION** failures before proceeding.
+
+### Failed checks
+
+| Check | Status | Classification |
+|-------|--------|----------------|
+| Go tests | failure | **NEW REGRESSION** |
+| Go vet | failure | pre-existing (also failing on base branch) |
+
+### Base branch CI status (for comparison)
+
+| Check | Status |
+|-------|--------|
+| Go tests | success |
+| Go vet | failure |
+```
+
+- **NEW REGRESSION** — the check passes on the base branch but fails on this PR. The agent should fix these.
+- **pre-existing** — the check also fails on the base branch. The agent should not attempt to fix these.
+
+The agent should fix NEW REGRESSION failures, commit, push, and **not** emit `FABRIK_STAGE_COMPLETE`. Fabrik re-evaluates CI on the next poll and advances the issue once all checks pass.
+
+#### Two-Prong CI Gate
+
+The CI gate operates on two different paths depending on whether the item is being auto-merged or just being polled:
+
+**Merge guard (Validate+yolo auto-merge path):**
+- Checks CI before attempting the merge in `attemptMergeOnValidate()`
+- While CI is pending: returns an error (no label applied — avoids churn)
+- On CI failure: adds `fabrik:awaiting-ci`, returns error (skips merge)
+- On timeout (pending too long): pauses with `fabrik:paused` + `fabrik:awaiting-input`
+
+**Catch-up loop (all other paths):**
+- Evaluates CI on every poll for `stage:<X>:complete` items with `wait_for_ci: true`
+- On pending: skips (no label applied — R10c)
+- On failure: adds `fabrik:awaiting-ci`; dispatches CI-fix re-invocation
+- On timeout: pauses with `fabrik:paused` + `fabrik:awaiting-input`; timeout measured from when `fabrik:awaiting-ci` was first applied (durable across restarts)
+
+#### CI-Fix Skill
+
+By default, CI-fix re-invocations use the stage's `comment_skill`. To use a dedicated skill for CI fixes, set `ci_fix_skill`:
+
+```yaml
+name: Validate
+order: 5
+wait_for_ci: true
+ci_fix_skill: fabrik-validate-ci-fix   # Custom skill for CI-fix re-invocations
+comment_skill: fabrik-validate-comment  # Used for regular comment processing
+...
+```
+
+When `ci_fix_skill` is not set, `comment_skill` is used. When neither is set, the stage's primary skill is used.
+
+#### Cycle Limit
+
+To prevent infinite loops (e.g., a non-deterministic flaky test that keeps failing), Fabrik caps the number of CI-fix re-invocation cycles per issue per stage per engine session:
+
+```bash
+FABRIK_MAX_CI_FIX_CYCLES=3  # Limit to 3 CI-fix cycles per issue per stage (default: 5)
+# or equivalently:
+fabrik --max-ci-fix-cycles=3
+```
+
+The cycle count resets on engine restart, and is also reset by `clearFailedStage()` when the user manually unpauses a failed issue.
+
+#### Timeout Configuration
+
+`FABRIK_CI_WAIT_TIMEOUT` sets the timeout in minutes for the CI gate (catch-up loop path). If `fabrik:awaiting-ci` has been present for longer than this duration, Fabrik pauses the issue with `fabrik:awaiting-input` rather than continuing to re-invoke.
+
+```bash
+FABRIK_CI_WAIT_TIMEOUT=60  # Wait up to 60 minutes for CI to pass (default: 30)
+# or equivalently:
+fabrik --ci-wait-timeout=60
+```
+
+Unlike the review gate, the CI timeout is measured from when `fabrik:awaiting-ci` was first applied — not from stage completion. This timeout only starts after a CI failure is confirmed; while checks are merely pending, no timeout accumulates.
+
+#### Restart Persistence
+
+The CI timeout is measured from the `fabrik:awaiting-ci` label's creation timestamp (fetched via the GitHub API), making it durable across engine restarts. The cycle count is in-memory and resets on restart.
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -52,6 +52,7 @@ These labels define distinct states (their presence changes what the engine does
 | `fabrik:paused` | Pause | Yes — blocks all processing unless a comment arrives |
 | `fabrik:awaiting-input` | Sub-pause | Yes (with `fabrik:paused`) — blocked-on-input variant |
 | `fabrik:awaiting-review` | Gate | Yes — review gate is active |
+| `fabrik:awaiting-ci` | Gate | Yes — CI gate is active; CI checks failed on the PR |
 | `fabrik:blocked` | Dependency | Yes — blocked by open dependency issues |
 | `stage:<X>:in_progress` | Progress | Yes — a stage invocation is active |
 | `stage:<X>:complete` | Completion | Yes — stage finished successfully |

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -89,6 +89,7 @@ Each active stage column has the same set of reachable sub-states:
 | **Paused + Failed** | `fabrik:paused`, `stage:<X>:failed` | Engine paused after MaxRetries exhausted |
 | **Awaiting Input** | `fabrik:paused`, `fabrik:awaiting-input` | Claude signaled FABRIK_BLOCKED_ON_INPUT; waiting for user comment |
 | **Awaiting Review** | `fabrik:awaiting-review`, `stage:<X>:complete` | Review gate active; waiting for PR reviewers (only on stages with `wait_for_reviews: true`) |
+| **Awaiting CI** | `fabrik:awaiting-ci`, `stage:<X>:complete` | CI gate active; PR CI checks failed; engine dispatching CI-fix re-invocation (only on stages with `wait_for_ci: true`) |
 | **Blocked** | `fabrik:blocked` | Dependency gate active; waiting for blocking issues to close |
 | **Complete** | `stage:<X>:complete` | Stage finished; waiting for advancement (manual or auto) |
 | **Locked by Other** | `fabrik:locked:<other_user>` | Another Fabrik instance owns this issue |
@@ -110,9 +111,10 @@ Each active stage column has the same set of reachable sub-states:
 |-------|----------|------------|------------|--------------|-------|
 | `fabrik:locked:<user>` | `processItem` | Before stage invocation (lock-then-verify protocol) | `releaseLock` | On stage completion, permanent failure, blocked-on-input, decomposed, or lock conflict loss | Prevents other instances from processing the item |
 | `fabrik:editing` | `processComments` | Step 2 of comment processing | `processComments` | Step 9 of comment processing (also on error paths) | Prevents `processItem` from starting a new stage invocation |
-| `fabrik:paused` | `escalateFailedStage`, `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `attemptMergeOnValidate` (on ErrNotMergeable) | After MaxRetries, FABRIK_BLOCKED_ON_INPUT, review timeout, review cycle limit, or unmergeable PR | User (manual removal), or `processItem` (on new comment that triggers unpause) | When user removes it manually, or user comments on a paused issue | Blocks all processing; user comment is an implicit resume |
-| `fabrik:awaiting-input` | `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit` | After FABRIK_BLOCKED_ON_INPUT or review timeout/cycle limit | `unblockAwaitingInput` | When user comment arrives | Combined with `fabrik:paused`, identifies the "awaiting user input" pause variant |
+| `fabrik:paused` | `escalateFailedStage`, `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `pauseForCITimeout`, `pauseForCIFixCycleLimit`, `attemptMergeOnValidate` (on ErrNotMergeable or CI wait timeout) | After MaxRetries, FABRIK_BLOCKED_ON_INPUT, review/CI timeout, review/CI cycle limit, or unmergeable PR | User (manual removal), or `processItem` (on new comment that triggers unpause) | When user removes it manually, or user comments on a paused issue | Blocks all processing; user comment is an implicit resume |
+| `fabrik:awaiting-input` | `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `pauseForCITimeout`, `pauseForCIFixCycleLimit` | After FABRIK_BLOCKED_ON_INPUT or review/CI timeout/cycle limit | `unblockAwaitingInput` | When user comment arrives | Combined with `fabrik:paused`, identifies the "awaiting user input" pause variant |
 | `fabrik:awaiting-review` | `handleStageComplete` (Path 1), `checkReviewGate` (Path 2) | Path 1: optimistically after stage completion when `wait_for_reviews: true` (does not check reviewer state — data is stale). Path 2: when `LinkedPRReviewRequests` is non-empty (real gate evaluation) | `checkReviewGate` (both natural clear and timeout paths) | When all reviewers submit, or when timeout elapses (removed by `checkReviewGate` before `pauseForReviewTimeout` is called) | Blocks auto-advance until review gate clears |
+| `fabrik:awaiting-ci` | `checkCIGate` (catch-up loop), `attemptMergeOnValidate` (merge guard) | When CI check runs for the PR head SHA have `conclusion: failure/timed_out/action_required`. NOT added for pending/queued checks (R10c — no label churn for transient states). Applied idempotently. | `checkCIGate` (when CI passes or gate times out); `attemptMergeOnValidate` (when CI passes) | When all CI checks pass (green); or when timeout elapses (removed before `pauseForCITimeout` is called) | Signals confirmed CI failure; triggers `itemMayNeedWork` updatedAt cache bypass; blocks auto-advance until CI gate clears |
 | `fabrik:blocked` | `checkDependencies` | When open blocking issues exist (first transition only — idempotent) | `checkDependencies` | When all blocking issues close | Blocks stage start (first stage is exempt) |
 | `stage:<X>:in_progress` | `processItem` | After lock acquired and verified | `releaseLock` | Same as `fabrik:locked:<user>` | Informational — shows which stage is active on GitHub |
 | `stage:<X>:complete` | `handleStageComplete`, `handleDecomposed`, cleanup stage handler | After Claude signals FABRIK_STAGE_COMPLETE or FABRIK_DECOMPOSED; or after worktree cleanup | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
@@ -129,7 +131,7 @@ Each active stage column has the same set of reachable sub-states:
 
 ## 2. Event Enumeration
 
-Nine distinct event types drive state transitions:
+Ten distinct event types drive state transitions:
 
 ### 2.1 Poll Tick
 
@@ -227,6 +229,20 @@ Nine distinct event types drive state transitions:
 - The `inFlight` guard prevents double-dispatch across poll cycles
 - Resolves review threads (marks them resolved on GitHub) after processing
 
+### 2.10 CI Check Completed
+
+**Trigger:** CI check runs on the PR head SHA transition from pending to a terminal state (success, failure, etc.). Fabrik detects this by polling `FetchCheckRuns` (REST) on each catch-up loop iteration — there are no webhooks.
+
+**Code path:** `poll()` catch-up loop Phase 1 → `checkCIGate()` → `FetchLinkedPR()` (REST, for head SHA) → `FetchCheckRuns()` (REST) → evaluates check run statuses → optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
+
+**Distinct from Review Reinvoke because:**
+- Triggered by check run status changes, not reviewer submissions
+- Uses `fabrik:awaiting-ci` label (not `fabrik:awaiting-review`)
+- Only active on stages with `wait_for_ci: true`
+- `fabrik:awaiting-ci` is only applied on **confirmed failure**, not on pending/queued checks (R10c)
+- Timeout tracked via `FetchLabelAppliedAt` on `fabrik:awaiting-ci` (durable across restarts), not in-memory
+- CI-fix cycle counter is `ciFixCycleCount` (keyed by `issueKey + "-" + stageName`)
+
 ---
 
 ## 3. Transition Tables
@@ -304,6 +320,16 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Same column, Awaiting Review + Complete | PR review submitted | All reviewers submitted | Same column, Complete → advance | | `fabrik:awaiting-review` | Gate cleared; falls through to advance or review reinvoke |
 | Same column, Awaiting Review + Complete | Poll tick (catch-up) | Timeout elapsed | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:awaiting-review` | `pauseForReviewTimeout()` posts explanatory comment |
 
+#### Awaiting CI (wait_for_ci gate)
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE | `wait_for_ci: true`, yolo active, stage is Validate | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Approach A: completion label added; merge and advancement deferred to catch-up loop (no `fabrik:awaiting-ci` at this point — CI not yet checked) |
+| Same column, Complete | Poll tick (catch-up) | CI checks still pending (no failure) | Same (blocked) | (none — R10c: no label for pending) | | `checkCIGate` logs pending checks; re-evaluates next poll |
+| Same column, Complete | Poll tick (catch-up) | Any CI check failed | Same column, Awaiting CI | `fabrik:awaiting-ci` | | CI failure detected; dispatch CI-fix reinvoke or pause on cycle limit |
+| Same column, Awaiting CI + Complete | Poll tick (catch-up) | All CI checks green | Same column, Complete → advance | | `fabrik:awaiting-ci` | Gate cleared; falls through to advance (or merge for Validate+yolo) |
+| Same column, Awaiting CI + Complete | Poll tick (catch-up) | `fabrik:awaiting-ci` applied ≥ CIWaitTimeout ago | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:awaiting-ci` | `pauseForCITimeout()` posts explanatory comment; timeout detected via `FetchLabelAppliedAt` |
+
 #### Cooldown Retry and Failed Stage Escalation
 
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
@@ -327,6 +353,14 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Column `<X>`, Awaiting Review + Complete | Review gate clears + unresolved thread comments | Not in-flight, cycle count < MaxReviewCycles | Same column (comment processing via async goroutine) | `fabrik:editing` (during processing) | | `dispatchReviewReinvoke()` spawns goroutine; `reviewCycleCount` incremented; `inFlight` set; semaphore acquired |
 | Column `<X>`, Awaiting Review + Complete | Review gate clears + unresolved thread comments | Cycle count ≥ MaxReviewCycles | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | | `pauseForReviewCycleLimit()` posts comment |
 | Column `<X>`, Awaiting Review + Complete | Review gate clears + unresolved thread comments | Already in-flight | Same (skipped) | | | Previous reinvoke goroutine still running; skipped entirely (no cycle-limit check) |
+
+#### CI Fix Reinvoke
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Awaiting CI + Complete | Poll tick (catch-up) | CI failed; not in-flight; `ciFixCycleCount` < MaxCiFixCycles | Same column (CI-fix goroutine running) | `fabrik:editing` (during processing) | | `dispatchCIFixReinvoke()` spawns goroutine; `ciFixCycleCount` incremented; `inFlight` set; semaphore acquired; synthetic CI-fix comment passed to `processComments()` |
+| Column `<X>`, Awaiting CI + Complete | Poll tick (catch-up) | CI failed; `ciFixCycleCount` ≥ MaxCiFixCycles | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | | `pauseForCIFixCycleLimit()` posts explanatory comment |
+| Column `<X>`, Awaiting CI + Complete | Poll tick (catch-up) | CI failed; already in-flight | Same (skipped) | | | Previous CI-fix goroutine still running; skipped entirely |
 
 ---
 
@@ -490,7 +524,71 @@ The catch-up loop in `poll()` is split into two phases for every `stage:<X>:comp
 | PR summary posting | None | Posts `"<StageName> (review feedback addressed)"` on the linked PR with per-thread footer (one `path:line — resolved` bullet per unique `ReviewThreadID`); skipped when `output == ""` or no linked PR |
 | inFlight guard | Uses dispatch loop's `inFlight` check | Has its own `inFlight` check in catch-up loop |
 
-### 6.4 Decompose Path
+### 6.4 CI Gate and CI-Fix Reinvoke
+
+#### 6.4.1 Two-Phase CI Gate
+
+The CI gate has two paths that handle different timing scenarios:
+
+**Path 1: `attemptMergeOnValidate()` (Merge Guard)**
+- Embedded directly in the auto-merge path for Validate+yolo items
+- Uses in-memory `ciMergePendingSince` map (keyed by `issueKey`) to track how long CI has been pending
+- Fetches PR head SHA via `FetchLinkedPR()` (REST), then check run statuses via `FetchCheckRuns()` (REST)
+- **R5:** No check runs → gate clears (repo has no CI)
+- **R4:** All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge
+- **R3:** Any check failed → add `fabrik:awaiting-ci`; return error (advance skipped)
+- **R2:** Any check pending → start timer in `ciMergePendingSince` (first observation); return error (**R10c:** no label applied — avoids label churn for transient pending state)
+- **R6:** Pending elapsed ≥ `CIWaitTimeout` → post comment; add `fabrik:paused` + `fabrik:awaiting-input`; return error
+
+**Path 2: Catch-up loop Phase 1 (`checkCIGate()`)**
+- Runs for all `stage:<X>:complete` items on stages with `wait_for_ci: true`
+- Has FRESH data from `FetchItemDetails()` and makes targeted REST calls for head SHA and check runs
+- Uses `FetchLabelAppliedAt` on `fabrik:awaiting-ci` for timeout tracking (durable across restarts)
+- Three outcomes:
+  - `(ciBlocked=true, ciFailure=false, ciTimedOut=false)` — checks still pending; skip to next item (**R10c**: no label applied — no churn for transient pending state)
+  - `(ciBlocked=true, ciFailure=true, ciTimedOut=false)` — failure confirmed; `fabrik:awaiting-ci` applied (idempotent); dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
+  - `(ciBlocked=false, ciFailure=false, ciTimedOut=true)` — `fabrik:awaiting-ci` has been present ≥ `CIWaitTimeout`; pause via `pauseForCITimeout()`
+
+**Two different timeout strategies:**
+- **Path 1** (merge guard): In-memory `ciMergePendingSince` map. Acceptable because merge-guard state is transient — engine restarts simply re-evaluate CI on the next poll.
+- **Path 2** (catch-up loop): `FetchLabelAppliedAt` REST call on `fabrik:awaiting-ci`. Durable across restarts because the label itself persists. Only called when CI has already failed and the label is present — a rare, high-signal path.
+
+#### 6.4.2 CI Fix Reinvoke Mechanics
+
+The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. When CI has failed:
+
+1. **inFlight guard:** If a CI-fix goroutine from a previous poll is still running for this item, skip dispatch entirely (no cycle-limit check either)
+2. **Cycle limit check:** `ciFixCycleCount[stageKey]` is compared against `MaxCiFixCycles` (default 5)
+   - If exceeded: `pauseForCIFixCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
+   - If not exceeded: increment count, dispatch reinvoke via `dispatchCIFixReinvoke()`:
+     - Marks item in `inFlight` (prevents double-dispatch)
+     - Acquires semaphore slot (respects `MaxConcurrent`)
+     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch)
+     - Calls `processComments()` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if unset)
+     - On exit: releases semaphore, clears `inFlight`
+
+**`DatabaseID: 0` guard:** Synthetic CI-fix comments have `DatabaseID: 0`, which skips the 👀 and 🚀 reaction steps in `processComments()` (reactions require a real GitHub comment ID).
+
+**CI-fix cycle counter reset:** `ciFixCycleCount[stageKey]` is reset to 0 by `clearFailedStage()` when the user removes `fabrik:paused` from a paused-failed item, allowing fresh CI-fix attempts after human intervention.
+
+#### 6.4.3 CI Fix Reinvoke vs Review Reinvoke
+
+| Aspect | Review Reinvoke | CI Fix Reinvoke |
+|--------|-----------------|-----------------|
+| Trigger | Unresolved PR review thread comments | CI check runs with failure/timed_out/action_required conclusion |
+| Source data | `item.LinkedPRReviewThreadComments` | `FetchCheckRuns()` REST call on PR head SHA |
+| Label on waiting | `fabrik:awaiting-review` (always applied) | `fabrik:awaiting-ci` (only on confirmed failure — R10c) |
+| Timeout tracking | In-memory `ReviewWaitTimeout` timer | `FetchLabelAppliedAt` on `fabrik:awaiting-ci` (durable across restarts) |
+| Cycle counter | `reviewCycleCount[stageKey]` | `ciFixCycleCount[stageKey]` |
+| Max cycles | `MaxReviewCycles` (default 5) | `MaxCiFixCycles` (default 5) |
+| Skill | `comment_skill` | `ci_fix_skill` (falls back to `comment_skill`) |
+| Synthetic comment | PR review thread text | Structured CI failure report with NEW REGRESSION classification |
+| inFlight guard | Yes — shared `inFlight` sync.Map | Yes — same `inFlight` sync.Map |
+| Thread resolution | Yes — `ResolveReviewThread()` after processing | No |
+| PR summary comment | Yes — `"<StageName> (review feedback addressed)"` on linked PR | No |
+| Stage gate config | `wait_for_reviews: true` | `wait_for_ci: true` |
+
+### 6.5 Decompose Path
 
 **Trigger:** Claude outputs `FABRIK_DECOMPOSED` marker (expected only from Plan stage).
 
@@ -564,6 +662,8 @@ Closed issues are normally skipped by `itemMayNeedWork()` and `itemNeedsWork()`.
 | Retry count | `retryCount[stageKey]` | None | Lost — retries restart from 0 |
 | Paused-due-to-retries | `pausedDueToRetries[stageKey]` | `fabrik:paused` + `stage:<X>:failed` | Labels survive; in-memory flag lost but `processItem()` detects the failed label directly |
 | Review cycle count | `reviewCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
+| CI-fix cycle count | `ciFixCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
+| CI merge pending since | `ciMergePendingSince[issueKey]` | None | Lost — merge guard re-evaluates CI fresh on next poll |
 | Comment processed | `processedSet[key]` | ROCKET (🚀) reaction | Reaction survives restart; in-memory dedup is defense-in-depth |
 | Lock tracking | `lockedIssues[iKey]` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
 | Last updatedAt | `lastUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |
@@ -626,15 +726,15 @@ No special handling. Each is independent. The engine only checks the in_progress
 
 ### 9.1 Semaphore
 
-`Engine.sem` is a buffered channel of size `MaxConcurrent` (default 5). Both the dispatch loop and `dispatchReviewReinvoke()` acquire slots from this semaphore before invoking Claude.
+`Engine.sem` is a buffered channel of size `MaxConcurrent` (default 5). The dispatch loop, `dispatchReviewReinvoke()`, and `dispatchCIFixReinvoke()` all acquire slots from this semaphore before invoking Claude.
 
 ### 9.2 inFlight Map
 
 `Engine.inFlight` (`sync.Map`) tracks items currently being processed by worker goroutines. Key: `issueKey` string, Value: `bool` (isPR).
 
-- **Set by:** dispatch loop (before goroutine launch) and `dispatchReviewReinvoke()` (inside goroutine, before semaphore acquire)
+- **Set by:** dispatch loop (before goroutine launch), `dispatchReviewReinvoke()` (inside goroutine, before semaphore acquire), and `dispatchCIFixReinvoke()` (inside goroutine, before semaphore acquire)
 - **Cleared by:** goroutine defer (after `processItem()` or `processComments()` returns)
-- **Used by:** dispatch loop (skip already in-flight items) and catch-up loop (skip reinvoke if already in-flight)
+- **Used by:** dispatch loop (skip already in-flight items) and catch-up loop (skip reinvoke/CI-fix dispatch if already in-flight)
 
 ### 9.3 Worktree Mutex
 
@@ -651,7 +751,7 @@ The `advancedItems` map prevents items advanced by the catch-up loop from having
 
 ### 9.5 processedSet Mutex
 
-`Engine.mu` (sync.Mutex) protects all in-memory state maps: `processedSet`, `lockedIssues`, `retryCount`, `pausedDueToRetries`, `reviewCycleCount`, `lastUpdatedAt`, `deepFetchFailureTime`, `lastUsage`, `lastCompleted`, `lastBlocked`, `totalTokens`, `lastReportedCost`. Critical sections are kept small — typically a single map read/write.
+`Engine.mu` (sync.Mutex) protects all in-memory state maps: `processedSet`, `lockedIssues`, `retryCount`, `pausedDueToRetries`, `reviewCycleCount`, `ciFixCycleCount`, `ciMergePendingSince`, `lastUpdatedAt`, `deepFetchFailureTime`, `lastUsage`, `lastCompleted`, `lastBlocked`, `totalTokens`, `lastReportedCost`. Critical sections are kept small — typically a single map read/write.
 
 ---
 
@@ -723,6 +823,13 @@ stateDiagram-v2
         AwaitingReview --> NextStage : Gate clears, no threads
         ReviewReinvoke --> AwaitingReview : Reinvoke completes, new reviews arrive
         ReviewReinvoke --> AwaitingInput : Cycle limit exceeded
+
+        Complete --> AwaitingCI : wait_for_ci gate (CI failure detected)
+        AwaitingCI --> CIFixReinvoke : CI failed, cycle ok
+        AwaitingCI --> NextStage : CI checks all pass
+        AwaitingCI --> AwaitingInput : CI timeout or cycle limit
+        CIFixReinvoke --> AwaitingCI : Reinvoke completes, CI re-evaluated next poll
+        CIFixReinvoke --> AwaitingInput : Cycle limit exceeded
 
         Complete --> NextStage : Auto-advance or human move
         CommentProcessing --> Complete : FABRIK_STAGE_COMPLETE in comment output
@@ -800,10 +907,10 @@ Stage advancement can occur through two code paths:
 
 | Phase | Gate | What it does |
 |-------|------|--------------|
-| **Phase 1** | Unconditional (all `stage:<X>:complete` non-paused non-cleanup items) | `checkDependencies()` → `checkReviewGate()` → `buildReviewThreadComments()` / `dispatchReviewReinvoke()` |
+| **Phase 1** | Unconditional (all `stage:<X>:complete` non-paused non-cleanup items) | `checkDependencies()` → `checkReviewGate()` → `checkCIGate()` → `buildReviewThreadComments()` / `dispatchReviewReinvoke()` / `dispatchCIFixReinvoke()` |
 | **Phase 2** | `fabrik:yolo` (cfg or label) OR `fabrik:cruise` label OR stage `auto_advance: true` | `attemptMergeOnValidate()` (yolo only) → `findNewComments()` deferral → `advanceToNextStage()` |
 
-Phase 1 ensures inline PR review thread comments (from Copilot, Gemini, or human reviewers) are addressed on **all** issues, not just yolo/cruise ones. Phase 2 keeps stage advancement gated as before. Items that pass Phase 1 (review reinvoke dispatched) skip Phase 2 on that poll cycle and are re-evaluated on the next poll.
+Phase 1 ensures inline PR review thread comments (from Copilot, Gemini, or human reviewers) are addressed and CI failures are fixed on **all** issues, not just yolo/cruise ones. Phase 2 keeps stage advancement gated as before. Items that dispatch a reinvoke in Phase 1 (review reinvoke or CI-fix reinvoke) skip Phase 2 on that poll cycle and are re-evaluated on the next poll.
 
 ## Appendix B: Guard Evaluation in `itemMayNeedWork()` (Shallow Pre-Filter)
 
@@ -814,7 +921,7 @@ Phase 1 ensures inline PR review thread comments (from Copilot, Gemini, or human
 | Stage exists | `FindStage(stages, item.Status) != nil` |
 | Closed issue | Not closed, OR cleanup stage, OR has `stage:<X>:complete` label |
 | Cleanup stage | Worktree exists on disk (local filesystem check only) |
-| updatedAt cache | `item.UpdatedAt` is newer than cached value, OR cooldown expired, OR `fabrik:blocked` label present |
+| updatedAt cache | `item.UpdatedAt` is newer than cached value, OR cooldown expired, OR `fabrik:blocked` or `fabrik:awaiting-ci` label present |
 | Deep-fetch failure cooldown | No recent `FetchItemDetails` failure, OR failure cooldown expired |
 
 **Note:** `itemMayNeedWork()` intentionally does NOT check lock, editing, pause, or dependency labels — those require the full label set from deep fetch and are checked in `itemNeedsWork()`.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -499,9 +499,16 @@ The catch-up loop in `poll()` is split into two phases for every `stage:<X>:comp
      - Acquires semaphore slot (respects `MaxConcurrent`)
      - Calls `processComments()` with the synthetic review comments asynchronously
      - On exit: releases semaphore, clears `inFlight`
+   - Either way: `continue` — Phase 2 is skipped this cycle; item re-evaluated on next poll
+6. **CI gate** (only reached if no review reinvoke was dispatched in step 5): `checkCIGate()` evaluates CI check runs for stages with `wait_for_ci: true`
+   - Pending/API error: skip (blocked, not failed); item re-evaluated on next poll
+   - Timed out: `pauseForCITimeout()` pauses issue
+   - CI failed: **inFlight guard** + **cycle limit check** (`ciFixCycleCount[stageKey]` vs `MaxCiFixCycles`):
+     - If exceeded: `pauseForCIFixCycleLimit()` pauses issue
+     - If not exceeded: dispatch `dispatchCIFixReinvoke()`; `continue`
 
 **Phase 2 — gated (yolo/cruise/auto_advance only):**
-- Only runs when no unresolved review threads remain (Phase 1 `continue`s on reinvoke)
+- Only runs when no reinvoke was dispatched in Phase 1 (review or CI-fix reinvoke both `continue`)
 - Gated on: `e.cfg.Yolo` OR `fabrik:yolo` label OR `fabrik:cruise` label OR stage `auto_advance: true`
 - Runs `attemptMergeOnValidate()` (yolo only), skips if unprocessed comments exist, then calls `advanceToNextStage()`
 
@@ -907,7 +914,7 @@ Stage advancement can occur through two code paths:
 
 | Phase | Gate | What it does |
 |-------|------|--------------|
-| **Phase 1** | Unconditional (all `stage:<X>:complete` non-paused non-cleanup items) | `checkDependencies()` → `checkReviewGate()` → `checkCIGate()` → `buildReviewThreadComments()` / `dispatchReviewReinvoke()` / `dispatchCIFixReinvoke()` |
+| **Phase 1** | Unconditional (all `stage:<X>:complete` non-paused non-cleanup items) | `checkDependencies()` → `checkReviewGate()` → `buildReviewThreadComments()` / `dispatchReviewReinvoke()` → `checkCIGate()` / `dispatchCIFixReinvoke()` (review reinvoke and CI-fix reinvoke are mutually exclusive per poll cycle) |
 | **Phase 2** | `fabrik:yolo` (cfg or label) OR `fabrik:cruise` label OR stage `auto_advance: true` | `attemptMergeOnValidate()` (yolo only) → `findNewComments()` deferral → `advanceToNextStage()` |
 
 Phase 1 ensures inline PR review thread comments (from Copilot, Gemini, or human reviewers) are addressed and CI failures are fixed on **all** issues, not just yolo/cruise ones. Phase 2 keeps stage advancement gated as before. Items that dispatch a reinvoke in Phase 1 (review reinvoke or CI-fix reinvoke) skip Phase 2 on that poll cycle and are re-evaluated on the next poll.

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -1,0 +1,393 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+	"github.com/verveguy/fabrik/tui"
+)
+
+// checkCIGate inspects CI check runs for the linked PR to determine whether the
+// CI gate is blocking stage advancement or merge.
+//
+// The gate is only active when stage.WaitForCI is true. It fetches the PR's
+// head SHA via FetchLinkedPR (REST), then fetches check runs via FetchCheckRuns.
+//
+// Returns (blocked, ciFailure, timedOut):
+//
+//   - (false, false, false) — gate cleared; advance/merge may proceed.
+//     This includes: no PR found, no check runs (R5), all checks green.
+//
+//   - (true, false, false)  — checks still pending (in_progress/queued); re-evaluate on next poll.
+//     fabrik:awaiting-ci is NOT applied for pending checks (R10c).
+//
+//   - (true, true, false)   — CI failed; fabrik:awaiting-ci applied; caller should dispatch CI-fix.
+//
+//   - (false, false, true)  — CI wait timeout elapsed; caller should pause the issue.
+//     fabrik:awaiting-ci is removed before returning.
+func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) (blocked, ciFailure, timedOut bool) {
+	if stage.WaitForCI == nil || !*stage.WaitForCI {
+		return false, false, false
+	}
+
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	if err != nil {
+		e.logf(item.Number, "ci-gate", "could not fetch linked PR: %v — skipping CI gate\n", err)
+		return false, false, false
+	}
+	if pr == nil || pr.HeadSHA == "" {
+		e.logf(item.Number, "ci-gate", "no linked PR found; skipping CI gate\n")
+		return false, false, false
+	}
+
+	checkRuns, err := e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
+	if err != nil {
+		e.logf(item.Number, "ci-gate", "could not fetch check runs: %v — skipping CI gate\n", err)
+		return false, false, false
+	}
+
+	// R5: no check runs = no CI configured; gate clears.
+	if len(checkRuns) == 0 {
+		e.logf(item.Number, "ci-gate", "no check runs found for SHA %s; CI gate clears (no CI configured)\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
+		e.removeAwaitingCILabel(owner, repo, item)
+		return false, false, false
+	}
+
+	// Classify check runs.
+	var pending, failed []gh.CheckRun
+	for _, cr := range checkRuns {
+		switch cr.Status {
+		case "queued", "in_progress":
+			pending = append(pending, cr)
+		case "completed":
+			switch cr.Conclusion {
+			case "failure", "timed_out", "action_required":
+				failed = append(failed, cr)
+			}
+		}
+	}
+
+	// All checks green (no pending, no failed) — gate clears.
+	if len(pending) == 0 && len(failed) == 0 {
+		e.logf(item.Number, "ci-gate", "all CI checks passed for SHA %s\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
+		e.removeAwaitingCILabel(owner, repo, item)
+		return false, false, false
+	}
+
+	// Checks still running — block but do NOT apply label (R10c).
+	if len(failed) == 0 {
+		names := make([]string, 0, len(pending))
+		for _, cr := range pending {
+			names = append(names, cr.Name)
+		}
+		e.logf(item.Number, "ci-gate", "CI still running — pending: %s\n", strings.Join(names, ", "))
+		return true, false, false
+	}
+
+	// CI failed — check timeout via label timestamp.
+	timeout := e.cfg.CIWaitTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Minute
+	}
+	for _, l := range item.Labels {
+		if l == "fabrik:awaiting-ci" {
+			appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
+			if err != nil {
+				e.logf(item.Number, "warn", "could not fetch awaiting-ci label timestamp: %v\n", err)
+			} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
+				failedNames := make([]string, 0, len(failed))
+				for _, cr := range failed {
+					failedNames = append(failedNames, cr.Name)
+				}
+				e.logf(item.Number, "warn", "CI wait timeout elapsed; pausing issue — failed: %s\n", strings.Join(failedNames, ", "))
+				e.removeAwaitingCILabel(owner, repo, item)
+				return false, false, true
+			}
+			break
+		}
+	}
+
+	// Apply fabrik:awaiting-ci on confirmed failure (idempotent).
+	failedNames := make([]string, 0, len(failed))
+	for _, cr := range failed {
+		failedNames = append(failedNames, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
+	}
+	e.logf(item.Number, "ci-gate", "CI check(s) failed: %s\n", strings.Join(failedNames, ", "))
+
+	alreadyWaiting := false
+	for _, l := range item.Labels {
+		if l == "fabrik:awaiting-ci" {
+			alreadyWaiting = true
+			break
+		}
+	}
+	if !alreadyWaiting {
+		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
+		}
+	}
+
+	return true, true, false
+}
+
+// removeAwaitingCILabel removes fabrik:awaiting-ci if present on the item.
+func (e *Engine) removeAwaitingCILabel(owner, repo string, item gh.ProjectItem) {
+	for _, l := range item.Labels {
+		if l == "fabrik:awaiting-ci" {
+			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
+				e.logf(item.Number, "warn", "could not remove fabrik:awaiting-ci label: %v\n", err)
+			}
+			return
+		}
+	}
+}
+
+// buildCIFixComment constructs the synthetic comment body for a CI-fix reinvocation.
+// It fetches current PR CI status, fetches base branch CI status for comparison,
+// and formats both into a structured message Claude can use to diagnose failures.
+func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, workDir string) gh.Comment {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	var prFailures, baseRuns []gh.CheckRun
+	var baseBranch string
+
+	// Fetch PR check runs.
+	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	if err == nil && pr != nil && pr.HeadSHA != "" {
+		prFailures, _ = e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
+	}
+
+	// Fetch base branch check runs for comparison.
+	wm := e.worktreesFor(item.Repo)
+	bb, err := e.baseBranchForItem(item, wm)
+	if err == nil {
+		baseBranch = bb
+		if baseSHA, err := gitRevParse(workDir, "origin/"+baseBranch); err == nil && baseSHA != "" {
+			baseRuns, _ = e.client.FetchCheckRuns(owner, repo, baseSHA)
+		}
+	}
+
+	// Classify PR failures.
+	var failedLines []string
+	baseFailedNames := make(map[string]bool)
+	for _, cr := range baseRuns {
+		if cr.Status == "completed" {
+			switch cr.Conclusion {
+			case "failure", "timed_out", "action_required":
+				baseFailedNames[cr.Name] = true
+			}
+		}
+	}
+	for _, cr := range prFailures {
+		if cr.Status == "completed" {
+			switch cr.Conclusion {
+			case "failure", "timed_out", "action_required":
+				note := "NEW REGRESSION"
+				if baseFailedNames[cr.Name] {
+					note = "pre-existing (also fails on base branch)"
+				}
+				failedLines = append(failedLines, fmt.Sprintf("- **%s**: %s [%s]", cr.Name, cr.Conclusion, note))
+			}
+		}
+	}
+
+	// Format base branch status.
+	var baseLines []string
+	for _, cr := range baseRuns {
+		if cr.Status == "completed" {
+			baseLines = append(baseLines, fmt.Sprintf("- %s: %s", cr.Name, cr.Conclusion))
+		}
+	}
+
+	branchName := fmt.Sprintf("fabrik/issue-%d", item.Number)
+	var sb strings.Builder
+	sb.WriteString("🏭 **Fabrik — CI Fix Required**\n\n")
+	sb.WriteString(fmt.Sprintf("The following CI check runs failed for this PR (branch: `%s`):\n\n", branchName))
+
+	if len(failedLines) > 0 {
+		sb.WriteString("**Failed checks on PR branch:**\n")
+		for _, l := range failedLines {
+			sb.WriteString(l + "\n")
+		}
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString("*(Could not determine specific failed checks — check GitHub Actions for details)*\n\n")
+	}
+
+	if len(baseLines) > 0 && baseBranch != "" {
+		sb.WriteString(fmt.Sprintf("**Base branch (`%s`) check run status:**\n", baseBranch))
+		for _, l := range baseLines {
+			sb.WriteString(l + "\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("**Instructions:**\n")
+	sb.WriteString("1. Checks marked **NEW REGRESSION** were introduced by this PR — fix these.\n")
+	sb.WriteString("2. Checks marked **pre-existing** also fail on the base branch — note them but do NOT attempt to fix them.\n")
+	sb.WriteString(fmt.Sprintf("3. To investigate failure logs: `gh run list --branch %s --limit 5` then `gh run view <run-id> --log-failed`\n", branchName))
+	sb.WriteString("4. After fixing, commit and push. The engine will re-evaluate CI on the next poll cycle.\n")
+	sb.WriteString(fmt.Sprintf("5. Do not signal `FABRIK_STAGE_COMPLETE` — the engine will advance once CI passes.\n"))
+
+	return gh.Comment{
+		ID:         "ci-fix-synthetic",
+		DatabaseID: 0, // synthetic — no GitHub comment to react to
+		Body:       sb.String(),
+		Author:     "fabrik",
+	}
+}
+
+// dispatchCIFixReinvoke spawns a goroutine to re-invoke the stage agent via
+// processComments with a synthetic CI-failure context comment. It mirrors
+// dispatchReviewReinvoke exactly: marks inFlight, acquires semaphore, calls
+// processComments, then releases both.
+func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
+	iKey := issueKey(item, e.defaultRepo())
+
+	// Mark in-flight to prevent the next poll cycle from double-dispatching.
+	e.inFlight.Store(iKey, item.IsPR)
+	e.wg.Add(1)
+
+	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
+
+	go func() {
+		defer e.wg.Done()
+		defer e.inFlight.Delete(iKey)
+
+		select {
+		case e.sem <- struct{}{}:
+		case <-ctx.Done():
+			e.logf(item.Number, "ci-fix-reinvoke", "context cancelled before semaphore acquired\n")
+			return
+		}
+		defer func() { <-e.sem }()
+
+		if err := e.ensureRepoReady(ctx, item); err != nil {
+			if errors.Is(err, ErrSkipItem) {
+				e.logf(item.Number, "ci-fix-reinvoke", "repo not ready, skipping reinvoke\n")
+				return
+			}
+			e.logf(item.Number, "warn", "ci-fix reinvoke: ensureRepoReady failed: %v\n", err)
+			return
+		}
+
+		// Get worktree path for base branch CI comparison.
+		wm := e.worktreesFor(item.Repo)
+		workDir := wm.WorktreeDir(item.Number)
+
+		// Build the synthetic comment with CI failure context.
+		syntheticComment := e.buildCIFixComment(item, stage, workDir)
+
+		// Use ci_fix_skill if configured; fall back to comment_skill.
+		ciFixStage := *stage
+		if stage.CIFixSkill != "" {
+			ciFixStage.CommentSkill = stage.CIFixSkill
+			ciFixStage.CommentPrompt = ""
+		}
+
+		startTime := time.Now()
+		e.emitStructural(tui.JobStartedEvent{
+			IssueNumber: item.Number,
+			Repo:        itemRepo,
+			Title:       item.Title,
+			StageName:   stage.Name,
+			IsComment:   true,
+			StartedAt:   startTime,
+		})
+
+		e.logf(item.Number, "ci-fix-reinvoke", "re-invoking stage %q via comment processing with CI failure context\n", stage.Name)
+		err := e.processComments(ctx, board, item, &ciFixStage, []gh.Comment{syntheticComment})
+
+		e.mu.Lock()
+		usage := e.lastUsage[iKey]
+		completed := e.lastCompleted[iKey]
+		blocked := e.lastBlocked[iKey]
+		delete(e.lastUsage, iKey)
+		delete(e.lastCompleted, iKey)
+		delete(e.lastBlocked, iKey)
+		e.mu.Unlock()
+		e.emitStructural(tui.JobCompletedEvent{
+			IssueNumber:    item.Number,
+			Repo:           itemRepo,
+			Title:          item.Title,
+			StageName:      stage.Name,
+			StageModel:     stage.Model,
+			IsComment:      true,
+			Success:        err == nil,
+			Completed:      completed,
+			BlockedOnInput: blocked,
+			Duration:       time.Since(startTime),
+			CompletedAt:    time.Now(),
+			TurnsUsed:      usage.TurnsUsed,
+			MaxTurns:       usage.MaxTurns,
+			CostUSD:        usage.CostUSD,
+		})
+
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			e.logf(item.Number, "warn", "CI-fix re-invocation failed: %v\n", err)
+		}
+	}()
+}
+
+// pauseForCITimeout pauses the issue when the CI wait timeout in the catch-up
+// loop elapses. It posts an explanatory comment and applies fabrik:paused +
+// fabrik:awaiting-input.
+func (e *Engine) pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	e.logf(item.Number, "ci-timeout", "CI wait timeout elapsed — pausing for human intervention\n")
+
+	msg := fmt.Sprintf(
+		"🏭 **Fabrik — CI wait timeout**\n\nThe CI gate for stage **%s** timed out waiting for checks to pass.\n\n"+
+			"Fabrik has paused this issue. Please check the PR's CI status, address any failures, and then remove the `fabrik:paused` label to resume.",
+		stage.Name,
+	)
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+		e.logf(item.Number, "warn", "could not post CI timeout comment: %v\n", err)
+	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	}
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	}
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	}
+}
+
+// pauseForCIFixCycleLimit pauses the issue when the maximum CI-fix
+// re-invocation cycle count is reached.
+func (e *Engine) pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	e.logf(item.Number, "ci-cycles", "CI-fix cycle limit %d reached — pausing for human intervention\n", maxCycles)
+
+	msg := fmt.Sprintf(
+		"🏭 **Fabrik — CI fix cycle limit reached**\n\nThe stage **%s** has been re-invoked to fix CI failures %d time(s), "+
+			"which has reached the maximum configured limit (`FABRIK_MAX_CI_FIX_CYCLES=%d`).\n\n"+
+			"CI checks are still failing after repeated fix attempts. "+
+			"Fabrik has paused this issue for human review. Once the CI situation is resolved, "+
+			"remove the `fabrik:paused` label to resume.",
+		stage.Name, cycleCount, maxCycles,
+	)
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+		e.logf(item.Number, "warn", "could not post CI cycle limit comment: %v\n", err)
+	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	}
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	}
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	}
+}
+

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -23,8 +23,9 @@ import (
 //   - (false, false, false) — gate cleared; advance/merge may proceed.
 //     This includes: no PR found, no check runs (R5), all checks green.
 //
-//   - (true, false, false)  — checks still pending (in_progress/queued); re-evaluate on next poll.
-//     fabrik:awaiting-ci is NOT applied for pending checks (R10c).
+//   - (true, false, false)  — gate blocked but no confirmed failure; re-evaluate on next poll.
+//     Covers: checks still pending (in_progress/queued), and transient API errors
+//     (FetchLinkedPR or FetchCheckRuns fail). fabrik:awaiting-ci is NOT applied (R10c).
 //
 //   - (true, true, false)   — CI failed; fabrik:awaiting-ci applied; caller should dispatch CI-fix.
 //
@@ -39,8 +40,8 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 
 	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
-		e.logf(item.Number, "ci-gate", "could not fetch linked PR: %v — skipping CI gate\n", err)
-		return false, false, false
+		e.logf(item.Number, "ci-gate", "could not fetch linked PR: %v — blocking until API recovers\n", err)
+		return true, false, false // transient error; retry on next poll
 	}
 	if pr == nil || pr.HeadSHA == "" {
 		e.logf(item.Number, "ci-gate", "no linked PR found; skipping CI gate\n")
@@ -49,8 +50,8 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 
 	checkRuns, err := e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
 	if err != nil {
-		e.logf(item.Number, "ci-gate", "could not fetch check runs: %v — skipping CI gate\n", err)
-		return false, false, false
+		e.logf(item.Number, "ci-gate", "could not fetch check runs: %v — blocking until API recovers\n", err)
+		return true, false, false // transient error; retry on next poll
 	}
 
 	// R5: no check runs = no CI configured; gate clears.

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -1,0 +1,275 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// ── checkCIGate ──────────────────────────────────────────────────────────────
+
+func TestCheckCIGate_WaitForCIFalse_ClearsImmediately(t *testing.T) {
+	called := false
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate"} // WaitForCI is nil
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if blocked || ciFailure || timedOut {
+		t.Errorf("expected all false when wait_for_ci not set, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
+	}
+	if called {
+		t.Error("should not call FetchLinkedPR when wait_for_ci is not set")
+	}
+}
+
+func TestCheckCIGate_NoPR_ClearsGate(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if blocked || ciFailure || timedOut {
+		t.Errorf("expected clear when no PR, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
+	}
+}
+
+func TestCheckCIGate_NoCheckRuns_ClearsGate(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha1"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if blocked || ciFailure || timedOut {
+		t.Errorf("expected clear for no check runs (R5), got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
+	}
+}
+
+func TestCheckCIGate_AllGreen_ClearsGate(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha2"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "completed", Conclusion: "success"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if blocked || ciFailure || timedOut {
+		t.Errorf("expected clear for all-green CI, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
+	}
+}
+
+func TestCheckCIGate_Pending_BlocksNoLabel(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha3"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "ci", Status: "in_progress"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked {
+		t.Error("expected blocked=true for pending CI")
+	}
+	if ciFailure || timedOut {
+		t.Errorf("expected ciFailure=false timedOut=false for pending, got ciFailure=%v timedOut=%v", ciFailure, timedOut)
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			t.Error("fabrik:awaiting-ci must NOT be added when CI is only pending (R10c)")
+		}
+	}
+}
+
+func TestCheckCIGate_Failed_BlocksAndAddsLabel(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha4"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "lint", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked || !ciFailure {
+		t.Errorf("expected blocked=true ciFailure=true for failed CI, got blocked=%v ciFailure=%v", blocked, ciFailure)
+	}
+	if timedOut {
+		t.Error("expected timedOut=false for failed CI without timeout")
+	}
+	found := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected fabrik:awaiting-ci to be added on CI failure")
+	}
+}
+
+func TestCheckCIGate_Failed_AlreadyLabeledWithTimeout_TimesOut(t *testing.T) {
+	appliedAt := time.Now().Add(-2 * time.Hour) // well past any timeout
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha5"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "lint", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+			return appliedAt, nil
+		},
+	}
+	stgs := testStagesWithValidate()
+	eng := testEngineWithStages(client, stgs)
+	eng.cfg.CIWaitTimeout = 1 * time.Millisecond // tiny timeout
+
+	tr := true
+	// Item already has fabrik:awaiting-ci
+	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if blocked || ciFailure {
+		t.Errorf("expected blocked=false ciFailure=false on timeout, got blocked=%v ciFailure=%v", blocked, ciFailure)
+	}
+	if !timedOut {
+		t.Error("expected timedOut=true when timeout elapses")
+	}
+	// fabrik:awaiting-ci should be removed
+	found := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected fabrik:awaiting-ci to be removed on timeout")
+	}
+}
+
+func TestCheckCIGate_Failed_AlreadyLabeledNotYetTimedOut_Blocked(t *testing.T) {
+	appliedAt := time.Now().Add(-1 * time.Minute) // within a 30-min window
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha6"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "lint", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+			return appliedAt, nil
+		},
+	}
+	eng := testEngineForMerge(client) // CIWaitTimeout = 0 → defaults to 30 min
+
+	tr := true
+	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked || !ciFailure {
+		t.Errorf("expected blocked=true ciFailure=true when not yet timed out, got blocked=%v ciFailure=%v", blocked, ciFailure)
+	}
+	if timedOut {
+		t.Error("expected timedOut=false when timeout has not elapsed")
+	}
+}
+
+// ── buildCIFixComment ─────────────────────────────────────────────────────────
+
+func TestBuildCIFixComment_IncludesFailedChecks(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha7"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1}
+	tr := true
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	comment := eng.buildCIFixComment(item, stage, "/tmp")
+	if comment.DatabaseID != 0 {
+		t.Error("synthetic comment should have DatabaseID=0")
+	}
+	if !strings.Contains(comment.Body, "build") {
+		t.Error("expected failed check name 'build' in comment body")
+	}
+	if !strings.Contains(comment.Body, "CI Fix Required") {
+		t.Error("expected CI Fix Required header in comment body")
+	}
+}
+
+func TestBuildCIFixComment_SyntheticHasDatabaseIDZero(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 42}
+	stage := &stages.Stage{Name: "Validate"}
+
+	comment := eng.buildCIFixComment(item, stage, "/tmp")
+	if comment.DatabaseID != 0 {
+		t.Errorf("DatabaseID = %d, want 0 (synthetic)", comment.DatabaseID)
+	}
+	if comment.Author != "fabrik" {
+		t.Errorf("Author = %q, want %q", comment.Author, "fabrik")
+	}
+}

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -256,6 +257,54 @@ func TestBuildCIFixComment_IncludesFailedChecks(t *testing.T) {
 	}
 	if !strings.Contains(comment.Body, "CI Fix Required") {
 		t.Error("expected CI Fix Required header in comment body")
+	}
+}
+
+// TestCheckCIGate_FetchLinkedPRError_BlocksGate verifies that a transient
+// FetchLinkedPR API error returns blocked=true rather than clearing the gate,
+// preventing auto-advance when CI status is unknown.
+func TestCheckCIGate_FetchLinkedPRError_BlocksGate(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, fmt.Errorf("transient network error")
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked {
+		t.Error("expected blocked=true when FetchLinkedPR returns an error")
+	}
+	if ciFailure || timedOut {
+		t.Errorf("expected ciFailure=false timedOut=false on API error, got ciFailure=%v timedOut=%v", ciFailure, timedOut)
+	}
+}
+
+// TestCheckCIGate_FetchCheckRunsError_BlocksGate verifies that a transient
+// FetchCheckRuns API error returns blocked=true rather than clearing the gate.
+func TestCheckCIGate_FetchCheckRunsError_BlocksGate(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha1"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, fmt.Errorf("GitHub API 503")
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked {
+		t.Error("expected blocked=true when FetchCheckRuns returns an error")
+	}
+	if ciFailure || timedOut {
+		t.Errorf("expected ciFailure=false timedOut=false on API error, got ciFailure=%v timedOut=%v", ciFailure, timedOut)
 	}
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -30,6 +30,8 @@ type Config struct {
 	MaxRetries        int
 	ReviewWaitTimeout time.Duration // How long to wait for PR reviewers before auto-advancing anyway (default 15m)
 	MaxReviewCycles   int           // Max review re-invocation cycles per issue before pausing (default 5)
+	CIWaitTimeout     time.Duration // How long to wait for CI in the merge guard before pausing (default 30m)
+	MaxCiFixCycles    int           // Max CI-fix re-invocation cycles per issue before pausing (default 5)
 	DebugOutput       bool
 	PluginDir         string
 	Stages            []*stages.Stage
@@ -62,6 +64,8 @@ type Engine struct {
 	retryCount           map[string]int        // key: "owner/repo#N-stageName", value: failed attempt count
 	pausedDueToRetries   map[string]bool       // key: "owner/repo#N-stageName", true if engine paused this issue
 	reviewCycleCount     map[string]int        // key: "owner/repo#N-stageName"; review re-invocation cycle count per stage
+	ciFixCycleCount      map[string]int        // key: "owner/repo#N-stageName"; CI-fix re-invocation cycle count per stage
+	ciMergePendingSince  map[string]time.Time  // key: issueKey; when CI was first observed in_progress in the merge guard
 	lastUsage            map[string]TokenUsage // key: issueKey; per-issue token usage from last processItem (for TUI)
 	lastCompleted        map[string]bool       // key: issueKey; per-issue stage completion from last processItem (for TUI)
 	lastBlocked          map[string]bool       // key: issueKey; per-issue blocked-on-input from last processItem (for TUI)
@@ -122,6 +126,8 @@ func New(cfg Config) (*Engine, error) {
 		retryCount:           make(map[string]int),
 		pausedDueToRetries:   make(map[string]bool),
 		reviewCycleCount:     make(map[string]int),
+		ciFixCycleCount:      make(map[string]int),
+		ciMergePendingSince:  make(map[string]time.Time),
 		sem:                  make(chan struct{}, cfg.MaxConcurrent),
 	}
 
@@ -168,6 +174,8 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		retryCount:           make(map[string]int),
 		pausedDueToRetries:   make(map[string]bool),
 		reviewCycleCount:     make(map[string]int),
+		ciFixCycleCount:      make(map[string]int),
+		ciMergePendingSince:  make(map[string]time.Time),
 		sem:                  make(chan struct{}, maxConcurrent),
 	}
 	if worktrees != nil {

--- a/engine/handle_stage_complete_test.go
+++ b/engine/handle_stage_complete_test.go
@@ -102,8 +102,8 @@ func TestHandleStageComplete_YoloLabel_Advances(t *testing.T) {
 
 func TestHandleStageComplete_YoloLabel_ValidateMergeableAdvances(t *testing.T) {
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 99, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, HeadSHA: "abc123"}, nil
 		},
 	}
 	stgs := testStagesWithValidate()
@@ -130,8 +130,8 @@ func TestHandleStageComplete_YoloLabel_ValidateMergeableAdvances(t *testing.T) {
 
 func TestHandleStageComplete_YoloLabel_ValidateUnmergeable_CommentPauseNoAdvance(t *testing.T) {
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 99, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, HeadSHA: "abc123"}, nil
 		},
 		mergePRFn: func(owner, repo string, prNumber int) error {
 			return gh.ErrNotMergeable
@@ -167,10 +167,10 @@ func TestHandleStageComplete_YoloLabel_ValidateUnmergeable_CommentPauseNoAdvance
 }
 
 func TestHandleStageComplete_YoloLabel_ValidateNoPR_AdvancesAnyway(t *testing.T) {
-	// FindPRForIssue returns 0 — no PR found
+	// FetchLinkedPR returns nil — no PR found
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 0, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
 		},
 	}
 	stgs := testStagesWithValidate()
@@ -219,8 +219,8 @@ func TestHandleStageComplete_AutoAdvanceFalse_OverridesAdvanceButMergeStillFires
 	// auto_advance:false is respected (item-level yolo would override it).
 	f := false
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 77, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 77, HeadSHA: "abc123"}, nil
 		},
 	}
 	stgs := testStagesWithValidate()
@@ -248,8 +248,8 @@ func TestHandleStageComplete_MergeAPIError_LogsAndDoesNotAdvance(t *testing.T) {
 	// This prevents silently moving to Done when the PR merge failed (e.g. transient
 	// 5xx, permissions). The engine will retry Validate on the next cooldown cycle.
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 88, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 88, HeadSHA: "abc123"}, nil
 		},
 		mergePRFn: func(owner, repo string, prNumber int) error {
 			return errors.New("network error")
@@ -306,11 +306,7 @@ func TestHandleStageComplete_CruiseLabel_NonValidate_Advances(t *testing.T) {
 // TestHandleStageComplete_CruiseLabel_Validate_NoMergeNoAdvance verifies that
 // fabrik:cruise does NOT merge the PR and does NOT advance at Validate completion.
 func TestHandleStageComplete_CruiseLabel_Validate_NoMergeNoAdvance(t *testing.T) {
-	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 99, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
 	eng := testEngineWithStages(client, stgs)
 
@@ -354,8 +350,8 @@ func TestHandleStageComplete_CruiseLabel_OverridesAutoAdvanceFalse(t *testing.T)
 // the PR is merged and the stage advances past Validate.
 func TestHandleStageComplete_BothCruiseAndYolo_YoloWins(t *testing.T) {
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 99, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, HeadSHA: "abc123"}, nil
 		},
 	}
 	stgs := testStagesWithValidate()

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -26,6 +26,8 @@ type GitHubClient interface {
 	ArchiveProjectItem(projectID, itemID string) error
 	GetIssueBody(owner, repo string, issueNumber int) (string, error)
 	FindPRForIssue(owner, repo string, issueNumber int) (int, error)
+	FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)
+	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)
 	GetPRBase(owner, repo string, prNumber int) (string, error)
 	UpdatePRBase(owner, repo string, prNumber int, newBase string) error
 	CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error)

--- a/engine/item.go
+++ b/engine/item.go
@@ -139,7 +139,7 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 			// a PR review bumps the linked PR's updatedAt (which Fabrik tracks in the
 			// shallow query via closedByPullRequestsReferences).
 			for _, l := range item.Labels {
-				if l == "fabrik:blocked" {
+				if l == "fabrik:blocked" || l == "fabrik:awaiting-ci" {
 					return true
 				}
 			}
@@ -868,8 +868,9 @@ func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	e.mu.Lock()
 	delete(e.retryCount, stageKey)
 	delete(e.pausedDueToRetries, stageKey)
-	delete(e.processedSet, stageKey)    // clear cooldown so the stage retries immediately
+	delete(e.processedSet, stageKey)     // clear cooldown so the stage retries immediately
 	delete(e.reviewCycleCount, stageKey) // reset review cycle counter on unpause
+	delete(e.ciFixCycleCount, stageKey)  // reset CI-fix cycle counter on unpause
 	e.mu.Unlock()
 }
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -134,12 +134,22 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 			// Force deep-fetch for items whose gate condition changes independently
 			// of the issue's updatedAt:
 			// - fabrik:blocked: a blocking issue may close without updating this issue's updatedAt
+			// - fabrik:awaiting-ci: CI check run completions don't bump the issue/PR updatedAt
 			// Note: fabrik:awaiting-input and fabrik:awaiting-review do NOT need forced
 			// deep-fetch — adding a comment bumps the issue's updatedAt, and submitting
 			// a PR review bumps the linked PR's updatedAt (which Fabrik tracks in the
 			// shallow query via closedByPullRequestsReferences).
 			for _, l := range item.Labels {
 				if l == "fabrik:blocked" || l == "fabrik:awaiting-ci" {
+					return true
+				}
+			}
+			// Force deep-fetch for CI-gated stages with a completion label but no
+			// fabrik:awaiting-ci label yet (CI still running): CI check run status
+			// changes don't bump the issue/PR updatedAt, so items waiting for CI
+			// would be permanently filtered by the updatedAt cache.
+			if stage.WaitForCI != nil && *stage.WaitForCI {
+				if hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) {
 					return true
 				}
 			}

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -662,3 +662,55 @@ func TestProcessItem_EvictsLastUpdatedAtAfterStageRun(t *testing.T) {
 		t.Error("lastUpdatedAt should be evicted after a stage runs so next poll re-evaluates the item")
 	}
 }
+
+// TestItemMayNeedWork_AwaitingCI_BypassesUpdatedAtCache verifies that items with
+// fabrik:awaiting-ci bypass the updatedAt cache so the catch-up loop can
+// re-evaluate CI status on every poll even when the issue hasn't changed.
+func TestItemMayNeedWork_AwaitingCI_BypassesUpdatedAtCache(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.PollSeconds = 60 // long cooldown that would normally suppress
+
+	ts := time.Now().Add(-time.Minute)
+	item := gh.ProjectItem{
+		Number:    61,
+		Status:    "Research",
+		ItemID:    "PVTI_61",
+		UpdatedAt: ts,
+		Labels:    []string{"fabrik:awaiting-ci"},
+	}
+
+	// Seed lastUpdatedAt so the "unchanged" path would normally trigger.
+	eng.mu.Lock()
+	eng.lastUpdatedAt["owner/repo#61"] = ts
+	eng.processedSet["owner/repo#61-Research"] = time.Now() // just processed — within cooldown
+	eng.mu.Unlock()
+
+	if !eng.itemMayNeedWork(item) {
+		t.Error("item with fabrik:awaiting-ci should bypass the updatedAt cache and return true")
+	}
+}
+
+// TestItemMayNeedWork_NoSpecialLabel_RespectsUpdatedAtCache verifies that without
+// fabrik:awaiting-ci, a stale item within cooldown is filtered (cache respected).
+func TestItemMayNeedWork_NoSpecialLabel_RespectsUpdatedAtCache(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.PollSeconds = 60 // long cooldown
+
+	ts := time.Now().Add(-time.Minute)
+	item := gh.ProjectItem{
+		Number:    62,
+		Status:    "Research",
+		ItemID:    "PVTI_62",
+		UpdatedAt: ts,
+		Labels:    []string{"stage:Validate:complete"}, // no fabrik:awaiting-ci
+	}
+
+	eng.mu.Lock()
+	eng.lastUpdatedAt["owner/repo#62"] = ts
+	eng.processedSet["owner/repo#62-Research"] = time.Now()
+	eng.mu.Unlock()
+
+	if eng.itemMayNeedWork(item) {
+		t.Error("item without bypass labels should be filtered by updatedAt cache")
+	}
+}

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -27,6 +27,8 @@ type mockGitHubClient struct {
 	updateIssueBodyFn         func(owner, repo string, issueNumber int, body string) error
 	updateProjectItemStatusFn func(projectID, itemID, statusFieldID, statusOptionID string) error
 	findPRForIssueFn          func(owner, repo string, issueNumber int) (int, error)
+	fetchLinkedPRFn           func(owner, repo string, issueNumber int) (*gh.PRDetails, error)
+	fetchCheckRunsFn          func(owner, repo, sha string) ([]gh.CheckRun, error)
 	getPRBaseFn               func(owner, repo string, prNumber int) (string, error)
 	updatePRBaseFn            func(owner, repo string, prNumber int, newBase string) error
 	mergePRFn                 func(owner, repo string, prNumber int) error
@@ -265,6 +267,26 @@ func (m *mockGitHubClient) FindPRForIssue(owner, repo string, issueNumber int) (
 		return fn(owner, repo, issueNumber)
 	}
 	return 0, nil
+}
+
+func (m *mockGitHubClient) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	m.mu.Lock()
+	fn := m.fetchLinkedPRFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, issueNumber)
+	}
+	return nil, nil
+}
+
+func (m *mockGitHubClient) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	m.mu.Lock()
+	fn := m.fetchCheckRunsFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, sha)
+	}
+	return nil, nil
 }
 
 func (m *mockGitHubClient) GetPRBase(owner, repo string, prNumber int) (string, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -679,6 +679,40 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			continue
 		}
 
+		// CI gate: evaluate CI status for stages configured with wait_for_ci: true.
+		// This runs in Phase 1 (unconditional) so CI failures are fixed regardless
+		// of auto-advance setting. checkCIGate returns (blocked, ciFailure, timedOut).
+		ciBlocked, ciFailure, ciTimedOut := e.checkCIGate(board, item, stage)
+		if ciTimedOut {
+			e.pauseForCITimeout(board, item, stage)
+			continue
+		}
+		if ciFailure {
+			iKey := issueKey(item, e.defaultRepo())
+			stageKey := iKey + "-" + stage.Name
+			if _, ok := e.inFlight.Load(iKey); ok {
+				e.logf(item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
+				continue
+			}
+			e.mu.Lock()
+			cycleCount := e.ciFixCycleCount[stageKey]
+			maxCycles := e.cfg.MaxCiFixCycles
+			e.mu.Unlock()
+			if cycleCount >= maxCycles {
+				e.pauseForCIFixCycleLimit(board, item, stage, cycleCount, maxCycles)
+			} else {
+				e.mu.Lock()
+				e.ciFixCycleCount[stageKey]++
+				e.mu.Unlock()
+				e.dispatchCIFixReinvoke(ctx, board, item, stage)
+				advancedItems[issueKey(item, e.defaultRepo())] = true
+			}
+			continue
+		}
+		if ciBlocked {
+			continue // CI still pending; re-evaluate on next poll
+		}
+
 		// Phase 2: gated stage advancement.
 		// Gate: yolo (cfg or label), cruise label, or stage-level auto_advance:true.
 		isAutoAdvance := hasYoloLabel(item) || hasCruiseLabel(item)

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -589,8 +589,8 @@ func TestYoloCatchUpMergesBeforeAdvance(t *testing.T) {
 				},
 			}, nil
 		},
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 99, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, HeadSHA: "sha1"}, nil
 		},
 	}
 	// Set after construction so the closure can reference client.
@@ -658,8 +658,8 @@ func TestYoloCatchUpSkipsAdvanceOnMergeError(t *testing.T) {
 				},
 			}, nil
 		},
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 99, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, HeadSHA: "sha1"}, nil
 		},
 		mergePRFn: func(owner, repo string, prNumber int) error {
 			return gh.ErrNotMergeable
@@ -899,8 +899,8 @@ func TestCruiseCatchUp_BothCruiseAndYolo_YoloWins(t *testing.T) {
 				},
 			}, nil
 		},
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 66, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 66, HeadSHA: "sha1"}, nil
 		},
 	}
 	eng := testEngineWithStages(client, testStagesWithValidate())

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1015,3 +1015,87 @@ func TestComputeEffectiveInterval_RateLimitExceeds5Min(t *testing.T) {
 		t.Errorf("expected 6m (rate-limit 2x of 3min base), got %v", got)
 	}
 }
+
+// TestItemMayNeedWork_WaitForCI_CompleteLabel_BypassesCache verifies that an item
+// whose stage has wait_for_ci: true AND has a stage:<name>:complete label is NOT
+// filtered by the updatedAt cache. CI check run completions don't bump the issue's
+// updatedAt, so items waiting for CI would be permanently skipped without this bypass.
+func TestItemMayNeedWork_WaitForCI_CompleteLabel_BypassesCache(t *testing.T) {
+	waitForCI := true
+	stgs := []*stages.Stage{
+		{
+			Name:       "Validate",
+			Order:      3,
+			Prompt:     "Validate it",
+			WaitForCI:  &waitForCI,
+			Completion: stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+	client := &mockGitHubClient{}
+	eng := NewWithDeps(Config{
+		Owner:         "owner",
+		Repo:          "repo",
+		ProjectNum:    1,
+		User:          "testuser",
+		Token:         "token",
+		MaxConcurrent: 5,
+		Stages:        stgs,
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+
+	fixedTime := time.Now().Add(-time.Hour)
+	item := gh.ProjectItem{
+		Number:    99,
+		ItemID:    "PVTI_99",
+		Status:    "Validate",
+		Repo:      "owner/repo",
+		UpdatedAt: fixedTime,
+		Labels:    []string{"stage:Validate:complete"},
+	}
+	// Pre-seed lastUpdatedAt so the updatedAt cache would normally return false.
+	eng.lastUpdatedAt["owner/repo#99"] = fixedTime
+
+	if !eng.itemMayNeedWork(item) {
+		t.Error("expected itemMayNeedWork to return true for wait_for_ci: true stage with complete label, got false")
+	}
+}
+
+// TestItemMayNeedWork_NoWaitForCI_CompleteLabel_FilteredByCache verifies that an item
+// whose stage does NOT have wait_for_ci: true is still filtered by the updatedAt cache
+// even when it has a stage:<name>:complete label. The CI bypass must be conditional.
+func TestItemMayNeedWork_NoWaitForCI_CompleteLabel_FilteredByCache(t *testing.T) {
+	stgs := []*stages.Stage{
+		{
+			Name:       "Validate",
+			Order:      3,
+			Prompt:     "Validate it",
+			WaitForCI:  nil, // wait_for_ci not set
+			Completion: stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+	client := &mockGitHubClient{}
+	eng := NewWithDeps(Config{
+		Owner:         "owner",
+		Repo:          "repo",
+		ProjectNum:    1,
+		User:          "testuser",
+		Token:         "token",
+		MaxConcurrent: 5,
+		Stages:        stgs,
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+
+	fixedTime := time.Now().Add(-time.Hour)
+	item := gh.ProjectItem{
+		Number:    99,
+		ItemID:    "PVTI_99",
+		Status:    "Validate",
+		Repo:      "owner/repo",
+		UpdatedAt: fixedTime,
+		Labels:    []string{"stage:Validate:complete"},
+	}
+	// Pre-seed lastUpdatedAt so the updatedAt cache returns false.
+	eng.lastUpdatedAt["owner/repo#99"] = fixedTime
+
+	if eng.itemMayNeedWork(item) {
+		t.Error("expected itemMayNeedWork to return false for non-wait_for_ci stage (filtered by cache), got true")
+	}
+}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -160,8 +160,8 @@ func (e *Engine) attemptMergeOnValidate(item gh.ProjectItem) error {
 	// Use FetchLinkedPR (REST) to get both the PR number and head SHA in one call.
 	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
-		e.logf(item.Number, "warn", "could not find PR for merge: %v\n", err)
-		return nil
+		e.logf(item.Number, "warn", "could not fetch linked PR for merge: %v — will retry\n", err)
+		return fmt.Errorf("fetch linked PR: %w", err)
 	}
 	if pr == nil {
 		e.logf(item.Number, "warn", "no linked PR found at Validate completion; skipping auto-merge\n")
@@ -172,7 +172,8 @@ func (e *Engine) attemptMergeOnValidate(item gh.ProjectItem) error {
 	if pr.HeadSHA != "" {
 		checkRuns, err := e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
 		if err != nil {
-			e.logf(item.Number, "warn", "could not fetch check runs for merge guard: %v — proceeding\n", err)
+			e.logf(item.Number, "warn", "could not fetch check runs for merge guard: %v — skipping merge until CI status can be fetched\n", err)
+			return fmt.Errorf("merge guard: fetch check runs: %w", err)
 		} else if len(checkRuns) > 0 {
 			var pending, failed []gh.CheckRun
 			for _, cr := range checkRuns {

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
@@ -66,9 +68,14 @@ func (e *Engine) handleStageComplete(board *gh.ProjectBoard, item gh.ProjectItem
 	cruiseActive := !yoloActive && hasCruiseLabel(item)
 
 	// Attempt PR merge after Validate when yolo is active.
+	// When wait_for_ci: true, skip attemptMergeOnValidate here and defer to the
+	// catch-up loop's Phase 2 CI gate (Approach A). The completion label is added
+	// below so the catch-up loop can evaluate the CI gate and attempt merge after
+	// CI passes. See ADR 027 for design rationale.
 	// This runs BEFORE adding the completion label so that on merge failure the
 	// engine can retry Validate (itemNeedsWork skips stages with a complete label).
-	if yoloActive && stage.Name == "Validate" {
+	waitForCI := stage.WaitForCI != nil && *stage.WaitForCI
+	if yoloActive && stage.Name == "Validate" && !waitForCI {
 		if err := e.attemptMergeOnValidate(item); err != nil {
 			// Merge failed: post/pause already handled inside attemptMergeOnValidate.
 			e.logf(item.Number, "warn", "PR not merged: %v\n", err)
@@ -119,6 +126,14 @@ func (e *Engine) handleStageComplete(board *gh.ProjectBoard, item gh.ProjectItem
 			}
 			return // catch-up loop will advance once reviewers submit
 		}
+		// When wait_for_ci is enabled, the catch-up loop evaluates the CI gate
+		// (checkCIGate) and dispatches CI-fix reinvokes as needed before advancing.
+		// fabrik:awaiting-ci is NOT applied here (R10c) — the catch-up loop adds
+		// it only on confirmed failure, after FetchCheckRuns.
+		if waitForCI {
+			e.logf(item.Number, "awaiting-ci", "waiting for CI checks before advancing\n")
+			return // catch-up loop evaluates CI gate and advances once checks pass
+		}
 		if err := e.advanceToNextStage(board, item, stage); err != nil {
 			e.logf(item.Number, "warn", "could not advance: %v\n", err)
 		}
@@ -127,24 +142,126 @@ func (e *Engine) handleStageComplete(board *gh.ProjectBoard, item gh.ProjectItem
 	}
 }
 
-// attemptMergeOnValidate finds the linked PR for item and merges it.
-// Returns nil on success or when no PR exists (no-PR is logged and skipped).
-// Returns an error that has been handled (comment+pause posted) on ErrNotMergeable.
+// attemptMergeOnValidate finds the linked PR for item, gates on CI status,
+// and merges it. Returns nil on success or when no PR exists.
+// Returns a handled error (comment+pause already posted) on ErrNotMergeable or
+// CI timeout. Returns a retriable error (caller should retry) when CI is pending
+// or when a transient API error occurs.
+//
+// CI gate logic (R1–R6):
+//   - No check runs → gate clears (R5: repo has no CI)
+//   - Any pending/queued → block; track ciMergePendingSince; pause after CIWaitTimeout
+//   - Any failed → add fabrik:awaiting-ci; return error
+//   - All green → clear ciMergePendingSince; clear fabrik:awaiting-ci; proceed to merge
 func (e *Engine) attemptMergeOnValidate(item gh.ProjectItem) error {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-	prNumber, err := e.client.FindPRForIssue(owner, repo, item.Number)
+	iKey := issueKey(item, e.defaultRepo())
+
+	// Use FetchLinkedPR (REST) to get both the PR number and head SHA in one call.
+	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
 		e.logf(item.Number, "warn", "could not find PR for merge: %v\n", err)
 		return nil
 	}
-	if prNumber == 0 {
+	if pr == nil {
 		e.logf(item.Number, "warn", "no linked PR found at Validate completion; skipping auto-merge\n")
 		return nil
 	}
 
-	if err := e.client.MergePR(owner, repo, prNumber); err != nil {
+	// CI gate: fetch check runs and evaluate (R1-R6).
+	if pr.HeadSHA != "" {
+		checkRuns, err := e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
+		if err != nil {
+			e.logf(item.Number, "warn", "could not fetch check runs for merge guard: %v — proceeding\n", err)
+		} else if len(checkRuns) > 0 {
+			var pending, failed []gh.CheckRun
+			for _, cr := range checkRuns {
+				switch cr.Status {
+				case "queued", "in_progress":
+					pending = append(pending, cr)
+				case "completed":
+					switch cr.Conclusion {
+					case "failure", "timed_out", "action_required":
+						failed = append(failed, cr)
+					}
+				}
+			}
+
+			if len(failed) > 0 {
+				// R3: CI failed — apply label and block merge.
+				names := make([]string, 0, len(failed))
+				for _, cr := range failed {
+					names = append(names, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
+				}
+				e.logf(item.Number, "ci-gate", "merge blocked — CI failed: %s\n", strings.Join(names, ", "))
+				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); lerr != nil {
+					e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci: %v\n", lerr)
+				}
+				// Clean up pending timer since we now have a definitive failure state.
+				e.mu.Lock()
+				delete(e.ciMergePendingSince, iKey)
+				e.mu.Unlock()
+				return fmt.Errorf("merge blocked: CI checks failed")
+			}
+
+			if len(pending) > 0 {
+				// R2: CI still running — check timeout (R6).
+				names := make([]string, 0, len(pending))
+				for _, cr := range pending {
+					names = append(names, cr.Name)
+				}
+				e.logf(item.Number, "ci-gate", "merge blocked — CI still running: %s\n", strings.Join(names, ", "))
+
+				timeout := e.cfg.CIWaitTimeout
+				if timeout <= 0 {
+					timeout = 30 * time.Minute
+				}
+				e.mu.Lock()
+				since, tracked := e.ciMergePendingSince[iKey]
+				if !tracked {
+					e.ciMergePendingSince[iKey] = time.Now()
+					since = e.ciMergePendingSince[iKey]
+				}
+				e.mu.Unlock()
+
+				if time.Since(since) >= timeout {
+					// R6: timeout elapsed — pause issue.
+					e.mu.Lock()
+					delete(e.ciMergePendingSince, iKey)
+					e.mu.Unlock()
+					msg := fmt.Sprintf("🏭 **Fabrik — CI wait timeout (merge guard)**\n\n"+
+						"Auto-merge blocked: CI checks for PR #%d have been in progress for longer than "+
+						"the configured timeout (%s). Fabrik has paused this issue for human review.\n\n"+
+						"Pending checks: %s\n\nOnce CI resolves, remove `fabrik:paused` to resume.",
+						pr.Number, timeout, strings.Join(names, ", "))
+					if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
+						e.logf(item.Number, "warn", "could not post CI timeout comment: %v\n", cerr)
+					} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+						e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+					}
+					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); lerr != nil {
+						e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", lerr)
+					}
+					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); lerr != nil {
+						e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", lerr)
+					}
+					return fmt.Errorf("merge guard: CI wait timeout elapsed after %s", timeout)
+				}
+				return fmt.Errorf("merge blocked: CI checks still running")
+			}
+
+			// R4: All checks green — clear pending timer and awaiting-ci label.
+			e.mu.Lock()
+			delete(e.ciMergePendingSince, iKey)
+			e.mu.Unlock()
+			e.removeAwaitingCILabel(owner, repo, item)
+		}
+		// R5: len(checkRuns) == 0 — no CI configured; gate clears.
+	}
+
+	if err := e.client.MergePR(owner, repo, pr.Number); err != nil {
 		if errors.Is(err, gh.ErrNotMergeable) {
-			msg := fmt.Sprintf("🏭 **Fabrik — auto-merge skipped**\n\nAuto-merge skipped: PR #%d is not mergeable (GitHub reports a merge conflict or the mergeable status is not yet computed). Please resolve any conflicts and merge manually.", prNumber)
+			msg := fmt.Sprintf("🏭 **Fabrik — auto-merge skipped**\n\nAuto-merge skipped: PR #%d is not mergeable (GitHub reports a merge conflict or the mergeable status is not yet computed). Please resolve any conflicts and merge manually.", pr.Number)
 			if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
 				e.logf(item.Number, "warn", "could not post unmergeable comment: %v\n", cerr)
 			} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -153,16 +270,15 @@ func (e *Engine) attemptMergeOnValidate(item gh.ProjectItem) error {
 			if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); lerr != nil {
 				e.logf(item.Number, "warn", "could not add fabrik:paused label: %v\n", lerr)
 			}
-			return fmt.Errorf("PR #%d not mergeable", prNumber)
+			return fmt.Errorf("PR #%d not mergeable", pr.Number)
 		}
 		// Other API errors (transient 5xx, permissions, etc.): log and return an
-		// error so the caller skips the completion label and stage advancement.
-		// The engine will retry Validate on the next cooldown cycle.
-		e.logf(item.Number, "warn", "auto-merge of PR #%d failed: %v\n", prNumber, err)
+		// error so the caller retries on the next cooldown cycle.
+		e.logf(item.Number, "warn", "auto-merge of PR #%d failed: %v\n", pr.Number, err)
 		return fmt.Errorf("auto-merge failed: %w", err)
 	}
 
-	e.logf(item.Number, "info", "auto-merged PR #%d\n", prNumber)
+	e.logf(item.Number, "info", "auto-merged PR #%d\n", pr.Number)
 	return nil
 }
 

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -1,0 +1,317 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// testEngineForMerge returns a minimal engine wired for attemptMergeOnValidate tests.
+func testEngineForMerge(client *mockGitHubClient) *Engine {
+	stgs := testStagesWithValidate()
+	return testEngineWithStages(client, stgs)
+}
+
+// TestAttemptMergeOnValidate_NoCheckRuns_MergeProceeds verifies R5: when there are
+// no CI check runs at all the gate clears and MergePR is called.
+func TestAttemptMergeOnValidate_NoCheckRuns_MergeProceeds(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil // R5: no CI
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	if err := eng.attemptMergeOnValidate(item); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(client.mergePRCalls) != 1 {
+		t.Fatalf("expected MergePR called once, got %d", len(client.mergePRCalls))
+	}
+	if client.mergePRCalls[0].prNumber != 10 {
+		t.Errorf("MergePR called with pr %d, want 10", client.mergePRCalls[0].prNumber)
+	}
+}
+
+// TestAttemptMergeOnValidate_AllGreen_MergeProceeds verifies R4: all checks green clears
+// the pending timer, removes fabrik:awaiting-ci, and proceeds to merge.
+func TestAttemptMergeOnValidate_AllGreen_MergeProceeds(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 11, HeadSHA: "sha2"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "completed", Conclusion: "success"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	// Seed a stale pending timer to confirm it gets cleared on green.
+	iKey := "owner/repo#1"
+	eng.mu.Lock()
+	eng.ciMergePendingSince[iKey] = time.Now().Add(-1 * time.Minute)
+	eng.mu.Unlock()
+
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+	if err := eng.attemptMergeOnValidate(item); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(client.mergePRCalls) != 1 {
+		t.Fatalf("expected MergePR called once, got %d", len(client.mergePRCalls))
+	}
+	eng.mu.Lock()
+	_, still := eng.ciMergePendingSince[iKey]
+	eng.mu.Unlock()
+	if still {
+		t.Error("ciMergePendingSince should be cleared on all-green")
+	}
+}
+
+// TestAttemptMergeOnValidate_CIFailed_BlocksMerge verifies R3: when any check fails,
+// merge is blocked, fabrik:awaiting-ci is added, and error is returned.
+func TestAttemptMergeOnValidate_CIFailed_BlocksMerge(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 12, HeadSHA: "sha3"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "lint", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	err := eng.attemptMergeOnValidate(item)
+	if err == nil {
+		t.Fatal("expected error when CI failed, got nil")
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("expected no MergePR on CI failure, got %d", len(client.mergePRCalls))
+	}
+	found := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected fabrik:awaiting-ci to be added on CI failure")
+	}
+}
+
+// TestAttemptMergeOnValidate_CIPending_BlocksMergeNoLabel verifies R2 + R10c: when
+// checks are still running, merge is blocked but fabrik:awaiting-ci is NOT applied.
+func TestAttemptMergeOnValidate_CIPending_BlocksMergeNoLabel(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 13, HeadSHA: "sha4"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "in_progress", Conclusion: ""},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	err := eng.attemptMergeOnValidate(item)
+	if err == nil {
+		t.Fatal("expected error when CI pending, got nil")
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("expected no MergePR on pending CI, got %d", len(client.mergePRCalls))
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			t.Error("fabrik:awaiting-ci must NOT be added when CI is only pending (R10c)")
+		}
+	}
+}
+
+// TestAttemptMergeOnValidate_CIPending_TracksTimer verifies R2: on first pending observation
+// ciMergePendingSince is populated so the timeout clock starts.
+func TestAttemptMergeOnValidate_CIPending_TracksTimer(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 14, HeadSHA: "sha5"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "ci", Status: "queued", Conclusion: ""},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+	iKey := "owner/repo#1"
+
+	eng.mu.Lock()
+	_, before := eng.ciMergePendingSince[iKey]
+	eng.mu.Unlock()
+	if before {
+		t.Fatal("expected no pending entry before first call")
+	}
+
+	_ = eng.attemptMergeOnValidate(item)
+
+	eng.mu.Lock()
+	_, after := eng.ciMergePendingSince[iKey]
+	eng.mu.Unlock()
+	if !after {
+		t.Error("expected ciMergePendingSince to be set after first pending observation")
+	}
+}
+
+// TestAttemptMergeOnValidate_CIPendingTimeout_PausesIssue verifies R6: when CI has
+// been pending longer than CIWaitTimeout the issue is paused with a comment.
+func TestAttemptMergeOnValidate_CIPendingTimeout_PausesIssue(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 15, HeadSHA: "sha6"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "slow-ci", Status: "in_progress", Conclusion: ""},
+			}, nil
+		},
+	}
+	stgs := testStagesWithValidate()
+	eng := testEngineWithStages(client, stgs)
+	eng.cfg.CIWaitTimeout = 1 * time.Millisecond // tiny timeout for test
+
+	// Pre-seed as if first observed 1 second ago (well past 1ms timeout).
+	iKey := "owner/repo#1"
+	eng.mu.Lock()
+	eng.ciMergePendingSince[iKey] = time.Now().Add(-1 * time.Second)
+	eng.mu.Unlock()
+
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+	err := eng.attemptMergeOnValidate(item)
+	if err == nil {
+		t.Fatal("expected error on CI timeout, got nil")
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("expected no MergePR on timeout, got %d", len(client.mergePRCalls))
+	}
+	if len(client.addCommentCalls) == 0 {
+		t.Error("expected timeout comment to be posted")
+	}
+	foundPaused := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			foundPaused = true
+		}
+	}
+	if !foundPaused {
+		t.Error("expected fabrik:paused label on CI timeout")
+	}
+	// ciMergePendingSince entry should be cleared after timeout.
+	eng.mu.Lock()
+	_, still := eng.ciMergePendingSince[iKey]
+	eng.mu.Unlock()
+	if still {
+		t.Error("ciMergePendingSince should be deleted after timeout fires")
+	}
+}
+
+// TestAttemptMergeOnValidate_NoPR_ReturnsNil verifies that when FetchLinkedPR finds
+// no PR, attemptMergeOnValidate returns nil (no error, no merge).
+func TestAttemptMergeOnValidate_NoPR_ReturnsNil(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	if err := eng.attemptMergeOnValidate(item); err != nil {
+		t.Fatalf("expected nil when no PR, got %v", err)
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("expected no MergePR when no PR, got %d", len(client.mergePRCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_ErrNotMergeable_PostsComment verifies that
+// ErrNotMergeable results in a comment and fabrik:paused, but no advance.
+func TestAttemptMergeOnValidate_ErrNotMergeable_PostsComment(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 20, HeadSHA: "sha7"}, nil
+		},
+		mergePRFn: func(owner, repo string, prNumber int) error {
+			return gh.ErrNotMergeable
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	err := eng.attemptMergeOnValidate(item)
+	if err == nil {
+		t.Fatal("expected error for ErrNotMergeable")
+	}
+	if len(client.addCommentCalls) == 0 {
+		t.Error("expected unmergeable comment")
+	}
+	found := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected fabrik:paused on ErrNotMergeable")
+	}
+}
+
+// TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns verifies Approach A: when
+// wait_for_ci is true, handleStageComplete adds the completion label and returns
+// without calling attemptMergeOnValidate.
+func TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns(t *testing.T) {
+	merged := false
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, HeadSHA: "sha8"}, nil
+		},
+		mergePRFn: func(owner, repo string, prNumber int) error {
+			merged = true
+			return nil
+		},
+	}
+	stgs := testStagesWithValidate()
+	eng := testEngineWithStages(client, stgs)
+
+	tr := true
+	validateStage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
+
+	eng.handleStageComplete(board, item, validateStage)
+
+	if merged {
+		t.Error("MergePR must not be called when wait_for_ci is true (Approach A)")
+	}
+	// Completion label should still be added.
+	found := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Validate:complete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected stage:Validate:complete label even with wait_for_ci=true")
+	}
+}

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -313,5 +314,50 @@ func TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected stage:Validate:complete label even with wait_for_ci=true")
+	}
+}
+
+// TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError verifies that a
+// transient FetchLinkedPR API error returns an error (retriable) rather than nil
+// (which would allow the caller to advance past Validate without merging the PR).
+func TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, errors.New("network error")
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	err := eng.attemptMergeOnValidate(item)
+	if err == nil {
+		t.Fatal("expected error when FetchLinkedPR fails, got nil (would incorrectly allow advancement)")
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("expected no MergePR on FetchLinkedPR error, got %d", len(client.mergePRCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_FetchCheckRunsError_ReturnsError verifies that a
+// transient FetchCheckRuns API error returns an error (retriable) rather than
+// proceeding to merge with unknown CI status.
+func TestAttemptMergeOnValidate_FetchCheckRunsError_ReturnsError(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, errors.New("GitHub API 503")
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	err := eng.attemptMergeOnValidate(item)
+	if err == nil {
+		t.Fatal("expected error when FetchCheckRuns fails, got nil (would proceed to merge with unknown CI status)")
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("expected no MergePR on FetchCheckRuns error, got %d", len(client.mergePRCalls))
 	}
 }

--- a/github/labels.go
+++ b/github/labels.go
@@ -28,6 +28,7 @@ var staticLabelDefs = []labelDef{
 	{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "e4e669"},
 	{"fabrik:awaiting-input", "Stage blocked on FABRIK_BLOCKED_ON_INPUT; comment to unblock", "e4e669"},
 	{"fabrik:awaiting-review", "Validate complete; waiting for requested PR reviewers", "e4e669"},
+	{"fabrik:awaiting-ci", "CI checks failed; engine is retrying CI-fix invocation", "e4e669"},
 
 	// --- danger labels (red) ---
 	{"fabrik:blocked", "Blocked by one or more open dependency issues", "d73a4a"},

--- a/github/prs.go
+++ b/github/prs.go
@@ -44,6 +44,7 @@ func (c *Client) FetchPRDetails(owner, repo string, prNumber int) (*PRDetails, e
 
 // CheckRun holds the result of a single CI check run.
 type CheckRun struct {
+	ID         int64  // GitHub check run ID (used to fetch logs via gh run view)
 	Name       string
 	Status     string // "queued", "in_progress", "completed"
 	Conclusion string // "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required", or ""
@@ -54,6 +55,7 @@ func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/check-runs", c.baseURL, owner, repo, sha)
 	var raw struct {
 		CheckRuns []struct {
+			ID         int64  `json:"id"`
 			Name       string `json:"name"`
 			Status     string `json:"status"`
 			Conclusion string `json:"conclusion"`
@@ -64,7 +66,7 @@ func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
 	}
 	out := make([]CheckRun, len(raw.CheckRuns))
 	for i, cr := range raw.CheckRuns {
-		out[i] = CheckRun{Name: cr.Name, Status: cr.Status, Conclusion: cr.Conclusion}
+		out[i] = CheckRun{ID: cr.ID, Name: cr.Name, Status: cr.Status, Conclusion: cr.Conclusion}
 	}
 	return out, nil
 }

--- a/github/prs.go
+++ b/github/prs.go
@@ -44,7 +44,7 @@ func (c *Client) FetchPRDetails(owner, repo string, prNumber int) (*PRDetails, e
 
 // CheckRun holds the result of a single CI check run.
 type CheckRun struct {
-	ID         int64  // GitHub check run ID (used to fetch logs via gh run view)
+	ID         int64  // GitHub check run ID
 	Name       string
 	Status     string // "queued", "in_progress", "completed"
 	Conclusion string // "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required", or ""

--- a/plugin/fabrik-plugin/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-review/SKILL.md
@@ -186,6 +186,16 @@ This applies anywhere in your output that reaches a GitHub comment body — Revi
 
 **If you find unfixable issues**: Do NOT output the completion marker. Describe the blocker clearly. The engine will retry after a cooldown, giving the user time to intervene.
 
+**CI-fix re-invocation**: If `wait_for_ci: true` is configured for this stage and CI checks fail after your work, the engine re-invokes you with a `🏭 **Fabrik — CI Fix Required**` comment containing:
+- Which checks failed (marked **NEW REGRESSION** if introduced by this PR, or **pre-existing** if also failing on the base branch)
+- The base branch CI status for comparison
+
+When you receive this comment:
+1. Run `gh run list --branch fabrik/issue-<N> --limit 5` then `gh run view <run-id> --log-failed` to inspect logs
+2. Fix only **NEW REGRESSION** failures — do not attempt to fix pre-existing base-branch failures
+3. Commit and push your fixes
+4. **Do NOT emit `FABRIK_STAGE_COMPLETE`** — the engine will advance once CI passes on the next poll
+
 **Output routing**: When `post_to_pr: true`, your detailed output goes on the PR and a summary goes on the issue. Include `FABRIK_SUMMARY_BEGIN`/`END` markers for the issue summary.
 
 **Mark PR ready**: If `mark_pr_ready_on_complete: true`, the engine transitions the draft PR to ready-for-review after you signal completion. Make sure everything is pushed first.

--- a/plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md
@@ -164,7 +164,17 @@ If you find major issues (wrong architecture, missing feature, design flaw):
 
 **Output routing**: When `post_to_pr: true`, detailed report goes on the PR, summary on the issue. Include `FABRIK_SUMMARY_BEGIN`/`END` markers.
 
-**After completion**: The engine may auto-advance the issue to Done. The PR is ready for human merge review.
+**After completion**: The engine evaluates CI before advancing. With `wait_for_ci: true` (default), the engine re-checks CI on every poll after you emit `FABRIK_STAGE_COMPLETE`. Advancement and auto-merge only happen once all CI checks pass.
+
+**CI-fix re-invocation**: If CI checks fail after your work, the engine re-invokes you with a `🏭 **Fabrik — CI Fix Required**` comment containing:
+- Which checks failed (marked **NEW REGRESSION** if introduced by this PR, or **pre-existing** if also failing on the base branch)
+- The base branch CI status for comparison
+
+When you receive this comment:
+1. Run `gh run list --branch fabrik/issue-<N> --limit 5` then `gh run view <run-id> --log-failed` to inspect logs
+2. Fix only **NEW REGRESSION** failures — do not attempt to fix pre-existing base-branch failures
+3. Commit and push your fixes
+4. **Do NOT emit `FABRIK_STAGE_COMPLETE`** — the engine will advance once CI passes on the next poll
 
 **If blocked**: The engine retries after a cooldown. The user can intervene via comments.
 

--- a/stages/examples/validate.yaml
+++ b/stages/examples/validate.yaml
@@ -6,5 +6,6 @@ model: sonnet
 max_turns: 50
 post_to_pr: true
 wait_for_reviews: true
+wait_for_ci: true
 completion:
   type: claude

--- a/stages/stages.go
+++ b/stages/stages.go
@@ -87,6 +87,17 @@ type Stage struct {
 	// Defaults to false (opt-in, consistent with all other stage YAML flags).
 	WaitForReviews *bool `yaml:"wait_for_reviews,omitempty"`
 
+	// WaitForCI enables the CI gate on auto-advance for this stage. When true,
+	// auto-advance is held until all CI check runs complete successfully. If any
+	// check fails, the engine dispatches a CI-fix re-invocation (mirroring the
+	// review reinvoke pattern). Defaults to false; the default Validate stage
+	// sets this to true.
+	WaitForCI *bool `yaml:"wait_for_ci,omitempty"`
+
+	// CIFixSkill names the plugin skill to invoke for CI-fix re-invocations.
+	// When absent, falls back to CommentSkill.
+	CIFixSkill string `yaml:"ci_fix_skill,omitempty"`
+
 	// CleanupWorktree causes the engine to remove the issue's worktree directory
 	// instead of invoking Claude. No prompt, lock, or in_progress label is needed.
 	// Use this for terminal stages like "Done" to reclaim disk space.


### PR DESCRIPTION
## Summary

Two coordinated engine changes address this, following the engine-driven architecture established by the review-gate pattern:

1. **Engine-level CI gate before merge.** `attemptMergeOnValidate` checks CI via `FetchCheckRuns` before calling `MergePR`. Blocks on in-progress or failed checks.

2. **Engine-level CI-fix reinvoke in the catch-up loop.** After a stage completes, the catch-up loop evaluates a `checkCIGate` function alongside `checkReviewGate`. If CI fails, it dispatches a CI-fix re-invocation (mirroring `dispatchReviewReinvoke`) — Claude is given the failure logs and base branch CI status as context, fixes, commits, pushes. The engine resumes polling. Skills are updated to document CI awareness but do not poll or wait themselves.

This is engine-driven throughout: the catch-up loop polls CI via REST (not GraphQL), keeping cost near zero and not burning stage `max_turns` on sleeping. `wait_for_ci: true` defaults to enabled on Validate only — the final gate before merge. Review and earlier stages default to `wait_for_ci: false` (opt-in per project).

## Problem

Fabrik does not check CI/CD status at any point in the pipeline. `attemptMergeOnValidate` checks `mergeable` (merge conflicts) but not commit status checks or check runs. If CI is red, Fabrik will still attempt to merge. And when CI fails during Review or Validate, there is no mechanism to address the failures — the stage signals completion and advances.

This was observed in practice: Fabrik merged PRs with failing CI checks because neither the engine nor the skills checked external CI status. Local tests (run by Claude in the Review/Validate skills) and external CI may diverge due to different environments, additional linting, or integration tests that only run in CI.

## Approach

### Approach

The implementation follows the review-gate pattern (ADR 017 + ADR 026) exactly, mirroring the two-phase design:

**Phase 1** — `checkCIGate` in the catch-up loop evaluates CI check runs via REST (`FetchCheckRuns`), returns `(blocked, ciFailure, timedOut bool)`. When CI fails, the catch-up loop dispatches `dispatchCIFixReinvoke` (like `dispatchReviewReinvoke`), which invokes Claude with failure context and base-branch CI status as a synthetic comment. Cycle cap and inFlight guard prevent tight loops.

**Phase 2 (merge guard)** — `attemptMergeOnValidate` gains a CI gate as a final safety net before calling `MergePR`, regardless of `wait_for_ci`. It calls `FetchLinkedPR` to get the head SHA, then `FetchCheckRuns` to evaluate. Timeout for the pending case is tracked via `ciMergePendingSince` (in-memory map on Engine), which is reset when CI clears.

**`handleStageComplete` integration (Approach A)** — For Validate + `wait_for_ci: true` + yolo, `handleStageComplete` adds the completion label and returns immediately (mirrors the `wait_for_reviews` path). The catch-up loop Phase 2 then calls `attemptMergeOnValidate` (with the CI gate). This is architecturally cleaner and uses the same two-phase pattern as the review gate.

**Head SHA acquisition** — Use `FetchLinkedPR` (REST, not GraphQL). It returns `PRDetails` including `HeadSHA` in one call. Both `FetchLinkedPR` and `FetchCheckRuns` are added to the `GitHubClient` interface.

**`checkCIGate` signature** — Returns `(blocked, ciFailure, timedOut bool)`. `ciFailure=true` signals CI has failed and the caller should dispatch. The catch-up loop handles dispatch, cycle count, and inFlight guard — matching the review reinvoke pattern where `buildReviewThreadComments` returns the signal and the loop decides to dispatch.

**`fabrik:awaiting-ci` label** — Added only on confirmed CI failure (R10c). Items waiting with CI still pending use a new `itemMayNeedWork` bypass: if the current stage has `WaitForCI: true` and has a `stage:X:complete` label, force-bypass the `updatedAt` cache.

All CI logic lives in a new `engine/ci.go` file (mirrors `engine/reviews.go`).

### New/Modified Files

| File | Change |
|------|--------|
| `engine/ci.go` | New: `checkCIGate`, `dispatchCIFixReinvoke`, `pauseForCITimeout`, `pauseForCIFixCycleLimit`, `removeAwaitingCILabel` |
| `engine/ci_test.go` | New: unit tests for CI gate logic |
| `stages/stages.go` | Add `WaitForCI *bool` and `CIFixSkill string` to `Stage` |
| `github/labels.go` | Add `fabrik:awaiting-ci` to `staticLabelDefs` (yellow) |
| `engine/interfaces.go` | Add `FetchCheckRuns` and `FetchLinkedPR` to `GitHubClient` |
| `engine/mocks_test.go` | Add mock fields + implementations for `FetchCheckRuns` and `FetchLinkedPR` |
| `engine/engine.go` | Add `CIWaitTimeout`, `MaxCiFixCycles` to `Config`; `ciFixCycleCount`, `ciMergePendingSince` to `Engine`; initialize in `New`/`NewWithDeps` |
| `engine/stages.go` | Modify `handleStageComplete` (Approach A); add CI gate to `attemptMergeOnValidate` |
| `engine/stages_test.go` | Add tests for CI gate in `attemptMergeOnValidate` |
| `engine/item.go` | Add `wait_for_ci` bypass in `itemMayNeedWork`; reset `ciFixCycleCount` in `clearFailedStage` |
| `engine/poll.go` | Wire `checkCIGate` and `dispatchCIFixReinvoke` into catch-up loop Phase 1 |
| `cmd/root.go` | Add `--ci-wait-timeout`, `--max-ci-fix-cycles` flags; env vars; helper functions |
| `stages/examples/validate.yaml` | Add `wait_for_ci: true` |
| `.fabrik/stages/validate.yaml` | Add `wait_for_ci: true` |
| `plugin/fabrik-plugin/skills/fabrik-review/SKILL.md` | Add CI awareness section (R11) |
| `plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md` | Add CI awareness section (R11) |
| `docs/state-machine.md` | Updates per R14 (§1.1, §1.2, §1.3, §2, §3.2, §6, §9, §10, Appendix A, §1.4) |
| `docs/USER_GUIDE.md` | New section per R15 |
| `adrs/027-ci-gate-and-fix-reinvoke.md` | New ADR for CI gate design decisions |

### Key Decisions

- **Approach A for `handleStageComplete`**: When `wait_for_ci: true`, the completion label is added and the function returns immediately — no `attemptMergeOnValidate` call. The catch-up loop Phase 2 handles merge (with its own CI gate). This mirrors the `wait_for_reviews` path exactly and prevents the current problem where `attemptMergeOnValidate` failing before the completion label blocks the catch-up loop from ever evaluating the item.

- **`checkCIGate` returns `(blocked, ciFailure, timedOut bool)`**: Third return value distinguishes "CI pending, just wait" from "CI failed, dispatch fix". This keeps `checkCIGate` as a pure gate function (like `checkReviewGate`) with dispatch handled externally by the catch-up loop. The `ciFailure` flag avoids the caller needing to re-read item labels to determine if dispatch is needed.

- **REST `FetchLinkedPR` for head SHA**: Called on each `checkCIGate` evaluation. One REST call per catch-up iteration per CI-gated item. Avoids GraphQL schema changes and quota impact. The `FetchLinkedPR` method already exists in `github/prs.go`.

- **Merge guard `ciMergePendingSince` map**: Tracks when CI was first observed as in-progress in `attemptMergeOnValidate`, keyed by `issueKey`. Cleaned up when CI clears or when the issue is paused. This enables R6 (merge guard timeout for slow CI) without requiring a GitHub label.

- **No pagination in `FetchCheckRuns`**: The existing implementation fetches one page (GitHub default: 30 check runs). This covers all practical repos. Adding pagination is out of scope. A comment in the code notes the limit.

- **`engine/ci.go` new file**: Mirrors `engine/reviews.go` structurally. All CI gate logic is co-located. The catch-up loop in `poll.go` calls into both files symmetrically.

- **ADR warranted**: The "CI label only on confirmed failure" semantics (R10c), Approach A for `handleStageComplete`, and REST-over-GraphQL for head SHA are non-obvious constraints not captured by existing ADRs. ADR 027 documents these alongside the catch-up loop extension pattern.

### Task Checklist

- [x] **Task 1**: Add `WaitForCI *bool` (yaml: `wait_for_ci,omitempty`) and `CIFixSkill string` (yaml: `ci_fix_skill,omitempty`) to `Stage` struct in `stages/stages.go`. No validation changes needed (both optional).

- [x] **Task 2**: Add `fabrik:awaiting-ci` to `staticLabelDefs` in `github/labels.go` with yellow color (`e4e669`) and description "CI checks failed; engine is retrying CI-fix invocation". Add alongside `fabrik:awaiting-review`.

- [x] **Task 3**: Add `FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)` and `FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)` to the `GitHubClient` interface in `engine/interfaces.go`.

- [x] **Task 4**: Add `fetchCheckRunsFn` and `fetchLinkedPRFn` fields plus stub implementations to `mockGitHubClient` in `engine/mocks_test.go`. Follow existing patterns (mutex-protected call tracking, fn override support).

- [x] **Task 5**: Add `CIWaitTimeout time.Duration` and `MaxCiFixCycles int` to `Config` in `engine/engine.go`. Add `ciFixCycleCount map[string]int` and `ciMergePendingSince map[string]time.Time` to `Engine`. Initialize both maps in `New()` and `NewWithDeps()`.

- [x] **Task 6**: Add `--ci-wait-timeout` (default 0, env `FABRIK_CI_WAIT_TIMEOUT`) and `--max-ci-fix-cycles` (default 0, env `FABRIK_MAX_CI_FIX_CYCLES`) flags to `cmd/root.go`. Add `ciWaitTimeout(minutes int) time.Duration` (default 30 min) and `maxCiFixCycles(n int) int` (default 5) helper functions. Wire into `engine.Config` in the `run()` function.

- [x] **Task 7**: Create `engine/ci.go` with:
  - `checkCIGate(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) (blocked, ciFailure, timedOut bool)` — calls `FetchLinkedPR` then `FetchCheckRuns`; returns appropriate flags; applies `fabrik:awaiting-ci` on failure (idempotent); removes it on green; checks timeout via `FetchLabelAppliedAt` when label is present.
  - `dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage)` — mirrors `dispatchReviewReinvoke`: marks inFlight, acquires semaphore, calls `ensureRepoReady`, emits `JobStarted/JobCompleted` events, calls `processComments` with synthetic comment containing CI failure logs + base-branch CI status. The synthetic comment body is built by: calling `FetchCheckRuns` for PR head SHA (failed runs), calling `FetchCheckRuns` for base branch HEAD SHA via `gitRevParse(workDir, "origin/"+baseBranch)`, formatting both into a structured message that identifies new regressions vs pre-existing failures.
  - `pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage)` — mirrors `pauseForReviewTimeout`; posts explanatory comment; adds `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:awaiting-ci`.
  - `pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int)` — mirrors `pauseForReviewCycleLimit`.
  - `removeAwaitingCILabel(owner, repo string, item gh.ProjectItem)` — mirrors `removeAwaitingReviewLabel`.

- [x] **Task 8**: Modify `handleStageComplete` in `engine/stages.go`: when `yoloActive && stage.Name == "Validate" && stage.WaitForCI != nil && *stage.WaitForCI`, skip `attemptMergeOnValidate` and instead add the completion label and return (catch-up loop handles merge via Phase 2 with CI gate). The existing `yoloActive && stage.Name == "Validate"` block becomes conditional on `!waitForCI`.

- [x] **Task 9**: Add CI gate to `attemptMergeOnValidate` in `engine/stages.go`: call `e.client.FetchLinkedPR(owner, repo, item.Number)` to get `PRDetails` (including head SHA). Then call `e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)`. Evaluate check runs per R1-R6: pending → check `ciMergePendingSince` timeout (if elapsed, post comment + pause + clear map entry; else return retriable error); failed → add `fabrik:awaiting-ci` label + return error; green/empty → clear `ciMergePendingSince` + proceed. Replace existing `FindPRForIssue` call with the `FetchLinkedPR` call (which returns both the PR number and head SHA in one REST call). Remove `fabrik:awaiting-ci` when CI clears.

- [x] **Task 10**: Write tests for the CI gate in `attemptMergeOnValidate` in `engine/stages_test.go`: all checks green → merge proceeds; any check failed → merge blocked, `fabrik:awaiting-ci` added; checks pending → merge blocked, no label; no check runs → merge proceeds; merge guard timeout via `ciMergePendingSince`.

- [x] **Task 11**: Add `wait_for_ci` + complete-label bypass in `itemMayNeedWork` in `engine/item.go`. After the existing `fabrik:blocked` bypass: look up the stage for `item.Status` using `stages.FindStage(e.cfg.Stages, item.Status)`. If the stage has `WaitForCI != nil && *stage.WaitForCI`, check if item has `stage:<name>:complete` label — if so, return `true` (force bypass). Also add `fabrik:awaiting-ci` to the existing label bypass loop alongside `fabrik:blocked`. In `clearFailedStage`, reset `e.ciFixCycleCount[stageKey] = 0`.

- [x] **Task 12**: Wire `checkCIGate` and `dispatchCIFixReinvoke` into the catch-up loop Phase 1 in `engine/poll.go`, after the `checkReviewGate` block. Pattern: `ciBlocked, ciFailure, ciTimedOut := e.checkCIGate(ctx, board, item, stage)`. If `ciTimedOut` → `e.pauseForCITimeout(...)`, continue. If `ciBlocked` and `ciFailure` → check inFlight; check `ciFixCycleCount` vs `MaxCiFixCycles`; either pause (`pauseForCIFixCycleLimit`) or increment count and dispatch (`dispatchCIFixReinvoke`), then continue. If `ciBlocked` (pending, no failure) → continue. If not blocked → advance proceeds.

- [x] **Task 13**: Write tests in `engine/ci_test.go`: gate clears when all checks green; gate blocks when checks in_progress; gate dispatches fix when checks failed; timeout pauses issue; no check runs returns not-blocked; `dispatchCIFixReinvoke` marks inFlight and posts synthetic comment; cycle limit pauses issue.

- [x] **Task 14**: Write test for `itemMayNeedWork` bypass in `engine/item_test.go` (or `engine/poll_test.go`): item with `wait_for_ci: true` stage and `stage:X:complete` label is not filtered by `updatedAt` cache; item without `wait_for_ci` stage is still filtered.

- [x] **Task 15**: Add `wait_for_ci: true` to `stages/examples/validate.yaml` and `.fabrik/stages/validate.yaml`.

- [x] **Task 16**: Update `plugin/fabrik-plugin/skills/fabrik-review/SKILL.md` and `plugin/fabrik-plugin/skills/fabrik-validate/SKILL.md` with a CI awareness section per R11: explain engine checks CI after completion; document `gh run view <runId> --log-failed`; explain pre-existing vs regression classification using base-branch CI context provided; note that engine pauses after `MaxCiFixCycles` failures.

- [x] **Task 17**: Update `docs/state-machine.md` per R14: add `fabrik:awaiting-ci` row to §1.1 and §1.4; add `wait_for_ci` to §1.2; add "Awaiting CI" sub-state to §1.3; add "CI check completed" event to §2; add "Awaiting CI" transition table to §3.2; add §6.3 CI Gate and CI-Fix Reinvoke section; note CI-fix in §9; update §10 off-path diagram; update Appendix A catch-up description.

- [x] **Task 18**: Update `docs/USER_GUIDE.md` per R15: add `wait_for_ci` and `ci_fix_skill` to stage config reference; add `FABRIK_CI_WAIT_TIMEOUT`/`--ci-wait-timeout` and `FABRIK_MAX_CI_FIX_CYCLES`/`--max-ci-fix-cycles` to config reference; add a "CI gate and CI-fix workflow" section explaining the full flow (engine polls after stage completes, dispatches Claude to fix, cycle cap, pause on limit).

- [x] **Task 19**: Create `adrs/027-ci-gate-and-fix-reinvoke.md` documenting: (a) Approach A for `handleStageComplete` (completion label first, catch-up loop merges) over Approach B; (b) `fabrik:awaiting-ci` label only on confirmed failure (not on pending) to avoid label churn; (c) REST `FetchLinkedPR` for head SHA over extending GraphQL; (d) merge guard as independent safety net regardless of `wait_for_ci`; (e) `checkCIGate` returns `ciFailure` flag rather than dispatching internally.

- [x] **Task 20**: Run `go build -o fabrik . && go test -race ./... && go vet ./...` and fix any compilation errors or test failures.

### Risks

- **`dispatchCIFixReinvoke` CI failure context**: The synthetic comment must include actual log content (not just check run names) so Claude can diagnose failures. The implementation needs to call `gh run view <runId> --log-failed` (via Bash in the goroutine) to fetch log text. `FetchCheckRuns` returns check run names but not log URLs or IDs. The engine needs to fetch the run ID separately (via the REST check runs API which includes `id` field — add `ID int64` to `CheckRun` struct in `github/prs.go`). The synthetic comment body then includes both the structured summary and the log content. This is a non-trivial addition to Task 7 that must not be skipped — without actual log content, Claude cannot diagnose failures.

- **`handleStageComplete` restructure**: The `yoloActive && stage.Name == "Validate"` block currently runs `attemptMergeOnValidate` unconditionally. Adding a `wait_for_ci` condition changes behavior: for `wait_for_ci: true`, no merge attempt happens in `handleStageComplete`. Tests that mock `MergePR` being called from `handleStageComplete` may need updating to reflect the new path (merge now happens in catch-up loop Phase 2).

- **inFlight guard for `dispatchCIFixReinvoke`**: The CI-fix goroutine uses `e.inFlight.Store(iKey, ...)` exactly like review reinvoke. If the review reinvoke is simultaneously in-flight for the same issue, the CI-fix dispatch would also be skipped (same key). This is correct behavior — only one reinvoke per issue can be in-flight — but it means review and CI fixes are serialized. This is intentional and matches the review gate behavior.

- **`ciMergePendingSince` for merge guard timeout (R6)**: This in-memory map resets on engine restart. If CI is pending for longer than `CIWaitTimeout` but the engine restarts during that window, the timeout clock resets. This is acceptable (same limitation as `reviewCycleCount`), but document it in the ADR.

- **`stages.FindStage` call in `itemMayNeedWork`**: `itemMayNeedWork` is called frequently (every poll, every item). Adding a `stages.FindStage` call here is a linear scan through stages. With typical Fabrik configs (5-10 stages), this is negligible. But it must be gated: only call `FindStage` if the item has any `stage:X:complete` label (check first to short-circuit).

---
Used 19/50 turns, 10k input / 15k output tokens.

## Verification

Completed all 20 plan tasks implementing the CI gate and CI-fix reinvoke workflow. Key additions: `engine/ci.go` with `checkCIGate`/`dispatchCIFixReinvoke` (mirroring the review-gate pattern), CI guard in `attemptMergeOnValidate`, `wait_for_ci`/`ci_fix_skill` stage config fields, `fabrik:awaiting-ci` label, `itemMayNeedWork` bypass for CI-pending items, CLI flags and env vars, updated Review/Validate skills with CI awareness, and comprehensive docs in `state-machine.md`, `USER_GUIDE.md`, and ADR 027. All tests pass with race detector enabled.

---

Closes #418