### PR TITLE
Fabrik stage output uses bare #N ordinals that collide with GitHub cross-reference auto-linking

### DIFF
--- a/plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md
@@ -54,6 +54,17 @@ Then update the relevant checkbox in the comment body.
 
 Do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Implement returns control to the engine without advancing the pipeline. The Implement stage continues with the remaining tasks after the comment is processed.
 
+## Numbering in your output
+
+When you number items in output that posts to a GitHub comment body — changes applied, list entries, status items — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
+
+Use bracketed or descriptive numbering instead:
+
+- ✅ `[1]`, `(1)`, `change 1`, `item 1`
+- ❌ `#1`, `#2`
+
+This applies anywhere in your output that reaches a GitHub comment body — numbered changes, enumerated items, or any inline ordinal reference.
+
 ## What You Do NOT Do
 
 - **Do not signal stage completion** — never output `FABRIK_STAGE_COMPLETE`

--- a/plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md
@@ -63,7 +63,7 @@ Use bracketed or descriptive numbering instead:
 - ✅ `[1]`, `(1)`, `change 1`, `item 1`
 - ❌ `#1`, `#2`
 
-This applies anywhere in your output that reaches a GitHub comment body — numbered changes, enumerated items, or any inline ordinal reference.
+This applies when you are using `#N` as an ordinal label for your own numbered changes, enumerated items, or inline references in content that will reach a GitHub comment body. If you intentionally mean a real GitHub issue or PR reference, using `#NNN` for that purpose is allowed.
 
 ## What You Do NOT Do
 

--- a/plugin/fabrik-plugin/skills/fabrik-plan-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-plan-comment/SKILL.md
@@ -49,6 +49,17 @@ Do not signal completion if the plan still has ambiguities, unresolved questions
 
 If the user's comment adjusts the plan but the plan still needs further refinement or the user is clearly not done providing feedback, do not signal completion.
 
+## Numbering in your output
+
+When you number items in output that posts to a GitHub comment body — tasks, decisions, list entries — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
+
+Use bracketed or descriptive numbering instead:
+
+- ✅ `[1]`, `(1)`, `task 1`, `item 1`
+- ❌ `#1`, `#2`
+
+This applies anywhere in your output that reaches a GitHub comment body — numbered tasks, enumerated decisions, or any inline ordinal reference.
+
 ## What You Do NOT Do
 
 - **Do not commit code changes** — Plan is a read-only stage; no code is modified

--- a/plugin/fabrik-plugin/skills/fabrik-plan-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-plan-comment/SKILL.md
@@ -58,7 +58,7 @@ Use bracketed or descriptive numbering instead:
 - ✅ `[1]`, `(1)`, `task 1`, `item 1`
 - ❌ `#1`, `#2`
 
-This applies anywhere in your output that reaches a GitHub comment body — numbered tasks, enumerated decisions, or any inline ordinal reference.
+This applies anywhere in your output that reaches a GitHub comment body where you are numbering your own tasks, decisions, or other inline ordinals. If you intentionally mean a GitHub issue or PR reference, `#NNN` is fine.
 
 ## What You Do NOT Do
 

--- a/plugin/fabrik-plugin/skills/fabrik-research-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-research-comment/SKILL.md
@@ -56,7 +56,7 @@ Use bracketed or descriptive numbering instead:
 - ✅ `[1]`, `(1)`, `finding 1`, `item 1`
 - ❌ `#1`, `#2`
 
-This applies anywhere in your output that reaches a GitHub comment body — numbered findings, enumerated questions, or any inline ordinal reference.
+This applies to ordinal labels for your own findings, questions, and list items anywhere in output that reaches a GitHub comment body. If you intentionally mean a GitHub cross-reference to an issue or PR, `#NNN` is allowed.
 
 ## What You Do NOT Do
 

--- a/plugin/fabrik-plugin/skills/fabrik-research-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-research-comment/SKILL.md
@@ -47,6 +47,17 @@ Do not signal completion if open questions remain, or if the research still has 
 
 If the user's comment only partially answers questions and new questions arise, do not signal completion — let the research continue.
 
+## Numbering in your output
+
+When you number items in output that posts to a GitHub comment body — findings, questions, list entries — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
+
+Use bracketed or descriptive numbering instead:
+
+- ✅ `[1]`, `(1)`, `finding 1`, `item 1`
+- ❌ `#1`, `#2`
+
+This applies anywhere in your output that reaches a GitHub comment body — numbered findings, enumerated questions, or any inline ordinal reference.
+
 ## What You Do NOT Do
 
 - **Do not commit code changes** — Research is a read-only stage; no code is modified

--- a/plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md
@@ -78,14 +78,14 @@ Do not signal completion if open questions remain or if the spec still has ambig
 
 ## Numbering in your output
 
-When you number items in output that posts to a GitHub issue or comment body — requirements, questions, list entries — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
+When you number items in output that posts to a GitHub issue or comment body — requirements, questions, list entries — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in an issue or comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
 
 Use bracketed or descriptive numbering instead:
 
 - ✅ `[1]`, `(1)`, `finding 1`, `item 1`
 - ❌ `#1`, `#2`
 
-This applies anywhere in your output that reaches a GitHub comment body — numbered lists, enumerated questions, or any inline ordinal reference.
+This applies to your own numbered items or inline ordinal references anywhere in output that reaches a GitHub issue or comment body. If you intentionally mean to reference an actual GitHub issue or PR, using `#NNN` is allowed.
 
 ## What You Do NOT Do
 

--- a/plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md
@@ -76,6 +76,17 @@ When all questions are resolved and the spec is clear and complete, signal compl
 
 Do not signal completion if open questions remain or if the spec still has ambiguities that would impede the Research stage.
 
+## Numbering in your output
+
+When you number items in output that posts to a GitHub issue or comment body — requirements, questions, list entries — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
+
+Use bracketed or descriptive numbering instead:
+
+- ✅ `[1]`, `(1)`, `finding 1`, `item 1`
+- ❌ `#1`, `#2`
+
+This applies anywhere in your output that reaches a GitHub comment body — numbered lists, enumerated questions, or any inline ordinal reference.
+
 ## What You Do NOT Do
 
 - **Do not add new scope or requirements** unless the user's comment explicitly introduces them

--- a/plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md
@@ -63,7 +63,7 @@ Use bracketed or descriptive numbering instead:
 - ✅ `[1]`, `(1)`, `check 1`, `finding 1`
 - ❌ `#1`, `#2`
 
-This applies anywhere in your output that reaches a GitHub comment body — numbered findings, enumerated checks, or any inline ordinal reference.
+This applies to ordinal numbering in any output that reaches a GitHub comment body — numbered findings, enumerated checks, or inline references to your own list items. If you intentionally mean a GitHub issue or PR cross-reference, `#NNN` is allowed.
 
 ## What You Do NOT Do
 

--- a/plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md
@@ -54,6 +54,17 @@ By default, do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Validat
 
 When in doubt, do not signal completion — let the user be explicit.
 
+## Numbering in your output
+
+When you number items in output that posts to a GitHub comment body — validation findings, checks, list entries — **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
+
+Use bracketed or descriptive numbering instead:
+
+- ✅ `[1]`, `(1)`, `check 1`, `finding 1`
+- ❌ `#1`, `#2`
+
+This applies anywhere in your output that reaches a GitHub comment body — numbered findings, enumerated checks, or any inline ordinal reference.
+
 ## What You Do NOT Do
 
 - **Do not signal completion without explicit user direction** — do not infer completion from partial positive feedback


### PR DESCRIPTION
## Summary

Update the affected comment-review skills (at minimum `fabrik-review-comment`, likely also `fabrik-specify-comment`, `fabrik-research-comment`, `fabrik-plan-comment`, `fabrik-implement-comment`, `fabrik-validate-comment`) to explicitly prohibit bare `#N` ordinals when numbering review findings or list items. Suggest `[1]`, `(1)`, `finding 1:`, or `Gemini finding 1:` as safe alternatives.

Consider whether the same guidance belongs in the non-comment stage skills too (Review, Implement, Validate) — any stage output that reaches a GitHub comment body is vulnerable.

## Problem

When the Review (and likely other) comment-review stage produces output that numbers findings with bare `#1`, `#2`, etc., GitHub's issue renderer treats those tokens as cross-references to **issues #1 and #2 in the same repository**. This produces jarring, incorrect-looking output where totally unrelated issue titles are auto-linked into Fabrik's stage comment.

### Concrete example (verveguy/liminis#609, comment 4256711678)

Claude's raw output contained:

```
Fixed:
- **Gemini #1** (security-medium, beads-handlers.ts line 90): ...
- **Gemini #2** (UX, AgentSidebar.tsx line 257): ...

Dismissed:
- **Copilot #1** (20-item pagination limit): ...
- **Copilot #2** (defaults in createBead() wrapper): ...
```

GitHub's renderer linked `#1` → liminis#1 ("Redesign app icon and enhance Settings panel") and `#2` → liminis#2 ("Add 'New Folder' button to onboarding file picker"), so hovercards / client previews surface those unrelated titles right next to the reviewer name. The user reading the issue sees "Gemini Redesign app icon and enhance Settings panel #1" and reasonably asks why the comment is quoting PRs from other issues.

This was produced by the `fabrik-review-comment` skill, which does NOT templatize `#N` — the pattern came from Claude's freeform prose. Any skill that outputs markdown into a GitHub issue/PR body has the same hazard.

## Approach

### Approach

All required changes are already committed on branch `fabrik/issue-410` across two commits:
- User's manual patch (`e99436c`, merged into main): `fabrik-review/SKILL.md` and `fabrik-review-comment/SKILL.md`
- Automated patch (`31bdf68`, on this branch): remaining five `*-comment` skill files

The approach is prompt-only: add a "Numbering findings in your output" section to each affected skill file that provides both a positive instruction (use `[N]` or `(N)`) and a negative instruction (don't use `#N`) with the rationale (GitHub auto-links bare `#N` to unrelated issues in the same repository). No engine code was changed, consistent with R5.

The Implement stage's job is to verify the changes are correct and complete, confirm the binary builds cleanly (embedded skill files compile as part of the binary), and close out the checklist.

### New/Modified Files

| File | Change |
|------|--------|
| `plugin/fabrik-plugin/skills/fabrik-review-comment/SKILL.md` | Added "Numbering findings in your output" section (R1, R2) |
| `plugin/fabrik-plugin/skills/fabrik-review/SKILL.md` | Added "Numbering findings in your output" section (R3) |
| `plugin/fabrik-plugin/skills/fabrik-specify-comment/SKILL.md` | Added "Numbering in your output" section (R2) |
| `plugin/fabrik-plugin/skills/fabrik-research-comment/SKILL.md` | Added "Numbering in your output" section (R2) |
| `plugin/fabrik-plugin/skills/fabrik-plan-comment/SKILL.md` | Added "Numbering in your output" section (R2) |
| `plugin/fabrik-plugin/skills/fabrik-implement-comment/SKILL.md` | Added "Numbering in your output" section (R2) |
| `plugin/fabrik-plugin/skills/fabrik-validate-comment/SKILL.md` | Added "Numbering in your output" section (R2) |

### Key Decisions

- **Prompt guidance only, no engine post-processing**: R5 explicitly rules out regex substitution. False positives (mangling legitimate `#392` references) outweigh the marginal safety benefit. Prompt guidance with clear rationale is reliable for this well-understood pattern.
- **Both positive and negative instructions with rationale**: R4 requires the "why" (GitHub cross-reference auto-linking). Agents reliably follow rules when the reason is explicit.
- **Acceptable forms**: `[N]`, `(N)`, or descriptive forms like `finding 1` / `Gemini finding 1`. The exact form is left flexible per R1.
- **No ADR needed**: This is a prompt-wording convention, not a design decision that constrains future contributors or requires discovery. The guidance is self-contained in the skill files.
- **No documentation update needed**: These are internal skill prompts that guide Claude's output formatting. They don't add CLI commands, config options, labels, or user-visible workflow steps. Neither `docs/state-machine.md` nor `docs/stage-lifecycle.md` is affected.

### Task Checklist

- [ ] Task 1: Verify `fabrik-review-comment/SKILL.md` contains the "Numbering findings in your output" section with positive instruction (`[N]`/`(N)`), negative instruction (no bare `#N`), and rationale (GitHub auto-link) — satisfies R1 and R2
- [ ] Task 2: Verify `fabrik-review/SKILL.md` contains the equivalent numbering guidance section targeting the Review Findings output template — satisfies R3
- [ ] Task 3: Verify `fabrik-specify-comment/SKILL.md`, `fabrik-research-comment/SKILL.md`, `fabrik-plan-comment/SKILL.md`, `fabrik-implement-comment/SKILL.md`, and `fabrik-validate-comment/SKILL.md` each contain the equivalent guidance — satisfies R2
- [ ] Task 4: Confirm all seven sections include both the positive instruction and negative instruction with rationale (R4 compliance check)
- [ ] Task 5: Build the binary (`go build -o fabrik .`) to confirm the embedded skill files compile cleanly — the `//go:embed` directive in `plugin/embed.go` bakes these files in; a build failure would indicate a file path or embed issue
- [ ] Task 6: Run `go vet ./...` to confirm no static analysis issues
- [ ] Task 7: Confirm no incidental `#N` occurrences in the added guidance sections themselves (the guidance should not accidentally create what it prohibits)

### Risks

- **No implementation risks**: All changes are prompt text additions. The only binary risk is an embed path error, which `go build` will catch immediately.
- **Incidental `#N` in examples**: The guidance sections use `#N` in their negative examples (showing what NOT to do). These are in skill files embedded in the binary, not GitHub comment bodies, so they don't trigger auto-linking — but Implement should confirm this is handled clearly in context.

---
Used 8/50 turns, 3k input / 3k output tokens.

## Verification

All seven skill files already had the required `#N` auto-link prohibition guidance committed. Verified each file contains both the positive instruction (use `[N]`/`(N)`) and negative instruction (avoid `#N`) with the GitHub cross-reference rationale. Binary builds cleanly with embedded skills, `go vet` passes, and all `#N` occurrences in examples are wrapped in backtick code spans (which GitHub does not auto-link). No new code changes were needed.

---

Closes #410