### PR TITLE
Update docs for v0.0.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ requires auto-advance to be active):
 > built-in default is used and the env var is bypassed. See
 > [USER_GUIDE.md §10](docs/USER_GUIDE.md#pending-reviewer-gate) for details.
 
+The Validate stage also ships with `wait_for_ci: true` enabled by default. Fabrik gates auto-advance and auto-merge on CI checks passing; if checks fail, it re-invokes the stage agent with a structured failure report to fix the regression.
+
 If a stage doesn't complete (e.g., unfixable issues found), it retries after
 a cooldown period rather than being permanently skipped.
 
@@ -306,6 +308,7 @@ Fabrik uses labels to track state:
 | `fabrik:awaiting-input` | Stage is paused waiting for user input; auto-clears when a new comment from the configured user (`--user`) is received |
 | `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; managed automatically by the engine |
 | `fabrik:awaiting-review` | Applied optimistically by the engine whenever a `wait_for_reviews: true` stage completes (reviewer request data may still be stale at that moment); removed when no requested reviewers are outstanding and at least one review has been submitted (the dual condition catches bot reviewers like Copilot and Gemini that self-trigger via webhook without appearing in the formal reviewer list), or when the reviewer-wait timeout elapses as a fallback (`--review-wait-timeout` / `FABRIK_REVIEW_WAIT_TIMEOUT`), at which point the issue is paused with `fabrik:awaiting-input` |
+| `fabrik:awaiting-ci` | Applied when CI checks fail on a `wait_for_ci: true` stage; triggers cache bypass so CI results are re-evaluated on every poll; cleared when all checks pass or the CI wait timeout elapses, at which point the issue is paused with `fabrik:awaiting-input` |
 | `stage:<name>:complete` | Stage has been completed |
 | `stage:<name>:in_progress` | Stage is actively running |
 | `stage:<name>:failed` | Stage hit max retries and was paused |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ requires auto-advance to be active):
 > built-in default is used and the env var is bypassed. See
 > [USER_GUIDE.md §10](docs/USER_GUIDE.md#pending-reviewer-gate) for details.
 
-The Validate stage also ships with `wait_for_ci: true` enabled by default. Fabrik gates auto-advance and auto-merge on CI checks passing; if checks fail, it re-invokes the stage agent with a structured failure report to fix the regression.
+The Validate stage also ships with `wait_for_ci: true` enabled by default. Fabrik gates auto-advance and, when applicable, auto-merge on CI checks passing; if checks fail, it re-invokes the stage agent with a structured CI-fix report to address new-regression failures.
 
 If a stage doesn't complete (e.g., unfixable issues found), it retries after
 a cooldown period rather than being permanently skipped.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1219,6 +1219,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:paused` | Processing paused (max retries exceeded or manual) |
 | `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user |
 | `fabrik:awaiting-review` | Set when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding **and** at least one review has been submitted (then re-invocation fires unconditionally), or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
+| `fabrik:awaiting-ci` | Set when CI checks fail on a `wait_for_ci: true` stage; triggers `itemMayNeedWork` cache bypass so CI results are re-evaluated on every poll; cleared when all checks pass or the CI wait timeout elapses (then issue is paused with `fabrik:awaiting-input`). See [§3 CI Gate](USER_GUIDE.md#ci-gate-and-ci-fix-workflow). |
 | `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; added and removed automatically by the engine (Fabrik creates this label on first use — no pre-creation needed) |
 | `stage:<name>:in_progress` | Stage actively running |
 | `stage:<name>:complete` | Stage completed successfully |
@@ -1254,7 +1255,7 @@ The `base:<branch>` label is read on every stage invocation, so a change takes e
 | **After Specify, before Research** | Fairly clean. The worktree exists but no commits yet. The next stage's `updateWorktreeFromMain` rebases onto the new base — usually no conflict. |
 | **After Research, before Implement** | Similar — Research is read-only, so no commits. Rebase onto the new base works. |
 | **After Implement (commits exist, no PR yet)** | Messy. The issue branch has commits forked from the old base. Rebase onto the new base may produce conflicts that Claude must resolve. The PR, when created, will target the new base correctly. |
-| **After PR creation** | **Broken without manual intervention today.** The PR's base is set at creation time. Fabrik does not currently update the PR's base when the label changes, so the PR keeps targeting the old base even though new stage runs use the new base. Tracking the fix in issue #416. Workaround: edit the PR's base branch manually via the GitHub UI, or close the PR and delete the issue branch to let Fabrik recreate it. |
+| **After PR creation** | Fabrik automatically updates the PR's base branch when the `base:<branch>` label changes mid-pipeline. No manual intervention required. |
 
 **Natural language in the issue body is NOT parsed.** Writing "use the `develop` branch" in the Problem section has no effect on Fabrik's base-branch selection. The `base:<branch>` label is the only structured signal.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -295,6 +295,20 @@ description: >-
           <code>fabrik:awaiting-input</code> for human review.
         </div>
       </div>
+      <div class="feature-card">
+        <span class="feature-icon">✅</span>
+        <div class="feature-title">CI Gate</div>
+        <div class="feature-desc">
+          Set <code>wait_for_ci: true</code> on a stage (the Validate stage ships
+          with this enabled by default) and Fabrik blocks auto-advance and
+          auto-merge until all CI checks pass. On failure, Fabrik re-invokes the
+          stage agent with a structured report classifying each failed check as a
+          new regression or pre-existing failure, so it can fix the code and push
+          again. Cycle limit (<code>--max-ci-fix-cycles</code>) and timeout
+          (<code>FABRIK_CI_WAIT_TIMEOUT</code>) exceeded pauses the issue with
+          <code>fabrik:awaiting-input</code> for human review.
+        </div>
+      </div>
     </div>
 
     <div class="factory-callout">

--- a/docs/index.md
+++ b/docs/index.md
@@ -304,9 +304,10 @@ description: >-
           auto-merge until all CI checks pass. On failure, Fabrik re-invokes the
           stage agent with a structured report classifying each failed check as a
           new regression or pre-existing failure, so it can fix the code and push
-          again. Cycle limit (<code>--max-ci-fix-cycles</code>) and timeout
-          (<code>FABRIK_CI_WAIT_TIMEOUT</code>) exceeded pauses the issue with
-          <code>fabrik:awaiting-input</code> for human review.
+          again. If the cycle limit (<code>--max-ci-fix-cycles</code>) or
+          timeout (<code>FABRIK_CI_WAIT_TIMEOUT</code>) is exceeded, Fabrik
+          pauses the issue with <code>fabrik:awaiting-input</code> for human
+          review.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Apply targeted updates to three files:
- **USER_GUIDE.md**: Add `fabrik:awaiting-ci` to the §6 Fabrik-Managed Labels table; update the `base:<branch>` timing table's "After PR creation" row to reflect the #416 fix (remove broken/workaround language, document current behavior).
- **README.md**: Add `fabrik:awaiting-ci` to the Labels table; add a sentence about the CI gate in the "Review and Fix" section or a nearby feature list entry.
- **docs/index.md**: Add a CI Gate feature card to the features grid (parallel to the existing "Pending Reviewer Gate" card).

## Problem

v0.0.43 shipped two new features that are either missing from or incorrectly documented in the user-facing docs:
1. The CI gate (`wait_for_ci: true`) label `fabrik:awaiting-ci` is absent from every label reference table (USER_GUIDE §6, README.md).
2. The `base:<branch>` mid-pipeline PR sync fix (#416) is shipped, but the timing table in USER_GUIDE §6 still describes it as "broken without manual intervention today" with a workaround — the workaround and broken-status language must be removed and replaced with current behavior.
3. The CI gate is a significant feature not represented in the docs/index.md features grid (the reviewer gate has a card; the CI gate does not).

## Approach

### Approach

Pure documentation edit — 5 targeted changes across 3 files. Each change is independent; they can be made in any order. No code, no tests, no ADRs. The research has already specified exact content for every edit; the Implement agent can apply them mechanically.

The approach is to make each edit as a distinct commit so the history is traceable, then push.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add `fabrik:awaiting-ci` row to Fabrik-Managed Labels table; replace broken "After PR creation" row in base-branch timing table |
| `README.md` | Add `fabrik:awaiting-ci` row to Labels table; add CI gate sentence after review-gate config block |
| `docs/index.md` | Add CI Gate feature card to features-grid div |

### Key Decisions

- **All 5 edits in 3 commits (one per file)**: Grouping edits by file keeps each commit cohesive and easier to review. The alternative (one commit per logical change) would produce 5 commits for what is essentially a single documentation update pass.
- **No ADRs**: This is documentation-only. No architectural decisions are being made.
- **No new USER_GUIDE sections**: As specified, §3 already has comprehensive CI gate prose. The label table rows reference it rather than duplicating content.

### Task Checklist

- [ ] Task 1: Edit `docs/USER_GUIDE.md` — add `fabrik:awaiting-ci` row after `fabrik:awaiting-review` in the Fabrik-Managed Labels table (line 1221), and replace the "After PR creation" row in the base-branch timing table (line 1257) with current behavior text; commit
- [ ] Task 2: Edit `README.md` — add `fabrik:awaiting-ci` row after `fabrik:awaiting-review` in the Labels table (line 308), and add CI gate sentence after the review-gate config block (after line 145); commit
- [ ] Task 3: Edit `docs/index.md` — add CI Gate feature card after the Pending Reviewer Gate card (after line 297, before closing `</div>` of `features-grid`); commit
- [ ] Task 4: Push branch and verify all three files look correct with `git diff origin/main`

### Exact content for each edit

**Task 1a — USER_GUIDE.md labels table** (insert after line 1221):
```
| `fabrik:awaiting-ci` | Set when CI checks fail on a `wait_for_ci: true` stage; triggers `itemMayNeedWork` cache bypass so CI results are re-evaluated on every poll; cleared when all checks pass or the CI wait timeout elapses (then issue is paused with `fabrik:awaiting-input`). See [§3 CI Gate](USER_GUIDE.md#ci-gate-and-ci-fix-workflow). |
```

**Task 1b — USER_GUIDE.md base-branch timing table** (replace line 1257 "After PR creation" row entirely):
```
| **After PR creation** | Fabrik automatically updates the PR's base branch when the `base:<branch>` label changes mid-pipeline. No manual intervention required. |
```

**Task 2a — README.md labels table** (insert after line 308):
```
| `fabrik:awaiting-ci` | Applied when CI checks fail on a `wait_for_ci: true` stage; triggers cache bypass so CI results are re-evaluated on every poll; cleared when all checks pass or the CI wait timeout elapses, at which point the issue is paused with `fabrik:awaiting-input` |
```

**Task 2b — README.md CI gate sentence** (insert after line 145, after the review-gate config block):
```
The Validate stage also ships with `wait_for_ci: true` enabled by default. Fabrik gates auto-advance and auto-merge on CI checks passing; if checks fail, it re-invokes the stage agent with a structured failure report to fix the regression.
```

**Task 3 — docs/index.md CI Gate card** (insert after line 297, before `</div>` closing features-grid):
```html
      <div class="feature-card">
        <span class="feature-icon">✅</span>
        <div class="feature-title">CI Gate</div>
        <div class="feature-desc">
          Set <code>wait_for_ci: true</code> on a stage (the Validate stage ships
          with this enabled by default) and Fabrik blocks auto-advance and
          auto-merge until all CI checks pass. On failure, Fabrik re-invokes the
          stage agent with a structured report classifying each failed check as a
          new regression or pre-existing failure, so it can fix the code and push
          again. Cycle limit (<code>--max-ci-fix-cycles</code>) and timeout
          (<code>FABRIK_CI_WAIT_TIMEOUT</code>) exceeded pauses the issue with
          <code>fabrik:awaiting-input</code> for human review.
        </div>
      </div>
```

### Risks

None. All changes are isolated documentation edits. No logic, no tests, no dependencies.

---
Used 10/50 turns, 3k input / 2k output tokens.

## Verification

Applied all 5 targeted documentation edits across 3 files: added `fabrik:awaiting-ci` to the Fabrik-Managed Labels tables in both `docs/USER_GUIDE.md` and `README.md`; replaced the stale "Broken without manual intervention today" row in the `base:<branch>` timing table with accurate current behavior; added a CI gate sentence in the README "Review and Fix" section; and added a CI Gate feature card to the `docs/index.md` features grid. Three commits pushed to `fabrik/issue-424`.

---

Closes #424