### PR TITLE
Silent breaking change: update_issue_body flag has no migration for existing projects

### DIFF
--- a/.fabrik/stages/specify.yaml
+++ b/.fabrik/stages/specify.yaml
@@ -3,7 +3,6 @@ order: 0
 skill: fabrik-specify
 comment_skill: fabrik-specify-comment
 auto_advance: false
-update_issue_body: true
 model: sonnet
 max_turns: 50
 read_only: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,6 @@ allowed_tools:                  # Optional: REPLACES the default tool set (not a
                                 # Bash(pnpm:*), Bash(make:*), Bash(cargo:*), Bash(python:*), Bash(pip:*),
                                 # Bash(uv:*), Bash(pytest:*), Bash(ls:*), Bash(cat:*), Bash(rm:*), Bash(cp:*),
                                 # Bash(mv:*), Bash(mkdir:*), Bash(find:*).
-update_issue_body: false        # Allow FABRIK_ISSUE_UPDATE markers to modify issue body (by convention, Specify only)
 post_to_pr: true                # Post output to linked PR instead of issue
 create_draft_pr: true           # Create draft PR before stage runs
 mark_pr_ready_on_complete: true # Mark PR ready when stage completes

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ model: sonnet             # Optional: claude model to use
 max_turns: 50             # Optional: max conversation turns per stage invocation
 comment_max_turns: 15     # Optional: max turns when processing user comments (default: min(max_turns,15))
 read_only: false          # Optional: stash/restore worktree; use for analysis stages (Specify, Research)
-update_issue_body: false  # Optional: allow FABRIK_ISSUE_UPDATE markers to modify issue body (Specify only)
 post_to_pr: true          # Optional: post output on linked PR instead of issue
 create_draft_pr: true     # Optional: push branch and create draft PR before Claude runs
 mark_pr_ready_on_complete: true  # Optional: mark PR ready after stage completes

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -457,9 +457,6 @@ comment_max_turns: 15     # Optional. Max turns when processing user comments. D
 read_only: true           # Optional. Stashes the dirty worktree before Claude runs and
                           #   restores it after. Use for analysis stages that should not
                           #   modify files (e.g., Specify, Research).
-update_issue_body: false  # Optional. Allow FABRIK_ISSUE_UPDATE_BEGIN/END markers in Claude
-                          #   output to update the issue body. By convention only Specify
-                          #   sets this to true.
 post_to_pr: true          # Optional. Routes detailed Claude output to the linked PR; a
                           #   brief summary is still posted on the issue. Falls back to
                           #   posting on the issue if no linked PR is found.

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -17,11 +17,11 @@ Backlog → Specify → Research → Plan → Implement → Review → Validate 
 
 | Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | MaxTurns |
 |-------|-------|-----------|----------|---------------|-------------|----------|
-| Specify | 0 | Yes | No | No | No | 20 |
+| Specify | 0 | Yes | No | No | No | 50 |
 | Research | 1 | Yes | No | No | No | 50 |
 | Plan | 2 | Yes | No | No | No | 50 |
 | Implement | 3 | No | Yes | Yes | Yes | 50 |
-| Review | 4 | No | Yes | No | Yes | 30 |
+| Review | 4 | No | Yes | No | Yes | 50 |
 | Validate | 5 | No | Yes | No | No | 50 |
 | Done | 99 | N/A | No | No | No | N/A |
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -15,15 +15,15 @@ This document describes what the Fabrik engine does before, during, and after ea
 Backlog → Specify → Research → Plan → Implement → Review → Validate → Done
 ```
 
-| Stage | Order | Read-Only | UpdateIssueBody | PostToPR | CreateDraftPR | MarkPRReady | MaxTurns |
-|-------|-------|-----------|-----------------|----------|---------------|-------------|----------|
-| Specify | 0 | Yes | Yes | No | No | No | 20 |
-| Research | 1 | Yes | No | No | No | No | 50 |
-| Plan | 2 | Yes | No | No | No | No | 50 |
-| Implement | 3 | No | No | Yes | Yes | Yes | 50 |
-| Review | 4 | No | No | Yes | No | Yes | 30 |
-| Validate | 5 | No | No | Yes | No | No | 50 |
-| Done | 99 | N/A | N/A | No | No | No | N/A |
+| Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | MaxTurns |
+|-------|-------|-----------|----------|---------------|-------------|----------|
+| Specify | 0 | Yes | No | No | No | 20 |
+| Research | 1 | Yes | No | No | No | 50 |
+| Plan | 2 | Yes | No | No | No | 50 |
+| Implement | 3 | No | Yes | Yes | Yes | 50 |
+| Review | 4 | No | Yes | No | Yes | 30 |
+| Validate | 5 | No | Yes | No | No | 50 |
+| Done | 99 | N/A | No | No | No | N/A |
 
 ---
 
@@ -186,9 +186,9 @@ If parsing fails: error message posted instead of raw output. Full output in log
 ### Issue Body Update
 
 Before posting output, checks for `FABRIK_ISSUE_UPDATE_BEGIN`/`END` markers:
-- **Only applied if `update_issue_body: true`** (Specify only)
-- Other stages: warning logged, markers stripped, issue body untouched
-- Enforced by the engine — skills can't override this
+- When present, the issue body is updated unconditionally
+- By convention, only the Specify stage produces these markers
+- Markers are always stripped from output before posting
 
 ### Marker Stripping
 
@@ -265,7 +265,7 @@ A comment is "new" if it:
 5. **Claude invoked** with `comment_skill` (or default comment prompt)
    - Always resumes existing session
 6. **Output processed**:
-   - `FABRIK_ISSUE_UPDATE` markers: applied if `update_issue_body: true`, stripped regardless
+   - `FABRIK_ISSUE_UPDATE` markers: applied unconditionally when present, then stripped
    - All Fabrik markers stripped
    - Stage comment rewritten (or created) via `findStageComment` + `UpdateComment`
    - Exception: `post_to_pr` stages post a new "(comment review)" comment on the issue
@@ -299,7 +299,7 @@ For `post_to_pr` stages, comment processing posts a new "(comment review)" comme
 | Worktree update | Skip on retry | Always rebase |
 | Completion | Checked, honored | Checked, honored |
 | Blocked-on-input | Checked, honored | Not checked |
-| Issue body update | If `update_issue_body: true` | If `update_issue_body: true` |
+| Issue body update | When markers present | When markers present |
 | Output destination | Stage comment or PR | Rewrite stage comment or new issue comment |
 | Lock | `fabrik:locked:<user>` | `fabrik:editing` |
 | Reaction flow | Comments marked seen (rocket) | Eyes → editing → rocket |
@@ -323,7 +323,7 @@ The Done stage (`cleanup_worktree: true`) is terminal:
 |--------|-----------|---------|---------------|
 | `FABRIK_STAGE_COMPLETE` | Claude -> Engine | Stage finished successfully; honored even on non-zero Claude exit (v0.0.26+) — engine logs a warning | Stage runs AND comment processing |
 | `FABRIK_BLOCKED_ON_INPUT` | Claude -> Engine | Stage needs user input | Stage runs only |
-| `FABRIK_ISSUE_UPDATE_BEGIN/END` | Claude -> Engine | Updated issue body | Stage runs AND comment processing (gated by `update_issue_body`) |
+| `FABRIK_ISSUE_UPDATE_BEGIN/END` | Claude -> Engine | Updated issue body | Stage runs AND comment processing |
 | `FABRIK_SUMMARY_BEGIN/END` | Claude -> Engine | Brief summary for issue | Stage runs with `post_to_pr: true` |
 
 ## Labels Reference
@@ -357,7 +357,6 @@ allowed_tools:              # Optional: restrict Claude's tools
   - Read
   - Grep
 read_only: false            # Stash/restore worktree (for analysis stages)
-update_issue_body: false    # Allow FABRIK_ISSUE_UPDATE to modify issue body (Specify only)
 post_to_pr: false           # Route output to linked PR
 create_draft_pr: false      # Create draft PR on completion
 mark_pr_ready_on_complete: false  # Mark PR ready on completion

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -23,15 +23,15 @@ Issues traverse a linear pipeline of stages, each corresponding to a column on t
 Specify → Research → Plan → Implement → Review → Validate → Done
 ```
 
-| Stage | Order | Read-Only | UpdateIssueBody | PostToPR | CreateDraftPR | MarkPRReady | WaitForReviews | CleanupWorktree |
-|-------|-------|-----------|-----------------|----------|---------------|-------------|----------------|-----------------|
-| Specify | 0 | Yes | Yes | No | No | No | No | No |
-| Research | 1 | Yes | No | No | No | No | No | No |
-| Plan | 2 | Yes | No | No | No | No | No | No |
-| Implement | 3 | No | No | Yes | Yes | Yes | No | No |
-| Review | 4 | No | No | Yes | No | Yes | Yes* | No |
-| Validate | 5 | No | No | Yes | No | No | Yes* | No |
-| Done | 99 | N/A | N/A | No | No | No | No | Yes |
+| Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | WaitForReviews | CleanupWorktree |
+|-------|-------|-----------|----------|---------------|-------------|----------------|-----------------|
+| Specify | 0 | Yes | No | No | No | No | No |
+| Research | 1 | Yes | No | No | No | No | No |
+| Plan | 2 | Yes | No | No | No | No | No |
+| Implement | 3 | No | Yes | Yes | Yes | No | No |
+| Review | 4 | No | Yes | No | Yes | Yes* | No |
+| Validate | 5 | No | Yes | No | No | Yes* | No |
+| Done | 99 | N/A | No | No | No | No | Yes |
 
 \* All flags in this table reflect the **default stage configuration** shipped in `.fabrik/stages/`. Each flag is opt-in per stage YAML and may differ in custom configurations. `wait_for_reviews` is enabled for Review and Validate in the defaults.
 
@@ -393,7 +393,7 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 3 | Ensure worktree exists | `EnsureWorktree()` | Creates or updates worktree; writes context files |
 | 4 | Invoke Claude with comment review prompt | `InvokeForComments()` | Uses `comment_prompt` / `comment_skill` and `comment_max_turns` |
 | 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
-| 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Only applied if `update_issue_body: true` |
+| 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Applied unconditionally when markers are present; stripped from output regardless |
 | 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_SUMMARY_BEGIN/END |
 | 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
 | 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -149,15 +149,11 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	completed := checkCompletion(stage, output)
 	summary := extractSummary(output)
 
-	// Step 6: Strip FABRIK_ISSUE_UPDATE block from output, then update issue body if allowed.
+	// Step 6: Strip FABRIK_ISSUE_UPDATE block from output, then update issue body.
 	if updatedBody := extractUpdatedBody(output); updatedBody != "" {
-		if stage.UpdateIssueBody {
-			e.logf(item.Number, "edit", "updating issue body\n")
-			if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
-				e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
-			}
-		} else {
-			e.logf(item.Number, "warn", "stage %q comment processing produced FABRIK_ISSUE_UPDATE markers but is not allowed to update the issue body — ignoring\n", stage.Name)
+		e.logf(item.Number, "edit", "updating issue body\n")
+		if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
+			e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
 		}
 		output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 	}

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -183,7 +183,7 @@ func TestProcessComments_UpdatesIssueBodyOnMarker(t *testing.T) {
 
 	eng := testEngineWithRepo(t, client, claude)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
-	stage := &stages.Stage{Name: "Specify", Order: 0, UpdateIssueBody: true}
+	stage := &stages.Stage{Name: "Specify", Order: 0}
 	item := gh.ProjectItem{
 		Number: 13,
 		Body:   "old spec",

--- a/engine/item.go
+++ b/engine/item.go
@@ -650,19 +650,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	branch, commit, mainSHA, timestamp := captureGitMeta(workDir, baseBranch)
 
 	// Check for issue body update markers in stage output.
-	// Only stages with UpdateIssueBody=true (e.g., Specify) are allowed to
-	// update the issue body. Other stages post output as stage comments only.
 	if output != "" {
 		if updatedBody := extractUpdatedBody(output); updatedBody != "" {
-			if stage.UpdateIssueBody {
-				e.logf(item.Number, "edit", "updating issue body from stage output\n")
-				if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
-					e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
-				}
-			} else {
-				e.logf(item.Number, "warn", "stage %q produced FABRIK_ISSUE_UPDATE markers but is not allowed to update the issue body — ignoring\n", stage.Name)
+			e.logf(item.Number, "edit", "updating issue body from stage output\n")
+			if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
+				e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
 			}
-			// Always strip the markers from the output
 			output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 		}
 	}

--- a/stages/examples/specify.yaml
+++ b/stages/examples/specify.yaml
@@ -3,7 +3,6 @@ order: 0
 skill: fabrik-specify
 comment_skill: fabrik-specify-comment
 auto_advance: false
-update_issue_body: true
 model: sonnet
 max_turns: 50
 read_only: true

--- a/stages/stages.go
+++ b/stages/stages.go
@@ -72,11 +72,6 @@ type Stage struct {
 	// the draft PR and triggers external review bots.
 	MarkPRReadyOnComplete bool `yaml:"mark_pr_ready_on_complete,omitempty"`
 
-	// UpdateIssueBody allows this stage to update the issue body via
-	// FABRIK_ISSUE_UPDATE markers. Only the Specify stage should have this
-	// set to true — other stages post output as stage comments.
-	UpdateIssueBody bool `yaml:"update_issue_body,omitempty"`
-
 	// AutoAdvance overrides the global yolo setting for this specific stage.
 	// nil means use the global setting.
 	AutoAdvance *bool `yaml:"auto_advance,omitempty"`


### PR DESCRIPTION
## Summary

Commit `04057e84` (April 3, 2026) introduced the `update_issue_body` stage config flag, gating `FABRIK_ISSUE_UPDATE` marker processing behind an explicit `update_issue_body: true` in the stage YAML. The default is `false`. This introduced a silent breaking change for existing projects that relied on the previously ungated behavior.

The chosen fix is to remove the `update_issue_body` flag entirely from the stage config schema and revert to the pre-`04057e84` behavior: any stage that produces `FABRIK_ISSUE_UPDATE_BEGIN`/`END` markers may update the issue body. By convention, only the Specify stage does this, so no explicit gating is necessary.

## Problem

## Summary

## Approach

### Approach

This is a targeted removal: delete the `UpdateIssueBody` bool field from the `Stage` struct, remove the two conditional gates that checked it (in `engine/item.go` and `engine/comments.go`), clean up the one test that references the field, remove the flag from both copies of `specify.yaml`, and scrub all documentation references.

The `yaml.v3` silent-ignore behavior (confirmed by Research) means no migration tooling is needed — user stage YAMLs with `update_issue_body: true` will load cleanly after the struct field is removed, the field simply won't be parsed.

The `UpdateIssueBody` method on `GitHubClient` / `engine/interfaces.go` is unrelated to the flag and must **not** be removed.

### New/Modified Files

| File | Change |
|------|--------|
| `stages/stages.go` | Remove `UpdateIssueBody bool` field from `Stage` struct |
| `engine/item.go` | Remove `UpdateIssueBody` gate; unconditionally call `updateIssueBody` when markers present |
| `engine/comments.go` | Remove `UpdateIssueBody` gate; unconditionally call `updateIssueBody` when markers present |
| `engine/comments_test.go` | Remove `UpdateIssueBody: true` from stage struct literal |
| `stages/examples/specify.yaml` | Remove `update_issue_body: true` line |
| `.fabrik/stages/specify.yaml` | Remove `update_issue_body: true` line |
| `CLAUDE.md` | Remove `update_issue_body: false` row from Stage Config Options table |
| `README.md` | Remove `update_issue_body: false` line from stage config reference |
| `docs/USER_GUIDE.md` | Remove `update_issue_body: false` option block (lines 460–462) |
| `docs/stage-lifecycle.md` | Remove/update 6 references (pipeline table column, Issue Body Update section, comment processing note, comparison table row, Markers Reference, YAML Options) |
| `docs/state-machine.md` | Remove/update 2 references (pipeline table column, Step 6 "Only applied if…" text) |

### Key Decisions

- **Silent ignore on load (not a hard error)**: Removing the struct field from `stages/stages.go` while leaving `yaml.Unmarshal` (without `KnownFields(true)`) in `loadOne` naturally produces silent-ignore behavior. This is the preferred outcome per the spec. No change to the YAML loading code is needed.

- **No ADR**: This change reverts a short-lived mistaken flag to prior behavior. It is not a new design decision and does not constrain future contributors in a non-obvious way. ADR 009 already documents the `FABRIK_ISSUE_UPDATE` protocol without mentioning the gate; no update to ADR 009 is needed.

- **Two separate `specify.yaml` files**: `stages/examples/specify.yaml` is the embedded source baked into the binary; `.fabrik/stages/specify.yaml` is the live project config tracked in git for this repo. Both must be cleaned up, but they are independent changes.

### Task Checklist

- [ ] Task 1: Remove `UpdateIssueBody bool` field from `Stage` struct in `stages/stages.go`
- [ ] Task 2: Remove `UpdateIssueBody` gate in `engine/item.go` (~line 652–667) — unconditionally apply the issue body update when `FABRIK_ISSUE_UPDATE_BEGIN/END` markers are present
- [ ] Task 3: Remove `UpdateIssueBody` gate in `engine/comments.go` (~line 152–162) — unconditionally apply the issue body update when markers are present
- [ ] Task 4: Remove `UpdateIssueBody: true` from the stage struct literal in `engine/comments_test.go` (~line 186)
- [ ] Task 5: Remove `update_issue_body: true` from `stages/examples/specify.yaml` (embedded default)
- [ ] Task 6: Remove `update_issue_body: true` from `.fabrik/stages/specify.yaml` (live project config)
- [ ] Task 7: Remove `update_issue_body: false` row from Stage Config Options table in `CLAUDE.md` (~line 108)
- [ ] Task 8: Remove `update_issue_body: false` line from stage config reference in `README.md` (~line 193)
- [ ] Task 9: Remove `update_issue_body: false` option block from `docs/USER_GUIDE.md` (~lines 460–462)
- [ ] Task 10: Update `docs/stage-lifecycle.md` — remove `UpdateIssueBody` column from pipeline table (line 18), rewrite "Issue Body Update" section (lines 189–191) to say markers are always applied, remove gate condition from comment processing note (line 268), remove conditional from comparison table row (line 302), remove "gated by `update_issue_body`" from Markers Reference (line 326), remove `update_issue_body: false` from YAML Options example (line 360)
- [ ] Task 11: Update `docs/state-machine.md` — remove `UpdateIssueBody` column from pipeline table (line 26), rewrite Step 6 description (line 396) to say always applied rather than "Only applied if `update_issue_body: true`"
- [ ] Task 12: Run `go build -o fabrik .` and `go test ./...` to confirm the binary compiles and all tests pass

### Risks

- **Accidental body mutations in other stages**: Post-change, any stage emitting `FABRIK_ISSUE_UPDATE` markers will update the issue body. This is acceptable (matches pre-`04057e84` behavior, per spec) but is worth noting for operators who extend Fabrik with custom stages.
- **Missed reference in docs**: Research catalogued 13 specific locations. Implement should grep for `update_issue_body` after completing all tasks to catch any references not listed, since the research was done against a snapshot.

---
Used 6/50 turns, 3k input / 2k output tokens.

## Verification

Removed the `update_issue_body` stage config flag introduced in `04057e84`. The `Stage` struct field was deleted from `stages/stages.go`, and both conditional gates in `engine/item.go` and `engine/comments.go` were replaced with unconditional issue-body updates. Both `specify.yaml` copies were cleaned up, the test was fixed, and all documentation references (CLAUDE.md, README.md, USER_GUIDE.md, stage-lifecycle.md, state-machine.md) were updated. Build succeeds and all tests pass.

---

Closes #419