### PR TITLE
Update docs for v0.0.44

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1456,10 +1456,11 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
    labels, status). Items whose `updatedAt` hasn't changed since the last poll are
    skipped entirely.
 2. **Targeted detail fetch** — runs only for items that passed the shallow filter.
-   The one exception is `fabrik:blocked` items, which always receive a forced
-   deep-fetch regardless of `updatedAt`. This is necessary because the issue that's
-   _blocking_ a blocked item can be closed without bumping the blocked item's own
-   `updatedAt` timestamp.
+   `fabrik:blocked` items do not receive a forced deep-fetch. Instead, they are
+   re-evaluated via the standard `processedSet` cooldown (every `10 × poll interval`,
+   typically ~5 minutes at the default 30s base). If GitHub bumps the blocked item's
+   `updatedAt` when a dependency closes, unblocking may also be detected sooner — on
+   the next poll cycle.
 
    Items with `fabrik:awaiting-input` or `fabrik:awaiting-review` do **not** force a
    deep-fetch. New user comments bump the issue's `updatedAt`; PR review submissions

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1456,11 +1456,12 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
    labels, status). Items whose `updatedAt` hasn't changed since the last poll are
    skipped entirely.
 2. **Targeted detail fetch** — runs only for items that passed the shallow filter.
-   `fabrik:blocked` items do not receive a forced deep-fetch. Instead, they are
-   re-evaluated via the standard `processedSet` cooldown (every `10 × poll interval`,
-   typically ~5 minutes at the default 30s base). If GitHub bumps the blocked item's
-   `updatedAt` when a dependency closes, unblocking may also be detected sooner — on
-   the next poll cycle.
+   `fabrik:blocked` items do not receive a forced deep-fetch on every poll. Instead,
+   they are re-evaluated via the standard `processedSet` cooldown (every
+   `10 × poll interval`, typically ~5 minutes at the default 30s base) — when the
+   cooldown fires, Fabrik deep-fetches the blocked item to check whether its
+   dependencies have closed. If GitHub bumps the blocked item's `updatedAt` when a
+   dependency closes, unblocking may also be detected sooner — on the next poll cycle.
 
    Items with `fabrik:awaiting-input` or `fabrik:awaiting-review` do **not** force a
    deep-fetch. New user comments bump the issue's `updatedAt`; PR review submissions


### PR DESCRIPTION
## Summary

Audit USER_GUIDE.md, README.md, and docs/index.md against v0.0.44 changes. The only substantive doc fix needed is updating the Rate Limit Monitoring section of USER_GUIDE.md to remove the stale claim that `fabrik:blocked` items always receive a forced deep-fetch.

## Problem

Three behavioral changes shipped in v0.0.44 that require documentation updates:

1. **Rate-limit backoff hysteresis** (#420): The `fabrik:blocked` forced deep-fetch bypass was removed. Blocked items now use the standard `processedSet` cooldown for re-evaluation. USER_GUIDE.md still documents the old bypass behavior.
2. **`update_issue_body` flag removed** (#419): All engine and stage YAML references were already cleaned up in the same PR; docs need to confirm clean.
3. **`#N` ordinal prohibition narrowed** (#410): Skill guidance updated in the binary; USER_GUIDE.md does not need to document internal skill rules.

## Approach

### Approach

This is a single-paragraph text replacement in `docs/USER_GUIDE.md`. No code changes, no new files, no ADR needed (the design decision is already captured in ADR 028). The Implement agent performs the edit and verifies the three confirm-only items before committing.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Replace stale `fabrik:blocked` forced deep-fetch paragraph (lines 1459–1462) |

### Key Decisions

- **One file, one edit**: Research and manual verification confirm all other items (§Dependency Detection, `update_issue_body` occurrences, docs/index.md) are already correct. No other edits needed.
- **No ADR needed**: The architectural decision is already recorded in ADR 028. This change only corrects a user-facing doc to match that existing record.
- **Replacement text**: Use the exact text drafted in Research — it precisely mirrors the ADR 028 description and the already-correct §Dependency Detection paragraph at line 679.

### Task Checklist

- [ ] **Task 1 — Confirm clean**: Grep `docs/USER_GUIDE.md` and `README.md` for `update_issue_body`; confirm zero hits. Grep `docs/index.md` for `fabrik:blocked` and rate-limit content; confirm clean. These are all pre-confirmed by Research but verify before committing.
- [ ] **Task 2 — Replace stale paragraph**: In `docs/USER_GUIDE.md`, replace lines 1459–1462 (the `fabrik:blocked` forced deep-fetch exception paragraph under §Rate Limit Monitoring) with the accurate cooldown-based description. The old text begins with `The one exception is \`fabrik:blocked\` items` and ends at `\`updatedAt\` timestamp.`. Replace it with:

  ```
     `fabrik:blocked` items do not receive a forced deep-fetch. Instead, they are
     re-evaluated via the standard `processedSet` cooldown (every `10 × poll interval`,
     typically ~5 minutes at the default 30s base). If GitHub bumps the blocked item's
     `updatedAt` when a dependency closes, unblocking may also be detected sooner — on
     the next poll cycle.
  ```

- [ ] **Task 3 — Verify §Dependency Detection unchanged**: Confirm `docs/USER_GUIDE.md` line ~679 still reads "Fabrik re-evaluates blocked items periodically via a cooldown timer…" — no edit needed, just verify it wasn't accidentally touched.
- [ ] **Task 4 — Commit**: Commit the single-file change with a clear message referencing issue #427 and the v0.0.44 behavioral fix.

### Risks

None. Pure documentation edit; no runtime behavior affected. The replacement text was validated against both ADR 028 and the already-correct §Dependency Detection paragraph.

---
Used 7/50 turns, 2k input / 1k output tokens.

## Verification

Updated `docs/USER_GUIDE.md` §Rate Limit Monitoring to remove the stale claim that `fabrik:blocked` items receive a forced deep-fetch. Replaced with accurate v0.0.44 behavior: blocked items re-evaluate via the standard `processedSet` cooldown (~5 min). All confirm-only checks passed clean (zero `update_issue_body` occurrences, `docs/index.md` unaffected, §Dependency Detection already correct).

---

Closes #427