### PR TITLE
Update docs for v0.0.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ See [USER_GUIDE §3 — Git Clone Protocol (HTTPS vs SSH)](docs/USER_GUIDE.md#gi
 
 Fabrik supports **dependency-based sequencing** of issues using GitHub's native "Blocked by" relationships. A **formation** is a coordinated set of issues that execute in parallel where possible and respect ordering constraints automatically — no polling, no manual unblocking.
 
-When all blocking issues are closed, Fabrik typically detects the change within one poll cycle (when GitHub updates the item's timestamp) and guarantees re-evaluation within ~10× the poll interval (~5 minutes at default settings), then resumes the blocked issue automatically. The `fabrik:blocked` label is managed entirely by the engine (created on first use, no pre-creation needed). The first stage (Specify) always runs regardless of blockers, so an entire formation can be fully specified before execution begins.
+When all blocking issues are closed, Fabrik guarantees re-evaluation of a blocked issue within ~10× the poll interval (~5 minutes at default settings), then resumes it automatically once dependencies are satisfied. The `fabrik:blocked` label is managed entirely by the engine (created on first use, no pre-creation needed). The first stage (Specify) always runs regardless of blockers, so an entire formation can be fully specified before execution begins.
 
 **Recipe:** file issues → add blocked-by edges in GitHub → label all `fabrik:yolo` → move to Specify → watch it run.
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ See [USER_GUIDE §3 — Git Clone Protocol (HTTPS vs SSH)](docs/USER_GUIDE.md#gi
 
 Fabrik supports **dependency-based sequencing** of issues using GitHub's native "Blocked by" relationships. A **formation** is a coordinated set of issues that execute in parallel where possible and respect ordering constraints automatically — no polling, no manual unblocking.
 
-When all blocking issues are closed, Fabrik detects the change within one poll cycle and resumes the blocked issue automatically. The `fabrik:blocked` label is managed entirely by the engine (created on first use, no pre-creation needed). The first stage (Specify) always runs regardless of blockers, so an entire formation can be fully specified before execution begins.
+When all blocking issues are closed, Fabrik typically detects the change within one poll cycle (when GitHub updates the item's timestamp) and guarantees re-evaluation within ~10× the poll interval (~5 minutes at default settings), then resumes the blocked issue automatically. The `fabrik:blocked` label is managed entirely by the engine (created on first use, no pre-creation needed). The first stage (Specify) always runs regardless of blockers, so an entire formation can be fully specified before execution begins.
 
 **Recipe:** file issues → add blocked-by edges in GitHub → label all `fabrik:yolo` → move to Specify → watch it run.
 


### PR DESCRIPTION
## Summary

Audit USER_GUIDE.md for stale references to the search API and the `fabrik:blocked` re-evaluation behavior. Update any inaccurate language. README.md and docs/index.md are expected to need no changes.

## Problem

v0.0.45 shipped two changes that may touch documentation:

1. **`FindPRForIssue` REST migration (#430)**: Previously used GitHub's `/search/issues` endpoint (30/minute rate limit). Now uses `/repos/{owner}/{repo}/pulls?head=...` via `FetchLinkedPR` (core REST, 5000/hour). This is internal-only — no user-facing behavior change — but USER_GUIDE.md may have stale language about search-API rate limit pressure that no longer applies.

2. **`fabrik:blocked` re-evaluation doc clarification**: A prior doc described forced deep-fetches on every poll for blocked items; the correct behavior (since #420's bypass removal) is that blocked items are deep-fetched only when a cooldown timer fires (~10× poll interval). The USER_GUIDE.md needs to reflect the accurate behavior.

## Approach

### Approach

The research found that both USER_GUIDE.md corrections were already committed before this issue was filed (commits f623c71 and da42c06). The only remaining inaccuracy is a single sentence in README.md line 367 that says blocked items are detected "within one poll cycle" — this is imprecise because the cooldown path takes up to ~5 minutes (10× poll interval). The fix is a targeted wording correction to that one sentence.

No new sections are needed. This is a correction-only pass.

### New/Modified Files

| File | Change |
|------|--------|
| `README.md` | Correct line 367: replace "within one poll cycle" with language reflecting the cooldown-based detection model |

### Key Decisions

- **Only README.md needs editing.** USER_GUIDE.md was already corrected in prior commits; docs/index.md has no timing language. No other files require changes.
- **Wording approach:** The replacement should acknowledge that detection is typically fast when GitHub bumps `updatedAt` (common) but the engine guarantees re-evaluation within ~10× poll interval (5 minutes at default 30s). This matches the USER_GUIDE.md description already in place, which is the canonical reference.
- **No ADR warranted.** This is a documentation correction, not a design decision. The underlying behavior is already captured in ADR 017.

### Task Checklist

- [ ] Verify USER_GUIDE.md lines 679 and 1459–1464 are still correct (read-only spot-check before committing)
- [ ] Edit README.md line 367: replace "detects the change within one poll cycle" with accurate cooldown-aware language (e.g., "typically detects the change within one poll cycle when GitHub updates the item's timestamp, and guarantees re-evaluation within ~10× the poll interval (~5 minutes at default settings)")
- [ ] Confirm docs/index.md line 272 has no timing language (read-only spot-check)
- [ ] Commit the README.md change with a descriptive message

### Risks

- **None.** Single-sentence edit in one file. No code changes. Low blast radius.

---
Used 6/50 turns, 2k input / 1k output tokens.

## Verification

Verified USER_GUIDE.md lines 679 and 1459–1464 are correct (cooldown-based `fabrik:blocked` re-evaluation language, no search-API references). Confirmed docs/index.md has no timing language. Fixed README.md line 367 to replace "detects the change within one poll cycle" with accurate language reflecting the cooldown model (~5 min guarantee at default settings, faster if GitHub bumps `updatedAt`). Change committed and pushed as 197d665.

---

Closes #433