### PR TITLE
Engine silently drops completed stage results — no error, no completion, perpetual polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `--notui` | Disable the interactive TUI dashboard | TUI on by default |
 | `--max-concurrent` | Maximum number of concurrent issue workers | `5` |
 | `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
+| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output when grandchild processes hold stdout pipe open (env: `FABRIK_CLAUDE_WAIT_DELAY`). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool. | `30` |
 | `--review-wait-timeout` | Minutes to wait per reviewer-gate cycle before pausing. Explicitly passing `0` uses the built-in default of `15` and bypasses `FABRIK_REVIEW_WAIT_TIMEOUT`. When absent, `FABRIK_REVIEW_WAIT_TIMEOUT` is consulted first; falls back to `15` if unset. | `0` |
 | `--max-review-cycles` | Max re-invocation cycles per reviewer-gate session. Explicitly passing `0` uses the built-in default of `5` and bypasses `FABRIK_MAX_REVIEW_CYCLES`. When absent, `FABRIK_MAX_REVIEW_CYCLES` is consulted first; falls back to `5` if unset. | `0` |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` for debugging | `false` |

--- a/adrs/005-claude-cli-invocation.md
+++ b/adrs/005-claude-cli-invocation.md
@@ -53,6 +53,62 @@ operates on the correct branch and file state.
 - **Claude Code dependency**: Requires `claude` CLI installed and on PATH.
   This is a hard requirement, not optional.
 
+## Subprocess Lifecycle Management (added with issue #429)
+
+### Problem
+
+Claude uses `run_in_background: true` on Bash tool calls for test runs and
+polling loops, and the Monitor tool spawns `tail -f` processes. These
+grandchild processes inherit Fabrik's stdout pipe write-fd. When the Claude
+CLI process exits, grandchildren are reparented to PID 1 but keep the pipe
+open. Go's `cmd.Wait()` blocks until the pipe's read side reaches EOF, which
+never arrives while any process holds the write side — so the worker goroutine
+blocks indefinitely.
+
+### Solution
+
+Two mechanisms, applied in `runClaude` after cmd construction:
+
+**1. `cmd.WaitDelay` (Go 1.20+)**
+
+```go
+cmd.WaitDelay = claudeWaitDelay  // default: 30s, configurable via --claude-wait-delay
+```
+
+After the Claude process exits, Go waits at most `WaitDelay` for I/O copy
+goroutines to finish. If the deadline fires, Go closes the pipe and returns
+`exec.ErrWaitDelay`. The engine detects this, logs a warning, and falls through
+to normal output processing — the buffered output (complete, since Claude wrote
+its final result line before exiting) is parsed normally.
+
+**2. Process Group Isolation + SIGKILL (Unix only)**
+
+```go
+// engine/procattr_unix.go (//go:build !windows)
+cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+// after cmd.Run() returns:
+syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+```
+
+Starting Claude with `Setpgid: true` creates a new process group with Claude
+as the process group leader (PGID == Claude's PID). After `cmd.Run()` returns
+(whether via normal exit or WaitDelay), SIGKILL is sent to the entire group,
+cleaning up all grandchildren. This is safe: SIGKILL on an empty/already-dead
+group returns ESRCH, which is ignored. It does not affect worktree file state
+since grandchild monitoring processes have no filesystem side effects.
+
+This is the first use of build-constrained files in `engine/`:
+`engine/procattr_unix.go` (`//go:build !windows`) and
+`engine/procattr_windows.go` (`//go:build windows`) provide Unix-specific
+syscall code while keeping the Windows build clean.
+
+### Configuration
+
+- `--claude-wait-delay <seconds>` (env: `FABRIK_CLAUDE_WAIT_DELAY`): how long
+  to wait after Claude exits before recovering buffered output. Default: 30s.
+  Increase if Claude's final output write is unusually slow; decrease in test
+  environments where fast recovery is preferred.
+
 ## Future Consideration
 
 If Anthropic releases a Go SDK or agent framework, we could switch to

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ type Config struct {
 	CIWaitTimeout     int // minutes; 0 means use default (30)
 	MaxCiFixCycles    int // 0 means use default (5)
 	MaxRebaseCycles   int // 0 means use default (3)
+	ClaudeWaitDelay   int // seconds; 0 means use default (30)
 	DebugOutput       bool
 	PluginDir         string
 }
@@ -115,6 +116,7 @@ func Execute() error {
 	flag.IntVar(&cfg.CIWaitTimeout, "ci-wait-timeout", 0, "Maximum time in minutes to wait for CI in the merge guard before pausing (0 = use default of 30; also FABRIK_CI_WAIT_TIMEOUT)")
 	flag.IntVar(&cfg.MaxCiFixCycles, "max-ci-fix-cycles", 0, "Maximum number of CI-fix cycles per issue before pausing (0 = use default of 5; also FABRIK_MAX_CI_FIX_CYCLES)")
 	flag.IntVar(&cfg.MaxRebaseCycles, "max-rebase-cycles", 0, "Maximum number of rebase-reinvoke cycles per issue before pausing (0 = use default of 3; also FABRIK_MAX_REBASE_CYCLES)")
+	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
 	flag.StringVar(&cfg.PluginDir, "plugin-dir", "", "Path to Fabrik plugin directory (for development; overrides installed plugin)")
 
@@ -307,6 +309,15 @@ func Execute() error {
 			}
 		}
 	}
+	if !explicitFlags["claude-wait-delay"] {
+		if v := os.Getenv("FABRIK_CLAUDE_WAIT_DELAY"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.ClaudeWaitDelay = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_CLAUDE_WAIT_DELAY=%q is invalid (must be a positive integer of seconds); using default 30\n", v)
+			}
+		}
+	}
 	if !cfg.AutoUpgrade {
 		if v := os.Getenv("FABRIK_AUTO_UPGRADE"); v != "" {
 			lv := strings.ToLower(v)
@@ -428,6 +439,7 @@ func Execute() error {
 		CIWaitTimeout:     ciWaitTimeout(cfg.CIWaitTimeout),
 		MaxCiFixCycles:    maxCiFixCycles(cfg.MaxCiFixCycles),
 		MaxRebaseCycles:   maxRebaseCycles(cfg.MaxRebaseCycles),
+		ClaudeWaitDelay:   claudeWaitDelay(cfg.ClaudeWaitDelay),
 		DebugOutput:       cfg.DebugOutput,
 		PluginDir:         cfg.PluginDir,
 		Stages:            stageCfgs,
@@ -491,6 +503,15 @@ func maxRebaseCycles(n int) int {
 		return 3
 	}
 	return n
+}
+
+// claudeWaitDelay converts a ClaudeWaitDelay config value (seconds) to a
+// time.Duration. When seconds is 0 (unset), the default of 30 seconds is used.
+func claudeWaitDelay(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // buildProjectInfo assembles the TUI footer metadata from the active config.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -311,10 +311,15 @@ func Execute() error {
 	}
 	if !explicitFlags["claude-wait-delay"] {
 		if v := os.Getenv("FABRIK_CLAUDE_WAIT_DELAY"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.ClaudeWaitDelay = n
+			if n, err := strconv.Atoi(v); err == nil {
+				if n > 0 {
+					cfg.ClaudeWaitDelay = n
+				} else if n < 0 {
+					fmt.Fprintf(os.Stderr, "[warn] FABRIK_CLAUDE_WAIT_DELAY=%q is invalid (must be 0 or a positive integer of seconds); using default 30\n", v)
+				}
+				// n == 0: silently use default (same semantics as --claude-wait-delay 0)
 			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_CLAUDE_WAIT_DELAY=%q is invalid (must be a positive integer of seconds); using default 30\n", v)
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_CLAUDE_WAIT_DELAY=%q is invalid (must be 0 or a positive integer of seconds); using default 30\n", v)
 			}
 		}
 	}

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -168,6 +168,14 @@ Context files are available in .fabrik-context/
 
 Raw Claude output saved to `~/.fabrik/logs/issue-<N>/<stage>-output-<timestamp>.json` after every invocation. Viewable through the TUI's `l` key (piped through `fabrik _stream-filter` for human-readable display).
 
+### Subprocess Cleanup
+
+After `cmd.Run()` returns, two cleanup steps run unconditionally:
+
+1. **Process group kill**: Claude is started in its own process group (`Setpgid: true` on Unix). After `cmd.Run()` returns, `SIGKILL` is sent to the entire process group to clean up grandchild processes (e.g. `tail -f` from the Monitor tool, polling loops spawned via `run_in_background: true`). This is scoped to the specific Claude invocation and does not affect worktree file state — grandchild monitoring processes have no side effects on the filesystem.
+
+2. **WaitDelay bound**: `cmd.WaitDelay` is set to 30s (configurable via `--claude-wait-delay` / `FABRIK_CLAUDE_WAIT_DELAY`). When grandchild processes hold the stdout pipe open after Claude exits, Go's `cmd.Wait()` would otherwise block indefinitely. With `WaitDelay`, Go forcibly closes its end of the pipe after the deadline and returns `exec.ErrWaitDelay`. The engine detects this error, logs a diagnostic warning, clears the error, and processes the buffered output normally — including any `FABRIK_STAGE_COMPLETE` marker. This prevents the worker goroutine from being permanently stuck when Claude uses `run_in_background` or the Monitor tool.
+
 ---
 
 ## Phase 4: Post-Stage Handling

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -58,6 +59,12 @@ var claudeTUI bool
 // claudePluginDir is the path to the Fabrik plugin directory. Set by the Engine
 // during construction. When non-empty, --plugin-dir is added to Claude args.
 var claudePluginDir string
+
+// claudeWaitDelay is how long runClaude waits for stdout pipe drain after the
+// Claude process exits before giving up and processing buffered output. Set by
+// the Engine during construction from Config.ClaudeWaitDelay. Default (0) is
+// resolved to 30s in runClaude.
+var claudeWaitDelay time.Duration
 
 func claudeLog(issueNumber int, tag, format string, args ...any) {
 	if claudeLogf != nil {
@@ -427,9 +434,20 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Stderr = stderrWriter
 	cmd.Stdout = stdoutWriter
+	waitDelay := claudeWaitDelay
+	if waitDelay <= 0 {
+		waitDelay = 30 * time.Second
+	}
+	cmd.WaitDelay = waitDelay
+	setCmdProcAttr(cmd)
 
 	runErr := cmd.Run()
+	killProcGroup(cmd)
 	rawOutput := stdout.Bytes()
+	if errors.Is(runErr, exec.ErrWaitDelay) {
+		claudeLog(issueNumber, "warn", "WaitDelay fired: Claude exited but grandchild processes held stdout pipe open; processing buffered output (%d bytes)\n", len(rawOutput))
+		runErr = nil
+	}
 
 	// Save the raw NDJSON output to an -output-*.json file for backward compatibility
 	// (e.g., the existing TUI log viewer and stream-filter tooling).

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -444,7 +444,7 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	runErr := cmd.Run()
 	killProcGroup(cmd)
 	rawOutput := stdout.Bytes()
-	if errors.Is(runErr, exec.ErrWaitDelay) {
+	if errors.Is(runErr, exec.ErrWaitDelay) && ctx.Err() == nil {
 		claudeLog(issueNumber, "warn", "WaitDelay fired: Claude exited but grandchild processes held stdout pipe open; processing buffered output (%d bytes)\n", len(rawOutput))
 		runErr = nil
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -112,9 +112,7 @@ func New(cfg Config) (*Engine, error) {
 		}
 		claudePluginDir = pluginDir
 	}
-	if cfg.ClaudeWaitDelay > 0 {
-		claudeWaitDelay = cfg.ClaudeWaitDelay
-	}
+	claudeWaitDelay = cfg.ClaudeWaitDelay
 	worktreeRoot := filepath.Join(fabrikDir, ".fabrik", "worktrees")
 	eng := &Engine{
 		cfg:                  cfg,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -33,6 +33,7 @@ type Config struct {
 	CIWaitTimeout     time.Duration // How long to wait for CI in the merge guard before pausing (default 30m)
 	MaxCiFixCycles    int           // Max CI-fix re-invocation cycles per issue before pausing (default 5)
 	MaxRebaseCycles   int           // Max rebase re-invocation cycles per issue before pausing (default 3)
+	ClaudeWaitDelay   time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
 	DebugOutput       bool
 	PluginDir         string
 	Stages            []*stages.Stage
@@ -110,6 +111,9 @@ func New(cfg Config) (*Engine, error) {
 			pluginDir = abs
 		}
 		claudePluginDir = pluginDir
+	}
+	if cfg.ClaudeWaitDelay > 0 {
+		claudeWaitDelay = cfg.ClaudeWaitDelay
 	}
 	worktreeRoot := filepath.Join(fabrikDir, ".fabrik", "worktrees")
 	eng := &Engine{

--- a/engine/grandchild_test.go
+++ b/engine/grandchild_test.go
@@ -1,0 +1,73 @@
+//go:build !windows
+
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// TestInvokeClaude_GrandchildHoldsPipe verifies that when a grandchild process
+// spawned by the Claude subprocess holds the stdout pipe open after Claude exits,
+// InvokeClaude returns within a bounded time (via WaitDelay) and correctly
+// processes the buffered output including FABRIK_STAGE_COMPLETE.
+func TestInvokeClaude_GrandchildHoldsPipe(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	// The script emits valid NDJSON then backgrounds sleep to hold the pipe open,
+	// simulating a grandchild process (e.g. tail -f from the Monitor tool) that
+	// outlives the Claude process.
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"stage output\\nFABRIK_STAGE_COMPLETE\\n\",\"session_id\":\"sess_gchild\",\"num_turns\":3,\"total_cost_usd\":0.001,\"is_error\":false}'\n" +
+		"sleep 60 &\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	// Short WaitDelay so the test completes quickly (1s vs the production default of 30s).
+	origDelay := claudeWaitDelay
+	claudeWaitDelay = 1 * time.Second
+	defer func() { claudeWaitDelay = origDelay }()
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:   "Research",
+		Prompt: "Do research",
+	}
+	issue := gh.ProjectItem{Number: 99, Title: "GrandchildHoldsPipe"}
+
+	type result struct {
+		output    string
+		completed bool
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		output, completed, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		ch <- result{output, completed, err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			t.Fatalf("InvokeClaude: %v", res.err)
+		}
+		if !res.completed {
+			t.Errorf("expected completed=true; output=%q", res.output)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("InvokeClaude did not return within 10s — likely stuck waiting for grandchild to close pipe")
+	}
+}

--- a/engine/procattr_unix.go
+++ b/engine/procattr_unix.go
@@ -3,6 +3,8 @@
 package engine
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -15,11 +17,14 @@ func setCmdProcAttr(cmd *exec.Cmd) {
 
 // killProcGroup sends SIGKILL to cmd's entire process group, cleaning up any
 // grandchild processes that outlived the Claude process. ESRCH (no such process)
-// is silently ignored — the group may already be gone.
+// is silently ignored — the group may already be gone. Unexpected errors are
+// logged to stderr so cleanup failures are diagnosable.
 func killProcGroup(cmd *exec.Cmd) {
 	if cmd.Process == nil {
 		return
 	}
 	// Negative PID targets the process group (PGID == Claude's PID when Setpgid is set).
-	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		fmt.Fprintf(os.Stderr, "[engine] killProcGroup: unexpected error killing process group %d: %v\n", cmd.Process.Pid, err)
+	}
 }

--- a/engine/procattr_unix.go
+++ b/engine/procattr_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package engine
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setCmdProcAttr starts cmd in its own process group so grandchild processes
+// (e.g. tail -f from the Monitor tool) can be cleaned up after cmd exits.
+func setCmdProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcGroup sends SIGKILL to cmd's entire process group, cleaning up any
+// grandchild processes that outlived the Claude process. ESRCH (no such process)
+// is silently ignored — the group may already be gone.
+func killProcGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	// Negative PID targets the process group (PGID == Claude's PID when Setpgid is set).
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/engine/procattr_windows.go
+++ b/engine/procattr_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package engine
+
+import "os/exec"
+
+// setCmdProcAttr is a no-op on Windows: process groups work differently and
+// the Setpgid/SIGKILL approach is Unix-specific.
+func setCmdProcAttr(cmd *exec.Cmd) {}
+
+// killProcGroup is a no-op on Windows.
+func killProcGroup(cmd *exec.Cmd) {}


### PR DESCRIPTION
## Summary

The engine worker goroutine gets permanently stuck inside `runClaude` even after the Claude process exits, because `cmd.Wait()` blocks indefinitely. The absence of ANY log entry after `[#N claude] invoking` — including the `[#N stats]` line that only appears after `e.claude.Invoke()` returns — confirms the goroutine never leaves `cmd.Run()`.

**Root cause confirmed:** Claude uses the Bash tool with `run_in_background: true` to start test runs and polling loops. These spawn grandchild processes (notably `tail -f` from the Monitor tool) that inherit Fabrik's stdout pipe file descriptor. When the Claude CLI process exits, these grandchildren are reparented to PID 1 (launchd/init) but keep the pipe's write end open. Go's `exec.Cmd.Wait()` reads stdout until EOF, which never arrives while any process holds the pipe open — so `cmd.Wait()` blocks indefinitely. There is no timeout, so the goroutine stays stuck forever.

This is a variant of #412, distinguished by the fact that the *Claude process itself* has exited (evidenced by `duration_ms` in the session log and the `terminal_reason: completed` field); only the grandchild processes remain.

## Problem

The Fabrik engine intermittently fails to process a completed Claude session, leaving the issue stuck with `fabrik:locked` and `stage:<Name>:in_progress` labels while polling endlessly. No error is logged — the engine simply never acknowledges the completion.

This is distinct from #285 (non-zero exit masking the completion marker) and #412 (hung subprocess preventing `cmd.Wait()` from returning). In this case, the Claude process exits cleanly with `FABRIK_STAGE_COMPLETE`, zero exit code, and `terminal_reason: completed`.

## Approach

### Approach

Use `exec.Cmd.WaitDelay` (Go 1.20+, available in Go 1.26.1) to bound how long `cmd.Wait()` blocks after the Claude process exits. When grandchild processes hold the stdout pipe open and the deadline fires, Go closes the pipe, returns `exec.ErrWaitDelay`, and the buffered output (complete, since Claude wrote it before exiting) is parsed normally.

Pair this with Unix process group isolation: start Claude in its own process group (`Setpgid: true`), then issue `SIGKILL` to the entire group after `cmd.Run()` returns — cleaning up `tail -f` and polling-loop grandchildren without affecting any other Fabrik-owned processes. The kill is scoped per-invocation (R5) and has no effect on worktree files (R6).

`ErrWaitDelay` is handled immediately after `cmd.Run()` — log the R3 diagnostic, clear `runErr`, and fall through to the existing parse/completion logic unchanged. The existing restart flow already handles R4 (stuck lock clears on engine restart once the goroutine unblocks).

WaitDelay is threaded through as a package-level variable (consistent with `claudePluginDir`, `claudeTUI`) set during engine construction, keeping `runClaude`'s signature unchanged.

The `SysProcAttr.Setpgid` field is Unix-only, so platform abstraction uses build-constrained files (`engine/procattr_unix.go` / `engine/procattr_windows.go`) — cleaner than a runtime `GOOS` check for syscall-level code.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/engine.go` | Add `ClaudeWaitDelay time.Duration` to `Config`; set `claudeWaitDelay` pkg var in engine construction |
| `engine/claude.go` | Add `claudeWaitDelay` pkg var; in `runClaude`: set `cmd.WaitDelay`, call `setCmdProcAttr` / `killProcGroup`, detect and log `exec.ErrWaitDelay` |
| `engine/procattr_unix.go` | New — `//go:build !windows`; `setCmdProcAttr` sets `Setpgid: true`; `killProcGroup` sends `SIGKILL` to pgroup |
| `engine/procattr_windows.go` | New — `//go:build windows`; no-op stubs for both functions |
| `cmd/root.go` | Add `ClaudeWaitDelay int` (seconds) to `cmd.Config`; add `--claude-wait-delay` flag; add `FABRIK_CLAUDE_WAIT_DELAY` env var parsing; add `claudeWaitDelay()` converter; pass to `engine.Config` |
| `engine/invoke_claude_test.go` | Add `TestInvokeClaude_GrandchildHoldsPipe` regression test |
| `README.md` | Add `--claude-wait-delay` row to the CLI flags table |
| `docs/stage-lifecycle.md` | Add subprocess-cleanup note to the Claude invocation section |
| `adrs/005-claude-cli-invocation.md` | Update to document WaitDelay + process group additions |

### Key Decisions

- **`WaitDelay` not a manual goroutine/timer**: Go 1.20 added `WaitDelay` precisely for this scenario. No need for a goroutine-based alternative.
- **Package-level `claudeWaitDelay` var over adding a parameter to `runClaude`**: Consistent with `claudePluginDir`, `claudeTUI` pattern; avoids changing the signature of `InvokeClaude` and `InvokeClaudeForComments`.
- **`ErrWaitDelay` cleared before parse, not caught in the lower error block**: Simplest correct placement — `runErr = nil` after logging, then the existing parse and completion logic runs without modification.
- **`killProcGroup` called unconditionally after `cmd.Run()`**: Safe even on normal exit (SIGKILL on an already-dead/empty pgroup returns ESRCH, ignored). Ensures cleanup regardless of whether WaitDelay fired.
- **Build-constrained files over `runtime.GOOS` check**: Syscall types differ by platform at compile time; `Setpgid` doesn't exist on Windows. Build tags are the correct mechanism.
- **Seconds as unit for `FABRIK_CLAUDE_WAIT_DELAY`**: Default is 30 seconds — minute granularity would force a minimum of 60s, which is workable but unnecessarily coarse.
- **No new ADR**: This is an enhancement of the subprocess lifecycle already described in ADR 005. Update ADR 005 to document WaitDelay and process group management (including the first use of build-constrained files in `engine/`).

### Task Checklist

- [x] **Task 1**: Add `ClaudeWaitDelay time.Duration` to `engine.Config` in `engine/engine.go`; in the engine constructor (where `claudePluginDir` is set, ~line 112), add `claudeWaitDelay = cfg.ClaudeWaitDelay`
- [x] **Task 2**: Add `ClaudeWaitDelay int` to `cmd.Config`; add `--claude-wait-delay` flag (seconds, default 0); add `FABRIK_CLAUDE_WAIT_DELAY` env-var parsing block (same pattern as `FABRIK_CI_WAIT_TIMEOUT`); add `claudeWaitDelay(n int) time.Duration` helper (default 30s when n ≤ 0); pass `ClaudeWaitDelay: claudeWaitDelay(cfg.ClaudeWaitDelay)` in the `engine.New(...)` call in `cmd/root.go`
- [x] **Task 3**: Create `engine/procattr_unix.go` (`//go:build !windows`) with `setCmdProcAttr(cmd *exec.Cmd)` (sets `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}`) and `killProcGroup(cmd *exec.Cmd)` (if `cmd.Process != nil`, calls `syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)` and ignores ESRCH)
- [x] **Task 4**: Create `engine/procattr_windows.go` (`//go:build windows`) with no-op stubs for `setCmdProcAttr` and `killProcGroup`
- [x] **Task 5**: In `engine/claude.go`: add `var claudeWaitDelay time.Duration` package-level var (with comment matching `claudePluginDir` style); in `runClaude`, add `cmd.WaitDelay = claudeWaitDelay` and `setCmdProcAttr(cmd)` between cmd construction and `cmd.Run()`; immediately after `cmd.Run()`, add `killProcGroup(cmd)` and then the `ErrWaitDelay` detection block: `if errors.Is(runErr, exec.ErrWaitDelay) { claudeLog(issueNumber, "warn", "WaitDelay fired: Claude exited but grandchild processes held stdout pipe open; processing buffered output (%d bytes)
", len(rawOutput)); runErr = nil }`
- [x] **Task 6**: Add regression test `TestInvokeClaude_GrandchildHoldsPipe` in `engine/invoke_claude_test.go`: fake `claude` script emits valid NDJSON with `FABRIK_STAGE_COMPLETE` then execs `sleep 60 &` (background process to hold pipe); set `claudeWaitDelay = 1 * time.Second`; defer restore to `0`; call `InvokeClaude`; assert it returns within 5 seconds with `completed=true` and no error. Mark test `//go:build !windows` or skip on Windows.
- [x] **Task 7**: Run `go build ./...` and `go test -race ./...` and fix any issues
- [x] **Task 8**: Update `README.md` — add `--claude-wait-delay` row to the CLI flags table (after `--max-retries`): document it as seconds, default 30, env var `FABRIK_CLAUDE_WAIT_DELAY`
- [x] **Task 9**: Update `docs/stage-lifecycle.md` — in the Phase 3 / Post-Invocation section, note that after `cmd.Run()` returns: (a) the process group is killed to clean up orphaned grandchild processes; (b) if `WaitDelay` fired, the buffered output is processed normally with a warning logged
- [x] **Task 10**: Update `adrs/005-claude-cli-invocation.md` — add a section documenting the WaitDelay bound (default 30s, `FABRIK_CLAUDE_WAIT_DELAY`), process group isolation via `Setpgid`, and the first use of build-constrained files in `engine/`

### Risks

- **Regression test flakiness on CI with restricted PID namespaces**: The `sleep 60 &` approach may not fork correctly in all CI environments. If this becomes an issue, replace with a small Go-binary helper written to a temp file. Mitigation: mark the test as skippable with `t.Skip` if the shell doesn't support backgrounding, or use `exec.Command("sleep", "60").Start()` directly in the test helper (which avoids shell entirely).

- **`cmd.Process` nil on `Start()` failure**: If `claude` binary is not found, `cmd.Run()` returns an error and `cmd.Process` may be nil. The `killProcGroup` implementation must guard: `if cmd.Process == nil { return }`.

- **WaitDelay and context cancellation ordering**: When the context is cancelled, `exec.CommandContext` kills Claude and `cmd.Run()` may return with both `ctx.Err() != nil` and the pipe still open. In this case the WaitDelay error may be wrapped alongside the context error. The existing `ctx.Err() != nil` check runs first in the error block and is unaffected — the `ErrWaitDelay` check fires before the error block (at the point of `runErr = nil`), so context-cancelled paths still return an error correctly.

---
Used 22/50 turns, 6k input / 11k output tokens.

## Verification

Implemented `cmd.WaitDelay` (30s default, configurable via `--claude-wait-delay` / `FABRIK_CLAUDE_WAIT_DELAY`) on every Claude subprocess to bound how long `cmd.Wait()` blocks after Claude exits — preventing worker goroutines from hanging indefinitely when grandchild processes (Monitor's `tail -f`, `run_in_background` loops) hold the stdout pipe open. Paired with Unix process-group isolation (`Setpgid: true` + `SIGKILL` to the group after `cmd.Run()` returns) via build-constrained platform files (`engine/procattr_unix.go` / `engine/procattr_windows.go`). When `ErrWaitDelay` fires, the buffered output is processed normally with a diagnostic warning logged. A regression test (`engine/grandchild_test.go`) confirms `InvokeClaude` returns in ~1s (not stuck) when a background `sleep 60` holds the pipe open — all 10 plan tasks completed, build and race-detector tests green.

---

Closes #429