### PR TITLE
Add per-stage wall-clock timeout to prevent indefinite hangs on stuck Claude processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,11 @@ mark_pr_ready_on_complete: true # Mark PR ready when stage completes
 auto_advance: false             # Override global yolo setting
 read_only: false                # Stash/restore worktree changes (for Specify/Research stages that don't write code)
 cleanup_worktree: false         # Remove worktree when stage completes (for Done/cleanup stages)
+max_wall_time: "45m"            # Optional: wall-clock deadline for a single Claude invocation (e.g. "30m", "1h").
+                                # When exceeded, SIGTERM → 10s → SIGKILL sent to the process group. Output
+                                # collected before the kill is scanned for FABRIK_STAGE_COMPLETE so completed
+                                # stages are not re-run. Absent or zero = no cap. A hardcoded 15-minute
+                                # inactivity timeout (no output received) applies to every invocation regardless.
 disable_adaptive_thinking: true # Disable Claude Code's adaptive (auto-reduced) thinking budget. Default: true.
 effort_level: max               # Claude Code thinking effort: low, medium, high, max. Default: high.
 ```

--- a/adrs/005-claude-cli-invocation.md
+++ b/adrs/005-claude-cli-invocation.md
@@ -109,6 +109,10 @@ syscall code while keeping the Windows build clean.
   Increase if Claude's final output write is unusually slow; decrease in test
   environments where fast recovery is preferred.
 
+### Proactive Kill for Stuck Processes
+
+`WaitDelay` only fires after Claude exits. It provides no bound when Claude itself hangs and never exits. [ADR 029](029-proactive-kill-timeout.md) adds two proactive kill mechanisms on top of this passive layer: a per-stage `max_wall_time` YAML field and a hardcoded 15-minute inactivity watchdog, both using the SIGTERM→10s→SIGKILL sequence via `killProcGroupGraceful`. After either kill, the already-buffered output is scanned for `FABRIK_STAGE_COMPLETE` in intermediate assistant NDJSON turns so completed work is not re-run.
+
 ## Future Consideration
 
 If Anthropic releases a Go SDK or agent framework, we could switch to

--- a/adrs/029-proactive-kill-timeout.md
+++ b/adrs/029-proactive-kill-timeout.md
@@ -1,0 +1,124 @@
+# ADR 029: Proactive Kill Timeouts for Stuck Claude Invocations
+
+## Status
+
+Accepted
+
+## Context
+
+Claude Code invocations can hang indefinitely. Two incident classes have been observed:
+
+1. **Grandchild pipe hold** (ADR 005, issue #429): A background process spawned by Claude (e.g., `tail -f` via Monitor, `sleep` in a test loop) inherits the stdout pipe write-fd and keeps it open after the Claude process exits. ADR 005's `WaitDelay` mechanism bounds this: after Claude exits, `cmd.Wait()` caps the pipe-drain delay at `claudeWaitDelay` (default 30s) and returns `exec.ErrWaitDelay`. The buffered output (complete, since Claude wrote its final result line before exiting) is then parsed normally.
+
+2. **Stuck Claude process** (graphiti#26 and class of related incidents): The Claude CLI process itself hangs — never exiting, producing no output for an extended period. Causes include: model-side infinite loop, stuck network request, deadlocked tool invocation, or a stage whose prompt creates a runaway session. `WaitDelay` is ineffective here because it only fires *after* Claude exits; it provides no bound on a process that never exits.
+
+These are distinct failure modes. ADR 005 addresses the grandchild pipe problem passively (drain-and-discard). This ADR addresses the stuck-process problem proactively (kill with recovery).
+
+## Decision
+
+Add two proactive kill mechanisms to `runClaude()` in `engine/claude.go`:
+
+1. **`max_wall_time` per-stage field**: a Go duration string in stage YAML that caps the total wall-clock runtime of a single Claude invocation via `context.WithTimeout`.
+
+2. **Inactivity timeout (hardcoded 15 minutes)**: a watchdog goroutine that kills the process if no stdout bytes have been received for 15 consecutive minutes, regardless of whether a `max_wall_time` is configured.
+
+Both use the SIGTERM→10s grace→SIGKILL sequence targeting the entire process group.
+
+After either kill, the already-buffered output is scanned for `FABRIK_STAGE_COMPLETE` in intermediate `{"type":"assistant"}` NDJSON lines so completed work is not re-run.
+
+## Rationale
+
+### Why two mechanisms?
+
+`max_wall_time` is opt-in per stage and requires the operator to reason about expected stage durations. It catches the case where a stage runs longer than ever expected. The inactivity timeout is a no-configuration backstop: even a stage with no `max_wall_time` is bounded against processes that produce occasional output but never complete a turn.
+
+### Why proactive kill instead of passive drain?
+
+`WaitDelay` (ADR 005) is passive — it only fires after the Claude process exits. A process that never exits requires a different approach: the engine must actively decide to end the invocation. The `context.WithTimeout` approach reuses Go's existing cancellation machinery; the inactivity watchdog handles the case where the process is still writing (slowly) but will never terminate.
+
+### Why SIGTERM→10s→SIGKILL (not immediate SIGKILL)?
+
+Claude Code may have staged partial file edits, open worktree file handles, or in-progress git operations. SIGTERM gives it a 10-second window to flush and clean up. If it does not exit within 10 seconds, SIGKILL is sent unconditionally. This is the same sequence used by most process supervision systems and is a well-understood contract.
+
+### Why target the process group?
+
+Claude spawns grandchild processes via `run_in_background: true` Bash tool calls (test runners, polling loops) and Monitor tool invocations (`tail -f`, `watch`). Sending the kill signal to the negative PID (`syscall.Kill(-pid, sig)`) targets the entire process group — Claude plus all descendants. This prevents grandchild processes from holding the stdout pipe open after the kill, which would otherwise cause `cmd.Wait()` to block until `WaitDelay` fires (adding 30s to every timeout recovery).
+
+### Why scan the buffer post-kill? (R9: stream marker detection)
+
+A stage that signals completion — then hangs in a post-completion loop — should not be re-run. The Claude CLI emits NDJSON per turn: each assistant turn is a `{"type":"assistant",...}` line with a `content` array. If Claude wrote `FABRIK_STAGE_COMPLETE` in a completed turn before hanging, that text is already in the buffer. `extractTextFromAssistantTurns()` scans the buffer for assistant turns and concatenates their text blocks; if `FABRIK_STAGE_COMPLETE` appears, `completed=true` is returned and the same completion flow runs as for a live marker. Without this scan, a timed-out stage that actually completed would be re-invoked — wasting time and potentially duplicating side effects.
+
+### Why not re-run the stage immediately on timeout?
+
+A timed-out invocation without `FABRIK_STAGE_COMPLETE` follows the same cooldown/retry path as any no-marker run. This gives the operator time to investigate (check the stage comment for partial output, inspect the worktree) before the engine retries. The `wasTimedOut` flag distinguishes our kills from engine-shutdown context cancellation so that only timeout kills enter the retry path, not graceful shutdowns.
+
+### Why hardcode 15 minutes for the inactivity timeout?
+
+15 minutes is chosen to exceed any expected per-turn latency (including reasoning + tool calls + model response) while bounding the worst-case hang to under an hour. It is configurable via the `claudeInactivityTimeout` package variable for tests. If experience shows 15 minutes is too tight, it can be made configurable via an env var; for now, the `max_wall_time` field provides per-stage control for operators who need tighter bounds.
+
+### Why is `cmd.Cancel` used for `max_wall_time` (not direct kill)?
+
+Go 1.20+ allows overriding `cmd.Cancel` — the function called when the context is cancelled. The default `cmd.Cancel` sends SIGKILL to the process (not the process group). Overriding it lets us run the SIGTERM→10s→SIGKILL graceful sequence while still using `context.WithTimeout` for deadline management. This keeps the kill logic in one place (`killProcGroupGraceful`) shared between both mechanisms.
+
+## How It Works
+
+```
+runClaude()
+│
+├── stageCtx = context.WithTimeout(ctx, maxWallTime)   // if maxWallTime > 0
+│
+├── cmd.Cancel = func() {                               // called on stageCtx deadline
+│     killProcGroupGraceful(pid, ...)
+│   }
+│
+├── cmd.Start()
+│   pid := cmd.Process.Pid
+│
+├── watchdog goroutine(pid):
+│   │  timer = 15min
+│   │  on timer fire:
+│   │    if idle >= 15min: inactivityFired=true; killProcGroupGraceful(pid,...)
+│   │    else: reset timer for remaining time
+│   └── exits on watchdogCtx.Done()
+│
+├── cmd.Wait()                         // blocks until process group done
+├── watchdogCancel()
+├── killProcGroup(cmd)                 // cleanup: SIGKILL any remaining grandchildren
+│
+├── wasTimedOut = inactivityFired || (stageCtx.Err()==DeadlineExceeded && ctx.Err()==nil)
+│
+└── output parsing:
+    ├── if parseClaudeJSON ok → normal path
+    ├── else if wasTimedOut:
+    │     text = extractTextFromAssistantTurns(rawOutput)
+    │     completed = strings.Contains(text, "FABRIK_STAGE_COMPLETE")
+    │     return text, completed, usage, nil   // not an error
+    └── else → error path (engine-shutdown or parse failure)
+```
+
+`extractTextFromAssistantTurns(rawOutput []byte)` reads `rawOutput` line by line, JSON-decodes lines with `"type":"assistant"`, and concatenates all `"text"` blocks from the message content array.
+
+## Stage Config
+
+```yaml
+max_wall_time: "45m"   # Optional. Absent or 0 = no wall-clock cap (inactivity backstop still applies).
+```
+
+Recommended values: `"45m"` for Implement and Review stages in typical repos. Research and Plan stages are generally faster but can be given `"20m"` as a conservative cap.
+
+## Trade-offs
+
+- **False positives on `max_wall_time`:** If a stage legitimately needs more time than configured, it will be killed and retried. Operators must tune `max_wall_time` to be conservatively large. The inactivity timeout does not have this problem for active (but slow) processes.
+
+- **10-second grace period adds latency:** Every `max_wall_time` kill takes at least 10 seconds past the deadline (the SIGTERM grace window). This is acceptable — hung processes are the exception, not the rule, and partial cleanup is preferable to corruption.
+
+- **Windows:** `killProcGroupGraceful` is a no-op on Windows (process groups work differently). Both mechanisms still fire and set their flags, but the kill is a best-effort `cmd.Cancel` (the default SIGKILL to the main process). Grandchild cleanup is weaker on Windows.
+
+- **Race on PID access:** `cmd.Process` is written by `cmd.Start()` and must not be read before `Start()` completes. The solution is to capture `pid := cmd.Process.Pid` in the main goroutine immediately after `cmd.Start()` succeeds, then pass `pid` as a parameter to the watchdog goroutine closure. This is race-free because the goroutine is launched after `cmd.Start()` completes and only reads the local `pid` copy.
+
+## References
+
+- [ADR 005: Shell Out to Claude Code CLI](005-claude-cli-invocation.md) — subprocess lifecycle; `WaitDelay` and `killProcGroup`; process group isolation
+- Issue #429 — grandchild pipe hold problem (led to ADR 005 subprocess lifecycle section)
+- Issue #412 — stuck Claude process problem (this ADR)
+- graphiti#26 — production incident that motivated this change

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -458,6 +458,18 @@ max_turns: 50             # Optional. Max conversation turns per main stage invo
 comment_max_turns: 15     # Optional. Max turns when processing user comments. Defaults to
                           #   min(max_turns, 15) when max_turns is set, otherwise 15.
                           #   Keeps comment processing bounded independently of stage budget.
+max_wall_time: "45m"      # Optional. Wall-clock deadline for a single Claude invocation.
+                          #   Accepts Go duration strings (e.g. "30m", "1h", "1h30m").
+                          #   When the deadline is reached, Fabrik sends SIGTERM to the
+                          #   Claude process group, waits 10 s, then sends SIGKILL (reaping
+                          #   any hung background children). Output collected before the kill
+                          #   is processed normally — if FABRIK_STAGE_COMPLETE appears in
+                          #   the streamed output, the stage is marked complete without a
+                          #   retry. When absent or zero, no wall-clock cap is applied.
+                          #   Recommended: "45m" for Implement and Review stages in
+                          #   production use. The hardcoded 15-minute inactivity timeout
+                          #   (see below) acts as a universal backstop even when this field
+                          #   is not set.
 read_only: true           # Optional. Stashes the dirty worktree before Claude runs and
                           #   restores it after. Use for analysis stages that should not
                           #   modify files (e.g., Specify, Research).
@@ -535,6 +547,16 @@ A fifth case applies at the issue level: adding the `fabrik:yolo` label to an is
 **Thinking budget (`disable_adaptive_thinking`, `effort_level`):**
 
 These two fields control how much Claude "thinks" before responding. `disable_adaptive_thinking: true` (the default) turns off Claude Code's adaptive thinking budget, which would otherwise auto-reduce thinking depth to save tokens. With adaptive thinking disabled, the `effort_level` field directly controls thinking intensity: `low`, `medium`, `high`, or `max`. The default `effort_level` is `high` (changed from `max` in v0.0.33 to reduce token usage without sacrificing quality). Use `effort_level: max` only for your most demanding stages — complex implementation or thorough review work — where higher token cost is justified.
+
+**Timeout and inactivity protection (`max_wall_time` + 15-minute inactivity kill):**
+
+Fabrik applies two complementary timeout mechanisms to every Claude invocation to prevent indefinite hangs from stuck background processes:
+
+1. **`max_wall_time` (per-stage, opt-in):** A hard wall-clock deadline. When the deadline expires, Fabrik sends `SIGTERM` to the Claude process group (which includes any background children spawned during the session), waits 10 seconds for a graceful exit, then sends `SIGKILL` to any surviving processes. Recommended: `"45m"` for Implement and Review stages in production. Legitimately long stages (e.g., a 90-minute Review on a large PR) should either set a higher limit or leave this field unset.
+
+2. **15-minute inactivity timeout (global, always active):** If no streamed output is received from Claude for 15 consecutive minutes, the process group is killed using the same SIGTERM → 10s → SIGKILL sequence. This catches sessions that are stuck on a hung background task even when `max_wall_time` is not set — as long as Claude is actively producing output, it continues indefinitely. The threshold is hardcoded and cannot be configured.
+
+In both cases, if `FABRIK_STAGE_COMPLETE` was emitted before the kill (visible in the streamed `assistant` turns), the stage is treated as successfully completed without retrying. Both timeouts apply equally to main-stage invocations and comment-processing invocations.
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -196,6 +196,8 @@ Ten distinct event types drive state transitions:
 - **FABRIK_BLOCKED_ON_INPUT:** `blockOnInput()` — adds `fabrik:paused` + `fabrik:awaiting-input`
 - **None of the above:** cooldown retry path; eventually `escalateFailedStage()` if MaxRetries exceeded
 
+**Invocation-level kill paths:** The `max_wall_time` and inactivity timeout mechanisms (see §7.6) can terminate the Claude process before it writes a clean `{"type":"result"}` line. After such a kill, `runClaude()` retroactively scans the already-buffered output for `FABRIK_STAGE_COMPLETE` in intermediate `{"type":"assistant"}` NDJSON lines via `extractTextFromAssistantTurns()`. If found, `completed=true` is returned and the invocation is treated identically to a live `FABRIK_STAGE_COMPLETE`. If not found, `completed=false` is returned and the invocation routes to the cooldown/retry path. These kills are distinguished from engine-shutdown cancellation by the `wasTimedOut` flag, so they do not trigger the hard-error path.
+
 ### 2.7 Manual Label Change
 
 **Trigger:** A human adds or removes a label on the issue via the GitHub UI.
@@ -361,6 +363,10 @@ This table shows the normal flow when an issue progresses through the pipeline w
 
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
 |--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | `max_wall_time` exceeded | SIGTERM→10s→SIGKILL; `FABRIK_STAGE_COMPLETE` found in buffered assistant stream | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `extractTextFromAssistantTurns()` recovers marker; same completion flow as live FABRIK_STAGE_COMPLETE |
+| Column `<X>`, Locked + In Progress | `max_wall_time` exceeded | SIGTERM→10s→SIGKILL; no `FABRIK_STAGE_COMPLETE` in buffered stream | Same column, Cooldown | | | `wasTimedOut=true`; routes to cooldown/retry (not a hard error); lock NOT released |
+| Column `<X>`, Locked + In Progress | Inactivity timeout (15m) | No streamed output for 15 consecutive minutes; `FABRIK_STAGE_COMPLETE` found in buffered stream | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Same completion flow |
+| Column `<X>`, Locked + In Progress | Inactivity timeout (15m) | No streamed output for 15 consecutive minutes; no `FABRIK_STAGE_COMPLETE` in buffered stream | Same column, Cooldown | | | `wasTimedOut=true`; routes to cooldown/retry; lock NOT released |
 | Column `<X>`, Locked + In Progress | No marker in output | `claudeRan` is true (includes both error-free runs and runs that errored mid-execution; excludes only start failures like binary-not-found) | Same column, Cooldown | | | `processedSet[stageKey]` updated; cooldown = `PollSeconds * 10`; lock NOT released (stays locked through retries) |
 | Same column, Cooldown | Poll tick | Cooldown expired | Same column, Locked + In Progress (retry) | | `stage:<X>:failed` (if present from prior escalation) | Claude re-invoked with `resume=true` |
 | Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && MaxRetries > 0` | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released |
@@ -777,6 +783,32 @@ Closed issues are normally skipped by `itemMayNeedWork()` and `itemNeedsWork()`.
 | Lock tracking | `lockedIssues[iKey]` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
 | Last updatedAt | `lastUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |
 | Deep-fetch failure | `deepFetchFailureTime[iKey]` | None | Lost — failed items retried immediately |
+
+### 7.6 Invocation-Level Kill Mechanisms
+
+Two proactive kill mechanisms cap how long a single Claude invocation can run. Both are implemented in `runClaude()` in `engine/claude.go` and operate independently of the engine-level context cancellation.
+
+**`max_wall_time` (per-stage YAML field)**
+- Configured as a Go duration string in stage YAML (e.g., `max_wall_time: "45m"`). Absent or zero means no cap.
+- Implemented via `context.WithTimeout` wrapping the invocation context; the clock starts when the process is spawned.
+- When the deadline fires, `cmd.Cancel` executes the graceful kill sequence: SIGTERM to the process group, 10-second grace, SIGKILL.
+- Recommended for long-running stages (Implement, Review) to bound worst-case hang time.
+
+**Inactivity timeout (hardcoded 15 minutes)**
+- A watchdog goroutine resets a 15-minute timer on every byte of stdout received via `activityWriter`.
+- When no output arrives for 15 consecutive minutes, the watchdog calls `killProcGroupGraceful()` directly and sets `inactivityFired`.
+- Acts as backstop for stages with no `max_wall_time` (or when the process produces occasional output but never completes).
+
+**Shared post-kill behavior:**
+1. `extractTextFromAssistantTurns(rawOutput)` scans the already-buffered output for `FABRIK_STAGE_COMPLETE` appearing in the `text` content of any `{"type":"assistant"}` NDJSON line.
+2. If found: returns `completed=true` — the invocation is treated identically to a live `FABRIK_STAGE_COMPLETE`.
+3. If not found: returns `completed=false` — routes to cooldown/retry (see §3.2 and §7.1), not a hard error.
+
+**`wasTimedOut` flag:** `inactivityFired.Load() || (stageCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil)` — distinguishes our kills from engine-shutdown context cancellation. When `wasTimedOut=true`, the no-marker path follows the same cooldown/retry flow as a clean exit without markers. When `ctx.Err() != nil && !wasTimedOut` (engine shutdown), `runClaude` returns immediately with zero output.
+
+**Kill sequence:** `killProcGroupGraceful(pid, issueNumber, label)` sends `syscall.SIGTERM` to `-pid` (the entire process group), sleeps 10 seconds, then sends `syscall.SIGKILL`. This terminates grandchild processes (e.g., background `sleep` spawned by Monitor tool) that would otherwise hold the stdout pipe open past `cmd.WaitDelay`.
+
+**No-op on Windows:** `killProcGroupGraceful` is a no-op on Windows (process groups work differently). Both timeout mechanisms still fire and set their flags, but the kill is a best-effort `cmd.Cancel`.
 
 ---
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -65,6 +66,23 @@ var claudePluginDir string
 // the Engine during construction from Config.ClaudeWaitDelay. Default (0) is
 // resolved to 30s in runClaude.
 var claudeWaitDelay time.Duration
+
+// claudeInactivityTimeout is the maximum time runClaude will wait without
+// receiving any streamed output before killing the Claude process. Hardcoded
+// at 15 minutes; overridable in tests.
+var claudeInactivityTimeout = 15 * time.Minute
+
+// activityWriter wraps an io.Writer and updates a shared atomic timestamp on
+// every Write call. Used by the inactivity watchdog to detect stuck sessions.
+type activityWriter struct {
+	inner        io.Writer
+	lastActivity *atomic.Int64
+}
+
+func (w *activityWriter) Write(p []byte) (int, error) {
+	w.lastActivity.Store(time.Now().UnixNano())
+	return w.inner.Write(p)
+}
 
 func claudeLog(issueNumber int, tag, format string, args ...any) {
 	if claudeLogf != nil {
@@ -223,7 +241,7 @@ func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem
 	args := buildClaudeArgs(stage, sessFilePath, resume, opts.ModelOverride, stage.MaxTurns, hasUnrestrictedLabel(issue), workDir)
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
-	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv)
+	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv, stage.MaxWallTime)
 	usage.MaxTurns = stage.MaxTurns
 	if err != nil {
 		return output, completed, usage, err
@@ -252,7 +270,7 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 	args := buildClaudeArgs(stage, sessFilePath, true, opts.ModelOverride, limit, hasUnrestrictedLabel(issue), workDir) // resume existing session
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
-	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review", sessFilePath, ld, extraEnv)
+	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review", sessFilePath, ld, extraEnv, stage.MaxWallTime)
 	usage.MaxTurns = limit
 	return output, completed, usage, err
 }
@@ -393,7 +411,7 @@ type claudeResponse struct {
 	} `json:"usage"`
 }
 
-func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string, sessFilePath string, logDir string, extraEnv []string) (string, bool, TokenUsage, error) {
+func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string, sessFilePath string, logDir string, extraEnv []string, maxWallTime time.Duration) (string, bool, TokenUsage, error) {
 	claudeLog(issueNumber, "claude", "invoking (%s) in %s\n", label, workDir)
 
 	// Set up stderr: in TUI mode discard; in plain mode forward to os.Stderr.
@@ -428,7 +446,22 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "claude", args...)
+	// Per-invocation context: with wall-time timeout if configured, or plain parent ctx.
+	// Clock starts here (after log setup) — at process spawn time, satisfying R2.
+	stageCtx := ctx
+	stageCancel := context.CancelFunc(func() {})
+	if maxWallTime > 0 {
+		stageCtx, stageCancel = context.WithTimeout(ctx, maxWallTime)
+	}
+	defer stageCancel()
+
+	// Track last-write timestamp for the inactivity watchdog.
+	var lastActivity atomic.Int64
+	lastActivity.Store(time.Now().UnixNano())
+	// Wrap stdoutWriter so every write updates lastActivity, resetting the inactivity timer.
+	stdoutWriter = &activityWriter{inner: stdoutWriter, lastActivity: &lastActivity}
+
+	cmd := exec.CommandContext(stageCtx, "claude", args...)
 	cmd.Dir = workDir
 	cmd.Env = mergeEnv(os.Environ(), extraEnv)
 	cmd.Stdin = strings.NewReader(prompt)
@@ -441,9 +474,56 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	cmd.WaitDelay = waitDelay
 	setCmdProcAttr(cmd)
 
+	// Override cmd.Cancel to use a graceful SIGTERM → 10s → SIGKILL sequence
+	// (targeting the process group) when stageCtx is cancelled (wall-time exceeded).
+	// This reaps hung background children (dangling pytest, tail -f, polling loops).
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			claudeLog(issueNumber, "warn", "stage %q exceeded max_wall_time — killing Claude process\n", label)
+			killProcGroupGraceful(cmd.Process.Pid, issueNumber, label)
+		}
+		return nil
+	}
+
+	// Inactivity watchdog: kills the process group if no stdout is received for
+	// claudeInactivityTimeout, indicating a stuck session regardless of wall time.
+	// Runs concurrently with cmd.Run(); stopped via watchdogCtx after Run returns.
+	var inactivityFired atomic.Bool
+	watchdogCtx, watchdogCancel := context.WithCancel(context.Background())
+	defer watchdogCancel() // ensures goroutine is cleaned up even on panic
+	go func() {
+		timer := time.NewTimer(claudeInactivityTimeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				since := time.Since(time.Unix(0, lastActivity.Load()))
+				if since >= claudeInactivityTimeout {
+					if cmd.Process != nil {
+						claudeLog(issueNumber, "warn", "stage %q idle for 15m with no output — killing Claude process\n", label)
+						inactivityFired.Store(true)
+						killProcGroupGraceful(cmd.Process.Pid, issueNumber, label)
+					}
+					return
+				}
+				timer.Reset(claudeInactivityTimeout - since)
+			case <-watchdogCtx.Done():
+				return
+			}
+		}
+	}()
+
 	runErr := cmd.Run()
+	watchdogCancel() // stop the watchdog goroutine promptly
 	killProcGroup(cmd)
 	rawOutput := stdout.Bytes()
+
+	// wasTimedOut is true when this process was terminated by our own timeout
+	// (wall-time deadline or inactivity watchdog) rather than an external engine
+	// shutdown. When true, the ctx.Err() engine-shutdown guard is bypassed so
+	// we still process whatever output was collected before the kill.
+	wasTimedOut := inactivityFired.Load() || (stageCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil)
+
 	if errors.Is(runErr, exec.ErrWaitDelay) && ctx.Err() == nil {
 		claudeLog(issueNumber, "warn", "WaitDelay fired: Claude exited but grandchild processes held stdout pipe open; processing buffered output (%d bytes)\n", len(rawOutput))
 		runErr = nil
@@ -490,21 +570,27 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 			claudeLog(issueNumber, "claude", "completed in %d turns, $%.4f\n", resp.NumTurns, resp.CostUSD)
 		}
 		saveSessionIDDirect(sessFilePath, resp.SessionID)
+	} else if wasTimedOut {
+		// Process was killed before emitting a result JSON line. Extract text from
+		// intermediate assistant turns collected before the kill so we can detect
+		// FABRIK_STAGE_COMPLETE and avoid a costly re-run of an already-done stage.
+		text = extractTextFromAssistantTurns(rawOutput)
+		claudeLog(issueNumber, "warn", "timeout: processing %d bytes of streamed output for markers\n", len(rawOutput))
 	} else {
 		claudeLog(issueNumber, "warn", "JSON parse failed (%d bytes); output not posted\n", len(rawOutput))
 		text = fmt.Sprintf("⚠️ Claude output could not be parsed (raw output was %d bytes). Check logs at `%s` for details.", len(rawOutput), logDir)
 	}
 
 	if runErr != nil {
-		// If the context was cancelled (shutdown), treat as interrupted regardless of
-		// marker presence — the engine is going away, bookkeeping would be partial.
-		if ctx.Err() != nil {
+		// If the context was cancelled (engine shutdown) and this was NOT our own
+		// timeout kill, treat as interrupted — the engine is going away, bookkeeping
+		// would be partial.
+		if ctx.Err() != nil && !wasTimedOut {
 			return text, false, usage, fmt.Errorf("claude exited with error: %w", runErr)
 		}
 		// Check whether the agent emitted the completion marker before the error.
-		// This handles the case where the agent correctly signals completion but then
-		// continues doing extra work (e.g. post-completion verification) and the session
-		// ends non-zero (max_turns exceeded, API error, etc.).
+		// This handles: (a) normal completion followed by extra work that ends non-zero,
+		// and (b) timeout kills where FABRIK_STAGE_COMPLETE appeared in streamed output.
 		if stageCompleteRE.MatchString(text) {
 			claudeLog(issueNumber, "warn", "stage completed (marker found) but Claude exited with error: %v\n", runErr)
 			return text, true, usage, fmt.Errorf("claude exited with error: %w", runErr)
@@ -837,6 +923,39 @@ func extractIssueUpdateFromAssistantTurns(rawOutput []byte) string {
 		}
 	}
 	return lastBlock
+}
+
+// extractTextFromAssistantTurns scans raw NDJSON output and concatenates all text
+// content from {"type":"assistant",...} messages. Used after a timeout kill to
+// recover FABRIK_STAGE_COMPLETE and other markers from the streamed output when
+// the Claude process was terminated before emitting a final "result" JSON line.
+func extractTextFromAssistantTurns(rawOutput []byte) string {
+	var sb strings.Builder
+	lines := bytes.Split(rawOutput, []byte("\n"))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var envelope struct {
+			Type    string `json:"type"`
+			Message struct {
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(line, &envelope); err != nil || envelope.Type != "assistant" {
+			continue
+		}
+		for _, block := range envelope.Message.Content {
+			if block.Type == "text" {
+				sb.WriteString(block.Text)
+			}
+		}
+	}
+	return sb.String()
 }
 
 // parseClaudeJSON parses the JSON output from claude --output-format json.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -479,12 +479,16 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	defer watchdogCancel() // ensures goroutine is cleaned up even on panic
 
 	// Override cmd.Cancel to use a graceful SIGTERM → 10s → SIGKILL sequence
-	// (targeting the process group) when stageCtx is cancelled (wall-time exceeded).
-	// cmd.Cancel is only invoked by Go's exec cancel goroutine, which is started
-	// inside cmd.Start() after cmd.Process is set — so cmd.Process.Pid is safe here.
+	// (targeting the process group) when stageCtx is cancelled. cmd.Cancel is only
+	// invoked by Go's exec cancel goroutine, started inside cmd.Start() after
+	// cmd.Process is set — so cmd.Process.Pid is safe to read here.
 	cmd.Cancel = func() error {
 		if cmd.Process != nil {
-			claudeLog(issueNumber, "warn", "stage %q exceeded max_wall_time — killing Claude process\n", label)
+			if maxWallTime > 0 {
+				claudeLog(issueNumber, "warn", "stage %q exceeded max_wall_time (%s) — killing Claude process\n", label, maxWallTime)
+			} else {
+				claudeLog(issueNumber, "warn", "stage %q context cancelled — killing Claude process gracefully\n", label)
+			}
 			killProcGroupGraceful(cmd.Process.Pid, issueNumber, label)
 		}
 		return nil

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -517,7 +517,7 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 			case <-timer.C:
 				since := time.Since(time.Unix(0, lastActivity.Load()))
 				if since >= claudeInactivityTimeout {
-					claudeLog(issueNumber, "warn", "stage %q idle for 15m with no output — killing Claude process\n", label)
+					claudeLog(issueNumber, "warn", "stage %q idle for %s with no output — killing Claude process\n", label, claudeInactivityTimeout)
 					inactivityFired.Store(true)
 					killProcGroupGraceful(pid, issueNumber, label)
 					return

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -474,9 +474,14 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	cmd.WaitDelay = waitDelay
 	setCmdProcAttr(cmd)
 
+	// watchdogCtx is used to stop the inactivity goroutine after cmd.Wait returns.
+	watchdogCtx, watchdogCancel := context.WithCancel(context.Background())
+	defer watchdogCancel() // ensures goroutine is cleaned up even on panic
+
 	// Override cmd.Cancel to use a graceful SIGTERM → 10s → SIGKILL sequence
 	// (targeting the process group) when stageCtx is cancelled (wall-time exceeded).
-	// This reaps hung background children (dangling pytest, tail -f, polling loops).
+	// cmd.Cancel is only invoked by Go's exec cancel goroutine, which is started
+	// inside cmd.Start() after cmd.Process is set — so cmd.Process.Pid is safe here.
 	cmd.Cancel = func() error {
 		if cmd.Process != nil {
 			claudeLog(issueNumber, "warn", "stage %q exceeded max_wall_time — killing Claude process\n", label)
@@ -485,13 +490,22 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 		return nil
 	}
 
+	// Split Start + Wait so we can capture the PID before starting the watchdog
+	// goroutine, avoiding a data race on cmd.Process between the goroutine and
+	// cmd.Start (which writes cmd.Process).
+	if err := cmd.Start(); err != nil {
+		watchdogCancel()
+		return "", false, TokenUsage{}, fmt.Errorf("starting claude: %w", err)
+	}
+	// cmd.Process is written once by cmd.Start and never modified again.
+	// Capture it here (same goroutine, post-Start) for the watchdog.
+	pid := cmd.Process.Pid
+
 	// Inactivity watchdog: kills the process group if no stdout is received for
 	// claudeInactivityTimeout, indicating a stuck session regardless of wall time.
-	// Runs concurrently with cmd.Run(); stopped via watchdogCtx after Run returns.
+	// Stopped via watchdogCtx after cmd.Wait returns.
 	var inactivityFired atomic.Bool
-	watchdogCtx, watchdogCancel := context.WithCancel(context.Background())
-	defer watchdogCancel() // ensures goroutine is cleaned up even on panic
-	go func() {
+	go func(pid int) {
 		timer := time.NewTimer(claudeInactivityTimeout)
 		defer timer.Stop()
 		for {
@@ -499,11 +513,9 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 			case <-timer.C:
 				since := time.Since(time.Unix(0, lastActivity.Load()))
 				if since >= claudeInactivityTimeout {
-					if cmd.Process != nil {
-						claudeLog(issueNumber, "warn", "stage %q idle for 15m with no output — killing Claude process\n", label)
-						inactivityFired.Store(true)
-						killProcGroupGraceful(cmd.Process.Pid, issueNumber, label)
-					}
+					claudeLog(issueNumber, "warn", "stage %q idle for 15m with no output — killing Claude process\n", label)
+					inactivityFired.Store(true)
+					killProcGroupGraceful(pid, issueNumber, label)
 					return
 				}
 				timer.Reset(claudeInactivityTimeout - since)
@@ -511,9 +523,9 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 				return
 			}
 		}
-	}()
+	}(pid)
 
-	runErr := cmd.Run()
+	runErr := cmd.Wait()
 	watchdogCancel() // stop the watchdog goroutine promptly
 	killProcGroup(cmd)
 	rawOutput := stdout.Bytes()

--- a/engine/grandchild_test.go
+++ b/engine/grandchild_test.go
@@ -71,3 +71,164 @@ func TestInvokeClaude_GrandchildHoldsPipe(t *testing.T) {
 		t.Fatal("InvokeClaude did not return within 10s — likely stuck waiting for grandchild to close pipe")
 	}
 }
+
+// TestInvokeClaude_MaxWallTimeKillsWithComplete verifies that when a Claude process
+// emits FABRIK_STAGE_COMPLETE in an assistant turn and then hangs, a max_wall_time
+// kill still surfaces completed=true by scanning the streamed assistant output.
+func TestInvokeClaude_MaxWallTimeKillsWithComplete(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	// Print a valid assistant NDJSON line with FABRIK_STAGE_COMPLETE, then hang.
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"printf '%s\\n' '{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Done!\\nFABRIK_STAGE_COMPLETE\\n\"}]}}'\n" +
+		"sleep 60\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	origDelay := claudeWaitDelay
+	claudeWaitDelay = 1 * time.Second
+	defer func() { claudeWaitDelay = origDelay }()
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:        "Review",
+		Prompt:      "Do review",
+		MaxWallTime: 500 * time.Millisecond,
+	}
+	issue := gh.ProjectItem{Number: 99, Title: "MaxWallTimeWithComplete"}
+
+	type result struct {
+		output    string
+		completed bool
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		output, completed, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		ch <- result{output, completed, err}
+	}()
+
+	select {
+	case res := <-ch:
+		if !res.completed {
+			t.Errorf("expected completed=true (FABRIK_STAGE_COMPLETE in stream); err=%v; output=%q", res.err, res.output)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("InvokeClaude did not return within 15s after max_wall_time kill")
+	}
+}
+
+// TestInvokeClaude_MaxWallTimeKillsWithoutComplete verifies that when a Claude
+// process hangs without emitting FABRIK_STAGE_COMPLETE, a max_wall_time kill
+// results in completed=false.
+func TestInvokeClaude_MaxWallTimeKillsWithoutComplete(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	// Just hang — no output.
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"sleep 60\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	origDelay := claudeWaitDelay
+	claudeWaitDelay = 1 * time.Second
+	defer func() { claudeWaitDelay = origDelay }()
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:        "Review",
+		Prompt:      "Do review",
+		MaxWallTime: 500 * time.Millisecond,
+	}
+	issue := gh.ProjectItem{Number: 99, Title: "MaxWallTimeWithoutComplete"}
+
+	type result struct {
+		output    string
+		completed bool
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		output, completed, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		ch <- result{output, completed, err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.completed {
+			t.Errorf("expected completed=false (no FABRIK_STAGE_COMPLETE); output=%q", res.output)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("InvokeClaude did not return within 15s after max_wall_time kill")
+	}
+}
+
+// TestInvokeClaude_InactivityTimeout verifies that when no streamed output is
+// received for claudeInactivityTimeout, the process is killed and completed=false.
+func TestInvokeClaude_InactivityTimeout(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	// Hang with no output.
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"sleep 60\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	origDelay := claudeWaitDelay
+	claudeWaitDelay = 1 * time.Second
+	defer func() { claudeWaitDelay = origDelay }()
+
+	// Override inactivity timeout to 2s so the test completes quickly.
+	origInactivity := claudeInactivityTimeout
+	claudeInactivityTimeout = 2 * time.Second
+	defer func() { claudeInactivityTimeout = origInactivity }()
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:   "Review",
+		Prompt: "Do review",
+		// No MaxWallTime — only the inactivity timeout applies.
+	}
+	issue := gh.ProjectItem{Number: 99, Title: "InactivityTimeout"}
+
+	type result struct {
+		output    string
+		completed bool
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		output, completed, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		ch <- result{output, completed, err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.completed {
+			t.Errorf("expected completed=false (inactivity kill); output=%q", res.output)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("InvokeClaude did not return within 20s after inactivity timeout")
+	}
+}

--- a/engine/procattr_unix.go
+++ b/engine/procattr_unix.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 // setCmdProcAttr starts cmd in its own process group so grandchild processes
@@ -26,5 +27,19 @@ func killProcGroup(cmd *exec.Cmd) {
 	// Negative PID targets the process group (PGID == Claude's PID when Setpgid is set).
 	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 		fmt.Fprintf(os.Stderr, "[engine] killProcGroup: unexpected error killing process group %d: %v\n", cmd.Process.Pid, err)
+	}
+}
+
+// killProcGroupGraceful sends SIGTERM to the process group, waits 10 seconds for
+// a graceful shutdown, then sends SIGKILL. This reaps hung background children
+// (dangling pytest, tail -f, polling loops) in addition to the Claude CLI itself.
+// ESRCH is silently ignored — the group may already be gone.
+func killProcGroupGraceful(pid, issueNumber int, label string) {
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+		fmt.Fprintf(os.Stderr, "[#%d engine] killProcGroupGraceful %q: SIGTERM error on pgid %d: %v\n", issueNumber, label, pid, err)
+	}
+	time.Sleep(10 * time.Second)
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		fmt.Fprintf(os.Stderr, "[#%d engine] killProcGroupGraceful %q: SIGKILL error on pgid %d: %v\n", issueNumber, label, pid, err)
 	}
 }

--- a/engine/procattr_unix.go
+++ b/engine/procattr_unix.go
@@ -33,12 +33,22 @@ func killProcGroup(cmd *exec.Cmd) {
 // killProcGroupGraceful sends SIGTERM to the process group, waits 10 seconds for
 // a graceful shutdown, then sends SIGKILL. This reaps hung background children
 // (dangling pytest, tail -f, polling loops) in addition to the Claude CLI itself.
-// ESRCH is silently ignored — the group may already be gone.
+// Returns immediately if the process group is already gone (ESRCH) — avoids the
+// PID-reuse hazard where sleeping 10s then SIGKILLing could hit an unrelated group
+// that recycled the same PGID.
 func killProcGroupGraceful(pid, issueNumber int, label string) {
-	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil {
+		if err == syscall.ESRCH {
+			return // group already gone; nothing to clean up
+		}
 		fmt.Fprintf(os.Stderr, "[#%d engine] killProcGroupGraceful %q: SIGTERM error on pgid %d: %v\n", issueNumber, label, pid, err)
 	}
 	time.Sleep(10 * time.Second)
+	// Re-probe before SIGKILL: if the group exited during the grace period, return
+	// rather than risk hitting a recycled PGID.
+	if err := syscall.Kill(-pid, 0); err == syscall.ESRCH {
+		return
+	}
 	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 		fmt.Fprintf(os.Stderr, "[#%d engine] killProcGroupGraceful %q: SIGKILL error on pgid %d: %v\n", issueNumber, label, pid, err)
 	}

--- a/engine/procattr_windows.go
+++ b/engine/procattr_windows.go
@@ -10,3 +10,6 @@ func setCmdProcAttr(cmd *exec.Cmd) {}
 
 // killProcGroup is a no-op on Windows.
 func killProcGroup(cmd *exec.Cmd) {}
+
+// killProcGroupGraceful is a no-op on Windows.
+func killProcGroupGraceful(pid, issueNumber int, label string) {}

--- a/stages/stages.go
+++ b/stages/stages.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -114,6 +115,14 @@ type Stage struct {
 	// "low", "medium", "high", "max". Empty string means use the default ("max").
 	// Maps to the CLAUDE_CODE_EFFORT_LEVEL environment variable.
 	EffortLevel string `yaml:"effort_level,omitempty"`
+
+	// MaxWallTimeRaw is the raw YAML string (e.g. "30m", "1h") parsed into MaxWallTime.
+	// Use MaxWallTime for runtime comparisons; MaxWallTimeRaw is only for YAML round-tripping.
+	MaxWallTimeRaw string `yaml:"max_wall_time,omitempty"`
+
+	// MaxWallTime is the parsed wall-clock timeout for a single Claude invocation.
+	// Zero means no wall-clock timeout (the default). Set from MaxWallTimeRaw by loadOne.
+	MaxWallTime time.Duration `yaml:"-"`
 }
 
 // CompletionCriteria defines how to determine if a stage is complete.
@@ -188,6 +197,17 @@ func loadOne(path string) (*Stage, error) {
 	validEffortLevels := map[string]bool{"": true, "low": true, "medium": true, "high": true, "max": true}
 	if !validEffortLevels[s.EffortLevel] {
 		return nil, fmt.Errorf("stage %q: invalid effort_level %q (must be one of: low, medium, high, max)", s.Name, s.EffortLevel)
+	}
+
+	if s.MaxWallTimeRaw != "" {
+		d, err := time.ParseDuration(s.MaxWallTimeRaw)
+		if err != nil {
+			return nil, fmt.Errorf("stage %q: invalid max_wall_time %q: %w", s.Name, s.MaxWallTimeRaw, err)
+		}
+		if d < 0 {
+			return nil, fmt.Errorf("stage %q: max_wall_time must not be negative, got %q", s.Name, s.MaxWallTimeRaw)
+		}
+		s.MaxWallTime = d
 	}
 
 	return &s, nil

--- a/stages/stages_test.go
+++ b/stages/stages_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func writeStageFile(t *testing.T, dir, name, content string) {
@@ -388,6 +389,69 @@ effort_level: `+level+`
 		if err == nil {
 			t.Errorf("effort_level %q: expected error, got nil", level)
 		}
+	}
+}
+
+func TestLoadAll_MaxWallTime(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantErr   bool
+		wantValue time.Duration
+	}{
+		{
+			name: "valid minutes",
+			yaml: `name: Implement
+prompt: "do it"
+max_wall_time: "45m"`,
+			wantValue: 45 * time.Minute,
+		},
+		{
+			name: "valid hours",
+			yaml: `name: Implement
+prompt: "do it"
+max_wall_time: "1h30m"`,
+			wantValue: 90 * time.Minute,
+		},
+		{
+			name: "absent means zero (no timeout)",
+			yaml: `name: Implement
+prompt: "do it"`,
+			wantValue: 0,
+		},
+		{
+			name: "invalid format",
+			yaml: `name: Implement
+prompt: "do it"
+max_wall_time: "forever"`,
+			wantErr: true,
+		},
+		{
+			name: "negative value",
+			yaml: `name: Implement
+prompt: "do it"
+max_wall_time: "-5m"`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeStageFile(t, dir, "stage.yaml", tt.yaml)
+			stages, err := LoadAll(dir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadAll: %v", err)
+			}
+			if got := stages[0].MaxWallTime; got != tt.wantValue {
+				t.Errorf("MaxWallTime = %v, want %v", got, tt.wantValue)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Add two complementary timeout mechanisms to prevent indefinitely stuck Claude processes. First, an optional per-stage `max_wall_time` field caps total process runtime. Second, a global hardcoded inactivity timeout kills the process if no streamed output has been received in 15 consecutive minutes — indicating a stuck session regardless of elapsed wall time. In both cases, output collected up to the kill point is processed normally using markers detected from the live stream, not only from the final result JSON. Kill signals target the entire process group so hung background children are also reaped. This issue builds the proactive-kill layer on top of issue #429's passive-recovery baseline (`WaitDelay`).

## Problem

Fabrik waits indefinitely for the Claude CLI process to exit via `cmd.Wait()` in `runClaude`. There is no wall-clock timeout. If a child process spawned during a Claude session hangs (stuck test suite, dangling git lock, process waiting on stdin), the Claude CLI stays alive and Fabrik's worker goroutine blocks forever — consuming a semaphore slot and preventing other work.

Observed on verveguy/graphiti#26: the Review stage completed (FABRIK_STAGE_COMPLETE emitted, 65 turns, $2.90), but Claude ran background pytest invocations that hung. The TUI showed the job at 39+ minutes "In Progress" even though the stage was done. The only fix was manual process kill.

`max_turns` bounds the conversation length but NOT wall time. A single turn with a hung Bash background task can block indefinitely.

## Approach

### Approach

This issue requires three interlocking capabilities: (1) a per-stage `max_wall_time` YAML field with `context.WithTimeout` enforcement, (2) a hardcoded 15-minute inactivity watchdog goroutine, and (3) post-kill NDJSON scanning to detect `FABRIK_STAGE_COMPLETE` from intermediate `assistant` turns when the process is killed before emitting a final `result` line.

**Process kill sequence** (`cmd.Cancel` override): Override `cmd.Cancel` on the `exec.Cmd` to call a new `killProcGroupGraceful` (SIGTERM → 10s sleep → SIGKILL, targeting the process group). Go fires `cmd.Cancel` immediately when `stageCtx` is cancelled, so effective kill latency is ≤10s grace + WaitDelay for I/O drain. Works because `go.mod` requires Go 1.26.1 (well past the 1.20 minimum where `cmd.Cancel` was introduced).

**Inactivity tracking** (`activityWriter`): A minimal `io.Writer` wrapper that stores `time.Now().UnixNano()` atomically on every `Write`. It wraps the existing `stdoutWriter` chain. A watchdog goroutine resets a timer based on elapsed inactivity. When the timer fires, the watchdog calls `killProcGroupGraceful` directly — NOT via context cancellation — to avoid triggering the `ctx.Err() != nil` engine-shutdown guard. A `watchdogCtx` (cancelled in a `defer` after `cmd.Run()`) prevents goroutine leaks.

**R9 marker detection**: Do NOT parse NDJSON in the write path. All bytes streamed up to the kill are already in `stdout bytes.Buffer` (via `activityWriter` forwarding). When `parseClaudeJSON` fails AND `wasTimedOut` is true, call `extractTextFromAssistantTurns(rawOutput)` — a companion to the existing `extractIssueUpdateFromAssistantTurns` — to extract concatenated text from `assistant`-type NDJSON lines. The standard `stageCompleteRE.MatchString(text)` check then handles the marker.

**`wasTimedOut` flag** distinguishes our kills from engine shutdown: `inactivityFired atomic.Bool` (set by watchdog before firing) `||` `(stageCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil)`. When `wasTimedOut`, the existing `if ctx.Err() != nil { return text, false, ... }` guard is gated out, allowing normal marker processing.

**`max_wall_time` field encoding**: Two exported fields on `Stage` — `MaxWallTimeRaw string yaml:"max_wall_time,omitempty"` (YAML-facing) and `MaxWallTime time.Duration yaml:"-"` (programmatic, set by `loadOne` via `time.ParseDuration`). Simpler than a custom `UnmarshalYAML` type and consistent with how `EffortLevel` is a validated string.

**Timeout context location**: `context.WithTimeout` is created inside `runClaude` (not `processItem`) so the clock starts at process spawn, satisfying R2. `stage.MaxWallTime` is threaded as a new `maxWallTime time.Duration` parameter on `runClaude`.

### New/Modified Files

| File | Change |
|------|--------|
| `stages/stages.go` | Add `MaxWallTimeRaw`/`MaxWallTime` fields; parse/validate in `loadOne` |
| `engine/procattr_unix.go` | Add `killProcGroupGraceful(pid, issueNumber int, label string)` |
| `engine/procattr_windows.go` | Add no-op `killProcGroupGraceful` stub |
| `engine/claude.go` | Add `activityWriter`, `extractTextFromAssistantTurns`; refactor `runClaude` with watchdog goroutine, timeout ctx, `cmd.Cancel` override, `wasTimedOut` logic; add `maxWallTime` param; update both `InvokeClaude` and `InvokeClaudeForComments` call sites |
| `engine/grandchild_test.go` | Add three timeout/inactivity tests using the fake-binary pattern |
| `docs/USER_GUIDE.md` | Add `max_wall_time` field entry + inactivity timeout note |
| `docs/state-machine.md` | Add kill-path guard conditions to `itemMayNeedWork` section |
| `adrs/029-proactive-kill-timeout.md` | New ADR (R11) — check highest existing number at implementation time |
| `adrs/005-claude-cli-invocation.md` | Add cross-reference to the new ADR |

### Key Decisions

- **`MaxWallTime` field encoding**: `MaxWallTimeRaw string yaml:"max_wall_time,omitempty"` + `MaxWallTime time.Duration yaml:"-"`, parsed in `loadOne`. Rejected: custom `UnmarshalYAML` type — more complex, no existing precedent in this file.

- **`cmd.Cancel` for wall-time kill**: Overriding `cmd.Cancel` (available since Go 1.20, we're on 1.26) keeps `runClaude` sequential. Go fires `cmd.Cancel` immediately on context cancellation. Rejected: `cmd.Start()` + manual `cmd.Wait()` goroutine — more complex restructuring for identical semantics.

- **Activity tracking via minimal writer**: `activityWriter` only updates an atomic timestamp; no NDJSON parsing in the write path. Rejected: full streaming NDJSON parser in the writer — unnecessary complexity since `rawOutput` is already fully buffered at kill time.

- **R9 via post-kill scan of `rawOutput`**: `extractTextFromAssistantTurns(rawOutput)` in the `!ok` + `wasTimedOut` branch. Rejected: live marker detection in the writer — equivalent result (all streamed bytes are in `rawOutput`) with more implementation complexity and partial-line accumulation hazards.

- **`wasTimedOut` boolean flag**: Set by `inactivityFired` atomic or by stageCtx DeadlineExceeded check. Rejected: new error types — unnecessary abstraction; the two sources are fully covered.

- **`context.WithTimeout` inside `runClaude`**: Most precise (R2) and requires only adding `maxWallTime` to `runClaude`'s signature. Both `InvokeClaude` and `InvokeClaudeForComments` pass `stage.MaxWallTime`.

- **ADR 029 warranted** (R11): The layered passive+proactive kill design is a non-obvious architectural constraint that future contributors need to know without reading the code.

### Task Checklist

- [ ] **Task 1 — Stage struct + loadOne** (`stages/stages.go`): Add `MaxWallTimeRaw string yaml:"max_wall_time,omitempty"` and `MaxWallTime time.Duration yaml:"-"` to `Stage`. In `loadOne`, after the `EffortLevel` validation block, if `s.MaxWallTimeRaw != ""`: call `time.ParseDuration(s.MaxWallTimeRaw)` and reject with an error if it fails or is negative; store the parsed value in `s.MaxWallTime`. Zero/absent = no timeout (backward compatible).

- [ ] **Task 2 — `killProcGroupGraceful`** (`engine/procattr_unix.go`, `engine/procattr_windows.go`): Add `killProcGroupGraceful(pid, issueNumber int, label string)` to the Unix file: `syscall.SIGTERM` to `-pid` (silent `ESRCH`), `time.Sleep(10 * time.Second)`, `syscall.SIGKILL` to `-pid` (silent `ESRCH`). Add no-op stub with same signature to the Windows file.

- [ ] **Task 3 — `activityWriter`** (`engine/claude.go`): Add `activityWriter` struct with `inner io.Writer` and `lastActivity *atomic.Int64`. Its `Write(p []byte) (int, error)` stores `time.Now().UnixNano()` atomically then delegates to `inner`. Add `var claudeInactivityTimeout = 15 * time.Minute` package-level var (settable in tests, same pattern as `claudeWaitDelay`).

- [ ] **Task 4 — `extractTextFromAssistantTurns`** (`engine/claude.go`): Add function that scans NDJSON lines in `rawOutput`, extracts and concatenates text content from all `assistant`-type messages (using the same envelope struct as `extractIssueUpdateFromAssistantTurns`). Returns the full concatenated text — `stageCompleteRE.MatchString` will then detect the marker if present.

- [ ] **Task 5 — `runClaude` setup refactor** (`engine/claude.go`): Add `maxWallTime time.Duration` as the last parameter. After log file setup: (a) create `stageCtx, stageCancel := context.WithTimeout(ctx, maxWallTime)` if `maxWallTime > 0`, else `stageCtx = ctx; stageCancel = func(){}`, always `defer stageCancel()`; (b) initialize `var lastActivity atomic.Int64; lastActivity.Store(time.Now().UnixNano())`; (c) wrap `stdoutWriter` in `activityWriter{inner: stdoutWriter, lastActivity: &lastActivity}` and assign as `cmd.Stdout`; (d) use `stageCtx` in `exec.CommandContext`; (e) after `setCmdProcAttr`, set `cmd.Cancel = func() error { if cmd.Process != nil { logf(issueNumber, "warn", "stage %q exceeded max_wall_time — killing Claude process\n", label); killProcGroupGraceful(cmd.Process.Pid, issueNumber, label) }; return nil }`.

- [ ] **Task 6 — Inactivity watchdog goroutine** (`engine/claude.go`): After configuring `cmd` (before `cmd.Run()`), declare `var inactivityFired atomic.Bool`, then start the watchdog: `watchdogCtx, watchdogCancel := context.WithCancel(context.Background()); go func() { defer watchdogCancel(); timer := time.NewTimer(claudeInactivityTimeout); defer timer.Stop(); for { select { case <-timer.C: since := time.Since(time.Unix(0, lastActivity.Load())); if since >= claudeInactivityTimeout { logf(issueNumber, "warn", "stage %q idle for 15m with no output — killing Claude process\n", label); inactivityFired.Store(true); killProcGroupGraceful(cmd.Process.Pid, issueNumber, label); return }; timer.Reset(claudeInactivityTimeout - since); case <-watchdogCtx.Done(): return } } }()`. After `cmd.Run()` returns, call `watchdogCancel()` immediately (in a `defer` placed before starting the goroutine).

- [ ] **Task 7 — Result processing with `wasTimedOut`** (`engine/claude.go`): After `watchdogCancel()` and `killProcGroup(cmd)`, compute `wasTimedOut := inactivityFired.Load() || (stageCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil)`. In the `parseClaudeJSON` `!ok` branch: if `wasTimedOut`, set `text = extractTextFromAssistantTurns(rawOutput)` and log a warning; otherwise keep the existing error-message path. In the `runErr != nil` block: replace `if ctx.Err() != nil {` with `if ctx.Err() != nil && !wasTimedOut {` so killed-process paths still check for `stageCompleteRE` in `text`.

- [ ] **Task 8 — Thread `maxWallTime` through call chain** (`engine/claude.go`): In `InvokeClaude`, update the `runClaude(...)` call to append `stage.MaxWallTime`. In `InvokeClaudeForComments`, do the same. No changes to `processItem`, `processComments`, or interface signatures.

- [ ] **Task 9 — Tests** (`engine/grandchild_test.go`): Add three `//go:build !windows` tests following the fake-binary pattern:
  - `TestInvokeClaude_MaxWallTimeKillsWithComplete`: fake `claude` prints a valid `assistant` NDJSON line containing `FABRIK_STAGE_COMPLETE` then hangs (`sleep 60`); stage has `MaxWallTime = 500ms`; set `claudeWaitDelay = 1s`; assert `completed=true` and returns within 10s.
  - `TestInvokeClaude_MaxWallTimeKillsWithoutComplete`: fake `claude` hangs immediately (`sleep 60`); `MaxWallTime = 500ms`; assert `completed=false`, returns within 10s.
  - `TestInvokeClaude_InactivityTimeout`: set `claudeInactivityTimeout = 2s`; fake `claude` hangs immediately; assert returns within 15s with `completed=false`.

- [ ] **Task 10 — `docs/USER_GUIDE.md`**: Add `max_wall_time` entry to the Stage YAML Reference section (after `comment_max_turns`). Document: duration string format (e.g. `30m`, `1h`), default (absent = unlimited), suggested `45m` for Implement and Review stages. Add a separate paragraph documenting the hardcoded 15-minute inactivity timeout that applies to every invocation.

- [ ] **Task 11 — `docs/state-machine.md`**: Add two entries to the guard conditions section (invocation kill guards): `max_wall_time exceeded` — wall-clock deadline reached; SIGTERM→SIGKILL sequence terminates the invocation; routes to completion if STAGE_COMPLETE found in stream, otherwise to cooldown/retry. `Inactivity timeout (15m)` — no streamed output for 15 consecutive minutes; same kill and routing behavior.

- [ ] **Task 12 — ADR**: Check `adrs/` for the current highest number at implementation time; create `adrs/NNN-proactive-kill-timeout.md`. Document: the triggering incident (graphiti#26), the layered design (ADR 005 passive WaitDelay + this ADR proactive kill), the `max_wall_time` + 15m inactivity mechanisms, why R9 (stream marker detection) is critical for avoiding re-runs of already-completed stages, and the SIGTERM→10s→SIGKILL sequence reusing #429's process-group plumbing. Add a cross-reference sentence to `adrs/005-claude-cli-invocation.md`.

- [ ] **Task 13 — Build and test**: Run `go build ./...`, `go vet ./...`, and `go test -race ./...` to verify no regressions.

### Risks

1. **Inactivity goroutine leak if `cmd.Run()` panics**: Mitigated by placing `defer watchdogCancel()` before starting the goroutine (defers run even on panic).

2. **Race on `cmd.Process.Pid` in `cmd.Cancel`**: `cmd.Cancel` is only invoked after `cmd.Start()` sets `cmd.Process`, but guard with `if cmd.Process != nil` defensively.

3. **Simultaneous inactivity + wall-time fire**: Both call `killProcGroupGraceful`. The second call gets `ESRCH` (silently ignored). `wasTimedOut` is set by either path. Safe.

4. **`extractTextFromAssistantTurns` edge case — STAGE_COMPLETE split across turns**: If Claude emits the marker string split across two assistant messages, concatenation still assembles it correctly since the whole output is concatenated before the regex check.

5. **WaitDelay interaction with `cmd.Cancel`**: Go calls `cmd.Cancel` on context cancellation, then waits for the process to die. After the process exits, `WaitDelay` drains any remaining I/O (up to 30s). Maximum latency from `max_wall_time` expiry to `cmd.Run()` returning: ≤10s (SIGTERM grace) + 30s (WaitDelay) = ≤40s. Implementer should verify Go 1.26 exec sequencing matches this description (test `TestInvokeClaude_MaxWallTimeKillsWithComplete` will catch divergence).

6. **Fake binary test for inactivity**: The 2s `claudeInactivityTimeout` override must be restored with `defer` to avoid contaminating other tests. Use the same `origDelay` pattern as in `TestInvokeClaude_GrandchildHoldsPipe`.

---
Used 21/50 turns, 8k input / 23k output tokens.

## Verification

(Populated by Implement on completion)

---

Closes #412