### PR TITLE
Update docs for v0.0.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output when grandchild processes hold stdout pipe open (env: `FABRIK_CLAUDE_WAIT_DELAY`). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool. | `30` |
 | `--review-wait-timeout` | Minutes to wait per reviewer-gate cycle before pausing. Explicitly passing `0` uses the built-in default of `15` and bypasses `FABRIK_REVIEW_WAIT_TIMEOUT`. When absent, `FABRIK_REVIEW_WAIT_TIMEOUT` is consulted first; falls back to `15` if unset. | `0` |
 | `--max-review-cycles` | Max re-invocation cycles per reviewer-gate session. Explicitly passing `0` uses the built-in default of `5` and bypasses `FABRIK_MAX_REVIEW_CYCLES`. When absent, `FABRIK_MAX_REVIEW_CYCLES` is consulted first; falls back to `5` if unset. | `0` |
+| `--max-rebase-cycles` | Maximum rebase re-invocation cycles per issue before pausing (0 = default 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` for debugging | `false` |
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides installed plugin) | `""` |
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `--notui` | Disable the interactive TUI dashboard | TUI on by default |
 | `--max-concurrent` | Maximum number of concurrent issue workers | `5` |
 | `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
-| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output when grandchild processes hold stdout pipe open (env: `FABRIK_CLAUDE_WAIT_DELAY`). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool. | `30` |
+| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output when grandchild processes hold stdout pipe open (0 = use built-in default of 30 sec; env: `FABRIK_CLAUDE_WAIT_DELAY`). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool. | `0` (30 sec) |
 | `--review-wait-timeout` | Minutes to wait per reviewer-gate cycle before pausing. Explicitly passing `0` uses the built-in default of `15` and bypasses `FABRIK_REVIEW_WAIT_TIMEOUT`. When absent, `FABRIK_REVIEW_WAIT_TIMEOUT` is consulted first; falls back to `15` if unset. | `0` |
 | `--max-review-cycles` | Max re-invocation cycles per reviewer-gate session. Explicitly passing `0` uses the built-in default of `5` and bypasses `FABRIK_MAX_REVIEW_CYCLES`. When absent, `FABRIK_MAX_REVIEW_CYCLES` is consulted first; falls back to `5` if unset. | `0` |
 | `--max-rebase-cycles` | Maximum rebase re-invocation cycles per issue before pausing (0 = default 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -408,7 +408,7 @@ FABRIK_USER=my-personal-username
 | `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
 | `--max-ci-fix-cycles` | Maximum number of CI-fix re-invocation cycles per issue (0 = use default of 5; also `FABRIK_MAX_CI_FIX_CYCLES`) | `0` (5 cycles) |
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
-| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (also `FABRIK_CLAUDE_WAIT_DELAY`) | `30` |
+| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
 
 ### Environment Variables
@@ -435,7 +435,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |
 | `FABRIK_MAX_CI_FIX_CYCLES` | *(no config.yaml key)* | Maximum number of CI-fix re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 | `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
-| `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (positive integer; invalid or unset values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
+| `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
 
@@ -938,7 +938,7 @@ The CI gate operates on two different paths depending on whether the item is bei
 
 In addition to checking CI status, the catch-up loop also checks the `mergeable` field of the linked PR. When GitHub reports `mergeable: false` (confirmed — not null or pending) while the item is in the CI-await window, Fabrik applies the `fabrik:rebase-needed` label and dispatches a rebase re-invocation. Claude is instructed to `git fetch`, rebase the branch onto the base branch, resolve any conflicts, and force-push. The label clears automatically on the next poll when GitHub flips `mergeable` back to `true`.
 
-The rebase cycle cap is controlled by `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` (default 3). When the cap is exceeded, Fabrik posts a comment, removes `fabrik:rebase-needed`, and pauses the issue with `fabrik:paused` + `fabrik:awaiting-input`. The default of 3 is intentionally lower than the CI-fix and review defaults (both 5): a rebase either succeeds in one automated pass or it has a semantic conflict that requires human judgment. More than a handful of automated attempts without success almost always means a human needs to look at it.
+The rebase cycle cap is controlled by `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` (default 3). When the cap is exceeded, Fabrik posts a comment, keeps `fabrik:rebase-needed` applied so the reason for the pause remains visible, and pauses the issue with `fabrik:paused` + `fabrik:awaiting-input`. The pause comment instructs the operator to resolve the conflict manually, then remove both `fabrik:paused` and `fabrik:rebase-needed` to resume. The default of 3 is intentionally lower than the CI-fix and review defaults (both 5): a rebase either succeeds in one automated pass or it has a semantic conflict that requires human judgment. More than a handful of automated attempts without success almost always means a human needs to look at it.
 
 #### CI-Fix Skill
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -408,6 +408,7 @@ FABRIK_USER=my-personal-username
 | `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
 | `--max-ci-fix-cycles` | Maximum number of CI-fix re-invocation cycles per issue (0 = use default of 5; also `FABRIK_MAX_CI_FIX_CYCLES`) | `0` (5 cycles) |
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
+| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (also `FABRIK_CLAUDE_WAIT_DELAY`) | `30` |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
 
 ### Environment Variables
@@ -434,6 +435,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |
 | `FABRIK_MAX_CI_FIX_CYCLES` | *(no config.yaml key)* | Maximum number of CI-fix re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 | `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
+| `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (positive integer; invalid or unset values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
 
@@ -931,6 +933,12 @@ The CI gate operates on two different paths depending on whether the item is bei
 - On pending: skips (no label applied — R10c)
 - On failure: adds `fabrik:awaiting-ci`; dispatches CI-fix re-invocation
 - On timeout: pauses with `fabrik:paused` + `fabrik:awaiting-input`; timeout measured from when `fabrik:awaiting-ci` was first applied (durable across restarts)
+
+#### Merge-Conflict Gate
+
+In addition to checking CI status, the catch-up loop also checks the `mergeable` field of the linked PR. When GitHub reports `mergeable: false` (confirmed — not null or pending) while the item is in the CI-await window, Fabrik applies the `fabrik:rebase-needed` label and dispatches a rebase re-invocation. Claude is instructed to `git fetch`, rebase the branch onto the base branch, resolve any conflicts, and force-push. The label clears automatically on the next poll when GitHub flips `mergeable` back to `true`.
+
+The rebase cycle cap is controlled by `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` (default 3). When the cap is exceeded, Fabrik posts a comment, removes `fabrik:rebase-needed`, and pauses the issue with `fabrik:paused` + `fabrik:awaiting-input`. The default of 3 is intentionally lower than the CI-fix and review defaults (both 5): a rebase either succeeds in one automated pass or it has a semantic conflict that requires human judgment. More than a handful of automated attempts without success almost always means a human needs to look at it.
 
 #### CI-Fix Skill
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,7 +185,10 @@ description: >-
         <div class="feature-title">Configurable Stages</div>
         <div class="feature-desc">
           Each stage is a YAML file: custom prompt, model choice, tool restrictions,
-          max turns, PR posting, and more. Ship the default pipeline or build your own.
+          max turns, PR posting, and more. Per-stage wall-clock caps
+          (<code>max_wall_time</code>) and a 15-minute inactivity watchdog keep
+          runaway sessions from blocking the pipeline. Ship the default pipeline
+          or build your own.
         </div>
       </div>
       <div class="feature-card">
@@ -307,7 +310,11 @@ description: >-
           again. If the cycle limit (<code>--max-ci-fix-cycles</code>) or
           timeout (<code>FABRIK_CI_WAIT_TIMEOUT</code>) is exceeded, Fabrik
           pauses the issue with <code>fabrik:awaiting-input</code> for human
-          review.
+          review. When GitHub reports the PR as <code>mergeable: false</code>
+          (a conflicting merge landed on the base branch), Fabrik applies
+          <code>fabrik:rebase-needed</code> and dispatches a rebase
+          re-invocation for Claude to fetch, rebase, resolve conflicts, and
+          force-push.
         </div>
       </div>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -311,7 +311,7 @@ description: >-
           timeout (<code>FABRIK_CI_WAIT_TIMEOUT</code>) is exceeded, Fabrik
           pauses the issue with <code>fabrik:awaiting-input</code> for human
           review. When GitHub reports the PR as <code>mergeable: false</code>
-          (a conflicting merge landed on the base branch), Fabrik applies
+          (the PR has merge conflicts with the base branch), Fabrik applies
           <code>fabrik:rebase-needed</code> and dispatches a rebase
           re-invocation for Claude to fetch, rebase, resolve conflicts, and
           force-push.


### PR DESCRIPTION
## Summary

Audit `USER_GUIDE.md`, `README.md`, and `docs/index.md` against the v0.0.46 change set, fill identified gaps, and verify existing sections are complete and accurate end-to-end. No new architectural decisions are needed — the behavior is already implemented and partially documented; this is a gap-filling and consistency pass.

## Problem

v0.0.46 shipped three notable additions — a merge-conflict gate, per-stage wall-time caps + inactivity kill, and a grandchild pipe-hold fix (`--claude-wait-delay`) — that partially landed in the docs during development but were not consistently backfilled across all three surfaces. A reader consulting any one of these files may not find the full picture.

## Approach

### Approach

This is a pure prose documentation gap-fill across three files. No code changes. The research identified exact insertion points and the spec is fully prescriptive about content. Tasks are ordered by file, with each file's changes as a single atomic commit.

**Decision: One commit per file.** Each file change is independently verifiable and cohesive — grouping all three into one commit would make review harder; doing a commit per individual insertion would be overly granular. Three commits, one per file.

**Decision: No new ADRs needed.** All v0.0.46 architectural decisions already have ADRs (ADR-028, ADR-029, ADR-005). The documentation gap-fill doesn't introduce any new decisions.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add `--claude-wait-delay` row to flags table (after line 410); add `FABRIK_CLAUDE_WAIT_DELAY` row to env vars table (after line 436); add `#### Merge-Conflict Gate` prose subsection after line 933 (before `#### CI-Fix Skill`) |
| `README.md` | Add `--max-rebase-cycles` row to flags table (after `--max-review-cycles`, line 262) |
| `docs/index.md` | Expand CI Gate feature card body (lines 301-311) to include merge-conflict gate; expand Configurable Stages feature card body (lines 186-189) to mention `max_wall_time` and inactivity watchdog |

### Key Decisions

- **USER_GUIDE flags table insertion point**: `--claude-wait-delay` goes after `--max-rebase-cycles` (line 410) and before `--debug-output` (line 411). This preserves logical grouping — cycle/timeout flags together, operational flags (`--debug-output`) after.
- **USER_GUIDE env vars table insertion point**: `FABRIK_CLAUDE_WAIT_DELAY` goes after `FABRIK_MAX_REBASE_CYCLES` (line 436). Same rationale — keeps related vars grouped.
- **USER_GUIDE "Merge-Conflict Gate" subsection placement**: After the Two-Prong CI Gate prose (line 933) and before `#### CI-Fix Skill` (line 935). This makes the three-prong narrative contiguous before the implementation-detail subsections.
- **README.md flag insertion**: `--max-rebase-cycles` goes after `--max-review-cycles` (line 262) and before `--debug-output` (line 263). Keeps the review/ci/rebase cycle flags together.
- **docs/index.md CI Gate card**: Append one sentence about the third prong at end of the existing description. Keeps additions minimal (per the brief-card constraint).
- **docs/index.md Configurable Stages card**: Add a trailing clause or sentence about `max_wall_time` and the 15-minute inactivity watchdog. Keep it to one sentence.

### Task Checklist

- [ ] Task 1: **USER_GUIDE.md — flags table**: Add `--claude-wait-delay` row after the `--max-rebase-cycles` row (line 410). Content: seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool; default 30; also `FABRIK_CLAUDE_WAIT_DELAY`.
- [ ] Task 2: **USER_GUIDE.md — env vars table**: Add `FABRIK_CLAUDE_WAIT_DELAY` row after the `FABRIK_MAX_REBASE_CYCLES` row (line 436). Content: `*(no config.yaml key)*`; description matching the detail level of the surrounding rows (positive integer, invalid values default to 30, purpose of grandchild pipe-hold prevention); default 30.
- [ ] Task 3: **USER_GUIDE.md — CI Gate prose subsection**: Insert a new `#### Merge-Conflict Gate` subsection between the Two-Prong CI Gate catch-up loop description (line 933) and the `#### CI-Fix Skill` heading (line 935). Content must cover: trigger condition (`mergeable=false` while in CI-await window), label applied (`fabrik:rebase-needed`), what Claude is instructed to do (fetch + rebase + resolve + force-push), how the label clears (GitHub flips `mergeable` back to true), cycle cap (`--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES`, default 3), and why the default is lower than CI/review defaults (rebase either succeeds in one shot or requires human judgment for semantic conflicts).
- [ ] Task 4: **Consistency cross-check**: Verify the new subsection prose is consistent with (a) the `fabrik:rebase-needed` labels table entry at line ~1246 and (b) the `--max-rebase-cycles` flag description at line 410. Adjust wording if any inconsistency is found.
- [ ] Task 5: **README.md — flags table**: Add `--max-rebase-cycles` row after `--max-review-cycles` (line 262). Content: maximum rebase re-invocation cycles per issue before pausing (0 = default 3; also `FABRIK_MAX_REBASE_CYCLES`); default `0` (3 cycles).
- [ ] Task 6: **docs/index.md — CI Gate card**: Append a sentence to the CI Gate feature card body (lines 301-311) noting the third path: when GitHub reports `mergeable=false`, Fabrik applies `fabrik:rebase-needed` and dispatches a rebase re-invocation for Claude to fetch, rebase, resolve conflicts, and force-push. Keep additions to 1-2 sentences; do not mirror USER_GUIDE depth.
- [ ] Task 7: **docs/index.md — Configurable Stages card**: Expand the feature description (lines 186-189) to add a brief mention of `max_wall_time` (per-stage wall-clock cap) and the 15-minute inactivity watchdog. One sentence, consistent with the "and more" brevity of the existing text.
- [ ] Task 8: **Verify no-change items**: Confirm `max_wall_time` prose sections in USER_GUIDE (lines ~461-472 and ~551-558) are accurate and complete. Confirm `fabrik:rebase-needed` label entry in README (line 312) is accurate. No edits expected — this task is a read-only sanity check.

### Risks

- **USER_GUIDE line drift**: The file is 1,270+ lines. Research identified insertion points by line number; if the file was edited since Research ran, line numbers may have shifted. Mitigation: use `Grep` to locate anchor strings (`--max-rebase-cycles`, `FABRIK_MAX_REBASE_CYCLES`, `#### CI-Fix Skill`) rather than relying on raw line numbers.
- **CI Gate card brevity**: The card is intentionally terse. Over-expanding the merge-conflict gate description to match USER_GUIDE depth would break the design intent. Mitigation: draft the addition as a single sentence maximum and compare visually with the existing card text length.
- **Cross-consistency**: The new "Merge-Conflict Gate" subsection must match the wording in the existing labels table entry (USER_GUIDE §6) and the existing flag description. Mitigation: Task 4 is a dedicated cross-check step before committing.

---
Used 9/50 turns, 4k input / 3k output tokens.

## Verification

Filled all six documentation gaps identified in the v0.0.46 audit across three files in three commits. USER_GUIDE.md gains the `--claude-wait-delay` flag row, `FABRIK_CLAUDE_WAIT_DELAY` env var row, and a new "Merge-Conflict Gate" prose subsection in the CI Gate section. README.md gains the missing `--max-rebase-cycles` flag row. docs/index.md's CI Gate feature card now describes the third prong (mergeable=false → rebase re-invocation) and the Configurable Stages card now mentions `max_wall_time` and the inactivity watchdog. All no-change items (max_wall_time prose sections in USER_GUIDE, rebase-needed label entry in README) verified accurate and untouched.

---

Closes #438