### PR TITLE
Extend turn limit via TUI hotkey or fabrik:extend-turns label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,21 +127,22 @@ effort_level: max               # Claude Code thinking effort: low, medium, high
 - **Commit frequently** during implementation — preserves progress if session is interrupted
 - **Rebase onto the latest base branch** (default branch, or the branch specified by `base:<branch>` label) in Review and Validate stages before signaling completion
 - **Check `git status` first** in any stage — there may be uncommitted work from a previous session
-- **Labels are state**: `fabrik:locked:<user>`, `fabrik:editing`, `fabrik:paused`, `fabrik:awaiting-input`, `fabrik:awaiting-review`, `stage:<name>:in_progress`, `stage:<name>:complete`, `stage:<name>:failed`, `model:<name>`, `effort:<level>`, `fabrik:yolo`, `fabrik:cruise`, `fabrik:unrestricted`, `base:<branch>`
+- **Labels are state**: `fabrik:locked:<user>`, `fabrik:editing`, `fabrik:paused`, `fabrik:awaiting-input`, `fabrik:awaiting-review`, `stage:<name>:in_progress`, `stage:<name>:complete`, `stage:<name>:failed`, `model:<name>`, `effort:<level>`, `fabrik:yolo`, `fabrik:cruise`, `fabrik:unrestricted`, `fabrik:extend-turns`, `base:<branch>`
   - `model:<name>` — set by user to select a specific model for this issue (e.g. `model:opus`)
   - `effort:<level>` — set by user to override the stage's configured thinking effort for this issue only; valid values: `low`, `medium`, `high`, `max`; if multiple `effort:` labels are present, precedence is `max > high > medium > low`
   - `fabrik:yolo` — set by user to force auto-advance even when `auto_advance: false` in stage YAML; also triggers auto-merge of the linked PR when Validate completes
   - `fabrik:cruise` — set by user to auto-advance through all stages without auto-merging the PR or advancing to Done at Validate completion; if both cruise and yolo are present, yolo takes precedence
   - `fabrik:awaiting-review` — set by engine when a stage with `wait_for_reviews: true` completes and outstanding PR reviewer requests remain; cleared when all reviewers submit or `FABRIK_REVIEW_WAIT_TIMEOUT` elapses
   - `fabrik:unrestricted` — passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk`; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set (e.g. non-standard toolchains). **Caution:** removes all tool restrictions.
+  - `fabrik:extend-turns` — set by user as a manual override to pre-grant 2× the stage's `max_turns` budget for the next invocation; auto-removed by the engine on successful stage completion; no-op when `max_turns == 0` (unlimited); subsequent extensions beyond 2× still require automatic progress detection; use as a safety valve when progress detection misfires
   - `base:<branch>` — set by user to override the worktree base branch for this issue; Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default; must be set before Research; multiple `base:` labels use the first and logs a warning; if the branch does not exist on the remote, Fabrik falls back to the default and posts a comment
 
 ## Canonical Documentation
 
 These files are the authoritative as-built specifications for Fabrik's engine behavior. They must be kept in sync with the code — any PR that changes behavior in the areas they cover must update the corresponding doc in the same change set.
 
-- **`docs/state-machine.md`** — As-built specification for: engine state transitions, label semantics, `FABRIK_*` marker handling, comment processing lifecycle, review gate and review reinvoke, PR lifecycle coupling, and guard/filter behavior in `itemMayNeedWork` / `itemNeedsWork`.
-- **`docs/stage-lifecycle.md`** — As-built specification for the per-invocation lifecycle: what happens before, during, and after a single Claude invocation (context files, worktree setup, Claude invocation, output handling).
+- **`docs/state-machine.md`** — As-built specification for: engine state transitions, label semantics, `FABRIK_*` marker handling, comment processing lifecycle, review gate and review reinvoke, PR lifecycle coupling, progress-based turn extension, and guard/filter behavior in `itemMayNeedWork` / `itemNeedsWork`.
+- **`docs/stage-lifecycle.md`** — As-built specification for the per-invocation lifecycle: what happens before, during, and after a single Claude invocation (context files, worktree setup, Claude invocation, progress baseline snapshot, extension loop, output handling).
 
 These are **as-built docs** — they describe what the engine currently does. They are distinct from `adrs/*.md`, which record architectural decisions and design rationale, not current state. Do not put state-machine content into ADRs or vice versa.
 

--- a/adrs/030-progress-based-turn-extension.md
+++ b/adrs/030-progress-based-turn-extension.md
@@ -1,0 +1,78 @@
+# ADR 030: Progress-Based Turn Extension
+
+**Status**: Accepted  
+**Date**: 2026-04-24
+
+## Context
+
+Some issues legitimately require more turns than the stage YAML `max_turns` default: large implementations, complex reviews with many reviewer threads to resolve, or multi-faceted validation tasks. The previous behavior was unconditional: once `max_turns` was hit, the stage failed and entered the cooldown/retry cycle regardless of whether the stage was actually stuck or just doing legitimate work.
+
+The symptom-level fix — bumping `max_turns` globally in the stage YAML — blunts the budget signal for all issues. A per-issue label (`fabrik:extend-turns`) was also considered as the primary mechanism, but a label that requires human intervention for every long-running stage is error-prone and adds operational friction.
+
+The root gap is that the engine had no way to distinguish "legitimately busy" from "genuinely stuck." Observable GitHub and git signals exist for most stages that would allow the engine to make this determination automatically.
+
+## Decision
+
+Add an **in-dispatch extension loop** to `processItem` that wraps the single `e.claude.Invoke()` call. When Claude exits due to `max_turns`, the engine:
+
+1. Checks whether observable progress has been made since the baseline snapshot taken before the first invocation.
+2. If progress is detected → extend by one additional `stage.MaxTurns` quantum (re-invoke with `--resume`).
+3. If no progress → treat as turn-limit failure (same behavior as before).
+4. Hard cap: 3× `stage.MaxTurns` total across all invocations.
+
+Progress signals are per-stage and observable without parsing Claude's output stream:
+
+| Stage | Signal |
+|-------|--------|
+| Implement | New git commit on `fabrik/issue-N` (HEAD SHA changed) |
+| Review | New git commit OR resolved reviewer thread count increased |
+| Validate | Total comment count on issue or linked PR increased |
+| All others | No signal — always fail on turn-limit |
+
+A `fabrik:extend-turns` label is retained as a **manual safety valve**: when present, the first invocation gets 2× the normal budget without requiring a progress check. Subsequent extensions beyond 2× still require progress. The label is auto-removed on successful completion.
+
+## Why In-Dispatch (Not a Catch-Up Loop)
+
+Three existing re-invocation patterns (review reinvoke, CI-fix reinvoke, rebase reinvoke — ADRs 026–028) all operate across poll cycles via the catch-up loop. The extension loop is architecturally different:
+
+- **Output must be accumulated before posting.** Each `--resume` invocation returns only its delta output. Posting after each invocation would produce multiple fragmented stage comments, confusing the issue thread. The extension loop must accumulate all output in memory before posting a single `🏭 Fabrik — stage: <Name>` comment.
+- **WIP commit and push must be deferred.** Committing a WIP in the middle of a multi-invocation stage would create misleading commits and corrupt the progress baseline (since new commits would look like progress on the next extension check). The loop defers `commitWIP` and `PushBranch` to after all invocations complete.
+- **No poll-cycle gap.** The catch-up loop approach would introduce a cooldown period between extensions, increasing latency and complexity. An in-dispatch loop extends within the same goroutine, with no gap.
+- **No goroutine dispatch.** The catch-up loop spawns async goroutines. Extensions do not require goroutine dispatch — they are sequential within `processItem`.
+
+These constraints make the in-dispatch loop the right primitive for turn extension.
+
+## Why In-Memory Baseline (Not Persisted)
+
+The baseline (git HEAD SHA, comment count, resolved thread count) is captured in a local struct within `processItem` and is lost on engine restart. Alternatives considered:
+
+- **`.fabrik-context/` file**: Survives restarts but adds file I/O, introduces a write-before-invoke ordering constraint, and would need cleanup logic. The restart-gap risk (a fresh baseline after restart grants extensions that wouldn't have been granted with full history) is rare and bounded: the engine would simply grant an extension if any progress exists since the fresh baseline.
+- **Issue body annotation**: Too visible and noisy for users; creates merge conflicts.
+- **Engine state file**: Adds persistence infrastructure for a single struct.
+
+In-memory is simpler and the restart-gap risk is acceptable.
+
+## Why Implement Uses Git Commits (Not Checkbox Counting)
+
+The spec mentioned checkbox counting (`- [x]`) as a progress signal for the Implement stage. Research found that `stage-Plan.md` (the canonical plan document) is written once by `writeContextFiles` before the Implement stage starts and does not change during the Implement run. Checked boxes accumulate in the file only when the engine re-writes context files for a new invocation, not mid-run.
+
+Git commits are the right signal for Implement: they reflect actual durable work done in the worktree.
+
+## Why `fabrik:extend-turns` Is Retained
+
+Automatic progress detection may fail in edge cases:
+- The Review stage may have resolved threads before the engine re-fetches (race).
+- The Validate stage may have comments that are not visible in the FetchItemDetails response for timing reasons.
+- Progress detection for Review/Validate has a one-GraphQL-call overhead per turn-limit hit, which may have transient failures.
+
+The `fabrik:extend-turns` label provides a bypass that does not depend on progress detection. It is a safety valve, not the default path.
+
+## Consequences
+
+- Stages with measurable progress no longer fail spuriously at `max_turns`.
+- The hard cap (3×) bounds runaway extension.
+- Per-stage comments are clean: one comment per stage invocation (from all extensions combined).
+- The `fabrik:extend-turns` label is seeded by `SeedLabels` at engine startup.
+- Review and Validate progress detection costs one GraphQL call per turn-limit hit — bounded and acceptable.
+- Plan, Research, and Specify always fail on turn-limit (no observable progress signal within a dispatch).
+- ADRs 026–028 (reinvoke patterns) are unaffected; extension is orthogonal to those patterns.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -24,3 +24,4 @@ contributors and future maintainers.
 | [012](012-stage-comment-living-document.md) | Stage Comment as Living Document | Accepted |
 | [013](013-project-config-yaml.md) | `.fabrik/config.yaml` as Project-Level Config Source | Accepted |
 | [028](028-rate-limit-backoff-hysteresis.md) | Two-Threshold Hysteresis for Rate-Limit Backoff | Accepted |
+| [030](030-progress-based-turn-extension.md) | Progress-Based Turn Extension | Accepted |

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -176,6 +176,43 @@ After `cmd.Run()` returns, two cleanup steps run unconditionally:
 
 2. **WaitDelay bound**: `cmd.WaitDelay` is set to 30s (configurable via `--claude-wait-delay` / `FABRIK_CLAUDE_WAIT_DELAY`). When grandchild processes hold the stdout pipe open after Claude exits, Go's `cmd.Wait()` would otherwise block indefinitely. With `WaitDelay`, Go forcibly closes its end of the pipe after the deadline and returns `exec.ErrWaitDelay`. The engine detects this error, logs a diagnostic warning, clears the error, and processes the buffered output normally — including any `FABRIK_STAGE_COMPLETE` marker. This prevents the worker goroutine from being permanently stuck when Claude uses `run_in_background` or the Monitor tool.
 
+### Progress Baseline Snapshot
+
+Immediately before the first invocation, `snapshotBaseline` captures observable progress state for this stage:
+
+| Stage | Baseline fields captured |
+|-------|--------------------------|
+| **Implement** | `gitHeadSHA` — `git rev-parse HEAD` in the worktree |
+| **Review** | `gitHeadSHA` + `resolvedThreadCount` — `LinkedPRResolvedThreadCount` from the poll cycle's `FetchItemDetails` |
+| **Validate** | `commentCount` — `len(item.Comments)` from the poll cycle's `FetchItemDetails` |
+| **All others** | (empty — no extension possible) |
+
+The baseline is purely in-memory; it is lost on engine restart (an acceptable risk per ADR 030).
+
+### Turn-Limit Extension Loop
+
+The `e.claude.Invoke()` call runs inside an extension loop. On each iteration:
+
+1. `opts.MaxTurnsOverride` is set to `currentBudget` (first iteration: `stage.MaxTurns`, or `2 × stage.MaxTurns` if `fabrik:extend-turns` is present).
+2. Claude is invoked. Output is appended to `totalOutput`; usage is accumulated into `totalUsage`.
+3. Turn-limit check: `!completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget`.
+4. If turn limit was NOT hit (or stage completed), exit the loop.
+5. If `totalMultiple >= 3` (hard cap), exit the loop (fail as turn-limit).
+6. Call `detectProgress`. If progress → `totalMultiple++`, set `currentBudget = stage.MaxTurns`, set `resume = true`, log `[#N extend-turns]`, loop.
+7. If no progress or progress check fails → exit the loop (fail as turn-limit).
+
+**`detectProgress` per stage:**
+- **Implement**: `git rev-parse HEAD` in worktree; progress if SHA changed.
+- **Review**: `git rev-parse HEAD`; if SHA same → `FetchItemDetails` re-fetch; progress if `LinkedPRResolvedThreadCount` increased. One GraphQL call only when no new commits.
+- **Validate**: `FetchItemDetails` re-fetch; progress if `len(Comments)` increased. One GraphQL call per check.
+- **All others**: return `false` immediately.
+
+**Output accumulation:** Each `--resume` invocation produces only the delta output for that session continuation. The engine concatenates all invocations' output before posting. The empty-output check (`strings.TrimSpace(output) == ""`) applies to the accumulated total.
+
+**Deferred WIP commit and push:** The `commitWIP` and `PushBranch` calls happen AFTER the extension loop completes, not between invocations. This preserves worktree state across extensions.
+
+**Stats footer:** After the loop, `usage.MaxTurns` is set to `totalMultiple × stage.MaxTurns`, so the stats line reflects the total budget (e.g., `used 130/150 turns`).
+
 ---
 
 ## Phase 4: Post-Stage Handling
@@ -225,10 +262,11 @@ After a stage runs, any pre-existing user comments get a rocket reaction via `ma
 When `FABRIK_STAGE_COMPLETE` is detected (regardless of Claude's exit code — as of v0.0.26, a non-zero exit is treated as a warning, not a failure, when the marker is present):
 1. Lock released (`fabrik:locked:<user>` and `stage:<name>:in_progress` removed)
 2. Retry tracking cleared
-3. Draft PR created (if `create_draft_pr: true`)
-4. PR marked ready (if `mark_pr_ready_on_complete: true`)
-5. `stage:<name>:complete` label added
-6. Auto-advance to next stage (if `auto_advance: true` or global `yolo`)
+3. `fabrik:extend-turns` removed (if present); `ErrNotFound` treated as success (user already removed it)
+4. Draft PR created (if `create_draft_pr: true`)
+5. PR marked ready (if `mark_pr_ready_on_complete: true`)
+6. `stage:<name>:complete` label added
+7. Auto-advance to next stage (if `auto_advance: true` or global `yolo`)
 
 ### Blocked-on-Input Path
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -376,9 +376,9 @@ This table shows the normal flow when an issue progresses through the pipeline w
 
 #### Turn Limit Extension
 
-When Claude exits a stage invocation due to `max_turns` (i.e., `usage.TurnsUsed >= currentBudget && !completed && err == nil`), the engine evaluates whether to extend before entering the cooldown/retry path.
+When Claude exits a stage invocation due to `max_turns` (i.e., the per-invocation turn usage satisfies `invUsage.TurnsUsed >= currentBudget` and `!completed && err == nil`), the engine evaluates whether to extend before entering the cooldown/retry path.
 
-**Extension trigger condition:** `!completed && err == nil && stage.MaxTurns > 0 && usage.TurnsUsed >= currentBudget`
+**Extension trigger condition:** `!completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget`
 
 **Hard cap:** 3× `stage.MaxTurns` total across all invocations. When `totalMultiple >= 3`, no further extension is attempted.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -68,6 +68,7 @@ These labels do not define distinct states but influence transition behavior:
 | `fabrik:yolo` | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` |
 | `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
+| `fabrik:extend-turns` | Pre-grants a 2× turn budget for the next stage invocation; auto-removed on stage success; no-op when `max_turns == 0` |
 | `model:<name>` | Selects a specific model for this issue (e.g., `model:opus`) |
 | `effort:<level>` | Overrides stage effort level (`low`, `medium`, `high`, `max`); highest wins |
 | `base:<branch>` | Overrides worktree base branch; falls back to default if not on remote; updates PR base if PR exists |
@@ -125,6 +126,7 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
 | `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
 | `fabrik:unrestricted` | User (manual) | Any time | User (manual) | Any time | Passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` |
+| `fabrik:extend-turns` | User (manual) | Any time | `processItem` (on success) or User (manual) | On successful stage completion; or manual removal | Pre-grants 2× `stage.MaxTurns` budget for the first invocation; no-op when `max_turns == 0` (unlimited); subsequent extensions beyond 2× still require progress detection |
 | `model:<name>` | User (manual) | Any time | User (manual) | Any time | Selects Claude model; first label wins if multiple present |
 | `effort:<level>` | User (manual) | Any time | User (manual) | Any time | Overrides stage effort level; highest-ranked wins if multiple present |
 | `base:<branch>` | User (manual) | Before Research (recommended) | User (manual) | Any time | Overrides worktree base branch; falls back to default if branch not found on remote; if a PR exists, its base branch is updated to match on each stage invocation |
@@ -371,6 +373,42 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Same column, Cooldown | Poll tick | Cooldown expired | Same column, Locked + In Progress (retry) | | `stage:<X>:failed` (if present from prior escalation) | Claude re-invoked with `resume=true` |
 | Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && MaxRetries > 0` | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released |
 | Same column, Paused + Failed | Human removes `fabrik:paused` | `stage:<X>:failed` present OR `pausedDueToRetries` in memory | Same column, Idle | | `stage:<X>:failed` | `clearFailedStage()` resets retryCount, pausedDueToRetries, processedSet, reviewCycleCount |
+
+#### Turn Limit Extension
+
+When Claude exits a stage invocation due to `max_turns` (i.e., `usage.TurnsUsed >= currentBudget && !completed && err == nil`), the engine evaluates whether to extend before entering the cooldown/retry path.
+
+**Extension trigger condition:** `!completed && err == nil && stage.MaxTurns > 0 && usage.TurnsUsed >= currentBudget`
+
+**Hard cap:** 3× `stage.MaxTurns` total across all invocations. When `totalMultiple >= 3`, no further extension is attempted.
+
+**Per-stage progress signals:**
+
+| Stage | Progress Signal | API Cost |
+|-------|----------------|----------|
+| **Implement** | New git commit on `fabrik/issue-N` branch (HEAD SHA changed) | Zero — local git only |
+| **Review** | New git commit OR `LinkedPRResolvedThreadCount` increased | One `FetchItemDetails` GraphQL call (only if no new commit) |
+| **Validate** | Total comment count on issue/PR increased | One `FetchItemDetails` GraphQL call |
+| **All others** (Research, Specify, Plan, custom) | No signal — always fail on turn-limit | None |
+
+**Extension loop behavior (within a single `processItem` call — no poll-cycle gap):**
+
+1. At invocation start, a `progressBaseline` is snapshotted (git HEAD SHA, comment count, resolved thread count).
+2. Claude is invoked with the current budget.
+3. If the turn limit is hit AND `totalMultiple < 3`: call `detectProgress`. If progress → `totalMultiple++`, re-invoke with `--resume`. If no progress or progress check fails → proceed to cooldown/retry as today.
+4. Output is accumulated across all invocations before posting as a single stage comment.
+5. WIP commit and push are deferred to after the loop.
+
+**`fabrik:extend-turns` label:** When present at invocation start, the first invocation receives `2 × stage.MaxTurns` as its budget (pre-granted extension, no progress check required for the first turn-limit hit). Subsequent extensions beyond 2× still require the progress check. The label is auto-removed on successful stage completion; `ErrNotFound` on removal is treated as success (user removed it manually). The label is a no-op when `stage.MaxTurns == 0`.
+
+**Log tag:** `[#N extend-turns]` — emitted when an extension is granted, including the new multiple and cumulative turns used.
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple < 3`; progress detected | Same column, Locked + In Progress (extension) | | | `totalMultiple++`; `resume=true`; output accumulated; no WIP commit or push between extensions |
+| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; treated as turn-limit failure; `processedSet` updated; WIP commit + push |
+| Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; treated as turn-limit failure; `processedSet` updated; WIP commit + push |
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE (any extension) | `completed = true` | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress`, `fabrik:extend-turns` (if present) | Normal completion flow; extend-turns label auto-removed |
 
 #### Cleanup Stage
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -111,6 +111,7 @@ func (t TokenUsage) add(other TokenUsage) TokenUsage {
 		CacheCreationTokens: t.CacheCreationTokens + other.CacheCreationTokens,
 		CacheReadTokens:     t.CacheReadTokens + other.CacheReadTokens,
 		CostUSD:             t.CostUSD + other.CostUSD,
+		TurnsUsed:           t.TurnsUsed + other.TurnsUsed,
 	}
 }
 
@@ -238,11 +239,15 @@ func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem
 	ld := logDirForItem(issue)
 
 	prompt := buildPrompt(stage, issue, newComments, opts.BaseBranch)
-	args := buildClaudeArgs(stage, sessFilePath, resume, opts.ModelOverride, stage.MaxTurns, hasUnrestrictedLabel(issue), workDir)
+	effectiveBudget := stage.MaxTurns
+	if opts.MaxTurnsOverride > 0 {
+		effectiveBudget = opts.MaxTurnsOverride
+	}
+	args := buildClaudeArgs(stage, sessFilePath, resume, opts.ModelOverride, effectiveBudget, hasUnrestrictedLabel(issue), workDir)
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
 	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv, stage.MaxWallTime)
-	usage.MaxTurns = stage.MaxTurns
+	usage.MaxTurns = effectiveBudget
 	if err != nil {
 		return output, completed, usage, err
 	}

--- a/engine/extend_test.go
+++ b/engine/extend_test.go
@@ -1,0 +1,276 @@
+package engine
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+func TestHasExtendTurnsLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"label present", []string{"fabrik:extend-turns"}, true},
+		{"label absent", []string{"fabrik:yolo", "model:opus"}, false},
+		{"empty labels", nil, false},
+		{"wrong prefix only", []string{"extend-turns", "fabrik:extend"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			item := gh.ProjectItem{Labels: tc.labels}
+			if got := hasExtendTurnsLabel(item); got != tc.want {
+				t.Errorf("hasExtendTurnsLabel = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSnapshotBaseline_NoSignalStages(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	item := gh.ProjectItem{
+		Comments: []gh.Comment{{Body: "c1"}, {Body: "c2"}},
+		LinkedPRResolvedThreadCount: 3,
+	}
+
+	for _, stageName := range []string{"Research", "Specify", "Done"} {
+		stage := &stages.Stage{Name: stageName}
+		b := snapshotBaseline(stage, item, repoDir)
+		if b.gitHeadSHA != "" {
+			t.Errorf("stage %s: expected empty gitHeadSHA for no-signal stage, got %q", stageName, b.gitHeadSHA)
+		}
+		if b.commentCount != 0 {
+			t.Errorf("stage %s: expected 0 commentCount, got %d", stageName, b.commentCount)
+		}
+		if b.resolvedThreadCount != 0 {
+			t.Errorf("stage %s: expected 0 resolvedThreadCount, got %d", stageName, b.resolvedThreadCount)
+		}
+	}
+}
+
+func TestSnapshotBaseline_Implement(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{Comments: []gh.Comment{{Body: "c1"}}, LinkedPRResolvedThreadCount: 5}
+	b := snapshotBaseline(stage, item, repoDir)
+
+	if b.gitHeadSHA == "" {
+		t.Fatal("expected non-empty gitHeadSHA for Implement stage")
+	}
+	if b.commentCount != 0 {
+		t.Errorf("Implement: commentCount should be 0 (not a Validate signal), got %d", b.commentCount)
+	}
+	if b.resolvedThreadCount != 0 {
+		t.Errorf("Implement: resolvedThreadCount should be 0, got %d", b.resolvedThreadCount)
+	}
+}
+
+func TestSnapshotBaseline_Review(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	stage := &stages.Stage{Name: "Review"}
+	item := gh.ProjectItem{LinkedPRResolvedThreadCount: 7}
+	b := snapshotBaseline(stage, item, repoDir)
+
+	if b.gitHeadSHA == "" {
+		t.Fatal("expected non-empty gitHeadSHA for Review stage")
+	}
+	if b.resolvedThreadCount != 7 {
+		t.Errorf("Review: resolvedThreadCount = %d, want 7", b.resolvedThreadCount)
+	}
+}
+
+func TestSnapshotBaseline_Validate(t *testing.T) {
+	stage := &stages.Stage{Name: "Validate"}
+	item := gh.ProjectItem{Comments: []gh.Comment{{Body: "a"}, {Body: "b"}, {Body: "c"}}}
+	b := snapshotBaseline(stage, item, "/irrelevant")
+
+	if b.commentCount != 3 {
+		t.Errorf("Validate: commentCount = %d, want 3", b.commentCount)
+	}
+	if b.gitHeadSHA != "" {
+		t.Errorf("Validate: gitHeadSHA should be empty, got %q", b.gitHeadSHA)
+	}
+}
+
+func TestDetectProgress_NoSignalStage(t *testing.T) {
+	ctx := context.Background()
+	for _, stageName := range []string{"Research", "Specify", "Plan", "Done"} {
+		stage := &stages.Stage{Name: stageName}
+		item := gh.ProjectItem{}
+		b := progressBaseline{}
+		progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", &mockGitHubClient{})
+		if err != nil {
+			t.Errorf("stage %s: unexpected error: %v", stageName, err)
+		}
+		if progress {
+			t.Errorf("stage %s: expected no progress for no-signal stage", stageName)
+		}
+	}
+}
+
+func TestDetectProgress_Implement_NoNewCommits(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	sha, err := gitHeadSHA(repoDir)
+	if err != nil {
+		t.Fatalf("gitHeadSHA: %v", err)
+	}
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: sha}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if progress {
+		t.Error("expected no progress when SHA unchanged")
+	}
+}
+
+func TestDetectProgress_Implement_NewCommit(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	// Snapshot the old SHA
+	oldSHA, err := gitHeadSHA(repoDir)
+	if err != nil {
+		t.Fatalf("gitHeadSHA: %v", err)
+	}
+
+	// Create a new commit
+	cmds := [][]string{
+		{"git", "commit", "--allow-empty", "-m", "progress commit"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: oldSHA}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !progress {
+		t.Error("expected progress detected after new commit")
+	}
+}
+
+func TestDetectProgress_Validate_NoNewComments(t *testing.T) {
+	ctx := context.Background()
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.Comments = []gh.Comment{{Body: "existing"}}
+			return nil
+		},
+	}
+	stage := &stages.Stage{Name: "Validate"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{commentCount: 1}
+
+	progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if progress {
+		t.Error("expected no progress when comment count unchanged")
+	}
+}
+
+func TestDetectProgress_Validate_NewComment(t *testing.T) {
+	ctx := context.Background()
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.Comments = []gh.Comment{{Body: "old"}, {Body: "new"}}
+			return nil
+		},
+	}
+	stage := &stages.Stage{Name: "Validate"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{commentCount: 1}
+
+	progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !progress {
+		t.Error("expected progress when comment count increased")
+	}
+}
+
+func TestDetectProgress_Review_NewResolvedThread(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	sha, err := gitHeadSHA(repoDir)
+	if err != nil {
+		t.Fatalf("gitHeadSHA: %v", err)
+	}
+
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRResolvedThreadCount = 2
+			return nil
+		},
+	}
+	stage := &stages.Stage{Name: "Review"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: sha, resolvedThreadCount: 1}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !progress {
+		t.Error("expected progress when resolved thread count increased")
+	}
+}
+
+func TestDetectProgress_Review_FetchError(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	sha, err := gitHeadSHA(repoDir)
+	if err != nil {
+		t.Fatalf("gitHeadSHA: %v", err)
+	}
+
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			return &testError{"api failure"}
+		},
+	}
+	stage := &stages.Stage{Name: "Review"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: sha, resolvedThreadCount: 0}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, client)
+	if err == nil {
+		t.Fatal("expected error when FetchItemDetails fails")
+	}
+	if progress {
+		t.Error("expected no progress on fetch error")
+	}
+}
+

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -44,9 +44,10 @@ type GitHubClient interface {
 // Using a struct rather than individual parameters means future overrides
 // (e.g. DisableAdaptiveThinking) are zero-churn field additions.
 type InvokeOptions struct {
-	ModelOverride  string // from "model:<name>" label, overrides stage.Model
-	EffortOverride string // from "effort:<level>" label, overrides stage.EffortLevel
-	BaseBranch     string // actual default base branch for the managed repo (e.g. "liminis", not always "main")
+	ModelOverride    string // from "model:<name>" label, overrides stage.Model
+	EffortOverride   string // from "effort:<level>" label, overrides stage.EffortLevel
+	BaseBranch       string // actual default base branch for the managed repo (e.g. "liminis", not always "main")
+	MaxTurnsOverride int    // when > 0, overrides stage.MaxTurns for this invocation; 0 means use stage.MaxTurns
 }
 
 // ClaudeInvoker defines the interface for invoking Claude Code.

--- a/engine/item.go
+++ b/engine/item.go
@@ -624,7 +624,53 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.logf(item.Number, "effort", "using effort override %q\n", effortOverride)
 	}
 	resume := attempted // resume session if we've processed this before
-	output, completed, usage, err := e.claude.Invoke(ctx, stage, item, nil, resume, workDir, InvokeOptions{ModelOverride: modelOverride, EffortOverride: effortOverride, BaseBranch: baseBranch})
+	opts := InvokeOptions{ModelOverride: modelOverride, EffortOverride: effortOverride, BaseBranch: baseBranch}
+
+	// Determine initial turn budget. When fabrik:extend-turns is present the first
+	// invocation gets a 2× budget (pre-granted extension, no progress check needed).
+	firstBudget := stage.MaxTurns
+	totalMultiple := 1
+	if hasExtendTurnsLabel(item) && stage.MaxTurns > 0 {
+		firstBudget = 2 * stage.MaxTurns
+		totalMultiple = 2
+	}
+	baseline := snapshotBaseline(stage, item, workDir)
+
+	// Extension loop: re-invoke with --resume when max_turns is hit and progress is detected.
+	// Hard cap is 3× stage.MaxTurns total across all invocations.
+	var output string
+	var completed bool
+	var usage TokenUsage
+	currentBudget := firstBudget
+	for {
+		opts.MaxTurnsOverride = currentBudget
+		var invOutput string
+		var invUsage TokenUsage
+		invOutput, completed, invUsage, err = e.claude.Invoke(ctx, stage, item, nil, resume, workDir, opts)
+		output += invOutput
+		usage = usage.add(invUsage)
+
+		hitLimit := !completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget
+		if !hitLimit || totalMultiple >= 3 {
+			break
+		}
+		hasProgress, progressErr := detectProgress(ctx, stage, &item, baseline, workDir, e.client)
+		if progressErr != nil {
+			e.logf(item.Number, "extend-turns", "progress check failed: %v\n", progressErr)
+			break
+		}
+		if !hasProgress {
+			break
+		}
+		totalMultiple++
+		currentBudget = stage.MaxTurns
+		e.logf(item.Number, "extend-turns", "progress detected — extending to %d× budget (%d turns used)\n",
+			totalMultiple, usage.TurnsUsed)
+		resume = true
+	}
+	// Report cumulative budget across all extensions in stats footer.
+	usage.MaxTurns = totalMultiple * stage.MaxTurns
+
 	if usage.TurnsUsed > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
 		if usage.MaxTurns > 0 {
 			e.logf(item.Number, "stats", "used %d/%d turns, %dk input / %dk output tokens\n",
@@ -793,6 +839,14 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			delete(e.retryCount, stageKey)
 			delete(e.pausedDueToRetries, stageKey)
 		}()
+		// Remove fabrik:extend-turns on successful completion so the next stage
+		// gets a normal budget. ErrNotFound means the user already removed it.
+		if hasExtendTurnsLabel(item) {
+			if removeErr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:extend-turns"); removeErr != nil &&
+				!errors.Is(removeErr, gh.ErrNotFound) {
+				e.logf(item.Number, "warn", "could not remove extend-turns label: %v\n", removeErr)
+			}
+		}
 		// Post-stage: create draft PR and/or mark ready now that commits exist
 		var prNumber int
 		if stage.CreateDraftPR {
@@ -1118,4 +1172,83 @@ func (e *Engine) commitWIP(workDir string, issueNumber int, stageName string) {
 	}
 
 	e.logf(issueNumber, "info", "committed WIP changes for incomplete %s stage\n", stageName)
+}
+
+// progressBaseline captures observable progress signals at the start of a stage
+// invocation. Used by detectProgress to determine whether extension is warranted
+// when Claude hits max_turns.
+type progressBaseline struct {
+	gitHeadSHA          string // HEAD commit SHA in the worktree (Implement, Review)
+	commentCount        int    // total comment count on item (Validate)
+	resolvedThreadCount int    // resolved PR review threads (Review)
+}
+
+// hasExtendTurnsLabel returns true if item carries the "fabrik:extend-turns" label.
+func hasExtendTurnsLabel(item gh.ProjectItem) bool {
+	return hasLabel(item, "fabrik:extend-turns")
+}
+
+// snapshotBaseline captures observable progress state for stage before the first invocation.
+func snapshotBaseline(stage *stages.Stage, item gh.ProjectItem, workDir string) progressBaseline {
+	var b progressBaseline
+	switch stage.Name {
+	case "Implement":
+		if sha, err := gitHeadSHA(workDir); err == nil {
+			b.gitHeadSHA = sha
+		}
+	case "Review":
+		if sha, err := gitHeadSHA(workDir); err == nil {
+			b.gitHeadSHA = sha
+		}
+		b.resolvedThreadCount = item.LinkedPRResolvedThreadCount
+	case "Validate":
+		b.commentCount = len(item.Comments)
+	}
+	return b
+}
+
+// gitHeadSHA runs "git rev-parse HEAD" in dir and returns the trimmed SHA.
+func gitHeadSHA(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// detectProgress checks whether measurable progress was made since baseline.
+// Implement: new commits (git HEAD SHA changed). Review: new commits OR resolved
+// reviewer thread count increased (GitHub re-fetch). Validate: total comment count
+// increased (GitHub re-fetch). All other stages return false — no extension.
+// If a GitHub re-fetch fails, returns false and the error (conservative: fail as today).
+func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem, baseline progressBaseline, workDir string, client GitHubClient) (bool, error) {
+	switch stage.Name {
+	case "Implement":
+		sha, err := gitHeadSHA(workDir)
+		if err != nil {
+			return false, err
+		}
+		return sha != baseline.gitHeadSHA, nil
+	case "Review":
+		sha, err := gitHeadSHA(workDir)
+		if err != nil {
+			return false, err
+		}
+		if sha != baseline.gitHeadSHA {
+			return true, nil
+		}
+		// No new commits — re-fetch to check resolved reviewer threads.
+		if err := client.FetchItemDetails(item); err != nil {
+			return false, fmt.Errorf("re-fetching item for progress check: %w", err)
+		}
+		return item.LinkedPRResolvedThreadCount > baseline.resolvedThreadCount, nil
+	case "Validate":
+		if err := client.FetchItemDetails(item); err != nil {
+			return false, fmt.Errorf("re-fetching item for progress check: %w", err)
+		}
+		return len(item.Comments) > baseline.commentCount, nil
+	}
+	return false, nil
 }

--- a/engine/item.go
+++ b/engine/item.go
@@ -626,11 +626,17 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	resume := attempted // resume session if we've processed this before
 	opts := InvokeOptions{ModelOverride: modelOverride, EffortOverride: effortOverride, BaseBranch: baseBranch}
 
+	// Snapshot extend-turns presence before any FetchItemDetails re-fetches (which
+	// refresh item.Labels). Using a stable boolean ensures the first-budget calc and
+	// the completion-block auto-removal decision are consistent regardless of what
+	// a mid-loop re-fetch changes in item.Labels.
+	hadExtendTurnsLabel := hasExtendTurnsLabel(item)
+
 	// Determine initial turn budget. When fabrik:extend-turns is present the first
 	// invocation gets a 2× budget (pre-granted extension, no progress check needed).
 	firstBudget := stage.MaxTurns
 	totalMultiple := 1
-	if hasExtendTurnsLabel(item) && stage.MaxTurns > 0 {
+	if hadExtendTurnsLabel && stage.MaxTurns > 0 {
 		firstBudget = 2 * stage.MaxTurns
 		totalMultiple = 2
 	}
@@ -841,7 +847,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		}()
 		// Remove fabrik:extend-turns on successful completion so the next stage
 		// gets a normal budget. ErrNotFound means the user already removed it.
-		if hasExtendTurnsLabel(item) {
+		if hadExtendTurnsLabel {
 			if removeErr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:extend-turns"); removeErr != nil &&
 				!errors.Is(removeErr, gh.ErrNotFound) {
 				e.logf(item.Number, "warn", "could not remove extend-turns label: %v\n", removeErr)

--- a/engine/item_test.go
+++ b/engine/item_test.go
@@ -44,7 +44,7 @@ func TestExtensionLoop_ProgressDetected(t *testing.T) {
 				cmd := exec.Command("git", "commit", "--allow-empty", "-m", "progress commit")
 				cmd.Dir = workDir
 				if out, err := cmd.CombinedOutput(); err != nil {
-					t.Logf("git commit in mock: %s: %v", out, err)
+					t.Fatalf("git commit in mock failed: %s: %v", out, err)
 				}
 				return "output-from-ext1\n", false, TokenUsage{TurnsUsed: 10, InputTokens: 100}, nil
 			case 2:
@@ -163,7 +163,7 @@ func TestExtensionLoop_HardCap(t *testing.T) {
 				"-m", "progress commit "+string(rune('0'+callCount)))
 			cmd.Dir = workDir
 			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Logf("git commit: %s: %v", out, err)
+				t.Fatalf("git commit failed: %s: %v", out, err)
 			}
 			return "output\n", false, TokenUsage{TurnsUsed: 10}, nil
 		},

--- a/engine/item_test.go
+++ b/engine/item_test.go
@@ -1,0 +1,296 @@
+package engine
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/stages"
+)
+
+// implementStages returns a minimal stage list with a single Implement stage
+// that has MaxTurns set so turn-limit detection works.
+func implementStages(maxTurns int) []*stages.Stage {
+	return []*stages.Stage{
+		{
+			Name:       "Implement",
+			Order:      1,
+			MaxTurns:   maxTurns,
+			Prompt:     "Implement it",
+			Completion: stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+}
+
+// TestExtensionLoop_ProgressDetected verifies that when the first invocation hits
+// max_turns and the mock makes a git commit (simulating real progress), the engine
+// performs a second invocation with resume=true, concatenates output, and marks
+// the stage complete.
+func TestExtensionLoop_ProgressDetected(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				// Simulate progress: make a commit in the worktree, then return turn-limit hit.
+				cmd := exec.Command("git", "commit", "--allow-empty", "-m", "progress commit")
+				cmd.Dir = workDir
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Logf("git commit in mock: %s: %v", out, err)
+				}
+				return "output-from-ext1\n", false, TokenUsage{TurnsUsed: 10, InputTokens: 100}, nil
+			case 2:
+				if !resume {
+					t.Error("second invocation must use resume=true")
+				}
+				return "output-from-ext2\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{TurnsUsed: 8, InputTokens: 80}, nil
+			default:
+				t.Errorf("unexpected invocation #%d", callCount)
+				return "", false, TokenUsage{}, nil
+			}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			Stages:     implementStages(10),
+		},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 1,
+		Title:  "Extend Test",
+		Status: "Implement",
+		ItemID: "PVTI_1",
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 claude invocations, got %d", callCount)
+	}
+
+	// Output posted should contain both invocations' output
+	if len(client.addCommentCalls) == 0 {
+		t.Fatal("expected at least one comment posted")
+	}
+	posted := client.addCommentCalls[0].body
+	if !strings.Contains(posted, "output-from-ext1") {
+		t.Errorf("posted comment missing output from first extension: %q", posted)
+	}
+	if !strings.Contains(posted, "output-from-ext2") {
+		t.Errorf("posted comment missing output from second extension: %q", posted)
+	}
+}
+
+// TestExtensionLoop_NoProgress verifies that when the first invocation hits max_turns
+// but no git progress is detected, the engine does NOT perform a second invocation.
+func TestExtensionLoop_NoProgress(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			// Hit turn limit; make NO commit — progress detection should fail.
+			return "partial output\n", false, TokenUsage{TurnsUsed: 10}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			Stages:     implementStages(10),
+		},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 2,
+		Title:  "No Progress Test",
+		Status: "Implement",
+		ItemID: "PVTI_2",
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 claude invocation (no extension without progress), got %d", callCount)
+	}
+}
+
+// TestExtensionLoop_HardCap verifies that extensions stop at 3× stage.MaxTurns
+// even when progress is detected each time.
+func TestExtensionLoop_HardCap(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			// Always make a commit to simulate progress, always hit max_turns.
+			cmd := exec.Command("git", "commit", "--allow-empty",
+				"-m", "progress commit "+string(rune('0'+callCount)))
+			cmd.Dir = workDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Logf("git commit: %s: %v", out, err)
+			}
+			return "output\n", false, TokenUsage{TurnsUsed: 10}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			Stages:     implementStages(10),
+		},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 3,
+		Title:  "Hard Cap Test",
+		Status: "Implement",
+		ItemID: "PVTI_3",
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// 3× hard cap: first invocation (totalMultiple=1), second (totalMultiple=2), third (totalMultiple=3).
+	// After the third invocation, totalMultiple >= 3 → no more extensions.
+	if callCount != 3 {
+		t.Errorf("expected 3 claude invocations (hard cap), got %d", callCount)
+	}
+}
+
+// TestExtensionLoop_ExtendTurnsLabel verifies that when fabrik:extend-turns is present,
+// the first invocation gets 2× the normal budget (opts.MaxTurnsOverride = 2×MaxTurns).
+func TestExtensionLoop_ExtendTurnsLabel(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Verify that on the first call the override is 2×10=20
+			if opts.MaxTurnsOverride != 20 {
+				t.Errorf("first invocation MaxTurnsOverride = %d, want 20 (2× MaxTurns)", opts.MaxTurnsOverride)
+			}
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			Stages:     implementStages(10),
+		},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 4,
+		Title:  "Extend Label Test",
+		Status: "Implement",
+		ItemID: "PVTI_4",
+		Labels: []string{"fabrik:extend-turns"},
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+}
+
+// TestExtensionLoop_ExtendTurnsLabel_AutoRemoved verifies that fabrik:extend-turns
+// is removed after successful stage completion.
+func TestExtensionLoop_ExtendTurnsLabel_AutoRemoved(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			Stages:     implementStages(10),
+		},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 5,
+		Title:  "Auto Remove Test",
+		Status: "Implement",
+		ItemID: "PVTI_5",
+		Labels: []string{"fabrik:extend-turns"},
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// Verify fabrik:extend-turns was removed
+	found := false
+	for _, call := range client.removeLabelCalls {
+		if call.labelName == "fabrik:extend-turns" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected fabrik:extend-turns to be removed on successful completion")
+	}
+}

--- a/github/labels.go
+++ b/github/labels.go
@@ -23,6 +23,7 @@ var staticLabelDefs = []labelDef{
 	// --- behaviour labels (blue) ---
 	{"fabrik:yolo", "Auto-advance all stages and auto-merge the PR at Validate", "0075ca"},
 	{"fabrik:cruise", "Auto-advance all stages; stop at Validate without merging", "0075ca"},
+	{"fabrik:extend-turns", "Override: pre-grant 2× turn budget; auto-removed on stage success", "0075ca"},
 
 	// --- warning / waiting labels (yellow) ---
 	{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "e4e669"},

--- a/github/project.go
+++ b/github/project.go
@@ -582,6 +582,7 @@ query($id: ID!) {
 			}
 			for _, thread := range pr.ReviewThreads.Nodes {
 				if thread.IsResolved {
+					item.LinkedPRResolvedThreadCount++
 					continue
 				}
 				for _, cm := range thread.Comments.Nodes {

--- a/github/project.go
+++ b/github/project.go
@@ -538,6 +538,14 @@ query($id: ID!) {
 		}
 	}
 
+	// Reset append-to fields before repopulating so repeated FetchItemDetails calls
+	// (e.g. during progress detection in the turn-extension loop) are idempotent.
+	item.Comments = nil
+	item.LinkedPRReviewRequests = nil
+	item.LinkedPRReviews = nil
+	item.LinkedPRReviewThreadComments = nil
+	item.LinkedPRResolvedThreadCount = 0
+
 	// Process issue/PR comments
 	commentNodes := node.Comments.Nodes
 	if node.Comments.PageInfo.HasNextPage {

--- a/github/types.go
+++ b/github/types.go
@@ -63,6 +63,9 @@ type ProjectItem struct {
 	// unresolved review threads on the linked PR. These are real GitHub
 	// comments with DatabaseIDs and can be reacted to / resolved.
 	LinkedPRReviewThreadComments []Comment
+	// LinkedPRResolvedThreadCount is the number of review threads on the linked PR
+	// that are currently resolved. Used by progress detection during turn extension.
+	LinkedPRResolvedThreadCount int
 }
 
 // Comment represents a comment on an issue or linked PR.


### PR DESCRIPTION
## Summary

Add automatic progress-based turn extension to the engine: when a stage hits `max_turns`, the engine checks observable GitHub/git signals to determine whether the stage has made measurable progress since the last budget check. If progress is detected, extend by one additional `max_turns` quantum and re-invoke (resuming the existing session). If no progress is detected, treat as failure as today.

A manual `fabrik:extend-turns` label is retained as a bypass safety valve for cases where progress detection misfires.

The TUI hotkey approach (and associated engine↔TUI IPC) is out of scope.

## Problem

Some issues legitimately require more turns than the stage YAML default: large implementations, complex reviews with many Copilot/Gemini threads to resolve, or any multi-faceted task that exceeds the global `max_turns` cap. Currently the only option is to bump `max_turns` globally in the stage YAML, which affects every issue and blunts the budget signal.

The manual label/hotkey approach treats a symptom. The real gap is that the engine gives up at `max_turns` without checking whether the stage is actually stuck or just doing legitimate work. A stage doing real work should be extended automatically; a genuinely stuck stage should fail as today.

## Approach

### Approach

The core change is wrapping the single `e.claude.Invoke(...)` call in `processItem` (currently at `engine/item.go:627`) with an extension loop. The loop:
1. Snapshots observable progress state before the first invocation (git HEAD SHA, comment count, resolved thread count)
2. On each turn-limit exit: checks hard cap, checks progress, extends or breaks
3. Accumulates output and usage across all invocations
4. Defers WIP commit + push to after the loop (not mid-loop)
5. Auto-removes `fabrik:extend-turns` on successful completion

The baseline lives in-memory as a local struct in `processItem` — lost on engine restart, which the spec accepts as an acceptable risk. No `.fabrik-context/` persistence.

The `fabrik:extend-turns` label, when present, causes the first invocation to use `2 × stage.MaxTurns` as its budget (pre-granted extension, no progress check required for the first turn-limit hit). Subsequent extensions still require progress. Hard cap is `3 × stage.MaxTurns` total turns across all invocations.

Progress signals per stage:
- **Implement**: git HEAD SHA changed in worktree (commits indicate real work) — pure local git, zero API cost
- **Review**: git HEAD SHA changed OR `LinkedPRResolvedThreadCount` increased (re-fetched from GitHub)
- **Validate**: `len(item.Comments)` increased (re-fetched from GitHub via `FetchItemDetails`)
- **Plan, Research, Specify, and all others**: no signal — always fail on turn-limit (no extension)

Note: the spec also mentions checkbox counting for Implement, but Research found git commits alone are the correct signal (Plan stage posts comments only on completion, not mid-run; `stage-Plan.md` is written once before Implement starts and doesn't change during the Implement run). Checkbox counting adds complexity for no additional signal.

### New/Modified Files

| File | Change |
|------|--------|
| `github/types.go` | Add `LinkedPRResolvedThreadCount int` to `ProjectItem` |
| `github/project.go` | Populate `LinkedPRResolvedThreadCount` in parsing loop (no GraphQL changes) |
| `github/labels.go` | Add `fabrik:extend-turns` to `staticLabelDefs` |
| `engine/interfaces.go` | Add `MaxTurnsOverride int` to `InvokeOptions` |
| `engine/claude.go` | Use `opts.MaxTurnsOverride` (when non-zero) in `buildClaudeArgs` and `usage.MaxTurns` |
| `engine/item.go` | Extension loop, `progressBaseline`, `snapshotBaseline`, `detectProgress`, `hasExtendTurnsLabel`, auto-removal |
| `engine/item_test.go` (or new `engine/extend_test.go`) | Unit tests for new helpers and loop behavior |
| `CLAUDE.md` | Add `fabrik:extend-turns` to labels table |
| `docs/state-machine.md` | Document extension behavior, label, hard cap, log tag |
| `docs/stage-lifecycle.md` | Document baseline snapshot, extension loop, deferred WIP/push, auto-removal |
| `adrs/030-progress-based-turn-extension.md` | New ADR |

### Key Decisions

- **In-memory baseline only**: No `.fabrik-context/` file. Restart gap risk is rare and acceptable per spec. Persistence adds restart-resume logic and file I/O overhead with minimal benefit.

- **Output concatenation**: Each `--resume` invocation returns only its delta output. Accumulate across all invocations before posting as a single stage comment. Empty-output check applies to the concatenated total.

- **`MaxTurnsOverride == 0` means "use stage.MaxTurns"**: Zero-value is the no-op sentinel, consistent with ADR 025 pattern for `InvokeOptions` fields.

- **`detectProgress` returns `(bool, error)`**: If the GitHub re-fetch fails (rate limit, network), treat as "no progress" and break. Conservative: fail as today rather than spuriously extending.

- **Implement signal = git commits only**: Research confirmed that `stage-Plan.md` doesn't change during an Implement run and that git HEAD SHA change is sufficient signal. The spec's checkbox-counting mention is superseded by Research's analysis.

- **`FetchItemDetails` re-fetch for Review/Validate**: Called only on actual turn-limit exits (not every poll). The existing `FetchItemDetails` path already fetches linked PR comments via `closedByPullRequestsReferences`, making it sufficient for both stages.

- **Stats footer shows cumulative across extensions**: After the loop, set `totalUsage.MaxTurns = totalMultiple * stage.MaxTurns` so the stats line reads "used 130/150 turns" (meaningful budget signal to the user).

- **Label checked once at processItem entry**: Consistent with `model:` and `effort:` — snapshot from poll cycle, not re-fetched mid-run. User must wait for next poll cycle if they add the label during a run.

- **ADR warranted**: The in-dispatch extension loop is architecturally distinct from the three existing reinvoke patterns (review, CI, rebase), which all operate across poll cycles via the catch-up loop. New contributors need to understand why extensions happen within a single `processItem` call (no goroutine dispatch, output accumulated before posting, WIP commit deferred). These constraints are non-obvious and would affect future feature work.

### Extension Loop Structure

```go
// In processItem, replacing the single Invoke call:
firstBudget := stage.MaxTurns
hardCap := 3 * stage.MaxTurns
if hasExtendTurnsLabel(item) && stage.MaxTurns > 0 {
    firstBudget = 2 * stage.MaxTurns
}
totalMultiple := firstBudget / max(stage.MaxTurns, 1)  // 1 or 2

baseline := snapshotBaseline(stage, item, workDir)
currentBudget := firstBudget
var totalOutput string
var totalUsage TokenUsage

for {
    opts.MaxTurnsOverride = currentBudget  // 0 when MaxTurns==0 (unlimited)
    output, completed, usage, err = e.claude.Invoke(ctx, stage, item, nil, resume, workDir, opts)
    totalOutput += output
    totalUsage = totalUsage.add(usage)

    hitLimit := !completed && err == nil && stage.MaxTurns > 0 && usage.TurnsUsed >= currentBudget
    if !hitLimit || totalMultiple >= 3 { break }
    hasProgress, progressErr := detectProgress(ctx, stage, &item, baseline, workDir, e.client)
    if progressErr != nil {
        e.logf(item.Number, "extend-turns", "progress check failed: %v\n", progressErr)
        break
    }
    if !hasProgress { break }
    totalMultiple++
    currentBudget = stage.MaxTurns
    e.logf(item.Number, "extend-turns", "progress detected — extending to %d× budget (%d turns used)\n",
        totalMultiple, totalUsage.TurnsUsed)
    resume = true
}
// After loop: totalOutput replaces output, totalUsage replaces usage
// totalUsage.MaxTurns = totalMultiple * stage.MaxTurns
```

### Task Checklist

- [ ] Task 1: Add `LinkedPRResolvedThreadCount int` to `ProjectItem` in `github/types.go`; populate it in `FetchItemDetails` parsing loop in `github/project.go` by counting `thread.IsResolved == true` threads (no GraphQL changes, `isResolved` already fetched at line 583)

- [ ] Task 2: Add `fabrik:extend-turns` label to `staticLabelDefs` in `github/labels.go` with description "Override: pre-grant 2× turn budget; auto-removed on stage success" and blue color (`0075ca`, behavior label)

- [ ] Task 3: Add `MaxTurnsOverride int` to `InvokeOptions` in `engine/interfaces.go` with doc comment explaining zero-value = "use stage.MaxTurns"

- [ ] Task 4: Apply `MaxTurnsOverride` in `engine/claude.go`: in `InvokeClaude`, compute `effectiveBudget := stage.MaxTurns; if opts.MaxTurnsOverride > 0 { effectiveBudget = opts.MaxTurnsOverride }`, pass `effectiveBudget` to `buildClaudeArgs` and assign `usage.MaxTurns = effectiveBudget`

- [ ] Task 5: Add `progressBaseline` struct, `snapshotBaseline(stage *stages.Stage, item gh.ProjectItem, workDir string) progressBaseline` function, and `hasExtendTurnsLabel(item gh.ProjectItem) bool` helper in `engine/item.go`. The baseline holds: `gitHeadSHA string`, `commentCount int`, `resolvedThreadCount int`. `snapshotBaseline` runs `git rev-parse HEAD` for Implement/Review stages, reads `len(item.Comments)` for Validate, and `item.LinkedPRResolvedThreadCount` for Review

- [ ] Task 6: Add `detectProgress(ctx context.Context, stage *stages.Stage, item *gh.ProjectItem, baseline progressBaseline, workDir string, client GitHubClient) (bool, error)` in `engine/item.go`. Implement: compare `git rev-parse HEAD` to baseline SHA. Review: compare HEAD SHA AND re-fetch item to compare `LinkedPRResolvedThreadCount`. Validate: re-fetch item to compare `len(Comments)`. All others: return `false, nil`

- [ ] Task 7: Wrap the `e.claude.Invoke(...)` call at `item.go:627` in the extension loop per the structure above. Accumulate `totalOutput` and `totalUsage`. Move the stats `logf` call to after the loop. Defer the `commitWIP` and `PushBranch` calls to after the loop. Fix the empty-output check at `item.go:735` to use `totalOutput` not per-invocation output

- [ ] Task 8: Add `fabrik:extend-turns` auto-removal in the `completed` block of `processItem` (near `item.go:787`): call `e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:extend-turns")`; treat any error from `RemoveLabelFromIssue` as non-fatal (log warn); specifically treat `ErrNotFound` (if detectable) as success — the label was already removed manually

- [ ] Task 9: Add unit tests in `engine/` (new file `engine/extend_test.go`) for: `hasExtendTurnsLabel` (present/absent/wrong-prefix), `snapshotBaseline` (verify git HEAD read and item field extraction per stage), `detectProgress` (Implement: same/different SHA; Validate: same/different comment count; no-signal stage returns false)

- [ ] Task 10: Add integration test for the extension loop in `engine/item_test.go` using a mock `ClaudeInvoker`. Scenario: first invocation hits turn limit (returns `completed=false`, `TurnsUsed=maxTurns`), progress detected (mock git commit), second invocation completes. Verify: output is concatenated, stage advances to complete, `extend-turns` log emitted. Second scenario: no progress → no extension

- [ ] Task 11: Update `docs/state-machine.md` — add a subsection under the turn-limit / failure section describing: the extension loop trigger condition (`usage.TurnsUsed >= budget && !completed`), per-stage progress signals table, `fabrik:extend-turns` label semantics (2× first budget, auto-removed on completion), 3× hard cap, and the `[#N extend-turns]` log tag

- [ ] Task 12: Update `docs/stage-lifecycle.md` — extend Phase 3 (Claude Invocation) to describe: baseline snapshot step before first invocation, extension loop mechanics, output accumulation across invocations, deferred WIP commit and push; extend Phase 4 (Post-Stage Handling) to describe `fabrik:extend-turns` auto-removal on completion

- [ ] Task 13: Update `CLAUDE.md` labels table — add `fabrik:extend-turns` entry documenting: 2× first-invocation budget, auto-removed on stage success, no-op when `MaxTurns==0`

- [ ] Task 14: Create `adrs/030-progress-based-turn-extension.md` documenting: why in-dispatch loop (not catch-up loop), why output accumulated before posting, why in-memory baseline (not persisted), why Implement uses git commits not checkbox counting

### Risks

- **Turn-limit detection edge case**: Claude exits due to `context.DeadlineExceeded` or other error with `TurnsUsed == stage.MaxTurns` coincidentally — the `err == nil` guard in the loop prevents false extension. Verify the existing error path sets `err != nil` in these cases.

- **`FABRIK_STAGE_COMPLETE` marker from extension output**: `checkCompletion(stage, output)` in `InvokeClaude` reads from per-invocation output. If an intermediate extension produces `FABRIK_STAGE_COMPLETE`, `completed = true` is returned and the loop breaks on the first check. This is correct behavior.

- **WIP commit deferral**: Partial work from extension 1 isn't committed to git until after extension 2 finishes. If the engine crashes between extensions, Claude-authored commits are preserved (Claude commits frequently), but any uncommitted file changes in extension 1 are lost. Acceptable: Claude is expected to commit as it works; WIP commit is a fallback, not the primary mechanism.

- **Re-fetch cost for Review/Validate progress detection**: One `FetchItemDetails` GraphQL call per turn-limit exit per stage. Bounded to actual turn-limit exits only. With `FABRIK_REVIEW_WAIT_TIMEOUT` and rate-limit backoff already in place, a small number of additional calls is manageable.

- **`ErrNotFound` on label removal**: The current `RemoveLabelFromIssue` implementation uses REST; whether it surfaces a typed `ErrNotFound` needs verification at implementation time. If it doesn't, check for HTTP 404 status in the error message, or treat all errors from this call as non-fatal (log and continue).

---
Used 14/50 turns, 9k input / 13k output tokens.

## Verification

Implemented progress-based turn extension (issue #432) across 3 commits: the core engine extension loop wrapping `processItem`'s `Invoke` call with a 3× hard cap, per-stage progress signals (Implement: git commits, Review: git commits OR resolved threads, Validate: comment count), the `fabrik:extend-turns` label (2× pre-granted budget, auto-removed on success), `MaxTurnsOverride` in `InvokeOptions`, `LinkedPRResolvedThreadCount` in `ProjectItem`, and full test coverage (17 new tests). Docs updated in `docs/state-machine.md`, `docs/stage-lifecycle.md`, `CLAUDE.md`, and new ADR 030.

---

Closes #432