### PR TITLE
Show live turn count in TUI for in-progress stages

### DIFF
--- a/adrs/031-watch-view-log-file-turn-counting.md
+++ b/adrs/031-watch-view-log-file-turn-counting.md
@@ -1,0 +1,51 @@
+# ADR 031: Watch View Parses NDJSON Log Files for Real-Time Turn Data
+
+**Status:** Accepted  
+**Date:** 2026-04-26  
+**Issue:** #431 (Show live turn count in TUI for in-progress stages)
+
+## Context
+
+The `fabrik watch <N>` view displays live Claude output for a single issue. Issue #431 requires adding a real-time turn counter to this view, updating as each Claude assistant turn completes.
+
+The overview TUI (the main `fabrik` process) solves this by having the engine emit `TurnProgressEvent` messages through its in-process TUI channel. The watch view runs as a **separate process** (`fabrik watch` is a separate CLI invocation) and cannot receive events through the engine's channel.
+
+Two approaches were considered for the watch view:
+
+### Option A: Engine writes a state file
+
+The engine writes a small JSON file (e.g., `.fabrik/state/issue-<N>-turns.json`) after each assistant turn. The watch view polls this file.
+
+**Pros:** Clean separation; watch view doesn't need to understand NDJSON format.  
+**Cons:** Introduces new persistent state that must be cleaned up; adds file I/O on every turn on the critical Claude output path; creates a new data contract that every future real-time metric would need to replicate.
+
+### Option B: Watch view parses the live NDJSON log file
+
+The watch view's `followFile` goroutine already reads individual NDJSON lines from the live log file (written by the engine in real time). It can detect `{"type":"assistant"}` lines and count them locally, with no engine-side changes beyond what the log already records.
+
+**Pros:** Zero new I/O on the engine's critical path; no new files to clean up; self-contained in the watch package; any existing log file can be replayed to reconstruct the count.  
+**Cons:** Watch view must understand enough NDJSON to detect assistant turns; count may approximate Claude's internal `num_turns` (in practice they match, since each assistant response = one turn).
+
+## Decision
+
+**Option B**: The watch view parses `{"type":"assistant"}` NDJSON lines from the live log file directly.
+
+The `followFile` goroutine in `watch/logfollow.go` already reads individual NDJSON lines using `bufio.Reader.ReadBytes('\n')`. Adding a minimal JSON type-check (`json.Unmarshal` into `struct{ Type string }`) on each line is fast and self-contained. The turn count is incremented in a local variable that resets when `followFile` switches to a new log file (stage transition).
+
+## Implementation
+
+- `watch/logfollow.go`: `isAssistantTurn(line []byte) bool` helper; `followFile` counts turns and sends `TurnCountMsg{TurnsUsed int}` on each match
+- `watch/events.go`: new `TurnCountMsg` message type
+- `watch/model.go`: `turnsUsed` field updated on each `TurnCountMsg`; reset to 0 on `NewLogFileMsg` (stage transition); `effectiveMaxTurns()` derives the budget heuristically from stage config + `fabrik:extend-turns` label + log file count
+
+## Implications for Future Real-Time Data in the Watch View
+
+The core constraint driving this decision — **the watch view is a separate process and cannot receive the engine's in-process TUI channel events** — applies to any future real-time data addition to the watch view.
+
+Future contributors who want to surface additional real-time engine state in `fabrik watch` have two viable paths:
+
+1. **Parse existing log output**: If the data is already present in the NDJSON log stream (e.g., token usage from `{"type":"result"}`), add detection in `followFile` and send a new message type.
+
+2. **Write an intermediate state file**: For data that is NOT in the log stream (e.g., cost accumulation mid-invocation, extension-loop budget upgrades), the engine can write a small JSON state file to `.fabrik/state/` that the watch view polls alongside the log file. This file should be cleaned up when the issue transitions to Done.
+
+Option A (state file) was rejected here because the turn count is already available in the log stream. If a future feature requires data that is genuinely not in the log (e.g., the extension-loop `totalMultiple` value), a state file is the appropriate choice.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1375,7 +1375,7 @@ In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), is
 
 ### What's Displayed
 
-**In Progress**: Issue number, stage name, elapsed time, a live turn counter (`[N/M turns]` or compact `[N/M]` when terminal width is tight), issue title, and latest status message. The turn counter updates in real time as Claude advances through turns; the denominator reflects the effective budget, which is `2× stage.MaxTurns` when `fabrik:extend-turns` is present. Review-reinvoke jobs appear here alongside regular stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time, just like a normal stage invocation.
+**In Progress**: Issue number, stage name, elapsed time, a live turn counter (`[N/M turns]` or compact `[N/M]` when terminal width is tight), issue title, and latest status message. The turn counter updates in real time as Claude advances through turns; the denominator reflects the effective per-invocation budget. With `fabrik:extend-turns`, the first invocation may use a denominator of `2× stage.MaxTurns`, while subsequent extension invocations revert to `stage.MaxTurns` each. Review-reinvoke jobs appear here alongside regular stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time, just like a normal stage invocation.
 
 Pressing `Enter` on an active item opens the inline detail panel, which shows Issue, Stage, Elapsed, and a live `Turns: N/M` counter for in-progress stages.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1375,7 +1375,9 @@ In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), is
 
 ### What's Displayed
 
-**In Progress**: Issue number, stage name, elapsed time, issue title, latest status message. Review-reinvoke jobs appear here alongside regular stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time, just like a normal stage invocation.
+**In Progress**: Issue number, stage name, elapsed time, a live turn counter (`[N/M turns]` or compact `[N/M]` when terminal width is tight), issue title, and latest status message. The turn counter updates in real time as Claude advances through turns; the denominator reflects the effective budget, which is `2× stage.MaxTurns` when `fabrik:extend-turns` is present. Review-reinvoke jobs appear here alongside regular stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time, just like a normal stage invocation.
+
+Pressing `Enter` on an active item opens the inline detail panel, which shows Issue, Stage, Elapsed, and a live `Turns: N/M` counter for in-progress stages.
 
 **History**: Issue number, stage name, success/fail icon, duration, timestamp, turns used,
 cost, and issue title. Status icons:
@@ -1409,6 +1411,7 @@ fabrik watch 42 --owner myorg --repo myrepo --token ghp_...
 This opens a real-time terminal UI that shows:
 - Issue title, labels, and current stage
 - **Live Claude output** — streams from the `.log` file as Claude writes it (no polling)
+- **Live turn counter** — `turn N/M` shown inline in the PR/CI row while a stage is active; updates in real time as Claude advances through turns (`turn N` when the stage has no turn limit)
 - **Stage history** — completed stages with duration and cost
 - **PR status** — linked PR number, open/draft/merged state
 - **CI check results** — compact pass/fail/pending summary

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -168,6 +168,16 @@ Context files are available in .fabrik-context/
 
 Raw Claude output saved to `~/.fabrik/logs/issue-<N>/<stage>-output-<timestamp>.json` after every invocation. Viewable through the TUI's `l` key (piped through `fabrik _stream-filter` for human-readable display).
 
+### Turn Progress Emission
+
+During each Claude invocation, the engine counts intermediate assistant turns in real time via a `turnCountingWriter` wrapping the stdout pipe. Each time a `{"type":"assistant"}` NDJSON line is detected, the writer increments a per-invocation counter and fires the `claudeTurnProgress` callback (set during engine construction), which emits a `TurnProgressEvent` to the TUI channel. The event carries:
+
+- `IssueNumber` — the issue being processed
+- `TurnsUsed` — the current per-invocation assistant-turn count
+- `MaxTurns` — the effective budget for this invocation (accounts for `opts.MaxTurnsOverride` from the extension loop)
+
+This is a purely additive display mechanism — it does not affect Claude's execution, the output buffer, or any engine state. In plain-text mode and tests, `claudeTurnProgress` is nil and no events are emitted.
+
 ### Subprocess Cleanup
 
 After `cmd.Run()` returns, two cleanup steps run unconditionally:

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -136,7 +136,7 @@ Each active stage column has the same set of reachable sub-states:
 
 ## 2. Event Enumeration
 
-Ten distinct event types drive state transitions:
+Eleven distinct event types drive state transitions (§2.1–2.11), plus one TUI display event (§2.12) that does not drive transitions:
 
 ### 2.1 Poll Tick
 
@@ -264,6 +264,23 @@ Ten distinct event types drive state transitions:
 - `fabrik:rebase-needed` is only applied on **confirmed conflict** (`mergeable == false`), not on `mergeable == null` (GitHub still computing)
 - Rebase cycle counter is `rebaseCycleCount` (keyed by `issueKey + "-" + stageName`)
 - Resolution relies on Claude rebasing in the worktree (to handle semantic collisions like duplicated ADR numbers) rather than an engine-side `git rebase`
+
+### 2.12 TurnProgressEvent (TUI Display Event)
+
+**Trigger:** A `{"type":"assistant"}` NDJSON line is written to Claude's stdout pipe during a Claude invocation, indicating that one assistant turn has completed.
+
+**Code path:** `runClaude()` stdout pipe → `turnCountingWriter.Write()` → detects `type == "assistant"` line → increments per-invocation counter → calls `claudeTurnProgress(issueNumber, turnsUsed, maxTurns)` → `Engine.emitStructural(TurnProgressEvent{...})` → TUI channel
+
+**Effect:** Purely additive display — does not trigger any state transitions, label mutations, or issue processing. The TUI consumes `TurnProgressEvent` to update the live turn counter shown in:
+- The In Progress pane row for the active issue (width-adaptive badge `[N/M turns]` / `[N/M]` / omitted)
+- The detail panel for the selected active item (`Turns: N/M`)
+
+`TurnProgressEvent` is only emitted in TUI mode (`claudeTurnProgress` is nil in plain-text mode and tests). It uses `emitStructural` (blocking channel send) to avoid dropping events; at most one event per assistant turn, so the 256-deep channel buffer is not a concern in normal operation.
+
+**`MaxTurns` in the event** carries the effective budget for the current invocation — `effectiveBudget` as computed in `InvokeClaude()` (which already accounts for `opts.MaxTurnsOverride` from the extension loop). This means:
+- First invocation without `fabrik:extend-turns`: `stage.MaxTurns`
+- First invocation with `fabrik:extend-turns`: `2 × stage.MaxTurns`
+- Extension loop second iteration: `stage.MaxTurns` (per-invocation limit, not cumulative)
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -269,13 +269,13 @@ Eleven distinct event types drive state transitions (§2.1–2.11), plus one TUI
 
 **Trigger:** A `{"type":"assistant"}` NDJSON line is written to Claude's stdout pipe during a Claude invocation, indicating that one assistant turn has completed.
 
-**Code path:** `runClaude()` stdout pipe → `turnCountingWriter.Write()` → detects `type == "assistant"` line → increments per-invocation counter → calls `claudeTurnProgress(issueNumber, turnsUsed, maxTurns)` → `Engine.emitStructural(TurnProgressEvent{...})` → TUI channel
+**Code path:** `runClaude()` stdout pipe → `turnCountingWriter.Write()` → detects `type == "assistant"` line → increments per-invocation counter → calls `claudeTurnProgress(issueNumber, turnsUsed, maxTurns)` → `Engine.emit(TurnProgressEvent{...})` → TUI channel
 
 **Effect:** Purely additive display — does not trigger any state transitions, label mutations, or issue processing. The TUI consumes `TurnProgressEvent` to update the live turn counter shown in:
 - The In Progress pane row for the active issue (width-adaptive badge `[N/M turns]` / `[N/M]` / omitted)
 - The detail panel for the selected active item (`Turns: N/M`)
 
-`TurnProgressEvent` is only emitted in TUI mode (`claudeTurnProgress` is nil in plain-text mode and tests). It uses `emitStructural` (blocking channel send) to avoid dropping events; at most one event per assistant turn, so the 256-deep channel buffer is not a concern in normal operation.
+`TurnProgressEvent` is only emitted in TUI mode (`claudeTurnProgress` is nil in plain-text mode and tests). It uses the non-blocking `emit` path (drop-if-full), so turn-progress updates are best-effort and may be dropped under backpressure. This does not affect engine behavior because the event is display-only; at most one event is produced per assistant turn.
 
 **`MaxTurns` in the event** carries the effective budget for the current invocation — `effectiveBudget` as computed in `InvokeClaude()` (which already accounts for `opts.MaxTurnsOverride` from the extension loop). This means:
 - First invocation without `fabrik:extend-turns`: `stage.MaxTurns`

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -53,6 +53,11 @@ func CheckDecomposed(output string) bool {
 // Falls back to stderr when nil (e.g. in tests).
 var claudeLogf func(issueNumber int, tag, format string, args ...any)
 
+// claudeTurnProgress is called after each assistant turn completes during a Claude
+// invocation. Set by the Engine during construction (same block as claudeLogf).
+// nil when no TUI is active (tests, plain-text mode).
+var claudeTurnProgress func(issueNumber, turnsUsed, maxTurns int)
+
 // claudeTUI indicates whether the TUI is active. When true, Claude's child
 // process stderr is sent only to the log file (not the terminal).
 var claudeTUI bool
@@ -82,6 +87,49 @@ type activityWriter struct {
 func (w *activityWriter) Write(p []byte) (int, error) {
 	w.lastActivity.Store(time.Now().UnixNano())
 	return w.inner.Write(p)
+}
+
+// turnCountingWriter wraps an io.Writer, counts assistant turns from the NDJSON
+// stream in real time, and calls claudeTurnProgress after each turn.
+// It buffers bytes until '\n', then checks each line for type == "assistant".
+// Safe for use from a single goroutine only (one per runClaude invocation).
+type turnCountingWriter struct {
+	inner       io.Writer
+	issueNumber int
+	maxTurns    int
+	buf         []byte
+	count       int
+}
+
+func (w *turnCountingWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	for {
+		idx := bytes.IndexByte(w.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		line := w.buf[:idx+1]
+		w.buf = w.buf[idx+1:]
+		if isAssistantTurnLine(line) {
+			w.count++
+			if claudeTurnProgress != nil {
+				claudeTurnProgress(w.issueNumber, w.count, w.maxTurns)
+			}
+		}
+	}
+	return w.inner.Write(p)
+}
+
+// isAssistantTurnLine returns true if line is a JSON object with type == "assistant".
+func isAssistantTurnLine(line []byte) bool {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 || line[0] != '{' {
+		return false
+	}
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(line, &envelope) == nil && envelope.Type == "assistant"
 }
 
 func claudeLog(issueNumber int, tag, format string, args ...any) {
@@ -246,7 +294,7 @@ func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem
 	args := buildClaudeArgs(stage, sessFilePath, resume, opts.ModelOverride, effectiveBudget, hasUnrestrictedLabel(issue), workDir)
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
-	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv, stage.MaxWallTime)
+	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv, stage.MaxWallTime, effectiveBudget)
 	usage.MaxTurns = effectiveBudget
 	if err != nil {
 		return output, completed, usage, err
@@ -275,7 +323,7 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 	args := buildClaudeArgs(stage, sessFilePath, true, opts.ModelOverride, limit, hasUnrestrictedLabel(issue), workDir) // resume existing session
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
-	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review", sessFilePath, ld, extraEnv, stage.MaxWallTime)
+	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review", sessFilePath, ld, extraEnv, stage.MaxWallTime, limit)
 	usage.MaxTurns = limit
 	return output, completed, usage, err
 }
@@ -416,7 +464,7 @@ type claudeResponse struct {
 	} `json:"usage"`
 }
 
-func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string, sessFilePath string, logDir string, extraEnv []string, maxWallTime time.Duration) (string, bool, TokenUsage, error) {
+func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string, sessFilePath string, logDir string, extraEnv []string, maxWallTime time.Duration, maxTurns int) (string, bool, TokenUsage, error) {
 	claudeLog(issueNumber, "claude", "invoking (%s) in %s\n", label, workDir)
 
 	// Set up stderr: in TUI mode discard; in plain mode forward to os.Stderr.
@@ -463,8 +511,10 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	// Track last-write timestamp for the inactivity watchdog.
 	var lastActivity atomic.Int64
 	lastActivity.Store(time.Now().UnixNano())
-	// Wrap stdoutWriter so every write updates lastActivity, resetting the inactivity timer.
-	stdoutWriter = &activityWriter{inner: stdoutWriter, lastActivity: &lastActivity}
+	// Wrap stdoutWriter with a turn-counting writer that fires claudeTurnProgress on
+	// each assistant turn, then with the activity writer for inactivity tracking.
+	tcw := &turnCountingWriter{inner: stdoutWriter, issueNumber: issueNumber, maxTurns: maxTurns}
+	stdoutWriter = &activityWriter{inner: tcw, lastActivity: &lastActivity}
 
 	cmd := exec.CommandContext(stageCtx, "claude", args...)
 	cmd.Dir = workDir

--- a/engine/claude_extra_test.go
+++ b/engine/claude_extra_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,4 +55,91 @@ func TestSaveDebugLog_WritesFile(t *testing.T) {
 	if len(entries) == 0 {
 		t.Error("expected at least one debug log file")
 	}
+}
+
+// TestIsAssistantTurnLine verifies assistant-type detection from NDJSON lines.
+func TestIsAssistantTurnLine(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{`{"type":"assistant","message":{}}` + "\n", true},
+		{`{"type":"result","num_turns":5}` + "\n", false},
+		{`{"type":"tool_use"}` + "\n", false},
+		{"not json\n", false},
+		{"", false},
+		{"{}\n", false},
+	}
+	for _, tt := range tests {
+		got := isAssistantTurnLine([]byte(tt.line))
+		if got != tt.want {
+			t.Errorf("isAssistantTurnLine(%q) = %v, want %v", tt.line, got, tt.want)
+		}
+	}
+}
+
+// TestTurnCountingWriter_CountsAssistantTurns verifies that turnCountingWriter
+// increments count and calls the callback on each assistant-type NDJSON line.
+func TestTurnCountingWriter_CountsAssistantTurns(t *testing.T) {
+	var inner bytes.Buffer
+	var calls []struct{ turns, max int }
+	prev := claudeTurnProgress
+	claudeTurnProgress = func(issueNumber, turnsUsed, maxTurns int) {
+		if issueNumber != 42 {
+			t.Errorf("unexpected issueNumber %d", issueNumber)
+		}
+		calls = append(calls, struct{ turns, max int }{turnsUsed, maxTurns})
+	}
+	defer func() { claudeTurnProgress = prev }()
+
+	tcw := &turnCountingWriter{inner: &inner, issueNumber: 42, maxTurns: 10}
+
+	// Write two assistant lines and one non-assistant line.
+	line1 := []byte(`{"type":"assistant"}` + "\n")
+	line2 := []byte(`{"type":"result","num_turns":1}` + "\n")
+	line3 := []byte(`{"type":"assistant"}` + "\n")
+
+	tcw.Write(line1)
+	tcw.Write(line2)
+	tcw.Write(line3)
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 callback calls, got %d", len(calls))
+	}
+	if calls[0].turns != 1 || calls[0].max != 10 {
+		t.Errorf("call[0] = %+v, want {1 10}", calls[0])
+	}
+	if calls[1].turns != 2 || calls[1].max != 10 {
+		t.Errorf("call[1] = %+v, want {2 10}", calls[1])
+	}
+}
+
+// TestTurnCountingWriter_SplitLine verifies detection when a line arrives in multiple writes.
+func TestTurnCountingWriter_SplitLine(t *testing.T) {
+	var inner bytes.Buffer
+	callCount := 0
+	prev := claudeTurnProgress
+	claudeTurnProgress = func(_, _, _ int) { callCount++ }
+	defer func() { claudeTurnProgress = prev }()
+
+	tcw := &turnCountingWriter{inner: &inner, issueNumber: 1, maxTurns: 5}
+	// Split the line across two Write calls.
+	tcw.Write([]byte(`{"type":"assi`))
+	tcw.Write([]byte(`stant"}` + "\n"))
+
+	if callCount != 1 {
+		t.Errorf("expected 1 callback after split-line write, got %d", callCount)
+	}
+}
+
+// TestTurnCountingWriter_NilCallback verifies that a nil claudeTurnProgress does not panic.
+func TestTurnCountingWriter_NilCallback(t *testing.T) {
+	prev := claudeTurnProgress
+	claudeTurnProgress = nil
+	defer func() { claudeTurnProgress = prev }()
+
+	var inner bytes.Buffer
+	tcw := &turnCountingWriter{inner: &inner, issueNumber: 1, maxTurns: 5}
+	// Should not panic.
+	tcw.Write([]byte(`{"type":"assistant"}` + "\n"))
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -251,7 +251,7 @@ func (e *Engine) SetEvents(ch chan tui.Event) {
 	claudeTUI = ch != nil
 	if ch != nil {
 		claudeTurnProgress = func(issueNumber, turnsUsed, maxTurns int) {
-			e.emitStructural(tui.TurnProgressEvent{
+			e.emit(tui.TurnProgressEvent{
 				IssueNumber: issueNumber,
 				TurnsUsed:   turnsUsed,
 				MaxTurns:    maxTurns,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -249,6 +249,17 @@ func (e *Engine) SetEvents(ch chan tui.Event) {
 	tuiMode = ch != nil
 	claudeLogf = e.logf
 	claudeTUI = ch != nil
+	if ch != nil {
+		claudeTurnProgress = func(issueNumber, turnsUsed, maxTurns int) {
+			e.emitStructural(tui.TurnProgressEvent{
+				IssueNumber: issueNumber,
+				TurnsUsed:   turnsUsed,
+				MaxTurns:    maxTurns,
+			})
+		}
+	} else {
+		claudeTurnProgress = nil
+	}
 	// Update logfFn for all registered WorktreeManagers.
 	e.mu.Lock()
 	for _, wm := range e.worktreeManagers {

--- a/tui/active.go
+++ b/tui/active.go
@@ -143,7 +143,7 @@ func (a ActivePaneComponent) View(width int) string {
 			stageDisplay += strings.Repeat(" ", stagePad)
 		}
 		essential := fmt.Sprintf("#%-5d %s %s %s  ", job.IssueNumber, stageDisplay, spinner, elapsed)
-		remaining := maxWidth - len([]rune(essential))
+		remaining := maxWidth - lipgloss.Width(essential)
 		badge := turnBadge(job.TurnsUsed, job.MaxTurns, remaining)
 		if badge != "" {
 			badge += " "

--- a/tui/active.go
+++ b/tui/active.go
@@ -62,6 +62,14 @@ func (a ActivePaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 			a.activeIdx = len(a.active) - 1
 		}
 
+	case TurnProgressEvent:
+		if key, known := a.activeNumToKey[ev.IssueNumber]; known {
+			if job, ok := a.active[key]; ok {
+				job.TurnsUsed = ev.TurnsUsed
+				job.MaxTurns = ev.MaxTurns
+			}
+		}
+
 	case LogEvent:
 		if ev.IssueNumber != 0 {
 			if key, known := a.activeNumToKey[ev.IssueNumber]; known {
@@ -134,8 +142,13 @@ func (a ActivePaneComponent) View(width int) string {
 		if stagePad > 0 {
 			stageDisplay += strings.Repeat(" ", stagePad)
 		}
-		line := fmt.Sprintf("#%-5d %s %s %s  %s%s %s",
-			job.IssueNumber, stageDisplay, spinner, elapsed, titleStr, tag, msg)
+		essential := fmt.Sprintf("#%-5d %s %s %s  ", job.IssueNumber, stageDisplay, spinner, elapsed)
+		remaining := maxWidth - len([]rune(essential))
+		badge := turnBadge(job.TurnsUsed, job.MaxTurns, remaining)
+		if badge != "" {
+			badge += " "
+		}
+		line := essential + badge + titleStr + tag + " " + msg
 		if runes := []rune(line); len(runes) > maxWidth {
 			line = string(runes[:maxWidth-1]) + "…"
 		}
@@ -225,6 +238,31 @@ func (a ActivePaneComponent) Height() int {
 	// inside Active handles anything that still can't fit.
 	n := len(a.active) + len(a.blocked)
 	return max(n+1, 2) + 2
+}
+
+// turnBadge returns a turn counter badge string that fits within available rune columns.
+// Returns full "[N/M turns]", compact "[N/M]", or "" depending on available space.
+// When maxTurns == 0 (unlimited), returns "[N turns]" / "[N]" / "".
+func turnBadge(turnsUsed, maxTurns, available int) string {
+	if turnsUsed <= 0 || available <= 0 {
+		return ""
+	}
+	var full, compact string
+	if maxTurns > 0 {
+		full = fmt.Sprintf("[%d/%d turns]", turnsUsed, maxTurns)
+		compact = fmt.Sprintf("[%d/%d]", turnsUsed, maxTurns)
+	} else {
+		full = fmt.Sprintf("[%d turns]", turnsUsed)
+		compact = fmt.Sprintf("[%d]", turnsUsed)
+	}
+	switch {
+	case len([]rune(full)) <= available:
+		return full
+	case len([]rune(compact)) <= available:
+		return compact
+	default:
+		return ""
+	}
 }
 
 // sortedActiveKeys returns job keys from the active map in sorted order.

--- a/tui/active_test.go
+++ b/tui/active_test.go
@@ -254,3 +254,87 @@ func TestViewActive_BlockedCountIncludedInHeader(t *testing.T) {
 func TestIssueBlockedEvent_tuiEvent(t *testing.T) {
 	IssueBlockedEvent{}.tuiEvent() // satisfies interface
 }
+
+// TestTurnBadge verifies full/compact/omit rendering.
+func TestTurnBadge(t *testing.T) {
+	tests := []struct {
+		turnsUsed int
+		maxTurns  int
+		available int
+		want      string
+	}{
+		{5, 50, 100, "[5/50 turns]"},
+		{5, 50, 12, "[5/50 turns]"},
+		{5, 50, 11, "[5/50]"},
+		{5, 50, 7, "[5/50]"},
+		{5, 50, 6, "[5/50]"},
+		{5, 50, 5, ""},
+		{0, 50, 100, ""},    // no turns yet
+		{5, 50, 0, ""},      // no space
+		{5, 50, -1, ""},     // negative space
+		{3, 0, 100, "[3 turns]"},  // unlimited
+		{3, 0, 9, "[3 turns]"},
+		{3, 0, 8, "[3]"},
+		{3, 0, 2, ""},
+	}
+	for _, tt := range tests {
+		got := turnBadge(tt.turnsUsed, tt.maxTurns, tt.available)
+		if got != tt.want {
+			t.Errorf("turnBadge(%d,%d,%d) = %q, want %q",
+				tt.turnsUsed, tt.maxTurns, tt.available, got, tt.want)
+		}
+	}
+}
+
+// TestUpdate_TurnProgressEvent_UpdatesJob verifies that TurnProgressEvent updates the active job.
+func TestUpdate_TurnProgressEvent_UpdatesJob(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil)
+	key42 := activeJobKey("", 42)
+	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Research", StartedAt: time.Now()}
+	m.active.activeNumToKey[42] = key42
+
+	next, _ := m.Update(TurnProgressEvent{IssueNumber: 42, TurnsUsed: 7, MaxTurns: 50})
+	nm := next.(Model)
+
+	job, ok := nm.active.active[key42]
+	if !ok {
+		t.Fatal("issue 42 missing from active after TurnProgressEvent")
+	}
+	if job.TurnsUsed != 7 {
+		t.Errorf("TurnsUsed = %d, want 7", job.TurnsUsed)
+	}
+	if job.MaxTurns != 50 {
+		t.Errorf("MaxTurns = %d, want 50", job.MaxTurns)
+	}
+}
+
+// TestUpdate_TurnProgressEvent_UnknownIssue verifies that an unknown issue number does not panic.
+func TestUpdate_TurnProgressEvent_UnknownIssue(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil)
+	// Should not panic for an issue not in the active map.
+	next, _ := m.Update(TurnProgressEvent{IssueNumber: 999, TurnsUsed: 5, MaxTurns: 30})
+	nm := next.(Model)
+	if _, ok := nm.active.active[activeJobKey("", 999)]; ok {
+		t.Error("unknown issue should not be added to active via TurnProgressEvent")
+	}
+}
+
+// TestUpdate_TurnProgressEvent_ResetOnJobStarted verifies that starting a new job resets turn state.
+func TestUpdate_TurnProgressEvent_ResetOnJobStarted(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil)
+	key5 := activeJobKey("", 5)
+	m.active.active[key5] = &activeJob{IssueNumber: 5, StageName: "Research", StartedAt: time.Now(), TurnsUsed: 10, MaxTurns: 30}
+	m.active.activeNumToKey[5] = key5
+
+	// Simulate a new stage start that replaces the existing job.
+	next, _ := m.Update(JobStartedEvent{IssueNumber: 5, StageName: "Plan", StartedAt: time.Now()})
+	nm := next.(Model)
+
+	job := nm.active.active[activeJobKey("", 5)]
+	if job.TurnsUsed != 0 {
+		t.Errorf("TurnsUsed = %d after new JobStartedEvent, want 0", job.TurnsUsed)
+	}
+	if job.MaxTurns != 0 {
+		t.Errorf("MaxTurns = %d after new JobStartedEvent, want 0", job.MaxTurns)
+	}
+}

--- a/tui/detail.go
+++ b/tui/detail.go
@@ -54,6 +54,13 @@ func (d DetailPanelComponent) View(width int) string {
 		}
 		lines = append(lines, fmt.Sprintf("Stage:   %s", item.StageName))
 		lines = append(lines, fmt.Sprintf("Elapsed: %s", fmtDuration(item.Elapsed)))
+		if item.TurnsUsed > 0 {
+			if item.MaxTurns > 0 {
+				lines = append(lines, fmt.Sprintf("Turns:   %d/%d", item.TurnsUsed, item.MaxTurns))
+			} else {
+				lines = append(lines, fmt.Sprintf("Turns:   %d", item.TurnsUsed))
+			}
+		}
 	} else {
 		statusStr := "success"
 		if !item.Success {

--- a/tui/events.go
+++ b/tui/events.go
@@ -101,3 +101,14 @@ type ProjectMetaEvent struct {
 }
 
 func (ProjectMetaEvent) tuiEvent() {}
+
+// TurnProgressEvent is emitted after each assistant turn completes during a
+// Claude invocation. It carries the current live turn count and effective budget
+// so the TUI can display a real-time turn counter for in-progress stages.
+type TurnProgressEvent struct {
+	IssueNumber int
+	TurnsUsed   int
+	MaxTurns    int // 0 means unlimited
+}
+
+func (TurnProgressEvent) tuiEvent() {}

--- a/tui/model.go
+++ b/tui/model.go
@@ -37,6 +37,8 @@ type activeJob struct {
 	StartedAt   time.Time
 	LastTag     string
 	LastLine    string
+	TurnsUsed   int
+	MaxTurns    int // 0 means unlimited
 }
 
 // blockedIssue tracks an issue held at the dependency gate.
@@ -412,6 +414,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case TurnProgressEvent:
+		comp, _ := m.active.Update(msg)
+		m.active = comp.(ActivePaneComponent)
+		return m, nil
+
 	}
 
 	return m, nil
@@ -462,6 +469,8 @@ func (m *Model) prepareDetailItem() {
 				StageName:   job.StageName,
 				IsActive:    true,
 				Elapsed:     m.header.now.Sub(job.StartedAt),
+				TurnsUsed:   job.TurnsUsed,
+				MaxTurns:    job.MaxTurns,
 			})
 		} else {
 			m.detail.SetItem(nil)

--- a/watch/events.go
+++ b/watch/events.go
@@ -30,3 +30,9 @@ type ClaudeFinishedMsg struct {
 type StatusMsgMsg struct {
 	Text string
 }
+
+// TurnCountMsg is sent by the log follower each time it detects an assistant
+// turn in the live NDJSON stream, carrying the cumulative per-invocation count.
+type TurnCountMsg struct {
+	TurnsUsed int
+}

--- a/watch/logfollow.go
+++ b/watch/logfollow.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"bufio"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -282,6 +283,7 @@ func followFile(path, logDir string, send func(tea.Msg), done <-chan struct{}) {
 
 		reader := bufio.NewReader(f)
 		switchFile := false
+		turnCount := 0
 	readLoop:
 		for {
 			select {
@@ -293,6 +295,10 @@ func followFile(path, logDir string, send func(tea.Msg), done <-chan struct{}) {
 
 			line, err := reader.ReadBytes('\n')
 			if len(line) > 0 {
+				if isAssistantTurn(line) {
+					turnCount++
+					send(TurnCountMsg{TurnsUsed: turnCount})
+				}
 				if rendered := streamfilter.RenderLine(line); rendered != "" {
 					send(LogLineMsg{Text: rendered})
 				}
@@ -324,6 +330,17 @@ func followFile(path, logDir string, send func(tea.Msg), done <-chan struct{}) {
 			return
 		}
 	}
+}
+
+// isAssistantTurn returns true if line is a JSON object with type == "assistant".
+func isAssistantTurn(line []byte) bool {
+	if len(line) == 0 || line[0] != '{' {
+		return false
+	}
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(line, &envelope) == nil && envelope.Type == "assistant"
 }
 
 // pollForNewLogFile polls logDir every 2 seconds. When it observes a .log

--- a/watch/logfollow_test.go
+++ b/watch/logfollow_test.go
@@ -135,6 +135,27 @@ func TestBuildStageTabs_EmptyDir(t *testing.T) {
 	}
 }
 
+// TestIsAssistantTurn verifies NDJSON assistant-type detection for the watch follower.
+func TestIsAssistantTurn(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{`{"type":"assistant","message":{}}` + "\n", true},
+		{`{"type":"result","num_turns":10}` + "\n", false},
+		{`{"type":"tool_use"}` + "\n", false},
+		{"not json\n", false},
+		{"", false},
+		{"{}\n", false},
+	}
+	for _, tt := range tests {
+		got := isAssistantTurn([]byte(tt.line))
+		if got != tt.want {
+			t.Errorf("isAssistantTurn(%q) = %v, want %v", tt.line, got, tt.want)
+		}
+	}
+}
+
 // TestBuildStageTabs_IsLive_ByTimestampNotLabel is a regression test for the
 // bug where an alphabetically-later stage label (e.g. "Specify" > "Research")
 // would be wrongly selected as IsLive even when its log has an older timestamp.

--- a/watch/model.go
+++ b/watch/model.go
@@ -59,6 +59,10 @@ type WatchModel struct {
 	selectedTabIdx int
 	stageOrder     map[string]int // stage name -> pipeline order (from stages YAML)
 
+	// Turn counter for the live stage (resets on stage transition)
+	turnsUsed     int
+	stageMaxTurns map[string]int // stage name -> configured max_turns (0 = unlimited)
+
 	// Transient status message (shown in status bar, cleared on TickMsg)
 	statusMsg string
 
@@ -85,6 +89,7 @@ func NewModel(issueNumber int, opts GitHubOptions, stagesDir string) WatchModel 
 	vp.SetContent("")
 
 	stageOrder := buildStageOrder(stagesDir)
+	stageMaxTurns := buildStageMaxTurns(stagesDir)
 	tabs := buildStageTabs(logDir, stageOrder)
 	selectedTabIdx := liveTabIdx(tabs)
 
@@ -97,6 +102,7 @@ func NewModel(issueNumber int, opts GitHubOptions, stagesDir string) WatchModel 
 		stageTabs:      tabs,
 		selectedTabIdx: selectedTabIdx,
 		stageOrder:     stageOrder,
+		stageMaxTurns:  stageMaxTurns,
 		done:           make(chan struct{}),
 	}
 }
@@ -117,6 +123,63 @@ func buildStageOrder(stagesDir string) map[string]int {
 		order[s.Name] = s.Order
 	}
 	return order
+}
+
+// buildStageMaxTurns loads stage configs from stagesDir and returns a map of
+// stage name → max_turns value. Returns an empty map on any error.
+func buildStageMaxTurns(stagesDir string) map[string]int {
+	m := make(map[string]int)
+	if stagesDir == "" {
+		return m
+	}
+	loaded, err := stages.LoadAll(stagesDir)
+	if err != nil {
+		return m
+	}
+	for _, s := range loaded {
+		m[s.Name] = s.MaxTurns
+	}
+	return m
+}
+
+// logFileCountForStage counts .log files in logDir whose stage label matches stageName.
+func logFileCountForStage(logDir, stageName string) int {
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".log") &&
+			stageNameFromFilename(e.Name()) == stageName {
+			count++
+		}
+	}
+	return count
+}
+
+// effectiveMaxTurns returns the effective turn budget for the currently live stage.
+// Applies 2× multiplier when fabrik:extend-turns label is present and this is the
+// first invocation for the stage (one log file = not yet in extension loop).
+// Returns 0 when the stage has no configured limit.
+func (m *WatchModel) effectiveMaxTurns() int {
+	stageName := currentStageFromLog(m.logDir)
+	if stageName == "" {
+		return 0
+	}
+	base, ok := m.stageMaxTurns[stageName]
+	if !ok || base == 0 {
+		return 0
+	}
+	for _, lbl := range m.github.labels {
+		if lbl == "fabrik:extend-turns" {
+			if logFileCountForStage(m.logDir, stageName) == 1 {
+				return 2 * base
+			}
+			break
+		}
+	}
+	return base
 }
 
 // liveTabIdx returns the index of the live tab in tabs, or 0 if none.
@@ -344,11 +407,16 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case TurnCountMsg:
+		m.turnsUsed = ev.TurnsUsed
+		return m, nil
+
 	case NewLogFileMsg:
 		// Stage transition: clear live buffer, rebuild tabs, move to live tab.
 		m.lines = nil
 		m.currentLogPath = ""
 		m.vp.SetContent("")
+		m.turnsUsed = 0
 		newTabs := buildStageTabs(m.logDir, m.stageOrder)
 		m.stageTabs = newTabs
 		m.selectedTabIdx = liveTabIdx(newTabs)
@@ -475,10 +543,19 @@ func (m WatchModel) View() string {
 		b.WriteString("\n")
 	}
 
-	// PR/CI row
+	// PR/CI row (also shows live turn counter when a stage is active)
 	prLine := m.prStatusLine()
 	if m.github.commentCnt > 0 {
 		prLine += dimStyle.Render(fmt.Sprintf("  |  %d comments", m.github.commentCnt))
+	}
+	isLive := len(m.stageTabs) == 0 || (m.selectedTabIdx < len(m.stageTabs) && m.stageTabs[m.selectedTabIdx].IsLive)
+	if isLive && m.turnsUsed > 0 {
+		effective := m.effectiveMaxTurns()
+		if effective > 0 {
+			prLine += dimStyle.Render(fmt.Sprintf("  |  turn %d/%d", m.turnsUsed, effective))
+		} else {
+			prLine += dimStyle.Render(fmt.Sprintf("  |  turn %d", m.turnsUsed))
+		}
 	}
 	b.WriteString(prLine)
 	b.WriteString("\n")

--- a/watch/model.go
+++ b/watch/model.go
@@ -59,9 +59,10 @@ type WatchModel struct {
 	selectedTabIdx int
 	stageOrder     map[string]int // stage name -> pipeline order (from stages YAML)
 
-	// Turn counter for the live stage (resets on stage transition)
-	turnsUsed     int
-	stageMaxTurns map[string]int // stage name -> configured max_turns (0 = unlimited)
+	// Turn counter for the live stage (resets on new log file / invocation change)
+	turnsUsed              int
+	cachedEffectiveMaxTurns int            // cached result of effectiveMaxTurns(); updated on NewLogFileMsg/GitHubPollMsg
+	stageMaxTurns          map[string]int  // stage name -> configured max_turns (0 = unlimited)
 
 	// Transient status message (shown in status bar, cleared on TickMsg)
 	statusMsg string
@@ -161,10 +162,15 @@ func logFileCountForStage(logDir, stageName string) int {
 // effectiveMaxTurns returns the effective turn budget for the currently live stage.
 // Applies 2× multiplier when fabrik:extend-turns label is present and this is the
 // first invocation for the stage (one log file = not yet in extension loop).
-// Returns 0 when the stage has no configured limit.
+// Returns 0 when the stage has no configured limit or for comment-review invocations
+// (which use their own smaller budget not tracked in stageMaxTurns).
 func (m *WatchModel) effectiveMaxTurns() int {
 	stageName := currentStageFromLog(m.logDir)
 	if stageName == "" {
+		return 0
+	}
+	// Comment-review invocations use comment_max_turns (not stage.MaxTurns); show turn N without denominator.
+	if strings.HasSuffix(stageName, "-comment-review") {
 		return 0
 	}
 	base, ok := m.stageMaxTurns[stageName]
@@ -420,6 +426,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		newTabs := buildStageTabs(m.logDir, m.stageOrder)
 		m.stageTabs = newTabs
 		m.selectedTabIdx = liveTabIdx(newTabs)
+		m.cachedEffectiveMaxTurns = m.effectiveMaxTurns()
 		return m, nil
 
 	case GitHubPollMsg:
@@ -428,6 +435,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		newTabs := buildStageTabs(m.logDir, m.stageOrder)
 		m.selectedTabIdx = mergeTabSelection(newTabs, m.stageTabs, m.selectedTabIdx)
 		m.stageTabs = newTabs
+		m.cachedEffectiveMaxTurns = m.effectiveMaxTurns()
 		return m, nextGitHubPoll(m.opts.PollInterval)
 
 	case TickMsg:
@@ -550,9 +558,8 @@ func (m WatchModel) View() string {
 	}
 	isLive := len(m.stageTabs) == 0 || (m.selectedTabIdx < len(m.stageTabs) && m.stageTabs[m.selectedTabIdx].IsLive)
 	if isLive && m.turnsUsed > 0 {
-		effective := m.effectiveMaxTurns()
-		if effective > 0 {
-			prLine += dimStyle.Render(fmt.Sprintf("  |  turn %d/%d", m.turnsUsed, effective))
+		if m.cachedEffectiveMaxTurns > 0 {
+			prLine += dimStyle.Render(fmt.Sprintf("  |  turn %d/%d", m.turnsUsed, m.cachedEffectiveMaxTurns))
 		} else {
 			prLine += dimStyle.Render(fmt.Sprintf("  |  turn %d", m.turnsUsed))
 		}

--- a/watch/model_test.go
+++ b/watch/model_test.go
@@ -119,3 +119,81 @@ func TestUpdate_CtrlC_Quits(t *testing.T) {
 		t.Errorf("expected tea.QuitMsg, got %T", msg)
 	}
 }
+
+// TestUpdate_TurnCountMsg_UpdatesTurnsUsed verifies that TurnCountMsg sets turnsUsed.
+func TestUpdate_TurnCountMsg_UpdatesTurnsUsed(t *testing.T) {
+	m := newTestModel()
+	model, _ := m.Update(TurnCountMsg{TurnsUsed: 7})
+	wm := model.(WatchModel)
+	if wm.turnsUsed != 7 {
+		t.Errorf("turnsUsed = %d, want 7", wm.turnsUsed)
+	}
+
+	// Subsequent message updates the count.
+	model2, _ := wm.Update(TurnCountMsg{TurnsUsed: 12})
+	wm2 := model2.(WatchModel)
+	if wm2.turnsUsed != 12 {
+		t.Errorf("turnsUsed = %d after second TurnCountMsg, want 12", wm2.turnsUsed)
+	}
+}
+
+// TestUpdate_NewLogFileMsg_ResetsTurnsUsed verifies that NewLogFileMsg resets turnsUsed.
+func TestUpdate_NewLogFileMsg_ResetsTurnsUsed(t *testing.T) {
+	m := newTestModel()
+	m.turnsUsed = 23
+	model, _ := m.Update(NewLogFileMsg{Path: "/tmp/fake-Research-20260101-100000-000000000.log"})
+	wm := model.(WatchModel)
+	if wm.turnsUsed != 0 {
+		t.Errorf("turnsUsed = %d after NewLogFileMsg, want 0", wm.turnsUsed)
+	}
+}
+
+// TestView_TurnCounter_WithDenominator verifies that View shows "turn N/M" when
+// a live stage tab is present and cachedEffectiveMaxTurns > 0.
+func TestView_TurnCounter_WithDenominator(t *testing.T) {
+	m := newTestModel()
+	m.vp = viewport.New(80, 20)
+	m.stageTabs = []stageTab{{Label: "Research", IsLive: true}}
+	m.selectedTabIdx = 0
+	m.turnsUsed = 5
+	m.cachedEffectiveMaxTurns = 50
+
+	view := m.View()
+	if !strings.Contains(view, "turn 5/50") {
+		t.Errorf("expected 'turn 5/50' in view, got:\n%s", view)
+	}
+}
+
+// TestView_TurnCounter_Unlimited verifies "turn N" (no denominator) when
+// cachedEffectiveMaxTurns == 0 (unlimited stage).
+func TestView_TurnCounter_Unlimited(t *testing.T) {
+	m := newTestModel()
+	m.vp = viewport.New(80, 20)
+	m.stageTabs = []stageTab{{Label: "Research", IsLive: true}}
+	m.selectedTabIdx = 0
+	m.turnsUsed = 3
+	m.cachedEffectiveMaxTurns = 0
+
+	view := m.View()
+	if !strings.Contains(view, "turn 3") {
+		t.Errorf("expected 'turn 3' in view, got:\n%s", view)
+	}
+	if strings.Contains(view, "turn 3/") {
+		t.Errorf("expected no denominator for unlimited stage, got:\n%s", view)
+	}
+}
+
+// TestView_TurnCounter_Hidden_WhenNoTurns verifies turn counter is absent when turnsUsed == 0.
+func TestView_TurnCounter_Hidden_WhenNoTurns(t *testing.T) {
+	m := newTestModel()
+	m.vp = viewport.New(80, 20)
+	m.stageTabs = []stageTab{{Label: "Research", IsLive: true}}
+	m.selectedTabIdx = 0
+	m.turnsUsed = 0
+	m.cachedEffectiveMaxTurns = 50
+
+	view := m.View()
+	if strings.Contains(view, "turn") {
+		t.Errorf("expected no turn counter when turnsUsed=0, got:\n%s", view)
+	}
+}


### PR DESCRIPTION
## Summary

Add turn count display to two TUI surfaces: (1) the overview list's In Progress pane, shown when terminal width permits, and (2) the single-issue watch view (`fabrik watch <N>`), where space is always available. The counter applies to all in-progress stages uniformly. Both surfaces require new real-time data delivery from the engine, since turn counts are currently only finalized at the end of a Claude invocation.

## Problem

Fabrik's TUI shows only elapsed time for in-progress stages. Turn count — the primary signal for anticipating a turn-limit failure — is invisible until after the stage ends, when it appears in the log as `used 31/30 turns`. By then, it's too late to act.

When a stage hits its turn limit, the engine retries after a cooldown period, up to ~3 times, then requires user interaction (a comment) before trying again. Users watching an issue cannot tell whether a stage is using 5 of 50 turns or 48 of 50 turns. Surfacing the live count gives them time to intervene — by adding `fabrik:extend-turns`, writing a comment, or simply knowing to stay close — before the retry/cooldown cycle begins.

## Approach

### Approach

This feature adds real-time turn counters to two TUI surfaces. The architecture uses two independent data paths:

1. **Engine → overview TUI**: A new `claudeTurnProgress` package-level callback (mirroring `claudeLogf`) is set during engine construction. A new `turnCountingWriter` wraps Claude's stdout pipe, detects `type: "assistant"` NDJSON lines in real time, and fires the callback after each turn. The callback emits a `TurnProgressEvent` to the TUI channel. `runClaude` receives `maxTurns int` as a new parameter so the effective budget is included in emitted events.

2. **Watch view → log files**: The `followFile` goroutine in `watch/logfollow.go` already reads individual NDJSON lines. It detects `type: "assistant"` lines and sends a new `TurnCountMsg{TurnsUsed int}` carrying the per-invocation turn count. The `WatchModel` derives the effective budget heuristically from stage config + `fabrik:extend-turns` label + log file count for the current stage.

**Watch view budget derivation**:
- If `stageMaxTurns == 0` (unlimited): show `turn N` (no denominator)
- If only 1 log file for current stage AND `fabrik:extend-turns` is present: budget = `2 × stageMaxTurns`  
- Otherwise: budget = `stageMaxTurns` (extension loop invocations use the base budget per invocation)

**Width-adaptive badge in overview**: Build essential content (`#N stage spinner elapsed`) first, compute remaining space, append the full badge `[N/M turns]` or compact `[N/M]` or nothing based on what fits, then append optional content (title/tag/msg) with the existing truncation.

**Turn count reset semantics**: `TurnsUsed` in `activeJob` resets to 0 on each `JobStartedEvent`. `turnsUsed` in `WatchModel` resets to 0 on each `NewLogFileMsg` (the `followFile` goroutine naturally resets its local counter when switching to a new file).

### New/Modified Files

| File | Change |
|------|--------|
| `tui/events.go` | Add `TurnProgressEvent` (IssueNumber, TurnsUsed, MaxTurns) |
| `tui/model.go` | Add `TurnsUsed`/`MaxTurns` fields to `activeJob`; update `prepareDetailItem()` to populate them |
| `tui/active.go` | Handle `TurnProgressEvent` in `Update()`; width-adaptive badge in `View()` |
| `tui/detail.go` | Populate `Turns: N/M` for active items (currently only shown for history) |
| `engine/claude.go` | Add `claudeTurnProgress` var; add `turnCountingWriter`; add `maxTurns` param to `runClaude` |
| `engine/engine.go` | Wire `claudeTurnProgress` during engine construction (same block as `claudeLogf`) |
| `watch/events.go` | Add `TurnCountMsg{TurnsUsed int}` |
| `watch/logfollow.go` | Add `isAssistantTurn(line []byte) bool` helper; modify `followFile` to count turns and send `TurnCountMsg` |
| `watch/model.go` | Add `turnsUsed`/`stageMaxTurns` fields; add `buildStageMaxTurns`; add `effectiveMaxTurns()`; handle `TurnCountMsg` and `NewLogFileMsg` turn reset; update `View()` header row |
| `docs/state-machine.md` | Document `TurnProgressEvent` in the event system section |
| `docs/stage-lifecycle.md` | Note that `TurnProgressEvent` is emitted after each assistant turn during per-invocation lifecycle |
| `adrs/031-watch-view-log-file-turn-counting.md` | ADR for watch view parsing log files for real-time turn data (vs. engine events) |

### Key Decisions

- **`claudeTurnProgress` follows the `claudeLogf` pattern**: This is the established extension point for getting data out of the package-level `runClaude` function into the engine event system. No alternatives considered — the research confirmed this is the correct approach.

- **`turnCountingWriter` wraps the full stdout chain**: The writer buffers bytes until `\n`, then does a minimal JSON unmarshal checking only `type`. It sits as the `activityWriter`'s `inner`, so inactivity tracking continues to work correctly. No mutex is needed — the writer instance is per-invocation and only written by the single goroutine draining Claude's stdout pipe.

- **Watch view counts assistant turns from live log file, not engine events**: The watch view runs as a separate process and cannot receive in-process engine events. Parsing the NDJSON log file (already done by `followFile` for rendering) is the only viable approach. Per-invocation counts are used (not cumulative) to match what the engine uses for each `--max-turns` limit. Turn count naturally resets when `followFile` opens a new file.

- **`maxTurns` added as explicit parameter to `runClaude`**: `effectiveBudget` is already computed at both call sites (`InvokeClaude`, `InvokeClaudeForComments`). Passing it explicitly keeps `runClaude` stateless and avoids a per-call global variable.

- **`stageMaxTurns` loaded in watch model via new `buildStageMaxTurns` helper**: Mirrors the existing `buildStageOrder` pattern. Both functions call `stages.LoadAll` — they could be merged into one combined function, but keeping them separate preserves the single-responsibility of each and the existing call site for `buildStageOrder`.

- **Width-adaptive badge uses rune-length comparison (not `lipgloss.Width`)**: ANSI styling is only applied after badge-placement decisions, so raw rune length is correct here. The existing `stagePad` already mixes `lipgloss.Width` (for styled stage name width) with unformatted rune lengths — the badge can use the same pattern.

- **ADR warranted for watch view log-file parsing**: The constraint "watch view cannot receive in-process engine events" and the resulting "parse log files directly for real-time data" decision is non-obvious and constrains any future contributor wanting to add other real-time data to the watch view. ADR 031 documents this.

### Task Checklist

- [ ] Task 1: Add `TurnProgressEvent` to `tui/events.go` with `IssueNumber int`, `TurnsUsed int`, `MaxTurns int` fields; add `func (TurnProgressEvent) tuiEvent() {}` implementation
- [ ] Task 2: Add `TurnsUsed int` and `MaxTurns int` to the `activeJob` struct in `tui/model.go`; in `ActivePaneComponent.Update()`, reset both to 0 in the `JobStartedEvent` case; add `TurnProgressEvent` case that looks up the job via `activeNumToKey` and updates `TurnsUsed`/`MaxTurns`
- [ ] Task 3: Update `prepareDetailItem()` in `tui/model.go` to populate `TurnsUsed` and `MaxTurns` from the active job when building the `DetailItem` for active items
- [ ] Task 4: Update `tui/detail.go` active-item branch (lines 50–56) to show `Turns: N/M` (or `Turns: N` when `MaxTurns == 0`) using the same format as the existing history-entry turns display
- [ ] Task 5: Add `var claudeTurnProgress func(issueNumber, turnsUsed, maxTurns int)` to `engine/claude.go`; add `turnCountingWriter` struct implementing `io.Writer` that buffers bytes, detects `type: "assistant"` NDJSON lines, increments a counter, and calls `claudeTurnProgress` (nil-guarded); add `maxTurns int` parameter to `runClaude`; wire `turnCountingWriter` as `activityWriter.inner`; update both `runClaude` call sites in `InvokeClaude` and `InvokeClaudeForComments` to pass `effectiveBudget`/`limit`
- [ ] Task 6: In `engine/engine.go`, set `claudeTurnProgress` in the engine construction block (same location where `claudeLogf` is set) to a closure that calls `e.emitStructural(tui.TurnProgressEvent{IssueNumber: issueNumber, TurnsUsed: turnsUsed, MaxTurns: maxTurns})`; nil out `claudeTurnProgress` alongside `claudeLogf` on engine shutdown if applicable
- [ ] Task 7: Update `tui/active.go` `View()`: before appending optional content (titleStr/tag/msg), compute available width after the essential part (`#N stageDisplay spinner elapsed`), then append the full badge `[N/M turns]` (when MaxTurns > 0) or `[N]` (when 0) if it fits, or compact `[N/M]` / `[N]` if that fits, or omit; apply the existing truncation after all content is assembled
- [ ] Task 8: Add `TurnCountMsg struct { TurnsUsed int }` to `watch/events.go`
- [ ] Task 9: In `watch/logfollow.go`, add `isAssistantTurn(line []byte) bool` that does a minimal JSON unmarshal checking `type == "assistant"`; in `followFile`, declare `turnCount := 0` before the read loop, increment it and `send(TurnCountMsg{TurnsUsed: turnCount})` on each assistant turn line; reset `turnCount = 0` at the top of each outer loop iteration (file switch)
- [ ] Task 10: In `watch/model.go`, add `turnsUsed int` and `stageMaxTurns map[string]int` fields to `WatchModel`; add `buildStageMaxTurns(stagesDir string) map[string]int` function alongside `buildStageOrder`; load it in `NewModel`; add `effectiveMaxTurns() int` method that uses `currentStageFromLog`, `stageMaxTurns`, label check for `fabrik:extend-turns`, and log file count for the current stage; handle `TurnCountMsg` in `Update()` to set `m.turnsUsed = ev.TurnsUsed`; reset `m.turnsUsed = 0` in `NewLogFileMsg` handler; update `View()` header row (after the labels row, or inline with the PR/CI row) to show `turn N/M` or `turn N` when stage is live and `turnsUsed > 0`
- [ ] Task 11: Update `docs/state-machine.md` to add `TurnProgressEvent` to the event system section — describe it as emitted after each assistant turn during a Claude invocation, carrying the current turn count and effective budget; update `docs/stage-lifecycle.md` to note turn progress emission in the per-invocation lifecycle section
- [ ] Task 12: Create `adrs/031-watch-view-log-file-turn-counting.md` documenting the decision to parse NDJSON log files for real-time turn data in the watch view, the constraint that prevents using in-process engine events, and implications for future real-time data additions to the watch view (use the next sequential number; check `adrs/` at implementation time to confirm 031 is still correct)
- [ ] Task 13: Run `go build ./...`, `go test ./...`, and `go vet ./...`; verify no regressions; manually check that `TurnProgressEvent` is not emitted when `events` channel is nil (plain-text/test mode)

### Risks

- **`nil` guard on `claudeTurnProgress`**: The callback must always be nil-checked before calling (same pattern as the `claudeLogf` nil check already exists in `claudeLog`). If forgotten at any call site, it panics in plain-text mode where the callback is not set.

- **`emitStructural` blocks on full channel**: Turn progress events are higher-frequency than structural events (job started/completed). Using `emitStructural` (blocking send) with a 256-deep channel should be sufficient for normal concurrency levels, but under extreme load (many concurrent stages + slow TUI consumer) could block worker goroutines. Mitigate by monitoring channel depth in testing; if this proves problematic in practice, switch to the non-blocking `emit` pattern for `TurnProgressEvent`.

- **Watch view `effectiveMaxTurns` may be stale between GitHub polls**: The labels are fetched every poll interval. If `fabrik:extend-turns` is added by a user mid-stage, the denominator may show the wrong value until the next poll. This is acceptable — the denominator will self-correct within the poll interval.

- **`turnCountingWriter` on the critical stdout path**: The JSON unmarshal in `isAssistantTurn` runs for every newline in Claude's output. This is fast for a minimal struct, but it runs on every NDJSON line including tool results and other messages. In practice Claude's output rate is low (< 10 lines/second), making this a non-issue, but implementers should profile if they notice latency.

- **`followFile` turn count reset timing**: `TurnCountMsg` with the new file's count could arrive before `NewLogFileMsg` (since `pollForNewLogFile` has a 2s polling interval). This means `WatchModel.turnsUsed` might briefly show the new file's count under the old file's max budget. Since `TurnCountMsg.TurnsUsed` is an absolute per-file count (not a delta), the worst case is a slightly wrong denominator for up to 2 seconds. No functional impact — both values self-correct quickly.

---
Used 19/50 turns, 7k input / 14k output tokens.

## Verification

(Populated by Implement on completion)

---

Closes #431