### PR TITLE
Update docs for v0.0.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Fabrik uses labels to track state:
 | `fabrik:yolo` | Force auto-advance even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes |
 | `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` to Claude Code for this issue only, bypassing the default `--permission-mode dontAsk` posture and the entire tool allowlist. Use only when a stage needs tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains). **Caution:** removes all tool restrictions. |
-| `fabrik:extend-turns` | Pre-grant 2× `max_turns` budget for the next invocation; auto-extends to 3× when progress is detected (new git commit or new comment, depending on stage); auto-removed on successful stage completion. |
+| `fabrik:extend-turns` | Pre-grant 2× `max_turns` budget for the next invocation; auto-extends to 3× when stage progress is detected; auto-removed on successful stage completion. |
 | `base:<branch>` | Override the base branch for this issue — Fabrik forks from, rebases onto, and targets PRs at `<branch>` instead of the repository default. Must be set before Research. If the branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment. |
 
 ## Multi-User

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ Fabrik ships two user-invocable Claude Code skills (type `/skill-name` in any Cl
 | `/cut-release` | Pre-flight checks, curated release notes, commit/tag/push, and auto-files a doc-update issue — see [§5 of the User Guide](docs/USER_GUIDE.md#built-in-skill-cut-release) |
 | `/audit-documentation` | Scans recently shipped issues, identifies documentation gaps, closes covered issues, and files new gap issues — see [§5 of the User Guide](docs/USER_GUIDE.md#built-in-skill-audit-documentation) |
 
+The main Fabrik dashboard (enabled by default; disable with `--notui`) shows a live turn counter (`[N/M turns]`) for each active job in the In Progress pane.
+
 ### `fabrik watch`
 
 Monitor a single issue in real time without running the engine:
@@ -319,6 +321,7 @@ Fabrik uses labels to track state:
 | `fabrik:yolo` | Force auto-advance even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes |
 | `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` to Claude Code for this issue only, bypassing the default `--permission-mode dontAsk` posture and the entire tool allowlist. Use only when a stage needs tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains). **Caution:** removes all tool restrictions. |
+| `fabrik:extend-turns` | Pre-grant 2× `max_turns` budget for the next invocation; auto-extends to 3× when progress is detected (new git commit or new comment, depending on stage); auto-removed on successful stage completion. |
 | `base:<branch>` | Override the base branch for this issue — Fabrik forks from, rebases onto, and targets PRs at `<branch>` instead of the repository default. Must be set before Research. If the branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment. |
 
 ## Multi-User

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1271,6 +1271,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:yolo` | Force auto-advance for this issue even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes. If the linked PR was already manually merged when auto-merge runs, Fabrik treats it as a success and advances the issue to Done normally. |
 | `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` for this issue; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set or when the default posture prevents required work. **Caution:** removes all tool restrictions. |
+| `fabrik:extend-turns` | Pre-grant 2× `max_turns` for the first invocation of the next stage. Auto-extends to 3× when actual progress is detected during that invocation (new git commit for Implement/Review stages; new comment for Validate). Auto-removed by the engine on successful stage completion. No-op when `max_turns` is 0 (unlimited). The displayed turn counter denominator always reflects the effective budget. |
 | `base:<branch>` | Override the base branch for this issue (e.g. `base:liminis`). Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default. Apply before Research; adding mid-pipeline is unsupported and may produce unexpected results. Branch names containing `/` are supported (e.g. `base:release/1.x`). If the named branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment on the issue. |
 
 Model label precedence: `model:<name>` label > stage YAML `model` field > default.
@@ -1367,6 +1368,7 @@ Pressing `?` opens an overlay that displays all keybindings and a labels referen
 | `model:<name>` | Override the model for this issue (e.g. `model:opus`) |
 | `effort:<level>` | Override thinking effort for this issue (`low`, `medium`, `high`, `max`) |
 | `fabrik:unrestricted` | Bypass default permission posture; passes `--dangerously-skip-permissions` instead |
+| `fabrik:extend-turns` | Pre-grant 2× max turns budget; auto-extends to 3× on detected progress; auto-removed on success; the turn counter denominator reflects the effective budget |
 | `base:<branch>` | Override base branch for this issue (e.g. `base:liminis`); Fabrik forks from, rebases onto, and targets PRs at this branch |
 
 Dismiss the panel by pressing `?` again or `Esc`.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1271,7 +1271,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:yolo` | Force auto-advance for this issue even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes. If the linked PR was already manually merged when auto-merge runs, Fabrik treats it as a success and advances the issue to Done normally. |
 | `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` for this issue; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set or when the default posture prevents required work. **Caution:** removes all tool restrictions. |
-| `fabrik:extend-turns` | Pre-grant 2× `max_turns` for the first invocation of the next stage. Auto-extends to 3× when actual progress is detected during that invocation (new git commit for Implement/Review stages; new comment for Validate). Auto-removed by the engine on successful stage completion. No-op when `max_turns` is 0 (unlimited). The displayed turn counter denominator always reflects the effective budget. |
+| `fabrik:extend-turns` | Pre-grant 2× `max_turns` for the first invocation of the next stage. Auto-extends to 3× when actual progress is detected during that invocation (Implement: new git commit; Review: new git commit or resolved reviewer thread count; Validate: new comment; other stages: no progress signal). Auto-removed by the engine on successful stage completion. No-op when `max_turns` is 0 (unlimited). The displayed turn counter denominator always reflects the effective budget. |
 | `base:<branch>` | Override the base branch for this issue (e.g. `base:liminis`). Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default. Apply before Research; adding mid-pipeline is unsupported and may produce unexpected results. Branch names containing `/` are supported (e.g. `base:release/1.x`). If the named branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment on the issue. |
 
 Model label precedence: `model:<name>` label > stage YAML `model` field > default.
@@ -1368,7 +1368,7 @@ Pressing `?` opens an overlay that displays all keybindings and a labels referen
 | `model:<name>` | Override the model for this issue (e.g. `model:opus`) |
 | `effort:<level>` | Override thinking effort for this issue (`low`, `medium`, `high`, `max`) |
 | `fabrik:unrestricted` | Bypass default permission posture; passes `--dangerously-skip-permissions` instead |
-| `fabrik:extend-turns` | Pre-grant 2× max turns budget; auto-extends to 3× on detected progress; auto-removed on success; the turn counter denominator reflects the effective budget |
+| `fabrik:extend-turns` | Pre-grant 2× max turns budget; auto-extends to 3× when progress is detected (see the Labels Reference / state-machine semantics for the full definition); auto-removed on success; the turn counter denominator reflects the effective budget |
 | `base:<branch>` | Override base branch for this issue (e.g. `base:liminis`); Fabrik forks from, rebases onto, and targets PRs at this branch |
 
 Dismiss the panel by pressing `?` again or `Esc`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -241,6 +241,7 @@ description: >-
           toggle an inline detail panel, <code>r</code> to resume a Claude session
           from history, <code>?</code> to open a help panel (all keybindings and
           labels reference), and <code>q</code> to quit. In supported terminals (Ghostty, iTerm2, WezTerm, Kitty), <strong>Cmd+click</strong> (macOS) or <strong>Ctrl+click</strong> (Linux) on issue numbers to open them in your browser, or on the board title in the footer to open the project board.
+          Active jobs show a live turn counter (<code>[N/M turns]</code>) in the In Progress pane.
         </div>
       </div>
       <div class="feature-card">


### PR DESCRIPTION
## Summary

Add `fabrik:extend-turns` to all labels reference locations, and add a brief mention of the live turn counter to the README Terminal UI feature description and the marketing site Terminal UI feature card. The USER_GUIDE already covers the turn counter behavior across all three TUI surfaces in §8 and §9 — no new sections are needed there beyond adding `fabrik:extend-turns` to the two labels tables.

## Problem

Two features shipped in v0.0.47 are not fully reflected in the user-facing documentation:

1. **Real-time turn counter** (#431) — visible in the overview pane (`[N/M turns]`, width-adaptive), the inline detail panel (`Turns: N/M`), and the `fabrik watch <N>` view (`turn N/M`). The USER_GUIDE already documents this in §8 and §9, but the README's Terminal UI feature description and the marketing site's Terminal UI feature card do not mention it.

2. **Progress-based turn extension via `fabrik:extend-turns`** (#432) — pre-grants 2× the stage's `max_turns` budget, auto-extends to 3× when progress is detected, and auto-removes on successful stage completion. The displayed turn counter denominator reflects the effective (extended) budget. This label is missing from: (a) the USER_GUIDE §6 Labels Reference "User-Set Labels" table, (b) the USER_GUIDE §8 TUI Help Panel labels table, and (c) the README Labels table.

## Approach

### Approach

This is a documentation-only change across five locations in three files. Each edit is additive — inserting new rows or a new sentence into existing structures. No code changes, no tests, no new files.

**README placement decision (Option B):** The research found two options for where to add the overview-pane turn counter sentence in the README. I chose to add a standalone paragraph *before* `### fabrik watch` rather than appending to the watch description. The overview pane and the per-issue watch TUI are distinct surfaces; mixing them in one paragraph creates ambiguity about which display the turn counter refers to. One clear sentence about the main dashboard TUI, followed by the existing watch section, is structurally cleaner.

**`fabrik:extend-turns` row wording, per location:**
- **§6 USER_GUIDE** (full semantics): pre-grants 2× `max_turns` for the first invocation; auto-extends to 3× when actual progress is detected (new git commit for Implement/Review; new comment for Validate); auto-removed on successful stage completion; no-op when `max_turns` is 0 (unlimited); the displayed turn counter denominator always reflects the effective budget.
- **§8 Help Panel** (concise): Pre-grant 2× max turns budget; auto-extends to 3× on detected progress; auto-removed on success; the turn counter denominator reflects the effective budget.
- **README Labels table** (brief): Pre-grant 2× `max_turns` budget for the next invocation; auto-extends to 3× when progress is detected (new git commit or new comment, depending on stage); auto-removed on successful stage completion.

**No ADR warranted:** All semantics are already documented in ADR 030 and ADR 031. This is a gap-fill, not a new decision.

---

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add `fabrik:extend-turns` row to §6 User-Set Labels table (after `base:<branch>` row, ~line 1274) |
| `docs/USER_GUIDE.md` | Add `fabrik:extend-turns` row to §8 Help Panel labels table (after `base:<branch>` row, ~line 1370) |
| `README.md` | Add one-sentence overview-TUI turn counter paragraph before `### fabrik watch` (after line 287) |
| `README.md` | Add `fabrik:extend-turns` row to Labels table (after `base:<branch>` row, ~line 322) |
| `docs/index.md` | Add one-sentence turn counter mention to Terminal UI feature card `<div class="feature-desc">` block (~line 243) |

---

### Key Decisions

- **README placement (Option B over Option A):** Distinct surfaces need distinct descriptions. One new sentence before `### fabrik watch` keeps the overview-pane mention visually and semantically separate from the per-issue watch TUI.
- **Row ordering:** `fabrik:extend-turns` goes after `fabrik:unrestricted` and before `base:<branch>` in the USER_GUIDE §6 table (matching alphabetical-ish clustering of user-set behavioral labels), and after `base:<branch>` at the end of the README table (minimizes diff; all other labels there have a stable order already).
- **No ADR:** No new design decision is being made. The semantics were settled when ADR 030 was merged.

---

### Task Checklist

- [ ] Task 1: Add `fabrik:extend-turns` row to `docs/USER_GUIDE.md` §6 User-Set Labels table — insert after the `base:<branch>` row (~line 1274), full semantics as specified in requirements
- [ ] Task 2: Add `fabrik:extend-turns` row to `docs/USER_GUIDE.md` §8 Help Panel labels table — insert after the `base:<branch>` row (~line 1370), concise one-liner consistent with other rows
- [ ] Task 3: Add one-sentence overview-TUI turn counter mention to `README.md` — insert a new paragraph after the subcommands table (after line 287, before `### fabrik watch`): e.g., "The main Fabrik dashboard (enabled by default; disable with `--notui`) shows a live turn counter (`[N/M turns]`) for each active job in the In Progress pane."
- [ ] Task 4: Add `fabrik:extend-turns` row to `README.md` Labels table — insert after the `base:<branch>` row (~line 322), brief description matching existing table style
- [ ] Task 5: Add one-sentence turn counter mention to `docs/index.md` Terminal UI feature card — append inside the `<div class="feature-desc">` block (~line 243), consistent with the card's existing style: e.g., "Active jobs show a live turn counter (`[N/M turns]`) in the In Progress pane."
- [ ] Task 6: Commit all changes on the `fabrik/issue-442` branch

---

### Risks

None. Pure documentation. No code paths are touched, no behavior changes, no tests required. The existing §8 and §9 USER_GUIDE turn counter prose is already accurate and complete — these changes are purely additive with no regression risk.

---
Used 9/50 turns, 3k input / 3k output tokens.

## Verification

Added `fabrik:extend-turns` to the USER_GUIDE §6 User-Set Labels table (full semantics) and §8 Help Panel labels table (concise one-liner), and to the README Labels table. Added one sentence about the live `[N/M turns]` turn counter to the README (before the `fabrik watch` section) and to the `docs/index.md` Terminal UI feature card. All changes committed and pushed in a single commit on `fabrik/issue-442`.

---

Closes #442