### PR TITLE
Marketing front page: feature cards are too text-heavy; make them brief, clickable links to docs

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -297,9 +297,9 @@ experience as release binaries.
 
 ### Startup Board Validation
 
-On every startup, Fabrik fetches the project board and compares stage names in your YAML configs against the column names on the board. If any non-cleanup stage is missing from the board, Fabrik exits with a detailed error listing the mismatched names — catching config drift before any work begins. Extra board columns without a matching stage produce a warning but do not block startup.
+On startup, Fabrik attempts to fetch the project board and status field so it can compare stage names in your YAML configs against the column names on the board. When that metadata is fetched successfully, any non-cleanup stage missing from the board causes Fabrik to exit with a detailed error listing the mismatched names — catching config drift before any work begins. Extra board columns without a matching stage produce a warning but do not block startup. If Fabrik cannot fetch the board or status field, it logs a warning and continues without blocking startup.
 
-See [§10 Troubleshooting → Startup Board Validation Failure](#startup-board-validation-failure) if you encounter this error.
+See [§10 Troubleshooting → Startup Board Validation Failure](#startup-board-validation-failure) if validation succeeds and reports a mismatch.
 
 ### Instance Lock
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -193,6 +193,10 @@ To restrict processing to a single repository, pass `--repo owner/repo`.
 
 The `.fabrik/` directory (config, stages, plugin) always lives in the directory where you run `fabrik`.
 
+### Multi-Repo Support
+
+Fabrik can manage issues across every repository on the board in a single run. To enable multi-repo mode, omit (or comment out) the `repo:` field in `.fabrik/config.yaml` — Fabrik then discovers repositories lazily from the project board and processes issues from all of them. Each repository gets its own bare clone at `.fabrik/repos/<owner>-<repo>.git` and its own set of worktrees, all driven by the same poll loop.
+
 ### Git Clone Protocol (HTTPS vs SSH)
 
 By default, Fabrik uses HTTPS to bare-clone managed repos (`https://github.com/<owner>/<repo>.git`). Users who authenticate via SSH keys can switch to SSH clone URLs instead.
@@ -290,6 +294,12 @@ experience as release binaries.
 >   -O - | tar xz
 > ```
 > After that, `--auto-upgrade` will keep you current automatically.
+
+### Startup Board Validation
+
+On every startup, Fabrik fetches the project board and compares stage names in your YAML configs against the column names on the board. If any non-cleanup stage is missing from the board, Fabrik exits with a detailed error listing the mismatched names — catching config drift before any work begins. Extra board columns without a matching stage produce a warning but do not block startup.
+
+See [§10 Troubleshooting → Startup Board Validation Failure](#startup-board-validation-failure) if you encounter this error.
 
 ### Instance Lock
 
@@ -629,6 +639,14 @@ You do not need to babysit the pipeline. The intended human role is:
 - **Move cards** (or use `--yolo` to automate this).
 - **Comment** to steer when the plan goes sideways or you want to redirect.
 - **Review PRs** before merging -- Fabrik gets them review-ready, not merge-ready (unless `--yolo` or `fabrik:yolo` label is active, in which case Fabrik auto-merges after Validate).
+
+### Yolo Mode and Auto-Merge
+
+Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and auto-merges the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
+
+For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you.
+
+See [Stage YAML Reference](#stage-yaml-reference) for the `auto_advance` field, which controls auto-advance behavior per stage independent of the global `--yolo` flag.
 
 ### Draft PR Workflow
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -417,13 +417,30 @@ section {
 }
 
 .feature-card {
+  display: block;
   background: $color-surface;
   border: 1px solid $color-border;
   border-radius: $radius-lg;
   padding: 24px;
-  transition: border-color 0.2s;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  transition: border-color 0.2s, background-color 0.2s;
 
-  &:hover { border-color: $color-accent; }
+  &:hover {
+    border-color: $color-accent;
+    background: $color-surface-2;
+    text-decoration: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-accent-2;
+    outline-offset: 2px;
+    border-color: $color-accent-2;
+  }
 
   .feature-icon {
     font-size: 1.6rem;

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -418,7 +418,7 @@ section {
 
 .feature-card {
   display: block;
-  background: $color-surface;
+  background-color: $color-surface;
   border: 1px solid $color-border;
   border-radius: $radius-lg;
   padding: 24px;
@@ -432,7 +432,7 @@ section {
 
   &:hover {
     border-color: $color-accent;
-    background: $color-surface-2;
+    background-color: $color-surface-2;
     text-decoration: none;
   }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ description: >-
         <span class="feature-icon">📋</span>
         <div class="feature-title">GitHub-Native Pipeline</div>
         <div class="feature-desc">
-          Board columns are stages and labels are state — no CI glue needed.
+          Board columns define stages and labels define state.
         </div>
       </a>
       <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#git-repositories-and-worktrees" aria-label="Isolated Git Worktrees — open documentation">

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,188 +136,111 @@ description: >-
     </p>
 
     <div class="features-grid">
-      <div class="feature-card">
+      <a class="feature-card" href="{{ '/state-machine' | relative_url }}#pipeline-overview" aria-label="GitHub-Native Pipeline — open documentation">
         <span class="feature-icon">📋</span>
         <div class="feature-title">GitHub-Native Pipeline</div>
         <div class="feature-desc">
-          Board columns <em>are</em> stages. Move a card to trigger a stage.
-          Labels track completion state. No external CI glue required.
+          Board columns are stages and labels are state — no CI glue needed.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#git-repositories-and-worktrees" aria-label="Isolated Git Worktrees — open documentation">
         <span class="feature-icon">🌿</span>
         <div class="feature-title">Isolated Git Worktrees</div>
         <div class="feature-desc">
-          Each issue gets its own worktree at <code>.fabrik/worktrees/&lt;owner&gt;-&lt;repo&gt;/issue-N/</code>
-          on branch <code>fabrik/issue-N</code>. Multiple issues run in parallel,
-          zero cross-contamination. The <code>base:&lt;branch&gt;</code> label overrides
-          the fork and PR target branch per issue — useful for feature branches and release trains.
+          Every issue gets a dedicated branch and worktree with zero cross-contamination.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/state-machine' | relative_url }}#4-comment-processing-lifecycle" aria-label="Comment-Driven Steering — open documentation">
         <span class="feature-icon">💬</span>
         <div class="feature-title">Comment-Driven Steering</div>
         <div class="feature-desc">
-          Comment on an issue mid-stage to redirect the work.
-          Fabrik reacts with 👀, processes the comment, and continues.
-          Comments from any author trigger processing — colleagues, code-review bots,
-          and other Fabrik instances alike. Only Fabrik's own output and
-          rocket-reacted (already-processed) comments are skipped.
-          When Claude needs input, it signals <code>FABRIK_BLOCKED_ON_INPUT</code> —
-          the issue pauses and automatically resumes the moment you reply.
+          Comment on any issue mid-stage to redirect the work in progress.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#yolo-mode-and-auto-merge" aria-label="Yolo Mode &amp; Auto-Merge — open documentation">
         <span class="feature-icon">⚡</span>
         <div class="feature-title">Yolo Mode &amp; Auto-Merge</div>
         <div class="feature-desc">
-          Enable <code>--yolo</code> and Fabrik auto-advances issues through
-          every stage without human approval — and auto-merges the PR when
-          Validate completes. Apply the <code>fabrik:yolo</code> label to a
-          single issue to get the same behavior scoped to just that issue.
-          For lighter automation without auto-merge, use <code>fabrik:cruise</code> —
-          it auto-advances through all stages but stops at Validate, leaving
-          the merge decision to you.
+          Auto-advances through every stage and merges the PR on Validate completion.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#stage-yaml-reference" aria-label="Configurable Stages — open documentation">
         <span class="feature-icon">🔧</span>
         <div class="feature-title">Configurable Stages</div>
         <div class="feature-desc">
-          Each stage is a YAML file: custom prompt, model choice, tool restrictions,
-          max turns, PR posting, and more. Per-stage wall-clock caps
-          (<code>max_wall_time</code>) and a 15-minute inactivity watchdog keep
-          runaway sessions from blocking the pipeline. Ship the default pipeline
-          or build your own.
+          Customize each stage's prompt, model, tools, and turn budget in YAML.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#multi-user-and-multi-instance-operation" aria-label="Multi-User Safe — open documentation">
         <span class="feature-icon">👥</span>
         <div class="feature-title">Multi-User Safe</div>
         <div class="feature-desc">
-          Run multiple Fabrik instances against the same board.
-          <code>fabrik:locked:&lt;user&gt;</code> labels prevent conflicts.
-          Stage work is scoped to each instance's <code>--user</code>;
-          comment processing handles comments from any author.
+          Multiple Fabrik instances share one project board without conflicts.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#startup-board-validation" aria-label="Startup Board Validation — open documentation">
         <span class="feature-icon">✅</span>
         <div class="feature-title">Startup Board Validation</div>
         <div class="feature-desc">
-          On every startup, Fabrik validates that stage names in your YAML configs
-          match board column names exactly. Mismatches are reported with a clear
-          error before any work begins — no silent misconfiguration.
+          Stage configs are validated against board columns on every startup.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#auto-upgrade" aria-label="Self-Upgrade — open documentation">
         <span class="feature-icon">🔄</span>
         <div class="feature-title">Self-Upgrade</div>
         <div class="feature-desc">
-          Pass <code>--auto-upgrade</code> and Fabrik keeps itself current when idle.
-          Release binaries check <code>shadoworg/fabrik</code> GitHub Releases and
-          download the latest version. Dev builds (built from source) detect local or
-          remote commits ahead of the running binary and rebuild in place — both paths
-          re-exec automatically with no manual deploys.
+          Detects and installs the latest release automatically when idle.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/state-machine' | relative_url }}#5-pr-lifecycle-integration" aria-label="PR Lifecycle Management — open documentation">
         <span class="feature-icon">🔀</span>
         <div class="feature-title">PR Lifecycle Management</div>
         <div class="feature-desc">
-          Implement creates a draft PR. Review rebases, fixes conflicts, posts
-          detailed output. Validate marks the PR ready. Full lifecycle, zero
-          manual steps.
+          Draft PR created at Implement and marked ready to merge at Validate.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#8-tui-dashboard" aria-label="Terminal UI — open documentation">
         <span class="feature-icon">🖥️</span>
         <div class="feature-title">Terminal UI</div>
         <div class="feature-desc">
-          Fabrik launches a bubbletea control panel by default: active jobs,
-          stage progress, token costs, and history across all issues. Press
-          <code>l</code> to open <code>fabrik watch</code> for the selected issue
-          (live log streaming, stage tabs, CI/PR status), <code>enter</code> to
-          toggle an inline detail panel, <code>r</code> to resume a Claude session
-          from history, <code>?</code> to open a help panel (all keybindings and
-          labels reference), and <code>q</code> to quit. In supported terminals (Ghostty, iTerm2, WezTerm, Kitty), <strong>Cmd+click</strong> (macOS) or <strong>Ctrl+click</strong> (Linux) on issue numbers to open them in your browser, or on the board title in the footer to open the project board.
-          Active jobs show a live turn counter (<code>[N/M turns]</code>) in the In Progress pane.
+          Live dashboard shows active jobs, stage progress, token costs, and history.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#multi-repo-support" aria-label="Multi-Repo Support — open documentation">
         <span class="feature-icon">🗂️</span>
         <div class="feature-title">Multi-Repo Support</div>
         <div class="feature-desc">
-          Fabrik always bare-clones every managed repository on first access.
-          Run it from any directory — no checkout needed. Repos are discovered
-          lazily from the project board; worktrees are created per repo and per
-          issue automatically. Enable multi-repo mode by omitting (or commenting
-          out) <code>repo:</code> in <code>.fabrik/config.yaml</code> — Fabrik
-          then processes issues from all repositories on the board.
+          One Fabrik instance manages issues across every repo on the board.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#5-plugin--skills" aria-label="Plugin &amp; Skills — open documentation">
         <span class="feature-icon">🧩</span>
         <div class="feature-title">Plugin &amp; Skills</div>
         <div class="feature-desc">
-          Customize Claude's methodology per stage with markdown skill files in
-          <code>.fabrik/plugin/skills/</code>. Reference a skill by name in your
-          stage YAML — Fabrik injects it into Claude's prompt. Default skills
-          ship with Fabrik; <code>fabrik init</code> installs them and
-          <code>fabrik upgrade</code> refreshes them.
+          Inject custom methodology per stage with plain markdown skill files.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#dependency-based-sequencing-formations" aria-label="Formations — open documentation">
         <span class="feature-icon">🔗</span>
         <div class="feature-title">Formations</div>
         <div class="feature-desc">
-          Coordinate multi-issue projects using GitHub's native "Blocked by"
-          relationships. Independent issues execute in parallel; dependent issues
-          gate automatically. The <code>fabrik:blocked</code> label is managed
-          entirely by the engine — no pre-creation needed. See the
-          <a href="{{ '/USER_GUIDE' | relative_url }}#dependency-based-sequencing-formations">USER_GUIDE §3</a>
-          for the full recipe and real-world validation numbers.
+          Chain issues with GitHub's blocked-by relationships for automatic parallel execution.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#pending-reviewer-gate" aria-label="Pending Reviewer Gate — open documentation">
         <span class="feature-icon">👁️</span>
         <div class="feature-title">Pending Reviewer Gate</div>
         <div class="feature-desc">
-          Set <code>wait_for_reviews: true</code> on a stage and Fabrik uses
-          a three-phase gate: (1) immediately apply <code>fabrik:awaiting-review</code>
-          on completion, (2) poll until all requested reviewers submit, (3)
-          unconditionally re-invoke the stage agent to address any unresolved
-          inline PR review thread comments — regardless of whether auto-advance
-          is active. Reviews with only top-level text (e.g., bot approvals or
-          summary-only comments) skip re-invocation. Auto-advancement to the
-          next stage after re-invocation still requires auto-advance to be
-          active. Controlled by <code>--review-wait-timeout</code> /
-          <code>FABRIK_REVIEW_WAIT_TIMEOUT</code> (default 15
-          min per cycle) and <code>--max-review-cycles</code> /
-          <code>FABRIK_MAX_REVIEW_CYCLES</code> (default 5
-          cycles). Timeout or cycle-limit exceeded pauses the issue with
-          <code>fabrik:awaiting-input</code> for human review.
+          Waits for all requested PR reviewers then re-invokes the stage to address comments.
         </div>
-      </div>
-      <div class="feature-card">
+      </a>
+      <a class="feature-card" href="{{ '/state-machine' | relative_url }}#64-ci-gate-and-ci-fix-reinvoke" aria-label="CI Gate — open documentation">
         <span class="feature-icon">✅</span>
         <div class="feature-title">CI Gate</div>
         <div class="feature-desc">
-          Set <code>wait_for_ci: true</code> on a stage (the Validate stage ships
-          with this enabled by default) and Fabrik blocks auto-advance and
-          auto-merge until all CI checks pass. On failure, Fabrik re-invokes the
-          stage agent with a structured report classifying each failed check as a
-          new regression or pre-existing failure, so it can fix the code and push
-          again. If the cycle limit (<code>--max-ci-fix-cycles</code>) or
-          timeout (<code>FABRIK_CI_WAIT_TIMEOUT</code>) is exceeded, Fabrik
-          pauses the issue with <code>fabrik:awaiting-input</code> for human
-          review. When GitHub reports the PR as <code>mergeable: false</code>
-          (the PR has merge conflicts with the base branch), Fabrik applies
-          <code>fabrik:rebase-needed</code> and dispatches a rebase
-          re-invocation for Claude to fetch, rebase, resolve conflicts, and
-          force-push.
+          Blocks merge until CI passes and auto-fixes failing checks each cycle.
         </div>
-      </div>
+      </a>
     </div>
 
     <div class="factory-callout">


### PR DESCRIPTION
## Summary

Replace each feature card's multi-sentence description with a single 6–15 word tagline, wrap every card in a `<a>` link to the canonical detail section in the docs, and update the CSS so cards are visually interactive (cursor, hover tint, focus ring) while disabling text selection. If a feature lacks a canonical detail section in the docs, add a brief stub rather than leaving the card un-linked.

## Problem

The 15 feature cards on https://fabrik.shadoworg.dev/ (`docs/index.md`, `<section id="features">` lines 128–321) currently contain 4–10 sentences of dense prose each — the longest cards (Comment-Driven Steering, Yolo Mode & Auto-Merge, Pending Reviewer Gate, CI Gate, Terminal UI) reach ~120 words. The combined effect is a wall of text that is intimidating to scan, hides the key feature names visually, and forces users to read entire paragraphs to learn what's available.

Most of the prose in each card duplicates content that already lives in `docs/USER_GUIDE.md` or `docs/state-machine.md`. The cards should act as a quick visual index that gets users to the right detailed docs page in one click — not a complete reference inline.

## Approach

### Approach

The change is purely front-end (HTML, SCSS) and docs prose — no Go code changes. The work falls into three independent units that are sequenced by dependency:

1. **USER_GUIDE.md stubs first** — create the three missing anchor targets (`### Multi-Repo Support`, `### Startup Board Validation`, `### Yolo Mode and Auto-Merge`) so card links don't point at non-existent anchors before merging.
2. **CSS update** — extend `.feature-card` to work correctly as a block `<a>` element (display, color, cursor, user-select, hover tint, focus ring, touch-action).
3. **HTML rewrite** — change every `<div class="feature-card">` to `<a class="feature-card" href="..." aria-label="...">`, rewrite each `.feature-desc` to a single tagline, remove the nested `<a>` from the Formations card.

The approach for card interactivity follows the existing `.link-card` pattern already in `style.scss` (lines 613–635): block `<a>`, `color: $color-text`, `text-decoration: none` in both normal and hover. For the hover background tint, `$color-surface-2` (`#21262d`) is chosen over `rgba($color-accent, 0.05)` because it is the established card-hover color elsewhere in the codebase (`.pipeline-stage.stage-active`, `.video-placeholder`). The `transition` property will be extended to include `background-color` alongside the existing `border-color` transition.

For focus visibility, `&:focus-visible` (not `:focus`) is used so mouse clicks don't produce a ring — consistent with how modern browser UIs work and matching the intent of R4.

**Startup Board Validation placement decision**: Add a new `### Startup Board Validation` section in `## 1. Getting Started` (after `### Auto-upgrade`). Linking the feature card to the §10 troubleshooting heading (`### Startup Board Validation Failure`) would send a curious new user to a troubleshooting page, which is wrong UX for a feature highlight. A two-sentence intro stub in §1 is the right target.

**Yolo Mode stub placement**: Add `### Yolo Mode and Auto-Merge` under `## 3. Workflow Patterns`, after `### When to Intervene`. §3 is where pipeline automation patterns live; this is the natural home.

**Multi-Repo Support stub placement**: Add `### Multi-Repo Support` under `## 1. Getting Started`, directly after `### Git Repositories and Worktrees` (line 196). Onboarding readers land here first when trying to understand the repo model.

**Plugin & Skills anchor**: Expected to be `#5-plugin--skills` (kramdown strips `&` leaving a double-space, which becomes `--`). Implementer must verify by running `bundle exec jekyll serve` and inspecting the rendered heading's `id` attribute — use the actual rendered anchor, not the predicted one.

**Relative URL pattern**: Use `{{ '/PAGE' | relative_url }}#anchor` (two-part form), consistent with the existing nested link in the Formations card (line 278) and other links in `index.md`.

**No ADR needed**: All decisions here are CSS conventions and docs placement — nothing that would constrain future contributors in a non-obvious architectural way.

---

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add 3 short stubs: `### Multi-Repo Support` (after §1 `### Git Repositories and Worktrees`), `### Startup Board Validation` (after §1 `### Auto-upgrade`), `### Yolo Mode and Auto-Merge` (after §3 `### When to Intervene`) |
| `docs/assets/css/style.scss` | Extend `.feature-card` rule: `display: block`, `color: inherit`, `text-decoration: none`, `cursor: pointer`, `user-select: none`, `-webkit-user-select: none`, `touch-action: manipulation`; extend `transition` to include `background-color`; `&:hover` add `background: $color-surface-2` and `text-decoration: none`; add `&:focus-visible` with `outline: 2px solid $color-accent-2; outline-offset: 2px; border-color: $color-accent-2` |
| `docs/index.md` | Convert all 15 `<div class="feature-card">` to `<a class="feature-card" href="..." aria-label="...">` + `</a>`, rewrite each `.feature-desc` to a tagline, remove the nested `<a>` in the Formations card |

---

### Key Decisions

- **`$color-surface-2` for hover tint over `rgba($color-accent, 0.05)`**: `$color-surface-2` is already the established "active/hover" background for cards in this codebase (pipeline stage active state, video placeholder). Using it is consistent and avoids introducing a new color recipe.
- **`&:focus-visible` not `&:focus`**: Avoids painting a focus ring on mouse clicks while still providing keyboard users with a visible ring. This is the current browser default for `:focus-visible` and requires no JS.
- **`touch-action: manipulation`**: Prevents double-tap-to-zoom on iOS/Android without requiring JS, so tapping the card navigates immediately. Required by the spec's mobile risk note.
- **New `### Startup Board Validation` stub in §1 over linking to §10 troubleshooting**: A feature card should link to a feature description, not a troubleshooting entry. Two-sentence stub at the top-level Getting Started section is correct for the audience.
- **`{{ '/PAGE' | relative_url }}#anchor` URL form**: Matches the existing Formations card link pattern (line 278) already in the file.

---

### Task Checklist

- [ ] **Task 1 — USER_GUIDE.md: Add `### Multi-Repo Support` stub** directly after `### Git Repositories and Worktrees` in §1. Two or three sentences: Fabrik can manage issues across all repos on the board; omit (or comment out) `repo:` in `.fabrik/config.yaml` to enable multi-repo mode; repos are bare-cloned and worktrees created lazily per issue.

- [ ] **Task 2 — USER_GUIDE.md: Add `### Startup Board Validation` stub** after `### Auto-upgrade` in §1. Two sentences: on startup Fabrik compares stage names in YAML to board column names and exits on mismatch; this catches config drift before any work begins. (Link to §10 `### Startup Board Validation Failure` for the troubleshooting detail.)

- [ ] **Task 3 — USER_GUIDE.md: Add `### Yolo Mode and Auto-Merge` stub** after `### When to Intervene` in §3. Three to four sentences covering: `--yolo` flag enables global auto-advance and auto-merge; `fabrik:yolo` label scopes the same behavior to one issue; `fabrik:cruise` auto-advances through all stages but stops before merge. Point to `### Stage YAML Reference` for `auto_advance` field details.

- [ ] **Task 4 — style.scss: Update `.feature-card` rule** to support block `<a>` usage:
  - Add `display: block`, `color: inherit`, `text-decoration: none`, `cursor: pointer`, `user-select: none`, `-webkit-user-select: none`, `touch-action: manipulation`.
  - Extend `transition` to `border-color 0.2s, background-color 0.2s`.
  - In `&:hover`: add `background: $color-surface-2` and `text-decoration: none`.
  - Add `&:focus-visible { outline: 2px solid $color-accent-2; outline-offset: 2px; border-color: $color-accent-2; }`.

- [ ] **Task 5 — index.md: Convert feature cards and rewrite taglines.** For each of the 15 cards:
  - Replace `<div class="feature-card">` with `<a class="feature-card" href="{{ '/TARGET' | relative_url }}#anchor" aria-label="CARD TITLE — open documentation">`.
  - Replace closing `</div>` (matching the card's opening tag) with `</a>`.
  - Replace the contents of `<div class="feature-desc">...</div>` with a single tagline (6–15 words, declarative, no `<code>`, no semicolons, no compound clauses). Use the suggested taglines below as a starting point; refine for length and voice:
    - **GitHub-Native Pipeline** → "Board columns are stages and labels are state — no CI glue needed." → link: `{{ '/state-machine' | relative_url }}#pipeline-overview`
    - **Isolated Git Worktrees** → "Every issue gets a dedicated branch and worktree with zero cross-contamination." → link: `{{ '/USER_GUIDE' | relative_url }}#git-repositories-and-worktrees`
    - **Comment-Driven Steering** → "Comment on any issue mid-stage to redirect the work in progress." → link: `{{ '/state-machine' | relative_url }}#4-comment-processing-lifecycle`
    - **Yolo Mode & Auto-Merge** → "Auto-advances through every stage and merges the PR on Validate completion." → link: `{{ '/USER_GUIDE' | relative_url }}#yolo-mode-and-auto-merge`
    - **Configurable Stages** → "Customize each stage's prompt, model, tools, and turn budget in YAML." → link: `{{ '/USER_GUIDE' | relative_url }}#stage-yaml-reference`
    - **Multi-User Safe** → "Multiple Fabrik instances share one project board without conflicts." → link: `{{ '/USER_GUIDE' | relative_url }}#multi-user-and-multi-instance-operation`
    - **Startup Board Validation** → "Stage configs are validated against board columns on every startup." → link: `{{ '/USER_GUIDE' | relative_url }}#startup-board-validation`
    - **Self-Upgrade** → "Detects and installs the latest release automatically when idle." → link: `{{ '/USER_GUIDE' | relative_url }}#auto-upgrade`
    - **PR Lifecycle Management** → "Draft PR created at Implement and marked ready to merge at Validate." → link: `{{ '/state-machine' | relative_url }}#5-pr-lifecycle-integration`
    - **Terminal UI** → "Live dashboard shows active jobs, stage progress, token costs, and history." → link: `{{ '/USER_GUIDE' | relative_url }}#8-tui-dashboard`
    - **Multi-Repo Support** → "One Fabrik instance manages issues across every repo on the board." → link: `{{ '/USER_GUIDE' | relative_url }}#multi-repo-support`
    - **Plugin & Skills** → "Inject custom methodology per stage with plain markdown skill files." → link: `{{ '/USER_GUIDE' | relative_url }}#5-plugin--skills` ⚠️ verify anchor in Task 6
    - **Formations** → "Chain issues with GitHub's blocked-by relationships for automatic parallel execution." → link: `{{ '/USER_GUIDE' | relative_url }}#dependency-based-sequencing-formations`; confirm nested `<a>` is fully removed
    - **Pending Reviewer Gate** → "Waits for all requested PR reviewers then re-invokes the stage to address comments." → link: `{{ '/USER_GUIDE' | relative_url }}#pending-reviewer-gate`
    - **CI Gate** → "Blocks merge until CI passes and auto-fixes failing checks each cycle." → link: `{{ '/state-machine' | relative_url }}#64-ci-gate-and-ci-fix-reinvoke`

- [ ] **Task 6 — Verify all anchor targets.** Run `bundle exec jekyll serve` locally (or inspect `_site/`). For each of the 15 card links:
  - Open the rendered page, click the card, and confirm the browser navigates to a heading (not a 404 or blank).
  - Specifically confirm the Plugin & Skills anchor: inspect the `id` attribute on the `## 5. Plugin & Skills` heading and correct the link in index.md if the actual anchor differs from `#5-plugin--skills`.
  - Confirm no nested `<a>` elements exist inside any `.feature-card` `<a>` (grep for `<a class="feature-card"` in the rendered HTML and ensure no child `<a>` appears within).

---

### Risks

- **Plugin & Skills anchor ambiguity**: Kramdown's treatment of `&` in heading text may produce `#5-plugin--skills` or `#5-plugin-skills`. Task 6 forces verification before merging — do not skip this step.
- **Base `a:hover` underline override**: The global `a:hover { text-decoration: underline }` rule at line 47 of style.scss fires for `<a>` elements. If `text-decoration: none` is missing from `.feature-card:hover`, all cards show an underline on hover. Task 4 includes this override explicitly.
- **`color: inherit` critical**: Without `color: inherit` on `.feature-card`, converting `<div>` to `<a>` turns all card text blue (`$color-accent-2` inherited from the base `a` rule). Implement must include this in Task 4.
- **Formations nested `<a>` must be fully removed**: The tagline rewrite in Task 5 eliminates the prose containing the nested link, but Implement must confirm the literal `<a>` HTML tag is gone. Task 6 grep verification catches this.
- **Stub sections must appear before the card links are published**: Tasks 1–3 (USER_GUIDE stubs) and Tasks 4–5 (CSS + HTML) can be developed in parallel, but all must be in the same PR/commit for the anchors to exist when the cards go live.

---
Used 9/50 turns, 6k input / 7k output tokens.

## Verification

Rewrote all 15 feature cards on the marketing page: replaced verbose multi-sentence descriptions with single brief taglines (6–15 words each), converted each card to a clickable `<a>` element linking to the canonical docs section, and updated CSS for cursor, hover tint, focus ring, and text-selection disable. Added three new USER_GUIDE.md stubs (`### Multi-Repo Support`, `### Startup Board Validation`, `### Yolo Mode and Auto-Merge`) to provide anchor targets for cards that previously had none. All 15 link targets verified against source headings.

---

Closes #446