### PR TITLE
Investigate why progress-based extension did not fire on Implement run that hit max_turns

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -416,14 +416,16 @@ When Claude exits a stage invocation due to `max_turns` (i.e., the per-invocatio
 
 | Stage | Progress Signal | API Cost |
 |-------|----------------|----------|
-| **Implement** | New git commit on `fabrik/issue-N` branch (HEAD SHA changed) | Zero — local git only |
+| **Implement** | New git commit (HEAD SHA changed) OR (baseline was clean AND working tree is now dirty — uncommitted file edits by Claude) | Zero — local git only |
 | **Review** | New git commit OR `LinkedPRResolvedThreadCount` increased | One `FetchItemDetails` GraphQL call (only if no new commit) |
 | **Validate** | Total comment count on issue/PR increased | One `FetchItemDetails` GraphQL call |
 | **All others** (Research, Specify, Plan, custom) | No signal — always fail on turn-limit | None |
 
+The "baseline clean AND working tree dirty" guard for Implement prevents a pre-existing dirty worktree (e.g. from a prior interrupted session) from counting as progress. Only new uncommitted changes made during the invocation trigger extension.
+
 **Extension loop behavior (within a single `processItem` call — no poll-cycle gap):**
 
-1. At invocation start, a `progressBaseline` is snapshotted (git HEAD SHA, comment count, resolved thread count).
+1. At invocation start, a `progressBaseline` is snapshotted: git HEAD SHA (Implement, Review), working-tree dirty state (Implement), comment count (Validate), and resolved thread count (Review).
 2. Claude is invoked with the current budget.
 3. If the turn limit is hit AND `totalMultiple < 3`: call `detectProgress`. If progress → `totalMultiple++`, re-invoke with `--resume`. If no progress or progress check fails → proceed to cooldown/retry as today.
 4. Output is accumulated across all invocations before posting as a single stage comment.
@@ -431,7 +433,7 @@ When Claude exits a stage invocation due to `max_turns` (i.e., the per-invocatio
 
 **`fabrik:extend-turns` label:** When present at invocation start, the first invocation receives `2 × stage.MaxTurns` as its budget (pre-granted extension, no progress check required for the first turn-limit hit). Subsequent extensions beyond 2× still require the progress check. The label is auto-removed on successful stage completion; `ErrNotFound` on removal is treated as success (user removed it manually). The label is a no-op when `stage.MaxTurns == 0`.
 
-**Log tag:** `[#N extend-turns]` — emitted when an extension is granted, including the new multiple and cumulative turns used.
+**Log tag:** `[#N extend-turns]` — emitted on **every** `detectProgress` call (pass or fail), reporting the evaluated signals and `has_progress=true/false`. When extension is granted, an additional line logs the new budget multiple and cumulative turns used.
 
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
 |--------------|-------|-------|-----------------|--------------|----------------|--------------|

--- a/engine/extend_test.go
+++ b/engine/extend_test.go
@@ -287,8 +287,8 @@ func TestDetectProgress_Review_FetchError(t *testing.T) {
 func captureLogf() (func(tag, format string, args ...any), func() []string) {
 	var lines []string
 	fn := func(tag, format string, args ...any) {
-		import_ := fmt.Sprintf("[%s] ", tag) + fmt.Sprintf(format, args...)
-		lines = append(lines, import_)
+		line := fmt.Sprintf("[%s] ", tag) + fmt.Sprintf(format, args...)
+		lines = append(lines, line)
 	}
 	return fn, func() []string { return lines }
 }

--- a/engine/extend_test.go
+++ b/engine/extend_test.go
@@ -2,12 +2,19 @@ package engine
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
+
+// nopLogf is a no-op logfFn for tests that don't assert log output.
+func nopLogf(tag, format string, args ...any) {}
 
 func TestHasExtendTurnsLabel(t *testing.T) {
 	tests := []struct {
@@ -107,7 +114,7 @@ func TestDetectProgress_NoSignalStage(t *testing.T) {
 		stage := &stages.Stage{Name: stageName}
 		item := gh.ProjectItem{}
 		b := progressBaseline{}
-		progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", &mockGitHubClient{})
+		progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", &mockGitHubClient{}, nopLogf)
 		if err != nil {
 			t.Errorf("stage %s: unexpected error: %v", stageName, err)
 		}
@@ -130,7 +137,7 @@ func TestDetectProgress_Implement_NoNewCommits(t *testing.T) {
 	item := gh.ProjectItem{}
 	b := progressBaseline{gitHeadSHA: sha}
 
-	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{})
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{}, nopLogf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -166,7 +173,7 @@ func TestDetectProgress_Implement_NewCommit(t *testing.T) {
 	item := gh.ProjectItem{}
 	b := progressBaseline{gitHeadSHA: oldSHA}
 
-	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{})
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{}, nopLogf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -187,7 +194,7 @@ func TestDetectProgress_Validate_NoNewComments(t *testing.T) {
 	item := gh.ProjectItem{}
 	b := progressBaseline{commentCount: 1}
 
-	progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", client)
+	progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", client, nopLogf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,7 +215,7 @@ func TestDetectProgress_Validate_NewComment(t *testing.T) {
 	item := gh.ProjectItem{}
 	b := progressBaseline{commentCount: 1}
 
-	progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", client)
+	progress, err := detectProgress(ctx, stage, &item, b, "/irrelevant", client, nopLogf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -237,7 +244,7 @@ func TestDetectProgress_Review_NewResolvedThread(t *testing.T) {
 	item := gh.ProjectItem{}
 	b := progressBaseline{gitHeadSHA: sha, resolvedThreadCount: 1}
 
-	progress, err := detectProgress(ctx, stage, &item, b, repoDir, client)
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, client, nopLogf)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -265,12 +272,213 @@ func TestDetectProgress_Review_FetchError(t *testing.T) {
 	item := gh.ProjectItem{}
 	b := progressBaseline{gitHeadSHA: sha, resolvedThreadCount: 0}
 
-	progress, err := detectProgress(ctx, stage, &item, b, repoDir, client)
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, client, nopLogf)
 	if err == nil {
 		t.Fatal("expected error when FetchItemDetails fails")
 	}
 	if progress {
 		t.Error("expected no progress on fetch error")
+	}
+}
+
+// --- logging tests ---
+
+// captureLogf returns a logfFn that records all calls and a getter function.
+func captureLogf() (func(tag, format string, args ...any), func() []string) {
+	var lines []string
+	fn := func(tag, format string, args ...any) {
+		import_ := fmt.Sprintf("[%s] ", tag) + fmt.Sprintf(format, args...)
+		lines = append(lines, import_)
+	}
+	return fn, func() []string { return lines }
+}
+
+func TestDetectProgress_Implement_SHAChanged_LogsProgress(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	oldSHA, err := gitHeadSHA(repoDir)
+	if err != nil {
+		t.Fatalf("gitHeadSHA: %v", err)
+	}
+	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "new work")
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %s: %v", out, err)
+	}
+	newSHA, _ := gitHeadSHA(repoDir)
+
+	logFn, getLines := captureLogf()
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: oldSHA}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{}, logFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !progress {
+		t.Error("expected progress=true when SHA changed")
+	}
+	lines := getLines()
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "has_progress=true") {
+		t.Errorf("log line should contain has_progress=true: %q", lines[0])
+	}
+	if !strings.Contains(lines[0], oldSHA) || !strings.Contains(lines[0], newSHA) {
+		t.Errorf("log line should contain both SHAs: %q", lines[0])
+	}
+}
+
+func TestDetectProgress_Implement_NoCommitCleanTree_LogsFalse(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	sha, _ := gitHeadSHA(repoDir)
+	logFn, getLines := captureLogf()
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: sha, workingTreeDirty: false}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{}, logFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if progress {
+		t.Error("expected progress=false when SHA unchanged and tree clean")
+	}
+	lines := getLines()
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "has_progress=false") {
+		t.Errorf("log line should contain has_progress=false: %q", lines[0])
+	}
+}
+
+func TestDetectProgress_Implement_DirtyTree_BaselineClean_LogsProgress(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	sha, _ := gitHeadSHA(repoDir)
+	// Create an uncommitted file (not engine-managed).
+	if err := os.WriteFile(filepath.Join(repoDir, "work.go"), []byte("package foo\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	logFn, getLines := captureLogf()
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{}
+	b := progressBaseline{gitHeadSHA: sha, workingTreeDirty: false}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{}, logFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !progress {
+		t.Error("expected progress=true when baseline clean and working tree dirty")
+	}
+	lines := getLines()
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "has_progress=true") {
+		t.Errorf("log line should contain has_progress=true: %q", lines[0])
+	}
+}
+
+func TestDetectProgress_Implement_DirtyTree_BaselineDirty_NoProgress(t *testing.T) {
+	skipIfNoGit(t)
+	ctx := context.Background()
+	repoDir := initBareRepo(t)
+
+	sha, _ := gitHeadSHA(repoDir)
+	// Pre-existing dirty file at baseline time.
+	if err := os.WriteFile(filepath.Join(repoDir, "old-work.go"), []byte("package foo\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	logFn, getLines := captureLogf()
+	stage := &stages.Stage{Name: "Implement"}
+	item := gh.ProjectItem{}
+	// Baseline records dirty=true (already dirty going in).
+	b := progressBaseline{gitHeadSHA: sha, workingTreeDirty: true}
+
+	progress, err := detectProgress(ctx, stage, &item, b, repoDir, &mockGitHubClient{}, logFn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if progress {
+		t.Error("expected progress=false when baseline was already dirty")
+	}
+	lines := getLines()
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "has_progress=false") {
+		t.Errorf("log line should contain has_progress=false: %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "baseline already dirty") {
+		t.Errorf("log line should mention baseline guard: %q", lines[0])
+	}
+}
+
+// --- isWorkingTreeDirty tests ---
+
+func TestIsWorkingTreeDirty_CleanRepo(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	dirty, err := isWorkingTreeDirty(repoDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dirty {
+		t.Error("expected clean repo to report dirty=false")
+	}
+}
+
+func TestIsWorkingTreeDirty_WithUncommittedFile(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	if err := os.WriteFile(filepath.Join(repoDir, "changes.go"), []byte("package foo\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	dirty, err := isWorkingTreeDirty(repoDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !dirty {
+		t.Error("expected repo with uncommitted file to report dirty=true")
+	}
+}
+
+func TestIsWorkingTreeDirty_EngineManagedOnly(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	// Create a .fabrik-context/ file — should be ignored.
+	contextDir := filepath.Join(repoDir, ".fabrik-context")
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contextDir, "issue.md"), []byte("# Issue\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	dirty, err := isWorkingTreeDirty(repoDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dirty {
+		t.Error("engine-managed files should not cause dirty=true")
 	}
 }
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -23,7 +23,7 @@ var lockVerifyDelay = 2 * time.Second
 // engine itself and should never be treated as user-generated dirty content.
 // These paths must not block cleanup or worktree updates.
 func isEngineManagedPath(path string) bool {
-	return strings.HasPrefix(path, ".fabrik-context/")
+	return strings.HasPrefix(path, ".fabrik-context/") || path == ".fabrik/issue.md"
 }
 
 // isAwaitingInput returns true iff the item has both fabrik:paused and
@@ -1241,7 +1241,7 @@ func isWorkingTreeDirty(dir string) (bool, error) {
 			continue
 		}
 		path := strings.TrimSpace(line[2:])
-		if isEngineManagedPath(path) || strings.HasPrefix(path, ".fabrik/issue.md") {
+		if isEngineManagedPath(path) {
 			continue
 		}
 		return true, nil
@@ -1261,6 +1261,7 @@ func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem
 	case "Implement":
 		sha, err := gitHeadSHA(workDir)
 		if err != nil {
+			logfFn("extend-turns", "progress check: git HEAD lookup failed: %v, has_progress=false — no extension\n", err)
 			return false, err
 		}
 		if sha != baseline.gitHeadSHA {
@@ -1287,6 +1288,7 @@ func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem
 	case "Review":
 		sha, err := gitHeadSHA(workDir)
 		if err != nil {
+			logfFn("extend-turns", "progress check: git HEAD lookup failed: %v, has_progress=false — no extension\n", err)
 			return false, err
 		}
 		if sha != baseline.gitHeadSHA {
@@ -1295,6 +1297,7 @@ func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem
 		}
 		// No new commits — re-fetch to check resolved reviewer threads.
 		if err := client.FetchItemDetails(item); err != nil {
+			logfFn("extend-turns", "progress check: HEAD %s (unchanged), re-fetch failed: %v, has_progress=false — no extension\n", sha, err)
 			return false, fmt.Errorf("re-fetching item for progress check: %w", err)
 		}
 		progress := item.LinkedPRResolvedThreadCount > baseline.resolvedThreadCount
@@ -1308,7 +1311,9 @@ func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem
 		return progress, nil
 	case "Validate":
 		if err := client.FetchItemDetails(item); err != nil {
-			return false, fmt.Errorf("re-fetching item for progress check: %w", err)
+			fetchErr := fmt.Errorf("re-fetching item for progress check: %w", err)
+			logfFn("extend-turns", "progress check: comments %d (fetch failed), has_progress=false, err=%v\n", baseline.commentCount, fetchErr)
+			return false, fetchErr
 		}
 		progress := len(item.Comments) > baseline.commentCount
 		if progress {

--- a/engine/item.go
+++ b/engine/item.go
@@ -660,7 +660,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		if !hitLimit || totalMultiple >= 3 {
 			break
 		}
-		hasProgress, progressErr := detectProgress(ctx, stage, &item, baseline, workDir, e.client)
+		issueLogf := func(tag, format string, args ...any) {
+			e.logf(item.Number, tag, format, args...)
+		}
+		hasProgress, progressErr := detectProgress(ctx, stage, &item, baseline, workDir, e.client, issueLogf)
 		if progressErr != nil {
 			e.logf(item.Number, "extend-turns", "progress check failed: %v\n", progressErr)
 			break
@@ -670,8 +673,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		}
 		totalMultiple++
 		currentBudget = stage.MaxTurns
-		e.logf(item.Number, "extend-turns", "progress detected — extending to %d× budget (%d turns used)\n",
-			totalMultiple, usage.TurnsUsed)
+		e.logf(item.Number, "extend-turns", "extending to %d× budget (%d turns used)\n", totalMultiple, usage.TurnsUsed)
 		resume = true
 	}
 	// Report cumulative budget across all extensions in stats footer.
@@ -1141,12 +1143,9 @@ func (e *Engine) removeFailedLabel(owner, repo string, issueNumber int, stageNam
 // commitWIP commits any uncommitted changes in the worktree as a WIP commit.
 // This preserves partial work when Claude hits max_turns or errors out.
 func (e *Engine) commitWIP(workDir string, issueNumber int, stageName string) {
-	// Check for uncommitted changes
-	statusCmd := exec.Command("git", "status", "--porcelain")
-	statusCmd.Dir = workDir
-	out, err := statusCmd.Output()
-	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
-		return // clean worktree, nothing to commit
+	dirty, err := isWorkingTreeDirty(workDir)
+	if err != nil || !dirty {
+		return // clean worktree or error checking, nothing to commit
 	}
 
 	// Stage all changes
@@ -1187,6 +1186,7 @@ type progressBaseline struct {
 	gitHeadSHA          string // HEAD commit SHA in the worktree (Implement, Review)
 	commentCount        int    // total comment count on item (Validate)
 	resolvedThreadCount int    // resolved PR review threads (Review)
+	workingTreeDirty    bool   // true if worktree had uncommitted changes at baseline (Implement)
 }
 
 // hasExtendTurnsLabel returns true if item carries the "fabrik:extend-turns" label.
@@ -1201,6 +1201,9 @@ func snapshotBaseline(stage *stages.Stage, item gh.ProjectItem, workDir string) 
 	case "Implement":
 		if sha, err := gitHeadSHA(workDir); err == nil {
 			b.gitHeadSHA = sha
+		}
+		if dirty, err := isWorkingTreeDirty(workDir); err == nil {
+			b.workingTreeDirty = dirty
 		}
 	case "Review":
 		if sha, err := gitHeadSHA(workDir); err == nil {
@@ -1224,37 +1227,97 @@ func gitHeadSHA(dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// isWorkingTreeDirty returns true if dir has uncommitted changes other than
+// engine-managed files (.fabrik-context/, .fabrik/issue.md).
+func isWorkingTreeDirty(dir string) (bool, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git status --porcelain: %w", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		path := strings.TrimSpace(line[2:])
+		if isEngineManagedPath(path) || strings.HasPrefix(path, ".fabrik/issue.md") {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
 // detectProgress checks whether measurable progress was made since baseline.
-// Implement: new commits (git HEAD SHA changed). Review: new commits OR resolved
-// reviewer thread count increased (GitHub re-fetch). Validate: total comment count
-// increased (GitHub re-fetch). All other stages return false — no extension.
+// Implement: new commits OR (baseline was clean AND working tree is now dirty).
+// Review: new commits OR resolved reviewer thread count increased (GitHub re-fetch).
+// Validate: total comment count increased (GitHub re-fetch).
+// All other stages return false — no extension.
+// logfFn is called exactly once per invocation with the verdict and evaluated signals.
 // If a GitHub re-fetch fails, returns false and the error (conservative: fail as today).
-func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem, baseline progressBaseline, workDir string, client GitHubClient) (bool, error) {
+func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem, baseline progressBaseline, workDir string, client GitHubClient, logfFn func(tag, format string, args ...any)) (bool, error) {
 	switch stage.Name {
 	case "Implement":
 		sha, err := gitHeadSHA(workDir)
 		if err != nil {
 			return false, err
 		}
-		return sha != baseline.gitHeadSHA, nil
+		if sha != baseline.gitHeadSHA {
+			logfFn("extend-turns", "progress check: HEAD %s → %s (new commits), has_progress=true\n", baseline.gitHeadSHA, sha)
+			return true, nil
+		}
+		// HEAD unchanged — check for uncommitted working-tree changes, but only
+		// if the baseline was clean. A pre-existing dirty worktree does not count.
+		dirty, err := isWorkingTreeDirty(workDir)
+		if err != nil {
+			logfFn("extend-turns", "progress check: HEAD %s (unchanged), working-tree check failed: %v, has_progress=false — no extension\n", sha, err)
+			return false, nil
+		}
+		if !baseline.workingTreeDirty && dirty {
+			logfFn("extend-turns", "progress check: HEAD %s (unchanged), working-tree dirty (baseline was clean), has_progress=true\n", sha)
+			return true, nil
+		}
+		reason := "working-tree clean"
+		if baseline.workingTreeDirty {
+			reason = "baseline already dirty"
+		}
+		logfFn("extend-turns", "progress check: HEAD %s (unchanged), %s, has_progress=false — no extension\n", sha, reason)
+		return false, nil
 	case "Review":
 		sha, err := gitHeadSHA(workDir)
 		if err != nil {
 			return false, err
 		}
 		if sha != baseline.gitHeadSHA {
+			logfFn("extend-turns", "progress check: HEAD %s → %s (new commits), has_progress=true\n", baseline.gitHeadSHA, sha)
 			return true, nil
 		}
 		// No new commits — re-fetch to check resolved reviewer threads.
 		if err := client.FetchItemDetails(item); err != nil {
 			return false, fmt.Errorf("re-fetching item for progress check: %w", err)
 		}
-		return item.LinkedPRResolvedThreadCount > baseline.resolvedThreadCount, nil
+		progress := item.LinkedPRResolvedThreadCount > baseline.resolvedThreadCount
+		if progress {
+			logfFn("extend-turns", "progress check: HEAD %s (unchanged), resolved threads %d → %d, has_progress=true\n",
+				sha, baseline.resolvedThreadCount, item.LinkedPRResolvedThreadCount)
+		} else {
+			logfFn("extend-turns", "progress check: HEAD %s (unchanged), resolved threads %d (unchanged), has_progress=false — no extension\n",
+				sha, baseline.resolvedThreadCount)
+		}
+		return progress, nil
 	case "Validate":
 		if err := client.FetchItemDetails(item); err != nil {
 			return false, fmt.Errorf("re-fetching item for progress check: %w", err)
 		}
-		return len(item.Comments) > baseline.commentCount, nil
+		progress := len(item.Comments) > baseline.commentCount
+		if progress {
+			logfFn("extend-turns", "progress check: comments %d → %d, has_progress=true\n", baseline.commentCount, len(item.Comments))
+		} else {
+			logfFn("extend-turns", "progress check: comments %d (unchanged), has_progress=false — no extension\n", baseline.commentCount)
+		}
+		return progress, nil
 	}
+	logfFn("extend-turns", "progress check: stage %s has no progress signal, has_progress=false\n", stage.Name)
 	return false, nil
 }

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -262,30 +262,13 @@ func (wm *WorktreeManager) branchExists(branch string) bool {
 // Errors are non-fatal — the worktree is still usable, just potentially behind.
 func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string, issueNumber int) {
 	// Check for uncommitted changes — skip update if dirty.
-	// Ignore .fabrik-context/ (engine-written context files) which are always
+	// Engine-managed files (.fabrik-context/, .fabrik/issue.md) are always
 	// present but should never block a rebase. Other untracked files (e.g. new
 	// source files from an interrupted Claude session) DO block the rebase
 	// to avoid losing work-in-progress.
-	statusCmd := exec.Command("git", "status", "--porcelain")
-	statusCmd.Dir = wtDir
-	if out, err := statusCmd.Output(); err == nil {
-		dirty := false
-		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-			if line == "" {
-				continue
-			}
-			// Extract the file path (status is first 2 chars + space + path)
-			path := strings.TrimSpace(line[2:])
-			if strings.HasPrefix(path, ".fabrik-context/") || strings.HasPrefix(path, ".fabrik/issue.md") {
-				continue // engine-managed, safe to ignore
-			}
-			dirty = true
-			break
-		}
-		if dirty {
-			wm.logf(issueNumber, "worktree", "has uncommitted changes, skipping update from main\n")
-			return
-		}
+	if dirty, err := isWorkingTreeDirty(wtDir); err == nil && dirty {
+		wm.logf(issueNumber, "worktree", "has uncommitted changes, skipping update from main\n")
+		return
 	}
 
 	// Fetch latest from origin


### PR DESCRIPTION
## Summary

Add per-call diagnostic logging to `detectProgress` (emitting verdict + raw signals on every invocation, pass or fail), investigate whether the current Implement heuristic is correct, and fix any bugs found. If the heuristic correctly detected zero progress for #705 (i.e. Claude genuinely made no commits), document that finding and determine whether uncommitted working-tree changes should also count as a progress signal.

## Problem

On issue #705 (Onboarding wizard / Service registry), an Implement run hit `max_turns` (51/50, recorded in TUI history with "(retry)" status) but the progress-based turn extension (shipped in #432) did **not** fire — the `MaxTurns` recorded in history is 50, not 100, which proves `detectProgress` returned `false` and the extension loop exited after the first invocation.

This is suspicious because Implement stages that hit `max_turns` after 50 turns of substantive work almost always do have made progress. If `detectProgress` is rejecting legitimate runs, the feature provides little practical value over the pre-extension behavior.

There are two compounding problems:

1. **The heuristic may be buggy.** `detectProgress` for Implement only checks whether the git HEAD SHA changed — it does not consider uncommitted file changes, nor does it check checkbox ticking in the plan doc (which the original #432 design described as a secondary signal). A run where Claude did 50 turns of file edits without committing would correctly report `sha unchanged` but would incorrectly indicate zero progress.

2. **There is no logging when extension does not fire.** The only `extend-turns` log line today is the affirmative one at `item.go:673`. A false-negative is completely silent, making post-mortem diagnosis require manual worktree inspection.

## Approach

(Populated by Implement)

## Verification

Fixed the `detectProgress` Implement heuristic that caused issue #705 to retry 3 times at ~$21 total: added uncommitted working-tree changes as a secondary progress signal (with a baseline-clean guard to prevent false positives from pre-existing dirty state). Added always-on structured logging to `detectProgress` so future silent non-extensions are diagnosable without post-hoc forensics. Extracted `isWorkingTreeDirty` helper to consolidate dirty-check logic across `commitWIP`, `updateWorktreeFromMain`, and the progress check.

---

Closes #448