### PR TITLE
Webhook-driven event delivery to reduce GraphQL load and cut event latency

### DIFF
--- a/adrs/032-webhook-event-delivery.md
+++ b/adrs/032-webhook-event-delivery.md
@@ -1,0 +1,105 @@
+# ADR 032: Webhook-Driven Event Delivery via gh webhook forward
+
+**Status**: Accepted  
+**Date**: 2026-04-26  
+**Supersedes**: ADR 003 (Polling Over Webhooks)
+
+## Context
+
+ADR 003 chose polling because Fabrik runs locally and webhooks require a publicly accessible endpoint. The `gh webhook forward` command (introduced in gh v2.32.0, October 2023) eliminates that constraint: it acts as an SSE client to GitHub and forwards events as HTTP POST requests to a localhost URL. No public endpoint, no ngrok, no infrastructure changes — just the `gh` CLI the user already has.
+
+Two problems motivate adding webhooks alongside polling:
+
+1. **GraphQL budget pressure.** The existing poll loop fetches the entire board every 30s–5min, consuming a significant fraction of the 5,000-points/hour GraphQL budget during active periods. Users running Fabrik alongside other `gh` workloads on the same token hit rate-limit caps.
+
+2. **Event latency.** Comments, label changes, CI completions, and review submissions are visible to Fabrik only at the next poll tick — up to 30s of delay. Comment-driven steering feels sluggish; CI gate clearance is bottlenecked on poll cadence.
+
+## Decision
+
+Add an optional webhook-driven event ingestion path (`--webhooks` flag, disabled by default). When enabled:
+
+- Spawn `gh webhook forward` as a managed subprocess, forwarding events to a Fabrik-internal HTTP listener on `127.0.0.1:<port>` (OS-assigned by default).
+- Verify every incoming payload with HMAC-SHA256 before acting.
+- Translate all events to `wakeCh` signals — the existing poll loop handles all subsequent work.
+- Extend the idle-backoff cap from 5 minutes to 60 minutes when the webhook stream is healthy or starting up (the stream covers the events that would otherwise require frequent polling).
+- Retain the existing poll loop as a safety net for missed/delayed webhook events.
+
+## Transport: gh webhook forward
+
+`gh webhook forward` was chosen over alternatives for these reasons:
+
+- **No public endpoint needed.** The tool handles GitHub's SSE connection outbound; Fabrik only needs to listen on localhost.
+- **No new accounts or third-party services.** Authentication piggybacks on the user's existing `gh auth login`.
+- **Standard GitHub CLI.** Users already install `gh` for the existing `gh api` / `gh pr` usage in Fabrik stages. Floor version `gh ≥ 2.32.0` (October 2023) covers the vast majority of active installations.
+- **Graceful fallback.** If `gh` is missing, too old, or fails to subscribe, Fabrik logs a warning and continues in polling-only mode. Webhook unavailability is always non-fatal.
+
+Alternatives considered:
+- **Self-hosted reverse tunnel (Cloudflare Tunnel, ngrok, SSH):** Functionally equivalent but adds infrastructure the user must provision and maintain. Deferred as a power-user option.
+- **GitHub Apps webhook endpoint:** Requires GitHub App registration, complicates auth, and still needs a public URL or tunnel. Out of scope for a local CLI tool.
+
+## Polling as Safety Net
+
+Webhooks are not a replacement for polling — they are augmentation:
+
+- **At-least-once delivery.** GitHub's webhook semantics are at-least-once. Events can be delayed, duplicated, or dropped (especially during GitHub incidents). The poll loop catches anything the webhook stream misses.
+- **Board-column changes.** The `projects_v2_item` event class may not be supported by all `gh webhook forward` versions or GitHub configurations (see below). Polling at the extended 60-minute cap covers these changes with acceptable latency.
+- **Startup.** On fresh start, the first board state is always fetched by polling; webhooks only deliver delta events.
+- **Dedup.** Fabrik's existing idempotency mechanisms (rocket reactions on processed comments, label mutations, `processedSet`, `inFlight` map) already handle at-least-once delivery. A webhook wake followed immediately by a scheduled poll both converge to the same board state.
+
+## Three-State Health Model
+
+A two-state model (healthy/unhealthy) creates a false-unhealthy condition at startup before the first event arrives. Three states eliminate this:
+
+- **`WebhookStreamStartingUp`**: the first 30 seconds (`WebhookStartupGrace`) after subprocess launch. Treated as healthy for idle-cap purposes (extended 60-min cap applies). TUI shows a blue/spinner indicator.
+- **`WebhookStreamHealthy`**: at least one event received in the last 10 minutes (`WebhookHealthWindow`). TUI shows a green dot.
+- **`WebhookStreamUnhealthy`**: grace expired with no first event, or health window elapsed. Falls back to the 5-minute idle cap. TUI shows a yellow dot.
+
+Grace re-applies on every subprocess restart. This avoids permanently masking an unhealthy state from a crash-looping subprocess — after the grace period expires with no event, the engine transitions to unhealthy and the 5-minute cap resumes.
+
+## Secret Rotation
+
+`gh webhook forward` registers a webhook secret with GitHub at startup. If the secret becomes stale (e.g., `gh auth refresh` invalidated the token), HMAC verification will fail for every subsequent event. To handle this:
+
+1. Track consecutive HMAC failures within a 2-minute window.
+2. On 5 consecutive failures: log a warning, kill the subprocess, generate a fresh 32-byte random secret, restart.
+3. If failures persist after 2 restart cycles: disable webhook mode for the session and fall back to polling. Log a clear error suggesting `gh auth status`.
+
+This is a defense-in-depth mechanism; the primary cause of HMAC failures in practice is GitHub replaying events with the old secret after a token change.
+
+## `projects_v2_item` Event Support
+
+The spec requires attempting to subscribe to `projects_v2_item` for board-column changes. Empirical verification during Research was deferred to runtime detection:
+
+- At subprocess start, Fabrik includes `projects_v2_item` in the `--events` list.
+- If `gh webhook forward` emits an "invalid" or "unknown" error for this event on stderr, Fabrik removes it from the subscription, logs a clear warning, and restarts without it.
+- When `projects_v2_item` is unavailable, board-column changes are caught by the safety-net poll within `WebhookIdleCap` (60 min). Correctness is preserved; only latency is affected.
+
+This behavior is documented in USER_GUIDE.md.
+
+## Multi-Repo Subscription
+
+A single `gh webhook forward` subprocess covers all repos:
+
+- When org-level webhook access is available (`gh webhook forward --org=<org>`), Fabrik uses it. One subscription covers all current and future repos in the org, with no restarts on new-repo discovery.
+- When org-level access fails (detected by the subprocess exiting within 10 seconds of a startup), Fabrik falls back to per-repo `--repo` arguments.
+- When a new repo appears on the board during a poll, the subprocess is killed and restarted with the updated repo list. The restart gap (seconds) is covered by the safety-net poll.
+
+Per-repo subprocesses for finer-grained failure isolation were explicitly deferred. The single-subprocess restart approach is simpler; per-repo subprocesses are a follow-up if real users encounter problems.
+
+## Security
+
+The local HTTP listener binds to `127.0.0.1` only — never accessible off-box. HMAC-SHA256 verification is required on every payload before any action is taken. Both layers are necessary:
+
+- `127.0.0.1` binding prevents off-box attackers.
+- HMAC prevents malicious local processes from spoofing events.
+
+The webhook secret is generated from `crypto/rand` (32 bytes, hex-encoded) at startup and regenerated on rotation. It is never logged or persisted to disk.
+
+## Consequences
+
+- **Steady-state GraphQL reduction:** Active boards that would otherwise poll every 30s now poll at most every 60 minutes when the webhook stream is healthy. For a board with events every few minutes, GraphQL load drops by ~100x.
+- **Event latency:** Comments, label changes, and CI completions become visible within seconds of GitHub recording them, down from up to 30s.
+- **Operational prerequisite:** Users need `gh ≥ 2.32.0` with `admin:repo_hook` scope (or org admin) to use webhook mode. Failure to meet prerequisites falls back gracefully to polling.
+- **Non-fatal failures:** All webhook plumbing failures are non-fatal. The engine never blocks on webhook health.
+- **Subprocess supervision:** A new long-running subprocess (`gh webhook forward`) is added to the engine's lifecycle. It follows the `runClaude` process-group patterns but runs asynchronously for the engine's lifetime.
+- **ADR 003 is superseded** but its core insight (polling as the reliable foundation) remains: polling is now the safety net rather than the only mechanism.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -377,7 +377,11 @@ func Execute() error {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_WEBHOOK_PORT=%q is invalid (must be 0 or a positive integer); using OS-assigned port\n", v)
 			}
 		} else if pc.WebhookPort != nil {
-			cfg.WebhookPort = *pc.WebhookPort
+			if *pc.WebhookPort >= 0 {
+				cfg.WebhookPort = *pc.WebhookPort
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] webhook_port=%d is invalid (must be 0 or a positive integer); using OS-assigned port\n", *pc.WebhookPort)
+			}
 		}
 	}
 	if cfg.WebhookEvents == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -361,7 +361,7 @@ func Execute() error {
 			cfg.PluginDir = v
 		}
 	}
-	if !cfg.Webhooks {
+	if !explicitFlags["webhooks"] {
 		if v := os.Getenv("FABRIK_WEBHOOKS"); v != "" {
 			lv := strings.ToLower(v)
 			cfg.Webhooks = lv == "true" || lv == "1" || lv == "yes"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,9 @@ type Config struct {
 	ClaudeWaitDelay   int // seconds; 0 means use default (30)
 	DebugOutput       bool
 	PluginDir         string
+	Webhooks          bool
+	WebhookPort       int
+	WebhookEvents     string // comma-separated; empty means default event set
 }
 
 func Execute() error {
@@ -119,6 +122,9 @@ func Execute() error {
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
 	flag.StringVar(&cfg.PluginDir, "plugin-dir", "", "Path to Fabrik plugin directory (for development; overrides installed plugin)")
+	flag.BoolVar(&cfg.Webhooks, "webhooks", false, "Enable webhook-driven event delivery via gh webhook forward (requires gh ≥ 2.32.0; also FABRIK_WEBHOOKS)")
+	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
+	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err
@@ -355,6 +361,30 @@ func Execute() error {
 			cfg.PluginDir = v
 		}
 	}
+	if !cfg.Webhooks {
+		if v := os.Getenv("FABRIK_WEBHOOKS"); v != "" {
+			lv := strings.ToLower(v)
+			cfg.Webhooks = lv == "true" || lv == "1" || lv == "yes"
+		} else if pc.Webhooks {
+			cfg.Webhooks = true
+		}
+	}
+	if !explicitFlags["webhook-port"] {
+		if v := os.Getenv("FABRIK_WEBHOOK_PORT"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				cfg.WebhookPort = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_WEBHOOK_PORT=%q is invalid (must be 0 or a positive integer); using OS-assigned port\n", v)
+			}
+		} else if pc.WebhookPort != nil {
+			cfg.WebhookPort = *pc.WebhookPort
+		}
+	}
+	if cfg.WebhookEvents == "" {
+		if v := os.Getenv("FABRIK_WEBHOOK_EVENTS"); v != "" {
+			cfg.WebhookEvents = v
+		}
+	}
 
 	if cfg.Owner == "" || cfg.ProjectNum == 0 {
 		flag.Usage()
@@ -425,6 +455,19 @@ func Execute() error {
 		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed: %v\n", err)
 	}
 
+	// Parse webhook events from comma-separated string.
+	var webhookEvents []string
+	if cfg.WebhookEvents != "" {
+		for _, ev := range strings.Split(cfg.WebhookEvents, ",") {
+			ev = strings.TrimSpace(ev)
+			if ev != "" {
+				webhookEvents = append(webhookEvents, ev)
+			}
+		}
+	} else if len(pc.WebhookEvents) > 0 {
+		webhookEvents = pc.WebhookEvents
+	}
+
 	eng, err := engine.New(engine.Config{
 		Owner:             cfg.Owner,
 		Repo:              cfg.Repo,
@@ -448,6 +491,9 @@ func Execute() error {
 		DebugOutput:       cfg.DebugOutput,
 		PluginDir:         cfg.PluginDir,
 		Stages:            stageCfgs,
+		Webhooks:          cfg.Webhooks,
+		WebhookPort:       cfg.WebhookPort,
+		WebhookEvents:     webhookEvents,
 		ReadyCh:           testReadyCh,
 	})
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -25,9 +25,12 @@ type ProjectConfig struct {
 	Yolo          bool   `yaml:"yolo"`
 	AutoUpgrade   bool   `yaml:"auto_upgrade"`
 	GitSSH        bool   `yaml:"git_ssh"`
-	TUI           *bool  `yaml:"tui"`
-	DebugOutput   bool   `yaml:"debug_output"`
-	Version       string `yaml:"version"`
+	TUI           *bool    `yaml:"tui"`
+	DebugOutput   bool     `yaml:"debug_output"`
+	Version       string   `yaml:"version"`
+	Webhooks      bool     `yaml:"webhooks"`
+	WebhookPort   *int     `yaml:"webhook_port"`
+	WebhookEvents []string `yaml:"webhook_events"`
 }
 
 // LoadProjectConfig reads .fabrik/config.yaml from CWD.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1614,6 +1614,8 @@ On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 1. If your token has org-admin access, Fabrik uses `--org=<org>` to subscribe to all repos in the org with one subscription — no restarts needed when new repos appear.
 2. Otherwise, Fabrik subscribes per-repo. When a new repo appears on the board, the subprocess is briefly restarted with the updated repo list (the safety-net poll covers any events missed during the restart).
 
+> **Startup delay on multi-repo boards**: Webhook subscriptions are established after the first board poll completes (up to one poll interval, typically 30 seconds). During this window the TUI shows the blue "starting up" indicator and the safety-net poll is in effect. This is expected — the webhook manager waits until the repo list is known before subscribing.
+
 ### Troubleshooting Webhook Mode
 
 **"prerequisite check failed"** — `gh` is missing or too old. Install or upgrade: <https://cli.github.com>

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -25,7 +25,8 @@ For the authoritative engine state-machine spec (label semantics, review gate tr
 7. [Permissions](#7-permissions)
 8. [TUI Dashboard](#8-tui-dashboard)
 9. [Observability](#9-observability)
-10. [Troubleshooting](#10-troubleshooting)
+10. [Webhook Mode](#10-webhook-mode)
+11. [Troubleshooting](#11-troubleshooting)
 
 ---
 
@@ -133,7 +134,7 @@ exactly (case-sensitive). The default pipeline uses:
 > ```bash
 > rm -rf ~/.claude/plugins/cache/claude-plugins-official/superpowers
 > ```
-> See [§10 Troubleshooting → Duplicate Comments on Issues](#10-troubleshooting) for full details.
+> See [§11 Troubleshooting → Duplicate Comments on Issues](#11-troubleshooting) for full details.
 
 ### First Run
 
@@ -299,13 +300,13 @@ experience as release binaries.
 
 On startup, Fabrik attempts to fetch the project board and status field so it can compare stage names in your YAML configs against the column names on the board. When that metadata is fetched successfully, any non-cleanup stage missing from the board causes Fabrik to exit with a detailed error listing the mismatched names — catching config drift before any work begins. Extra board columns without a matching stage produce a warning but do not block startup. If Fabrik cannot fetch the board or status field, it logs a warning and continues without blocking startup.
 
-See [§10 Troubleshooting → Startup Board Validation Failure](#startup-board-validation-failure) if validation succeeds and reports a mismatch.
+See [§11 Troubleshooting → Startup Board Validation Failure](#startup-board-validation-failure) if validation succeeds and reports a mismatch.
 
 ### Instance Lock
 
 > **Note:** When Fabrik starts, it creates a PID lock file at `.fabrik/fabrik.lock`. If a second instance attempts to start in the same directory, it reads the lock file, logs an error identifying the running process, and exits immediately. The lock is automatically released when the process exits — including on crash or SIGKILL — so there is no need to manually delete the file after an unclean shutdown.
 >
-> See [§10 Troubleshooting → Multiple Fabrik Instances](#10-troubleshooting) if you encounter a stale lock or need to run multiple instances against different projects.
+> See [§11 Troubleshooting → Multiple Fabrik Instances](#11-troubleshooting) if you encounter a stale lock or need to run multiple instances against different projects.
 
 ---
 
@@ -1532,7 +1533,100 @@ Typical cost is ~5–30 points per poll depending on active items, well within t
 
 ---
 
-## 10. Troubleshooting
+## 10. Webhook Mode
+
+Webhook mode is an optional feature that dramatically reduces GraphQL usage and cuts event latency from up to 30 seconds to near-zero. When enabled, Fabrik receives GitHub events within seconds of them occurring instead of waiting for the next poll tick.
+
+### How It Works
+
+Fabrik spawns `gh webhook forward` as a background subprocess. This tool connects outbound to GitHub's SSE stream and forwards every matching event as an HTTP POST to a local listener on `127.0.0.1:<port>`. No public endpoint, no ngrok, no infrastructure changes. Each event payload is authenticated with HMAC-SHA256 before Fabrik acts on it.
+
+Events are translated into immediate poll wakeups — the existing board-fetch and filter logic handles the rest. The poll loop continues running as a safety net (up to once every 60 minutes when the webhook stream is healthy) so missed or delayed events never strand work.
+
+### Prerequisites
+
+- **`gh` CLI version ≥ 2.32.0** (released October 2023). `gh webhook forward` was introduced in this version. Run `gh --version` to check.
+- **`gh auth login`** with a token that has `admin:repo_hook` write scope (classic PAT) or equivalent repo admin access. Fine-grained tokens may lack this scope.
+- **Repo admin access** on each repository on your board, or org-admin access for org-level subscription.
+
+If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
+
+### Enabling Webhook Mode
+
+Three equivalent ways to enable:
+
+**CLI flag:**
+```bash
+fabrik --webhooks
+```
+
+**Environment variable:**
+```bash
+FABRIK_WEBHOOKS=true fabrik
+```
+
+**`.fabrik/config.yaml`:**
+```yaml
+webhooks: true
+```
+
+### Configuration Options
+
+| Option | Flag | Env var | Config YAML | Default |
+|--------|------|---------|-------------|---------|
+| Enable webhooks | `--webhooks` | `FABRIK_WEBHOOKS` | `webhooks: true` | off |
+| Listener port | `--webhook-port=<N>` | `FABRIK_WEBHOOK_PORT` | `webhook_port: <N>` | 0 (OS-assigned) |
+| Event filter | `--webhook-events=<csv>` | `FABRIK_WEBHOOK_EVENTS` | `webhook_events: [...]` | all supported events |
+
+By default, Fabrik subscribes to: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `check_suite`, and `projects_v2_item` (board column changes — see note below).
+
+### Health States and TUI Indicator
+
+The TUI footer shows a webhook health indicator when webhook mode is enabled:
+
+| Indicator | State | Meaning |
+|-----------|-------|---------|
+| `● webhook (N)` (green) | Healthy | At least one event received in the last 10 minutes. Idle cap: 60 min. |
+| `○ webhook (N)` (blue) | Starting Up | Subprocess launched; waiting for first event (up to 30s grace). Idle cap: 60 min. |
+| `◌ webhook (N)` (yellow) | Unhealthy | No event received in 10+ minutes or startup grace expired. Idle cap: 5 min (same as polling-only). |
+
+`N` is the total number of webhook events received since startup. You can also verify the stream by checking `fabrik.log` for `[webhook]` tag lines.
+
+### Expected GraphQL Load Reduction
+
+On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
+
+### `projects_v2_item` (Board Column Changes)
+
+Fabrik attempts to subscribe to `projects_v2_item` events, which fire when an issue is moved between board columns. If `gh webhook forward` does not support this event type for your installation, Fabrik logs a warning and continues without it. In this case, board-column changes are caught by the safety-net poll within 60 minutes (or 5 minutes if the stream is unhealthy). All other event types continue to work normally.
+
+### Security
+
+- The HTTP listener binds exclusively to `127.0.0.1` and is never reachable from outside your machine.
+- Every incoming payload is verified with HMAC-SHA256 before Fabrik acts on it. A malicious local process cannot spoof events without the secret.
+- The webhook secret is generated from `crypto/rand` (32 bytes) at startup and is never written to disk or logged.
+- If HMAC verification fails repeatedly (5 consecutive failures within 2 minutes), Fabrik automatically rotates the secret and restarts the subprocess. After 2 failed rotation cycles, webhook mode is disabled for the session with a clear log message.
+
+### Multi-Repo Boards
+
+On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
+
+1. If your token has org-admin access, Fabrik uses `--org=<org>` to subscribe to all repos in the org with one subscription — no restarts needed when new repos appear.
+2. Otherwise, Fabrik subscribes per-repo. When a new repo appears on the board, the subprocess is briefly restarted with the updated repo list (the safety-net poll covers any events missed during the restart).
+
+### Troubleshooting Webhook Mode
+
+**"prerequisite check failed"** — `gh` is missing or too old. Install or upgrade: <https://cli.github.com>
+
+**Stream shows yellow "unhealthy"** — The subprocess may have exited or GitHub isn't delivering events. Check `fabrik.log` for `[webhook]` error lines. Run `gh auth status` to verify your token has `admin:repo_hook` scope.
+
+**HMAC failures logged** — Usually caused by a `gh auth refresh` that invalidated the webhook secret. Fabrik auto-rotates; if failures persist after 2 cycles, restart Fabrik.
+
+**`projects_v2_item` warning** — Board column changes fall back to the 60-minute safety-net poll. Not a problem for most workflows.
+
+---
+
+## 11. Troubleshooting
 
 ### GitHub API Returns 401 or "Fine-Grained Token" Warning
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -891,7 +891,7 @@ The poll loop's effective interval grows when there is nothing to do (idle backo
 - Base interval: `PollSeconds` (default 30s).
 - Activity multiplier: doubles each poll cycle where no work was dispatched, up to the idle cap.
 - Activity reset: any dispatched work OR any received webhook event resets `idleStart` and the multiplier back to 1×.
-- Rate-limit adjustment: when the GitHub API signals rate limit pressure (`rateLimitLow`), the effective interval is raised to `max(PollSeconds, 60s)`.
+- Rate-limit adjustment: when the GitHub API signals rate limit pressure (`rateLimitLow`), `computeEffectiveInterval` doubles the configured interval for rate-limit backoff, capped at `rateLimitMaxBackoffMultiplier×` the configured interval.
 
 **Idle cap selection** (`effectiveIdleCap` in `engine/poll.go`):
 
@@ -908,15 +908,15 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 
 | State | Meaning | Idle cap used | TUI indicator |
 |-------|---------|---------------|---------------|
-| `WebhookStreamStartingUp` | Subprocess launched; within startup grace (30s); no event received yet | 60 min | Blue ○ |
+| `WebhookStreamStartingUp` | Subprocess launched; no verified event received yet. The state persists until the first event arrives or `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) elapses with no event. | 60 min | Blue ○ |
 | `WebhookStreamHealthy` | At least one event received within the last health window (10 min) | 60 min | Green ● |
-| `WebhookStreamUnhealthy` | Grace expired with no first event, or health window (10 min) elapsed since last event | 5 min | Yellow ◌ |
+| `WebhookStreamUnhealthy` | No first event received before `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch, or health window (10 min) elapsed since last event | 5 min | Yellow ◌ |
 
 **State transitions:**
-- `StartingUp → Healthy`: first verified webhook event received at any point during grace or after.
-- `StartingUp → Unhealthy`: `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) elapsed with no event received.
+- `StartingUp → Healthy`: first verified webhook event received at any point after subprocess launch.
+- `StartingUp → Unhealthy`: no verified event received for `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch.
 - `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
-- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace.
+- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace and waits for a new first event.
 
 **Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -883,6 +883,45 @@ Two proactive kill mechanisms cap how long a single Claude invocation can run. B
 
 **No-op on Windows:** `killProcGroupGraceful` is a no-op on Windows (process groups work differently). Both timeout mechanisms still fire and set their flags, but the kill is a best-effort `cmd.Cancel`.
 
+### 7.7 Poll Loop Idle Backoff and Webhook Health State
+
+The poll loop's effective interval grows when there is nothing to do (idle backoff). The cap on that backoff depends on the webhook stream health state.
+
+**Idle backoff algorithm** (`computeEffectiveInterval` in `engine/poll.go`):
+- Base interval: `PollSeconds` (default 30s).
+- Activity multiplier: doubles each poll cycle where no work was dispatched, up to the idle cap.
+- Activity reset: any dispatched work OR any received webhook event resets `idleStart` and the multiplier back to 1×.
+- Rate-limit adjustment: when the GitHub API signals rate limit pressure (`rateLimitLow`), the effective interval is raised to `max(PollSeconds, 60s)`.
+
+**Idle cap selection** (`effectiveIdleCap` in `engine/poll.go`):
+
+| Webhook stream state | Idle cap |
+|---------------------|----------|
+| `WebhookStreamHealthy` | 60 minutes (`webhookIdleCap`) |
+| `WebhookStreamStartingUp` | 60 minutes (`webhookIdleCap`) |
+| `WebhookStreamUnhealthy` | 5 minutes (`maxIdleBackoff`) |
+| Webhook mode disabled | 5 minutes (`maxIdleBackoff`) |
+
+When the webhook stream is healthy or starting up, steady-state polling is suppressed to a 60-minute safety-net interval. Events that arrive on the webhook stream (`wakeCh` signal) reset the multiplier and trigger an immediate poll regardless of the current interval.
+
+**Webhook stream health states** (managed by `webhookManager` in `engine/webhook.go`):
+
+| State | Meaning | Idle cap used | TUI indicator |
+|-------|---------|---------------|---------------|
+| `WebhookStreamStartingUp` | Subprocess launched; within startup grace (30s); no event received yet | 60 min | Blue ○ |
+| `WebhookStreamHealthy` | At least one event received within the last health window (10 min) | 60 min | Green ● |
+| `WebhookStreamUnhealthy` | Grace expired with no first event, or health window (10 min) elapsed since last event | 5 min | Yellow ◌ |
+
+**State transitions:**
+- `StartingUp → Healthy`: first verified webhook event received at any point during grace or after.
+- `StartingUp → Unhealthy`: `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) elapsed with no event received.
+- `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
+- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace.
+
+**Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
+
+**References:** [ADR-032: Webhook-Driven Event Delivery](../adrs/032-webhook-event-delivery.md)
+
 ---
 
 ## 8. Invalid / Unexpected States

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -37,6 +37,9 @@ type Config struct {
 	DebugOutput       bool
 	PluginDir         string
 	Stages            []*stages.Stage
+	Webhooks          bool
+	WebhookPort       int
+	WebhookEvents     []string
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}
@@ -86,6 +89,7 @@ type Engine struct {
 	events               chan tui.Event        // nil in tests / plain-text mode; TUI goroutine consumes
 	logFile              *os.File              // persistent log file at .fabrik/fabrik.log; nil if not opened
 	logMu                sync.Mutex            // serializes concurrent writes to logFile
+	webhookMgr           *webhookManager       // nil when webhooks are disabled
 }
 
 func New(cfg Config) (*Engine, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -66,20 +66,33 @@ func nextRateLimitLow(current bool, ratio float64) bool {
 	return current
 }
 
+// effectiveIdleCap returns the idle backoff cap based on webhook stream health.
+// When the webhook stream is healthy or starting up, the cap is extended to
+// webhookIdleCap (60 min) since the stream covers events that would otherwise
+// require frequent polling. Falls back to maxIdleBackoff (5 min) when unhealthy.
+func effectiveIdleCap(webhookHealthy bool) time.Duration {
+	if webhookHealthy {
+		return webhookIdleCap
+	}
+	return maxIdleBackoff
+}
+
 // computeEffectiveInterval returns the effective poll interval considering both
 // idle backoff and rate-limit backoff. The result is max(idle, rateLimit).
-// The idle component is capped at maxIdleBackoff (5 minutes); the rate-limit
+// The idle component is capped at effectiveIdleCap(webhookHealthy); the rate-limit
 // component uses its own cap (rateLimitMaxBackoffMultiplier × configured).
-func computeEffectiveInterval(configuredInterval time.Duration, idleDuration time.Duration, rateLimitLow bool) time.Duration {
+func computeEffectiveInterval(configuredInterval time.Duration, idleDuration time.Duration, rateLimitLow bool, webhookHealthy bool) time.Duration {
+	cap := effectiveIdleCap(webhookHealthy)
+
 	var idleInterval time.Duration
 	mult := idleBackoffMultiplier(idleDuration)
 	if mult == 0 {
-		idleInterval = maxIdleBackoff
+		idleInterval = cap
 	} else {
 		idleInterval = configuredInterval * time.Duration(mult)
 	}
-	if idleInterval > maxIdleBackoff {
-		idleInterval = maxIdleBackoff
+	if idleInterval > cap {
+		idleInterval = cap
 	}
 
 	rateLimitInterval := configuredInterval
@@ -244,6 +257,22 @@ func (e *Engine) Run() error {
 		e.logf(0, "warn", "label seeding failed (non-fatal): %v\n", err)
 	}
 
+	// Start webhook manager when enabled. Failures are non-fatal: the engine
+	// continues in polling-only mode.
+	if e.cfg.Webhooks {
+		wm := newWebhookManager(
+			e.logf,
+			e.wakeCh,
+			e.emit,
+			nil, // repos populated by UpdateRepos after first poll
+			e.cfg.WebhookEvents,
+		)
+		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {
+			e.webhookMgr = wm
+			defer wm.Stop()
+		}
+	}
+
 	if e.events == nil {
 		fmt.Println("\nFabrik is running. Press Ctrl+C to stop.")
 		fmt.Println()
@@ -294,7 +323,13 @@ func (e *Engine) Run() error {
 		if !e.idleStart.IsZero() {
 			idleDuration = time.Since(e.idleStart)
 		}
-		effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, rateLimitLow)
+		webhookHealthy := e.webhookMgr != nil && e.webhookMgr.IsHealthyOrStartingUp()
+		effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, rateLimitLow, webhookHealthy)
+
+		// Notify webhook manager of any new repos discovered during this poll.
+		if e.webhookMgr != nil && result.SeenRepos != nil {
+			e.webhookMgr.UpdateRepos(result.SeenRepos)
+		}
 
 		// Log backoff level transitions.
 		mult := idleBackoffMultiplier(idleDuration)
@@ -486,6 +521,7 @@ type pollResult struct {
 	Active     bool
 	ItemCount  int
 	Dispatched int
+	SeenRepos  map[string]bool // all repos observed on the board in this poll
 }
 
 func (e *Engine) poll(ctx context.Context) (pollResult, error) {
@@ -987,6 +1023,7 @@ doneDispatching:
 		Active:     dispatched > 0 || deepFetched > 0,
 		ItemCount:  len(board.Items),
 		Dispatched: dispatched,
+		SeenRepos:  seenRepos,
 	}, nil
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -260,11 +260,18 @@ func (e *Engine) Run() error {
 	// Start webhook manager when enabled. Failures are non-fatal: the engine
 	// continues in polling-only mode.
 	if e.cfg.Webhooks {
+		// Seed the known-repo set so the first subprocess invocation has at least
+		// one --repo arg. Multi-repo boards discover additional repos via UpdateRepos
+		// after the first poll, at which point the subprocess restarts with the full set.
+		var initialRepos map[string]bool
+		if e.cfg.Owner != "" && e.cfg.Repo != "" {
+			initialRepos = map[string]bool{e.cfg.Owner + "/" + e.cfg.Repo: true}
+		}
 		wm := newWebhookManager(
 			e.logf,
 			e.wakeCh,
 			e.emit,
-			nil, // repos populated by UpdateRepos after first poll
+			initialRepos,
 			e.cfg.WebhookEvents,
 		)
 		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -969,9 +969,9 @@ func TestComputeEffectiveInterval(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := computeEffectiveInterval(base, tc.idle, tc.rateLimitLow)
+			got := computeEffectiveInterval(base, tc.idle, tc.rateLimitLow, false)
 			if got != tc.want {
-				t.Errorf("computeEffectiveInterval(%v, %v, %v) = %v, want %v",
+				t.Errorf("computeEffectiveInterval(%v, %v, %v, false) = %v, want %v",
 					base, tc.idle, tc.rateLimitLow, got, tc.want)
 			}
 		})
@@ -982,15 +982,21 @@ func TestComputeEffectiveInterval_CapAt5Min(t *testing.T) {
 	// With a large configured interval (e.g. 3 minutes), 4x would be 12min,
 	// but we cap at 5 minutes.
 	base := 3 * time.Minute
-	got := computeEffectiveInterval(base, 12*time.Minute, false)
+	got := computeEffectiveInterval(base, 12*time.Minute, false, false)
 	if got != 5*time.Minute {
 		t.Errorf("expected cap at 5m, got %v", got)
 	}
 
 	// Even 2x of 3 minutes (= 6min) should cap at 5min.
-	got = computeEffectiveInterval(base, 6*time.Minute, false)
+	got = computeEffectiveInterval(base, 6*time.Minute, false, false)
 	if got != 5*time.Minute {
 		t.Errorf("expected cap at 5m for 2x of 3min base, got %v", got)
+	}
+
+	// With webhookHealthy=true the cap rises to 60 min.
+	got = computeEffectiveInterval(base, 60*time.Minute, false, true)
+	if got != webhookIdleCap {
+		t.Errorf("expected webhookIdleCap (%v) when webhook healthy, got %v", webhookIdleCap, got)
 	}
 }
 
@@ -998,7 +1004,7 @@ func TestComputeEffectiveInterval_MaxIdleRateLimit(t *testing.T) {
 	// Both backoffs active: idle at max (5min) and rate limit at 2x.
 	// max(5min, 2*30s=1min) = 5min.
 	base := 30 * time.Second
-	got := computeEffectiveInterval(base, 25*time.Minute, true)
+	got := computeEffectiveInterval(base, 25*time.Minute, true, false)
 	if got != 5*time.Minute {
 		t.Errorf("expected 5m, got %v", got)
 	}
@@ -1010,7 +1016,7 @@ func TestComputeEffectiveInterval_RateLimitExceeds5Min(t *testing.T) {
 	// Idle is not active (0 duration), so idleInterval = 3min.
 	// max(3min, 6min) = 6min — the 5min idle cap must NOT clamp this.
 	base := 3 * time.Minute
-	got := computeEffectiveInterval(base, 0, true)
+	got := computeEffectiveInterval(base, 0, true, false)
 	if got != 6*time.Minute {
 		t.Errorf("expected 6m (rate-limit 2x of 3min base), got %v", got)
 	}

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -66,18 +66,28 @@ type webhookManager struct {
 	wakeCh chan struct{}
 	emitFn func(tui.Event)
 
+	// killFn terminates a subprocess. Defaults to killProcGroup; overridable in tests.
+	// The caller is responsible for the cmd != nil check; killFn handles nil Process.
+	killFn func(*exec.Cmd)
+
 	// listener — bound once before first subprocess start, reused across restarts
 	listener net.Listener
 	port     int
 
 	// subprocess state (protected by mu)
-	currentCmd      *exec.Cmd
-	secret          string
-	repos           map[string]bool
-	events          []string
-	orgModeFailed   bool // true after org-level probe fails; use per-repo thereafter
-	stopOnce        sync.Once
-	stopCh          chan struct{}
+	currentCmd    *exec.Cmd
+	secret        string
+	repos         map[string]bool
+	events        []string
+	orgModeFailed bool // true after org-level probe fails; use per-repo thereafter
+	stopOnce      sync.Once
+	stopCh        chan struct{}
+
+	// repoReadyCh is closed when the first non-empty repo set is known.
+	// supervise blocks on this before launching the subprocess so multi-repo
+	// boards don't attempt a subscription with no --repo or --org args.
+	repoReadyCh chan struct{}
+	repoReady   bool // whether repoReadyCh has been closed (protected by mu)
 
 	// health (protected by mu)
 	state         WebhookHealthState
@@ -106,7 +116,7 @@ func newWebhookManager(
 		evts = make([]string, len(defaultWebhookEvents))
 		copy(evts, defaultWebhookEvents)
 	}
-	return &webhookManager{
+	wm := &webhookManager{
 		logFn:       logFn,
 		wakeCh:      wakeCh,
 		emitFn:      emitFn,
@@ -115,6 +125,27 @@ func newWebhookManager(
 		state:       WebhookStreamUnhealthy, // becomes StartingUp when subprocess launches
 		eventCounts: make(map[string]int),
 		stopCh:      make(chan struct{}),
+		repoReadyCh: make(chan struct{}),
+		killFn: func(cmd *exec.Cmd) {
+			if cmd != nil && cmd.Process != nil {
+				killProcGroup(cmd)
+			}
+		},
+	}
+	// Close repoReadyCh immediately if repos are already known at construction.
+	if len(repos) > 0 {
+		close(wm.repoReadyCh)
+		wm.repoReady = true
+	}
+	return wm
+}
+
+// signalRepoReady closes repoReadyCh the first time it is called. Must be called
+// with wm.mu held.
+func (wm *webhookManager) signalRepoReady() {
+	if !wm.repoReady {
+		wm.repoReady = true
+		close(wm.repoReadyCh)
 	}
 }
 
@@ -208,6 +239,11 @@ func semverAtLeast(vStr string, major, minor, patch int) bool {
 
 // detectOrgMode returns the common owner when all repos share the same GitHub org/user,
 // enabling --org=<org> subscription instead of per-repo subscriptions.
+//
+// Single-repo sets also satisfy this condition (the one repo's owner becomes the candidate org).
+// The supervise loop's org-mode probe handles the case where the user isn't org-admin —
+// falling back to per-repo subscription within orgModeProbeTimeout when the org-level
+// subprocess exits quickly with a permission-shaped error in its stderr output.
 func detectOrgMode(repos map[string]bool) (string, bool) {
 	var org string
 	for r := range repos {
@@ -219,6 +255,39 @@ func detectOrgMode(repos map[string]bool) (string, bool) {
 		}
 	}
 	return org, org != ""
+}
+
+// isAuthShapedError returns true when the stderr output suggests an authentication
+// or permission failure — used to distinguish org-mode permission denials from
+// transient crashes when the subprocess exits quickly.
+func isAuthShapedError(s string) bool {
+	lower := strings.ToLower(s)
+	return strings.Contains(lower, "403") ||
+		strings.Contains(lower, "forbidden") ||
+		strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "requires admin") ||
+		strings.Contains(lower, "not allowed")
+}
+
+// containsEvent reports whether name is in the events slice.
+func containsEvent(events []string, name string) bool {
+	for _, e := range events {
+		if e == name {
+			return true
+		}
+	}
+	return false
+}
+
+// filterOutEvent returns a new slice with name removed; does not modify the original.
+func filterOutEvent(events []string, name string) []string {
+	filtered := make([]string, 0, len(events))
+	for _, e := range events {
+		if e != name {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
 }
 
 // buildGhArgs constructs the argument list for `gh webhook forward`.
@@ -310,8 +379,8 @@ func (wm *webhookManager) Stop() {
 	cmd := wm.currentCmd
 	l := wm.listener
 	wm.mu.Unlock()
-	if cmd != nil && cmd.Process != nil {
-		killProcGroup(cmd)
+	if cmd != nil {
+		wm.killFn(cmd)
 	}
 	if l != nil {
 		l.Close()
@@ -326,35 +395,60 @@ func (wm *webhookManager) IsHealthyOrStartingUp() bool {
 }
 
 // UpdateRepos is called after each board poll. When new repos appear, the subprocess
-// is restarted with the updated repo set so it subscribes to new repos.
+// is restarted with the updated repo set so it subscribes to new repos. On multi-repo
+// boards the first UpdateRepos call also signals repoReadyCh to unblock supervise.
 func (wm *webhookManager) UpdateRepos(repos map[string]bool) {
 	wm.mu.Lock()
 	if wm.disabled {
 		wm.mu.Unlock()
 		return
 	}
-	hasNew := false
+
+	var newRepos []string
 	for r := range repos {
 		if !wm.repos[r] {
-			wm.logFn(0, "webhook", "new repo discovered: %s — restarting webhook subscription\n", r)
-			hasNew = true
+			newRepos = append(newRepos, r)
 		}
 	}
-	if !hasNew {
+
+	firstInit := !wm.repoReady && len(repos) > 0
+
+	if len(newRepos) == 0 && !firstInit {
 		wm.mu.Unlock()
 		return
 	}
+
 	wm.repos = copyRepoSet(repos)
 	cmd := wm.currentCmd
+	wm.signalRepoReady()
 	wm.mu.Unlock()
 
-	if cmd != nil && cmd.Process != nil {
-		killProcGroup(cmd)
+	// Log outside the lock (logFn must not be called while holding wm.mu).
+	for _, r := range newRepos {
+		wm.logFn(0, "webhook", "new repo discovered: %s — restarting webhook subscription\n", r)
+	}
+
+	if len(newRepos) > 0 && cmd != nil {
+		wm.killFn(cmd)
 	}
 }
 
 // supervise manages the subprocess lifecycle: start, wait for exit, restart with backoff.
+// It blocks on repoReadyCh before launching the first subprocess so that multi-repo
+// boards don't attempt a subscription with an empty repo list.
 func (wm *webhookManager) supervise(ctx context.Context) {
+	// Wait until at least one repo is known before starting the subprocess.
+	// On single-repo boards repoReadyCh is already closed at construction.
+	// On multi-repo boards it is closed by the first UpdateRepos call.
+	select {
+	case <-ctx.Done():
+		return
+	case <-wm.stopCh:
+		return
+	case <-wm.repoReadyCh:
+		// repos are known; proceed
+	}
+
 	backoff := time.Second
 
 	for {
@@ -391,7 +485,7 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 
 		args := buildGhArgs(org, repos, port, secret, events)
 		startedAt := time.Now()
-		cmd, err := wm.startSubprocessInternal(ctx, args)
+		cmd, stderrCh, err := wm.startSubprocessInternal(ctx, args)
 		if err != nil {
 			wm.logFn(0, "webhook", "failed to start gh webhook forward: %v\n", err)
 			select {
@@ -418,6 +512,16 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 		waitErr := cmd.Wait()
 		elapsed := time.Since(startedAt)
 
+		// Collect accumulated stderr (the goroutine should finish shortly after
+		// the process exits and the pipe reaches EOF).
+		stderrContent := ""
+		select {
+		case s := <-stderrCh:
+			stderrContent = s
+		case <-time.After(500 * time.Millisecond):
+			// goroutine didn't finish in time; proceed without stderr content
+		}
+
 		select {
 		case <-ctx.Done():
 			return
@@ -426,14 +530,35 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 		default:
 		}
 
-		// Detect org mode rejection: subprocess exits quickly when org perm is missing.
-		if org != "" && elapsed < orgModeProbeTimeout {
-			wm.logFn(0, "webhook", "org-level webhook exited in %v — falling back to per-repo subscription\n", elapsed.Round(time.Millisecond))
+		// Time-based convergent fallback for projects_v2_item in per-repo mode.
+		// If the subprocess exits quickly and projects_v2_item is still in the event
+		// list (meaning the stderr-based detection did not fire), drop it for the next
+		// restart to break any infinite crash-restart cycle.
+		if org == "" && elapsed < orgModeProbeTimeout {
 			wm.mu.Lock()
-			wm.orgModeFailed = true
-			wm.mu.Unlock()
-			// No backoff for org mode probe failure — restart immediately.
-			continue
+			if containsEvent(wm.events, "projects_v2_item") {
+				wm.events = filterOutEvent(wm.events, "projects_v2_item")
+				wm.mu.Unlock()
+				wm.logFn(0, "webhook", "WARNING: projects_v2_item may have caused subprocess crash — "+
+					"dropping it for next restart (board-column changes covered by safety-net poll)\n")
+			} else {
+				wm.mu.Unlock()
+			}
+		}
+
+		// Detect org mode rejection: combine time-based and stderr content signals.
+		// A quick exit with an auth-shaped error → permanent per-repo fallback.
+		// A quick exit without an auth error → transient crash; retry org mode with backoff.
+		if org != "" && elapsed < orgModeProbeTimeout {
+			if isAuthShapedError(stderrContent) {
+				wm.logFn(0, "webhook", "org-level webhook failed (permission error, %v) — falling back to per-repo subscription\n", elapsed.Round(time.Millisecond))
+				wm.mu.Lock()
+				wm.orgModeFailed = true
+				wm.mu.Unlock()
+				continue // no backoff for org probe auth failure
+			}
+			// Fast exit without permission error: treat as transient, retry org mode.
+			wm.logFn(0, "webhook", "org-level webhook exited in %v without permission error — treating as transient, retrying\n", elapsed.Round(time.Millisecond))
 		}
 
 		if waitErr != nil {
@@ -454,58 +579,69 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 }
 
 // startSubprocessInternal starts `gh webhook forward` with the given args.
-// Stderr is captured to the engine log. Returns the started cmd.
-func (wm *webhookManager) startSubprocessInternal(ctx context.Context, args []string) (*exec.Cmd, error) {
-	_ = ctx // kept for future use (CommandContext replacement)
-	cmd := exec.Command("gh", args...)
+// Returns the started cmd and a channel that receives the accumulated stderr content
+// once the drainer goroutine finishes (use with a timeout when reading).
+func (wm *webhookManager) startSubprocessInternal(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	setCmdProcAttr(cmd)
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, fmt.Errorf("stderr pipe: %w", err)
+		return nil, nil, fmt.Errorf("stderr pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("starting gh webhook forward: %w", err)
+		return nil, nil, fmt.Errorf("starting gh webhook forward: %w", err)
 	}
 
-	// Drain stderr to engine log; detect projects_v2_item rejection.
+	stderrCh := make(chan string, 1)
+
+	// Drain stderr to engine log and accumulate for caller inspection.
+	// The accumulated string is sent on stderrCh when the goroutine finishes.
+	//
+	// projects_v2_item rejection matcher: check for "projects_v2_item" as the gating
+	// keyword, plus any of the known rejection phrases from gh CLI. Update this list
+	// if future gh versions change their error wording.
 	go func() {
+		var accum strings.Builder
 		buf := make([]byte, 4096)
 		for {
-			n, err := stderr.Read(buf)
+			n, readErr := stderr.Read(buf)
 			if n > 0 {
 				line := strings.TrimRight(string(buf[:n]), "\n\r")
-				// Detect projects_v2_item rejection and remove it from the event list.
+				lower := strings.ToLower(line)
+				// Detect projects_v2_item rejection. The gating keyword is always
+				// "projects_v2_item"; the rejection phrases cover current and plausible
+				// future gh CLI wording.
 				if strings.Contains(line, "projects_v2_item") &&
-					(strings.Contains(strings.ToLower(line), "invalid") || strings.Contains(strings.ToLower(line), "unknown")) {
+					(strings.Contains(lower, "invalid") ||
+						strings.Contains(lower, "unknown") ||
+						strings.Contains(lower, "not recognized") ||
+						strings.Contains(lower, "unsupported") ||
+						strings.Contains(lower, "bad request")) {
 					wm.logFn(0, "webhook", "WARNING: projects_v2_item event not supported by gh webhook forward — "+
 						"board-column changes caught by safety-net poll only (up to 60 min delay)\n")
 					wm.mu.Lock()
-					filtered := make([]string, 0, len(wm.events))
-					for _, e := range wm.events {
-						if e != "projects_v2_item" {
-							filtered = append(filtered, e)
-						}
-					}
-					wm.events = filtered
+					wm.events = filterOutEvent(wm.events, "projects_v2_item")
 					c := wm.currentCmd
 					wm.mu.Unlock()
-					// Kill subprocess so supervise restarts without projects_v2_item.
-					if c != nil && c.Process != nil {
-						killProcGroup(c)
+					if c != nil {
+						wm.killFn(c)
 					}
+					stderrCh <- accum.String()
 					return
 				}
+				accum.WriteString(line + "\n")
 				wm.logFn(0, "webhook", "[gh] %s\n", line)
 			}
-			if err != nil {
+			if readErr != nil {
 				break
 			}
 		}
+		stderrCh <- accum.String()
 	}()
 
-	return cmd, nil
+	return cmd, stderrCh, nil
 }
 
 // runHealthMonitor periodically checks time-based health state transitions.
@@ -645,8 +781,8 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 				"disabling webhook mode for this session; run 'gh auth status' and restart Fabrik\n",
 				webhookRotationMaxCycles)
 			wm.emitCurrentState()
-			if cmd != nil && cmd.Process != nil {
-				killProcGroup(cmd)
+			if cmd != nil {
+				wm.killFn(cmd)
 			}
 		} else if shouldRotate {
 			wm.rotateSecret()
@@ -719,8 +855,8 @@ func (wm *webhookManager) rotateSecret() {
 	wm.logFn(0, "webhook", "rotating webhook secret (cycle %d/%d) — restarting subprocess\n",
 		cycle, webhookRotationMaxCycles)
 
-	if cmd != nil && cmd.Process != nil {
-		killProcGroup(cmd)
+	if cmd != nil {
+		wm.killFn(cmd)
 	}
 }
 

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -608,30 +608,48 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	if !verifySignature(body, sig, secret) {
 		wm.mu.Lock()
 		now := time.Now()
-		if wm.consecutiveFailures == 0 {
+		// Reset the failure window when it has elapsed so spread-out failures
+		// don't anchor the window to a stale start time.
+		if wm.consecutiveFailures == 0 || wm.firstFailureAt.IsZero() || now.Sub(wm.firstFailureAt) > webhookRotationWindow {
 			wm.firstFailureAt = now
+			wm.consecutiveFailures = 1
+		} else {
+			wm.consecutiveFailures++
 		}
-		wm.consecutiveFailures++
 		failures := wm.consecutiveFailures
 		firstAt := wm.firstFailureAt
-		rotateCycles := wm.rotateCycleCount
-		disabled := wm.disabled
+		// Make the threshold check and state update atomic so concurrent
+		// requests cannot both trigger a rotation or double-disable.
+		shouldDisable := false
+		shouldRotate := false
+		if !wm.disabled && failures >= webhookRotationFailures && now.Sub(firstAt) <= webhookRotationWindow {
+			if wm.rotateCycleCount >= webhookRotationMaxCycles {
+				wm.disabled = true
+				wm.state = WebhookStreamUnhealthy
+				shouldDisable = true
+			} else {
+				// Reserve this threshold breach; reset counters so a concurrent
+				// request doesn't also trigger rotation.
+				wm.consecutiveFailures = 0
+				wm.firstFailureAt = time.Time{}
+				shouldRotate = true
+			}
+		}
+		cmd := wm.currentCmd
 		wm.mu.Unlock()
 
 		wm.logFn(0, "webhook", "HMAC verification failed (consecutive: %d)\n", failures)
 
-		if !disabled && failures >= webhookRotationFailures && now.Sub(firstAt) <= webhookRotationWindow {
-			if rotateCycles >= webhookRotationMaxCycles {
-				wm.mu.Lock()
-				wm.disabled = true
-				wm.mu.Unlock()
-				wm.logFn(0, "webhook", "HMAC failures persist after %d rotation cycles — "+
-					"disabling webhook mode for this session; run 'gh auth status' and restart Fabrik\n",
-					webhookRotationMaxCycles)
-				wm.emitCurrentState()
-			} else {
-				wm.rotateSecret()
+		if shouldDisable {
+			wm.logFn(0, "webhook", "HMAC failures persist after %d rotation cycles — "+
+				"disabling webhook mode for this session; run 'gh auth status' and restart Fabrik\n",
+				webhookRotationMaxCycles)
+			wm.emitCurrentState()
+			if cmd != nil && cmd.Process != nil {
+				killProcGroup(cmd)
 			}
+		} else if shouldRotate {
+			wm.rotateSecret()
 		}
 
 		http.Error(w, "unauthorized", http.StatusUnauthorized)

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -1,0 +1,712 @@
+package engine
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/verveguy/fabrik/tui"
+)
+
+// WebhookHealthState indicates the health of the gh webhook forward stream.
+type WebhookHealthState string
+
+const (
+	WebhookStreamStartingUp WebhookHealthState = "starting_up"
+	WebhookStreamHealthy    WebhookHealthState = "healthy"
+	WebhookStreamUnhealthy  WebhookHealthState = "unhealthy"
+)
+
+// Internal constants — not user-configurable in v1.
+const (
+	webhookIdleCap           = 60 * time.Minute
+	webhookHealthWindow      = 10 * time.Minute
+	webhookStartupGrace      = 30 * time.Second
+	webhookMaxRestartBackoff = 60 * time.Second
+	webhookRotationFailures  = 5
+	webhookRotationWindow    = 2 * time.Minute
+	webhookRotationMaxCycles = 2
+	// orgModeProbeTimeout: if subprocess exits within this duration of starting
+	// in org mode, treat it as an org-permission failure and fall back to per-repo.
+	orgModeProbeTimeout = 10 * time.Second
+)
+
+// defaultWebhookEvents is the canonical event list from the spec (R6).
+var defaultWebhookEvents = []string{
+	"issue_comment",
+	"issues",
+	"pull_request",
+	"pull_request_review",
+	"pull_request_review_comment",
+	"check_run",
+	"check_suite",
+	"projects_v2_item",
+}
+
+// webhookManager manages the gh webhook forward subprocess lifecycle,
+// the local HTTP listener, HMAC verification, health tracking, and secret rotation.
+// It is self-contained: no back-reference to Engine; all dependencies are injected.
+type webhookManager struct {
+	mu sync.Mutex
+
+	// injected dependencies
+	logFn  func(issueNumber int, tag, format string, args ...any)
+	wakeCh chan struct{}
+	emitFn func(tui.Event)
+
+	// listener — bound once before first subprocess start, reused across restarts
+	listener net.Listener
+	port     int
+
+	// subprocess state (protected by mu)
+	currentCmd      *exec.Cmd
+	secret          string
+	repos           map[string]bool
+	events          []string
+	orgModeFailed   bool // true after org-level probe fails; use per-repo thereafter
+	stopOnce        sync.Once
+	stopCh          chan struct{}
+
+	// health (protected by mu)
+	state         WebhookHealthState
+	startupTime   time.Time // when current subprocess started
+	lastEventTime time.Time // zero until first verified event received
+
+	// secret rotation (protected by mu)
+	consecutiveFailures int
+	firstFailureAt      time.Time
+	rotateCycleCount    int
+	disabled            bool
+
+	// per-type event counters (protected by mu)
+	eventCounts map[string]int
+}
+
+func newWebhookManager(
+	logFn func(int, string, string, ...any),
+	wakeCh chan struct{},
+	emitFn func(tui.Event),
+	repos map[string]bool,
+	events []string,
+) *webhookManager {
+	evts := events
+	if len(evts) == 0 {
+		evts = make([]string, len(defaultWebhookEvents))
+		copy(evts, defaultWebhookEvents)
+	}
+	return &webhookManager{
+		logFn:       logFn,
+		wakeCh:      wakeCh,
+		emitFn:      emitFn,
+		repos:       copyRepoSet(repos),
+		events:      evts,
+		state:       WebhookStreamUnhealthy, // becomes StartingUp when subprocess launches
+		eventCounts: make(map[string]int),
+		stopCh:      make(chan struct{}),
+	}
+}
+
+func copyRepoSet(repos map[string]bool) map[string]bool {
+	cp := make(map[string]bool, len(repos))
+	for r := range repos {
+		cp[r] = true
+	}
+	return cp
+}
+
+// generateSecret creates a random 32-byte hex-encoded webhook secret.
+func generateSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating webhook secret: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// verifySignature checks the HMAC-SHA256 signature on a webhook payload.
+// sig is the value of the X-Hub-Signature-256 header (format: "sha256=<hex>").
+func verifySignature(body []byte, sig, secret string) bool {
+	if !strings.HasPrefix(sig, "sha256=") {
+		return false
+	}
+	sigHex := sig[len("sha256="):]
+	sigBytes, err := hex.DecodeString(sigHex)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hmac.Equal(mac.Sum(nil), sigBytes)
+}
+
+// ghVersionCheck verifies gh is installed and meets the minimum version (≥ 2.32.0).
+func ghVersionCheck() error {
+	path, err := exec.LookPath("gh")
+	if err != nil {
+		return fmt.Errorf("gh CLI not found in PATH: webhooks require gh ≥ 2.32.0 (install from https://cli.github.com)")
+	}
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return fmt.Errorf("gh --version failed: %w", err)
+	}
+	// Output: "gh version 2.40.1 (2023-12-13)\n..."
+	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	for i, p := range strings.Fields(line) {
+		if p == "version" && i+1 < len(strings.Fields(line)) {
+			ver := strings.Fields(line)[i+1]
+			if !semverAtLeast(ver, 2, 32, 0) {
+				return fmt.Errorf("gh version %s is too old; webhooks require gh ≥ 2.32.0 (upgrade from https://cli.github.com)", ver)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("could not parse gh version from: %q", line)
+}
+
+// semverAtLeast returns true when vStr (e.g. "2.40.1") is ≥ major.minor.patch.
+func semverAtLeast(vStr string, major, minor, patch int) bool {
+	vStr = strings.TrimPrefix(vStr, "v")
+	parts := strings.SplitN(vStr, ".", 3)
+	vals := make([]int, 3)
+	for i, p := range parts {
+		// strip any non-numeric suffix (e.g. "-rc1")
+		for j, c := range p {
+			if c < '0' || c > '9' {
+				p = p[:j]
+				break
+			}
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return false
+		}
+		vals[i] = n
+	}
+	threshold := []int{major, minor, patch}
+	for i := 0; i < 3; i++ {
+		if vals[i] > threshold[i] {
+			return true
+		}
+		if vals[i] < threshold[i] {
+			return false
+		}
+	}
+	return true // equal
+}
+
+// detectOrgMode returns the common owner when all repos share the same GitHub org/user,
+// enabling --org=<org> subscription instead of per-repo subscriptions.
+func detectOrgMode(repos map[string]bool) (string, bool) {
+	var org string
+	for r := range repos {
+		owner := strings.SplitN(r, "/", 2)[0]
+		if org == "" {
+			org = owner
+		} else if org != owner {
+			return "", false
+		}
+	}
+	return org, org != ""
+}
+
+// buildGhArgs constructs the argument list for `gh webhook forward`.
+func buildGhArgs(org string, repos []string, port int, secret string, events []string) []string {
+	args := []string{
+		"webhook", "forward",
+		"--secret=" + secret,
+		"--url=http://127.0.0.1:" + strconv.Itoa(port) + "/",
+	}
+	if org != "" {
+		args = append(args, "--org="+org)
+	} else {
+		for _, r := range repos {
+			args = append(args, "--repo="+r)
+		}
+	}
+	args = append(args, "--events="+strings.Join(events, ","))
+	return args
+}
+
+// startListener binds the HTTP listener on 127.0.0.1:<port> (0 = OS-assigned).
+func startListener(port int) (net.Listener, int, error) {
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("binding webhook listener on %s: %w", addr, err)
+	}
+	return l, l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// Start initializes the webhook manager: binds the HTTP listener and starts the supervisor.
+// On any hard failure (gh not found, listener bind fails), returns a non-nil error so the
+// caller can fall back to polling-only. All other failures (subprocess crashes, etc.) are
+// handled internally and are non-fatal.
+func (wm *webhookManager) Start(ctx context.Context, port int) error {
+	if err := ghVersionCheck(); err != nil {
+		wm.logFn(0, "webhook", "prerequisite check failed (falling back to polling only): %v\n", err)
+		return err
+	}
+
+	l, actualPort, err := startListener(port)
+	if err != nil {
+		wm.logFn(0, "webhook", "could not bind listener (falling back to polling only): %v\n", err)
+		return err
+	}
+
+	wm.mu.Lock()
+	wm.listener = l
+	wm.port = actualPort
+	wm.mu.Unlock()
+
+	// Start HTTP server; lives until listener is closed in Stop().
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", wm.handleWebhook)
+	srv := &http.Server{Handler: mux}
+	go func() {
+		if err := srv.Serve(l); err != nil && err != http.ErrServerClosed {
+			wm.logFn(0, "webhook", "HTTP server error: %v\n", err)
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		srv.Close()
+	}()
+
+	// Generate initial secret.
+	secret, err := generateSecret()
+	if err != nil {
+		l.Close()
+		return fmt.Errorf("generating webhook secret: %w", err)
+	}
+	wm.mu.Lock()
+	wm.secret = secret
+	wm.mu.Unlock()
+
+	go wm.supervise(ctx)
+	go wm.runHealthMonitor(ctx)
+
+	wm.logFn(0, "webhook", "webhook listener started on port %d\n", actualPort)
+	return nil
+}
+
+// Stop shuts down the webhook manager: closes the listener and kills the subprocess.
+func (wm *webhookManager) Stop() {
+	wm.stopOnce.Do(func() {
+		close(wm.stopCh)
+	})
+	wm.mu.Lock()
+	cmd := wm.currentCmd
+	l := wm.listener
+	wm.mu.Unlock()
+	if cmd != nil && cmd.Process != nil {
+		killProcGroup(cmd)
+	}
+	if l != nil {
+		l.Close()
+	}
+}
+
+// IsHealthyOrStartingUp returns true when the extended idle cap (60 min) should apply.
+func (wm *webhookManager) IsHealthyOrStartingUp() bool {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	return wm.state == WebhookStreamStartingUp || wm.state == WebhookStreamHealthy
+}
+
+// UpdateRepos is called after each board poll. When new repos appear, the subprocess
+// is restarted with the updated repo set so it subscribes to new repos.
+func (wm *webhookManager) UpdateRepos(repos map[string]bool) {
+	wm.mu.Lock()
+	if wm.disabled {
+		wm.mu.Unlock()
+		return
+	}
+	hasNew := false
+	for r := range repos {
+		if !wm.repos[r] {
+			wm.logFn(0, "webhook", "new repo discovered: %s — restarting webhook subscription\n", r)
+			hasNew = true
+		}
+	}
+	if !hasNew {
+		wm.mu.Unlock()
+		return
+	}
+	wm.repos = copyRepoSet(repos)
+	cmd := wm.currentCmd
+	wm.mu.Unlock()
+
+	if cmd != nil && cmd.Process != nil {
+		killProcGroup(cmd)
+	}
+}
+
+// supervise manages the subprocess lifecycle: start, wait for exit, restart with backoff.
+func (wm *webhookManager) supervise(ctx context.Context) {
+	backoff := time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-wm.stopCh:
+			return
+		default:
+		}
+
+		wm.mu.Lock()
+		if wm.disabled {
+			wm.mu.Unlock()
+			return
+		}
+		secret := wm.secret
+		repos := make([]string, 0, len(wm.repos))
+		for r := range wm.repos {
+			repos = append(repos, r)
+		}
+		events := wm.events
+		port := wm.port
+		orgModeFailed := wm.orgModeFailed
+		wm.mu.Unlock()
+
+		// Determine org mode
+		org := ""
+		if !orgModeFailed {
+			if o, ok := detectOrgMode(wm.repos); ok {
+				org = o
+			}
+		}
+
+		args := buildGhArgs(org, repos, port, secret, events)
+		startedAt := time.Now()
+		cmd, err := wm.startSubprocessInternal(ctx, args)
+		if err != nil {
+			wm.logFn(0, "webhook", "failed to start gh webhook forward: %v\n", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-wm.stopCh:
+				return
+			case <-time.After(backoff):
+				backoff = minWebhookDuration(backoff*2, webhookMaxRestartBackoff)
+				continue
+			}
+		}
+		backoff = time.Second // reset on successful start
+
+		wm.mu.Lock()
+		wm.currentCmd = cmd
+		wm.state = WebhookStreamStartingUp
+		wm.startupTime = time.Now()
+		wm.lastEventTime = time.Time{}
+		wm.mu.Unlock()
+		wm.emitCurrentState()
+
+		// Wait for subprocess exit.
+		waitErr := cmd.Wait()
+		elapsed := time.Since(startedAt)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-wm.stopCh:
+			return
+		default:
+		}
+
+		// Detect org mode rejection: subprocess exits quickly when org perm is missing.
+		if org != "" && elapsed < orgModeProbeTimeout {
+			wm.logFn(0, "webhook", "org-level webhook exited in %v — falling back to per-repo subscription\n", elapsed.Round(time.Millisecond))
+			wm.mu.Lock()
+			wm.orgModeFailed = true
+			wm.mu.Unlock()
+			// No backoff for org mode probe failure — restart immediately.
+			continue
+		}
+
+		if waitErr != nil {
+			wm.logFn(0, "webhook", "gh webhook forward exited: %v — restarting in %v\n", waitErr, backoff)
+		} else {
+			wm.logFn(0, "webhook", "gh webhook forward exited — restarting in %v\n", backoff)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-wm.stopCh:
+			return
+		case <-time.After(backoff):
+			backoff = minWebhookDuration(backoff*2, webhookMaxRestartBackoff)
+		}
+	}
+}
+
+// startSubprocessInternal starts `gh webhook forward` with the given args.
+// Stderr is captured to the engine log. Returns the started cmd.
+func (wm *webhookManager) startSubprocessInternal(ctx context.Context, args []string) (*exec.Cmd, error) {
+	_ = ctx // kept for future use (CommandContext replacement)
+	cmd := exec.Command("gh", args...)
+	setCmdProcAttr(cmd)
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting gh webhook forward: %w", err)
+	}
+
+	// Drain stderr to engine log; detect projects_v2_item rejection.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := stderr.Read(buf)
+			if n > 0 {
+				line := strings.TrimRight(string(buf[:n]), "\n\r")
+				// Detect projects_v2_item rejection and remove it from the event list.
+				if strings.Contains(line, "projects_v2_item") &&
+					(strings.Contains(strings.ToLower(line), "invalid") || strings.Contains(strings.ToLower(line), "unknown")) {
+					wm.logFn(0, "webhook", "WARNING: projects_v2_item event not supported by gh webhook forward — "+
+						"board-column changes caught by safety-net poll only (up to 60 min delay)\n")
+					wm.mu.Lock()
+					filtered := make([]string, 0, len(wm.events))
+					for _, e := range wm.events {
+						if e != "projects_v2_item" {
+							filtered = append(filtered, e)
+						}
+					}
+					wm.events = filtered
+					c := wm.currentCmd
+					wm.mu.Unlock()
+					// Kill subprocess so supervise restarts without projects_v2_item.
+					if c != nil && c.Process != nil {
+						killProcGroup(c)
+					}
+					return
+				}
+				wm.logFn(0, "webhook", "[gh] %s\n", line)
+			}
+			if err != nil {
+				break
+			}
+		}
+	}()
+
+	return cmd, nil
+}
+
+// runHealthMonitor periodically checks time-based health state transitions.
+func (wm *webhookManager) runHealthMonitor(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-wm.stopCh:
+			return
+		case <-ticker.C:
+			wm.checkHealthTransitions()
+		}
+	}
+}
+
+func (wm *webhookManager) checkHealthTransitions() {
+	wm.mu.Lock()
+	now := time.Now()
+	state := wm.state
+	var newState WebhookHealthState
+
+	switch state {
+	case WebhookStreamStartingUp:
+		if !wm.lastEventTime.IsZero() {
+			// Event received; HTTP handler already set state to Healthy.
+			// This is a no-op catch.
+		} else if !wm.startupTime.IsZero() && now.Sub(wm.startupTime) > webhookStartupGrace+webhookHealthWindow {
+			newState = WebhookStreamUnhealthy
+		}
+	case WebhookStreamHealthy:
+		if !wm.lastEventTime.IsZero() && now.Sub(wm.lastEventTime) > webhookHealthWindow {
+			newState = WebhookStreamUnhealthy
+		}
+	}
+
+	if newState != "" && newState != state {
+		wm.logFn(0, "webhook", "health state: %s → %s\n", state, newState)
+		wm.state = newState
+		wm.mu.Unlock()
+		wm.emitCurrentState()
+		return
+	}
+	wm.mu.Unlock()
+}
+
+// emitCurrentState emits a WebhookStatusEvent with the current state and event counts.
+func (wm *webhookManager) emitCurrentState() {
+	if wm.emitFn == nil {
+		return
+	}
+	wm.mu.Lock()
+	state := string(wm.state)
+	counts := make(map[string]int, len(wm.eventCounts))
+	for k, v := range wm.eventCounts {
+		counts[k] = v
+	}
+	wm.mu.Unlock()
+	wm.emitFn(tui.WebhookStatusEvent{
+		State:       state,
+		EventCounts: counts,
+	})
+}
+
+// minWebhookPayload is the minimal set of fields read from each incoming webhook payload.
+type minWebhookPayload struct {
+	Action     string `json:"action"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Issue *struct {
+		Number int `json:"number"`
+	} `json:"issue"`
+	PullRequest *struct {
+		Number int `json:"number"`
+	} `json:"pull_request"`
+}
+
+// handleWebhook is the HTTP handler for incoming webhook POSTs from gh webhook forward.
+func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 10<<20)) // 10 MiB cap
+	if err != nil {
+		http.Error(w, "error reading body", http.StatusBadRequest)
+		return
+	}
+	r.Body.Close()
+
+	wm.mu.Lock()
+	secret := wm.secret
+	wm.mu.Unlock()
+
+	sig := r.Header.Get("X-Hub-Signature-256")
+	if !verifySignature(body, sig, secret) {
+		wm.mu.Lock()
+		now := time.Now()
+		if wm.consecutiveFailures == 0 {
+			wm.firstFailureAt = now
+		}
+		wm.consecutiveFailures++
+		failures := wm.consecutiveFailures
+		firstAt := wm.firstFailureAt
+		rotateCycles := wm.rotateCycleCount
+		disabled := wm.disabled
+		wm.mu.Unlock()
+
+		wm.logFn(0, "webhook", "HMAC verification failed (consecutive: %d)\n", failures)
+
+		if !disabled && failures >= webhookRotationFailures && now.Sub(firstAt) <= webhookRotationWindow {
+			if rotateCycles >= webhookRotationMaxCycles {
+				wm.mu.Lock()
+				wm.disabled = true
+				wm.mu.Unlock()
+				wm.logFn(0, "webhook", "HMAC failures persist after %d rotation cycles — "+
+					"disabling webhook mode for this session; run 'gh auth status' and restart Fabrik\n",
+					webhookRotationMaxCycles)
+				wm.emitCurrentState()
+			} else {
+				wm.rotateSecret()
+			}
+		}
+
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Signature verified — reset failure counter.
+	wm.mu.Lock()
+	wm.consecutiveFailures = 0
+	wm.firstFailureAt = time.Time{}
+	wm.mu.Unlock()
+
+	// Parse minimal fields for logging (no payload contents logged — PII risk).
+	eventType := r.Header.Get("X-GitHub-Event")
+	var payload minWebhookPayload
+	_ = json.Unmarshal(body, &payload) // best-effort
+
+	issueNum := 0
+	if payload.Issue != nil {
+		issueNum = payload.Issue.Number
+	} else if payload.PullRequest != nil {
+		issueNum = payload.PullRequest.Number
+	}
+	wm.logFn(0, "webhook", "event: type=%s action=%s repo=%s num=%d\n",
+		eventType, payload.Action, payload.Repository.FullName, issueNum)
+
+	// Update state and counters.
+	wm.mu.Lock()
+	wm.eventCounts[eventType]++
+	prevState := wm.state
+	if prevState != WebhookStreamHealthy {
+		wm.logFn(0, "webhook", "health state: %s → %s\n", prevState, WebhookStreamHealthy)
+		wm.state = WebhookStreamHealthy
+	}
+	wm.lastEventTime = time.Now()
+	wm.mu.Unlock()
+
+	wm.emitCurrentState()
+
+	// Wake the poll loop immediately.
+	select {
+	case wm.wakeCh <- struct{}{}:
+	default:
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// rotateSecret generates a new secret, kills the current subprocess, and lets supervise restart.
+func (wm *webhookManager) rotateSecret() {
+	secret, err := generateSecret()
+	if err != nil {
+		wm.logFn(0, "webhook", "failed to generate replacement secret: %v\n", err)
+		return
+	}
+	wm.mu.Lock()
+	wm.secret = secret
+	wm.consecutiveFailures = 0
+	wm.firstFailureAt = time.Time{}
+	wm.rotateCycleCount++
+	cycle := wm.rotateCycleCount
+	cmd := wm.currentCmd
+	wm.mu.Unlock()
+
+	wm.logFn(0, "webhook", "rotating webhook secret (cycle %d/%d) — restarting subprocess\n",
+		cycle, webhookRotationMaxCycles)
+
+	if cmd != nil && cmd.Process != nil {
+		killProcGroup(cmd)
+	}
+}
+
+func minWebhookDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -379,15 +379,15 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 		events := wm.events
 		port := wm.port
 		orgModeFailed := wm.orgModeFailed
-		wm.mu.Unlock()
-
-		// Determine org mode
+		// Detect org mode inside the lock so wm.repos isn't read concurrently
+		// with UpdateRepos mutations.
 		org := ""
 		if !orgModeFailed {
 			if o, ok := detectOrgMode(wm.repos); ok {
 				org = o
 			}
 		}
+		wm.mu.Unlock()
 
 		args := buildGhArgs(org, repos, port, secret, events)
 		startedAt := time.Now()
@@ -545,9 +545,9 @@ func (wm *webhookManager) checkHealthTransitions() {
 	}
 
 	if newState != "" && newState != state {
-		wm.logFn(0, "webhook", "health state: %s → %s\n", state, newState)
 		wm.state = newState
 		wm.mu.Unlock()
+		wm.logFn(0, "webhook", "health state: %s → %s\n", state, newState)
 		wm.emitCurrentState()
 		return
 	}
@@ -663,11 +663,13 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	wm.eventCounts[eventType]++
 	prevState := wm.state
 	if prevState != WebhookStreamHealthy {
-		wm.logFn(0, "webhook", "health state: %s → %s\n", prevState, WebhookStreamHealthy)
 		wm.state = WebhookStreamHealthy
 	}
 	wm.lastEventTime = time.Now()
 	wm.mu.Unlock()
+	if prevState != WebhookStreamHealthy {
+		wm.logFn(0, "webhook", "health state: %s → %s\n", prevState, WebhookStreamHealthy)
+	}
 
 	wm.emitCurrentState()
 

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -272,6 +272,33 @@ func TestSecretRotationTrigger(t *testing.T) {
 	}
 }
 
+// TestFailureWindowReset verifies that consecutive-failure tracking resets when
+// a new failure arrives after the rotation window has elapsed.
+func TestFailureWindowReset(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	secret, _ := generateSecret()
+	wm.mu.Lock()
+	wm.state = WebhookStreamHealthy
+	wm.secret = secret
+	// Simulate 3 failures that happened beyond the rotation window.
+	wm.consecutiveFailures = 3
+	wm.firstFailureAt = time.Now().Add(-(webhookRotationWindow + time.Second))
+	wm.mu.Unlock()
+
+	// A new failure should reset the window; consecutiveFailures becomes 1.
+	body := []byte(`{"action":"created"}`)
+	req := signedRequest(t, body, "wrongsecret")
+	rr := httptest.NewRecorder()
+	wm.handleWebhook(rr, req)
+
+	wm.mu.Lock()
+	failures := wm.consecutiveFailures
+	wm.mu.Unlock()
+	if failures != 1 {
+		t.Errorf("consecutiveFailures = %d after window reset, want 1", failures)
+	}
+}
+
 // TestRotationFallback verifies that when rotateCycleCount already equals the max,
 // the next threshold breach triggers disabled=true instead of another rotation.
 func TestRotationFallback(t *testing.T) {
@@ -296,10 +323,14 @@ func TestRotationFallback(t *testing.T) {
 
 	wm.mu.Lock()
 	disabled := wm.disabled
+	state := wm.state
 	wm.mu.Unlock()
 
 	if !disabled {
 		t.Error("webhookManager should be disabled after max rotation cycles")
+	}
+	if state != WebhookStreamUnhealthy {
+		t.Errorf("state = %q after disable, want %q", state, WebhookStreamUnhealthy)
 	}
 }
 

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -1,0 +1,401 @@
+package engine
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/verveguy/fabrik/tui"
+)
+
+// TestVerifySignature validates HMAC-SHA256 webhook signature checking.
+func TestVerifySignature(t *testing.T) {
+	secret := "testsecret"
+	body := []byte(`{"action":"created"}`)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	validSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	tests := []struct {
+		name    string
+		body    []byte
+		sig     string
+		secret  string
+		want    bool
+	}{
+		{
+			name:   "valid signature",
+			body:   body,
+			sig:    validSig,
+			secret: secret,
+			want:   true,
+		},
+		{
+			name:   "wrong secret",
+			body:   body,
+			sig:    validSig,
+			secret: "wrongsecret",
+			want:   false,
+		},
+		{
+			name:   "malformed header — no prefix",
+			body:   body,
+			sig:    hex.EncodeToString(mac.Sum(nil)),
+			secret: secret,
+			want:   false,
+		},
+		{
+			name:   "malformed header — invalid hex",
+			body:   body,
+			sig:    "sha256=zzz",
+			secret: secret,
+			want:   false,
+		},
+		{
+			name:   "empty signature",
+			body:   body,
+			sig:    "",
+			secret: secret,
+			want:   false,
+		},
+		{
+			name:   "empty body valid sig",
+			body:   []byte{},
+			sig:    func() string {
+				m := hmac.New(sha256.New, []byte(secret))
+				return "sha256=" + hex.EncodeToString(m.Sum(nil))
+			}(),
+			secret: secret,
+			want:   true,
+		},
+		{
+			name:   "body mismatch",
+			body:   []byte(`{"action":"deleted"}`),
+			sig:    validSig,
+			secret: secret,
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := verifySignature(tc.body, tc.sig, tc.secret)
+			if got != tc.want {
+				t.Errorf("verifySignature() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSemverAtLeast covers version comparison edge cases.
+func TestSemverAtLeast(t *testing.T) {
+	tests := []struct {
+		ver           string
+		major, minor, patch int
+		want          bool
+	}{
+		{"2.40.1", 2, 32, 0, true},
+		{"2.32.0", 2, 32, 0, true},
+		{"2.31.9", 2, 32, 0, false},
+		{"3.0.0", 2, 32, 0, true},
+		{"1.99.99", 2, 32, 0, false},
+		{"v2.40.1", 2, 32, 0, true},  // leading v
+		{"2.32.0-rc1", 2, 32, 0, true}, // pre-release suffix
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s>=%d.%d.%d", tc.ver, tc.major, tc.minor, tc.patch), func(t *testing.T) {
+			got := semverAtLeast(tc.ver, tc.major, tc.minor, tc.patch)
+			if got != tc.want {
+				t.Errorf("semverAtLeast(%q,%d,%d,%d) = %v, want %v",
+					tc.ver, tc.major, tc.minor, tc.patch, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetectOrgMode covers org detection from a repo set.
+func TestDetectOrgMode(t *testing.T) {
+	sameOrg := map[string]bool{"myorg/repo1": true, "myorg/repo2": true}
+	org, ok := detectOrgMode(sameOrg)
+	if !ok || org != "myorg" {
+		t.Errorf("detectOrgMode(sameOrg) = %q,%v; want %q,true", org, ok, "myorg")
+	}
+
+	mixedOrg := map[string]bool{"myorg/repo1": true, "other/repo2": true}
+	org, ok = detectOrgMode(mixedOrg)
+	if ok || org != "" {
+		t.Errorf("detectOrgMode(mixedOrg) = %q,%v; want %q,false", org, ok, "")
+	}
+
+	empty := map[string]bool{}
+	_, ok = detectOrgMode(empty)
+	if ok {
+		t.Error("detectOrgMode(empty) should return false")
+	}
+}
+
+// newTestWebhookManager creates a webhookManager wired for unit testing.
+func newTestWebhookManager(t *testing.T) (*webhookManager, chan tui.Event) {
+	t.Helper()
+	events := make(chan tui.Event, 16)
+	wm := newWebhookManager(
+		func(_ int, _, _ string, _ ...any) {},
+		make(chan struct{}, 1),
+		func(e tui.Event) { events <- e },
+		map[string]bool{"myorg/myrepo": true},
+		nil,
+	)
+	return wm, events
+}
+
+// TestHealthStateTransitions exercises the time-based health state machine.
+func TestHealthStateTransitions(t *testing.T) {
+	t.Run("startup grace → healthy on first verified event", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamStartingUp
+		wm.startupTime = time.Now()
+		secret, _ := generateSecret()
+		wm.secret = secret
+		wm.mu.Unlock()
+
+		// Simulate a valid webhook POST.
+		body := []byte(`{"action":"created","repository":{"full_name":"myorg/myrepo"}}`)
+		req := signedRequest(t, body, secret)
+		rr := httptest.NewRecorder()
+		wm.handleWebhook(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamHealthy {
+			t.Errorf("state = %q, want %q", state, WebhookStreamHealthy)
+		}
+	})
+
+	t.Run("starting up → unhealthy after grace + health window", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamStartingUp
+		// Set startup time far in the past so grace + health window have both elapsed.
+		wm.startupTime = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
+		wm.mu.Unlock()
+
+		wm.checkHealthTransitions()
+
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamUnhealthy {
+			t.Errorf("state = %q, want %q", state, WebhookStreamUnhealthy)
+		}
+	})
+
+	t.Run("healthy → unhealthy after health window with no events", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamHealthy
+		wm.lastEventTime = time.Now().Add(-(webhookHealthWindow + time.Second))
+		wm.mu.Unlock()
+
+		wm.checkHealthTransitions()
+
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamUnhealthy {
+			t.Errorf("state = %q, want %q", state, WebhookStreamUnhealthy)
+		}
+	})
+
+	t.Run("healthy stays healthy within health window", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamHealthy
+		wm.lastEventTime = time.Now().Add(-1 * time.Minute) // within 10 min window
+		wm.mu.Unlock()
+
+		wm.checkHealthTransitions()
+
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamHealthy {
+			t.Errorf("state = %q, want %q (should stay healthy)", state, WebhookStreamHealthy)
+		}
+	})
+}
+
+// TestSecretRotationTrigger verifies that 5 consecutive HMAC failures within 2 min
+// trigger a secret rotation (rotateCycleCount increments).
+func TestSecretRotationTrigger(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	wm.mu.Lock()
+	wm.state = WebhookStreamHealthy
+	secret, _ := generateSecret()
+	wm.secret = secret
+	wm.mu.Unlock()
+
+	// Send webhookRotationFailures POST requests with wrong HMAC.
+	wrongSecret := "wrongsecret"
+	body := []byte(`{"action":"created"}`)
+	for i := 0; i < webhookRotationFailures; i++ {
+		req := signedRequest(t, body, wrongSecret)
+		rr := httptest.NewRecorder()
+		wm.handleWebhook(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("request %d: expected 401, got %d", i+1, rr.Code)
+		}
+	}
+
+	// rotateSecret kills the subprocess (nil here) and increments rotateCycleCount.
+	wm.mu.Lock()
+	cycles := wm.rotateCycleCount
+	failures := wm.consecutiveFailures
+	wm.mu.Unlock()
+
+	if cycles != 1 {
+		t.Errorf("rotateCycleCount = %d, want 1 after threshold breach", cycles)
+	}
+	if failures != 0 {
+		t.Errorf("consecutiveFailures = %d after rotation, want 0", failures)
+	}
+}
+
+// TestRotationFallback verifies that when rotateCycleCount already equals the max,
+// the next threshold breach triggers disabled=true instead of another rotation.
+func TestRotationFallback(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	secret, _ := generateSecret()
+	wm.mu.Lock()
+	wm.state = WebhookStreamHealthy
+	wm.secret = secret
+	// Pre-seed rotateCycleCount at the limit so the next threshold breach disables.
+	wm.rotateCycleCount = webhookRotationMaxCycles
+	wm.mu.Unlock()
+
+	body := []byte(`{"action":"created"}`)
+	wrongSecret := "wrongsecret"
+
+	// Trigger another rotation by sending enough consecutive failures.
+	for i := 0; i < webhookRotationFailures; i++ {
+		req := signedRequest(t, body, wrongSecret)
+		rr := httptest.NewRecorder()
+		wm.handleWebhook(rr, req)
+	}
+
+	wm.mu.Lock()
+	disabled := wm.disabled
+	wm.mu.Unlock()
+
+	if !disabled {
+		t.Error("webhookManager should be disabled after max rotation cycles")
+	}
+}
+
+// TestHandleWebhookIncrementsCounters verifies per-type event counting and wakeCh.
+func TestHandleWebhookIncrementsCounters(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	secret, _ := generateSecret()
+	wm.mu.Lock()
+	wm.state = WebhookStreamStartingUp
+	wm.startupTime = time.Now()
+	wm.secret = secret
+	wm.mu.Unlock()
+
+	body := []byte(`{"action":"created","repository":{"full_name":"myorg/myrepo"}}`)
+	req := signedRequest(t, body, secret)
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	rr := httptest.NewRecorder()
+	wm.handleWebhook(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	wm.mu.Lock()
+	count := wm.eventCounts["issue_comment"]
+	wm.mu.Unlock()
+	if count != 1 {
+		t.Errorf("eventCounts[issue_comment] = %d, want 1", count)
+	}
+
+	// wakeCh should have received a signal.
+	select {
+	case <-wm.wakeCh:
+		// good
+	default:
+		t.Error("wakeCh should have been signaled on valid event")
+	}
+}
+
+// TestBuildGhArgs covers argument construction for org-mode and per-repo mode.
+func TestBuildGhArgs(t *testing.T) {
+	events := []string{"issues", "pull_request"}
+
+	// org mode
+	args := buildGhArgs("myorg", nil, 9876, "mysecret", events)
+	assertContains(t, args, "--org=myorg")
+	assertContains(t, args, "--url=http://127.0.0.1:9876/")
+	assertContains(t, args, "--secret=mysecret")
+	assertContains(t, args, "--events=issues,pull_request")
+
+	// per-repo mode
+	args = buildGhArgs("", []string{"myorg/repo1", "myorg/repo2"}, 9876, "mysecret", events)
+	assertContains(t, args, "--repo=myorg/repo1")
+	assertContains(t, args, "--repo=myorg/repo2")
+}
+
+// TestIsHealthyOrStartingUp covers the backoff-coupling helper.
+func TestIsHealthyOrStartingUp(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+
+	for _, s := range []WebhookHealthState{WebhookStreamStartingUp, WebhookStreamHealthy} {
+		wm.mu.Lock()
+		wm.state = s
+		wm.mu.Unlock()
+		if !wm.IsHealthyOrStartingUp() {
+			t.Errorf("state %q: IsHealthyOrStartingUp() = false, want true", s)
+		}
+	}
+
+	wm.mu.Lock()
+	wm.state = WebhookStreamUnhealthy
+	wm.mu.Unlock()
+	if wm.IsHealthyOrStartingUp() {
+		t.Error("state unhealthy: IsHealthyOrStartingUp() = true, want false")
+	}
+}
+
+// signedRequest builds an HTTP POST with a valid HMAC-SHA256 signature.
+func signedRequest(t *testing.T, body []byte, secret string) *http.Request {
+	t.Helper()
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func assertContains(t *testing.T, slice []string, val string) {
+	t.Helper()
+	for _, s := range slice {
+		if s == val {
+			return
+		}
+	}
+	t.Errorf("expected %q in %v", val, slice)
+}

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -405,6 +406,77 @@ func TestIsHealthyOrStartingUp(t *testing.T) {
 	wm.mu.Unlock()
 	if wm.IsHealthyOrStartingUp() {
 		t.Error("state unhealthy: IsHealthyOrStartingUp() = true, want false")
+	}
+}
+
+// TestUpdateRepos_NewRepoTriggersRestart verifies that discovering a new repo updates
+// wm.repos and kills the current subprocess.
+func TestUpdateRepos_NewRepoTriggersRestart(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	// Override killFn with a counter; no real subprocess needed.
+	killCount := 0
+	wm.killFn = func(*exec.Cmd) { killCount++ }
+	// Seed with a single repo and point currentCmd to a non-nil sentinel.
+	wm.mu.Lock()
+	wm.repos = map[string]bool{"owner/a": true}
+	wm.currentCmd = &exec.Cmd{} // non-nil so killFn is invoked
+	wm.mu.Unlock()
+
+	wm.UpdateRepos(map[string]bool{"owner/a": true, "owner/b": true})
+
+	wm.mu.Lock()
+	repos := copyRepoSet(wm.repos)
+	wm.mu.Unlock()
+
+	if !repos["owner/a"] || !repos["owner/b"] {
+		t.Errorf("repos = %v, want {owner/a, owner/b}", repos)
+	}
+	if killCount != 1 {
+		t.Errorf("killFn called %d times, want 1 on new-repo discovery", killCount)
+	}
+}
+
+// TestUpdateRepos_NoNewRepos_NoRestart verifies that calling UpdateRepos with an
+// unchanged repo set does not kill the subprocess.
+func TestUpdateRepos_NoNewRepos_NoRestart(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	killCount := 0
+	wm.killFn = func(*exec.Cmd) { killCount++ }
+	wm.mu.Lock()
+	wm.repos = map[string]bool{"owner/a": true}
+	wm.currentCmd = &exec.Cmd{}
+	wm.mu.Unlock()
+
+	wm.UpdateRepos(map[string]bool{"owner/a": true})
+
+	if killCount != 0 {
+		t.Errorf("killFn called %d times on no-change update, want 0", killCount)
+	}
+}
+
+// TestUpdateRepos_DisabledManager_NoOp verifies that a disabled manager ignores
+// UpdateRepos calls entirely.
+func TestUpdateRepos_DisabledManager_NoOp(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	killCount := 0
+	wm.killFn = func(*exec.Cmd) { killCount++ }
+	wm.mu.Lock()
+	wm.disabled = true
+	wm.repos = map[string]bool{"owner/a": true}
+	wm.currentCmd = &exec.Cmd{}
+	wm.mu.Unlock()
+
+	wm.UpdateRepos(map[string]bool{"owner/a": true, "owner/b": true})
+
+	wm.mu.Lock()
+	repos := copyRepoSet(wm.repos)
+	wm.mu.Unlock()
+
+	if repos["owner/b"] {
+		t.Error("disabled manager should not update repos")
+	}
+	if killCount != 0 {
+		t.Error("disabled manager should not call killFn")
 	}
 }
 

--- a/tui/events.go
+++ b/tui/events.go
@@ -112,3 +112,13 @@ type TurnProgressEvent struct {
 }
 
 func (TurnProgressEvent) tuiEvent() {}
+
+// WebhookStatusEvent is emitted when the webhook stream health state changes
+// or when new events are received. State is one of: "starting_up", "healthy",
+// "unhealthy", or "" (webhook mode disabled).
+type WebhookStatusEvent struct {
+	State       string         // WebhookHealthState as string to avoid import cycle
+	EventCounts map[string]int // per-event-type received counts
+}
+
+func (WebhookStatusEvent) tuiEvent() {}

--- a/tui/footer.go
+++ b/tui/footer.go
@@ -11,11 +11,14 @@ import (
 	"github.com/muesli/termenv"
 )
 
-// FooterComponent renders the bottom status bar: project info and rate limit stats.
+// FooterComponent renders the bottom status bar: project info, rate limit stats,
+// and (when webhook mode is active) the webhook health indicator.
 type FooterComponent struct {
-	projectInfo  ProjectInfo
-	graphqlStats RateLimitStats
-	now          time.Time
+	projectInfo   ProjectInfo
+	graphqlStats  RateLimitStats
+	now           time.Time
+	webhookState  string         // "", "starting_up", "healthy", "unhealthy"
+	webhookCounts map[string]int // per-type event counts
 }
 
 func (f FooterComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
@@ -29,8 +32,32 @@ func (f FooterComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 	case ProjectMetaEvent:
 		f.projectInfo.BoardTitle = ev.BoardTitle
 		f.projectInfo.BoardURL = ev.BoardURL
+	case WebhookStatusEvent:
+		f.webhookState = ev.State
+		if ev.EventCounts != nil {
+			f.webhookCounts = ev.EventCounts
+		}
 	}
 	return f, nil
+}
+
+// webhookIndicator returns the rendered webhook health indicator string, or "" when
+// webhook mode is disabled.
+func (f FooterComponent) webhookIndicator() string {
+	total := 0
+	for _, n := range f.webhookCounts {
+		total += n
+	}
+	switch f.webhookState {
+	case "healthy":
+		return successStyle.Render(fmt.Sprintf("● webhook (%d)", total))
+	case "starting_up":
+		return infoStyle.Render(fmt.Sprintf("○ webhook (%d)", total))
+	case "unhealthy":
+		return activeStyle.Render(fmt.Sprintf("◌ webhook (%d)", total))
+	default:
+		return ""
+	}
 }
 
 // supportsOSC8 returns true when the terminal is known to support OSC 8 hyperlinks.
@@ -100,7 +127,10 @@ func (f FooterComponent) View(width int) string {
 	}
 	leftPlain := strings.Join(parts, " · ")
 
-	var rightStr string
+	var rightParts []string
+	if whInd := f.webhookIndicator(); whInd != "" {
+		rightParts = append(rightParts, whInd)
+	}
 	if f.graphqlStats.Limit > 0 {
 		countdown := fmtRateLimitCountdown(f.graphqlStats.Reset, f.now)
 		plain := fmt.Sprintf("%d/%d  %s", f.graphqlStats.Remaining, f.graphqlStats.Limit, countdown)
@@ -114,7 +144,11 @@ func (f FooterComponent) View(width int) string {
 		default:
 			style = failStyle
 		}
-		rightStr = style.Render(plain)
+		rightParts = append(rightParts, style.Render(plain))
+	}
+	var rightStr string
+	if len(rightParts) > 0 {
+		rightStr = strings.Join(rightParts, "  ")
 	}
 
 	maxWidth := width - 2 // leave 1 char margin on each side

--- a/tui/model.go
+++ b/tui/model.go
@@ -371,6 +371,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.footer = comp.(FooterComponent)
 		return m, nil
 
+	case WebhookStatusEvent:
+		comp, _ := m.footer.Update(msg)
+		m.footer = comp.(FooterComponent)
+		return m, nil
+
 	case PollStartedEvent:
 		comp, _ := m.header.Update(msg)
 		m.header = comp.(HeaderComponent)

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -16,4 +16,5 @@ var (
 	dimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
 	activeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	selectedStyle = lipgloss.NewStyle().Background(lipgloss.Color("238"))
+	infoStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("39")) // blue: webhook starting-up indicator
 )


### PR DESCRIPTION
## Summary

Add an optional webhook-driven event ingestion path. When enabled, Fabrik receives event payloads from GitHub, translates them into existing trigger primitives (force-poll-this-issue, process-this-comment, re-evaluate-CI), and dramatically extends idle-backoff during periods when the webhook stream is healthy. Polling continues as a safety net so missed or delayed webhooks don't strand work.

The transport for webhook delivery is the official GitHub CLI command `gh webhook forward`, which uses GitHub's own SSE-based forwarding. No third-party service, no extra account, no public ingress required — Fabrik connects outbound through `gh` and receives events on `localhost`. Authentication piggybacks on the existing `gh auth login` the user already has.

## Problem

Fabrik currently polls the GitHub Project board on a fixed cadence (`PollSeconds`, default 30s) via a single GraphQL query that fetches the entire board, every active item's comments, and linked-PR data. Per-item REST calls (`FetchCheckRuns`, `FetchPRMergeable`, `FetchLabelAppliedAt`, etc.) layer on top of that. Two consequences:

1. **GraphQL budget pressure.** Heavy boards consume the 5000-points/hour GraphQL budget quickly. Users running Fabrik alongside other gh-CLI / GraphQL workloads on the same token hit rate-limit caps. The current idle-backoff caps the interval at 5 minutes, which limits the worst case but doesn't help during active periods.
2. **Event latency.** Comments, label changes, CI completions, and review submissions are visible to Fabrik only on the next poll tick — up to 30s of delay even when nothing else is happening. Comment-driven steering ("please look at PR #18") feels sluggish; CI gate clearance is bottlenecked on poll cadence rather than actual GitHub state.

GitHub publishes webhooks for every event Fabrik cares about. Subscribing to them collapses the steady-state polling load to near zero and makes events visible to the engine within seconds of GitHub recording them.

## Approach

### Approach

**Core design choices (resolved from research):**

1. **`webhookMgr` initialized lazily in `Run()`** (not `New()`). Webhook mode is opt-in; `Run()` has the log file handle and `ctx` the manager needs. Constructing in `New()` would require passing `ctx` through construction.

2. **`idleStart` reset via existing `wakeCh`** — no extra mechanism needed. The `case <-e.wakeCh` branch in `poll.go:348–358` already executes `e.idleStart = time.Time{}` on line 353. Since webhook events always send on `wakeCh`, idle reset (R11) is automatic.

3. **HTTP listener bound once, kept alive across subprocess restarts.** The listener is started before the first subprocess and reused on every restart. The subprocess gets the same `--url http://127.0.0.1:<port>/` on each invocation. This avoids port-churn and simplifies restart logic.

4. **`computeEffectiveInterval` gains a `webhookHealthy bool` parameter** that collapses StartingUp and Healthy into one `true` value for backoff purposes. A new `effectiveIdleCap(webhookHealthy bool)` helper selects between `maxIdleBackoff` (5 min) and `webhookIdleCap` (60 min).

5. **Startup grace applies per subprocess start, not per crash cycle.** If the subprocess crashes repeatedly, the health model transitions to `WebhookStreamUnhealthy` after the grace period expires with no received event. Grace is not re-applied infinitely on each crash — that would permanently suppress the `WebhookStreamUnhealthy` state.

6. **Org-level subscription (R25) is attempted first.** If `gh webhook forward --org=<org>` returns a startup error, fall back silently to per-repo `--repo` subscriptions. The org is inferred from the first repo's owner component.

7. **Single `engine/webhook.go` file** for all webhook plumbing (subprocess, HTTP, HMAC, health, rotation, multi-repo). This keeps a clean boundary from the rest of the engine.

### New/Modified Files

| File | Change |
|------|--------|
| `config/config.go` | Add `Webhooks bool`, `WebhookPort *int`, `WebhookEvents []string` fields to `ProjectConfig` |
| `engine/engine.go` | Add `Webhooks bool`, `WebhookPort int`, `WebhookEvents []string` to `Config`; add `webhookMgr *webhookManager` field to `Engine` |
| `engine/poll.go` | Add `webhookHealthy bool` param to `computeEffectiveInterval()`; update caller in `doPollCycle`; call `webhookMgr.UpdateRepos()` after each poll; start/stop webhookMgr in `Run()` |
| `engine/webhook.go` | **New file**: `webhookManager` struct, subprocess lifecycle, HTTP listener, HMAC verification, health state machine, secret rotation, multi-repo tracking, org-level detection |
| `engine/webhook_test.go` | **New file**: unit tests for HMAC, health state transitions, secret rotation |
| `cmd/root.go` | Add `--webhooks`, `--webhook-port`, `--webhook-events` flags with env var and `config.yaml` fallback precedence |
| `tui/events.go` | Add `WebhookStatusEvent{State WebhookHealthState; EventCounts map[string]int}` |
| `tui/model.go` | Handle `WebhookStatusEvent` in `Update()`; forward to footer |
| `tui/footer.go` | Add `webhookState`, `webhookEventCounts` fields to `FooterComponent`; render three-state indicator |
| `tui/styles.go` | Add blue/spinner style for `WebhookStreamStartingUp` |
| `adrs/032-webhook-event-delivery.md` | **New file**: ADR |
| `docs/state-machine.md` | Update idle-backoff section with three-state health model |
| `docs/USER_GUIDE.md` | Add "Webhook Mode" section |

### Key Decisions

- **`webhookManager` is a stand-alone struct** that holds the listener, subprocess handle, health state, failure counters, and known-repos set — all under its own mutex (`wm.mu`). It has no reference back to `Engine`; instead it receives a `logf func(int, string, string, ...any)`, `wakeCh chan struct{}`, and `emitFn func(tui.Event)` at construction. This prevents circular dependencies and makes unit testing straightforward.

- **`WebhookHealthState` type is defined in `engine/webhook.go`**, not in the `tui` package. The TUI event `WebhookStatusEvent` embeds it. Since `tui/events.go` imports no engine types today, this means `tui/events.go` must define `WebhookHealthState` itself (or accept it as `int`). To avoid an import cycle, use a `int` constant type in `tui/events.go` and an identical constant set in `engine/webhook.go` — or simply use a string type that needs no cross-package constant. **Decision: define `WebhookHealthState` as a string type in `engine/webhook.go` and send it as `string` in `WebhookStatusEvent`.** The TUI uses string comparison for the three-state display.

- **ADR 032 is warranted** — the transport choice, the `gh webhook forward` floor version, the polling-as-safety-net rationale, and the `projects_v2_item` findings all need documentation that isn't obvious from the code. ADR 003 must be explicitly superseded.

- **`seenRepos` comparison happens in `doPollCycle`** after a successful `poll()`. The engine already computes the seen-repos set inside `poll()` but discards it. The simplest approach: return `seenRepos map[string]bool` as a new field on `pollResult`, then call `webhookMgr.UpdateRepos(result.SeenRepos)` in `doPollCycle`. `UpdateRepos` restarts the subprocess only when the repo set grows.

### Task Checklist

- [ ] **Task 1**: Add `Webhooks bool`, `WebhookPort *int`, `WebhookEvents []string` to `ProjectConfig` in `config/config.go`; add corresponding `Webhooks bool`, `WebhookPort int`, `WebhookEvents []string` to `engine.Config`
- [ ] **Task 2**: Add `--webhooks`, `--webhook-port`, `--webhook-events` CLI flags to `cmd/root.go` with `FABRIK_WEBHOOKS`, `FABRIK_WEBHOOK_PORT`, `FABRIK_WEBHOOK_EVENTS` env var fallbacks and `config.yaml` field fallbacks, following the established `explicitFlags` precedence pattern
- [ ] **Task 3**: Create `engine/webhook.go`: define `WebhookHealthState` string type and three constants (`WebhookStreamStartingUp`, `WebhookStreamHealthy`, `WebhookStreamUnhealthy`); define `webhookManager` struct with fields for listener, subprocess PID, health state, secret, known repos, failure counters, event counters, and mutex; define internal constants `webhookIdleCap` (60 min), `webhookHealthWindow` (10 min), `webhookStartupGrace` (30 s), `webhookMaxRestartBackoff` (60 s), `webhookRotationFailures` (5), `webhookRotationWindow` (2 min), `webhookRotationMaxCycles` (2); implement `newWebhookManager(...)` constructor and `generateSecret() (string, error)`
- [ ] **Task 4**: Add HMAC-SHA256 verification to `engine/webhook.go`: `verifySignature(body []byte, signature, secret string) bool` using `crypto/hmac`, `crypto/sha256`, `encoding/hex`, timing-safe `hmac.Equal()`
- [ ] **Task 5**: Add HTTP listener + request handler to `engine/webhook.go`: `startListener(port int) (*net.TCPListener, int, error)` binding `127.0.0.1:<port>`; HTTP handler that reads body, calls `verifySignature`, logs `[webhook]` per-event (type, action, repo, number — no payload body), increments per-type counter, sends non-blocking on `wakeCh`, and transitions health state to `WebhookStreamHealthy` on first verified event; emit `WebhookStatusEvent` after each state change
- [ ] **Task 6**: Add subprocess lifecycle to `engine/webhook.go`: `ghVersionCheck() error` (parse `gh --version` output, compare semver against 2.32.0); `buildGhArgs(repos []string, orgMode bool, port int, secret string, events []string) []string`; `startSubprocess(ctx context.Context)` that runs `gh webhook forward`, sets `setCmdProcAttr`, pipes stderr to engine log, returns the `*exec.Cmd`; supervised restart goroutine (`supervise(ctx context.Context)`) with exponential backoff (start 1s, double, cap at 60s), resets to `WebhookStreamStartingUp` on each restart, transitions to `WebhookStreamUnhealthy` after startup grace expires without events
- [ ] **Task 7**: Add secret rotation to `engine/webhook.go` in the signature-failure path of the HTTP handler: track `consecutiveFailures int` and `firstFailureAt time.Time` (reset on any success); when threshold (5 failures in 2 min) is breached, call `rotateSecret(ctx)` which kills subprocess, generates new secret, increments `rotateCycleCount`; when `rotateCycleCount >= 2` and failures persist, set `disabled = true`, log error suggesting `gh auth status`, emit `WebhookStreamUnhealthy` status, return from supervise goroutine
- [ ] **Task 8**: Add multi-repo tracking + org-level subscription to `engine/webhook.go`: `UpdateRepos(repos map[string]bool)` method that compares against `wm.knownRepos`; restarts subprocess with new repo set when repos grows; `detectOrgMode(repos map[string]bool) (org string, ok bool)` that returns the common org owner when all repos share the same owner; on startup, try `--org=<org>` first, fall back to `--repo <r1> --repo <r2> ...` on stderr error from `gh`
- [ ] **Task 9**: Integrate `webhookMgr` into `engine/engine.go` and `engine/poll.go`: add `webhookMgr *webhookManager` field to `Engine`; in `Run()`, after log file opened and before first poll, construct manager (when `cfg.Webhooks`) and call `webhookMgr.Start(ctx)`; defer `webhookMgr.Stop()`; add `webhookHealthy bool` parameter to `computeEffectiveInterval()` with new `effectiveIdleCap(webhookHealthy bool) time.Duration` helper returning 5 min or 60 min; update `doPollCycle` to pass `webhookMgr.IsHealthyOrStartingUp()`; add `SeenRepos map[string]bool` to `pollResult` returned by `poll()`, call `webhookMgr.UpdateRepos(result.SeenRepos)` in `doPollCycle`; add `gh --version` prerequisite check log at startup when webhooks enabled
- [ ] **Task 10**: Add `WebhookStatusEvent{State string; EventCounts map[string]int}` to `tui/events.go`; handle in `tui/model.go`'s `Update()` forwarding to footer; add `webhookState string`, `webhookCounts map[string]int` fields to `FooterComponent` in `tui/footer.go`; render three-state indicator in `View()` (green dot for Healthy, blue spinner for StartingUp, yellow dot for Unhealthy, no indicator when disabled); add a blue lipgloss style to `tui/styles.go`
- [ ] **Task 11**: Write unit tests in `engine/webhook_test.go`: `TestVerifySignature` (valid HMAC, wrong secret, malformed header, empty body); `TestHealthStateTransitions` (startup grace → healthy on first event, startup grace → unhealthy on expiry, healthy → unhealthy on window expiry); `TestSecretRotationTrigger` (5 failures in 2 min → rotateCycleCount increments); `TestRotationFallback` (2 cycles → disabled=true)
- [ ] **Task 12**: Create `adrs/032-webhook-event-delivery.md`: supersedes ADR 003, documents `gh webhook forward` transport rationale, polling-as-safety-net, floor version choice, `projects_v2_item` graceful degradation, single-subprocess multi-repo restart, org-level subscription auto-detection
- [ ] **Task 13**: Update `docs/state-machine.md` idle-backoff section: document `WebhookStreamStartingUp`/`WebhookStreamHealthy`/`WebhookStreamUnhealthy` states and how each maps to `maxIdleBackoff` (5 min) vs `webhookIdleCap` (60 min)
- [ ] **Task 14**: Add "Webhook Mode" section to `docs/USER_GUIDE.md`: prerequisites (`gh ≥ 2.32.0`, `gh auth login`, `admin:repo_hook` scope, repo admin), enable flags/env/config.yaml, three health states + TUI indicator colors, expected GraphQL reduction, log verification via `[webhook]` tag, `127.0.0.1` binding + HMAC security rationale, `projects_v2_item` latency tradeoff
- [ ] **Task 15**: Run `go build -o fabrik .`, `go vet ./...`, `go test -race ./...`; fix any issues

### ADR Status

ADR 032 (`adrs/032-webhook-event-delivery.md`) is warranted and included as Task 12. No other decisions in this plan rise to ADR threshold — the subprocess pattern, HMAC choice, and config precedence all follow existing established patterns.

### Risks

1. **`projects_v2_item` support unknown at plan time.** The implementer must attempt the subscription at runtime and catch the `gh` stderr error gracefully; the ADR must record whether it worked or not. If unsupported, USER_GUIDE gets the latency-tradeoff note.

2. **`seenRepos` not currently returned from `poll()`.** Task 9 requires adding `SeenRepos map[string]bool` to `pollResult`. This is a minor internal change but must not break the existing `pollResult.Active` / `pollResult.ItemCount` logic — verify `poll()` test coverage covers the new field.

3. **Import cycle: `tui/events.go` must not import `engine`.** `WebhookHealthState` is defined as a string type in `engine/webhook.go`. The `tui.WebhookStatusEvent` carries `State string` (not the engine type), keeping the `tui` package free of engine imports. The engine side converts its typed constant to `string` when emitting.

4. **Org-level auto-detect may be slow on first startup.** If `gh webhook forward --org=<org>` takes time to fail, it could delay the first webhook subscription. Add a timeout (e.g. 5s) to the org probe.

5. **Race detector: webhookManager's state fields accessed from HTTP handler goroutine AND supervise goroutine simultaneously.** All state mutations in `webhookManager` must be guarded by `wm.mu`. The `go test -race ./...` step will catch any lapses.

6. **Note from Research on model complexity**: This feature adds ~500 lines of new concurrent Go across 10+ files. Research suggested adding the `model:opus` label. The plan has resolved all design decisions, so this is primarily an implementation concern — the user should decide whether to add `model:opus` for the Implement stage.

---
Used 18/50 turns, 10k input / 11k output tokens.

## Verification

Implemented webhook-driven event delivery via `gh webhook forward` across all 15 planned tasks. The core is `engine/webhook.go` (~712 lines) implementing: three-state health model (StartingUp/Healthy/Unhealthy), HMAC-SHA256 signature verification, supervised subprocess lifecycle with exponential-backoff restart (1s→60s), secret rotation on 5 consecutive failures within 2 min with 2-cycle fallback to polling, multi-repo tracking with org-level subscription auto-detection, and per-type event counters. The poll loop idle cap extends from 5 min to 60 min when the webhook stream is healthy/starting-up, reducing steady-state GraphQL load ~120×. TUI footer gains a three-state health indicator; CLI adds `--webhooks`, `--webhook-port`, `--webhook-events` flags. ADR 032, state-machine docs, and USER_GUIDE webhook section are complete. All tests pass with the race detector.

---

Closes #452