### PR TITLE
checkCIGate R5 race: post-push window where new check runs haven't registered yet incorrectly clears the gate

### DIFF
--- a/adrs/027-ci-gate-and-fix-reinvoke.md
+++ b/adrs/027-ci-gate-and-fix-reinvoke.md
@@ -22,7 +22,7 @@ The `yolo` auto-merge path already called `MergePR` directly. A CI gate is embed
 
 - Fetch the PR's head SHA via `FetchLinkedPR` (REST — avoids extending the existing large GraphQL query).
 - Fetch check runs via `FetchCheckRuns`.
-- **R5**: No check runs → gate clears (repo has no CI).
+- **R5**: No check runs → if `prHasHadChecks[issueKey]` is true (this PR previously had check runs), gate blocks and waits — the engine is in the post-push registration window. If the flag is false (first-ever poll for this PR), gate clears (repo has no CI).
 - **R4**: All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge.
 - **R3**: Any check failed → add `fabrik:awaiting-ci`; return error (caller logs and skips advance).
 - **R2**: Any check pending → track start time in `ciMergePendingSince`; return error (no label added — R10c).
@@ -40,7 +40,7 @@ For stages with `wait_for_ci: true`, `handleStageComplete` uses **Approach A**:
 The catch-up loop Phase 1 (`poll()`) now calls `checkCIGate(board, item, stage)` after the review gate:
 
 - `(false, false, false)` — gate clear; fall through to Phase 2 (advancement/merge).
-- `(true, false, false)` — CI still pending; skip to next item. **`fabrik:awaiting-ci` is NOT applied (R10c)** — label churn from transient pending states would produce noise and mislead users. The item's `fabrik:awaiting-ci` label presence triggers `itemMayNeedWork` to bypass the `updatedAt` cache, ensuring re-evaluation on every poll.
+- `(true, false, false)` — CI still pending, **or** post-push registration delay (R5: zero check runs but `prHasHadChecks[issueKey]` is true); skip to next item. **`fabrik:awaiting-ci` is NOT applied (R10c)** — label churn from transient pending states would produce noise and mislead users. The item's `fabrik:awaiting-ci` label presence triggers `itemMayNeedWork` to bypass the `updatedAt` cache, ensuring re-evaluation on every poll.
 - `(true, true, false)` — CI failed; `fabrik:awaiting-ci` applied (idempotent); dispatch `dispatchCIFixReinvoke` or pause if cycle limit exceeded.
 - `(false, false, true)` — Timeout: `fabrik:awaiting-ci` already present ≥ `CIWaitTimeout` (checked via `FetchLabelAppliedAt`); pause with `fabrik:paused` + `fabrik:awaiting-input`.
 
@@ -50,6 +50,7 @@ The two prongs use different timeout strategies due to their different lifecycle
 
 - **Prong 1** (merge guard): Uses an in-memory `ciMergePendingSince` map. Acceptable because merge-guard state is transient — if the engine restarts, it simply re-evaluates CI on the next poll.
 - **Prong 2** (catch-up loop): Uses `FetchLabelAppliedAt` on `fabrik:awaiting-ci`. The label is durable across restarts. `FetchLabelAppliedAt` makes a REST API call, but only when CI has already failed and the label is present — a rare, high-signal path.
+- **Post-push registration delay guard**: The in-memory `prHasHadChecks map[string]bool` (keyed by `issueKey`) records whether `FetchCheckRuns` has ever returned a non-empty result for a given issue in this process lifetime. When R5 fires (zero check runs), `checkCIGate` consults this flag: if true, the gate blocks (post-push window); if false, the gate clears (no CI configured). On engine restart the flag resets — the worst case is one poll cycle where a newly-registered post-push SHA gets a false "no CI" read, after which the next poll will re-block correctly.
 
 ### CI-Fix Re-invocation
 

--- a/adrs/027-ci-gate-and-fix-reinvoke.md
+++ b/adrs/027-ci-gate-and-fix-reinvoke.md
@@ -22,7 +22,7 @@ The `yolo` auto-merge path already called `MergePR` directly. A CI gate is embed
 
 - Fetch the PR's head SHA via `FetchLinkedPR` (REST — avoids extending the existing large GraphQL query).
 - Fetch check runs via `FetchCheckRuns`.
-- **R5**: No check runs → if `prHasHadChecks[issueKey]` is true (this PR previously had check runs), gate blocks and waits — the engine is in the post-push registration window. If the flag is false (first-ever poll for this PR), gate clears (repo has no CI).
+- **R5**: No check runs → gate clears (repo has no CI). The post-push registration-window guard based on `prHasHadChecks[issueKey]` applies to the catch-up loop (`checkCIGate`, Prong 2) only — not here.
 - **R4**: All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge.
 - **R3**: Any check failed → add `fabrik:awaiting-ci`; return error (caller logs and skips advance).
 - **R2**: Any check pending → track start time in `ciMergePendingSince`; return error (no label added — R10c).

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -660,7 +660,7 @@ The CI gate has two paths that handle different timing scenarios:
 - Embedded directly in the auto-merge path for Validate+yolo items
 - Uses in-memory `ciMergePendingSince` map (keyed by `issueKey`) to track how long CI has been pending
 - Fetches PR head SHA via `FetchLinkedPR()` (REST), then check run statuses via `FetchCheckRuns()` (REST)
-- **R5:** No check runs → if `prHasHadChecks[issueKey]` is true (PR has had checks this process lifetime), return `(true, false, false)` — post-push registration delay, gate blocks and waits; if false, gate clears (repo has no CI)
+- **R5:** No check runs → gate clears (repo has no CI). The `prHasHadChecks` post-push delay guard applies to `checkCIGate()` (Path 2) only, not to this merge-guard path
 - **R4:** All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge
 - **R3:** Any check failed → add `fabrik:awaiting-ci`; return error (advance skipped)
 - **R2:** Any check pending → start timer in `ciMergePendingSince` (first observation); return error (**R10c:** no label applied — avoids label churn for transient pending state)

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -660,7 +660,7 @@ The CI gate has two paths that handle different timing scenarios:
 - Embedded directly in the auto-merge path for Validate+yolo items
 - Uses in-memory `ciMergePendingSince` map (keyed by `issueKey`) to track how long CI has been pending
 - Fetches PR head SHA via `FetchLinkedPR()` (REST), then check run statuses via `FetchCheckRuns()` (REST)
-- **R5:** No check runs → gate clears (repo has no CI)
+- **R5:** No check runs → if `prHasHadChecks[issueKey]` is true (PR has had checks this process lifetime), return `(true, false, false)` — post-push registration delay, gate blocks and waits; if false, gate clears (repo has no CI)
 - **R4:** All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge
 - **R3:** Any check failed → add `fabrik:awaiting-ci`; return error (advance skipped)
 - **R2:** Any check pending → start timer in `ciMergePendingSince` (first observation); return error (**R10c:** no label applied — avoids label churn for transient pending state)

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -38,6 +38,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 	}
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	key := issueKey(item, e.defaultRepo())
 
 	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
@@ -56,8 +57,22 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 		return true, false, false // transient error; retry on next poll
 	}
 
-	// R5: no check runs = no CI configured; gate clears.
+	if len(checkRuns) > 0 {
+		e.mu.Lock()
+		e.prHasHadChecks[key] = true
+		e.mu.Unlock()
+	}
+
+	// R5: no check runs found. If this PR has had checks before, we're likely in
+	// the post-push registration window — block and wait rather than clearing.
 	if len(checkRuns) == 0 {
+		e.mu.Lock()
+		hadChecks := e.prHasHadChecks[key]
+		e.mu.Unlock()
+		if hadChecks {
+			e.logf(item.Number, "ci-gate", "no check runs for SHA %s — likely post-push registration delay; waiting\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
+			return true, false, false
+		}
 		e.logf(item.Number, "ci-gate", "no check runs found for SHA %s; CI gate clears (no CI configured)\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
 		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
 		return false, false, false

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -21,11 +21,12 @@ import (
 // Returns (blocked, ciFailure, timedOut):
 //
 //   - (false, false, false) — gate cleared; stage:X:complete added, fabrik:awaiting-ci removed.
-//     This includes: no PR found, no check runs (R5), all checks green.
+//     This includes: no PR found, no check runs when prHasHadChecks is false (R5 — no CI configured), all checks green.
 //
 //   - (true, false, false)  — gate blocked but no confirmed failure; re-evaluate on next poll.
-//     Covers: checks still pending (in_progress/queued) and not yet timed out,
-//     and transient API errors (FetchLinkedPR or FetchCheckRuns fail).
+//     Covers: checks still pending (in_progress/queued) and not yet timed out;
+//     transient API errors (FetchLinkedPR or FetchCheckRuns fail);
+//     and post-push registration delay — no check runs for new SHA but prHasHadChecks is true (R5).
 //     fabrik:awaiting-ci is NOT modified.
 //
 //   - (true, true, false)   — CI failed; fabrik:awaiting-ci applied; caller should dispatch CI-fix.

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -70,6 +70,37 @@ func TestCheckCIGate_NoCheckRuns_ClearsGate(t *testing.T) {
 	}
 }
 
+func TestCheckCIGate_PostPushDelay_BlocksGate(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, HeadSHA: "sha-new"}, nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil // no checks yet for the new SHA
+		},
+	}
+	eng := testEngineForMerge(client)
+	// Pre-seed: this issue has previously had check runs registered.
+	eng.prHasHadChecks["owner/repo#1"] = true
+
+	tr := true
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked {
+		t.Error("expected blocked=true when zero check runs after previously seeing checks (post-push delay)")
+	}
+	if ciFailure || timedOut {
+		t.Errorf("expected ciFailure=false timedOut=false for post-push delay, got ciFailure=%v timedOut=%v", ciFailure, timedOut)
+	}
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			t.Error("fabrik:awaiting-ci must NOT be removed during post-push registration delay")
+		}
+	}
+}
+
 func TestCheckCIGate_AllGreen_ClearsGate(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -69,6 +69,7 @@ type Engine struct {
 	ciFixCycleCount      map[string]int        // key: "owner/repo#N-stageName"; CI-fix re-invocation cycle count per stage
 	rebaseCycleCount     map[string]int        // key: "owner/repo#N-stageName"; rebase re-invocation cycle count per stage
 	ciMergePendingSince  map[string]time.Time  // key: issueKey; when CI was first observed in_progress in the merge guard
+	prHasHadChecks       map[string]bool       // key: issueKey; true once FetchCheckRuns has returned non-empty for this issue
 	lastUsage            map[string]TokenUsage // key: issueKey; per-issue token usage from last processItem (for TUI)
 	lastCompleted        map[string]bool       // key: issueKey; per-issue stage completion from last processItem (for TUI)
 	lastBlocked          map[string]bool       // key: issueKey; per-issue blocked-on-input from last processItem (for TUI)
@@ -133,6 +134,7 @@ func New(cfg Config) (*Engine, error) {
 		ciFixCycleCount:      make(map[string]int),
 		rebaseCycleCount:     make(map[string]int),
 		ciMergePendingSince:  make(map[string]time.Time),
+		prHasHadChecks:       make(map[string]bool),
 		sem:                  make(chan struct{}, cfg.MaxConcurrent),
 	}
 
@@ -182,6 +184,7 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		ciFixCycleCount:      make(map[string]int),
 		rebaseCycleCount:     make(map[string]int),
 		ciMergePendingSince:  make(map[string]time.Time),
+		prHasHadChecks:       make(map[string]bool),
 		sem:                  make(chan struct{}, maxConcurrent),
 	}
 	if worktrees != nil {


### PR DESCRIPTION
## Summary

Add sticky per-issue CI memory to the engine: once `FetchCheckRuns` returns a non-empty result for a given issue, the engine remembers that this PR has had check runs. On subsequent polls where `FetchCheckRuns` returns zero, R5 no longer clears the gate — instead it returns `(true, false, false)` (blocked, no failure) and waits for the check runs to register. Issues where `FetchCheckRuns` has never returned a non-empty result still clear immediately (preserving the "no CI configured" behavior).

## Problem

`checkCIGate` rule R5 (`engine/ci.go:57-62`) treats `len(checkRuns) == 0` as "no CI configured — gate clears":

```go
if len(checkRuns) == 0 {
    e.logf(item.Number, "ci-gate", "no check runs found for SHA %s; CI gate clears (no CI configured)\n", ...)
    e.removeAwaitingCILabel(owner, repo, item)
    return false, false, false
}
```

But during the window between Claude's CI-fix push and GitHub registering the new check runs against the new HEAD SHA, `FetchCheckRuns(newSHA)` legitimately returns zero. The current code interprets this as "no CI" and prematurely clears `fabrik:awaiting-ci`.

### Why this matters more after #456

Today, the race is *partially* masked: by the next poll the new check runs have usually registered, so `checkCIGate` blocks again and the engine self-corrects within a poll cycle.

Under #456's conjunctive-gate design:
- `fabrik:awaiting-ci` is the dispatcher's "do not invoke Claude" signal.
- An R5 firing strips `awaiting-ci`.
- Next poll: dispatcher sees no `stage:Validate:complete` and no `awaiting-ci` → fires a fresh Validate Claude run.
- Re-introduces the v0.0.48 bug shape (#705-style repeated Validate dispatches), just on a smaller window.

So the conjunctive-gate fix needs this race closed alongside it to be airtight.

## Approach

### Approach

The fix adds a sticky in-memory flag, `prHasHadChecks map[string]bool`, to the `Engine` struct. The flag records, per issue, whether `FetchCheckRuns` has ever returned a non-empty result during this engine process lifetime. This disambiguates two scenarios that both produce `len(checkRuns) == 0`:

1. **No CI configured** — `FetchCheckRuns` has always returned zero for this issue. R5 clears the gate as today.
2. **Post-push registration delay** — `FetchCheckRuns` previously returned non-empty (flag is `true`) but returns zero now because GitHub hasn't registered new check runs against the new HEAD SHA yet. R5 blocks and waits.

The implementation follows the established pattern of `ciMergePendingSince`, `reviewCycleCount`, and similar per-issue in-memory maps in the engine. No persistence, no new external dependencies, no changes outside the three in-scope files.

**Lock discipline:** The flag is read and written under `e.mu`, consistent with how all other per-issue maps are protected. The lock is acquired and released in two separate fine-grained sections: once to write (after a non-empty `FetchCheckRuns` succeeds), once to read (in the R5 `len == 0` branch). This avoids holding the lock across network calls.

**Key computation:** `issueKey(item, e.defaultRepo())` is called once at the top of `checkCIGate`, right after `itemOwnerRepo`, and reused for both the write and the read.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/engine.go` | Add `prHasHadChecks map[string]bool` field to `Engine` struct; initialize in `New()` and `NewWithDeps()` |
| `engine/ci.go` | Compute `issueKey` at top of `checkCIGate`; write flag when `FetchCheckRuns` returns non-empty; branch R5 on flag value |
| `engine/ci_test.go` | Add R7 test (flag set → zero runs → blocked); R8 is implicit (existing `TestCheckCIGate_NoCheckRuns_ClearsGate` must still pass) |
| `adrs/027-ci-gate-and-fix-reinvoke.md` | Update R5 rule to document the conditional behavior |
| `docs/state-machine.md` | Update the R5 entry (line 661) to reflect the conditional behavior |

### Key Decisions

- **Map key type is `string`**, not a named type. `issueKey()` returns `string`, matching all other per-issue maps in the struct. Consistent with `ciMergePendingSince`, `reviewCycleCount`, etc.
- **Write placement is just before the R5 check**, after `FetchCheckRuns` succeeds and after the error-return branch. The write `if len(checkRuns) > 0` and the R5 check `if len(checkRuns) == 0` are mutually exclusive, so there is no interleaving concern.
- **No new ADR**. ADR 027 already owns the R5 rule. The change is a guarded amendment to R5, not a new architectural decision. An addendum to ADR 027 is the correct vehicle.
- **`docs/state-machine.md` requires a one-line update** at line 661 to reflect the guard, so the as-built spec stays in sync per the project convention in CLAUDE.md.

### Task Checklist

- [ ] **Task 1:** Add `prHasHadChecks map[string]bool` field to `Engine` struct in `engine/engine.go` (after `ciMergePendingSince` field, following field ordering convention)
- [ ] **Task 2:** Initialize `prHasHadChecks: make(map[string]bool)` in `New()` constructor in `engine/engine.go` (after `ciMergePendingSince` initialization)
- [ ] **Task 3:** Initialize `prHasHadChecks: make(map[string]bool)` in `NewWithDeps()` constructor in `engine/engine.go` (after `ciMergePendingSince` initialization)
- [ ] **Task 4:** In `checkCIGate` (`engine/ci.go`), compute `key := issueKey(item, e.defaultRepo())` immediately after the `itemOwnerRepo` call on line 39
- [ ] **Task 5:** In `checkCIGate`, after the `FetchCheckRuns` error-return branch (line 54), add: if `len(checkRuns) > 0`, acquire `e.mu`, set `e.prHasHadChecks[key] = true`, release `e.mu`
- [ ] **Task 6:** In `checkCIGate`, replace the R5 block (lines 57-62) with the guarded version: acquire `e.mu`, read `hadChecks := e.prHasHadChecks[key]`, release `e.mu`; if `hadChecks`, log the post-push registration delay message and return `(true, false, false)`; otherwise preserve existing log + `removeAwaitingCILabel` + return `(false, false, false)`
- [ ] **Task 7:** Add `TestCheckCIGate_PostPushDelay_BlocksGate` to `engine/ci_test.go` (R7): create engine via `testEngineForMerge`, pre-set `eng.prHasHadChecks["owner/repo#1"] = true`, call `checkCIGate` with `fetchCheckRunsFn` returning nil — assert `blocked=true`, `ciFailure=false`, `timedOut=false`, and no `removeLabelCalls` for `fabrik:awaiting-ci`
- [ ] **Task 8:** Verify existing `TestCheckCIGate_NoCheckRuns_ClearsGate` still passes (R8 / R4 regression guard) — no code change needed, but run `go test -run TestCheckCIGate ./engine/...` to confirm before completing
- [ ] **Task 9:** Update ADR 027 (`adrs/027-ci-gate-and-fix-reinvoke.md`) R5 entry to document the post-push registration delay guard and the `prHasHadChecks` flag
- [ ] **Task 10:** Update `docs/state-machine.md` line 661 R5 entry to reflect that zero check runs blocks (not clears) when `prHasHadChecks` is true

### Risks

- **Test pre-seeding pattern:** Task 7 directly sets `eng.prHasHadChecks[key] = true` without locking. This is safe in tests (single-goroutine, no concurrent access), and mirrors how other per-issue maps are pre-seeded in tests across the codebase (e.g., `eng.ciFixCycleCount`, `eng.reviewCycleCount`).
- **`issueKey` placement:** The key computation must be inserted early in `checkCIGate`, before the first early-return path that could skip it. The function currently has two early returns before the `FetchCheckRuns` call (WaitForCI false at line 36, no PR at line 46-48). Since neither of those polls check runs, the key doesn't need to be computed before them. Computing the key right after `itemOwnerRepo` (line 39) is the safest, cleanest placement and avoids any risk of using the key before it's defined.
- **Blocked by #456:** This branch should not be merged to main until #456 lands. The PR description must include a note to the reviewer about this dependency. The Implement agent should set a `base:<branch>` label or simply leave a PR note.

---
Used 12/50 turns, 4k input / 5k output tokens.

## Verification

Added `prHasHadChecks map[string]bool` to the Engine struct (initialized in both `New` and `NewWithDeps`) to track per-issue CI history. Updated `checkCIGate` to set the flag when `FetchCheckRuns` returns non-empty, and updated R5 to block and wait (return `true, false, false`) instead of clearing the gate when zero check runs are seen but the flag is true — closing the post-push registration race. Added `TestCheckCIGate_PostPushDelay_BlocksGate` (R7) and verified the existing R8 regression test still passes. Updated ADR 027 and `docs/state-machine.md` to reflect the new conditional R5 behavior.

---

Closes #457