### PR TITLE
Update docs for v0.0.51 + v0.0.52

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ requires auto-advance to be active):
 > built-in default is used and the env var is bypassed. See
 > [USER_GUIDE.md §10](docs/USER_GUIDE.md#pending-reviewer-gate) for details.
 
-The Validate stage also ships with `wait_for_ci: true` enabled by default. Fabrik gates auto-advance and, when applicable, auto-merge on CI checks passing; if checks fail, it re-invokes the stage agent with a structured CI-fix report to address new-regression failures.
+The Validate stage also ships with `wait_for_ci: true` enabled by default. Fabrik gates auto-advance and, when applicable, auto-merge on CI checks passing; if checks fail, it re-invokes the stage agent with a structured CI-fix report to address new-regression failures. Non-required check_run failures do not block the gate — Fabrik trusts GitHub's `mergeable_state` as the authoritative merge-readiness signal, so only failures that branch protection itself considers blocking will prevent auto-merge.
 
 If a stage doesn't complete (e.g., unfixable issues found), it retries after
 a cooldown period rather than being permanently skipped.

--- a/adrs/033-mergeable-state-over-check-runs.md
+++ b/adrs/033-mergeable-state-over-check-runs.md
@@ -9,7 +9,7 @@ Fabrik's CI gate (ADR 027) and conjunctive completion label design (ADR 032) bot
 
 This approach has a fundamental flaw: Fabrik's per-check classification does not know which checks are *required* by branch protection. A non-required check_run (e.g., a `Cleanup artifacts` workflow job, a notification step, or an informational check) can fail without affecting branch-protection-level mergeability — GitHub itself will allow the merge — but Fabrik's gate treats it as a blocking NEW REGRESSION and prevents auto-merge.
 
-This was observed in production: liminis issues #716 and #717 were blocked by a failing `Cleanup artifacts` check_run for hours even though all required checks were green and GitHub's own merge button was enabled. `mergeable_state` was `CLEAN` throughout. The only way to resolve the block without Fabrik support was to manually remove `fabrik:awaiting-ci` and trigger the merge.
+This was observed in production: liminis issues #716 and #717 were blocked by a failing `Cleanup artifacts` check_run for hours even though all required checks were green and GitHub's own merge button was enabled. `mergeable_state` was `clean` throughout. The only way to resolve the block without Fabrik support was to manually remove `fabrik:awaiting-ci` and trigger the merge.
 
 ### The `mergeable_state` Field
 
@@ -65,7 +65,7 @@ For all other values, the gate falls through to the original per-check classific
 
 Replicating this logic in Fabrik via raw check_run analysis is redundant at best and error-prone in practice. Non-required check_runs appear identical to required ones in the Checks API response — Fabrik has no reliable way to distinguish them without querying the branch protection rules themselves (an additional API call that would require repository admin scope). Trusting `mergeable_state` avoids this complexity entirely.
 
-The `unstable` state is intentionally included in the shortcut: GitHub defines `unstable` as "non-required checks have failed, but all branch-protection-required checks are satisfied and GitHub allows the merge." Blocking on `unstable` would replicate the same over-aggressive gate that caused liminis#716/717.
+The `unstable` state is intentionally included in the shortcut: GitHub uses `unstable` for PRs that remain mergeable under branch protection even though some non-blocking checks may still be pending or failing. The required branch-protection conditions are satisfied enough for GitHub to allow the merge; any remaining failing or incomplete checks are non-required. Blocking on `unstable` would replicate the same over-aggressive gate that caused liminis#716/717.
 
 ## Alternatives Considered
 

--- a/adrs/033-mergeable-state-over-check-runs.md
+++ b/adrs/033-mergeable-state-over-check-runs.md
@@ -18,7 +18,7 @@ GitHub's `mergeable_state` field on a PR aggregates all branch protection signal
 | Value | Meaning |
 |-------|---------|
 | `clean` | All branch-protection requirements satisfied; PR is ready to merge |
-| `unstable` | CI checks are still running but no required check has failed; GitHub allows merge |
+| `unstable` | Non-required checks have failed but all branch-protection-required checks are satisfied; GitHub allows merge |
 | `blocked` | A branch protection rule is blocking the merge (required check failed, approval missing, etc.) |
 | `behind` | Branch is behind the base; a rebase or merge is required |
 | `dirty` | Merge conflict |
@@ -65,7 +65,7 @@ For all other values, the gate falls through to the original per-check classific
 
 Replicating this logic in Fabrik via raw check_run analysis is redundant at best and error-prone in practice. Non-required check_runs appear identical to required ones in the Checks API response — Fabrik has no reliable way to distinguish them without querying the branch protection rules themselves (an additional API call that would require repository admin scope). Trusting `mergeable_state` avoids this complexity entirely.
 
-The `unstable` state is intentionally included in the shortcut: GitHub defines `unstable` as "some checks have not completed, but the branch protection rules that *are* required are all satisfied and GitHub allows the merge." Blocking on `unstable` would replicate the same over-aggressive gate that caused liminis#716/717.
+The `unstable` state is intentionally included in the shortcut: GitHub defines `unstable` as "non-required checks have failed, but all branch-protection-required checks are satisfied and GitHub allows the merge." Blocking on `unstable` would replicate the same over-aggressive gate that caused liminis#716/717.
 
 ## Alternatives Considered
 

--- a/adrs/033-mergeable-state-over-check-runs.md
+++ b/adrs/033-mergeable-state-over-check-runs.md
@@ -1,0 +1,93 @@
+# ADR 033: Trust `mergeable_state` Over Raw Check-Run Classification
+
+**Status**: Accepted  
+**Date**: 2026-04-27
+
+## Context
+
+Fabrik's CI gate (ADR 027) and conjunctive completion label design (ADR 032) both rely on classifying raw check_runs from the GitHub Checks API to determine whether a PR is safe to merge or advance. Each check_run is categorized as NEW REGRESSION, pre-existing failure, pending, or green; the gate blocks until all NEW REGRESSION checks either pass or are resolved by a CI-fix re-invocation.
+
+This approach has a fundamental flaw: Fabrik's per-check classification does not know which checks are *required* by branch protection. A non-required check_run (e.g., a `Cleanup artifacts` workflow job, a notification step, or an informational check) can fail without affecting branch-protection-level mergeability — GitHub itself will allow the merge — but Fabrik's gate treats it as a blocking NEW REGRESSION and prevents auto-merge.
+
+This was observed in production: liminis issues #716 and #717 were blocked by a failing `Cleanup artifacts` check_run for hours even though all required checks were green and GitHub's own merge button was enabled. `mergeable_state` was `CLEAN` throughout. The only way to resolve the block without Fabrik support was to manually remove `fabrik:awaiting-ci` and trigger the merge.
+
+### The `mergeable_state` Field
+
+GitHub's `mergeable_state` field on a PR aggregates all branch protection signals into a single value:
+
+| Value | Meaning |
+|-------|---------|
+| `clean` | All branch-protection requirements satisfied; PR is ready to merge |
+| `unstable` | CI checks are still running but no required check has failed; GitHub allows merge |
+| `blocked` | A branch protection rule is blocking the merge (required check failed, approval missing, etc.) |
+| `behind` | Branch is behind the base; a rebase or merge is required |
+| `dirty` | Merge conflict |
+| `unknown` | GitHub hasn't computed the value yet |
+| `has_hooks` | Repository has pre-receive hooks that affect mergeability |
+| `draft` | PR is in draft state |
+
+When `mergeable_state` is `clean` or `unstable`, GitHub's own branch protection has determined the PR is mergeable. Fabrik's raw check_run analysis cannot be more accurate than this signal — branch protection is the authoritative source, and any check_run failures it ignores are by definition non-blocking.
+
+## Decision
+
+Consult `mergeable_state` before per-check classification in both prongs of the CI gate.
+
+### Prong 1 — Merge Guard (`attemptMergeOnValidate`)
+
+Before fetching and classifying check_runs, `attemptMergeOnValidate` now calls `FetchPRMergeableState`. If the result is `clean` or `unstable`:
+
+- The gate clears immediately.
+- `fabrik:awaiting-ci` is removed if present (idempotent).
+- Execution proceeds directly to `MergePR`.
+- Per-check classification (`FetchCheckRuns` + NEW REGRESSION analysis) is **skipped entirely**.
+
+For all other `mergeable_state` values (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`), the gate falls through to the original per-check classification path.
+
+### Prong 2 — Catch-up Loop (`checkCIGate`)
+
+Before per-check classification, `checkCIGate` now calls `FetchPRMergeableState`. If the result is `clean` or `unstable`:
+
+- `addCompleteLabelAndRemoveCI` runs immediately (clears `fabrik:awaiting-ci`, adds `stage:<X>:complete`).
+- Stale `fabrik:awaiting-ci` labels are explicitly cleared by this function.
+- Per-check classification is **skipped entirely**.
+- The gate returns `(false, false, false)` — gate clear.
+
+For all other values, the gate falls through to the original per-check classification path. The existing rules (pending → skip, failure → CI-fix re-invoke, timeout → pause) apply unchanged.
+
+## Rationale
+
+**GitHub's branch protection is the authoritative source of truth for PR mergeability.** `mergeable_state` already aggregates:
+
+- Required check status (only *required* checks block `clean`)
+- Reviewer approval requirements
+- Branch protection rules (up-to-date branch, signed commits, etc.)
+- Status check configuration
+
+Replicating this logic in Fabrik via raw check_run analysis is redundant at best and error-prone in practice. Non-required check_runs appear identical to required ones in the Checks API response — Fabrik has no reliable way to distinguish them without querying the branch protection rules themselves (an additional API call that would require repository admin scope). Trusting `mergeable_state` avoids this complexity entirely.
+
+The `unstable` state is intentionally included in the shortcut: GitHub defines `unstable` as "some checks have not completed, but the branch protection rules that *are* required are all satisfied and GitHub allows the merge." Blocking on `unstable` would replicate the same over-aggressive gate that caused liminis#716/717.
+
+## Alternatives Considered
+
+### Configurable check-name ignore list
+
+Users could specify a list of check names (e.g., `ignore_checks: ["Cleanup artifacts"]`) in stage YAML. Fabrik would skip these checks during classification.
+
+**Rejected**: This is a whack-a-mole solution. Non-required check names vary by repository and change as CI pipelines evolve. Users should not need to maintain an ignore list to match GitHub's own branch protection configuration. The ignore list would always lag behind the actual required-vs-non-required division.
+
+### Query only `required` checks via the Checks API
+
+GitHub's Checks API can filter by `app_id` or other parameters, but does not expose a `required` flag directly. The Branch Protection API (`GET /repos/{owner}/{repo}/branches/{branch}/protection`) returns the list of required status check contexts — Fabrik could fetch this list and intersect it with the check_run results.
+
+**Rejected**: This requires an additional API call per CI gate evaluation, demands `repo` or `admin:repo` scope, and the required-context list is keyed by context name (a string), not by check_run ID — making matching brittle when check names are templated or dynamic. `mergeable_state` already does this intersection correctly inside GitHub's own infrastructure, with no additional scope or round-trips.
+
+### No change — document the workaround
+
+Accept the over-aggressive gate and document that users should manually remove `fabrik:awaiting-ci` when non-required checks fail.
+
+**Rejected**: This places an operational burden on users for a class of failure that GitHub itself does not treat as blocking. The fix is clean, the correctness argument is strong, and the operator experience is materially better.
+
+## Predecessor Context
+
+- **ADR 027** (`027-ci-gate-and-fix-reinvoke.md`): Defines the two-prong CI gate structure that this ADR extends. ADR 033's shortcut applies *before* the per-check classification described in ADR 027 — it is additive, not a replacement.
+- **ADR 032** (`032-ci-gate-conjunctive-completion-label.md`): Defines `fabrik:awaiting-ci` semantics and `addCompleteLabelAndRemoveCI` as the gate-clearing function. The Prong 2 shortcut path calls the same function — fully compatible with ADR 032's conjunctive label design.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -169,6 +169,14 @@ or `poll:` in `config.yaml`).
 
 Rate-limit backoff uses two-threshold hysteresis to prevent thrashing: it **activates** when GraphQL remaining quota drops below **20%** of the hourly limit, and **clears only when quota rises above 50%** of the limit. Activity detection (items deep-fetched or dispatched) resets idle backoff but does NOT reset rate-limit backoff — the two concerns are independent. When rate-limit backoff is active, Fabrik logs the effective poll interval each cycle so operators can observe the actual cadence.
 
+**Board fetch resilience**: `FetchProjectBoard` automatically retries up to 3 times (with 1s/2s backoff) when GitHub returns fewer nodes than `totalCount` reports. This masks transient GitHub Projects v2 indexer degradation that intermittently returns empty or incomplete boards for non-empty projects. The log line:
+
+```
+[warn] project board fetch returned N items, totalCount=M (attempt X/3) — retrying in case of indexer hiccup
+```
+
+indicates the retry is occurring. It is transient and requires no user action unless it persists across all three attempts (in which case Fabrik accepts the last response and continues, which may appear as a temporarily idle engine).
+
 Move an issue to `Specify` on the board to start processing it.
 
 ### Git Repositories and Worktrees
@@ -944,15 +952,19 @@ The CI gate operates on two different paths depending on whether the item is bei
 
 **Merge guard (Validate+yolo auto-merge path):**
 - Checks CI before attempting the merge in `attemptMergeOnValidate()`
+- **`mergeable_state` shortcut (v0.0.52):** `attemptMergeOnValidate` queries GitHub's `mergeable_state` first; if `clean` or `unstable`, the gate clears immediately and proceeds to merge — per-check classification is skipped entirely
 - While CI is pending: returns an error (no label applied — avoids churn)
 - On CI failure: adds `fabrik:awaiting-ci`, returns error (skips merge)
 - On timeout (pending too long): pauses with `fabrik:paused` + `fabrik:awaiting-input`
 
 **Catch-up loop (all other paths):**
 - Evaluates CI on every poll for items with `fabrik:awaiting-ci` on stages with `wait_for_ci: true`
+- **`mergeable_state` shortcut (v0.0.52):** `checkCIGate` queries GitHub's `mergeable_state` first; if `clean` or `unstable`, `addCompleteLabelAndRemoveCI` runs immediately — stale `fabrik:awaiting-ci` is cleared, `stage:<X>:complete` is added, and per-check classification is skipped entirely
 - On pending: `fabrik:awaiting-ci` is already present (applied at FABRIK_STAGE_COMPLETE); no additional label applied, re-evaluates next poll
 - On failure: `fabrik:awaiting-ci` applied idempotently; dispatches CI-fix re-invocation
 - On timeout: pauses with `fabrik:paused` + `fabrik:awaiting-input`; timeout measured from when `fabrik:awaiting-ci` was first applied (durable across restarts)
+
+> **Rationale for the `mergeable_state` shortcut:** GitHub's `mergeable_state` reflects branch protection rules — it already aggregates required check status, reviewer approvals, and protection constraints. Non-required check_run failures (e.g., cleanup workflow jobs, notification steps) do not block merges per branch protection, so Fabrik's gate must not block on them either. Consulting `mergeable_state` first avoids over-aggressive blocking caused by raw per-check classification that cannot distinguish required from non-required checks.
 
 #### Merge-Conflict Gate
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -169,7 +169,7 @@ or `poll:` in `config.yaml`).
 
 Rate-limit backoff uses two-threshold hysteresis to prevent thrashing: it **activates** when GraphQL remaining quota drops below **20%** of the hourly limit, and **clears only when quota rises above 50%** of the limit. Activity detection (items deep-fetched or dispatched) resets idle backoff but does NOT reset rate-limit backoff — the two concerns are independent. When rate-limit backoff is active, Fabrik logs the effective poll interval each cycle so operators can observe the actual cadence.
 
-**Board fetch resilience**: `FetchProjectBoard` automatically retries up to 3 times (with 1s/2s backoff) when GitHub returns fewer nodes than `totalCount` reports. This masks transient GitHub Projects v2 indexer degradation that intermittently returns empty or incomplete boards for non-empty projects. The log line:
+**Board fetch resilience**: `FetchProjectBoard` automatically retries up to 3 times (with 1s/2s backoff) when GitHub returns an empty response (zero items), which occurs during transient Projects v2 indexer degradation that intermittently returns empty boards for non-empty projects (both returned node count and `totalCount` are zero in degraded responses). The log line:
 
 ```
 [warn] project board fetch returned N items, totalCount=M (attempt X/3) — retrying in case of indexer hiccup


### PR DESCRIPTION
## Summary

Update `docs/USER_GUIDE.md`, `README.md`, and create a new ADR to document the behavioral changes shipped in v0.0.51 and v0.0.52. The marketing site (`docs/index.md`) does not need changes — these are resilience fixes and bug fixes, not new user-facing features.

## Problem

Two behavioral changes shipped in v0.0.51 and v0.0.52 that affect observable engine behavior but are not yet reflected in user-facing documentation:

**v0.0.51 — Project board fetch resilience:** `FetchProjectBoard` now silently retries (up to 3 attempts, 1s/2s backoff) when GitHub's Projects v2 indexer returns fewer nodes than its reported `totalCount`. This masks transient GitHub indexer degradation that intermittently returned empty boards for non-empty projects. A `[warn] project board fetch returned N items, totalCount=M — retrying` log line is emitted during retries. Users who see this log line have no documentation explaining it.

**v0.0.52 — CI gate trusts `mergeable_state`:** The CI gate in `checkCIGate` and `attemptMergeOnValidate` now consults GitHub's `mergeable_state` field before classifying raw check_runs. When `mergeable_state` is `clean` or `unstable`, the gate clears immediately, bypassing the per-check classification. This fixes a long-standing bug where non-required check_run failures (e.g., `Cleanup artifacts` workflow jobs) blocked auto-merge even when GitHub's own branch protection reported the PR as mergeable. The `docs/state-machine.md` was updated as part of the v0.0.52 release, but `docs/USER_GUIDE.md` and `README.md` have not been updated.

## Approach

### Approach

This is a documentation-only PR with no code changes. The three files to touch are fully identified; the content for each is specified in the issue and research. The work is ordered so the ADR is created first (it is self-contained and provides authoritative rationale that the USER_GUIDE prose should echo), then USER_GUIDE, then README.

The ADR number `033` is confirmed — the current highest in `adrs/` is `032-ci-gate-conjunctive-completion-label.md`.

### New/Modified Files

| File | Change |
|------|--------|
| `adrs/033-mergeable-state-over-check-runs.md` | New ADR: trust `mergeable_state` over raw check_run classification |
| `docs/USER_GUIDE.md` | Add board-fetch resilience note in polling section (after rate-limit backoff, ~line 168); add `mergeable_state` shortcut to both prongs of Two-Prong CI Gate (~lines 945–955) |
| `README.md` | Add one sentence to CI gate blurb (~line 147) noting non-required failures don't block the gate |

### Key Decisions

- **ADR number hardcoded to 033.** Confirmed by listing `adrs/`; the highest current ADR is `032`. No parallel issue is expected to create an ADR concurrently, so the number is safe to hardcode in the checklist.
- **Log line quoted exactly from source.** The documentation must quote `project board fetch returned N items, totalCount=M (attempt X/3) — retrying in case of indexer hiccup` to match what users actually see in `fabrik.log`. The issue's simplified form (without attempt count) is inaccurate and would make the log harder to search.
- **Distinguish merge-guard vs catch-up behavior.** Research confirmed that in the merge-guard path (`attemptMergeOnValidate`) the shortcut proceeds directly to `MergePR` — there is no `addCompleteLabelAndRemoveCI` call. In the catch-up loop path (`checkCIGate`), `addCompleteLabelAndRemoveCI` is called explicitly. USER_GUIDE prose must reflect this distinction.
- **No ADR assessment needed for the other decisions.** Placement choices in USER_GUIDE (after rate-limit backoff paragraph, before blank line in README) are purely editorial — no architectural decision is being made. The ADR that *is* needed is the one the issue explicitly specifies (ADR 033).

### Task Checklist

- [ ] Task 1: Create `adrs/033-mergeable-state-over-check-runs.md` — new ADR documenting the decision to trust `mergeable_state` over raw check_run classification. Cover: context (over-aggressive per-check gate; liminis#716/717 real-world failure), decision (consult `mergeable_state` first; `clean`/`unstable` short-circuits; all other states fall through), rationale (GitHub branch protection is authoritative; replicating it in Fabrik is redundant and error-prone), alternatives considered (configurable ignore-list; Checks API `required` filter), status: Accepted, date: 2026-04-27. Reference ADR 027 and ADR 032 as predecessor context.

- [ ] Task 2: Update `docs/USER_GUIDE.md` — Polling section: insert a "**Board fetch resilience**" paragraph immediately after the rate-limit backoff paragraph (~line 168), before the "Move an issue to `Specify`…" line. Content: `FetchProjectBoard` automatically retries up to 3 times (with 1s/2s backoff) when GitHub returns fewer nodes than `totalCount` reports. The log line `[warn] project board fetch returned N items, totalCount=M (attempt X/3) — retrying in case of indexer hiccup` indicates the retry is occurring; it is transient and requires no user action unless it persists across all three attempts.

- [ ] Task 3: Update `docs/USER_GUIDE.md` — Two-Prong CI Gate section (~lines 945–955): prepend a `mergeable_state` shortcut bullet to each prong. **Merge guard:** before "While CI is pending", insert: `attemptMergeOnValidate` queries `mergeable_state` first; if `clean` or `unstable`, the gate clears immediately and proceeds to merge — per-check classification is skipped. **Catch-up loop:** before "On pending", insert: `checkCIGate` queries `mergeable_state` first; if `clean` or `unstable`, `addCompleteLabelAndRemoveCI` runs immediately, stale `fabrik:awaiting-ci` is cleared, and per-check classification is skipped. Add a rationale note: GitHub's `mergeable_state` reflects branch protection rules; non-required check_run failures do not block merges per branch protection, so Fabrik must not block on them either.

- [ ] Task 4: Update `README.md` — CI gate blurb (~line 147): append a sentence after "…address new-regression failures." noting that non-required check_run failures do not block the gate — Fabrik trusts GitHub's `mergeable_state` as the authoritative merge-readiness signal, so only failures that branch protection itself blocks on will prevent auto-merge.

### Risks

- **Log line paraphrase:** The only real risk is misquoting the exact log string. Implement must copy it verbatim from `github/project.go:146` — do not paraphrase.
- **Merge-guard vs catch-up distinction:** Getting the behavior wrong in USER_GUIDE prose (e.g., saying `addCompleteLabelAndRemoveCI` is called in the merge-guard path) would be inaccurate. The research note is clear: merge guard goes straight to `MergePR`; only catch-up calls `addCompleteLabelAndRemoveCI`.
- No ordering dependencies between tasks 2–4; they can be done in any order after Task 1.

---
Used 10/50 turns, 4k input / 2k output tokens.

## Verification

Created ADR 033 documenting the architectural decision to trust `mergeable_state` over raw check_run classification, with context from the liminis#716/717 incident, rationale, and alternatives considered. Updated `docs/USER_GUIDE.md` with a board-fetch resilience note (v0.0.51) in the polling section and `mergeable_state` shortcut bullets in both prongs of the Two-Prong CI Gate section (v0.0.52). Added a sentence to `README.md` clarifying that non-required check failures don't block the CI gate. All changes committed in 3 separate commits and pushed to `fabrik/issue-463`.

---

Closes #463