### PR TITLE
Update docs for v0.0.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ After 2 idle polls, Fabrik upgrades itself automatically and re-execs:
 - **Dev builds** (built from source via `go build`): detects local or remote commits
   ahead of the running binary and rebuilds in place from `origin/main`.
 
+When Fabrik is upgraded, it also compares your `.fabrik/stages/*.yaml` files against the embedded defaults and prints a startup warning for any stage file that is missing fields added in the newer binary. Run `fabrik refresh-stages --apply` to add the missing keys, then review with `git diff` and commit. See [Stage YAML Drift Warning](docs/USER_GUIDE.md#stage-yaml-drift-warning) in the User Guide for details.
+
 ## How It Works
 
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -322,7 +322,7 @@ See [§11 Troubleshooting → Startup Board Validation Failure](#startup-board-v
 After loading your stage YAMLs from `.fabrik/stages/`, Fabrik compares each stage against the embedded default with the same `name:` field. If the embedded default contains top-level YAML keys that your file does not, Fabrik prints a warning to stderr at startup:
 
 ```
-[startup] warning: .fabrik/stages/validate.yaml is missing fields present in v0.0.49 defaults: wait_for_ci, wait_for_reviews. Run `fabrik refresh-stages --apply` to add the missing keys.
+[startup] warning: .fabrik/stages/validate.yaml is missing fields present in v0.0.53 defaults: wait_for_ci, wait_for_reviews. Run `fabrik refresh-stages --apply` to add the missing keys.
 ```
 
 This warning is **informational only** — the engine continues running with your existing config. The missing keys are behavioral options added in a newer binary that your stage file predates.
@@ -1719,6 +1719,18 @@ Fabrik requires a **classic** personal access token (`ghp_...`). Fine-grained to
 On every startup, Fabrik fetches the project board and compares stage names in `.fabrik/stages/*.yaml` to the column names on the board. If any non-cleanup stage is missing from the board, Fabrik exits with an error listing the mismatched names.
 
 To fix: ensure stage YAML `name` fields match board column names exactly (case-sensitive). If you renamed a column on the board, update the matching stage YAML. Extra board columns (with no matching stage) produce a warning but don't block startup.
+
+### Stage YAML Drift Warning
+
+At startup, Fabrik prints a warning when a `.fabrik/stages/*.yaml` file is missing top-level keys that exist in the embedded defaults for the same stage name:
+
+```
+[startup] warning: .fabrik/stages/validate.yaml is missing fields present in v0.0.53 defaults: wait_for_ci, wait_for_reviews. Run `fabrik refresh-stages --apply` to add the missing keys.
+```
+
+This is informational — the engine continues running. It means your stage file predates behavioral options added in a newer binary.
+
+To resolve: run `fabrik refresh-stages --apply` to add the missing keys to your stage YAMLs, then `git diff` and `git commit` to record the update. See [§1 Stage YAML Drift Warning](#stage-yaml-drift-warning) for a full explanation and list of common keys.
 
 ### Issue Not Being Picked Up
 


### PR DESCRIPTION
## Summary

Update `README.md` and verify `docs/USER_GUIDE.md` correctly document the stage YAML drift detection feature introduced in v0.0.53. The USER_GUIDE already has a "Stage YAML Drift Warning" section (added in commit `bc874cf`). The README needs a single bullet pointing to this feature so users are aware of startup drift warnings.

## Problem

When Fabrik is upgraded, users with customized `.fabrik/stages/*.yaml` files may see new `[startup] warning: ...` messages they don't understand — these indicate their stage files predate new YAML fields added in a newer binary. Without documentation, users may be confused or alarmed by these warnings. This issue ensures the v0.0.53 drift-detection feature is properly surfaced in user-facing documentation.

## Approach

### Approach

This is a pure documentation change — three targeted edits across two files, no code changes. All three changes are independent and can be applied in any order.

**README.md placement decision**: Place the drift detection bullet at the end of the `Auto-upgrade` subsection (after line 68). The reasoning: drift warnings are resolved by running `fabrik upgrade`, so the natural reading path is "I see a drift warning → I should upgrade → I go to the Auto-upgrade section → the bullet explains what the warning was about." This aligns with spec option 2 (callout near Auto-upgrade) and avoids burying it in the dense Stage Configuration YAML block.

**USER_GUIDE.md §10 placement**: Insert the new troubleshooting entry immediately after the existing "Startup Board Validation Failure" entry (currently ending around line 1591). Drift warnings are also startup-time behavior, so grouping them with the board validation entry keeps startup issues together.

**No ADRs warranted**: These are editorial/documentation changes with no architectural decisions.

### New/Modified Files

| File | Change |
|------|--------|
| `README.md` | Add one bullet after the Auto-upgrade subsection about drift detection |
| `docs/USER_GUIDE.md` | Fix `v0.0.49` → `v0.0.53` in line 317 example; add "Stage YAML Drift Warning" entry in §10 after "Startup Board Validation Failure" |
| `docs/troubleshooting.md` | No change — it is a redirect stub; USER_GUIDE §10 additions cover it |

### Key Decisions

- **README placement near Auto-upgrade, not Stage Configuration**: The Stage Configuration section is already dense with a long YAML reference block. A drift warning note there would be visually lost. The Auto-upgrade section is short (4 lines of prose) and the resolution path — `fabrik upgrade` — is already the section's subject. Users who encounter the warning and search the README for "upgrade" land exactly here.
- **USER_GUIDE §10 entry after Startup Board Validation Failure**: Both are startup-time events. A user scanning §10 for startup problems will see them together. The board validation entry ends with a one-line fix; the drift entry should follow the same compact format.
- **No change to docs/troubleshooting.md**: Confirmed redirect stub — its 5 lines point to USER_GUIDE §10. Any §10 addition is automatically surfaced.

### Task Checklist

- [ ] **Task 1**: Update `docs/USER_GUIDE.md` line 317 — change `v0.0.49` to `v0.0.53` in the example warning message inside the "Stage YAML Drift Warning" section
- [ ] **Task 2**: Add a "Stage YAML Drift Warning" troubleshooting entry in `docs/USER_GUIDE.md §10` immediately after the "Startup Board Validation Failure" entry (after line 1591). The entry should: name the symptom (startup warning with missing fields), explain it means the stage YAML predates new embedded defaults, and give the fix (see §1 Stage YAML Drift Warning; run `fabrik upgrade`, review missing keys, merge manually).
- [ ] **Task 3**: Add one bullet to `README.md` at the end of the `Auto-upgrade` subsection (after line 68, before the `## How It Works` heading). The bullet should state that Fabrik prints a startup warning when `.fabrik/stages/*.yaml` files are missing fields from embedded defaults, and that running `fabrik upgrade` is the resolution path (with a cross-reference to USER_GUIDE drift warning section).

### Risks

- **None significant.** Pure doc edits with no behavioral impact. The only risk is a line-number drift from the research findings — verify exact insertion points by reading the files at implementation time rather than trusting the line numbers from research.

---
Used 10/50 turns, 3k input / 2k output tokens.

## Verification

Updated README.md and docs/USER_GUIDE.md to document the v0.0.53 stage YAML drift detection feature: fixed the example warning version from `v0.0.49` to `v0.0.53` in USER_GUIDE §1, added a "Stage YAML Drift Warning" troubleshooting entry in USER_GUIDE §10 after the "Startup Board Validation Failure" entry, and added a drift detection callout paragraph in README.md's Auto-upgrade subsection. All changes committed and pushed in one commit (`56fc2e4`).

---

Closes #467