### PR TITLE
fix(webhook): recognize HTTP 404 on /orgs|repos hooks as auth-shaped (closes #485)

### DIFF
--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -260,13 +260,27 @@ func detectOrgMode(repos map[string]bool) (string, bool) {
 // isAuthShapedError returns true when the stderr output suggests an authentication
 // or permission failure — used to distinguish org-mode permission denials from
 // transient crashes when the subprocess exits quickly.
+//
+// GitHub returns HTTP 404 (not 403) for permission-denied access to org and repo
+// resources, to avoid leaking org/repo existence. So we also recognize 404 errors
+// scoped to a /orgs/<org>/hooks or /repos/<owner>/<repo>/hooks endpoint as
+// auth-shaped. A bare 404 on any other path is not treated as auth-shaped to
+// avoid false positives on legitimate not-found errors.
 func isAuthShapedError(s string) bool {
 	lower := strings.ToLower(s)
-	return strings.Contains(lower, "403") ||
+	if strings.Contains(lower, "403") ||
 		strings.Contains(lower, "forbidden") ||
 		strings.Contains(lower, "permission denied") ||
 		strings.Contains(lower, "requires admin") ||
-		strings.Contains(lower, "not allowed")
+		strings.Contains(lower, "not allowed") {
+		return true
+	}
+	if strings.Contains(lower, "404") &&
+		(strings.Contains(lower, "/orgs/") || strings.Contains(lower, "/repos/")) &&
+		strings.Contains(lower, "/hooks") {
+		return true
+	}
+	return false
 }
 
 // containsEvent reports whether name is in the events slice.

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -121,6 +121,44 @@ func TestSemverAtLeast(t *testing.T) {
 	}
 }
 
+// TestIsAuthShapedError covers stderr-shape detection for org/repo permission denials.
+// GitHub returns 404 (not 403) for permission-denied access to org/repo resources to
+// avoid leaking existence — the matcher must recognize that shape on hooks endpoints
+// so the supervise loop falls back to per-repo mode instead of looping on transient
+// retries.
+func TestIsAuthShapedError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		// Classic auth-shaped messages.
+		{"403", "Error: HTTP 403", true},
+		{"forbidden", "Forbidden: insufficient scopes", true},
+		{"permission denied", "permission denied for hook", true},
+		{"requires admin", "this action requires admin access", true},
+		{"not allowed", "operation not allowed for this user", true},
+		// 404 on org hooks endpoint — the bug this test guards against.
+		{"404 on /orgs/.../hooks", "Error: error creating webhook: HTTP 404: Not Found (https://api.github.com/orgs/tenaciousvc/hooks)", true},
+		// 404 on repo hooks endpoint — symmetric per-repo case.
+		{"404 on /repos/.../hooks", "Error: error creating webhook: HTTP 404: Not Found (https://api.github.com/repos/tenaciousvc/fabrik/hooks)", true},
+		// Negative cases — bare 404s on other paths must not be treated as auth-shaped
+		// (false positives would cause permanent fallback on legitimate not-found errors).
+		{"404 unrelated path", "Error: HTTP 404: Not Found (https://api.github.com/users/missing)", false},
+		{"404 issues endpoint", "Error: HTTP 404: Not Found (https://api.github.com/repos/x/y/issues/9999)", false},
+		{"empty", "", false},
+		{"unrelated noise", "connection reset by peer", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isAuthShapedError(tc.in)
+			if got != tc.want {
+				t.Errorf("isAuthShapedError(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDetectOrgMode covers org detection from a repo set.
 func TestDetectOrgMode(t *testing.T) {
 	sameOrg := map[string]bool{"myorg/repo1": true, "myorg/repo2": true}


### PR DESCRIPTION
## Summary

Fixes the engine half of #485. GitHub returns HTTP **404** (not 403) for permission-denied access to org and repo resources, to avoid leaking existence. Fabrik's `isAuthShapedError` matcher only checked for 403/`forbidden`/etc., so an org-level webhook subscription that 404'd because the user lacked org admin was treated as a transient crash. The supervise loop restarted the subprocess every second forever, never falling back to per-repo mode.

This change adds a targeted 404 detector that requires the path component to include `/orgs/.../hooks` or `/repos/.../hooks` — keeping the matcher tight so legitimate 404s on unrelated endpoints don't cause spurious permanent fallback.

## Repro (before this fix)

1. `gh extension install cli/gh-webhook`
2. Set `webhooks: true` in a project where the user is a contributor but not an org admin.
3. Start fabrik. Tight restart loop with these log entries:

```
[webhook] [gh] Error: error creating webhook: HTTP 404: Not Found (https://api.github.com/orgs/<org>/hooks)
[webhook] org-level webhook exited in 253ms without permission error — treating as transient, retrying
[webhook] gh webhook forward exited: exit status 1 — restarting in 1s
```

## Validation

- Verified locally — fresh binary built from this branch falls back to per-repo mode after one probe cycle (issue #485 spec).
- New `TestIsAuthShapedError` covers: classic auth strings (existing behaviour preserved), 404 on `/orgs/.../hooks` (the bug), 404 on `/repos/.../hooks` (symmetric case), and 4 negative cases (bare 404 on unrelated paths must not be treated as auth-shaped).
- `go build ./...`, `go vet ./...`, `go test ./engine/...` all green.

## Out of scope (still tracked under #485)

- The companion **docs bug** in `docs/USER_GUIDE.md:1585` — claims the only prereq is `gh ≥ 2.32.0`, but `gh webhook` is the `cli/gh-webhook` extension and must be installed separately. That fix wants its own commit since it's a doc-only change with different review surface.

## Test plan

- [x] `go test ./engine/...` (TestIsAuthShapedError passes; existing webhook tests unaffected)
- [x] `go vet ./...`
- [ ] Smoke test on the fabrik dev instance — restart with this binary + `webhooks: true`, confirm log shows `org-level webhook failed (permission error...) — falling back to per-repo subscription` exactly once, then a stable per-repo subscription.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)