### PR TITLE
Bot-reviewer reprompt: use @copilot instead of @<login> for Copilot reviewer bots

### DIFF
--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -171,7 +171,7 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 						if err := e.client.AddReviewRequest(owner, repo, item.LinkedPRNumber, []string{login}); err != nil {
 							e.logf(item.Number, "warn", "phase 1: could not re-add review request for %s: %v\n", login, err)
 						}
-						msg := fmt.Sprintf("🏭 **Fabrik — review re-prompt**\n\n@%s just checking in — could you take a look at this PR?", login)
+						msg := fmt.Sprintf("🏭 **Fabrik — review re-prompt**\n\n@%s just checking in — could you take a look at this PR?", botMentionHandle(login))
 						if dbID, err := e.client.AddComment(owner, repo, item.LinkedPRNumber, msg); err != nil {
 							e.logf(item.Number, "warn", "phase 1: could not post re-prompt comment for %s: %v\n", login, err)
 						} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -485,4 +485,12 @@ func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.Projec
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
 	}
+}
+
+// botMentionHandle maps copilot-* logins to "copilot" — GitHub's canonical mention surface for the reviewer bot.
+func botMentionHandle(login string) string {
+	if strings.HasPrefix(login, "copilot") {
+		return "copilot"
+	}
+	return login
 }

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -489,7 +489,7 @@ func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.Projec
 
 // botMentionHandle maps copilot-* logins to "copilot" — GitHub's canonical mention surface for the reviewer bot.
 func botMentionHandle(login string) string {
-	if strings.HasPrefix(login, "copilot") {
+	if strings.HasPrefix(strings.ToLower(login), "copilot") {
 		return "copilot"
 	}
 	return login

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -617,6 +617,13 @@ func TestCheckReviewGate_BotPhase1_Reprompts(t *testing.T) {
 	if client.addCommentCalls[0].issueNumber != 42 {
 		t.Errorf("expected comment on PR #42, got #%d", client.addCommentCalls[0].issueNumber)
 	}
+	// Copilot login must be mentioned as @copilot, not @copilot-pull-request-reviewer.
+	if !strings.Contains(client.addCommentCalls[0].body, "@copilot") {
+		t.Errorf("expected @copilot in reprompt comment body, got: %q", client.addCommentCalls[0].body)
+	}
+	if strings.Contains(client.addCommentCalls[0].body, "@copilot-pull-request-reviewer") {
+		t.Errorf("reprompt comment must not contain @copilot-pull-request-reviewer, got: %q", client.addCommentCalls[0].body)
+	}
 
 	// fabrik:bot-reprompted label should have been applied once (not per-login).
 	var foundReprompted bool
@@ -944,4 +951,60 @@ func containsAll(s string, subs ...string) bool {
 // boolPtr is a helper to create a *bool from a bool literal.
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func TestBotMentionHandle(t *testing.T) {
+	cases := []struct {
+		login string
+		want  string
+	}{
+		{"copilot-pull-request-reviewer", "copilot"},
+		{"copilot", "copilot"},
+		{"dependabot[bot]", "dependabot[bot]"},
+		{"someuser", "someuser"},
+	}
+	for _, tc := range cases {
+		got := botMentionHandle(tc.login)
+		if got != tc.want {
+			t.Errorf("botMentionHandle(%q) = %q, want %q", tc.login, got, tc.want)
+		}
+	}
+}
+
+// Phase 1: non-Copilot bot reviewer — reprompt comment must mention @<login> directly.
+func TestCheckReviewGate_BotPhase1_NonCopilot_MentionsLogin(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := reviewTestEngine(client)
+	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
+
+	awaitingApplied := time.Now().Add(-10 * time.Minute)
+	client.fetchLabelAppliedAtFn = func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+		if labelName == "fabrik:awaiting-review" {
+			return awaitingApplied, nil
+		}
+		return time.Time{}, nil
+	}
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		LinkedPRNumber: 42,
+		Labels:         []string{"fabrik:awaiting-review"},
+		LinkedPRReviewRequests: []gh.ReviewRequest{
+			{Login: "dependabot[bot]", IsBot: true},
+		},
+		LinkedPRReviews: nil,
+	}
+	stage := &stages.Stage{Name: "Implement", WaitForReviews: boolPtr(true)}
+
+	eng.checkReviewGate(board, item, stage)
+
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected 1 PR @mention comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if !strings.Contains(body, "@dependabot[bot]") {
+		t.Errorf("expected @dependabot[bot] in reprompt comment body, got: %q", body)
+	}
 }

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -960,6 +960,7 @@ func TestBotMentionHandle(t *testing.T) {
 	}{
 		{"copilot-pull-request-reviewer", "copilot"},
 		{"copilot", "copilot"},
+		{"Copilot-pull-request-reviewer", "copilot"},
 		{"dependabot[bot]", "dependabot[bot]"},
 		{"someuser", "someuser"},
 	}


### PR DESCRIPTION
## Summary

Add a `botMentionHandle` helper in `engine/reviews.go` that maps any login starting with `copilot` to the canonical `@copilot` mention handle. Use it when building the Phase 1 reprompt comment body. The DELETE+POST review-request API calls continue to use the literal login unchanged.

## Problem

Fabrik's Phase 1 bot-reviewer reprompt currently @-mentions the reviewer's literal GitHub login. For Copilot, that login is `copilot-pull-request-reviewer`:

```go
// engine/reviews.go:174
msg := fmt.Sprintf("🏭 **Fabrik — review re-prompt**\n\n@%s just checking in — could you take a look at this PR?", login)
```

Posting `@copilot-pull-request-reviewer` doesn't reliably wake the reviewer bot. Observed on PR #468 (issue #467):

- 2026-05-02T23:59:25Z — Fabrik posted: `@copilot-pull-request-reviewer just checking in...`
- 2026-05-03T00:06:32Z — `copilot-swe-agent` (a *different* Copilot bot — the coding agent, not the reviewer) responded with a comment about firewall rules.
- The reviewer bot (`copilot-pull-request-reviewer`) **never submitted a review**.
- `fabrik:awaiting-review` and `fabrik:bot-reprompted` remain set; the gate is now waiting for Phase 2 timeout to advance past the unresponsive bot.

The mention got cross-routed to the wrong Copilot product because `copilot-pull-request-reviewer` is GitHub's internal user identifier for the reviewer bot, not its user-facing mention name.

`@copilot` is GitHub's canonical mention surface for Copilot — it routes to the appropriate Copilot context (reviewer when on a PR, agent when given a coding task) and is what humans actually use to summon Copilot.

## Approach

### Approach

This is a minimal, targeted bug fix. Add a single unexported helper function `botMentionHandle(login string) string` to `engine/reviews.go` that maps any login with the `copilot` prefix to the canonical `@copilot` mention handle, then apply it at the one call site (line 174) where the Phase 1 comment body is constructed. Everything else — DELETE+POST review-request API calls, gate logic, label state, timing — stays exactly the same.

The `strings` package is already imported; no new imports or dependencies are needed.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/reviews.go` | Add `botMentionHandle` helper function; apply it at Phase 1 comment construction (line 174) |
| `engine/reviews_test.go` | Add `TestBotMentionHandle` unit test covering Copilot login and non-Copilot login branches |

### Key Decisions

- **Helper is unexported**: `botMentionHandle` is a private formatting utility with no callers outside `engine/reviews.go`. Exporting it would widen the API surface unnecessarily.
- **Login prefix `"copilot"` is the sole detection criterion**: The spec explicitly rules out detection via user type `Bot`, app slug, or any other mechanism. `strings.HasPrefix(login, "copilot")` matches `copilot-pull-request-reviewer` and any other Copilot-family logins without over-engineering.
- **Direct unit test of the helper** (not only via `checkReviewGate`): Testing `botMentionHandle` directly is simpler and more precise than constructing a full `checkReviewGate` fixture for each mention-handle branch. A `checkReviewGate`-level test that asserts `addCommentCalls[0].body` is also added to close the gap the research identified.
- **No ADR warranted**: This is a one-line behavioral correction within an existing, already-documented mechanism. The decision (map Copilot logins to `@copilot`) doesn't constrain future contributors in a non-obvious way and doesn't need to be discoverable outside the code and commit history.

### Task Checklist

- [ ] Task 1: Add `botMentionHandle(login string) string` to `engine/reviews.go` — place it near the Phase 1 block (after line 186 or as a package-level helper at the bottom of the file); implement using `strings.HasPrefix(login, "copilot")` → return `"copilot"`, else return `login`
- [ ] Task 2: Apply `botMentionHandle` at line 174 — replace `login` with `botMentionHandle(login)` in the `fmt.Sprintf` that builds the Phase 1 PR comment body; leave both `login` usages in the DELETE+POST review-request calls unchanged
- [ ] Task 3: Add `TestBotMentionHandle` in `engine/reviews_test.go` — table-driven test covering: `"copilot-pull-request-reviewer"` → `"copilot"`, `"copilot"` → `"copilot"`, `"dependabot[bot]"` → `"dependabot[bot]"`, `"someuser"` → `"someuser"`
- [ ] Task 4: Add a body assertion to the existing `TestCheckReviewGate_BotPhase1_Reprompts` test (or add a new sibling test) that verifies `client.addCommentCalls[0].body` contains `@copilot` when the bot login starts with `copilot`, and `@<login>` for a non-Copilot bot
- [ ] Task 5: Run `go test ./engine/... -race` and `go vet ./...` — confirm all tests pass and no races are introduced

### Risks

- None material. The change is two lines of production code and a test. No interface changes, no new packages, no concurrency surface.

---
Used 5/50 turns, 3k input / 1k output tokens.

## Verification

Added `botMentionHandle` helper to `engine/reviews.go` that maps any login with the `copilot` prefix to `"copilot"`, and applied it at the Phase 1 reprompt comment construction site. Added `TestBotMentionHandle` (table-driven, 4 cases) and `TestCheckReviewGate_BotPhase1_NonCopilot_MentionsLogin` in `engine/reviews_test.go`, plus body assertions in the existing `TestCheckReviewGate_BotPhase1_Reprompts` test. All tests pass with `-race`; `go vet` is clean.

---

Closes #484