### PR TITLE
Rate-limit backoff doesn't escalate — flat 2× multiplier defeats the documented 10× cap

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -166,9 +166,16 @@ or `poll:` in `config.yaml`).
 | 10–20 min | 4× | 120s |
 | 20+ min | max (5 minutes) | 300s |
 
-**Rate-limit backoff**: When Fabrik detects GraphQL API quota pressure, the same interval infrastructure adds a separate rate-limit component. This component is capped at `10 × configured poll interval` (300s at the default 30s base; 600s at 60s base) — there is no separate 5-minute ceiling for the rate-limit contributor. The effective poll interval is `max(idle interval, rate-limit interval)`, so whichever is larger governs at any given moment.
+**Rate-limit backoff**: When Fabrik detects GraphQL API quota pressure, the same interval infrastructure adds a separate rate-limit component that escalates as quota depletes. There is no separate 5-minute ceiling for the rate-limit contributor — it can exceed 5 minutes when the configured base interval is large. The effective poll interval is `max(idle interval, rate-limit interval)`, so whichever is larger governs at any given moment.
 
-Rate-limit backoff uses two-threshold hysteresis to prevent thrashing: it **activates** when GraphQL remaining quota drops below **20%** of the hourly limit, and **clears only when quota rises above 50%** of the limit. Activity detection (items deep-fetched or dispatched) resets idle backoff but does NOT reset rate-limit backoff — the two concerns are independent. When rate-limit backoff is active, Fabrik logs the effective poll interval each cycle so operators can observe the actual cadence.
+| Remaining GraphQL quota | Multiplier | At 30s base | At 60s base |
+|---|---|---|---|
+| 10%–20% (backoff active) | 2× | 60s | 120s |
+| 5%–10% | 4× | 120s | 240s |
+| 1%–5% | 6× | 180s | 360s |
+| < 1% | 10× (cap) | 300s | 600s |
+
+Rate-limit backoff uses two-threshold hysteresis to prevent thrashing: it **activates** when GraphQL remaining quota drops below **20%** of the hourly limit, and **clears only when quota rises above 50%** of the limit. While quota is recovering (20%–50%, sticky zone), the 2× tier applies. Activity detection (items deep-fetched or dispatched) resets idle backoff but does NOT reset rate-limit backoff — the two concerns are independent. When rate-limit backoff is active, Fabrik logs the effective poll interval each cycle so operators can observe the actual cadence.
 
 **Board fetch resilience**: `FetchProjectBoard` automatically retries up to 3 times (with 1s/2s backoff) when GitHub returns an empty response (zero items), which occurs during transient Projects v2 indexer degradation that intermittently returns empty boards for non-empty projects (both returned node count and `totalCount` are zero in degraded responses). The log line:
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -170,10 +170,10 @@ or `poll:` in `config.yaml`).
 
 | Remaining GraphQL quota | Multiplier | At 30s base | At 60s base |
 |---|---|---|---|
-| 10%–20% (backoff active) | 2× | 60s | 120s |
-| 5%–10% | 4× | 120s | 240s |
-| 1%–5% | 6× | 180s | 360s |
-| < 1% | 10× (cap) | 300s | 600s |
+| >=10% (incl. sticky zone 20%–50%) | 2× | 60s | 120s |
+| >=5% and <10% | 4× | 120s | 240s |
+| >=1% and <5% | 6× | 180s | 360s |
+| <1% | 10× (cap) | 300s | 600s |
 
 Rate-limit backoff uses two-threshold hysteresis to prevent thrashing: it **activates** when GraphQL remaining quota drops below **20%** of the hourly limit, and **clears only when quota rises above 50%** of the limit. While quota is recovering (20%–50%, sticky zone), the 2× tier applies. Activity detection (items deep-fetched or dispatched) resets idle backoff but does NOT reset rate-limit backoff — the two concerns are independent. When rate-limit backoff is active, Fabrik logs the effective poll interval each cycle so operators can observe the actual cadence.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -933,7 +933,7 @@ The poll loop's effective interval grows when there is nothing to do (idle backo
 - Base interval: `PollSeconds` (default 30s).
 - Activity multiplier: doubles each poll cycle where no work was dispatched, up to the idle cap.
 - Activity reset: any dispatched work OR any received webhook event resets `idleStart` and the multiplier back to 1×.
-- Rate-limit adjustment: when the GitHub API signals rate limit pressure (`rateLimitLow`), `computeEffectiveInterval` doubles the configured interval for rate-limit backoff, capped at `rateLimitMaxBackoffMultiplier×` the configured interval.
+- Rate-limit adjustment: when `rateLimitRatio < 1.0` (backoff active), `computeEffectiveInterval` applies a stepwise escalation — 2× at 10%–100% remaining (including the 20%–50% sticky hysteresis zone), 4× at 5%–10%, 6× at 1%–5%, and 10× (`rateLimitMaxBackoffMultiplier`) below 1%. The rate-limit component has no 5-minute ceiling; only the caller-supplied `rateLimitMaxBackoffMultiplier` cap applies.
 
 **Idle cap selection** (`effectiveIdleCap` in `engine/poll.go`):
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -933,7 +933,12 @@ The poll loop's effective interval grows when there is nothing to do (idle backo
 - Base interval: `PollSeconds` (default 30s).
 - Activity multiplier: doubles each poll cycle where no work was dispatched, up to the idle cap.
 - Activity reset: any dispatched work OR any received webhook event resets `idleStart` and the multiplier back to 1×.
-- Rate-limit adjustment: when `rateLimitRatio < 1.0` (backoff active), `computeEffectiveInterval` applies a stepwise escalation — 2× at >=10% remaining (including the 20%–50% sticky hysteresis zone), 4× at >=5% and <10%, 6× at >=1% and <5%, and 10× (`rateLimitMaxBackoffMultiplier`) below 1%. The rate-limit component has no 5-minute ceiling; only the caller-supplied `rateLimitMaxBackoffMultiplier` cap applies.
+- Rate-limit adjustment (`nextRateLimitLow` + `computeEffectiveInterval` in `engine/poll.go`):
+  - **Activation**: rate-limit backoff engages when remaining GraphQL quota drops below 20% (`rateLimitBackoffThreshold`). The actual remaining fraction is passed to `computeEffectiveInterval` as `rateLimitRatio`.
+  - **Clearance**: backoff clears only when quota rises above 50% (`rateLimitHealthyThreshold`). Between 20% and 50% the state is sticky — backoff remains active to prevent thrashing on boards where quota fluctuates near the activation point.
+  - **Stepwise escalation**: the multiplier scales with depletion depth — 2× at >=10% remaining (includes the 20%–50% sticky zone), 4× at >=5% and <10%, 6× at >=1% and <5%, 10× (`rateLimitMaxBackoffMultiplier`) below 1%.
+  - **No idle cap**: the rate-limit component has no 5-minute ceiling; it is capped only at `rateLimitMaxBackoffMultiplier × configuredInterval`.
+  - **Independence from idle backoff**: activity detection (items dispatched or webhooks received) resets idle backoff but does NOT reset rate-limit backoff.
 
 **Idle cap selection** (`effectiveIdleCap` in `engine/poll.go`):
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -933,7 +933,7 @@ The poll loop's effective interval grows when there is nothing to do (idle backo
 - Base interval: `PollSeconds` (default 30s).
 - Activity multiplier: doubles each poll cycle where no work was dispatched, up to the idle cap.
 - Activity reset: any dispatched work OR any received webhook event resets `idleStart` and the multiplier back to 1×.
-- Rate-limit adjustment: when `rateLimitRatio < 1.0` (backoff active), `computeEffectiveInterval` applies a stepwise escalation — 2× at 10%–100% remaining (including the 20%–50% sticky hysteresis zone), 4× at 5%–10%, 6× at 1%–5%, and 10× (`rateLimitMaxBackoffMultiplier`) below 1%. The rate-limit component has no 5-minute ceiling; only the caller-supplied `rateLimitMaxBackoffMultiplier` cap applies.
+- Rate-limit adjustment: when `rateLimitRatio < 1.0` (backoff active), `computeEffectiveInterval` applies a stepwise escalation — 2× at >=10% remaining (including the 20%–50% sticky hysteresis zone), 4× at >=5% and <10%, 6× at >=1% and <5%, and 10× (`rateLimitMaxBackoffMultiplier`) below 1%. The rate-limit component has no 5-minute ceiling; only the caller-supplied `rateLimitMaxBackoffMultiplier` cap applies.
 
 **Idle cap selection** (`effectiveIdleCap` in `engine/poll.go`):
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -82,7 +82,16 @@ func effectiveIdleCap(webhookHealthy bool) time.Duration {
 // idle backoff and rate-limit backoff. The result is max(idle, rateLimit).
 // The idle component is capped at effectiveIdleCap(webhookHealthy); the rate-limit
 // component uses its own cap (rateLimitMaxBackoffMultiplier × configured).
-func computeEffectiveInterval(configuredInterval time.Duration, idleDuration time.Duration, rateLimitLow bool, webhookHealthy bool) time.Duration {
+//
+// rateLimitRatio is the remaining-to-total GraphQL quota fraction. Pass 1.0 when
+// no rate-limit backoff is active; pass the actual fraction when backoff is active.
+// The stepwise escalation schedule (activates when ratio < 1.0):
+//
+//	10%–100% remaining: 2× configured  (includes sticky hysteresis zone 20%–50%)
+//	 5%–10% remaining:  4× configured
+//	 1%– 5% remaining:  6× configured
+//	  < 1% remaining:  10× configured  (rateLimitMaxBackoffMultiplier)
+func computeEffectiveInterval(configuredInterval time.Duration, idleDuration time.Duration, rateLimitRatio float64, webhookHealthy bool) time.Duration {
 	cap := effectiveIdleCap(webhookHealthy)
 
 	var idleInterval time.Duration
@@ -97,8 +106,19 @@ func computeEffectiveInterval(configuredInterval time.Duration, idleDuration tim
 	}
 
 	rateLimitInterval := configuredInterval
-	if rateLimitLow {
-		rateLimitInterval = configuredInterval * 2
+	if rateLimitRatio < 1.0 {
+		var rlMult int
+		switch {
+		case rateLimitRatio >= 0.10:
+			rlMult = 2
+		case rateLimitRatio >= 0.05:
+			rlMult = 4
+		case rateLimitRatio >= 0.01:
+			rlMult = 6
+		default:
+			rlMult = rateLimitMaxBackoffMultiplier
+		}
+		rateLimitInterval = configuredInterval * time.Duration(rlMult)
 		maxRL := configuredInterval * time.Duration(rateLimitMaxBackoffMultiplier)
 		if rateLimitInterval > maxRL {
 			rateLimitInterval = maxRL
@@ -301,6 +321,7 @@ func (e *Engine) Run() error {
 
 	prevMultiplier := 1
 	rateLimitLow := false
+	rateLimitRatio := 1.0
 
 	// doPollCycle runs poll(), updates idle/backoff state, emits PollCompletedEvent,
 	// and resets the ticker to the effective interval. Returns the error from poll().
@@ -333,6 +354,11 @@ func (e *Engine) Run() error {
 				e.logf(0, "poll", "GraphQL rate limit recovered (%.0f%% remaining)\n", ratio*100)
 			}
 			rateLimitLow = newRateLimitLow
+			if rateLimitLow {
+				rateLimitRatio = ratio
+			} else {
+				rateLimitRatio = 1.0
+			}
 		}
 
 		// Compute and apply effective interval.
@@ -341,7 +367,7 @@ func (e *Engine) Run() error {
 			idleDuration = time.Since(e.idleStart)
 		}
 		webhookHealthy := e.webhookMgr != nil && e.webhookMgr.IsHealthyOrStartingUp()
-		effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, rateLimitLow, webhookHealthy)
+		effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, rateLimitRatio, webhookHealthy)
 
 		// Notify webhook manager of any new repos discovered during this poll.
 		if e.webhookMgr != nil && result.SeenRepos != nil {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -87,10 +87,10 @@ func effectiveIdleCap(webhookHealthy bool) time.Duration {
 // no rate-limit backoff is active; pass the actual fraction when backoff is active.
 // The stepwise escalation schedule (activates when ratio < 1.0):
 //
-//	10%–100% remaining: 2× configured  (includes sticky hysteresis zone 20%–50%)
-//	 5%–10% remaining:  4× configured
-//	 1%– 5% remaining:  6× configured
-//	  < 1% remaining:  10× configured  (rateLimitMaxBackoffMultiplier)
+//	>=10% remaining: 2× configured  (includes sticky hysteresis zone 20%–50%)
+//	>=5% and <10%:   4× configured
+//	>=1% and <5%:    6× configured
+//	    <1%:        10× configured  (rateLimitMaxBackoffMultiplier)
 func computeEffectiveInterval(configuredInterval time.Duration, idleDuration time.Duration, rateLimitRatio float64, webhookHealthy bool) time.Duration {
 	cap := effectiveIdleCap(webhookHealthy)
 

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1076,8 +1076,11 @@ func TestComputeEffectiveInterval_RateLimitStepwise(t *testing.T) {
 		{"not in backoff (1.0)", 1.0, 30 * time.Second},
 		{"sticky zone (0.35)", 0.35, 60 * time.Second},
 		{"active 10-20% (0.15)", 0.15, 60 * time.Second},
+		{"boundary exactly 10% (0.10)", 0.10, 60 * time.Second},  // >=0.10 → 2× tier
 		{"just below 10% (0.099)", 0.099, 2 * time.Minute},
+		{"boundary exactly 5% (0.05)", 0.05, 2 * time.Minute},    // >=0.05 → 4× tier
 		{"just below 5% (0.049)", 0.049, 3 * time.Minute},
+		{"boundary exactly 1% (0.01)", 0.01, 3 * time.Minute},    // >=0.01 → 6× tier
 		{"just below 1% (0.009)", 0.009, 5 * time.Minute},
 		{"zero remaining (0.0)", 0.0, 5 * time.Minute},
 	}

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -968,27 +968,27 @@ func TestComputeEffectiveInterval(t *testing.T) {
 	base := 30 * time.Second
 
 	cases := []struct {
-		name         string
-		idle         time.Duration
-		rateLimitLow bool
-		want         time.Duration
+		name           string
+		idle           time.Duration
+		rateLimitRatio float64
+		want           time.Duration
 	}{
-		{"no idle no rateLimit", 0, false, 30 * time.Second},
-		{"3min idle no rateLimit", 3 * time.Minute, false, 30 * time.Second},
-		{"6min idle (2x)", 6 * time.Minute, false, 60 * time.Second},
-		{"12min idle (4x)", 12 * time.Minute, false, 2 * time.Minute},
-		{"25min idle (max)", 25 * time.Minute, false, 5 * time.Minute},
-		{"rateLimit only", 0, true, 60 * time.Second},
-		{"idle 2x wins over rateLimit 2x", 6 * time.Minute, true, 60 * time.Second},
-		{"idle 4x wins over rateLimit 2x", 12 * time.Minute, true, 2 * time.Minute},
-		{"rateLimit 2x wins over idle 1x", 3 * time.Minute, true, 60 * time.Second},
+		{"no idle no rateLimit", 0, 1.0, 30 * time.Second},
+		{"3min idle no rateLimit", 3 * time.Minute, 1.0, 30 * time.Second},
+		{"6min idle (2x)", 6 * time.Minute, 1.0, 60 * time.Second},
+		{"12min idle (4x)", 12 * time.Minute, 1.0, 2 * time.Minute},
+		{"25min idle (max)", 25 * time.Minute, 1.0, 5 * time.Minute},
+		{"rateLimit only (2x tier)", 0, 0.15, 60 * time.Second},
+		{"idle 2x wins over rateLimit 2x", 6 * time.Minute, 0.15, 60 * time.Second},
+		{"idle 4x wins over rateLimit 2x", 12 * time.Minute, 0.15, 2 * time.Minute},
+		{"rateLimit 2x wins over idle 1x", 3 * time.Minute, 0.15, 60 * time.Second},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := computeEffectiveInterval(base, tc.idle, tc.rateLimitLow, false)
+			got := computeEffectiveInterval(base, tc.idle, tc.rateLimitRatio, false)
 			if got != tc.want {
 				t.Errorf("computeEffectiveInterval(%v, %v, %v, false) = %v, want %v",
-					base, tc.idle, tc.rateLimitLow, got, tc.want)
+					base, tc.idle, tc.rateLimitRatio, got, tc.want)
 			}
 		})
 	}
@@ -998,43 +998,97 @@ func TestComputeEffectiveInterval_CapAt5Min(t *testing.T) {
 	// With a large configured interval (e.g. 3 minutes), 4x would be 12min,
 	// but we cap at 5 minutes.
 	base := 3 * time.Minute
-	got := computeEffectiveInterval(base, 12*time.Minute, false, false)
+	got := computeEffectiveInterval(base, 12*time.Minute, 1.0, false)
 	if got != 5*time.Minute {
 		t.Errorf("expected cap at 5m, got %v", got)
 	}
 
 	// Even 2x of 3 minutes (= 6min) should cap at 5min.
-	got = computeEffectiveInterval(base, 6*time.Minute, false, false)
+	got = computeEffectiveInterval(base, 6*time.Minute, 1.0, false)
 	if got != 5*time.Minute {
 		t.Errorf("expected cap at 5m for 2x of 3min base, got %v", got)
 	}
 
 	// With webhookHealthy=true the cap rises to 60 min.
-	got = computeEffectiveInterval(base, 60*time.Minute, false, true)
+	got = computeEffectiveInterval(base, 60*time.Minute, 1.0, true)
 	if got != webhookIdleCap {
 		t.Errorf("expected webhookIdleCap (%v) when webhook healthy, got %v", webhookIdleCap, got)
 	}
 }
 
 func TestComputeEffectiveInterval_MaxIdleRateLimit(t *testing.T) {
-	// Both backoffs active: idle at max (5min) and rate limit at 2x.
-	// max(5min, 2*30s=1min) = 5min.
 	base := 30 * time.Second
-	got := computeEffectiveInterval(base, 25*time.Minute, true, false)
+
+	// Both backoffs active: idle at max (5min) and rate limit at 2× tier (0.15).
+	// max(5min, 2*30s=60s) = 5min.
+	got := computeEffectiveInterval(base, 25*time.Minute, 0.15, false)
 	if got != 5*time.Minute {
-		t.Errorf("expected 5m, got %v", got)
+		t.Errorf("expected 5m (idle wins over 2× rate-limit), got %v", got)
+	}
+
+	// Both backoffs active: idle at max (5min) and rate limit at 10× tier (0.005).
+	// 10×30s = 300s = 5min. max(5min, 5min) = 5min (tie — idle cap governs).
+	got = computeEffectiveInterval(base, 25*time.Minute, 0.005, false)
+	if got != 5*time.Minute {
+		t.Errorf("expected 5m (tie: idle cap == 10× rate-limit at 30s base), got %v", got)
 	}
 }
 
 func TestComputeEffectiveInterval_RateLimitExceeds5Min(t *testing.T) {
 	// Rate-limit backoff alone can exceed 5 minutes (the idle cap doesn't apply).
-	// With 3min base and rateLimitLow=true, rate-limit interval = 6min.
-	// Idle is not active (0 duration), so idleInterval = 3min.
-	// max(3min, 6min) = 6min — the 5min idle cap must NOT clamp this.
+	// Idle is not active (0 duration), so idleInterval = 3min base.
 	base := 3 * time.Minute
-	got := computeEffectiveInterval(base, 0, true, false)
+
+	// ratio=0.15 (2× tier): rate-limit interval = 2*3min = 6min.
+	// max(3min, 6min) = 6min — the 5min idle cap must NOT clamp this.
+	got := computeEffectiveInterval(base, 0, 0.15, false)
 	if got != 6*time.Minute {
-		t.Errorf("expected 6m (rate-limit 2x of 3min base), got %v", got)
+		t.Errorf("expected 6m (2× of 3min base), got %v", got)
+	}
+
+	// ratio=0.07 (4× tier): rate-limit interval = 4*3min = 12min.
+	got = computeEffectiveInterval(base, 0, 0.07, false)
+	if got != 12*time.Minute {
+		t.Errorf("expected 12m (4× of 3min base), got %v", got)
+	}
+
+	// ratio=0.03 (6× tier): rate-limit interval = 6*3min = 18min.
+	got = computeEffectiveInterval(base, 0, 0.03, false)
+	if got != 18*time.Minute {
+		t.Errorf("expected 18m (6× of 3min base), got %v", got)
+	}
+
+	// ratio=0.005 (10× tier): rate-limit interval = 10*3min = 30min.
+	got = computeEffectiveInterval(base, 0, 0.005, false)
+	if got != 30*time.Minute {
+		t.Errorf("expected 30m (10× of 3min base), got %v", got)
+	}
+}
+
+func TestComputeEffectiveInterval_RateLimitStepwise(t *testing.T) {
+	base := 30 * time.Second
+
+	cases := []struct {
+		name  string
+		ratio float64
+		want  time.Duration
+	}{
+		{"not in backoff (1.0)", 1.0, 30 * time.Second},
+		{"sticky zone (0.35)", 0.35, 60 * time.Second},
+		{"active 10-20% (0.15)", 0.15, 60 * time.Second},
+		{"just below 10% (0.099)", 0.099, 2 * time.Minute},
+		{"just below 5% (0.049)", 0.049, 3 * time.Minute},
+		{"just below 1% (0.009)", 0.009, 5 * time.Minute},
+		{"zero remaining (0.0)", 0.0, 5 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeEffectiveInterval(base, 0, tc.ratio, false)
+			if got != tc.want {
+				t.Errorf("computeEffectiveInterval(30s, 0, %v, false) = %v, want %v",
+					tc.ratio, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix `computeEffectiveInterval` to accept the actual remaining rate-limit ratio and implement a proper escalation curve that scales the poll multiplier from 2× (at ~20% budget) up to 10× (at or near 0% budget), capping at `rateLimitMaxBackoffMultiplier × configuredInterval`. Update the tests and `docs/USER_GUIDE.md` to match.

## Problem

When the GraphQL rate-limit ratio drops below 20%, the engine logs `[poll] rate-limit backoff active — effective poll interval: <interval>` but the interval **never escalates beyond 2× the configured poll interval**, regardless of how depleted the budget gets. The documented "cap at 10× configured" is dead code.

## Approach

### Approach

Fix `computeEffectiveInterval` in `engine/poll.go` by replacing its `rateLimitLow bool` parameter with `rateLimitRatio float64`, then implement the stepwise escalation curve recommended by Research. The call site in `doPollCycle` must be updated to track and pass the actual ratio. Tests are rewritten to cover all four escalation tiers. Two docs files are updated to reflect the actual behavior.

**Escalation curve chosen: Stepwise** (Research recommendation, confirmed here)

Four tiers mirroring `idleBackoffMultiplier`'s switch-statement pattern:

| Remaining quota | Multiplier | At 30s base | At 60s base |
|---|---|---|---|
| 10%–20% | 2× | 60s | 120s |
| 5%–10% | 4× | 120s | 240s |
| 1%–5% | 6× | 180s | 360s |
| < 1% | 10× | 300s | 600s |

**Sentinel design for "not in backoff"**: `rateLimitRatio = 1.0`. The activation guard inside `computeEffectiveInterval` becomes `if rateLimitRatio < 1.0`. This avoids coupling the activation check to `rateLimitBackoffThreshold` and correctly handles the sticky zone (ratio 20%–50%: caller passes actual ratio when `rateLimitLow == true`, which lands in the default 2× tier since no escalation tiers cover that range).

**Caller design**: Add `rateLimitRatio float64 = 1.0` as a closure variable alongside `rateLimitLow` in `doPollCycle`. Inside `if graphqlStats.Limit > 0`, update `rateLimitRatio = ratio` when `rateLimitLow` is true after the hysteresis update, or reset to `1.0` when `rateLimitLow` is false. Pass `rateLimitRatio` instead of `rateLimitLow` to `computeEffectiveInterval`.

**No ADR needed**: This is an implementation bug fix completing originally-intended behavior. ADR 028 covers hysteresis (unchanged). The escalation curve choice (stepwise vs. linear) does not constrain future contributors in a non-obvious way.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/poll.go` | Change `computeEffectiveInterval` signature + stepwise rate-limit logic; add `rateLimitRatio` closure var + update call site in `doPollCycle` |
| `engine/poll_test.go` | Rewrite 4 existing rate-limit test functions; add new escalation tier coverage |
| `docs/USER_GUIDE.md` | Replace rate-limit backoff paragraph with a tiered-table description (§1, lines ~169–171) |
| `docs/state-machine.md` | Update §7.7 line 936: "doubles the configured interval" → stepwise escalation description |

### Key Decisions

- **Stepwise over linear**: Architecturally consistent with `idleBackoffMultiplier`, produces exact integer expected values in tests, and operators can read the table without knowing a formula. Linear requires floating-point tolerance in assertions and the `2 + 8*(1-ratio/0.20)` formula is harder to audit under sticky-zone edge cases.

- **Sentinel `1.0` not `rateLimitBackoffThreshold`**: `computeEffectiveInterval` should not know about the hysteresis thresholds — that's `nextRateLimitLow`'s concern. Using `1.0` as the "not in backoff" sentinel keeps the function's activation check independent of the threshold constants, so the sticky-zone case (ratio 20%–50%) correctly defaults to 2× without any special handling.

- **`rateLimitRatio` as closure variable**: Mirrors the existing `rateLimitLow` closure variable. No architectural change to `doPollCycle` — just a second piece of backoff state that persists across poll cycles. The alternative (re-reading stats inside the function) would require an additional dependency injection and is out of scope.

- **`TestComputeEffectiveInterval_RateLimitExceeds5Min` rewritten but not deleted**: The test's purpose (confirming rate-limit backoff is NOT clamped by the 5-min idle cap) is still valid. The assertion changes from 6min (2× of 3min base) to a ratio-specific expected value. A ratio of `0.15` still produces 2×, so the expected value stays 6min — only the parameter type changes.

- **`TestComputeEffectiveInterval_MaxIdleRateLimit` similarly rewritten**: Passes `0.15` (2× tier) to match the original assertion (5min idle wins). An additional case should be added at `0.005` (10× tier) to confirm that `max(5min, 10×30s=300s)` = 5min still holds.

### Task Checklist

- [ ] **Task 1**: In `engine/poll.go`, rewrite `computeEffectiveInterval` — change signature from `rateLimitLow bool` to `rateLimitRatio float64`, replace the fixed-2× block (lines 99–106) with a stepwise switch, update the function docstring (lines 81–85) to document the new signature and four-tier escalation table.

- [ ] **Task 2**: In `engine/poll.go`, update `doPollCycle` — add `rateLimitRatio := 1.0` alongside `rateLimitLow` on line 303, update it inside the `if graphqlStats.Limit > 0` block after the hysteresis update (set to `ratio` when `rateLimitLow` is true, reset to `1.0` otherwise), and update the `computeEffectiveInterval` call on line 344 to pass `rateLimitRatio` instead of `rateLimitLow`.

- [ ] **Task 3**: In `engine/poll_test.go`, rewrite `TestComputeEffectiveInterval` (lines 967–994) — change the table's `rateLimitLow bool` field to `rateLimitRatio float64`, update the function call on line 988, choose representative ratio values for each case (e.g., `0.15` for 2× tier, `0.0` for "not applicable" mapped to `1.0`), and update expected values where they change.

- [ ] **Task 4**: In `engine/poll_test.go`, rewrite `TestComputeEffectiveInterval_MaxIdleRateLimit` (lines 1019–1027) — replace `true` with `0.15`; add a second assertion at `0.005` (10× tier, rate-limit = 300s = 5min, idle = 5min, result = 5min).

- [ ] **Task 5**: In `engine/poll_test.go`, rewrite `TestComputeEffectiveInterval_RateLimitExceeds5Min` (lines 1029–1039) — replace `true` with `0.15` (2× tier, 3min base → 6min, assertion unchanged); add assertions for ratio `0.07` (4× tier → 12min), ratio `0.03` (6× tier → 18min), and ratio `0.005` (10× tier → 30min).

- [ ] **Task 6**: In `engine/poll_test.go`, add a new `TestComputeEffectiveInterval_RateLimitStepwise` function covering: `1.0` (not in backoff → 1×), `0.35` (sticky zone → 2×), `0.15` (10%–20% → 2×), `0.099` (just below 10% → 4×), `0.049` (just below 5% → 6×), `0.009` (just below 1% → 10×), `0.0` (zero remaining → 10×). Use a 30s base.

- [ ] **Task 7**: In `docs/USER_GUIDE.md` (lines ~169–171), replace the current prose description of rate-limit backoff (which mentions only the 10× cap, not escalation steps) with a paragraph plus a four-row table matching the idle backoff table format above it, documenting the four quota tiers and example intervals at 30s and 60s bases.

- [ ] **Task 8**: In `docs/state-machine.md` (§7.7, line 936), update the bullet "Rate-limit adjustment: when … `computeEffectiveInterval` doubles the configured interval for rate-limit backoff, capped at `rateLimitMaxBackoffMultiplier×` the configured interval" to describe the stepwise escalation (reference the four tiers; match the language used in USER_GUIDE.md).

- [ ] **Task 9**: Run `go build ./...` and `go test -race ./...` — all tests pass, build clean.

### Risks

- **Sticky-zone test coverage gap**: The sticky zone (ratio 20%–50%, `rateLimitLow = true`) is the trickiest edge case — callers pass a ratio > 20% but the function must still apply the minimum 2× backoff. Task 6 explicitly includes `0.35` as a sticky-zone test case to guard against this.

- **`TestComputeEffectiveInterval_MaxIdleRateLimit` misleading at high escalation**: At 10× tier (300s rate-limit, 300s idle), the test returns 5min regardless of which wins. Adding the `0.005` case in Task 4 confirms the correct value, but reviewers may not notice it tests a tie. The assertion comment should clarify.

- **Docstring and docs drift**: The function docstring at lines 81–85 currently says nothing about the escalation curve. Task 1 must update it, or `docs/state-machine.md` and the code will diverge again within the same PR. The task checklist explicitly includes the docstring update in Task 1 so it is not skipped.

- **No call-site count surprise**: Research confirmed `computeEffectiveInterval` is called in exactly one production location (line 344). If a new call site was added between the research commit and implementation, the build will catch the signature mismatch at compile time. No manual grep is needed.

---
Used 10/50 turns, 5k input / 7k output tokens.

## Verification

Fixed `computeEffectiveInterval` in `engine/poll.go` to replace the hardcoded `rateLimitLow bool` parameter with `rateLimitRatio float64`, implementing a four-tier stepwise escalation (2×/4×/6×/10×) that scales as GraphQL quota depletes — bringing the 10× cap from dead code to active behavior. Updated tests, `docs/USER_GUIDE.md` (added escalation table), and `docs/state-machine.md` §7.7 to match.

---

Closes #487