### PR TITLE
Docs: USER_GUIDE webhook prereq is wrong — gh webhook is an extension, not a built-in subcommand

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1586,7 +1586,7 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
   ```bash
   gh extension install cli/gh-webhook
   ```
-  Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). No minimum `gh` version is required.
+  Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). No specific minimum version is pinned; any recent `gh` with extension support works.
 - **`gh auth login`** with a token that has `admin:repo_hook` write scope (classic PAT) or equivalent repo admin access. Fine-grained tokens may lack this scope.
 - **Repo admin access** on each repository on your board, or org-admin access for org-level subscription.
 
@@ -1659,7 +1659,7 @@ On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 
 ### Troubleshooting Webhook Mode
 
-**"prerequisite check failed"** — `gh` is missing or the `gh-webhook` extension is not installed. Install `gh` at <https://cli.github.com>, then run `gh extension install cli/gh-webhook`.
+**"prerequisite check failed"** — `gh` is missing or the `cli/gh-webhook` extension is not installed. Install `gh` at <https://cli.github.com>, then run `gh extension install cli/gh-webhook`.
 
 **Stream shows yellow "unhealthy"** — The subprocess may have exited or GitHub isn't delivering events. Check `fabrik.log` for `[webhook]` error lines. Run `gh auth status` to verify your token has `admin:repo_hook` scope.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1582,7 +1582,11 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
 
 ### Prerequisites
 
-- **`gh` CLI version ≥ 2.32.0** (released October 2023). `gh webhook forward` was introduced in this version. Run `gh --version` to check.
+- **`cli/gh-webhook` extension** — `gh webhook forward` is **not** a built-in `gh` subcommand; it ships as a separate extension that must be installed once:
+  ```bash
+  gh extension install cli/gh-webhook
+  ```
+  Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). No minimum `gh` version is required.
 - **`gh auth login`** with a token that has `admin:repo_hook` write scope (classic PAT) or equivalent repo admin access. Fine-grained tokens may lack this scope.
 - **Repo admin access** on each repository on your board, or org-admin access for org-level subscription.
 
@@ -1655,7 +1659,7 @@ On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 
 ### Troubleshooting Webhook Mode
 
-**"prerequisite check failed"** — `gh` is missing or too old. Install or upgrade: <https://cli.github.com>
+**"prerequisite check failed"** — `gh` is missing or the `gh-webhook` extension is not installed. Install `gh` at <https://cli.github.com>, then run `gh extension install cli/gh-webhook`.
 
 **Stream shows yellow "unhealthy"** — The subprocess may have exited or GitHub isn't delivering events. Check `fabrik.log` for `[webhook]` error lines. Run `gh auth status` to verify your token has `admin:repo_hook` scope.
 
@@ -1809,6 +1813,25 @@ the same project, it exits with a clear error. The lock is automatically
 released if the process crashes.
 
 To check for stale instances: `pgrep -la fabrik`
+
+### `unknown command "webhook" for "gh"` in Webhook Mode
+
+**Symptom:** Fabrik logs lines like:
+
+```
+[webhook] [gh] unknown command "webhook" for "gh"
+[webhook] gh webhook forward exited: exit status 1 — restarting in 1s
+```
+
+**Cause:** `gh webhook forward` is not a built-in `gh` subcommand — it is the [`cli/gh-webhook`](https://github.com/cli/gh-webhook) extension, which must be installed separately.
+
+**Fix:**
+```bash
+gh extension install cli/gh-webhook
+gh webhook --help   # verify: should print usage
+```
+
+Then restart Fabrik. The extension is a one-time install and persists across `gh` upgrades.
 
 ### Plugin Not Loading
 


### PR DESCRIPTION
## Summary

Fix `docs/USER_GUIDE.md` to remove the incorrect minimum `gh` version claim and replace it with the correct `cli/gh-webhook` extension installation requirement, then add a troubleshooting entry for the `unknown command "webhook"` error.

## Problem

`docs/USER_GUIDE.md:1585` currently states:

> - **`gh` CLI version ≥ 2.32.0** (released October 2023). `gh webhook forward` was introduced in this version. Run `gh --version` to check.

This is **wrong**. `gh webhook` is not a built-in subcommand of the `gh` CLI at any version — it ships as the `cli/gh-webhook` extension and must be installed separately:

```
gh extension install cli/gh-webhook
```

On `gh 2.89.0` (and any version) without the extension:

```
$ gh webhook --help
unknown command "webhook" for "gh"
```

In a Fabrik instance with `webhooks: true` and the extension missing, the engine log shows:

```
[webhook] [gh] unknown command "webhook" for "gh"
[webhook] [gh]   cache
[webhook] gh webhook forward exited: exit status 1 — restarting in 1s
```

The user has no actionable signal pointing them at the extension install command.

## Approach

### Approach

This is a pure documentation change — two targeted edits to `docs/USER_GUIDE.md`:

1. **Replace the incorrect prerequisite bullet** (~line 1585): Remove the erroneous `gh` CLI version claim and substitute a correct bullet covering the `cli/gh-webhook` extension (install command, verification step, and explicit "not built-in" statement).

2. **Fix the now-inconsistent §10 troubleshooting entry** (line 1658): The research flagged that `"prerequisite check failed" — gh is missing or too old` becomes misleading once the version requirement is gone. Update "or too old" → "or the `gh-webhook` extension is not installed" for cohesion. This is a minor two-word fix in the same area and avoids leaving a contradictory sentence immediately above the new troubleshooting entry.

3. **Add a §11 troubleshooting entry**: New `###` heading covering the `unknown command "webhook" for "gh"` error, pointing to `gh extension install cli/gh-webhook` and a Fabrik restart.

No ADR is warranted — this is a documentation correction with no architectural decision content.

No code changes. No new files. No tests (pure docs).

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Replace line 1585 (incorrect `gh` version prereq), update line 1658 (fix "or too old"), add §11 troubleshooting entry |

### Key Decisions

- **Also fix line 1658 (`"or too old"`)**: Research called this out as a cohesion issue. Since the incorrect version claim is being removed from the prerequisites, the adjacent troubleshooting entry that says `gh is missing or too old` would directly contradict the new prereq text. The fix is two words in the same file; skipping it would leave the doc internally inconsistent.
- **§11 entry only** (not §10): The spec directs the new `unknown command "webhook"` entry to §11. §10 already has its own troubleshooting block and will get the line-1658 cohesion fix; no further new content is needed there.
- **No minimum `gh` version stated**: The extension works with any modern `gh`; pinning a version would repeat the original mistake. The new bullet omits any version constraint.

### Task Checklist

- [ ] Task 1: Replace the incorrect `gh` version prerequisite bullet at line 1585 with a correct bullet naming `cli/gh-webhook` as the requirement, including install command (`gh extension install cli/gh-webhook`), verification step (`gh webhook --help`), and explicit "not a built-in subcommand" statement
- [ ] Task 2: Update the §10 troubleshooting entry at line 1658 — change `gh is missing or too old` to `gh is missing or the gh-webhook extension is not installed` to match the corrected prerequisite
- [ ] Task 3: Add a new `###` troubleshooting entry to §11 covering `unknown command "webhook" for "gh"` — cite the exact error string, provide `gh extension install cli/gh-webhook`, and instruct the user to restart Fabrik

### Risks

- **Line drift**: The line numbers cited (1585, 1658) are from the research snapshot; the implementer must verify them against the current file before editing. The surrounding text is stable enough to locate the right spot by content if the line numbers have shifted slightly.

---
Used 7/50 turns, 2k input / 1k output tokens.

## Verification

Fixed `docs/USER_GUIDE.md` in three places: replaced the incorrect `gh` CLI ≥ 2.32.0 prerequisite bullet with the correct `cli/gh-webhook` extension requirement (including install command and verification step); updated the §10 troubleshooting entry to replace "too old" with "gh-webhook extension is not installed"; and added a new §11 troubleshooting entry covering the `unknown command "webhook" for "gh"` error with the fix and restart instruction. All changes are in a single commit on `fabrik/issue-491`.

---

Closes #491