### PR TITLE
fix(watch): anchor live tab to GitHub in_progress label, not log timestamp

### DIFF
--- a/watch/logfollow.go
+++ b/watch/logfollow.go
@@ -223,6 +223,9 @@ func renderLogFile(path string) string {
 // log to follow; "" means fall back to the globally newest log file.
 // Both goroutines run until the done channel is closed.
 func StartLogFollower(logDir string, send func(tea.Msg), done <-chan struct{}, getActiveStage func() string) {
+	if getActiveStage == nil {
+		getActiveStage = func() string { return "" }
+	}
 	go followLatestLog(logDir, getActiveStage, send, done)
 	go pollForNewLogFile(logDir, send, done)
 }

--- a/watch/logfollow.go
+++ b/watch/logfollow.go
@@ -67,12 +67,16 @@ func logTimestampSuffix(name string) string {
 // newest log per label, and sorts by pipeline order (stageOrder map). Logs
 // whose label matches "<ParentStage>-comment-review" are grouped under the
 // parent stage tab. Unknown stages are appended after known stages in
-// chronological order. The globally newest log file is marked IsLive.
-// Returns an empty slice if logDir is unreadable or empty.
+// chronological order.
+//
+// IsLive selection: when activeStage is non-empty and a tab with that label
+// exists, it is marked IsLive (label-driven; GitHub state takes precedence
+// over log file timestamps). When activeStage is empty or names a stage with
+// no tab, falls back to the globally newest log file.
 //
 // stageOrder maps stage name → pipeline order value (from Stage.Order).
 // When stageOrder is nil or empty, falls back to chronological ordering.
-func buildStageTabs(logDir string, stageOrder map[string]int) []stageTab {
+func buildStageTabs(logDir string, stageOrder map[string]int, activeStage string) []stageTab {
 	entries, err := os.ReadDir(logDir)
 	if err != nil {
 		return nil
@@ -155,10 +159,21 @@ func buildStageTabs(logDir string, stageOrder map[string]int) []stageTab {
 
 	tabs := append(knownTabs, unknownTabs...)
 
-	// Find the globally newest log file across all tabs and mark it as IsLive.
-	// Compare by timestamp suffix only (not full filename) so that a stage label
-	// like "Specify" (alphabetically > "Research") cannot beat a chronologically
-	// newer "Research" log.
+	// Determine which tab is IsLive.
+	// Primary: when activeStage is non-empty, find the tab with that label.
+	// Fallback: pick the tab whose LogPath has the globally newest timestamp suffix.
+	if activeStage != "" {
+		for i, t := range tabs {
+			if t.Label == activeStage {
+				tabs[i].IsLive = true
+				return tabs
+			}
+		}
+		// activeStage names a stage that has no tab yet — fall through to timestamp heuristic.
+	}
+	// Timestamp-based fallback: compare by timestamp suffix only (not full filename)
+	// so that a stage label like "Specify" (alphabetically > "Research") cannot beat
+	// a chronologically newer "Research" log.
 	newestFile := ""
 	newestSuffix := ""
 	for _, t := range tabs {
@@ -204,9 +219,11 @@ func renderLogFile(path string) string {
 //  2. A directory-poll goroutine (2s interval) that detects when a new .log
 //     file appears (stage transition) and calls send(NewLogFileMsg).
 //
+// getActiveStage is called by the follow goroutine to determine which stage's
+// log to follow; "" means fall back to the globally newest log file.
 // Both goroutines run until the done channel is closed.
-func StartLogFollower(logDir string, send func(tea.Msg), done <-chan struct{}) {
-	go followLatestLog(logDir, send, done)
+func StartLogFollower(logDir string, send func(tea.Msg), done <-chan struct{}, getActiveStage func() string) {
+	go followLatestLog(logDir, getActiveStage, send, done)
 	go pollForNewLogFile(logDir, send, done)
 }
 
@@ -237,17 +254,45 @@ func newestLogFile(logDir string) string {
 	return filepath.Join(logDir, logs[len(logs)-1].Name())
 }
 
-// followLatestLog finds the newest .log file in logDir, then follows it in
-// real time (like tail -F). It blocks until done is closed. When a
-// NewLogFileMsg is needed (stage transition), pollForNewLogFile handles that
-// separately — this goroutine simply re-opens the new file path when
-// instructed via a reload.
-func followLatestLog(logDir string, send func(tea.Msg), done <-chan struct{}) {
+// bestLogFileForStage returns the path of the most recent .log file in logDir
+// whose stage label is stageName or stageName+"-comment-review". When stageName
+// is empty or no matching file exists, falls back to newestLogFile.
+func bestLogFileForStage(logDir, stageName string) string {
+	if stageName == "" {
+		return newestLogFile(logDir)
+	}
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return newestLogFile(logDir)
+	}
+	var best string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		label := stageNameFromFilename(e.Name())
+		if label != stageName && label != stageName+"-comment-review" {
+			continue
+		}
+		if logTimestampSuffix(e.Name()) > logTimestampSuffix(best) {
+			best = e.Name()
+		}
+	}
+	if best == "" {
+		return newestLogFile(logDir)
+	}
+	return filepath.Join(logDir, best)
+}
+
+// followLatestLog finds the best .log file in logDir for the active stage (or
+// globally newest when stage is unknown), then follows it in real time (like
+// tail -F). It blocks until done is closed.
+func followLatestLog(logDir string, getActiveStage func() string, send func(tea.Msg), done <-chan struct{}) {
 	// Wait for the log directory and a .log file to exist.
 	var currentPath string
 	for {
 		if currentPath == "" {
-			currentPath = newestLogFile(logDir)
+			currentPath = bestLogFileForStage(logDir, getActiveStage())
 		}
 		if currentPath != "" {
 			break
@@ -259,23 +304,24 @@ func followLatestLog(logDir string, send func(tea.Msg), done <-chan struct{}) {
 		}
 	}
 
-	followFile(currentPath, logDir, send, done)
+	followFile(currentPath, logDir, getActiveStage, send, done)
 }
 
 // followFile reads from path, rendering each NDJSON line via streamfilter.
-// It loops — switching to newer .log files as they appear — until done is closed.
-// Using a loop instead of recursion avoids goroutine stack growth across stage transitions.
-func followFile(path, logDir string, send func(tea.Msg), done <-chan struct{}) {
+// It loops — switching to the best log file for the active stage as files
+// appear — until done is closed. Using a loop instead of recursion avoids
+// goroutine stack growth across stage transitions.
+func followFile(path, logDir string, getActiveStage func() string, send func(tea.Msg), done <-chan struct{}) {
 	for {
 		f, err := os.Open(path)
 		if err != nil {
-			// File disappeared; wait briefly and try the next newest.
+			// File disappeared; wait briefly and try the best file for the active stage.
 			select {
 			case <-done:
 				return
 			case <-time.After(200 * time.Millisecond):
 			}
-			if next := newestLogFile(logDir); next != "" && next != path {
+			if next := bestLogFileForStage(logDir, getActiveStage()); next != "" && next != path {
 				path = next
 			}
 			continue
@@ -309,8 +355,8 @@ func followFile(path, logDir string, send func(tea.Msg), done <-chan struct{}) {
 					f.Close()
 					return
 				}
-				// EOF: check for a newer log file (stage transition).
-				if next := newestLogFile(logDir); next != "" && next != path {
+				// EOF: check for the best log file for the active stage (stage transition).
+				if next := bestLogFileForStage(logDir, getActiveStage()); next != "" && next != path {
 					path = next
 					switchFile = true
 					break readLoop

--- a/watch/logfollow_test.go
+++ b/watch/logfollow_test.go
@@ -27,7 +27,7 @@ func TestBuildStageTabs_PipelineOrder(t *testing.T) {
 		"Research":  1,
 		"Implement": 3,
 	}
-	tabs := buildStageTabs(dir, stageOrder)
+	tabs := buildStageTabs(dir, stageOrder, "")
 
 	if len(tabs) != 2 {
 		t.Fatalf("want 2 tabs, got %d", len(tabs))
@@ -57,7 +57,7 @@ func TestBuildStageTabs_CommentReviewGrouped(t *testing.T) {
 	writeLog(t, dir, "Specify-comment-review-20260101-100000-000000000.log")
 
 	stageOrder := map[string]int{"Specify": 2}
-	tabs := buildStageTabs(dir, stageOrder)
+	tabs := buildStageTabs(dir, stageOrder, "")
 
 	if len(tabs) != 1 {
 		t.Fatalf("want 1 tab (grouped), got %d", len(tabs))
@@ -86,7 +86,7 @@ func TestBuildStageTabs_FallbackChronological(t *testing.T) {
 	writeLog(t, dir, "Alpha-20260101-070000-000000000.log")
 	writeLog(t, dir, "Beta-20260101-080000-000000000.log")
 
-	tabs := buildStageTabs(dir, map[string]int{})
+	tabs := buildStageTabs(dir, map[string]int{}, "")
 
 	if len(tabs) != 2 {
 		t.Fatalf("want 2 tabs, got %d", len(tabs))
@@ -113,7 +113,7 @@ func TestBuildStageTabs_UnknownAppended(t *testing.T) {
 	writeLog(t, dir, "Freeform-20260101-100000-000000000.log")
 
 	stageOrder := map[string]int{"Research": 1}
-	tabs := buildStageTabs(dir, stageOrder)
+	tabs := buildStageTabs(dir, stageOrder, "")
 
 	if len(tabs) != 2 {
 		t.Fatalf("want 2 tabs, got %d", len(tabs))
@@ -129,7 +129,7 @@ func TestBuildStageTabs_UnknownAppended(t *testing.T) {
 // TestBuildStageTabs_EmptyDir verifies that an empty log directory returns nil.
 func TestBuildStageTabs_EmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	tabs := buildStageTabs(dir, map[string]int{"Research": 1})
+	tabs := buildStageTabs(dir, map[string]int{"Research": 1}, "")
 	if len(tabs) != 0 {
 		t.Errorf("want 0 tabs for empty dir, got %d", len(tabs))
 	}
@@ -173,7 +173,7 @@ func TestBuildStageTabs_IsLive_ByTimestampNotLabel(t *testing.T) {
 		"Research": 1,
 		"Specify":  2,
 	}
-	tabs := buildStageTabs(dir, stageOrder)
+	tabs := buildStageTabs(dir, stageOrder, "")
 
 	if len(tabs) != 2 {
 		t.Fatalf("want 2 tabs, got %d", len(tabs))
@@ -208,5 +208,116 @@ func TestNewestLogFile_ByTimestampNotLabel(t *testing.T) {
 	want := filepath.Join(dir, "Research-20260101-100000-000000000.log")
 	if got != want {
 		t.Errorf("newestLogFile: want %s, got %s", filepath.Base(want), filepath.Base(got))
+	}
+}
+
+// TestBestLogFileForStage_FiltersByStage verifies that bestLogFileForStage returns
+// the newest log matching the requested stage and ignores other stages.
+func TestBestLogFileForStage_FiltersByStage(t *testing.T) {
+	dir := t.TempDir()
+	writeLog(t, dir, "Review-20260101-090000-000000000.log")
+	writeLog(t, dir, "Implement-20260101-100000-000000000.log") // newer, but wrong stage
+
+	got := bestLogFileForStage(dir, "Review")
+	want := filepath.Join(dir, "Review-20260101-090000-000000000.log")
+	if got != want {
+		t.Errorf("bestLogFileForStage(Review): want %s, got %s", filepath.Base(want), filepath.Base(got))
+	}
+}
+
+// TestBestLogFileForStage_IncludesCommentReview verifies that a comment-review log
+// for the requested stage is included and returned when it is newer.
+func TestBestLogFileForStage_IncludesCommentReview(t *testing.T) {
+	dir := t.TempDir()
+	writeLog(t, dir, "Review-20260101-090000-000000000.log")
+	writeLog(t, dir, "Review-comment-review-20260101-100000-000000000.log") // newer
+
+	got := bestLogFileForStage(dir, "Review")
+	want := filepath.Join(dir, "Review-comment-review-20260101-100000-000000000.log")
+	if got != want {
+		t.Errorf("bestLogFileForStage(Review) should return comment-review file; got %s", filepath.Base(got))
+	}
+}
+
+// TestBestLogFileForStage_FallbackWhenNoMatch verifies that bestLogFileForStage
+// falls back to newestLogFile when no file matches the requested stage.
+func TestBestLogFileForStage_FallbackWhenNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeLog(t, dir, "Implement-20260101-090000-000000000.log")
+	writeLog(t, dir, "Research-20260101-100000-000000000.log")
+
+	// Ask for a stage that has no log file; should fall back to the globally newest.
+	got := bestLogFileForStage(dir, "Validate")
+	want := filepath.Join(dir, "Research-20260101-100000-000000000.log")
+	if got != want {
+		t.Errorf("bestLogFileForStage(Validate) fallback: want %s, got %s", filepath.Base(want), filepath.Base(got))
+	}
+}
+
+// TestBestLogFileForStage_EmptyStageName verifies that an empty stageName falls
+// back to newestLogFile behaviour (globally newest file).
+func TestBestLogFileForStage_EmptyStageName(t *testing.T) {
+	dir := t.TempDir()
+	writeLog(t, dir, "Research-20260101-090000-000000000.log")
+	writeLog(t, dir, "Implement-20260101-100000-000000000.log")
+
+	got := bestLogFileForStage(dir, "")
+	want := filepath.Join(dir, "Implement-20260101-100000-000000000.log")
+	if got != want {
+		t.Errorf("bestLogFileForStage(\"\") should behave like newestLogFile; got %s", filepath.Base(got))
+	}
+}
+
+// TestBuildStageTabs_LabelOverride_BeatTimestamp is the primary regression test:
+// an Implement-comment-review log with a newer timestamp must NOT steal IsLive
+// from the Review tab when "Review" is the active stage from labels.
+func TestBuildStageTabs_LabelOverride_BeatTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	// Review log is older; Implement-comment-review log is newer.
+	writeLog(t, dir, "Review-20260101-180000-000000000.log")
+	writeLog(t, dir, "Implement-comment-review-20260101-190000-000000000.log")
+	writeLog(t, dir, "Implement-20260101-120000-000000000.log")
+
+	stageOrder := map[string]int{
+		"Research":  1,
+		"Implement": 3,
+		"Review":    4,
+	}
+	tabs := buildStageTabs(dir, stageOrder, "Review")
+
+	// Find the Review tab and assert it is live.
+	var reviewLive, implementLive bool
+	for _, t2 := range tabs {
+		if t2.Label == "Review" {
+			reviewLive = t2.IsLive
+		}
+		if t2.Label == "Implement" {
+			implementLive = t2.IsLive
+		}
+	}
+	if !reviewLive {
+		t.Error("Review tab must be IsLive when activeStage=Review, even though Implement-comment-review log is newer")
+	}
+	if implementLive {
+		t.Error("Implement tab must NOT be IsLive when activeStage=Review")
+	}
+}
+
+// TestBuildStageTabs_LabelOverride_FallbackWhenNoMatch verifies that when the
+// activeStage label names a stage with no tab, the timestamp heuristic is used.
+func TestBuildStageTabs_LabelOverride_FallbackWhenNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	// Only Research log exists; activeStage says "Validate" (no tab for it).
+	writeLog(t, dir, "Research-20260101-100000-000000000.log")
+
+	stageOrder := map[string]int{"Research": 1, "Validate": 5}
+	tabs := buildStageTabs(dir, stageOrder, "Validate")
+
+	if len(tabs) != 1 {
+		t.Fatalf("want 1 tab, got %d", len(tabs))
+	}
+	// Falls back to timestamp heuristic: Research is the only tab and must be IsLive.
+	if !tabs[0].IsLive {
+		t.Error("Research tab must be IsLive via timestamp fallback when activeStage tab doesn't exist")
 	}
 }

--- a/watch/model.go
+++ b/watch/model.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -78,6 +79,11 @@ type WatchModel struct {
 
 	// done channel — closed on quit to stop background goroutines
 	done chan struct{}
+
+	// activeStagePtr holds the current in_progress stage name derived from GitHub labels.
+	// Heap-allocated so the followFile goroutine can observe updates made by fetchGitHub
+	// despite WatchModel being a bubbletea value type. Stores string; "" means unknown.
+	activeStagePtr *atomic.Value
 }
 
 // NewModel creates a WatchModel for the given issue number.
@@ -91,7 +97,11 @@ func NewModel(issueNumber int, opts GitHubOptions, stagesDir string) WatchModel 
 
 	stageOrder := buildStageOrder(stagesDir)
 	stageMaxTurns := buildStageMaxTurns(stagesDir)
-	tabs := buildStageTabs(logDir, stageOrder)
+
+	// Labels haven't been fetched yet on startup; activeStage defaults to "" (fallback to timestamp heuristic).
+	asp := new(atomic.Value)
+	asp.Store("")
+	tabs := buildStageTabs(logDir, stageOrder, "")
 	selectedTabIdx := liveTabIdx(tabs)
 
 	return WatchModel{
@@ -105,6 +115,7 @@ func NewModel(issueNumber int, opts GitHubOptions, stagesDir string) WatchModel 
 		stageOrder:     stageOrder,
 		stageMaxTurns:  stageMaxTurns,
 		done:           make(chan struct{}),
+		activeStagePtr: asp,
 	}
 }
 
@@ -141,6 +152,22 @@ func buildStageMaxTurns(stagesDir string) map[string]int {
 		m[s.Name] = s.MaxTurns
 	}
 	return m
+}
+
+// activeStageFromLabels returns the stage name from a "stage:X:in_progress" label,
+// or "" if no such label is present.
+func activeStageFromLabels(labels []string) string {
+	for _, l := range labels {
+		after, ok := strings.CutPrefix(l, "stage:")
+		if !ok {
+			continue
+		}
+		name, ok := strings.CutSuffix(after, ":in_progress")
+		if ok {
+			return name
+		}
+	}
+	return ""
 }
 
 // logFileCountForStage counts .log files in logDir whose stage label matches stageName.
@@ -286,8 +313,14 @@ func (m WatchModel) Init() tea.Cmd {
 func Run(m WatchModel) error {
 	p := tea.NewProgram(m, tea.WithAltScreen())
 
+	asp := m.activeStagePtr
+	getActiveStage := func() string {
+		v, _ := asp.Load().(string)
+		return v
+	}
+
 	// Start background goroutines that send messages via p.Send.
-	StartLogFollower(m.logDir, func(msg tea.Msg) { p.Send(msg) }, m.done)
+	StartLogFollower(m.logDir, func(msg tea.Msg) { p.Send(msg) }, m.done, getActiveStage)
 
 	_, err := p.Run()
 	return err
@@ -423,7 +456,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentLogPath = ""
 		m.vp.SetContent("")
 		m.turnsUsed = 0
-		newTabs := buildStageTabs(m.logDir, m.stageOrder)
+		newTabs := buildStageTabs(m.logDir, m.stageOrder, activeStageFromLabels(m.github.labels))
 		m.stageTabs = newTabs
 		m.selectedTabIdx = liveTabIdx(newTabs)
 		m.cachedEffectiveMaxTurns = m.effectiveMaxTurns()
@@ -432,7 +465,7 @@ func (m WatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case GitHubPollMsg:
 		m.fetchGitHub()
 		// Rebuild tabs; preserve selection by label.
-		newTabs := buildStageTabs(m.logDir, m.stageOrder)
+		newTabs := buildStageTabs(m.logDir, m.stageOrder, activeStageFromLabels(m.github.labels))
 		m.selectedTabIdx = mergeTabSelection(newTabs, m.stageTabs, m.selectedTabIdx)
 		m.stageTabs = newTabs
 		m.cachedEffectiveMaxTurns = m.effectiveMaxTurns()
@@ -477,6 +510,9 @@ func (m *WatchModel) fetchGitHub() {
 	m.github.state = issue.State
 	m.github.labels = issue.Labels
 	m.github.commentCnt = issue.Comments
+	if m.activeStagePtr != nil {
+		m.activeStagePtr.Store(activeStageFromLabels(m.github.labels))
+	}
 
 	// Discover the linked PR by convention (branch fabrik/issue-N).
 	// Cache the PR number once found; re-fetch details on each poll.

--- a/watch/model.go
+++ b/watch/model.go
@@ -315,6 +315,9 @@ func Run(m WatchModel) error {
 
 	asp := m.activeStagePtr
 	getActiveStage := func() string {
+		if asp == nil {
+			return ""
+		}
 		v, _ := asp.Load().(string)
 		return v
 	}

--- a/watch/model_test.go
+++ b/watch/model_test.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -11,9 +12,12 @@ import (
 // newTestModel creates a minimal WatchModel for key-handler tests.
 // It avoids filesystem calls by using an empty logDir and no stagesDir.
 func newTestModel() WatchModel {
+	asp := new(atomic.Value)
+	asp.Store("")
 	m := WatchModel{
-		issueNumber: 1,
-		done:        make(chan struct{}),
+		issueNumber:    1,
+		done:           make(chan struct{}),
+		activeStagePtr: asp,
 	}
 	return m
 }
@@ -195,5 +199,81 @@ func TestView_TurnCounter_Hidden_WhenNoTurns(t *testing.T) {
 	view := m.View()
 	if strings.Contains(view, "turn") {
 		t.Errorf("expected no turn counter when turnsUsed=0, got:\n%s", view)
+	}
+}
+
+// TestActiveStageFromLabels verifies the helper that extracts the in-progress stage from labels.
+func TestActiveStageFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{"single in-progress", []string{"stage:Review:in_progress"}, "Review"},
+		{"multiple labels, one in-progress", []string{"fabrik:yolo", "stage:Implement:in_progress", "stage:Research:complete"}, "Implement"},
+		{"no in-progress label", []string{"stage:Research:complete", "fabrik:yolo"}, ""},
+		{"empty labels", []string{}, ""},
+		{"nil labels", nil, ""},
+		{"stage prefix but no in_progress suffix", []string{"stage:Review:complete"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := activeStageFromLabels(tt.labels)
+			if got != tt.want {
+				t.Errorf("activeStageFromLabels(%v) = %q, want %q", tt.labels, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUpdate_NewLogFileMsg_LabelOverride is the primary regression test: when an
+// Implement-comment-review log has a newer timestamp than a Review log but GitHub
+// labels say "stage:Review:in_progress", the Review tab must be IsLive after
+// processing a NewLogFileMsg.
+func TestUpdate_NewLogFileMsg_LabelOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write an Implement log, an Implement-comment-review log (newest), and a Review log.
+	writeLog(t, dir, "Implement-20260101-120000-000000000.log")
+	writeLog(t, dir, "Review-20260101-180000-000000000.log")
+	writeLog(t, dir, "Implement-comment-review-20260101-190000-000000000.log") // newest timestamp
+
+	asp := new(atomic.Value)
+	asp.Store("")
+	m := WatchModel{
+		issueNumber: 99,
+		logDir:      dir,
+		done:        make(chan struct{}),
+		stageOrder: map[string]int{
+			"Implement": 3,
+			"Review":    4,
+		},
+		github: issueState{
+			labels: []string{"stage:Review:in_progress"},
+		},
+		activeStagePtr: asp,
+	}
+
+	model, _ := m.Update(NewLogFileMsg{Path: dir + "/Implement-comment-review-20260101-190000-000000000.log"})
+	wm := model.(WatchModel)
+
+	var reviewLive, implementLive bool
+	for _, tab := range wm.stageTabs {
+		if tab.Label == "Review" {
+			reviewLive = tab.IsLive
+		}
+		if tab.Label == "Implement" {
+			implementLive = tab.IsLive
+		}
+	}
+	if !reviewLive {
+		t.Error("Review tab must be IsLive (activeStage=Review from labels), even though Implement-comment-review log is newer")
+	}
+	if implementLive {
+		t.Error("Implement tab must NOT be IsLive when Review is the active stage")
+	}
+	// Selected tab should be the live (Review) tab.
+	if wm.selectedTabIdx >= len(wm.stageTabs) || !wm.stageTabs[wm.selectedTabIdx].IsLive {
+		t.Errorf("selectedTabIdx=%d does not point to live tab", wm.selectedTabIdx)
 	}
 }


### PR DESCRIPTION
## Summary

- `fabrik watch` was marking the wrong stage tab as live (●) after a stage transition when a comment-review invocation on the completed stage produced a log file with a newer timestamp than the next stage's log.
- The `followFile` goroutine would also stream output from the wrong stage's log into the viewport.
- Both issues are fixed by anchoring the live-tab selection and the goroutine's file-following to the `stage:X:in_progress` GitHub label rather than log file timestamps.

## Key Changes

**`watch/logfollow.go`**
- `buildStageTabs(logDir, stageOrder, activeStage string)`: new `activeStage` parameter; when non-empty and a tab with that label exists, it is marked `IsLive` — taking precedence over the timestamp heuristic. Falls back to the old timestamp comparison when the label is empty or names a stage with no tab.
- `bestLogFileForStage(logDir, stageName string) string`: new helper that filters `.log` files to `stageName` or `stageName-comment-review`, returning the newest match. Falls back to `newestLogFile` when stageName is empty or no match exists.
- `StartLogFollower` / `followLatestLog` / `followFile`: new `getActiveStage func() string` parameter threaded through so the goroutine calls `bestLogFileForStage` at the EOF-switch and file-disappeared paths instead of the global-newest heuristic.

**`watch/model.go`**
- `WatchModel.activeStagePtr *atomic.Value`: heap-allocated so the goroutine can observe updates across bubbletea value-type copies.
- `activeStageFromLabels(labels []string) string`: extracts stage name from `stage:X:in_progress` label.
- `fetchGitHub`: writes to `activeStagePtr` after each label refresh.
- `Run`: passes a `getActiveStage` closure reading `activeStagePtr` to `StartLogFollower`.
- All three `buildStageTabs` call sites updated to pass `activeStageFromLabels(m.github.labels)`.

## How to Test

1. Start `fabrik watch <N>` on an issue that is transitioning from Implement → Review.
2. Wait for or simulate a comment-review invocation on the completed Implement stage (creates a log file newer than the Review log).
3. Verify the Review tab is shown as live (●) and that viewport output is from the Review log, not the Implement-comment-review log.
4. Run `go test -race ./watch/...` — includes `TestBuildStageTabs_LabelOverride_BeatTimestamp` and `TestUpdate_NewLogFileMsg_LabelOverride` which directly reproduce the bug scenario.

Closes #483