### PR TITLE
feat(boardcache): event-sourced in-memory board cache via webhook deltas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ go vet ./...             # Lint
 - `plugin/refresh.go` — `RefreshPlugin()` overwrites `.fabrik/plugin/` from the embedded source
 - `cmd/init.go` — `fabrik init` subcommand; extracts embedded YAMLs to `.fabrik/stages/`
 - `.fabrik/stages/` — Live stage configs for this project (tracked in git)
+- `boardcache/boardcache.go` — `ReadClient` interface (9-method read-only subset of `GitHubClient`), `GitHubAdapter` (pass-through), `CacheImpl` (in-memory cache with delta, reconcile, pause/resume)
+- `boardcache/delta.go` — Typed webhook delta functions: apply `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, and `projects_v2_item` payloads as state mutations
 
 > **Editing built-in skills**: modify `plugin/fabrik-plugin/skills/<name>/SKILL.md` — the embedded source baked into the binary. `.fabrik/plugin/` is the local deployed copy written by `fabrik init` and refreshed by `fabrik upgrade`; it is not tracked in git and edits there will be silently overwritten on the next refresh.
 

--- a/adrs/003-polling-over-webhooks.md
+++ b/adrs/003-polling-over-webhooks.md
@@ -38,3 +38,8 @@ Use polling via the GitHub GraphQL API at a configurable interval (default 30s).
 
 If real-time responsiveness becomes important, we could add optional webhook
 support alongside polling, using polling as the fallback.
+
+## Superseded by
+
+- **ADR 032** (Webhook-Driven Event Delivery via gh webhook forward) implements this future consideration: an optional `--webhooks` mode delivers events in real-time while retaining polling as a safety net.
+- **ADR 034** (Event-Sourced Board Cache via Webhook Deltas) extends ADR 032: incoming webhook payloads are applied as typed state deltas to an in-memory cache, reducing per-event GraphQL consumption. The core principle of this ADR — that polling is the reliable foundation — is preserved: the cache reconciles against GitHub every 60 minutes and falls back to live API calls when the webhook stream is unhealthy.

--- a/adrs/034-boardcache-event-sourced-delta.md
+++ b/adrs/034-boardcache-event-sourced-delta.md
@@ -1,0 +1,82 @@
+# ADR 034: Event-Sourced Board Cache via Webhook Deltas
+
+**Status**: Accepted  
+**Date**: 2026-05-02  
+**Supplements**: ADR 032 (Webhook-Driven Event Delivery)
+
+## Context
+
+ADR 032 added webhook-driven event delivery: each verified payload wakes the poll loop, which immediately fetches the full board from GitHub GraphQL. This eliminated the 30-second polling wait but did not reduce the GraphQL points consumed _per event_. On a busy board with dozens of events per minute (CI check runs, PR review comments, label mutations), the board-fetch cost is replicated on every webhook wake.
+
+Two additional problems motivate this ADR:
+
+1. **Redundant deep-fetches.** `FetchItemDetails` is called for every item that passes `itemMayNeedWork`. Even after a single `issues.labeled` webhook that adds one label to one issue, the poll loop deep-fetches all items that might need work, paying GraphQL points for data that has not changed.
+
+2. **Read amplification in the CI gate.** `checkCIGate` and `checkMergeabilityGate` call `FetchCheckRuns`, `FetchLinkedPR`, and `FetchPRMergeableState` on every poll cycle while an issue is in CI await. With webhook-driven wakes every 30–60 seconds during an active CI run, this multiplies quickly.
+
+## Decision
+
+Add an optional in-memory board cache (`boardcache.CacheImpl`) that is:
+
+1. **Populated at startup** via a full `FetchProjectBoard` call immediately after the webhook listener starts.
+2. **Kept current by webhook deltas** — typed pure functions apply incoming payloads as state mutations to the cache before the poll loop wakes.
+3. **Served to read callers** via the existing `ReadClient` interface, replacing direct GitHub API calls for board/item/PR/check-run reads.
+4. **Reconciled periodically** (every 60 minutes) via a full board fetch, healing any deltas missed by the webhook stream.
+5. **Failed over on stream degradation** — when `checkHealthTransitions` fires `WebhookStreamUnhealthy`, the cache is paused and all reads fall back to GitHub. On recovery, the cache reconciles and resumes.
+
+The cache is enabled by default when `--webhooks` is active and disabled otherwise. The `--board-cache` flag (and `FABRIK_BOARD_CACHE` env var) allows explicit override.
+
+## Architecture
+
+### Interface boundary
+
+A new `boardcache.ReadClient` interface captures the 9 read-only methods from `engine.GitHubClient` that access board/item/PR/check-run state. `Engine.readClient` holds a `boardcache.ReadClient` instead of calling `Engine.client` directly for reads.
+
+Two implementations:
+
+- `boardcache.GitHubAdapter` — pass-through wrapper around any `ReadClient`. Used when `--board-cache=none`.
+- `boardcache.CacheImpl` — in-memory cache with delta application and fallback. Used when `--board-cache=in-memory`.
+
+`Engine.client` (the full `GitHubClient`) is retained for all write operations (mutations, label adds, PR creation, etc.) and for the direct GitHub fetches used in bootstrap and reconciliation. This keeps the cache's fallback path clean and prevents write paths from going through the cache.
+
+### Delta functions
+
+Each supported webhook event type maps to a typed delta function that parses the minimal required fields from the JSON payload and mutates the cache under a write lock. Delta functions are idempotent: applying the same event twice produces the same result as applying it once (idempotency keys: NodeID for comments/review-comments, DatabaseID for reviews, CheckRun.ID for check runs).
+
+### Interface satisfaction via Go structural typing
+
+`engine.GitHubClient` is a strict superset of `boardcache.ReadClient`. The concrete `gh.Client` (and the test mock `mockGitHubClient`) satisfy `boardcache.ReadClient` via Go's structural (implicit) typing without any additional adapter code. This means `boardcache.NewGitHubAdapter(engine.client)` works directly — no intermediate conversion type is needed.
+
+### Shallow vs. deep cache fields
+
+`Bootstrap` and `Reconcile` only populate shallow fields (the data returned by the board GraphQL query). Deep fields (comments, linked PR data, check runs) are populated lazily on cache miss via `FetchItemDetails`. The `deepFetched` set tracks which items have been deep-fetched; once set, subsequent `FetchItemDetails` calls are served from cache.
+
+`Reconcile` preserves deep fields when updating an item: it copies shallow fields from the fresh snapshot but does not overwrite deep fields. This prevents a 60-minute reconciliation from triggering a burst of FetchItemDetails calls.
+
+## Trade-offs
+
+**Benefits:**
+- Webhook wakes that touch a single item no longer trigger full board deep-fetches for unchanged items.
+- CI gate polls during `fabrik:awaiting-ci` serve check runs from cache rather than GitHub API.
+- The `ReadClient` abstraction is testable in isolation (`boardcache_test.go` tests the cache against a `mockClient` with call counters).
+
+**Costs:**
+- Cache coherence depends on the webhook stream. Missed events produce stale reads until the next reconciliation (up to 60 min). This was an accepted trade-off in ADR 032 for the poll loop; the same reasoning applies here.
+- A stream-healthy cache that reads stale data (e.g., a label change not yet delivered) may cause the poll loop to make a decision based on cached state. The reconciliation loop and the safety-net poll bound the staleness window.
+- Bootstrap requires a full `FetchProjectBoard` call at startup, adding one extra GraphQL request. This is amortized immediately.
+- Additional complexity: `CacheImpl`, delta functions, reconciliation loop, stream-health callbacks.
+
+## Alternatives Rejected
+
+**Per-event live fetch (status quo):** The existing behavior after ADR 032. Simple but does not reduce per-event GraphQL cost.
+
+**Full replacement of the poll loop with event sourcing:** Would require perfectly reliable webhook delivery and complex replay-on-restart logic. The existing poll-as-safety-net architecture is a better fit for a local CLI tool.
+
+**External cache (Redis, SQLite):** Adds infrastructure. The in-memory approach is sufficient for a single-process tool; the cache is rebuilt cheaply from a single API call on restart.
+
+## Consequences
+
+- Steady-state GraphQL usage for read paths drops proportionally to the fraction of reads that hit the cache. For a board in CI await (frequent check_run events), the reduction is significant.
+- The `boardcache` package is a new dependency of the `engine` package. It has no external imports beyond the existing `github` package types.
+- `engine.GitHubClient` remains the single write-path interface; `boardcache.ReadClient` is read-only. This separation is enforced by the type system.
+- ADR 032's health model (three states, grace period, unhealthy fallback) is reused as the cache failover trigger. No new health state is introduced.

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -1,0 +1,469 @@
+package boardcache
+
+import (
+	"strconv"
+	"sync"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ReadClient is the subset of engine.GitHubClient covering read-only board/item/PR/check-run state.
+// engine.GitHubClient is a strict superset; the concrete gh.Client satisfies this interface.
+type ReadClient interface {
+	FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error)
+	FetchItemDetails(item *gh.ProjectItem) error
+	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)
+	FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)
+	FetchPRMergeable(owner, repo string, prNumber int) (*bool, error)
+	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
+	FetchLabels(owner, repo string, issueNumber int) ([]string, error)
+	FetchStatusField(projectID string) (*gh.StatusField, error)
+	RateLimitStats() (rest, graphql gh.RateLimitStats)
+}
+
+// GitHubAdapter wraps a ReadClient with pass-through implementations.
+// When --board-cache=none, the engine sets e.readClient = NewGitHubAdapter(e.client).
+type GitHubAdapter struct {
+	client ReadClient
+}
+
+// NewGitHubAdapter wraps any ReadClient as a pass-through GitHubAdapter.
+func NewGitHubAdapter(client ReadClient) *GitHubAdapter {
+	return &GitHubAdapter{client: client}
+}
+
+func (a *GitHubAdapter) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	return a.client.FetchProjectBoard(owner, repo, projectNum, ownerType)
+}
+
+func (a *GitHubAdapter) FetchItemDetails(item *gh.ProjectItem) error {
+	return a.client.FetchItemDetails(item)
+}
+
+func (a *GitHubAdapter) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	return a.client.FetchCheckRuns(owner, repo, sha)
+}
+
+func (a *GitHubAdapter) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	return a.client.FetchLinkedPR(owner, repo, issueNumber)
+}
+
+func (a *GitHubAdapter) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
+	return a.client.FetchPRMergeable(owner, repo, prNumber)
+}
+
+func (a *GitHubAdapter) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
+	return a.client.FetchPRMergeableState(owner, repo, prNumber)
+}
+
+func (a *GitHubAdapter) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
+	return a.client.FetchLabels(owner, repo, issueNumber)
+}
+
+func (a *GitHubAdapter) FetchStatusField(projectID string) (*gh.StatusField, error) {
+	return a.client.FetchStatusField(projectID)
+}
+
+func (a *GitHubAdapter) RateLimitStats() (rest, graphql gh.RateLimitStats) {
+	return a.client.RateLimitStats()
+}
+
+// itemKey returns the cache key for an issue item: "owner/repo#number".
+func itemKey(repo string, number int) string {
+	return repo + "#" + strconv.Itoa(number)
+}
+
+// prKey returns the cache key for a PR: "owner/repo#pr<prNumber>".
+func prKey(repo string, prNumber int) string {
+	return repo + "#pr" + strconv.Itoa(prNumber)
+}
+
+// CacheImpl is a goroutine-safe in-memory board cache. Webhook delta functions write
+// to it; the poll loop reads from it via the ReadClient interface. Falls back to a
+// fallback ReadClient on cache miss.
+type CacheImpl struct {
+	mu sync.RWMutex
+
+	// Board items: key = owner/repo#issueNumber
+	items      map[string]*gh.ProjectItem
+	deepFetched map[string]bool // set of keys that have had FetchItemDetails called
+
+	// Check runs: key = commit SHA
+	checkRuns map[string][]gh.CheckRun
+
+	// PR details: key = owner/repo#pr<prNumber>
+	linkedPRs map[string]*gh.PRDetails
+
+	// Reverse lookups
+	shaToKey    map[string]string // SHA → issueKey (owner/repo#number)
+	itemIDToKey map[string]string // ItemID → issueKey
+
+	// Board metadata (from last Bootstrap/Reconcile)
+	projectID       string
+	projectTitle    string
+	projectOwnerType string
+
+	// Stream health: when paused, ApplyDelta is a no-op
+	paused bool
+
+	// Fallback for cache misses
+	fallback ReadClient
+	logFn    func(format string, args ...any)
+}
+
+// NewCacheImpl creates an empty cache backed by fallback for misses.
+func NewCacheImpl(fallback ReadClient, logFn func(format string, args ...any)) *CacheImpl {
+	return &CacheImpl{
+		items:       make(map[string]*gh.ProjectItem),
+		deepFetched: make(map[string]bool),
+		checkRuns:   make(map[string][]gh.CheckRun),
+		linkedPRs:   make(map[string]*gh.PRDetails),
+		shaToKey:    make(map[string]string),
+		itemIDToKey: make(map[string]string),
+		fallback:    fallback,
+		logFn:       logFn,
+	}
+}
+
+// Bootstrap populates the cache wholesale from a freshly-fetched board.
+// Called once at engine startup before the first dispatch cycle.
+func (c *CacheImpl) Bootstrap(board *gh.ProjectBoard) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.populateFromBoard(board)
+	c.logFn("[cache] bootstrap complete: %d items\n", len(board.Items))
+}
+
+// Reconcile replaces shallow board state from a fresh board fetch.
+// Preserves deep fields (Comments, LinkedPRReviews, etc.) for items that have
+// already been deep-fetched. Logs the drift count when items differ.
+func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	newKeys := make(map[string]bool, len(board.Items))
+	drifted := 0
+
+	for i := range board.Items {
+		item := &board.Items[i]
+		key := itemKey(item.Repo, item.Number)
+		newKeys[key] = true
+
+		if existing, ok := c.items[key]; ok {
+			if existing.Status != item.Status ||
+				len(existing.Labels) != len(item.Labels) ||
+				existing.UpdatedAt != item.UpdatedAt {
+				drifted++
+			}
+			// Update shallow fields; preserve deep fields from cache.
+			existing.Status = item.Status
+			existing.Labels = cloneStrings(item.Labels)
+			existing.Title = item.Title
+			existing.UpdatedAt = item.UpdatedAt
+			existing.IsClosed = item.IsClosed
+			existing.IsPR = item.IsPR
+			existing.ItemID = item.ItemID
+			existing.URL = item.URL
+			// Update the ItemID reverse lookup.
+			if item.ItemID != "" {
+				c.itemIDToKey[item.ItemID] = key
+			}
+		} else {
+			drifted++
+			cp := *item
+			c.items[key] = &cp
+			if item.ItemID != "" {
+				c.itemIDToKey[item.ItemID] = key
+			}
+		}
+	}
+
+	// Remove items that are no longer on the board.
+	for key := range c.items {
+		if !newKeys[key] {
+			drifted++
+			delete(c.items, key)
+			delete(c.deepFetched, key)
+		}
+	}
+
+	c.projectID = board.ProjectID
+	c.projectTitle = board.Title
+	c.projectOwnerType = board.OwnerType
+
+	if drifted > 0 {
+		c.logFn("[reconciliation] %d items differed\n", drifted)
+	}
+}
+
+// populateFromBoard replaces items map entirely from a board fetch.
+// Must be called with c.mu held (write).
+func (c *CacheImpl) populateFromBoard(board *gh.ProjectBoard) {
+	c.projectID = board.ProjectID
+	c.projectTitle = board.Title
+	c.projectOwnerType = board.OwnerType
+
+	c.items = make(map[string]*gh.ProjectItem, len(board.Items))
+	c.itemIDToKey = make(map[string]string, len(board.Items))
+	c.deepFetched = make(map[string]bool)
+
+	for i := range board.Items {
+		item := board.Items[i]
+		key := itemKey(item.Repo, item.Number)
+		cp := item
+		c.items[key] = &cp
+		if item.ItemID != "" {
+			c.itemIDToKey[item.ItemID] = key
+		}
+	}
+}
+
+// Pause stops delta application (called on WebhookStreamUnhealthy transition).
+func (c *CacheImpl) Pause() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.paused = true
+}
+
+// Resume re-enables delta application (called after reconciliation on stream recovery).
+func (c *CacheImpl) Resume() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.paused = false
+}
+
+// IsPaused returns true when delta application is paused.
+func (c *CacheImpl) IsPaused() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.paused
+}
+
+// FetchProjectBoard returns a *gh.ProjectBoard reconstructed from the items map.
+// Falls back to GitHub when the cache has not been bootstrapped.
+func (c *CacheImpl) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	c.mu.RLock()
+
+	if len(c.items) == 0 {
+		c.mu.RUnlock()
+		c.logFn("[cache] miss: FetchProjectBoard not yet bootstrapped — fetching from GitHub\n")
+		return c.fallback.FetchProjectBoard(owner, repo, projectNum, ownerType)
+	}
+
+	items := make([]gh.ProjectItem, 0, len(c.items))
+	for _, item := range c.items {
+		items = append(items, *item)
+	}
+	board := &gh.ProjectBoard{
+		ProjectID: c.projectID,
+		Title:     c.projectTitle,
+		OwnerType: c.projectOwnerType,
+		Items:     items,
+	}
+	c.mu.RUnlock()
+	return board, nil
+}
+
+// FetchItemDetails copies cached deep fields into the passed item pointer.
+// Deep fields: Body, URL, Author, Assignees, BlockedBy, Comments, LinkedPRNumber,
+// LinkedPRReviewRequests, LinkedPRReviews, LinkedPRReviewThreadComments, LinkedPRResolvedThreadCount.
+// Falls back to GitHub on cache miss and populates the cache with the result.
+func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
+	key := itemKey(item.Repo, item.Number)
+
+	c.mu.RLock()
+	cached, ok := c.items[key]
+	deepFetched := c.deepFetched[key]
+	if ok && deepFetched {
+		copyDeepFields(item, cached)
+		c.mu.RUnlock()
+		return nil
+	}
+	c.mu.RUnlock()
+
+	c.logFn("[cache] miss for #%d — fetching from GitHub\n", item.Number)
+	if err := c.fallback.FetchItemDetails(item); err != nil {
+		return err
+	}
+
+	// Store the deep fields in the cache.
+	c.mu.Lock()
+	if cached, ok := c.items[key]; ok {
+		mergeDeepFields(cached, item)
+	} else {
+		cp := *item
+		c.items[key] = &cp
+	}
+	c.deepFetched[key] = true
+	c.mu.Unlock()
+	return nil
+}
+
+// FetchCheckRuns returns cached check runs for a SHA; falls back to GitHub on miss.
+func (c *CacheImpl) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	c.mu.RLock()
+	if runs, ok := c.checkRuns[sha]; ok {
+		result := make([]gh.CheckRun, len(runs))
+		copy(result, runs)
+		c.mu.RUnlock()
+		return result, nil
+	}
+	c.mu.RUnlock()
+
+	c.logFn("[cache] miss: FetchCheckRuns sha=%s — fetching from GitHub\n", sha)
+	runs, err := c.fallback.FetchCheckRuns(owner, repo, sha)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.checkRuns[sha] = runs
+	c.mu.Unlock()
+	return runs, nil
+}
+
+// FetchLinkedPR returns cached PR details for an issue; falls back to GitHub on miss.
+func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	issKey := itemKey(owner+"/"+repo, issueNumber)
+
+	c.mu.RLock()
+	item, itemOK := c.items[issKey]
+	if itemOK && item.LinkedPRNumber != 0 {
+		pk := prKey(owner+"/"+repo, item.LinkedPRNumber)
+		if pr, ok := c.linkedPRs[pk]; ok {
+			prCopy := *pr
+			c.mu.RUnlock()
+			return &prCopy, nil
+		}
+	}
+	c.mu.RUnlock()
+
+	c.logFn("[cache] miss: FetchLinkedPR #%d — fetching from GitHub\n", issueNumber)
+	pr, err := c.fallback.FetchLinkedPR(owner, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	if pr != nil {
+		pk := prKey(owner+"/"+repo, pr.Number)
+		c.mu.Lock()
+		c.linkedPRs[pk] = pr
+		// Update item's LinkedPRNumber if not set.
+		if item2, ok := c.items[issKey]; ok && item2.LinkedPRNumber == 0 {
+			item2.LinkedPRNumber = pr.Number
+		}
+		c.mu.Unlock()
+	}
+	return pr, nil
+}
+
+// FetchPRMergeable always delegates to GitHub — mergeability changes without webhooks.
+func (c *CacheImpl) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
+	return c.fallback.FetchPRMergeable(owner, repo, prNumber)
+}
+
+// FetchPRMergeableState always delegates to GitHub — mergeability changes without webhooks.
+func (c *CacheImpl) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
+	return c.fallback.FetchPRMergeableState(owner, repo, prNumber)
+}
+
+// FetchLabels returns the cached label list for an issue; falls back to GitHub on miss.
+func (c *CacheImpl) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
+	key := itemKey(owner+"/"+repo, issueNumber)
+
+	c.mu.RLock()
+	if item, ok := c.items[key]; ok {
+		labels := cloneStrings(item.Labels)
+		c.mu.RUnlock()
+		return labels, nil
+	}
+	c.mu.RUnlock()
+
+	c.logFn("[cache] miss: FetchLabels #%d — fetching from GitHub\n", issueNumber)
+	return c.fallback.FetchLabels(owner, repo, issueNumber)
+}
+
+// FetchStatusField always delegates to GitHub — project metadata, not board-item state.
+func (c *CacheImpl) FetchStatusField(projectID string) (*gh.StatusField, error) {
+	return c.fallback.FetchStatusField(projectID)
+}
+
+// RateLimitStats always delegates to GitHub.
+func (c *CacheImpl) RateLimitStats() (rest, graphql gh.RateLimitStats) {
+	return c.fallback.RateLimitStats()
+}
+
+// copyDeepFields overlays the deep fields from src onto dst.
+// Shallow fields (Labels, Status, Title, UpdatedAt) are left unchanged in dst.
+func copyDeepFields(dst, src *gh.ProjectItem) {
+	dst.Body = src.Body
+	dst.URL = src.URL
+	dst.Author = src.Author
+	dst.Assignees = cloneStrings(src.Assignees)
+	dst.BlockedBy = cloneDependencies(src.BlockedBy)
+	dst.Comments = cloneComments(src.Comments)
+	dst.LinkedPRNumber = src.LinkedPRNumber
+	dst.LinkedPRReviewRequests = cloneReviewRequests(src.LinkedPRReviewRequests)
+	dst.LinkedPRReviews = clonePRReviews(src.LinkedPRReviews)
+	dst.LinkedPRReviewThreadComments = cloneComments(src.LinkedPRReviewThreadComments)
+	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
+}
+
+// mergeDeepFields copies deep fields from src into dst (for cache population after fallback).
+func mergeDeepFields(dst, src *gh.ProjectItem) {
+	dst.Body = src.Body
+	dst.URL = src.URL
+	dst.Author = src.Author
+	dst.Assignees = cloneStrings(src.Assignees)
+	dst.BlockedBy = cloneDependencies(src.BlockedBy)
+	dst.Comments = cloneComments(src.Comments)
+	dst.LinkedPRNumber = src.LinkedPRNumber
+	dst.LinkedPRReviewRequests = cloneReviewRequests(src.LinkedPRReviewRequests)
+	dst.LinkedPRReviews = clonePRReviews(src.LinkedPRReviews)
+	dst.LinkedPRReviewThreadComments = cloneComments(src.LinkedPRReviewThreadComments)
+	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
+}
+
+func cloneStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+func cloneComments(s []gh.Comment) []gh.Comment {
+	if s == nil {
+		return nil
+	}
+	out := make([]gh.Comment, len(s))
+	copy(out, s)
+	return out
+}
+
+func cloneDependencies(s []gh.Dependency) []gh.Dependency {
+	if s == nil {
+		return nil
+	}
+	out := make([]gh.Dependency, len(s))
+	copy(out, s)
+	return out
+}
+
+func cloneReviewRequests(s []gh.ReviewRequest) []gh.ReviewRequest {
+	if s == nil {
+		return nil
+	}
+	out := make([]gh.ReviewRequest, len(s))
+	copy(out, s)
+	return out
+}
+
+func clonePRReviews(s []gh.PRReview) []gh.PRReview {
+	if s == nil {
+		return nil
+	}
+	out := make([]gh.PRReview, len(s))
+	copy(out, s)
+	return out
+}

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -289,7 +289,7 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 	// Store the deep fields in the cache.
 	c.mu.Lock()
 	if cached, ok := c.items[key]; ok {
-		mergeDeepFields(cached, item)
+		copyDeepFields(cached, item)
 	} else {
 		cp := *item
 		c.items[key] = &cp
@@ -408,20 +408,6 @@ func copyDeepFields(dst, src *gh.ProjectItem) {
 	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
 }
 
-// mergeDeepFields copies deep fields from src into dst (for cache population after fallback).
-func mergeDeepFields(dst, src *gh.ProjectItem) {
-	dst.Body = src.Body
-	dst.URL = src.URL
-	dst.Author = src.Author
-	dst.Assignees = cloneStrings(src.Assignees)
-	dst.BlockedBy = cloneDependencies(src.BlockedBy)
-	dst.Comments = cloneComments(src.Comments)
-	dst.LinkedPRNumber = src.LinkedPRNumber
-	dst.LinkedPRReviewRequests = cloneReviewRequests(src.LinkedPRReviewRequests)
-	dst.LinkedPRReviews = clonePRReviews(src.LinkedPRReviews)
-	dst.LinkedPRReviewThreadComments = cloneComments(src.LinkedPRReviewThreadComments)
-	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
-}
 
 func cloneStrings(s []string) []string {
 	if s == nil {

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -240,13 +240,15 @@ func (c *CacheImpl) IsPaused() bool {
 }
 
 // FetchProjectBoard returns a *gh.ProjectBoard reconstructed from the items map.
-// Falls back to GitHub when the cache has not been bootstrapped.
+// Falls back to GitHub when the cache has not been bootstrapped or is paused.
 func (c *CacheImpl) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
 	c.mu.RLock()
 
-	if len(c.items) == 0 {
+	if len(c.items) == 0 || c.paused {
 		c.mu.RUnlock()
-		c.logFn("[cache] miss: FetchProjectBoard not yet bootstrapped — fetching from GitHub\n")
+		if len(c.items) == 0 {
+			c.logFn("[cache] miss: FetchProjectBoard not yet bootstrapped — fetching from GitHub\n")
+		}
 		return c.fallback.FetchProjectBoard(owner, repo, projectNum, ownerType)
 	}
 
@@ -272,6 +274,10 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 	key := itemKey(item.Repo, item.Number)
 
 	c.mu.RLock()
+	if c.paused {
+		c.mu.RUnlock()
+		return c.fallback.FetchItemDetails(item)
+	}
 	cached, ok := c.items[key]
 	deepFetched := c.deepFetched[key]
 	if ok && deepFetched {
@@ -302,6 +308,10 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 // FetchCheckRuns returns cached check runs for a SHA; falls back to GitHub on miss.
 func (c *CacheImpl) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
 	c.mu.RLock()
+	if c.paused {
+		c.mu.RUnlock()
+		return c.fallback.FetchCheckRuns(owner, repo, sha)
+	}
 	if runs, ok := c.checkRuns[sha]; ok {
 		result := make([]gh.CheckRun, len(runs))
 		copy(result, runs)
@@ -327,6 +337,10 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 	issKey := itemKey(owner+"/"+repo, issueNumber)
 
 	c.mu.RLock()
+	if c.paused {
+		c.mu.RUnlock()
+		return c.fallback.FetchLinkedPR(owner, repo, issueNumber)
+	}
 	item, itemOK := c.items[issKey]
 	if itemOK && item.LinkedPRNumber != 0 {
 		pk := prKey(owner+"/"+repo, item.LinkedPRNumber)
@@ -371,6 +385,10 @@ func (c *CacheImpl) FetchLabels(owner, repo string, issueNumber int) ([]string, 
 	key := itemKey(owner+"/"+repo, issueNumber)
 
 	c.mu.RLock()
+	if c.paused {
+		c.mu.RUnlock()
+		return c.fallback.FetchLabels(owner, repo, issueNumber)
+	}
 	if item, ok := c.items[key]; ok {
 		labels := cloneStrings(item.Labels)
 		c.mu.RUnlock()

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -463,6 +463,64 @@ func TestDeltaPullRequestReviewSubmittedUpsert(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Delta: pull_request_review_comment.created — idempotent by NodeID
+// ---------------------------------------------------------------------------
+
+func pullRequestReviewCommentPayloadJSON(action, repo string, prNum, dbID int, nodeID, body, user string) []byte {
+	p := pullRequestReviewCommentPayload{Action: action}
+	p.Repository.FullName = repo
+	p.PullRequest.Number = prNum
+	p.Comment.NodeID = nodeID
+	p.Comment.DatabaseID = dbID
+	p.Comment.Body = body
+	p.Comment.User.Login = user
+	p.Comment.CreatedAt = time.Now().Format(time.RFC3339)
+	p.Comment.DiffHunk = "@@ -1,3 +1,4 @@"
+	p.Comment.Path = "main.go"
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaPullRequestReviewCommentCreated(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	c.mu.Unlock()
+
+	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_node_1", "looks good", "bob")
+	c.ApplyDelta("pull_request_review_comment", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	comments := cloneComments(item.LinkedPRReviewThreadComments)
+	c.mu.RUnlock()
+
+	if len(comments) != 1 || comments[0].ID != "RC_node_1" || comments[0].Author != "bob" {
+		t.Errorf("unexpected review thread comments: %+v", comments)
+	}
+}
+
+func TestDeltaPullRequestReviewCommentCreatedIdempotent(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	c.mu.Unlock()
+
+	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_node_1", "looks good", "bob")
+	c.ApplyDelta("pull_request_review_comment", payload)
+	c.ApplyDelta("pull_request_review_comment", payload) // duplicate
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	count := len(item.LinkedPRReviewThreadComments)
+	c.mu.RUnlock()
+
+	if count != 1 {
+		t.Errorf("expected exactly 1 review thread comment after duplicate, got %d", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Delta: check_run.completed — upsert by ID
 // ---------------------------------------------------------------------------
 

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -798,3 +798,67 @@ func TestResumeReenablesDeltaApplication(t *testing.T) {
 		t.Error("delta should have been applied after resume")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Paused read methods fall through to GitHub (stream-health failover)
+// ---------------------------------------------------------------------------
+
+func TestFetchProjectBoardFallsThroughWhenPaused(t *testing.T) {
+	mc := &mockClient{projectBoardResult: &gh.ProjectBoard{
+		ProjectID: "PID2", Items: []gh.ProjectItem{{Number: 42, Repo: "o/r"}},
+	}}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}},
+	})
+	c.Pause()
+
+	board, err := c.FetchProjectBoard("o", "r", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	// Should return the fallback's board (ProjectID: "PID2"), not the cached one.
+	if board.ProjectID != "PID2" {
+		t.Errorf("expected fallback board (PID2) when paused, got %q", board.ProjectID)
+	}
+}
+
+func TestFetchLabelsFallsThroughWhenPaused(t *testing.T) {
+	mc := &mockClient{labelsResult: []string{"live-label"}}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Labels: []string{"cached-label"}}},
+	})
+	c.Pause()
+
+	labels, err := c.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "live-label" {
+		t.Errorf("expected live-label from fallback when paused, got %v", labels)
+	}
+	if mc.fetchLabelsCount != 1 {
+		t.Errorf("expected exactly 1 fallback call, got %d", mc.fetchLabelsCount)
+	}
+}
+
+func TestFetchCheckRunsFallsThroughWhenPaused(t *testing.T) {
+	mc := &mockClient{checkRunsResult: []gh.CheckRun{{ID: 99, Name: "live", Status: "completed", Conclusion: "success"}}}
+	c := NewCacheImpl(mc, nopLog)
+	// Pre-populate cache check runs so we can verify the paused path bypasses them.
+	c.mu.Lock()
+	c.checkRuns["sha_x"] = []gh.CheckRun{{ID: 1, Name: "cached"}}
+	c.mu.Unlock()
+	c.Pause()
+
+	runs, err := c.FetchCheckRuns("owner", "repo", "sha_x")
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != 99 {
+		t.Errorf("expected live run (ID=99) from fallback when paused, got %+v", runs)
+	}
+}

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -800,6 +800,54 @@ func TestResumeReenablesDeltaApplication(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Delta: UpdatedAt bumped so itemMayNeedWork picks up webhook-changed items
+// ---------------------------------------------------------------------------
+
+func TestDeltaBumpsUpdatedAt(t *testing.T) {
+	c := seedCache(t)
+
+	// Record item #1's initial UpdatedAt (zero from seed).
+	c.mu.RLock()
+	before := c.items[itemKey("owner/repo", 1)].UpdatedAt
+	c.mu.RUnlock()
+
+	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "newlabel")
+	c.ApplyDelta("issues", payload)
+
+	c.mu.RLock()
+	after := c.items[itemKey("owner/repo", 1)].UpdatedAt
+	c.mu.RUnlock()
+
+	if !after.After(before) {
+		t.Errorf("expected UpdatedAt to advance after labeled delta; before=%v after=%v", before, after)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta: pull_request_review_comment resets deepFetched for ReviewThreadID
+// ---------------------------------------------------------------------------
+
+func TestDeltaReviewCommentResetsDeepFetched(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	// Mark as already deep-fetched.
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+
+	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_node_2", "inline comment", "alice")
+	c.ApplyDelta("pull_request_review_comment", payload)
+
+	c.mu.RLock()
+	df := c.deepFetched[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+
+	if df {
+		t.Error("expected deepFetched to be reset after review comment delta so next FetchItemDetails fetches ReviewThreadID from GitHub")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Paused read methods fall through to GitHub (stream-health failover)
 // ---------------------------------------------------------------------------
 

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1,0 +1,742 @@
+package boardcache
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ---------------------------------------------------------------------------
+// Mock ReadClient for testing
+// ---------------------------------------------------------------------------
+
+type mockClient struct {
+	fetchItemDetailsCount int
+	fetchCheckRunsCount   int
+	fetchLinkedPRCount    int
+	fetchLabelsCount      int
+
+	itemDetailsResult  *gh.ProjectItem
+	checkRunsResult    []gh.CheckRun
+	linkedPRResult     *gh.PRDetails
+	labelsResult       []string
+	projectBoardResult *gh.ProjectBoard
+}
+
+func (m *mockClient) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	if m.projectBoardResult != nil {
+		return m.projectBoardResult, nil
+	}
+	return &gh.ProjectBoard{ProjectID: "PID", Items: nil}, nil
+}
+
+func (m *mockClient) FetchItemDetails(item *gh.ProjectItem) error {
+	m.fetchItemDetailsCount++
+	if m.itemDetailsResult != nil {
+		item.Body = m.itemDetailsResult.Body
+		item.Comments = cloneComments(m.itemDetailsResult.Comments)
+		item.LinkedPRNumber = m.itemDetailsResult.LinkedPRNumber
+		item.LinkedPRReviews = clonePRReviews(m.itemDetailsResult.LinkedPRReviews)
+		item.LinkedPRReviewRequests = cloneReviewRequests(m.itemDetailsResult.LinkedPRReviewRequests)
+		item.LinkedPRReviewThreadComments = cloneComments(m.itemDetailsResult.LinkedPRReviewThreadComments)
+		item.LinkedPRResolvedThreadCount = m.itemDetailsResult.LinkedPRResolvedThreadCount
+		item.Author = m.itemDetailsResult.Author
+		item.Assignees = cloneStrings(m.itemDetailsResult.Assignees)
+		item.BlockedBy = cloneDependencies(m.itemDetailsResult.BlockedBy)
+	}
+	return nil
+}
+
+func (m *mockClient) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	m.fetchCheckRunsCount++
+	return m.checkRunsResult, nil
+}
+
+func (m *mockClient) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	m.fetchLinkedPRCount++
+	return m.linkedPRResult, nil
+}
+
+func (m *mockClient) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
+	return nil, nil
+}
+
+func (m *mockClient) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
+	return "", nil
+}
+
+func (m *mockClient) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
+	m.fetchLabelsCount++
+	return m.labelsResult, nil
+}
+
+func (m *mockClient) FetchStatusField(projectID string) (*gh.StatusField, error) {
+	return &gh.StatusField{FieldID: "SF1", Options: map[string]string{"Research": "opt1"}}, nil
+}
+
+func (m *mockClient) RateLimitStats() (rest, graphql gh.RateLimitStats) {
+	return gh.RateLimitStats{}, gh.RateLimitStats{}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+var nopLog = func(format string, args ...any) {}
+
+func seedCache(t *testing.T) *CacheImpl {
+	t.Helper()
+	c := NewCacheImpl(&mockClient{}, nopLog)
+	board := &gh.ProjectBoard{
+		ProjectID: "PID",
+		Title:     "Test Board",
+		OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{
+				ID:     "I_001",
+				ItemID: "PVTI_001",
+				Number: 1,
+				Title:  "Issue One",
+				Repo:   "owner/repo",
+				Status: "Research",
+				Labels: []string{"enhancement"},
+			},
+			{
+				ID:     "I_002",
+				ItemID: "PVTI_002",
+				Number: 2,
+				Title:  "Issue Two",
+				Repo:   "owner/repo",
+				Status: "Plan",
+			},
+		},
+	}
+	c.Bootstrap(board)
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap / FetchProjectBoard tests
+// ---------------------------------------------------------------------------
+
+func TestBootstrapPopulatesItems(t *testing.T) {
+	c := seedCache(t)
+	board, err := c.FetchProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 2 {
+		t.Errorf("want 2 items, got %d", len(board.Items))
+	}
+}
+
+func TestFetchProjectBoardFallsBackWhenEmpty(t *testing.T) {
+	mc := &mockClient{projectBoardResult: &gh.ProjectBoard{
+		ProjectID: "PID", Items: []gh.ProjectItem{{Number: 5, Repo: "o/r"}},
+	}}
+	c := NewCacheImpl(mc, nopLog)
+	board, err := c.FetchProjectBoard("o", "r", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 1 || board.Items[0].Number != 5 {
+		t.Error("expected fallback board item #5")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchItemDetails — cache miss → fallback → populate
+// ---------------------------------------------------------------------------
+
+func TestFetchItemDetailsFallbackPopulatesCache(t *testing.T) {
+	mc := &mockClient{
+		itemDetailsResult: &gh.ProjectItem{
+			Body:           "body text",
+			Author:         "alice",
+			LinkedPRNumber: 99,
+			Comments: []gh.Comment{
+				{ID: "C1", DatabaseID: 1, Author: "bob", Body: "hello"},
+			},
+		},
+	}
+	c := NewCacheImpl(mc, nopLog)
+	board := &gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}},
+	}
+	c.Bootstrap(board)
+
+	item := gh.ProjectItem{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}
+	if err := c.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+	if item.Body != "body text" {
+		t.Errorf("want body 'body text', got %q", item.Body)
+	}
+	if len(item.Comments) != 1 {
+		t.Errorf("want 1 comment, got %d", len(item.Comments))
+	}
+	if item.LinkedPRNumber != 99 {
+		t.Errorf("want LinkedPRNumber 99, got %d", item.LinkedPRNumber)
+	}
+	if mc.fetchItemDetailsCount != 1 {
+		t.Errorf("expected exactly 1 fallback call, got %d", mc.fetchItemDetailsCount)
+	}
+
+	// Second call — must be served from cache without another fallback call.
+	item2 := gh.ProjectItem{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}
+	if err := c.FetchItemDetails(&item2); err != nil {
+		t.Fatalf("FetchItemDetails second: %v", err)
+	}
+	if mc.fetchItemDetailsCount != 1 {
+		t.Errorf("expected no additional fallback calls, got %d", mc.fetchItemDetailsCount)
+	}
+	if item2.Body != "body text" {
+		t.Errorf("second call: want body 'body text', got %q", item2.Body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta: issue_comment.created — idempotent by comment ID
+// ---------------------------------------------------------------------------
+
+func issueCommentPayloadJSON(action, repo string, issueNum int, nodeID string, dbID int, body, user string) []byte {
+	p := issueCommentPayload{Action: action}
+	p.Repository.FullName = repo
+	p.Issue.Number = issueNum
+	p.Comment.NodeID = nodeID
+	p.Comment.DatabaseID = dbID
+	p.Comment.Body = body
+	p.Comment.User.Login = user
+	p.Comment.CreatedAt = time.Now().Format(time.RFC3339)
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaIssueCommentCreated(t *testing.T) {
+	c := seedCache(t)
+	// Make sure item #1 is deep-fetched first (so Comments isn't nil from fallback).
+	c.mu.Lock()
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+
+	payload := issueCommentPayloadJSON("created", "owner/repo", 1, "C_abc", 100, "test comment", "alice")
+	c.ApplyDelta("issue_comment", payload)
+
+	board, _ := c.FetchProjectBoard("", "", 0, "")
+	var item *gh.ProjectItem
+	for i := range board.Items {
+		if board.Items[i].Number == 1 {
+			item = &board.Items[i]
+			break
+		}
+	}
+	if item == nil {
+		t.Fatal("item #1 not found")
+	}
+	// FetchProjectBoard returns shallow copy; comments are in cache.
+	// We need to check via FetchItemDetails.
+	c.mu.RLock()
+	cached := c.items[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+	if len(cached.Comments) != 1 || cached.Comments[0].ID != "C_abc" {
+		t.Errorf("expected comment C_abc, got %+v", cached.Comments)
+	}
+}
+
+func TestDeltaIssueCommentCreatedIdempotent(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+
+	payload := issueCommentPayloadJSON("created", "owner/repo", 1, "C_abc", 100, "test", "alice")
+	c.ApplyDelta("issue_comment", payload)
+	c.ApplyDelta("issue_comment", payload) // duplicate
+
+	c.mu.RLock()
+	cached := c.items[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+	if len(cached.Comments) != 1 {
+		t.Errorf("expected exactly 1 comment after duplicate, got %d", len(cached.Comments))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta: issues.labeled / unlabeled — set membership
+// ---------------------------------------------------------------------------
+
+func issuesLabeledPayloadJSON(action, repo string, issueNum int, label string) []byte {
+	p := issuesPayload{Action: action}
+	p.Repository.FullName = repo
+	p.Issue.Number = issueNum
+	p.Label.Name = label
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaIssuesLabeled(t *testing.T) {
+	c := seedCache(t)
+	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "bug")
+	c.ApplyDelta("issues", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	labels := cloneStrings(item.Labels)
+	c.mu.RUnlock()
+
+	found := false
+	for _, l := range labels {
+		if l == "bug" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected label 'bug', got %v", labels)
+	}
+}
+
+func TestDeltaIssuesLabeledIdempotent(t *testing.T) {
+	c := seedCache(t)
+	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "enhancement")
+	c.ApplyDelta("issues", payload)
+	c.ApplyDelta("issues", payload) // add same label twice
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	count := 0
+	for _, l := range item.Labels {
+		if l == "enhancement" {
+			count++
+		}
+	}
+	c.mu.RUnlock()
+
+	if count != 1 {
+		t.Errorf("label 'enhancement' should appear exactly once, got %d", count)
+	}
+}
+
+func TestDeltaIssuesUnlabeled(t *testing.T) {
+	c := seedCache(t)
+	// Seed has "enhancement" on item #1.
+	payload := issuesLabeledPayloadJSON("unlabeled", "owner/repo", 1, "enhancement")
+	c.ApplyDelta("issues", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	for _, l := range item.Labels {
+		if l == "enhancement" {
+			c.mu.RUnlock()
+			t.Error("label 'enhancement' should have been removed")
+			return
+		}
+	}
+	c.mu.RUnlock()
+}
+
+// ---------------------------------------------------------------------------
+// Delta: pull_request — update linkedPRs and shaToKey
+// ---------------------------------------------------------------------------
+
+func pullRequestPayloadJSON(action, repo string, prNum int, sha, state string, merged, draft bool) []byte {
+	p := pullRequestPayload{Action: action}
+	p.Repository.FullName = repo
+	p.PullRequest.Number = prNum
+	p.PullRequest.Head.SHA = sha
+	p.PullRequest.State = state
+	p.PullRequest.Merged = merged
+	p.PullRequest.Draft = draft
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaPullRequestOpened(t *testing.T) {
+	c := seedCache(t)
+	// Set LinkedPRNumber on item #1 so shaToKey can be populated.
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	c.mu.Unlock()
+
+	payload := pullRequestPayloadJSON("opened", "owner/repo", 42, "sha123", "open", false, false)
+	c.ApplyDelta("pull_request", payload)
+
+	c.mu.RLock()
+	pr, ok := c.linkedPRs[prKey("owner/repo", 42)]
+	shaKey, shaOK := c.shaToKey["sha123"]
+	c.mu.RUnlock()
+
+	if !ok || pr == nil {
+		t.Error("expected linkedPRs entry for PR #42")
+	}
+	if pr != nil && pr.HeadSHA != "sha123" {
+		t.Errorf("expected HeadSHA sha123, got %q", pr.HeadSHA)
+	}
+	if !shaOK || shaKey != itemKey("owner/repo", 1) {
+		t.Errorf("expected shaToKey[sha123] = owner/repo#1, got %q (ok=%v)", shaKey, shaOK)
+	}
+}
+
+func TestDeltaPullRequestSynchronizeUpdatesShaTKey(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	c.mu.Unlock()
+
+	// Initial SHA
+	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha_old", "open", false, false))
+	// New push — SHA changes
+	c.ApplyDelta("pull_request", pullRequestPayloadJSON("synchronize", "owner/repo", 42, "sha_new", "open", false, false))
+
+	c.mu.RLock()
+	_, oldOK := c.shaToKey["sha_old"]
+	_, newOK := c.shaToKey["sha_new"]
+	c.mu.RUnlock()
+
+	if oldOK {
+		t.Error("old SHA should have been removed from shaToKey")
+	}
+	if !newOK {
+		t.Error("new SHA should be in shaToKey")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta: pull_request_review.submitted — upsert by DatabaseID
+// ---------------------------------------------------------------------------
+
+func pullRequestReviewPayloadJSON(action, repo string, prNum, reviewID int, state, login string) []byte {
+	p := pullRequestReviewPayload{Action: action}
+	p.Repository.FullName = repo
+	p.PullRequest.Number = prNum
+	p.Review.DatabaseID = reviewID
+	p.Review.State = state
+	p.Review.User.Login = login
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaPullRequestReviewSubmitted(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	c.mu.Unlock()
+
+	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "approved", "alice")
+	c.ApplyDelta("pull_request_review", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	reviews := clonePRReviews(item.LinkedPRReviews)
+	c.mu.RUnlock()
+
+	if len(reviews) != 1 || reviews[0].Author != "alice" || reviews[0].State != "APPROVED" {
+		t.Errorf("unexpected reviews: %+v", reviews)
+	}
+}
+
+func TestDeltaPullRequestReviewSubmittedUpsert(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	c.mu.Unlock()
+
+	// First review: changes_requested
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "changes_requested", "alice"))
+	// Second review with same ID: approve (author re-reviews)
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "approved", "alice"))
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	reviews := clonePRReviews(item.LinkedPRReviews)
+	c.mu.RUnlock()
+
+	if len(reviews) != 1 {
+		t.Errorf("upsert: expected 1 review after re-review, got %d", len(reviews))
+	}
+	if reviews[0].State != "APPROVED" {
+		t.Errorf("expected APPROVED state after upsert, got %q", reviews[0].State)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta: check_run.completed — upsert by ID
+// ---------------------------------------------------------------------------
+
+func checkRunPayloadJSON(action, repo string, id int64, name, status, conclusion, sha string) []byte {
+	p := checkRunPayload{Action: action}
+	p.Repository.FullName = repo
+	p.CheckRun.ID = id
+	p.CheckRun.Name = name
+	p.CheckRun.Status = status
+	p.CheckRun.Conclusion = conclusion
+	p.CheckRun.HeadSHA = sha
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaCheckRunCompleted(t *testing.T) {
+	c := seedCache(t)
+	payload := checkRunPayloadJSON("completed", "owner/repo", 9001, "build", "completed", "success", "sha_abc")
+	c.ApplyDelta("check_run", payload)
+
+	c.mu.RLock()
+	runs := c.checkRuns["sha_abc"]
+	c.mu.RUnlock()
+
+	if len(runs) != 1 || runs[0].ID != 9001 || runs[0].Conclusion != "success" {
+		t.Errorf("unexpected check runs: %+v", runs)
+	}
+}
+
+func TestDeltaCheckRunUpsertById(t *testing.T) {
+	c := seedCache(t)
+	// First run: failure
+	c.ApplyDelta("check_run", checkRunPayloadJSON("completed", "owner/repo", 9001, "build", "completed", "failure", "sha_abc"))
+	// Same ID: success (re-run)
+	c.ApplyDelta("check_run", checkRunPayloadJSON("completed", "owner/repo", 9001, "build", "completed", "success", "sha_abc"))
+
+	c.mu.RLock()
+	runs := c.checkRuns["sha_abc"]
+	c.mu.RUnlock()
+
+	if len(runs) != 1 {
+		t.Errorf("upsert: expected 1 run after re-run, got %d", len(runs))
+	}
+	if runs[0].Conclusion != "success" {
+		t.Errorf("expected success after upsert, got %q", runs[0].Conclusion)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delta: projects_v2_item.edited — updates Status via ItemID
+// ---------------------------------------------------------------------------
+
+func projectsV2ItemPayloadJSON(action, itemID, statusName string) []byte {
+	p := projectsV2ItemPayload{Action: action}
+	p.ProjectsV2Item.ID = itemID
+	p.Changes.FieldValue.FieldType = "single_select"
+	p.Changes.FieldValue.To.Name = statusName
+	b, _ := json.Marshal(p)
+	return b
+}
+
+func TestDeltaProjectsV2ItemEdited(t *testing.T) {
+	c := seedCache(t)
+	// Item #1 has ItemID "PVTI_001", status "Research".
+	payload := projectsV2ItemPayloadJSON("edited", "PVTI_001", "Plan")
+	c.ApplyDelta("projects_v2_item", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	status := item.Status
+	c.mu.RUnlock()
+
+	if status != "Plan" {
+		t.Errorf("expected status 'Plan', got %q", status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchCheckRuns — cache miss → fallback → populate
+// ---------------------------------------------------------------------------
+
+func TestFetchCheckRunsFallback(t *testing.T) {
+	mc := &mockClient{checkRunsResult: []gh.CheckRun{{ID: 42, Name: "test", Status: "completed", Conclusion: "success"}}}
+	c := NewCacheImpl(mc, nopLog)
+
+	runs, err := c.FetchCheckRuns("owner", "repo", "sha_xyz")
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != 42 {
+		t.Errorf("unexpected runs: %+v", runs)
+	}
+	if mc.fetchCheckRunsCount != 1 {
+		t.Errorf("expected 1 fallback call, got %d", mc.fetchCheckRunsCount)
+	}
+
+	// Second call — from cache.
+	runs2, err := c.FetchCheckRuns("owner", "repo", "sha_xyz")
+	if err != nil {
+		t.Fatalf("FetchCheckRuns second: %v", err)
+	}
+	if mc.fetchCheckRunsCount != 1 {
+		t.Errorf("expected no additional fallback, got %d", mc.fetchCheckRunsCount)
+	}
+	if len(runs2) != 1 {
+		t.Errorf("expected 1 cached run, got %d", len(runs2))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchLabels — from cache
+// ---------------------------------------------------------------------------
+
+func TestFetchLabelsFromCache(t *testing.T) {
+	c := seedCache(t)
+	labels, err := c.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "enhancement" {
+		t.Errorf("unexpected labels: %v", labels)
+	}
+}
+
+func TestFetchLabelsFallbackOnMiss(t *testing.T) {
+	mc := &mockClient{labelsResult: []string{"foo"}}
+	c := NewCacheImpl(mc, nopLog)
+	// No bootstrap — empty cache.
+	labels, err := c.FetchLabels("owner", "repo", 99)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if mc.fetchLabelsCount != 1 {
+		t.Errorf("expected 1 fallback call, got %d", mc.fetchLabelsCount)
+	}
+	if len(labels) != 1 || labels[0] != "foo" {
+		t.Errorf("unexpected labels: %v", labels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile — wholesale replace, drift logging
+// ---------------------------------------------------------------------------
+
+func TestReconcileReplacesShallowData(t *testing.T) {
+	var logBuf strings.Builder
+	logFn := func(format string, args ...any) {
+		logBuf.WriteString(format)
+	}
+	c := NewCacheImpl(&mockClient{}, logFn)
+	c.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Research"},
+		},
+	})
+
+	// Reconcile with updated status.
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+
+	c.mu.RLock()
+	status := c.items[itemKey("owner/repo", 1)].Status
+	c.mu.RUnlock()
+
+	if status != "Plan" {
+		t.Errorf("expected status 'Plan' after reconcile, got %q", status)
+	}
+	if !strings.Contains(logBuf.String(), "reconciliation") {
+		t.Errorf("expected [reconciliation] log, got: %q", logBuf.String())
+	}
+}
+
+func TestReconcilePreservesDeepFields(t *testing.T) {
+	c := seedCache(t)
+	c.mu.Lock()
+	c.items[itemKey("owner/repo", 1)].Comments = []gh.Comment{{ID: "C1", Body: "preserved"}}
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	preserved := len(item.Comments) == 1 && item.Comments[0].ID == "C1"
+	deepFetched := c.deepFetched[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+
+	if !preserved {
+		t.Error("expected deep-fetched comments to be preserved after reconcile")
+	}
+	if !deepFetched {
+		t.Error("expected deepFetched flag to be preserved after reconcile")
+	}
+}
+
+func TestReconcileRemovesStaleItems(t *testing.T) {
+	c := seedCache(t) // has items #1 and #2
+
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research"},
+			// Item #2 removed from board
+		},
+	})
+
+	c.mu.RLock()
+	_, item2Exists := c.items[itemKey("owner/repo", 2)]
+	c.mu.RUnlock()
+
+	if item2Exists {
+		t.Error("item #2 should have been removed from cache after reconcile")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pause / Resume — delta application gate
+// ---------------------------------------------------------------------------
+
+func TestPauseStopsDeltaApplication(t *testing.T) {
+	c := seedCache(t)
+	c.Pause()
+
+	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "blocked")
+	c.ApplyDelta("issues", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	for _, l := range item.Labels {
+		if l == "blocked" {
+			c.mu.RUnlock()
+			t.Error("delta should not have been applied when paused")
+			return
+		}
+	}
+	c.mu.RUnlock()
+}
+
+func TestResumeReenablesDeltaApplication(t *testing.T) {
+	c := seedCache(t)
+	c.Pause()
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research", Labels: []string{"enhancement"}},
+			{ID: "I_002", ItemID: "PVTI_002", Number: 2, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+	c.Resume()
+
+	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "newlabel")
+	c.ApplyDelta("issues", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	found := false
+	for _, l := range item.Labels {
+		if l == "newlabel" {
+			found = true
+		}
+	}
+	c.mu.RUnlock()
+
+	if !found {
+		t.Error("delta should have been applied after resume")
+	}
+}

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -1,0 +1,448 @@
+package boardcache
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ApplyDelta dispatches a webhook payload to the appropriate typed delta function.
+// It is a no-op when the cache is paused (stream unhealthy).
+func (c *CacheImpl) ApplyDelta(eventType string, payload []byte) {
+	if c.IsPaused() {
+		return
+	}
+
+	switch eventType {
+	case "issue_comment":
+		c.applyIssueCommentCreated(payload)
+	case "issues":
+		c.applyIssuesDelta(payload)
+	case "pull_request":
+		c.applyPullRequestDelta(payload)
+	case "pull_request_review":
+		c.applyPullRequestReviewSubmitted(payload)
+	case "pull_request_review_comment":
+		c.applyPullRequestReviewCommentCreated(payload)
+	case "check_run":
+		c.applyCheckRunCompleted(payload)
+	case "projects_v2_item":
+		c.applyProjectsV2ItemEdited(payload)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Webhook payload structs (minimal — only fields needed for delta application)
+// ---------------------------------------------------------------------------
+
+type issueCommentPayload struct {
+	Action  string `json:"action"`
+	Comment struct {
+		NodeID     string `json:"node_id"`
+		DatabaseID int    `json:"id"`
+		Body       string `json:"body"`
+		CreatedAt  string `json:"created_at"`
+		User       struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	} `json:"comment"`
+	Issue struct {
+		Number int `json:"number"`
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type issuesPayload struct {
+	Action string `json:"action"`
+	Label  struct {
+		Name string `json:"name"`
+	} `json:"label"`
+	Issue struct {
+		Number int `json:"number"`
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type pullRequestPayload struct {
+	Action      string `json:"action"`
+	PullRequest struct {
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		State   string `json:"state"`
+		Merged  bool   `json:"merged"`
+		Draft   bool   `json:"draft"`
+		Head    struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+		MergeableState string `json:"mergeable_state"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type pullRequestReviewPayload struct {
+	Action string `json:"action"`
+	Review struct {
+		DatabaseID int    `json:"id"`
+		Body       string `json:"body"`
+		State      string `json:"state"`
+		User       struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	} `json:"review"`
+	PullRequest struct {
+		Number int `json:"number"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type pullRequestReviewCommentPayload struct {
+	Action  string `json:"action"`
+	Comment struct {
+		NodeID     string  `json:"node_id"`
+		DatabaseID int     `json:"id"`
+		Body       string  `json:"body"`
+		CreatedAt  string  `json:"created_at"`
+		DiffHunk   string  `json:"diff_hunk"`
+		Path       string  `json:"path"`
+		Line       *int    `json:"line"`
+		OriginalLine *int  `json:"original_line"`
+		User       struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		PullRequestURL string `json:"pull_request_url"`
+	} `json:"comment"`
+	PullRequest struct {
+		Number int `json:"number"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type checkRunPayload struct {
+	Action   string `json:"action"`
+	CheckRun struct {
+		ID         int64  `json:"id"`
+		Name       string `json:"name"`
+		Status     string `json:"status"`
+		Conclusion string `json:"conclusion"`
+		HeadSHA    string `json:"head_sha"`
+	} `json:"check_run"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+type projectsV2ItemPayload struct {
+	Action  string `json:"action"`
+	Changes struct {
+		FieldValue struct {
+			FieldType string `json:"field_type"`
+			To        struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"to"`
+		} `json:"field_value"`
+	} `json:"changes"`
+	ProjectsV2Item struct {
+		ID            string `json:"id"`
+		ContentNodeID string `json:"content_node_id"`
+		ContentType   string `json:"content_type"`
+	} `json:"projects_v2_item"`
+}
+
+// ---------------------------------------------------------------------------
+// Delta functions
+// ---------------------------------------------------------------------------
+
+func (c *CacheImpl) applyIssueCommentCreated(payload []byte) {
+	var p issueCommentPayload
+	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "created" {
+		return
+	}
+	key := itemKey(p.Repository.FullName, p.Issue.Number)
+
+	createdAt, _ := time.Parse(time.RFC3339, p.Comment.CreatedAt)
+	comment := gh.Comment{
+		ID:         p.Comment.NodeID,
+		DatabaseID: p.Comment.DatabaseID,
+		Author:     p.Comment.User.Login,
+		Body:       p.Comment.Body,
+		CreatedAt:  createdAt,
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item, ok := c.items[key]
+	if !ok {
+		return
+	}
+	// Idempotent: skip if comment with this ID already exists.
+	for _, existing := range item.Comments {
+		if existing.ID == comment.ID {
+			return
+		}
+	}
+	item.Comments = append(item.Comments, comment)
+}
+
+func (c *CacheImpl) applyIssuesDelta(payload []byte) {
+	var p issuesPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return
+	}
+	switch p.Action {
+	case "labeled":
+		c.applyIssuesLabeled(p)
+	case "unlabeled":
+		c.applyIssuesUnlabeled(p)
+	}
+}
+
+func (c *CacheImpl) applyIssuesLabeled(p issuesPayload) {
+	key := itemKey(p.Repository.FullName, p.Issue.Number)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item, ok := c.items[key]
+	if !ok {
+		return
+	}
+	// Set-membership add: skip if label already present.
+	for _, l := range item.Labels {
+		if l == p.Label.Name {
+			return
+		}
+	}
+	item.Labels = append(item.Labels, p.Label.Name)
+}
+
+func (c *CacheImpl) applyIssuesUnlabeled(p issuesPayload) {
+	key := itemKey(p.Repository.FullName, p.Issue.Number)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item, ok := c.items[key]
+	if !ok {
+		return
+	}
+	filtered := item.Labels[:0]
+	for _, l := range item.Labels {
+		if l != p.Label.Name {
+			filtered = append(filtered, l)
+		}
+	}
+	item.Labels = filtered
+}
+
+func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
+	var p pullRequestPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return
+	}
+	switch p.Action {
+	case "opened", "closed", "synchronize", "reopened":
+	default:
+		return
+	}
+
+	repo := p.Repository.FullName
+	pk := prKey(repo, p.PullRequest.Number)
+	prDetails := &gh.PRDetails{
+		Number:         p.PullRequest.Number,
+		Title:          p.PullRequest.Title,
+		State:          p.PullRequest.State,
+		Merged:         p.PullRequest.Merged,
+		Draft:          p.PullRequest.Draft,
+		HeadSHA:        p.PullRequest.Head.SHA,
+		MergeableState: p.PullRequest.MergeableState,
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Store/update PR details.
+	c.linkedPRs[pk] = prDetails
+
+	// Find the issue in cache that links this PR and update shaToKey.
+	sha := p.PullRequest.Head.SHA
+	for key, item := range c.items {
+		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
+			if sha != "" {
+				// On synchronize, the old SHA is now stale — remove it from the map
+				// by overwriting any existing entry for this issue with the new SHA.
+				for existingSHA, existingKey := range c.shaToKey {
+					if existingKey == key && existingSHA != sha {
+						delete(c.shaToKey, existingSHA)
+					}
+				}
+				c.shaToKey[sha] = key
+			}
+			break
+		}
+	}
+
+	// Also index by new SHA for check_run lookup.
+	if sha != "" {
+		// If we don't know the issue yet, the SHA entry will be populated when
+		// the item is deep-fetched (LinkedPRNumber set) and the next PR event arrives.
+		// For now, try to find via the PR cache entries.
+	}
+}
+
+func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
+	var p pullRequestReviewPayload
+	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "submitted" {
+		return
+	}
+	repo := p.Repository.FullName
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Find the issue that has this PR linked.
+	for _, item := range c.items {
+		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
+			review := gh.PRReview{
+				Author:     p.Review.User.Login,
+				State:      strings.ToUpper(p.Review.State),
+				Body:       p.Review.Body,
+				DatabaseID: p.Review.DatabaseID,
+			}
+			// Idempotent: upsert by DatabaseID (replace existing review from same author/id).
+			updated := false
+			for i, r := range item.LinkedPRReviews {
+				if r.DatabaseID == review.DatabaseID && review.DatabaseID != 0 {
+					item.LinkedPRReviews[i] = review
+					updated = true
+					break
+				}
+			}
+			if !updated {
+				item.LinkedPRReviews = append(item.LinkedPRReviews, review)
+			}
+			break
+		}
+	}
+}
+
+func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
+	var p pullRequestReviewCommentPayload
+	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "created" {
+		return
+	}
+	repo := p.Repository.FullName
+
+	createdAt, _ := time.Parse(time.RFC3339, p.Comment.CreatedAt)
+	comment := gh.Comment{
+		ID:         p.Comment.NodeID,
+		DatabaseID: p.Comment.DatabaseID,
+		Author:     p.Comment.User.Login,
+		Body:       p.Comment.Body,
+		CreatedAt:  createdAt,
+		DiffHunk:   p.Comment.DiffHunk,
+		Path:       p.Comment.Path,
+		FromPR:     p.PullRequest.Number,
+	}
+	if p.Comment.Line != nil {
+		comment.Line = *p.Comment.Line
+	}
+	if p.Comment.OriginalLine != nil {
+		comment.OriginalLine = *p.Comment.OriginalLine
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, item := range c.items {
+		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
+			// Idempotent: skip if comment with this ID already exists.
+			for _, existing := range item.LinkedPRReviewThreadComments {
+				if existing.ID == comment.ID {
+					return
+				}
+			}
+			item.LinkedPRReviewThreadComments = append(item.LinkedPRReviewThreadComments, comment)
+			break
+		}
+	}
+}
+
+func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
+	var p checkRunPayload
+	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "completed" {
+		return
+	}
+	sha := p.CheckRun.HeadSHA
+	if sha == "" {
+		return
+	}
+	cr := gh.CheckRun{
+		ID:         p.CheckRun.ID,
+		Name:       p.CheckRun.Name,
+		Status:     p.CheckRun.Status,
+		Conclusion: p.CheckRun.Conclusion,
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Upsert by ID: replace existing check run with same ID, or append.
+	runs := c.checkRuns[sha]
+	updated := false
+	for i, existing := range runs {
+		if existing.ID == cr.ID {
+			runs[i] = cr
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		runs = append(runs, cr)
+	}
+	c.checkRuns[sha] = runs
+
+	// shaToKey reverse lookup is updated by pull_request deltas.
+	// The check_run delta is stored by SHA; the engine always has the SHA from the linked PR.
+}
+
+func (c *CacheImpl) applyProjectsV2ItemEdited(payload []byte) {
+	var p projectsV2ItemPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return
+	}
+	if p.Action != "edited" {
+		return
+	}
+	if p.Changes.FieldValue.FieldType != "single_select" {
+		return
+	}
+	newStatus := p.Changes.FieldValue.To.Name
+	if newStatus == "" {
+		return
+	}
+	itemID := p.ProjectsV2Item.ID
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key, ok := c.itemIDToKey[itemID]
+	if !ok {
+		return
+	}
+	item, ok := c.items[key]
+	if !ok {
+		return
+	}
+	item.Status = newStatus
+}

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -194,6 +194,8 @@ func (c *CacheImpl) applyIssueCommentCreated(payload []byte) {
 		}
 	}
 	item.Comments = append(item.Comments, comment)
+	// Bump UpdatedAt so itemMayNeedWork detects this item as changed on the next poll.
+	item.UpdatedAt = time.Now()
 }
 
 func (c *CacheImpl) applyIssuesDelta(payload []byte) {
@@ -225,6 +227,7 @@ func (c *CacheImpl) applyIssuesLabeled(p issuesPayload) {
 		}
 	}
 	item.Labels = append(item.Labels, p.Label.Name)
+	item.UpdatedAt = time.Now()
 }
 
 func (c *CacheImpl) applyIssuesUnlabeled(p issuesPayload) {
@@ -236,6 +239,7 @@ func (c *CacheImpl) applyIssuesUnlabeled(p issuesPayload) {
 	if !ok {
 		return
 	}
+	before := len(item.Labels)
 	filtered := item.Labels[:0]
 	for _, l := range item.Labels {
 		if l != p.Label.Name {
@@ -243,6 +247,9 @@ func (c *CacheImpl) applyIssuesUnlabeled(p issuesPayload) {
 		}
 	}
 	item.Labels = filtered
+	if len(item.Labels) < before {
+		item.UpdatedAt = time.Now()
+	}
 }
 
 func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
@@ -324,6 +331,7 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 			if !updated {
 				item.LinkedPRReviews = append(item.LinkedPRReviews, review)
 			}
+			item.UpdatedAt = time.Now()
 			break
 		}
 	}
@@ -357,7 +365,7 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for _, item := range c.items {
+	for key, item := range c.items {
 		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
 			// Idempotent: skip if comment with this ID already exists.
 			for _, existing := range item.LinkedPRReviewThreadComments {
@@ -366,6 +374,12 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 				}
 			}
 			item.LinkedPRReviewThreadComments = append(item.LinkedPRReviewThreadComments, comment)
+			item.UpdatedAt = time.Now()
+			// The webhook payload does not carry the review thread's GraphQL node ID
+			// (ReviewThreadID). Reset deepFetched so the next FetchItemDetails call
+			// fetches from GitHub and populates ReviewThreadID correctly, allowing the
+			// engine to resolve the review thread after it's addressed.
+			delete(c.deepFetched, key)
 			break
 		}
 	}
@@ -438,4 +452,5 @@ func (c *CacheImpl) applyProjectsV2ItemEdited(payload []byte) {
 		return
 	}
 	item.Status = newStatus
+	item.UpdatedAt = time.Now()
 }

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -291,13 +291,6 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 			break
 		}
 	}
-
-	// Also index by new SHA for check_run lookup.
-	if sha != "" {
-		// If we don't know the issue yet, the SHA entry will be populated when
-		// the item is deep-fetched (LinkedPRNumber set) and the next PR event arrives.
-		// For now, try to find via the PR cache entries.
-	}
 }
 
 func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ type Config struct {
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     string // comma-separated; empty means default event set
+	BoardCacheMode    string // "in-memory" or "none"; empty = auto (in-memory when webhooks enabled)
 }
 
 func Execute() error {
@@ -129,6 +130,7 @@ func Execute() error {
 	flag.BoolVar(&cfg.Webhooks, "webhooks", false, "Enable webhook-driven event delivery via gh webhook forward (requires gh ≥ 2.32.0; also FABRIK_WEBHOOKS)")
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
+	flag.StringVar(&cfg.BoardCacheMode, "board-cache", "", `Board cache mode: "in-memory" (cache board state; requires --webhooks) or "none" (always fetch from GitHub). Default: "in-memory" when --webhooks is enabled, "none" otherwise. Also FABRIK_BOARD_CACHE.`)
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err
@@ -393,6 +395,27 @@ func Execute() error {
 			cfg.WebhookEvents = v
 		}
 	}
+	if !explicitFlags["board-cache"] {
+		if v := os.Getenv("FABRIK_BOARD_CACHE"); v != "" {
+			cfg.BoardCacheMode = v
+		}
+	}
+
+	// Apply board-cache default: "in-memory" when webhooks are enabled; "none" otherwise.
+	// Explicit --board-cache=in-memory without --webhooks is a configuration error.
+	if cfg.BoardCacheMode == "" {
+		if cfg.Webhooks {
+			cfg.BoardCacheMode = "in-memory"
+		} else {
+			cfg.BoardCacheMode = "none"
+		}
+	}
+	if cfg.BoardCacheMode == "in-memory" && !cfg.Webhooks {
+		return fmt.Errorf("--board-cache=in-memory requires --webhooks (no delta source without webhook events)")
+	}
+	if cfg.BoardCacheMode != "in-memory" && cfg.BoardCacheMode != "none" {
+		return fmt.Errorf("invalid --board-cache value %q: must be \"in-memory\" or \"none\"", cfg.BoardCacheMode)
+	}
 
 	if cfg.Owner == "" || cfg.ProjectNum == 0 {
 		flag.Usage()
@@ -505,6 +528,7 @@ func Execute() error {
 		Webhooks:          cfg.Webhooks,
 		WebhookPort:       cfg.WebhookPort,
 		WebhookEvents:     webhookEvents,
+		BoardCacheMode:    cfg.BoardCacheMode,
 		ReadyCh:           testReadyCh,
 	})
 	if err != nil {

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1625,6 +1625,7 @@ webhooks: true
 | Enable webhooks | `--webhooks` | `FABRIK_WEBHOOKS` | `webhooks: true` | off |
 | Listener port | `--webhook-port=<N>` | `FABRIK_WEBHOOK_PORT` | `webhook_port: <N>` | 0 (OS-assigned) |
 | Event filter | `--webhook-events=<csv>` | `FABRIK_WEBHOOK_EVENTS` | `webhook_events: [...]` | all supported events |
+| Board cache | `--board-cache=<mode>` | `FABRIK_BOARD_CACHE` | `board_cache: <mode>` | `in-memory` when `--webhooks`, else `none` |
 
 By default, Fabrik subscribes to: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `check_suite`, and `projects_v2_item` (board column changes — see note below).
 
@@ -1643,6 +1644,28 @@ The TUI footer shows a webhook health indicator when webhook mode is enabled:
 ### Expected GraphQL Load Reduction
 
 On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
+
+### In-Memory Board Cache (`--board-cache`)
+
+When webhook mode is active, Fabrik maintains an in-memory board cache (`--board-cache=in-memory`, the default). Incoming webhook payloads are applied as typed state deltas to the cache before the poll loop wakes, so most reads are served from memory rather than GitHub's API.
+
+**Cache modes:**
+
+| Mode | When | Behavior |
+|------|------|----------|
+| `in-memory` | `--webhooks` enabled (default) | Cache populated at startup; deltas from webhooks; reconciles every 60 min; falls back to GitHub when stream is unhealthy |
+| `none` | `--webhooks` disabled (default), or explicit override | All reads go directly to GitHub API (original behavior) |
+
+**To disable the cache while keeping webhooks:**
+```bash
+fabrik --webhooks --board-cache=none
+```
+
+**Stream-health failover:** If the webhook stream goes unhealthy (no events for 10 minutes), the cache pauses and all reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. This ensures correctness is never compromised by a degraded webhook stream.
+
+**Reconciliation:** Every 60 minutes (matching the idle-cap for healthy webhook streams), Fabrik fetches a fresh board snapshot from GitHub and updates the cache. This heals any events the webhook stream may have missed. Reconciliation also runs inline when the stream recovers from unhealthy.
+
+> **Note:** `--board-cache=in-memory` requires `--webhooks`. Without a webhook stream, there is no delta source and the cache would only reconcile every 60 minutes — worse than the default polling behavior.
 
 ### `projects_v2_item` (Board Column Changes)
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1287,3 +1287,84 @@ The `processedSet` map (in-memory, keyed by `issueKey(item, defaultRepo()) + "-"
 | 8 | PR item | Not a PR (PRs only support comments, checked after comment check) |
 | 9 | Stage complete | No `stage:<X>:complete` label |
 | 10 | Cooldown | Not attempted, OR cooldown expired |
+
+---
+
+## Appendix D: In-Memory Board Cache Lifecycle
+
+When `--webhooks` and `--board-cache=in-memory` are both active (the default when webhooks are enabled), the engine maintains an in-memory cache of board state in `boardcache.CacheImpl`. This appendix describes the cache lifecycle, delta semantics, reconciliation, and stream-health failover.
+
+### D.1 Bootstrap
+
+Immediately after `wm.Start()` succeeds (webhook manager listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` directly — bypassing the cache — and passes the result to `cacheImpl.Bootstrap(board)`. Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
+
+If the bootstrap fetch fails (e.g., transient network error), the cache starts empty and populates through fallback on the first cache miss. No data is lost; latency for the first deep-fetch is slightly higher.
+
+### D.2 Delta Application
+
+Every verified webhook payload is passed to `cacheImpl.ApplyDelta(eventType, payload []byte)` before the poll loop is woken. `ApplyDelta` is a no-op when `IsPaused()` returns true. Otherwise it dispatches to a typed handler:
+
+| Event type | Handler | Effect |
+|------------|---------|--------|
+| `issue_comment.created` | `applyIssueCommentCreated` | Appends comment to `item.Comments`; idempotent by NodeID |
+| `issues.labeled` | `applyIssuesLabeled` | Adds label to `item.Labels`; set-membership (no duplicates) |
+| `issues.unlabeled` | `applyIssuesUnlabeled` | Removes label from `item.Labels` |
+| `pull_request.opened/closed/synchronize` | `applyPullRequestDelta` | Upserts `linkedPRs[prKey]`; updates `shaToKey[sha]`; rotates old SHA on synchronize |
+| `pull_request_review.submitted` | `applyPullRequestReviewSubmitted` | Upserts review in `linkedPRs[prKey].Reviews` by DatabaseID |
+| `pull_request_review_comment.created` | `applyPullRequestReviewCommentCreated` | Appends to `LinkedPRReviewThreadComments`; idempotent by NodeID |
+| `check_run.completed` | `applyCheckRunCompleted` | Upserts check run in `checkRuns[sha]` by CheckRun.ID |
+| `projects_v2_item.edited` | `applyProjectsV2ItemEdited` | Updates `item.Status` via `itemIDToKey` reverse lookup |
+
+All delta functions hold the write lock for their mutation only. They silently drop events for unknown items (e.g., items not yet on the board) rather than returning errors.
+
+### D.3 Cache Read Semantics
+
+`CacheImpl` implements `boardcache.ReadClient`. When the poll loop calls a read method:
+
+| Method | Cache behavior |
+|--------|----------------|
+| `FetchProjectBoard` | Returns reconstructed board from `items` map; falls back to GitHub when cache is empty |
+| `FetchItemDetails` | Serves deep fields from cache when `deepFetched[key]` is true; falls back to GitHub and populates on miss; logs `[cache] miss for #N — fetching from GitHub` |
+| `FetchCheckRuns` | Serves from `checkRuns[sha]`; falls back and caches on miss |
+| `FetchLinkedPR` | Looks up `linkedPRs[prKey]` via `item.LinkedPRNumber`; falls back on miss |
+| `FetchPRMergeable` | Always delegates to fallback (mergeability changes without webhook events) |
+| `FetchPRMergeableState` | Always delegates to fallback |
+| `FetchLabels` | Serves from `item.Labels` when item is cached; falls back on miss |
+| `FetchStatusField` | Always delegates to fallback (static field metadata) |
+| `RateLimitStats` | Always delegates to fallback |
+
+### D.4 Reconciliation
+
+A `runReconciliationLoop` goroutine tickers at `webhookIdleCap` (60 min). Each tick calls `e.client.FetchProjectBoard(...)` directly and passes the result to `cacheImpl.Reconcile(board)`.
+
+`Reconcile` performs a partial update:
+- For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.
+- Items present in the cache but absent from the new snapshot are removed (they were archived or moved off the board).
+- `itemIDToKey` and `shaToKey` are rebuilt.
+- Logs `[reconciliation] N items differed` at the end.
+
+Reconciliation is also triggered inline on stream recovery (see §D.5).
+
+### D.5 Stream-Health Failover
+
+The `healthChangeFn` callback injected into `webhookManager` is called on health state transitions:
+
+| Transition | Action |
+|------------|--------|
+| Any → `WebhookStreamUnhealthy` (from `checkHealthTransitions`) | `cacheImpl.Pause()` |
+| Any → `WebhookStreamHealthy` (from `handleWebhook` on first recovery event) | `reconcileCache()` inline → `cacheImpl.Resume()` |
+
+When `IsPaused()` is true:
+- `ApplyDelta` is a no-op (deltas are dropped rather than applied to a potentially stale cache).
+- All `CacheImpl` read methods fall through to the `fallback` ReadClient (live GitHub API), so correctness is preserved at the cost of increased GraphQL usage.
+
+On recovery, `reconcileCache()` fetches a fresh board snapshot before `Resume()` so the cache is coherent immediately when `IsPaused()` returns false.
+
+### D.6 Cache Mode Selection
+
+| `--board-cache` | `--webhooks` | Behavior |
+|-----------------|--------------|----------|
+| `in-memory` (default when webhooks on) | required | `CacheImpl` with delta/failover |
+| `none` | any | `GitHubAdapter` pass-through (no caching) |
+
+Specifying `--board-cache=in-memory` without `--webhooks` is a configuration error: without a webhook stream there is no delta source and the cache would only reconcile every 60 minutes, which is worse than direct polling.

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -41,7 +41,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	key := issueKey(item, e.defaultRepo())
 
-	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
 		e.logf(item.Number, "ci-gate", "could not fetch linked PR: %v — blocking until API recovers\n", err)
 		return true, false, false // transient error; retry on next poll
@@ -60,7 +60,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 	// workflow jobs like "Cleanup artifacts" that GitHub itself does not treat
 	// as merge blockers). Falls through to per-check classification when
 	// mergeable_state is empty/unknown/blocked/etc.
-	if mergeableState, msErr := e.client.FetchPRMergeableState(owner, repo, pr.Number); msErr != nil {
+	if mergeableState, msErr := e.readClient.FetchPRMergeableState(owner, repo, pr.Number); msErr != nil {
 		e.logf(item.Number, "warn", "could not fetch mergeable_state: %v — falling back to check-runs gate\n", msErr)
 	} else if gh.MergeableStateAccepted(mergeableState) {
 		e.logf(item.Number, "ci-gate", "mergeable_state=%q — gate clears (skipping check_runs classification)\n", mergeableState)
@@ -68,7 +68,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 		return false, false, false
 	}
 
-	checkRuns, err := e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
+	checkRuns, err := e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
 	if err != nil {
 		e.logf(item.Number, "ci-gate", "could not fetch check runs: %v — blocking until API recovers\n", err)
 		return true, false, false // transient error; retry on next poll
@@ -205,9 +205,9 @@ func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, wor
 	var baseBranch string
 
 	// Fetch PR check runs.
-	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
 	if err == nil && pr != nil && pr.HeadSHA != "" {
-		prFailures, _ = e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
+		prFailures, _ = e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
 	}
 
 	// Fetch base branch check runs for comparison.
@@ -216,7 +216,7 @@ func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, wor
 	if err == nil {
 		baseBranch = bb
 		if baseSHA, err := gitRevParse(workDir, "origin/"+baseBranch); err == nil && baseSHA != "" {
-			baseRuns, _ = e.client.FetchCheckRuns(owner, repo, baseSHA)
+			baseRuns, _ = e.readClient.FetchCheckRuns(owner, repo, baseSHA)
 		}
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -40,6 +41,7 @@ type Config struct {
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     []string
+	BoardCacheMode    string // "in-memory" or "none"; default "none" when webhooks off, "in-memory" when on
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}
@@ -57,6 +59,7 @@ type cloneCall struct {
 type Engine struct {
 	cfg                  Config
 	client               GitHubClient
+	readClient           boardcache.ReadClient // read-only GitHub calls; may be CacheImpl or GitHubAdapter
 	claude               ClaudeInvoker
 	statusField          *gh.StatusField
 	worktreeManagers     map[string]*WorktreeManager // key: "owner/repo"; one WM per discovered repo
@@ -163,6 +166,16 @@ func New(cfg Config) (*Engine, error) {
 	// fabrik.log in both TUI and plain-text modes.
 	gh.Logf = eng.logf
 
+	// Initialize the read client: GitHubAdapter (pass-through) unless the in-memory
+	// board cache is enabled, in which case CacheImpl is created (bootstrap happens in Run()).
+	adapter := boardcache.NewGitHubAdapter(eng.client)
+	if cfg.BoardCacheMode == "in-memory" {
+		cacheLogFn := func(format string, args ...any) { eng.logf(0, "cache", format, args...) }
+		eng.readClient = boardcache.NewCacheImpl(adapter, cacheLogFn)
+	} else {
+		eng.readClient = adapter
+	}
+
 	return eng, nil
 }
 
@@ -204,6 +217,8 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		}
 		wms[key] = worktrees
 	}
+	// Tests always use pass-through adapter (--board-cache=none behavior).
+	eng.readClient = boardcache.NewGitHubAdapter(client)
 	return eng
 }
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -579,7 +579,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// and treated as "win" (both proceed), consistent with single-instance use.
 	if lockAcquired {
 		time.Sleep(lockVerifyDelay)
-		labels, err := e.readClient.FetchLabels(owner, repo, item.Number)
+		// Lock verification needs live labels, not cached state — another instance
+		// may have written its lock label in the window since we read from cache.
+		labels, err := e.client.FetchLabels(owner, repo, item.Number)
 		if err != nil {
 			e.logf(item.Number, "warn", "could not re-fetch labels for lock verify: %v\n", err)
 		} else {

--- a/engine/item.go
+++ b/engine/item.go
@@ -579,7 +579,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// and treated as "win" (both proceed), consistent with single-instance use.
 	if lockAcquired {
 		time.Sleep(lockVerifyDelay)
-		labels, err := e.client.FetchLabels(owner, repo, item.Number)
+		labels, err := e.readClient.FetchLabels(owner, repo, item.Number)
 		if err != nil {
 			e.logf(item.Number, "warn", "could not re-fetch labels for lock verify: %v\n", err)
 		} else {

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -35,7 +35,7 @@ func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage)
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
 		// Transient API error. Block this item for the rest of Phase 1 so we
 		// don't run the CI gate on stale data (it would make its own REST
@@ -48,7 +48,7 @@ func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage)
 		return false, false
 	}
 
-	mergeable, err := e.client.FetchPRMergeable(owner, repo, pr.Number)
+	mergeable, err := e.readClient.FetchPRMergeable(owner, repo, pr.Number)
 	if err != nil {
 		e.logf(item.Number, "merge-gate", "could not fetch mergeable: %v — blocking until API recovers\n", err)
 		return true, false

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -287,6 +288,9 @@ func (e *Engine) Run() error {
 		e.logf(0, "warn", "label seeding failed (non-fatal): %v\n", err)
 	}
 
+	// Extract in-memory cache if configured (nil when board-cache=none).
+	cacheImpl, _ := e.readClient.(*boardcache.CacheImpl)
+
 	// Start webhook manager when enabled. Failures are non-fatal: the engine
 	// continues in polling-only mode.
 	if e.cfg.Webhooks {
@@ -297,16 +301,40 @@ func (e *Engine) Run() error {
 		if e.cfg.Owner != "" && e.cfg.Repo != "" {
 			initialRepos = map[string]bool{e.cfg.Owner + "/" + e.cfg.Repo: true}
 		}
+		var deltaFn func(string, []byte)
+		var healthChangeFn func(bool)
+		if cacheImpl != nil {
+			deltaFn = cacheImpl.ApplyDelta
+			healthChangeFn = func(healthy bool) {
+				if healthy {
+					e.reconcileCache(cacheImpl)
+					cacheImpl.Resume()
+				} else {
+					cacheImpl.Pause()
+				}
+			}
+		}
 		wm := newWebhookManager(
 			e.logf,
 			e.wakeCh,
 			e.emit,
 			initialRepos,
 			e.cfg.WebhookEvents,
+			deltaFn,
+			healthChangeFn,
 		)
 		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {
 			e.webhookMgr = wm
 			defer wm.Stop()
+			if cacheImpl != nil {
+				board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+				if err != nil {
+					e.logf(0, "cache", "bootstrap fetch failed — cache will be populated on first miss: %v\n", err)
+				} else {
+					cacheImpl.Bootstrap(board)
+				}
+				go e.runReconciliationLoop(ctx, cacheImpl)
+			}
 		}
 	}
 
@@ -1347,4 +1375,31 @@ func (e *Engine) checkURLRewrite() bool {
 		}
 	}
 	return false
+}
+
+// reconcileCache fetches a fresh board snapshot from GitHub and applies it to
+// the in-memory cache, preserving deep fields already fetched for individual items.
+func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
+	board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+	if err != nil {
+		e.logf(0, "cache", "reconciliation fetch failed: %v\n", err)
+		return
+	}
+	cache.Reconcile(board)
+}
+
+// runReconciliationLoop periodically reconciles the in-memory cache with GitHub
+// by fetching a full board snapshot. It runs once per webhookIdleCap (60 min)
+// so the cache self-heals any deltas missed by the webhook stream.
+func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.CacheImpl) {
+	ticker := time.NewTicker(webhookIdleCap)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.reconcileCache(cache)
+		}
+	}
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -323,16 +323,20 @@ func (e *Engine) Run() error {
 			deltaFn,
 			healthChangeFn,
 		)
+		// Bootstrap the cache before accepting webhook events so no delta is
+		// dropped into an empty cache during the startup window.
+		if cacheImpl != nil {
+			board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+			if err != nil {
+				e.logf(0, "cache", "bootstrap fetch failed — cache will be populated on first miss: %v\n", err)
+			} else {
+				cacheImpl.Bootstrap(board)
+			}
+		}
 		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {
 			e.webhookMgr = wm
 			defer wm.Stop()
 			if cacheImpl != nil {
-				board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
-				if err != nil {
-					e.logf(0, "cache", "bootstrap fetch failed — cache will be populated on first miss: %v\n", err)
-				} else {
-					cacheImpl.Bootstrap(board)
-				}
 				go e.runReconciliationLoop(ctx, cacheImpl)
 			}
 		}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -569,7 +569,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	e.emitStructural(tui.PollStartedEvent{Owner: e.cfg.Owner, Repo: e.cfg.Repo, Project: e.cfg.ProjectNum})
 	e.logf(0, "poll", "fetching project board %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
 
-	board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+	board, err := e.readClient.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 	if err != nil {
 		pollStatusClear()
 		return pollResult{}, err
@@ -578,7 +578,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// Fetch status field metadata (for mutations) on first poll
 	e.mu.Lock()
 	if e.statusField == nil && board.ProjectID != "" {
-		sf, err := e.client.FetchStatusField(board.ProjectID)
+		sf, err := e.readClient.FetchStatusField(board.ProjectID)
 		if err != nil {
 			e.logf(0, "warn", "could not fetch status field: %v\n", err)
 		} else {
@@ -694,7 +694,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		}
 		e.logf(0, "poll", "deep-fetching details for #%d\n", board.Items[i].Number)
 		iKey := issueKey(board.Items[i], e.defaultRepo())
-		if err := e.client.FetchItemDetails(&board.Items[i]); err != nil {
+		if err := e.readClient.FetchItemDetails(&board.Items[i]); err != nil {
 			e.logf(0, "warn", "could not fetch details for #%d: %v\n", board.Items[i].Number, err)
 			e.mu.Lock()
 			e.deepFetchFailureTime[iKey] = time.Now()

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -60,9 +60,9 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	e.removeFailedLabel(owner, repo, item.Number, stage.Name)
 
 	// Re-fetch labels so we see changes made while the stage was running
-	// (e.g., fabrik:yolo added mid-run). The item snapshot from dispatch
-	// time may be stale. On error, keep existing labels.
-	if freshLabels, err := e.readClient.FetchLabels(e.cfg.Owner, e.cfg.Repo, item.Number); err == nil && len(freshLabels) > 0 {
+	// (e.g., fabrik:yolo added mid-run). Must bypass cache — the webhook for a
+	// label added mid-run may not have been applied yet. On error, keep existing labels.
+	if freshLabels, err := e.client.FetchLabels(e.cfg.Owner, e.cfg.Repo, item.Number); err == nil && len(freshLabels) > 0 {
 		item.Labels = freshLabels
 	}
 

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -62,7 +62,7 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	// Re-fetch labels so we see changes made while the stage was running
 	// (e.g., fabrik:yolo added mid-run). The item snapshot from dispatch
 	// time may be stale. On error, keep existing labels.
-	if freshLabels, err := e.client.FetchLabels(e.cfg.Owner, e.cfg.Repo, item.Number); err == nil && len(freshLabels) > 0 {
+	if freshLabels, err := e.readClient.FetchLabels(e.cfg.Owner, e.cfg.Repo, item.Number); err == nil && len(freshLabels) > 0 {
 		item.Labels = freshLabels
 	}
 
@@ -209,7 +209,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 	iKey := issueKey(item, e.defaultRepo())
 
 	// Use FetchLinkedPR (REST) to get both the PR number and head SHA in one call.
-	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
 		e.logf(item.Number, "warn", "could not fetch linked PR for merge: %v — will retry\n", err)
 		return fmt.Errorf("fetch linked PR: %w", err)
@@ -229,7 +229,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 	// endpoint, so this requires an extra REST call.
 	bypassCheckRunsGate := false
 	if pr.HeadSHA != "" {
-		mergeableState, msErr := e.client.FetchPRMergeableState(owner, repo, pr.Number)
+		mergeableState, msErr := e.readClient.FetchPRMergeableState(owner, repo, pr.Number)
 		if msErr != nil {
 			e.logf(item.Number, "warn", "could not fetch mergeable_state: %v — falling back to check-runs gate\n", msErr)
 		} else if gh.MergeableStateAccepted(mergeableState) {
@@ -247,7 +247,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 	// CI gate: fetch check runs and evaluate (R1-R6). Skipped when GitHub's
 	// mergeable_state already says the PR is mergeable (above).
 	if !bypassCheckRunsGate && pr.HeadSHA != "" {
-		checkRuns, err := e.client.FetchCheckRuns(owner, repo, pr.HeadSHA)
+		checkRuns, err := e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
 		if err != nil {
 			e.logf(item.Number, "warn", "could not fetch check runs for merge guard: %v — skipping merge until CI status can be fetched\n", err)
 			return fmt.Errorf("merge guard: fetch check runs: %w", err)

--- a/engine/startup.go
+++ b/engine/startup.go
@@ -22,7 +22,7 @@ import (
 // On success the fetched StatusField is stored in e.statusField so poll()'s
 // lazy guard skips the redundant second FetchStatusField call.
 func (e *Engine) checkStageColumnAlignment(ctx context.Context) error {
-	board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+	board, err := e.readClient.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 	if err != nil {
 		e.logf(0, "startup", "warning: could not fetch project board for startup check: %v\n", err)
 		return nil
@@ -42,7 +42,7 @@ func (e *Engine) checkStageColumnAlignment(ctx context.Context) error {
 		e.emitStructural(tui.ProjectMetaEvent{BoardTitle: board.Title, BoardURL: boardURL})
 	}
 
-	sf, err := e.client.FetchStatusField(board.ProjectID)
+	sf, err := e.readClient.FetchStatusField(board.ProjectID)
 	if err != nil {
 		e.logf(0, "startup", "warning: could not fetch status field for startup check: %v\n", err)
 		return nil

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -850,14 +850,17 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 
 	wm.emitCurrentState()
 
-	// Apply cache delta before waking the poll loop, so the cache is fresh when poll runs.
-	if wm.deltaFn != nil {
-		wm.deltaFn(eventType, body)
-	}
-
-	// Notify health-change listener when stream recovers from unhealthy/starting-up.
+	// On recovery from unhealthy/starting-up, reconcile and resume the cache first
+	// so the delta applied below lands on coherent state rather than being dropped
+	// because the cache is still paused.
 	if prevState != WebhookStreamHealthy && wm.healthChangeFn != nil {
 		wm.healthChangeFn(true)
+	}
+
+	// Apply cache delta after any recovery reconciliation, so the cache is fresh
+	// when the poll loop wakes.
+	if wm.deltaFn != nil {
+		wm.deltaFn(eventType, body)
 	}
 
 	// Wake the poll loop immediately.

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -62,9 +62,11 @@ type webhookManager struct {
 	mu sync.Mutex
 
 	// injected dependencies
-	logFn  func(issueNumber int, tag, format string, args ...any)
-	wakeCh chan struct{}
-	emitFn func(tui.Event)
+	logFn         func(issueNumber int, tag, format string, args ...any)
+	wakeCh        chan struct{}
+	emitFn        func(tui.Event)
+	deltaFn       func(eventType string, payload []byte) // nil when board cache disabled
+	healthChangeFn func(healthy bool)                    // nil when board cache disabled
 
 	// killFn terminates a subprocess. Defaults to killProcGroup; overridable in tests.
 	// The caller is responsible for the cmd != nil check; killFn handles nil Process.
@@ -110,6 +112,8 @@ func newWebhookManager(
 	emitFn func(tui.Event),
 	repos map[string]bool,
 	events []string,
+	deltaFn func(string, []byte),
+	healthChangeFn func(bool),
 ) *webhookManager {
 	evts := events
 	if len(evts) == 0 {
@@ -117,15 +121,17 @@ func newWebhookManager(
 		copy(evts, defaultWebhookEvents)
 	}
 	wm := &webhookManager{
-		logFn:       logFn,
-		wakeCh:      wakeCh,
-		emitFn:      emitFn,
-		repos:       copyRepoSet(repos),
-		events:      evts,
-		state:       WebhookStreamUnhealthy, // becomes StartingUp when subprocess launches
-		eventCounts: make(map[string]int),
-		stopCh:      make(chan struct{}),
-		repoReadyCh: make(chan struct{}),
+		logFn:          logFn,
+		wakeCh:         wakeCh,
+		emitFn:         emitFn,
+		deltaFn:        deltaFn,
+		healthChangeFn: healthChangeFn,
+		repos:          copyRepoSet(repos),
+		events:         evts,
+		state:          WebhookStreamUnhealthy, // becomes StartingUp when subprocess launches
+		eventCounts:    make(map[string]int),
+		stopCh:         make(chan struct{}),
+		repoReadyCh:    make(chan struct{}),
 		killFn: func(cmd *exec.Cmd) {
 			if cmd != nil && cmd.Process != nil {
 				killProcGroup(cmd)
@@ -699,6 +705,9 @@ func (wm *webhookManager) checkHealthTransitions() {
 		wm.mu.Unlock()
 		wm.logFn(0, "webhook", "health state: %s → %s\n", state, newState)
 		wm.emitCurrentState()
+		if newState == WebhookStreamUnhealthy && wm.healthChangeFn != nil {
+			wm.healthChangeFn(false)
+		}
 		return
 	}
 	wm.mu.Unlock()
@@ -840,6 +849,16 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	}
 
 	wm.emitCurrentState()
+
+	// Apply cache delta before waking the poll loop, so the cache is fresh when poll runs.
+	if wm.deltaFn != nil {
+		wm.deltaFn(eventType, body)
+	}
+
+	// Notify health-change listener when stream recovers from unhealthy/starting-up.
+	if prevState != WebhookStreamHealthy && wm.healthChangeFn != nil {
+		wm.healthChangeFn(true)
+	}
 
 	// Wake the poll loop immediately.
 	select {

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -190,6 +190,8 @@ func newTestWebhookManager(t *testing.T) (*webhookManager, chan tui.Event) {
 		func(e tui.Event) { events <- e },
 		map[string]bool{"myorg/myrepo": true},
 		nil,
+		nil,
+		nil,
 	)
 	return wm, events
 }


### PR DESCRIPTION
## What this PR does

Adds an in-memory board cache that is populated at startup via a full GraphQL fetch and kept current by applying typed state deltas from incoming webhook payloads. When `--webhooks` is enabled, the engine reads board/item/PR/check-run state from the cache instead of issuing per-event GraphQL fetches. This eliminates the \"one full GraphQL fetch per webhook event\" cost introduced in #452, turning per-event GraphQL consumption from O(events) to near-zero during steady state.

## Key changes

**New `boardcache` package** (`boardcache/boardcache.go`, `boardcache/delta.go`):
- `ReadClient` interface — 9-method read-only subset of `engine.GitHubClient`
- `GitHubAdapter` — pass-through wrapper (used when `--board-cache=none`)
- `CacheImpl` — in-memory cache with `sync.RWMutex`, delta application, bootstrap/reconcile, pause/resume for stream-health failover
- Typed delta functions for all 7 subscribed event types: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `projects_v2_item`

**Engine integration**:
- `Engine.readClient boardcache.ReadClient` field replaces 19 `e.client.Fetch*` call sites across `poll.go`, `item.go`, `merge_gate.go`, `stages.go`, `ci.go`, `startup.go`
- Bootstrap: after webhook listener starts, one full board fetch populates the cache before the first poll cycle
- Reconciliation goroutine: tickers at `webhookIdleCap` (60 min), fetching a fresh board snapshot and calling `cacheImpl.Reconcile()`
- Stream-health failover: `healthChangeFn` callback pauses the cache on `WebhookStreamUnhealthy`, reconciles + resumes on recovery

**CLI**: `--board-cache` flag (`FABRIK_BOARD_CACHE` env var) — defaults to `in-memory` when `--webhooks` is enabled, `none` otherwise. Validation error if `in-memory` is requested without `--webhooks`.

**Documentation**:
- `docs/state-machine.md` Appendix D: cache lifecycle, delta semantics, reconciliation, stream-health failover
- `adrs/034-boardcache-event-sourced-delta.md`: new ADR documenting the Go-struct boundary choice
- `adrs/003-polling-over-webhooks.md`: updated to reference ADR 032 and ADR 034
- `docs/USER_GUIDE.md`: `--board-cache` flag documentation
- `CLAUDE.md`: boardcache package added to Architecture section

## How to test

1. Enable webhooks: `fabrik --webhooks` (requires `gh ≥ 2.32.0`)
2. Observe `[cache] bootstrap complete: N items` in startup log
3. Trigger a webhook event (add a label, post a comment on an issue); observe poll wakes without `[graphql]` fetch logs for board reads
4. After 60 min (or restart with a short ticker for testing): observe `[reconciliation]` log entry
5. Simulate unhealthy stream: stop `gh webhook forward` subprocess; observe `[cache]` paused log and poll loop falling back to GitHub reads
6. Disable cache: `fabrik --webhooks --board-cache=none` — should behave identically to pre-#478 webhook behavior

**Unit tests** (`boardcache/boardcache_test.go`): delta semantics, idempotency, cache-miss fallback, reconciliation drift count, pause/resume stream failover.

```bash
go test -race ./...
```

Closes #478