### PR TITLE
Add /llms.txt and /llms-full.txt to docs site (fabrik.shadoworg.dev)

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,28 @@
+name: Docs drift check
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "scripts/generate-llms-full.sh"
+
+jobs:
+  check-llms-full:
+    name: Verify llms-full.txt is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Regenerate llms-full.txt
+        run: scripts/generate-llms-full.sh
+
+      - name: Fail if llms-full.txt is out of date
+        run: |
+          if ! git diff --exit-code docs/llms-full.txt; then
+            echo ""
+            echo "docs/llms-full.txt is out of date."
+            echo "Run 'scripts/generate-llms-full.sh' and commit the result alongside your doc changes."
+            exit 1
+          fi

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -6,6 +6,9 @@ on:
       - "docs/**"
       - "scripts/generate-llms-full.sh"
 
+permissions:
+  contents: read
+
 jobs:
   check-llms-full:
     name: Verify llms-full.txt is up to date
@@ -16,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Regenerate llms-full.txt
-        run: scripts/generate-llms-full.sh
+        run: bash scripts/generate-llms-full.sh
 
       - name: Fail if llms-full.txt is out of date
         run: |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,3743 @@
+# Fabrik User Guide
+
+Source: https://fabrik.shadoworg.dev/USER_GUIDE
+
+
+Fabrik is an automated Claude Code SDLC driver powered by GitHub Issues and Projects.
+This guide covers everything you need to set up, configure, and use Fabrik effectively.
+
+For a quick overview see the [README](../README.md).
+For details on the internal stage lifecycle, see [Stage Lifecycle](stage-lifecycle.md).
+For the authoritative engine state-machine spec (label semantics, review gate transitions, marker handling), see [State Machine](state-machine.md).
+
+---
+
+## Table of Contents
+
+1. [Getting Started](#1-getting-started)
+2. [Configuration Reference](#2-configuration-reference)
+3. [Workflow Patterns](#3-workflow-patterns)
+4. [Stage Reference](#4-stage-reference)
+5. [Plugin & Skills](#5-plugin--skills)
+6. [Labels Reference](#6-labels-reference)
+7. [Permissions](#7-permissions)
+8. [TUI Dashboard](#8-tui-dashboard)
+9. [Observability](#9-observability)
+10. [Webhook Mode](#10-webhook-mode)
+11. [Troubleshooting](#11-troubleshooting)
+
+---
+
+## 1. Getting Started
+
+### Prerequisites
+
+- Go 1.26.1+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+- GitHub **classic** personal access token (`ghp_...`) with `repo`, `project`, and `workflow` scopes
+  - Fine-grained tokens (`github_pat_...`) are **not supported** — GitHub Projects v2 GraphQL requires a classic PAT
+  - Create one at: https://github.com/settings/tokens (select "Tokens (classic)")
+  - If a fine-grained token is detected at startup, Fabrik prints a `[warn]` message and subsequent API calls include an actionable hint; see [GitHub API Returns 401 or Fine-Grained Token Warning](#github-api-returns-401-or-fine-grained-token-warning)
+- A GitHub Project (v2) with board columns matching your stage names
+
+
+### Initial Setup
+
+**Option A: Install binary (requires `gh`)**
+
+```bash
+# Requires: gh auth login (with access to shadoworg/fabrik)
+cd ~/bin  # or any directory on your PATH
+gh release download --repo shadoworg/fabrik \
+  --pattern "fabrik_*_$(uname -s | tr A-Z a-z)_$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').tar.gz" \
+  -O - | tar xz
+# Platform-specific alternatives:
+#   darwin/arm64:  --pattern "fabrik_*_darwin_arm64.tar.gz"
+#   darwin/amd64:  --pattern "fabrik_*_darwin_amd64.tar.gz"
+#   linux/amd64:   --pattern "fabrik_*_linux_amd64.tar.gz"
+#   linux/arm64:   --pattern "fabrik_*_linux_arm64.tar.gz"
+```
+
+**Option B: Build from source (requires Go)**
+
+```bash
+# Build
+go build -o fabrik .
+```
+
+Then initialize:
+
+```bash
+# Initialize stage configs, plugin, and config template
+./fabrik init
+# Creates:
+#   .fabrik/stages/       — stage YAML configs
+#   .fabrik/plugin/       — Claude Code plugin
+#   .fabrik/config.yaml   — project config template (edit this)
+# Updates:
+#   .git/info/exclude     — adds .fabrik/repos/, .fabrik/worktrees/, .fabrik/debug/,
+#                           and .fabrik/history.json so they don't appear as untracked
+#                           in git status (local excludes, not committed to the repo)
+```
+
+Pass your GitHub Project URL to auto-populate `owner`, `project`, and `owner_type` in
+`config.yaml`. The `--user` flag enables fully non-interactive setup:
+
+```bash
+./fabrik init --user you https://github.com/orgs/your-org/projects/5
+# or for a personal project:
+./fabrik init --user you https://github.com/users/you/projects/3
+```
+
+Without a URL, `fabrik init` behaves as before: if your terminal is interactive it
+prompts for owner, repo, project number, and username; otherwise it writes a
+fully-commented template for you to fill in.
+
+To refresh plugin skills without touching stages or config (e.g., after upgrading Fabrik):
+
+```bash
+./fabrik upgrade
+```
+
+Edit `.fabrik/config.yaml` with your project settings and commit it to git. Add your
+GitHub token to a gitignored `.env` file:
+
+```
+# .env (gitignored — keep secrets here)
+# Use a CLASSIC personal access token (ghp_...) — not a fine-grained token (github_pat_...)
+# Required scopes: repo, project, workflow
+# Create at: https://github.com/settings/tokens (select "Tokens (classic)")
+FABRIK_TOKEN=ghp_...
+```
+
+> **Note:** When a `.git/` directory is present, Fabrik refuses to start if `.env` exists but is not listed in `.gitignore` (prevents accidental token leaks). In directories **without** `.git/` — containers, CI workspaces, or bare directories — this check is skipped and `.env` is loaded normally without requiring a `.gitignore` entry.
+
+### Create a Project Board
+
+Create a GitHub Project (v2) for your repository. Add board columns that correspond to
+your stage names -- the column name must match the `name` field in each stage YAML file
+exactly (case-sensitive). The default pipeline uses:
+
+`Backlog` -> `Specify` -> `Research` -> `Plan` -> `Implement` -> `Review` -> `Validate` -> `Done`
+
+### Compatibility Notes
+
+> **Warning:** Global Claude Code plugins can interfere with Fabrik's headless sessions. Do not install global plugins on machines running Fabrik as a service. The `superpowers` plugin is a known offender — if installed globally, it injects unexpected behaviour into Fabrik's Claude sessions and causes duplicate comments on issues.
+>
+> To check for the problematic plugin:
+> ```bash
+> ls ~/.claude/plugins/cache/claude-plugins-official/
+> ```
+> If `superpowers` appears, remove it:
+> ```bash
+> rm -rf ~/.claude/plugins/cache/claude-plugins-official/superpowers
+> ```
+> See [§11 Troubleshooting → Duplicate Comments on Issues](#11-troubleshooting) for full details.
+
+### First Run
+
+With settings in `.fabrik/config.yaml`:
+
+```bash
+./fabrik
+```
+
+Or pass settings as flags:
+
+```bash
+./fabrik \
+  --owner your-org \
+  --repo your-repo \
+  --project 1 \
+  --user your-github-username
+```
+
+Fabrik polls the project board every 30 seconds by default (configurable with `--poll`
+or `poll:` in `config.yaml`).
+
+**Idle backoff**: When nothing needs work, Fabrik progressively slows down polling to conserve API rate limit budget. The backoff is time-based — after 5 minutes of idle polls, the interval doubles; after 10 minutes it quadruples; after 20 minutes it caps at 5 minutes. Any activity (items dispatched or deep-fetched) immediately resets the interval to the configured value. Press `w` in the TUI to wake polling instantly if you've just made changes on the board.
+
+| Idle duration | Effective interval | At 30s base |
+|---|---|---|
+| 0–5 min | 1× (configured) | 30s |
+| 5–10 min | 2× | 60s |
+| 10–20 min | 4× | 120s |
+| 20+ min | max (5 minutes) | 300s |
+
+**Rate-limit backoff**: When Fabrik detects GraphQL API quota pressure, the same interval infrastructure adds a separate rate-limit component that escalates as quota depletes. There is no separate 5-minute ceiling for the rate-limit contributor — it can exceed 5 minutes when the configured base interval is large. The effective poll interval is `max(idle interval, rate-limit interval)`, so whichever is larger governs at any given moment.
+
+| Remaining GraphQL quota | Multiplier | At 30s base | At 60s base |
+|---|---|---|---|
+| >=10% (incl. sticky zone 20%–50%) | 2× | 60s | 120s |
+| >=5% and <10% | 4× | 120s | 240s |
+| >=1% and <5% | 6× | 180s | 360s |
+| <1% | 10× (cap) | 300s | 600s |
+
+Rate-limit backoff uses two-threshold hysteresis to prevent thrashing: it **activates** when GraphQL remaining quota drops below **20%** of the hourly limit, and **clears only when quota rises above 50%** of the limit. While quota is recovering (20%–50%, sticky zone), the 2× tier applies. Activity detection (items deep-fetched or dispatched) resets idle backoff but does NOT reset rate-limit backoff — the two concerns are independent. When rate-limit backoff is active, Fabrik logs the effective poll interval each cycle so operators can observe the actual cadence.
+
+**Board fetch resilience**: `FetchProjectBoard` automatically retries up to 3 times (with 1s/2s backoff) when GitHub returns an empty response (zero items), which occurs during transient Projects v2 indexer degradation that intermittently returns empty boards for non-empty projects (both returned node count and `totalCount` are zero in degraded responses). The log line:
+
+```
+[warn] project board fetch returned N items, totalCount=M (attempt X/3) — retrying in case of indexer hiccup
+```
+
+indicates the retry is occurring. It is transient and requires no user action unless it persists across all three attempts (in which case Fabrik accepts the last response and continues, which may appear as a temporarily idle engine).
+
+Move an issue to `Specify` on the board to start processing it.
+
+### Git Repositories and Worktrees
+
+Fabrik always bare-clones each managed repository on first access. Run Fabrik from any directory (no need to be inside a git checkout of a managed repo):
+
+```bash
+mkdir ~/my-fabrik-dir && cd ~/my-fabrik-dir
+fabrik init
+./fabrik --owner myorg --project 5 --user me
+# No --repo needed — Fabrik processes all repos on the board
+```
+
+Fabrik **always bare-clones** each managed repository on first access:
+- Bare clones are stored at `.fabrik/repos/<owner>-<repo>.git`
+- Worktrees are created at `.fabrik/worktrees/<owner>-<repo>/issue-N/` on branch `fabrik/issue-N`
+- One worktree manager runs per discovered repository, all sharing the same poll loop
+
+**`.fabrik/repos/` is excluded from git tracking by default** (gitignored). Bare clone directories can be very large and should not be committed to your repository. When you run `fabrik init` inside a git repo, these paths are also added to `.git/info/exclude` automatically.
+
+To restrict processing to a single repository, pass `--repo owner/repo`.
+
+The `.fabrik/` directory (config, stages, plugin) always lives in the directory where you run `fabrik`.
+
+### Multi-Repo Support
+
+Fabrik can manage issues across every repository on the board in a single run. To enable multi-repo mode, omit (or comment out) the `repo:` field in `.fabrik/config.yaml` — Fabrik then discovers repositories lazily from the project board and processes issues from all of them. Each repository gets its own bare clone at `.fabrik/repos/<owner>-<repo>.git` and its own set of worktrees, all driven by the same poll loop.
+
+### Git Clone Protocol (HTTPS vs SSH)
+
+By default, Fabrik uses HTTPS to bare-clone managed repos (`https://github.com/<owner>/<repo>.git`). Users who authenticate via SSH keys can switch to SSH clone URLs instead.
+
+#### Using SSH
+
+Pass `--ssh` on the command line or add `git_ssh: true` to `.fabrik/config.yaml`:
+
+```bash
+# One-time: use SSH for this run
+fabrik --ssh --owner myorg --project 5 --user me
+
+# Persistent: add to .fabrik/config.yaml
+git_ssh: true
+```
+
+The environment variable `FABRIK_GIT_SSH=true` is also supported (useful in CI).
+
+When SSH mode is active, Fabrik uses `git@github.com:<owner>/<repo>.git` as the clone URL. This requires your SSH key to be registered with GitHub and accessible via `ssh-agent`.
+
+> **Startup behavior with SSH mode:** When `--ssh` / `git_ssh: true` is set, Fabrik suppresses the HTTPS credential helper startup check (described below) — it is not applicable. No equivalent SSH agent availability check runs at startup. If your SSH key is absent or unloaded when a clone or fetch runs, git will fail at that point rather than at startup. To verify your agent before running Fabrik: `ssh -T git@github.com`.
+
+#### HTTPS Credential Helper Warning
+
+When using HTTPS (the default), Fabrik checks at startup whether a git credential helper is configured. If none is found, you'll see an advisory warning:
+
+```
+[startup] warn: no git credential helper configured; HTTPS cloning may prompt for credentials.
+[startup] warn: configure one (e.g. git-credential-osxkeychain) or use --ssh / git_ssh: true in .fabrik/config.yaml.
+```
+
+This warning is non-fatal. If you use a GitHub token in your environment (`FABRIK_TOKEN` or `GITHUB_TOKEN`) and your git is configured to use it (e.g., via a credential helper or token-in-URL), cloning will work without further configuration.
+
+To resolve the warning, either:
+- Configure a credential helper: `git config --global credential.helper osxkeychain` (macOS), or `git config --global credential.helper store`
+- Or switch to SSH mode with `--ssh` / `git_ssh: true`
+
+#### Existing Bare Clones
+
+**Switching between HTTPS and SSH does not re-clone existing bare repos.** Once Fabrik has cloned a repo, it reuses the existing bare clone with its original remote URL. The SSH/HTTPS setting only affects new clones.
+
+If you switch to SSH mode after existing bare clones were created, those clones will continue to fetch via HTTPS. To switch an existing bare clone to SSH, update its remote URL directly:
+
+```bash
+git -C .fabrik/repos/owner-repo.git remote set-url origin git@github.com:owner/repo.git
+```
+
+#### URL Rewriting
+
+If you have `url.<base>.insteadOf` configured in your global `~/.gitconfig` (a common way to redirect HTTPS to SSH globally), Fabrik will notice at startup and print an informational message. Git applies URL rewriting transparently, so Fabrik's HTTPS clone URLs will automatically use your SSH configuration — no additional Fabrik setting is needed.
+
+### Auto-upgrade
+
+The `--auto-upgrade` flag enables Fabrik to upgrade itself when idle. After 2
+consecutive idle polls, Fabrik checks the GitHub Releases API for a newer version.
+If one is found, it downloads the new binary, replaces the running executable,
+runs `fabrik upgrade` to refresh plugin skills, and re-execs itself.
+
+**Dev builds (built from source)** follow the same 2 idle poll threshold but use a
+different upgrade path. Fabrik detects that it is a dev build (version string starts
+with `dev`) and checks whether it is running from a `tenaciousvc/fabrik` or
+`verveguy/fabrik` source checkout. If so, it compares the running binary's embedded
+commit SHA against the local `HEAD`:
+
+- **Local commits ahead of the binary**: rebuild immediately from the current working
+  tree (`go build -o fabrik .`) without pulling — useful when you have local changes
+  you've already compiled once.
+- **Remote `origin/main` ahead of HEAD**: run `git pull --ff-only` to update, then
+  rebuild.
+
+After rebuilding, Fabrik runs `fabrik upgrade` (non-interactive, silent — see below)
+and re-execs the new binary. This keeps dev builds current with the same hands-off
+experience as release binaries.
+
+> **`fabrik upgrade` in non-interactive mode**: Whether called automatically during
+> auto-upgrade or run standalone, `fabrik upgrade` behaves differently depending on
+> whether a TTY is attached. With no TTY (non-interactive), it auto-refreshes plugin
+> skills silently — no prompt, no confirmation required. With a TTY (interactive), it
+> prompts once before applying any skill updates. This means automated environments
+> (CI, background processes, auto-upgrade re-exec) always get a clean, unattended
+> skill refresh.
+
+```bash
+./fabrik --auto-upgrade --owner your-org --repo your-repo --project 1 --user you
+```
+
+> **Upgrading from v0.0.28 or earlier?** Before v0.0.29, `--auto-upgrade` fetched
+> from the private `tenaciousvc/fabrik` repo. The v0.0.29 release switched the
+> upgrade source to the public `shadoworg/fabrik` repo — but this change cannot
+> self-apply: a binary built before v0.0.29 will never auto-receive it. If you are
+> running an older binary, upgrade once manually:
+> ```bash
+> gh release download --repo shadoworg/fabrik \
+>   --pattern "fabrik_*_$(uname -s | tr A-Z a-z)_$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').tar.gz" \
+>   -O - | tar xz
+> ```
+> After that, `--auto-upgrade` will keep you current automatically.
+
+### Startup Board Validation
+
+On startup, Fabrik attempts to fetch the project board and status field so it can compare stage names in your YAML configs against the column names on the board. When that metadata is fetched successfully, any non-cleanup stage missing from the board causes Fabrik to exit with a detailed error listing the mismatched names — catching config drift before any work begins. Extra board columns without a matching stage produce a warning but do not block startup. If Fabrik cannot fetch the board or status field, it logs a warning and continues without blocking startup.
+
+See [§11 Troubleshooting → Startup Board Validation Failure](#startup-board-validation-failure) if validation succeeds and reports a mismatch.
+
+### Stage YAML Drift Warning
+
+After loading your stage YAMLs from `.fabrik/stages/`, Fabrik compares each stage against the embedded default with the same `name:` field. If the embedded default contains top-level YAML keys that your file does not, Fabrik prints a warning to stderr at startup:
+
+```
+[startup] warning: .fabrik/stages/validate.yaml is missing fields present in v0.0.53 defaults: wait_for_ci, wait_for_reviews. Run `fabrik refresh-stages --apply` to add the missing keys.
+```
+
+This warning is **informational only** — the engine continues running with your existing config. The missing keys are behavioral options added in a newer binary that your stage file predates.
+
+**What to do:**
+
+1. Run `fabrik refresh-stages` to preview missing keys as a unified diff (no file changes).
+2. Run `fabrik refresh-stages --apply` to add the missing keys to your stage YAMLs (additive only — never removes or overwrites existing values).
+3. Run `git diff` to review the changes.
+4. `git commit` to record the update.
+
+**Common keys that trigger this warning:**
+
+- `wait_for_ci: true` — enables the CI gate on Validate auto-advance (added in v0.0.49)
+- `wait_for_reviews: true` — enables the reviewer gate on Validate auto-advance (added in v0.0.49)
+- `completion:` — marks the stage completion type (added as an explicit top-level key; omitting it is safe for normal Claude-invoked stages because the engine defaults it to `{type: claude}`)
+
+Custom stages (names not present in any embedded default) are silently skipped — no warning is produced for them.
+
+### Instance Lock
+
+> **Note:** When Fabrik starts, it creates a PID lock file at `.fabrik/fabrik.lock`. If a second instance attempts to start in the same directory, it reads the lock file, logs an error identifying the running process, and exits immediately. The lock is automatically released when the process exits — including on crash or SIGKILL — so there is no need to manually delete the file after an unclean shutdown.
+>
+> See [§11 Troubleshooting → Multiple Fabrik Instances](#11-troubleshooting) if you encounter a stale lock or need to run multiple instances against different projects.
+
+---
+
+## 2. Configuration Reference
+
+### Settings Overview
+
+Fabrik resolves settings in this order (highest to lowest priority):
+
+```
+CLI flag  >  shell env var  >  .env file  >  .fabrik/config.yaml  >  built-in default
+```
+
+Use `.fabrik/config.yaml` for non-secret project settings (commit it to git).
+Use `.env` for secrets only (`FABRIK_TOKEN` / `GITHUB_TOKEN`).
+
+### `.fabrik/config.yaml`
+
+Generated by `fabrik init`. Commit this file — it carries project settings with the repo.
+
+```yaml
+# .fabrik/config.yaml
+owner: your-org
+# repo: your-repo  # omit for multi-repo mode (processes all repos on the board)
+project: 1
+user: your-github-username
+
+# Optional settings (defaults shown):
+
+# Path to stage YAML configs directory.
+# stages: ./.fabrik/stages
+
+# Polling interval in seconds. Lower values are more responsive; higher values
+# reduce GitHub API usage. Tradeoff: 10s is very responsive but consumes ~360 REST
+# requests/hour; 30s (default) is a good balance.
+# poll: 30
+
+# Maximum number of parallel Claude sessions. Tune based on your API tier capacity.
+# Each active session counts against your Anthropic API concurrency limit.
+# max_concurrent: 5
+
+# Maximum stage failures before pausing an issue. When exceeded, fabrik:paused and
+# stage:<name>:failed labels are applied. Set to 0 for unlimited retries.
+# max_retries: 3
+
+# Auto-advance issues through stages without human card moves on the board.
+# When true, completed issues advance to the next stage automatically.
+# Per-stage auto_advance: in stage YAML can override this setting per-stage.
+# yolo: false
+
+# When idle, check shadoworg/fabrik GitHub Releases for a newer version. After 2
+# consecutive idle polls, Fabrik downloads the new binary, runs fabrik upgrade,
+# and re-execs. Requires internet access to the GitHub Releases API.
+# auto_upgrade: false
+
+# Disable the interactive TUI dashboard (enabled by default when a real terminal is detected).
+# tui: false
+
+# Save raw Claude output to .fabrik/debug/ for diagnosing unexpected behavior
+# or prompt issues. Files are named by issue number and stage.
+# debug_output: false
+
+# Project version shown in the TUI footer. Auto-inferred from package.json,
+# go.mod (returns module path, not semver), Cargo.toml, or pyproject.toml.
+# Set explicitly to override auto-inference (e.g., version: "1.2.0").
+# version: ""
+```
+
+**Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
+
+**Note:** `.fabrik/config.yaml` should NOT be listed in `.gitignore`. Fabrik warns
+(non-fatal) if it is.
+
+### `.env` File
+
+Keep only secrets here. When a `.git/` directory is present, Fabrik refuses to start if `.env` exists but is not listed in `.gitignore` (prevents accidental token leaks). In directories without `.git/` (containers, CI, bare directories), this check is skipped and `.env` is loaded normally.
+
+```
+# .env (gitignored)
+# Classic personal access token (ghp_...) required — see https://github.com/settings/tokens
+FABRIK_TOKEN=ghp_...         # Preferred token env var (needs repo, project, workflow scopes)
+GITHUB_TOKEN=ghp_...         # Fallback token env var
+```
+
+For per-developer identity overrides (when your username differs from config.yaml):
+
+```
+FABRIK_USER=my-personal-username
+```
+
+### Command-Line Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--owner` | GitHub repo owner (org or user) | required |
+| `--repo` | GitHub repo name; omit to enable multi-repo mode (processes all repos on the board) | optional |
+| `--project` | GitHub Project (v2) number | required |
+| `--user` | Your GitHub username -- only processes comments by this user | required |
+| `--token` | GitHub API token | `$GITHUB_TOKEN` |
+| `--stages` | Directory containing stage YAML configs | `./.fabrik/stages` |
+| `--yolo` | Auto-advance issues through stages without human approval; also auto-merges the linked PR when Validate completes | `false` |
+| `--auto-upgrade` | When idle, check GitHub Releases for a newer version and self-upgrade; dev builds (built from source) rebuild from `origin/main` instead | `false` |
+| `--notui` | Disable the interactive TUI dashboard | TUI on by default |
+| `--plugin-dir` | Path to Fabrik plugin directory (overrides `.fabrik/plugin/`) | auto-detected |
+| `--poll` | Poll interval in seconds | `30` |
+| `--max-concurrent` | Maximum number of concurrent issue workers | `5` |
+| `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
+| `--review-wait-timeout` | Minutes to wait for all requested PR reviewers before advancing (0 = use default of 15; also `FABRIK_REVIEW_WAIT_TIMEOUT`) | `0` (15 min) |
+| `--max-review-cycles` | Maximum number of review-and-fix cycles per issue (0 = use default of 5; also `FABRIK_MAX_REVIEW_CYCLES`) | `0` (5 cycles) |
+| `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
+| `--max-ci-fix-cycles` | Maximum number of CI-fix re-invocation cycles per issue (0 = use default of 5; also `FABRIK_MAX_CI_FIX_CYCLES`) | `0` (5 cycles) |
+| `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
+| `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
+| `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
+
+### Environment Variables
+
+| Variable | `config.yaml` key | Description | Default |
+|----------|-------------------|-------------|---------|
+| `FABRIK_TOKEN` | *(secrets only)* | GitHub **classic** personal access token (`ghp_...`) with `repo`, `project`, `workflow` scopes (preferred) | required |
+| `GITHUB_TOKEN` | *(secrets only)* | GitHub **classic** personal access token (`ghp_...`) — fallback when `FABRIK_TOKEN` is unset | required |
+| `FABRIK_OWNER` | `owner` | GitHub repo owner | -- |
+| `FABRIK_REPO` | `repo` | GitHub repo name; optional — omitting enables multi-repo mode (all repos on the board) | -- |
+| `FABRIK_PROJECT_NUMBER` | `project` | GitHub Project (v2) number | -- |
+| `FABRIK_USER` | `user` | Your GitHub username | -- |
+| `FABRIK_STAGES` | `stages` | Stage configs directory | `./.fabrik/stages` |
+| `FABRIK_YOLO` | `yolo` | Auto-advance (`true`/`1`/`yes`) | `false` |
+| `FABRIK_POLL` | `poll` | Poll interval in seconds | `30` |
+| `FABRIK_MAX_CONCURRENT` | `max_concurrent` | Max parallel Claude sessions | `5` |
+| `FABRIK_MAX_RETRIES` | `max_retries` | Max retries before pausing (0 = unlimited) | `3` |
+| `FABRIK_AUTO_UPGRADE` | `auto_upgrade` | Self-upgrade when idle (`true`/`1`/`yes`) | `false` |
+| `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
+| `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
+| `FABRIK_DEBUG_OUTPUT` | `debug_output` | Save raw Claude output for debugging | `false` |
+| `FABRIK_REVIEW_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait per review cycle at the review gate (whether waiting for requested reviewers to submit or for at least one review to exist) before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 15) | `15` |
+| `FABRIK_MAX_REVIEW_CYCLES` | *(no config.yaml key)* | Maximum number of review re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
+| `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |
+| `FABRIK_MAX_CI_FIX_CYCLES` | *(no config.yaml key)* | Maximum number of CI-fix re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
+| `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
+| `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
+
+Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
+
+### Stage YAML Reference
+
+Each stage is a YAML file in your stages directory. The filename is arbitrary; the
+`name` field determines which board column it matches.
+
+```yaml
+name: Research            # Required. Must match a Project board column exactly.
+order: 2                  # Required. Lower values processed earlier in the pipeline.
+skill: fabrik-research    # Plugin skill to use (recommended; alternative to inline prompt).
+                          #   When set, Fabrik sends a minimal directive and Claude loads
+                          #   the skill methodology via the plugin system.
+comment_skill: fabrik-research-comment  # Plugin skill for comment review (overrides comment_prompt).
+prompt: |                 # Inline prompt (used when skill is not set; legacy but still supported).
+  You are a research agent...
+comment_prompt: |         # Inline comment-review prompt (used when comment_skill is not set).
+  You are reviewing user comments...
+model: sonnet             # Optional. Claude model: "opus", "sonnet", etc.
+max_turns: 50             # Optional. Max conversation turns per main stage invocation.
+comment_max_turns: 15     # Optional. Max turns when processing user comments. Defaults to
+                          #   min(max_turns, 15) when max_turns is set, otherwise 15.
+                          #   Keeps comment processing bounded independently of stage budget.
+max_wall_time: "45m"      # Optional. Wall-clock deadline for a single Claude invocation.
+                          #   Accepts Go duration strings (e.g. "30m", "1h", "1h30m").
+                          #   When the deadline is reached, Fabrik sends SIGTERM to the
+                          #   Claude process group, waits 10 s, then sends SIGKILL (reaping
+                          #   any hung background children). Output collected before the kill
+                          #   is processed normally — if FABRIK_STAGE_COMPLETE appears in
+                          #   the streamed output, the stage is marked complete without a
+                          #   retry. When absent or zero, no wall-clock cap is applied.
+                          #   Recommended: "45m" for Implement and Review stages in
+                          #   production use. The hardcoded 15-minute inactivity timeout
+                          #   (see below) acts as a universal backstop even when this field
+                          #   is not set.
+read_only: true           # Optional. Stashes the dirty worktree before Claude runs and
+                          #   restores it after. Use for analysis stages that should not
+                          #   modify files (e.g., Specify, Research).
+post_to_pr: true          # Optional. Routes detailed Claude output to the linked PR; a
+                          #   brief summary is still posted on the issue. Falls back to
+                          #   posting on the issue if no linked PR is found.
+create_draft_pr: true     # Optional. Pushes the branch and creates a draft PR *before*
+                          #   Claude runs. Idempotent if a PR already exists.
+mark_pr_ready_on_complete: true  # Optional. Marks the draft PR as review-ready after the
+                                 #   stage completes. Triggers external review bots.
+auto_advance: false       # Optional. Per-stage override for the global yolo setting.
+                          #   true  = always auto-advance this stage (even if yolo: false)
+                          #   false = never auto-advance this stage (even if yolo: true)
+                          #   omit  = inherit the global yolo setting
+cleanup_worktree: false   # Optional. Removes the issue worktree instead of invoking Claude.
+                          #   Use for terminal stages (e.g., Done) where no further work
+                          #   is needed on the branch.
+wait_for_reviews: false   # Optional. When true, Fabrik waits for all requested PR reviewers
+                          #   to submit and re-invokes the stage agent via the comment-processing
+                          #   path to address submitted inline feedback. Re-invocation is
+                          #   unconditional — it fires regardless of the auto-advance setting.
+                          #   Auto-advancement to the next stage after re-invocation still requires
+                          #   auto-advance to be active. This loop repeats until no reviewers are
+                          #   pending (up to FABRIK_MAX_REVIEW_CYCLES cycles). On timeout or cycle
+                          #   limit, Fabrik pauses with fabrik:awaiting-input instead of advancing.
+                          #   See §3 Pending Reviewer Gate for full details.
+wait_for_ci: false        # Optional. When true, Fabrik gates auto-advance (and auto-merge for
+                          #   Validate+yolo) on CI checks passing on the PR head. At
+                          #   FABRIK_STAGE_COMPLETE, Fabrik immediately adds `fabrik:awaiting-ci`
+                          #   and withholds `stage:X:complete` until the CI gate clears (covering
+                          #   both pending and failed CI states). When CI fails, Fabrik re-invokes
+                          #   the stage agent via ci_fix_skill (falls back to comment_skill) with a
+                          #   structured report classifying each failed check as NEW REGRESSION or
+                          #   pre-existing. Re-invocation repeats up to FABRIK_MAX_CI_FIX_CYCLES
+                          #   times. On CI timeout or cycle limit, Fabrik pauses with
+                          #   fabrik:awaiting-input. Enabled by default on the Validate stage.
+                          #   See §3 CI Gate and CI-Fix Workflow for full details.
+ci_fix_skill:             # Optional. Plugin skill name for CI-fix re-invocations (the synthetic
+                          #   CI failure report comment). Defaults to comment_skill if unset.
+allowed_tools:            # Optional. REPLACES the default tool set — not additive. When set,
+  - Read                  #   only these tools are allowed; the default list is not added.
+  - Grep                  #   When omitted, Fabrik uses a comprehensive default covering common
+  - Glob                  #   SDLC tools: Read, Edit, Write, Glob, Grep, TodoWrite, Skill, Task,
+                          #   Bash(git:*), Bash(gh:*), Bash(go:*), Bash(npm:*), Bash(npx:*),
+                          #   Bash(yarn:*), Bash(pnpm:*), Bash(make:*), Bash(cargo:*),
+                          #   Bash(python:*), Bash(pip:*), Bash(uv:*), Bash(pytest:*),
+                          #   Bash(ls:*), Bash(cat:*), Bash(rm:*), Bash(cp:*), Bash(mv:*),
+                          #   Bash(mkdir:*), Bash(find:*).
+                          #   Use this to restrict read-only stages (Research, Plan, Specify)
+                          #   or to limit Claude to project-specific tools.
+disable_adaptive_thinking: true  # Optional. Disables Claude Code's adaptive (auto-reduced)
+                                 #   thinking budget. Default: true.
+effort_level: high        # Optional. Claude Code thinking effort: low, medium, high, max.
+                          #   Default: high. Controls how much the model "thinks" before
+                          #   responding. Higher values use more tokens.
+completion:
+  type: claude            # Only supported type (default).
+```
+
+Either `skill` or `prompt` is required (unless `cleanup_worktree` is true). When `skill`
+is set, Fabrik sends a directive prompt telling Claude to follow the named skill; the
+skill provides the detailed methodology via the plugin system. Prefer `skill` for complex
+stages — it supports rich methodology, quality checklists, and scope boundaries. Use
+`prompt` for simple single-purpose stages or quick overrides.
+
+**`auto_advance` and `yolo` interaction:**
+
+There are four cases:
+
+1. Global `yolo: true` in `config.yaml` → all stages auto-advance after completion.
+2. Per-stage `auto_advance: true` in stage YAML → this stage always auto-advances, regardless of whether global `yolo` is true or false.
+3. Per-stage `auto_advance: false` in stage YAML → this stage never auto-advances, even when global `yolo: true`. This is a meaningful override — explicitly setting `false` is different from omitting the field.
+4. Per-stage `auto_advance:` absent from stage YAML → the stage inherits the global `yolo` setting.
+
+A fifth case applies at the issue level: adding the `fabrik:yolo` label to an issue forces auto-advance for that issue even when `auto_advance: false` is set in the stage YAML. The `fabrik:yolo` label also triggers auto-merge of the linked PR when the Validate stage completes (equivalent to running with `--yolo` globally, but scoped to a single issue).
+
+**Thinking budget (`disable_adaptive_thinking`, `effort_level`):**
+
+These two fields control how much Claude "thinks" before responding. `disable_adaptive_thinking: true` (the default) turns off Claude Code's adaptive thinking budget, which would otherwise auto-reduce thinking depth to save tokens. With adaptive thinking disabled, the `effort_level` field directly controls thinking intensity: `low`, `medium`, `high`, or `max`. The default `effort_level` is `high` (changed from `max` in v0.0.33 to reduce token usage without sacrificing quality). Use `effort_level: max` only for your most demanding stages — complex implementation or thorough review work — where higher token cost is justified.
+
+**Timeout and inactivity protection (`max_wall_time` + 15-minute inactivity kill):**
+
+Fabrik applies two complementary timeout mechanisms to every Claude invocation to prevent indefinite hangs from stuck background processes:
+
+1. **`max_wall_time` (per-stage, opt-in):** A hard wall-clock deadline. When the deadline expires, Fabrik sends `SIGTERM` to the Claude process group (which includes any background children spawned during the session), waits 10 seconds for a graceful exit, then sends `SIGKILL` to any surviving processes. Recommended: `"45m"` for Implement and Review stages in production. Legitimately long stages (e.g., a 90-minute Review on a large PR) should either set a higher limit or leave this field unset.
+
+2. **15-minute inactivity timeout (global, always active):** If no streamed output is received from Claude for 15 consecutive minutes, the process group is killed using the same SIGTERM → 10s → SIGKILL sequence. This catches sessions that are stuck on a hung background task even when `max_wall_time` is not set — as long as Claude is actively producing output, it continues indefinitely. The threshold is hardcoded and cannot be configured.
+
+In both cases, if `FABRIK_STAGE_COMPLETE` was emitted before the kill (visible in the streamed `assistant` turns), the stage is treated as successfully completed without retrying. Both timeouts apply equally to main-stage invocations and comment-processing invocations.
+
+---
+
+## 3. Workflow Patterns
+
+### How Issues Move Through the Pipeline
+
+1. Create an issue and add it to your GitHub Project board.
+2. Move the issue to a stage column (e.g., `Specify`).
+3. Fabrik picks it up on the next poll, creates a worktree, and invokes Claude Code.
+4. Claude works in the worktree and posts progress as issue comments.
+5. When Claude completes the stage, the `stage:<name>:complete` label is applied.
+6. In `--yolo` mode, the issue is automatically moved to the next stage column.
+   Otherwise, a human reviews and drags the card.
+
+### The Specify Stage
+
+The Specify stage is the first active stage. It takes a rough backlog issue and
+refines it into a clear, unambiguous spec:
+
+- Surfaces missing requirements, ambiguities, and edge cases as questions
+- Checks consistency with existing project features and documentation
+- Researches prior art and established patterns on the web
+- Rewrites the issue body with a structured spec
+
+The user answers questions via comments. Claude incorporates the answers and updates
+the issue body. Once all questions are resolved, the stage completes and the issue is
+ready for Research.
+
+### Steering with Comments
+
+Fabrik responds to natural language comments you post on an issue. Claude sees the full
+issue body and all prior comments, so context carries forward.
+
+**Effective comment patterns:**
+
+- *"Please link the PR to this issue"* -- Claude creates the PR link
+- *"Let's use approach B instead"* -- Claude updates the plan and continues
+- *"The answer to your question about X is Y"* -- Claude incorporates your answer
+- *"Please push and link the PR"* -- Claude pushes the branch and creates a draft PR
+
+When you post a comment:
+1. Fabrik reacts with eyes to acknowledge the comment.
+2. Claude is invoked with the stage's comment prompt (or a default).
+3. Claude performs any requested actions.
+4. If the issue body should be updated, Claude outputs the new body between
+   `FABRIK_ISSUE_UPDATE_BEGIN` and `FABRIK_ISSUE_UPDATE_END` markers.
+5. Fabrik updates the issue body and strips the markers from the posted comment.
+6. Fabrik reacts with rocket to mark the comment as processed.
+
+The rocket reaction is durable -- on restart, Fabrik skips comments that already have it.
+
+Engine-posted comments are identified by **two dedup signals**: the `🏭 **Fabrik` header (primary) and the 🚀 rocket reaction (secondary). Both categories are skipped when scanning for new user comments to process.
+
+### Reaction Flow
+
+| Reaction | Meaning |
+|----------|---------|
+| Eyes | Comment received and queued for processing |
+| Rocket | Comment has been fully processed |
+
+### When to Intervene
+
+You do not need to babysit the pipeline. The intended human role is:
+
+- **File issues** with clear specs in the body (or let Specify refine them).
+- **Answer questions** when Specify or Research surfaces unknowns.
+- **Move cards** (or use `--yolo` to automate this).
+- **Comment** to steer when the plan goes sideways or you want to redirect.
+- **Review PRs** before merging -- Fabrik gets them review-ready, not merge-ready (unless `--yolo` or `fabrik:yolo` label is active, in which case Fabrik auto-merges after Validate).
+
+### Yolo Mode and Auto-Merge
+
+Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and auto-merges the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
+
+For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you.
+
+See [Stage YAML Reference](#stage-yaml-reference) for the `auto_advance` field, which controls auto-advance behavior per stage independent of the global `--yolo` flag.
+
+### Draft PR Workflow
+
+The Implement stage creates a **draft PR** linked to the issue when `create_draft_pr: true` is set (the default for Implement). This gives you a place to review incrementally. The Review stage then rebases, reviews, fixes, and pushes — turning the draft into a review-ready PR.
+
+**PR body seeding**: When the draft PR is created, Fabrik seeds the PR body from context files already written in the worktree:
+
+| Section | Source |
+|---------|--------|
+| `## Summary` | Extracted from the issue spec (`.fabrik-context/issue.md`) |
+| `## Problem` | Extracted from the issue spec (`.fabrik-context/issue.md`) |
+| `## Approach` | Extracted from the Plan stage output (`.fabrik-context/stage-Plan.md`); falls back to a placeholder if absent |
+| `## Verification` | Placeholder text, auto-replaced by an extracted stage summary when available |
+
+The `Closes #N` footer in the PR body links the PR to the issue so Fabrik can discover PR comments via GraphQL.
+
+**Verification auto-update**: For draft PRs created with `create_draft_pr: true`, Fabrik updates the `## Verification` section only when it can extract a summary block delimited by `FABRIK_SUMMARY_BEGIN` and `FABRIK_SUMMARY_END` from stage output. This keeps the PR description current when a stage provides a structured summary for PR-body updates.
+
+### Retry and Escalation
+
+When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
+
+1. **Cooldown**: Fabrik waits `poll_interval x 10` seconds (default 5 minutes) before retrying.
+2. **Resume**: On retry, Claude resumes the existing conversation session with full context.
+   The worktree is left as-is (no rebase) to preserve Claude's context.
+3. **WIP commit**: Partial work is committed and pushed to preserve progress.
+4. **Max retries**: After `--max-retries` failures (default 3):
+   - `fabrik:paused` and `stage:<name>:failed` labels are added
+   - An explanatory comment is posted on the issue
+   - The issue stops being processed until a human investigates
+
+To resume after escalation: remove the `fabrik:paused` label. Fabrik will clear the
+failed label, reset the retry count, and try again immediately.
+
+### Stages Waiting for Input
+
+A stage can signal that it needs user input before it can proceed by outputting
+`FABRIK_BLOCKED_ON_INPUT`. This is different from a failure — the stage is not broken,
+it just needs a question answered.
+
+When a stage outputs `FABRIK_BLOCKED_ON_INPUT`:
+1. `fabrik:paused` and `fabrik:awaiting-input` labels are added to the issue
+2. The retry counter is **not** incremented — this does not count as a failure
+3. The issue waits silently until the configured Fabrik user (`--user` / `FABRIK_USER`) posts a new comment
+
+When the configured user posts a new comment:
+1. Fabrik detects the comment and automatically removes both labels
+2. Comment processing is triggered immediately (no manual card move needed)
+3. The comment processing run can output `FABRIK_STAGE_COMPLETE` to finish the stage
+   directly, without needing an additional stage invocation
+
+This is the intended mechanism for Q&A in stages like Specify — Claude asks a question,
+the configured user answers it in a comment, and the stage resumes automatically.
+
+### Dependency-Based Sequencing (Formations)
+
+Fabrik supports dependency-based sequencing of issues using GitHub's native "Blocked by" relationships. This enables **formations** — coordinated sets of issues that execute in parallel where possible and respect ordering constraints automatically.
+
+#### Setting Up Dependencies
+
+To mark one issue as blocked by another on GitHub.com:
+
+1. Open the issue in GitHub
+2. In the right sidebar, find the **Relationships** section
+3. Click **"Mark as blocked by"**
+4. Search for and select the blocking issue (same repo or cross-repo)
+
+Repeat for each dependency. This uses GitHub's native `blockedBy` GraphQL field (available on all GitHub plans since August 21, 2025).
+
+#### How Fabrik Detects and Respects Dependencies
+
+Fabrik uses the `fabrik:blocked` label to track blocked issues. The label lifecycle is fully automatic:
+
+1. **Detection**: Fabrik re-evaluates blocked items periodically via a cooldown timer (every `10 × poll interval`, typically ~5 minutes at the default 30s poll). When the timer fires, Fabrik deep-fetches the blocked item and checks whether its dependencies have closed. If GitHub also bumps the blocked item's `updatedAt` when a dependency closes (common but not guaranteed), unblocking is detected sooner — on the next poll cycle.
+2. **First block**: When Fabrik first detects that an issue is blocked, it posts a comment listing the open blocking issues and adds the `fabrik:blocked` label automatically. Fabrik creates this label on first use — no pre-creation needed.
+3. **While blocked**: The issue is skipped silently each poll cycle (no duplicate comments).
+4. **Automatic unblocking**: When all blocking issues are closed, Fabrik removes `fabrik:blocked` and resumes processing on the next poll — no human action required.
+
+**Key behavior callouts:**
+
+- **The first stage (Specify) always runs regardless of blockers** — dependencies only gate subsequent stages. This allows a formation to be fully specified before execution begins.
+- **Independent issues start in parallel** — issues with no blockers are dispatched concurrently up to the configured `MaxConcurrent` limit.
+- **Failed issues retry independently** — a failure in one formation member does not affect siblings.
+- **Cross-repo dependencies are supported** — a blocking issue can be in a different repository. Fabrik displays cross-repo blockers as `owner/repo#N` in log output.
+
+#### Formation Recipe
+
+1. **File all issues** for the formation. Write specs at the right level of granularity — each issue should be independently implementable.
+2. **Add blocked-by edges** in GitHub using the Relationships sidebar (see above).
+3. **Label all issues `fabrik:yolo`** — this makes the formation hands-free. Without `fabrik:yolo`, each stage requires a manual card move on the project board.
+4. **Move all issues to Specify** on the project board. Fabrik will pick them up on the next poll.
+5. **Watch it run** — Fabrik executes Specify for all issues in parallel, then gates subsequent stages on dependency resolution automatically.
+
+#### Example Formation
+
+```mermaid
+graph TD
+    A["#1 Data model design"] --> C["#3 API layer"]
+    B["#2 Auth design"] --> C
+    C --> D["#4 Frontend integration"]
+    C --> E["#5 Background jobs"]
+```
+
+In this 5-issue formation:
+- Issues #1 and #2 start immediately in parallel (no blockers)
+- Issue #3 starts after both #1 and #2 are closed
+- Issues #4 and #5 start after #3 is closed (in parallel with each other)
+
+**Real-world validation:** A 9-issue formation with 7 dependency edges was run on the Ambient project — 4 issues started in parallel, all pipeline constraints were respected automatically, completing in ~88 minutes wall-clock time at $31 total cost.
+
+### Issue Decomposition
+
+When Plan determines that an issue is too broad for a single Implement cycle, it can autonomously split it into focused sub-issues — each small enough to implement cleanly and independently.
+
+**No user configuration required.** Decomposition is Plan's judgment call. If the issue is well-scoped, Plan produces a normal implementation plan. If it's too broad, Plan decomposes it.
+
+#### What Happens
+
+1. **Plan creates sub-issues** via `gh` CLI, labels them `fabrik:sub-issue`, and adds them to the project board.
+2. **Plan sets up "blocked by" edges** between sub-issues where sequential ordering is required.
+3. **Plan outputs `FABRIK_DECOMPOSED`** and stops — no `FABRIK_STAGE_COMPLETE` is emitted.
+4. **The engine adds `stage:Plan:complete`** to the parent issue and moves it to Done.
+5. **Sub-issues appear in Research** and flow through the full pipeline independently.
+
+Sub-issues form a [formation](#dependency-based-sequencing-formations) automatically — dependency edges set by Plan are enforced during execution.
+
+#### What You Observe
+
+- The parent issue moves to Done on the project board (its label set shows `stage:Plan:complete`).
+- New issues appear in Research, each labeled `fabrik:sub-issue`.
+- If Plan set up blocking edges, sub-issues that depend on each other will wait as a formation.
+
+#### Depth Limit
+
+Sub-issues (those labeled `fabrik:sub-issue`) are **never decomposed further**. If Plan encounters an issue with that label, it produces a normal implementation plan regardless of scope. Maximum decomposition depth is 1.
+
+### Pending Reviewer Gate
+
+When a stage has `wait_for_reviews: true` set, Fabrik waits for all requested PR reviewers to submit their reviews, then re-invokes the stage agent to address any submitted inline feedback. **Re-invocation is unconditional** — it fires for any issue with submitted inline review thread comments, regardless of whether auto-advance is active. Auto-advancement to the next stage after re-invocation still requires auto-advance to be active (global `yolo: true`, per-stage `auto_advance: true`, or the `fabrik:yolo` label on the issue).
+
+For the authoritative spec on label lifecycle and gate transitions, see [State Machine](state-machine.md).
+
+The Review and Validate stages ship with `wait_for_reviews: true` enabled by default.
+
+#### Enabling the Gate
+
+Add `wait_for_reviews: true` to the relevant stage YAML:
+
+```yaml
+name: Review
+order: 4
+wait_for_reviews: true
+...
+```
+
+The reviewer wait and re-invocation cycle fire unconditionally — they activate whenever `wait_for_reviews: true` and inline review feedback is present, regardless of whether auto-advance is active. If you're manually dragging cards through the board, re-invocation still happens; the issue will not advance automatically after the cycle completes — you still move the card manually.
+
+#### Label Lifecycle
+
+When the gate is active, Fabrik adds the `fabrik:awaiting-review` label to the issue. This label:
+
+- Makes the wait state visible on the project board
+- Is cleared automatically either when no requested reviewers are outstanding **and** at least one review has been submitted — this dual condition catches bot reviewers (Copilot, Gemini) that self-trigger via webhook without ever appearing in the formal requested-reviewer list — **or** when the review-wait timeout expires and Fabrik removes the label before pausing with `fabrik:awaiting-input`
+- Triggers a re-invocation of the stage agent (via the comment-processing path) to address the submitted review feedback
+- After re-invocation, if new reviewers are assigned (e.g. bots triggered by a fresh push), the label is re-applied and the cycle continues
+
+#### Three-Phase Mechanism
+
+The gate uses a three-phase design:
+
+1. **Phase 1 (always-gate):** On stage completion, Fabrik immediately adds `fabrik:awaiting-review` and skips auto-advance. This fires even before reviewer assignments propagate.
+2. **Phase 2 (gate evaluation):** On subsequent poll cycles, Fabrik re-fetches the PR with fresh GraphQL data and evaluates the dual condition: the gate clears only when no requested reviewers are outstanding **and** at least one review has been submitted. Requiring at least one review (not just an empty pending list) is what catches bot reviewers like Copilot and Gemini that self-trigger via webhook without ever appearing in the formal requested-reviewer list — if only the pending list were checked, the gate would race through while bots were still processing. If still pending → wait. If timed out → pause with `fabrik:awaiting-input`.
+3. **Phase 3 (re-invocation):** When the gate clears with submitted reviews present, Fabrik re-invokes the stage agent via the comment-processing skill (`comment_skill`) with the unresolved inline review thread comments as input. Top-level PR review bodies are not included, so a review that only contains general feedback without inline thread comments does not provide re-invocation input. Each inline thread comment is enriched with its **file path** and, when available, **line number** and **raw diff-hunk context** (line number and hunk may be absent for file-level or outdated comments) so the agent understands where in the code the reviewer's feedback applies. The agent addresses the feedback, commits, and signals `FABRIK_STAGE_COMPLETE`. This re-applies `fabrik:awaiting-review`, and the cycle returns to Phase 2 until the gate clears again under the same dual condition — no requested reviewers outstanding **and** at least one review submitted — or, if that does not happen before the wait limit, Fabrik falls back to `fabrik:awaiting-input`. **As of v0.0.39, re-invocation is unconditional** — it fires for any issue with `wait_for_reviews: true` and submitted inline feedback, regardless of whether auto-advance is active.
+
+This means there is always at least one extra poll cycle delay after stage completion — typically 30 seconds.
+
+#### No Inline-Thread Feedback Skip
+
+If a submitted-review batch leaves no unresolved inline PR review thread comments to process, Fabrik skips re-invocation entirely and advances the issue normally. Top-level review bodies are ignored for this decision, so a review body containing text like "APPROVED" does not trigger re-invocation unless there is unresolved line-level thread feedback to address.
+
+This prevents spurious re-invocation cycles when reviews contain no actionable inline thread feedback for the agent to address.
+
+#### PR Summary Comment
+
+After each re-invocation cycle, Fabrik posts a summary comment on the **linked PR** (not the issue) with the following format:
+
+```
+🏭 **Fabrik — stage: {StageName} (review feedback addressed)**
+*branch: {branch} | commit: {sha} | main: {mainSHA} | {timestamp}*
+
+{Claude output}
+
+---
+**Threads addressed:**
+- `path/to/file.go:42` — resolved
+- `other/file.go` — resolved
+
+Resolved N review thread(s) across M comment(s).
+```
+
+The "Threads addressed" footer lists each inline thread by file path and line number (when available); file-level or outdated threads show only the file path. This comment is posted only when Claude produces output and a linked PR is found. It carries the `🏭 **Fabrik` header so it is not reprocessed as user input on subsequent polls.
+
+#### Cycle Limit
+
+To prevent infinite loops (e.g., a bot that always posts new reviews after every push), Fabrik caps the number of re-invocation cycles per issue per stage per engine session. When the limit is reached with reviewers still pending, Fabrik pauses the issue with `fabrik:awaiting-input` and posts a comment explaining the situation.
+
+```bash
+FABRIK_MAX_REVIEW_CYCLES=3  # Limit to 3 re-invocation cycles per issue per stage (default: 5)
+# or equivalently:
+fabrik --max-review-cycles=3
+```
+
+The cycle count resets on engine restart.
+
+#### Timeout Configuration
+
+`FABRIK_REVIEW_WAIT_TIMEOUT` sets the per-cycle timeout in minutes for the review gate. If the gate is still waiting within the timeout — whether for requested reviewers to submit or simply for at least one review to exist — Fabrik **pauses** the issue with `fabrik:awaiting-input` (rather than auto-advancing) so a human can investigate. This timeout also acts as the fallback when no reviews ever arrive — for example, if all bot reviewers fail to post — since the dual-condition gate requires at least one submitted review and would otherwise wait indefinitely.
+
+```bash
+FABRIK_REVIEW_WAIT_TIMEOUT=30  # Wait up to 30 minutes per cycle for reviewers (default: 15)
+# or equivalently:
+fabrik --review-wait-timeout=30
+```
+
+#### Restart Persistence
+
+The timeout is based on the timestamp of when the `fabrik:awaiting-review` label was added to the issue, which is stored in GitHub's event history. If Fabrik restarts while waiting, it recalculates the remaining wait time from the label timestamp rather than resetting the clock. The cycle count is in-memory and resets on restart.
+
+---
+
+### CI Gate and CI-Fix Workflow
+
+When a stage has `wait_for_ci: true` set, Fabrik gates auto-advance (and auto-merge for Validate+yolo) on CI checks passing on the PR head. If checks fail, Fabrik re-invokes the stage agent with a structured failure report so it can fix the regression and push again. **Re-invocation is unconditional** — it fires for any issue with `wait_for_ci: true` and a failing CI check, regardless of whether auto-advance is active.
+
+For the authoritative spec on label lifecycle and gate transitions, see [State Machine](state-machine.md).
+
+The Validate stage ships with `wait_for_ci: true` enabled by default.
+
+#### Enabling the Gate
+
+Add `wait_for_ci: true` to the relevant stage YAML:
+
+```yaml
+name: Validate
+order: 5
+wait_for_ci: true
+...
+```
+
+CI checks are only evaluated on the **PR head SHA** — Fabrik makes two REST calls per poll: one to get the head SHA via the linked PR, and one to fetch the check runs. If no check runs exist (the repo has no CI), the gate clears immediately.
+
+#### Label Lifecycle
+
+When a `wait_for_ci: true` stage emits `FABRIK_STAGE_COMPLETE`, Fabrik immediately adds the `fabrik:awaiting-ci` label to the issue — it means "CI gate active" and covers both pending and failed CI states. `stage:X:complete` is withheld until `checkCIGate` confirms all checks pass (conjunctive gate, ADR 032). This label:
+
+- Makes the CI-blocked state visible on the project board; present whether checks are still running or have failed
+- Is cleared automatically when all CI checks pass; or when the CI wait timeout elapses (removed before pausing with `fabrik:awaiting-input`)
+- Triggers the `itemMayNeedWork` cache bypass — CI results change independently of the issue's GitHub `updatedAt`, so items with `fabrik:awaiting-ci` bypass the staleness cache and are re-evaluated on every poll
+- **R5 post-push guard**: within the current engine run, if the PR has previously had check runs, empty check run results after a push are treated as a post-push registration delay (GitHub takes a few seconds to register new runs) rather than "no CI configured" — the gate does not prematurely clear
+
+#### The CI-Fix Report
+
+When CI fails and Fabrik re-invokes the stage agent, it passes a synthetic CI failure comment with the following structure:
+
+```
+🏭 **Fabrik — CI Fix Required**
+
+CI checks failed on the PR head. Fix **NEW REGRESSION** failures before proceeding.
+
+### Failed checks
+
+| Check | Status | Classification |
+|-------|--------|----------------|
+| Go tests | failure | **NEW REGRESSION** |
+| Go vet | failure | pre-existing (also failing on base branch) |
+
+### Base branch CI status (for comparison)
+
+| Check | Status |
+|-------|--------|
+| Go tests | success |
+| Go vet | failure |
+```
+
+- **NEW REGRESSION** — the check passes on the base branch but fails on this PR. The agent should fix these.
+- **pre-existing** — the check also fails on the base branch. The agent should not attempt to fix these.
+
+The agent should fix NEW REGRESSION failures, commit, push, and **not** emit `FABRIK_STAGE_COMPLETE`. Fabrik re-evaluates CI on the next poll and advances the issue once all checks pass.
+
+#### Two-Prong CI Gate
+
+The CI gate operates on two different paths depending on whether the item is being auto-merged or just being polled:
+
+**Merge guard (Validate+yolo auto-merge path):**
+- Checks CI before attempting the merge in `attemptMergeOnValidate()`
+- **`mergeable_state` shortcut (v0.0.52):** `attemptMergeOnValidate` queries GitHub's `mergeable_state` first; if `clean` or `unstable`, the gate clears immediately and proceeds to merge — per-check classification is skipped entirely
+- While CI is pending: returns an error (no label applied — avoids churn)
+- On CI failure: adds `fabrik:awaiting-ci`, returns error (skips merge)
+- On timeout (pending too long): pauses with `fabrik:paused` + `fabrik:awaiting-input`
+
+**Catch-up loop (all other paths):**
+- Evaluates CI on every poll for items with `fabrik:awaiting-ci` on stages with `wait_for_ci: true`
+- **`mergeable_state` shortcut (v0.0.52):** `checkCIGate` queries GitHub's `mergeable_state` first; if `clean` or `unstable`, `addCompleteLabelAndRemoveCI` runs immediately — stale `fabrik:awaiting-ci` is cleared, `stage:<X>:complete` is added, and per-check classification is skipped entirely
+- On pending: `fabrik:awaiting-ci` is already present (applied at FABRIK_STAGE_COMPLETE); no additional label applied, re-evaluates next poll
+- On failure: `fabrik:awaiting-ci` applied idempotently; dispatches CI-fix re-invocation
+- On timeout: pauses with `fabrik:paused` + `fabrik:awaiting-input`; timeout measured from when `fabrik:awaiting-ci` was first applied (durable across restarts)
+
+> **Rationale for the `mergeable_state` shortcut:** GitHub's `mergeable_state` reflects branch protection rules — it already aggregates required check status, reviewer approvals, and protection constraints. Non-required check_run failures (e.g., cleanup workflow jobs, notification steps) do not block merges per branch protection, so Fabrik's gate must not block on them either. Consulting `mergeable_state` first avoids over-aggressive blocking caused by raw per-check classification that cannot distinguish required from non-required checks.
+
+#### Merge-Conflict Gate
+
+In addition to checking CI status, the catch-up loop also checks the `mergeable` field of the linked PR. When GitHub reports `mergeable: false` (confirmed — not null or pending) while the item is in the CI-await window, Fabrik applies the `fabrik:rebase-needed` label and dispatches a rebase re-invocation. Claude is instructed to `git fetch`, rebase the branch onto the base branch, resolve any conflicts, and force-push. The label clears automatically on the next poll when GitHub flips `mergeable` back to `true`.
+
+The rebase cycle cap is controlled by `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` (default 3). When the cap is exceeded, Fabrik posts a comment, keeps `fabrik:rebase-needed` applied so the reason for the pause remains visible, and pauses the issue with `fabrik:paused` + `fabrik:awaiting-input`. The pause comment instructs the operator to resolve the conflict manually, then remove both `fabrik:paused` and `fabrik:rebase-needed` to resume. The default of 3 is intentionally lower than the CI-fix and review defaults (both 5): a rebase either succeeds in one automated pass or it has a semantic conflict that requires human judgment. More than a handful of automated attempts without success almost always means a human needs to look at it.
+
+#### CI-Fix Skill
+
+By default, CI-fix re-invocations use the stage's `comment_skill`. To use a dedicated skill for CI fixes, set `ci_fix_skill`:
+
+```yaml
+name: Validate
+order: 5
+wait_for_ci: true
+ci_fix_skill: fabrik-validate-ci-fix   # Custom skill for CI-fix re-invocations
+comment_skill: fabrik-validate-comment  # Used for regular comment processing
+...
+```
+
+When `ci_fix_skill` is not set, `comment_skill` is used. When neither is set, the stage's primary skill is used.
+
+#### Cycle Limit
+
+To prevent infinite loops (e.g., a non-deterministic flaky test that keeps failing), Fabrik caps the number of CI-fix re-invocation cycles per issue per stage per engine session:
+
+```bash
+FABRIK_MAX_CI_FIX_CYCLES=3  # Limit to 3 CI-fix cycles per issue per stage (default: 5)
+# or equivalently:
+fabrik --max-ci-fix-cycles=3
+```
+
+The cycle count resets on engine restart, and is also reset by `clearFailedStage()` when the user manually unpauses a failed issue.
+
+#### Timeout Configuration
+
+`FABRIK_CI_WAIT_TIMEOUT` sets the timeout in minutes for the CI gate (catch-up loop path). If `fabrik:awaiting-ci` has been present for longer than this duration, Fabrik pauses the issue with `fabrik:awaiting-input` rather than continuing to re-invoke.
+
+```bash
+FABRIK_CI_WAIT_TIMEOUT=60  # Wait up to 60 minutes for CI to pass (default: 30)
+# or equivalently:
+fabrik --ci-wait-timeout=60
+```
+
+The CI timeout is measured from when `fabrik:awaiting-ci` was first applied. Because the label is applied immediately at FABRIK_STAGE_COMPLETE, the timeout covers both pending and failed CI states — it starts from when the stage finishes, not from when CI first fails.
+
+#### Restart Persistence
+
+The CI timeout is measured from the `fabrik:awaiting-ci` label's creation timestamp (fetched via the GitHub API), making it durable across engine restarts. The cycle count is in-memory and resets on restart.
+
+---
+
+## 4. Stage Reference
+
+### Default Pipeline
+
+| Stage | Order | Purpose |
+|-------|-------|---------|
+| **Backlog** | -- | Parking lot. No stage config needed. |
+| **Specify** | 0 | Refine rough issues into clear, unambiguous specs. |
+| **Research** | 1 | Explore codebase, surface technical findings and questions. |
+| **Plan** | 2 | Design implementation approach with task checklist. |
+| **Implement** | 3 | Write code and tests, commit frequently, push to branch. |
+| **Review** | 4 | Rebase, review, fix issues, push. Posts output on PR. |
+| **Validate** | 5 | Run tests, verify requirements, confirm PR is ready. |
+| **Done** | 99 | Terminal state. Cleanup stage removes worktree. Item remains on the board. |
+
+#### Done Stage and Archiving
+
+When an issue reaches Done, Fabrik:
+1. **Removes the worktree** — frees disk space from the issue's working copy
+2. **Adds `stage:Done:complete`** — marks cleanup as finished
+
+**Note:** Auto-archive is currently disabled. It was removing items from the board before users could see them, and is being reworked to track actual Done stage completion time. Items will remain in the Done column until auto-archive is re-enabled in a future release. When re-enabled, archived items will not be deleted — they will remain accessible via the project board's "Archive" view in GitHub.
+
+**Closed-issue auto-advance:** In auto-advance mode (`--yolo`, `fabrik:yolo`, or `fabrik:cruise`), if an issue is closed externally (for example, a PR merge closes it) while it is still in an intermediate stage column with a `stage:<name>:complete` label already applied, Fabrik automatically advances it to Done on the next poll. No manual board move is required — Fabrik detects the closed state and runs the normal catch-up path. This typically happens when a PR merge closes an issue sitting in the Validate column. Without auto-advance, closed issues with a stage-complete label are not moved automatically; you can drag the card to Done manually.
+
+### Customizing Stages
+
+```bash
+# Initialize with defaults
+./fabrik init
+
+# Edit stage configs and skills
+vim .fabrik/stages/research.yaml
+vim .fabrik/plugin/skills/fabrik-research/SKILL.md
+
+# Or point to a custom stages directory
+./fabrik --stages ./my-custom-stages ...
+```
+
+You can add, remove, or reorder stages. Stages must have `name`, `order`, and either
+`skill` or `prompt`. The `name` must match a board column and `order` values define
+the sequence.
+
+---
+
+## 5. Plugin & Skills
+
+### How Skills Work
+
+Each stage references a **skill** -- a markdown file that contains detailed methodology
+for how Claude should approach the stage. Skills are packaged as a Claude Code plugin
+in `.fabrik/plugin/` and loaded via `--plugin-dir` on each Claude invocation.
+
+The default skills are:
+
+| Skill | Purpose |
+|-------|---------|
+| `fabrik-specify` | Requirements clarification, consistency checks, prior art research; preserves the Problem section verbatim (never compressed) and places it first in the spec |
+| `fabrik-research` | Codebase exploration, technical analysis, constraint discovery; includes a Documentation Impact section for user-facing features |
+| `fabrik-plan` | Implementation design, task checklist, decision documentation; includes explicit doc update tasks in the checklist for user-facing features |
+| `fabrik-implement` | Code writing, testing, committing, pushing; updates `USER_GUIDE.md` and/or `README.md` in the same PR for user-facing features — never defers documentation to a follow-up issue |
+| `fabrik-review` | Code review, fix issues, rebase, prepare PR |
+| `fabrik-validate` | Final verification, test suite, requirements check |
+
+### Customizing Skills
+
+Skills live in `.fabrik/plugin/skills/<skill-name>/SKILL.md`. Edit them to change
+how Claude approaches each stage. Changes take effect on the next Claude invocation.
+
+The stage YAML references the skill by name:
+```yaml
+skill: fabrik-research    # loads .fabrik/plugin/skills/fabrik-research/SKILL.md
+```
+
+### Skill vs Prompt
+
+- **`skill:`** references a plugin skill file (recommended). The skill contains rich
+  methodology, quality checklists, and scope boundaries.
+- **`prompt:`** is an inline prompt string in the YAML (legacy, still supported).
+  Useful for quick customization but harder to maintain for complex stages.
+
+When `skill` is set, Fabrik sends a minimal directive:
+```
+You are operating as the Fabrik Research agent for issue #42.
+Follow the instructions in the fabrik-research skill exactly.
+```
+
+The skill is auto-loaded by Claude Code via the plugin system.
+
+### Built-in Skill: `/cut-release`
+
+The `/cut-release` skill automates the Fabrik release process — pre-flight checks, release notes, commit/tag/push, and documentation issue filing — in a single invocation.
+
+#### Invocation
+
+```
+/cut-release              # Auto-suggests next patch bump; confirms version with you
+/cut-release v0.0.12      # Uses the explicit version; no confirmation prompt
+```
+
+#### Pre-flight checks
+
+Before doing anything, `/cut-release`:
+
+1. Verifies the working tree is clean (`git status --porcelain`). Stops if dirty.
+2. Pulls latest main (`git pull origin main`).
+3. Runs `go build ./...` and `go test -race ./...`. Stops if either fails.
+
+The build/test gate is mandatory — broken releases are worse than delayed ones.
+
+#### Version determination
+
+- Reads the latest tag via `git describe --tags --abbrev=0`.
+- If you provided an explicit version, validates it: must be valid semver with a `v` prefix and greater than the current tag.
+- If no version is provided, auto-suggests the next patch bump (e.g. `v0.0.11` → `v0.0.12`) and confirms with you before proceeding.
+
+#### Change gathering
+
+Runs `git log <last-tag>..HEAD --oneline` and groups commits into four categories:
+
+| Category | What goes here |
+|----------|---------------|
+| **Features** | New user-facing capabilities |
+| **Fixes** | Bug fixes |
+| **Improvements** | Enhancements to existing features |
+| **Internal** | Refactoring, test improvements, CI — summarized briefly, not enumerated |
+
+Merge commits and `Co-Authored-By` lines are ignored.
+
+#### Release notes format
+
+Writes `release-notes.md` in the repo root:
+
+```markdown
+# Fabrik <version>
+
+## Features
+- Description of feature (#issue)
+
+## Fixes
+- Description of fix (#issue)
+
+## Improvements
+- Description of improvement (#issue)
+
+## Internal
+- Summary of internal changes
+
+## Upgrading
+
+\```bash
+# Auto-upgrade from a running Fabrik instance
+# Fabrik checks for new releases each poll cycle and upgrades automatically with --auto-upgrade
+
+# Or download directly
+gh release download --repo shadoworg/fabrik --pattern '*<os>_<arch>*' -O - | tar xz
+\```
+```
+
+Empty category sections are omitted. The `release-notes.md` file **must be committed before the tag push** because the GitHub Actions release workflow (`release.yml`) uses it to populate the GitHub Release body.
+
+#### Commit, tag, and push
+
+Once the release notes are written, `/cut-release` proceeds without a confirmation prompt (pre-flight already passed):
+
+1. `git add release-notes.md`
+2. Commits with message: `Release notes for <version>`
+3. Creates the tag: `git tag <version>`
+4. Pushes branch and tag together: `git push origin main <version>`
+5. Reports the triggered GitHub Actions run URL.
+
+**Never force-push tags.** If a tag already exists at that version, `/cut-release` stops and tells you.
+
+#### Documentation issue
+
+After a successful push, `/cut-release` automatically files a GitHub issue:
+
+- **Title**: `Update docs for v<version>`
+- **Labels**: `documentation`, `fabrik:yolo`
+- **Board position**: Added to the Fabrik PM project board and moved to the **Specify** column
+
+The `fabrik:yolo` label means Fabrik will pick it up automatically and run it through the pipeline. You don't need to do anything else for documentation updates after cutting a release.
+
+### Built-in Skill: `/audit-documentation`
+
+The `/audit-documentation` skill compares recently shipped features against `USER_GUIDE.md`, `README.md`, and `docs/index.md`, then files GitHub issues for gaps and closes existing documentation issues whose gaps are now covered.
+
+#### Invocation
+
+```
+/audit-documentation                  # Scan issues closed in the last 30 days
+/audit-documentation --since v0.0.20  # Scan issues referenced in commits since a tag
+```
+
+#### What it does
+
+1. **Discovers source issues** — finds recently closed issues using the selected mode (see below).
+2. **Filters** — excludes issues labeled `documentation` and issues that are infrastructure/tooling-only with no user-facing behavior change.
+3. **Reads the docs** — reads `USER_GUIDE.md`, `README.md`, and `docs/index.md` in full.
+4. **Analyzes gaps** — for each filtered issue, checks whether the feature is adequately described in the docs. Groups related issues into single gap entries. Errs on the side of filing — false positives are refined by the Specify stage; false negatives cause documentation drift.
+5. **Clears the deck** — for each existing open `documentation` issue whose gap is now clearly and completely covered, closes it with a comment.
+6. **Files new gap issues** — for each newly identified gap, creates a GitHub issue labeled `documentation` and `fabrik:yolo`, and places it in the **Specify** column on the PM board.
+
+#### Modes
+
+**Date-based mode (default):** Fetches closed issues via `gh issue list --state closed --search "closed:>$CUTOFF_DATE" --limit 200`.
+
+**Tag-based mode (`--since <tag>`):** Two passes — extracts `#NNN` references from commit messages since the tag, then scans merged PRs for `Closes #NNN` references.
+
+#### Output
+
+After running, `/audit-documentation` prints a structured summary:
+
+```
+## Audit Documentation — Summary
+
+**Period**: <date range or tag range scanned>
+
+**Issues scanned**: <N>
+**Issues excluded**: <N>
+  - <issue#>: <title> — <reason>
+
+**Documentation gaps found**: <N>
+
+**New gap issues filed** (<N>):
+  - #<number>: <title>
+
+**Existing documentation issues closed** (<N>):
+  - #<number>: <title>
+
+**Existing documentation issues left open** (<N>):
+  - #<number>: <title> — <reason left open>
+```
+
+If no gaps are found, it reports: "No documentation gaps found — docs appear current."
+
+#### Known limitations
+
+- **Rate limits**: May apply for repos with hundreds of closed issues.
+- **Tag-based mode coverage**: Misses issues whose PRs used `Fixes` or bare URLs instead of `Closes #NNN` in the PR body.
+
+### Plugin Development
+
+For developing the plugin itself, use `--plugin-dir` to point at your working copy:
+```bash
+./fabrik --plugin-dir ./plugin/fabrik-plugin ...
+```
+
+---
+
+## 6. Labels Reference
+
+> For the authoritative label lifecycle spec — when each label is added, cleared, and what transitions it guards — see [State Machine](state-machine.md).
+
+### Fabrik-Managed Labels
+
+> Fabrik auto-seeds all managed labels on the configured repository at startup — creating them with their descriptions and colors if they do not already exist, so the GitHub UI shows meaningful hover text.
+
+| Label | Purpose |
+|-------|---------|
+| `fabrik:locked:<user>` | Issue being processed by this user's instance |
+| `fabrik:editing` | Issue body being updated (comment processing) |
+| `fabrik:paused` | Processing paused (max retries exceeded or manual) |
+| `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user |
+| `fabrik:awaiting-review` | Set when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding **and** at least one review has been submitted (then re-invocation fires unconditionally), or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
+| `fabrik:awaiting-ci` | Applied immediately when a `wait_for_ci: true` stage emits `FABRIK_STAGE_COMPLETE`; means "CI gate active" and covers both pending and failed CI states; `stage:X:complete` is applied only when CI passes — not when this label is cleared by timeout (conjunctive gate, ADR 032). Triggers `itemMayNeedWork` cache bypass so CI results are re-evaluated on every poll. Cleared when all checks pass or the CI wait timeout elapses (then issue is paused with `fabrik:awaiting-input`). See [§3 CI Gate](USER_GUIDE.md#ci-gate-and-ci-fix-workflow). |
+| `fabrik:rebase-needed` | Set when GitHub reports the linked PR as `mergeable: false` on a `wait_for_ci: true` stage — typically because another PR merged into the base branch during the CI-await window. The engine dispatches a rebase re-invocation instructing Claude to `git fetch && git rebase origin/<base>`, resolve conflicts conservatively (watching for semantic collisions like duplicated ADR numbers), and force-push. The label clears when GitHub flips `mergeable` back to `true`. Triggers `itemMayNeedWork` cache bypass because base-branch advances don't bump the item's `updatedAt`. |
+| `fabrik:blocked` | Issue is waiting for one or more blocking issues to close; added and removed automatically by the engine (Fabrik creates this label on first use — no pre-creation needed) |
+| `stage:<name>:in_progress` | Stage actively running |
+| `stage:<name>:complete` | Stage completed successfully |
+| `stage:<name>:failed` | Stage hit max retries |
+
+### User-Set Labels
+
+| Label | Effect |
+|-------|--------|
+| `model:opus` | Override Claude model to Opus for this issue |
+| `model:sonnet` | Override Claude model to Sonnet for this issue |
+| `effort:low` | Override thinking effort to low for this issue |
+| `effort:medium` | Override thinking effort to medium for this issue |
+| `effort:high` | Override thinking effort to high for this issue |
+| `effort:max` | Override thinking effort to max for this issue |
+| `fabrik:paused` | Manually pause processing (add to pause, remove to resume) |
+| `fabrik:yolo` | Force auto-advance for this issue even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes. If the linked PR was already manually merged when auto-merge runs, Fabrik treats it as a success and advances the issue to Done normally. |
+| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
+| `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` for this issue; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set or when the default posture prevents required work. **Caution:** removes all tool restrictions. |
+| `fabrik:extend-turns` | Pre-grant 2× `max_turns` for the first invocation of the next stage. Auto-extends to 3× when actual progress is detected during that invocation (Implement: new git commit (HEAD SHA changed) OR (baseline was clean AND working tree is now dirty — uncommitted file edits by Claude); Review: new git commit or resolved reviewer thread count; Validate: new comment; other stages: no progress signal). Auto-removed by the engine on successful stage completion. No-op when `max_turns` is 0 (unlimited). The displayed turn counter denominator always reflects the effective budget. |
+| `base:<branch>` | Override the base branch for this issue (e.g. `base:liminis`). Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default. Apply before Research; adding mid-pipeline is unsupported and may produce unexpected results. Branch names containing `/` are supported (e.g. `base:release/1.x`). If the named branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment on the issue. |
+
+Model label precedence: `model:<name>` label > stage YAML `model` field > default.
+
+Effort label precedence: `max > high > medium > low`. If multiple `effort:` labels are present, the highest-ranked value wins and a warning is logged.
+
+### Advanced: `base:<branch>` timing
+
+The `base:<branch>` label is read on every stage invocation, so a change takes effect from the next stage onward. However, Fabrik cannot retroactively re-create past work — the issue branch is forked once, commits accumulate on it, and the PR is opened once. The later you apply or change the label, the more of that history is already locked to the original base.
+
+| When applied | Effect |
+|---|---|
+| **Before any stage runs** | Clean. The issue branch is forked from the specified base, all commits stack on the right base, the PR targets the right base. This is the intended path. |
+| **After Specify, before Research** | Fairly clean. The worktree exists but no commits yet. The next stage's `updateWorktreeFromMain` rebases onto the new base — usually no conflict. |
+| **After Research, before Implement** | Similar — Research is read-only, so no commits. Rebase onto the new base works. |
+| **After Implement (commits exist, no PR yet)** | Messy. The issue branch has commits forked from the old base. Rebase onto the new base may produce conflicts that Claude must resolve. The PR, when created, will target the new base correctly. |
+| **After PR creation** | Fabrik automatically updates the PR's base branch when the `base:<branch>` label changes mid-pipeline. No manual intervention required. |
+
+**Natural language in the issue body is NOT parsed.** Writing "use the `develop` branch" in the Problem section has no effect on Fabrik's base-branch selection. The `base:<branch>` label is the only structured signal.
+
+If the named branch does not exist on the remote, Fabrik falls back to the repository's default branch and posts a comment on the issue explaining the fallback. Fabrik keeps `refs/remotes/origin/HEAD` in sync with the remote's current default branch on every fetch, so a default-branch change on the remote (after Fabrik initially cloned the repo) is detected automatically on the next stage invocation.
+
+---
+
+## 7. Permissions
+
+Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In this mode Claude does not prompt for tool permissions — tools not in the allowed set are silently denied rather than triggering an interactive prompt. This ensures Fabrik works correctly in headless mode and shared environments regardless of the user's `~/.claude/settings.json`. Fabrik does not require users to pre-configure permissions in their Claude Code settings.
+
+**Default allowed-tool set** (used when a stage does not specify `allowed_tools`):
+
+| Category | Tools |
+|----------|-------|
+| File operations | `Read`, `Edit`, `Write`, `Glob`, `Grep` |
+| Task management | `TodoWrite`, `Skill`, `Task` |
+| Git & GitHub | `Bash(git:*)`, `Bash(gh:*)` |
+| Build systems | `Bash(go:*)`, `Bash(npm:*)`, `Bash(npx:*)`, `Bash(yarn:*)`, `Bash(pnpm:*)`, `Bash(make:*)`, `Bash(cargo:*)` |
+| Python | `Bash(python:*)`, `Bash(pip:*)`, `Bash(uv:*)`, `Bash(pytest:*)` |
+| Shell utilities | `Bash(ls:*)`, `Bash(cat:*)`, `Bash(rm:*)`, `Bash(cp:*)`, `Bash(mv:*)`, `Bash(mkdir:*)`, `Bash(find:*)` |
+
+**`allowed_tools` replaces the defaults — it is not additive.** When a stage sets `allowed_tools`, only those tools are permitted; the default list above is not merged in. This is intentional: Research, Plan, and Specify stages set `allowed_tools` to a read-only subset to prevent Claude from writing files during those stages.
+
+**`fabrik:unrestricted` bypasses everything** — passes `--dangerously-skip-permissions` instead, granting Claude full tool access. Use this label only when a stage requires tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains).
+
+**Note on personal `~/.claude/settings.json`:** Under `dontAsk` mode, tools the user has explicitly allowed in their own `permissions.allow` remain allowed in addition to Fabrik's list — this does not break the isolation goal, it just means personal extras carry through. If your organization deploys managed settings (MDM/enterprise level), a `deny` rule in managed settings cannot be overridden by `--allowedTools` — that is outside Fabrik's control.
+
+---
+
+## 8. TUI Dashboard
+
+The interactive terminal dashboard is enabled by default when running in a real terminal. To disable it, use `--notui`:
+
+```bash
+./fabrik --notui --owner your-org --repo your-repo --project 1 --user you
+```
+
+### Layout
+
+The TUI shows a compact header with poll status, an In Progress pane showing active
+Claude sessions, a scrollable History pane with completed jobs, and a status bar
+(footer) displaying REST and GraphQL rate limit stats.
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Switch focus between In Progress and History panes |
+| `Up/Down` or `j/k` | Navigate items within the focused pane |
+| `l` | Open `fabrik watch` for selected issue (live Claude output, stage tabs, PR/CI status) |
+| `enter` | Toggle inline detail panel for the selected item |
+| `r` | Resume Claude session for selected history item (history pane only, item must not be active) |
+| `Escape` | Close open dialogs; with no dialog open, triggers quit confirmation |
+| `n` / `N` | Cancel quit or clear-all confirmation dialogs |
+| `c` | Delete selected history entry |
+| `C` | Clear all history (with confirmation) |
+| `w` | Wake: reset idle backoff and poll immediately |
+| `?` | Toggle help panel (keybindings and labels reference) |
+| `q` | Quit |
+
+#### Help Panel (`?`)
+
+Pressing `?` opens an overlay that displays all keybindings and a labels reference. The labels reference covers every label Fabrik uses:
+
+| Label | Meaning |
+|-------|---------|
+| `fabrik:yolo` | Auto-advance through all stages and auto-merge PR on Validate completion |
+| `fabrik:cruise` | Auto-advance through all stages without auto-merging the PR |
+| `fabrik:paused` | Issue processing is paused |
+| `fabrik:awaiting-input` | Stage is blocked waiting for user input |
+| `fabrik:awaiting-review` | Stage completed; waiting for outstanding PR reviewer requests; clears when no requested reviewers are outstanding and at least one review has been submitted, then re-invokes the stage agent to address feedback |
+| `fabrik:locked:<user>` | Issue is locked for editing by the specified user |
+| `stage:<name>:in_progress` | Named stage is currently running |
+| `stage:<name>:complete` | Named stage completed successfully |
+| `stage:<name>:failed` | Named stage failed (hit max retries) |
+| `model:<name>` | Override the model for this issue (e.g. `model:opus`) |
+| `effort:<level>` | Override thinking effort for this issue (`low`, `medium`, `high`, `max`) |
+| `fabrik:unrestricted` | Bypass default permission posture; passes `--dangerously-skip-permissions` instead |
+| `fabrik:extend-turns` | Pre-grant 2× max turns budget; auto-extends to 3× when progress is detected (see the Labels Reference / state-machine semantics for the full definition); auto-removed on success; the turn counter denominator reflects the effective budget |
+| `base:<branch>` | Override base branch for this issue (e.g. `base:liminis`); Fabrik forks from, rebases onto, and targets PRs at this branch |
+
+Dismiss the panel by pressing `?` again or `Esc`.
+
+In terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, WezTerm, Kitty), issue numbers (`#NNN`) in the In Progress and History panes are hyperlinks. **Cmd+click** (macOS) or **Ctrl+click** (Linux) on a `#NNN` to open the corresponding GitHub issue in your browser; **Cmd+click** / **Ctrl+click** the board title in the footer to open the project board. Use keyboard navigation for selection and scrolling.
+
+### What's Displayed
+
+**In Progress**: Issue number, stage name, elapsed time, a live turn counter (`[N/M turns]` or compact `[N/M]` when terminal width is tight), issue title, and latest status message. The turn counter updates in real time as Claude advances through turns; the denominator reflects the effective per-invocation budget. With `fabrik:extend-turns`, the first invocation may use a denominator of `2× stage.MaxTurns`, while subsequent extension invocations revert to `stage.MaxTurns` each. Review-reinvoke jobs appear here alongside regular stage jobs — they emit `JobStarted`/`JobCompleted` events and display with the issue number, stage name, and elapsed time, just like a normal stage invocation.
+
+Pressing `Enter` on an active item opens the inline detail panel, which shows Issue, Stage, Elapsed, and a live `Turns: N/M` counter for in-progress stages.
+
+**History**: Issue number, stage name, success/fail icon, duration, timestamp, turns used,
+cost, and issue title. Status icons:
+
+| Icon | Meaning |
+|------|---------|
+| `✓` | Stage completed successfully |
+| `✗` | Stage failed (hit max retries) |
+| `?` | Stage blocked / awaiting user input |
+| `↻` | Stage retrying |
+| `💬` | Issue has unprocessed comments |
+
+### History Persistence
+
+Job history is saved to `.fabrik/history.json` (project-local, alongside `.fabrik/config.yaml`) and restored on restart.
+
+---
+
+## 9. Observability
+
+### `fabrik watch` — Per-Issue TUI
+
+The recommended way to monitor a running issue is `fabrik watch`:
+
+```bash
+fabrik watch 42
+# or with explicit credentials:
+fabrik watch 42 --owner myorg --repo myrepo --token ghp_...
+```
+
+This opens a real-time terminal UI that shows:
+- Issue title, labels, and current stage
+- **Live Claude output** — streams from the `.log` file as Claude writes it (no polling)
+- **Live turn counter** — `turn N/M` shown inline in the PR/CI row while a stage is active; updates in real time as Claude advances through turns (`turn N` when the stage has no turn limit)
+- **Stage history** — completed stages with duration and cost
+- **PR status** — linked PR number, open/draft/merged state
+- **CI check results** — compact pass/fail/pending summary
+- **Comment count** — updates on each GitHub poll
+
+#### Keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` or `k` / `j` | Scroll live output |
+| `g` / `G` | Jump to top / bottom of output |
+| `left` / `h` | Switch to previous stage tab |
+| `right` / `l` | Switch to next stage tab |
+| `i` | Open interactive Claude session in the issue's worktree (resumes current stage) |
+| `esc` | Quit (same as `q`) |
+| `q` / `ctrl+c` | Quit |
+
+The session ID for the active Claude session is shown in the header when available.
+
+#### Credentials
+
+`fabrik watch` reads owner, repo, and poll interval from `.fabrik/config.yaml` (see §2). Without a GitHub token, it shows local log output and stage history but skips GitHub API calls (PR/CI/comments).
+
+### Log Files
+
+Session logs are saved to `.fabrik/logs/<owner>-<repo>/issue-<N>/` (relative to the project working directory) as NDJSON (one JSON event per line). Each stage produces a `.log` file written continuously during execution — `fabrik watch` follows this file live. To view a log manually:
+
+```bash
+ls -lt .fabrik/logs/<owner>-<repo>/issue-42/
+
+# Render a completed log as human-readable text
+cat .fabrik/logs/<owner>-<repo>/issue-42/<stage>-output-<timestamp>.json | fabrik stream-filter | less -R
+```
+
+Logs are namespaced by repository: `.fabrik/logs/<owner>-<repo>/issue-<N>/`.
+
+`fabrik stream-filter` reads NDJSON or JSON array Claude output from stdin and renders thinking blocks, text responses, and tool calls as human-readable text.
+
+### Poll Log
+
+Fabrik writes engine-level output to `.fabrik/fabrik.log` in the project working directory. This file is **truncated on each startup** and contains only the current run.
+
+The poll log captures:
+- Deep-fetch decisions (which issues were shallow-skipped vs. fully fetched)
+- Dispatch events (which issues were dispatched to workers and why)
+- Upgrade checks and idle-upgrade transitions
+- GitHub API rate limit stats per poll cycle
+- `[#N extend-turns]` verdict lines — emitted on every `detectProgress` call (pass or fail) without `--debug-output`; useful for diagnosing why a stage did or didn't receive a turn extension
+
+The poll log is written in both TUI and non-TUI modes. It is most useful for post-mortem debugging of engine-level behavior — for example, diagnosing why an issue was not picked up during a poll cycle.
+
+### Auto-migration from `~/.fabrik/`
+
+On the first startup after upgrading from a pre-v0.0.32 release, Fabrik automatically migrates session files and stage logs from `~/.fabrik/sessions/` and `~/.fabrik/logs/` to `<cwd>/.fabrik/sessions/` and `<cwd>/.fabrik/logs/`. The migration is idempotent (files whose destination already exists are skipped) and handles cross-device filesystems. Empty source directories are removed after migration.
+
+### Debug Output
+
+Enable `--debug-output` to save Claude's raw output to `.fabrik/debug/` in the
+working directory. Useful for diagnosing prompt issues or unexpected behavior.
+
+### Subprocess Environment
+
+Claude Code is invoked with a clean, isolated environment — environment variables
+from the parent process do not leak into Claude subprocesses. If you previously
+relied on ambient env vars being available inside Claude (e.g., API keys or tool
+paths set in your shell), pass them explicitly via your stage YAML or a shell
+wrapper script.
+
+### Rate Limit Monitoring
+
+Fabrik reports GitHub API rate limit stats in each poll cycle (visible in the TUI
+status bar (footer) or plain-text log output):
+- REST API: requests remaining / limit
+- GraphQL API: points remaining / limit
+
+The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
+
+1. **Shallow board scan** — fetches all items with lightweight fields (`updatedAt`,
+   labels, status). Items whose `updatedAt` hasn't changed since the last poll are
+   skipped entirely.
+2. **Targeted detail fetch** — runs only for items that passed the shallow filter.
+   `fabrik:blocked` items do not receive a forced deep-fetch on every poll. Instead,
+   they are re-evaluated via the standard `processedSet` cooldown (every
+   `10 × poll interval`, typically ~5 minutes at the default 30s base) — when the
+   cooldown fires, Fabrik deep-fetches the blocked item to check whether its
+   dependencies have closed. If GitHub bumps the blocked item's `updatedAt` when a
+   dependency closes, unblocking may also be detected sooner — on the next poll cycle.
+
+   Items with `fabrik:awaiting-input` or `fabrik:awaiting-review` do **not** force a
+   deep-fetch. New user comments bump the issue's `updatedAt`; PR review submissions
+   bump the linked PR's `updatedAt` — both are captured by the shallow scan, so the
+   targeted detail fetch fires naturally when there is actually something new to see.
+
+Typical cost is ~5–30 points per poll depending on active items, well within the
+5,000 points/hour limit.
+
+---
+
+## 10. Webhook Mode
+
+Webhook mode is an optional feature that dramatically reduces GraphQL usage and cuts event latency from up to 30 seconds to near-zero. When enabled, Fabrik receives GitHub events within seconds of them occurring instead of waiting for the next poll tick.
+
+### How It Works
+
+Fabrik spawns `gh webhook forward` as a background subprocess. This tool connects outbound to GitHub's SSE stream and forwards every matching event as an HTTP POST to a local listener on `127.0.0.1:<port>`. No public endpoint, no ngrok, no infrastructure changes. Each event payload is authenticated with HMAC-SHA256 before Fabrik acts on it.
+
+Events are translated into immediate poll wakeups — the existing board-fetch and filter logic handles the rest. The poll loop continues running as a safety net (up to once every 60 minutes when the webhook stream is healthy) so missed or delayed events never strand work.
+
+### Prerequisites
+
+- **`cli/gh-webhook` extension** — `gh webhook forward` is **not** a built-in `gh` subcommand; it ships as a separate extension that must be installed once:
+  ```bash
+  gh extension install cli/gh-webhook
+  ```
+  Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). No specific minimum version is pinned; any recent `gh` with extension support works.
+- **`gh auth login`** with a token that has `admin:repo_hook` write scope (classic PAT) or equivalent repo admin access. Fine-grained tokens may lack this scope.
+- **Repo admin access** on each repository on your board, or org-admin access for org-level subscription.
+
+If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
+
+### Enabling Webhook Mode
+
+Three equivalent ways to enable:
+
+**CLI flag:**
+```bash
+fabrik --webhooks
+```
+
+**Environment variable:**
+```bash
+FABRIK_WEBHOOKS=true fabrik
+```
+
+**`.fabrik/config.yaml`:**
+```yaml
+webhooks: true
+```
+
+### Configuration Options
+
+| Option | Flag | Env var | Config YAML | Default |
+|--------|------|---------|-------------|---------|
+| Enable webhooks | `--webhooks` | `FABRIK_WEBHOOKS` | `webhooks: true` | off |
+| Listener port | `--webhook-port=<N>` | `FABRIK_WEBHOOK_PORT` | `webhook_port: <N>` | 0 (OS-assigned) |
+| Event filter | `--webhook-events=<csv>` | `FABRIK_WEBHOOK_EVENTS` | `webhook_events: [...]` | all supported events |
+| Board cache | `--board-cache=<mode>` | `FABRIK_BOARD_CACHE` | `board_cache: <mode>` | `in-memory` when `--webhooks`, else `none` |
+
+By default, Fabrik subscribes to: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `check_suite`, and `projects_v2_item` (board column changes — see note below).
+
+### Health States and TUI Indicator
+
+The TUI footer shows a webhook health indicator when webhook mode is enabled:
+
+| Indicator | State | Meaning |
+|-----------|-------|---------|
+| `● webhook (N)` (green) | Healthy | At least one event received in the last 10 minutes. Idle cap: 60 min. |
+| `○ webhook (N)` (blue) | Starting Up | Subprocess launched; waiting for first event (up to 30s grace). Idle cap: 60 min. |
+| `◌ webhook (N)` (yellow) | Unhealthy | No event received in 10+ minutes or startup grace expired. Idle cap: 5 min (same as polling-only). |
+
+`N` is the total number of webhook events received since startup. You can also verify the stream by checking `fabrik.log` for `[webhook]` tag lines.
+
+### Expected GraphQL Load Reduction
+
+On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
+
+### In-Memory Board Cache (`--board-cache`)
+
+When webhook mode is active, Fabrik maintains an in-memory board cache (`--board-cache=in-memory`, the default). Incoming webhook payloads are applied as typed state deltas to the cache before the poll loop wakes, so most reads are served from memory rather than GitHub's API.
+
+**Cache modes:**
+
+| Mode | When | Behavior |
+|------|------|----------|
+| `in-memory` | `--webhooks` enabled (default) | Cache populated at startup; deltas from webhooks; reconciles every 60 min; falls back to GitHub when stream is unhealthy |
+| `none` | `--webhooks` disabled (default), or explicit override | All reads go directly to GitHub API (original behavior) |
+
+**To disable the cache while keeping webhooks:**
+```bash
+fabrik --webhooks --board-cache=none
+```
+
+**Stream-health failover:** If the webhook stream goes unhealthy (no events for 10 minutes), the cache pauses and all reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. This ensures correctness is never compromised by a degraded webhook stream.
+
+**Reconciliation:** Every 60 minutes (matching the idle-cap for healthy webhook streams), Fabrik fetches a fresh board snapshot from GitHub and updates the cache. This heals any events the webhook stream may have missed. Reconciliation also runs inline when the stream recovers from unhealthy.
+
+> **Note:** `--board-cache=in-memory` requires `--webhooks`. Without a webhook stream, there is no delta source and the cache would only reconcile every 60 minutes — worse than the default polling behavior.
+
+### `projects_v2_item` (Board Column Changes)
+
+Fabrik attempts to subscribe to `projects_v2_item` events, which fire when an issue is moved between board columns. If `gh webhook forward` does not support this event type for your installation, Fabrik logs a warning and continues without it. In this case, board-column changes are caught by the safety-net poll within 60 minutes (or 5 minutes if the stream is unhealthy). All other event types continue to work normally.
+
+### Security
+
+- The HTTP listener binds exclusively to `127.0.0.1` and is never reachable from outside your machine.
+- Every incoming payload is verified with HMAC-SHA256 before Fabrik acts on it. A malicious local process cannot spoof events without the secret.
+- The webhook secret is generated from `crypto/rand` (32 bytes) at startup and is never written to disk or logged.
+- If HMAC verification fails repeatedly (5 consecutive failures within 2 minutes), Fabrik automatically rotates the secret and restarts the subprocess. After 2 failed rotation cycles, webhook mode is disabled for the session with a clear log message.
+
+### Multi-Repo Boards
+
+On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
+
+1. If your token has org-admin access, Fabrik uses `--org=<org>` to subscribe to all repos in the org with one subscription — no restarts needed when new repos appear.
+2. Otherwise, Fabrik subscribes per-repo. When a new repo appears on the board, the subprocess is briefly restarted with the updated repo list (the safety-net poll covers any events missed during the restart).
+
+> **Startup delay on multi-repo boards**: Webhook subscriptions are established after the first board poll completes (up to one poll interval, typically 30 seconds). During this window the TUI shows the blue "starting up" indicator and the safety-net poll is in effect. This is expected — the webhook manager waits until the repo list is known before subscribing.
+
+### Troubleshooting Webhook Mode
+
+**"prerequisite check failed"** — `gh` is missing or the `cli/gh-webhook` extension is not installed. Install `gh` at <https://cli.github.com>, then run `gh extension install cli/gh-webhook`.
+
+**Stream shows yellow "unhealthy"** — The subprocess may have exited or GitHub isn't delivering events. Check `fabrik.log` for `[webhook]` error lines. Run `gh auth status` to verify your token has `admin:repo_hook` scope.
+
+**HMAC failures logged** — Usually caused by a `gh auth refresh` that invalidated the webhook secret. Fabrik auto-rotates; if failures persist after 2 cycles, restart Fabrik.
+
+**`projects_v2_item` warning** — Board column changes fall back to the 60-minute safety-net poll. Not a problem for most workflows.
+
+---
+
+## 11. Troubleshooting
+
+### GitHub API Returns 401 or "Fine-Grained Token" Warning
+
+Fabrik requires a **classic** personal access token (`ghp_...`). Fine-grained tokens (`github_pat_...`) are **not supported** because GitHub Projects v2 GraphQL — which Fabrik uses for status updates and board queries — is not available to fine-grained PATs.
+
+**Symptoms:**
+- Startup warning: `[warn] Fine-grained personal access tokens (github_pat_...) do not support GitHub Projects v2 GraphQL...`
+- Error on first API call: `GitHub API returned 401: ... If you used a fine-grained access token...`
+
+**Fix:**
+1. Go to https://github.com/settings/tokens and select **"Tokens (classic)"**
+2. Generate a new token with scopes: `repo`, `project`, `workflow`
+3. Update `FABRIK_TOKEN` in your `.env` file with the new `ghp_...` token
+
+### Startup Board Validation Failure
+
+On every startup, Fabrik fetches the project board and compares stage names in `.fabrik/stages/*.yaml` to the column names on the board. If any non-cleanup stage is missing from the board, Fabrik exits with an error listing the mismatched names.
+
+To fix: ensure stage YAML `name` fields match board column names exactly (case-sensitive). If you renamed a column on the board, update the matching stage YAML. Extra board columns (with no matching stage) produce a warning but don't block startup.
+
+### Stage YAML Drift Warning
+
+At startup, Fabrik prints a warning when a `.fabrik/stages/*.yaml` file is missing top-level keys that exist in the embedded defaults for the same stage name:
+
+```
+[startup] warning: .fabrik/stages/validate.yaml is missing fields present in v0.0.53 defaults: wait_for_ci, wait_for_reviews. Run `fabrik refresh-stages --apply` to add the missing keys.
+```
+
+This is informational — the engine continues running. It means your stage file predates behavioral options added in a newer binary.
+
+To resolve: run `fabrik refresh-stages --apply` to add the missing keys to your stage YAMLs, then `git diff` and `git commit` to record the update. See [§1 Stage YAML Drift Warning](#stage-yaml-drift-warning) for a full explanation and list of common keys.
+
+### Issue Not Being Picked Up
+
+- Confirm the board column name exactly matches a stage YAML `name` (case-sensitive).
+- Confirm the issue is on the project board.
+- Check for `fabrik:locked:<other-user>` label (another instance has it).
+- Check for stuck `fabrik:editing` label (remove manually if stale).
+- Check the poll log -- the issue may be filtered by `updatedAt` caching. Restart Fabrik
+  to force a fresh scan.
+
+### Stage Keeps Retrying
+
+A stage that never outputs `FABRIK_STAGE_COMPLETE` retries after each cooldown. Causes:
+
+- **Claude needs user input** -- answer the questions in the issue comments.
+- **Missing context** -- add detail to the issue body.
+- **Bug in the skill** -- check the SKILL.md in `.fabrik/plugin/skills/`.
+
+After `--max-retries` failures, the issue is paused with `fabrik:paused`. Remove the
+label to resume.
+
+### Stale Worktrees
+
+Worktrees are at `.fabrik/worktrees/<owner>-<repo>/issue-N/` on branch `fabrik/issue-N`. On each stage
+invocation, Fabrik rebases onto the latest base branch (or the branch specified by a
+`base:<branch>` label), unless it's a retry, which preserves the worktree as-is to
+maintain Claude's context. If the rebase conflicts, it's silently aborted and Claude
+works from the current base.
+
+To manually clean up:
+```bash
+git worktree remove --force .fabrik/worktrees/<owner>-<repo>/issue-N
+git branch -D fabrik/issue-N
+```
+
+### Killed or Interrupted Sessions
+
+Claude sessions are stored at `.fabrik/sessions/issue-N/<stage>.session` (relative to the project working directory). On retry, Fabrik resumes from the session file. The Implement stage commits frequently to minimize lost work.
+
+To force a fresh session:
+1. Remove: `rm .fabrik/sessions/issue-N/<stage>.session`
+2. Remove `stage:<name>:complete` label if incorrectly applied
+3. Fabrik starts a fresh session on next poll
+
+### Comment Reprocessed After Restart
+
+The rocket reaction is the durable "processed" marker. If a comment gets reprocessed
+after restart, it means the rocket was not applied before shutdown (killed mid-flight).
+This is expected for in-flight comments.
+
+### Issue Body Not Updated
+
+If you see `FABRIK_ISSUE_UPDATE_BEGIN/END` markers in stage comments, the markers
+are being processed correctly -- the issue body is updated and the markers are stripped
+from the posted comment. If the markers appear verbatim, update Fabrik to the latest
+version.
+
+### Post-to-PR Output Missing
+
+For stages with `post_to_pr: true`:
+- Confirm the issue has a linked PR (via "Development" section or `Closes #N` in PR body)
+- If no PR is found, output falls back to the issue
+
+### Raw JSON in Comments
+
+If you see raw JSON dumped in issue/PR comments, the output was too large for the JSON
+parser or the format changed. Fabrik now posts an error message instead of raw JSON.
+Check `.fabrik/logs/<owner>-<repo>/issue-N/` for the full output.
+
+### Multi-User and Multi-Instance Operation
+
+Multiple users and multiple Fabrik instances can safely share a project board.
+
+**Comment processing**: Fabrik processes comments from *any* author, not just the
+configured `--user`. Human colleagues, code-review bots (Copilot, Gemini), and
+other Fabrik instances all trigger comment processing. Only two categories are
+skipped: comments that start with `🏭 **Fabrik` (Fabrik's own output) and comments
+that already carry a 🚀 rocket reaction (already processed).
+
+**Multi-instance locking**: The `fabrik:locked:<user>` label is still the
+concurrency guard, but acquisition now uses a **lock-then-verify** protocol:
+
+1. An instance adds its `fabrik:locked:<username>` label.
+2. It waits 2 seconds to let a competing instance place its own lock.
+3. It re-fetches the issue's labels.
+4. If no other `fabrik:locked:*` label is present → proceed.
+5. If a competing lock exists → **lexicographic tie-breaking**: the instance
+   whose username sorts *lower* alphabetically keeps its lock and proceeds;
+   the instance whose username sorts *higher* removes its lock and skips this
+   issue for this poll cycle. On the next poll, the winner's lock is already
+   visible, so the loser skips cleanly without retrying.
+
+This guarantees that exactly one instance processes each issue at a time, even
+when multiple instances poll simultaneously.
+
+### Duplicate Comments on Issues
+
+If a single stage run produces multiple comments on the issue (each with the
+`🏭 Fabrik — stage:` header), the cause is almost always globally-installed
+Claude Code plugins interfering with Fabrik's headless sessions.
+
+The `superpowers` plugin is a known offender — its SessionStart hook causes
+Claude to spawn parallel Agent subagents, each producing separate output that
+Fabrik posts as individual comments.
+
+**Fix:**
+- Remove interfering global plugins: `rm -rf ~/.claude/plugins/cache/claude-plugins-official/superpowers`
+- Check for other global plugins: `ls ~/.claude/plugins/cache/claude-plugins-official/`
+- Fabrik's behavior should be governed only by the repo's CLAUDE.md and the Fabrik plugin — not personal global plugins
+
+**Prevention:** Avoid installing global Claude Code plugins on machines that run Fabrik.
+
+### Multiple Fabrik Instances
+
+Running two Fabrik processes against the same project board causes duplicate
+dispatches, wasted API credits, and conflicting comments. Each instance has its
+own in-memory deduplication, so they can't detect each other.
+
+Starting with v0.0.30, Fabrik acquires an exclusive file lock on
+`.fabrik/fabrik.lock` at startup. If another instance is already running for
+the same project, it exits with a clear error. The lock is automatically
+released if the process crashes.
+
+To check for stale instances: `pgrep -la fabrik`
+
+### `unknown command "webhook" for "gh"` in Webhook Mode
+
+**Symptom:** Fabrik logs lines like:
+
+```
+[webhook] [gh] unknown command "webhook" for "gh"
+[webhook] gh webhook forward exited: exit status 1 — restarting in 1s
+```
+
+**Cause:** `gh webhook forward` is not a built-in `gh` subcommand — it is the [`cli/gh-webhook`](https://github.com/cli/gh-webhook) extension, which must be installed separately.
+
+**Fix:**
+```bash
+gh extension install cli/gh-webhook
+gh webhook --help   # verify: should print usage
+```
+
+Then restart Fabrik. The extension is a one-time install and persists across `gh` upgrades.
+
+### Plugin Not Loading
+
+If Claude doesn't seem to follow the skill instructions:
+- Verify `.fabrik/plugin/` exists (run `fabrik init` if not)
+- Check that the stage YAML has `skill:` set (not `prompt:`)
+- For development, use `--plugin-dir` to point at your working copy
+- Verify Claude Code version supports `--plugin-dir`
+
+---
+
+# Fabrik Issue State Machine
+
+Source: https://fabrik.shadoworg.dev/state-machine
+
+
+Every issue in Fabrik follows a defined lifecycle: from intake through a series of AI-driven stages (Specify → Research → Plan → Implement → Review → Validate → Done), with automated gates at key transitions. The diagram below shows the happy path at a glance.
+
+<figure>
+<img src="{{ '/assets/diagrams/lifecycle.svg' | relative_url }}" alt="Fabrik issue lifecycle: linear pipeline from Specify through Done with review, CI, and merge-conflict gates" style="max-width: 100%; height: auto;">
+<figcaption>Fabrik issue lifecycle — linear pipeline with gate annotations. Review Gate holds advancement until all PR reviewers submit; CI Gate holds until checks pass; Merge Gate holds until rebase conflicts are resolved.</figcaption>
+</figure>
+
+**Not an engineer?** The diagram and the [Pipeline Overview](#pipeline-overview) table are the fastest way to understand Fabrik's workflow.
+
+**Engine contributor or debugger?** The dense reference below covers every reachable state, every label mutation, every guard condition, and the visual state diagrams in [§10](#10-state-diagrams). Use the [State Enumeration](#1-state-enumeration) section as the authoritative source when diagnosing unexpected engine behavior.
+
+---
+
+This document is the formal specification of Fabrik's issue-level state machine: how an issue moves between states across multiple invocations of the engine. It covers every reachable state, every event that triggers a transition, every label mutation, and every guard condition.
+
+**Companion document:** [`stage-lifecycle.md`](stage-lifecycle.md) describes the per-invocation lifecycle (what happens before, during, and after a single Claude invocation). This document describes the cross-invocation state machine (how an issue progresses through the pipeline over time). They are complementary.
+
+**As-built specification:** This document describes what the code actually does, not what it ideally should do. Discrepancies between intended and actual behavior are flagged with `> **Bug?:**` callout blocks.
+
+**Source of truth for:** state enumeration, transition tables, label semantics, and guard conditions. Supersedes partial label references in CLAUDE.md.
+
+---
+
+## Pipeline Overview
+
+Issues traverse a linear pipeline of stages, each corresponding to a column on the GitHub Project board:
+
+```
+Specify → Research → Plan → Implement → Review → Validate → Done
+```
+
+| Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | WaitForReviews | CleanupWorktree |
+|-------|-------|-----------|----------|---------------|-------------|----------------|-----------------|
+| Specify | 0 | Yes | No | No | No | No | No |
+| Research | 1 | Yes | No | No | No | No | No |
+| Plan | 2 | Yes | No | No | No | No | No |
+| Implement | 3 | No | Yes | Yes | Yes | No | No |
+| Review | 4 | No | Yes | No | Yes | Yes* | No |
+| Validate | 5 | No | Yes | No | No | Yes* | No |
+| Done | 99 | N/A | No | No | No | No | Yes |
+
+\* All flags in this table reflect the **default stage configuration** shipped in `.fabrik/stages/`. Each flag is opt-in per stage YAML and may differ in custom configurations. `wait_for_reviews` is enabled for Review and Validate in the defaults.
+
+---
+
+## 1. State Enumeration
+
+A state is defined by the tuple `(BoardColumn, ControllingLabelSet)`. Not every label combination is a valid state — only reachable combinations are enumerated.
+
+### 1.1 Controlling Labels
+
+These labels define distinct states (their presence changes what the engine does with an item):
+
+| Label | Type | Defines State? |
+|-------|------|----------------|
+| `fabrik:locked:<user>` | Lock | Yes — gates processing by other instances |
+| `fabrik:editing` | Mutex | Yes — prevents stage dispatch during comment processing |
+| `fabrik:paused` | Pause | Yes — blocks all processing unless a comment arrives |
+| `fabrik:awaiting-input` | Sub-pause | Yes (with `fabrik:paused`) — blocked-on-input variant |
+| `fabrik:awaiting-review` | Gate | Yes — review gate is active |
+| `fabrik:awaiting-ci` | Gate | Yes — CI gate is active; waiting for CI checks to pass (checks may be running or have failed) |
+| `fabrik:rebase-needed` | Gate | Yes — merge-conflict gate is active; PR is not mergeable against its base |
+| `fabrik:blocked` | Dependency | Yes — blocked by open dependency issues |
+| `stage:<X>:in_progress` | Progress | Yes — a stage invocation is active |
+| `stage:<X>:complete` | Completion | Yes — stage finished successfully |
+| `stage:<X>:failed` | Failure | Yes — stage exhausted retry limit |
+
+### 1.2 Modifier Labels (Guard Conditions)
+
+These labels do not define distinct states but influence transition behavior:
+
+| Label | Effect |
+|-------|--------|
+| `fabrik:yolo` | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` |
+| `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
+| `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
+| `fabrik:extend-turns` | Pre-grants a 2× turn budget for the next stage invocation; auto-removed on stage success; no-op when `max_turns == 0` |
+| `model:<name>` | Selects a specific model for this issue (e.g., `model:opus`) |
+| `effort:<level>` | Overrides stage effort level (`low`, `medium`, `high`, `max`); highest wins |
+| `base:<branch>` | Overrides worktree base branch; falls back to default if not on remote; updates PR base if PR exists |
+| `fabrik:sub-issue` | Informational; marks issue as created by decomposition |
+
+### 1.3 Reachable States by Board Column
+
+For each board column, the reachable sub-states are listed. States are written as `Column + {labels}`. An issue in a column with no controlling labels is in the **Idle** sub-state for that column.
+
+#### Specify / Research / Plan / Implement / Review / Validate (Active Stages)
+
+Each active stage column has the same set of reachable sub-states:
+
+| Sub-State | Labels Present | Description |
+|-----------|---------------|-------------|
+| **Idle** | (none of the controlling labels) | Ready for the engine to pick up |
+| **Locked + In Progress** | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Stage invocation is active |
+| **Editing** | `fabrik:editing` | Comment processing is active (Claude invoked for comment review) |
+| **Paused** | `fabrik:paused` | Manually paused or engine-escalated pause; no work until unpause or comment |
+| **Paused + Failed** | `fabrik:paused`, `stage:<X>:failed` | Engine paused after MaxRetries exhausted |
+| **Awaiting Input** | `fabrik:paused`, `fabrik:awaiting-input` | Claude signaled FABRIK_BLOCKED_ON_INPUT; waiting for user comment |
+| **Awaiting Review** | `fabrik:awaiting-review`, `stage:<X>:complete` | Review gate active; waiting for PR reviewers (only on stages with `wait_for_reviews: true`) |
+| **Awaiting CI** | `fabrik:awaiting-ci` | CI gate active; waiting for CI checks to pass (pending or failed); `stage:<X>:complete` is withheld until CI clears (only on stages with `wait_for_ci: true`) |
+| **Rebase Needed** | `fabrik:rebase-needed` (+ `fabrik:awaiting-ci` when `wait_for_ci: true`) | Merge-conflict detected; PR is not mergeable against its base; engine dispatching a rebase re-invocation. Applies to both the conjunctive gate path (`wait_for_ci: true` stages, via `checkMergeabilityGate`) and the legacy auto-merge path (yolo+Validate without `wait_for_ci`, via `attemptMergeOnValidate`) |
+| **Blocked** | `fabrik:blocked` | Dependency gate active; waiting for blocking issues to close |
+| **Complete** | `stage:<X>:complete` | Stage finished; waiting for advancement (manual or auto) |
+| **Locked by Other** | `fabrik:locked:<other_user>` | Another Fabrik instance owns this issue |
+| **Cooldown** | (no label; in-memory `processedSet` timestamp) | Stage attempted but didn't complete; waiting for cooldown to expire |
+
+> **Note:** The Cooldown sub-state is purely in-memory — there is no label for it. The engine uses `processedSet[stageKey]` timestamps to enforce cooldown. On restart, cooldown state is lost and the item is retried immediately.
+
+#### Done (Cleanup Stage)
+
+| Sub-State | Labels Present | Description |
+|-----------|---------------|-------------|
+| **Pending Cleanup** | (none) | Worktree exists; engine will remove it |
+| **Complete** | `stage:Done:complete` | Worktree removed; terminal state |
+| **Paused** | `fabrik:paused` | Manually paused; cleanup skipped |
+
+### 1.4 Label Semantics Reference
+
+| Label | Added By | When Added | Removed By | When Removed | Gates |
+|-------|----------|------------|------------|--------------|-------|
+| `fabrik:locked:<user>` | `processItem` | Before stage invocation (lock-then-verify protocol) | `releaseLock` | On stage completion, permanent failure, blocked-on-input, decomposed, or lock conflict loss | Prevents other instances from processing the item |
+| `fabrik:editing` | `processComments` | Step 2 of comment processing | `processComments` | Step 9 of comment processing (also on error paths) | Prevents `processItem` from starting a new stage invocation |
+| `fabrik:paused` | `escalateFailedStage`, `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `pauseForCITimeout`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `attemptMergeOnValidate` (on ErrNotMergeable rebase cycle limit reached, or CI wait timeout) | After MaxRetries, FABRIK_BLOCKED_ON_INPUT, review/CI/rebase timeout or cycle limit | User (manual removal), or `processItem` (on new comment that triggers unpause) | When user removes it manually, or user comments on a paused issue | Blocks all processing; user comment is an implicit resume |
+| `fabrik:awaiting-input` | `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `pauseForCITimeout`, `pauseForCIFixCycleLimit` | After FABRIK_BLOCKED_ON_INPUT or review/CI timeout/cycle limit | `unblockAwaitingInput` | When user comment arrives | Combined with `fabrik:paused`, identifies the "awaiting user input" pause variant |
+| `fabrik:awaiting-review` | `handleStageComplete` (Path 1), `checkReviewGate` (Path 2) | Path 1: optimistically after stage completion when `wait_for_reviews: true` (does not check reviewer state — data is stale). Path 2: when `LinkedPRReviewRequests` is non-empty OR when `len(outstanding)==0 && !hasReviews` (the bot self-submission case — covers Copilot/Gemini-style reviewers that don't appear in the formal requested-reviewer list but still need to submit a review) | `checkReviewGate` (both natural clear and timeout paths) | When all reviewers submit, or when timeout elapses (removed by `checkReviewGate` before `pauseForReviewTimeout` is called) | Phase 1 / Phase 2 reprompt timers in `checkReviewGate` fire on label-applied-at age (not on `updatedAt` movement). A non-responsive bot reviewer produces no comment / no review / no PR activity, so `updatedAt` never moves — without periodic re-evaluation the timers would never get a chance to fire. The catch-up loop's blocked-path records `processedSet[stageKey]` so `itemMayNeedWork`'s cooldown retry path re-admits the item every 10 × `PollSeconds` (same pattern as `fabrik:blocked`); a per-poll cache bypass is intentionally avoided because long-lived review-waiting items would otherwise become a permanent GraphQL hot path. Blocks auto-advance until review gate clears |
+| `fabrik:awaiting-ci` | `handleStageComplete` (on FABRIK_STAGE_COMPLETE for `wait_for_ci: true` stages; idempotent); `checkCIGate` (on confirmed CI failure; idempotent) | `handleStageComplete`: immediately on FABRIK_STAGE_COMPLETE — replaces premature `stage:X:complete` and keeps the item in the CI-await window (ADR 032). `checkCIGate`: when CI check runs for the PR head SHA have `conclusion: failure/timed_out/action_required`. | `checkCIGate` (when `mergeable_state ∈ {clean, unstable}`, when CI check classification reports all-green, or when gate times out); `attemptMergeOnValidate` (when `mergeable_state ∈ {clean, unstable}` shortcut fires) | When GitHub's `mergeable_state` indicates the PR is mergeable (v0.0.52 shortcut — the `MergeableStateAccepted` allowlist); when all CI checks pass (green) under the per-check classification fallback; or when timeout elapses (removed before `pauseForCITimeout` is called) | Signals CI gate is active (pending or failed); triggers `itemMayNeedWork` updatedAt cache bypass; suppresses dispatcher re-invocation (`itemNeedsWork` returns false); blocks auto-advance until CI gate clears. **`stage:X:complete` is absent while this label is present — it is added by `checkCIGate` when CI clears (R5) or when `mergeable_state` shortcut clears the gate (v0.0.52).** |
+| `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `attemptMergeOnValidate` (legacy auto-merge path, yolo+Validate without `wait_for_ci`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `attemptMergeOnValidate` (on successful merge, via `removeRebaseNeededLabel` — no-op when absent) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when `MergePR` succeeds | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
+| `fabrik:blocked` | `checkDependencies` | When open blocking issues exist (first transition only — idempotent) | `checkDependencies` | When all blocking issues close | Blocks stage start (first stage is exempt) |
+| `stage:<X>:in_progress` | `processItem` | After lock acquired and verified | `releaseLock` | Same as `fabrik:locked:<user>` | Informational — shows which stage is active on GitHub |
+| `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleDecomposed`, cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_DECOMPOSED or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
+| `stage:<X>:failed` | `escalateFailedStage` | After MaxRetries exhausted | `clearFailedStage` | When user removes `fabrik:paused` (manual unpause) | Indicates permanent failure; paired with `fabrik:paused` |
+| `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
+| `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
+| `fabrik:unrestricted` | User (manual) | Any time | User (manual) | Any time | Passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` |
+| `fabrik:extend-turns` | User (manual) | Any time | `processItem` (on success) or User (manual) | On successful stage completion; or manual removal | Pre-grants 2× `stage.MaxTurns` budget for the first invocation; no-op when `max_turns == 0` (unlimited); subsequent extensions beyond 2× still require progress detection |
+| `model:<name>` | User (manual) | Any time | User (manual) | Any time | Selects Claude model; first label wins if multiple present |
+| `effort:<level>` | User (manual) | Any time | User (manual) | Any time | Overrides stage effort level; highest-ranked wins if multiple present |
+| `base:<branch>` | User (manual) | Before Research (recommended) | User (manual) | Any time | Overrides worktree base branch; falls back to default if branch not found on remote; if a PR exists, its base branch is updated to match on each stage invocation |
+| `fabrik:sub-issue` | Plan stage (via Claude) | During decomposition | N/A | N/A | Informational — marks sub-issues created by decomposition |
+
+---
+
+## 2. Event Enumeration
+
+Eleven distinct event types drive state transitions (§2.1–2.11), plus one TUI display event (§2.12) that does not drive transitions:
+
+### 2.1 Poll Tick
+
+**Trigger:** The engine's poll loop fires on a configurable interval (`PollSeconds`).
+
+**Code path:** `poll()` → `itemMayNeedWork()` (shallow filter) → `FetchItemDetails()` (deep fetch) → `itemNeedsWork()` (full filter) → catch-up loop → dispatch loop → `processItem()`
+
+**Effect:** The primary driver of all state transitions. Each poll cycle evaluates every item on the board through the filter chain and dispatches work for qualifying items.
+
+### 2.2 New User Comment
+
+**Trigger:** A user posts a comment on an issue or its linked PR. Detected by `findNewComments()` — filters out Fabrik-generated comments (prefix `🏭 **Fabrik`) and already-processed comments (ROCKET reaction or `processedSet` entry).
+
+**Code path:** `itemNeedsWork()` detects new comments → `processItem()` routes to `processComments()` or triggers unpause/unblock
+
+**Effect:** Can trigger three distinct behaviors:
+1. **Unpause:** On a paused issue, the comment removes `fabrik:paused` (and clears failed state if present) and falls through to comment processing
+2. **Unblock awaiting-input:** On an awaiting-input issue, removes both `fabrik:paused` and `fabrik:awaiting-input`, then routes to `processComments()`
+3. **Comment processing:** On an active (non-paused) issue, routes directly to `processComments()`
+
+### 2.3 PR Review Submitted
+
+**Trigger:** A reviewer submits a review on the linked PR (APPROVED, CHANGES_REQUESTED, or COMMENTED). Changes `item.LinkedPRReviewRequests` — a submitted reviewer is removed from the outstanding requests list.
+
+**Code path:** Detected by the catch-up loop in `poll()` via `checkReviewGate()`, which inspects `item.LinkedPRReviewRequests` after `FetchItemDetails()`
+
+**Effect:** Can clear the review gate (all outstanding reviewers submitted), allowing auto-advance to proceed. Does not directly trigger a stage invocation.
+
+### 2.4 PR Review Threads with Feedback
+
+**Trigger:** Reviewers leave inline code comments on the linked PR in unresolved review threads. These are real GitHub comments with `DatabaseID`s.
+
+**Code path:** Detected by `buildReviewThreadComments()` in the catch-up loop → `dispatchReviewReinvoke()` → async `processComments()` with synthetic comments
+
+**Effect:** Triggers a review reinvocation cycle — the stage agent is re-invoked via `processComments()` with the review thread comments as input, allowing it to address reviewer feedback. This is a **distinct event type** from regular comment processing (see §6.2).
+
+### 2.5 Blocking Issue Closed
+
+**Trigger:** An issue listed in `item.BlockedBy` transitions to the CLOSED state.
+
+**Code path:** `processItem()` → `checkDependencies()` inspects `item.BlockedBy[].State`
+
+**Effect:** When all blocking issues are closed, `fabrik:blocked` is removed and the stage proceeds. Blocked items are subject to normal `updatedAt` cache filtering — no forced deep-fetch on every poll. `processItem()` sets `processedSet[stageKey]` each time `checkDependencies()` returns true (blocked). This ensures the cooldown-retry path in `itemMayNeedWork()` re-evaluates blocked items after `10 × PollSeconds` even if the blocked item's own `updatedAt` never changes when its dependency closes.
+
+### 2.6 Claude Output Markers
+
+**Trigger:** Claude's output contains one of the Fabrik markers. Checked after each stage invocation.
+
+**Markers and priority order** (enforced by the `if/else if` dispatch chain in `processItem()`):
+1. `FABRIK_STAGE_COMPLETE` — highest priority; checked first via `checkCompletion()`
+2. `FABRIK_DECOMPOSED` — checked second; only honored if `completed` is false and `err == nil`
+3. `FABRIK_BLOCKED_ON_INPUT` — checked third; only honored if `completed` and `decomposed` are both false and `err == nil`
+
+**Code path:** `processItem()` → outcome dispatch based on which marker is present
+
+**Effect:**
+- **FABRIK_STAGE_COMPLETE:** `handleStageComplete()` — adds completion label, potentially advances to next stage
+- **FABRIK_DECOMPOSED:** `handleDecomposed()` — adds completion label, moves issue directly to Done
+- **FABRIK_BLOCKED_ON_INPUT:** `blockOnInput()` — adds `fabrik:paused` + `fabrik:awaiting-input`
+- **None of the above:** cooldown retry path; eventually `escalateFailedStage()` if MaxRetries exceeded
+
+**Invocation-level kill paths:** The `max_wall_time` and inactivity timeout mechanisms (see §7.6) can terminate the Claude process before it writes a clean `{"type":"result"}` line. After such a kill, `runClaude()` retroactively scans the already-buffered output for `FABRIK_STAGE_COMPLETE` in intermediate `{"type":"assistant"}` NDJSON lines via `extractTextFromAssistantTurns()`. If found, `completed=true` is returned and the invocation is treated identically to a live `FABRIK_STAGE_COMPLETE`. If not found, `completed=false` is returned and the invocation routes to the cooldown/retry path. These kills are distinguished from engine-shutdown cancellation by the `wasTimedOut` flag, so they do not trigger the hard-error path.
+
+### 2.7 Manual Label Change
+
+**Trigger:** A human adds or removes a label on the issue via the GitHub UI.
+
+**Code path:** Detected on the next poll cycle when labels are fetched
+
+**Effect varies by label:**
+- Adding `fabrik:paused` → engine skips the item (unless a comment arrives)
+- Removing `fabrik:paused` from a failed issue → `clearFailedStage()` resets retry state
+- Adding `fabrik:yolo` or `fabrik:cruise` → enables auto-advance (even mid-run, due to label re-fetch in `handleStageComplete()`)
+- Adding `model:<name>` or `effort:<level>` → takes effect on next Claude invocation
+
+### 2.8 Issue Closed
+
+**Trigger:** The issue is closed on GitHub (e.g., by PR merge with `Closes #N`).
+
+**Code path:** `itemMayNeedWork()` and `itemNeedsWork()` check `item.IsClosed`
+
+**Effect:** Closed issues are skipped unless:
+1. The current stage is a cleanup stage (`CleanupWorktree: true`) — cleanup can remove the worktree
+2. The current stage has a `stage:<X>:complete` label — the catch-up loop can advance to the next stage (e.g., a PR merge closes an issue sitting in Validate with `stage:Validate:complete`; it needs to move to Done)
+
+### 2.9 Review Reinvoke
+
+**Trigger:** The catch-up loop Phase 1 detects unresolved PR review thread comments on any `stage:<X>:complete` item (or `fabrik:awaiting-ci` item on a `wait_for_ci: true` stage) — regardless of whether the item has `fabrik:yolo`, `fabrik:cruise`, or any `auto_advance` config. Phase 1 runs unconditionally; only Phase 2 (stage advancement) is gated on those labels.
+
+**Code path:** `poll()` catch-up loop Phase 1 → `buildReviewThreadComments()` → cycle limit check → `dispatchReviewReinvoke()` → async goroutine → `processComments()` with synthetic comments
+
+**Distinct from regular comment processing because:**
+- Uses synthetic comments derived from PR review threads (`LinkedPRReviewThreadComments`), not issue comments
+- Has cycle limits (`MaxReviewCycles`, default 5) — exceeding pauses the issue
+- Has timeout integration (review wait timeout can also trigger pause)
+- Dispatches asynchronously via goroutine with semaphore slot
+- The `inFlight` guard prevents double-dispatch across poll cycles
+- Resolves review threads (marks them resolved on GitHub) after processing
+
+### 2.10 CI Check Completed
+
+**Trigger:** CI check runs on the PR head SHA transition from pending to a terminal state (success, failure, etc.). Fabrik detects this by polling `FetchCheckRuns` (REST) on each catch-up loop iteration — there are no webhooks.
+
+**Code path:** `poll()` catch-up loop Phase 1 → `checkCIGate()` → `FetchLinkedPR()` (REST, for head SHA) → `FetchPRMergeableState()` (REST, single-PR endpoint) → if `mergeable_state ∈ {clean, unstable}`: gate clears immediately (`addCompleteLabelAndRemoveCI`); otherwise → `FetchCheckRuns()` (REST) → evaluates check run statuses → optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
+
+**`mergeable_state` shortcut (v0.0.52):** Before classifying raw check_runs, `checkCIGate` queries GitHub's branch-protection-aware `mergeable_state` on the linked PR. When the value is `clean` (ready to merge per branch protection) or `unstable` (non-required checks failing but still mergeable per `github.MergeableStateAccepted`), the gate clears immediately and the per-check classification is skipped. Other states (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`, empty) fall through to the existing classification so failure-vs-pending dispatch decisions still work for genuinely-blocked PRs. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs like `Cleanup artifacts`) do not block merges per branch protection, so Fabrik's gate must not block on them either. The `mergeable_state` field is null on the list endpoint used by `FetchLinkedPR`, so a separate single-PR REST call is required (`FetchPRMergeableState`).
+
+**Distinct from Review Reinvoke because:**
+- Triggered by check run status changes, not reviewer submissions
+- Uses `fabrik:awaiting-ci` label (not `fabrik:awaiting-review`)
+- Only active on stages with `wait_for_ci: true`
+- `fabrik:awaiting-ci` is applied by `handleStageComplete` on FABRIK_STAGE_COMPLETE (the in-flight CI-await marker, present for both pending and failed checks); `stage:X:complete` is **withheld** until `checkCIGate` confirms CI is green (ADR 032)
+- Timeout tracked via `FetchLabelAppliedAt` on `fabrik:awaiting-ci` (durable across restarts), not in-memory
+- CI-fix cycle counter is `ciFixCycleCount` (keyed by `issueKey + "-" + stageName`)
+
+### 2.11 Base Branch Advanced
+
+**Trigger:** The PR's base branch moves forward (a different PR merges) while this branch is sitting in the post-`stage:Validate:complete` catch-up window. GitHub recomputes `mergeable` on the linked PR; if the new base conflicts with this branch, `mergeable` transitions from `true` (or `null`) to `false`.
+
+**Code path:** `poll()` catch-up loop Phase 1 → `checkMergeabilityGate()` → `FetchLinkedPR()` (REST, for PR number) → `FetchPRMergeable()` (REST, for the single-PR `mergeable` field) → evaluates the flag → optionally dispatches `dispatchRebaseReinvoke()` → async goroutine → `processComments()` with a synthetic rebase-required comment
+
+**Distinct from CI Check Completed because:**
+- Triggered by base-branch movement, not check run status changes
+- Uses `fabrik:rebase-needed` label (not `fabrik:awaiting-ci`)
+- Runs **before** the CI gate in catch-up Phase 1 — a PR that cannot merge has no reason to spin on CI-await
+- Only active on stages with `wait_for_ci: true` (same opt-in as the CI gate — these are the stages admitted to the catch-up window via `fabrik:awaiting-ci`)
+- `fabrik:rebase-needed` is only applied on **confirmed conflict** (`mergeable == false`), not on `mergeable == null` (GitHub still computing)
+- Rebase cycle counter is `rebaseCycleCount` (keyed by `issueKey + "-" + stageName`)
+- Resolution relies on Claude rebasing in the worktree (to handle semantic collisions like duplicated ADR numbers) rather than an engine-side `git rebase`
+
+### 2.12 TurnProgressEvent (TUI Display Event)
+
+**Trigger:** A `{"type":"user"}` NDJSON line is written to Claude's stdout pipe during a Claude invocation. Each logical turn (one user→assistant cycle) begins with exactly one such line (either the initial prompt or a tool-result response), so this fires once per logical turn.
+
+**Code path:** `runClaude()` stdout pipe → `turnCountingWriter.Write()` → detects `type == "user"` line → increments per-invocation counter → calls `claudeTurnProgress(issueNumber, turnsUsed, maxTurns)` → `Engine.emit(TurnProgressEvent{...})` → TUI channel
+
+**Effect:** Purely additive display — does not trigger any state transitions, label mutations, or issue processing. The TUI consumes `TurnProgressEvent` to update the live turn counter shown in:
+- The In Progress pane row for the active issue (width-adaptive badge `[N/M turns]` / `[N/M]` / omitted)
+- The detail panel for the selected active item (`Turns: N/M`)
+
+`TurnProgressEvent` is only emitted in TUI mode (`claudeTurnProgress` is nil in plain-text mode and tests). It uses the non-blocking `emit` path (drop-if-full), so turn-progress updates are best-effort and may be dropped under backpressure. This does not affect engine behavior because the event is display-only; at most one event is produced per logical turn.
+
+**`MaxTurns` in the event** carries the effective budget for the current invocation — `effectiveBudget` as computed in `InvokeClaude()` (which already accounts for `opts.MaxTurnsOverride` from the extension loop). This means:
+- First invocation without `fabrik:extend-turns`: `stage.MaxTurns`
+- First invocation with `fabrik:extend-turns`: `2 × stage.MaxTurns`
+- Extension loop second iteration: `stage.MaxTurns` (per-invocation limit, not cumulative)
+
+---
+
+## 3. Transition Tables
+
+### 3.1 Happy Path — Linear Stage Progression
+
+This table shows the normal flow when an issue progresses through the pipeline without interruption.
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Idle | Poll tick | Stage exists, not paused/locked/editing/blocked, cooldown expired | Column `<X>`, Locked + In Progress | `fabrik:locked:<user>`, `stage:<X>:in_progress` | | Lock-then-verify protocol (2s delay), worktree ensured, Claude invoked |
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE | shouldAdvance=false (see below) | Column `<X>`, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress`, `stage:<X>:failed` (if present) | Output posted; draft PR created (if `create_draft_pr`); PR marked ready (if `mark_pr_ready_on_complete`); lock released |
+| Column `<X>`, Complete | Human moves to next column | — | Column `<Y>`, Idle | | | Manual board column move |
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE | shouldAdvance=true (see below) | Column `<Y>`, Idle | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress`, `stage:<X>:failed` (if present) | Output posted; draft PR / mark ready (if configured); board column updated to next stage; lock released |
+| Column `<X>`, Complete | Poll tick (catch-up) | yolo or cruise active, `stage:<X>:complete` present, no pending comments | Column `<Y>`, Idle | | | Board column updated to next stage (Path 2 advancement) |
+
+**`shouldAdvance` resolution (Path 1, `handleStageComplete`):**
+
+1. `yoloActive = cfg.Yolo || hasYoloLabel(item)` — re-fetches labels first to pick up mid-run changes
+2. `cruiseActive = !yoloActive && hasCruiseLabel(item)` — suppressed when yolo is active
+3. `shouldAdvance = yoloActive || cruiseActive`
+4. If `stage.AutoAdvance != nil` AND neither `fabrik:yolo` nor `fabrik:cruise` label is present: `shouldAdvance = *stage.AutoAdvance` — this means `auto_advance: false` in YAML overrides `cfg.Yolo` (the `--yolo` flag), but explicit yolo/cruise labels override `auto_advance: false`
+5. If `cruiseActive && stage.Name == "Validate"`: `shouldAdvance = false` — cruise stops at Validate
+
+**Catch-up loop `shouldAdvance` resolution (Path 2):** The catch-up loop first checks `cfg.Yolo || hasYoloLabel(item) || hasCruiseLabel(item)` — items without any of these are skipped entirely. Then: if neither yolo nor cruise LABEL is present and `stage.AutoAdvance` is explicitly false, the item is skipped. This produces the same behavior as Path 1.
+
+**Validate → Done special cases:**
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Validate, Locked + In Progress | FABRIK_STAGE_COMPLETE | yolo active | Done, Pending Cleanup | `stage:Validate:complete` | `fabrik:locked:<user>`, `stage:Validate:in_progress` | PR merged; board column updated to Done |
+| Validate, Complete | Poll tick (catch-up) | yolo active | Done, Pending Cleanup | | | PR merged; board column updated to Done |
+| Validate, Locked + In Progress | FABRIK_STAGE_COMPLETE | cruise active (no yolo) | Validate, Complete | `stage:Validate:complete` | `fabrik:locked:<user>`, `stage:Validate:in_progress` | Cruise stops here — no merge, no advancement to Done |
+| Validate, Complete | Poll tick (catch-up) | cruise active (no yolo) | Validate, Complete | | | Cruise catch-up skips Validate — no merge, no advancement |
+| Done, Pending Cleanup | Poll tick | Worktree exists on disk | Done, Complete | `stage:Done:complete` | | Worktree removed from disk |
+
+### 3.2 Off-Path Transitions
+
+#### Pause / Unpause
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Any active column, Idle | Human adds `fabrik:paused` | — | Same column, Paused | | | Engine skips item on next poll |
+| Same column, Paused | Human removes `fabrik:paused` | — | Same column, Idle | | | Engine processes item on next poll |
+| Same column, Paused | New user comment | — | Same column, Idle → comment processing | | `fabrik:paused` | Unpause; `clearFailedStage()` also called (clears any failed label + resets retries); falls through to `processComments()` |
+
+#### Lock Conflict (Multi-Instance)
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Any column, Idle | Poll tick (two instances) | Both acquire lock | Depends on tie-break | `fabrik:locked:<user>` (both) | Loser's lock removed | 2s verify delay; lexicographic tie-break: lower username wins, higher username yields |
+| Any column, Locked by Other | Poll tick | `fabrik:locked:<other>` present | Same (skipped) | | | `itemNeedsWork` returns false; `processItem` also checks and skips |
+
+#### Dependency Blocking
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Any column (not first stage), Idle | Poll tick | Open blockers in `item.BlockedBy` | Same column, Blocked | `fabrik:blocked` | | Comment posted listing blockers (first time only); TUI event emitted |
+| Same column, Blocked | Poll tick | All blockers now CLOSED | Same column, Idle | | `fabrik:blocked` | Item eligible for processing on next poll |
+| First stage, Idle | Poll tick | Open blockers exist | Same column, Idle | | | First stage is exempt from dependency blocking |
+
+#### Awaiting Input (FABRIK_BLOCKED_ON_INPUT)
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | FABRIK_BLOCKED_ON_INPUT | `completed` and `decomposed` both false, no error | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Lock released |
+| Same column, Awaiting Input | New user comment | — | Same column → comment processing | | `fabrik:paused`, `fabrik:awaiting-input` | `unblockAwaitingInput()` clears processedSet entry; routes to `processComments()` |
+
+#### Awaiting Review (wait_for_reviews gate)
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE | `wait_for_reviews: true`, shouldAdvance | Same column, Awaiting Review | `stage:<X>:complete`, `fabrik:awaiting-review` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Path 1: optimistic label application; lock released; returns without advancing |
+| Same column, Awaiting Review + Complete | Poll tick (catch-up) | Outstanding reviewers remain, not timed out | Same (blocked) | `fabrik:awaiting-review` (idempotent) | | checkReviewGate logs pending reviewers |
+| Same column, Awaiting Review + Complete | PR review submitted | All reviewers submitted | Same column, Complete → advance | | `fabrik:awaiting-review` | Gate cleared; falls through to advance or review reinvoke |
+| Same column, Awaiting Review + Complete | Poll tick (catch-up) | Timeout elapsed | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:awaiting-review` | `pauseForReviewTimeout()` posts explanatory comment |
+
+#### Awaiting CI (wait_for_ci gate)
+
+In the conjunctive gate design (ADR 032), `stage:X:complete` is **withheld** until the CI gate actually clears. `handleStageComplete` adds `fabrik:awaiting-ci` as the durable in-flight marker; `checkCIGate` adds `stage:X:complete` once CI passes.
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE | `wait_for_ci: true` | Same column, Awaiting CI | `fabrik:awaiting-ci` (+ `fabrik:awaiting-review` if `wait_for_reviews: true`) | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Conjunctive gate: `stage:<X>:complete` NOT added here — deferred to `checkCIGate` when CI passes (ADR 032). Dispatcher will not re-invoke while `fabrik:awaiting-ci` is present (`itemNeedsWork` returns false for R3). |
+| Same column, Awaiting CI | Poll tick (catch-up) | CI checks still pending (no failure) | Same (blocked) | (none — `fabrik:awaiting-ci` already present) | | `checkCIGate` logs pending checks; re-evaluates next poll |
+| Same column, Awaiting CI | Poll tick (catch-up) | Any CI check failed | Same column, Awaiting CI (failure confirmed) | `fabrik:awaiting-ci` (idempotent) | | CI failure detected; dispatch CI-fix reinvoke or pause on cycle limit |
+| Same column, Awaiting CI | Poll tick (catch-up) | All CI checks green (or no CI configured — R5) | Same column, Complete → advance | `stage:<X>:complete` | `fabrik:awaiting-ci` | Gate cleared; `checkCIGate` adds `stage:<X>:complete` and removes `fabrik:awaiting-ci`; falls through to advance (or merge for Validate+yolo) |
+| Same column, Awaiting CI | Poll tick (catch-up) | `mergeable_state ∈ {clean, unstable}` (v0.0.52 shortcut) | Same column, Complete → advance | `stage:<X>:complete` | `fabrik:awaiting-ci` | Gate cleared via `mergeable_state` shortcut **before** the per-check classification runs; non-required check_run failures (e.g. workflow cleanup jobs) no longer block. `addCompleteLabelAndRemoveCI` runs; falls through to advance. |
+| Same column, Awaiting CI | Poll tick (catch-up) | `fabrik:awaiting-ci` applied ≥ CIWaitTimeout ago | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:awaiting-ci` | `pauseForCITimeout()` posts explanatory comment; timeout detected via `FetchLabelAppliedAt` |
+
+**Merge-conflict gate (`wait_for_ci: true` only; runs before the CI gate):**
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Same column, Awaiting CI | Poll tick (catch-up) | `mergeable == false` on linked PR | Same column, Rebase Needed | `fabrik:rebase-needed` | | Dispatch rebase reinvoke or pause on cycle limit |
+| Same column, Rebase Needed (Awaiting CI + rebase-needed) | Poll tick (catch-up) | `mergeable == true` on linked PR (Claude's rebase push landed) | Same column, Awaiting CI → (CI gate evaluates next) | | `fabrik:rebase-needed` | Gate cleared; catch-up falls through to the CI gate on the same poll |
+| Same column, Awaiting CI | Poll tick (catch-up) | `mergeable == null` (GitHub still computing) | Same (blocked, no label) | | | Re-evaluated on next poll; no label churn for transient unknown state |
+| Same column, Rebase Needed | Poll tick (catch-up) | `rebaseCycleCount` ≥ `MaxRebaseCycles` | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | | `pauseForRebaseCycleLimit()` posts explanatory comment; `fabrik:rebase-needed` is left in place so the human can see why Fabrik stopped |
+
+#### Cooldown Retry and Failed Stage Escalation
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | `max_wall_time` exceeded | SIGTERM→10s→SIGKILL; `FABRIK_STAGE_COMPLETE` found in buffered assistant stream | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `extractTextFromAssistantTurns()` recovers marker; same completion flow as live FABRIK_STAGE_COMPLETE |
+| Column `<X>`, Locked + In Progress | `max_wall_time` exceeded | SIGTERM→10s→SIGKILL; no `FABRIK_STAGE_COMPLETE` in buffered stream | Same column, Cooldown | | | `wasTimedOut=true`; routes to cooldown/retry (not a hard error); lock NOT released |
+| Column `<X>`, Locked + In Progress | Inactivity timeout (15m) | No streamed output for 15 consecutive minutes; `FABRIK_STAGE_COMPLETE` found in buffered stream | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Same completion flow |
+| Column `<X>`, Locked + In Progress | Inactivity timeout (15m) | No streamed output for 15 consecutive minutes; no `FABRIK_STAGE_COMPLETE` in buffered stream | Same column, Cooldown | | | `wasTimedOut=true`; routes to cooldown/retry; lock NOT released |
+| Column `<X>`, Locked + In Progress | No marker in output | `claudeRan` is true (includes both error-free runs and runs that errored mid-execution; excludes only start failures like binary-not-found) | Same column, Cooldown | | | `processedSet[stageKey]` updated; cooldown = `PollSeconds * 10`; lock NOT released (stays locked through retries) |
+| Same column, Cooldown | Poll tick | Cooldown expired | Same column, Locked + In Progress (retry) | | `stage:<X>:failed` (if present from prior escalation) | Claude re-invoked with `resume=true` |
+| Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && MaxRetries > 0` | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released |
+| Same column, Paused + Failed | Human removes `fabrik:paused` | `stage:<X>:failed` present OR `pausedDueToRetries` in memory | Same column, Idle | | `stage:<X>:failed` | `clearFailedStage()` resets retryCount, pausedDueToRetries, processedSet, reviewCycleCount |
+
+#### Turn Limit Extension
+
+When Claude exits a stage invocation due to `max_turns` (i.e., the per-invocation turn usage satisfies `invUsage.TurnsUsed >= currentBudget` and `!completed && err == nil`), the engine evaluates whether to extend before entering the cooldown/retry path.
+
+**Extension trigger condition:** `!completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget`
+
+**Hard cap:** 3× `stage.MaxTurns` total across all invocations. When `totalMultiple >= 3`, no further extension is attempted.
+
+**Per-stage progress signals:**
+
+| Stage | Progress Signal | API Cost |
+|-------|----------------|----------|
+| **Implement** | New git commit (HEAD SHA changed) OR (baseline was clean AND working tree is now dirty — uncommitted file edits by Claude) | Zero — local git only |
+| **Review** | New git commit OR `LinkedPRResolvedThreadCount` increased | One `FetchItemDetails` GraphQL call (only if no new commit) |
+| **Validate** | Total comment count on issue/PR increased | One `FetchItemDetails` GraphQL call |
+| **All others** (Research, Specify, Plan, custom) | No signal — always fail on turn-limit | None |
+
+The "baseline clean AND working tree dirty" guard for Implement prevents a pre-existing dirty worktree (e.g. from a prior interrupted session) from counting as progress. Only new uncommitted changes made during the invocation trigger extension.
+
+**Extension loop behavior (within a single `processItem` call — no poll-cycle gap):**
+
+1. At invocation start, a `progressBaseline` is snapshotted: git HEAD SHA (Implement, Review), working-tree dirty state (Implement), comment count (Validate), and resolved thread count (Review).
+2. Claude is invoked with the current budget.
+3. If the turn limit is hit AND `totalMultiple < 3`: call `detectProgress`. If progress → `totalMultiple++`, re-invoke with `--resume`. If no progress or progress check fails → proceed to cooldown/retry as today.
+4. Output is accumulated across all invocations before posting as a single stage comment.
+5. WIP commit and push are deferred to after the loop.
+
+**`fabrik:extend-turns` label:** When present at invocation start, the first invocation receives `2 × stage.MaxTurns` as its budget (pre-granted extension, no progress check required for the first turn-limit hit). Subsequent extensions beyond 2× still require the progress check. The label is auto-removed on successful stage completion; `ErrNotFound` on removal is treated as success (user removed it manually). The label is a no-op when `stage.MaxTurns == 0`.
+
+**Log tag:** `[#N extend-turns]` — emitted on **every** `detectProgress` call (pass or fail), reporting the evaluated signals and `has_progress=true/false`. When extension is granted, an additional line logs the new budget multiple and cumulative turns used.
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple < 3`; progress detected | Same column, Locked + In Progress (extension) | | | `totalMultiple++`; `resume=true`; output accumulated; no WIP commit or push between extensions |
+| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; treated as turn-limit failure; `processedSet` updated; WIP commit + push |
+| Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; treated as turn-limit failure; `processedSet` updated; WIP commit + push |
+| Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE (any extension) | `completed = true` | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress`, `fabrik:extend-turns` (if present) | Normal completion flow; extend-turns label auto-removed |
+
+#### Cleanup Stage
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Done, Pending Cleanup | Poll tick | Worktree exists, not paused, not already complete | Done, Complete | `stage:Done:complete` | | Worktree removed; no lock/Claude/comment processing |
+| Done, Complete | Poll tick | Already complete | Done, Complete (no-op) | | | Skipped by both `itemMayNeedWork` and `processItem` |
+
+#### Review Reinvoke
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Awaiting Review + Complete | Review gate clears + unresolved thread comments | Not in-flight, cycle count < MaxReviewCycles | Same column (comment processing via async goroutine) | `fabrik:editing` (during processing) | | `dispatchReviewReinvoke()` spawns goroutine; `reviewCycleCount` incremented; `inFlight` set; semaphore acquired |
+| Column `<X>`, Awaiting Review + Complete | Review gate clears + unresolved thread comments | Cycle count ≥ MaxReviewCycles | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | | `pauseForReviewCycleLimit()` posts comment |
+| Column `<X>`, Awaiting Review + Complete | Review gate clears + unresolved thread comments | Already in-flight | Same (skipped) | | | Previous reinvoke goroutine still running; skipped entirely (no cycle-limit check) |
+
+#### CI Fix Reinvoke
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Awaiting CI | Poll tick (catch-up) | CI failed; not in-flight; `ciFixCycleCount` < MaxCiFixCycles | Same column (CI-fix goroutine running) | `fabrik:editing` (during processing) | | `dispatchCIFixReinvoke()` spawns goroutine; `ciFixCycleCount` incremented; `inFlight` set; semaphore acquired; synthetic CI-fix comment passed to `processComments()` |
+| Column `<X>`, Awaiting CI | Poll tick (catch-up) | CI failed; `ciFixCycleCount` ≥ MaxCiFixCycles | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | | `pauseForCIFixCycleLimit()` posts explanatory comment |
+| Column `<X>`, Awaiting CI | Poll tick (catch-up) | CI failed; already in-flight | Same (skipped) | | | Previous CI-fix goroutine still running; skipped entirely |
+
+#### Rebase Reinvoke
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Column `<X>`, Rebase Needed + Complete | Poll tick (catch-up) | `mergeable == false`; not in-flight; `rebaseCycleCount` < MaxRebaseCycles | Same column (rebase goroutine running) | `fabrik:editing` (during processing) | | `dispatchRebaseReinvoke()` spawns goroutine; `rebaseCycleCount` incremented; `inFlight` set; semaphore acquired; synthetic rebase-required comment passed to `processComments()` |
+| Column `<X>`, Rebase Needed + Complete | Poll tick (catch-up) | `mergeable == false`; `rebaseCycleCount` ≥ MaxRebaseCycles | Same column, Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | | `pauseForRebaseCycleLimit()` posts explanatory comment (usually signals a semantic conflict needing human judgment) |
+| Column `<X>`, Rebase Needed + Complete | Poll tick (catch-up) | `mergeable == false`; already in-flight | Same (skipped) | | | Previous rebase goroutine still running; skipped entirely |
+
+---
+
+## 4. Comment Processing Lifecycle
+
+When new comments are detected on an issue (or synthetic review comments on a PR), the engine processes them through `processComments()`. This is an 11-step flow.
+
+### 4.1 Comment Detection
+
+`findNewComments()` filters `item.Comments` to find unprocessed comments using three independent dedup signals:
+
+1. **In-memory `processedSet`** (session-scoped) — skip comments whose key is already present. Fast but lost on restart.
+2. **`🏭 **Fabrik` body prefix** (engine-authored output convention) — skip comments whose body starts with this header. Durable but requires the header to be present.
+3. **🚀 ROCKET reaction** (durable, cross-restart) — skip comments that already have a rocket reaction. Applied to user comments by `processComments` step 10 after processing; **also applied by the engine to every comment it posts** immediately after `AddComment` succeeds.
+
+Any single signal catching the comment is sufficient to skip it. The three signals are orthogonal — any two can fail independently without triggering the self-review loop.
+
+**Dedup coverage by comment type:**
+- **Engine-authored comments**: carry signals (2) and (3) — the `🏭 **Fabrik` prefix (when formatted via `formatOutputComment`) and a 🚀 reaction added by the engine at post time.
+- **User comments**: carry signals (1) and (3) after processing — the `processedSet` entry added during `processComments`, and the 🚀 reaction added at step 10.
+
+> **Invariant:** every engine-emitted `AddComment` call must start with `🏭 **Fabrik — <context>**`. This is an engine-wide convention enforced by `TestAddCommentCompliance` in `engine/compliance_test.go`, not just a detection heuristic.
+
+### 4.2 The 11-Step Flow
+
+| Step | Action | Code | Side Effects |
+|------|--------|------|--------------|
+| 1 | React with 👀 to all new comments | `AddCommentReaction("eyes")` / `AddPRReviewCommentReaction("eyes")` | Signals acknowledgment to the user |
+| 2 | Add `fabrik:editing` label | `AddLabelToIssue("fabrik:editing")` | Prevents `processItem` from starting a new stage invocation |
+| 3 | Ensure worktree exists | `EnsureWorktree()` | Creates or updates worktree; writes context files |
+| 4 | Invoke Claude with comment review prompt | `InvokeForComments()` | Uses `comment_prompt` / `comment_skill` and `comment_max_turns` |
+| 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
+| 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Applied unconditionally when markers are present; stripped from output regardless |
+| 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_SUMMARY_BEGIN/END |
+| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
+| 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |
+| 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
+| 11 | If FABRIK_STAGE_COMPLETE was detected: handle completion | `handleStageComplete()` | Same completion flow as a normal stage invocation (advance, PR ops, etc.) |
+
+### 4.3 Comment Processing Entry Points
+
+Comments can trigger processing through three paths in `processItem()`:
+
+1. **Awaiting-input unblock:** `isAwaitingInput(item)` is true + new comments → `unblockAwaitingInput()` → `processComments()`
+2. **Paused unpause:** `fabrik:paused` present + new comments → remove `fabrik:paused`, `clearFailedStage()` → fall through → `processComments()`
+3. **Normal comment processing:** Item is not paused → `findNewComments()` finds comments → `processComments()`
+
+### 4.4 markCommentsSeenByStage
+
+After a stage invocation (not comment processing), `markCommentsSeenByStage()` adds ROCKET reactions to all pre-existing comments that were included in the prompt as context. This prevents those comments from triggering the awaiting-input unblock logic on subsequent polls.
+
+---
+
+## 5. PR Lifecycle Integration
+
+### 5.1 Draft PR Creation
+
+**When:** After a stage signals FABRIK_STAGE_COMPLETE, if the stage has `create_draft_pr: true`.
+
+**Code path:** `processItem()` → `ensureDraftPR()`
+
+**Flow:**
+1. Check for existing PR via `FindPRForIssue()` — if found, ensure body contains `Closes #N` and return
+2. Push the issue branch via `PushBranch()`
+3. Create draft PR via `CreateDraftPR()` with title from issue, targeting `baseBranch`, body containing `Closes #N`
+
+### 5.2 Mark PR Ready
+
+**When:** After a stage signals FABRIK_STAGE_COMPLETE, if the stage has `mark_pr_ready_on_complete: true`.
+
+**Code path:** `processItem()` → `markPRReady()`
+
+**Flow:**
+1. Push the issue branch
+2. Find PR number (uses `knownPR` from `ensureDraftPR` if available, else `FindPRForIssue()`)
+3. `MarkPRReady()` transitions draft → ready-for-review
+
+**Note:** This triggers external review bots and populates `LinkedPRReviewRequests`, which is why the review gate in `handleStageComplete()` (Path 1) is always optimistic — reviewer data is stale at that point.
+
+### 5.3 Linked PR Discovery
+
+Fabrik discovers PR comments through the `closedByPullRequestsReferences` GraphQL field, which traverses issue → linked PRs → PR comments. The `Closes #N` keyword in the PR body creates this linkage.
+
+### 5.4 Auto-Merge on Validate
+
+**When:** Validate stage completes and yolo is active (either `cfg.Yolo` or `fabrik:yolo` label).
+
+**Code path:** `handleStageComplete()` → `attemptMergeOnValidate()` (Path 1); or catch-up loop → `attemptMergeOnValidate()` (Path 2)
+
+**Flow:**
+1. Find linked PR via `FindPRForIssue()` / `FetchLinkedPR()` (the latter also returns the head SHA needed for the per-check classification fallback).
+2. Query `FetchPRMergeableState()` (REST single-PR endpoint). If the result is `clean` or `unstable` (per `github.MergeableStateAccepted`), **skip the raw check_runs gate**: clear any stale `fabrik:awaiting-ci` label, drop the in-memory `ciMergePendingSince` entry, and proceed directly to step 4. Other states fall through to the per-check classification in step 3.
+3. **Per-check classification (fallback)**: fetch check runs via `FetchCheckRuns()`. Apply R1–R6 rules (no checks → R5 clears; failed → R3 applies `fabrik:awaiting-ci` and returns error; pending → R2 returns error and tracks `ciMergePendingSince` for the timeout; all green → R4 clears).
+4. Attempt merge via `MergePR()`. `MergePR` first checks the PR's `merged` field — if the PR was already merged (e.g., by a human), it returns nil immediately (no-op success). Otherwise it checks `mergeable` and attempts the merge.
+5. On `ErrNotMergeable`: apply `fabrik:rebase-needed` idempotently. Then:
+   - **inFlight guard:** if a rebase goroutine is already running for this item, return a plain error (skip — prevents cycle-counter drift).
+   - **Cycle limit check:** compare `rebaseCycleCount[stageKey]` against `MaxRebaseCycles` (default 3):
+     - If at or above the limit: call `pauseForRebaseCycleLimit()` (`fabrik:paused` + `fabrik:awaiting-input` + explanatory comment); return a plain error.
+     - If below the limit: increment `rebaseCycleCount[stageKey]`, call `dispatchRebaseReinvoke()`, return the `errRebaseDispatched` sentinel.
+6. On other API errors: return error (same retry behavior)
+7. On success (including already-merged): call `removeRebaseNeededLabel()` (no-op when absent), log and return nil — advancement proceeds
+
+**Why the `mergeable_state` shortcut (v0.0.52):** the per-check classification at step 3 was over-aggressive — any check_run with `conclusion ∈ {failure, timed_out, action_required}` blocked the merge, including non-required workflow jobs (e.g. `Cleanup artifacts`) that GitHub itself does not treat as merge blockers per branch protection. When `mergeable_state` says the PR is mergeable, Fabrik now trusts that and bypasses the per-check gate. The shortcut sits *after* `stage:Validate:complete` is already on the issue (the catch-up loop's entry condition), so it cannot cause Validate-Claude work to be skipped — it only changes the behavior of the post-completion CI wait.
+
+**Unified rebase-reinvoke recovery (Path 1 and Path 2):** Both code paths now use the same `rebaseCycleCount[stageKey]` map, `dispatchRebaseReinvoke()`, and `pauseForRebaseCycleLimit()`. The `MaxRebaseCycles` and `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` controls apply to both paths. Previously, Path 1 immediately paused on `ErrNotMergeable`; it now dispatches the rebase reinvoke autopilot instead, falling back to the pause only when the cycle limit is reached.
+
+**Important — Path 1 vs Path 2 distinction:** In Path 1 (`handleStageComplete`), the merge runs BEFORE adding `stage:Validate:complete`. On a plain merge failure (non-`ErrNotMergeable`), no completion label is added, so `itemNeedsWork` can retry the full Validate invocation after cooldown. On `ErrNotMergeable`, `handleStageComplete` detects the `errRebaseDispatched` sentinel and **adds `stage:Validate:complete` before returning** — ensuring the catch-up loop's Phase 2 drives the merge retry rather than `itemNeedsWork` triggering a new full Validate invocation. In Path 2 (catch-up loop), `stage:Validate:complete` already exists when `attemptMergeOnValidate()` runs; on `ErrNotMergeable` the rebase is dispatched and the catch-up loop retries on the next poll.
+
+---
+
+## 6. Review Gate and Review Reinvoke
+
+### 6.1 Two-Phase Review Gate
+
+The review gate has two paths that handle different timing scenarios:
+
+**Path 1: `handleStageComplete()` (inside worker goroutine)**
+- Runs immediately after a stage completes
+- Reviewer data is STALE (reviewers are assigned only after `MarkPRReady`, which just ran)
+- Optimistically applies `fabrik:awaiting-review` label
+- Returns without advancing — defers to Path 2
+
+**Path 2: Catch-up loop in `poll()` (in poll goroutine)**
+- Runs on subsequent poll cycles for items with `stage:<X>:complete`
+- Has FRESH reviewer data from `FetchItemDetails()` (both `LinkedPRReviewRequests` and `LinkedPRReviews`)
+- Calls `checkReviewGate()` for the real gate evaluation
+- **Gate clears only when `len(LinkedPRReviewRequests) == 0` AND `len(LinkedPRReviews) > 0`.** This means: no requested reviewers are outstanding AND at least one review has been submitted. Waiting on `LinkedPRReviews` (not just `LinkedPRReviewRequests`) is what catches bot reviewers like Copilot and Gemini that self-trigger via webhooks without ever appearing in the formal requested-reviewer list.
+- `ReviewRequest.IsBot` is populated from `requestedReviewer.__typename == "Bot"` in the GraphQL query, with a login-pattern fallback (`*[bot]`, `*-bot`, `copilot-*`, `dependabot`, `gemini-code-assist`). This drives the bot-aware escalation ladder.
+- Four outcomes from `checkReviewGate()`:
+  - `(blocked=true, timedOut=false)` — still waiting; `fabrik:awaiting-review` maintained. Either outstanding requested reviewers remain, or no reviews submitted yet (bots may still be processing). Also returned after Phase 1 (bot re-prompt fired, waiting for Phase 2 window).
+  - `(blocked=false, timedOut=false)` — gate cleared naturally; `fabrik:awaiting-review` removed; `fabrik:bot-reprompted` label cleaned if present; advance or reinvoke.
+  - `(blocked=false, timedOut=true)` — gate cleared by timeout; `fabrik:awaiting-review` removed; `pauseForReviewTimeout()` pauses issue. Fires at `1× ReviewWaitTimeout` for mixed/pure-human outstanding (existing path) or at `2× ReviewWaitTimeout` for pure-bot outstanding (Phase 2 — after the re-prompt window expired).
+
+**Bot-aware escalation ladder (pure-bot outstanding only):**
+
+When all outstanding requested reviewers are bots (detected via `ReviewRequest.IsBot`) and `item.LinkedPRNumber > 0`, `checkReviewGate` applies a two-phase escalation instead of immediately pausing:
+
+- **Phase 1 (fires at 1× `ReviewWaitTimeout` from `fabrik:awaiting-review`):** For each outstanding bot reviewer: deletes then re-adds the formal review request (DELETE+POST to `requested_reviewers` — the delete-then-add cycle is required to re-trigger the bot's webhook; a plain POST is a silent no-op if the reviewer is already listed), posts an `@<login> just checking in` comment on the linked PR. After processing all bot reviewers, applies the single fixed label `fabrik:bot-reprompted` (idempotency guard — ≤50 chars, GitHub REST API limit). Returns `(true, false)` — still blocked. Phase 1 fires once per gate cycle (idempotency enforced by presence of `fabrik:bot-reprompted`).
+
+- **Phase 2 (fires at 1× `ReviewWaitTimeout` from `fabrik:bot-reprompted`):** If the bot still has not responded after a full additional `ReviewWaitTimeout` window, `fabrik:bot-reprompted` is removed, `fabrik:awaiting-review` is removed, and `(false, true)` is returned. The caller fires `pauseForReviewTimeout()`, which detects Phase 2 context from the pre-cleanup `item.Labels` snapshot and posts a named, contextual pause comment explaining that a re-prompt was already attempted. Bot logins in the Phase 2 comment are derived from `LinkedPRReviewRequests` (bots haven't responded, so they're still in the list). Human-in-the-loop is preserved — the engine never auto-advances past a `wait_for_reviews: true` gate.
+
+**Mixed bot+human outstanding:** Phase 1 does NOT fire. The gate falls through to the existing `pauseForReviewTimeout()` at `1× ReviewWaitTimeout` from `fabrik:awaiting-review`, unchanged. Re-prompting humans is not appropriate (they have inbox notifications; webhooks don't apply).
+
+**`pauseForReviewTimeout()` enhanced comment:** In all timeout paths (Phase 2, mixed, pure-human), the pause comment now names all outstanding reviewers and tags each as `(bot)` or `(human)` for easy triage. In Phase 2, the comment explicitly notes that a re-prompt was already attempted and provides four recovery options.
+
+**`ReviewWaitTimeout` semantics (depends on outstanding-reviewer mix):**
+
+| Outstanding reviewers | Meaning of `ReviewWaitTimeout` |
+|---|---|
+| Pure bot(s) | How long before Phase 1 fires (bot re-prompt); Phase 2 pause triggers at 2× (1× from `fabrik:awaiting-review` + 1× from `fabrik:bot-reprompted`) |
+| Mixed bot(s) + human(s) | How long before the engine pauses for human input (existing behavior, Phase 1 does not fire) |
+| Pure human(s) | How long before the engine pauses for human input (existing behavior, unchanged) |
+
+**Label lifecycle for bot escalation:**
+- `fabrik:bot-reprompted` — single fixed label (22 chars, well under GitHub's 50-char REST API limit); applied once after Phase 1 finishes re-prompting all outstanding bots; removed when Phase 2 fires (as part of Phase 2 cleanup) or when the gate clears naturally via `removeAwaitingReviewLabel` (all reviewers submitted). Only exists while the pure-bot escalation is in progress within a gate cycle.
+- `fabrik:awaiting-review` — applied on first block; removed on natural gate clear or when Phase 2 fires; persists while the issue is paused (mixed/human/Phase-2 timeout paths — `pauseForReviewTimeout` does not remove it).
+
+### 6.2 Review Reinvoke Mechanics
+
+The catch-up loop in `poll()` is split into two phases for every non-paused non-cleanup item that has either `stage:<X>:complete` OR `fabrik:awaiting-ci` (on a `wait_for_ci: true` stage):
+
+**Phase 1 — unconditional (all items, regardless of yolo/cruise/auto_advance):**
+1. `checkDependencies()` — if blocked, skip
+2. `checkReviewGate()` — if awaiting reviewers, skip; if timed out, pause
+3. `buildReviewThreadComments()` collects inline comments from unresolved review threads (no ROCKET reaction, not in `processedSet`)
+4. **inFlight guard:** If a reinvoke goroutine from a previous poll cycle is still running, the entire reinvoke path is skipped (including cycle-limit checks)
+5. **Cycle limit check:** `reviewCycleCount[stageKey]` is compared against `MaxReviewCycles` (default 5)
+   - If exceeded: `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
+   - If not exceeded: increment count, dispatch reinvoke via `dispatchReviewReinvoke()`:
+     - Marks item in `inFlight` (prevents double-dispatch)
+     - Acquires semaphore slot (respects `MaxConcurrent`)
+     - Calls `processComments()` with the synthetic review comments asynchronously
+     - On exit: releases semaphore, clears `inFlight`
+   - Either way: `continue` — Phase 2 is skipped this cycle; item re-evaluated on next poll
+6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`, the same opt-in as the CI gate): `checkMergeabilityGate()` fetches GitHub's `mergeable` flag for the linked PR
+   - `mergeable == true` (or no PR): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
+   - `mergeable == null` (GitHub still computing) **or** transient API error on either REST call: block this item for the rest of Phase 1 (skip to next item) — re-evaluated on the next poll (**no label churn** — mirrors the CI gate's R10c rule and matches how the CI gate handles its own transient errors)
+   - `mergeable == false` (confirmed conflict): apply `fabrik:rebase-needed` idempotently, then **inFlight guard** + **cycle limit check** (`rebaseCycleCount[stageKey]` vs `MaxRebaseCycles`, default 3):
+     - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
+     - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
+7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` evaluates CI for stages with `wait_for_ci: true`
+   - **`mergeable_state` shortcut (v0.0.52):** before fetching check runs, `checkCIGate` queries `FetchPRMergeableState()` on the linked PR. If the value is `clean` or `unstable` (per `github.MergeableStateAccepted`), the gate clears immediately: `addCompleteLabelAndRemoveCI()` adds `stage:<X>:complete` and removes `fabrik:awaiting-ci`; the per-check classification is skipped. Other states (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`, empty) fall through to the per-check classification below. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+   - Per-check classification (fallback): fetches `FetchCheckRuns()` and applies R1–R6
+   - Pending/API error: skip (blocked, not failed); item re-evaluated on next poll
+   - Timed out: `pauseForCITimeout()` pauses issue
+   - CI failed: **inFlight guard** + **cycle limit check** (`ciFixCycleCount[stageKey]` vs `MaxCiFixCycles`):
+     - If exceeded: `pauseForCIFixCycleLimit()` pauses issue
+     - If not exceeded: dispatch `dispatchCIFixReinvoke()`; `continue`
+
+**Phase 2 — gated (yolo/cruise/auto_advance only):**
+- Only runs when no reinvoke was dispatched in Phase 1 (review, rebase, and CI-fix reinvoke all `continue`)
+- Gated on: `e.cfg.Yolo` OR `fabrik:yolo` label OR `fabrik:cruise` label OR stage `auto_advance: true`
+- Runs `attemptMergeOnValidate()` (yolo only), skips if unprocessed comments exist, then calls `advanceToNextStage()`
+
+**processComments widening:** `processComments()` itself also merges any unresolved `LinkedPRReviewThreadComments` at entry, before Step 1. This closes the race where a user nudge arrives before the catch-up loop Phase 1 fires — the review thread comments are addressed in the same invocation as the nudge comment.
+
+**Review thread resolution:** Step 10 of `processComments()` resolves addressed review threads via `ResolveReviewThread()` after adding ROCKET reactions.
+
+**PR summary comment:** Step 8b of `processComments()` posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR when the invocation is a review-reinvoke (all-`ReviewThreadID` batch) and `output != ""`. The comment includes Claude's cleaned output plus a machine-generated per-thread footer listing `path:line — resolved` for each unique `ReviewThreadID` in the input batch (deduped; line resolved from `Comment.Line` with `OriginalLine` fallback). This gives reviewers a visible record in the PR timeline that their inline feedback was addressed.
+
+### 6.3 Review Reinvoke vs Regular Comment Processing
+
+| Aspect | Regular Comments | Review Reinvoke |
+|--------|-----------------|-----------------|
+| Source | `item.Comments` (issue comments) | `item.LinkedPRReviewThreadComments` (PR inline comments) |
+| Detection | `findNewComments()` | `buildReviewThreadComments()` |
+| Dispatch | Synchronous in `processItem()` | Async goroutine via `dispatchReviewReinvoke()` |
+| Cycle limits | None | `MaxReviewCycles` (default 5) |
+| Timeout | None | Integrated with `ReviewWaitTimeout` |
+| Thread resolution | Yes — `processComments()` merges unresolved `LinkedPRReviewThreadComments` at entry, so a user nudge resolves threads in the same invocation | Yes — resolves review threads after processing |
+| PR summary posting | None | Posts `"<StageName> (review feedback addressed)"` on the linked PR with per-thread footer (one `path:line — resolved` bullet per unique `ReviewThreadID`); skipped when `output == ""` or no linked PR |
+| inFlight guard | Uses dispatch loop's `inFlight` check | Has its own `inFlight` check in catch-up loop |
+
+### 6.4 CI Gate and CI-Fix Reinvoke
+
+#### 6.4.1 Two-Phase CI Gate
+
+The CI gate has two paths that handle different timing scenarios:
+
+**Path 1: `attemptMergeOnValidate()` (Merge Guard)**
+- Embedded directly in the auto-merge path for Validate+yolo items
+- Uses in-memory `ciMergePendingSince` map (keyed by `issueKey`) to track how long CI has been pending
+- Fetches PR head SHA via `FetchLinkedPR()` (REST), then check run statuses via `FetchCheckRuns()` (REST)
+- **R5:** No check runs → gate clears (repo has no CI). The `prHasHadChecks` post-push delay guard applies to `checkCIGate()` (Path 2) only, not to this merge-guard path
+- **R4:** All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge
+- **R3:** Any check failed → add `fabrik:awaiting-ci`; return error (advance skipped)
+- **R2:** Any check pending → start timer in `ciMergePendingSince` (first observation); return error (**R10c:** no label applied — avoids label churn for transient pending state)
+- **R6:** Pending elapsed ≥ `CIWaitTimeout` → post comment; add `fabrik:paused` + `fabrik:awaiting-input`; return error
+
+**Path 2: Catch-up loop Phase 1 (`checkCIGate()`)**
+- Runs for items with `fabrik:awaiting-ci` on stages with `wait_for_ci: true` (admitted by broadened catch-up loop entry guard: `!hasComplete && !(hasAwaitingCI && isWaitForCI)` — see ADR 032)
+- Has FRESH data from `FetchItemDetails()` and makes targeted REST calls for head SHA and check runs
+- Uses `FetchLabelAppliedAt` on `fabrik:awaiting-ci` for timeout tracking (durable across restarts)
+- Three outcomes:
+  - `(ciBlocked=true, ciFailure=false, ciTimedOut=false)` — checks still pending; skip to next item (`fabrik:awaiting-ci` already present — no additional label needed)
+  - `(ciBlocked=true, ciFailure=true, ciTimedOut=false)` — failure confirmed; `fabrik:awaiting-ci` applied idempotently; dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
+  - `(ciBlocked=false, ciFailure=false, ciTimedOut=true)` — `fabrik:awaiting-ci` has been present ≥ `CIWaitTimeout`; pause via `pauseForCITimeout()`
+- **Gate cleared outcome:** When all checks pass (or no check runs exist — R5), `checkCIGate` calls `addCompleteLabelAndRemoveCI`: adds `stage:X:complete` and removes `fabrik:awaiting-ci`. This is the only place `stage:X:complete` is added for `wait_for_ci: true` stages (conjunctive gate invariant, ADR 032).
+
+**Two different timeout strategies:**
+- **Path 1** (merge guard): In-memory `ciMergePendingSince` map. Acceptable because merge-guard state is transient — engine restarts simply re-evaluate CI on the next poll.
+- **Path 2** (catch-up loop): `FetchLabelAppliedAt` REST call on `fabrik:awaiting-ci`. Durable across restarts because the label itself persists. The label is present from the moment Claude emits FABRIK_STAGE_COMPLETE on a `wait_for_ci: true` stage, so timeout tracking is accurate from the start of the CI-await window.
+
+#### 6.4.2 CI Fix Reinvoke Mechanics
+
+The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. When CI has failed:
+
+1. **inFlight guard:** If a CI-fix goroutine from a previous poll is still running for this item, skip dispatch entirely (no cycle-limit check either)
+2. **Cycle limit check:** `ciFixCycleCount[stageKey]` is compared against `MaxCiFixCycles` (default 5)
+   - If exceeded: `pauseForCIFixCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
+   - If not exceeded: increment count, dispatch reinvoke via `dispatchCIFixReinvoke()`:
+     - Marks item in `inFlight` (prevents double-dispatch)
+     - Acquires semaphore slot (respects `MaxConcurrent`)
+     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch)
+     - Calls `processComments()` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if unset)
+     - On exit: releases semaphore, clears `inFlight`
+
+**`DatabaseID: 0` guard:** Synthetic CI-fix comments have `DatabaseID: 0`, which skips the 👀 and 🚀 reaction steps in `processComments()` (reactions require a real GitHub comment ID).
+
+**CI-fix cycle counter reset:** `ciFixCycleCount[stageKey]` is reset to 0 by `clearFailedStage()` when the user removes `fabrik:paused` from a paused-failed item, allowing fresh CI-fix attempts after human intervention. `rebaseCycleCount[stageKey]` is reset in the same call for the same reason.
+
+#### 6.4.3 CI Fix Reinvoke vs Review Reinvoke
+
+| Aspect | Review Reinvoke | CI Fix Reinvoke |
+|--------|-----------------|-----------------|
+| Trigger | Unresolved PR review thread comments | CI check runs with failure/timed_out/action_required conclusion |
+| Source data | `item.LinkedPRReviewThreadComments` | `FetchCheckRuns()` REST call on PR head SHA |
+| Label on waiting | `fabrik:awaiting-review` (always applied) | `fabrik:awaiting-ci` (applied by `handleStageComplete` on FABRIK_STAGE_COMPLETE; present for both pending and failed checks — covers the full CI-await window) |
+| Timeout tracking | In-memory `ReviewWaitTimeout` timer | `FetchLabelAppliedAt` on `fabrik:awaiting-ci` (durable across restarts; label is present from FABRIK_STAGE_COMPLETE onwards) |
+| Cycle counter | `reviewCycleCount[stageKey]` | `ciFixCycleCount[stageKey]` |
+| Max cycles | `MaxReviewCycles` (default 5) | `MaxCiFixCycles` (default 5) |
+| Skill | `comment_skill` | `ci_fix_skill` (falls back to `comment_skill`) |
+| Synthetic comment | PR review thread text | Structured CI failure report with NEW REGRESSION classification |
+| inFlight guard | Yes — shared `inFlight` sync.Map | Yes — same `inFlight` sync.Map |
+| Thread resolution | Yes — `ResolveReviewThread()` after processing | No |
+| PR summary comment | Yes — `"<StageName> (review feedback addressed)"` on linked PR | No |
+| Stage gate config | `wait_for_reviews: true` | `wait_for_ci: true` |
+
+### 6.5 Merge-Conflict Gate and Rebase Reinvoke
+
+The merge-conflict gate is a third prong of the catch-up loop Phase 1, sitting between review reinvoke and the CI gate. It is the direct response to the failure mode in which a base-branch advance during the CI-await window leaves a PR unmergeable — the CI gate alone will happily keep polling check runs on the branch head while the real blocker is a conflict.
+
+**Note:** `attemptMergeOnValidate()` (§5.4, the legacy auto-merge path for stages without `wait_for_ci: true`) now uses the same `rebaseCycleCount[stageKey]`, `dispatchRebaseReinvoke()`, and `pauseForRebaseCycleLimit()` pattern as the conjunctive gate described in this section. The two paths share the same cycle-counter map; `MaxRebaseCycles` applies to both.
+
+#### 6.5.1 Gate Mechanics
+
+`checkMergeabilityGate()` runs only when `stage.WaitForCI` is true (the same opt-in that admits items to the catch-up window via `fabrik:awaiting-ci`). It returns `(blocked, conflict)`:
+
+- `(false, false)` — clear: no linked PR, or `mergeable == true`. Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
+- `(true, false)` — GitHub reports `mergeable == null` (still computing) **or** a transient API error was seen on either REST call. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
+- `(true, true)` — confirmed conflict (`mergeable == false`). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
+
+Two REST calls are made: `FetchLinkedPR` for the PR number, then `FetchPRMergeable` (hitting `/repos/{owner}/{repo}/pulls/{number}`). The single-PR endpoint is required — the list endpoint used by `FetchLinkedPR` does not return `mergeable`.
+
+#### 6.5.2 Ordering Against the CI Gate
+
+The merge-conflict gate runs **before** the CI gate so that a confirmed conflict preempts CI-await polling. The rationale: a PR that cannot merge has no reason to wait for CI, and Claude on CI-fix reinvoke cannot productively act on a branch that must first be rebased. When the merge gate emits `conflict`, Phase 1 `continue`s without reaching the CI gate.
+
+When the merge gate clears (`mergeable == true`), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked with no confirmed conflict (`mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
+
+#### 6.5.3 Rebase Reinvoke Mechanics
+
+When `checkMergeabilityGate` returns `conflict=true`:
+
+1. **inFlight guard:** if a rebase goroutine from a previous poll is still running for this item, skip dispatch entirely (no cycle-limit check).
+2. **Cycle limit check:** `rebaseCycleCount[stageKey]` is compared against `MaxRebaseCycles` (default 3 — lower than review/CI because rebase either works in one shot or needs human judgment):
+   - If exceeded: `pauseForRebaseCycleLimit()` pauses the issue with `fabrik:paused` + `fabrik:awaiting-input`; `fabrik:rebase-needed` is intentionally left in place so the reason is visible.
+   - If not exceeded: increment count, dispatch `dispatchRebaseReinvoke()`:
+     - Marks item in `inFlight` (prevents double-dispatch)
+     - Acquires semaphore slot (respects `MaxConcurrent`)
+     - Calls `buildRebaseComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) instructing Claude to `git fetch origin <base> && git rebase origin/<base>`, resolve conflicts conservatively (never dropping code from base), watch for semantic collisions (duplicated ADR numbers, migration slots), run the project's build + tests, and force-push with `--force-with-lease`.
+     - Calls `processComments()` with the synthetic comment and the `rebase_skill` (falls back to `comment_skill` if unset)
+     - On exit: releases semaphore, clears `inFlight`
+
+**`DatabaseID: 0` guard:** like the CI-fix and review synthetic comments, the rebase synthetic comment uses `DatabaseID: 0` so `processComments()` skips the 👀 and 🚀 reaction steps (no real GitHub comment exists to react to).
+
+#### 6.5.4 Why Claude Rebases (Not the Engine)
+
+The engine could in principle run `git fetch && git rebase` directly from the worker, but does not. Automatic rebase is *right most of the time* and *catastrophically wrong sometimes*: two PRs independently pick `adr-054.md`, both PRs pick migration slot `0042`, both PRs add a new line at the same point in a shared config file. A mechanical rebase drops one side silently; a Claude-driven rebase can rename, renumber, and keep both contributions. The synthetic comment explicitly flags this — "watch for semantic collisions" — so Claude's judgment is applied where it matters.
+
+The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRebaseCycles` defaults to 3 rather than 5: if Claude cannot rebase cleanly in three attempts the conflict almost certainly needs a human.
+
+#### 6.5.5 Rebase Reinvoke vs CI Fix Reinvoke
+
+| Aspect | CI Fix Reinvoke | Rebase Reinvoke |
+|--------|-----------------|-----------------|
+| Trigger | CI check runs in failure state | `mergeable == false` on linked PR |
+| Source data | `FetchCheckRuns()` REST call on PR head SHA | `FetchPRMergeable()` REST call on linked PR |
+| Label on waiting | `fabrik:awaiting-ci` (only on confirmed failure) | `fabrik:rebase-needed` (only on confirmed `mergeable == false`) |
+| Order in Phase 1 | After merge-conflict gate | Before CI gate |
+| Cycle counter | `ciFixCycleCount[stageKey]` | `rebaseCycleCount[stageKey]` |
+| Max cycles | `MaxCiFixCycles` (default 5) | `MaxRebaseCycles` (default 3) |
+| Skill | `ci_fix_skill` (falls back to `comment_skill`) | `rebase_skill` (falls back to `comment_skill`) |
+| Synthetic comment | Structured CI failure report with NEW REGRESSION classification | Rebase instructions with explicit semantic-collision guidance |
+| Thread resolution | No | No |
+| PR summary comment | No | No |
+| Stage gate config | `wait_for_ci: true` | `wait_for_ci: true` (same opt-in — these are the stages that enter the catch-up window) |
+| Label left on pause | `fabrik:awaiting-ci` removed before pause | `fabrik:rebase-needed` **retained** on pause so the human sees the reason |
+
+**References:** [ADR-028: Merge-Conflict Gate and Rebase Reinvoke](../adrs/028-merge-conflict-gate-and-rebase-reinvoke.md)
+
+### 6.6 Decompose Path
+
+**Trigger:** Claude outputs `FABRIK_DECOMPOSED` marker (expected only from Plan stage).
+
+**Marker priority:** `FABRIK_STAGE_COMPLETE` > `FABRIK_DECOMPOSED` > `FABRIK_BLOCKED_ON_INPUT`. If `completed` is true, `decomposed` is not checked. Both `decomposed` and `blockedOnInput` require `err == nil`.
+
+**Code path:** `processItem()` → `handleDecomposed()`
+
+**Flow:**
+1. Add `stage:<X>:complete` label (prevents re-invocation on restart)
+2. Look up "Done" column on the project board
+3. Move the issue directly to Done, bypassing all remaining pipeline stages
+
+**References:** [ADR-017: Decomposed Marker State Machine](../adrs/017-decomposed-marker-state-machine.md)
+
+---
+
+## 7. Edge Case States
+
+### 7.1 Cooldown Retry
+
+When Claude runs but does not output any completion marker, the engine enters a cooldown retry loop. This applies both when Claude exits cleanly without a marker and when it exits with an error (e.g., timeout, crash). Only start failures (binary not found, `exec.Error`, `os.PathError`) skip the cooldown — the item is retried on the next poll instead.
+
+- **Cooldown duration:** `PollSeconds * 10` (e.g., 30s poll → 300s cooldown)
+- **State:** In-memory only (`processedSet[stageKey]` timestamp). No label is added for cooldown.
+- **Lock behavior:** The lock (`fabrik:locked:<user>` and `stage:<X>:in_progress`) is NOT released during cooldown. This prevents other instances from picking up the item.
+- **Resume behavior:** On retry, `resume=true` is passed to Claude (resumes the session rather than starting fresh)
+- **On restart:** Cooldown state is lost. The lock label is still present but `lockedIssues` in-memory map is empty — the shutdown cleanup removes lock labels. If the process crashes without cleanup, the lock label remains as a stale artifact until another instance or manual cleanup removes it.
+- **Stage-complete exemption:** Items where `stage:X:complete` appears in the shallow label set are NOT subject to cooldown retry — they have no work to retry. When the cooldown-expired branch fires in `itemMayNeedWork()`, the engine checks for `stage:X:complete` in shallow labels before returning `true`; if present, it returns `false`. This prevents perpetual deep-fetch loops for terminal items (cruise+Validate complete, paused+complete, closed-with-stage-complete) where every poll after cooldown expiry would otherwise trigger a no-op deep-fetch indefinitely.
+
+### 7.2 Failed Stage / Pause on Retry Limit
+
+When a stage fails `MaxRetries` times (default: configurable, 0 disables):
+
+1. `escalateFailedStage()` adds `fabrik:paused` + `stage:<X>:failed`
+2. Posts an explanatory comment
+3. Sets `pausedDueToRetries[stageKey] = true` in memory
+4. Releases the lock
+
+**Recovery:** User investigates, makes fixes, then removes `fabrik:paused`. On next poll, `processItem()` detects the failed label (or in-memory `pausedDueToRetries`) and calls `clearFailedStage()`, which:
+- Removes `stage:<X>:failed`
+- Resets `retryCount`, `pausedDueToRetries`, `processedSet` (clears cooldown), and `reviewCycleCount`
+
+### 7.3 Multi-Instance Lock Protocol
+
+Per [ADR-007](../adrs/007-label-based-locking.md):
+
+1. Instance acquires `fabrik:locked:<user>` label
+2. Waits `lockVerifyDelay` (2 seconds) for competing instances to place their locks
+3. Re-fetches labels via `FetchLabels()`
+4. If another `fabrik:locked:*` label is present: **lexicographic tie-break** — lower username wins (proceeds), higher username loses (releases lock and skips)
+5. Winner proceeds with stage invocation; loser returns nil
+
+**Edge cases:**
+- Identical usernames: both proceed (unsupported configuration)
+- API error on re-fetch: winner proceeds (optimistic; logs warning)
+- Lock is released on: completion, permanent failure (MaxRetries), blocked-on-input, decomposed, or lock conflict loss. NOT released on cooldown retry.
+
+### 7.4 Closed-Issue Catch-Up
+
+Closed issues are normally skipped by `itemMayNeedWork()` and `itemNeedsWork()`. Exceptions:
+
+1. **Cleanup stages:** A closed issue in Done with a worktree still needs cleanup
+2. **Complete-labeled items:** A closed issue with `stage:<X>:complete` can be advanced by the catch-up loop (e.g., PR merge closes the issue while it's in Validate with the complete label — it needs to move to Done)
+
+**Stale lock cleanup:** `cleanupClosedIssueLocks()` runs every poll cycle and removes `fabrik:locked:<user>` labels from any closed issues on the board. This handles stale locks left when an issue was closed while a stage was in-flight.
+
+### 7.5 In-Memory vs Durable State
+
+| State | In-Memory | Durable (Label/Reaction) | Behavior on Restart |
+|-------|-----------|--------------------------|---------------------|
+| Cooldown timer | `processedSet[stageKey]` | None | Lost — item retried immediately |
+| Retry count | `retryCount[stageKey]` | None | Lost — retries restart from 0 |
+| Paused-due-to-retries | `pausedDueToRetries[stageKey]` | `fabrik:paused` + `stage:<X>:failed` | Labels survive; in-memory flag lost but `processItem()` detects the failed label directly |
+| Review cycle count | `reviewCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
+| CI-fix cycle count | `ciFixCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
+| CI merge pending since | `ciMergePendingSince[issueKey]` | None | Lost — merge guard re-evaluates CI fresh on next poll |
+| Comment processed | `processedSet[key]` | ROCKET (🚀) reaction | Reaction survives restart; in-memory dedup is defense-in-depth |
+| Lock tracking | `lockedIssues[iKey]` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
+| Last updatedAt | `lastUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |
+| Deep-fetch failure | `deepFetchFailureTime[iKey]` | None | Lost — failed items retried immediately |
+
+### 7.6 Invocation-Level Kill Mechanisms
+
+Two proactive kill mechanisms cap how long a single Claude invocation can run. Both are implemented in `runClaude()` in `engine/claude.go` and operate independently of the engine-level context cancellation.
+
+**`max_wall_time` (per-stage YAML field)**
+- Configured as a Go duration string in stage YAML (e.g., `max_wall_time: "45m"`). Absent or zero means no cap.
+- Implemented via `context.WithTimeout` wrapping the invocation context; the clock starts when the process is spawned.
+- When the deadline fires, `cmd.Cancel` executes the graceful kill sequence: SIGTERM to the process group, 10-second grace, SIGKILL.
+- Recommended for long-running stages (Implement, Review) to bound worst-case hang time.
+
+**Inactivity timeout (hardcoded 15 minutes)**
+- A watchdog goroutine resets a 15-minute timer on every byte of stdout received via `activityWriter`.
+- When no output arrives for 15 consecutive minutes, the watchdog calls `killProcGroupGraceful()` directly and sets `inactivityFired`.
+- Acts as backstop for stages with no `max_wall_time` (or when the process produces occasional output but never completes).
+
+**Shared post-kill behavior:**
+1. `extractTextFromAssistantTurns(rawOutput)` scans the already-buffered output for `FABRIK_STAGE_COMPLETE` appearing in the `text` content of any `{"type":"assistant"}` NDJSON line.
+2. If found: returns `completed=true` — the invocation is treated identically to a live `FABRIK_STAGE_COMPLETE`.
+3. If not found: returns `completed=false` — routes to cooldown/retry (see §3.2 and §7.1), not a hard error.
+
+**`wasTimedOut` flag:** `inactivityFired.Load() || (stageCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil)` — distinguishes our kills from engine-shutdown context cancellation. When `wasTimedOut=true`, the no-marker path follows the same cooldown/retry flow as a clean exit without markers. When `ctx.Err() != nil && !wasTimedOut` (engine shutdown), `runClaude` returns immediately with zero output.
+
+**Kill sequence:** `killProcGroupGraceful(pid, issueNumber, label)` sends `syscall.SIGTERM` to `-pid` (the entire process group), sleeps 10 seconds, then sends `syscall.SIGKILL`. This terminates grandchild processes (e.g., background `sleep` spawned by Monitor tool) that would otherwise hold the stdout pipe open past `cmd.WaitDelay`.
+
+**No-op on Windows:** `killProcGroupGraceful` is a no-op on Windows (process groups work differently). Both timeout mechanisms still fire and set their flags, but the kill is a best-effort `cmd.Cancel`.
+
+### 7.7 Poll Loop Idle Backoff and Webhook Health State
+
+The poll loop's effective interval grows when there is nothing to do (idle backoff). The cap on that backoff depends on the webhook stream health state.
+
+**Idle backoff algorithm** (`computeEffectiveInterval` in `engine/poll.go`):
+- Base interval: `PollSeconds` (default 30s).
+- Activity multiplier: doubles each poll cycle where no work was dispatched, up to the idle cap.
+- Activity reset: only a poll cycle where `result.Active == true` (work was dispatched or a deep fetch ran) resets `idleStart` and the multiplier back to 1×. A `wakeCh` signal triggers an immediate poll but does **not** unconditionally reset the backoff — the multiplier is only reset if that poll finds active work.
+- Rate-limit adjustment (`nextRateLimitLow` + `computeEffectiveInterval` in `engine/poll.go`):
+  - **Activation**: rate-limit backoff engages when remaining GraphQL quota drops below 20% (`rateLimitBackoffThreshold`). The actual remaining fraction is passed to `computeEffectiveInterval` as `rateLimitRatio`.
+  - **Clearance**: backoff clears only when quota rises above 50% (`rateLimitHealthyThreshold`). Between 20% and 50% the state is sticky — backoff remains active to prevent thrashing on boards where quota fluctuates near the activation point.
+  - **Stepwise escalation**: the multiplier scales with depletion depth — 2× at >=10% remaining (includes the 20%–50% sticky zone), 4× at >=5% and <10%, 6× at >=1% and <5%, 10× (`rateLimitMaxBackoffMultiplier`) below 1%.
+  - **No idle cap**: the rate-limit component has no 5-minute ceiling; it is capped only at `rateLimitMaxBackoffMultiplier × configuredInterval`.
+  - **Independence from idle backoff**: activity detection (items dispatched) resets idle backoff but does NOT reset rate-limit backoff.
+
+**Idle cap selection** (`effectiveIdleCap` in `engine/poll.go`):
+
+| Webhook stream state | Idle cap |
+|---------------------|----------|
+| `WebhookStreamHealthy` | 60 minutes (`webhookIdleCap`) |
+| `WebhookStreamStartingUp` | 60 minutes (`webhookIdleCap`) |
+| `WebhookStreamUnhealthy` | 5 minutes (`maxIdleBackoff`) |
+| Webhook mode disabled | 5 minutes (`maxIdleBackoff`) |
+
+When the webhook stream is healthy or starting up, steady-state polling is suppressed to a 60-minute safety-net interval. Events that arrive on the webhook stream signal the `wakeCh` channel, which triggers an immediate poll regardless of the current interval. The backoff multiplier is preserved unless that poll finds active work (see "Activity reset" above).
+
+**Webhook stream health states** (managed by `webhookManager` in `engine/webhook.go`):
+
+| State | Meaning | Idle cap used | TUI indicator |
+|-------|---------|---------------|---------------|
+| `WebhookStreamStartingUp` | Subprocess launched; no verified event received yet. The state persists until the first event arrives or `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) elapses with no event. | 60 min | Blue ○ |
+| `WebhookStreamHealthy` | At least one event received within the last health window (10 min) | 60 min | Green ● |
+| `WebhookStreamUnhealthy` | No first event received before `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch, or health window (10 min) elapsed since last event | 5 min | Yellow ◌ |
+
+**State transitions:**
+- `StartingUp → Healthy`: first verified webhook event received at any point after subprocess launch.
+- `StartingUp → Unhealthy`: no verified event received for `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch.
+- `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
+- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace and waits for a new first event.
+
+**Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
+
+**References:** [ADR-032: Webhook-Driven Event Delivery](../adrs/032-webhook-event-delivery.md)
+
+### 7.8 Webhook Wake Semantics: Burst Coalescence and Self-Feedback
+
+**Burst coalescence.** `wakeCh` is a buffered channel with capacity 1. When multiple webhook events arrive in rapid succession, at most one wake is queued. Additional sends while the channel is full are dropped (non-blocking). This means a burst of N simultaneous events produces at most 1 extra poll cycle rather than N. Test: `TestHandleWebhookBurstCoalescence` in `engine/webhook_test.go`.
+
+**Self-feedback loop (known gap).** Fabrik runs as the human operator's own GitHub account. Every API action Fabrik takes — label mutations, comment posts, status field updates, PR opens — generates webhook events from that account. These events arrive at the webhook handler and signal `wakeCh`, triggering one extra poll cycle per burst of activity. The burst-coalescence guarantee bounds the damage: a stage advance producing N API actions generates at most 1 extra poll.
+
+**Sender-filter approach — considered and rejected.** Suppressing `wakeCh` signals when `sender.login` matches `cfg.User` would eliminate these spurious wakes, but `cfg.User` is the human operator's login. Filtering by it would also suppress every event the user generates (comments, label changes, PR reviews) — the most important input class. Sender filtering is only viable when Fabrik runs as a dedicated bot account separate from any human user. That is a future change; no sender filtering is currently implemented.
+
+**Backoff impact.** Before the fix for issue #490, the `case <-e.wakeCh:` branch unconditionally reset `e.idleStart` and `prevMultiplier = 1` before calling `doPollCycle`. Self-feedback events would therefore destroy the idle-backoff state on every stage advance, defeating the GraphQL budget savings webhooks provide. After the fix, those unconditional resets are removed. A webhook wake triggers an immediate poll, but backoff is preserved unless `result.Active == true` (see 7.7).
+
+---
+
+## 8. Invalid / Unexpected States
+
+The engine handles unexpected label combinations (from manual human manipulation) through its guard chain. The behavior is defined by the order of checks in `itemMayNeedWork()`, `itemNeedsWork()`, and `processItem()`.
+
+### 8.1 Guard Chain Order in `processItem()`
+
+Guards are checked in this order. The first matching guard determines behavior:
+
+| Priority | Guard | Check | Behavior |
+|----------|-------|-------|----------|
+| 1 | No matching stage | `FindStage(stages, item.Status) == nil` | Skip (return nil) |
+| 2 | Repo not ready | `ensureRepoReady()` fails | Skip (ErrSkipItem) or return error |
+| 3 | Locked by other user | `fabrik:locked:<other>` present | Skip with log |
+| 4 | Editing | `fabrik:editing` present | Skip with log |
+| 5 | Awaiting input + comment | `isAwaitingInput()` + new comments | Unblock → comment processing |
+| 6 | Awaiting input, no comment | `isAwaitingInput()` | Skip with log |
+| 7 | Paused + comment | `fabrik:paused` + new comments | Unpause → fall through |
+| 8 | Paused, no comment | `fabrik:paused` | Skip with log |
+| 9 | Dependencies blocked | `checkDependencies()` returns true | Skip (label + comment handled by checkDependencies) |
+| 10 | Cleanup stage | `stage.CleanupWorktree` | Remove worktree, add complete label |
+| 11 | Failed label + unpause detection | `stage:<X>:failed` present or `pausedDueToRetries` | `clearFailedStage()` then continue |
+| 12 | New comments | `findNewComments()` non-empty | `processComments()` |
+| 13 | PR item | `item.IsPR` | Skip (PRs only support comments) |
+| 14 | Stage complete | `stage:<X>:complete` present | Skip |
+| 15 | Cooldown active | `processedSet[stageKey]` within cooldown | Skip |
+| 16 | (all guards pass) | — | Acquire lock → invoke Claude |
+
+### 8.2 Notable Unexpected Scenarios
+
+**`fabrik:editing` without active comment processing:**
+If a human manually adds `fabrik:editing`, the engine skips the item (guard 4). The label must be manually removed for processing to resume.
+
+**`stage:<X>:complete` without board column advancement:**
+The item is skipped by guard 14 in `processItem()`. The catch-up loop will attempt to advance it if yolo/cruise/autoAdvance is active. Without auto-advance, it waits for a human to move the board column.
+
+**`fabrik:paused` on a complete item:**
+The catch-up loop checks `fabrik:paused` and skips paused items. The item will not be advanced until unpaused.
+
+**`fabrik:awaiting-review` without `stage:<X>:complete`:**
+The catch-up loop only processes items with the complete label, so `fabrik:awaiting-review` alone has no effect in the catch-up path. In `processItem()`, the label is not checked — it's only relevant in the catch-up loop.
+
+**`stage:<X>:failed` without `fabrik:paused`:**
+`processItem()` guard 11 detects this as an "unpause" scenario — the user has already removed `fabrik:paused`, so `clearFailedStage()` resets retry state and processing continues.
+
+**Multiple `stage:<X>:in_progress` labels:**
+No special handling. Each is independent. The engine only checks the in_progress label for the current stage's column.
+
+> **Bug?:** The catch-up loop checks `fabrik:paused` but does NOT check `fabrik:editing`. If a human manually applies `stage:<X>:complete` while `fabrik:editing` is on, the catch-up loop would attempt to advance the item. In practice, `fabrik:editing` is only present during the brief window of comment processing (seconds to minutes), making this race unlikely but theoretically possible.
+
+---
+
+## 9. Concurrency Model
+
+### 9.1 Semaphore
+
+`Engine.sem` is a buffered channel of size `MaxConcurrent` (default 5). The dispatch loop, `dispatchReviewReinvoke()`, and `dispatchCIFixReinvoke()` all acquire slots from this semaphore before invoking Claude.
+
+### 9.2 inFlight Map
+
+`Engine.inFlight` (`sync.Map`) tracks items currently being processed by worker goroutines. Key: `issueKey` string, Value: `bool` (isPR).
+
+- **Set by:** dispatch loop (before goroutine launch), `dispatchReviewReinvoke()` (inside goroutine, before semaphore acquire), and `dispatchCIFixReinvoke()` (inside goroutine, before semaphore acquire)
+- **Cleared by:** goroutine defer (after `processItem()` or `processComments()` returns)
+- **Used by:** dispatch loop (skip already in-flight items) and catch-up loop (skip reinvoke/CI-fix dispatch if already in-flight)
+
+### 9.3 Worktree Mutex
+
+Git operations that write `.git/config` are not concurrent-safe. `WorktreeManager.mu` serializes worktree creation and updates within a single repo.
+
+### 9.4 Catch-Up vs Dispatch Ordering
+
+Within a single `poll()` call:
+
+1. **Catch-up loop** runs first — processes items with `stage:<X>:complete` labels for yolo/cruise advancement, review gate evaluation, and review reinvoke dispatch
+2. **Dispatch loop** runs second — processes items that need stage invocations or comment processing
+
+The `advancedItems` map prevents items advanced by the catch-up loop from having their `lastUpdatedAt` re-cached (which would make them invisible on the next poll). The `inFlight` map prevents items dispatched by `dispatchReviewReinvoke()` in the catch-up loop from being double-dispatched by the dispatch loop.
+
+### 9.5 processedSet Mutex
+
+`Engine.mu` (sync.Mutex) protects all in-memory state maps: `processedSet`, `lockedIssues`, `retryCount`, `pausedDueToRetries`, `reviewCycleCount`, `ciFixCycleCount`, `ciMergePendingSince`, `lastUpdatedAt`, `deepFetchFailureTime`, `lastUsage`, `lastCompleted`, `lastBlocked`, `totalTokens`, `lastReportedCost`. Critical sections are kept small — typically a single map read/write.
+
+---
+
+## 10. State Diagrams
+
+### 10.1 Happy Path — Linear Stage Progression
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    [*] --> Specify_Idle : Issue added to board
+    Specify_Idle --> Specify_Running : Poll tick
+    Specify_Running --> Specify_Complete : FABRIK_STAGE_COMPLETE
+
+    Specify_Complete --> Research_Idle : Auto-advance or human move
+    Research_Idle --> Research_Running : Poll tick
+    Research_Running --> Research_Complete : FABRIK_STAGE_COMPLETE
+
+    Research_Complete --> Plan_Idle : Auto-advance or human move
+    Plan_Idle --> Plan_Running : Poll tick
+    Plan_Running --> Plan_Complete : FABRIK_STAGE_COMPLETE
+
+    Plan_Complete --> Implement_Idle : Auto-advance or human move
+    Implement_Idle --> Implement_Running : Poll tick
+    Implement_Running --> Implement_Complete : FABRIK_STAGE_COMPLETE
+    note right of Implement_Running
+        Draft PR created
+        PR marked ready
+    end note
+
+    Implement_Complete --> Review_Idle : Auto-advance or human move
+    Review_Idle --> Review_Running : Poll tick
+    Review_Running --> Review_Complete : FABRIK_STAGE_COMPLETE
+
+    Review_Complete --> Validate_Idle : Auto-advance or human move
+    Validate_Idle --> Validate_Running : Poll tick
+    Validate_Running --> Validate_Complete : FABRIK_STAGE_COMPLETE
+    Validate_Complete --> Done_Pending : Yolo: merge + advance
+
+    Done_Pending --> Done_Complete : Worktree cleaned up
+    Done_Complete --> [*]
+```
+
+### 10.2 Off-Path Flows
+
+```mermaid
+stateDiagram-v2
+    state "Active Stage" as Active {
+        Idle --> Running : Poll tick
+        Running --> Complete : FABRIK_STAGE_COMPLETE
+        Running --> AwaitingInput : FABRIK_BLOCKED_ON_INPUT
+        Running --> Cooldown : No marker (incomplete)
+        Running --> Decomposed : FABRIK_DECOMPOSED (Plan only)
+
+        Cooldown --> Running : Cooldown expired (retry)
+        Cooldown --> PausedFailed : MaxRetries exceeded
+
+        AwaitingInput --> CommentProcessing : User comment
+        PausedFailed --> Idle : User removes fabrik:paused
+
+        Idle --> Paused : Human adds fabrik:paused
+        Paused --> CommentProcessing : User comment (implicit unpause)
+        Paused --> Idle : Human removes fabrik:paused
+
+        Idle --> Blocked : Open dependencies
+        Blocked --> Idle : All dependencies closed
+
+        Complete --> AwaitingReview : wait_for_reviews gate
+        AwaitingReview --> ReviewReinvoke : Gate clears + unresolved threads
+        AwaitingReview --> AwaitingInput : Review timeout
+        AwaitingReview --> NextStage : Gate clears, no threads
+        ReviewReinvoke --> AwaitingReview : Reinvoke completes, new reviews arrive
+        ReviewReinvoke --> AwaitingInput : Cycle limit exceeded
+
+        Complete --> AwaitingCI : wait_for_ci gate (CI failure detected)
+        AwaitingCI --> CIFixReinvoke : CI failed, cycle ok
+        AwaitingCI --> NextStage : CI checks all pass
+        AwaitingCI --> AwaitingInput : CI timeout or cycle limit
+        CIFixReinvoke --> AwaitingCI : Reinvoke completes, CI re-evaluated next poll
+        CIFixReinvoke --> AwaitingInput : Cycle limit exceeded
+
+        Complete --> NextStage : Auto-advance or human move
+        CommentProcessing --> Complete : FABRIK_STAGE_COMPLETE in comment output
+        CommentProcessing --> Idle : Comment processed (no completion)
+    }
+
+    Decomposed --> Done : Direct move to Done
+
+    state "Next Stage" as NextStage
+    NextStage --> Active : Board column updated
+```
+
+### 10.3 Review Reinvoke Cycle
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    StageComplete --> CheckDependencies : Catch-up loop Phase 1 (unconditional — all items)
+    CheckDependencies --> Blocked : Has open blockers
+    CheckDependencies --> CheckReviewGate : No blockers
+
+    Blocked --> CheckDependencies : Next poll tick
+
+    CheckReviewGate --> WaitingForReviewers : Outstanding reviewers
+    CheckReviewGate --> TimedOut : Timeout elapsed
+    CheckReviewGate --> GateCleared : All reviewers submitted
+
+    WaitingForReviewers --> CheckReviewGate : Next poll tick
+
+    TimedOut --> PausedForTimeout : pauseForReviewTimeout()
+    note right of PausedForTimeout
+        fabrik:paused
+        fabrik:awaiting-input
+    end note
+
+    GateCleared --> CheckThreads : buildReviewThreadComments()
+    CheckThreads --> Phase2 : No unresolved threads → Phase 2
+    CheckThreads --> CheckInFlight : Unresolved threads exist
+
+    CheckInFlight --> SkipReinvoke : Already in-flight
+    CheckInFlight --> CheckCycleLimit : Not in-flight
+
+    CheckCycleLimit --> PausedForCycles : cycleCount >= MaxReviewCycles
+    note right of PausedForCycles
+        fabrik:paused
+        fabrik:awaiting-input
+    end note
+
+    CheckCycleLimit --> DispatchReinvoke : cycleCount < MaxReviewCycles
+    DispatchReinvoke --> ProcessComments : Async goroutine
+    ProcessComments --> CheckReviewGate : Next poll (if new reviews arrive)
+    ProcessComments --> Phase2 : Stage complete after addressing feedback
+
+    SkipReinvoke --> CheckReviewGate : Next poll tick
+
+    Phase2 --> Advance : yolo/cruise/auto_advance gate passes
+    Phase2 --> Idle : Gate not met — no advancement
+    note right of Idle
+        Item stays in stage:X:complete
+        until user advances manually
+        or adds yolo/cruise label
+    end note
+```
+
+---
+
+## Appendix A: Two Paths to Stage Advancement
+
+Stage advancement can occur through two code paths:
+
+| Aspect | Path 1: `handleStageComplete()` | Path 2: Catch-up loop in `poll()` |
+|--------|--------------------------------|-----------------------------------|
+| **Runs in** | Worker goroutine | Poll goroutine |
+| **Triggered by** | Claude outputs FABRIK_STAGE_COMPLETE | Poll cycle finds `stage:<X>:complete` label |
+| **Review data** | Stale (just ran MarkPRReady) | Fresh (from FetchItemDetails) |
+| **Review gate** | Optimistic: applies `fabrik:awaiting-review`, returns | Real: calls `checkReviewGate()`, evaluates timeout |
+| **Label freshness** | Re-fetched (handles mid-run yolo/cruise) | Already fresh from deep fetch |
+| **Merge at Validate** | `attemptMergeOnValidate()` called directly | `attemptMergeOnValidate()` called from catch-up (yolo only) |
+| **Advancement** | `advanceToNextStage()` if should advance and no gate | `advanceToNextStage()` after Phase 2 gate (yolo/cruise/auto_advance) |
+
+**Label re-fetch in Path 1:** At `stages.go:55`, `handleStageComplete()` calls `FetchLabels()` to pick up changes made while the stage was running (e.g., `fabrik:yolo` added mid-run). This ensures the advancement decision uses current label state, not the stale snapshot from dispatch time.
+
+**Path 2 is split into two phases:**
+
+| Phase | Gate | What it does |
+|-------|------|--------------|
+| **Phase 1** | Unconditional (all `stage:<X>:complete` non-paused non-cleanup items; also items with `fabrik:awaiting-ci` on `wait_for_ci: true` stages — they have no `stage:<X>:complete` until CI clears) | `checkDependencies()` → `checkReviewGate()` → `buildReviewThreadComments()` / `dispatchReviewReinvoke()` → `checkMergeabilityGate()` → `checkCIGate()` / `dispatchCIFixReinvoke()` (review reinvoke and CI-fix reinvoke are mutually exclusive per poll cycle) |
+| **Phase 2** | `fabrik:yolo` (cfg or label) OR `fabrik:cruise` label OR stage `auto_advance: true` | `attemptMergeOnValidate()` (yolo only) → `findNewComments()` deferral → `advanceToNextStage()` |
+
+Phase 1 ensures inline PR review thread comments (from Copilot, Gemini, or human reviewers) are addressed and CI failures are fixed on **all** issues, not just yolo/cruise ones. Phase 2 keeps stage advancement gated as before. Items that dispatch a reinvoke in Phase 1 (review reinvoke or CI-fix reinvoke) skip Phase 2 on that poll cycle and are re-evaluated on the next poll.
+
+## Appendix B: Guard Evaluation in `itemMayNeedWork()` (Shallow Pre-Filter)
+
+`itemMayNeedWork()` runs on shallow board data (limited labels, no comments) and determines whether an item warrants the expensive `FetchItemDetails()` call.
+
+| Check | Passes If |
+|-------|-----------|
+| Stage exists | `FindStage(stages, item.Status) != nil` |
+| Closed issue | Not closed, OR cleanup stage, OR has `stage:<X>:complete` label |
+| Cleanup stage | Worktree exists on disk (local filesystem check only) |
+| updatedAt cache | `item.UpdatedAt` is newer than cached value, OR (cooldown expired AND `stage:X:complete` absent from shallow labels, OR `stage:X:complete` present but `fabrik:awaiting-review` also present), OR `fabrik:awaiting-ci` label present (CI check-run completions don't bump `updatedAt`), OR `fabrik:rebase-needed` label present (base-branch advances don't bump `updatedAt`). See processedSet cache-key strategy below. |
+| Deep-fetch failure cooldown | No recent `FetchItemDetails` failure, OR failure cooldown expired |
+
+**Note:** `itemMayNeedWork()` intentionally does NOT check lock, editing, pause, or dependency labels — those require the full label set from deep fetch and are checked in `itemNeedsWork()`.
+
+### processedSet Cache-Key Strategy
+
+The `processedSet` map (in-memory, keyed by `issueKey(item, defaultRepo()) + "-" + stage.Name`) provides a cooldown mechanism for items whose `updatedAt` hasn't changed but may need periodic re-evaluation:
+
+**What writes `processedSet[stageKey]`:**
+- `processItem()` sets it when `claudeRan=true` — stage ran (whether completed or not)
+- `processItem()` sets it when `checkDependencies()` returns true — item is blocked
+- `processItem()` sets it when cleanup completes
+- `checkReviewGate()` (catch-up loop) sets it when the review gate blocks — ensures Phase 1/Phase 2 reprompt timers fire via the cooldown retry path even when no `updatedAt` change occurs
+- The deferred cache-write block in `Engine.poll()` (invoked by the `doPollCycle` closure) resets an *existing* entry for non-advanced items after each full poll cycle — a belt-and-suspenders refresh that caps deep-fetch frequency to once per cooldown period even when Part 1's stage-complete check doesn't fire (e.g., if the label is beyond position 15 in the shallow query window); items with no prior `processedSet` entry are not affected
+
+**What bypasses the cooldown gate (returns `true` regardless of cooldown):**
+- `fabrik:awaiting-ci` label: CI check-run completions don't bump `updatedAt`, so forced re-evaluation is necessary
+- `fabrik:rebase-needed` label: base-branch advances don't bump `updatedAt`
+- `stage:X:complete` label is ABSENT and cooldown has expired: retry for genuinely incomplete stages
+
+**What suppresses the cooldown gate (returns `false` despite expired cooldown):**
+- `stage:X:complete` label is PRESENT in shallow labels AND `fabrik:awaiting-review` is absent: completed stages with no pending review need no retry (introduced in #488 to fix perpetual deep-fetch loop). Items with both `stage:X:complete` and `fabrik:awaiting-review` are still retried every cooldown period so Phase 1/Phase 2 timers can fire.
+
+**Root-cause fix (#488):** Terminal items (cruise+Validate complete, paused+complete, closed-with-stage-complete) triggered a perpetual deep-fetch loop: `processedSet[stageKey]` was only written by `processItem()` when work actually ran, so after cooldown expiry, `itemMayNeedWork()` returned `true` on every poll cycle indefinitely — each producing a no-op deep-fetch that did not update `processedSet`. The fix has two parts: (1) primary — check `stage:X:complete` in shallow labels before returning `true` from the cooldown-expired branch, with an exemption for `fabrik:awaiting-review` items (which also carry `stage:X:complete` but need periodic re-evaluation for Phase 1/Phase 2 timers); (2) belt-and-suspenders — the deferred block in `Engine.poll()` now refreshes an existing `processedSet[stageKey]` entry for non-advanced items after each full cycle, capping deep-fetch frequency to once per cooldown period for items where Part 1 doesn't fire.
+
+## Appendix C: Guard Evaluation in `itemNeedsWork()` (Full Filter)
+
+`itemNeedsWork()` runs after `FetchItemDetails()` has populated comments and the full label set.
+
+| Priority | Check | Passes If |
+|----------|-------|-----------|
+| 1 | Stage exists | `FindStage` returns non-nil |
+| 2 | Closed issue | Not closed, OR cleanup stage, OR has `stage:<X>:complete` |
+| 3 | Cleanup stage | Not paused, not complete, worktree exists |
+| 4 | Locked by other | No `fabrik:locked:<other>` label |
+| 5 | Awaiting input | `isAwaitingInput()` true AND new comments exist |
+| 6 | Paused | Not paused, OR paused with new comments |
+| 7 | New comments | Any unprocessed comments → true |
+| 8 | PR item | Not a PR (PRs only support comments, checked after comment check) |
+| 9 | Stage complete | No `stage:<X>:complete` label |
+| 10 | Cooldown | Not attempted, OR cooldown expired |
+
+---
+
+## Appendix D: In-Memory Board Cache Lifecycle
+
+When `--webhooks` and `--board-cache=in-memory` are both active (the default when webhooks are enabled), the engine maintains an in-memory cache of board state in `boardcache.CacheImpl`. This appendix describes the cache lifecycle, delta semantics, reconciliation, and stream-health failover.
+
+### D.1 Bootstrap
+
+Immediately after `wm.Start()` succeeds (webhook manager listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` directly — bypassing the cache — and passes the result to `cacheImpl.Bootstrap(board)`. Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
+
+If the bootstrap fetch fails (e.g., transient network error), the cache starts empty and populates through fallback on the first cache miss. No data is lost; latency for the first deep-fetch is slightly higher.
+
+### D.2 Delta Application
+
+Every verified webhook payload is passed to `cacheImpl.ApplyDelta(eventType, payload []byte)` before the poll loop is woken. `ApplyDelta` is a no-op when `IsPaused()` returns true. Otherwise it dispatches to a typed handler:
+
+| Event type | Handler | Effect |
+|------------|---------|--------|
+| `issue_comment.created` | `applyIssueCommentCreated` | Appends comment to `item.Comments`; idempotent by NodeID |
+| `issues.labeled` | `applyIssuesLabeled` | Adds label to `item.Labels`; set-membership (no duplicates) |
+| `issues.unlabeled` | `applyIssuesUnlabeled` | Removes label from `item.Labels` |
+| `pull_request.opened/closed/synchronize` | `applyPullRequestDelta` | Upserts `linkedPRs[prKey]`; updates `shaToKey[sha]`; rotates old SHA on synchronize |
+| `pull_request_review.submitted` | `applyPullRequestReviewSubmitted` | Upserts review in `linkedPRs[prKey].Reviews` by DatabaseID |
+| `pull_request_review_comment.created` | `applyPullRequestReviewCommentCreated` | Appends to `LinkedPRReviewThreadComments`; idempotent by NodeID |
+| `check_run.completed` | `applyCheckRunCompleted` | Upserts check run in `checkRuns[sha]` by CheckRun.ID |
+| `projects_v2_item.edited` | `applyProjectsV2ItemEdited` | Updates `item.Status` via `itemIDToKey` reverse lookup |
+
+All delta functions hold the write lock for their mutation only. They silently drop events for unknown items (e.g., items not yet on the board) rather than returning errors.
+
+### D.3 Cache Read Semantics
+
+`CacheImpl` implements `boardcache.ReadClient`. When the poll loop calls a read method:
+
+| Method | Cache behavior |
+|--------|----------------|
+| `FetchProjectBoard` | Returns reconstructed board from `items` map; falls back to GitHub when cache is empty |
+| `FetchItemDetails` | Serves deep fields from cache when `deepFetched[key]` is true; falls back to GitHub and populates on miss; logs `[cache] miss for #N — fetching from GitHub` |
+| `FetchCheckRuns` | Serves from `checkRuns[sha]`; falls back and caches on miss |
+| `FetchLinkedPR` | Looks up `linkedPRs[prKey]` via `item.LinkedPRNumber`; falls back on miss |
+| `FetchPRMergeable` | Always delegates to fallback (mergeability changes without webhook events) |
+| `FetchPRMergeableState` | Always delegates to fallback |
+| `FetchLabels` | Serves from `item.Labels` when item is cached; falls back on miss |
+| `FetchStatusField` | Always delegates to fallback (static field metadata) |
+| `RateLimitStats` | Always delegates to fallback |
+
+### D.4 Reconciliation
+
+A `runReconciliationLoop` goroutine tickers at `webhookIdleCap` (60 min). Each tick calls `e.client.FetchProjectBoard(...)` directly and passes the result to `cacheImpl.Reconcile(board)`.
+
+`Reconcile` performs a partial update:
+- For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.
+- Items present in the cache but absent from the new snapshot are removed (they were archived or moved off the board).
+- `itemIDToKey` and `shaToKey` are rebuilt.
+- Logs `[reconciliation] N items differed` at the end.
+
+Reconciliation is also triggered inline on stream recovery (see §D.5).
+
+### D.5 Stream-Health Failover
+
+The `healthChangeFn` callback injected into `webhookManager` is called on health state transitions:
+
+| Transition | Action |
+|------------|--------|
+| Any → `WebhookStreamUnhealthy` (from `checkHealthTransitions`) | `cacheImpl.Pause()` |
+| Any → `WebhookStreamHealthy` (from `handleWebhook` on first recovery event) | `reconcileCache()` inline → `cacheImpl.Resume()` |
+
+When `IsPaused()` is true:
+- `ApplyDelta` is a no-op (deltas are dropped rather than applied to a potentially stale cache).
+- All `CacheImpl` read methods fall through to the `fallback` ReadClient (live GitHub API), so correctness is preserved at the cost of increased GraphQL usage.
+
+On recovery, `reconcileCache()` fetches a fresh board snapshot before `Resume()` so the cache is coherent immediately when `IsPaused()` returns false.
+
+### D.6 Cache Mode Selection
+
+| `--board-cache` | `--webhooks` | Behavior |
+|-----------------|--------------|----------|
+| `in-memory` (default when webhooks on) | required | `CacheImpl` with delta/failover |
+| `none` | any | `GitHubAdapter` pass-through (no caching) |
+
+Specifying `--board-cache=in-memory` without `--webhooks` is a configuration error: without a webhook stream there is no delta source and the cache would only reconcile every 60 minutes, which is worse than direct polling.
+
+---
+
+# Fabrik Stage Lifecycle
+
+Source: https://fabrik.shadoworg.dev/stage-lifecycle
+
+
+This document describes what the Fabrik engine does before, during, and after each stage invocation, including comment processing. It is intended as a reference for writing and refining stage skills.
+
+---
+
+## Pipeline Overview
+
+```
+Backlog → Specify → Research → Plan → Implement → Review → Validate → Done
+```
+
+| Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | MaxTurns |
+|-------|-------|-----------|----------|---------------|-------------|----------|
+| Specify | 0 | Yes | No | No | No | 50 |
+| Research | 1 | Yes | No | No | No | 50 |
+| Plan | 2 | Yes | No | No | No | 50 |
+| Implement | 3 | No | Yes | Yes | Yes | 50 |
+| Review | 4 | No | Yes | No | Yes | 50 |
+| Validate | 5 | No | Yes | No | No | 50 |
+| Done | 99 | N/A | No | No | No | N/A |
+
+---
+
+## Phase 1: Item Qualification (Poll Loop)
+
+### Two-Phase Filtering
+
+1. **Shallow pre-filter** (`itemMayNeedWork`): Uses board data only (no comments). Checks stage exists, `updatedAt` changed, not paused (unless awaiting-input), not locked by another user. Does NOT filter on completion labels — completed items may have new comments.
+
+2. **Deep fetch** (`FetchItemDetails`): Only for items that pass the shallow filter. Fetches comments and linked PR `updatedAt` from GitHub GraphQL (~2 points each).
+
+3. **Full check** (`itemNeedsWork`): With comments loaded. New comments trigger processing even on completed stages. PRs only support comment processing. Awaiting-input items only pass if new comments exist (the resume trigger).
+
+### Rate Limit Cost
+
+Shallow query: ~16 points/poll. Deep fetch: ~2 points per active item. Typical poll: ~20-30 points, well within the 5,000/hour GraphQL limit.
+
+---
+
+## Phase 2: Pre-Stage Setup
+
+### Lock & Label Acquisition
+
+- `fabrik:locked:<user>` — prevents other instances from picking up the issue
+- `stage:<name>:in_progress` — signals active work on the board
+- Both held through cooldown retries (not released until completion or permanent failure)
+
+### Worktree Setup
+
+Each issue gets `.fabrik/worktrees/issue-<N>` on branch `fabrik/issue-<N>`:
+- **First run**: Created from `origin/main`, rebased onto latest
+- **Retry** (`attempted=true`): Returned as-is — no rebase, preserves Claude's context
+- **Rebase conflicts**: Silently aborted (`git rebase --abort`) — Claude works from current base
+
+### Read-Only Stage Stashing
+
+For `read_only: true` stages (Specify, Research, Plan): dirty state is auto-stashed before Claude runs and restored after. Claude sees a clean worktree.
+
+### Context Files
+
+Before each Claude invocation, the engine writes context documents to `.fabrik-context/` in the worktree. These files are excluded from git by two mechanisms: a `.gitignore` file written inside `.fabrik-context/` that excludes all files in the directory, and a pre-rebase step that runs `git rm -rf --cached .fabrik-context/` to remove any accidentally tracked context files before rebasing.
+
+| File | Content |
+|------|---------|
+| `.fabrik-context/issue.md` | The issue body (spec) — always written |
+| `.fabrik-context/stage-Specify.md` | Specify stage comment output |
+| `.fabrik-context/stage-Research.md` | Research stage comment output |
+| `.fabrik-context/stage-Plan.md` | Plan stage comment output |
+| `.fabrik-context/stage-Implement.md` | Implement stage comment output |
+| `.fabrik-context/stage-Review.md` | Review stage comment output |
+| `.fabrik-context/pr-description.md` | Linked PR description (for `post_to_pr` stages) |
+| `.fabrik-context/codebase-changes.md` | Files changed on `origin/<baseBranch>` since the prior stage ran (omitted on first stage or when no changes) |
+
+**Stage invocation**: Writes only stages *prior* to the current stage. Implement sees Specify, Research, Plan but not its own output.
+
+**Comment processing**: Writes prior stages *and* the current stage. Claude needs to see the current stage output to build upon it.
+
+### Session Resume
+
+Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, loaded via `--resume` to restore conversation context.
+
+### Model Override
+
+Labels matching `model:<name>` on the issue override the stage's configured model.
+
+---
+
+## Phase 3: Claude Invocation
+
+### Prompt Construction
+
+When `skill:` is set (recommended), the prompt is a minimal directive:
+
+```
+You are operating as the Fabrik <StageName> agent for issue #<N>.
+Follow the instructions in the <skill-name> skill exactly.
+
+---
+# Issue #N: <title>
+URL: <url>
+
+## Spec / Issue Body
+<full issue body>
+
+## Labels
+<comma-separated>
+
+## Prior Discussion
+<all comments>
+
+## New Comments
+<unprocessed comments only>
+
+---
+Context files are available in .fabrik-context/ in your working directory:
+- .fabrik-context/issue.md — the issue body (spec)
+- .fabrik-context/stage-{Name}.md — output from prior stages
+- .fabrik-context/pr-description.md — the linked PR description (if applicable)
+
+When you have completed all work for this stage, end your response with:
+FABRIK_STAGE_COMPLETE
+
+If you have unresolved questions that must be answered before the stage can proceed:
+FABRIK_BLOCKED_ON_INPUT
+
+These two markers are mutually exclusive.
+```
+
+### Comment Review Prompt
+
+When `comment_skill:` is set, comment processing uses a similar directive:
+
+```
+You are operating as the Fabrik <StageName> comment reviewer for issue #<N>.
+Follow the instructions in the <comment-skill> skill exactly.
+
+---
+# Issue #N: <title>
+URL: <url>
+
+## New Comments to Process
+<each comment with author, timestamp, body>
+
+---
+Context files are available in .fabrik-context/
+...
+```
+
+### Claude Arguments
+
+```
+--plugin-dir <absolute-path-to-.fabrik/plugin>
+--output-format json
+--verbose
+--resume <sessionID>          (if retry)
+--model <override>            (if label or stage config)
+--max-turns <N>               (if configured)
+--allowedTools <tool> ...     (if restricted)
+```
+
+### Output Logging
+
+Raw Claude output saved to `~/.fabrik/logs/issue-<N>/<stage>-output-<timestamp>.json` after every invocation. Viewable through the TUI's `l` key (piped through `fabrik _stream-filter` for human-readable display).
+
+### Turn Progress Emission
+
+During each Claude invocation, the engine counts logical turns in real time via a `turnCountingWriter` wrapping the stdout pipe. Each time a `{"type":"user"}` NDJSON line is detected (one per logical turn — the initial prompt or a tool-result round), the writer increments a per-invocation counter and fires the `claudeTurnProgress` callback (set during engine construction), which emits a `TurnProgressEvent` to the TUI channel. The event carries:
+
+- `IssueNumber` — the issue being processed
+- `TurnsUsed` — the current per-invocation logical-turn count
+- `MaxTurns` — the effective budget for this invocation (accounts for `opts.MaxTurnsOverride` from the extension loop)
+
+This is a purely additive display mechanism — it does not affect Claude's execution, the output buffer, or any engine state. In plain-text mode and tests, `claudeTurnProgress` is nil and no events are emitted.
+
+### Subprocess Cleanup
+
+After `cmd.Run()` returns, two cleanup steps run unconditionally:
+
+1. **Process group kill**: Claude is started in its own process group (`Setpgid: true` on Unix). After `cmd.Run()` returns, `SIGKILL` is sent to the entire process group to clean up grandchild processes (e.g. `tail -f` from the Monitor tool, polling loops spawned via `run_in_background: true`). This is scoped to the specific Claude invocation and does not affect worktree file state — grandchild monitoring processes have no side effects on the filesystem.
+
+2. **WaitDelay bound**: `cmd.WaitDelay` is set to 30s (configurable via `--claude-wait-delay` / `FABRIK_CLAUDE_WAIT_DELAY`). When grandchild processes hold the stdout pipe open after Claude exits, Go's `cmd.Wait()` would otherwise block indefinitely. With `WaitDelay`, Go forcibly closes its end of the pipe after the deadline and returns `exec.ErrWaitDelay`. The engine detects this error, logs a diagnostic warning, clears the error, and processes the buffered output normally — including any `FABRIK_STAGE_COMPLETE` marker. This prevents the worker goroutine from being permanently stuck when Claude uses `run_in_background` or the Monitor tool.
+
+### Progress Baseline Snapshot
+
+Immediately before the first invocation, `snapshotBaseline` captures observable progress state for this stage:
+
+| Stage | Baseline fields captured |
+|-------|--------------------------|
+| **Implement** | `gitHeadSHA` — `git rev-parse HEAD` in the worktree |
+| **Review** | `gitHeadSHA` + `resolvedThreadCount` — `LinkedPRResolvedThreadCount` from the poll cycle's `FetchItemDetails` |
+| **Validate** | `commentCount` — `len(item.Comments)` from the poll cycle's `FetchItemDetails` |
+| **All others** | (empty — no extension possible) |
+
+The baseline is purely in-memory; it is lost on engine restart (an acceptable risk per ADR 030).
+
+### Turn-Limit Extension Loop
+
+The `e.claude.Invoke()` call runs inside an extension loop. On each iteration:
+
+1. `opts.MaxTurnsOverride` is set to `currentBudget` (first iteration: `stage.MaxTurns`, or `2 × stage.MaxTurns` if `fabrik:extend-turns` is present).
+2. Claude is invoked. Output is appended to `totalOutput`; usage is accumulated into `totalUsage`.
+3. Turn-limit check: `!completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget`.
+4. If turn limit was NOT hit (or stage completed), exit the loop.
+5. If `totalMultiple >= 3` (hard cap), exit the loop (fail as turn-limit).
+6. Call `detectProgress`. If progress → `totalMultiple++`, set `currentBudget = stage.MaxTurns`, set `resume = true`, log `[#N extend-turns]`, loop.
+7. If no progress or progress check fails → exit the loop (fail as turn-limit).
+
+**`detectProgress` per stage:**
+- **Implement**: `git rev-parse HEAD` in worktree; progress if SHA changed.
+- **Review**: `git rev-parse HEAD`; if SHA same → `FetchItemDetails` re-fetch; progress if `LinkedPRResolvedThreadCount` increased. One GraphQL call only when no new commits.
+- **Validate**: `FetchItemDetails` re-fetch; progress if `len(Comments)` increased. One GraphQL call per check.
+- **All others**: return `false` immediately.
+
+**Output accumulation:** Each `--resume` invocation produces only the delta output for that session continuation. The engine concatenates all invocations' output before posting. The empty-output check (`strings.TrimSpace(output) == ""`) applies to the accumulated total.
+
+**Deferred WIP commit and push:** The `commitWIP` and `PushBranch` calls happen AFTER the extension loop completes, not between invocations. This preserves worktree state across extensions.
+
+**Stats footer:** After the loop, `usage.MaxTurns` is set to `totalMultiple × stage.MaxTurns`, so the stats line reflects the total budget (e.g., `used 130/150 turns`).
+
+---
+
+## Phase 4: Post-Stage Handling
+
+### Output Parsing
+
+Three JSON formats supported (tried in order):
+1. Single result object: `{"result": "...", "session_id": "..."}`
+2. JSON array: `[{"type":"system",...}, ..., {"type":"result","result":"..."}]`
+3. NDJSON (stream-json): One JSON object per line
+
+Empty result with valid session ID is accepted (max turns hit — Claude was mid-tool-use).
+
+If parsing fails: error message posted instead of raw output. Full output in log files.
+
+### Issue Body Update
+
+Before posting output, checks for `FABRIK_ISSUE_UPDATE_BEGIN`/`END` markers:
+- When present, the issue body is updated unconditionally
+- By convention, only the Specify stage produces these markers
+- Markers are always stripped from output before posting
+
+### Marker Stripping
+
+All Fabrik markers are stripped from output before posting:
+- `FABRIK_STAGE_COMPLETE`
+- `FABRIK_BLOCKED_ON_INPUT`
+- `FABRIK_SUMMARY_BEGIN` / `FABRIK_SUMMARY_END`
+- `FABRIK_ISSUE_UPDATE_BEGIN` / `FABRIK_ISSUE_UPDATE_END`
+
+### Output Posting
+
+**If `post_to_pr: true`** (Implement, Review, Validate):
+- Detailed output posted on the linked PR
+- Brief summary (from `FABRIK_SUMMARY` markers) posted on the issue
+- Falls back to issue if no PR found
+
+**Otherwise** (Specify, Research, Plan):
+- Full output posted directly on the issue as a stage comment
+
+### Comments Marked as Seen
+
+After a stage runs, any pre-existing user comments get a rocket reaction via `markCommentsSeenByStage`. They were included in the prompt as context and should not trigger the awaiting-input unblock logic on subsequent polls.
+
+### Completion Path
+
+When `FABRIK_STAGE_COMPLETE` is detected (regardless of Claude's exit code — as of v0.0.26, a non-zero exit is treated as a warning, not a failure, when the marker is present):
+1. Lock released (`fabrik:locked:<user>` and `stage:<name>:in_progress` removed)
+2. Retry tracking cleared
+3. `fabrik:extend-turns` removed (if present); `ErrNotFound` treated as success (user already removed it)
+4. Draft PR created (if `create_draft_pr: true`)
+5. PR marked ready (if `mark_pr_ready_on_complete: true`)
+6. `stage:<name>:complete` label added
+7. Auto-advance to next stage (if `auto_advance: true` or global `yolo`)
+
+### Blocked-on-Input Path
+
+When `FABRIK_BLOCKED_ON_INPUT` is detected (and Claude ran without error):
+1. `fabrik:paused` + `fabrik:awaiting-input` labels added
+2. Lock released
+3. Retry count NOT incremented, no `stage:<name>:failed` label
+4. Issue waits until user comments (auto-detected, see Comment Processing)
+
+### Incomplete Path (No Marker)
+
+1. WIP commit (unless read-only): `git add -A && git commit -m "WIP: ..."`
+2. Branch pushed
+3. Cooldown timer: `pollSeconds * 10` seconds
+4. Lock held through cooldown
+5. Retry count incremented; after `max_retries`: `fabrik:paused` + `stage:<name>:failed`, lock released
+
+### Branch Pushing
+
+Always pushed after Claude runs (success or failure): `git push --force-with-lease -u origin fabrik/issue-<N>`
+
+---
+
+## Phase 5: Comment Processing
+
+Comment processing is triggered when new comments from the configured user are found. It runs independently of stage processing — even completed stages can process new comments.
+
+### Comment Detection
+
+A comment is "new" if it:
+- Is authored by the configured user
+- Is not in the in-memory processed set
+- Doesn't start with `🏭 **Fabrik` (skip Fabrik's own output)
+- Doesn't have a ROCKET reaction (durable "processed" marker)
+
+### Comment Processing Flow
+
+1. **Eyes reaction** added to all new comments
+2. **`fabrik:editing` label** added
+3. **Worktree prepared** (fresh rebase, not a retry)
+4. **Context files written** (prior stages + current stage)
+5. **Claude invoked** with `comment_skill` (or default comment prompt)
+   - Always resumes existing session
+6. **Output processed**:
+   - `FABRIK_ISSUE_UPDATE` markers: applied unconditionally when present, then stripped
+   - All Fabrik markers stripped
+   - Stage comment rewritten (or created) via `findStageComment` + `UpdateComment`
+   - Exception: `post_to_pr` stages post a new "(comment review)" comment on the issue
+7. **`fabrik:editing` label** removed
+8. **Rocket reaction** added to processed comments
+9. **Completion check**: If `FABRIK_STAGE_COMPLETE` was in the output, `handleStageComplete` fires — the stage completes directly from comment processing without needing an extra stage invocation
+
+### Awaiting-Input Auto-Resume
+
+When a user comments on an issue with `fabrik:paused` + `fabrik:awaiting-input`:
+1. `itemMayNeedWork` lets it through (special exception for awaiting-input)
+2. `itemNeedsWork` checks `findNewComments` — returns true only if new comments exist
+3. `processItem` calls `unblockAwaitingInput` → removes both labels, clears cooldown
+4. Routes to `processComments` with the new comments
+5. Comment processing can signal `FABRIK_STAGE_COMPLETE` to complete the stage immediately
+
+### Stage Comment Rewriting
+
+For non-`post_to_pr` stages, comment processing rewrites the existing stage comment:
+- `findStageComment` scans for the most recent comment matching `🏭 **Fabrik — stage: {Name}**`
+- If found: `UpdateComment` replaces its body
+- If not found: `AddComment` creates a new stage comment
+
+For `post_to_pr` stages, comment processing posts a new "(comment review)" comment on the issue (not the PR).
+
+### Key Differences: Stage Run vs Comment Processing
+
+| Aspect | Stage Run | Comment Processing |
+|--------|-----------|-------------------|
+| Session | Fresh or resume on retry | Always resume |
+| Worktree update | Skip on retry | Always rebase |
+| Completion | Checked, honored | Checked, honored |
+| Blocked-on-input | Checked, honored | Not checked |
+| Issue body update | When markers present | When markers present |
+| Output destination | Stage comment or PR | Rewrite stage comment or new issue comment |
+| Lock | `fabrik:locked:<user>` | `fabrik:editing` |
+| Reaction flow | Comments marked seen (rocket) | Eyes → editing → rocket |
+
+---
+
+## Phase 6: Cleanup Stage (Done)
+
+The Done stage (`cleanup_worktree: true`) is terminal:
+- No Claude invocation, no lock, no labels
+- Skipped entirely if no worktree exists for the issue — no worktree means there's nothing to clean up
+- Removes worktree directory when it exists
+- Adds `stage:Done:complete` label
+- Respects `fabrik:paused` (skips if paused)
+
+---
+
+## Markers Reference
+
+| Marker | Direction | Purpose | Where Checked |
+|--------|-----------|---------|---------------|
+| `FABRIK_STAGE_COMPLETE` | Claude -> Engine | Stage finished successfully; honored even on non-zero Claude exit (v0.0.26+) — engine logs a warning | Stage runs AND comment processing |
+| `FABRIK_BLOCKED_ON_INPUT` | Claude -> Engine | Stage needs user input | Stage runs only |
+| `FABRIK_ISSUE_UPDATE_BEGIN/END` | Claude -> Engine | Updated issue body | Stage runs AND comment processing |
+| `FABRIK_SUMMARY_BEGIN/END` | Claude -> Engine | Brief summary for issue | Stage runs with `post_to_pr: true` |
+
+## Labels Reference
+
+| Label | Set by | Purpose |
+|-------|--------|---------|
+| `fabrik:locked:<user>` | Engine | Lock during stage processing |
+| `fabrik:editing` | Engine | Lock during comment processing |
+| `fabrik:paused` | Engine or User | Pause processing |
+| `fabrik:awaiting-input` | Engine | Paused waiting for user comment (auto-resumes) |
+| `stage:<name>:in_progress` | Engine | Stage actively running |
+| `stage:<name>:complete` | Engine | Stage completed successfully |
+| `stage:<name>:failed` | Engine | Stage hit max retries |
+| `model:<name>` | User | Override Claude model |
+
+## Stage YAML Options
+
+```yaml
+name: Research              # Required: matches board column name
+order: 2                    # Required: processing priority (lower = earlier)
+skill: fabrik-research      # Plugin skill name (recommended)
+comment_skill: fabrik-research-comment  # Plugin skill for comment processing
+prompt: |                   # Inline prompt (legacy, used when skill not set)
+  ...
+comment_prompt: |           # Inline comment prompt (legacy)
+  ...
+model: sonnet               # Optional: Claude model
+max_turns: 50               # Optional: turn limit per invocation
+comment_max_turns: 15       # Optional: max turns for comment review (default: min(max_turns, 15))
+allowed_tools:              # Optional: restrict Claude's tools
+  - Read
+  - Grep
+read_only: false            # Stash/restore worktree (for analysis stages)
+post_to_pr: false           # Route output to linked PR
+create_draft_pr: false      # Create draft PR on completion
+mark_pr_ready_on_complete: false  # Mark PR ready on completion
+auto_advance: null          # Override global yolo (true/false/null)
+cleanup_worktree: false     # Terminal stage — remove worktree
+completion:
+  type: claude              # Only supported type
+```
+
+Either `skill` or `prompt` is required (unless `cleanup_worktree` is true). When `skill` is set, the engine sends a directive prompt and the skill is loaded via `--plugin-dir`.
+
+---
+
+# Fabrik Positioning Notes
+
+Source: https://fabrik.shadoworg.dev/positioning
+
+
+> Working notes for future marketing use. Not finished copy. Landscape snapshot as of 2026-04.
+
+## Landscape
+
+### Proprietary / commercial kanban UIs for Claude Code
+
+- **Vibe Kanban** (BloopAI, github.com/BloopAI/vibe-kanban) — most polished; kanban issues drive agent workspaces, each with a branch + terminal + dev server; auto-updates issue status on PR open/merge; supports 10+ agents.
+- **Kanban Code** (langwatch, github.com/langwatch/kanban-code) — cards auto-move (In Progress → Waiting → In Review); GitHub issue backlog integration; session forking/checkpointing; remote SSH offload.
+- **Claude Code Board** (github.com/cablate/Claude-Code-Board) — multi-session management UI with workflow stages and agent selection.
+
+### Open source Claude Code + kanban
+
+- **NikiforovAll/claude-code-kanban** — hook-based observer; reflects Claude's internal task state onto a board (Pending → In Progress → Completed); npx install.
+- **cruzyjapan/Claude-Code-Kanban-Automator** — React/Node/SQLite; tasks on board trigger Claude Code execution.
+- **alessiocol/claude-kanban** — `ACTIVE.md` as shared kanban state across multiple agent sessions; addresses context amnesia between sessions; WIP limits per agent.
+- **The Claude Protocol** (github.com/AvivK5498/The-Claude-Protocol) — 13 Claude Code hooks enforce workflow; integrates with Beads (git-native tickets) as kanban; immutable closed issues; git worktree per task.
+
+### Platform-level
+
+- **Linear AI Agents** — first-class agent delegation from issues; Copilot integration opens draft PRs from Linear issues.
+- **GitHub Agentic Workflows** (technical preview, Feb 2026) — Markdown-described workflows run Claude Code/Copilot/Codex in GitHub Actions; triggered by issue events, schedules, or comment commands; MIT licensed.
+
+### Patterns observed
+
+- Most tools build their own proprietary kanban rather than integrating with GitHub Projects.
+- Split between *observer* tools (watch Claude, reflect state) vs *driver* tools (kanban is source of truth that triggers agent work).
+- Multi-agent coordination (alessiocol, The Claude Protocol) is a distinct and less crowded sub-pattern.
+- GitHub Agentic Workflows is the primary path toward using native GitHub Projects as the driver.
+
+## Where Fabrik sits uniquely
+
+1. **GitHub Projects *is* the kanban.** Unlike Vibe Kanban, Kanban Code, Claude Code Board, and the cruzyjapan/alessiocol/NikiforovAll cluster, Fabrik ships no UI. The board you already use in GitHub Projects is the driver. Same philosophical bucket as GitHub Agentic Workflows and Linear Agents, but without requiring GitHub Actions or a proprietary platform.
+
+2. **Driver, not observer.** The poll loop reads board columns and dispatches Claude Code per issue. NikiforovAll's observer model is the opposite direction.
+
+3. **YAML-configurable SDLC pipeline.** Research → Plan → Implement → Review → Validate are not hardcoded. Each stage has its own prompt, skill, model, tool allowlist, `max_turns`, and lifecycle flags (`post_to_pr`, `create_draft_pr`, `read_only`, `cleanup_worktree`, `wait_for_reviews`). Vibe Kanban and Kanban Code have fixed workflows; The Claude Protocol hardcodes 13 hooks. Closer to GitHub Agentic Workflows' markdown-described workflows, but typed and validated against the board on startup.
+
+4. **Durable state via GitHub-native primitives.** Comment reactions (👀/🚀) survive restarts; labels (`stage:*:complete`, `fabrik:paused`, `fabrik:awaiting-review`, `model:*`, `effort:*`, `fabrik:yolo`, `fabrik:cruise`) encode control flow. No SQLite, no `ACTIVE.md`, no proprietary store. Everything inspectable by a human on github.com.
+
+5. **Comment-driven revision loop.** Users comment on issues/PRs to steer a stage; each stage can define a separate `comment_prompt` / `comment_skill` / `comment_max_turns`. No project in the landscape above cleanly distinguishes initial-run prompts from comment-response prompts — most treat the whole agent session as one-shot per card.
+
+6. **Worktree-per-issue with preservation semantics.** Bare repo + per-issue worktree on `fabrik/issue-N`, `.fabrik-context/` files injected before each stage (issue body, prior stage outputs, PR description, codebase diff since last stage ran). The Claude Protocol also uses worktrees but couples them to Beads tickets; Vibe Kanban uses branches + terminals without the context-file discipline.
+
+## Where Fabrik is not differentiated
+
+- Git worktree per task — shared with Vibe Kanban and The Claude Protocol.
+- Draft PR → mark-ready lifecycle — shared with most driver tools.
+- Multi-agent support — Fabrik is Claude Code only; Vibe Kanban supports 10+ agents. Conscious scope choice, but worth naming when comparing.
+
+## Candidate positioning lines
+
+- *GitHub Agentic Workflows without GitHub Actions — your existing Project board becomes an SDLC pipeline, with YAML-configurable stages and per-stage Claude Code skills, state encoded entirely in issues, labels, and reactions.*
+- *Closest competitor by philosophy: GitHub Agentic Workflows (platform-native, Projects-compatible). Closest by feature set: The Claude Protocol (hooks + worktrees + tickets). Fabrik's niche is the intersection — platform-native and feature-rich, without requiring GHA or a separate ticket system like Beads.*
+
+---
+

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3680,7 +3680,7 @@ Either `skill` or `prompt` is required (unless `cleanup_worktree` is true). When
 
 ---
 
-# Fabrik Positioning Notes
+# Fabrik Positioning
 
 Source: https://fabrik.shadoworg.dev/positioning
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,22 @@
+# Fabrik
+
+> Fabrik is a Go CLI that orchestrates Claude Code through an SDLC pipeline
+> defined on a GitHub Project board. Issues are the unit of work; the pipeline
+> stages (Research → Plan → Implement → Review → Validate) are configured via
+> YAML files and driven by the Fabrik engine against your GitHub Project board.
+
+## User Guide
+
+- [User Guide](https://fabrik.shadoworg.dev/USER_GUIDE): Installation, configuration, pipeline walkthrough, and operational reference for running Fabrik.
+
+## State Machine
+
+- [Issue State Machine](https://fabrik.shadoworg.dev/state-machine): As-built specification of engine state transitions, label semantics, FABRIK_* marker handling, and guard/filter behavior.
+
+## Stage Lifecycle
+
+- [Stage Lifecycle](https://fabrik.shadoworg.dev/stage-lifecycle): Per-invocation lifecycle — context files, worktree setup, Claude invocation, progress baseline, extension loop, and output handling.
+
+## Positioning
+
+- [Fabrik Positioning](https://fabrik.shadoworg.dev/positioning): Landscape overview comparing Fabrik to similar agentic development tools.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,3 +1,8 @@
+---
+layout: docs
+title: Fabrik Positioning
+---
+
 # Fabrik Positioning Notes
 
 > Working notes for future marketing use. Not finished copy. Landscape snapshot as of 2026-04.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -3,7 +3,7 @@ layout: docs
 title: Fabrik Positioning
 ---
 
-# Fabrik Positioning Notes
+# Fabrik Positioning
 
 > Working notes for future marketing use. Not finished copy. Landscape snapshot as of 2026-04.
 

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -18,11 +18,14 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DOCS_DIR="${REPO_ROOT}/docs"
 OUT="${DOCS_DIR}/llms-full.txt"
 
-# Strip YAML front matter (---...---) from a file; pass through unchanged if none.
+TMPFILE="$(mktemp)"
+trap 'rm -f "${TMPFILE}"' EXIT
+
+# Strip YAML front matter (---...---) from a file into TMPFILE; pass through unchanged if none.
 # The done flag prevents --- horizontal rules in the body (e.g., USER_GUIDE.md) from
 # being misidentified as the front matter closing delimiter.
-strip_front_matter() {
-  awk 'BEGIN{fm=0; done=0} /^---$/ && !done { fm++; if(fm==2){done=1}; next } done || fm==0 {print}' "$1"
+strip_front_matter_to_tmp() {
+  awk 'BEGIN{fm=0; done=0} /^---$/ && !done { fm++; if(fm==2){done=1}; next } done || fm==0 {print}' "$1" > "${TMPFILE}"
 }
 
 # Pages in fixed order — do not reorder; CI drift checks require bitwise-identical output.
@@ -40,19 +43,21 @@ for entry in "${ORDERED[@]}"; do
   file="${DOCS_DIR}/${entry%%:*}"
   url="${entry#*:}"
 
-  # Extract the first H1 heading from the file body (after stripping front matter).
-  title=$(strip_front_matter "$file" | awk '/^# /{sub(/^# /, ""); print; exit}')
+  strip_front_matter_to_tmp "$file"
+
+  # Extract the first H1 heading from the body (reads from file, no SIGPIPE risk).
+  title=$(awk '/^# /{sub(/^# /, ""); print; exit}' "${TMPFILE}")
 
   printf '# %s\n\nSource: %s\n\n' "$title" "$url" >> "$OUT"
 
   # Output body content, skipping leading blank lines and the first H1 heading
-  # so the H1 appears exactly once (in the Source header above).
-  strip_front_matter "$file" | awk '
+  # so the H1 appears exactly once (in the section header above).
+  awk '
     BEGIN { skipping=1 }
     skipping && /^[[:space:]]*$/ { next }
     skipping && /^# /            { skipping=0; next }
     { skipping=0; print }
-  ' >> "$OUT"
+  ' "${TMPFILE}" >> "$OUT"
 
   printf '\n---\n\n' >> "$OUT"
 done

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# generate-llms-full.sh — Generate docs/llms-full.txt from canonical Fabrik doc pages.
+#
+# Usage: scripts/generate-llms-full.sh
+#   Run from the repo root or any directory — uses paths relative to this script.
+#
+# Output: docs/llms-full.txt — committed concatenated bundle checked by CI
+#
+# Workflow:
+#   1. Run this script after modifying any canonical doc page listed in ORDERED below
+#   2. Commit docs/llms-full.txt alongside your doc changes
+#   3. CI (docs-drift.yml) verifies the committed file matches what this script produces
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCS_DIR="${REPO_ROOT}/docs"
+OUT="${DOCS_DIR}/llms-full.txt"
+
+# Strip YAML front matter (---...---) from a file; pass through unchanged if none.
+# The done flag prevents --- horizontal rules in the body (e.g., USER_GUIDE.md) from
+# being misidentified as the front matter closing delimiter.
+strip_front_matter() {
+  awk 'BEGIN{fm=0; done=0} /^---$/ && !done { fm++; if(fm==2){done=1}; next } done || fm==0 {print}' "$1"
+}
+
+# Pages in fixed order — do not reorder; CI drift checks require bitwise-identical output.
+# Format: "filename:canonical-url"
+ORDERED=(
+  "USER_GUIDE.md:https://fabrik.shadoworg.dev/USER_GUIDE"
+  "state-machine.md:https://fabrik.shadoworg.dev/state-machine"
+  "stage-lifecycle.md:https://fabrik.shadoworg.dev/stage-lifecycle"
+  "positioning.md:https://fabrik.shadoworg.dev/positioning"
+)
+
+> "$OUT"
+
+for entry in "${ORDERED[@]}"; do
+  file="${DOCS_DIR}/${entry%%:*}"
+  url="${entry#*:}"
+
+  # Extract the first H1 heading from the file body (after stripping front matter).
+  title=$(strip_front_matter "$file" | awk '/^# /{sub(/^# /, ""); print; exit}')
+
+  printf '# %s\n\nSource: %s\n\n' "$title" "$url" >> "$OUT"
+
+  # Output body content, skipping leading blank lines and the first H1 heading
+  # so the H1 appears exactly once (in the Source header above).
+  strip_front_matter "$file" | awk '
+    BEGIN { skipping=1 }
+    skipping && /^[[:space:]]*$/ { next }
+    skipping && /^# /            { skipping=0; next }
+    { skipping=0; print }
+  ' >> "$OUT"
+
+  printf '\n---\n\n' >> "$OUT"
+done

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -47,6 +47,10 @@ for entry in "${ORDERED[@]}"; do
 
   # Extract the first H1 heading from the body (reads from file, no SIGPIPE risk).
   title=$(awk '/^# /{sub(/^# /, ""); print; exit}' "${TMPFILE}")
+  if [[ -z "$title" ]]; then
+    echo "error: no H1 heading found in ${file}" >&2
+    exit 1
+  fi
 
   printf '# %s\n\nSource: %s\n\n' "$title" "$url" >> "$OUT"
 


### PR DESCRIPTION
## Summary

Add two static files served from the Fabrik docs site root:

1. `/llms.txt` — A curated, structured index following the [llmstxt.org spec](https://llmstxt.org/), listing the canonical doc pages with one-line summaries.
2. `/llms-full.txt` — A single concatenated markdown bundle of the canonical doc pages, with each page preceded by an H1 and source URL.

`llms-full.txt` is generated by a script (not hand-maintained) and a CI check fails on any PR that modifies canonical docs without regenerating it.

## Problem

LLM tooling (Context7, Cursor, future Claude Code versions, and users pasting URLs into any agent) increasingly looks for `/llms.txt` as the canonical machine-readable index of a docs site. Without it, the only way to get Fabrik context into another LLM session is by pasting links one at a time, which loses the structure and is brittle.

The forthcoming Fabrik PM Claude Code plugin will need a reliable way to pull authoritative Fabrik docs into context efficiently. Publishing `llms.txt` and `llms-full.txt` at the docs site root enables this for all LLM consumers.

## Approach

### Approach

All design decisions were resolved in Research. The implementation is purely additive: no Go code changes, no engine changes, no `_config.yml` changes. The work breaks into five discrete deliverables applied in dependency order:

1. Add YAML front matter to `docs/positioning.md` so Jekyll serves it at `/positioning` (required before the generator script can treat all four source files uniformly).
2. Create `scripts/generate-llms-full.sh` — a deterministic shell script that strips front matter via `awk` and concatenates the four source pages in fixed order with H1 headings and `Source:` lines.
3. Create `docs/llms.txt` — hand-maintained llmstxt.org index with title, one-paragraph description, and one `##` section per canonical page.
4. Run the generator to produce `docs/llms-full.txt` and commit the output (the committed artifact CI will diff against).
5. Create `.github/workflows/docs-drift.yml` — a CI drift check that reruns the generator and fails on any diff between generated output and committed `llms-full.txt`.

Neither `llms.txt` nor `llms-full.txt` gets YAML front matter — they are static assets Jekyll serves verbatim as `text/plain`.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/positioning.md` | Prepend 3-line YAML front matter (`layout: docs`, `title: Fabrik Positioning`) |
| `scripts/generate-llms-full.sh` | Create — deterministic generator; `chmod +x` |
| `docs/llms.txt` | Create — hand-maintained llmstxt.org index |
| `docs/llms-full.txt` | Create — generated bundle (produced by running the script) |
| `.github/workflows/docs-drift.yml` | Create — CI drift check on `docs/**` and script PRs |

### Key Decisions

- **No front matter on `.txt` files**: Jekyll treats files without YAML front matter as static assets and serves them unchanged at their literal path with `text/plain`. Adding front matter would cause Jekyll to apply a layout, breaking the plain-text requirement. Confirmed by Research.
- **Shell script, not Makefile**: The project has no Makefile; a script in `scripts/` follows the convention established by `scripts/draft-release-notes.sh`.
- **Fixed page order for idempotency**: USER_GUIDE → state-machine → stage-lifecycle → positioning. This order is hardcoded in the script; CI drift checks depend on bitwise-identical output across runs.
- **`awk` front matter stripping**: The `done`-flag pattern stops consuming at the second `---` delimiter, correctly handling `USER_GUIDE.md`'s `---` horizontal rule dividers in the body. Pattern provided by Research.
- **CI trigger paths**: `docs/**` and `scripts/generate-llms-full.sh`. Changes to the generator script itself must also pass drift-check.
- **No ADR needed**: This is purely additive infrastructure — static files and a shell script with no architectural decisions constraining future contributors.

### Task Checklist

- [ ] Task 1: Add YAML front matter to `docs/positioning.md` — prepend `---\nlayout: docs\ntitle: Fabrik Positioning\n---` before the existing `# Fabrik Positioning Notes` line; commit
- [ ] Task 2: Create `scripts/generate-llms-full.sh` — `#!/usr/bin/env bash`, `set -euo pipefail`, header comment block (Usage/Output/Workflow), four source files in fixed order (USER_GUIDE → state-machine → stage-lifecycle → positioning), `awk` front matter stripping, H1 and `Source:` prefix per page, output to `docs/llms-full.txt`; `chmod +x`; commit
- [ ] Task 3: Create `docs/llms.txt` — no front matter; llmstxt.org format: `# Fabrik` H1, blockquote one-paragraph description, four `##` sections (User Guide, State Machine, Stage Lifecycle, Positioning), one bullet per section linking to canonical URL with one-line summary; commit
- [ ] Task 4: Run `scripts/generate-llms-full.sh` from repo root to produce `docs/llms-full.txt`; verify it contains all four pages in order with correct H1 and `Source:` lines and no front matter artifacts; commit
- [ ] Task 5: Create `.github/workflows/docs-drift.yml` — trigger `on: pull_request: paths: ['docs/**', 'scripts/generate-llms-full.sh']`; single job on `ubuntu-latest`: checkout with `actions/checkout@v4`, run `scripts/generate-llms-full.sh`, fail on `git diff --exit-code docs/llms-full.txt` with a clear error message instructing contributors to regenerate; commit

### `llms.txt` Content Spec (for Implement)

```
# Fabrik

> Fabrik is a Go CLI that orchestrates Claude Code through an SDLC pipeline 
> defined on a GitHub Project board. Issues are the unit of work; the pipeline 
> stages (Research → Plan → Implement → Review → Validate) are configured via 
> YAML files and driven by the Fabrik engine against your GitHub Project board.
```

## Verification

Added `/llms.txt` and `/llms-full.txt` to the Fabrik docs site. `positioning.md` received Jekyll front matter so it's served at `/positioning`. A deterministic generator script (`scripts/generate-llms-full.sh`) strips front matter and concatenates the four canonical doc pages in fixed order; the generated `docs/llms-full.txt` is committed and verified by a new `docs-drift.yml` CI workflow that fails if the file is out of sync with the sources.

---

Closes #476
