### PR TITLE
boardcache: Reconcile preserves stale LinkedPRNumber after issue/PR linkage materializes post-bootstrap

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -137,6 +137,8 @@ func (c *CacheImpl) Bootstrap(board *gh.ProjectBoard) {
 // Reconcile replaces shallow board state from a fresh board fetch.
 // Preserves deep fields (Comments, LinkedPRReviews, etc.) for items that have
 // already been deep-fetched. Logs the drift count when items differ.
+// Shallow drift in linkage (LinkedPRNumber) invalidates deep cache for the
+// affected key, forcing a fresh FetchItemDetails on next access.
 func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -167,6 +169,15 @@ func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
 			// Update the ItemID reverse lookup.
 			if item.ItemID != "" {
 				c.itemIDToKey[item.ItemID] = key
+			}
+			// Detect linkage drift: if deep cache says LinkedPRNumber=X but the
+			// fresh shallow board shows a different value, the cached deep state was
+			// captured before the issue↔PR linkage appeared (or changed) on GitHub.
+			// Invalidate deepFetched so the next FetchItemDetails re-fetches from GitHub.
+			if c.deepFetched[key] && existing.LinkedPRNumber != item.LinkedPRNumberShallow {
+				delete(c.deepFetched, key)
+				c.logFn("[cache] linkage drift detected for issue #%d: stale linked PR=%d, fresh=%d — invalidating deep cache\n",
+					item.Number, existing.LinkedPRNumber, item.LinkedPRNumberShallow)
 			}
 		} else {
 			drifted++

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -726,6 +726,58 @@ func TestReconcilePreservesDeepFields(t *testing.T) {
 	}
 }
 
+func TestReconcileLinkageDriftInvalidatesDeepCache(t *testing.T) {
+	mc := &mockClient{
+		itemDetailsResult: &gh.ProjectItem{
+			LinkedPRNumber: 502,
+		},
+	}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research",
+				LinkedPRNumber: 0, LinkedPRNumberShallow: 0},
+		},
+	})
+
+	// Mark as deep-fetched with LinkedPRNumber=0 (linkage not yet visible on GitHub).
+	c.mu.Lock()
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+
+	// Board now shows LinkedPRNumberShallow=502 — linkage has materialized.
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research",
+				LinkedPRNumberShallow: 502},
+		},
+	})
+
+	// deepFetched must be invalidated so next FetchItemDetails hits GitHub.
+	c.mu.RLock()
+	df := c.deepFetched[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+	if df {
+		t.Error("expected deepFetched to be invalidated when linkage drift is detected")
+	}
+
+	// Next FetchItemDetails call must fall through to the mock (cache miss).
+	beforeCount := mc.fetchItemDetailsCount
+	item := &gh.ProjectItem{Number: 1, Repo: "owner/repo", ID: "I_001"}
+	if err := c.FetchItemDetails(item); err != nil {
+		t.Fatalf("FetchItemDetails returned error: %v", err)
+	}
+	if mc.fetchItemDetailsCount <= beforeCount {
+		t.Error("expected FetchItemDetails to call fallback after deepFetched was invalidated")
+	}
+	// The mock should have populated LinkedPRNumber=502 into item.
+	if item.LinkedPRNumber != 502 {
+		t.Errorf("expected LinkedPRNumber=502 after re-fetch, got %d", item.LinkedPRNumber)
+	}
+}
+
 func TestReconcileRemovesStaleItems(t *testing.T) {
 	c := seedCache(t) // has items #1 and #2
 

--- a/github/fetch_board_test.go
+++ b/github/fetch_board_test.go
@@ -621,3 +621,80 @@ func TestFetchProjectBoard_AcceptsGenuinelyEmpty(t *testing.T) {
 		t.Errorf("expected empty board, got %d items", len(board.Items))
 	}
 }
+
+// TestFetchProjectBoard_LinkedPRNumberShallow_Populated verifies that
+// LinkedPRNumberShallow is set from the first closedByPullRequestsReferences node.
+func TestFetchProjectBoard_LinkedPRNumberShallow_Populated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := boardResponseWith([]interface{}{
+			map[string]interface{}{
+				"id":               "PVTI_001",
+				"fieldValueByName": nil,
+				"content": map[string]interface{}{
+					"id":     "I_1",
+					"number": 1,
+					"title":  "Issue with linked PR",
+					"labels": map[string]interface{}{"nodes": []interface{}{}},
+					"closedByPullRequestsReferences": map[string]interface{}{
+						"nodes": []interface{}{
+							map[string]interface{}{
+								"updatedAt": "2026-01-01T00:00:00Z",
+								"number":    502,
+							},
+						},
+					},
+				},
+			},
+		})
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	board, err := c.FetchProjectBoard("owner", "repo", 1, "user")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(board.Items))
+	}
+	if board.Items[0].LinkedPRNumberShallow != 502 {
+		t.Errorf("LinkedPRNumberShallow = %d, want 502", board.Items[0].LinkedPRNumberShallow)
+	}
+}
+
+// TestFetchProjectBoard_LinkedPRNumberShallow_Empty verifies that
+// LinkedPRNumberShallow stays 0 when closedByPullRequestsReferences is absent or empty.
+func TestFetchProjectBoard_LinkedPRNumberShallow_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := boardResponseWith([]interface{}{
+			map[string]interface{}{
+				"id":               "PVTI_001",
+				"fieldValueByName": nil,
+				"content": map[string]interface{}{
+					"id":     "I_1",
+					"number": 1,
+					"title":  "Issue without linked PR",
+					"labels": map[string]interface{}{"nodes": []interface{}{}},
+					"closedByPullRequestsReferences": map[string]interface{}{
+						"nodes": []interface{}{},
+					},
+				},
+			},
+		})
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	board, err := c.FetchProjectBoard("owner", "repo", 1, "user")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(board.Items))
+	}
+	if board.Items[0].LinkedPRNumberShallow != 0 {
+		t.Errorf("LinkedPRNumberShallow = %d, want 0 when no linked PRs", board.Items[0].LinkedPRNumberShallow)
+	}
+}

--- a/github/project.go
+++ b/github/project.go
@@ -57,6 +57,7 @@ type itemNode struct {
 		LinkedPRs *struct {
 			Nodes []struct {
 				UpdatedAt string `json:"updatedAt"`
+				Number    int    `json:"number"`
 			} `json:"nodes"`
 		} `json:"closedByPullRequestsReferences"`
 	} `json:"content"`
@@ -195,6 +196,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
               closedByPullRequestsReferences(first: 5) {
                 nodes {
                   updatedAt
+                  number
                 }
               }
             }
@@ -317,6 +319,9 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 				if t, err := parseTime(pr.UpdatedAt); err == nil && t.After(item.UpdatedAt) {
 					item.UpdatedAt = t
 				}
+			}
+			if len(node.Content.LinkedPRs.Nodes) > 0 {
+				item.LinkedPRNumberShallow = node.Content.LinkedPRs.Nodes[0].Number
 			}
 		}
 

--- a/github/types.go
+++ b/github/types.go
@@ -81,6 +81,10 @@ type ProjectItem struct {
 	Author                 string
 	BlockedBy              []Dependency    // Issues that must be closed before this one can advance
 	LinkedPRNumber         int             // PR number of the first linked PR (0 if none); for REST re-request calls
+	// LinkedPRNumberShallow is the PR number of the first linked PR from the shallow board query (0 if none).
+	// Populated only during shallow board parse and used only by Reconcile for linkage drift detection —
+	// do not use as a substitute for LinkedPRNumber at runtime.
+	LinkedPRNumberShallow int
 	LinkedPRReviewRequests []ReviewRequest // Outstanding reviewer requests on the linked PR
 	LinkedPRReviews        []PRReview      // Reviews already submitted on the linked PR
 	// LinkedPRReviewThreadComments holds the inline (per-line) comments from


### PR DESCRIPTION
## Summary

Make `Reconcile` detect issue↔PR linkage drift and invalidate `deepFetched[key]` so the next `FetchItemDetails` pulls fresh deep state from GitHub.

The shallow project board query already fetches `closedByPullRequestsReferences` for every issue — it just doesn't currently surface the PR number in a way the cache can compare against. The fix adds the PR number to the shallow query result, and uses it in `Reconcile` to detect when cached deep state disagrees with the current board.

(See companion issue #506 for webhook-time auto-healing — together they make the cache self-correcting at both poll-interval and sub-second latency.)

## Problem

`boardcache.Reconcile` (`boardcache/boardcache.go:140`) preserves all deep fields for items it considers already deep-fetched, including `LinkedPRNumber`, `LinkedPRReviewRequests`, `LinkedPRReviews`, and `LinkedPRReviewThreadComments`. The contract is "shallow update only — keep deep state from cache."

This is correct when the cache's deep state is fresher than the shallow board snapshot. It is **wrong** when the cache's deep state was captured at a moment the issue↔PR linkage hadn't yet appeared on GitHub. Once the linkage materializes (e.g. user fixes a malformed `Closes #N`, GitHub finally parses it, or a stale GraphQL window catches up), the cache holds `LinkedPRNumber = 0` forever for that issue.

This actually happened on issue #476 / PR #502 (see #503 for the upstream cause). After the PR body was fixed and GitHub created the auto-link, every subsequent `checkReviewGate` invocation evaluated against the stale cached view (`LinkedPRNumber = 0`, no reviews) and re-applied `fabrik:awaiting-review` even though Copilot's review was visible on the PR. The only recovery was a Fabrik restart so bootstrap could re-fetch.

## Approach

### Approach

Four files need changes; the work flows in strict dependency order:

1. Extend the `itemNode` Go struct and the shallow GraphQL query string to include the linked PR's `number` field — both in `github/project.go`. These two sub-changes are tightly coupled (struct must match query) so they land in one commit.
2. Add `LinkedPRNumberShallow int` to `github/types.go`'s `ProjectItem`. This is a pure struct addition with no logic; it compiles independently and makes the field available to callers.
3. Populate `LinkedPRNumberShallow` from the first linked PR node inside the shallow parse loop already in `github/project.go`. Depends on (1) and (2).
4. Add linkage drift detection to `Reconcile` in `boardcache/boardcache.go`. Depends on (3): `item.LinkedPRNumberShallow` must be populated before the comparison is meaningful. Also updates the doc-comment.
5. Add unit test covering the drift scenario. Depends on (4).

No ADR is warranted. The fix is a bounded exception to ADR 034's "preserve deep fields on reconcile" rule — the research confirms ADR 034 anticipated this kind of targeted drift detection, and the mechanism follows the exact precedent at `delta.go:382`. The decision does not introduce a new pattern; it reuses an existing one.

No user-facing documentation changes are needed (no new CLI options, config keys, labels, or observable behavior changes).

### New/Modified Files

| File | Change |
|------|--------|
| `github/project.go` | Add `Number int` to `itemNode` linked PR nodes struct; add `number` to shallow GraphQL query; populate `item.LinkedPRNumberShallow` from `Nodes[0].Number` in the parse loop |
| `github/types.go` | Add `LinkedPRNumberShallow int` to `ProjectItem` with doc comment |
| `boardcache/boardcache.go` | Add linkage drift detection block in `Reconcile`; update `Reconcile` doc-comment |
| `boardcache/boardcache_test.go` | Add `TestReconcileLinkageDriftInvalidatesDeepCache` unit test |

### Key Decisions

- **Two-field approach (`LinkedPRNumberShallow` vs. unifying into `LinkedPRNumber`)**: Chosen because `LinkedPRNumber == 0` currently means "deep fetch not done yet" at call sites in the engine. Changing its population semantics would require auditing every caller. The two-field approach is a safe, additive change. The doc comment on both fields must be explicit about which is set where.

- **Drift detection only in `Reconcile`, not in Bootstrap**: `Bootstrap` already does a full `populateFromBoard` which replaces `deepFetched` entirely — no stale state survives. `Reconcile` is the only path where stale deep state can persist across a shallow update.

- **No guard for `IsPR` items**: For PR-typed items, `closedByPullRequestsReferences` is in the `... on Issue` fragment only, so `node.Content.LinkedPRs` is nil and `LinkedPRNumberShallow` stays 0. `existing.LinkedPRNumber` is also 0 for PR items (PRs don't have linked PRs). No drift is ever detected — no guard needed.

- **Log format uses `c.logFn`**: Consistent with all other cache logging. Format: `[cache] linkage drift detected for issue #N: stale linked PR=%d, fresh=%d — invalidating deep cache`.

### Task Checklist

- [ ] Task 1 — `github/project.go`: Add `Number int` to `itemNode`'s `LinkedPRs.Nodes` struct (line 58-60) and add `number` to the shallow GraphQL query's `closedByPullRequestsReferences` node selection set (line 195-199)
- [ ] Task 2 — `github/types.go`: Add `LinkedPRNumberShallow int` to `ProjectItem` (after `LinkedPRNumber`), with doc comment: "PR number of the first linked PR from the shallow board query (0 if none); populated only during shallow board parse and used only by Reconcile for linkage drift detection — do not use as a substitute for LinkedPRNumber at runtime"
- [ ] Task 3 — `github/project.go`: In the shallow parse loop (lines 315-321), after the `updatedAt` aggregation over `node.Content.LinkedPRs.Nodes`, capture `item.LinkedPRNumberShallow = node.Content.LinkedPRs.Nodes[0].Number` when `len(node.Content.LinkedPRs.Nodes) > 0`
- [ ] Task 4 — `boardcache/boardcache.go`: In `Reconcile`, after the shallow-field copy block (after line 167, before the `else` for new items), add: if `c.deepFetched[key]` is true and `existing.LinkedPRNumber != item.LinkedPRNumberShallow`, call `delete(c.deepFetched, key)` and `c.logFn("[cache] linkage drift detected for issue #%d: stale linked PR=%d, fresh=%d — invalidating deep cache\n", item.Number, existing.LinkedPRNumber, item.LinkedPRNumberShallow)`. Also update the `Reconcile` doc-comment (line 137) to append: "Shallow drift in linkage (LinkedPRNumber) invalidates deep cache for the affected key, forcing a fresh FetchItemDetails on next access."
- [ ] Task 5 — `boardcache/boardcache_test.go`: Add `TestReconcileLinkageDriftInvalidatesDeepCache`: (a) bootstrap with one item having `LinkedPRNumber=0`, `LinkedPRNumberShallow=0`, mark it deep-fetched; (b) call `Reconcile` with a board where that item now has `LinkedPRNumberShallow=502`; (c) assert `deepFetched[key]` is absent; (d) call `FetchItemDetails` for the item and assert `fetchItemDetailsCount` incremented (i.e., the fallback to the mock was invoked). Use the `testCache` / `mockClient` pattern from `TestReconcilePreservesDeepFields` (line 701) as the structural template.

### Risks

- **Drift detection fires on nonzero→different-nonzero**: Spec requires this be detected. It can only happen if a PR is re-linked to a different PR, which is uncommon. The cost is one re-fetch — acceptable.
- **`LinkedPRNumberShallow` misuse**: Nothing prevents engine code from accidentally reading this field. The doc comment is the only enforcement. The field name's `Shallow` suffix should deter casual use.
- **`Reconcile` doc-comment sync**: The added sentence ("Shallow drift in linkage…") must appear in the doc-comment at line 137-139, not inline as a code comment.

---
Used 10/50 turns, 4k input / 4k output tokens.

## Verification

Added linkage drift detection to `boardcache.Reconcile`: the shallow GraphQL query now fetches the linked PR `number` alongside `updatedAt`, a new `LinkedPRNumberShallow` field on `ProjectItem` carries this value, and `Reconcile` compares it against the cached `LinkedPRNumber` — invalidating `deepFetched` when they differ so the next poll re-fetches fresh state from GitHub. A unit test verifies the zero→nonzero drift case (the exact failure mode from issue #503). All 4 changed files compile cleanly and the full test suite passes with `-race`.

---

Closes #505