### PR TITLE
Lightweight project-status polling: replace 60-min full-board reconcile with status-field-only fetch + opportunistic per-event refresh

### DIFF
--- a/adrs/032-webhook-event-delivery.md
+++ b/adrs/032-webhook-event-delivery.md
@@ -2,7 +2,8 @@
 
 **Status**: Accepted  
 **Date**: 2026-04-26  
-**Supersedes**: ADR 003 (Polling Over Webhooks)
+**Supersedes**: ADR 003 (Polling Over Webhooks)  
+**Supplemented by**: ADR 035 (Four-Layer Status Reconciliation) — replaces the 60-minute full-board reconcile described in §Board-column changes with a lightweight 10-minute status-only sweep
 
 ## Context
 

--- a/adrs/035-four-layer-status-reconciliation.md
+++ b/adrs/035-four-layer-status-reconciliation.md
@@ -1,0 +1,98 @@
+# ADR 035: Four-Layer Status Reconciliation for User Mode
+
+**Status**: Accepted  
+**Date**: 2026-05-03  
+**Supersedes (partially)**: ADR 032 (§Board-column changes and §`projects_v2_item` Event Support)  
+**Supplements**: ADR 034 (Event-Sourced Board Cache via Webhook Deltas)
+
+## Context
+
+ADR 032 established that board-column changes in user mode are caught by the safety-net poll within `WebhookIdleCap` (60 minutes). ADR 034 added an in-memory board cache that is reconciled by a full `FetchProjectBoard` call every 60 minutes.
+
+This 60-minute window produces unacceptable latency for users who manually move issues between board columns to trigger stage transitions. Issue #467 demonstrated a concrete 76-minute gap: a column move at ~16:20Z was not detected until ~17:36Z. GitHub does **not** deliver `projects_v2_item` events in user mode (PAT-based, repo-level webhooks via `gh webhook forward`), making the webhook stream blind to column moves permanently in this configuration.
+
+Running the full board reconcile more frequently is not a viable solution: `FetchProjectBoard` is Fabrik's most expensive GraphQL query (full nested fields, comments, labels, PRs). Running it every 10 minutes would drain the GraphQL budget without proportional benefit.
+
+## Decision
+
+Replace the single 60-minute full-board reconcile loop with a four-layer strategy:
+
+### Layer 0 — Write-through on self-driven transitions
+
+When Fabrik itself calls `UpdateProjectItemStatus` to advance an issue, the cache is updated immediately at the call site with zero GraphQL cost.
+
+**Implementation**: Every call site that invokes `UpdateProjectItemStatus` on success must also call `cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), newStatus)` via the safe type-assertion pattern:
+
+```go
+if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+    cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), newStatus)
+}
+```
+
+Current call sites: `engine/stages.go` `advanceToNextStage` and `moveToNextDone`. Future call sites must follow the same pattern — this is a load-bearing invariant.
+
+### Layer 1 — Opportunistic per-event Status refresh
+
+After the board cache applies a webhook delta for an `issues` or `issue_comment` event on a known item, a single-item `FetchProjectItemStatus` query is issued and the result is applied to the cache. Cost: ~1–5 GraphQL points per event.
+
+**Scope**: Restricted to `issues` and `issue_comment` event types. `pull_request`, `pull_request_review`, and `pull_request_review_comment` events require an O(N) cache scan to find the linked issue — the cost-benefit doesn't justify it for Layer 1. `check_run` events carry no item ID. Layer 2 covers these gaps within its cadence.
+
+**Failure mode**: Best-effort. Errors are logged as warnings; the delta pipeline is never blocked.
+
+**Paused cache**: Skipped when `IsPaused() == true` (cache is being fully reconciled on stream recovery).
+
+### Layer 2 — Periodic status-field-only sweep
+
+A `runReconciliationLoop` goroutine ticks at `ProjectStatusPollSeconds` (default 600 s, configurable via `--status-poll` / `FABRIK_STATUS_POLL` / `config.yaml status_poll`). Each tick calls `FetchProjectItemStatusBatch(projectID)` — a lightweight GraphQL query returning only `itemNodeID → statusName` for all board items — and applies drift via `ApplyStatusBatch`.
+
+**Cost**: O(⌈N/100⌉) requests per tick (pagination at 100 items per page). A 200-item board uses 2 requests per 10 minutes = 12 per hour, well within the 5,000-point/hour budget.
+
+**Empty project ID guard**: If `cacheImpl.ProjectID() == ""` (bootstrap not yet complete), the tick is skipped with a log warning.
+
+### Bootstrap and stream-recovery (unchanged)
+
+`FetchProjectBoard` (full board fetch) runs on startup (bootstrap) and on webhook stream recovery. These paths must handle all field types and remain unchanged.
+
+## Consequences
+
+### Residual latency
+
+| Change type | Detection mechanism | Worst-case latency |
+|-------------|--------------------|--------------------|
+| Fabrik-driven stage advance | Layer 0 write-through | Zero |
+| Column move + coincident issue activity | Layer 1 per-event refresh | Seconds |
+| Column move with no other activity | Layer 2 periodic sweep | `ProjectStatusPollSeconds` (default 10 min) |
+| Stream recovery (gap in webhook delivery) | Full reconcile | Until stream recovers |
+
+The 60-minute worst-case latency from ADR 032 is reduced to the Layer 2 cadence (default 10 minutes) at significantly lower GraphQL cost than running the full reconcile more frequently.
+
+### New exports from `boardcache`
+
+- `ItemKey(repo string, number int) string` — exported to prevent format duplication between packages. This format (`owner/repo#number`) is now the public API for constructing cache keys.
+- `CacheImpl.UpdateItemStatus(key, newStatus string)` — write lock, idempotent, no-op if key absent.
+- `CacheImpl.ApplyStatusBatch(updates map[string]string)` — batch drift application under one write lock.
+- `CacheImpl.GetItemID(key string) (string, bool)` — returns the PVTI_ node ID for Layer 1.
+- `CacheImpl.ProjectID() string` — returns the project node ID for Layer 2.
+
+### New `GitHubClient` methods
+
+- `FetchProjectItemStatus(itemID string) (string, error)` — single-item Status query.
+- `FetchProjectItemStatusBatch(projectID string) (map[string]string, error)` — paginated batch Status query.
+
+These methods belong on `GitHubClient` only, not on `boardcache.ReadClient`. They are called directly from engine code (`e.client.*`), not through the cache read path.
+
+### Write-through convention (load-bearing)
+
+**Every future call site that calls `UpdateProjectItemStatus` to mutate a project item's Status must also call `cacheImpl.UpdateItemStatus` on the success path.** Failure to do so means the cache stales on self-driven transitions and the issue will not advance until the next Layer 2 sweep. This invariant is documented in `docs/state-machine.md §D.7`.
+
+### `boardcache.ReadClient` unchanged
+
+The `ReadClient` interface (used by `GitHubAdapter` and `boardcache` tests) is not modified. The new methods are engine-facing only.
+
+## Alternatives Considered
+
+**Run full reconcile at 10-minute cadence**: Rejected. Full board fetch is Fabrik's most expensive query. Running it 6× more often provides no additional benefit over the lightweight status sweep and wastes GraphQL budget.
+
+**Include PR events in Layer 1**: Rejected. Mapping a PR number to a cache key requires an O(N) scan of all cached items under read lock. The marginal coverage improvement (catching column moves that coincide only with PR events, not issue events) doesn't justify the complexity and latency. Layer 2's 10-minute sweep covers the gap.
+
+**Export `ItemKey` vs. inline format string**: Exporting chosen. The format `repo + "#" + strconv.Itoa(number)` is simple but must be consistent across packages. An exported helper prevents a silent divergence if the format ever changes and signals to callers that the format is stable and intentional.

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -3,6 +3,7 @@ package boardcache
 import (
 	"strconv"
 	"sync"
+	"time"
 
 	gh "github.com/verveguy/fabrik/github"
 )
@@ -68,9 +69,16 @@ func (a *GitHubAdapter) RateLimitStats() (rest, graphql gh.RateLimitStats) {
 	return a.client.RateLimitStats()
 }
 
-// itemKey returns the cache key for an issue item: "owner/repo#number".
-func itemKey(repo string, number int) string {
+// ItemKey returns the cache key for an issue item: "owner/repo#number".
+// Exported so callers in other packages (e.g. engine) can construct keys
+// without duplicating the format string.
+func ItemKey(repo string, number int) string {
 	return repo + "#" + strconv.Itoa(number)
+}
+
+// itemKey is the package-internal alias for ItemKey.
+func itemKey(repo string, number int) string {
+	return ItemKey(repo, number)
 }
 
 // prKey returns the cache key for a PR: "owner/repo#pr<prNumber>".
@@ -419,6 +427,62 @@ func (c *CacheImpl) FetchStatusField(projectID string) (*gh.StatusField, error) 
 // RateLimitStats always delegates to GitHub.
 func (c *CacheImpl) RateLimitStats() (rest, graphql gh.RateLimitStats) {
 	return c.fallback.RateLimitStats()
+}
+
+// UpdateItemStatus updates the Status field for the item identified by key.
+// No-op when the key is not in the cache. Safe for concurrent use.
+func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item, ok := c.items[key]
+	if !ok {
+		c.logFn("[cache] UpdateItemStatus: key %q not found — no-op\n", key)
+		return
+	}
+	item.Status = newStatus
+	item.UpdatedAt = time.Now()
+}
+
+// ApplyStatusBatch updates Status for items identified by project-item node IDs.
+// Entries whose itemID is not in itemIDToKey are silently skipped (not yet bootstrapped).
+// Safe for concurrent use.
+func (c *CacheImpl) ApplyStatusBatch(updates map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for itemID, status := range updates {
+		key, ok := c.itemIDToKey[itemID]
+		if !ok {
+			continue
+		}
+		item, ok := c.items[key]
+		if !ok {
+			continue
+		}
+		if item.Status != status {
+			item.Status = status
+			item.UpdatedAt = time.Now()
+		}
+	}
+}
+
+// GetItemID returns the project-item node ID (PVTI_...) for the given cache key.
+// Returns ("", false) when the key is not present or has no ItemID.
+func (c *CacheImpl) GetItemID(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	item, ok := c.items[key]
+	if !ok || item.ItemID == "" {
+		return "", false
+	}
+	return item.ItemID, true
+}
+
+// ProjectID returns the project node ID stored from the last Bootstrap/Reconcile call.
+// Returns "" when the cache has not yet been bootstrapped.
+func (c *CacheImpl) ProjectID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.projectID
 }
 
 // copyDeepFields overlays the deep fields from src onto dst.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -962,3 +962,132 @@ func TestFetchCheckRunsFallsThroughWhenPaused(t *testing.T) {
 		t.Errorf("expected live run (ID=99) from fallback when paused, got %+v", runs)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// UpdateItemStatus tests
+// ---------------------------------------------------------------------------
+
+func TestUpdateItemStatusSetsStatusAndUpdatedAt(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+
+	before := time.Now()
+	c.UpdateItemStatus(key, "Plan")
+	after := time.Now()
+
+	c.mu.RLock()
+	item := c.items[key]
+	c.mu.RUnlock()
+
+	if item.Status != "Plan" {
+		t.Errorf("want Status %q, got %q", "Plan", item.Status)
+	}
+	if item.UpdatedAt.Before(before) || item.UpdatedAt.After(after) {
+		t.Errorf("UpdatedAt %v not in expected range [%v, %v]", item.UpdatedAt, before, after)
+	}
+}
+
+func TestUpdateItemStatusNoopForUnknownKey(t *testing.T) {
+	c := seedCache(t)
+	// Should not panic; just log and return.
+	c.UpdateItemStatus("nonexistent/repo#999", "Done")
+}
+
+func TestUpdateItemStatusIsIdempotent(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+	c.UpdateItemStatus(key, "Plan")
+	c.UpdateItemStatus(key, "Plan")
+
+	c.mu.RLock()
+	item := c.items[key]
+	c.mu.RUnlock()
+	if item.Status != "Plan" {
+		t.Errorf("want Status %q after repeated calls, got %q", "Plan", item.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ApplyStatusBatch tests
+// ---------------------------------------------------------------------------
+
+func TestApplyStatusBatchUpdatesDriftedItems(t *testing.T) {
+	c := seedCache(t)
+	// PVTI_001 is item #1 (status "Research"); drift it to "Plan".
+	c.ApplyStatusBatch(map[string]string{"PVTI_001": "Plan"})
+
+	c.mu.RLock()
+	item := c.items[ItemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+
+	if item.Status != "Plan" {
+		t.Errorf("want Status %q, got %q", "Plan", item.Status)
+	}
+}
+
+func TestApplyStatusBatchLeavesUndriftedItemsUnchanged(t *testing.T) {
+	c := seedCache(t)
+	key2 := ItemKey("owner/repo", 2)
+
+	c.mu.RLock()
+	origUpdatedAt := c.items[key2].UpdatedAt
+	c.mu.RUnlock()
+
+	// Item 2 already has Status "Plan" — sending same value should not change UpdatedAt.
+	c.ApplyStatusBatch(map[string]string{"PVTI_002": "Plan"})
+
+	c.mu.RLock()
+	item := c.items[key2]
+	c.mu.RUnlock()
+
+	if item.UpdatedAt != origUpdatedAt {
+		t.Error("UpdatedAt should not change when Status is already up to date")
+	}
+}
+
+func TestApplyStatusBatchSkipsUnknownItemIDs(t *testing.T) {
+	c := seedCache(t)
+	// Should not panic or add entries for unknown PVTI IDs.
+	c.ApplyStatusBatch(map[string]string{"PVTI_UNKNOWN": "Done"})
+	if len(c.items) != 2 {
+		t.Errorf("item count should remain 2, got %d", len(c.items))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetItemID and ProjectID tests
+// ---------------------------------------------------------------------------
+
+func TestGetItemIDReturnsNodeID(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+	itemID, ok := c.GetItemID(key)
+	if !ok {
+		t.Fatal("GetItemID returned !ok for known key")
+	}
+	if itemID != "PVTI_001" {
+		t.Errorf("want %q, got %q", "PVTI_001", itemID)
+	}
+}
+
+func TestGetItemIDReturnsFalseForUnknownKey(t *testing.T) {
+	c := seedCache(t)
+	_, ok := c.GetItemID("nonexistent/repo#999")
+	if ok {
+		t.Error("expected !ok for unknown key")
+	}
+}
+
+func TestProjectIDReturnsBootstrappedID(t *testing.T) {
+	c := seedCache(t)
+	if got := c.ProjectID(); got != "PID" {
+		t.Errorf("want %q, got %q", "PID", got)
+	}
+}
+
+func TestProjectIDReturnsEmptyBeforeBootstrap(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, nopLog)
+	if got := c.ProjectID(); got != "" {
+		t.Errorf("want empty string before bootstrap, got %q", got)
+	}
+}

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -112,6 +112,12 @@ func (m *testGitHubUpgradeClient) DeleteReviewRequest(owner, repo string, prNumb
 func (m *testGitHubUpgradeClient) AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error {
 	return nil
 }
+func (m *testGitHubUpgradeClient) FetchProjectItemStatus(itemID string) (string, error) {
+	return "", nil
+}
+func (m *testGitHubUpgradeClient) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
+	return nil, nil
+}
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,8 @@ type Config struct {
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     string // comma-separated; empty means default event set
-	BoardCacheMode    string // "in-memory" or "none"; empty = auto (in-memory when webhooks enabled)
+	BoardCacheMode       string // "in-memory" or "none"; empty = auto (in-memory when webhooks enabled)
+	StatusPollSeconds    int    // Layer 2 status-only sweep cadence in seconds; 0 = use default (600)
 }
 
 func Execute() error {
@@ -131,6 +132,7 @@ func Execute() error {
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.StringVar(&cfg.BoardCacheMode, "board-cache", "", `Board cache mode: "in-memory" (cache board state; requires --webhooks) or "none" (always fetch from GitHub). Default: "in-memory" when --webhooks is enabled, "none" otherwise. Also FABRIK_BOARD_CACHE.`)
+	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Cadence in seconds for the periodic status-only board sweep (Layer 2; 0 = use default of 600; also FABRIK_STATUS_POLL)")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err
@@ -400,6 +402,21 @@ func Execute() error {
 			cfg.BoardCacheMode = v
 		}
 	}
+	if !explicitFlags["status-poll"] {
+		if v := os.Getenv("FABRIK_STATUS_POLL"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.StatusPollSeconds = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_STATUS_POLL=%q is invalid (must be a positive integer); using default 600\n", v)
+			}
+		} else if pc.StatusPoll != nil {
+			if *pc.StatusPoll <= 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml status_poll=%d is invalid (must be a positive integer); using default 600\n", *pc.StatusPoll)
+			} else {
+				cfg.StatusPollSeconds = *pc.StatusPoll
+			}
+		}
+	}
 
 	// Apply board-cache default: "in-memory" when webhooks are enabled; "none" otherwise.
 	// Explicit --board-cache=in-memory without --webhooks is a configuration error.
@@ -528,8 +545,9 @@ func Execute() error {
 		Webhooks:          cfg.Webhooks,
 		WebhookPort:       cfg.WebhookPort,
 		WebhookEvents:     webhookEvents,
-		BoardCacheMode:    cfg.BoardCacheMode,
-		ReadyCh:           testReadyCh,
+		BoardCacheMode:           cfg.BoardCacheMode,
+		ProjectStatusPollSeconds: statusPollSeconds(cfg.StatusPollSeconds),
+		ReadyCh:                  testReadyCh,
 	})
 	if err != nil {
 		return err
@@ -598,6 +616,15 @@ func claudeWaitDelay(seconds int) time.Duration {
 		return 30 * time.Second
 	}
 	return time.Duration(seconds) * time.Second
+}
+
+// statusPollSeconds returns the configured ProjectStatusPollSeconds, defaulting
+// to 600 (10 min) when n is 0 (unset).
+func statusPollSeconds(n int) int {
+	if n <= 0 {
+		return 600
+	}
+	return n
 }
 
 // buildProjectInfo assembles the TUI footer metadata from the active config.

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type ProjectConfig struct {
 	Webhooks      bool     `yaml:"webhooks"`
 	WebhookPort   *int     `yaml:"webhook_port"`
 	WebhookEvents []string `yaml:"webhook_events"`
+	StatusPoll    *int     `yaml:"status_poll"`
 }
 
 // LoadProjectConfig reads .fabrik/config.yaml from CWD.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1585,7 +1585,7 @@ Webhook mode is an optional feature that dramatically reduces GraphQL usage and 
 
 Fabrik spawns `gh webhook forward` as a background subprocess. This tool connects outbound to GitHub's SSE stream and forwards every matching event as an HTTP POST to a local listener on `127.0.0.1:<port>`. No public endpoint, no ngrok, no infrastructure changes. Each event payload is authenticated with HMAC-SHA256 before Fabrik acts on it.
 
-Events are translated into immediate poll wakeups — the existing board-fetch and filter logic handles the rest. The poll loop continues running as a safety net (up to once every 60 minutes when the webhook stream is healthy) so missed or delayed events never strand work.
+Events are translated into immediate poll wakeups — the existing board-fetch and filter logic handles the rest. The poll loop continues running as a safety net (up to once every 60 minutes when the webhook stream is healthy) so missed or delayed events never strand work. Board-column changes that aren't delivered as events are caught by a lightweight status sweep that runs every 10 minutes by default (see `--status-poll`).
 
 ### Prerequisites
 
@@ -1635,8 +1635,8 @@ The TUI footer shows a webhook health indicator when webhook mode is enabled:
 
 | Indicator | State | Meaning |
 |-----------|-------|---------|
-| `● webhook (N)` (green) | Healthy | At least one event received in the last 10 minutes. Idle cap: 60 min. |
-| `○ webhook (N)` (blue) | Starting Up | Subprocess launched; waiting for first event (up to 30s grace). Idle cap: 60 min. |
+| `● webhook (N)` (green) | Healthy | At least one event received in the last 10 minutes. Full-board idle cap: 60 min; status sweep: 10 min. |
+| `○ webhook (N)` (blue) | Starting Up | Subprocess launched; waiting for first event (up to 30s grace). Full-board idle cap: 60 min; status sweep: 10 min. |
 | `◌ webhook (N)` (yellow) | Unhealthy | No event received in 10+ minutes or startup grace expired. Idle cap: 5 min (same as polling-only). |
 
 `N` is the total number of webhook events received since startup. You can also verify the stream by checking `fabrik.log` for `[webhook]` tag lines.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1643,7 +1643,7 @@ The TUI footer shows a webhook health indicator when webhook mode is enabled:
 
 ### Expected GraphQL Load Reduction
 
-On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
+On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state full-board GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. A lightweight status-only sweep (default every 10 minutes) runs separately at very low cost to catch board-column changes. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
 
 ### In-Memory Board Cache (`--board-cache`)
 
@@ -1653,7 +1653,7 @@ When webhook mode is active, Fabrik maintains an in-memory board cache (`--board
 
 | Mode | When | Behavior |
 |------|------|----------|
-| `in-memory` | `--webhooks` enabled (default) | Cache populated at startup; deltas from webhooks; reconciles every 60 min; falls back to GitHub when stream is unhealthy |
+| `in-memory` | `--webhooks` enabled (default) | Cache populated at startup; deltas from webhooks; status sweep every 10 min (default); full reconcile on stream recovery; falls back to GitHub when stream is unhealthy |
 | `none` | `--webhooks` disabled (default), or explicit override | All reads go directly to GitHub API (original behavior) |
 
 **To disable the cache while keeping webhooks:**
@@ -1663,13 +1663,13 @@ fabrik --webhooks --board-cache=none
 
 **Stream-health failover:** If the webhook stream goes unhealthy (no events for 10 minutes), the cache pauses and all reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. This ensures correctness is never compromised by a degraded webhook stream.
 
-**Reconciliation:** Every 60 minutes (matching the idle-cap for healthy webhook streams), Fabrik fetches a fresh board snapshot from GitHub and updates the cache. This heals any events the webhook stream may have missed. Reconciliation also runs inline when the stream recovers from unhealthy.
+**Reconciliation:** Fabrik uses a two-level reconciliation strategy. A lightweight status-only sweep runs every `--status-poll` seconds (default 10 minutes), fetching only the Status field for every board item at very low GraphQL cost — this is the primary mechanism for catching board-column changes. A full board snapshot is fetched only on stream recovery (webhook stream goes unhealthy then recovers), ensuring all cached fields are coherent after a gap in event delivery.
 
-> **Note:** `--board-cache=in-memory` requires `--webhooks`. Without a webhook stream, there is no delta source and the cache would only reconcile every 60 minutes — worse than the default polling behavior.
+> **Note:** `--board-cache=in-memory` requires `--webhooks`. Without a webhook stream, there is no delta source and the cache relies solely on the periodic status sweep — worse than the default polling behavior.
 
 ### `projects_v2_item` (Board Column Changes)
 
-Fabrik attempts to subscribe to `projects_v2_item` events, which fire when an issue is moved between board columns. If `gh webhook forward` does not support this event type for your installation, Fabrik logs a warning and continues without it. In this case, board-column changes are caught by the safety-net poll within 60 minutes (or 5 minutes if the stream is unhealthy). All other event types continue to work normally.
+Fabrik attempts to subscribe to `projects_v2_item` events, which fire when an issue is moved between board columns. If `gh webhook forward` does not support this event type for your installation, Fabrik logs a warning and continues without it. In this case, board-column changes are caught by the periodic status sweep within `--status-poll` seconds (default 10 minutes), or within 5 minutes if the stream is unhealthy (full reconcile on recovery). All other event types continue to work normally.
 
 ### Security
 
@@ -1695,7 +1695,7 @@ On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 
 **HMAC failures logged** — Usually caused by a `gh auth refresh` that invalidated the webhook secret. Fabrik auto-rotates; if failures persist after 2 cycles, restart Fabrik.
 
-**`projects_v2_item` warning** — Board column changes fall back to the 60-minute safety-net poll. Not a problem for most workflows.
+**`projects_v2_item` warning** — Board column changes are caught by the periodic status sweep (default every 10 minutes). Not a problem for most workflows.
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1335,15 +1335,30 @@ All delta functions hold the write lock for their mutation only. They silently d
 
 ### D.4 Reconciliation
 
-A `runReconciliationLoop` goroutine tickers at `webhookIdleCap` (60 min). Each tick calls `e.client.FetchProjectBoard(...)` directly and passes the result to `cacheImpl.Reconcile(board)`.
+Reconciliation operates at two levels:
 
-`Reconcile` performs a partial update:
+**Periodic status-only sweep (Layer 2)**
+
+A `runReconciliationLoop` goroutine ticks at `ProjectStatusPollSeconds` (default 600 s, configurable via `--status-poll` / `FABRIK_STATUS_POLL` / `config.yaml status_poll`). Each tick calls `e.client.FetchProjectItemStatusBatch(projectID)` — a lightweight GraphQL query returning only `itemNodeID → statusName` for every board item — and passes the result to `cacheImpl.ApplyStatusBatch(updates)`.
+
+`ApplyStatusBatch` holds the write lock for one pass:
+- For each `(itemID, newStatus)` pair, look up the cache key via `itemIDToKey`.
+- If the status differs from the cached value, update `Status` and `UpdatedAt`. Unchanged items are skipped.
+- Unknown item IDs (not yet bootstrapped) are silently skipped.
+
+This sweep is far cheaper than a full board fetch (no nested fields, no comments, no labels) and can run at 10-minute cadence without meaningful GraphQL budget pressure.
+
+The loop skips a tick and logs a warning if `cacheImpl.ProjectID()` is empty, which means the bootstrap has not yet completed.
+
+**Full reconcile — stream-recovery only**
+
+`reconcileCache` (which calls `e.client.FetchProjectBoard(...)` and `cacheImpl.Reconcile(board)`) is preserved but is **no longer called by the periodic loop**. It is called only on webhook stream recovery (see §D.5).
+
+`Reconcile` performs a deep partial update:
 - For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.
 - Items present in the cache but absent from the new snapshot are removed (they were archived or moved off the board).
 - `itemIDToKey` and `shaToKey` are rebuilt.
 - Logs `[reconciliation] N items differed` at the end.
-
-Reconciliation is also triggered inline on stream recovery (see §D.5).
 
 ### D.5 Stream-Health Failover
 
@@ -1367,4 +1382,27 @@ On recovery, `reconcileCache()` fetches a fresh board snapshot before `Resume()`
 | `in-memory` (default when webhooks on) | required | `CacheImpl` with delta/failover |
 | `none` | any | `GitHubAdapter` pass-through (no caching) |
 
-Specifying `--board-cache=in-memory` without `--webhooks` is a configuration error: without a webhook stream there is no delta source and the cache would only reconcile every 60 minutes, which is worse than direct polling.
+Specifying `--board-cache=in-memory` without `--webhooks` is a configuration error: without a webhook stream there is no delta source and the cache relies solely on the periodic status sweep — worse than direct polling.
+
+### D.7 Status field reconciliation in user mode
+
+In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub does **not** deliver `projects_v2_item` events. Board-column changes — including the Status field that drives stage selection — are invisible to the webhook stream. Fabrik uses a four-layer strategy to keep the cached Status current despite this gap:
+
+| Layer | Mechanism | Latency | Cost |
+|-------|-----------|---------|------|
+| **0** Write-through | After any successful `UpdateProjectItemStatus` call in the engine, `CacheImpl.UpdateItemStatus` is called immediately | Zero | Zero |
+| **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event on a known item, `FetchProjectItemStatus` fetches the current Status | Seconds (best-effort) | ~1–5 pts/event |
+| **2** Periodic status sweep | `runReconciliationLoop` calls `FetchProjectItemStatusBatch` at `ProjectStatusPollSeconds` cadence (default 10 min) | Up to 10 min | O(⌈N/100⌉) per sweep |
+| **Bootstrap / stream-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and on webhook stream recovery | Minutes | Full board cost |
+
+**Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the Layer 2 cadence (`ProjectStatusPollSeconds`). If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own stage transitions.
+
+**Layer 0 write-through convention**: Every call site that calls `UpdateProjectItemStatus` to mutate a project item's Status **must** also call `cacheImpl.UpdateItemStatus` on success. This invariant prevents the cache from staling on self-driven transitions. Use the safe type assertion pattern:
+
+```go
+if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+    cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), newStatus)
+}
+```
+
+**Layer 1 scope**: Only `issues` and `issue_comment` event types trigger a per-event status fetch. `pull_request`, `pull_request_review`, `check_run`, and other event types are excluded from Layer 1 (finding the linked issue for a PR event requires an O(N) cache scan; `check_run` does not carry an item ID). Layer 2's periodic sweep covers these cases within its cadence.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -41,7 +41,8 @@ type Config struct {
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     []string
-	BoardCacheMode    string // "in-memory" or "none"; default "none" when webhooks off, "in-memory" when on
+	BoardCacheMode           string // "in-memory" or "none"; default "none" when webhooks off, "in-memory" when on
+	ProjectStatusPollSeconds int    // Layer 2 status-only sweep cadence in seconds; default 600 (10 min)
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -41,6 +41,8 @@ type GitHubClient interface {
 	FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error)
 	SeedLabels(owner, repo string, stageNames []string, lockedUser string) error
 	RateLimitStats() (rest, graphql gh.RateLimitStats)
+	FetchProjectItemStatus(itemID string) (string, error)
+	FetchProjectItemStatusBatch(projectID string) (map[string]string, error)
 }
 
 // InvokeOptions bundles per-issue override parameters for Claude invocations.

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -42,7 +42,12 @@ type mockGitHubClient struct {
 	fetchLabelAppliedAtFn     func(owner, repo string, issueNumber int, labelName string) (time.Time, error)
 	archiveProjectItemFn      func(projectID, itemID string) error
 	deleteReviewRequestFn     func(owner, repo string, prNumber int, reviewers []string) error
-	addReviewRequestFn        func(owner, repo string, prNumber int, reviewers []string) error
+	addReviewRequestFn              func(owner, repo string, prNumber int, reviewers []string) error
+	fetchProjectItemStatusFn        func(itemID string) (string, error)
+	fetchProjectItemStatusBatchFn   func(projectID string) (map[string]string, error)
+
+	// Track call counts for FetchProjectItemStatus
+	fetchProjectItemStatusCalls []string
 
 	// Track calls for FetchLabelAppliedAt
 	fetchLabelAppliedAtCalls []fetchLabelAppliedAtCall
@@ -449,6 +454,27 @@ func (m *mockGitHubClient) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStat
 		return m.rateLimitStatsFn()
 	}
 	return gh.RateLimitStats{}, gh.RateLimitStats{}
+}
+
+func (m *mockGitHubClient) FetchProjectItemStatus(itemID string) (string, error) {
+	m.mu.Lock()
+	m.fetchProjectItemStatusCalls = append(m.fetchProjectItemStatusCalls, itemID)
+	fn := m.fetchProjectItemStatusFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(itemID)
+	}
+	return "", nil
+}
+
+func (m *mockGitHubClient) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
+	m.mu.Lock()
+	fn := m.fetchProjectItemStatusBatchFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(projectID)
+	}
+	return map[string]string{}, nil
 }
 
 // mockClaudeInvoker implements ClaudeInvoker for testing.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -304,7 +305,39 @@ func (e *Engine) Run() error {
 		var deltaFn func(string, []byte)
 		var healthChangeFn func(bool)
 		if cacheImpl != nil {
-			deltaFn = cacheImpl.ApplyDelta
+			deltaFn = func(eventType string, payload []byte) {
+				cacheImpl.ApplyDelta(eventType, payload)
+				if cacheImpl.IsPaused() {
+					return
+				}
+				if eventType != "issues" && eventType != "issue_comment" {
+					return
+				}
+				// Layer 1: opportunistic per-event Status refresh.
+				// Parse just enough to identify the project item.
+				var ev struct {
+					Issue struct {
+						Number int `json:"number"`
+					} `json:"issue"`
+					Repository struct {
+						FullName string `json:"full_name"`
+					} `json:"repository"`
+				}
+				if err := json.Unmarshal(payload, &ev); err != nil || ev.Repository.FullName == "" || ev.Issue.Number == 0 {
+					return
+				}
+				key := boardcache.ItemKey(ev.Repository.FullName, ev.Issue.Number)
+				itemID, ok := cacheImpl.GetItemID(key)
+				if !ok {
+					return
+				}
+				status, err := e.client.FetchProjectItemStatus(itemID)
+				if err != nil {
+					e.logf(ev.Issue.Number, "warn", "layer1 status fetch failed for %s: %v\n", itemID, err)
+					return
+				}
+				cacheImpl.UpdateItemStatus(key, status)
+			}
 			healthChangeFn = func(healthy bool) {
 				if healthy {
 					e.reconcileCache(cacheImpl)
@@ -1395,18 +1428,33 @@ func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
 	cache.Reconcile(board)
 }
 
-// runReconciliationLoop periodically reconciles the in-memory cache with GitHub
-// by fetching a full board snapshot. It runs once per webhookIdleCap (60 min)
-// so the cache self-heals any deltas missed by the webhook stream.
+// runReconciliationLoop periodically fetches only the Status field for every
+// project item and applies any drift to the in-memory cache (Layer 2).
+// This replaces the former 60-min full-board reconcile for the periodic path;
+// reconcileCache (full board fetch) is preserved for stream-recovery only.
 func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.CacheImpl) {
-	ticker := time.NewTicker(webhookIdleCap)
+	cadence := time.Duration(e.cfg.ProjectStatusPollSeconds) * time.Second
+	if cadence <= 0 {
+		cadence = 600 * time.Second
+	}
+	ticker := time.NewTicker(cadence)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			e.reconcileCache(cache)
+			projectID := cache.ProjectID()
+			if projectID == "" {
+				e.logf(0, "cache", "layer2 status sweep skipped: cache not yet bootstrapped\n")
+				continue
+			}
+			updates, err := e.client.FetchProjectItemStatusBatch(projectID)
+			if err != nil {
+				e.logf(0, "cache", "layer2 status sweep failed: %v\n", err)
+				continue
+			}
+			cache.ApplyStatusBatch(updates)
 		}
 	}
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1450,7 +1450,11 @@ func (e *Engine) applyLayer1StatusRefresh(eventType string, payload []byte, cach
 			FullName string `json:"full_name"`
 		} `json:"repository"`
 	}
-	if err := json.Unmarshal(payload, &ev); err != nil || ev.Repository.FullName == "" || ev.Issue.Number == 0 {
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		e.logf(0, "warn", "layer1 status refresh: failed to parse %s payload: %v\n", eventType, err)
+		return
+	}
+	if ev.Repository.FullName == "" || ev.Issue.Number == 0 {
 		return
 	}
 	key := boardcache.ItemKey(ev.Repository.FullName, ev.Issue.Number)

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -307,36 +307,7 @@ func (e *Engine) Run() error {
 		if cacheImpl != nil {
 			deltaFn = func(eventType string, payload []byte) {
 				cacheImpl.ApplyDelta(eventType, payload)
-				if cacheImpl.IsPaused() {
-					return
-				}
-				if eventType != "issues" && eventType != "issue_comment" {
-					return
-				}
-				// Layer 1: opportunistic per-event Status refresh.
-				// Parse just enough to identify the project item.
-				var ev struct {
-					Issue struct {
-						Number int `json:"number"`
-					} `json:"issue"`
-					Repository struct {
-						FullName string `json:"full_name"`
-					} `json:"repository"`
-				}
-				if err := json.Unmarshal(payload, &ev); err != nil || ev.Repository.FullName == "" || ev.Issue.Number == 0 {
-					return
-				}
-				key := boardcache.ItemKey(ev.Repository.FullName, ev.Issue.Number)
-				itemID, ok := cacheImpl.GetItemID(key)
-				if !ok {
-					return
-				}
-				status, err := e.client.FetchProjectItemStatus(itemID)
-				if err != nil {
-					e.logf(ev.Issue.Number, "warn", "layer1 status fetch failed for %s: %v\n", itemID, err)
-					return
-				}
-				cacheImpl.UpdateItemStatus(key, status)
+				e.applyLayer1StatusRefresh(eventType, payload, cacheImpl)
 			}
 			healthChangeFn = func(healthy bool) {
 				if healthy {
@@ -370,7 +341,11 @@ func (e *Engine) Run() error {
 			e.webhookMgr = wm
 			defer wm.Stop()
 			if cacheImpl != nil {
-				go e.runReconciliationLoop(ctx, cacheImpl)
+				cadence := time.Duration(e.cfg.ProjectStatusPollSeconds) * time.Second
+				if cadence <= 0 {
+					cadence = 600 * time.Second
+				}
+				go e.runReconciliationLoop(ctx, cacheImpl, cadence)
 			}
 		}
 	}
@@ -1432,11 +1407,7 @@ func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
 // project item and applies any drift to the in-memory cache (Layer 2).
 // This replaces the former 60-min full-board reconcile for the periodic path;
 // reconcileCache (full board fetch) is preserved for stream-recovery only.
-func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.CacheImpl) {
-	cadence := time.Duration(e.cfg.ProjectStatusPollSeconds) * time.Second
-	if cadence <= 0 {
-		cadence = 600 * time.Second
-	}
+func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.CacheImpl, cadence time.Duration) {
 	ticker := time.NewTicker(cadence)
 	defer ticker.Stop()
 	for {
@@ -1457,4 +1428,40 @@ func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.Ca
 			cache.ApplyStatusBatch(updates)
 		}
 	}
+}
+
+// applyLayer1StatusRefresh handles the Layer 1 opportunistic per-event Status
+// refresh. Called from the deltaFn closure after ApplyDelta. For issue and
+// issue_comment events on a known cache item, it fetches the current Status
+// from GitHub and updates the cache immediately. All errors are best-effort:
+// logged as warnings and never returned.
+func (e *Engine) applyLayer1StatusRefresh(eventType string, payload []byte, cache *boardcache.CacheImpl) {
+	if cache.IsPaused() {
+		return
+	}
+	if eventType != "issues" && eventType != "issue_comment" {
+		return
+	}
+	var ev struct {
+		Issue struct {
+			Number int `json:"number"`
+		} `json:"issue"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+	}
+	if err := json.Unmarshal(payload, &ev); err != nil || ev.Repository.FullName == "" || ev.Issue.Number == 0 {
+		return
+	}
+	key := boardcache.ItemKey(ev.Repository.FullName, ev.Issue.Number)
+	itemID, ok := cache.GetItemID(key)
+	if !ok {
+		return
+	}
+	status, err := e.client.FetchProjectItemStatus(itemID)
+	if err != nil {
+		e.logf(ev.Issue.Number, "warn", "layer1 status fetch failed for %s: %v\n", itemID, err)
+		return
+	}
+	cache.UpdateItemStatus(key, status)
 }

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1341,29 +1341,17 @@ func TestLayer1StatusRefresh_UpdatesCacheOnIssueCommentEvent(t *testing.T) {
 		t.Errorf("want FetchProjectItemStatus called once with %q, got %v", "PVTI_001", calls)
 	}
 
-	// Cache must reflect the new status without a Layer 2 sweep.
+	// Verify the item still exists in the cache (not corrupted by the refresh).
 	itemID, ok := cache.GetItemID(boardcache.ItemKey("owner/repo", 1))
 	if !ok {
-		t.Fatal("item not found in cache")
+		t.Fatal("item no longer found in cache after Layer 1 refresh")
 	}
 	if itemID != "PVTI_001" {
 		t.Fatalf("unexpected itemID %q", itemID)
 	}
-	// Read status via ApplyStatusBatch side-channel: verify by bootstrapping and checking.
-	// Easier: read directly via a status-batch round-trip.
-	// Actually the simplest check: call GetItemID to confirm item exists, and check via
-	// a single-item ApplyStatusBatch that won't touch our item if it's already "Plan".
-	// Let's bootstrap a second cache from the current state and compare.
-	// The simplest approach: verify via FetchProjectItemStatusBatch call above succeeding
-	// and then checking via cache-internal state. Since we're in a separate package,
-	// use the public API: UpdateItemStatus → GetItemID still returns the old/new value
-	// via indirect observation through ApplyStatusBatch.
-	// Simpler: just confirm no second FetchProjectItemStatus call was made (idempotent).
-	// The most direct check is via the UpdateItemStatus side-effect in ApplyStatusBatch.
-	// Since this is package engine (black-box for boardcache), use ProjectID as a canary.
-	if cache.ProjectID() != "PVT_test" {
-		t.Error("unexpected cache state after Layer 1 refresh")
-	}
+	// The cache-side update (UpdateItemStatus sets Status="Plan") is verified by
+	// boardcache_test.go:TestUpdateItemStatusSetsStatusAndUpdatedAt. Here we confirm
+	// the engine called the right API path, which is the engine-level invariant.
 }
 
 func TestLayer1StatusRefresh_SkipsWhenCachePaused(t *testing.T) {

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1341,17 +1341,20 @@ func TestLayer1StatusRefresh_UpdatesCacheOnIssueCommentEvent(t *testing.T) {
 		t.Errorf("want FetchProjectItemStatus called once with %q, got %v", "PVTI_001", calls)
 	}
 
-	// Verify the item still exists in the cache (not corrupted by the refresh).
-	itemID, ok := cache.GetItemID(boardcache.ItemKey("owner/repo", 1))
-	if !ok {
-		t.Fatal("item no longer found in cache after Layer 1 refresh")
+	// Verify the cache now reflects "Plan" — the status returned by FetchProjectItemStatus.
+	board, err := cache.FetchProjectBoard("owner", "repo", 1, "")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
 	}
-	if itemID != "PVTI_001" {
-		t.Fatalf("unexpected itemID %q", itemID)
+	var gotStatus string
+	for _, item := range board.Items {
+		if item.Number == 1 {
+			gotStatus = item.Status
+		}
 	}
-	// The cache-side update (UpdateItemStatus sets Status="Plan") is verified by
-	// boardcache_test.go:TestUpdateItemStatusSetsStatusAndUpdatedAt. Here we confirm
-	// the engine called the right API path, which is the engine-level invariant.
+	if gotStatus != "Plan" {
+		t.Errorf("want cached Status %q after Layer 1 refresh, got %q", "Plan", gotStatus)
+	}
 }
 
 func TestLayer1StatusRefresh_SkipsWhenCachePaused(t *testing.T) {
@@ -1422,17 +1425,40 @@ func TestRunReconciliationLoop_AppliesStatusDrift(t *testing.T) {
 	// Wait up to 500ms for the cache to reflect the drifted status.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		// Check via ApplyStatusBatch idempotency: if UpdatedAt advances, status changed.
-		// Simplest: try to detect via FetchProjectItemStatusBatch call count + direct read.
-		if atomic.LoadInt32(&batchCalls) > 0 {
-			break
+		board, err := cache.FetchProjectBoard("owner", "repo", 1, "")
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		for _, item := range board.Items {
+			if item.Number == 1 && item.Status == "Implement" {
+				cancel()
+				return
+			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 	cancel()
+	// Give the goroutine time to finish any in-flight ApplyStatusBatch.
+	time.Sleep(25 * time.Millisecond)
 
 	if atomic.LoadInt32(&batchCalls) == 0 {
 		t.Fatal("FetchProjectItemStatusBatch was never called within 500ms")
+	}
+
+	// Verify the cache reflects the drifted status.
+	board, err := cache.FetchProjectBoard("owner", "repo", 1, "")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard after layer2 sweep: %v", err)
+	}
+	var gotStatus string
+	for _, item := range board.Items {
+		if item.Number == 1 {
+			gotStatus = item.Status
+		}
+	}
+	if gotStatus != "Implement" {
+		t.Errorf("want cached Status %q after Layer 2 sweep, got %q", "Implement", gotStatus)
 	}
 }
 

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -2,13 +2,16 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -1294,5 +1297,176 @@ func TestPoll_CruiseValidateComplete_NoRepeatDeepFetch(t *testing.T) {
 
 	if deepFetchCount > 1 {
 		t.Errorf("FetchItemDetails called %d times across 2 polls; want at most 1 — perpetual deep-fetch loop must not recur", deepFetchCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1 — opportunistic per-event Status refresh
+// ---------------------------------------------------------------------------
+
+// seedTestCache creates a CacheImpl bootstrapped with one item (PVTI_001, owner/repo#1, "Research").
+func seedTestCache(t *testing.T, client *mockGitHubClient) *boardcache.CacheImpl {
+	t.Helper()
+	cache := boardcache.NewCacheImpl(client, func(format string, args ...any) {})
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_test",
+		Items: []gh.ProjectItem{
+			{Number: 1, ItemID: "PVTI_001", Status: "Research", Repo: "owner/repo"},
+		},
+	}
+	cache.Bootstrap(board)
+	return cache
+}
+
+func TestLayer1StatusRefresh_UpdatesCacheOnIssueCommentEvent(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectItemStatusFn: func(itemID string) (string, error) {
+			return "Plan", nil
+		},
+	}
+	cache := seedTestCache(t, client)
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	payload, _ := json.Marshal(map[string]any{
+		"issue":      map[string]any{"number": 1},
+		"repository": map[string]any{"full_name": "owner/repo"},
+	})
+	eng.applyLayer1StatusRefresh("issue_comment", payload, cache)
+
+	// FetchProjectItemStatus must have been called for PVTI_001.
+	client.mu.Lock()
+	calls := append([]string(nil), client.fetchProjectItemStatusCalls...)
+	client.mu.Unlock()
+	if len(calls) != 1 || calls[0] != "PVTI_001" {
+		t.Errorf("want FetchProjectItemStatus called once with %q, got %v", "PVTI_001", calls)
+	}
+
+	// Cache must reflect the new status without a Layer 2 sweep.
+	itemID, ok := cache.GetItemID(boardcache.ItemKey("owner/repo", 1))
+	if !ok {
+		t.Fatal("item not found in cache")
+	}
+	if itemID != "PVTI_001" {
+		t.Fatalf("unexpected itemID %q", itemID)
+	}
+	// Read status via ApplyStatusBatch side-channel: verify by bootstrapping and checking.
+	// Easier: read directly via a status-batch round-trip.
+	// Actually the simplest check: call GetItemID to confirm item exists, and check via
+	// a single-item ApplyStatusBatch that won't touch our item if it's already "Plan".
+	// Let's bootstrap a second cache from the current state and compare.
+	// The simplest approach: verify via FetchProjectItemStatusBatch call above succeeding
+	// and then checking via cache-internal state. Since we're in a separate package,
+	// use the public API: UpdateItemStatus → GetItemID still returns the old/new value
+	// via indirect observation through ApplyStatusBatch.
+	// Simpler: just confirm no second FetchProjectItemStatus call was made (idempotent).
+	// The most direct check is via the UpdateItemStatus side-effect in ApplyStatusBatch.
+	// Since this is package engine (black-box for boardcache), use ProjectID as a canary.
+	if cache.ProjectID() != "PVT_test" {
+		t.Error("unexpected cache state after Layer 1 refresh")
+	}
+}
+
+func TestLayer1StatusRefresh_SkipsWhenCachePaused(t *testing.T) {
+	var callCount int32
+	client := &mockGitHubClient{
+		fetchProjectItemStatusFn: func(itemID string) (string, error) {
+			atomic.AddInt32(&callCount, 1)
+			return "Plan", nil
+		},
+	}
+	cache := seedTestCache(t, client)
+	cache.Pause()
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	payload, _ := json.Marshal(map[string]any{
+		"issue":      map[string]any{"number": 1},
+		"repository": map[string]any{"full_name": "owner/repo"},
+	})
+	eng.applyLayer1StatusRefresh("issue_comment", payload, cache)
+
+	if n := atomic.LoadInt32(&callCount); n != 0 {
+		t.Errorf("FetchProjectItemStatus should not be called when cache is paused; got %d calls", n)
+	}
+}
+
+func TestLayer1StatusRefresh_SkipsNonIssueEvents(t *testing.T) {
+	var callCount int32
+	client := &mockGitHubClient{
+		fetchProjectItemStatusFn: func(itemID string) (string, error) {
+			atomic.AddInt32(&callCount, 1)
+			return "Plan", nil
+		},
+	}
+	cache := seedTestCache(t, client)
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	payload, _ := json.Marshal(map[string]any{
+		"pull_request": map[string]any{"number": 1},
+		"repository":   map[string]any{"full_name": "owner/repo"},
+	})
+	eng.applyLayer1StatusRefresh("pull_request", payload, cache)
+
+	if n := atomic.LoadInt32(&callCount); n != 0 {
+		t.Errorf("FetchProjectItemStatus should not be called for pull_request events; got %d calls", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — periodic status-field-only sweep
+// ---------------------------------------------------------------------------
+
+func TestRunReconciliationLoop_AppliesStatusDrift(t *testing.T) {
+	var batchCalls int32
+	client := &mockGitHubClient{
+		fetchProjectItemStatusBatchFn: func(projectID string) (map[string]string, error) {
+			atomic.AddInt32(&batchCalls, 1)
+			return map[string]string{"PVTI_001": "Implement"}, nil
+		},
+	}
+	cache := seedTestCache(t, client)
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go eng.runReconciliationLoop(ctx, cache, 50*time.Millisecond)
+
+	// Wait up to 500ms for the cache to reflect the drifted status.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		// Check via ApplyStatusBatch idempotency: if UpdatedAt advances, status changed.
+		// Simplest: try to detect via FetchProjectItemStatusBatch call count + direct read.
+		if atomic.LoadInt32(&batchCalls) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+
+	if atomic.LoadInt32(&batchCalls) == 0 {
+		t.Fatal("FetchProjectItemStatusBatch was never called within 500ms")
+	}
+}
+
+func TestRunReconciliationLoop_SkipsWhenProjectIDEmpty(t *testing.T) {
+	var batchCalls int32
+	client := &mockGitHubClient{
+		fetchProjectItemStatusBatchFn: func(projectID string) (map[string]string, error) {
+			atomic.AddInt32(&batchCalls, 1)
+			return map[string]string{}, nil
+		},
+	}
+	// Cache with no Bootstrap call — ProjectID() returns "".
+	cache := boardcache.NewCacheImpl(client, func(format string, args ...any) {})
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go eng.runReconciliationLoop(ctx, cache, 50*time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	if n := atomic.LoadInt32(&batchCalls); n != 0 {
+		t.Errorf("FetchProjectItemStatusBatch should not be called when ProjectID is empty; got %d calls", n)
 	}
 }

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
@@ -414,6 +415,10 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 	e.logf(item.Number, "advance", "moving decomposed issue to Done\n")
 	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
 		e.logf(item.Number, "warn", "could not move issue to Done: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Done")
+		}
 	}
 }
 
@@ -435,5 +440,11 @@ func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem,
 	}
 
 	e.logf(item.Number, "advance", "moving to stage %q\n", next.Name)
-	return e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID)
+	err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID)
+	if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), next.Name)
+		}
+	}
+	return err
 }

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
@@ -427,5 +428,93 @@ func TestAttemptMergeOnValidate_FetchCheckRunsError_ReturnsError(t *testing.T) {
 	}
 	if len(client.mergePRCalls) != 0 {
 		t.Errorf("expected no MergePR on FetchCheckRuns error, got %d", len(client.mergePRCalls))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Layer 0 write-through tests
+// ---------------------------------------------------------------------------
+
+// TestAdvanceToNextStage_WritesThrough_Cache verifies Layer 0: after a successful
+// advanceToNextStage call, the in-memory cache reflects the new status immediately,
+// without waiting for a Layer 2 sweep.
+func TestAdvanceToNextStage_WritesThrough_Cache(t *testing.T) {
+	const (
+		repo      = "owner/repo"
+		issueNum  = 42
+		itemID    = "PVTI_42"
+		projectID = "PID_1"
+	)
+
+	client := &mockGitHubClient{
+		updateProjectItemStatusFn: func(projectID, itemID, fieldID, optionID string) error {
+			return nil
+		},
+	}
+	stgs := testStagesWithValidate()
+	eng := testEngineWithStages(client, stgs)
+
+	// Replace readClient with a CacheImpl bootstrapped with the test item in Research.
+	cache := boardcache.NewCacheImpl(boardcache.NewGitHubAdapter(client), func(format string, args ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: projectID,
+		Items: []gh.ProjectItem{
+			{
+				ID:     "I_42",
+				ItemID: itemID,
+				Repo:   repo,
+				Number: issueNum,
+				Status: "Research",
+			},
+		},
+	})
+	eng.readClient = cache
+
+	board := &gh.ProjectBoard{ProjectID: projectID}
+	item := gh.ProjectItem{
+		ID:     "I_42",
+		ItemID: itemID,
+		Repo:   repo,
+		Number: issueNum,
+		Status: "Research",
+	}
+	currentStage := stgs[0] // Research
+
+	if err := eng.advanceToNextStage(board, item, currentStage); err != nil {
+		t.Fatalf("advanceToNextStage: %v", err)
+	}
+
+	// The cache should immediately reflect the new status without Layer 2 sweep.
+	gotID, ok := cache.GetItemID(boardcache.ItemKey(repo, issueNum))
+	if !ok {
+		t.Fatal("GetItemID returned !ok after advanceToNextStage")
+	}
+	if gotID != itemID {
+		t.Errorf("item ID mismatch: want %q, got %q", itemID, gotID)
+	}
+
+	// Read status via the cache internals using GetItemID to confirm the key.
+	key := boardcache.ItemKey(repo, issueNum)
+	_ = key // key confirmed via GetItemID above
+
+	// Use ApplyStatusBatch with a no-op to flush nothing; read via GetItemID side-channel.
+	// Directly verify by checking that the cache returns the updated status through the
+	// UpdateItemStatus path: the cache item should now have status "Plan".
+	gotItems, err := cache.FetchProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	var found *gh.ProjectItem
+	for i := range gotItems.Items {
+		if gotItems.Items[i].Number == issueNum {
+			found = &gotItems.Items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("item not found in cache after advanceToNextStage")
+	}
+	if found.Status != "Plan" {
+		t.Errorf("cache Status = %q after advanceToNextStage, want %q", found.Status, "Plan")
 	}
 }

--- a/github/project.go
+++ b/github/project.go
@@ -920,7 +920,7 @@ query($id: ID!) {
 
 	var result struct {
 		Data struct {
-			Node struct {
+			Node *struct {
 				FieldValueByName *struct {
 					Name string `json:"name"`
 				} `json:"fieldValueByName"`
@@ -930,6 +930,9 @@ query($id: ID!) {
 
 	if err := c.graphqlRequest(query, vars, &result); err != nil {
 		return "", fmt.Errorf("fetching status for item %s: %w", itemID, err)
+	}
+	if result.Data.Node == nil {
+		return "", fmt.Errorf("fetching status for item %s: item not found or not a ProjectV2Item", itemID)
 	}
 	if result.Data.Node.FieldValueByName == nil {
 		return "", nil
@@ -981,7 +984,7 @@ query($id: ID!, $cursor: String) {
 
 		var result struct {
 			Data struct {
-				Node struct {
+				Node *struct {
 					Items struct {
 						PageInfo struct {
 							HasNextPage bool   `json:"hasNextPage"`
@@ -995,6 +998,9 @@ query($id: ID!, $cursor: String) {
 
 		if err := c.graphqlRequest(query, vars, &result); err != nil {
 			return nil, fmt.Errorf("fetching project item status batch: %w", err)
+		}
+		if result.Data.Node == nil {
+			return nil, fmt.Errorf("fetching project item status batch: project not found or not a ProjectV2")
 		}
 
 		for _, n := range result.Data.Node.Items.Nodes {

--- a/github/project.go
+++ b/github/project.go
@@ -900,3 +900,119 @@ query($id: ID!, $cursor: String) {
 func parseTime(s string) (time.Time, error) {
 	return time.Parse(time.RFC3339, s)
 }
+
+// FetchProjectItemStatus fetches only the Status field value for a single project
+// item identified by its node ID (PVTI_...). Returns "" when no status is set.
+func (c *Client) FetchProjectItemStatus(itemID string) (string, error) {
+	query := `
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2Item {
+      fieldValueByName(name: "Status") {
+        ... on ProjectV2ItemFieldSingleSelectValue {
+          name
+        }
+      }
+    }
+  }
+}`
+	vars := map[string]interface{}{"id": itemID}
+
+	var result struct {
+		Data struct {
+			Node struct {
+				FieldValueByName *struct {
+					Name string `json:"name"`
+				} `json:"fieldValueByName"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return "", fmt.Errorf("fetching status for item %s: %w", itemID, err)
+	}
+	if result.Data.Node.FieldValueByName == nil {
+		return "", nil
+	}
+	return result.Data.Node.FieldValueByName.Name, nil
+}
+
+// FetchProjectItemStatusBatch fetches a map of projectItemNodeID → statusName for
+// every item in the project. Dramatically cheaper than FetchProjectBoard because it
+// fetches no nested fields. Paginates identically to fetchProjectBoardOnce.
+func (c *Client) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
+	query := `
+query($id: ID!, $cursor: String) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      items(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	type statusNode struct {
+		ID               string `json:"id"`
+		FieldValueByName *struct {
+			Name string `json:"name"`
+		} `json:"fieldValueByName"`
+	}
+
+	out := make(map[string]string)
+	cursor := ""
+
+	for {
+		vars := map[string]interface{}{"id": projectID}
+		if cursor != "" {
+			vars["cursor"] = cursor
+		}
+
+		var result struct {
+			Data struct {
+				Node struct {
+					Items struct {
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+						Nodes []statusNode `json:"nodes"`
+					} `json:"items"`
+				} `json:"node"`
+			} `json:"data"`
+		}
+
+		if err := c.graphqlRequest(query, vars, &result); err != nil {
+			return nil, fmt.Errorf("fetching project item status batch: %w", err)
+		}
+
+		for _, n := range result.Data.Node.Items.Nodes {
+			if n.FieldValueByName != nil {
+				out[n.ID] = n.FieldValueByName.Name
+			} else {
+				out[n.ID] = ""
+			}
+		}
+
+		if !result.Data.Node.Items.PageInfo.HasNextPage {
+			break
+		}
+		if result.Data.Node.Items.PageInfo.EndCursor == "" {
+			return nil, fmt.Errorf("fetching project item status batch: hasNextPage=true but endCursor is empty")
+		}
+		cursor = result.Data.Node.Items.PageInfo.EndCursor
+	}
+
+	return out, nil
+}


### PR DESCRIPTION
## Summary

Replace the single 60-min full board reconcile with a four-layer strategy that covers all scenarios under which Status can drift:

- **Layer 0 (write-through)**: When Fabrik itself mutates a project item's Status (e.g., `advanceToNextStage`), update the cache immediately at the mutation site — zero GraphQL cost, zero latency for self-driven changes.
- **Layer 1 (opportunistic per-event refresh)**: After applying any webhook delta for a known issue, issue a single-item Status fetch and update the cache. Very cheap (~1–5 points/event). Catches the common case where a column move coincides with any other activity on the same issue.
- **Layer 2 (periodic status-field-only sweep)**: Replace the 60-min full-board reconcile loop with a status-only sweep (new configurable cadence, default 10 min) that fetches only `(itemID, statusFieldValue)` for every item on the board. Order-of-magnitude cheaper than the full board fetch; can run at much tighter cadence without budget pressure.
- **Startup bootstrap + stream-recovery reconcile (unchanged)**: Full board fetch on startup and on webhook stream recovery remain as-is. Those paths must handle all field types, not just Status.

## Problem

In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub does **not** deliver `projects_v2_item` events. Board-column changes — including the Status field that drives stage selection — are invisible to the webhook stream and only propagate via Fabrik's periodic reconciliation. The reconciliation today is a **full board fetch** (`FetchProjectBoard` returning every item with full nested fields) running once every `webhookIdleCap = 60 min`.

Two consequences:

1. **Worst-case 60-min latency on column moves.** Concretely seen on issue #467: column moved at ~16:20Z, fresh Status not picked up until ~17:36Z (76 min later). Stuck issues, manual restart workarounds, support burden.
2. **Heavy GraphQL cost when it does run.** A full board fetch with nested fields is Fabrik's most expensive query. Running it more often to reduce latency would drain the budget faster, not less.

This issue is scoped to user mode only. App mode (#85 + follow-up) is the "right" fix for some users (org-owned projects) but doesn't help user-owned projects (Liminis-style) — those will rely on polling permanently due to GitHub's user-account-level webhook gap. Lightweight polling is needed regardless of #85's outcome.

## Approach

### Approach

Implement the four-layer status polling strategy exactly as specified and researched. All layers are tightly coupled (they share new cache methods, the new GraphQL helpers, and the new config field), so a single Implement cycle is appropriate.

**Three open questions resolved here:**

1. **Layer 1 PR-event scope** — Restrict Layer 1 to `issue_comment` and `issues` events only (not PR events). PR-event lookup requires an O(N) items scan to find the linked issue, which adds complexity for marginal benefit. Layer 2's 10-min sweep covers the PR-event gap. The `ItemKeyForLinkedPR` helper from the research notes is not needed and will not be built.

2. **Empty `projectID` guard in Layer 2** — Yes, add the guard. If `cacheImpl.ProjectID() == ""`, log a warning and skip that tick rather than calling `FetchProjectItemStatusBatch("")`.

3. **Export `ItemKey`** — Export `boardcache.ItemKey(repo string, number int) string` as a package-level helper. This avoids format duplication between `engine/stages.go` and the package's internal `itemKey`, and prevents a silent divergence bug if the format ever changes.

**ADR warranted**: The four-layer strategy introduces a non-obvious convention — Layer 0 requires every future call site that mutates a project item's Status to also call `UpdateItemStatus` on success. Without an ADR, future contributors will not know this invariant exists. An ADR should be created.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/interfaces.go` | Add `FetchProjectItemStatus` and `FetchProjectItemStatusBatch` to `GitHubClient` interface |
| `engine/mocks_test.go` | Add function fields and stub methods for both new interface methods |
| `boardcache/boardcache.go` | Export `ItemKey`; add `UpdateItemStatus`, `ApplyStatusBatch`, `GetItemID`, `ProjectID` methods to `CacheImpl` |
| `engine/engine.go` | Add `ProjectStatusPollSeconds int` to `Config` struct (default 600) |
| `config/config.go` | Add `StatusPoll *int \`yaml:"status_poll"\`` to `ProjectConfig` |
| `cmd/root.go` | Add `--status-poll` flag, `FABRIK_STATUS_POLL` env var, `status_poll` config.yaml wiring |
| `github/project.go` | Implement `FetchProjectItemStatus` and `FetchProjectItemStatusBatch` on `*Client` |
| `engine/stages.go` | Layer 0: write-through after successful `UpdateProjectItemStatus` in `moveToNextDone` and `advanceToNextStage` |
| `engine/poll.go` | Layer 1: replace `deltaFn = cacheImpl.ApplyDelta` with closure; Layer 2: rewrite `runReconciliationLoop` |
| `boardcache/boardcache_test.go` | Unit tests for `UpdateItemStatus` and `ApplyStatusBatch` |
| `engine/stages_test.go` | Unit test: Layer 0 write-through observable from cache after `advanceToNextStage` |
| `engine/poll_test.go` | Unit tests: Layer 1 closure behavior; Layer 2 cadence goroutine test |
| `docs/state-machine.md` | Update §D.4; add §D.7 "Status field reconciliation in user mode" |
| `docs/USER_GUIDE.md` | Update 8 stale "60 minutes" references |
| `adrs/NNN-four-layer-status-reconciliation.md` | New ADR documenting the four-layer strategy and Layer 0 write-through convention |

### Key Decisions

- **Layer 1 restricted to issue events only**: PR events would require `ItemKeyForLinkedPR`, an O(N) items scan in the cache under read lock. The cost-benefit doesn't justify it for Layer 1 — the 10-min Layer 2 sweep handles the gap. Keeping Layer 1 to `issues` and `issue_comment` event types keeps the closure simple and safe.

- **Export `ItemKey`**: `engine/stages.go` needs to construct cache keys; replicating the internal format string inline risks a silent divergence. Export it as `boardcache.ItemKey` — it's a stable, trivial function and there's no encapsulation benefit to keeping it private.

- **`runReconciliationLoop` is rewritten (not renamed)**: The function name is accurate for its new purpose (still a reconciliation loop, just lightweight). The comment is updated; the implementation body is replaced. `reconcileCache` is preserved unchanged for stream-recovery.

- **`ProjectStatusPollSeconds` default of 600**: Matches the spec. Distinct from `PollSeconds` (board poll interval) to avoid confusion. Wiring follows the exact same pattern as `PollSeconds` (flag → env var → config.yaml, with the last-writer-wins order in `cmd/root.go`).

- **ADR created**: Four-layer strategy documents the Layer 0 write-through convention that all future `UpdateProjectItemStatus` callers must follow. Also updates ADR 032 cross-reference since this replaces the 60-min poll described there.

### Task Checklist

- [ ] Task 1: Add `FetchProjectItemStatus(itemID string) (string, error)` and `FetchProjectItemStatusBatch(projectID string) (map[string]string, error)` to `GitHubClient` interface in `engine/interfaces.go`; add function fields and stub methods to `mockGitHubClient` in `engine/mocks_test.go`
- [ ] Task 2: Export `ItemKey(repo string, number int) string` from `boardcache/boardcache.go` (keep internal `itemKey` as an alias or replace all internal callers); add `UpdateItemStatus(key, newStatus string)`, `ApplyStatusBatch(updates map[string]string)`, `GetItemID(key string) (string, bool)`, and `ProjectID() string` methods to `CacheImpl`
- [ ] Task 3: Unit tests in `boardcache/boardcache_test.go`: (a) `UpdateItemStatus` sets `Status`+`UpdatedAt`, is a no-op for unknown key; (b) `ApplyStatusBatch` updates drifted items, leaves unchanged items untouched, skips unknown itemIDs
- [ ] Task 4: Add `ProjectStatusPollSeconds int` to `engine.Config` in `engine/engine.go` (default 600); add `StatusPoll *int \`yaml:"status_poll"\`` to `ProjectConfig` in `config/config.go`; add `--status-poll` flag, `FABRIK_STATUS_POLL` env var, and `config.StatusPoll` wiring in `cmd/root.go` following the `PollSeconds` pattern; pass to `engine.Config.ProjectStatusPollSeconds` at startup
- [ ] Task 5: Implement `FetchProjectItemStatus(itemID string) (string, error)` on `*Client` in `github/project.go`: GraphQL `node(id: $id)` query returning `fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }`; return `""` when no value set
- [ ] Task 6: Implement `FetchProjectItemStatusBatch(projectID string) (map[string]string, error)` on `*Client` in `github/project.go`: paginated GraphQL query fetching only `items { nodes { id fieldValueByName(name: "Status") { ... } } }` for the project; accumulate `nodeID → statusName` map; pagination mechanics identical to `fetchProjectBoardOnce`
- [ ] Task 7: Layer 0 in `engine/stages.go`: after the `if err != nil { ... return }` block in `moveToNextDone`, add write-through `if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok { cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Done") }`; in `advanceToNextStage`, add equivalent write-through after `return e.client.UpdateProjectItemStatus(...)` succeeds (change to check error inline)
- [ ] Task 8: Unit test in `engine/stages_test.go`: `advanceToNextStage` with a populated `CacheImpl` → cache `Status` reflects the next stage name immediately after the call, without a Layer 2 sweep
- [ ] Task 9: Layer 1 in `engine/poll.go`: replace `deltaFn = cacheImpl.ApplyDelta` (line ~307) with a closure that (a) calls `cacheImpl.ApplyDelta(eventType, payload)`, then (b) if `!cacheImpl.IsPaused()` and `eventType` is `"issues"` or `"issue_comment"`, parses `repository.full_name` + `issue.number` from payload, calls `cacheImpl.GetItemID(boardcache.ItemKey(repo, number))`, calls `e.client.FetchProjectItemStatus(itemID)`, calls `cacheImpl.UpdateItemStatus(key, newStatus)`; all errors logged as warnings, never returned
- [ ] Task 10: Unit test in `engine/poll_test.go` for Layer 1: fake `issue_comment` event payload → mock `FetchProjectItemStatus` called once → `CacheImpl.GetItemID` → `UpdateItemStatus` → cache reflects updated Status; verify skipped when `IsPaused() == true`
- [ ] Task 11: Layer 2 in `engine/poll.go`: rewrite `runReconciliationLoop` to tick at `time.Duration(cfg.ProjectStatusPollSeconds) * time.Second`; on each tick, call `cacheImpl.ProjectID()` and skip if empty (log warning); call `e.client.FetchProjectItemStatusBatch(projectID)`; call `cacheImpl.ApplyStatusBatch(updates)`; errors logged as warnings
- [ ] Task 12: Goroutine test in `engine/poll_test.go` for Layer 2: start loop with 50ms cadence → mock `FetchProjectItemStatusBatch` returns drift → assert `ApplyStatusBatch` applied (Status updated in cache) within deadline; verify empty `projectID` skips the API call
- [ ] Task 13: Update `docs/state-machine.md`: revise §D.4 (Reconciliation) to describe two-level reconcile (Layer 2 status-only sweep at `ProjectStatusPollSeconds`, full `reconcileCache` for stream-recovery only); add §D.7 "Status field reconciliation in user mode" covering the four-layer strategy, residual latency bounds, and the Layer 0 write-through convention
- [ ] Task 14: Update `docs/USER_GUIDE.md`: replace all 8 stale "60 minutes" references (lines 1588, 1638, 1639, 1646, 1656, 1666, 1668, 1672, 1698) to reflect the two-level strategy (10-min status sweep for column-move latency; full board fetch preserved for startup/stream-recovery)
- [ ] Task 15: Create ADR NNN `adrs/NNN-four-layer-status-reconciliation.md` documenting the four-layer strategy, the Layer 0 write-through convention (all future `UpdateProjectItemStatus` callers must also call `UpdateItemStatus`), the decision to exclude PR events from Layer 1, and the rationale for exporting `ItemKey`; add cross-reference note to ADR 032

### Risks

- **Layer 1 payload parsing** (`repository.full_name` + `issue.number`): the closure must handle malformed or missing fields gracefully. Use a minimal anonymous struct for unmarshalling and skip (log warning) if fields are absent — do not let a bad payload crash the closure or block the delta pipeline.
- **`advanceToNextStage` return-path change (Task 7)**: currently the function returns `e.client.UpdateProjectItemStatus(...)` directly. To add the write-through, the error must be captured before returning. This is a minor refactor at the call site — check that no tests depend on the current single-expression form.
- **Race detector**: `runReconciliationLoop` (Layer 2) and the `deltaFn` closure (Layer 1) both call `CacheImpl` mutations concurrently. Both use `c.mu` (write lock) — safe. Run `go test -race ./...` before final commit to confirm.
- **`FetchProjectItemStatusBatch` pagination at large scale**: pagination is required for boards > 100 items. Pattern is identical to `fetchProjectBoardOnce` — reuse the same cursor loop structure to avoid subtle differences.
- **ADR numbering**: check `adrs/` at implementation time for the current highest number (currently 034) and use the next available sequential number. Do not hardcode 035 in the plan.

---
Used 19/50 turns, 7k input / 7k output tokens.

## Verification

Implemented the four-layer status reconciliation strategy for issue #501. All layers are fully implemented: Layer 0 (write-through in `advanceToNextStage`/`moveToNextDone`), Layer 1 (opportunistic per-event refresh via `applyLayer1StatusRefresh`), Layer 2 (10-min periodic `FetchProjectItemStatusBatch` sweep replacing the 60-min full-board loop). New GraphQL helpers, `CacheImpl` methods (`UpdateItemStatus`, `ApplyStatusBatch`, `GetItemID`, `ProjectID`), config wiring (`--status-poll`/`FABRIK_STATUS_POLL`), docs (`state-machine.md §D.4+D.7`, `USER_GUIDE.md`), and ADR 035 are all committed; all tests pass with the race detector.

---

Closes #501