### PR TITLE
boardcache: auto-heal PR-targeted delta dispatch when no cached item links the PR

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -111,17 +111,20 @@ const recentMissTTL = 10 * time.Minute
 // resolvePRLinkage looks up which cached issue is closed by the given PR by
 // fetching the PR body via REST and parsing closing keywords. Must be called
 // without c.mu held (the REST call is a network operation). Returns the cache
-// key and issue number of the first closing issue found in c.items, or
-// ("", 0, false) when no match is found.
-func (c *CacheImpl) resolvePRLinkage(owner, repo string, prNumber int) (key string, issueNumber int, found bool) {
+// key and issue number of the first closing issue found in c.items. On a
+// transient REST error the error is returned and callers should NOT record a
+// negative-miss entry (a retry on the next webhook may succeed). Returns
+// ("", 0, false, nil) when the PR body has no recognized closing reference or
+// none of the referenced issues are in this cache.
+func (c *CacheImpl) resolvePRLinkage(owner, repo string, prNumber int) (key string, issueNumber int, found bool, err error) {
 	fullRepo := owner + "/" + repo
 	issues, err := c.fallback.FetchPRClosingIssues(owner, repo, prNumber)
 	if err != nil {
 		c.logFn("[cache] resolvePRLinkage: fetch closing issues for PR #%d: %v\n", prNumber, err)
-		return "", 0, false
+		return "", 0, false, err
 	}
 	if len(issues) == 0 {
-		return "", 0, false
+		return "", 0, false, nil
 	}
 
 	c.mu.RLock()
@@ -129,10 +132,10 @@ func (c *CacheImpl) resolvePRLinkage(owner, repo string, prNumber int) (key stri
 	for _, issNum := range issues {
 		k := itemKey(fullRepo, issNum)
 		if _, ok := c.items[k]; ok {
-			return k, issNum, true
+			return k, issNum, true, nil
 		}
 	}
-	return "", 0, false
+	return "", 0, false, nil
 }
 
 // CacheImpl is a goroutine-safe in-memory board cache. Webhook delta functions write

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -19,6 +19,8 @@ type ReadClient interface {
 	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
 	FetchLabels(owner, repo string, issueNumber int) ([]string, error)
 	FetchStatusField(projectID string) (*gh.StatusField, error)
+	FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)
+	FetchPRsForSHA(owner, repo, sha string) ([]int, error)
 	RateLimitStats() (rest, graphql gh.RateLimitStats)
 }
 
@@ -65,6 +67,14 @@ func (a *GitHubAdapter) FetchStatusField(projectID string) (*gh.StatusField, err
 	return a.client.FetchStatusField(projectID)
 }
 
+func (a *GitHubAdapter) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	return a.client.FetchPRClosingIssues(owner, repo, prNumber)
+}
+
+func (a *GitHubAdapter) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	return a.client.FetchPRsForSHA(owner, repo, sha)
+}
+
 func (a *GitHubAdapter) RateLimitStats() (rest, graphql gh.RateLimitStats) {
 	return a.client.RateLimitStats()
 }
@@ -84,6 +94,45 @@ func itemKey(repo string, number int) string {
 // prKey returns the cache key for a PR: "owner/repo#pr<prNumber>".
 func prKey(repo string, prNumber int) string {
 	return repo + "#pr" + strconv.Itoa(prNumber)
+}
+
+// missKey returns the negative-cache key for a PR number: "miss:owner/repo#prN".
+func missKey(repo string, prNumber int) string {
+	return "miss:" + repo + "#" + strconv.Itoa(prNumber)
+}
+
+// missKeyForSHA returns the negative-cache key for a commit SHA: "miss:sha:SHA".
+func missKeyForSHA(sha string) string {
+	return "miss:sha:" + sha
+}
+
+const recentMissTTL = 10 * time.Minute
+
+// resolvePRLinkage looks up which cached issue is closed by the given PR by
+// fetching the PR body via REST and parsing closing keywords. Must be called
+// without c.mu held (the REST call is a network operation). Returns the cache
+// key and issue number of the first closing issue found in c.items, or
+// ("", 0, false) when no match is found.
+func (c *CacheImpl) resolvePRLinkage(owner, repo string, prNumber int) (key string, issueNumber int, found bool) {
+	fullRepo := owner + "/" + repo
+	issues, err := c.fallback.FetchPRClosingIssues(owner, repo, prNumber)
+	if err != nil {
+		c.logFn("[cache] resolvePRLinkage: fetch closing issues for PR #%d: %v\n", prNumber, err)
+		return "", 0, false
+	}
+	if len(issues) == 0 {
+		return "", 0, false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, issNum := range issues {
+		k := itemKey(fullRepo, issNum)
+		if _, ok := c.items[k]; ok {
+			return k, issNum, true
+		}
+	}
+	return "", 0, false
 }
 
 // CacheImpl is a goroutine-safe in-memory board cache. Webhook delta functions write
@@ -114,6 +163,10 @@ type CacheImpl struct {
 	// Stream health: when paused, ApplyDelta is a no-op
 	paused bool
 
+	// Negative cache: keys are "miss:owner/repo#prN" or "miss:sha:SHA".
+	// Entries with TTL > 10 minutes are pruned lazily on access.
+	recentMissCache map[string]time.Time
+
 	// Fallback for cache misses
 	fallback ReadClient
 	logFn    func(format string, args ...any)
@@ -122,14 +175,15 @@ type CacheImpl struct {
 // NewCacheImpl creates an empty cache backed by fallback for misses.
 func NewCacheImpl(fallback ReadClient, logFn func(format string, args ...any)) *CacheImpl {
 	return &CacheImpl{
-		items:       make(map[string]*gh.ProjectItem),
-		deepFetched: make(map[string]bool),
-		checkRuns:   make(map[string][]gh.CheckRun),
-		linkedPRs:   make(map[string]*gh.PRDetails),
-		shaToKey:    make(map[string]string),
-		itemIDToKey: make(map[string]string),
-		fallback:    fallback,
-		logFn:       logFn,
+		items:           make(map[string]*gh.ProjectItem),
+		deepFetched:     make(map[string]bool),
+		checkRuns:       make(map[string][]gh.CheckRun),
+		linkedPRs:       make(map[string]*gh.PRDetails),
+		shaToKey:        make(map[string]string),
+		itemIDToKey:     make(map[string]string),
+		recentMissCache: make(map[string]time.Time),
+		fallback:        fallback,
+		logFn:           logFn,
 	}
 }
 
@@ -422,6 +476,16 @@ func (c *CacheImpl) FetchLabels(owner, repo string, issueNumber int) ([]string, 
 // FetchStatusField always delegates to GitHub — project metadata, not board-item state.
 func (c *CacheImpl) FetchStatusField(projectID string) (*gh.StatusField, error) {
 	return c.fallback.FetchStatusField(projectID)
+}
+
+// FetchPRClosingIssues always delegates to GitHub — used by the auto-heal path in delta handlers.
+func (c *CacheImpl) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	return c.fallback.FetchPRClosingIssues(owner, repo, prNumber)
+}
+
+// FetchPRsForSHA always delegates to GitHub — used by the auto-heal path in applyCheckRunCompleted.
+func (c *CacheImpl) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	return c.fallback.FetchPRsForSHA(owner, repo, sha)
 }
 
 // RateLimitStats always delegates to GitHub.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1112,3 +1112,231 @@ func TestProjectIDReturnsEmptyBeforeBootstrap(t *testing.T) {
 		t.Errorf("want empty string before bootstrap, got %q", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Auto-heal: PR-targeted delta handlers repair stale LinkedPRNumber
+// ---------------------------------------------------------------------------
+
+// seedCacheWithPR seeds a cache with item #1 at LinkedPRNumber=0 and deepFetched=true.
+func seedCacheWithStalePRLink(t *testing.T, mc *mockClient) *CacheImpl {
+	t.Helper()
+	c := NewCacheImpl(mc, nopLog)
+	board := &gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo",
+				Status: "Implement", LinkedPRNumber: 0},
+		},
+	}
+	c.Bootstrap(board)
+	// Mark as deep-fetched so we can verify deepFetched is cleared by heal.
+	c.mu.Lock()
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+	return c
+}
+
+func TestAutoHealPullRequestReviewSubmitted(t *testing.T) {
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return []int{1}, nil // PR #42 closes issue #1
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 2001, "approved", "reviewer")
+	c.ApplyDelta("pull_request_review", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	linkedPR := item.LinkedPRNumber
+	reviews := clonePRReviews(item.LinkedPRReviews)
+	df := c.deepFetched[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+
+	if linkedPR != 42 {
+		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
+	}
+	if len(reviews) != 1 || reviews[0].Author != "reviewer" || reviews[0].State != "APPROVED" {
+		t.Errorf("unexpected reviews after heal: %+v", reviews)
+	}
+	if df {
+		t.Error("expected deepFetched to be cleared after auto-heal")
+	}
+	if mc.fetchPRClosingIssuesCount != 1 {
+		t.Errorf("expected exactly 1 REST call, got %d", mc.fetchPRClosingIssuesCount)
+	}
+}
+
+func TestAutoHealPullRequestReviewCommentCreated(t *testing.T) {
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return []int{1}, nil
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 300, "RC_heal_1", "inline comment", "reviewer")
+	c.ApplyDelta("pull_request_review_comment", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	linkedPR := item.LinkedPRNumber
+	comments := cloneComments(item.LinkedPRReviewThreadComments)
+	df := c.deepFetched[itemKey("owner/repo", 1)]
+	c.mu.RUnlock()
+
+	if linkedPR != 42 {
+		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
+	}
+	if len(comments) != 1 || comments[0].ID != "RC_heal_1" {
+		t.Errorf("unexpected comments after heal: %+v", comments)
+	}
+	if df {
+		t.Error("expected deepFetched to be cleared after auto-heal")
+	}
+	if mc.fetchPRClosingIssuesCount != 1 {
+		t.Errorf("expected exactly 1 REST call, got %d", mc.fetchPRClosingIssuesCount)
+	}
+}
+
+func TestAutoHealCheckRunCompleted(t *testing.T) {
+	mc := &mockClient{
+		fetchPRsForSHAFn: func(owner, repo, sha string) ([]int, error) {
+			return []int{42}, nil
+		},
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return []int{1}, nil
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	before := time.Now()
+	payload := checkRunPayloadJSON("completed", "owner/repo", 5001, "ci", "completed", "success", "sha_heal")
+	c.ApplyDelta("check_run", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	linkedPR := item.LinkedPRNumber
+	shaKey, shaOK := c.shaToKey["sha_heal"]
+	df := c.deepFetched[itemKey("owner/repo", 1)]
+	updatedAt := item.UpdatedAt
+	c.mu.RUnlock()
+
+	if linkedPR != 42 {
+		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
+	}
+	if !shaOK || shaKey != itemKey("owner/repo", 1) {
+		t.Errorf("expected shaToKey[sha_heal]=owner/repo#1, got %q (ok=%v)", shaKey, shaOK)
+	}
+	if df {
+		t.Error("expected deepFetched to be cleared after auto-heal")
+	}
+	if !updatedAt.After(before) {
+		t.Error("expected UpdatedAt to be bumped after auto-heal")
+	}
+	if mc.fetchPRsForSHACount != 1 {
+		t.Errorf("expected 1 FetchPRsForSHA call, got %d", mc.fetchPRsForSHACount)
+	}
+	if mc.fetchPRClosingIssuesCount != 1 {
+		t.Errorf("expected 1 FetchPRClosingIssues call, got %d", mc.fetchPRClosingIssuesCount)
+	}
+}
+
+func TestAutoHealDropsWhenNoPRClosingKeyword(t *testing.T) {
+	var logBuf strings.Builder
+	logFn := func(format string, args ...any) { logBuf.WriteString(format) }
+
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return nil, nil // PR body has no closing reference
+		},
+	}
+	c := seedCacheWithStalePRLink2(t, logFn)
+	c.fallback = mc
+
+	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 99, 3001, "approved", "bot")
+	c.ApplyDelta("pull_request_review", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	linkedPR := item.LinkedPRNumber
+	reviews := clonePRReviews(item.LinkedPRReviews)
+	c.mu.RUnlock()
+
+	if linkedPR != 0 {
+		t.Errorf("expected LinkedPRNumber=0 (no mutation), got %d", linkedPR)
+	}
+	if len(reviews) != 0 {
+		t.Errorf("expected no reviews appended on drop, got %+v", reviews)
+	}
+	if !strings.Contains(logBuf.String(), "dropped") {
+		t.Errorf("expected 'dropped' in log, got: %q", logBuf.String())
+	}
+}
+
+func TestAutoHealDropsSilentlyWhenIssuNotInCache(t *testing.T) {
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return []int{999}, nil // issue #999 not in cache
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 77, 4001, "approved", "bot")
+	c.ApplyDelta("pull_request_review", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	linkedPR := item.LinkedPRNumber
+	reviews := clonePRReviews(item.LinkedPRReviews)
+	c.mu.RUnlock()
+
+	if linkedPR != 0 {
+		t.Errorf("expected no mutation (issue not in cache), got LinkedPRNumber=%d", linkedPR)
+	}
+	if len(reviews) != 0 {
+		t.Errorf("expected no reviews appended for unmanaged issue, got %+v", reviews)
+	}
+}
+
+func TestAutoHealNegativeCachePreventsRepeatedRESTCall(t *testing.T) {
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return nil, nil // no closing reference — will populate negative cache
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	// First delta — triggers REST call and populates negative cache.
+	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 55, 5001, "approved", "bot")
+	c.ApplyDelta("pull_request_review", payload)
+	if mc.fetchPRClosingIssuesCount != 1 {
+		t.Fatalf("expected 1 REST call after first delta, got %d", mc.fetchPRClosingIssuesCount)
+	}
+
+	// Second delta for same PR — negative cache should suppress the REST call.
+	payload2 := pullRequestReviewPayloadJSON("submitted", "owner/repo", 55, 5002, "approved", "bot2")
+	c.ApplyDelta("pull_request_review", payload2)
+	if mc.fetchPRClosingIssuesCount != 1 {
+		t.Errorf("expected negative cache to suppress second REST call, got %d calls total", mc.fetchPRClosingIssuesCount)
+	}
+}
+
+// seedCacheWithStalePRLink variant accepting a custom logFn for log-capture tests.
+func seedCacheWithStalePRLink2(t *testing.T, logFn func(string, ...any)) *CacheImpl {
+	t.Helper()
+	c := NewCacheImpl(&mockClient{}, logFn)
+	board := &gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo",
+				Status: "Implement", LinkedPRNumber: 0},
+		},
+	}
+	c.Bootstrap(board)
+	c.mu.Lock()
+	c.deepFetched[itemKey("owner/repo", 1)] = true
+	c.mu.Unlock()
+	return c
+}

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1323,6 +1323,43 @@ func TestAutoHealNegativeCachePreventsRepeatedRESTCall(t *testing.T) {
 	}
 }
 
+func TestAutoHealPullRequestDelta(t *testing.T) {
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return []int{1}, nil // PR #42 closes issue #1
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	before := time.Now()
+	payload := pullRequestPayloadJSON("opened", "owner/repo", 42, "sha_heal_pr", "open", false, false)
+	c.ApplyDelta("pull_request", payload)
+
+	c.mu.RLock()
+	item := c.items[itemKey("owner/repo", 1)]
+	linkedPR := item.LinkedPRNumber
+	shaKey, shaOK := c.shaToKey["sha_heal_pr"]
+	df := c.deepFetched[itemKey("owner/repo", 1)]
+	updatedAt := item.UpdatedAt
+	c.mu.RUnlock()
+
+	if linkedPR != 42 {
+		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
+	}
+	if !shaOK || shaKey != itemKey("owner/repo", 1) {
+		t.Errorf("expected shaToKey[sha_heal_pr]=%q, got %q (ok=%v)", itemKey("owner/repo", 1), shaKey, shaOK)
+	}
+	if df {
+		t.Error("expected deepFetched to be cleared after auto-heal")
+	}
+	if !updatedAt.After(before) {
+		t.Error("expected UpdatedAt to be bumped after auto-heal")
+	}
+	if mc.fetchPRClosingIssuesCount != 1 {
+		t.Errorf("expected exactly 1 REST call, got %d", mc.fetchPRClosingIssuesCount)
+	}
+}
+
 // seedCacheWithStalePRLink variant accepting a custom logFn for log-capture tests.
 func seedCacheWithStalePRLink2(t *testing.T, logFn func(string, ...any)) *CacheImpl {
 	t.Helper()

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -14,16 +14,21 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockClient struct {
-	fetchItemDetailsCount int
-	fetchCheckRunsCount   int
-	fetchLinkedPRCount    int
-	fetchLabelsCount      int
+	fetchItemDetailsCount      int
+	fetchCheckRunsCount        int
+	fetchLinkedPRCount         int
+	fetchLabelsCount           int
+	fetchPRClosingIssuesCount  int
+	fetchPRsForSHACount        int
 
 	itemDetailsResult  *gh.ProjectItem
 	checkRunsResult    []gh.CheckRun
 	linkedPRResult     *gh.PRDetails
 	labelsResult       []string
 	projectBoardResult *gh.ProjectBoard
+
+	fetchPRClosingIssuesFn func(owner, repo string, prNumber int) ([]int, error)
+	fetchPRsForSHAFn       func(owner, repo, sha string) ([]int, error)
 }
 
 func (m *mockClient) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
@@ -79,6 +84,22 @@ func (m *mockClient) FetchStatusField(projectID string) (*gh.StatusField, error)
 
 func (m *mockClient) RateLimitStats() (rest, graphql gh.RateLimitStats) {
 	return gh.RateLimitStats{}, gh.RateLimitStats{}
+}
+
+func (m *mockClient) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	m.fetchPRClosingIssuesCount++
+	if m.fetchPRClosingIssuesFn != nil {
+		return m.fetchPRClosingIssuesFn(owner, repo, prNumber)
+	}
+	return nil, nil
+}
+
+func (m *mockClient) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	m.fetchPRsForSHACount++
+	if m.fetchPRsForSHAFn != nil {
+		return m.fetchPRsForSHAFn(owner, repo, sha)
+	}
+	return nil, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -108,15 +108,15 @@ type pullRequestReviewPayload struct {
 type pullRequestReviewCommentPayload struct {
 	Action  string `json:"action"`
 	Comment struct {
-		NodeID     string  `json:"node_id"`
-		DatabaseID int     `json:"id"`
-		Body       string  `json:"body"`
-		CreatedAt  string  `json:"created_at"`
-		DiffHunk   string  `json:"diff_hunk"`
-		Path       string  `json:"path"`
-		Line       *int    `json:"line"`
-		OriginalLine *int  `json:"original_line"`
-		User       struct {
+		NodeID       string `json:"node_id"`
+		DatabaseID   int    `json:"id"`
+		Body         string `json:"body"`
+		CreatedAt    string `json:"created_at"`
+		DiffHunk     string `json:"diff_hunk"`
+		Path         string `json:"path"`
+		Line         *int   `json:"line"`
+		OriginalLine *int   `json:"original_line"`
+		User         struct {
 			Login string `json:"login"`
 		} `json:"user"`
 		PullRequestURL string `json:"pull_request_url"`
@@ -159,6 +159,58 @@ type projectsV2ItemPayload struct {
 		ContentNodeID string `json:"content_node_id"`
 		ContentType   string `json:"content_type"`
 	} `json:"projects_v2_item"`
+}
+
+// ---------------------------------------------------------------------------
+// Inner-mutation helpers — called by both normal and post-heal paths
+// ---------------------------------------------------------------------------
+
+// applyReviewToItem upserts a PR review into the item's LinkedPRReviews by DatabaseID.
+func applyReviewToItem(item *gh.ProjectItem, review gh.PRReview) {
+	for i, r := range item.LinkedPRReviews {
+		if r.DatabaseID == review.DatabaseID && review.DatabaseID != 0 {
+			item.LinkedPRReviews[i] = review
+			return
+		}
+	}
+	item.LinkedPRReviews = append(item.LinkedPRReviews, review)
+}
+
+// applyReviewCommentToItem appends a review thread comment to the item if not already
+// present (idempotent by NodeID), and clears the deepFetched flag so the next
+// FetchItemDetails call re-fetches the ReviewThreadID from GitHub.
+// Returns true if the comment was added, false if it was a duplicate.
+func applyReviewCommentToItem(item *gh.ProjectItem, comment gh.Comment, key string, deepFetched map[string]bool) bool {
+	for _, existing := range item.LinkedPRReviewThreadComments {
+		if existing.ID == comment.ID {
+			return false
+		}
+	}
+	item.LinkedPRReviewThreadComments = append(item.LinkedPRReviewThreadComments, comment)
+	delete(deepFetched, key)
+	return true
+}
+
+// updateSHAToKey removes stale SHA entries for the given key and sets the new SHA.
+func updateSHAToKey(shaToKey map[string]string, sha, key string) {
+	if sha == "" {
+		return
+	}
+	for existingSHA, existingKey := range shaToKey {
+		if existingKey == key && existingSHA != sha {
+			delete(shaToKey, existingSHA)
+		}
+	}
+	shaToKey[sha] = key
+}
+
+// splitRepo splits "owner/repo" into ("owner", "repo", true). Returns false on invalid input.
+func splitRepo(fullName string) (owner, repo string, ok bool) {
+	parts := strings.SplitN(fullName, "/", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 // ---------------------------------------------------------------------------
@@ -264,40 +316,73 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	}
 
 	repo := p.Repository.FullName
-	pk := prKey(repo, p.PullRequest.Number)
+	prNum := p.PullRequest.Number
+	pk := prKey(repo, prNum)
+	sha := p.PullRequest.Head.SHA
 	prDetails := &gh.PRDetails{
-		Number:         p.PullRequest.Number,
+		Number:         prNum,
 		Title:          p.PullRequest.Title,
 		State:          p.PullRequest.State,
 		Merged:         p.PullRequest.Merged,
 		Draft:          p.PullRequest.Draft,
-		HeadSHA:        p.PullRequest.Head.SHA,
+		HeadSHA:        sha,
 		MergeableState: p.PullRequest.MergeableState,
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	owner, repoName, ok := splitRepo(repo)
+	if !ok {
+		return
+	}
 
-	// Store/update PR details.
+	c.mu.Lock()
+
+	// Always store/update PR details regardless of whether we find a linked issue.
 	c.linkedPRs[pk] = prDetails
 
 	// Find the issue in cache that links this PR and update shaToKey.
-	sha := p.PullRequest.Head.SHA
 	for key, item := range c.items {
-		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
-			if sha != "" {
-				// On synchronize, the old SHA is now stale — remove it from the map
-				// by overwriting any existing entry for this issue with the new SHA.
-				for existingSHA, existingKey := range c.shaToKey {
-					if existingKey == key && existingSHA != sha {
-						delete(c.shaToKey, existingSHA)
-					}
-				}
-				c.shaToKey[sha] = key
-			}
-			break
+		if item.Repo == repo && item.LinkedPRNumber == prNum {
+			updateSHAToKey(c.shaToKey, sha, key)
+			c.mu.Unlock()
+			return
 		}
 	}
+
+	// Miss: check negative cache.
+	mk := missKey(repo, prNum)
+	if t, found := c.recentMissCache[mk]; found {
+		if time.Since(t) < recentMissTTL {
+			c.mu.Unlock()
+			return
+		}
+		delete(c.recentMissCache, mk)
+	}
+
+	c.mu.Unlock()
+
+	// Auto-heal: resolve PR linkage via REST.
+	key, _, found := c.resolvePRLinkage(owner, repoName, prNum)
+
+	c.mu.Lock()
+	if !found {
+		c.recentMissCache[mk] = time.Now()
+		c.mu.Unlock()
+		c.logFn("[cache] dropped pull_request delta for PR #%d: no closing issue in cache\n", prNum)
+		return
+	}
+	item, itemOK := c.items[key]
+	if !itemOK {
+		c.recentMissCache[mk] = time.Now()
+		c.mu.Unlock()
+		return
+	}
+	item.LinkedPRNumber = prNum
+	delete(c.deepFetched, key)
+	item.UpdatedAt = time.Now()
+	updateSHAToKey(c.shaToKey, sha, key)
+	issNum := item.Number
+	c.mu.Unlock()
+	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, issNum)
 }
 
 func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
@@ -306,35 +391,68 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 		return
 	}
 	repo := p.Repository.FullName
+	prNum := p.PullRequest.Number
+
+	owner, repoName, ok := splitRepo(repo)
+	if !ok {
+		return
+	}
+
+	review := gh.PRReview{
+		Author:     p.Review.User.Login,
+		State:      strings.ToUpper(p.Review.State),
+		Body:       p.Review.Body,
+		DatabaseID: p.Review.DatabaseID,
+	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
-	// Find the issue that has this PR linked.
+	// Normal path: find the item with this PR linked.
 	for _, item := range c.items {
-		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
-			review := gh.PRReview{
-				Author:     p.Review.User.Login,
-				State:      strings.ToUpper(p.Review.State),
-				Body:       p.Review.Body,
-				DatabaseID: p.Review.DatabaseID,
-			}
-			// Idempotent: upsert by DatabaseID (replace existing review from same author/id).
-			updated := false
-			for i, r := range item.LinkedPRReviews {
-				if r.DatabaseID == review.DatabaseID && review.DatabaseID != 0 {
-					item.LinkedPRReviews[i] = review
-					updated = true
-					break
-				}
-			}
-			if !updated {
-				item.LinkedPRReviews = append(item.LinkedPRReviews, review)
-			}
+		if item.Repo == repo && item.LinkedPRNumber == prNum {
+			applyReviewToItem(item, review)
 			item.UpdatedAt = time.Now()
-			break
+			c.mu.Unlock()
+			return
 		}
 	}
+
+	// Miss: check negative cache.
+	mk := missKey(repo, prNum)
+	if t, found := c.recentMissCache[mk]; found {
+		if time.Since(t) < recentMissTTL {
+			c.mu.Unlock()
+			c.logFn("[cache] dropped pull_request_review delta for PR #%d: negative cache hit\n", prNum)
+			return
+		}
+		delete(c.recentMissCache, mk)
+	}
+
+	c.mu.Unlock()
+
+	// Auto-heal: resolve PR linkage via REST.
+	key, _, found := c.resolvePRLinkage(owner, repoName, prNum)
+
+	c.mu.Lock()
+	if !found {
+		c.recentMissCache[mk] = time.Now()
+		c.mu.Unlock()
+		c.logFn("[cache] dropped pull_request_review delta for PR #%d: no closing issue in cache\n", prNum)
+		return
+	}
+	item, itemOK := c.items[key]
+	if !itemOK {
+		c.recentMissCache[mk] = time.Now()
+		c.mu.Unlock()
+		return
+	}
+	item.LinkedPRNumber = prNum
+	delete(c.deepFetched, key)
+	item.UpdatedAt = time.Now()
+	applyReviewToItem(item, review)
+	issNum := item.Number
+	c.mu.Unlock()
+	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, issNum)
 }
 
 func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
@@ -343,6 +461,12 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 		return
 	}
 	repo := p.Repository.FullName
+	prNum := p.PullRequest.Number
+
+	owner, repoName, ok := splitRepo(repo)
+	if !ok {
+		return
+	}
 
 	createdAt, _ := time.Parse(time.RFC3339, p.Comment.CreatedAt)
 	comment := gh.Comment{
@@ -353,7 +477,7 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 		CreatedAt:  createdAt,
 		DiffHunk:   p.Comment.DiffHunk,
 		Path:       p.Comment.Path,
-		FromPR:     p.PullRequest.Number,
+		FromPR:     prNum,
 	}
 	if p.Comment.Line != nil {
 		comment.Line = *p.Comment.Line
@@ -363,26 +487,54 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
+	// Normal path: find the item with this PR linked.
 	for key, item := range c.items {
-		if item.Repo == repo && item.LinkedPRNumber == p.PullRequest.Number {
-			// Idempotent: skip if comment with this ID already exists.
-			for _, existing := range item.LinkedPRReviewThreadComments {
-				if existing.ID == comment.ID {
-					return
-				}
+		if item.Repo == repo && item.LinkedPRNumber == prNum {
+			if applyReviewCommentToItem(item, comment, key, c.deepFetched) {
+				item.UpdatedAt = time.Now()
 			}
-			item.LinkedPRReviewThreadComments = append(item.LinkedPRReviewThreadComments, comment)
-			item.UpdatedAt = time.Now()
-			// The webhook payload does not carry the review thread's GraphQL node ID
-			// (ReviewThreadID). Reset deepFetched so the next FetchItemDetails call
-			// fetches from GitHub and populates ReviewThreadID correctly, allowing the
-			// engine to resolve the review thread after it's addressed.
-			delete(c.deepFetched, key)
-			break
+			c.mu.Unlock()
+			return
 		}
 	}
+
+	// Miss: check negative cache.
+	mk := missKey(repo, prNum)
+	if t, found := c.recentMissCache[mk]; found {
+		if time.Since(t) < recentMissTTL {
+			c.mu.Unlock()
+			c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: negative cache hit\n", prNum)
+			return
+		}
+		delete(c.recentMissCache, mk)
+	}
+
+	c.mu.Unlock()
+
+	// Auto-heal: resolve PR linkage via REST.
+	key, _, found := c.resolvePRLinkage(owner, repoName, prNum)
+
+	c.mu.Lock()
+	if !found {
+		c.recentMissCache[mk] = time.Now()
+		c.mu.Unlock()
+		c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: no closing issue in cache\n", prNum)
+		return
+	}
+	item, itemOK := c.items[key]
+	if !itemOK {
+		c.recentMissCache[mk] = time.Now()
+		c.mu.Unlock()
+		return
+	}
+	item.LinkedPRNumber = prNum
+	delete(c.deepFetched, key)
+	item.UpdatedAt = time.Now()
+	applyReviewCommentToItem(item, comment, key, c.deepFetched)
+	issNum := item.Number
+	c.mu.Unlock()
+	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, issNum)
 }
 
 func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
@@ -394,6 +546,13 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	if sha == "" {
 		return
 	}
+	repo := p.Repository.FullName
+
+	owner, repoName, ok := splitRepo(repo)
+	if !ok {
+		return
+	}
+
 	cr := gh.CheckRun{
 		ID:         p.CheckRun.ID,
 		Name:       p.CheckRun.Name,
@@ -402,9 +561,8 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
-	// Upsert by ID: replace existing check run with same ID, or append.
+	// Always upsert the check run by ID.
 	runs := c.checkRuns[sha]
 	updated := false
 	for i, existing := range runs {
@@ -419,8 +577,63 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	}
 	c.checkRuns[sha] = runs
 
-	// shaToKey reverse lookup is updated by pull_request deltas.
-	// The check_run delta is stored by SHA; the engine always has the SHA from the linked PR.
+	// shaToKey reverse lookup: if found, bump UpdatedAt on the linked issue.
+	if key, found := c.shaToKey[sha]; found {
+		if item, ok := c.items[key]; ok {
+			item.UpdatedAt = time.Now()
+		}
+		c.mu.Unlock()
+		return
+	}
+
+	// shaToKey miss: check negative cache for this SHA.
+	msha := missKeyForSHA(sha)
+	if t, found := c.recentMissCache[msha]; found {
+		if time.Since(t) < recentMissTTL {
+			c.mu.Unlock()
+			return
+		}
+		delete(c.recentMissCache, msha)
+	}
+
+	c.mu.Unlock()
+
+	// Auto-heal step 1: fetch PRs associated with this SHA.
+	prNums, err := c.fallback.FetchPRsForSHA(owner, repoName, sha)
+	if err != nil {
+		c.logFn("[cache] applyCheckRunCompleted: FetchPRsForSHA for %s: %v\n", sha, err)
+	}
+	if len(prNums) == 0 {
+		c.mu.Lock()
+		c.recentMissCache[msha] = time.Now()
+		c.mu.Unlock()
+		c.logFn("[cache] dropped check_run delta for SHA %s: no associated PR found\n", sha)
+		return
+	}
+	prNum := prNums[0]
+
+	// Auto-heal step 2: resolve which issue the PR closes.
+	key, issNum, found := c.resolvePRLinkage(owner, repoName, prNum)
+
+	c.mu.Lock()
+	if !found {
+		c.recentMissCache[msha] = time.Now()
+		c.mu.Unlock()
+		c.logFn("[cache] dropped check_run delta for SHA %s: no closing issue in cache for PR #%d\n", sha, prNum)
+		return
+	}
+	item, itemOK := c.items[key]
+	if !itemOK {
+		c.recentMissCache[msha] = time.Now()
+		c.mu.Unlock()
+		return
+	}
+	item.LinkedPRNumber = prNum
+	c.shaToKey[sha] = key
+	delete(c.deepFetched, key)
+	item.UpdatedAt = time.Now()
+	c.mu.Unlock()
+	c.logFn("[cache] auto-heal: check_run SHA %s → PR #%d → issue #%d; deep cache invalidated\n", sha, prNum, issNum)
 }
 
 func (c *CacheImpl) applyProjectsV2ItemEdited(payload []byte) {

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -361,11 +361,13 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	c.mu.Unlock()
 
 	// Auto-heal: resolve PR linkage via REST.
-	key, _, found := c.resolvePRLinkage(owner, repoName, prNum)
+	key, _, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
-		c.recentMissCache[mk] = time.Now()
+		if healErr == nil {
+			c.recentMissCache[mk] = time.Now()
+		}
 		c.mu.Unlock()
 		c.logFn("[cache] dropped pull_request delta for PR #%d: no closing issue in cache\n", prNum)
 		return
@@ -431,11 +433,13 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 	c.mu.Unlock()
 
 	// Auto-heal: resolve PR linkage via REST.
-	key, _, found := c.resolvePRLinkage(owner, repoName, prNum)
+	key, _, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
-		c.recentMissCache[mk] = time.Now()
+		if healErr == nil {
+			c.recentMissCache[mk] = time.Now()
+		}
 		c.mu.Unlock()
 		c.logFn("[cache] dropped pull_request_review delta for PR #%d: no closing issue in cache\n", prNum)
 		return
@@ -513,11 +517,13 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 	c.mu.Unlock()
 
 	// Auto-heal: resolve PR linkage via REST.
-	key, _, found := c.resolvePRLinkage(owner, repoName, prNum)
+	key, _, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
-		c.recentMissCache[mk] = time.Now()
+		if healErr == nil {
+			c.recentMissCache[mk] = time.Now()
+		}
 		c.mu.Unlock()
 		c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: no closing issue in cache\n", prNum)
 		return
@@ -602,6 +608,8 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	prNums, err := c.fallback.FetchPRsForSHA(owner, repoName, sha)
 	if err != nil {
 		c.logFn("[cache] applyCheckRunCompleted: FetchPRsForSHA for %s: %v\n", sha, err)
+		// Transient error — do not record a negative miss; retry on next webhook.
+		return
 	}
 	if len(prNums) == 0 {
 		c.mu.Lock()
@@ -613,11 +621,13 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	prNum := prNums[0]
 
 	// Auto-heal step 2: resolve which issue the PR closes.
-	key, issNum, found := c.resolvePRLinkage(owner, repoName, prNum)
+	key, issNum, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
-		c.recentMissCache[msha] = time.Now()
+		if healErr == nil {
+			c.recentMissCache[msha] = time.Now()
+		}
 		c.mu.Unlock()
 		c.logFn("[cache] dropped check_run delta for SHA %s: no closing issue in cache for PR #%d\n", sha, prNum)
 		return

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -118,6 +118,12 @@ func (m *testGitHubUpgradeClient) FetchProjectItemStatus(itemID string) (string,
 func (m *testGitHubUpgradeClient) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
 	return nil, nil
 }
+func (m *testGitHubUpgradeClient) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	return nil, nil
+}
+func (m *testGitHubUpgradeClient) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	return nil, nil
+}
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -30,6 +30,8 @@ type GitHubClient interface {
 	FetchPRMergeable(owner, repo string, prNumber int) (*bool, error)
 	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
 	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)
+	FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)
+	FetchPRsForSHA(owner, repo, sha string) ([]int, error)
 	GetPRBase(owner, repo string, prNumber int) (string, error)
 	UpdatePRBase(owner, repo string, prNumber int, newBase string) error
 	CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -45,6 +45,8 @@ type mockGitHubClient struct {
 	addReviewRequestFn              func(owner, repo string, prNumber int, reviewers []string) error
 	fetchProjectItemStatusFn        func(itemID string) (string, error)
 	fetchProjectItemStatusBatchFn   func(projectID string) (map[string]string, error)
+	fetchPRClosingIssuesFn          func(owner, repo string, prNumber int) ([]int, error)
+	fetchPRsForSHAFn                func(owner, repo, sha string) ([]int, error)
 
 	// Track call counts for FetchProjectItemStatus
 	fetchProjectItemStatusCalls []string
@@ -447,6 +449,26 @@ func (m *mockGitHubClient) AddReviewRequest(owner, repo string, prNumber int, re
 		return fn(owner, repo, prNumber, reviewers)
 	}
 	return nil
+}
+
+func (m *mockGitHubClient) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	m.mu.Lock()
+	fn := m.fetchPRClosingIssuesFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber)
+	}
+	return nil, nil
+}
+
+func (m *mockGitHubClient) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	m.mu.Lock()
+	fn := m.fetchPRsForSHAFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, sha)
+	}
+	return nil, nil
 }
 
 func (m *mockGitHubClient) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStats) {

--- a/github/prs.go
+++ b/github/prs.go
@@ -4,7 +4,66 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
+	"strconv"
 )
+
+// reClosingKeyword matches GitHub closing keywords followed by a same-repo issue
+// reference (#N). Cross-repo references (owner/repo#N) are intentionally excluded.
+var reClosingKeyword = regexp.MustCompile(`(?i)(?:closes|fixes|resolves)\s+#(\d+)`)
+
+// FetchPRClosingIssues returns the issue numbers referenced by GitHub closing keywords
+// (Closes, Fixes, Resolves + #N) in the body of the given pull request. Only same-repo
+// references are returned; cross-repo references are out of scope.
+// Returns nil, nil on 404 or when the PR body contains no recognized closing references.
+func (c *Client) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
+	var raw struct {
+		Body string `json:"body"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fetching PR #%d body: %w", prNumber, err)
+	}
+	matches := reClosingKeyword.FindAllStringSubmatch(raw.Body, -1)
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	out := make([]int, 0, len(matches))
+	for _, m := range matches {
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// FetchPRsForSHA returns the PR numbers associated with the given commit SHA via
+// GET /repos/{owner}/{repo}/commits/{sha}/pulls. Returns nil, nil on 404 or empty.
+func (c *Client) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/commits/%s/pulls", c.baseURL, owner, repo, sha)
+	var raw []struct {
+		Number int `json:"number"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fetching PRs for SHA %s: %w", sha, err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]int, len(raw))
+	for i, pr := range raw {
+		out[i] = pr.Number
+	}
+	return out, nil
+}
 
 // PRDetails holds the fields from a GitHub pull request needed by fabrik watch.
 type PRDetails struct {


### PR DESCRIPTION
## Summary

When a PR-targeted delta cannot locate a linked item by `LinkedPRNumber` (or by `shaToKey` for check runs), look up which issue the PR closes via GitHub REST, repair the cache, and re-apply the original delta — all transparently.

## Problem

When a PR-targeted webhook arrives (`pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`) the boardcache delta handlers walk `c.items` looking for an item where `item.LinkedPRNumber == webhookPRNumber`. If no item matches, the delta is silently dropped.

This is the wrong behavior when the cache's view of issue↔PR linkage is stale. Two real-world examples:

1. **PR body malformed at creation, then repaired** — Issue #476 / PR #502: `Closes #476` landed inside an unclosed code fence (#503), GitHub never parsed the linkage, the cache stored `LinkedPRNumber = 0` for #476. Even after the PR body was fixed and GitHub created the link, the Copilot review webhook for #502 found no item with `LinkedPRNumber == 502` and dropped the review payload.
2. **Out-of-order webhooks** — if a `pull_request_review` arrives before the `issues.labeled`/project-add events that would have caused the issue to be deep-fetched with its linkage, the review is dropped and never recovered.

The current state is a hidden cache miss. Logs at the drop site would help observability but don't repair the cache. We want self-healing: the next webhook to touch a stale PR linkage should be enough to make the cache correct.

## Approach

### Approach

The feature adds self-healing to the four PR-targeted delta handlers in `boardcache/delta.go`. When a handler finds no cached item with a matching `LinkedPRNumber` (or `shaToKey` for check runs), it releases the lock, makes one or two REST calls to resolve the issue linkage, re-acquires the lock, patches the cache, and re-applies the delta's inner mutation via a factored helper.

Three design decisions surfaced by research needed resolution:

**`resolvePRLinkage` lock access pattern**: `resolvePRLinkage` is called without `c.mu`. After the REST call completes, it acquires `c.mu.RLock()` to look up `c.items`. This is the minimal, safe approach — no snapshot passing, no extra mutex, no deadlock risk (RLock doesn't conflict with other RLocks; callers re-acquire a write lock after `resolvePRLinkage` returns).

**`applyPullRequestDelta` auto-heal**: The handler should also set `LinkedPRNumber`, `shaToKey`, invalidate `deepFetched`, and bump `UpdatedAt` on heal — consistent with the other three handlers. The PR details are already in the payload, so the inner mutation is cheap.

**`recentMissCache` expiry**: Lazy per-key prune: on every miss-check, delete the entry for the current key if it has expired before deciding whether to skip. A background goroutine and full-map iteration are both unnecessary given the bounded key count in a typical Fabrik session.

**Negative cache key format**: Use `"miss:"` prefix (`"miss:owner/repo#prN"`, `"miss:owner/repo#sha:SHA"`) to avoid visual confusion with `itemKey` format (`"owner/repo#N"`).

**`defer` removal**: All four handlers currently use `defer c.mu.Unlock()`. The auto-heal path requires releasing and re-acquiring mid-function, which is incompatible with `defer`. Every early-return path must add an explicit `c.mu.Unlock()`.

**No ADR needed**: The lock-release-REST-reacquire pattern is a standard Go idiom documented in the existing concurrency conventions. The feature is a behavioral extension of ADR 034's self-healing design intent, not a new architectural decision.

**Documentation**: Research confirmed no user-facing or engineering-doc impact. This is a transparent internal correctness fix.

### New/Modified Files

| File | Change |
|------|--------|
| `github/prs.go` | Add `FetchPRClosingIssues` and `FetchPRsForSHA` |
| `boardcache/boardcache.go` | Extend `ReadClient` interface; add `GitHubAdapter` pass-throughs; add `recentMissCache` to `CacheImpl`; add `resolvePRLinkage` method |
| `boardcache/delta.go` | Refactor all four PR-targeted handlers: remove `defer`, extract inner-mutation helpers, add auto-heal paths |
| `boardcache/boardcache_test.go` | Add `mockClient` stubs; add all six spec-required unit tests |
| `engine/mocks_test.go` | Add `mockGitHubClient` stubs for two new interface methods |

### Key Decisions

- **`resolvePRLinkage` acquires `c.mu.RLock()` for the items lookup** after the REST call, rather than having callers pass a snapshot. Simpler code path; the brief window between the unlock (miss detected) and the RLock (items lookup) is acceptable — the worst outcome is a redundant REST call if a concurrent goroutine heals first.
- **Negative cache keyed under `c.mu`**, not a separate lock. Both the miss-check and the miss-record happen under the write lock already held at the start and end of the handler, so no separate mutex is needed.
- **Inner mutation factored into private helpers** (`applyReviewToItem`, `applyReviewCommentToItem`) that take `*gh.ProjectItem` and the delta struct — called from both the normal path and the post-heal path. `applyPullRequestDelta`'s inner mutation (update `linkedPRs`, `shaToKey`) is simple enough to inline, but factoring it makes the heal-path code symmetric.
- **Loop guard by structure, not a flag**: the heal path calls the inner helper directly (not `ApplyDelta`), so recursion is impossible by construction.
- **`owner`/`repo` split**: handlers receive `p.Repository.FullName` as `"owner/repo"`. `resolvePRLinkage` and `FetchPRsForSHA` need them separately. Use `strings.SplitN(fullName, "/", 2)` at the top of each handler; fall through if the split yields fewer than 2 parts.

### Task Checklist

- [ ] **Task 1 — `github/prs.go`: Add `FetchPRClosingIssues` and `FetchPRsForSHA`**
  - `FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)`: `GET /repos/{owner}/{repo}/pulls/{prNumber}`, parse `body` field with case-insensitive regex `(?i)(?:closes|fixes|resolves)\s+#(\d+)`, return all matched issue numbers (same-repo only — no `owner/repo#N` pattern). Return `nil, nil` on 404 or empty body. Handle `ErrNotFound` from `restGetJSON` as "not found, return nil nil".
  - `FetchPRsForSHA(owner, repo, sha string) ([]int, error)`: `GET /repos/{owner}/{repo}/commits/{sha}/pulls`, parse array of `{"number": int}`, return slice of PR numbers. Return `nil, nil` on 404 or empty array.
  - Both follow the `restGetJSON` pattern from `FetchPRMergeable`/`FetchCheckRuns`. Both treat non-404 errors as errors (caller decides how to handle).

- [ ] **Task 2 — `boardcache/boardcache.go`: Extend interface, adapter, struct, and add `resolvePRLinkage`**
  - Add to `ReadClient` interface: `FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)` and `FetchPRsForSHA(owner, repo, sha string) ([]int, error)`.
  - Add pass-throughs to `GitHubAdapter` for both methods.
  - Add `recentMissCache map[string]time.Time` field to `CacheImpl` struct; initialize in `NewCacheImpl`.
  - Add `(c *CacheImpl) resolvePRLinkage(owner, repo string, prNumber int) (key string, issueNumber int, found bool)`:
    - Call `c.fallback.FetchPRClosingIssues(owner, repo, prNumber)` (no lock held).
    - On error or empty: return `"", 0, false`.
    - Acquire `c.mu.RLock()`; iterate closing issues; for the first one found in `c.items`, return its key and issue number. Release `c.mu.RUnlock()`.
  - Add helper `missKey(repo string, prNumber int) string` returning `"miss:" + repo + "#" + strconv.Itoa(prNumber)` and `missKeyForSHA(sha string) string` returning `"miss:sha:" + sha`. These deduplicate the key construction.

- [ ] **Task 3 — `engine/mocks_test.go` + `boardcache/boardcache_test.go`: Add stubs for two new interface methods (compile fix)**
  - In `engine/mocks_test.go`: add `fetchPRClosingIssuesFn func(...)` + `fetchPRsForSHAFn func(...)` fields and stub methods on `mockGitHubClient`. Stubs return `nil, nil` by default.
  - In `boardcache/boardcache_test.go`: add `FetchPRClosingIssues` and `FetchPRsForSHA` fields/methods on `mockClient`. Stubs return `nil, nil` by default (tests that exercise these paths will set the function field).
  - Verify: `go build ./...` compiles cleanly after this task.

- [ ] **Task 4 — `boardcache/delta.go`: Refactor `applyPullRequestReviewSubmitted` and `applyPullRequestReviewCommentCreated`**
  - Extract `applyReviewToItem(item *gh.ProjectItem, review gh.PRReview)` — the upsert-by-DatabaseID logic currently inside `applyPullRequestReviewSubmitted`. Call from both normal and post-heal paths.
  - Extract `applyReviewCommentToItem(item *gh.ProjectItem, comment gh.Comment, key string, deepFetched map[string]bool)` — the idempotent-append + `delete(c.deepFetched, key)` logic from `applyPullRequestReviewCommentCreated`.
  - Remove `defer c.mu.Unlock()` from both handlers. Restructure to:
    1. Parse payload; return early (no lock needed) on error or wrong action.
    2. Split `p.Repository.FullName` into `owner`/`repo`; if split fails, return.
    3. `c.mu.Lock()`; search `c.items`; on hit: call helper, `item.UpdatedAt = time.Now()`, `c.mu.Unlock()`, return.
    4. Check negative cache (still under lock); on hit: `c.mu.Unlock()`, log, return.
    5. `c.mu.Unlock()`.
    6. Call `resolvePRLinkage(owner, repo, prNum)`.
    7. `c.mu.Lock()`.
    8. On not found: update `recentMissCache`, `c.mu.Unlock()`, log drop, return.
    9. On found: set `item.LinkedPRNumber = prNum`, `delete(c.deepFetched, key)`, `item.UpdatedAt = time.Now()`, call helper, log auto-heal message, `c.mu.Unlock()`.

- [ ] **Task 5 — `boardcache/delta.go`: Refactor `applyPullRequestDelta`**
  - Remove `defer c.mu.Unlock()`.
  - The handler's inner mutation is: update `c.linkedPRs[pk]`, update `c.shaToKey[sha]` (with old-SHA cleanup). This is self-contained.
  - On a miss (no item has `LinkedPRNumber == prNum`): release lock, call `resolvePRLinkage`, re-acquire, on found: set `item.LinkedPRNumber = prNum`, `delete(c.deepFetched, key)`, `item.UpdatedAt = time.Now()`, then re-run the `shaToKey` update for this item. Log auto-heal.
  - Note: `c.linkedPRs[pk]` update happens regardless of whether a match was found (the PR details are stored even if no linked issue is known).

- [ ] **Task 6 — `boardcache/delta.go`: Refactor `applyCheckRunCompleted`**
  - Remove `defer c.mu.Unlock()`.
  - Current behavior: always upserts into `c.checkRuns[sha]` under lock. The `shaToKey` lookup that bumps `UpdatedAt` is currently commented as "updated by pull_request deltas" with no action on miss.
  - New behavior:
    1. Parse payload, check action and SHA (return early without lock if invalid).
    2. `c.mu.Lock()`; upsert into `c.checkRuns[sha]` (always).
    3. Check `c.shaToKey[sha]`: on hit: bump `c.items[key].UpdatedAt`, `c.mu.Unlock()`, return.
    4. Check negative cache for `"miss:sha:" + sha`: on hit: `c.mu.Unlock()`, return.
    5. `c.mu.Unlock()`.
    6. Split `p.Repository.FullName` into `owner`/`repo`.
    7. Call `c.fallback.FetchPRsForSHA(owner, repo, sha)` → `prNums`.
    8. If empty: `c.mu.Lock()`, update `recentMissCache`, `c.mu.Unlock()`, log drop, return.
    9. For first PR number in `prNums`: call `resolvePRLinkage(owner, repo, prNum)`.
    10. `c.mu.Lock()`.
    11. On not found: update `recentMissCache` for SHA, `c.mu.Unlock()`, log drop, return.
    12. On found: set `item.LinkedPRNumber = prNum`, `c.shaToKey[sha] = key`, `delete(c.deepFetched, key)`, `item.UpdatedAt = time.Now()`, log auto-heal, `c.mu.Unlock()`.

- [ ] **Task 7 — `boardcache/boardcache_test.go`: Add unit tests for all auto-heal and negative-cache scenarios**
  - Test: `pull_request_review.submitted` with `LinkedPRNumber == 0` — mock `FetchPRClosingIssues` to return an issue number, assert review appended and `deepFetched` cleared.
  - Test: `pull_request_review_comment.created` with `LinkedPRNumber == 0` — same assertion pattern.
  - Test: `check_run.completed` with SHA not in `shaToKey` — mock `FetchPRsForSHA` + `FetchPRClosingIssues`, assert `shaToKey` populated, `LinkedPRNumber` set, `deepFetched` cleared, `UpdatedAt` bumped.
  - Test: PR body has no closing keyword — mock `FetchPRClosingIssues` returns `nil`, assert delta dropped (no mutation to item), log contains "dropped".
  - Test: PR closes issue not in cache (different project) — mock `FetchPRClosingIssues` returns issue number not in `c.items`, assert silent drop.
  - Test: negative cache TTL — deliver two `pull_request_review` payloads for same PR; first triggers REST call; second (within 10 minutes) does not. Assert `FetchPRClosingIssues` called exactly once.

- [ ] **Task 8 — Build and test pass**
  - `go build ./...` — no compilation errors.
  - `go test -race ./...` — all tests pass, no data races.
  - `go vet ./...` — no warnings.

### Risks

- **Missed `c.mu.Unlock()` on early return**: removing `defer` from handlers with multiple return paths (JSON parse error, wrong action, etc.) requires an explicit unlock before each `return`. Highest risk in `applyCheckRunCompleted` which has the most code paths. Mitigation: the race detector will catch this immediately in tests.

- **`FetchPRsForSHA` returning empty for commits on closed/deleted branches**: treat as "not found" (add to negative cache). The check run is stored in `c.checkRuns[sha]`; the `UpdatedAt` bump is simply skipped. The next reconciliation will catch the issue state.

- **Concurrent heal for same PR**: two goroutines may both detect a miss and both call `resolvePRLinkage`. Both will succeed; the second will find `LinkedPRNumber` already set by the first and the inner mutation becomes a benign upsert. Safe but wastes one REST call. Acceptable as a rare edge case.

- **PR body parsing fragility**: the regex `(?i)(?:closes|fixes|resolves)\s+#(\d+)` handles the common cases. It will miss cross-repo references (intentionally out of scope) and unusual formatting. The scope is documented; any misses are handled by the reconciliation path (#505).

---
Used 9/50 turns, 6k input / 8k output tokens.

## Verification

Implemented boardcache auto-heal for PR-targeted delta handlers. Added `FetchPRClosingIssues` and `FetchPRsForSHA` to `github/prs.go` and the `ReadClient` interface. Added `resolvePRLinkage` helper and a 10-minute negative miss cache (`recentMissCache`) to `boardcache/boardcache.go`. Refactored all four PR-targeted delta handlers in `boardcache/delta.go` to detect linkage misses, release the lock, call the heal path via REST, and re-apply the inner mutation on success. All 8 unit tests (including the 6 spec-required scenarios) pass cleanly under `go test -race ./...`.

---

Closes #506