### PR TITLE
docs: cache architecture analysis + reactive single-owner design + ADR 036

### DIFF
--- a/adrs/036-reactive-cache-single-owner.md
+++ b/adrs/036-reactive-cache-single-owner.md
@@ -1,0 +1,113 @@
+# ADR 036 — Reactive Cache with Single State Owner
+
+**Status:** Proposed (2026-05-04)
+**Supersedes (in part):** ADR 034 (Boardcache event-sourced delta), ADR 035 (Four-layer status reconciliation) — these defined the previous design that this ADR replaces.
+
+## Context
+
+Between 2026-05-02 and 2026-05-03, fabrik shipped a substantial set of features — board-cache (#452/#455 + follow-ups), webhook-driven event delivery, four-layer status reconciliation (per ADR 035) — intended to dramatically reduce GraphQL load by serving most reads from an in-memory cache fed by webhook deltas.
+
+In production use over the following day, these features caused a cascade of cache-coherency failures:
+
+- Stale Status causing advance-loops on issues #501 and #506 (fabrik repeatedly tried to advance a stage that had already advanced on GitHub but not in cache).
+- "Fabrik went deaf" — newly opened issues invisible to the engine because `applyIssuesDelta` did not handle `action == "opened"` and the cache was the only path for reads.
+- Issue #467 column-move propagating with up to 76-min latency.
+- A regression in #488's deep-fetch-loop fix (#504): the cooldown was over-broadly refreshed, blocking incomplete-stage retries indefinitely.
+- Stale `fabrik:locked:<user>` labels persisting after worker crashes, with no automated recovery path.
+
+Investigation (documented in `docs/cache-refactor/01-state-inventory.md`) identified the structural cause: fabrik was already maintaining substantial in-memory state in the Engine struct (8+ maps including `processedSet`, `lastUpdatedAt`, `retryCount`, `lockedIssues`, etc.) before the boardcache feature was added. The cache feature was bolted on alongside this existing state rather than consolidating it. Result: 25+ separate state structures, with mutations through one path failing to propagate to the others.
+
+The fix is not another patch. The fix is to consolidate engine state into a single owner.
+
+## Decision
+
+Introduce a new `internal/itemstate` package with:
+
+1. A canonical `ItemState` struct that consolidates all per-item state currently spread across the boardcache and the engine.
+2. A `Store` type that owns all `ItemState` instances. All mutations flow through `Store.Apply(Mutation)`. All reads flow through `Store.Get` returning an immutable `Snapshot`.
+3. A `Mutation` interface — a discriminated union of every possible state change (webhook deltas, self-mutations, periodic reconcile updates, engine-internal counter changes).
+4. A `Subscribe`/`Observer` mechanism so downstream code can react to changes rather than poll for them.
+
+The migration is staged across 8 incremental PRs (Phase 3-A through 3-H, documented in `docs/cache-refactor/02-design.md` §5), each independently shipping value:
+
+- 3-A: Skeleton package, not yet wired in.
+- 3-B: Boardcache delegates to Store internally — behaviour-equivalent, no engine changes.
+- 3-C: Self-mutation write-through — fixes #501/#506 advance-loop class.
+- 3-D: Webhook delta complete coverage — fixes "fabrik went deaf" class.
+- 3-E: Engine state consolidation — moves per-item Engine maps into ItemState.
+- 3-F: Stage-state consolidation — moves stage-keyed maps; **splits `processedSet`** into separate retry-cooldown and re-eval-cooldown fields, structurally fixing #504.
+- 3-G: Worker handle — heartbeat-based liveness; fixes stale-lock recovery gap.
+- 3-H: Reactive observer plumbing — wakeCh, TUI events become observers.
+
+Then Phase 4 audits all downstream readers and Phase 5 lands per-reader fixes.
+
+## Consequences
+
+### Positive
+
+- **Single source of truth per item.** Bugs of the form "mutation path A updated structure X but forgot structure Y" become structurally impossible: there is one X.
+- **Inbound and outbound coherence checked structurally.** Both webhook deltas and self-mutations flow through the same `Apply` call, so the cache cannot diverge from operations the engine performed.
+- **Reactive downstream readers.** Observer pattern eliminates the redundant per-poll re-evaluation of `itemMayNeedWork`/`itemNeedsWork` for items that have not changed.
+- **Tests have a clear surface.** Invariants (I1-I10 in design doc §6) test the Store directly, not the entanglement of 25 maps.
+- **Crash recovery.** Worker handles with heartbeats let the engine detect dead workers and recover without manual label cleanup.
+- **Persistence boundary clear.** Store is in-memory; persistence (across restarts) is achieved by re-bootstrapping from GitHub. No half-persistent state to reason about.
+
+### Negative
+
+- **Substantial code change.** ~25 state structures redirect to a single new package. Every read site and write site touches.
+- **Migration risk.** Each Phase 3 PR has potential for regression. Incremental landing strategy mitigates this; thorough tests per PR (per the build-issue spec) further mitigate.
+- **Performance.** A Store under a mutex serializes all writes to all items. Profile during 3-A skeleton phase. If contention becomes a problem, shard by repo or by item-key.
+
+### Neutral
+
+- The boardcache package remains, but its internals become a thin adapter over Store. ADR 034 describes the previous boardcache architecture; this ADR supersedes it for the *internal structure*. The external API (`ReadClient` interface) is preserved.
+
+## Alternatives considered
+
+### Alternative 1: Continue patching individual bugs
+
+Bugs are found, issues filed, PRs land. No refactor.
+
+**Rejected.** The structural pattern (mutation paths forget to update co-dependent state) means the bugs come from a category, not a count. Patches address one site at a time; the next time a developer adds a new event type or a new mutation, they hit the same class of bug. Validated empirically: every cache bug filed on 2026-05-03/04 fits the pattern. The whack-a-mole is open-ended.
+
+### Alternative 2: Revert the cache entirely; return to direct GitHub queries
+
+Remove `boardcache` and webhook-delta machinery; engine talks directly to GitHub on every read.
+
+**Rejected.** Loses the GraphQL load reduction the cache was introduced to achieve. The cache is *fine in principle*; the implementation is fragmented. Reverting throws away too much, and would lose the work invested in webhook subscription, delta handlers, etc. (Most of which is correct in isolation; just not coherent in aggregate.)
+
+### Alternative 3: Multiple narrow fixes (e.g. just consolidate processedSet; just add `opened` action)
+
+Fix the most painful bugs without restructuring.
+
+**Rejected.** This is what we were doing on 2026-05-03; we filed 7+ issues in a day and they covered maybe a third of the structural-fragility surface. The user's framing — "we've lost cache coherency" — captured that this is not isolated bugs.
+
+### Alternative 4: Event-sourcing / CQRS architecture
+
+Treat all state as derived from an append-only log of events. Replay log to reconstruct state; never mutate.
+
+**Rejected for now.** Heavier than fabrik needs. Persistence concerns multiply (where does the log live, how is it bounded, what happens to it across restarts). The Store/Mutation design captures the most useful properties of CQRS (single mutator path, observers see all changes) without the persistence and replay overhead. Worth revisiting if fabrik later needs cross-instance coordination or audit-quality history.
+
+## Implementation notes
+
+The migration PRs (Phase 3-A through 3-H) are tracked as separate fabrik issues, each with thorough test requirements. The order is chosen to land bug-fix value early:
+
+- 3-C (self-mutation write-through) and 3-D (webhook complete coverage) ship before the bigger structural moves (3-E onward) so the operator-visible bugs are fixed first.
+- Each PR includes test coverage for at least one of the design invariants (I1-I10).
+- State-machine.md is updated as part of every PR that changes engine state semantics, per existing repo convention.
+
+## Status / progress
+
+- Phase 1 inventory: complete (`docs/cache-refactor/01-state-inventory.md`).
+- Phase 2 design: complete (`docs/cache-refactor/02-design.md`).
+- Phase 3-A through 3-H: filed as fabrik issues; pipeline executing.
+- Phase 4 audit: scheduled after Phase 3 lands.
+- Phase 5 refactor of downstream readers: scheduled after Phase 4.
+
+## References
+
+- `docs/cache-refactor/01-state-inventory.md` — inventory of every existing state structure with read/write sites and known bugs.
+- `docs/cache-refactor/02-design.md` — full design including data model, contracts, and migration strategy.
+- ADR 034 (boardcache event-sourced delta): the previous design this ADR supersedes for internal structure.
+- ADR 035 (four-layer status reconciliation): the layer model whose Layer 0 (write-through) gap motivated this work.
+- Issues filed during the 2026-05-03/04 cluster: #467, #501, #504, #506, plus the Specify-stage cluster on cache coherency.

--- a/docs/cache-refactor/01-state-inventory.md
+++ b/docs/cache-refactor/01-state-inventory.md
@@ -1,0 +1,286 @@
+# Phase 1 — State Map Inventory
+
+**Status:** as-built analysis as of `d4f69a2`. Read this alongside `02-design.md` (the proposed unified architecture) and the cluster of Specify-stage cache-coherency issues filed earlier.
+
+This document enumerates **every in-memory state structure that participates in fabrik's "view of the world"** — both the new `boardcache.CacheImpl` (introduced by issue #452 / PR #455 + follow-ups) and the older shadow caches that were maintained on the `Engine` struct before the cache feature. The premise of this work is that the cache feature was added *on top of* an engine that already kept significant state; instead of consolidating, it added another layer. The bugs we hit on 2026-05-03 (#467 stale Status, #501 advance loop, #504 cooldown regression, "fabrik went deaf" / `applyIssuesDelta` doesn't handle `opened`) are all symptoms of the same root cause: **state mutations through one path do not reach the other paths**.
+
+The remedy is sketched in `02-design.md`. This document is the inventory those design decisions have to address.
+
+## Reading guide
+
+- **§1** is a flat inventory: every structure, where it lives, what its key/value type is.
+- **§2** is per-structure analysis for the structures we have direct evidence are buggy or fragile. Each entry covers: purpose, update sites, read sites, invariants the code assumes but does not enforce, and known/observed bugs.
+- **§3** is cross-cutting observations about how these structures *interact* — which is where the real bugs live.
+- **§4** summarises the design implications carried forward into Phase 2.
+
+## §1 Inventory
+
+### 1.1 Engine state (`engine/engine.go:60-97`)
+
+Per-issue state (keyed by `issueKey` = `"owner/repo#N"`):
+
+| Field | Type | Purpose |
+|---|---|---|
+| `lockedIssues` | `map[string]bool` | Tracks issues for which `fabrik:locked:<self>` was added; cleanup driver on shutdown |
+| `lastUsage` | `map[string]TokenUsage` | Per-issue token usage from last `processItem` (TUI display) |
+| `lastCompleted` | `map[string]bool` | Per-issue completion state from last `processItem` (TUI display) |
+| `lastBlocked` | `map[string]bool` | Per-issue blocked-on-input state from last `processItem` (TUI display) |
+| `lastUpdatedAt` | `map[string]time.Time` | Last-seen `item.UpdatedAt` value; used by `itemMayNeedWork` poll filter |
+| `deepFetchFailureTime` | `map[string]time.Time` | When `FetchItemDetails` last failed (cooldown for retry) |
+| `prHasHadChecks` | `map[string]bool` | Has `FetchCheckRuns` ever returned non-empty; used to distinguish "checks not yet started" from "checks complete and absent" |
+| `ciMergePendingSince` | `map[string]time.Time` | When CI was first observed in_progress in the merge guard |
+
+Per-stage-attempt state (keyed by `stageKey` = `"owner/repo#N-stageName"` or `"owner/repo#N-comment-ID"`):
+
+| Field | Type | Purpose |
+|---|---|---|
+| `processedSet` | `map[string]time.Time` | Last attempt timestamp; drives both `itemMayNeedWork` cooldown bypass and `itemNeedsWork` retry cooldown. Heavily multi-purpose. |
+| `retryCount` | `map[string]int` | Failed-attempt counter per stage; escalates to `pausedDueToRetries` at `MaxRetries` |
+| `pausedDueToRetries` | `map[string]bool` | "Engine paused this issue" flag — distinguishes engine-pause from user-pause |
+| `reviewCycleCount` | `map[string]int` | Review-reinvoke cycle count per stage |
+| `ciFixCycleCount` | `map[string]int` | CI-fix-reinvoke cycle count per stage |
+| `rebaseCycleCount` | `map[string]int` | Rebase-reinvoke cycle count per stage |
+
+Concurrency primitives (`sync.Map`):
+
+| Field | Type | Purpose |
+|---|---|---|
+| `inFlight` | `sync.Map` | issueKey → bool (isPR); "currently being processed" gate against duplicate dispatch |
+| `cloneInFlight` | `sync.Map` | "owner/repo" → *cloneCall; per-repo bare-clone coordination |
+| `baseBranchWarnedSet` | `sync.Map` | "owner/repo#N:branch" → bool; deduplicates `base:<branch>` fallback comments |
+
+Global / aggregate state:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `totalTokens` | `TokenUsage` | Accumulated token usage since process start |
+| `lastReportedCost` | `float64` | Last printed cost in `[stats]` lines |
+| `idleCount` | `int` | Consecutive idle polls; drives self-upgrade trigger |
+| `idleStart` | `time.Time` | Start of current idle run; drives backoff calculation |
+
+### 1.2 Boardcache state (`boardcache/boardcache.go:144-176`)
+
+Per-item state (keyed by `itemKey` = `"owner/repo#N"`):
+
+| Field | Type | Purpose |
+|---|---|---|
+| `items` | `map[string]*gh.ProjectItem` | Full per-issue item including labels, Status, body, comments, linked-PR data |
+| `deepFetched` | `map[string]bool` | Has `FetchItemDetails` been called for this key (so reads can skip the network) |
+
+Per-PR / per-SHA / per-item-ID state:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `linkedPRs` | `map[string]*gh.PRDetails` | PR details by key `"owner/repo#prN"` |
+| `checkRuns` | `map[string][]gh.CheckRun` | CheckRun list by commit SHA |
+| `shaToKey` | `map[string]string` | SHA → issueKey (reverse lookup for webhook delta application) |
+| `itemIDToKey` | `map[string]string` | GitHub Project item ID → issueKey (reverse lookup for `projects_v2_item` delta) |
+
+Negative cache and metadata:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `recentMissCache` | `map[string]time.Time` | Negative-cache: TTL'd entries for "miss:owner/repo#prN" and "miss:sha:SHA"; prunes lazily |
+| `projectID` | `string` | Project ID from last bootstrap/reconcile |
+| `projectTitle` | `string` | Project title |
+| `projectOwnerType` | `string` | "organization" or "user" |
+
+Stream state:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `paused` | `bool` | When true, `ApplyDelta` is a no-op and read methods fall back to GitHub. Set during webhook stream unhealthy → recovery cycle. |
+
+### 1.3 Webhook manager state (`engine/webhook.go`)
+
+Outside the scope of this analysis — webhook health/secret/event-counter state is internal to the subprocess supervisor and does not affect the engine's view of *issue/PR* state. Mentioned here only for completeness; the only relevant interaction is that `ApplyDelta` writes to boardcache state (1.2 above) when events arrive, and `Pause`/`Resume` are called on the cache by the health-change handler.
+
+## §2 Per-structure deep dives (high-bug-density structures)
+
+### 2.1 `boardcache.items`
+
+**Purpose:** central per-issue record. The intent is "single source of truth for current state of every project item." In practice it is one of several views.
+
+**Update sites:**
+
+| Path | Effect |
+|---|---|
+| `Bootstrap` (called once at startup) | Replaces `items` map entirely from a fresh GitHub board fetch. |
+| `Reconcile` (periodic 60min + webhook health-change recovery) | For each item in fresh board: if existing in `items`, overlay shallow fields (`Status`, `Labels`, `Title`, `UpdatedAt`, `IsClosed`, `IsPR`, `ItemID`, `URL`). If new, add it. Items not in the fresh board: removed from `items`. |
+| `applyIssuesLabeled` / `applyIssuesUnlabeled` | Append/remove a label on `items[key].Labels` |
+| `applyIssueCommentCreated` | Append a comment to `items[key].Comments` |
+| `applyPullRequestDelta` | Update `items[key]` for ready-for-review / closed / reopened / synchronize on the issue's linked PR |
+| `applyPullRequestReviewSubmitted` | Update `items[key].LinkedPRReviews` |
+| `applyPullRequestReviewCommentCreated` | Update `items[key].LinkedPRReviewThreadComments` |
+| `applyCheckRunCompleted` | Updates `checkRuns` map, not `items` directly |
+| `applyProjectsV2ItemEdited` | Update `items[key].Status` (only when delivered — **NOT delivered to repo webhooks**) |
+| `FetchItemDetails` cache-miss path | Populate deep fields on `items[key]` via `copyDeepFields(cached, item)` after a fallback-to-GitHub call |
+
+**Read sites:**
+
+| Path | Use |
+|---|---|
+| `FetchProjectBoard` | Reconstructs and returns a `*gh.ProjectBoard` from `items[]` |
+| `FetchItemDetails` cache-hit | Copies deep fields from `items[key]` into the caller's item |
+| `applyIssuesLabeled/Unlabeled/etc.` (delta application) | Reads `items[key]`; bails silently with `if !ok { return }` when missing |
+| `applyProjectsV2ItemEdited` | Reads `items[key]` via `itemIDToKey`; bails silently |
+| `resolvePRLinkage` | Iterates `items` to find the issue closed by a given PR |
+
+**Implicit invariants the code assumes but does not enforce:**
+
+1. *Every issue currently on the GitHub Project board is in `items`.* Violated when a new issue is added: `applyIssuesDelta` does not handle `action == "opened"`, so the new issue is missing from `items` until next `Reconcile`. The label-add path then silently no-ops because the issue is not in the cache. **Direct cause of "fabrik went deaf to new issues" observed 2026-05-04.**
+2. *Status reflects current board column.* Violated in user mode where `projects_v2_item` is not delivered: only `Reconcile` updates Status, with worst-case 60min latency. **Direct cause of #467 stale-Status / advance-loop on #506 / advance-loop on #501 (all 2026-05-03).**
+3. *Self-mutations (e.g. `advanceToNextStage`'s `UpdateProjectItemStatus`) are reflected in the cache.* Violated: there is no write-through — only inbound webhook deltas and reconcile update `items`. **Direct cause of the multi-minute advance loop captured in `#501` and `#506` logs.**
+4. *Labels in the cache are the same set GitHub has.* Violated when the issue is not in the cache (gap 1) — label-add events are silently dropped.
+5. *`items` matches the truth across restarts.* Holds: bootstrap fetches fresh from GitHub. But at runtime, drift accumulates between bootstrap and the next reconcile.
+
+**Known bugs/gaps:**
+
+| ID | Symptom | Root cause |
+|---|---|---|
+| (cluster filed in Specify) | New issues invisible to fabrik | `applyIssuesDelta` missing `opened`, `closed`, `reopened`, `transferred` actions |
+| (cluster filed in Specify) | Label changes on new issues silently drop | `applyIssuesLabeled` looks up `items[key]` and bails; combined with gap 1 produces compound stuckness |
+| #501 / #506 advance loop | After local `UpdateProjectItemStatus`, cache Status stays stale; next poll re-attempts the advance every 15s | Layer 0 / write-through gap |
+| #467 column-move lag (~76min) | Cache Status only updates on `Reconcile`; reconcile fires on 60min timer or webhook health-change | `projects_v2_item` not delivered; periodic reconcile interval too slow |
+
+### 2.2 `engine.processedSet`
+
+**Purpose:** records "fabrik attempted this stageKey at time T." Used for two distinct purposes that are not separated:
+
+1. **Cooldown bypass / aliveness in `itemMayNeedWork`** (`item.go:128`): if `processedSet[stageKey]` is set and `time.Since(lastAttempt) >= 10×PollSeconds`, return true (re-admit the item). This is the path that makes `fabrik:blocked` items re-evaluated periodically.
+2. **Retry suppression in `itemNeedsWork`** (`item.go:315`): if `processedSet[stageKey]` is set and `time.Since(lastAttempt) < 10×PollSeconds`, return false (skip dispatch). This is the path that prevents thrashing when a stage attempt just ran.
+
+The same map serves both behaviours, with the same cooldown duration. Reads are at lines 128 and 315; writes are scattered across at least seven sites.
+
+**Update sites:**
+
+| Path | Effect | Notes |
+|---|---|---|
+| `processItem` after Claude ran (`item.go:411`, `821`) | Set `processedSet[stageKey] = now` | Original purpose: record an attempt happened |
+| Comment-handling paths (`comments.go:319, 331`) | Set `processedSet[<comment-key>] = now` | Comment processing has its own variant of the same map, keyed by comment ID |
+| Catch-up loop blocked-review-gate path (`poll.go:806`) | Set `processedSet[stageKey] = now` | Added in #497 to make the cooldown retry path drive re-evaluation of awaiting-review items |
+| Deep-fetch deferred refresh (`poll.go:674-681`) | Refresh `processedSet[stageKey] = now` if entry already exists | Added in #488 fix; **OVER-BROAD: refreshes for any item with existing entry, not just terminal items.** Direct cause of #504 regression. |
+| Comment-clear path (`comments.go:262`) | Delete from `retryCount`/`pausedDueToRetries`; processedSet not deleted but stage advance occurs | (Asymmetric — see invariants below) |
+
+**Read sites:**
+
+| Path | Use |
+|---|---|
+| `itemMayNeedWork` cooldown bypass (`item.go:128`) | Re-admit after cooldown so blocked items get periodic re-evaluation |
+| `itemNeedsWork` retry suppression (`item.go:315`) | Suppress dispatch within cooldown window |
+
+**Implicit invariants:**
+
+1. *processedSet timestamps reflect "when fabrik last actually tried to dispatch."* Violated by the deep-fetch refresh (`poll.go:674-681`) which bumps the timestamp every poll cycle, lying about when the attempt actually occurred. **Direct cause of #504.**
+2. *processedSet entries are removed when the underlying state changes (e.g., stage completes, issue advances, fabrik:paused removed).* Partially violated: stage completion does not remove the entry. Comments path deletes related counters but not processedSet itself.
+3. *cooldown is the same for "failed retry" and "blocked re-evaluation"* — coincidence rather than design.
+
+**Known bugs:**
+
+- **#504**: deep-fetch refresh is too broad → cooldown never expires → retries blocked indefinitely.
+- (Latent) The dual-purpose semantics make it impossible to set a long cooldown for retry-after-failure (where "do nothing for a while") without also slowing down re-evaluation of blocked items (where "check more often" is desired).
+
+### 2.3 `engine.lastUpdatedAt`
+
+**Purpose:** poll-time staleness filter. `itemMayNeedWork` returns false when `item.UpdatedAt <= lastUpdatedAt[iKey]`, suppressing the expensive deep-fetch for items that have not changed.
+
+**Update sites:**
+
+| Path | Effect |
+|---|---|
+| Poll deferred function (`poll.go:674`) | After successful deep-fetch, set `lastUpdatedAt[iKey] = item.UpdatedAt` (unless item was just advanced) |
+| `processItem` claudeRan path (`item.go:861`) | `delete(e.lastUpdatedAt, iKey)` to handle the race where a concurrent poll cycle cached updatedAt while the worker was running and a comment posted during the run would otherwise be missed |
+
+**Read site:** `itemMayNeedWork` (`item.go:122`).
+
+**Implicit invariants:**
+
+1. *`item.UpdatedAt` is monotonic and reflects every change worth reacting to.* Violated for column moves in user mode: `Status` field changes don't bump `updatedAt` of the issue itself, only of the project item — and the project item's `updatedAt` propagates to `item.UpdatedAt` only after the cache-side merge in `github/project.go:309`. Webhook deltas (which now drive `items[].UpdatedAt` updates via `applyIssuesLabeled` etc.) update `UpdatedAt` to `time.Now()`, but those don't bump `lastUpdatedAt` directly until the next poll deep-fetches the item.
+2. *Cache-bypass labels (`fabrik:awaiting-ci`, `fabrik:rebase-needed`) cover all cases where periodic re-evaluation is needed independent of UpdatedAt.* Was violated for `fabrik:awaiting-review` until #497 added the cooldown-recording path.
+
+**Known bugs:** the structure itself is mostly fine, but it depends on `item.UpdatedAt` being advanced correctly by *all* paths — and the boardcache's own update logic does that imperfectly (e.g. `applyIssuesLabeled` sets `UpdatedAt = time.Now()`, but `applyProjectsV2ItemEdited` is never called in user mode).
+
+### 2.4 `engine.inFlight` (sync.Map)
+
+**Purpose:** "currently dispatched a worker for this issueKey." Prevents a second poll cycle from dispatching a duplicate worker while the first is mid-flight.
+
+**Update sites:** `Store` at the start of dispatchers (`processItem`, `dispatchReviewReinvoke`, `dispatchCIFixReinvoke`, `dispatchRebaseReinvoke`, `attemptMergeOnValidate`). `Delete` via `defer` when the goroutine exits.
+
+**Read sites:** poll's dispatch loop (`poll.go:838`); review/rebase/CI-fix reinvoke entry points; rebase path in `stages.go:358`.
+
+**Implicit invariants:** *every Store has a matching Delete, even on panic.* Held by `defer` discipline.
+
+**Known bugs:** none observed *in this map*. But it is the only surviving "actually currently running" gate, and it is in-memory. Combined with stale lock-label ghost (`fabrik:locked:<self>` left on issue when worker dies), the engine's view of "is this running" diverges from reality. Lock-label cleanup on shutdown (`cleanupLockedIssues`) helps but does nothing for crashes mid-flight.
+
+### 2.5 `engine.lockedIssues`
+
+**Purpose:** track which issues this engine instance has applied a `fabrik:locked:<self>` label to, so they can be cleaned up on graceful shutdown.
+
+**Update sites:** `processItem` lock acquisition (`item.go:550`); cleanup loop (`item.go:565`, `poll.go:520`).
+
+**Read sites:** shutdown cleanup loop (`poll.go:500-520`).
+
+**Implicit invariants:** *fabrik:locked:<self> on GitHub == lockedIssues[key] == true.* Violated by crash, kill -9, or `pkill`. The label persists on the issue but the in-memory set is gone after restart. Stale labels become a manual-cleanup task forever.
+
+**Known bugs:** **stale-lock recovery has no automated path.** Dispatcher's `itemNeedsWork` correctly admits items locked by *self* (so retry can lock again), but the user-visible "fabrik:locked:verveguy" label persisting confuses the operator. We hit this on #501 today — manual label deletion was required.
+
+### 2.6 `engine.retryCount` + `pausedDueToRetries`
+
+**Purpose:** track failed stage attempts, escalate to engine-pause after `MaxRetries`.
+
+**Update sites:** seven sites (most in `item.go` and `comments.go`). Increments at `item.go:927`; resets/deletes at multiple places — including `comments.go:262-263` (when a new comment arrives), various paths in `item.go`, and `pauseForReviewTimeout`'s removal in `escalateFailedStage`.
+
+**Read sites:** decision in `processItem`'s "did not complete" path; `wasPaused` in `item.go:483`; `unblockAwaitingInput` reset path in `item.go:986-991`.
+
+**Implicit invariants:**
+
+1. *Increments and resets are paired correctly.* Mostly held; when something gets out of sync, the issue ends up paused with `pausedDueToRetries=false` (looking like user-paused) or unpaused with retryCount > 0 (looking like fresh attempts).
+2. *The pause originator is identifiable.* `pausedDueToRetries` is the only signal that distinguishes engine-pause from user-pause, and it is in-memory only — does not survive restart.
+
+**Known bugs:** none observed *in current behaviour*, but the in-memory-only nature of `pausedDueToRetries` means **after a restart the engine cannot tell why an issue is paused.** A user comment will resume the issue under "user paused this" semantics regardless.
+
+### 2.7 The "TUI mirror" trio: `lastUsage`, `lastCompleted`, `lastBlocked`
+
+**Purpose:** capture last-known per-issue state so the TUI can display it without re-reading from GitHub.
+
+**Update sites:** end of `processItem` and various comment / review / CI handlers. Each hander writes; some delete. Different handlers update different subsets — e.g. `merge_gate.go` updates `lastUsage` and `lastCompleted` but not `lastBlocked` (it deletes blocked).
+
+**Read sites:** TUI event emission paths in `poll.go:1046` (and equivalents) — read after `processItem` to populate TUI events.
+
+**Implicit invariants:** *all three are updated together.* Not enforced; in practice handlers update a subset and delete the others. The TUI reads what's there and prints stale data when handlers diverge.
+
+**Known bugs:** TUI can show inconsistent state across the three (e.g. completed but blocked-on-input both true). Not catastrophic, but a code smell — three pieces of derived state held separately when they should be one.
+
+## §3 Cross-cutting observations — where the bugs *actually* live
+
+The per-structure analyses above each report a few bugs. The deeper pattern is that **bugs cluster at the seams between structures**. Almost every bug we hit on 2026-05-03 was a state-update path that updated structure A but not structure B, where B was downstream of A in some implicit way:
+
+| Bug | Mutation site | Updated | Forgot |
+|---|---|---|---|
+| #501 advance loop | `advanceToNextStage` | GitHub project Status | `boardcache.items[key].Status` |
+| #467 76-min lag | external column move | GitHub project Status | `boardcache.items[key].Status` (no `projects_v2_item` delivery; reconcile only) |
+| "deaf to new issues" | external `issues.opened` | GitHub | `boardcache.items` (delta handler missing `opened`) |
+| New-issue label drop | external `issues.labeled` after `opened` | GitHub | `applyIssuesLabeled` bails because `items[key]` doesn't exist |
+| #504 cooldown regression | every successful deep-fetch | `processedSet[stageKey] = now` | (over-update — should not refresh when stage incomplete) |
+| Stale lock from crashed worker | worker process dies | `fabrik:locked:<self>` label on GitHub | `e.lockedIssues[iKey]` (in-memory only — gone on restart) |
+| TUI mirror divergence | various stage handlers | A subset of {lastUsage, lastCompleted, lastBlocked} | The other subset |
+
+The shape: **fabrik treats "the state that drives behaviour" and "the cache of GitHub state" as separate concepts, but in practice they overlap heavily.** No single code path owns the lifecycle of an item's state. Every mutation path is responsible for knowing all the downstream state to update — and this is fragile by construction.
+
+A second pattern: **silent no-ops on missing keys.** `applyIssuesLabeled` does `if !ok { return }` — same in `applyProjectsV2ItemEdited`, in `applyPullRequestDelta`, etc. The intent is "ignore events for items we don't know about." The effect is "silently drop label changes on issues the cache forgot to add." A cache miss should at minimum log; at most, fall back to a single-item GitHub fetch to populate the cache and try again. Neither happens.
+
+A third pattern: **shallow fields vs deep fields are not symmetric.** `boardcache.items[key]` holds both. Reconcile updates only shallow fields and preserves cached deep fields. `FetchItemDetails` updates only deep fields and reads shallow fields from whatever's there. When the two diverge (e.g. labels added to an item whose deep fields are stale), the read paths see inconsistent views.
+
+## §4 Design implications
+
+The unified-cache design in `02-design.md` has to address these directly:
+
+1. **One mutator API.** Every state change — webhook delta, fabrik's own mutation, periodic reconcile — flows through one `Apply(eventOrMutation)` call on the canonical item state. No "mutate GitHub then forget to update cache" gap.
+2. **Consolidated per-item state.** The 8+ engine maps that key on `iKey` or `stageKey` collapse into fields on a single `ItemState` struct. Reading that struct returns a consistent view by construction.
+3. **Cache-miss behaviour on inbound events.** When a webhook arrives for an unknown issue, the handler must add it (via single-item fetch) before applying the delta — never silently drop.
+4. **Self-mutation write-through.** `advanceToNextStage` and any other code path that mutates GitHub state must update the cache as part of the same logical operation, not rely on a webhook echo or periodic reconcile.
+5. **Stale-lock detection.** The cache should distinguish "we hold the lock and the worker is alive" from "we hold the lock and the worker is dead" — probably by tracking worker PIDs/heartbeats, with cleanup on process exit and on worker-process disappearance.
+6. **TUI mirror state should derive from canonical state.** No three-way map of "last X seen by stage handler"; just a snapshot of the current ItemState.
+7. **Separate concerns of "cooldown bypass for periodic re-evaluation" from "retry suppression after failure".** Currently both use `processedSet`, which is why #504 broke retries while trying to fix #488's loop.
+
+These are the foundations the Phase 2 design has to build on.

--- a/docs/cache-refactor/02-design.md
+++ b/docs/cache-refactor/02-design.md
@@ -1,0 +1,405 @@
+# Phase 2 — Reactive Cache Architecture Design
+
+**Read this after `01-state-inventory.md`.**
+
+This document specifies the unified single-owner cache architecture that replaces the fragmented state model documented in Phase 1. The goal is captured in the conversation that initiated this work:
+
+> *Refactor it to have a "reactive" architecture with a single cache owner and then validate that polling via GraphQL and webhook based incremental updates are both correctly updating that single cache. Once this is clean, we can check all the paths that are downstream of the cache that should be reactive.*
+
+The design is split into:
+- **§1** the core abstractions (ItemState, Store, mutator, observer);
+- **§2** the data model (what fields are stored per item, including the consolidation of the 8+ engine maps);
+- **§3** the input-channel contracts (poll, webhook, self-mutation);
+- **§4** the output-channel contracts (downstream readers and reactive change notifications);
+- **§5** the migration strategy (how to land this incrementally without a Big Rewrite);
+- **§6** invariants and how they will be tested.
+
+The companion ADR `03-adr-reactive-cache.md` records the design *decisions* and rejected alternatives. This doc describes the design *itself*.
+
+## §1 Core abstractions
+
+### 1.1 ItemState
+
+The unit of state. One `ItemState` per `(repo, issueNumber)` pair. Replaces the 8+ engine maps and the boardcache `items` map for a single item.
+
+```go
+package itemstate
+
+// ItemState is the canonical per-item state. All mutations flow through Store.Apply;
+// all reads flow through Store.Get or change subscriptions.
+//
+// Field grouping by lifecycle:
+//   - Identity: never changes after first Apply
+//   - GitHub state: mirrors GitHub's view of issue, project, and linked PR
+//   - Engine state: fabrik's local control state (locks, retries, cycle counts, cooldowns)
+//   - Derived state: computed on read, not stored (e.g. "current stage")
+type ItemState struct {
+    // -------- Identity (immutable post-creation) --------
+    Repo   string // "owner/repo"
+    Number int    // issue number
+    ItemID string // GitHub Project item node ID (or "" if not on the board)
+
+    // -------- GitHub state (mirrored from GitHub via webhook deltas + reconcile) --------
+    Title       string
+    Body        string
+    URL         string
+    Author      string
+    Assignees   []string
+    State       string    // "open" | "closed"
+    IsClosed    bool      // derived
+    IsPR        bool
+    Labels      []string
+    Status      string    // project board column ("Specify", "Implement", etc.)
+    UpdatedAt   time.Time // max(issue.updatedAt, projectItem.updatedAt, linkedPR.updatedAt)
+
+    BlockedBy []Dependency
+
+    Comments []Comment
+
+    LinkedPR *LinkedPRState // nil if no closing PR
+
+    // -------- Engine state (fabrik's local control) --------
+    Lock        *LockState // nil = unlocked; non-nil = our lock or an other-instance lock
+    StageState  StageState // per-stage attempt/cycle counters
+    CooldownAt  map[string]time.Time // by reason ("retry", "review-blocked", "ci-await", etc.)
+    Worker      *WorkerHandle        // present when a worker is in-flight for this item
+
+    // -------- Derived state (computed on read) --------
+    // Stage:        derived from Status by FindStage(stages, Status)
+    // CurrentRetryCount: derived from StageState
+    // EngineWantsToProcess: derived; replaces itemNeedsWork
+}
+
+type LinkedPRState struct {
+    Number          int
+    Mergeable       *bool          // nil = unknown; pointer for tri-state
+    MergeableState  string         // "clean", "unstable", "blocked", etc.
+    HeadSHA         string
+    Reviews         []PRReview
+    ReviewRequests  []ReviewRequest
+    ThreadComments  []Comment      // unresolved review-thread comments
+    ResolvedThreadCount int
+    CheckRuns       []CheckRun     // by SHA — but stored on the LinkedPRState for the current head SHA
+}
+
+type StageState struct {
+    // Per-stage counters, keyed by stage name (not stageKey — the issue identity is the
+    // ItemState owner). Replaces e.retryCount, e.reviewCycleCount, e.ciFixCycleCount,
+    // e.rebaseCycleCount.
+    Attempts        map[string]int       // stageName → number of times Claude was invoked
+    LastAttemptAt   map[string]time.Time // stageName → last invocation timestamp
+    PausedByEngine  map[string]bool      // stageName → engine-pause vs user-pause distinguisher
+    ReviewCycles    map[string]int
+    CIFixCycles     map[string]int
+    RebaseCycles    map[string]int
+    // Comment processing: keyed by comment ID
+    ProcessedComments map[string]time.Time // commentID → when fabrik finished processing
+}
+
+type LockState struct {
+    HolderUser  string    // user identity in the fabrik:locked:<user> label
+    HeldByThis  bool      // true if HolderUser == cfg.User AND Worker != nil
+    AcquiredAt  time.Time
+}
+
+type WorkerHandle struct {
+    PID         int
+    StageName   string
+    StartedAt   time.Time
+    LastSignAt  time.Time // updated by worker heartbeats; stale heartbeat → assume worker died
+}
+```
+
+### 1.2 Store
+
+The single owner. Hands out read snapshots; accepts mutations. All access goes through Store.
+
+```go
+package itemstate
+
+type Store struct {
+    mu    sync.RWMutex
+    items map[string]*ItemState // key: "owner/repo#N"
+
+    observers []Observer // registered listeners; called on every successful Apply
+
+    fallback FallbackFetcher // for cache-miss reads (single-item fetch from GitHub)
+    logger   Logger
+}
+
+// Apply mutates state. Every mutator flows through here. Returns the new ItemState
+// snapshot (immutable copy) and a list of changes for observers.
+func (s *Store) Apply(m Mutation) (Snapshot, []Change, error)
+
+// Get returns an immutable snapshot of the current ItemState for an item.
+// On cache miss, falls back to GitHub via fallback fetcher, then returns the snapshot.
+// Returns ErrNotFound only when the item legitimately does not exist.
+func (s *Store) Get(repo string, number int) (Snapshot, error)
+
+// Subscribe registers an observer. Returns an unsubscribe func.
+func (s *Store) Subscribe(o Observer) func()
+
+// Snapshot is an immutable copy of an ItemState. Returned by Get and Apply.
+type Snapshot struct {
+    state ItemState // copy, not pointer
+}
+
+// Change describes what fields a mutation altered. Used by observers to decide
+// whether to react.
+type Change struct {
+    Repo   string
+    Number int
+    Fields ChangeFlags // bitmask: StatusChanged | LabelsChanged | LockChanged | ...
+}
+```
+
+### 1.3 Mutation
+
+A discriminated union of every possible state change. **Every** code path that wants to update state expresses it as a Mutation and calls `store.Apply(m)`. There is no other write path.
+
+```go
+type Mutation interface {
+    isMutation()
+}
+
+// From inbound webhook deltas:
+type IssueOpened struct { Issue gh.Issue }
+type IssueLabeled struct { Repo string; Number int; Label string }
+type IssueUnlabeled struct { Repo string; Number int; Label string }
+type IssueClosed struct { Repo string; Number int }
+type IssueReopened struct { Repo string; Number int }
+type IssueCommentCreated struct { Repo string; Number int; Comment gh.Comment }
+type ProjectV2ItemEdited struct { ItemID string; NewStatus string }
+type PRReviewSubmitted struct { Repo string; Number int; Review gh.PRReview }
+type PRReviewCommentCreated struct { Repo string; PRNumber int; Comment gh.Comment }
+type CheckRunCompleted struct { Repo string; SHA string; Run gh.CheckRun }
+
+// From fabrik's own mutations (write-through):
+type LocalStatusUpdated struct { Repo string; Number int; NewStatus string }
+type LocalLabelAdded struct { Repo string; Number int; Label string }
+type LocalLabelRemoved struct { Repo string; Number int; Label string }
+type LocalCommentAdded struct { Repo string; Number int; Comment gh.Comment }
+type LocalLockAcquired struct { Repo string; Number int; User string; Worker *WorkerHandle }
+type LocalLockReleased struct { Repo string; Number int }
+
+// From periodic reconciliation:
+type BoardReconciled struct { Items []gh.ProjectItem } // bulk update, computed against existing
+type ItemDeepFetched struct { Repo string; Number int; FreshState gh.ProjectItem } // single-item fresh fetch
+
+// From engine internals:
+type StageAttempted struct { Repo string; Number int; StageName string; At time.Time }
+type StageRetryIncremented struct { Repo string; Number int; StageName string }
+type StageRetryCleared struct { Repo string; Number int; StageName string }
+type ReviewCycleIncremented struct { Repo string; Number int; StageName string }
+type CIFixCycleIncremented struct { Repo string; Number int; StageName string }
+type RebaseCycleIncremented struct { Repo string; Number int; StageName string }
+type EngineEnginePaused struct { Repo string; Number int; StageName string }
+type CooldownRecorded struct { Repo string; Number int; Reason string; Until time.Time }
+type WorkerHeartbeat struct { Repo string; Number int; At time.Time }
+type WorkerExited struct { Repo string; Number int }
+```
+
+### 1.4 Observer
+
+Anyone downstream of state changes registers an Observer. The observer receives a `Change` describing what changed and a `Snapshot` of the new state. It decides whether to act.
+
+```go
+type Observer interface {
+    OnChange(change Change, snapshot Snapshot)
+}
+```
+
+Examples of who observes:
+- The dispatcher: subscribes to Status changes, label changes, comment additions, cooldown expiries → decides whether to dispatch a worker.
+- The TUI: subscribes to all changes → updates display.
+- Logging / debug: subscribes to all changes → emits structured events.
+- The wake channel: subscribes to "could this item now have work?" changes → fires the existing wakeCh.
+
+This is the *reactive* part of the architecture. Today, downstream readers poll. With observers, they react.
+
+## §2 Data model — what consolidates into ItemState
+
+This section maps the Phase 1 inventory into the new model. Every existing state structure either:
+
+- **Becomes a field on ItemState** (consolidated into per-item state with single owner), OR
+- **Stays at engine-level but reads through Store** (e.g. global counters that aren't per-item), OR
+- **Is deleted** (because its reason for existing was an artefact of the fragmentation we're removing).
+
+| Old structure | New home | Rationale |
+|---|---|---|
+| `boardcache.items[key]` | `Store.items[key].ItemState` (the whole struct) | The new owner consolidates this directly |
+| `boardcache.deepFetched[key]` | Derived: `ItemState.LastDeepFetchAt != zero` | Was a flag; becomes a timestamp |
+| `boardcache.linkedPRs[prKey]` | `ItemState.LinkedPR` (per-item) | A linked PR belongs to its issue |
+| `boardcache.checkRuns[sha]` | `ItemState.LinkedPR.CheckRuns` (per-item, scoped to current head SHA) | Check runs are PR-scoped |
+| `boardcache.shaToKey[sha]` | Derived: index built lazily by Store from items[].LinkedPR.HeadSHA | Reverse-lookup index, computed not stored |
+| `boardcache.itemIDToKey[id]` | Derived index in Store, same pattern | |
+| `boardcache.recentMissCache` | Stays in Store as a separate negative-cache structure (it's not per-item state) | |
+| `boardcache.paused` | `Store.paused bool` (top-level) | |
+| `engine.lockedIssues[iKey]` | `ItemState.Lock.HeldByThis` | The lock IS per-item state |
+| `engine.lastUsage[iKey]` | `ItemState.LastTokenUsage` | TUI mirror state belongs to the item |
+| `engine.lastCompleted[iKey]` | `ItemState.LastInvocationCompleted` | |
+| `engine.lastBlocked[iKey]` | `ItemState.LastInvocationBlocked` | |
+| `engine.lastUpdatedAt[iKey]` | **Deleted.** | The "have I seen this version?" check is replaced by Store change-feed: observers see only NEW changes. Cache is the source; no separate "seen" tracker. |
+| `engine.deepFetchFailureTime[iKey]` | `ItemState.LastDeepFetchFailureAt` | Per-item cooldown |
+| `engine.processedSet[stageKey]` | **Split.** Retry-suppression cooldown → `ItemState.StageState.LastAttemptAt[stageName]`. "Periodic re-evaluation" cooldown → `ItemState.CooldownAt[reason]` (separate map keyed by reason, not by stage). | The dual-purpose `processedSet` is the root of #504. Split fixes that. |
+| `engine.retryCount[stageKey]` | `ItemState.StageState.Attempts[stageName]` | |
+| `engine.pausedDueToRetries[stageKey]` | `ItemState.StageState.PausedByEngine[stageName]` | Now persists across restarts via reconcile (durable label-derived) |
+| `engine.reviewCycleCount[stageKey]` | `ItemState.StageState.ReviewCycles[stageName]` | |
+| `engine.ciFixCycleCount[stageKey]` | `ItemState.StageState.CIFixCycles[stageName]` | |
+| `engine.rebaseCycleCount[stageKey]` | `ItemState.StageState.RebaseCycles[stageName]` | |
+| `engine.ciMergePendingSince[iKey]` | `ItemState.LinkedPR.CIMergePendingSince` | PR-scoped |
+| `engine.prHasHadChecks[iKey]` | `ItemState.LinkedPR.HasHadChecks` | PR-scoped |
+| `engine.inFlight (sync.Map)` | `ItemState.Worker != nil && WorkerHeartbeat fresh` | Worker presence becomes part of state |
+| `engine.cloneInFlight (sync.Map)` | Stays at engine level (per-repo, not per-item) | Not consolidated |
+| `engine.baseBranchWarnedSet (sync.Map)` | `ItemState.BaseBranchWarned[branch]` (small per-item map) | |
+| `engine.idleCount`, `idleStart`, `totalTokens`, `lastReportedCost` | Stay at engine level (not per-item) | Global engine state |
+
+## §3 Input-channel contracts
+
+Three inputs feed mutations into the Store:
+
+### 3.1 Webhook stream (incremental, fast)
+
+The webhook subprocess receives events; the manager passes them to a `WebhookDispatcher`, which translates each event into a Mutation and calls `store.Apply(m)`.
+
+**Critical contract:** if a webhook arrives for an issue not in the Store, the dispatcher must:
+1. Issue a single-item fetch from GitHub via `Store.fallback.FetchIssue(repo, number)`.
+2. `store.Apply(IssueOpened{...})` to populate the cache.
+3. THEN apply the original webhook delta.
+
+This replaces the silent `if !ok { return }` no-op pattern that caused "fabrik went deaf to new issues."
+
+**New action coverage required (currently missing):**
+- `issues.opened`, `issues.closed`, `issues.reopened`, `issues.transferred`, `issues.deleted`, `issues.assigned`, `issues.unassigned`, `issues.edited`
+- `pull_request.opened`, `pull_request.closed`, `pull_request.reopened`, `pull_request.synchronize`, `pull_request.ready_for_review`, `pull_request.converted_to_draft`, `pull_request.review_requested`, `pull_request.review_request_removed`
+- `projects_v2_item.edited` (when delivered — App-mode or org-mode webhooks; documented gap in user/repo mode)
+
+### 3.2 Periodic poll (full reconciliation)
+
+A timer (configurable cadence) fetches the full project board from GitHub and submits a `BoardReconciled` mutation. The Store computes per-item deltas (using the existing diff logic) and applies them as a sequence of focused mutations:
+
+```go
+// Pseudo-code for reconcile inside Store
+func (s *Store) Reconcile(boardItems []gh.ProjectItem) {
+    // For each new fresh item:
+    //   - if not in s.items: Apply(IssueOpened{Issue: itemAsIssue})
+    //   - else: compute diff, Apply each field change as its own Mutation
+    // For items in s.items but not in fresh: Apply(IssueRemoved or IssueClosed equivalent)
+}
+```
+
+Per-Phase-1 §2.1, this replaces today's reconcile semantics that update fields directly on `existing` — it goes through Apply so observers see changes.
+
+The lightweight Status-only sweep from issue #501 lives here too: `BoardReconciled` with a partial set of fields populated (just Status). The Store's diff logic must handle "field X is present in the input, others are zero/nil — only diff the present fields."
+
+### 3.3 Self-mutation (write-through from fabrik's own GitHub mutations)
+
+When fabrik calls a GitHub mutation API (label add, comment post, status field update, lock add, etc.), the call path is:
+
+```go
+// Old (broken):
+if err := e.client.UpdateProjectItemStatus(...); err != nil { return err }
+// — local cache stale until next reconcile
+
+// New (write-through):
+if err := e.client.UpdateProjectItemStatus(...); err != nil { return err }
+store.Apply(LocalStatusUpdated{Repo: repo, Number: n, NewStatus: newStatus})
+```
+
+This is the Layer 0 contract. Every site in `engine/` that mutates GitHub state has a parallel Apply call. **Code review enforcement:** a static check (lint or policy) requires that every site calling a `client.Update*`, `client.Add*`, `client.Remove*`, or `client.Create*` has an adjacent `store.Apply(Local*)` call.
+
+The list of self-mutation sites to add Apply calls to is known from Phase 1 §3 (the bug table). The Phase 4 audit catches any we miss.
+
+## §4 Output-channel contracts
+
+### 4.1 Reads via Snapshot
+
+All read paths go through `Store.Get(repo, number)` returning a `Snapshot` (immutable copy of ItemState). This replaces:
+
+- `c.items[key]` direct reads → `store.Get(...).Item()`
+- `e.lastUpdatedAt[iKey]` reads → not needed; observers see changes directly
+- `e.processedSet[stageKey]` reads → `snapshot.LastAttemptAt(stageName)` and `snapshot.CooldownAt(reason)`
+- ... etc.
+
+Snapshots are cheap (struct copy under read lock) and the consumer can hold them as long as desired without blocking writes. No concurrent-mutation hazards: the Snapshot is a value, not a pointer.
+
+### 4.2 Reactive subscriptions via Observer
+
+Some downstream code wants to *react* to changes, not just read on demand. Examples:
+
+| Today's pattern | Reactive equivalent |
+|---|---|
+| `wakeCh` triggered on every webhook event | An Observer that filters changes and fires wakeCh only when something interesting (status, labels, lock, etc.) changed |
+| TUI re-renders on every poll | Observer that emits TUI events scoped to which item changed |
+| `itemMayNeedWork` evaluated on every poll for every item | Observer maintains a "may-need-work set" updated only on relevant Changes; dispatch loop reads from the set |
+| `itemNeedsWork` re-evaluated on every poll | Same — derive needs-work from Snapshot, recompute on Change |
+
+The dispatcher itself stays loop-driven (it runs on a poll tick to acquire semaphore slots and start workers in order), but the *deciding which items need work* moves to observer-maintained sets, which collapses a lot of redundant per-poll re-evaluation.
+
+### 4.3 Cache-miss falls back, never silently drops
+
+Every read path has a fallback to GitHub on cache miss. Every write path either (a) creates the item if missing, or (b) explicitly fails with `ErrNotFound` and the caller decides — never silently no-ops. The "silent no-op on missing key" pattern from Phase 1 §3 is banned.
+
+## §5 Migration strategy
+
+The refactor lands as **a sequence of small PRs** — not one monolithic rewrite. Each PR is independently reviewable, ships with tests, and leaves the engine in a working state.
+
+### Phase 3-A: Skeleton (PR 1)
+
+Add `internal/itemstate/` package: ItemState struct, Store, Mutation interface, Apply method, Get method, Snapshot type, Observer interface, basic tests. **Not wired into the engine yet.** Pure addition. CI green.
+
+### Phase 3-B: Boardcache adapter (PR 2)
+
+Make boardcache `CacheImpl` *delegate* to the new Store internally. Existing boardcache APIs (`FetchProjectBoard`, `FetchItemDetails`, `ApplyDelta`, `Bootstrap`, `Reconcile`) keep working but their internal data structures are replaced by `Store`. No engine changes required — engine still talks to `CacheImpl` via `ReadClient`. Tests prove behaviour-equivalence.
+
+### Phase 3-C: Self-mutation write-through (PR 3)
+
+Identify all `engine/` self-mutation sites (advanceToNextStage, AddLabel, RemoveLabel, AddComment, UpdateProjectItemStatus, AcquireLock, ReleaseLock, …). Add `store.Apply(Local*)` calls after each. Tests covering: status-mutation followed by immediate read returns new status. **This single PR fixes the #501/#506 advance-loop class of bug** — independent value before any other phase lands.
+
+### Phase 3-D: Webhook delta complete coverage (PR 4)
+
+Audit `boardcache/delta.go` against the new Mutation list. Add handlers for missing actions (`opened`, `closed`, `reopened`, `transferred`, etc.). Replace silent `if !ok { return }` with single-item fallback fetch + retry. **This PR fixes "fabrik went deaf to new issues."** Tests covering: webhook for unknown issue triggers fallback fetch and applies delta.
+
+### Phase 3-E: Engine state consolidation (PR 5)
+
+Move per-item engine maps (`lockedIssues`, `lastUsage`, `lastCompleted`, `lastBlocked`, `lastUpdatedAt`, `deepFetchFailureTime`, `prHasHadChecks`, `ciMergePendingSince`) into ItemState fields, accessed via Snapshot. Engine's reads/writes redirected. Tests covering: read-write equivalence with old behaviour.
+
+### Phase 3-F: Stage-state consolidation (PR 6)
+
+Move stage-keyed engine maps (`processedSet`, `retryCount`, `pausedDueToRetries`, `reviewCycleCount`, `ciFixCycleCount`, `rebaseCycleCount`) into `ItemState.StageState`. **Split `processedSet` into `LastAttemptAt` and `CooldownAt[reason]`** — fixes #504-class regression structurally. Tests covering: retry cooldown expires when expected; periodic re-evaluation cooldown not affected by retry timestamps.
+
+### Phase 3-G: Worker handle (PR 7)
+
+Add `ItemState.Worker` and heartbeat plumbing. Update lock-acquire / lock-release paths to populate Worker. Add background goroutine that watches for stale heartbeats and clears stale lock-labels. **Fixes the stale-lock recovery gap** observed on #501. Tests covering: worker exit clears lock; stale heartbeat triggers cleanup.
+
+### Phase 3-H: Reactive observer plumbing (PR 8)
+
+Add Subscribe + change-feed. Wire wakeCh as an observer (replacing the existing direct wake-on-webhook). Wire TUI events as an observer. Tests covering: change to a state field fires the right observer events.
+
+Each PR is small (~500-1500 lines), independently testable, and leaves a working engine. The order is chosen to land bug-fix value early (Phase 3-C unsticks advance loops; 3-D unsticks new-issue blindness) before the bigger refactors.
+
+## §6 Invariants and validation
+
+The core invariants the design must hold:
+
+| Invariant | How tested |
+|---|---|
+| (I1) Every state mutation flows through `Store.Apply`. No bypassing writes. | Linter / static check that no code outside `internal/itemstate/` mutates ItemState fields. |
+| (I2) Inbound webhook deltas reach the cache for known and unknown items. | Test: send webhook for unknown item; assert cache populated with single-item fallback fetch. |
+| (I3) Self-mutations write-through to cache before returning. | Test: call `engine.advanceToNextStage`; assert `store.Get` immediately reflects new Status. |
+| (I4) Observers see every Change exactly once. | Test: register observer; apply N mutations; assert observer received exactly N Changes with correct field flags. |
+| (I5) Snapshots are immutable and consistent. | Test: hold a snapshot; mutate state; original snapshot unchanged. |
+| (I6) Reconcile is idempotent. | Test: apply the same `BoardReconciled` mutation twice; second has no observer events. |
+| (I7) Retry cooldown is independent of periodic-re-eval cooldown. | Test: failed stage; check LastAttemptAt set; deep-fetch the item N times; assert LastAttemptAt unchanged (not refreshed). Then assert: after cooldown elapses, dispatch fires. |
+| (I8) Worker death is detected and lock cleaned up. | Test: spawn a worker; kill it; assert WorkerHandle expires; assert lock released; assert next dispatch can re-acquire. |
+| (I9) Cache-miss reads fall back to GitHub. | Test: clear cache; read item; assert fallback hit; assert cache populated. |
+| (I10) Cache-miss webhook deltas trigger fallback fetch. | Test: clear cache; deliver webhook; assert fallback hit; assert delta applied. |
+
+**Test coverage requirement for build PRs:** every PR in Phase 3-A through 3-H must include unit tests for the invariants it touches. Per the user's explicit ask: *"Make sure all build phase issues specify thorough testing."*
+
+## §7 What this design does **not** do
+
+- **Persistence across restarts.** Store is in-memory only, same as today. The Bootstrap path on startup re-populates from GitHub.
+- **Cross-instance coordination.** Multiple fabrik instances each have their own Store, coordinated only through the durable label state on GitHub (`fabrik:locked:<user>`, `stage:X:complete`, etc.) — same as today.
+- **Replacing the GitHub state model.** GitHub remains the source of truth for everything observable; the Store is a working copy. The lock-then-verify protocol in `processItem` is unchanged: re-read from GitHub before committing destructive operations.
+- **Solving the `projects_v2_item` non-delivery in user mode.** That requires App auth (#85); the cache architecture mitigates by ensuring the Reconcile path correctly updates Status when it does run.


### PR DESCRIPTION
## Summary

Phase 1 + Phase 2 of the cache-architecture refactor outlined in last night's session.

- **Phase 1 inventory** (\`docs/cache-refactor/01-state-inventory.md\`) — exhaustive catalog of every in-memory state structure in engine + boardcache. The 8+ overlapping maps the user identified turn out to be 25+ when audited carefully. Per-structure: purpose, update sites, read sites, implicit invariants, known/observed bugs.
- **Phase 2 design** (\`docs/cache-refactor/02-design.md\`) — unified single-owner reactive cache architecture. Core abstractions: \`ItemState\`, \`Store\`, \`Mutation\` (discriminated union), \`Observer\` (reactive subscription). Eight-PR migration strategy with bug-fix-value PRs landing first.
- **ADR 036** (\`adrs/036-reactive-cache-single-owner.md\`) — records the design decision; supersedes ADR 034/035 for internal cache structure.

## Why now

The cluster of cache-coherency bugs hit on 2026-05-03/04 (#467 stale Status, #501/#506 advance loops, #504 cooldown regression, "fabrik went deaf to new issues") all share one structural pattern: state mutation through one path does not reach the other paths. Patching individually is open-ended whack-a-mole; the structural fix is to consolidate.

These docs are the basis for the Phase 3 build issues that will follow — each filed for the fabrik pipeline to execute autonomously, each with thorough test requirements per the user's explicit ask.

## Scope of this PR

**Docs only.** No engine code changes. Safe to merge with confidence — it adds files only.

## Test plan

- [x] Markdown renders correctly (visual check).
- [x] All file:line references in \`01-state-inventory.md\` verified against the current code.
- [x] No claims about behaviour without grep-verified evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)