### PR TITLE
feat: Phase 3-A itemstate skeleton package (Store, ItemState, Mutation, Observer)

### DIFF
--- a/internal/itemstate/change.go
+++ b/internal/itemstate/change.go
@@ -1,0 +1,51 @@
+package itemstate
+
+// ChangeFlags is a bitmask describing which logical field groups of an ItemState
+// were altered by a mutation. Observers use this to cheaply filter whether a
+// Change is relevant to them without inspecting the full Snapshot.
+type ChangeFlags uint32
+
+const (
+	// StatusChanged indicates the project-board Status column changed.
+	StatusChanged ChangeFlags = 1 << iota
+	// LabelsChanged indicates the Labels slice changed.
+	LabelsChanged
+	// LockChanged indicates Lock state was acquired, released, or modified.
+	LockChanged
+	// StageStateChanged indicates StageState (attempts, cycles, pauses) changed.
+	StageStateChanged
+	// WorkerChanged indicates the Worker handle was set or cleared.
+	WorkerChanged
+	// CooldownChanged indicates CooldownAt map entries were added or removed.
+	CooldownChanged
+	// LinkedPRChanged indicates LinkedPR state (including check runs) changed.
+	LinkedPRChanged
+	// CommentsChanged indicates Comments or PR thread comments changed.
+	CommentsChanged
+	// AssigneesChanged indicates the Assignees slice changed.
+	AssigneesChanged
+	// TitleBodyChanged indicates Title or Body changed.
+	TitleBodyChanged
+	// StateChanged indicates the open/closed State or IsClosed changed.
+	StateChanged
+	// BlockedByChanged indicates the BlockedBy dependency list changed.
+	BlockedByChanged
+	// DeepFetchChanged indicates LastDeepFetchAt or LastDeepFetchFailureAt changed.
+	DeepFetchChanged
+	// InvocationChanged indicates LastInvocationCompleted, LastInvocationBlocked,
+	// or LastTokenUsage changed.
+	InvocationChanged
+	// BaseBranchChanged indicates BaseBranchWarned map changed.
+	BaseBranchChanged
+)
+
+// Change describes what fields a mutation altered. Delivered to every Observer
+// after a successful Store.Apply.
+type Change struct {
+	// Repo is "owner/repo" identifying the item.
+	Repo string
+	// Number is the issue number.
+	Number int
+	// Fields is a bitmask of ChangeFlags indicating which field groups changed.
+	Fields ChangeFlags
+}

--- a/internal/itemstate/change.go
+++ b/internal/itemstate/change.go
@@ -24,7 +24,7 @@ const (
 	CommentsChanged
 	// AssigneesChanged indicates the Assignees slice changed.
 	AssigneesChanged
-	// TitleBodyChanged indicates Title or Body changed.
+	// TitleBodyChanged indicates Title, Body, URL, or Author changed.
 	TitleBodyChanged
 	// StateChanged indicates the open/closed State or IsClosed changed.
 	StateChanged

--- a/internal/itemstate/doc.go
+++ b/internal/itemstate/doc.go
@@ -1,0 +1,19 @@
+// Package itemstate provides the canonical single-owner state store for
+// per-issue tracking in the Fabrik engine.
+//
+// This package is the foundation of the reactive cache architecture described
+// in docs/cache-refactor/02-design.md. It replaces the 25+ fragmented in-memory
+// state structures spread across engine/ and boardcache/ with a single Store that
+// holds one ItemState per (repo, issueNumber) pair.
+//
+// The core contract:
+//   - All state mutations flow through Store.Apply — no bypassing writes.
+//   - All reads flow through Store.Get, which returns an immutable Snapshot.
+//   - Downstream components react to changes via Observer subscriptions.
+//
+// Design rationale is in adrs/036-reactive-cache-single-owner.md.
+// Phase-by-phase migration strategy is in docs/cache-refactor/02-design.md §5.
+//
+// This package (Phase 3-A) is a pure addition. It is not yet wired into the
+// engine or boardcache; that happens in Phase 3-B onward.
+package itemstate

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -1,0 +1,168 @@
+package itemstate
+
+import (
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ItemState is the canonical per-item state. All mutations flow through Store.Apply;
+// all reads flow through Store.Get or change subscriptions.
+//
+// Field grouping by lifecycle:
+//   - Identity: never changes after first Apply
+//   - GitHub state: mirrors GitHub's view of issue, project, and linked PR
+//   - Engine state: fabrik's local control state (locks, retries, cycle counts, cooldowns)
+//   - TUI state: mirrors last-invocation outcomes for display
+type ItemState struct {
+	// -------- Identity (immutable post-creation) --------
+
+	// Repo is "owner/repo".
+	Repo string
+	// Number is the issue number.
+	Number int
+	// ItemID is the GitHub Project item node ID (empty if not on the board).
+	ItemID string
+
+	// -------- GitHub state (mirrored from GitHub via webhook deltas + reconcile) --------
+
+	Title     string
+	Body      string
+	URL       string
+	Author    string
+	Assignees []string
+	// State is "open" or "closed".
+	State    string
+	IsClosed bool
+	IsPR     bool
+	Labels   []string
+	// Status is the project board column ("Specify", "Implement", etc.).
+	Status string
+	// UpdatedAt is max(issue.updatedAt, projectItem.updatedAt, linkedPR.updatedAt).
+	UpdatedAt time.Time
+
+	// BlockedBy holds issues that must be closed before this one can advance.
+	BlockedBy []gh.Dependency
+
+	// Comments holds all comments on this issue.
+	Comments []gh.Comment
+
+	// LinkedPR is the state of the closing PR; nil if none.
+	LinkedPR *LinkedPRState
+
+	// -------- Engine state (fabrik's local control) --------
+
+	// Lock is nil when unlocked; non-nil when this instance or another holds a lock.
+	Lock *LockState
+	// StageState holds per-stage attempt and cycle counters.
+	StageState StageState
+	// CooldownAt maps reason → expiry time (e.g. "retry", "review-blocked", "ci-await").
+	CooldownAt map[string]time.Time
+	// Worker is present when a worker is in-flight for this item.
+	Worker *WorkerHandle
+
+	// -------- TUI / invocation mirror state --------
+
+	// LastDeepFetchAt is the time of the last successful deep fetch for this item.
+	// A zero value means no deep fetch has occurred. Replaces boardcache.deepFetched[key].
+	LastDeepFetchAt time.Time
+
+	// LastDeepFetchFailureAt is the time the most recent deep fetch attempt failed.
+	// Replaces engine.deepFetchFailureTime[iKey].
+	LastDeepFetchFailureAt time.Time
+
+	// LastInvocationCompleted records whether the most recent Claude invocation
+	// emitted FABRIK_STAGE_COMPLETE. Replaces engine.lastCompleted[iKey].
+	LastInvocationCompleted bool
+
+	// LastInvocationBlocked records whether the most recent Claude invocation
+	// emitted FABRIK_BLOCKED_ON_INPUT. Replaces engine.lastBlocked[iKey].
+	LastInvocationBlocked bool
+
+	// LastTokenUsage holds token consumption from the most recent Claude invocation.
+	// Replaces engine.lastUsage[iKey].
+	LastTokenUsage TokenUsage
+
+	// BaseBranchWarned tracks which base-branch overrides have already produced a
+	// "branch not found" warning comment. Replaces engine.baseBranchWarnedSet.
+	BaseBranchWarned map[string]bool
+}
+
+// LinkedPRState holds the state of the closing pull request for an issue.
+type LinkedPRState struct {
+	Number int
+	// Mergeable is nil when unknown; true/false once GitHub resolves mergeability.
+	Mergeable      *bool
+	MergeableState string // "clean", "unstable", "blocked", etc.
+	HeadSHA        string
+	Reviews        []gh.PRReview
+	ReviewRequests []gh.ReviewRequest
+	// ThreadComments holds unresolved review-thread comments.
+	ThreadComments       []gh.Comment
+	ResolvedThreadCount  int
+	CheckRuns            []gh.CheckRun
+
+	// HasHadChecks records whether this PR has ever had CI check runs reported.
+	// Replaces engine.prHasHadChecks[iKey].
+	HasHadChecks bool
+
+	// CIMergePendingSince records when the engine began waiting for the merge
+	// to complete after CI passed. Zero if not currently pending.
+	// Replaces engine.ciMergePendingSince[iKey].
+	CIMergePendingSince time.Time
+}
+
+// StageState holds per-stage attempt counters and cycle counts.
+// Keys are stage names (e.g. "Implement", "Review").
+type StageState struct {
+	// Attempts counts how many times Claude was invoked for each stage.
+	// Replaces engine.retryCount[stageKey].
+	Attempts map[string]int
+	// LastAttemptAt records the last invocation timestamp per stage.
+	// Replaces engine.processedSet[stageKey] for retry-suppression.
+	LastAttemptAt map[string]time.Time
+	// PausedByEngine records engine-initiated pauses (vs user-initiated).
+	// Replaces engine.pausedDueToRetries[stageKey].
+	PausedByEngine map[string]bool
+	// ReviewCycles counts how many review iterations each stage has completed.
+	// Replaces engine.reviewCycleCount[stageKey].
+	ReviewCycles map[string]int
+	// CIFixCycles counts how many CI-fix iterations each stage has completed.
+	// Replaces engine.ciFixCycleCount[stageKey].
+	CIFixCycles map[string]int
+	// RebaseCycles counts how many rebase iterations each stage has completed.
+	// Replaces engine.rebaseCycleCount[stageKey].
+	RebaseCycles map[string]int
+	// ProcessedComments maps comment ID to the time Fabrik finished processing it.
+	ProcessedComments map[string]time.Time
+}
+
+// LockState describes who holds the fabrik:locked:<user> label on this issue.
+type LockState struct {
+	// HolderUser is the user identity from the fabrik:locked:<user> label.
+	HolderUser string
+	// HeldByThis is true if HolderUser matches this engine instance's user and Worker != nil.
+	HeldByThis bool
+	AcquiredAt time.Time
+}
+
+// WorkerHandle identifies an in-flight Claude invocation for this item.
+type WorkerHandle struct {
+	PID       int
+	StageName string
+	StartedAt time.Time
+	// LastSignAt is updated by worker heartbeats; a stale heartbeat implies the worker died.
+	LastSignAt time.Time
+}
+
+// TokenUsage records Claude API token counts for a single invocation.
+// Fields mirror engine.TokenUsage to enable zero-cost assignment in Phase 3-E.
+type TokenUsage struct {
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	CostUSD             float64
+	TurnsUsed           int
+	MaxTurns            int
+}

--- a/internal/itemstate/itemstate_test.go
+++ b/internal/itemstate/itemstate_test.go
@@ -60,6 +60,28 @@ func TestSnapshotDoesNotAliasStore(t *testing.T) {
 	}
 }
 
+// TestStateReturnIsDeepCopy verifies that mutating an element inside a slice
+// returned by State() does not affect the Snapshot (covers index-mutation,
+// not just append — the case that a shallow State() copy would fail).
+func TestStateReturnIsDeepCopy(t *testing.T) {
+	s := NewStore(nil)
+	snap := applyOpened(t, s, "owner/repo", 10)
+
+	// Index-assign into the Labels slice returned by State().
+	st := snap.State()
+	if len(st.Labels) == 0 {
+		t.Skip("no labels to mutate")
+	}
+	original := st.Labels[0]
+	st.Labels[0] = "MUTATED_IN_PLACE"
+
+	// The Snapshot itself must be unchanged.
+	st2 := snap.State()
+	if st2.Labels[0] != original {
+		t.Errorf("State() slice mutation affected Snapshot: got %q; want %q", st2.Labels[0], original)
+	}
+}
+
 // TestSnapshotLabelSliceIsIndependent verifies that appending to a Labels slice
 // returned by a Snapshot does not mutate the Snapshot itself or the Store.
 func TestSnapshotLabelSliceIsIndependent(t *testing.T) {

--- a/internal/itemstate/itemstate_test.go
+++ b/internal/itemstate/itemstate_test.go
@@ -1,0 +1,202 @@
+package itemstate
+
+import (
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ---- helpers ----
+
+func testProjectItem(repo string, number int) gh.ProjectItem {
+	return gh.ProjectItem{
+		Repo:      repo,
+		Number:    number,
+		Title:     "Test issue",
+		Body:      "Test body",
+		URL:       "https://github.com/" + repo + "/issues/" + itoa(number),
+		Author:    "user",
+		Labels:    []string{"bug"},
+		Assignees: []string{"alice"},
+		Status:    "Implement",
+		UpdatedAt: time.Unix(1000, 0),
+	}
+}
+
+func applyOpened(t *testing.T, s *Store, repo string, number int) Snapshot {
+	t.Helper()
+	snap, _, err := s.Apply(IssueOpened{Item: testProjectItem(repo, number)})
+	if err != nil {
+		t.Fatalf("Apply(IssueOpened): %v", err)
+	}
+	return snap
+}
+
+// ---- I1: Every state mutation flows through Apply; Snapshot is immutable ----
+
+// TestSnapshotDoesNotAliasStore verifies that mutating fields on a Snapshot's
+// internal state value does not affect the Store (invariant I1).
+func TestSnapshotDoesNotAliasStore(t *testing.T) {
+	s := NewStore(nil)
+	snap := applyOpened(t, s, "owner/repo", 1)
+
+	// Mutate the returned snapshot state — should not affect the store.
+	st := snap.State()
+	st.Status = "MUTATED"
+	st.Labels = append(st.Labels, "extra")
+
+	got, err := s.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State().Status == "MUTATED" {
+		t.Error("Snapshot mutation bled into Store (Status)")
+	}
+	for _, l := range got.State().Labels {
+		if l == "extra" {
+			t.Error("Snapshot mutation bled into Store (Labels)")
+		}
+	}
+}
+
+// TestSnapshotLabelSliceIsIndependent verifies that appending to a Labels slice
+// returned by a Snapshot does not mutate the Snapshot itself or the Store.
+func TestSnapshotLabelSliceIsIndependent(t *testing.T) {
+	s := NewStore(nil)
+	applyOpened(t, s, "owner/repo", 2)
+
+	snap, err := s.Get("owner/repo", 2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	labels := snap.Labels()
+	labels = append(labels, "injected")
+
+	// The store copy must be unaffected.
+	snap2, _ := s.Get("owner/repo", 2)
+	for _, l := range snap2.Labels() {
+		if l == "injected" {
+			t.Error("appending to Labels() slice mutated the store")
+		}
+	}
+}
+
+// ---- I5: Snapshots are immutable and consistent ----
+
+// TestHeldSnapshotUnchangedAfterMutations verifies that a Snapshot taken before
+// subsequent Apply calls retains its original values (invariant I5).
+func TestHeldSnapshotUnchangedAfterMutations(t *testing.T) {
+	s := NewStore(nil)
+	held := applyOpened(t, s, "owner/repo", 3)
+	originalStatus := held.State().Status // "Implement"
+
+	// Apply several mutations that change Status.
+	for _, newStatus := range []string{"Review", "Validate", "Done"} {
+		if _, _, err := s.Apply(LocalStatusUpdated{Repo: "owner/repo", Number: 3, NewStatus: newStatus}); err != nil {
+			t.Fatalf("Apply(LocalStatusUpdated %s): %v", newStatus, err)
+		}
+	}
+
+	// Original snapshot must still reflect the value at the time it was taken.
+	if held.State().Status != originalStatus {
+		t.Errorf("held snapshot Status = %q; want %q", held.State().Status, originalStatus)
+	}
+}
+
+// TestHeldSnapshotCommentsUnchangedAfterAddition verifies that a held Snapshot's
+// Comments slice is not affected by subsequent IssueCommentCreated mutations.
+func TestHeldSnapshotCommentsUnchangedAfterAddition(t *testing.T) {
+	s := NewStore(nil)
+	held := applyOpened(t, s, "owner/repo", 4)
+	originalCount := len(held.State().Comments)
+
+	for i := 0; i < 5; i++ {
+		s.Apply(IssueCommentCreated{
+			Repo:    "owner/repo",
+			Number:  4,
+			Comment: gh.Comment{ID: itoa(i), Body: "comment"},
+		})
+	}
+
+	if got := len(held.State().Comments); got != originalCount {
+		t.Errorf("held snapshot Comments len = %d; want %d", got, originalCount)
+	}
+}
+
+// TestHeldSnapshotLinkedPRUnchangedAfterReview verifies that a held Snapshot's
+// LinkedPR is not affected by subsequent PRReviewSubmitted mutations.
+func TestHeldSnapshotLinkedPRUnchangedAfterReview(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: func() gh.ProjectItem {
+		pi := testProjectItem("owner/repo", 5)
+		pi.LinkedPRNumber = 42
+		return pi
+	}()})
+	held, _ := s.Get("owner/repo", 5)
+	heldLinkedPR := held.LinkedPR()
+	reviewsBefore := 0
+	if heldLinkedPR != nil {
+		reviewsBefore = len(heldLinkedPR.Reviews)
+	}
+
+	s.Apply(PRReviewSubmitted{
+		Repo:   "owner/repo",
+		Number: 5,
+		Review: gh.PRReview{Author: "reviewer", State: "APPROVED"},
+	})
+
+	// Re-fetch held snapshot from the original variable — must be unchanged.
+	var reviewsAfter int
+	if lpr := held.LinkedPR(); lpr != nil {
+		reviewsAfter = len(lpr.Reviews)
+	}
+	if reviewsAfter != reviewsBefore {
+		t.Errorf("held snapshot LinkedPR reviews changed: before %d, after %d", reviewsBefore, reviewsAfter)
+	}
+}
+
+// ---- TokenUsage field alignment with engine.TokenUsage ----
+
+// TestTokenUsageFields is a compile-time check that our TokenUsage fields match
+// the field names from engine.TokenUsage. If this test fails to compile, the
+// Phase 3-E wire-in will require renaming.
+func TestTokenUsageFields(t *testing.T) {
+	var u TokenUsage
+	// Assign each field to confirm the names exist at compile time.
+	u.InputTokens = 1
+	u.OutputTokens = 2
+	u.CacheCreationTokens = 3
+	u.CacheReadTokens = 4
+	u.CostUSD = 1.5
+	u.TurnsUsed = 10
+	u.MaxTurns = 50
+	_ = u
+}
+
+// TestItemKeyFor verifies the canonical item key format.
+func TestItemKeyFor(t *testing.T) {
+	cases := []struct {
+		repo   string
+		number int
+		want   string
+	}{
+		{"owner/repo", 1, "owner/repo#1"},
+		{"org/myproject", 999, "org/myproject#999"},
+	}
+	for _, c := range cases {
+		got := itemKeyFor(c.repo, c.number)
+		if got != c.want {
+			t.Errorf("itemKeyFor(%q, %d) = %q; want %q", c.repo, c.number, got, c.want)
+		}
+	}
+}
+
+// TestParseKey verifies round-trip key parsing.
+func TestParseKey(t *testing.T) {
+	repo, number := parseKey("owner/repo#42")
+	if repo != "owner/repo" || number != 42 {
+		t.Errorf("parseKey = (%q, %d); want (\"owner/repo\", 42)", repo, number)
+	}
+}

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -1,0 +1,380 @@
+package itemstate
+
+import (
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// Mutation is a discriminated union of every possible state change.
+// Every code path that wants to update ItemState expresses it as a Mutation
+// and calls Store.Apply. There is no other write path.
+type Mutation interface {
+	// isMutation is a marker method that prevents non-Mutation types from
+	// accidentally satisfying the interface.
+	isMutation()
+	// itemKey returns the "owner/repo#N" key identifying the affected item.
+	// BoardReconciled returns "" because it affects multiple items.
+	itemKey() string
+}
+
+// ---- Inbound webhook deltas ----
+
+// IssueOpened is emitted when a new issue is created or first observed.
+// Item is a gh.ProjectItem because there is no separate gh.Issue type; ProjectItem
+// is the full per-item representation used throughout Fabrik.
+type IssueOpened struct {
+	Item gh.ProjectItem
+}
+
+func (IssueOpened) isMutation() {}
+func (m IssueOpened) itemKey() string {
+	return itemKeyFor(m.Item.Repo, m.Item.Number)
+}
+
+// IssueLabeled is emitted when a label is added to an issue.
+type IssueLabeled struct {
+	Repo   string
+	Number int
+	Label  string
+}
+
+func (IssueLabeled) isMutation() {}
+func (m IssueLabeled) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// IssueUnlabeled is emitted when a label is removed from an issue.
+type IssueUnlabeled struct {
+	Repo   string
+	Number int
+	Label  string
+}
+
+func (IssueUnlabeled) isMutation() {}
+func (m IssueUnlabeled) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// IssueClosed is emitted when an issue is closed.
+type IssueClosed struct {
+	Repo   string
+	Number int
+}
+
+func (IssueClosed) isMutation() {}
+func (m IssueClosed) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// IssueReopened is emitted when a previously closed issue is reopened.
+type IssueReopened struct {
+	Repo   string
+	Number int
+}
+
+func (IssueReopened) isMutation() {}
+func (m IssueReopened) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// IssueCommentCreated is emitted when a new comment is added to an issue.
+type IssueCommentCreated struct {
+	Repo    string
+	Number  int
+	Comment gh.Comment
+}
+
+func (IssueCommentCreated) isMutation() {}
+func (m IssueCommentCreated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// ProjectV2ItemEdited is emitted when the project board status field is changed.
+type ProjectV2ItemEdited struct {
+	// ItemID is the GitHub Project item node ID (matches ItemState.ItemID).
+	ItemID    string
+	NewStatus string
+}
+
+func (ProjectV2ItemEdited) isMutation() {}
+func (m ProjectV2ItemEdited) itemKey() string {
+	// ItemID-based lookup is resolved by Store using its itemIDToKey index.
+	return ""
+}
+
+// PRReviewSubmitted is emitted when a reviewer submits a review on the linked PR.
+type PRReviewSubmitted struct {
+	Repo   string
+	Number int
+	Review gh.PRReview
+}
+
+func (PRReviewSubmitted) isMutation() {}
+func (m PRReviewSubmitted) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// PRReviewCommentCreated is emitted when a new inline review comment is added.
+type PRReviewCommentCreated struct {
+	Repo     string
+	PRNumber int
+	Comment  gh.Comment
+}
+
+func (PRReviewCommentCreated) isMutation() {}
+func (m PRReviewCommentCreated) itemKey() string { return itemKeyFor(m.Repo, m.PRNumber) }
+
+// CheckRunCompleted is emitted when a CI check run reaches a terminal state.
+// The SHA field is used to route the run to the correct LinkedPRState.
+type CheckRunCompleted struct {
+	Repo string
+	SHA  string
+	Run  gh.CheckRun
+}
+
+func (CheckRunCompleted) isMutation() {}
+func (m CheckRunCompleted) itemKey() string {
+	// SHA-based lookup is resolved by Store using its shaToKey index.
+	return ""
+}
+
+// ---- Self-mutations (write-through from fabrik's own GitHub mutations) ----
+
+// LocalStatusUpdated is applied after fabrik calls UpdateProjectItemStatus.
+type LocalStatusUpdated struct {
+	Repo      string
+	Number    int
+	NewStatus string
+}
+
+func (LocalStatusUpdated) isMutation() {}
+func (m LocalStatusUpdated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// LocalLabelAdded is applied after fabrik adds a label to an issue.
+type LocalLabelAdded struct {
+	Repo   string
+	Number int
+	Label  string
+}
+
+func (LocalLabelAdded) isMutation() {}
+func (m LocalLabelAdded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// LocalLabelRemoved is applied after fabrik removes a label from an issue.
+type LocalLabelRemoved struct {
+	Repo   string
+	Number int
+	Label  string
+}
+
+func (LocalLabelRemoved) isMutation() {}
+func (m LocalLabelRemoved) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// LocalCommentAdded is applied after fabrik posts a comment on an issue.
+type LocalCommentAdded struct {
+	Repo    string
+	Number  int
+	Comment gh.Comment
+}
+
+func (LocalCommentAdded) isMutation() {}
+func (m LocalCommentAdded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// LocalLockAcquired is applied after fabrik adds the fabrik:locked:<user> label.
+type LocalLockAcquired struct {
+	Repo   string
+	Number int
+	User   string
+	Worker *WorkerHandle
+}
+
+func (LocalLockAcquired) isMutation() {}
+func (m LocalLockAcquired) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// LocalLockReleased is applied after fabrik removes the fabrik:locked:<user> label.
+type LocalLockReleased struct {
+	Repo   string
+	Number int
+}
+
+func (LocalLockReleased) isMutation() {}
+func (m LocalLockReleased) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// ---- Periodic reconciliation ----
+
+// BoardReconciled is submitted by the periodic poll loop after a full board fetch.
+// The Store computes per-item deltas and applies them as focused mutations.
+// itemKey returns "" because this mutation affects all items, not a single one.
+type BoardReconciled struct {
+	Items []gh.ProjectItem
+}
+
+func (BoardReconciled) isMutation() {}
+func (m BoardReconciled) itemKey() string { return "" }
+
+// ItemDeepFetched is applied after a single-item deep fetch from the GitHub API.
+type ItemDeepFetched struct {
+	Repo       string
+	Number     int
+	FreshState gh.ProjectItem
+}
+
+func (ItemDeepFetched) isMutation() {}
+func (m ItemDeepFetched) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// ---- Engine internals ----
+
+// StageAttempted records the start of a new Claude invocation for a stage.
+type StageAttempted struct {
+	Repo      string
+	Number    int
+	StageName string
+	At        time.Time
+}
+
+func (StageAttempted) isMutation() {}
+func (m StageAttempted) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// StageRetryIncremented increments the attempt counter for a stage.
+type StageRetryIncremented struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (StageRetryIncremented) isMutation() {}
+func (m StageRetryIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// StageRetryCleared resets the attempt counter for a stage.
+type StageRetryCleared struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (StageRetryCleared) isMutation() {}
+func (m StageRetryCleared) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// ReviewCycleIncremented increments the review cycle counter for a stage.
+type ReviewCycleIncremented struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (ReviewCycleIncremented) isMutation() {}
+func (m ReviewCycleIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// CIFixCycleIncremented increments the CI-fix cycle counter for a stage.
+type CIFixCycleIncremented struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (CIFixCycleIncremented) isMutation() {}
+func (m CIFixCycleIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// RebaseCycleIncremented increments the rebase cycle counter for a stage.
+type RebaseCycleIncremented struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (RebaseCycleIncremented) isMutation() {}
+func (m RebaseCycleIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// EnginePaused records that the engine has paused work on a stage due to
+// repeated failures. (The design doc listed this as "EngineEnginePaused" — typo.)
+type EnginePaused struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (EnginePaused) isMutation() {}
+func (m EnginePaused) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// CooldownRecorded sets a cooldown expiry for a given reason key.
+type CooldownRecorded struct {
+	Repo   string
+	Number int
+	Reason string
+	Until  time.Time
+}
+
+func (CooldownRecorded) isMutation() {}
+func (m CooldownRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// WorkerHeartbeat updates the LastSignAt timestamp for the active worker.
+type WorkerHeartbeat struct {
+	Repo   string
+	Number int
+	At     time.Time
+}
+
+func (WorkerHeartbeat) isMutation() {}
+func (m WorkerHeartbeat) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// WorkerExited clears the Worker handle when a Claude invocation finishes.
+type WorkerExited struct {
+	Repo   string
+	Number int
+}
+
+func (WorkerExited) isMutation() {}
+func (m WorkerExited) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// InvocationRecorded captures the outcome of a completed Claude invocation for TUI display.
+type InvocationRecorded struct {
+	Repo      string
+	Number    int
+	Completed bool
+	Blocked   bool
+	Usage     TokenUsage
+}
+
+func (InvocationRecorded) isMutation() {}
+func (m InvocationRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// DeepFetchFailed records that a deep-fetch attempt for this item failed.
+type DeepFetchFailed struct {
+	Repo   string
+	Number int
+	At     time.Time
+}
+
+func (DeepFetchFailed) isMutation() {}
+func (m DeepFetchFailed) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// BaseBranchWarnRecorded marks a base-branch override as having been warned about.
+type BaseBranchWarnRecorded struct {
+	Repo   string
+	Number int
+	Branch string
+}
+
+func (BaseBranchWarnRecorded) isMutation() {}
+func (m BaseBranchWarnRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// itemKeyFor constructs the canonical "owner/repo#N" item key used throughout the Store.
+func itemKeyFor(repo string, number int) string {
+	if repo == "" && number == 0 {
+		return ""
+	}
+	return repo + "#" + itoa(number)
+}
+
+// itoa converts an int to its decimal string representation without importing strconv.
+// Only called from itemKeyFor where performance is not critical.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	buf := make([]byte, 20)
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -1,6 +1,7 @@
 package itemstate
 
 import (
+	"strconv"
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
@@ -352,29 +353,8 @@ func itemKeyFor(repo string, number int) string {
 	if repo == "" && number == 0 {
 		return ""
 	}
-	return repo + "#" + itoa(number)
+	return repo + "#" + strconv.Itoa(number)
 }
 
-// itoa converts an int to its decimal string representation without importing strconv.
-// Only called from itemKeyFor where performance is not critical.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	buf := make([]byte, 20)
-	pos := len(buf)
-	for n > 0 {
-		pos--
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		pos--
-		buf[pos] = '-'
-	}
-	return string(buf[pos:])
-}
+// itoa is an alias for strconv.Itoa used by test helpers in this package.
+func itoa(n int) string { return strconv.Itoa(n) }

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -172,10 +172,11 @@ func (m LocalCommentAdded) itemKey() string { return itemKeyFor(m.Repo, m.Number
 
 // LocalLockAcquired is applied after fabrik adds the fabrik:locked:<user> label.
 type LocalLockAcquired struct {
-	Repo   string
-	Number int
-	User   string
-	Worker *WorkerHandle
+	Repo       string
+	Number     int
+	User       string
+	Worker     *WorkerHandle
+	AcquiredAt time.Time // caller-provided time; enables idempotent/no-op detection
 }
 
 func (LocalLockAcquired) isMutation() {}
@@ -349,8 +350,9 @@ func (BaseBranchWarnRecorded) isMutation() {}
 func (m BaseBranchWarnRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
 // itemKeyFor constructs the canonical "owner/repo#N" item key used throughout the Store.
+// Returns "" when repo is empty (indicating an invalid or unroutable mutation).
 func itemKeyFor(repo string, number int) string {
-	if repo == "" && number == 0 {
+	if repo == "" {
 		return ""
 	}
 	return repo + "#" + strconv.Itoa(number)

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -201,11 +201,15 @@ func TestApplyLocalCommentAdded(t *testing.T) {
 
 func TestApplyLocalLockAcquired(t *testing.T) {
 	s := newStoreWithItem(t, testRepo, 1)
-	w := &WorkerHandle{PID: 999, StageName: "Implement", StartedAt: time.Now()}
-	applyExpect(t, s, LocalLockAcquired{Repo: testRepo, Number: 1, User: "alice", Worker: w}, LockChanged|WorkerChanged)
+	acquiredAt := time.Now()
+	w := &WorkerHandle{PID: 999, StageName: "Implement", StartedAt: acquiredAt}
+	applyExpect(t, s, LocalLockAcquired{Repo: testRepo, Number: 1, User: "alice", Worker: w, AcquiredAt: acquiredAt}, LockChanged|WorkerChanged)
 	st := getItem(t, s, testRepo, 1)
 	if st.Lock == nil || st.Lock.HolderUser != "alice" || !st.Lock.HeldByThis {
 		t.Error("Lock not set correctly")
+	}
+	if !st.Lock.AcquiredAt.Equal(acquiredAt) {
+		t.Error("Lock.AcquiredAt not set from mutation")
 	}
 	if st.Worker == nil || st.Worker.PID != 999 {
 		t.Error("Worker not set correctly")
@@ -214,7 +218,7 @@ func TestApplyLocalLockAcquired(t *testing.T) {
 
 func TestApplyLocalLockReleased(t *testing.T) {
 	s := newStoreWithItem(t, testRepo, 1)
-	s.Apply(LocalLockAcquired{Repo: testRepo, Number: 1, User: "alice", Worker: nil})
+	s.Apply(LocalLockAcquired{Repo: testRepo, Number: 1, User: "alice", Worker: nil, AcquiredAt: time.Now()})
 	applyExpect(t, s, LocalLockReleased{Repo: testRepo, Number: 1}, LockChanged)
 	if getItem(t, s, testRepo, 1).Lock != nil {
 		t.Error("Lock not cleared")

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -1,0 +1,594 @@
+package itemstate
+
+import (
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+const testRepo = "owner/repo"
+
+func newStoreWithItem(t *testing.T, repo string, number int) *Store {
+	t.Helper()
+	s := NewStore(nil)
+	if _, _, err := s.Apply(IssueOpened{Item: testProjectItem(repo, number)}); err != nil {
+		t.Fatalf("seed IssueOpened: %v", err)
+	}
+	return s
+}
+
+func getItem(t *testing.T, s *Store, repo string, number int) ItemState {
+	t.Helper()
+	snap, err := s.Get(repo, number)
+	if err != nil {
+		t.Fatalf("Get(%q, %d): %v", repo, number, err)
+	}
+	return snap.State()
+}
+
+func applyExpect(t *testing.T, s *Store, m Mutation, wantFlags ChangeFlags) Snapshot {
+	t.Helper()
+	snap, changes, err := s.Apply(m)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if wantFlags != 0 {
+		if len(changes) == 0 {
+			t.Fatalf("Apply(%T): expected Change with flags %b, got no changes", m, wantFlags)
+		}
+		if changes[0].Fields&wantFlags == 0 {
+			t.Errorf("Apply(%T): flags %b does not include expected %b", m, changes[0].Fields, wantFlags)
+		}
+	}
+	return snap
+}
+
+// ---- IssueOpened ----
+
+func TestApplyIssueOpened(t *testing.T) {
+	s := NewStore(nil)
+	pi := testProjectItem(testRepo, 1)
+	pi.ItemID = "PVTI_abc"
+	snap := applyExpect(t, s, IssueOpened{Item: pi}, TitleBodyChanged)
+	st := snap.State()
+	if st.Title != "Test issue" {
+		t.Errorf("Title = %q; want %q", st.Title, "Test issue")
+	}
+	if st.Status != "Implement" {
+		t.Errorf("Status = %q; want %q", st.Status, "Implement")
+	}
+	if st.Repo != testRepo || st.Number != 1 {
+		t.Errorf("Repo/Number = %q/%d; want %q/1", st.Repo, st.Number, testRepo)
+	}
+}
+
+// ---- IssueLabeled / IssueUnlabeled ----
+
+func TestApplyIssueLabeled(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, IssueLabeled{Repo: testRepo, Number: 1, Label: "enhancement"}, LabelsChanged)
+	st := getItem(t, s, testRepo, 1)
+	if !containsString(st.Labels, "enhancement") {
+		t.Error("label 'enhancement' not added")
+	}
+}
+
+func TestApplyIssueUnlabeled(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1) // seeded with Labels: ["bug"]
+	applyExpect(t, s, IssueUnlabeled{Repo: testRepo, Number: 1, Label: "bug"}, LabelsChanged)
+	st := getItem(t, s, testRepo, 1)
+	if containsString(st.Labels, "bug") {
+		t.Error("label 'bug' not removed")
+	}
+}
+
+// ---- IssueClosed / IssueReopened ----
+
+func TestApplyIssueClosed(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, IssueClosed{Repo: testRepo, Number: 1}, StateChanged)
+	st := getItem(t, s, testRepo, 1)
+	if !st.IsClosed || st.State != "closed" {
+		t.Error("IssueClosed did not set IsClosed/State")
+	}
+}
+
+func TestApplyIssueReopened(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(IssueClosed{Repo: testRepo, Number: 1})
+	applyExpect(t, s, IssueReopened{Repo: testRepo, Number: 1}, StateChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.IsClosed || st.State != "open" {
+		t.Error("IssueReopened did not restore state")
+	}
+}
+
+// ---- IssueCommentCreated ----
+
+func TestApplyIssueCommentCreated(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	c := gh.Comment{ID: "c1", Body: "hello"}
+	applyExpect(t, s, IssueCommentCreated{Repo: testRepo, Number: 1, Comment: c}, CommentsChanged)
+	st := getItem(t, s, testRepo, 1)
+	found := false
+	for _, got := range st.Comments {
+		if got.ID == "c1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("comment not appended")
+	}
+}
+
+// ---- PRReviewSubmitted ----
+
+func TestApplyPRReviewSubmitted(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	rev := gh.PRReview{Author: "bob", State: "APPROVED"}
+	applyExpect(t, s, PRReviewSubmitted{Repo: testRepo, Number: 1, Review: rev}, LinkedPRChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LinkedPR == nil || len(st.LinkedPR.Reviews) == 0 {
+		t.Fatal("LinkedPR.Reviews not set")
+	}
+	if st.LinkedPR.Reviews[0].Author != "bob" {
+		t.Errorf("Reviews[0].Author = %q; want %q", st.LinkedPR.Reviews[0].Author, "bob")
+	}
+}
+
+// ---- PRReviewCommentCreated ----
+
+func TestApplyPRReviewCommentCreated(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	c := gh.Comment{ID: "rc1", Body: "nit"}
+	applyExpect(t, s, PRReviewCommentCreated{Repo: testRepo, PRNumber: 1, Comment: c}, LinkedPRChanged|CommentsChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LinkedPR == nil || len(st.LinkedPR.ThreadComments) == 0 {
+		t.Fatal("LinkedPR.ThreadComments not set")
+	}
+}
+
+// ---- LocalStatusUpdated ----
+
+func TestApplyLocalStatusUpdated(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Review"}, StatusChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.Status != "Review" {
+		t.Errorf("Status = %q; want Review", st.Status)
+	}
+}
+
+// ---- LocalLabelAdded / LocalLabelRemoved ----
+
+func TestApplyLocalLabelAdded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, LocalLabelAdded{Repo: testRepo, Number: 1, Label: "fabrik:yolo"}, LabelsChanged)
+	if !containsString(getItem(t, s, testRepo, 1).Labels, "fabrik:yolo") {
+		t.Error("label not added")
+	}
+}
+
+func TestApplyLocalLabelRemoved(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(LocalLabelAdded{Repo: testRepo, Number: 1, Label: "fabrik:yolo"})
+	applyExpect(t, s, LocalLabelRemoved{Repo: testRepo, Number: 1, Label: "fabrik:yolo"}, LabelsChanged)
+	if containsString(getItem(t, s, testRepo, 1).Labels, "fabrik:yolo") {
+		t.Error("label not removed")
+	}
+}
+
+// ---- LocalCommentAdded ----
+
+func TestApplyLocalCommentAdded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	c := gh.Comment{ID: "local1", Body: "Fabrik posted"}
+	applyExpect(t, s, LocalCommentAdded{Repo: testRepo, Number: 1, Comment: c}, CommentsChanged)
+	st := getItem(t, s, testRepo, 1)
+	found := false
+	for _, got := range st.Comments {
+		if got.ID == "local1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("local comment not appended")
+	}
+}
+
+// ---- LocalLockAcquired / LocalLockReleased ----
+
+func TestApplyLocalLockAcquired(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	w := &WorkerHandle{PID: 999, StageName: "Implement", StartedAt: time.Now()}
+	applyExpect(t, s, LocalLockAcquired{Repo: testRepo, Number: 1, User: "alice", Worker: w}, LockChanged|WorkerChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.Lock == nil || st.Lock.HolderUser != "alice" || !st.Lock.HeldByThis {
+		t.Error("Lock not set correctly")
+	}
+	if st.Worker == nil || st.Worker.PID != 999 {
+		t.Error("Worker not set correctly")
+	}
+}
+
+func TestApplyLocalLockReleased(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(LocalLockAcquired{Repo: testRepo, Number: 1, User: "alice", Worker: nil})
+	applyExpect(t, s, LocalLockReleased{Repo: testRepo, Number: 1}, LockChanged)
+	if getItem(t, s, testRepo, 1).Lock != nil {
+		t.Error("Lock not cleared")
+	}
+}
+
+// ---- ItemDeepFetched ----
+
+func TestApplyItemDeepFetched(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	fresh := testProjectItem(testRepo, 1)
+	fresh.Title = "Updated Title"
+	applyExpect(t, s, ItemDeepFetched{Repo: testRepo, Number: 1, FreshState: fresh}, DeepFetchChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.Title != "Updated Title" {
+		t.Errorf("Title = %q; want Updated Title", st.Title)
+	}
+	if st.LastDeepFetchAt.IsZero() {
+		t.Error("LastDeepFetchAt not set")
+	}
+}
+
+// ---- StageAttempted ----
+
+func TestApplyStageAttempted(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	at := time.Now()
+	applyExpect(t, s, StageAttempted{Repo: testRepo, Number: 1, StageName: "Implement", At: at}, StageStateChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.StageState.Attempts["Implement"] != 1 {
+		t.Errorf("Attempts[Implement] = %d; want 1", st.StageState.Attempts["Implement"])
+	}
+	if !st.StageState.LastAttemptAt["Implement"].Equal(at) {
+		t.Error("LastAttemptAt not set")
+	}
+}
+
+// ---- StageRetryIncremented ----
+
+func TestApplyStageRetryIncremented(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(StageAttempted{Repo: testRepo, Number: 1, StageName: "Review", At: time.Now()})
+	applyExpect(t, s, StageRetryIncremented{Repo: testRepo, Number: 1, StageName: "Review"}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.Attempts["Review"] != 2 {
+		t.Error("Attempts not incremented to 2")
+	}
+}
+
+// ---- StageRetryCleared ----
+
+func TestApplyStageRetryCleared(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(StageAttempted{Repo: testRepo, Number: 1, StageName: "Implement", At: time.Now()})
+	applyExpect(t, s, StageRetryCleared{Repo: testRepo, Number: 1, StageName: "Implement"}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.Attempts["Implement"] != 0 {
+		t.Error("Attempts not cleared")
+	}
+}
+
+// ---- ReviewCycleIncremented ----
+
+func TestApplyReviewCycleIncremented(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, ReviewCycleIncremented{Repo: testRepo, Number: 1, StageName: "Review"}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.ReviewCycles["Review"] != 1 {
+		t.Error("ReviewCycles not incremented")
+	}
+}
+
+// ---- CIFixCycleIncremented ----
+
+func TestApplyCIFixCycleIncremented(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, CIFixCycleIncremented{Repo: testRepo, Number: 1, StageName: "Validate"}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.CIFixCycles["Validate"] != 1 {
+		t.Error("CIFixCycles not incremented")
+	}
+}
+
+// ---- RebaseCycleIncremented ----
+
+func TestApplyRebaseCycleIncremented(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, RebaseCycleIncremented{Repo: testRepo, Number: 1, StageName: "Review"}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.RebaseCycles["Review"] != 1 {
+		t.Error("RebaseCycles not incremented")
+	}
+}
+
+// ---- EnginePaused ----
+
+func TestApplyEnginePaused(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, EnginePaused{Repo: testRepo, Number: 1, StageName: "Implement"}, StageStateChanged)
+	if !getItem(t, s, testRepo, 1).StageState.PausedByEngine["Implement"] {
+		t.Error("PausedByEngine not set")
+	}
+}
+
+// ---- CooldownRecorded ----
+
+func TestApplyCooldownRecorded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	until := time.Now().Add(10 * time.Minute)
+	applyExpect(t, s, CooldownRecorded{Repo: testRepo, Number: 1, Reason: "retry", Until: until}, CooldownChanged)
+	got := getItem(t, s, testRepo, 1).CooldownAt["retry"]
+	if !got.Equal(until) {
+		t.Errorf("CooldownAt[retry] = %v; want %v", got, until)
+	}
+}
+
+// ---- WorkerHeartbeat / WorkerExited ----
+
+func TestApplyWorkerHeartbeat(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	at := time.Now()
+	applyExpect(t, s, WorkerHeartbeat{Repo: testRepo, Number: 1, At: at}, WorkerChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.Worker == nil || !st.Worker.LastSignAt.Equal(at) {
+		t.Error("Worker.LastSignAt not set")
+	}
+}
+
+func TestApplyWorkerExited(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(WorkerHeartbeat{Repo: testRepo, Number: 1, At: time.Now()})
+	applyExpect(t, s, WorkerExited{Repo: testRepo, Number: 1}, WorkerChanged)
+	if getItem(t, s, testRepo, 1).Worker != nil {
+		t.Error("Worker not cleared")
+	}
+}
+
+// ---- InvocationRecorded ----
+
+func TestApplyInvocationRecorded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	usage := TokenUsage{InputTokens: 100, OutputTokens: 200, TurnsUsed: 5, MaxTurns: 50}
+	applyExpect(t, s, InvocationRecorded{
+		Repo:      testRepo,
+		Number:    1,
+		Completed: true,
+		Blocked:   false,
+		Usage:     usage,
+	}, InvocationChanged)
+	st := getItem(t, s, testRepo, 1)
+	if !st.LastInvocationCompleted {
+		t.Error("LastInvocationCompleted not set")
+	}
+	if st.LastTokenUsage.InputTokens != 100 {
+		t.Errorf("LastTokenUsage.InputTokens = %d; want 100", st.LastTokenUsage.InputTokens)
+	}
+}
+
+// ---- DeepFetchFailed ----
+
+func TestApplyDeepFetchFailed(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	at := time.Now()
+	applyExpect(t, s, DeepFetchFailed{Repo: testRepo, Number: 1, At: at}, DeepFetchChanged)
+	if !getItem(t, s, testRepo, 1).LastDeepFetchFailureAt.Equal(at) {
+		t.Error("LastDeepFetchFailureAt not set")
+	}
+}
+
+// ---- BaseBranchWarnRecorded ----
+
+func TestApplyBaseBranchWarnRecorded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, BaseBranchWarnRecorded{Repo: testRepo, Number: 1, Branch: "feat/x"}, BaseBranchChanged)
+	if !getItem(t, s, testRepo, 1).BaseBranchWarned["feat/x"] {
+		t.Error("BaseBranchWarned not set")
+	}
+}
+
+// ---- BoardReconciled ----
+
+func TestApplyBoardReconciled(t *testing.T) {
+	s := NewStore(nil)
+	items := []gh.ProjectItem{
+		testProjectItem(testRepo, 10),
+		testProjectItem(testRepo, 11),
+	}
+	_, changes, err := s.Apply(BoardReconciled{Items: items})
+	if err != nil {
+		t.Fatalf("Apply(BoardReconciled): %v", err)
+	}
+	if len(changes) != 2 {
+		t.Errorf("changes = %d; want 2", len(changes))
+	}
+	// Items should now be in the store.
+	for _, pi := range items {
+		if _, err := s.Get(pi.Repo, pi.Number); err != nil {
+			t.Errorf("Get(%d) after BoardReconciled: %v", pi.Number, err)
+		}
+	}
+}
+
+// ---- ProjectV2ItemEdited (itemID-based routing) ----
+
+func TestApplyProjectV2ItemEdited(t *testing.T) {
+	s := NewStore(nil)
+	pi := testProjectItem(testRepo, 1)
+	pi.ItemID = "PVTI_xyz"
+	s.Apply(IssueOpened{Item: pi})
+
+	applyExpect(t, s, ProjectV2ItemEdited{ItemID: "PVTI_xyz", NewStatus: "Review"}, StatusChanged)
+	if getItem(t, s, testRepo, 1).Status != "Review" {
+		t.Error("Status not updated via ProjectV2ItemEdited")
+	}
+}
+
+// ---- CheckRunCompleted (SHA-based routing) ----
+
+func TestApplyCheckRunCompleted(t *testing.T) {
+	s := NewStore(nil)
+	pi := testProjectItem(testRepo, 1)
+	pi.LinkedPRNumber = 10
+	s.Apply(IssueOpened{Item: pi})
+	// Directly set HeadSHA via a mutation that exercises the field.
+	s.mu.Lock()
+	key := itemKeyFor(testRepo, 1)
+	item := s.items[key]
+	if item.LinkedPR == nil {
+		item.LinkedPR = &LinkedPRState{Number: 10}
+	}
+	item.LinkedPR.HeadSHA = "abc123"
+	s.shaToKey["abc123"] = key
+	s.mu.Unlock()
+
+	run := gh.CheckRun{ID: 1, Name: "CI", Status: "completed", Conclusion: "success"}
+	applyExpect(t, s, CheckRunCompleted{Repo: testRepo, SHA: "abc123", Run: run}, LinkedPRChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LinkedPR == nil || len(st.LinkedPR.CheckRuns) == 0 {
+		t.Fatal("CheckRuns not set")
+	}
+	if !st.LinkedPR.HasHadChecks {
+		t.Error("HasHadChecks not set")
+	}
+}
+
+// ---- ChangeFlags coverage: every flag must be exercised ----
+
+func TestChangeFlagsCoverage(t *testing.T) {
+	// Maps every ChangeFlag to a mutation that should produce it.
+	type flagCase struct {
+		flag ChangeFlags
+		name string
+		mut  func(s *Store, number int) Mutation
+	}
+	cases := []flagCase{
+		{StatusChanged, "StatusChanged", func(s *Store, n int) Mutation {
+			return LocalStatusUpdated{Repo: testRepo, Number: n, NewStatus: "Review"}
+		}},
+		{LabelsChanged, "LabelsChanged", func(s *Store, n int) Mutation {
+			return IssueLabeled{Repo: testRepo, Number: n, Label: "new-label"}
+		}},
+		{LockChanged, "LockChanged", func(s *Store, n int) Mutation {
+			return LocalLockAcquired{Repo: testRepo, Number: n, User: "u"}
+		}},
+		{StageStateChanged, "StageStateChanged", func(s *Store, n int) Mutation {
+			return StageAttempted{Repo: testRepo, Number: n, StageName: "S", At: time.Now()}
+		}},
+		{WorkerChanged, "WorkerChanged", func(s *Store, n int) Mutation {
+			return WorkerHeartbeat{Repo: testRepo, Number: n, At: time.Now()}
+		}},
+		{CooldownChanged, "CooldownChanged", func(s *Store, n int) Mutation {
+			return CooldownRecorded{Repo: testRepo, Number: n, Reason: "r", Until: time.Now().Add(time.Minute)}
+		}},
+		{LinkedPRChanged, "LinkedPRChanged", func(s *Store, n int) Mutation {
+			return PRReviewSubmitted{Repo: testRepo, Number: n, Review: gh.PRReview{Author: "r"}}
+		}},
+		{CommentsChanged, "CommentsChanged", func(s *Store, n int) Mutation {
+			return IssueCommentCreated{Repo: testRepo, Number: n, Comment: gh.Comment{ID: "x"}}
+		}},
+		{AssigneesChanged, "AssigneesChanged", func(s *Store, n int) Mutation {
+			pi := testProjectItem(testRepo, n)
+			pi.Assignees = []string{"bob", "carol"}
+			return IssueOpened{Item: pi}
+		}},
+		{TitleBodyChanged, "TitleBodyChanged", func(s *Store, n int) Mutation {
+			pi := testProjectItem(testRepo, n)
+			pi.Title = "Changed Title"
+			return IssueOpened{Item: pi}
+		}},
+		{StateChanged, "StateChanged", func(s *Store, n int) Mutation {
+			return IssueClosed{Repo: testRepo, Number: n}
+		}},
+		{BlockedByChanged, "BlockedByChanged", func(s *Store, n int) Mutation {
+			pi := testProjectItem(testRepo, n)
+			pi.BlockedBy = []gh.Dependency{{Number: 99}}
+			return IssueOpened{Item: pi}
+		}},
+		{DeepFetchChanged, "DeepFetchChanged", func(s *Store, n int) Mutation {
+			return DeepFetchFailed{Repo: testRepo, Number: n, At: time.Now()}
+		}},
+		{InvocationChanged, "InvocationChanged", func(s *Store, n int) Mutation {
+			return InvocationRecorded{Repo: testRepo, Number: n, Completed: true}
+		}},
+		{BaseBranchChanged, "BaseBranchChanged", func(s *Store, n int) Mutation {
+			return BaseBranchWarnRecorded{Repo: testRepo, Number: n, Branch: "b"}
+		}},
+	}
+
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := NewStore(nil)
+			number := i + 100 // unique number per sub-test
+			s.Apply(IssueOpened{Item: testProjectItem(testRepo, number)})
+
+			_, changes, err := s.Apply(c.mut(s, number))
+			if err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if len(changes) == 0 {
+				t.Fatalf("expected Change with flag %b, got no changes", c.flag)
+			}
+			if changes[0].Fields&c.flag == 0 {
+				t.Errorf("Change.Fields %b does not include %b", changes[0].Fields, c.flag)
+			}
+		})
+	}
+}
+
+// ---- I6: No-op mutation idempotency ----
+
+// TestNoOpMutationProducesNoChange verifies that applying an identical mutation
+// twice produces no observer event the second time (invariant I6).
+func TestNoOpMutationProducesNoChange(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+	// First application: changes status.
+	s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Review"})
+
+	var fired int
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) { fired++ }))
+
+	// Second application: same status — should be a no-op.
+	_, changes, err := s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Review"})
+	if err != nil {
+		t.Fatalf("Apply no-op: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("no-op Apply returned %d changes; want 0", len(changes))
+	}
+	if fired != 0 {
+		t.Errorf("observer fired %d times for no-op mutation; want 0", fired)
+	}
+}
+
+// TestNoOpLabelAddProducesNoChange verifies label idempotency.
+func TestNoOpLabelAddProducesNoChange(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+	// "bug" is already in the seed item labels.
+	var fired int
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) { fired++ }))
+
+	_, changes, _ := s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: "bug"})
+	if len(changes) != 0 || fired != 0 {
+		t.Errorf("label no-op produced change (changes=%d, fired=%d)", len(changes), fired)
+	}
+}
+
+// TestNoOpCooldownSameValue verifies CooldownRecorded is a no-op when value unchanged.
+func TestNoOpCooldownSameValue(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+	until := time.Unix(9999, 0)
+	s.Apply(CooldownRecorded{Repo: testRepo, Number: 1, Reason: "retry", Until: until})
+
+	var fired int
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) { fired++ }))
+	_, changes, _ := s.Apply(CooldownRecorded{Repo: testRepo, Number: 1, Reason: "retry", Until: until})
+	if len(changes) != 0 || fired != 0 {
+		t.Errorf("cooldown no-op produced change (changes=%d, fired=%d)", len(changes), fired)
+	}
+}

--- a/internal/itemstate/observer.go
+++ b/internal/itemstate/observer.go
@@ -1,0 +1,27 @@
+package itemstate
+
+// Observer is implemented by any component that wants to react to ItemState changes.
+//
+// OnChange is called by Store.Apply after every successful, non-no-op mutation.
+// It is called outside the Store's write lock, so it is safe for observers to call
+// Store.Get or Store.Apply from within OnChange without deadlocking.
+//
+// Ordering note: when two goroutines call Apply concurrently, observers may see
+// their changes in a different order than the goroutines submitted them. The Store
+// does not guarantee total ordering of concurrent mutations; each Apply is atomic,
+// but relative ordering across concurrent callers is undefined.
+type Observer interface {
+	OnChange(change Change, snapshot Snapshot)
+}
+
+// Logger is an optional logging function for Store internals. Accepts a printf-style
+// format string and arguments. The default (nil) produces no output.
+type Logger func(format string, args ...any)
+
+// ObserverFunc adapts a plain function to the Observer interface.
+type ObserverFunc func(change Change, snapshot Snapshot)
+
+// OnChange implements Observer.
+func (f ObserverFunc) OnChange(change Change, snapshot Snapshot) {
+	f(change, snapshot)
+}

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -1,0 +1,236 @@
+package itemstate
+
+import (
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// Snapshot is an immutable copy of an ItemState returned by Store.Get and Store.Apply.
+// Because it wraps a value (not a pointer), callers can hold it as long as needed
+// without blocking writes and without risk of concurrent mutation.
+//
+// All slice and map fields are deep-copied when a Snapshot is constructed, so
+// mutations to the Store's internal state do not bleed into held Snapshots.
+type Snapshot struct {
+	// state is a deep copy — not a pointer — so Snapshot is safe to hold indefinitely.
+	state ItemState
+}
+
+// newSnapshot constructs a Snapshot from an ItemState, deep-copying all
+// reference-typed fields to satisfy invariant I5 (snapshot immutability).
+//
+// Slice / map fields that require deep copy:
+//   - ItemState.Labels
+//   - ItemState.Assignees
+//   - ItemState.Comments
+//   - ItemState.BlockedBy
+//   - ItemState.CooldownAt
+//   - ItemState.BaseBranchWarned
+//   - ItemState.StageState.Attempts
+//   - ItemState.StageState.LastAttemptAt
+//   - ItemState.StageState.PausedByEngine
+//   - ItemState.StageState.ReviewCycles
+//   - ItemState.StageState.CIFixCycles
+//   - ItemState.StageState.RebaseCycles
+//   - ItemState.StageState.ProcessedComments
+//   - LinkedPRState.Reviews
+//   - LinkedPRState.ReviewRequests
+//   - LinkedPRState.ThreadComments
+//   - LinkedPRState.CheckRuns
+func newSnapshot(s ItemState) Snapshot {
+	c := s
+
+	c.Labels = copyStrings(s.Labels)
+	c.Assignees = copyStrings(s.Assignees)
+	c.Comments = copyComments(s.Comments)
+	c.BlockedBy = copyDeps(s.BlockedBy)
+	c.CooldownAt = copyTimeMap(s.CooldownAt)
+	c.BaseBranchWarned = copyBoolMap(s.BaseBranchWarned)
+	c.StageState = copyStageState(s.StageState)
+
+	if s.LinkedPR != nil {
+		lpr := *s.LinkedPR
+		lpr.Reviews = copyPRReviews(s.LinkedPR.Reviews)
+		lpr.ReviewRequests = copyReviewRequests(s.LinkedPR.ReviewRequests)
+		lpr.ThreadComments = copyComments(s.LinkedPR.ThreadComments)
+		lpr.CheckRuns = copyCheckRuns(s.LinkedPR.CheckRuns)
+		c.LinkedPR = &lpr
+	}
+
+	if s.Lock != nil {
+		lock := *s.Lock
+		c.Lock = &lock
+	}
+
+	if s.Worker != nil {
+		w := *s.Worker
+		c.Worker = &w
+	}
+
+	return Snapshot{state: c}
+}
+
+// State returns the underlying ItemState value.
+// The returned value is itself a copy; mutating it does not affect the Snapshot.
+func (s Snapshot) State() ItemState {
+	return s.state
+}
+
+// Repo returns the "owner/repo" identifier.
+func (s Snapshot) Repo() string { return s.state.Repo }
+
+// Number returns the issue number.
+func (s Snapshot) Number() int { return s.state.Number }
+
+// Status returns the current project board column.
+func (s Snapshot) Status() string { return s.state.Status }
+
+// Labels returns a copy of the label slice.
+func (s Snapshot) Labels() []string { return copyStrings(s.state.Labels) }
+
+// IsClosed reports whether the issue is closed.
+func (s Snapshot) IsClosed() bool { return s.state.IsClosed }
+
+// Worker returns the active WorkerHandle, or nil if no worker is in-flight.
+func (s Snapshot) Worker() *WorkerHandle {
+	if s.state.Worker == nil {
+		return nil
+	}
+	w := *s.state.Worker
+	return &w
+}
+
+// Lock returns the current LockState, or nil if unlocked.
+func (s Snapshot) Lock() *LockState {
+	if s.state.Lock == nil {
+		return nil
+	}
+	l := *s.state.Lock
+	return &l
+}
+
+// LinkedPR returns the LinkedPRState, or nil if no closing PR exists.
+func (s Snapshot) LinkedPR() *LinkedPRState {
+	if s.state.LinkedPR == nil {
+		return nil
+	}
+	lpr := *s.state.LinkedPR
+	lpr.Reviews = copyPRReviews(s.state.LinkedPR.Reviews)
+	lpr.ReviewRequests = copyReviewRequests(s.state.LinkedPR.ReviewRequests)
+	lpr.ThreadComments = copyComments(s.state.LinkedPR.ThreadComments)
+	lpr.CheckRuns = copyCheckRuns(s.state.LinkedPR.CheckRuns)
+	return &lpr
+}
+
+// CooldownAt returns the expiry time for a given cooldown reason, or zero if none.
+func (s Snapshot) CooldownAt(reason string) time.Time {
+	return s.state.CooldownAt[reason]
+}
+
+// LastAttemptAt returns the last invocation timestamp for a given stage, or zero.
+func (s Snapshot) LastAttemptAt(stageName string) time.Time {
+	return s.state.StageState.LastAttemptAt[stageName]
+}
+
+// ---- deep-copy helpers ----
+
+func copyStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+	dst := make([]string, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func copyComments(src []gh.Comment) []gh.Comment {
+	if src == nil {
+		return nil
+	}
+	dst := make([]gh.Comment, len(src))
+	copy(dst, src)
+	// gh.Comment contains only value or string fields; a shallow element copy is sufficient.
+	return dst
+}
+
+func copyDeps(src []gh.Dependency) []gh.Dependency {
+	if src == nil {
+		return nil
+	}
+	dst := make([]gh.Dependency, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func copyPRReviews(src []gh.PRReview) []gh.PRReview {
+	if src == nil {
+		return nil
+	}
+	dst := make([]gh.PRReview, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func copyReviewRequests(src []gh.ReviewRequest) []gh.ReviewRequest {
+	if src == nil {
+		return nil
+	}
+	dst := make([]gh.ReviewRequest, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func copyCheckRuns(src []gh.CheckRun) []gh.CheckRun {
+	if src == nil {
+		return nil
+	}
+	dst := make([]gh.CheckRun, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func copyTimeMap(src map[string]time.Time) map[string]time.Time {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]time.Time, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func copyBoolMap(src map[string]bool) map[string]bool {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func copyIntMap(src map[string]int) map[string]int {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]int, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func copyStageState(s StageState) StageState {
+	return StageState{
+		Attempts:          copyIntMap(s.Attempts),
+		LastAttemptAt:     copyTimeMap(s.LastAttemptAt),
+		PausedByEngine:    copyBoolMap(s.PausedByEngine),
+		ReviewCycles:      copyIntMap(s.ReviewCycles),
+		CIFixCycles:       copyIntMap(s.CIFixCycles),
+		RebaseCycles:      copyIntMap(s.RebaseCycles),
+		ProcessedComments: copyTimeMap(s.ProcessedComments),
+	}
+}

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -71,10 +71,11 @@ func newSnapshot(s ItemState) Snapshot {
 	return Snapshot{state: c}
 }
 
-// State returns the underlying ItemState value.
-// The returned value is itself a copy; mutating it does not affect the Snapshot.
+// State returns a deep copy of the underlying ItemState value.
+// Mutating the returned value — including its slice and map fields — does not
+// affect the Snapshot or the Store.
 func (s Snapshot) State() ItemState {
-	return s.state
+	return newSnapshot(s.state).state
 }
 
 // Repo returns the "owner/repo" identifier.
@@ -150,7 +151,13 @@ func copyComments(src []gh.Comment) []gh.Comment {
 	}
 	dst := make([]gh.Comment, len(src))
 	copy(dst, src)
-	// gh.Comment contains only value or string fields; a shallow element copy is sufficient.
+	// gh.Comment.Reactions is a slice; copy it so Snapshot elements don't alias src.
+	for i := range dst {
+		if src[i].Reactions != nil {
+			dst[i].Reactions = make([]gh.ReactionGroup, len(src[i].Reactions))
+			copy(dst[i].Reactions, src[i].Reactions)
+		}
+	}
 	return dst
 }
 

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -224,9 +224,10 @@ func (s *Store) applySingleItem(m Mutation) (Snapshot, []Change, error) {
 	s.updateIndexes(before, *item, key)
 
 	snap := newSnapshot(*item)
+	repo, number := item.Repo, item.Number
 	s.mu.Unlock()
 
-	change := Change{Repo: item.Repo, Number: item.Number, Fields: flags}
+	change := Change{Repo: repo, Number: number, Fields: flags}
 	obs := s.captureObservers()
 	s.notify(obs, change, snap)
 

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -301,7 +301,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.Lock = &LockState{
 			HolderUser: v.User,
 			HeldByThis: true,
-			AcquiredAt: time.Now(),
+			AcquiredAt: v.AcquiredAt,
 		}
 		var flags ChangeFlags = LockChanged
 		if v.Worker != nil {
@@ -610,7 +610,10 @@ func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 			!reflect.DeepEqual(lpr.ReviewRequests, pi.LinkedPRReviewRequests) ||
 			!reflect.DeepEqual(lpr.ThreadComments, pi.LinkedPRReviewThreadComments) ||
 			lpr.ResolvedThreadCount != pi.LinkedPRResolvedThreadCount {
-			lpr.Number = pi.LinkedPRNumber
+			if lpr.Number != pi.LinkedPRNumber {
+				lpr.Number = pi.LinkedPRNumber
+				flags |= LinkedPRChanged
+			}
 			if !reflect.DeepEqual(lpr.Reviews, pi.LinkedPRReviews) {
 				lpr.Reviews = copyPRReviews(pi.LinkedPRReviews)
 				flags |= LinkedPRChanged

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -1,0 +1,724 @@
+package itemstate
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ErrNotFound is returned by Store.Get when an item does not exist in the cache
+// and the FallbackFetcher also cannot locate it.
+var ErrNotFound = errors.New("itemstate: item not found")
+
+// FallbackFetcher is called by Store.Get on cache miss to populate the item from GitHub.
+// The actual implementation (wrapping gh.Client) is wired in Phase 3-B.
+type FallbackFetcher interface {
+	FetchItem(repo string, number int) (gh.ProjectItem, error)
+}
+
+// Store is the single owner of all per-item state. All mutations flow through
+// Apply; all reads flow through Get or Observer subscriptions.
+//
+// Concurrency model:
+//   - mu guards items, shaToKey, and itemIDToKey.
+//   - observerMu guards the observers slice independently to avoid holding mu
+//     while calling observer callbacks (which may themselves call Apply or Get).
+//   - Apply holds mu for the write, captures the observer slice under observerMu,
+//     then calls observers after releasing both locks.
+type Store struct {
+	mu    sync.RWMutex
+	items map[string]*ItemState // key: "owner/repo#N"
+
+	// Reverse-lookup indexes maintained on every Apply that touches the relevant fields.
+	shaToKey    map[string]string // LinkedPR.HeadSHA → itemKey
+	itemIDToKey map[string]string // ItemState.ItemID → itemKey
+
+	observerMu sync.RWMutex
+	observers  []observerEntry
+
+	fallback FallbackFetcher
+	logger   Logger
+}
+
+type observerEntry struct {
+	o    Observer
+	id   uint64
+}
+
+// storeOptions holds optional Store configuration.
+type storeOptions struct {
+	logger Logger
+}
+
+// StoreOption is a functional option for NewStore.
+type StoreOption func(*storeOptions)
+
+// WithLogger sets a diagnostic logger on the Store. The default is no-op.
+func WithLogger(l Logger) StoreOption {
+	return func(o *storeOptions) { o.logger = l }
+}
+
+var nextObserverID uint64
+var observerIDMu sync.Mutex
+
+func newObserverID() uint64 {
+	observerIDMu.Lock()
+	defer observerIDMu.Unlock()
+	nextObserverID++
+	return nextObserverID
+}
+
+// NewStore creates a new Store. fallback may be nil, in which case cache misses
+// return ErrNotFound instead of triggering a live fetch.
+func NewStore(fallback FallbackFetcher, opts ...StoreOption) *Store {
+	o := &storeOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &Store{
+		items:       make(map[string]*ItemState),
+		shaToKey:    make(map[string]string),
+		itemIDToKey: make(map[string]string),
+		fallback:    fallback,
+		logger:      o.logger,
+	}
+}
+
+// Apply mutates state. Every state change flows through here.
+//
+// Returns the updated Snapshot for the affected item, a list of Changes (zero or
+// one for single-item mutations; multiple for BoardReconciled), and any error.
+//
+// If the mutation results in no field change (no-op), no Changes are returned
+// and no Observers are notified (invariant I6).
+//
+// For BoardReconciled, the returned Snapshot is zero-valued; each affected item
+// produces one Change in the returned slice.
+func (s *Store) Apply(m Mutation) (Snapshot, []Change, error) {
+	switch v := m.(type) {
+	case BoardReconciled:
+		return s.applyBoardReconciled(v)
+	case ProjectV2ItemEdited:
+		return s.applyProjectV2ItemEdited(v)
+	case CheckRunCompleted:
+		return s.applyCheckRunCompleted(v)
+	default:
+		return s.applySingleItem(m)
+	}
+}
+
+// Get returns an immutable snapshot of the current ItemState for the given item.
+//
+// On cache miss, Get calls FallbackFetcher.FetchItem (if set), applies the result
+// as an IssueOpened mutation, and returns the new snapshot (invariant I9).
+//
+// Returns ErrNotFound if:
+//   - the item is not in the cache AND
+//   - the fallback is nil OR the fallback also returns an error.
+func (s *Store) Get(repo string, number int) (Snapshot, error) {
+	key := itemKeyFor(repo, number)
+
+	// Fast path: item in cache.
+	s.mu.RLock()
+	item, ok := s.items[key]
+	if ok {
+		snap := newSnapshot(*item)
+		s.mu.RUnlock()
+		return snap, nil
+	}
+	s.mu.RUnlock()
+
+	// Cache miss — fetch from GitHub without holding any lock (avoids reentrancy
+	// deadlock if FetchItem calls Apply internally).
+	if s.fallback == nil {
+		return Snapshot{}, ErrNotFound
+	}
+	fetched, err := s.fallback.FetchItem(repo, number)
+	if err != nil {
+		return Snapshot{}, ErrNotFound
+	}
+	fetched.Repo = repo
+	fetched.Number = number
+
+	// Populate cache via the normal Apply path.
+	snap, _, applyErr := s.Apply(IssueOpened{Item: fetched})
+	if applyErr != nil {
+		return Snapshot{}, applyErr
+	}
+	return snap, nil
+}
+
+// Subscribe registers an observer that will be called after every successful
+// non-no-op Apply. Returns an unsubscribe function; calling it removes the
+// observer. The unsubscribe function is safe to call concurrently.
+func (s *Store) Subscribe(o Observer) func() {
+	id := newObserverID()
+	s.observerMu.Lock()
+	s.observers = append(s.observers, observerEntry{o: o, id: id})
+	s.observerMu.Unlock()
+	return func() {
+		s.observerMu.Lock()
+		defer s.observerMu.Unlock()
+		for i, e := range s.observers {
+			if e.id == id {
+				s.observers = append(s.observers[:i], s.observers[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// logf emits a diagnostic message if a logger is configured.
+func (s *Store) logf(format string, args ...any) {
+	if s.logger != nil {
+		s.logger(format, args...)
+	}
+}
+
+// notify calls each observer with the given Change and Snapshot, outside any lock.
+func (s *Store) notify(observers []observerEntry, change Change, snap Snapshot) {
+	for _, e := range observers {
+		e.o.OnChange(change, snap)
+	}
+}
+
+// captureObservers returns a snapshot of the current observer list under read lock.
+func (s *Store) captureObservers() []observerEntry {
+	s.observerMu.RLock()
+	defer s.observerMu.RUnlock()
+	if len(s.observers) == 0 {
+		return nil
+	}
+	obs := make([]observerEntry, len(s.observers))
+	copy(obs, s.observers)
+	return obs
+}
+
+// ---- single-item mutation dispatch ----
+
+func (s *Store) applySingleItem(m Mutation) (Snapshot, []Change, error) {
+	key := m.itemKey()
+	if key == "" {
+		return Snapshot{}, nil, errors.New("itemstate: mutation returned empty key")
+	}
+
+	s.mu.Lock()
+
+	item := s.getOrCreate(key, m)
+	// Deep-copy before state so no-op detection is not fooled by shared maps/pointers.
+	before := newSnapshot(*item).state
+
+	flags := s.applyToItem(item, m)
+
+	// No-op detection: if nothing changed, skip observers.
+	if reflect.DeepEqual(before, *item) {
+		s.mu.Unlock()
+		snap := newSnapshot(*item)
+		return snap, nil, nil
+	}
+
+	s.updateIndexes(before, *item, key)
+
+	snap := newSnapshot(*item)
+	s.mu.Unlock()
+
+	change := Change{Repo: item.Repo, Number: item.Number, Fields: flags}
+	obs := s.captureObservers()
+	s.notify(obs, change, snap)
+
+	return snap, []Change{change}, nil
+}
+
+// getOrCreate returns the existing *ItemState for key, or creates a new zero-value one.
+// Must be called with s.mu held for writing.
+func (s *Store) getOrCreate(key string, m Mutation) *ItemState {
+	if item, ok := s.items[key]; ok {
+		return item
+	}
+	// Parse repo and number from the key "owner/repo#N".
+	repo, number := parseKey(key)
+	item := &ItemState{Repo: repo, Number: number}
+	s.items[key] = item
+	return item
+}
+
+// applyToItem applies a single-item mutation to item in-place and returns ChangeFlags.
+// Must be called with s.mu held for writing.
+func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
+	switch v := m.(type) {
+
+	case IssueOpened:
+		return applyProjectItem(item, v.Item)
+
+	case IssueLabeled:
+		if !containsString(item.Labels, v.Label) {
+			item.Labels = append(item.Labels, v.Label)
+		}
+		return LabelsChanged
+
+	case IssueUnlabeled:
+		item.Labels = removeString(item.Labels, v.Label)
+		return LabelsChanged
+
+	case IssueClosed:
+		item.State = "closed"
+		item.IsClosed = true
+		return StateChanged
+
+	case IssueReopened:
+		item.State = "open"
+		item.IsClosed = false
+		return StateChanged
+
+	case IssueCommentCreated:
+		item.Comments = append(item.Comments, v.Comment)
+		return CommentsChanged
+
+	case LocalStatusUpdated:
+		item.Status = v.NewStatus
+		return StatusChanged
+
+	case LocalLabelAdded:
+		if !containsString(item.Labels, v.Label) {
+			item.Labels = append(item.Labels, v.Label)
+		}
+		return LabelsChanged
+
+	case LocalLabelRemoved:
+		item.Labels = removeString(item.Labels, v.Label)
+		return LabelsChanged
+
+	case LocalCommentAdded:
+		item.Comments = append(item.Comments, v.Comment)
+		return CommentsChanged
+
+	case LocalLockAcquired:
+		item.Lock = &LockState{
+			HolderUser: v.User,
+			HeldByThis: true,
+			AcquiredAt: time.Now(),
+		}
+		var flags ChangeFlags = LockChanged
+		if v.Worker != nil {
+			w := *v.Worker
+			item.Worker = &w
+			flags |= WorkerChanged
+		}
+		return flags
+
+	case LocalLockReleased:
+		item.Lock = nil
+		return LockChanged
+
+	case ItemDeepFetched:
+		flags := applyProjectItem(item, v.FreshState)
+		item.LastDeepFetchAt = time.Now()
+		return flags | DeepFetchChanged
+
+	case StageAttempted:
+		ensureStageStateMaps(item)
+		item.StageState.LastAttemptAt[v.StageName] = v.At
+		item.StageState.Attempts[v.StageName]++
+		return StageStateChanged
+
+	case StageRetryIncremented:
+		ensureStageStateMaps(item)
+		item.StageState.Attempts[v.StageName]++
+		return StageStateChanged
+
+	case StageRetryCleared:
+		ensureStageStateMaps(item)
+		item.StageState.Attempts[v.StageName] = 0
+		return StageStateChanged
+
+	case ReviewCycleIncremented:
+		ensureStageStateMaps(item)
+		item.StageState.ReviewCycles[v.StageName]++
+		return StageStateChanged
+
+	case CIFixCycleIncremented:
+		ensureStageStateMaps(item)
+		item.StageState.CIFixCycles[v.StageName]++
+		return StageStateChanged
+
+	case RebaseCycleIncremented:
+		ensureStageStateMaps(item)
+		item.StageState.RebaseCycles[v.StageName]++
+		return StageStateChanged
+
+	case EnginePaused:
+		ensureStageStateMaps(item)
+		item.StageState.PausedByEngine[v.StageName] = true
+		return StageStateChanged
+
+	case CooldownRecorded:
+		if item.CooldownAt == nil {
+			item.CooldownAt = make(map[string]time.Time)
+		}
+		item.CooldownAt[v.Reason] = v.Until
+		return CooldownChanged
+
+	case WorkerHeartbeat:
+		if item.Worker == nil {
+			item.Worker = &WorkerHandle{}
+		}
+		item.Worker.LastSignAt = v.At
+		return WorkerChanged
+
+	case WorkerExited:
+		item.Worker = nil
+		return WorkerChanged
+
+	case InvocationRecorded:
+		item.LastInvocationCompleted = v.Completed
+		item.LastInvocationBlocked = v.Blocked
+		item.LastTokenUsage = v.Usage
+		return InvocationChanged
+
+	case DeepFetchFailed:
+		item.LastDeepFetchFailureAt = v.At
+		return DeepFetchChanged
+
+	case BaseBranchWarnRecorded:
+		if item.BaseBranchWarned == nil {
+			item.BaseBranchWarned = make(map[string]bool)
+		}
+		item.BaseBranchWarned[v.Branch] = true
+		return BaseBranchChanged
+
+	case PRReviewSubmitted:
+		ensureLinkedPR(item, v.Number)
+		item.LinkedPR.Reviews = append(item.LinkedPR.Reviews, v.Review)
+		return LinkedPRChanged
+
+	case PRReviewCommentCreated:
+		ensureLinkedPR(item, v.PRNumber)
+		item.LinkedPR.ThreadComments = append(item.LinkedPR.ThreadComments, v.Comment)
+		return LinkedPRChanged | CommentsChanged
+	}
+
+	return 0
+}
+
+// applyBoardReconciled processes a bulk board snapshot, updating or creating each item.
+func (s *Store) applyBoardReconciled(v BoardReconciled) (Snapshot, []Change, error) {
+	var changes []Change
+
+	for _, pi := range v.Items {
+		key := itemKeyFor(pi.Repo, pi.Number)
+		if key == "" {
+			continue
+		}
+
+		s.mu.Lock()
+		item := s.getOrCreate(key, IssueOpened{Item: pi})
+		before := newSnapshot(*item).state
+		flags := applyProjectItem(item, pi)
+
+		if reflect.DeepEqual(before, *item) {
+			s.mu.Unlock()
+			continue
+		}
+
+		s.updateIndexes(before, *item, key)
+		snap := newSnapshot(*item)
+		repo, number := item.Repo, item.Number
+		s.mu.Unlock()
+
+		change := Change{Repo: repo, Number: number, Fields: flags}
+		obs := s.captureObservers()
+		s.notify(obs, change, snap)
+		changes = append(changes, change)
+	}
+
+	return Snapshot{}, changes, nil
+}
+
+// applyProjectV2ItemEdited handles a board-status update keyed by project item ID.
+func (s *Store) applyProjectV2ItemEdited(v ProjectV2ItemEdited) (Snapshot, []Change, error) {
+	s.mu.Lock()
+	key, ok := s.itemIDToKey[v.ItemID]
+	if !ok {
+		s.mu.Unlock()
+		s.logf("ProjectV2ItemEdited: unknown itemID %s", v.ItemID)
+		return Snapshot{}, nil, nil
+	}
+	item := s.items[key]
+	before := newSnapshot(*item).state
+	item.Status = v.NewStatus
+	if reflect.DeepEqual(before, *item) {
+		s.mu.Unlock()
+		return newSnapshot(*item), nil, nil
+	}
+	snap := newSnapshot(*item)
+	repo, number := item.Repo, item.Number
+	s.mu.Unlock()
+
+	change := Change{Repo: repo, Number: number, Fields: StatusChanged}
+	obs := s.captureObservers()
+	s.notify(obs, change, snap)
+	return snap, []Change{change}, nil
+}
+
+// applyCheckRunCompleted routes a check run to the item whose LinkedPR.HeadSHA matches.
+func (s *Store) applyCheckRunCompleted(v CheckRunCompleted) (Snapshot, []Change, error) {
+	s.mu.Lock()
+	key, ok := s.shaToKey[v.SHA]
+	if !ok {
+		s.mu.Unlock()
+		s.logf("CheckRunCompleted: unknown SHA %s", v.SHA)
+		return Snapshot{}, nil, nil
+	}
+	item := s.items[key]
+	before := newSnapshot(*item).state
+	if item.LinkedPR == nil {
+		item.LinkedPR = &LinkedPRState{}
+	}
+	// Update or append the check run by ID.
+	found := false
+	for i, cr := range item.LinkedPR.CheckRuns {
+		if cr.ID == v.Run.ID {
+			item.LinkedPR.CheckRuns[i] = v.Run
+			found = true
+			break
+		}
+	}
+	if !found {
+		item.LinkedPR.CheckRuns = append(item.LinkedPR.CheckRuns, v.Run)
+	}
+	item.LinkedPR.HasHadChecks = true
+
+	if reflect.DeepEqual(before, *item) {
+		s.mu.Unlock()
+		return newSnapshot(*item), nil, nil
+	}
+	snap := newSnapshot(*item)
+	repo, number := item.Repo, item.Number
+	s.mu.Unlock()
+
+	change := Change{Repo: repo, Number: number, Fields: LinkedPRChanged}
+	obs := s.captureObservers()
+	s.notify(obs, change, snap)
+	return snap, []Change{change}, nil
+}
+
+// updateIndexes keeps shaToKey and itemIDToKey consistent after a mutation.
+// Must be called with s.mu held for writing.
+func (s *Store) updateIndexes(before, after ItemState, key string) {
+	// ItemID index.
+	if before.ItemID != after.ItemID {
+		if before.ItemID != "" {
+			delete(s.itemIDToKey, before.ItemID)
+		}
+		if after.ItemID != "" {
+			s.itemIDToKey[after.ItemID] = key
+		}
+	} else if after.ItemID != "" {
+		s.itemIDToKey[after.ItemID] = key
+	}
+
+	// HeadSHA index.
+	beforeSHA := ""
+	afterSHA := ""
+	if before.LinkedPR != nil {
+		beforeSHA = before.LinkedPR.HeadSHA
+	}
+	if after.LinkedPR != nil {
+		afterSHA = after.LinkedPR.HeadSHA
+	}
+	if beforeSHA != afterSHA {
+		if beforeSHA != "" {
+			delete(s.shaToKey, beforeSHA)
+		}
+		if afterSHA != "" {
+			s.shaToKey[afterSHA] = key
+		}
+	} else if afterSHA != "" {
+		s.shaToKey[afterSHA] = key
+	}
+}
+
+// ---- helpers ----
+
+// applyProjectItem copies all fields from a gh.ProjectItem into item and returns ChangeFlags.
+func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
+	var flags ChangeFlags
+
+	if item.ItemID != pi.ItemID {
+		item.ItemID = pi.ItemID
+	}
+
+	if item.Title != pi.Title || item.Body != pi.Body || item.URL != pi.URL || item.Author != pi.Author {
+		item.Title = pi.Title
+		item.Body = pi.Body
+		item.URL = pi.URL
+		item.Author = pi.Author
+		flags |= TitleBodyChanged
+	}
+
+	if !reflect.DeepEqual(item.Assignees, pi.Assignees) {
+		item.Assignees = copyStrings(pi.Assignees)
+		flags |= AssigneesChanged
+	}
+
+	if item.State != stateFrom(pi) || item.IsClosed != pi.IsClosed || item.IsPR != pi.IsPR {
+		item.State = stateFrom(pi)
+		item.IsClosed = pi.IsClosed
+		item.IsPR = pi.IsPR
+		flags |= StateChanged
+	}
+
+	if !reflect.DeepEqual(item.Labels, pi.Labels) {
+		item.Labels = copyStrings(pi.Labels)
+		flags |= LabelsChanged
+	}
+
+	if item.Status != pi.Status {
+		item.Status = pi.Status
+		flags |= StatusChanged
+	}
+
+	if !item.UpdatedAt.Equal(pi.UpdatedAt) {
+		item.UpdatedAt = pi.UpdatedAt
+	}
+
+	if !reflect.DeepEqual(item.BlockedBy, pi.BlockedBy) {
+		item.BlockedBy = copyDeps(pi.BlockedBy)
+		flags |= BlockedByChanged
+	}
+
+	if !reflect.DeepEqual(item.Comments, pi.Comments) {
+		item.Comments = copyComments(pi.Comments)
+		flags |= CommentsChanged
+	}
+
+	// Sync LinkedPR fields from ProjectItem.
+	if pi.LinkedPRNumber != 0 {
+		if item.LinkedPR == nil {
+			item.LinkedPR = &LinkedPRState{}
+			flags |= LinkedPRChanged
+		}
+		lpr := item.LinkedPR
+		if lpr.Number != pi.LinkedPRNumber ||
+			lpr.HeadSHA != "" || // already set by richer fetch — don't overwrite
+			!reflect.DeepEqual(lpr.Reviews, pi.LinkedPRReviews) ||
+			!reflect.DeepEqual(lpr.ReviewRequests, pi.LinkedPRReviewRequests) ||
+			!reflect.DeepEqual(lpr.ThreadComments, pi.LinkedPRReviewThreadComments) ||
+			lpr.ResolvedThreadCount != pi.LinkedPRResolvedThreadCount {
+			lpr.Number = pi.LinkedPRNumber
+			if !reflect.DeepEqual(lpr.Reviews, pi.LinkedPRReviews) {
+				lpr.Reviews = copyPRReviews(pi.LinkedPRReviews)
+				flags |= LinkedPRChanged
+			}
+			if !reflect.DeepEqual(lpr.ReviewRequests, pi.LinkedPRReviewRequests) {
+				lpr.ReviewRequests = copyReviewRequests(pi.LinkedPRReviewRequests)
+				flags |= LinkedPRChanged
+			}
+			if !reflect.DeepEqual(lpr.ThreadComments, pi.LinkedPRReviewThreadComments) {
+				lpr.ThreadComments = copyComments(pi.LinkedPRReviewThreadComments)
+				flags |= LinkedPRChanged | CommentsChanged
+			}
+			if lpr.ResolvedThreadCount != pi.LinkedPRResolvedThreadCount {
+				lpr.ResolvedThreadCount = pi.LinkedPRResolvedThreadCount
+				flags |= LinkedPRChanged
+			}
+		}
+	} else if item.LinkedPR != nil && item.LinkedPR.Number != 0 {
+		// PR was delinked — only clear the number, preserve any richer state.
+		// (Full removal would need an explicit IssuePRDelinked mutation.)
+	}
+
+	if flags == 0 && item.Repo == "" {
+		// First-time population of identity fields.
+		item.Repo = pi.Repo
+		item.Number = pi.Number
+		return TitleBodyChanged | StatusChanged | LabelsChanged
+	}
+
+	item.Repo = pi.Repo
+	item.Number = pi.Number
+
+	return flags
+}
+
+func stateFrom(pi gh.ProjectItem) string {
+	if pi.IsClosed {
+		return "closed"
+	}
+	return "open"
+}
+
+func ensureLinkedPR(item *ItemState, prNumber int) {
+	if item.LinkedPR == nil {
+		item.LinkedPR = &LinkedPRState{Number: prNumber}
+	}
+}
+
+func ensureStageStateMaps(item *ItemState) {
+	ss := &item.StageState
+	if ss.Attempts == nil {
+		ss.Attempts = make(map[string]int)
+	}
+	if ss.LastAttemptAt == nil {
+		ss.LastAttemptAt = make(map[string]time.Time)
+	}
+	if ss.PausedByEngine == nil {
+		ss.PausedByEngine = make(map[string]bool)
+	}
+	if ss.ReviewCycles == nil {
+		ss.ReviewCycles = make(map[string]int)
+	}
+	if ss.CIFixCycles == nil {
+		ss.CIFixCycles = make(map[string]int)
+	}
+	if ss.RebaseCycles == nil {
+		ss.RebaseCycles = make(map[string]int)
+	}
+	if ss.ProcessedComments == nil {
+		ss.ProcessedComments = make(map[string]time.Time)
+	}
+}
+
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(ss []string, s string) []string {
+	out := ss[:0:0]
+	for _, v := range ss {
+		if v != s {
+			out = append(out, v)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseKey splits "owner/repo#N" into repo and number.
+func parseKey(key string) (string, int) {
+	idx := strings.LastIndex(key, "#")
+	if idx < 0 {
+		return key, 0
+	}
+	repo := key[:idx]
+	numStr := key[idx+1:]
+	n := 0
+	for _, c := range numStr {
+		if c < '0' || c > '9' {
+			return repo, 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return repo, n
+}

--- a/internal/itemstate/store_test.go
+++ b/internal/itemstate/store_test.go
@@ -1,0 +1,376 @@
+package itemstate
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// ---- stub FallbackFetcher ----
+
+type stubFallback struct {
+	mu    sync.Mutex
+	calls int
+	item  gh.ProjectItem
+	err   error
+}
+
+func (f *stubFallback) FetchItem(repo string, number int) (gh.ProjectItem, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	item := f.item
+	item.Repo = repo
+	item.Number = number
+	return item, f.err
+}
+
+func (f *stubFallback) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// ---- I4: Observers see every Change exactly once ----
+
+// TestObserverSeesEveryChange applies N mutations and verifies the observer receives
+// exactly N Changes (invariant I4).
+func TestObserverSeesEveryChange(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	var received []Change
+	var mu sync.Mutex
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) {
+		mu.Lock()
+		received = append(received, c)
+		mu.Unlock()
+	}))
+
+	statuses := []string{"Research", "Plan", "Implement", "Review", "Validate", "Done"}
+	for _, st := range statuses {
+		if _, _, err := s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: st}); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+	}
+
+	mu.Lock()
+	n := len(received)
+	mu.Unlock()
+
+	if n != len(statuses) {
+		t.Errorf("observer received %d changes; want %d", n, len(statuses))
+	}
+}
+
+// TestObserverReceivesCorrectFields verifies that the Change's Fields bitmask
+// matches what the mutation type should produce.
+func TestObserverReceivesCorrectFields(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	var lastChange Change
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) { lastChange = c }))
+
+	s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: "urgent"})
+	if lastChange.Fields&LabelsChanged == 0 {
+		t.Errorf("Change.Fields %b does not include LabelsChanged", lastChange.Fields)
+	}
+	if lastChange.Repo != testRepo || lastChange.Number != 1 {
+		t.Errorf("Change.Repo/Number = %q/%d; want %q/1", lastChange.Repo, lastChange.Number, testRepo)
+	}
+}
+
+// TestMultipleObserversAllNotified verifies that all registered observers are
+// called for each Change.
+func TestMultipleObserversAllNotified(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	counts := make([]int64, 3)
+	for i := range counts {
+		idx := i
+		s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {
+			atomic.AddInt64(&counts[idx], 1)
+		}))
+	}
+
+	for i := 0; i < 5; i++ {
+		s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: itoa(i) + "-label"})
+	}
+
+	for i, c := range counts {
+		if c != 5 {
+			t.Errorf("observer %d received %d changes; want 5", i, c)
+		}
+	}
+}
+
+// ---- I9: Cache-miss reads fall back to GitHub ----
+
+// TestCacheMissFallbackCalledOnce verifies that a missing item triggers exactly
+// one FallbackFetcher call and caches the result (invariant I9).
+func TestCacheMissFallbackCalledOnce(t *testing.T) {
+	fb := &stubFallback{item: gh.ProjectItem{
+		Title:  "Fetched Issue",
+		Status: "Implement",
+		Labels: []string{"fresh"},
+	}}
+	s := NewStore(fb)
+
+	snap, err := s.Get(testRepo, 42)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fb.callCount() != 1 {
+		t.Errorf("fallback called %d times; want 1", fb.callCount())
+	}
+	if snap.State().Title != "Fetched Issue" {
+		t.Errorf("Title = %q; want Fetched Issue", snap.State().Title)
+	}
+
+	// Second Get should hit the cache — no additional fallback call.
+	if _, err := s.Get(testRepo, 42); err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if fb.callCount() != 1 {
+		t.Errorf("fallback called %d times after cached Get; want 1", fb.callCount())
+	}
+}
+
+// TestCacheMissReturnsErrNotFoundWhenNoFallback verifies that a missing item
+// with no FallbackFetcher returns ErrNotFound.
+func TestCacheMissReturnsErrNotFoundWhenNoFallback(t *testing.T) {
+	s := NewStore(nil)
+	_, err := s.Get(testRepo, 999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get returned %v; want ErrNotFound", err)
+	}
+}
+
+// TestCacheMissFallbackErrorReturnsErrNotFound verifies that a fallback error
+// surfaces as ErrNotFound.
+func TestCacheMissFallbackErrorReturnsErrNotFound(t *testing.T) {
+	fb := &stubFallback{err: errors.New("not found on GitHub")}
+	s := NewStore(fb)
+	_, err := s.Get(testRepo, 1)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get returned %v; want ErrNotFound", err)
+	}
+}
+
+// TestFallbackPopulatesCache verifies that after a successful fallback, the item
+// is observable via the change feed.
+func TestFallbackPopulatesCache(t *testing.T) {
+	fb := &stubFallback{item: gh.ProjectItem{Title: "Fetched"}}
+	s := NewStore(fb)
+
+	var received []Change
+	var mu sync.Mutex
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {
+		mu.Lock()
+		received = append(received, c)
+		mu.Unlock()
+	}))
+
+	s.Get(testRepo, 5)
+
+	mu.Lock()
+	n := len(received)
+	mu.Unlock()
+	if n == 0 {
+		t.Error("fallback did not trigger an observer Change")
+	}
+}
+
+// ---- Subscribe / Unsubscribe ----
+
+// TestUnsubscribeStopsNotifications verifies that after calling the unsubscribe
+// function, the observer no longer receives changes.
+func TestUnsubscribeStopsNotifications(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	var count int64
+	unsub := s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {
+		atomic.AddInt64(&count, 1)
+	}))
+
+	s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: "before"})
+	unsub()
+	s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: "after"})
+
+	if atomic.LoadInt64(&count) != 1 {
+		t.Errorf("observer fired %d times; want exactly 1 (before unsubscribe)", atomic.LoadInt64(&count))
+	}
+}
+
+// TestUnsubscribeIdempotent verifies that calling the unsubscribe function
+// multiple times does not panic.
+func TestUnsubscribeIdempotent(t *testing.T) {
+	s := NewStore(nil)
+	unsub := s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {}))
+	unsub()
+	unsub() // should not panic
+}
+
+// ---- Concurrency tests ----
+
+// TestConcurrentApplyGet launches 100 goroutines each doing Apply/Get and
+// verifies the race detector reports no data races.
+func TestConcurrentApplyGet(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	var wg sync.WaitGroup
+	const goroutines = 100
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			// Alternate between Apply and Get.
+			if n%2 == 0 {
+				s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: itoa(n)})
+			} else {
+				s.Get(testRepo, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestConcurrentSubscribeUnsubscribeApply verifies that concurrent
+// Subscribe/Unsubscribe/Apply calls do not race or panic.
+func TestConcurrentSubscribeUnsubscribeApply(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(3)
+		go func(n int) {
+			defer wg.Done()
+			unsub := s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {}))
+			time.Sleep(time.Microsecond)
+			unsub()
+		}(i)
+		go func(n int) {
+			defer wg.Done()
+			s.Apply(IssueLabeled{Repo: testRepo, Number: 1, Label: itoa(n)})
+		}(i)
+		go func(n int) {
+			defer wg.Done()
+			s.Get(testRepo, 1)
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestConcurrentBoardReconcile verifies that concurrent BoardReconciled
+// mutations do not race.
+func TestConcurrentBoardReconcile(t *testing.T) {
+	s := NewStore(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			items := []gh.ProjectItem{
+				testProjectItem(testRepo, n+1000),
+			}
+			s.Apply(BoardReconciled{Items: items})
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestObserverSnapshotIsConsistentWithChange verifies that the Snapshot passed
+// to an observer reflects the state at the time the Change was generated.
+func TestObserverSnapshotIsConsistentWithChange(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	var observedStatus string
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) {
+		if c.Fields&StatusChanged != 0 {
+			observedStatus = snap.Status()
+		}
+	}))
+
+	s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Validate"})
+
+	if observedStatus != "Validate" {
+		t.Errorf("observer saw status %q; want Validate", observedStatus)
+	}
+}
+
+// TestObserverNotCalledUnderLock verifies observers can safely call Store.Get
+// without deadlocking (proves observers are called outside the write lock).
+func TestObserverNotCalledUnderLock(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	done := make(chan struct{}, 1)
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) {
+		// This would deadlock if called under the write lock.
+		s.Get(testRepo, 1)
+		done <- struct{}{}
+	}))
+
+	s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Review"})
+
+	select {
+	case <-done:
+		// OK — observer completed without deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: observer could not call Store.Get while change was being dispatched")
+	}
+}
+
+// TestItemIDIndexMaintained verifies that ProjectV2ItemEdited can resolve an item
+// via the itemIDToKey index after IssueOpened sets ItemID.
+func TestItemIDIndexMaintained(t *testing.T) {
+	s := NewStore(nil)
+	pi := testProjectItem(testRepo, 1)
+	pi.ItemID = "PVTI_test"
+	s.Apply(IssueOpened{Item: pi})
+
+	snap, changes, err := s.Apply(ProjectV2ItemEdited{ItemID: "PVTI_test", NewStatus: "Done"})
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("ProjectV2ItemEdited: err=%v changes=%d", err, len(changes))
+	}
+	_ = snap
+}
+
+// TestSHAIndexMaintained verifies that CheckRunCompleted can resolve an item
+// via the shaToKey index.
+func TestSHAIndexMaintained(t *testing.T) {
+	s := NewStore(nil)
+	pi := testProjectItem(testRepo, 1)
+	pi.LinkedPRNumber = 5
+	s.Apply(IssueOpened{Item: pi})
+
+	// Inject SHA via internal state (simulating a LinkedPR update).
+	s.mu.Lock()
+	key := itemKeyFor(testRepo, 1)
+	item := s.items[key]
+	if item.LinkedPR == nil {
+		item.LinkedPR = &LinkedPRState{Number: 5}
+	}
+	item.LinkedPR.HeadSHA = "sha999"
+	s.shaToKey["sha999"] = key
+	s.mu.Unlock()
+
+	_, changes, err := s.Apply(CheckRunCompleted{Repo: testRepo, SHA: "sha999", Run: gh.CheckRun{ID: 1}})
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("CheckRunCompleted: err=%v changes=%d", err, len(changes))
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds a new `internal/itemstate/` package — the foundation of the reactive single-owner cache architecture described in `docs/cache-refactor/02-design.md`. This is a **pure addition**: no existing packages are modified, and the new package is not yet imported by the engine or boardcache (that wiring happens in Phase 3-B).

The package introduces the core abstractions that will eventually replace the 25+ fragmented in-memory state structures currently spread across `engine/` and `boardcache/`.

## Key changes

| File | What it contains |
|------|-----------------|
| `internal/itemstate/itemstate.go` | `ItemState` struct (all fields from design §1.1 + §2 mapping table), `LinkedPRState`, `StageState`, `LockState`, `WorkerHandle`, `TokenUsage` |
| `internal/itemstate/store.go` | `Store` with `Apply`, `Get`, `Subscribe`; `FallbackFetcher` interface; `ErrNotFound` sentinel |
| `internal/itemstate/mutation.go` | `Mutation` interface + 31 concrete types covering webhook deltas, self-mutations, reconciliation, and engine internals |
| `internal/itemstate/snapshot.go` | `Snapshot` (immutable deep-copy of `ItemState`); all slice/map fields are deep-copied on construction |
| `internal/itemstate/change.go` | `ChangeFlags` bitmask (15 field-group constants) + `Change` struct |
| `internal/itemstate/observer.go` | `Observer` interface; `ObserverFunc` adapter; `Logger` type |

**Critical concurrency design decisions:**
- Observers are called *outside* the store's write lock — prevents deadlock when an observer calls `Store.Get` or `Store.Apply`
- `Store.Get` releases all locks before calling `FallbackFetcher.FetchItem` — prevents read-lock → write-lock reentrancy deadlock
- No-op detection uses `reflect.DeepEqual` on a deep-copied `before` state — prevents false no-ops from aliased maps/pointers

## How to test

```bash
go build ./...
go vet ./...
go test -race ./internal/itemstate/...
```

Tests cover all required invariants:
- **I1** — mutating a `Snapshot` doesn't affect the `Store`
- **I4** — observers receive exactly N Changes for N non-no-op mutations
- **I5** — snapshots held before subsequent Apply calls are unchanged
- **I6** — applying an identical mutation twice produces no observer event the second time
- **I9** — cache-miss `Get` calls `FallbackFetcher` exactly once, then caches
- Every exported method has at least one test; every `Mutation` type has an `Apply` test; every `ChangeFlag` is exercised

Closes #513