### PR TITLE
Phase 3-B: boardcache delegates to itemstate.Store internally (behaviour-equivalent)

### DIFF
--- a/adrs/037-phase3b-boardcache-store-delegation.md
+++ b/adrs/037-phase3b-boardcache-store-delegation.md
@@ -1,0 +1,73 @@
+# ADR 037 — Phase 3-B: CacheImpl Delegates to itemstate.Store
+
+**Status:** Accepted (2026-05-04)
+**Builds on:** ADR 036 (Reactive Cache with Single State Owner)
+
+## Context
+
+ADR 036 introduced `itemstate.Store` as the single owner of per-item state. Phase 3-B wires it into `boardcache.CacheImpl`: CacheImpl drops its own `items`, `deepFetched`, `shaToKey`, and `itemIDToKey` fields and delegates all state reads/writes to the Store.
+
+Three non-obvious constraints shaped the implementation. They are recorded here because violating any one silently reintroduces the cache-coherency failures ADR 036 was written to fix.
+
+## Decisions
+
+### 1. Lock-ordering invariant: never hold `c.mu` during any Store call
+
+`CacheImpl` has its own mutex (`c.mu`) protecting CacheImpl-local fields. `Store` has an independent internal mutex. The invariant is:
+
+> `c.mu` **must be released before any call to** `store.Apply`, `store.Get`, `store.All`, `store.Remove`, or `store.Reset`.
+
+Rationale: Store observers (registered via `store.Subscribe`) may call back into CacheImpl methods. If `c.mu` is held when the observer fires, the callback deadlocks. Because observers run outside the Store's own lock (by design in `Store.notify`), the only way to prevent deadlock is to ensure CacheImpl never holds its lock into a Store call.
+
+Pattern in practice:
+```go
+// Correct
+c.mu.Lock()
+key := c.prNumToKey[prKey(repo, prNum)]
+c.mu.Unlock()
+c.store.Apply(SomeMutation{...}) // no lock held
+
+// Wrong — deadlocks if an observer calls back into CacheImpl
+c.mu.Lock()
+defer c.mu.Unlock()
+c.store.Apply(SomeMutation{...}) // MUST NOT hold c.mu here
+```
+
+### 2. CacheImpl/Store field split — what stays on CacheImpl
+
+Five field families remain on CacheImpl after Phase 3-B:
+
+| Field | Reason it stays |
+|-------|----------------|
+| `paused bool` | Control flow only; no state semantics |
+| `recentMissCache map[string]time.Time` | Negative cache for REST calls; purely CacheImpl policy |
+| `checkRuns map[string][]gh.CheckRun` | Holds check runs for pre-linkage SHAs that Store silently drops |
+| `linkedPRs map[string]*gh.PRDetails` | `gh.PRDetails` has `Title`, `State`, `Merged`, `Draft`; `LinkedPRState` does not — migration deferred until `LinkedPRState` gains those fields |
+| `prNumToKey map[string]string` | PR-number → issue key index; not in Store because it is a CacheImpl routing concern, not item state |
+| `localDeltaAt map[string]time.Time` | Webhook-driven `UpdatedAt` override (see Decision 3) |
+
+**`linkedPRs` is the most important deferred migration.** A `// TODO(phase3-x)` comment marks the site. Do not silently remove it without also adding `Title`/`State`/`Merged`/`Draft` to `LinkedPRState` and migrating the callers.
+
+**`prNumToKey`** must be kept consistent with `Store` state. Every code path that learns of a PR-number → issue mapping (auto-heal in PR-delta, PR-review, PR-review-comment, and check-run handlers) must update both `c.prNumToKey` and the Store.
+
+### 3. `localDeltaAt` — webhook-driven UpdatedAt bumping
+
+`ItemState.UpdatedAt` mirrors GitHub's server-side timestamp. Webhook deltas arrive before GitHub updates that timestamp, so `FetchProjectBoard` would return a stale `UpdatedAt` for an item that was just modified — causing `itemMayNeedWork` to miss it.
+
+`c.localDeltaAt[key]` records the wall-clock time of the most recent webhook delta for an item. `FetchProjectBoard` overrides `UpdatedAt` at reconstruction time:
+
+```go
+updatedAt := snap.State().UpdatedAt
+if local, ok := c.localDeltaAt[key]; ok && local.After(updatedAt) {
+    updatedAt = local
+}
+```
+
+`localDeltaAt` is not in the Store because `UpdatedAt` is meant to be the GitHub timestamp; adding a separate `DeltaUpdatedAt` field to `ItemState` would be premature.
+
+## Consequences
+
+- All per-item state reads and writes now flow through `itemstate.Store`. CacheImpl is a routing and policy layer, not a state owner.
+- The lock-ordering invariant is the key invariant to maintain. Any new code path that holds `c.mu` while touching Store state will introduce a latent deadlock.
+- `localDeltaAt` entries accumulate forever for items that receive webhook deltas. This is acceptable for the expected cardinality (tens to hundreds of items per board). If boards grow large, a TTL eviction pass could be added.
+- The `linkedPRs` deferred migration creates a split where LinkedPR *routing* state lives in Store (via `LinkedPRState`) but *display* state lives in CacheImpl. This is intentional and documented with a TODO comment.

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -521,15 +521,19 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		c.mu.Lock()
 		c.linkedPRs[pk] = pr
 		c.mu.Unlock()
-		// If the item had no LinkedPRNumber in Store, update it via deep fetch write-back.
+		// If the item had no LinkedPRNumber in Store, update it without touching deep-fetch state.
+		// Original behavior: only set LinkedPRNumber; do not change LastDeepFetchAt.
 		if linkedPRNum == 0 && snapErr == nil {
-			// Construct a fresh ProjectItem from current Store state + new PR number.
-			pi := snapshotToProjectItem(snap)
-			pi.LinkedPRNumber = pr.Number
-			c.store.Apply(itemstate.ItemDeepFetched{
-				Repo:       fullRepo,
-				Number:     issueNumber,
-				FreshState: pi,
+			// Preserve existing HeadSHA if any (LinkedPR may already have a SHA from a webhook).
+			existingSHA := ""
+			if s := snap.State(); s.LinkedPR != nil {
+				existingSHA = s.LinkedPR.HeadSHA
+			}
+			c.store.Apply(itemstate.PRHeadSHAUpdated{
+				Repo:        fullRepo,
+				Number:      issueNumber,
+				LinkedPRNum: pr.Number,
+				SHA:         existingSHA,
 			})
 			// Also update prNumToKey.
 			pk2 := prKey(fullRepo, pr.Number)

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -130,6 +130,7 @@ func parseItemKey(key string) (repo string, number int, ok bool) {
 func snapshotToProjectItem(snap itemstate.Snapshot) gh.ProjectItem {
 	s := snap.State()
 	pi := gh.ProjectItem{
+		ID:        s.ID,
 		ItemID:    s.ItemID,
 		Number:    s.Number,
 		Title:     s.Title,
@@ -303,6 +304,13 @@ func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
 		if !newKeys[key] {
 			drifted++
 			c.store.Remove(snap.Repo(), snap.Number())
+			// Clean up CacheImpl-side prNumToKey so stale PR numbers don't resurrect ghost items.
+			if lpr := snap.LinkedPR(); lpr != nil && lpr.Number != 0 {
+				pk := prKey(snap.Repo(), lpr.Number)
+				c.mu.Lock()
+				delete(c.prNumToKey, pk)
+				c.mu.Unlock()
+			}
 		}
 	}
 
@@ -448,6 +456,17 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 		Number:     item.Number,
 		FreshState: *item,
 	})
+	// If FetchItemDetails learned a LinkedPRNumber, backfill prNumToKey so that
+	// future PR review/comment deltas can route via the normal (non-auto-heal) path.
+	if item.LinkedPRNumber != 0 {
+		pk := prKey(item.Repo, item.LinkedPRNumber)
+		issKey := itemKey(item.Repo, item.Number)
+		c.mu.Lock()
+		if _, exists := c.prNumToKey[pk]; !exists {
+			c.prNumToKey[pk] = issKey
+		}
+		c.mu.Unlock()
+	}
 	return nil
 }
 

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -2,10 +2,12 @@ package boardcache
 
 import (
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 )
 
 // ReadClient is the subset of engine.GitHubClient covering read-only board/item/PR/check-run state.
@@ -108,10 +110,217 @@ func missKeyForSHA(sha string) string {
 
 const recentMissTTL = 10 * time.Minute
 
+// parseItemKey parses "owner/repo#N" into (repo, number, true).
+// Returns ("", 0, false) on invalid input.
+func parseItemKey(key string) (repo string, number int, ok bool) {
+	idx := strings.LastIndex(key, "#")
+	if idx < 0 {
+		return "", 0, false
+	}
+	repo = key[:idx]
+	numStr := key[idx+1:]
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return "", 0, false
+	}
+	return repo, n, true
+}
+
+// snapshotToProjectItem converts a Store Snapshot to a gh.ProjectItem.
+func snapshotToProjectItem(snap itemstate.Snapshot) gh.ProjectItem {
+	s := snap.State()
+	pi := gh.ProjectItem{
+		ItemID:    s.ItemID,
+		Number:    s.Number,
+		Title:     s.Title,
+		Body:      s.Body,
+		Status:    s.Status,
+		URL:       s.URL,
+		Repo:      s.Repo,
+		IsPR:      s.IsPR,
+		IsClosed:  s.IsClosed,
+		UpdatedAt: s.UpdatedAt,
+		Labels:    s.Labels,
+		Assignees: s.Assignees,
+		Comments:  s.Comments,
+		Author:    s.Author,
+		BlockedBy: s.BlockedBy,
+	}
+	if s.LinkedPR != nil {
+		pi.LinkedPRNumber = s.LinkedPR.Number
+		pi.LinkedPRReviews = s.LinkedPR.Reviews
+		pi.LinkedPRReviewRequests = s.LinkedPR.ReviewRequests
+		pi.LinkedPRReviewThreadComments = s.LinkedPR.ThreadComments
+		pi.LinkedPRResolvedThreadCount = s.LinkedPR.ResolvedThreadCount
+	}
+	return pi
+}
+
+// CacheImpl is a goroutine-safe in-memory board cache. Webhook delta functions write
+// to it; the poll loop reads from it via the ReadClient interface. Falls back to a
+// fallback ReadClient on cache miss.
+//
+// Internal ownership split:
+//   - store owns: items, shaToKey, itemIDToKey
+//   - CacheImpl owns: paused, recentMissCache, projectID/Title/OwnerType,
+//     linkedPRs, checkRuns, prNumToKey, localDeltaAt
+//
+// Locking invariant: mu guards CacheImpl-local fields only. Store has its own
+// internal mutex. NEVER hold mu while calling any Store method — this prevents
+// deadlock if Store observers call back into CacheImpl.
+type CacheImpl struct {
+	// mu guards CacheImpl-local fields only. Never held during Store calls.
+	mu sync.RWMutex
+
+	// Board metadata (from last Bootstrap/Reconcile).
+	projectID        string
+	projectTitle     string
+	projectOwnerType string
+
+	// paused is a stream-health control flag. When true, ApplyDelta is a no-op.
+	paused bool
+
+	// recentMissCache is a negative cache preventing repeated REST lookups.
+	// Keys are "miss:owner/repo#prN" or "miss:sha:SHA".
+	recentMissCache map[string]time.Time
+
+	// checkRuns stores check runs keyed by commit SHA. Stays on CacheImpl because
+	// the Store silently drops CheckRunCompleted for SHAs not yet linked to any
+	// item. Pre-linkage runs are kept here and also forwarded to Store once linkage
+	// is resolved.
+	checkRuns map[string][]gh.CheckRun
+
+	// linkedPRs stores full PR details keyed by prKey(repo, prNum).
+	// TODO(phase3-x): migrate to Store when LinkedPRState gains Title/State/Merged/Draft.
+	linkedPRs map[string]*gh.PRDetails
+
+	// prNumToKey maps prKey(repo, prNum) → issue itemKey.
+	// Replaces the linear scan of Store items for PR-number → issue lookups in delta handlers.
+	prNumToKey map[string]string
+
+	// localDeltaAt records the last time a webhook bumped an item.
+	// FetchProjectBoard uses max(ItemState.UpdatedAt, localDeltaAt[key]) so that
+	// webhook-driven changes are visible to itemMayNeedWork before the next Reconcile.
+	localDeltaAt map[string]time.Time
+
+	// store owns per-item state (items, shaToKey, itemIDToKey).
+	store *itemstate.Store
+
+	fallback ReadClient
+	logFn    func(format string, args ...any)
+}
+
+// NewCacheImpl creates an empty cache backed by fallback for misses.
+func NewCacheImpl(fallback ReadClient, logFn func(format string, args ...any)) *CacheImpl {
+	return &CacheImpl{
+		checkRuns:       make(map[string][]gh.CheckRun),
+		linkedPRs:       make(map[string]*gh.PRDetails),
+		prNumToKey:      make(map[string]string),
+		localDeltaAt:    make(map[string]time.Time),
+		recentMissCache: make(map[string]time.Time),
+		store:           itemstate.NewStore(nil),
+		fallback:        fallback,
+		logFn:           logFn,
+	}
+}
+
+// Bootstrap populates the cache wholesale from a freshly-fetched board.
+// Called once at engine startup before the first dispatch cycle.
+func (c *CacheImpl) Bootstrap(board *gh.ProjectBoard) {
+	// Reset Store atomically — clears all prior item state and indexes.
+	c.store.Reset(board.Items)
+
+	c.mu.Lock()
+	c.projectID = board.ProjectID
+	c.projectTitle = board.Title
+	c.projectOwnerType = board.OwnerType
+	// Reset CacheImpl-local maps so they're consistent with the fresh Store state.
+	c.prNumToKey = make(map[string]string)
+	c.localDeltaAt = make(map[string]time.Time)
+	c.linkedPRs = make(map[string]*gh.PRDetails)
+	c.checkRuns = make(map[string][]gh.CheckRun)
+	c.mu.Unlock()
+
+	c.logFn("[cache] bootstrap complete: %d items\n", len(board.Items))
+}
+
+// Reconcile replaces shallow board state from a fresh board fetch.
+// Preserves deep fields (Comments, LinkedPRReviews, etc.) for items that have
+// already been deep-fetched. Logs the drift count when items differ.
+// Shallow drift in linkage (LinkedPRNumber) invalidates deep cache for the
+// affected key, forcing a fresh FetchItemDetails on next access.
+func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
+	newKeys := make(map[string]bool, len(board.Items))
+	drifted := 0
+
+	for i := range board.Items {
+		pi := &board.Items[i]
+		key := itemKey(pi.Repo, pi.Number)
+		newKeys[key] = true
+
+		snap, err := c.store.Get(pi.Repo, pi.Number)
+		if err != nil {
+			// New item not in Store — add it fully.
+			drifted++
+			c.store.Apply(itemstate.IssueOpened{Item: *pi})
+			continue
+		}
+
+		s := snap.State()
+
+		// Detect shallow drift to count items that differ.
+		if s.Status != pi.Status ||
+			len(s.Labels) != len(pi.Labels) ||
+			!s.UpdatedAt.Equal(pi.UpdatedAt) {
+			drifted++
+		}
+
+		// Apply shallow update to Store (preserves deep fields).
+		c.store.Apply(itemstate.ShallowBoardItemUpdated{
+			Repo:   pi.Repo,
+			Number: pi.Number,
+			Item:   *pi,
+		})
+
+		// Detect linkage drift: deep cache's LinkedPRNumber ≠ fresh shallow board value.
+		if !s.LastDeepFetchAt.IsZero() {
+			var deepPRNum int
+			if s.LinkedPR != nil {
+				deepPRNum = s.LinkedPR.Number
+			}
+			shallowPRNum := pi.LinkedPRNumberShallow
+			if deepPRNum != shallowPRNum {
+				c.store.Apply(itemstate.DeepFetchInvalidated{Repo: pi.Repo, Number: pi.Number})
+				c.logFn("[cache] linkage drift detected for issue #%d: stale linked PR=%d, fresh=%d — invalidating deep cache\n",
+					pi.Number, deepPRNum, shallowPRNum)
+			}
+		}
+	}
+
+	// Remove items no longer on the board.
+	for _, snap := range c.store.All() {
+		key := itemKey(snap.Repo(), snap.Number())
+		if !newKeys[key] {
+			drifted++
+			c.store.Remove(snap.Repo(), snap.Number())
+		}
+	}
+
+	c.mu.Lock()
+	c.projectID = board.ProjectID
+	c.projectTitle = board.Title
+	c.projectOwnerType = board.OwnerType
+	c.mu.Unlock()
+
+	if drifted > 0 {
+		c.logFn("[reconciliation] %d items differed\n", drifted)
+	}
+}
+
 // resolvePRLinkage looks up which cached issue is closed by the given PR by
 // fetching the PR body via REST and parsing closing keywords. Must be called
 // without c.mu held (the REST call is a network operation). Returns the cache
-// key and issue number of the first closing issue found in c.items. On a
+// key and issue number of the first closing issue found in the Store. On a
 // transient REST error the error is returned and callers should NOT record a
 // negative-miss entry (a retry on the next webhook may succeed). Returns
 // ("", 0, false, nil) when the PR body has no recognized closing reference or
@@ -127,171 +336,14 @@ func (c *CacheImpl) resolvePRLinkage(owner, repo string, prNumber int) (key stri
 		return "", 0, false, nil
 	}
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	// Store has nil fallback — Get returns ErrNotFound on miss without calling GitHub.
 	for _, issNum := range issues {
 		k := itemKey(fullRepo, issNum)
-		if _, ok := c.items[k]; ok {
+		if _, storeErr := c.store.Get(fullRepo, issNum); storeErr == nil {
 			return k, issNum, true, nil
 		}
 	}
 	return "", 0, false, nil
-}
-
-// CacheImpl is a goroutine-safe in-memory board cache. Webhook delta functions write
-// to it; the poll loop reads from it via the ReadClient interface. Falls back to a
-// fallback ReadClient on cache miss.
-type CacheImpl struct {
-	mu sync.RWMutex
-
-	// Board items: key = owner/repo#issueNumber
-	items      map[string]*gh.ProjectItem
-	deepFetched map[string]bool // set of keys that have had FetchItemDetails called
-
-	// Check runs: key = commit SHA
-	checkRuns map[string][]gh.CheckRun
-
-	// PR details: key = owner/repo#pr<prNumber>
-	linkedPRs map[string]*gh.PRDetails
-
-	// Reverse lookups
-	shaToKey    map[string]string // SHA → issueKey (owner/repo#number)
-	itemIDToKey map[string]string // ItemID → issueKey
-
-	// Board metadata (from last Bootstrap/Reconcile)
-	projectID       string
-	projectTitle    string
-	projectOwnerType string
-
-	// Stream health: when paused, ApplyDelta is a no-op
-	paused bool
-
-	// Negative cache: keys are "miss:owner/repo#prN" or "miss:sha:SHA".
-	// Entries with TTL > 10 minutes are pruned lazily on access.
-	recentMissCache map[string]time.Time
-
-	// Fallback for cache misses
-	fallback ReadClient
-	logFn    func(format string, args ...any)
-}
-
-// NewCacheImpl creates an empty cache backed by fallback for misses.
-func NewCacheImpl(fallback ReadClient, logFn func(format string, args ...any)) *CacheImpl {
-	return &CacheImpl{
-		items:           make(map[string]*gh.ProjectItem),
-		deepFetched:     make(map[string]bool),
-		checkRuns:       make(map[string][]gh.CheckRun),
-		linkedPRs:       make(map[string]*gh.PRDetails),
-		shaToKey:        make(map[string]string),
-		itemIDToKey:     make(map[string]string),
-		recentMissCache: make(map[string]time.Time),
-		fallback:        fallback,
-		logFn:           logFn,
-	}
-}
-
-// Bootstrap populates the cache wholesale from a freshly-fetched board.
-// Called once at engine startup before the first dispatch cycle.
-func (c *CacheImpl) Bootstrap(board *gh.ProjectBoard) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.populateFromBoard(board)
-	c.logFn("[cache] bootstrap complete: %d items\n", len(board.Items))
-}
-
-// Reconcile replaces shallow board state from a fresh board fetch.
-// Preserves deep fields (Comments, LinkedPRReviews, etc.) for items that have
-// already been deep-fetched. Logs the drift count when items differ.
-// Shallow drift in linkage (LinkedPRNumber) invalidates deep cache for the
-// affected key, forcing a fresh FetchItemDetails on next access.
-func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	newKeys := make(map[string]bool, len(board.Items))
-	drifted := 0
-
-	for i := range board.Items {
-		item := &board.Items[i]
-		key := itemKey(item.Repo, item.Number)
-		newKeys[key] = true
-
-		if existing, ok := c.items[key]; ok {
-			if existing.Status != item.Status ||
-				len(existing.Labels) != len(item.Labels) ||
-				existing.UpdatedAt != item.UpdatedAt {
-				drifted++
-			}
-			// Update shallow fields; preserve deep fields from cache.
-			existing.Status = item.Status
-			existing.Labels = cloneStrings(item.Labels)
-			existing.Title = item.Title
-			existing.UpdatedAt = item.UpdatedAt
-			existing.IsClosed = item.IsClosed
-			existing.IsPR = item.IsPR
-			existing.ItemID = item.ItemID
-			existing.URL = item.URL
-			// Update the ItemID reverse lookup.
-			if item.ItemID != "" {
-				c.itemIDToKey[item.ItemID] = key
-			}
-			// Detect linkage drift: if deep cache says LinkedPRNumber=X but the
-			// fresh shallow board shows a different value, the cached deep state was
-			// captured before the issue↔PR linkage appeared (or changed) on GitHub.
-			// Invalidate deepFetched so the next FetchItemDetails re-fetches from GitHub.
-			if c.deepFetched[key] && existing.LinkedPRNumber != item.LinkedPRNumberShallow {
-				delete(c.deepFetched, key)
-				c.logFn("[cache] linkage drift detected for issue #%d: stale linked PR=%d, fresh=%d — invalidating deep cache\n",
-					item.Number, existing.LinkedPRNumber, item.LinkedPRNumberShallow)
-			}
-		} else {
-			drifted++
-			cp := *item
-			c.items[key] = &cp
-			if item.ItemID != "" {
-				c.itemIDToKey[item.ItemID] = key
-			}
-		}
-	}
-
-	// Remove items that are no longer on the board.
-	for key := range c.items {
-		if !newKeys[key] {
-			drifted++
-			delete(c.items, key)
-			delete(c.deepFetched, key)
-		}
-	}
-
-	c.projectID = board.ProjectID
-	c.projectTitle = board.Title
-	c.projectOwnerType = board.OwnerType
-
-	if drifted > 0 {
-		c.logFn("[reconciliation] %d items differed\n", drifted)
-	}
-}
-
-// populateFromBoard replaces items map entirely from a board fetch.
-// Must be called with c.mu held (write).
-func (c *CacheImpl) populateFromBoard(board *gh.ProjectBoard) {
-	c.projectID = board.ProjectID
-	c.projectTitle = board.Title
-	c.projectOwnerType = board.OwnerType
-
-	c.items = make(map[string]*gh.ProjectItem, len(board.Items))
-	c.itemIDToKey = make(map[string]string, len(board.Items))
-	c.deepFetched = make(map[string]bool)
-
-	for i := range board.Items {
-		item := board.Items[i]
-		key := itemKey(item.Repo, item.Number)
-		cp := item
-		c.items[key] = &cp
-		if item.ItemID != "" {
-			c.itemIDToKey[item.ItemID] = key
-		}
-	}
 }
 
 // Pause stops delta application (called on WebhookStreamUnhealthy transition).
@@ -315,31 +367,51 @@ func (c *CacheImpl) IsPaused() bool {
 	return c.paused
 }
 
-// FetchProjectBoard returns a *gh.ProjectBoard reconstructed from the items map.
+// FetchProjectBoard returns a *gh.ProjectBoard reconstructed from the Store.
 // Falls back to GitHub when the cache has not been bootstrapped or is paused.
 func (c *CacheImpl) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	// Check paused first; Store.All is called outside any c.mu hold.
 	c.mu.RLock()
+	paused := c.paused
+	c.mu.RUnlock()
 
-	if len(c.items) == 0 || c.paused {
-		c.mu.RUnlock()
-		if len(c.items) == 0 {
+	snaps := c.store.All()
+
+	if len(snaps) == 0 || paused {
+		if len(snaps) == 0 {
 			c.logFn("[cache] miss: FetchProjectBoard not yet bootstrapped — fetching from GitHub\n")
 		}
 		return c.fallback.FetchProjectBoard(owner, repo, projectNum, ownerType)
 	}
 
-	items := make([]gh.ProjectItem, 0, len(c.items))
-	for _, item := range c.items {
-		items = append(items, *item)
-	}
-	board := &gh.ProjectBoard{
-		ProjectID: c.projectID,
-		Title:     c.projectTitle,
-		OwnerType: c.projectOwnerType,
-		Items:     items,
+	c.mu.RLock()
+	projectID := c.projectID
+	projectTitle := c.projectTitle
+	projectOwnerType := c.projectOwnerType
+	// Snapshot localDeltaAt for consistent max(UpdatedAt, deltaAt) computation.
+	localDeltaAtCopy := make(map[string]time.Time, len(c.localDeltaAt))
+	for k, v := range c.localDeltaAt {
+		localDeltaAtCopy[k] = v
 	}
 	c.mu.RUnlock()
-	return board, nil
+
+	items := make([]gh.ProjectItem, 0, len(snaps))
+	for _, snap := range snaps {
+		pi := snapshotToProjectItem(snap)
+		// Override UpdatedAt if a webhook has bumped it more recently than GitHub's timestamp.
+		key := itemKey(snap.Repo(), snap.Number())
+		if t, ok := localDeltaAtCopy[key]; ok && t.After(pi.UpdatedAt) {
+			pi.UpdatedAt = t
+		}
+		items = append(items, pi)
+	}
+
+	return &gh.ProjectBoard{
+		ProjectID: projectID,
+		Title:     projectTitle,
+		OwnerType: projectOwnerType,
+		Items:     items,
+	}, nil
 }
 
 // FetchItemDetails copies cached deep fields into the passed item pointer.
@@ -347,37 +419,35 @@ func (c *CacheImpl) FetchProjectBoard(owner, repo string, projectNum int, ownerT
 // LinkedPRReviewRequests, LinkedPRReviews, LinkedPRReviewThreadComments, LinkedPRResolvedThreadCount.
 // Falls back to GitHub on cache miss and populates the cache with the result.
 func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
-	key := itemKey(item.Repo, item.Number)
-
 	c.mu.RLock()
-	if c.paused {
-		c.mu.RUnlock()
+	paused := c.paused
+	c.mu.RUnlock()
+
+	if paused {
 		return c.fallback.FetchItemDetails(item)
 	}
-	cached, ok := c.items[key]
-	deepFetched := c.deepFetched[key]
-	if ok && deepFetched {
-		copyDeepFields(item, cached)
-		c.mu.RUnlock()
-		return nil
+
+	snap, err := c.store.Get(item.Repo, item.Number)
+	if err == nil {
+		s := snap.State()
+		if !s.LastDeepFetchAt.IsZero() {
+			// Cache hit — copy deep fields into item.
+			copyDeepFieldsFromState(item, s)
+			return nil
+		}
 	}
-	c.mu.RUnlock()
 
 	c.logFn("[cache] miss for #%d — fetching from GitHub\n", item.Number)
 	if err := c.fallback.FetchItemDetails(item); err != nil {
 		return err
 	}
 
-	// Store the deep fields in the cache.
-	c.mu.Lock()
-	if cached, ok := c.items[key]; ok {
-		copyDeepFields(cached, item)
-	} else {
-		cp := *item
-		c.items[key] = &cp
-	}
-	c.deepFetched[key] = true
-	c.mu.Unlock()
+	// Write back to Store via ItemDeepFetched.
+	c.store.Apply(itemstate.ItemDeepFetched{
+		Repo:       item.Repo,
+		Number:     item.Number,
+		FreshState: *item,
+	})
 	return nil
 }
 
@@ -410,23 +480,36 @@ func (c *CacheImpl) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, erro
 
 // FetchLinkedPR returns cached PR details for an issue; falls back to GitHub on miss.
 func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-	issKey := itemKey(owner+"/"+repo, issueNumber)
+	fullRepo := owner + "/" + repo
+	issKey := itemKey(fullRepo, issueNumber)
 
 	c.mu.RLock()
-	if c.paused {
-		c.mu.RUnlock()
+	paused := c.paused
+	c.mu.RUnlock()
+
+	if paused {
 		return c.fallback.FetchLinkedPR(owner, repo, issueNumber)
 	}
-	item, itemOK := c.items[issKey]
-	if itemOK && item.LinkedPRNumber != 0 {
-		pk := prKey(owner+"/"+repo, item.LinkedPRNumber)
+
+	// Get LinkedPRNumber from Store (Store has its own mutex; no c.mu held).
+	var linkedPRNum int
+	snap, snapErr := c.store.Get(fullRepo, issueNumber)
+	if snapErr == nil {
+		if lpr := snap.LinkedPR(); lpr != nil {
+			linkedPRNum = lpr.Number
+		}
+	}
+
+	if linkedPRNum != 0 {
+		pk := prKey(fullRepo, linkedPRNum)
+		c.mu.RLock()
 		if pr, ok := c.linkedPRs[pk]; ok {
 			prCopy := *pr
 			c.mu.RUnlock()
 			return &prCopy, nil
 		}
+		c.mu.RUnlock()
 	}
-	c.mu.RUnlock()
 
 	c.logFn("[cache] miss: FetchLinkedPR #%d — fetching from GitHub\n", issueNumber)
 	pr, err := c.fallback.FetchLinkedPR(owner, repo, issueNumber)
@@ -434,14 +517,26 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		return nil, err
 	}
 	if pr != nil {
-		pk := prKey(owner+"/"+repo, pr.Number)
+		pk := prKey(fullRepo, pr.Number)
 		c.mu.Lock()
 		c.linkedPRs[pk] = pr
-		// Update item's LinkedPRNumber if not set.
-		if item2, ok := c.items[issKey]; ok && item2.LinkedPRNumber == 0 {
-			item2.LinkedPRNumber = pr.Number
-		}
 		c.mu.Unlock()
+		// If the item had no LinkedPRNumber in Store, update it via deep fetch write-back.
+		if linkedPRNum == 0 && snapErr == nil {
+			// Construct a fresh ProjectItem from current Store state + new PR number.
+			pi := snapshotToProjectItem(snap)
+			pi.LinkedPRNumber = pr.Number
+			c.store.Apply(itemstate.ItemDeepFetched{
+				Repo:       fullRepo,
+				Number:     issueNumber,
+				FreshState: pi,
+			})
+			// Also update prNumToKey.
+			pk2 := prKey(fullRepo, pr.Number)
+			c.mu.Lock()
+			c.prNumToKey[pk2] = issKey
+			c.mu.Unlock()
+		}
 	}
 	return pr, nil
 }
@@ -458,19 +553,20 @@ func (c *CacheImpl) FetchPRMergeableState(owner, repo string, prNumber int) (str
 
 // FetchLabels returns the cached label list for an issue; falls back to GitHub on miss.
 func (c *CacheImpl) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
-	key := itemKey(owner+"/"+repo, issueNumber)
+	fullRepo := owner + "/" + repo
 
 	c.mu.RLock()
-	if c.paused {
-		c.mu.RUnlock()
+	paused := c.paused
+	c.mu.RUnlock()
+
+	if paused {
 		return c.fallback.FetchLabels(owner, repo, issueNumber)
 	}
-	if item, ok := c.items[key]; ok {
-		labels := cloneStrings(item.Labels)
-		c.mu.RUnlock()
-		return labels, nil
+
+	snap, err := c.store.Get(fullRepo, issueNumber)
+	if err == nil {
+		return cloneStrings(snap.Labels()), nil
 	}
-	c.mu.RUnlock()
 
 	c.logFn("[cache] miss: FetchLabels #%d — fetching from GitHub\n", issueNumber)
 	return c.fallback.FetchLabels(owner, repo, issueNumber)
@@ -499,49 +595,62 @@ func (c *CacheImpl) RateLimitStats() (rest, graphql gh.RateLimitStats) {
 // UpdateItemStatus updates the Status field for the item identified by key.
 // No-op when the key is not in the cache. Safe for concurrent use.
 func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	item, ok := c.items[key]
+	repo, number, ok := parseItemKey(key)
 	if !ok {
 		c.logFn("[cache] UpdateItemStatus: key %q not found — no-op\n", key)
 		return
 	}
-	item.Status = newStatus
-	item.UpdatedAt = time.Now()
+	_, changes, _ := c.store.Apply(itemstate.LocalStatusUpdated{
+		Repo:      repo,
+		Number:    number,
+		NewStatus: newStatus,
+	})
+	if len(changes) == 0 {
+		// Item not found in Store or status unchanged.
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
 }
 
 // ApplyStatusBatch updates Status for items identified by project-item node IDs.
-// Entries whose itemID is not in itemIDToKey are silently skipped (not yet bootstrapped).
+// Entries whose itemID is not in the Store's itemIDToKey index are silently skipped.
 // Safe for concurrent use.
 func (c *CacheImpl) ApplyStatusBatch(updates map[string]string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	for itemID, status := range updates {
-		key, ok := c.itemIDToKey[itemID]
-		if !ok {
+		snap, changes, _ := c.store.Apply(itemstate.ProjectV2ItemEdited{
+			ItemID:    itemID,
+			NewStatus: status,
+		})
+		if len(changes) == 0 {
 			continue
 		}
-		item, ok := c.items[key]
-		if !ok {
-			continue
-		}
-		if item.Status != status {
-			item.Status = status
-			item.UpdatedAt = time.Now()
-		}
+		key := itemKey(snap.Repo(), snap.Number())
+		now := time.Now()
+		c.mu.Lock()
+		c.localDeltaAt[key] = now
+		c.mu.Unlock()
 	}
 }
 
 // GetItemID returns the project-item node ID (PVTI_...) for the given cache key.
 // Returns ("", false) when the key is not present or has no ItemID.
 func (c *CacheImpl) GetItemID(key string) (string, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	item, ok := c.items[key]
-	if !ok || item.ItemID == "" {
+	repo, number, ok := parseItemKey(key)
+	if !ok {
 		return "", false
 	}
-	return item.ItemID, true
+	snap, err := c.store.Get(repo, number)
+	if err != nil {
+		return "", false
+	}
+	s := snap.State()
+	if s.ItemID == "" {
+		return "", false
+	}
+	return s.ItemID, true
 }
 
 // ProjectID returns the project node ID stored from the last Bootstrap/Reconcile call.
@@ -550,6 +659,24 @@ func (c *CacheImpl) ProjectID() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.projectID
+}
+
+// copyDeepFieldsFromState overlays deep fields from an ItemState onto a *gh.ProjectItem.
+// Shallow fields (Labels, Status, Title, UpdatedAt) are left unchanged in dst.
+func copyDeepFieldsFromState(dst *gh.ProjectItem, s itemstate.ItemState) {
+	dst.Body = s.Body
+	dst.URL = s.URL
+	dst.Author = s.Author
+	dst.Assignees = cloneStrings(s.Assignees)
+	dst.BlockedBy = cloneDependencies(s.BlockedBy)
+	dst.Comments = cloneComments(s.Comments)
+	if s.LinkedPR != nil {
+		dst.LinkedPRNumber = s.LinkedPR.Number
+		dst.LinkedPRReviews = clonePRReviews(s.LinkedPR.Reviews)
+		dst.LinkedPRReviewRequests = cloneReviewRequests(s.LinkedPR.ReviewRequests)
+		dst.LinkedPRReviewThreadComments = cloneComments(s.LinkedPR.ThreadComments)
+		dst.LinkedPRResolvedThreadCount = s.LinkedPR.ResolvedThreadCount
+	}
 }
 
 // copyDeepFields overlays the deep fields from src onto dst.
@@ -567,7 +694,6 @@ func copyDeepFields(dst, src *gh.ProjectItem) {
 	dst.LinkedPRReviewThreadComments = cloneComments(src.LinkedPRReviewThreadComments)
 	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
 }
-
 
 func cloneStrings(s []string) []string {
 	if s == nil {

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 )
 
 // ---------------------------------------------------------------------------
@@ -103,10 +104,56 @@ func (m *mockClient) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Test helpers — Store-based accessors
 // ---------------------------------------------------------------------------
 
 var nopLog = func(format string, args ...any) {}
+
+// testGetState returns a deep-copy of the ItemState for (repo, number).
+// Fails the test immediately if not found.
+func testGetState(t *testing.T, c *CacheImpl, repo string, number int) itemstate.ItemState {
+	t.Helper()
+	snap, err := c.store.Get(repo, number)
+	if err != nil {
+		t.Fatalf("testGetState: %s#%d: %v", repo, number, err)
+	}
+	return snap.State()
+}
+
+// testSetDeepFetched marks an item as deep-fetched in the Store by applying
+// an ItemDeepFetched mutation with the item's current shallow state.
+func testSetDeepFetched(c *CacheImpl, repo string, number int) {
+	snap, err := c.store.Get(repo, number)
+	if err != nil {
+		return
+	}
+	pi := snapshotToProjectItem(snap)
+	c.store.Apply(itemstate.ItemDeepFetched{Repo: repo, Number: number, FreshState: pi})
+}
+
+// testIsDeepFetched returns whether the item has a non-zero LastDeepFetchAt.
+func testIsDeepFetched(c *CacheImpl, repo string, number int) bool {
+	snap, err := c.store.Get(repo, number)
+	if err != nil {
+		return false
+	}
+	return !snap.State().LastDeepFetchAt.IsZero()
+}
+
+// testSetLinkedPR sets up item (repo, issNum) as linked to prNum in both the
+// Store and c.prNumToKey, so delta handlers can route events by PR number.
+func testSetLinkedPR(c *CacheImpl, repo string, issNum, prNum int) {
+	pk := prKey(repo, prNum)
+	ik := itemKey(repo, issNum)
+	c.store.Apply(itemstate.PRHeadSHAUpdated{Repo: repo, Number: issNum, LinkedPRNum: prNum})
+	c.mu.Lock()
+	c.prNumToKey[pk] = ik
+	c.mu.Unlock()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 func seedCache(t *testing.T) *CacheImpl {
 	t.Helper()
@@ -221,7 +268,7 @@ func TestFetchItemDetailsFallbackPopulatesCache(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Delta: issue_comment.created — idempotent by comment ID
+// Delta: issue_comment.created — idempotent by DatabaseID
 // ---------------------------------------------------------------------------
 
 func issueCommentPayloadJSON(action, repo string, issueNum int, nodeID string, dbID int, body, user string) []byte {
@@ -239,50 +286,26 @@ func issueCommentPayloadJSON(action, repo string, issueNum int, nodeID string, d
 
 func TestDeltaIssueCommentCreated(t *testing.T) {
 	c := seedCache(t)
-	// Make sure item #1 is deep-fetched first (so Comments isn't nil from fallback).
-	c.mu.Lock()
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
 
 	payload := issueCommentPayloadJSON("created", "owner/repo", 1, "C_abc", 100, "test comment", "alice")
 	c.ApplyDelta("issue_comment", payload)
 
-	board, _ := c.FetchProjectBoard("", "", 0, "")
-	var item *gh.ProjectItem
-	for i := range board.Items {
-		if board.Items[i].Number == 1 {
-			item = &board.Items[i]
-			break
-		}
-	}
-	if item == nil {
-		t.Fatal("item #1 not found")
-	}
-	// FetchProjectBoard returns shallow copy; comments are in cache.
-	// We need to check via FetchItemDetails.
-	c.mu.RLock()
-	cached := c.items[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
-	if len(cached.Comments) != 1 || cached.Comments[0].ID != "C_abc" {
-		t.Errorf("expected comment C_abc, got %+v", cached.Comments)
+	s := testGetState(t, c, "owner/repo", 1)
+	if len(s.Comments) != 1 || s.Comments[0].ID != "C_abc" {
+		t.Errorf("expected comment C_abc, got %+v", s.Comments)
 	}
 }
 
 func TestDeltaIssueCommentCreatedIdempotent(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
 
 	payload := issueCommentPayloadJSON("created", "owner/repo", 1, "C_abc", 100, "test", "alice")
 	c.ApplyDelta("issue_comment", payload)
 	c.ApplyDelta("issue_comment", payload) // duplicate
 
-	c.mu.RLock()
-	cached := c.items[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
-	if len(cached.Comments) != 1 {
-		t.Errorf("expected exactly 1 comment after duplicate, got %d", len(cached.Comments))
+	s := testGetState(t, c, "owner/repo", 1)
+	if len(s.Comments) != 1 {
+		t.Errorf("expected exactly 1 comment after duplicate, got %d", len(s.Comments))
 	}
 }
 
@@ -304,10 +327,8 @@ func TestDeltaIssuesLabeled(t *testing.T) {
 	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "bug")
 	c.ApplyDelta("issues", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	labels := cloneStrings(item.Labels)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	labels := cloneStrings(s.Labels)
 
 	found := false
 	for _, l := range labels {
@@ -326,15 +347,13 @@ func TestDeltaIssuesLabeledIdempotent(t *testing.T) {
 	c.ApplyDelta("issues", payload)
 	c.ApplyDelta("issues", payload) // add same label twice
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
+	s := testGetState(t, c, "owner/repo", 1)
 	count := 0
-	for _, l := range item.Labels {
+	for _, l := range s.Labels {
 		if l == "enhancement" {
 			count++
 		}
 	}
-	c.mu.RUnlock()
 
 	if count != 1 {
 		t.Errorf("label 'enhancement' should appear exactly once, got %d", count)
@@ -347,20 +366,17 @@ func TestDeltaIssuesUnlabeled(t *testing.T) {
 	payload := issuesLabeledPayloadJSON("unlabeled", "owner/repo", 1, "enhancement")
 	c.ApplyDelta("issues", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	for _, l := range item.Labels {
+	s := testGetState(t, c, "owner/repo", 1)
+	for _, l := range s.Labels {
 		if l == "enhancement" {
-			c.mu.RUnlock()
 			t.Error("label 'enhancement' should have been removed")
 			return
 		}
 	}
-	c.mu.RUnlock()
 }
 
 // ---------------------------------------------------------------------------
-// Delta: pull_request — update linkedPRs and shaToKey
+// Delta: pull_request — update linkedPRs and SHA index in Store
 // ---------------------------------------------------------------------------
 
 func pullRequestPayloadJSON(action, repo string, prNum int, sha, state string, merged, draft bool) []byte {
@@ -377,17 +393,14 @@ func pullRequestPayloadJSON(action, repo string, prNum int, sha, state string, m
 
 func TestDeltaPullRequestOpened(t *testing.T) {
 	c := seedCache(t)
-	// Set LinkedPRNumber on item #1 so shaToKey can be populated.
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
-	c.mu.Unlock()
+	// Set item #1 as linked to PR #42 so the delta handler routes correctly.
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 
 	payload := pullRequestPayloadJSON("opened", "owner/repo", 42, "sha123", "open", false, false)
 	c.ApplyDelta("pull_request", payload)
 
 	c.mu.RLock()
 	pr, ok := c.linkedPRs[prKey("owner/repo", 42)]
-	shaKey, shaOK := c.shaToKey["sha123"]
 	c.mu.RUnlock()
 
 	if !ok || pr == nil {
@@ -396,32 +409,28 @@ func TestDeltaPullRequestOpened(t *testing.T) {
 	if pr != nil && pr.HeadSHA != "sha123" {
 		t.Errorf("expected HeadSHA sha123, got %q", pr.HeadSHA)
 	}
-	if !shaOK || shaKey != itemKey("owner/repo", 1) {
-		t.Errorf("expected shaToKey[sha123] = owner/repo#1, got %q (ok=%v)", shaKey, shaOK)
+	// Verify SHA is indexed in Store by checking item's LinkedPR.HeadSHA.
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || s.LinkedPR.HeadSHA != "sha123" {
+		t.Errorf("expected item #1's LinkedPR.HeadSHA=sha123, got %v", s.LinkedPR)
 	}
 }
 
 func TestDeltaPullRequestSynchronizeUpdatesShaTKey(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
-	c.mu.Unlock()
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 
-	// Initial SHA
+	// Initial SHA.
 	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha_old", "open", false, false))
-	// New push — SHA changes
+	// New push — SHA changes.
 	c.ApplyDelta("pull_request", pullRequestPayloadJSON("synchronize", "owner/repo", 42, "sha_new", "open", false, false))
 
-	c.mu.RLock()
-	_, oldOK := c.shaToKey["sha_old"]
-	_, newOK := c.shaToKey["sha_new"]
-	c.mu.RUnlock()
-
-	if oldOK {
-		t.Error("old SHA should have been removed from shaToKey")
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR != nil && s.LinkedPR.HeadSHA == "sha_old" {
+		t.Error("old SHA should have been replaced in item's LinkedPR.HeadSHA")
 	}
-	if !newOK {
-		t.Error("new SHA should be in shaToKey")
+	if s.LinkedPR == nil || s.LinkedPR.HeadSHA != "sha_new" {
+		t.Error("new SHA should be stored in item's LinkedPR.HeadSHA")
 	}
 }
 
@@ -442,17 +451,16 @@ func pullRequestReviewPayloadJSON(action, repo string, prNum, reviewID int, stat
 
 func TestDeltaPullRequestReviewSubmitted(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
-	c.mu.Unlock()
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 
 	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "approved", "alice")
 	c.ApplyDelta("pull_request_review", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	reviews := clonePRReviews(item.LinkedPRReviews)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var reviews []gh.PRReview
+	if s.LinkedPR != nil {
+		reviews = clonePRReviews(s.LinkedPR.Reviews)
+	}
 
 	if len(reviews) != 1 || reviews[0].Author != "alice" || reviews[0].State != "APPROVED" {
 		t.Errorf("unexpected reviews: %+v", reviews)
@@ -461,24 +469,23 @@ func TestDeltaPullRequestReviewSubmitted(t *testing.T) {
 
 func TestDeltaPullRequestReviewSubmittedUpsert(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
-	c.mu.Unlock()
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 
-	// First review: changes_requested
+	// First review: changes_requested.
 	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "changes_requested", "alice"))
-	// Second review with same ID: approve (author re-reviews)
+	// Second review with same ID: approve (author re-reviews).
 	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "approved", "alice"))
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	reviews := clonePRReviews(item.LinkedPRReviews)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var reviews []gh.PRReview
+	if s.LinkedPR != nil {
+		reviews = clonePRReviews(s.LinkedPR.Reviews)
+	}
 
 	if len(reviews) != 1 {
 		t.Errorf("upsert: expected 1 review after re-review, got %d", len(reviews))
 	}
-	if reviews[0].State != "APPROVED" {
+	if len(reviews) > 0 && reviews[0].State != "APPROVED" {
 		t.Errorf("expected APPROVED state after upsert, got %q", reviews[0].State)
 	}
 }
@@ -504,17 +511,16 @@ func pullRequestReviewCommentPayloadJSON(action, repo string, prNum, dbID int, n
 
 func TestDeltaPullRequestReviewCommentCreated(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
-	c.mu.Unlock()
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 
 	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_node_1", "looks good", "bob")
 	c.ApplyDelta("pull_request_review_comment", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	comments := cloneComments(item.LinkedPRReviewThreadComments)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var comments []gh.Comment
+	if s.LinkedPR != nil {
+		comments = cloneComments(s.LinkedPR.ThreadComments)
+	}
 
 	if len(comments) != 1 || comments[0].ID != "RC_node_1" || comments[0].Author != "bob" {
 		t.Errorf("unexpected review thread comments: %+v", comments)
@@ -523,18 +529,17 @@ func TestDeltaPullRequestReviewCommentCreated(t *testing.T) {
 
 func TestDeltaPullRequestReviewCommentCreatedIdempotent(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
-	c.mu.Unlock()
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 
 	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_node_1", "looks good", "bob")
 	c.ApplyDelta("pull_request_review_comment", payload)
 	c.ApplyDelta("pull_request_review_comment", payload) // duplicate
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	count := len(item.LinkedPRReviewThreadComments)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var count int
+	if s.LinkedPR != nil {
+		count = len(s.LinkedPR.ThreadComments)
+	}
 
 	if count != 1 {
 		t.Errorf("expected exactly 1 review thread comment after duplicate, got %d", count)
@@ -573,9 +578,9 @@ func TestDeltaCheckRunCompleted(t *testing.T) {
 
 func TestDeltaCheckRunUpsertById(t *testing.T) {
 	c := seedCache(t)
-	// First run: failure
+	// First run: failure.
 	c.ApplyDelta("check_run", checkRunPayloadJSON("completed", "owner/repo", 9001, "build", "completed", "failure", "sha_abc"))
-	// Same ID: success (re-run)
+	// Same ID: success (re-run).
 	c.ApplyDelta("check_run", checkRunPayloadJSON("completed", "owner/repo", 9001, "build", "completed", "success", "sha_abc"))
 
 	c.mu.RLock()
@@ -585,7 +590,7 @@ func TestDeltaCheckRunUpsertById(t *testing.T) {
 	if len(runs) != 1 {
 		t.Errorf("upsert: expected 1 run after re-run, got %d", len(runs))
 	}
-	if runs[0].Conclusion != "success" {
+	if len(runs) > 0 && runs[0].Conclusion != "success" {
 		t.Errorf("expected success after upsert, got %q", runs[0].Conclusion)
 	}
 }
@@ -609,13 +614,9 @@ func TestDeltaProjectsV2ItemEdited(t *testing.T) {
 	payload := projectsV2ItemPayloadJSON("edited", "PVTI_001", "Plan")
 	c.ApplyDelta("projects_v2_item", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	status := item.Status
-	c.mu.RUnlock()
-
-	if status != "Plan" {
-		t.Errorf("expected status 'Plan', got %q", status)
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Plan" {
+		t.Errorf("expected status 'Plan', got %q", s.Status)
 	}
 }
 
@@ -707,12 +708,9 @@ func TestReconcileReplacesShallowData(t *testing.T) {
 		},
 	})
 
-	c.mu.RLock()
-	status := c.items[itemKey("owner/repo", 1)].Status
-	c.mu.RUnlock()
-
-	if status != "Plan" {
-		t.Errorf("expected status 'Plan' after reconcile, got %q", status)
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Plan" {
+		t.Errorf("expected status 'Plan' after reconcile, got %q", s.Status)
 	}
 	if !strings.Contains(logBuf.String(), "reconciliation") {
 		t.Errorf("expected [reconciliation] log, got: %q", logBuf.String())
@@ -721,10 +719,11 @@ func TestReconcileReplacesShallowData(t *testing.T) {
 
 func TestReconcilePreservesDeepFields(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].Comments = []gh.Comment{{ID: "C1", Body: "preserved"}}
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
+	// Set comments and mark as deep-fetched via ItemDeepFetched mutation.
+	snap, _ := c.store.Get("owner/repo", 1)
+	pi := snapshotToProjectItem(snap)
+	pi.Comments = []gh.Comment{{ID: "C1", Body: "preserved"}}
+	c.store.Apply(itemstate.ItemDeepFetched{Repo: "owner/repo", Number: 1, FreshState: pi})
 
 	c.Reconcile(&gh.ProjectBoard{
 		ProjectID: "PID", Title: "T", OwnerType: "organization",
@@ -733,17 +732,15 @@ func TestReconcilePreservesDeepFields(t *testing.T) {
 		},
 	})
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	preserved := len(item.Comments) == 1 && item.Comments[0].ID == "C1"
-	deepFetched := c.deepFetched[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	preserved := len(s.Comments) == 1 && s.Comments[0].ID == "C1"
+	deepFetched := !s.LastDeepFetchAt.IsZero()
 
 	if !preserved {
 		t.Error("expected deep-fetched comments to be preserved after reconcile")
 	}
 	if !deepFetched {
-		t.Error("expected deepFetched flag to be preserved after reconcile")
+		t.Error("expected LastDeepFetchAt to be preserved after reconcile")
 	}
 }
 
@@ -763,9 +760,7 @@ func TestReconcileLinkageDriftInvalidatesDeepCache(t *testing.T) {
 	})
 
 	// Mark as deep-fetched with LinkedPRNumber=0 (linkage not yet visible on GitHub).
-	c.mu.Lock()
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
+	testSetDeepFetched(c, "owner/repo", 1)
 
 	// Board now shows LinkedPRNumberShallow=502 — linkage has materialized.
 	c.Reconcile(&gh.ProjectBoard{
@@ -776,12 +771,9 @@ func TestReconcileLinkageDriftInvalidatesDeepCache(t *testing.T) {
 		},
 	})
 
-	// deepFetched must be invalidated so next FetchItemDetails hits GitHub.
-	c.mu.RLock()
-	df := c.deepFetched[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
-	if df {
-		t.Error("expected deepFetched to be invalidated when linkage drift is detected")
+	// LastDeepFetchAt must be zeroed so next FetchItemDetails hits GitHub.
+	if testIsDeepFetched(c, "owner/repo", 1) {
+		t.Error("expected deep cache to be invalidated when linkage drift is detected")
 	}
 
 	// Next FetchItemDetails call must fall through to the mock (cache miss).
@@ -791,7 +783,7 @@ func TestReconcileLinkageDriftInvalidatesDeepCache(t *testing.T) {
 		t.Fatalf("FetchItemDetails returned error: %v", err)
 	}
 	if mc.fetchItemDetailsCount <= beforeCount {
-		t.Error("expected FetchItemDetails to call fallback after deepFetched was invalidated")
+		t.Error("expected FetchItemDetails to call fallback after deep cache was invalidated")
 	}
 	// The mock should have populated LinkedPRNumber=502 into item.
 	if item.LinkedPRNumber != 502 {
@@ -806,15 +798,12 @@ func TestReconcileRemovesStaleItems(t *testing.T) {
 		ProjectID: "PID", Title: "T", OwnerType: "organization",
 		Items: []gh.ProjectItem{
 			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research"},
-			// Item #2 removed from board
+			// Item #2 removed from board.
 		},
 	})
 
-	c.mu.RLock()
-	_, item2Exists := c.items[itemKey("owner/repo", 2)]
-	c.mu.RUnlock()
-
-	if item2Exists {
+	_, err := c.store.Get("owner/repo", 2)
+	if err == nil {
 		t.Error("item #2 should have been removed from cache after reconcile")
 	}
 }
@@ -830,16 +819,13 @@ func TestPauseStopsDeltaApplication(t *testing.T) {
 	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "blocked")
 	c.ApplyDelta("issues", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	for _, l := range item.Labels {
+	s := testGetState(t, c, "owner/repo", 1)
+	for _, l := range s.Labels {
 		if l == "blocked" {
-			c.mu.RUnlock()
 			t.Error("delta should not have been applied when paused")
 			return
 		}
 	}
-	c.mu.RUnlock()
 }
 
 func TestResumeReenablesDeltaApplication(t *testing.T) {
@@ -857,15 +843,13 @@ func TestResumeReenablesDeltaApplication(t *testing.T) {
 	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "newlabel")
 	c.ApplyDelta("issues", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
+	s := testGetState(t, c, "owner/repo", 1)
 	found := false
-	for _, l := range item.Labels {
+	for _, l := range s.Labels {
 		if l == "newlabel" {
 			found = true
 		}
 	}
-	c.mu.RUnlock()
 
 	if !found {
 		t.Error("delta should have been applied after resume")
@@ -878,45 +862,40 @@ func TestResumeReenablesDeltaApplication(t *testing.T) {
 
 func TestDeltaBumpsUpdatedAt(t *testing.T) {
 	c := seedCache(t)
+	key := itemKey("owner/repo", 1)
 
-	// Record item #1's initial UpdatedAt (zero from seed).
+	// Record initial localDeltaAt (zero before any webhook).
 	c.mu.RLock()
-	before := c.items[itemKey("owner/repo", 1)].UpdatedAt
+	before := c.localDeltaAt[key]
 	c.mu.RUnlock()
 
 	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "newlabel")
 	c.ApplyDelta("issues", payload)
 
 	c.mu.RLock()
-	after := c.items[itemKey("owner/repo", 1)].UpdatedAt
+	after := c.localDeltaAt[key]
 	c.mu.RUnlock()
 
 	if !after.After(before) {
-		t.Errorf("expected UpdatedAt to advance after labeled delta; before=%v after=%v", before, after)
+		t.Errorf("expected localDeltaAt to advance after labeled delta; before=%v after=%v", before, after)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Delta: pull_request_review_comment resets deepFetched for ReviewThreadID
+// Delta: pull_request_review_comment resets deep cache for ReviewThreadID
 // ---------------------------------------------------------------------------
 
 func TestDeltaReviewCommentResetsDeepFetched(t *testing.T) {
 	c := seedCache(t)
-	c.mu.Lock()
-	c.items[itemKey("owner/repo", 1)].LinkedPRNumber = 42
+	testSetLinkedPR(c, "owner/repo", 1, 42)
 	// Mark as already deep-fetched.
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
+	testSetDeepFetched(c, "owner/repo", 1)
 
 	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_node_2", "inline comment", "alice")
 	c.ApplyDelta("pull_request_review_comment", payload)
 
-	c.mu.RLock()
-	df := c.deepFetched[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
-
-	if df {
-		t.Error("expected deepFetched to be reset after review comment delta so next FetchItemDetails fetches ReviewThreadID from GitHub")
+	if testIsDeepFetched(c, "owner/repo", 1) {
+		t.Error("expected deep cache to be reset after review comment delta so next FetchItemDetails fetches ReviewThreadID from GitHub")
 	}
 }
 
@@ -996,15 +975,17 @@ func TestUpdateItemStatusSetsStatusAndUpdatedAt(t *testing.T) {
 	c.UpdateItemStatus(key, "Plan")
 	after := time.Now()
 
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Plan" {
+		t.Errorf("want Status %q, got %q", "Plan", s.Status)
+	}
+	// UpdateItemStatus bumps localDeltaAt (not item.UpdatedAt directly).
 	c.mu.RLock()
-	item := c.items[key]
+	deltaAt := c.localDeltaAt[key]
 	c.mu.RUnlock()
 
-	if item.Status != "Plan" {
-		t.Errorf("want Status %q, got %q", "Plan", item.Status)
-	}
-	if item.UpdatedAt.Before(before) || item.UpdatedAt.After(after) {
-		t.Errorf("UpdatedAt %v not in expected range [%v, %v]", item.UpdatedAt, before, after)
+	if deltaAt.Before(before) || deltaAt.After(after) {
+		t.Errorf("localDeltaAt %v not in expected range [%v, %v]", deltaAt, before, after)
 	}
 }
 
@@ -1020,11 +1001,9 @@ func TestUpdateItemStatusIsIdempotent(t *testing.T) {
 	c.UpdateItemStatus(key, "Plan")
 	c.UpdateItemStatus(key, "Plan")
 
-	c.mu.RLock()
-	item := c.items[key]
-	c.mu.RUnlock()
-	if item.Status != "Plan" {
-		t.Errorf("want Status %q after repeated calls, got %q", "Plan", item.Status)
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Plan" {
+		t.Errorf("want Status %q after repeated calls, got %q", "Plan", s.Status)
 	}
 }
 
@@ -1037,12 +1016,9 @@ func TestApplyStatusBatchUpdatesDriftedItems(t *testing.T) {
 	// PVTI_001 is item #1 (status "Research"); drift it to "Plan".
 	c.ApplyStatusBatch(map[string]string{"PVTI_001": "Plan"})
 
-	c.mu.RLock()
-	item := c.items[ItemKey("owner/repo", 1)]
-	c.mu.RUnlock()
-
-	if item.Status != "Plan" {
-		t.Errorf("want Status %q, got %q", "Plan", item.Status)
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Plan" {
+		t.Errorf("want Status %q, got %q", "Plan", s.Status)
 	}
 }
 
@@ -1051,18 +1027,18 @@ func TestApplyStatusBatchLeavesUndriftedItemsUnchanged(t *testing.T) {
 	key2 := ItemKey("owner/repo", 2)
 
 	c.mu.RLock()
-	origUpdatedAt := c.items[key2].UpdatedAt
+	origDeltaAt := c.localDeltaAt[key2]
 	c.mu.RUnlock()
 
-	// Item 2 already has Status "Plan" — sending same value should not change UpdatedAt.
+	// Item 2 already has Status "Plan" — sending same value should not bump localDeltaAt.
 	c.ApplyStatusBatch(map[string]string{"PVTI_002": "Plan"})
 
 	c.mu.RLock()
-	item := c.items[key2]
+	newDeltaAt := c.localDeltaAt[key2]
 	c.mu.RUnlock()
 
-	if item.UpdatedAt != origUpdatedAt {
-		t.Error("UpdatedAt should not change when Status is already up to date")
+	if newDeltaAt != origDeltaAt {
+		t.Error("localDeltaAt should not change when Status is already up to date")
 	}
 }
 
@@ -1070,8 +1046,8 @@ func TestApplyStatusBatchSkipsUnknownItemIDs(t *testing.T) {
 	c := seedCache(t)
 	// Should not panic or add entries for unknown PVTI IDs.
 	c.ApplyStatusBatch(map[string]string{"PVTI_UNKNOWN": "Done"})
-	if len(c.items) != 2 {
-		t.Errorf("item count should remain 2, got %d", len(c.items))
+	if len(c.store.All()) != 2 {
+		t.Errorf("item count should remain 2, got %d", len(c.store.All()))
 	}
 }
 
@@ -1117,7 +1093,7 @@ func TestProjectIDReturnsEmptyBeforeBootstrap(t *testing.T) {
 // Auto-heal: PR-targeted delta handlers repair stale LinkedPRNumber
 // ---------------------------------------------------------------------------
 
-// seedCacheWithPR seeds a cache with item #1 at LinkedPRNumber=0 and deepFetched=true.
+// seedCacheWithStalePRLink seeds a cache with item #1 at LinkedPRNumber=0 and deep-fetched.
 func seedCacheWithStalePRLink(t *testing.T, mc *mockClient) *CacheImpl {
 	t.Helper()
 	c := NewCacheImpl(mc, nopLog)
@@ -1129,10 +1105,8 @@ func seedCacheWithStalePRLink(t *testing.T, mc *mockClient) *CacheImpl {
 		},
 	}
 	c.Bootstrap(board)
-	// Mark as deep-fetched so we can verify deepFetched is cleared by heal.
-	c.mu.Lock()
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
+	// Mark as deep-fetched so we can verify deep cache is cleared by heal.
+	testSetDeepFetched(c, "owner/repo", 1)
 	return c
 }
 
@@ -1147,12 +1121,14 @@ func TestAutoHealPullRequestReviewSubmitted(t *testing.T) {
 	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 2001, "approved", "reviewer")
 	c.ApplyDelta("pull_request_review", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	linkedPR := item.LinkedPRNumber
-	reviews := clonePRReviews(item.LinkedPRReviews)
-	df := c.deepFetched[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var linkedPR int
+	var reviews []gh.PRReview
+	if s.LinkedPR != nil {
+		linkedPR = s.LinkedPR.Number
+		reviews = clonePRReviews(s.LinkedPR.Reviews)
+	}
+	df := testIsDeepFetched(c, "owner/repo", 1)
 
 	if linkedPR != 42 {
 		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
@@ -1161,7 +1137,7 @@ func TestAutoHealPullRequestReviewSubmitted(t *testing.T) {
 		t.Errorf("unexpected reviews after heal: %+v", reviews)
 	}
 	if df {
-		t.Error("expected deepFetched to be cleared after auto-heal")
+		t.Error("expected deep cache to be cleared after auto-heal")
 	}
 	if mc.fetchPRClosingIssuesCount != 1 {
 		t.Errorf("expected exactly 1 REST call, got %d", mc.fetchPRClosingIssuesCount)
@@ -1179,12 +1155,14 @@ func TestAutoHealPullRequestReviewCommentCreated(t *testing.T) {
 	payload := pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 300, "RC_heal_1", "inline comment", "reviewer")
 	c.ApplyDelta("pull_request_review_comment", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	linkedPR := item.LinkedPRNumber
-	comments := cloneComments(item.LinkedPRReviewThreadComments)
-	df := c.deepFetched[itemKey("owner/repo", 1)]
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var linkedPR int
+	var comments []gh.Comment
+	if s.LinkedPR != nil {
+		linkedPR = s.LinkedPR.Number
+		comments = cloneComments(s.LinkedPR.ThreadComments)
+	}
+	df := testIsDeepFetched(c, "owner/repo", 1)
 
 	if linkedPR != 42 {
 		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
@@ -1193,7 +1171,7 @@ func TestAutoHealPullRequestReviewCommentCreated(t *testing.T) {
 		t.Errorf("unexpected comments after heal: %+v", comments)
 	}
 	if df {
-		t.Error("expected deepFetched to be cleared after auto-heal")
+		t.Error("expected deep cache to be cleared after auto-heal")
 	}
 	if mc.fetchPRClosingIssuesCount != 1 {
 		t.Errorf("expected exactly 1 REST call, got %d", mc.fetchPRClosingIssuesCount)
@@ -1215,25 +1193,29 @@ func TestAutoHealCheckRunCompleted(t *testing.T) {
 	payload := checkRunPayloadJSON("completed", "owner/repo", 5001, "ci", "completed", "success", "sha_heal")
 	c.ApplyDelta("check_run", payload)
 
+	s := testGetState(t, c, "owner/repo", 1)
+	var linkedPR int
+	if s.LinkedPR != nil {
+		linkedPR = s.LinkedPR.Number
+	}
+	// SHA indexed in Store when item's LinkedPR.HeadSHA is set.
+	shaIndexed := s.LinkedPR != nil && s.LinkedPR.HeadSHA == "sha_heal"
+	df := testIsDeepFetched(c, "owner/repo", 1)
 	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	linkedPR := item.LinkedPRNumber
-	shaKey, shaOK := c.shaToKey["sha_heal"]
-	df := c.deepFetched[itemKey("owner/repo", 1)]
-	updatedAt := item.UpdatedAt
+	deltaAt := c.localDeltaAt[itemKey("owner/repo", 1)]
 	c.mu.RUnlock()
 
 	if linkedPR != 42 {
 		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
 	}
-	if !shaOK || shaKey != itemKey("owner/repo", 1) {
-		t.Errorf("expected shaToKey[sha_heal]=owner/repo#1, got %q (ok=%v)", shaKey, shaOK)
+	if !shaIndexed {
+		t.Errorf("expected SHA sha_heal to be stored in item's LinkedPR.HeadSHA")
 	}
 	if df {
-		t.Error("expected deepFetched to be cleared after auto-heal")
+		t.Error("expected deep cache to be cleared after auto-heal")
 	}
-	if !updatedAt.After(before) {
-		t.Error("expected UpdatedAt to be bumped after auto-heal")
+	if !deltaAt.After(before) {
+		t.Error("expected localDeltaAt to be bumped after auto-heal")
 	}
 	if mc.fetchPRsForSHACount != 1 {
 		t.Errorf("expected 1 FetchPRsForSHA call, got %d", mc.fetchPRsForSHACount)
@@ -1258,11 +1240,13 @@ func TestAutoHealDropsWhenNoPRClosingKeyword(t *testing.T) {
 	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 99, 3001, "approved", "bot")
 	c.ApplyDelta("pull_request_review", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	linkedPR := item.LinkedPRNumber
-	reviews := clonePRReviews(item.LinkedPRReviews)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var linkedPR int
+	var reviews []gh.PRReview
+	if s.LinkedPR != nil {
+		linkedPR = s.LinkedPR.Number
+		reviews = clonePRReviews(s.LinkedPR.Reviews)
+	}
 
 	if linkedPR != 0 {
 		t.Errorf("expected LinkedPRNumber=0 (no mutation), got %d", linkedPR)
@@ -1286,11 +1270,13 @@ func TestAutoHealDropsSilentlyWhenIssuNotInCache(t *testing.T) {
 	payload := pullRequestReviewPayloadJSON("submitted", "owner/repo", 77, 4001, "approved", "bot")
 	c.ApplyDelta("pull_request_review", payload)
 
-	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	linkedPR := item.LinkedPRNumber
-	reviews := clonePRReviews(item.LinkedPRReviews)
-	c.mu.RUnlock()
+	s := testGetState(t, c, "owner/repo", 1)
+	var linkedPR int
+	var reviews []gh.PRReview
+	if s.LinkedPR != nil {
+		linkedPR = s.LinkedPR.Number
+		reviews = clonePRReviews(s.LinkedPR.Reviews)
+	}
 
 	if linkedPR != 0 {
 		t.Errorf("expected no mutation (issue not in cache), got LinkedPRNumber=%d", linkedPR)
@@ -1335,25 +1321,28 @@ func TestAutoHealPullRequestDelta(t *testing.T) {
 	payload := pullRequestPayloadJSON("opened", "owner/repo", 42, "sha_heal_pr", "open", false, false)
 	c.ApplyDelta("pull_request", payload)
 
+	s := testGetState(t, c, "owner/repo", 1)
+	var linkedPR int
+	if s.LinkedPR != nil {
+		linkedPR = s.LinkedPR.Number
+	}
+	shaIndexed := s.LinkedPR != nil && s.LinkedPR.HeadSHA == "sha_heal_pr"
+	df := testIsDeepFetched(c, "owner/repo", 1)
 	c.mu.RLock()
-	item := c.items[itemKey("owner/repo", 1)]
-	linkedPR := item.LinkedPRNumber
-	shaKey, shaOK := c.shaToKey["sha_heal_pr"]
-	df := c.deepFetched[itemKey("owner/repo", 1)]
-	updatedAt := item.UpdatedAt
+	deltaAt := c.localDeltaAt[itemKey("owner/repo", 1)]
 	c.mu.RUnlock()
 
 	if linkedPR != 42 {
 		t.Errorf("expected LinkedPRNumber=42 after heal, got %d", linkedPR)
 	}
-	if !shaOK || shaKey != itemKey("owner/repo", 1) {
-		t.Errorf("expected shaToKey[sha_heal_pr]=%q, got %q (ok=%v)", itemKey("owner/repo", 1), shaKey, shaOK)
+	if !shaIndexed {
+		t.Errorf("expected SHA sha_heal_pr to be stored in item's LinkedPR.HeadSHA")
 	}
 	if df {
-		t.Error("expected deepFetched to be cleared after auto-heal")
+		t.Error("expected deep cache to be cleared after auto-heal")
 	}
-	if !updatedAt.After(before) {
-		t.Error("expected UpdatedAt to be bumped after auto-heal")
+	if !deltaAt.After(before) {
+		t.Error("expected localDeltaAt to be bumped after auto-heal")
 	}
 	if mc.fetchPRClosingIssuesCount != 1 {
 		t.Errorf("expected exactly 1 REST call, got %d", mc.fetchPRClosingIssuesCount)
@@ -1372,8 +1361,6 @@ func seedCacheWithStalePRLink2(t *testing.T, logFn func(string, ...any)) *CacheI
 		},
 	}
 	c.Bootstrap(board)
-	c.mu.Lock()
-	c.deepFetched[itemKey("owner/repo", 1)] = true
-	c.mu.Unlock()
+	testSetDeepFetched(c, "owner/repo", 1)
 	return c
 }

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 )
 
 // ApplyDelta dispatches a webhook payload to the appropriate typed delta function.
@@ -162,47 +163,8 @@ type projectsV2ItemPayload struct {
 }
 
 // ---------------------------------------------------------------------------
-// Inner-mutation helpers — called by both normal and post-heal paths
+// Helpers
 // ---------------------------------------------------------------------------
-
-// applyReviewToItem upserts a PR review into the item's LinkedPRReviews by DatabaseID.
-func applyReviewToItem(item *gh.ProjectItem, review gh.PRReview) {
-	for i, r := range item.LinkedPRReviews {
-		if r.DatabaseID == review.DatabaseID && review.DatabaseID != 0 {
-			item.LinkedPRReviews[i] = review
-			return
-		}
-	}
-	item.LinkedPRReviews = append(item.LinkedPRReviews, review)
-}
-
-// applyReviewCommentToItem appends a review thread comment to the item if not already
-// present (idempotent by NodeID), and clears the deepFetched flag so the next
-// FetchItemDetails call re-fetches the ReviewThreadID from GitHub.
-// Returns true if the comment was added, false if it was a duplicate.
-func applyReviewCommentToItem(item *gh.ProjectItem, comment gh.Comment, key string, deepFetched map[string]bool) bool {
-	for _, existing := range item.LinkedPRReviewThreadComments {
-		if existing.ID == comment.ID {
-			return false
-		}
-	}
-	item.LinkedPRReviewThreadComments = append(item.LinkedPRReviewThreadComments, comment)
-	delete(deepFetched, key)
-	return true
-}
-
-// updateSHAToKey removes stale SHA entries for the given key and sets the new SHA.
-func updateSHAToKey(shaToKey map[string]string, sha, key string) {
-	if sha == "" {
-		return
-	}
-	for existingSHA, existingKey := range shaToKey {
-		if existingKey == key && existingSHA != sha {
-			delete(shaToKey, existingSHA)
-		}
-	}
-	shaToKey[sha] = key
-}
 
 // splitRepo splits "owner/repo" into ("owner", "repo", true). Returns false on invalid input.
 func splitRepo(fullName string) (owner, repo string, ok bool) {
@@ -211,6 +173,15 @@ func splitRepo(fullName string) (owner, repo string, ok bool) {
 		return "", "", false
 	}
 	return parts[0], parts[1], true
+}
+
+// bumpLocalDeltaAt records that a webhook has touched the item at key.
+// Must be called WITHOUT holding c.mu.
+func (c *CacheImpl) bumpLocalDeltaAt(key string) {
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
 }
 
 // ---------------------------------------------------------------------------
@@ -222,7 +193,9 @@ func (c *CacheImpl) applyIssueCommentCreated(payload []byte) {
 	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "created" {
 		return
 	}
-	key := itemKey(p.Repository.FullName, p.Issue.Number)
+	fullRepo := p.Repository.FullName
+	issNum := p.Issue.Number
+	key := itemKey(fullRepo, issNum)
 
 	createdAt, _ := time.Parse(time.RFC3339, p.Comment.CreatedAt)
 	comment := gh.Comment{
@@ -233,21 +206,20 @@ func (c *CacheImpl) applyIssueCommentCreated(payload []byte) {
 		CreatedAt:  createdAt,
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	item, ok := c.items[key]
-	if !ok {
+	// Guard: only apply to items already in the Store.
+	if _, err := c.store.Get(fullRepo, issNum); err != nil {
 		return
 	}
-	// Idempotent: skip if comment with this ID already exists.
-	for _, existing := range item.Comments {
-		if existing.ID == comment.ID {
-			return
-		}
+
+	_, changes, _ := c.store.Apply(itemstate.IssueCommentCreated{
+		Repo:    fullRepo,
+		Number:  issNum,
+		Comment: comment,
+	})
+	if len(changes) == 0 {
+		return // no-op (duplicate comment or item missing)
 	}
-	item.Comments = append(item.Comments, comment)
-	// Bump UpdatedAt so itemMayNeedWork detects this item as changed on the next poll.
-	item.UpdatedAt = time.Now()
+	c.bumpLocalDeltaAt(key)
 }
 
 func (c *CacheImpl) applyIssuesDelta(payload []byte) {
@@ -264,44 +236,43 @@ func (c *CacheImpl) applyIssuesDelta(payload []byte) {
 }
 
 func (c *CacheImpl) applyIssuesLabeled(p issuesPayload) {
-	key := itemKey(p.Repository.FullName, p.Issue.Number)
+	fullRepo := p.Repository.FullName
+	issNum := p.Issue.Number
+	key := itemKey(fullRepo, issNum)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	item, ok := c.items[key]
-	if !ok {
+	if _, err := c.store.Get(fullRepo, issNum); err != nil {
 		return
 	}
-	// Set-membership add: skip if label already present.
-	for _, l := range item.Labels {
-		if l == p.Label.Name {
-			return
-		}
+
+	_, changes, _ := c.store.Apply(itemstate.IssueLabeled{
+		Repo:   fullRepo,
+		Number: issNum,
+		Label:  p.Label.Name,
+	})
+	if len(changes) == 0 {
+		return // no-op (label already present or item missing)
 	}
-	item.Labels = append(item.Labels, p.Label.Name)
-	item.UpdatedAt = time.Now()
+	c.bumpLocalDeltaAt(key)
 }
 
 func (c *CacheImpl) applyIssuesUnlabeled(p issuesPayload) {
-	key := itemKey(p.Repository.FullName, p.Issue.Number)
+	fullRepo := p.Repository.FullName
+	issNum := p.Issue.Number
+	key := itemKey(fullRepo, issNum)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	item, ok := c.items[key]
-	if !ok {
+	if _, err := c.store.Get(fullRepo, issNum); err != nil {
 		return
 	}
-	before := len(item.Labels)
-	filtered := item.Labels[:0]
-	for _, l := range item.Labels {
-		if l != p.Label.Name {
-			filtered = append(filtered, l)
-		}
+
+	_, changes, _ := c.store.Apply(itemstate.IssueUnlabeled{
+		Repo:   fullRepo,
+		Number: issNum,
+		Label:  p.Label.Name,
+	})
+	if len(changes) == 0 {
+		return
 	}
-	item.Labels = filtered
-	if len(item.Labels) < before {
-		item.UpdatedAt = time.Now()
-	}
+	c.bumpLocalDeltaAt(key)
 }
 
 func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
@@ -334,34 +305,37 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		return
 	}
 
-	c.mu.Lock()
-
 	// Always store/update PR details regardless of whether we find a linked issue.
+	c.mu.Lock()
 	c.linkedPRs[pk] = prDetails
+	issKey, issFound := c.prNumToKey[pk]
+	c.mu.Unlock()
 
-	// Find the issue in cache that links this PR and update shaToKey.
-	for key, item := range c.items {
-		if item.Repo == repo && item.LinkedPRNumber == prNum {
-			updateSHAToKey(c.shaToKey, sha, key)
-			c.mu.Unlock()
-			return
+	if issFound {
+		// Normal path: linked issue is already known.
+		issRepo, issNum2, parseOK := parseItemKey(issKey)
+		if parseOK {
+			c.store.Apply(itemstate.PRHeadSHAUpdated{
+				Repo:   issRepo,
+				Number: issNum2,
+				SHA:    sha,
+			})
+			c.bumpLocalDeltaAt(issKey)
 		}
+		return
 	}
 
 	// Miss: check negative cache.
 	mk := missKey(repo, prNum)
-	if t, found := c.recentMissCache[mk]; found {
-		if time.Since(t) < recentMissTTL {
-			c.mu.Unlock()
-			return
-		}
-		delete(c.recentMissCache, mk)
+	c.mu.RLock()
+	if t, found := c.recentMissCache[mk]; found && time.Since(t) < recentMissTTL {
+		c.mu.RUnlock()
+		return
 	}
-
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	// Auto-heal: resolve PR linkage via REST.
-	key, _, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
+	key, resolvedIssNum, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
@@ -372,19 +346,24 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		c.logFn("[cache] dropped pull_request delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	item, itemOK := c.items[key]
-	if !itemOK {
+	// Confirm item still in Store before updating prNumToKey.
+	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return
 	}
-	item.LinkedPRNumber = prNum
-	delete(c.deepFetched, key)
-	item.UpdatedAt = time.Now()
-	updateSHAToKey(c.shaToKey, sha, key)
-	issNum := item.Number
+	c.prNumToKey[pk] = key
 	c.mu.Unlock()
-	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, issNum)
+
+	c.store.Apply(itemstate.PRHeadSHAUpdated{
+		Repo:        repo,
+		Number:      resolvedIssNum,
+		LinkedPRNum: prNum,
+		SHA:         sha,
+	})
+	c.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: resolvedIssNum})
+	c.bumpLocalDeltaAt(key)
+	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, resolvedIssNum)
 }
 
 func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
@@ -394,6 +373,7 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 	}
 	repo := p.Repository.FullName
 	prNum := p.PullRequest.Number
+	pk := prKey(repo, prNum)
 
 	owner, repoName, ok := splitRepo(repo)
 	if !ok {
@@ -407,33 +387,36 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 		DatabaseID: p.Review.DatabaseID,
 	}
 
-	c.mu.Lock()
+	// Normal path: look up issue via prNumToKey.
+	c.mu.RLock()
+	issKey, issFound := c.prNumToKey[pk]
+	c.mu.RUnlock()
 
-	// Normal path: find the item with this PR linked.
-	for _, item := range c.items {
-		if item.Repo == repo && item.LinkedPRNumber == prNum {
-			applyReviewToItem(item, review)
-			item.UpdatedAt = time.Now()
-			c.mu.Unlock()
-			return
+	if issFound {
+		issRepo, issNum, parseOK := parseItemKey(issKey)
+		if parseOK {
+			c.store.Apply(itemstate.PRReviewSubmitted{
+				Repo:   issRepo,
+				Number: issNum,
+				Review: review,
+			})
+			c.bumpLocalDeltaAt(issKey)
 		}
+		return
 	}
 
 	// Miss: check negative cache.
 	mk := missKey(repo, prNum)
-	if t, found := c.recentMissCache[mk]; found {
-		if time.Since(t) < recentMissTTL {
-			c.mu.Unlock()
-			c.logFn("[cache] dropped pull_request_review delta for PR #%d: negative cache hit\n", prNum)
-			return
-		}
-		delete(c.recentMissCache, mk)
+	c.mu.RLock()
+	if t, found := c.recentMissCache[mk]; found && time.Since(t) < recentMissTTL {
+		c.mu.RUnlock()
+		c.logFn("[cache] dropped pull_request_review delta for PR #%d: negative cache hit\n", prNum)
+		return
 	}
-
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	// Auto-heal: resolve PR linkage via REST.
-	key, _, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
+	key, resolvedIssNum, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
@@ -444,19 +427,27 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 		c.logFn("[cache] dropped pull_request_review delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	item, itemOK := c.items[key]
-	if !itemOK {
+	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return
 	}
-	item.LinkedPRNumber = prNum
-	delete(c.deepFetched, key)
-	item.UpdatedAt = time.Now()
-	applyReviewToItem(item, review)
-	issNum := item.Number
+	c.prNumToKey[pk] = key
 	c.mu.Unlock()
-	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, issNum)
+
+	c.store.Apply(itemstate.PRHeadSHAUpdated{
+		Repo:        repo,
+		Number:      resolvedIssNum,
+		LinkedPRNum: prNum,
+	})
+	c.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: resolvedIssNum})
+	c.store.Apply(itemstate.PRReviewSubmitted{
+		Repo:   repo,
+		Number: resolvedIssNum,
+		Review: review,
+	})
+	c.bumpLocalDeltaAt(key)
+	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, resolvedIssNum)
 }
 
 func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
@@ -466,6 +457,7 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 	}
 	repo := p.Repository.FullName
 	prNum := p.PullRequest.Number
+	pk := prKey(repo, prNum)
 
 	owner, repoName, ok := splitRepo(repo)
 	if !ok {
@@ -490,34 +482,40 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 		comment.OriginalLine = *p.Comment.OriginalLine
 	}
 
-	c.mu.Lock()
+	// Normal path: look up issue via prNumToKey.
+	c.mu.RLock()
+	issKey, issFound := c.prNumToKey[pk]
+	c.mu.RUnlock()
 
-	// Normal path: find the item with this PR linked.
-	for key, item := range c.items {
-		if item.Repo == repo && item.LinkedPRNumber == prNum {
-			if applyReviewCommentToItem(item, comment, key, c.deepFetched) {
-				item.UpdatedAt = time.Now()
+	if issFound {
+		issRepo, issNum, parseOK := parseItemKey(issKey)
+		if parseOK {
+			_, changes, _ := c.store.Apply(itemstate.ReviewThreadCommentAdded{
+				Repo:        issRepo,
+				IssueNumber: issNum,
+				Comment:     comment,
+			})
+			if len(changes) > 0 {
+				// New comment: invalidate deep cache (ReviewThreadID not yet populated).
+				c.store.Apply(itemstate.DeepFetchInvalidated{Repo: issRepo, Number: issNum})
+				c.bumpLocalDeltaAt(issKey)
 			}
-			c.mu.Unlock()
-			return
 		}
+		return
 	}
 
 	// Miss: check negative cache.
 	mk := missKey(repo, prNum)
-	if t, found := c.recentMissCache[mk]; found {
-		if time.Since(t) < recentMissTTL {
-			c.mu.Unlock()
-			c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: negative cache hit\n", prNum)
-			return
-		}
-		delete(c.recentMissCache, mk)
+	c.mu.RLock()
+	if t, found := c.recentMissCache[mk]; found && time.Since(t) < recentMissTTL {
+		c.mu.RUnlock()
+		c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: negative cache hit\n", prNum)
+		return
 	}
-
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	// Auto-heal: resolve PR linkage via REST.
-	key, _, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
+	key, resolvedIssNum, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
@@ -528,19 +526,27 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 		c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	item, itemOK := c.items[key]
-	if !itemOK {
+	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return
 	}
-	item.LinkedPRNumber = prNum
-	delete(c.deepFetched, key)
-	item.UpdatedAt = time.Now()
-	applyReviewCommentToItem(item, comment, key, c.deepFetched)
-	issNum := item.Number
+	c.prNumToKey[pk] = key
 	c.mu.Unlock()
-	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, issNum)
+
+	c.store.Apply(itemstate.PRHeadSHAUpdated{
+		Repo:        repo,
+		Number:      resolvedIssNum,
+		LinkedPRNum: prNum,
+	})
+	c.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: resolvedIssNum})
+	c.store.Apply(itemstate.ReviewThreadCommentAdded{
+		Repo:        repo,
+		IssueNumber: resolvedIssNum,
+		Comment:     comment,
+	})
+	c.bumpLocalDeltaAt(key)
+	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, resolvedIssNum)
 }
 
 func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
@@ -566,9 +572,10 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 		Conclusion: p.CheckRun.Conclusion,
 	}
 
+	// Always upsert the check run by ID into CacheImpl's checkRuns map.
+	// This keeps pre-linkage runs available via FetchCheckRuns even before
+	// the SHA↔item linkage is established in the Store.
 	c.mu.Lock()
-
-	// Always upsert the check run by ID.
 	runs := c.checkRuns[sha]
 	updated := false
 	for i, existing := range runs {
@@ -582,27 +589,29 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 		runs = append(runs, cr)
 	}
 	c.checkRuns[sha] = runs
+	c.mu.Unlock()
 
-	// shaToKey reverse lookup: if found, bump UpdatedAt on the linked issue.
-	if key, found := c.shaToKey[sha]; found {
-		if item, ok := c.items[key]; ok {
-			item.UpdatedAt = time.Now()
-		}
-		c.mu.Unlock()
+	// Also apply to the Store — only works if SHA is indexed in Store's shaToKey.
+	snap, changes, _ := c.store.Apply(itemstate.CheckRunCompleted{
+		Repo: repo,
+		SHA:  sha,
+		Run:  cr,
+	})
+	if len(changes) > 0 {
+		// SHA was known — bump localDeltaAt and return.
+		key := itemKey(snap.Repo(), snap.Number())
+		c.bumpLocalDeltaAt(key)
 		return
 	}
 
-	// shaToKey miss: check negative cache for this SHA.
+	// SHA not in Store's shaToKey index — check negative cache.
 	msha := missKeyForSHA(sha)
-	if t, found := c.recentMissCache[msha]; found {
-		if time.Since(t) < recentMissTTL {
-			c.mu.Unlock()
-			return
-		}
-		delete(c.recentMissCache, msha)
+	c.mu.RLock()
+	if t, found := c.recentMissCache[msha]; found && time.Since(t) < recentMissTTL {
+		c.mu.RUnlock()
+		return
 	}
-
-	c.mu.Unlock()
+	c.mu.RUnlock()
 
 	// Auto-heal step 1: fetch PRs associated with this SHA.
 	prNums, err := c.fallback.FetchPRsForSHA(owner, repoName, sha)
@@ -621,7 +630,7 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	prNum := prNums[0]
 
 	// Auto-heal step 2: resolve which issue the PR closes.
-	key, issNum, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
+	key, resolvedIssNum, found, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
 	c.mu.Lock()
 	if !found {
@@ -632,18 +641,29 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 		c.logFn("[cache] dropped check_run delta for SHA %s: no closing issue in cache for PR #%d\n", sha, prNum)
 		return
 	}
-	item, itemOK := c.items[key]
-	if !itemOK {
+	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
 		c.recentMissCache[msha] = time.Now()
 		c.mu.Unlock()
 		return
 	}
-	item.LinkedPRNumber = prNum
-	c.shaToKey[sha] = key
-	delete(c.deepFetched, key)
-	item.UpdatedAt = time.Now()
+	pk := prKey(repo, prNum)
+	c.prNumToKey[pk] = key
 	c.mu.Unlock()
-	c.logFn("[cache] auto-heal: check_run SHA %s → PR #%d → issue #%d; deep cache invalidated\n", sha, prNum, issNum)
+
+	// Update Store: set LinkedPRNum + SHA (updates shaToKey index), invalidate deep cache.
+	c.store.Apply(itemstate.PRHeadSHAUpdated{
+		Repo:        repo,
+		Number:      resolvedIssNum,
+		LinkedPRNum: prNum,
+		SHA:         sha,
+	})
+	c.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: resolvedIssNum})
+
+	// Now that shaToKey is updated, replay the CheckRunCompleted on the Store.
+	c.store.Apply(itemstate.CheckRunCompleted{Repo: repo, SHA: sha, Run: cr})
+
+	c.bumpLocalDeltaAt(key)
+	c.logFn("[cache] auto-heal: check_run SHA %s → PR #%d → issue #%d; deep cache invalidated\n", sha, prNum, resolvedIssNum)
 }
 
 func (c *CacheImpl) applyProjectsV2ItemEdited(payload []byte) {
@@ -663,17 +683,13 @@ func (c *CacheImpl) applyProjectsV2ItemEdited(payload []byte) {
 	}
 	itemID := p.ProjectsV2Item.ID
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	key, ok := c.itemIDToKey[itemID]
-	if !ok {
+	snap, changes, _ := c.store.Apply(itemstate.ProjectV2ItemEdited{
+		ItemID:    itemID,
+		NewStatus: newStatus,
+	})
+	if len(changes) == 0 {
 		return
 	}
-	item, ok := c.items[key]
-	if !ok {
-		return
-	}
-	item.Status = newStatus
-	item.UpdatedAt = time.Now()
+	key := itemKey(snap.Repo(), snap.Number())
+	c.bumpLocalDeltaAt(key)
 }

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -1,0 +1,316 @@
+package boardcache
+
+// Delegation-correctness tests for Phase 3-B.
+//
+// These tests verify that CacheImpl correctly delegates to itemstate.Store
+// internally while preserving all public-API semantics. They complement the
+// behavioral tests in boardcache_test.go with focused Store-delegation checks.
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
+)
+
+// ---------------------------------------------------------------------------
+// 1. Bootstrap store-delegation
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationBootstrap(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, nopLog)
+	board := &gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Research", Labels: []string{"a"}},
+			{ID: "I_2", ItemID: "PVTI_2", Number: 2, Repo: "owner/repo", Status: "Plan"},
+		},
+	}
+	c.Bootstrap(board)
+
+	// All items accessible via store.Get.
+	snap1, err := c.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get(1): %v", err)
+	}
+	if snap1.State().Status != "Research" {
+		t.Errorf("item1 Status: want Research, got %q", snap1.State().Status)
+	}
+	if !containsStr(snap1.Labels(), "a") {
+		t.Errorf("item1 Labels: want [a], got %v", snap1.Labels())
+	}
+
+	snap2, err := c.store.Get("owner/repo", 2)
+	if err != nil {
+		t.Fatalf("store.Get(2): %v", err)
+	}
+	if snap2.State().Status != "Plan" {
+		t.Errorf("item2 Status: want Plan, got %q", snap2.State().Status)
+	}
+
+	// store.All returns both items.
+	all := c.store.All()
+	if len(all) != 2 {
+		t.Errorf("store.All: want 2 items, got %d", len(all))
+	}
+
+	// FetchProjectBoard reconstructs identical board.
+	fetched, err := c.FetchProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(fetched.Items) != 2 {
+		t.Errorf("FetchProjectBoard: want 2 items, got %d", len(fetched.Items))
+	}
+	if fetched.ProjectID != "PID" {
+		t.Errorf("FetchProjectBoard.ProjectID: want PID, got %q", fetched.ProjectID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Reconcile drift log
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationReconcile(t *testing.T) {
+	var logBuf []string
+	logFn := func(format string, args ...any) { logBuf = append(logBuf, format) }
+	c := NewCacheImpl(&mockClient{}, logFn)
+	c.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Research"},
+			{ID: "I_2", ItemID: "PVTI_2", Number: 2, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+
+	// Item 1 status changed.
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Implement"},
+			{ID: "I_2", ItemID: "PVTI_2", Number: 2, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+
+	// Store reflects the new status.
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Implement" {
+		t.Errorf("after Reconcile: want Status Implement, got %q", s.Status)
+	}
+
+	// "[reconciliation] N items differed" log was emitted.
+	foundReconciliationLog := false
+	for _, line := range logBuf {
+		if len(line) >= 16 && line[:16] == "[reconciliation]" {
+			foundReconciliationLog = true
+			break
+		}
+	}
+	if !foundReconciliationLog {
+		t.Errorf("expected [reconciliation] log, got: %v", logBuf)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Per-action delta delegation — labeled
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationDeltaLabeled(t *testing.T) {
+	c := seedCache(t)
+	payload := issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "priority")
+	c.ApplyDelta("issues", payload)
+
+	snap, err := c.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if !containsStr(snap.Labels(), "priority") {
+		t.Errorf("Store.Labels after labeled delta: want priority, got %v", snap.Labels())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Per-action delta delegation — unlabeled
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationDeltaUnlabeled(t *testing.T) {
+	c := seedCache(t)
+	// Item #1 starts with "enhancement".
+	payload := issuesLabeledPayloadJSON("unlabeled", "owner/repo", 1, "enhancement")
+	c.ApplyDelta("issues", payload)
+
+	snap, err := c.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if containsStr(snap.Labels(), "enhancement") {
+		t.Errorf("Store.Labels after unlabeled: enhancement should be gone, got %v", snap.Labels())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Per-action delta delegation — issue_comment.created
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationDeltaComment(t *testing.T) {
+	c := seedCache(t)
+	payload := issueCommentPayloadJSON("created", "owner/repo", 1, "NC_1", 42, "hello", "alice")
+	c.ApplyDelta("issue_comment", payload)
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if len(s.Comments) != 1 || s.Comments[0].DatabaseID != 42 {
+		t.Errorf("Store.Comments after comment delta: want [{DatabaseID:42}], got %+v", s.Comments)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Per-action delta delegation — pull_request SHA update
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationDeltaPRSync(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 10)
+
+	payload := pullRequestPayloadJSON("synchronize", "owner/repo", 10, "sha_sync", "open", false, false)
+	c.ApplyDelta("pull_request", payload)
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || s.LinkedPR.HeadSHA != "sha_sync" {
+		t.Errorf("Store.LinkedPR.HeadSHA after PR sync: want sha_sync, got %v", s.LinkedPR)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. Per-action delta delegation — check_run routes via shaToKey
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationDeltaCheckRunViaSHA(t *testing.T) {
+	c := seedCache(t)
+	// Establish SHA → issue mapping via PR delta.
+	testSetLinkedPR(c, "owner/repo", 1, 10)
+	c.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha_ci"})
+
+	payload := checkRunPayloadJSON("completed", "owner/repo", 7777, "ci", "completed", "success", "sha_ci")
+	c.ApplyDelta("check_run", payload)
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || len(s.LinkedPR.CheckRuns) != 1 || s.LinkedPR.CheckRuns[0].ID != 7777 {
+		t.Errorf("Store.LinkedPR.CheckRuns after check_run: want [{ID:7777}], got %v", s.LinkedPR)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 8. Per-action delta delegation — projects_v2_item.edited via itemIDToKey
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationDeltaStatusEditViaItemID(t *testing.T) {
+	c := seedCache(t)
+	// PVTI_001 → item #1 (itemIDToKey index set by Bootstrap).
+	payload := projectsV2ItemPayloadJSON("edited", "PVTI_001", "Review")
+	c.ApplyDelta("projects_v2_item", payload)
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Status != "Review" {
+		t.Errorf("Store.Status after projects_v2_item edited: want Review, got %q", s.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 9. Concurrent access — race detector clean
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationConcurrentAccess(t *testing.T) {
+	c := seedCache(t)
+
+	var wg sync.WaitGroup
+	const goroutines = 100
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			switch idx % 5 {
+			case 0:
+				// Read via FetchProjectBoard.
+				c.FetchProjectBoard("owner", "repo", 1, "organization")
+			case 1:
+				// Write via ApplyDelta labeled.
+				label := "label-concurrent"
+				c.ApplyDelta("issues", issuesLabeledPayloadJSON("labeled", "owner/repo", 1, label))
+			case 2:
+				// Write via ApplyDelta unlabeled.
+				c.ApplyDelta("issues", issuesLabeledPayloadJSON("unlabeled", "owner/repo", 1, "label-concurrent"))
+			case 3:
+				// Read via store.Get.
+				c.store.Get("owner/repo", 1)
+			case 4:
+				// Write via UpdateItemStatus.
+				c.UpdateItemStatus(ItemKey("owner/repo", 1), "Research")
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify cache is still consistent.
+	_, err := c.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Errorf("store.Get after concurrent access: %v", err)
+	}
+	if len(c.store.All()) != 2 {
+		t.Errorf("store.All after concurrent access: want 2 items, got %d", len(c.store.All()))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 10. Negative cache TTL — expired entry allows fresh REST call
+// ---------------------------------------------------------------------------
+
+func TestStoreDelegationNegativeCacheTTLExpiry(t *testing.T) {
+	callCount := 0
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			callCount++
+			return nil, nil // no closing reference
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc)
+
+	// First delta — triggers REST call and populates negative cache.
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 33, 9001, "approved", "bot"))
+	if callCount != 1 {
+		t.Fatalf("want 1 REST call after first delta, got %d", callCount)
+	}
+
+	// Immediately replay — negative cache blocks second REST call.
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 33, 9002, "approved", "bot2"))
+	if callCount != 1 {
+		t.Errorf("want negative cache to block second REST call, got %d total calls", callCount)
+	}
+
+	// Manually expire the negative cache entry by back-dating it.
+	mk := missKey("owner/repo", 33)
+	c.mu.Lock()
+	c.recentMissCache[mk] = time.Now().Add(-(recentMissTTL + time.Second))
+	c.mu.Unlock()
+
+	// After TTL expiry, the REST call fires again.
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 33, 9003, "approved", "bot3"))
+	if callCount != 2 {
+		t.Errorf("want 2 REST calls after TTL expiry, got %d", callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func containsStr(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -56,7 +56,12 @@ func TestStoreDelegationBootstrap(t *testing.T) {
 		t.Errorf("store.All: want 2 items, got %d", len(all))
 	}
 
-	// FetchProjectBoard reconstructs identical board.
+	// Store preserves the content node ID (used by github.Client.FetchItemDetails GraphQL query).
+	if snap1.State().ID != "I_1" {
+		t.Errorf("store.Get(1) ID: want I_1, got %q", snap1.State().ID)
+	}
+
+	// FetchProjectBoard reconstructs identical board with ID preserved.
 	fetched, err := c.FetchProjectBoard("owner", "repo", 1, "organization")
 	if err != nil {
 		t.Fatalf("FetchProjectBoard: %v", err)
@@ -66,6 +71,16 @@ func TestStoreDelegationBootstrap(t *testing.T) {
 	}
 	if fetched.ProjectID != "PID" {
 		t.Errorf("FetchProjectBoard.ProjectID: want PID, got %q", fetched.ProjectID)
+	}
+	// Verify ID is present in reconstructed board items so FetchItemDetails GraphQL queries work.
+	found := false
+	for _, item := range fetched.Items {
+		if item.Number == 1 && item.ID == "I_1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FetchProjectBoard: item #1 ID not preserved; want I_1 in reconstructed items")
 	}
 }
 
@@ -299,6 +314,82 @@ func TestStoreDelegationNegativeCacheTTLExpiry(t *testing.T) {
 	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 33, 9003, "approved", "bot3"))
 	if callCount != 2 {
 		t.Errorf("want 2 REST calls after TTL expiry, got %d", callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 11. FetchItemDetails backfills prNumToKey so PR review/comment deltas route
+//     without auto-heal after the first deep fetch.
+// ---------------------------------------------------------------------------
+
+func TestFetchItemDetailsBackfillsPrNumToKey(t *testing.T) {
+	mc := &mockClient{
+		itemDetailsResult: &gh.ProjectItem{
+			Body:           "body",
+			Author:         "alice",
+			LinkedPRNumber: 42,
+		},
+	}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Research"},
+		},
+	})
+
+	item := gh.ProjectItem{ID: "I_1", Number: 1, Repo: "owner/repo"}
+	if err := c.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+	if item.LinkedPRNumber != 42 {
+		t.Fatalf("want LinkedPRNumber 42, got %d", item.LinkedPRNumber)
+	}
+
+	// prNumToKey must be backfilled so PR deltas can route by PR number.
+	pk := prKey("owner/repo", 42)
+	c.mu.RLock()
+	issKey, found := c.prNumToKey[pk]
+	c.mu.RUnlock()
+	if !found {
+		t.Errorf("prNumToKey not backfilled after FetchItemDetails with LinkedPRNumber=42")
+	}
+	wantKey := itemKey("owner/repo", 1)
+	if issKey != wantKey {
+		t.Errorf("prNumToKey: want %q, got %q", wantKey, issKey)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 12. Reconcile item removal cleans up stale prNumToKey entries.
+// ---------------------------------------------------------------------------
+
+func TestReconcileRemoveCleansUpPrNumToKey(t *testing.T) {
+	c := seedCache(t)
+	// Establish PR linkage for item #1 → PR #10.
+	testSetLinkedPR(c, "owner/repo", 1, 10)
+
+	pk := prKey("owner/repo", 10)
+	c.mu.RLock()
+	_, beforeReconcile := c.prNumToKey[pk]
+	c.mu.RUnlock()
+	if !beforeReconcile {
+		t.Fatalf("prNumToKey for PR #10 not set before Reconcile")
+	}
+
+	// Reconcile with a board that no longer contains item #1.
+	c.Reconcile(&gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_002", ItemID: "PVTI_002", Number: 2, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+
+	c.mu.RLock()
+	_, afterReconcile := c.prNumToKey[pk]
+	c.mu.RUnlock()
+	if afterReconcile {
+		t.Errorf("prNumToKey entry for PR #10 survived after item #1 removed by Reconcile")
 	}
 }
 

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -21,6 +21,9 @@ type ItemState struct {
 	Repo string
 	// Number is the issue number.
 	Number int
+	// ID is the GitHub content node ID (e.g. "I_kwDO..." for issues, "PR_kwDO..." for PRs).
+	// Used by github.Client.FetchItemDetails for its GraphQL node lookup.
+	ID string
 	// ItemID is the GitHub Project item node ID (empty if not on the board).
 	ItemID string
 

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -213,6 +213,57 @@ type ItemDeepFetched struct {
 func (ItemDeepFetched) isMutation() {}
 func (m ItemDeepFetched) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// DeepFetchInvalidated clears LastDeepFetchAt so the next FetchItemDetails call
+// re-fetches deep fields from GitHub. Used by delta handlers that detect stale
+// deep state (e.g., new PR linkage discovered, new review thread comment added).
+type DeepFetchInvalidated struct {
+	Repo   string
+	Number int
+}
+
+func (DeepFetchInvalidated) isMutation() {}
+func (m DeepFetchInvalidated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// PRHeadSHAUpdated sets LinkedPR.HeadSHA for the given item and triggers the
+// Store's shaToKey index to be updated. Used by delta handlers when a push event
+// updates the PR's head commit.
+// LinkedPRNum, if non-zero, also sets LinkedPR.Number (used in auto-heal paths
+// where the PR↔issue linkage is being established for the first time).
+type PRHeadSHAUpdated struct {
+	Repo        string
+	Number      int // issue number
+	LinkedPRNum int // PR number to set (0 = leave unchanged)
+	SHA         string
+}
+
+func (PRHeadSHAUpdated) isMutation() {}
+func (m PRHeadSHAUpdated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// ReviewThreadCommentAdded appends an inline review-thread comment to an item's
+// LinkedPR.ThreadComments, idempotent by NodeID. Uses the ISSUE number (not the
+// PR number) as the routing key. Used by boardcache delta handlers.
+type ReviewThreadCommentAdded struct {
+	Repo        string
+	IssueNumber int
+	Comment     gh.Comment
+}
+
+func (ReviewThreadCommentAdded) isMutation() {}
+func (m ReviewThreadCommentAdded) itemKey() string { return itemKeyFor(m.Repo, m.IssueNumber) }
+
+// ShallowBoardItemUpdated updates only the shallow fields of an existing item
+// during a Reconcile pass. Unlike ItemDeepFetched or IssueOpened, it does NOT
+// overwrite deep fields (Comments, Body, Assignees, BlockedBy, LinkedPRReviews,
+// etc.). Used exclusively by CacheImpl.Reconcile.
+type ShallowBoardItemUpdated struct {
+	Repo   string
+	Number int
+	Item   gh.ProjectItem
+}
+
+func (ShallowBoardItemUpdated) isMutation() {}
+func (m ShallowBoardItemUpdated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // ---- Engine internals ----
 
 // StageAttempted records the start of a new Claude invocation for a stage.

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -216,8 +216,8 @@ func (s *Store) applySingleItem(m Mutation) (Snapshot, []Change, error) {
 
 	// No-op detection: if nothing changed, skip observers.
 	if reflect.DeepEqual(before, *item) {
+		snap := newSnapshot(*item) // capture while lock held
 		s.mu.Unlock()
-		snap := newSnapshot(*item)
 		return snap, nil, nil
 	}
 
@@ -497,8 +497,9 @@ func (s *Store) applyProjectV2ItemEdited(v ProjectV2ItemEdited) (Snapshot, []Cha
 	before := newSnapshot(*item).state
 	item.Status = v.NewStatus
 	if reflect.DeepEqual(before, *item) {
+		snap := newSnapshot(*item)
 		s.mu.Unlock()
-		return newSnapshot(*item), nil, nil
+		return snap, nil, nil
 	}
 	snap := newSnapshot(*item)
 	repo, number := item.Repo, item.Number
@@ -539,8 +540,9 @@ func (s *Store) applyCheckRunCompleted(v CheckRunCompleted) (Snapshot, []Change,
 	item.LinkedPR.HasHadChecks = true
 
 	if reflect.DeepEqual(before, *item) {
+		snap := newSnapshot(*item)
 		s.mu.Unlock()
-		return newSnapshot(*item), nil, nil
+		return snap, nil, nil
 	}
 	snap := newSnapshot(*item)
 	repo, number := item.Repo, item.Number

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -276,6 +276,12 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		return StateChanged
 
 	case IssueCommentCreated:
+		// Idempotent: skip if comment with this DatabaseID already exists.
+		for _, existing := range item.Comments {
+			if existing.DatabaseID == v.Comment.DatabaseID && v.Comment.DatabaseID != 0 {
+				return 0
+			}
+		}
 		item.Comments = append(item.Comments, v.Comment)
 		return CommentsChanged
 
@@ -393,13 +399,52 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 
 	case PRReviewSubmitted:
 		ensureLinkedPR(item, v.Number)
+		// Upsert by DatabaseID so a re-review replaces the prior entry.
+		for i, r := range item.LinkedPR.Reviews {
+			if r.DatabaseID == v.Review.DatabaseID && v.Review.DatabaseID != 0 {
+				item.LinkedPR.Reviews[i] = v.Review
+				return LinkedPRChanged
+			}
+		}
 		item.LinkedPR.Reviews = append(item.LinkedPR.Reviews, v.Review)
 		return LinkedPRChanged
 
 	case PRReviewCommentCreated:
 		ensureLinkedPR(item, v.PRNumber)
+		// Idempotent: skip if comment with this NodeID already exists.
+		for _, existing := range item.LinkedPR.ThreadComments {
+			if existing.ID == v.Comment.ID {
+				return 0
+			}
+		}
 		item.LinkedPR.ThreadComments = append(item.LinkedPR.ThreadComments, v.Comment)
 		return LinkedPRChanged | CommentsChanged
+
+	case DeepFetchInvalidated:
+		item.LastDeepFetchAt = time.Time{}
+		return DeepFetchChanged
+
+	case PRHeadSHAUpdated:
+		ensureLinkedPR(item, v.LinkedPRNum)
+		if v.LinkedPRNum != 0 {
+			item.LinkedPR.Number = v.LinkedPRNum
+		}
+		item.LinkedPR.HeadSHA = v.SHA
+		return LinkedPRChanged
+
+	case ReviewThreadCommentAdded:
+		ensureLinkedPR(item, 0)
+		// Idempotent by NodeID.
+		for _, existing := range item.LinkedPR.ThreadComments {
+			if existing.ID == v.Comment.ID {
+				return 0
+			}
+		}
+		item.LinkedPR.ThreadComments = append(item.LinkedPR.ThreadComments, v.Comment)
+		return LinkedPRChanged | CommentsChanged
+
+	case ShallowBoardItemUpdated:
+		return applyShallowItem(item, v.Item)
 	}
 
 	return 0
@@ -645,6 +690,111 @@ func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 
 	item.Repo = pi.Repo
 	item.Number = pi.Number
+
+	return flags
+}
+
+// All returns an immutable snapshot of every item currently in the Store.
+// The returned slice is a point-in-time snapshot; subsequent mutations do not
+// affect it. Safe to call concurrently with Apply.
+func (s *Store) All() []Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	snaps := make([]Snapshot, 0, len(s.items))
+	for _, item := range s.items {
+		snaps = append(snaps, newSnapshot(*item))
+	}
+	return snaps
+}
+
+// Remove deletes the item identified by (repo, number) from the Store and
+// updates the shaToKey and itemIDToKey indexes accordingly.
+// No-op when the item is not present.
+func (s *Store) Remove(repo string, number int) {
+	key := itemKeyFor(repo, number)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.items[key]
+	if !ok {
+		return
+	}
+	if item.ItemID != "" {
+		delete(s.itemIDToKey, item.ItemID)
+	}
+	if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
+		delete(s.shaToKey, item.LinkedPR.HeadSHA)
+	}
+	delete(s.items, key)
+}
+
+// Reset atomically replaces all Store state with the items in the given slice.
+// Existing items, indexes, and deep-fetch state are cleared. This is used by
+// Bootstrap to ensure a clean slate (unlike Reconcile, which preserves deep state).
+func (s *Store) Reset(items []gh.ProjectItem) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = make(map[string]*ItemState, len(items))
+	s.shaToKey = make(map[string]string, len(items))
+	s.itemIDToKey = make(map[string]string, len(items))
+	for i := range items {
+		pi := items[i]
+		key := itemKeyFor(pi.Repo, pi.Number)
+		if key == "" {
+			continue
+		}
+		item := &ItemState{Repo: pi.Repo, Number: pi.Number}
+		applyProjectItem(item, pi)
+		s.items[key] = item
+		if item.ItemID != "" {
+			s.itemIDToKey[item.ItemID] = key
+		}
+		if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
+			s.shaToKey[item.LinkedPR.HeadSHA] = key
+		}
+	}
+}
+
+// applyShallowItem updates only the shallow board fields of item from pi.
+// Deep fields (Body, Comments, Assignees, BlockedBy, LinkedPRReviews, etc.)
+// are left unchanged. Used by CacheImpl.Reconcile to apply shallow board
+// updates without wiping deep-fetched data.
+func applyShallowItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
+	var flags ChangeFlags
+
+	if item.ItemID != pi.ItemID && pi.ItemID != "" {
+		item.ItemID = pi.ItemID
+	}
+
+	if item.Title != pi.Title {
+		item.Title = pi.Title
+		flags |= TitleBodyChanged
+	}
+
+	if item.URL != pi.URL && pi.URL != "" {
+		item.URL = pi.URL
+		flags |= TitleBodyChanged
+	}
+
+	if item.State != stateFrom(pi) || item.IsClosed != pi.IsClosed || item.IsPR != pi.IsPR {
+		item.State = stateFrom(pi)
+		item.IsClosed = pi.IsClosed
+		item.IsPR = pi.IsPR
+		flags |= StateChanged
+	}
+
+	if !reflect.DeepEqual(item.Labels, pi.Labels) {
+		item.Labels = copyStrings(pi.Labels)
+		flags |= LabelsChanged
+	}
+
+	if item.Status != pi.Status {
+		item.Status = pi.Status
+		flags |= StatusChanged
+	}
+
+	if !item.UpdatedAt.Equal(pi.UpdatedAt) {
+		item.UpdatedAt = pi.UpdatedAt
+	}
 
 	return flags
 }

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -596,6 +596,9 @@ func (s *Store) updateIndexes(before, after ItemState, key string) {
 func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 	var flags ChangeFlags
 
+	if item.ID != pi.ID && pi.ID != "" {
+		item.ID = pi.ID
+	}
 	if item.ItemID != pi.ItemID {
 		item.ItemID = pi.ItemID
 	}
@@ -763,6 +766,9 @@ func (s *Store) Reset(items []gh.ProjectItem) {
 func applyShallowItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 	var flags ChangeFlags
 
+	if item.ID != pi.ID && pi.ID != "" {
+		item.ID = pi.ID
+	}
 	if item.ItemID != pi.ItemID && pi.ItemID != "" {
 		item.ItemID = pi.ItemID
 	}


### PR DESCRIPTION
## Summary

Replace `CacheImpl`'s internal state maps with a delegating `itemstate.Store` instance. All reads and writes that previously touched `c.items`, `c.deepFetched`, `c.linkedPRs`, `c.checkRuns`, `c.shaToKey`, and `c.itemIDToKey` must route through `Store.Apply(mutation)` and `Store.Get(repo, number)`. Two fields — `paused` and `recentMissCache` — remain directly on `CacheImpl` (they are not per-item state). The public API surface is preserved byte-for-byte; the engine requires zero changes.

## Problem

Today's `boardcache.CacheImpl` maintains 9 separate state fields (`items`, `deepFetched`, `linkedPRs`, `checkRuns`, `shaToKey`, `itemIDToKey`, `recentMissCache`, `paused`, plus board metadata). After Phase 3-A these belong inside the new `itemstate.Store`.

This PR makes `boardcache.CacheImpl` a **thin delegate** over `itemstate.Store` while preserving its existing public API exactly. No engine changes required — the engine still calls `CacheImpl` through the `ReadClient` interface; only the *internals* of CacheImpl change.

## Approach

### Approach

Phase 3-B makes `CacheImpl` a thin delegate over `itemstate.Store` while preserving its public API byte-for-byte. The Store owns `items`, `shaToKey`, and `itemIDToKey` — everything else stays on `CacheImpl`.

**The six fields that stay on `CacheImpl`:**
- `paused bool` — control flag
- `recentMissCache map[string]time.Time` — negative cache
- `checkRuns map[string][]gh.CheckRun` — handles pre-linkage SHAs the Store silently drops
- `linkedPRs map[string]*gh.PRDetails` — `LinkedPRState` lacks `Title`, `State`, `Merged`, `Draft`; migration deferred until `LinkedPRState` gains these fields
- `prNumToKey map[string]string` — replaces `c.items` linear scan for PR-number → issue lookups
- `localDeltaAt map[string]time.Time` — records when a webhook last bumped an item; `FetchProjectBoard` uses `max(itemState.UpdatedAt, localDeltaAt[key])` to preserve `itemMayNeedWork` detection

**Locking invariant**: `c.mu` guards CacheImpl-local fields only. Store has its own internal mutex. Never hold `c.mu` while calling any Store method — this prevents deadlock if Store observers call back into CacheImpl.

**Extensions needed in `internal/itemstate`:**
1. `All() []Snapshot` — enables `FetchProjectBoard` reconstruction and `Reconcile` stale-item detection
2. `Remove(repo string, number int)` — enables `Reconcile` to delete stale items
3. `Reset(items []gh.ProjectItem)` — atomically replaces all items (for `Bootstrap`)
4. `DeepFetchInvalidated{Repo, Number}` mutation — clears `item.LastDeepFetchAt`
5. `PRHeadSHAUpdated{Repo, Number, SHA}` mutation — sets `item.LinkedPR.HeadSHA`, triggering `updateIndexes` to update `s.shaToKey`
6. Idempotency check in `PRReviewCommentCreated` handler (skip comment if `ThreadComments` already contains same ID)

**`applyReviewCommentToItem`** loses its `deepFetched` parameter — Store handles the append; callers that need deep-fetch invalidation call `store.Apply(DeepFetchInvalidated{...})` explicitly.

**`updateSHAToKey`** is deleted — SHA updates go through `store.Apply(PRHeadSHAUpdated{...})`.

**`resolvePRLinkage`** replaces `c.items[k]` with `store.Get(fullRepo, issNum)` (no lock held during the call).

**`PRReviewSubmitted` and `PRReviewCommentCreated` delta handlers**: The `Repo` and `Number` fields on these mutations reference the *issue*, not the PR. Current handlers scan `c.items` to find the issue — after Phase 3-B, `c.prNumToKey[prKey(repo, prNum)]` provides the issue key. The extracted issue number is passed to `store.Apply(PRReviewSubmitted{Repo: fullRepo, Number: issNum, Review: ...})`.

**`ApplyStatusBatch`**: Calls `store.Apply(ProjectV2ItemEdited{ItemID, NewStatus})` for each entry. The returned `Snapshot` provides the key for bumping `c.localDeltaAt`.

**Documentation**: No doc updates needed — this is an internal refactor with no externally visible behavior changes. The spec explicitly notes `docs/state-machine.md` is not updated.

**ADR**: The lock-ordering invariant (`c.mu` never held during Store calls), the split between CacheImpl-local fields and Store state (especially `linkedPRs` deferred migration and `prNumToKey` as a CacheImpl-side index), and the `localDeltaAt` pattern for webhook-driven `UpdatedAt` bumping are non-obvious constraints that would surprise a future contributor. One ADR is warranted.

### New/Modified Files

| File | Change |
|------|--------|
| `internal/itemstate/mutation.go` | Add `DeepFetchInvalidated` and `PRHeadSHAUpdated` mutations |
| `internal/itemstate/store.go` | Add `All()`, `Remove()`, `Reset()` methods; handle new mutations in `applyToItem`; add idempotency to `PRReviewCommentCreated` |
| `boardcache/boardcache.go` | Add `store *itemstate.Store` field; add `prNumToKey`, `localDeltaAt`; remove `items`, `deepFetched`, `shaToKey`, `itemIDToKey`; update all methods |
| `boardcache/delta.go` | Rewrite all delta handlers to use Store mutations + CacheImpl-local fields; fix `applyReviewCommentToItem` signature; delete `updateSHAToKey` |
| `boardcache/boardcache_test.go` | Update tests that directly access removed internal fields; use `store.Get()` / `store.All()` / public methods |
| `boardcache/delta_test.go` | New file: delegation-correctness tests (all 10 spec-mandated tests) |
| `adrs/NNN-phase3b-boardcache-delegate.md` | ADR documenting lock-ordering invariant, CacheImpl/Store field split, `prNumToKey` and `localDeltaAt` patterns |

### Key Decisions

- **`linkedPRs` stays on CacheImpl**: `LinkedPRState` lacks `Title`, `State`, `Merged`, `Draft` compared to `gh.PRDetails`. Extending `LinkedPRState` now is scope creep; mark with a `// TODO(phase3-x): migrate to Store when LinkedPRState gains these fields` comment.

- **`checkRuns` stays on CacheImpl**: Store silently drops `CheckRunCompleted` for unknown SHAs. `FetchCheckRuns` must still return results for pre-linkage SHAs. After a successful auto-heal, the store also receives the run via `store.Apply(CheckRunCompleted{...})`.

- **`localDeltaAt` not in Store**: Adding per-item `DeltaUpdatedAt` to `ItemState` would be premature — the `UpdatedAt` field is meant to mirror GitHub's timestamp. The pattern of overriding at read-time in `FetchProjectBoard` is the minimal-change path.

- **`Reset` over `BoardReconciled` for Bootstrap**: `Bootstrap` must clear prior deep-fetch state; `store.Apply(BoardReconciled{...})` preserves `LastDeepFetchAt` on existing items. `Reset` atomically replaces all Store state, matching current `populateFromBoard` semantics.

- **`c.prNumToKey` keyed by `prKey(repo, prNum)`**: Same format as the existing `c.linkedPRs` key — `"owner/repo#prN"`. Updated in every code path that sets `LinkedPRNumber` (auto-heal paths in PR-delta, PR-review, PR-review-comment, and check-run handlers).

- **ADR worthiness**: Yes — lock-ordering rule, CacheImpl/Store split rationale, and `localDeltaAt` pattern are non-obvious constraints on future contributors.

### Task Checklist

- [ ] Task 1: Add `DeepFetchInvalidated` and `PRHeadSHAUpdated` mutations to `internal/itemstate/mutation.go`; handle both in `applyToItem` in `store.go`; add idempotency guard to `PRReviewCommentCreated` handler
- [ ] Task 2: Add `All() []Snapshot`, `Remove(repo, number)`, and `Reset(items)` methods to `internal/itemstate/store.go`
- [ ] Task 3: Restructure `CacheImpl` struct in `boardcache/boardcache.go` — add `store`, `prNumToKey`, `localDeltaAt`; remove `items`, `deepFetched`, `shaToKey`, `itemIDToKey`; update `NewCacheImpl`
- [ ] Task 4: Update `Bootstrap` to call `c.store.Reset(board.Items)` and reset CacheImpl-local maps (`prNumToKey`, `localDeltaAt`, `linkedPRs`, `checkRuns`); update `Reconcile` to use `store.Get()` for per-item access, `store.All()` for stale-item detection, `store.Apply(BoardReconciled{...})` for shallow updates, `store.Apply(DeepFetchInvalidated{...})` for linkage drift, and `store.Remove()` for deleted items; track drift count manually
- [ ] Task 5: Update `FetchProjectBoard` to call `c.store.All()` and reconstruct board items, overriding `UpdatedAt` with `max(snap.UpdatedAt, c.localDeltaAt[key])`
- [ ] Task 6: Update `FetchItemDetails` to check `snap.State().LastDeepFetchAt != zero` (from `store.Get()`); write-back via `store.Apply(ItemDeepFetched{...})`
- [ ] Task 7: Update `FetchLabels` and `GetItemID` to use `store.Get()` instead of `c.items[key]`
- [ ] Task 8: Update `FetchLinkedPR` to use `store.Get()` for the item lookup; keep `c.linkedPRs` for PR details
- [ ] Task 9: Update `UpdateItemStatus` to call `store.Apply(LocalStatusUpdated{...})` and bump `c.localDeltaAt`; update `ApplyStatusBatch` to call `store.Apply(ProjectV2ItemEdited{...})` per entry and bump `c.localDeltaAt` using the returned `Snapshot`
- [ ] Task 10: Update `resolvePRLinkage` to use `store.Get()` without holding `c.mu`
- [ ] Task 11: Refactor `applyIssueCommentCreated`, `applyIssuesLabeled`, `applyIssuesUnlabeled` in `delta.go` to call Store mutations and update `c.localDeltaAt`
- [ ] Task 12: Refactor `applyPullRequestDelta` to store into `c.linkedPRs` and look up via `c.prNumToKey`; call `store.Apply(PRHeadSHAUpdated{...})` for SHA update; in auto-heal path also update `c.prNumToKey` and call `store.Apply(DeepFetchInvalidated{...})`
- [ ] Task 13: Refactor `applyPullRequestReviewSubmitted` and `applyPullRequestReviewCommentCreated` to use `c.prNumToKey` for issue lookup; call Store mutations; call `store.Apply(DeepFetchInvalidated{...})` in auto-heal paths; update `applyReviewCommentToItem` to remove `deepFetched` parameter
- [ ] Task 14: Refactor `applyCheckRunCompleted` to write into `c.checkRuns[sha]` as before, then call `store.Apply(CheckRunCompleted{...})`; check returned `changes` to determine if SHA was known; in auto-heal, update `c.prNumToKey` and call `store.Apply(PRHeadSHAUpdated{...})` + `DeepFetchInvalidated` + `CheckRunCompleted`; delete `updateSHAToKey` helper
- [ ] Task 15: Refactor `applyProjectsV2ItemEdited` to call `store.Apply(ProjectV2ItemEdited{...})` and bump `c.localDeltaAt` using returned Snapshot
- [ ] Task 16: Update existing tests in `boardcache/boardcache_test.go` that access removed fields — replace `c.items[key]` with `c.store.Get(repo, number)`, `c.deepFetched[key]` with `snap.State().LastDeepFetchAt != zero`, `c.shaToKey[sha]` and `c.checkRuns[sha]` with direct field access (still accessible since tests are in the same package)
- [ ] Task 17: Create `boardcache/delta_test.go` with all 10 delegation-correctness tests from the spec (Bootstrap store-delegation, Reconcile drift log, per-action delta tests, pause/resume, FetchItemDetails cache-hit/miss, concurrent access, negative cache TTL, shaToKey, itemIDToKey)
- [ ] Task 18: Verify `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./boardcache/...` all pass
- [ ] Task 19: Create ADR `adrs/NNN-phase3b-boardcache-delegate.md` documenting: lock-ordering invariant (never hold `c.mu` during Store calls), CacheImpl/Store field split rationale (especially `linkedPRs` deferred, `prNumToKey` as CacheImpl-side index), `localDeltaAt` pattern for webhook-driven UpdatedAt bumping

### Risks

- **Lock-ordering violations**: Every code path that previously held `c.mu` while mutating items must be reviewed. The key discipline: release `c.mu` before any Store call. Test with `-race`. The concurrent-access test (Task 17, test 7) exercises this directly.

- **Test mass-update**: 30+ existing tests in `boardcache_test.go` directly access `c.items`, `c.deepFetched`, etc. These are package-internal fields, so tests in the `boardcache` package can directly access `c.store`. Risk: incorrect test updates masking real behavioral bugs. Mitigation: update tests conservatively — prefer `store.Get()` snapshots over field access where possible, and keep test assertions focused on observable behavior.

- **`UpdatedAt` regression in `itemMayNeedWork`**: If any code path that previously bumped `item.UpdatedAt` is missed when populating `c.localDeltaAt`, the engine may miss webhook-driven changes. Mitigation: trace every `item.UpdatedAt = time.Now()` in the current code and ensure a corresponding `c.localDeltaAt[key] = time.Now()` is added.

- **`PRReviewCommentCreated` idempotency gap in Store**: The current `applyReviewCommentToItem` checks for duplicate comment IDs; the Store's `PRReviewCommentCreated` case does not. If Task 1's idempotency fix is missed, duplicate comments will accumulate. Mitigation: the idempotency fix is explicitly Task 1.

- **`applyBoardReconciled` in Store vs. `Reconcile` in CacheImpl**: Both paths can update an item's shallow fields. If `Reconcile` calls `store.Apply(BoardReconciled{Items: [item]})` for per-item updates, the `applyProjectItem` in Store may also clear `LinkedPR.Number = 0` if `pi.LinkedPRNumber == 0` (the else branch currently says "PR was delinked — only clear the number"). Implementer should verify the `applyProjectItem` "delinked" branch behaves correctly during reconcile.

- **`FetchCheckRuns` dual-state**: After Phase 3-B, check runs for linked items exist in both `c.checkRuns[sha]` and `store.LinkedPR.CheckRuns`. The engine calls `FetchCheckRuns` which reads from `c.checkRuns`. This is correct but creates dual state. Future phases can collapse this — it's acceptable for Phase 3-B.

---
Used 14/50 turns, 8k input / 17k output tokens.

## Verification

Phase 3-B is complete: `boardcache.CacheImpl` now delegates all per-item state to `itemstate.Store`. The `items`, `deepFetched`, `shaToKey`, and `itemIDToKey` fields were removed and replaced by `store *itemstate.Store`, `prNumToKey`, and `localDeltaAt`. Three new methods (`All`, `Remove`, `Reset`) and two new mutations (`DeepFetchInvalidated`, `PRHeadSHAUpdated`) were added to `internal/itemstate`. A data race in the Store's no-op paths (snapshot captured after mutex release) was found and fixed. All 49 existing boardcache tests pass; 10 new delegation-correctness tests added; full suite green with race detector.

---

Closes #514