### PR TITLE
Phase 3-C: self-mutation write-through (closes advance-loop bug class)

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -647,6 +647,10 @@ func (c *CacheImpl) ApplyLabelAdded(key, label string) {
 		c.logFn("[cache] ApplyLabelAdded: key %q invalid — no-op\n", key)
 		return
 	}
+	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
+	if _, err := c.store.Get(repo, number); err != nil {
+		return
+	}
 	_, changes, _ := c.store.Apply(itemstate.LocalLabelAdded{
 		Repo:   repo,
 		Number: number,
@@ -668,6 +672,10 @@ func (c *CacheImpl) ApplyLabelRemoved(key, label string) {
 	repo, number, ok := parseItemKey(key)
 	if !ok {
 		c.logFn("[cache] ApplyLabelRemoved: key %q invalid — no-op\n", key)
+		return
+	}
+	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
+	if _, err := c.store.Get(repo, number); err != nil {
 		return
 	}
 	_, changes, _ := c.store.Apply(itemstate.LocalLabelRemoved{
@@ -697,6 +705,10 @@ func (c *CacheImpl) ApplyCommentAdded(key string, comment gh.Comment) {
 	repo, number, ok := parseItemKey(key)
 	if !ok {
 		c.logFn("[cache] ApplyCommentAdded: key %q invalid — no-op\n", key)
+		return
+	}
+	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
+	if _, err := c.store.Get(repo, number); err != nil {
 		return
 	}
 	_, changes, _ := c.store.Apply(itemstate.LocalCommentAdded{

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -638,6 +638,81 @@ func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
 	c.mu.Unlock()
 }
 
+// ApplyLabelAdded updates the cached label list for the item identified by key,
+// appending label if not already present. No-op when the key is not in the cache.
+// Safe for concurrent use.
+func (c *CacheImpl) ApplyLabelAdded(key, label string) {
+	repo, number, ok := parseItemKey(key)
+	if !ok {
+		c.logFn("[cache] ApplyLabelAdded: key %q invalid — no-op\n", key)
+		return
+	}
+	_, changes, _ := c.store.Apply(itemstate.LocalLabelAdded{
+		Repo:   repo,
+		Number: number,
+		Label:  label,
+	})
+	if len(changes) == 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
+}
+
+// ApplyLabelRemoved updates the cached label list for the item identified by key,
+// removing label if present. No-op when the key is not in the cache or label is absent.
+// Safe for concurrent use.
+func (c *CacheImpl) ApplyLabelRemoved(key, label string) {
+	repo, number, ok := parseItemKey(key)
+	if !ok {
+		c.logFn("[cache] ApplyLabelRemoved: key %q invalid — no-op\n", key)
+		return
+	}
+	_, changes, _ := c.store.Apply(itemstate.LocalLabelRemoved{
+		Repo:   repo,
+		Number: number,
+		Label:  label,
+	})
+	if len(changes) == 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
+}
+
+// ApplyCommentAdded appends comment to the cached comment list for the item
+// identified by key. No-op when the key is not in the cache.
+// Safe for concurrent use.
+//
+// Note: LocalCommentAdded is a raw append (not idempotent by DatabaseID).
+// If a webhook echo for the same comment arrives before the next Reconcile,
+// the comment may appear twice in the cache until Reconcile replaces it.
+// This is acceptable because dispatch-relevant comment checks use rocket-reaction
+// detection rather than DatabaseID uniqueness.
+func (c *CacheImpl) ApplyCommentAdded(key string, comment gh.Comment) {
+	repo, number, ok := parseItemKey(key)
+	if !ok {
+		c.logFn("[cache] ApplyCommentAdded: key %q invalid — no-op\n", key)
+		return
+	}
+	_, changes, _ := c.store.Apply(itemstate.LocalCommentAdded{
+		Repo:    repo,
+		Number:  number,
+		Comment: comment,
+	})
+	if len(changes) == 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
+}
+
 // ApplyStatusBatch updates Status for items identified by project-item node IDs.
 // Entries whose itemID is not in the Store's itemIDToKey index are silently skipped.
 // Safe for concurrent use.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -3,6 +3,7 @@ package boardcache
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1363,4 +1364,215 @@ func seedCacheWithStalePRLink2(t *testing.T, logFn func(string, ...any)) *CacheI
 	c.Bootstrap(board)
 	testSetDeepFetched(c, "owner/repo", 1)
 	return c
+}
+
+// ---------------------------------------------------------------------------
+// ApplyLabelAdded tests
+// ---------------------------------------------------------------------------
+
+func TestApplyLabelAdded(t *testing.T) {
+	c := seedCache(t) // item #1 has labels: ["enhancement"]
+	key := ItemKey("owner/repo", 1)
+
+	before := time.Now()
+	c.ApplyLabelAdded(key, "fabrik:awaiting-ci")
+
+	labels, err := c.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	found := false
+	for _, l := range labels {
+		if l == "fabrik:awaiting-ci" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want fabrik:awaiting-ci in labels after ApplyLabelAdded, got %v", labels)
+	}
+
+	// localDeltaAt must be bumped.
+	c.mu.RLock()
+	deltaAt := c.localDeltaAt[key]
+	c.mu.RUnlock()
+	if !deltaAt.After(before) {
+		t.Error("want localDeltaAt bumped after ApplyLabelAdded")
+	}
+}
+
+func TestApplyLabelAddedIdempotent(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+
+	c.ApplyLabelAdded(key, "enhancement") // already present
+
+	labels, err := c.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	count := 0
+	for _, l := range labels {
+		if l == "enhancement" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("want exactly 1 'enhancement' label, got %d; labels=%v", count, labels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ApplyLabelRemoved tests
+// ---------------------------------------------------------------------------
+
+func TestApplyLabelRemoved(t *testing.T) {
+	c := seedCache(t) // item #1 has labels: ["enhancement"]
+	key := ItemKey("owner/repo", 1)
+
+	before := time.Now()
+	c.ApplyLabelRemoved(key, "enhancement")
+
+	labels, err := c.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	for _, l := range labels {
+		if l == "enhancement" {
+			t.Errorf("want 'enhancement' removed, still present in %v", labels)
+		}
+	}
+
+	c.mu.RLock()
+	deltaAt := c.localDeltaAt[key]
+	c.mu.RUnlock()
+	if !deltaAt.After(before) {
+		t.Error("want localDeltaAt bumped after ApplyLabelRemoved")
+	}
+}
+
+func TestApplyLabelRemovedNoopWhenAbsent(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+
+	before := time.Now()
+	c.ApplyLabelRemoved(key, "nonexistent-label")
+
+	// localDeltaAt must NOT be bumped — no state change.
+	c.mu.RLock()
+	deltaAt := c.localDeltaAt[key]
+	c.mu.RUnlock()
+	if deltaAt.After(before) {
+		t.Error("want localDeltaAt NOT bumped for no-op ApplyLabelRemoved")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ApplyCommentAdded tests
+// ---------------------------------------------------------------------------
+
+func TestApplyCommentAdded(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+
+	// First set up deep-fetch state so FetchItemDetails serves from cache.
+	testSetDeepFetched(c, "owner/repo", 1)
+
+	comment := gh.Comment{
+		ID:         "C_new",
+		DatabaseID: 42,
+		Author:     "fabrik-bot",
+		Body:       "Stage complete.",
+		CreatedAt:  time.Now(),
+	}
+
+	before := time.Now()
+	c.ApplyCommentAdded(key, comment)
+
+	// FetchItemDetails should now return the comment from cache (no fallback).
+	mc := &mockClient{} // empty fallback — fallback hit would panic on nil
+	c.fallback = mc
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if err := c.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+	if mc.fetchItemDetailsCount != 0 {
+		t.Errorf("want cache hit (no fallback), got %d fallback calls", mc.fetchItemDetailsCount)
+	}
+	found := false
+	for _, cm := range item.Comments {
+		if cm.DatabaseID == 42 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want comment #42 in item.Comments after ApplyCommentAdded, got %v", item.Comments)
+	}
+
+	c.mu.RLock()
+	deltaAt := c.localDeltaAt[key]
+	c.mu.RUnlock()
+	if !deltaAt.After(before) {
+		t.Error("want localDeltaAt bumped after ApplyCommentAdded")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unknown key — no-op tests
+// ---------------------------------------------------------------------------
+
+func TestWriteThroughNoopOnUnknownKey(t *testing.T) {
+	c := seedCache(t)
+	unknownKey := ItemKey("owner/repo", 9999)
+
+	c.ApplyLabelAdded(unknownKey, "foo")
+	c.ApplyLabelRemoved(unknownKey, "foo")
+	c.ApplyCommentAdded(unknownKey, gh.Comment{DatabaseID: 1, Body: "hello"})
+
+	// localDeltaAt must not contain the unknown key.
+	c.mu.RLock()
+	_, ok := c.localDeltaAt[unknownKey]
+	c.mu.RUnlock()
+	if ok {
+		t.Error("want localDeltaAt NOT updated for unknown key")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent write-through test
+// ---------------------------------------------------------------------------
+
+func TestConcurrentWriteThrough(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+
+	const iterations = 100
+	var wg sync.WaitGroup
+	wg.Add(iterations * 2)
+
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			c.ApplyLabelAdded(key, "concurrent-label")
+		}()
+		go func() {
+			defer wg.Done()
+			c.ApplyLabelRemoved(key, "concurrent-label")
+		}()
+	}
+	wg.Wait()
+
+	// Final label state must be consistent (no panic, no data race).
+	labels, err := c.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	count := 0
+	for _, l := range labels {
+		if l == "concurrent-label" {
+			count++
+		}
+	}
+	if count > 1 {
+		t.Errorf("want at most 1 'concurrent-label', got %d; labels=%v", count, labels)
+	}
 }

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1390,19 +1390,44 @@ In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub d
 
 | Layer | Mechanism | Latency | Cost |
 |-------|-----------|---------|------|
-| **0** Write-through | After any successful `UpdateProjectItemStatus` call in the engine, `CacheImpl.UpdateItemStatus` is called immediately | Zero | Zero |
+| **0** Write-through | After any successful mutation call in the engine (status, labels, comments), the corresponding `CacheImpl` method is called immediately | Zero | Zero |
 | **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event on a known item, `FetchProjectItemStatus` fetches the current Status | Seconds (best-effort) | ~1–5 pts/event |
 | **2** Periodic status sweep | `runReconciliationLoop` calls `FetchProjectItemStatusBatch` at `ProjectStatusPollSeconds` cadence (default 10 min) | Up to 10 min | O(⌈N/100⌉) per sweep |
 | **Bootstrap / stream-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and on webhook stream recovery | Minutes | Full board cost |
 
-**Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the Layer 2 cadence (`ProjectStatusPollSeconds`). If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own stage transitions.
+**Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the Layer 2 cadence (`ProjectStatusPollSeconds`). If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own mutations.
 
-**Layer 0 write-through convention**: Every call site that calls `UpdateProjectItemStatus` to mutate a project item's Status **must** also call `cacheImpl.UpdateItemStatus` on success. This invariant prevents the cache from staling on self-driven transitions. Use the safe type assertion pattern:
+**Layer 0 write-through convention**: Every engine call site that mutates dispatch-relevant cache state **must** call the corresponding `CacheImpl` write-through method immediately after the API call succeeds. The safe type-assertion pattern used at every site:
 
 ```go
 if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-    cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), newStatus)
+    cacheImpl.<Method>(boardcache.ItemKey(item.Repo, item.Number), ...)
 }
 ```
+
+This is a no-op when `e.readClient` is a `GitHubAdapter` (cache-disabled mode), so the guard is always safe to include.
+
+**Covered mutation types and their `CacheImpl` methods:**
+
+| Mutation | `CacheImpl` method | Dispatch relevance |
+|----------|--------------------|--------------------|
+| `UpdateProjectItemStatus` | `UpdateItemStatus` | Stage selection reads `Status` |
+| `AddLabelToIssue` | `ApplyLabelAdded` | Label guards (`fabrik:locked`, `stage:*:complete`, etc.) |
+| `RemoveLabelFromIssue` | `ApplyLabelRemoved` | Same |
+| `AddComment` (issue-targeted) | `ApplyCommentAdded` | Comment dispatch reads `Comments` for rocket-reaction checks |
+
+**Excluded mutation types** (annotated with `// no write-through: excluded —` at each call site):
+
+| Mutation | Reason excluded |
+|----------|----------------|
+| `AddCommentReaction` | Reactions are not read from cache for dispatch decisions |
+| `AddPRReviewCommentReaction` | Same |
+| `AddComment` targeting a PR number | Posts to PR comment thread, not issue cache |
+| `UpdateIssueBody` | Issue body is not read from cache for dispatch decisions |
+| `CreateDraftPR` | PR existence is resolved live via `FindPRForIssue`; not cached |
+| `MarkPRReady` | Draft state is not read from cache for dispatch decisions |
+| `MergePR` | Merge state is not read from cache for dispatch decisions |
+
+**`CacheImpl` existence guard**: All three new write-through methods (`ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded`) call `c.store.Get(repo, number)` before applying the mutation. If the key is not present in the Store (i.e., was never bootstrapped), the method returns without creating a phantom Store entry.
 
 **Layer 1 scope**: Only `issues` and `issue_comment` event types trigger a per-event status fetch. `pull_request`, `pull_request_review`, `check_run`, and other event types are excluded from Layer 1 (finding the linked issue for a PR event requires an O(N) cache scan; `check_run` does not carry an item ID). Layer 2's periodic sweep covers these cases within its cadence.

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -164,6 +165,8 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 	if !hasLabel(item, "fabrik:awaiting-ci") {
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 		}
 	}
 
@@ -176,6 +179,8 @@ func (e *Engine) removeAwaitingCILabel(owner, repo string, item gh.ProjectItem) 
 		if l == "fabrik:awaiting-ci" {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
 				e.logf(item.Number, "warn", "could not remove fabrik:awaiting-ci label: %v\n", err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 			}
 			return
 		}
@@ -191,6 +196,8 @@ func (e *Engine) addCompleteLabelAndRemoveCI(owner, repo string, item gh.Project
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label %s: %v\n", completeLabel, err)
 		return // preserve fabrik:awaiting-ci so the next poll retries
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 	}
 	e.removeAwaitingCILabel(owner, repo, item)
 }
@@ -399,14 +406,26 @@ func (e *Engine) pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, 
 	)
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post CI timeout comment: %v\n", err)
-	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 	}
 }
 
@@ -426,13 +445,25 @@ func (e *Engine) pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.Project
 	)
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post CI cycle limit comment: %v\n", err)
-	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 	}
 }

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
@@ -80,10 +81,12 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			continue
 		}
 		if c.ReviewThreadID != "" {
+			// no write-through: excluded — AddPRReviewCommentReaction does not affect dispatch-relevant cache state
 			if err := e.client.AddPRReviewCommentReaction(owner, repo, c.DatabaseID, "eyes"); err != nil {
 				e.logf(item.Number, "warn", "could not add 👀 to review thread comment %s: %v\n", c.ID, err)
 			}
 		} else {
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if err := e.client.AddCommentReaction(owner, repo, c.DatabaseID, "eyes"); err != nil {
 				e.logf(item.Number, "warn", "could not add 👀 to comment %s: %v\n", c.ID, err)
 			}
@@ -93,6 +96,8 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	// Step 2: Add editing label
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:editing"); err != nil {
 		return fmt.Errorf("adding editing label: %w", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:editing")
 	}
 
 	// Step 3: Ensure worktree
@@ -152,6 +157,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	// Step 6: Strip FABRIK_ISSUE_UPDATE block from output, then update issue body.
 	if updatedBody := extractUpdatedBody(output); updatedBody != "" {
 		e.logf(item.Number, "edit", "updating issue body\n")
+		// no write-through: excluded — issue body is not read from cache for dispatch decisions
 		if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
 			e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
 		}
@@ -174,8 +180,16 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			comment := formatOutputComment(stage.Name+" (comment review)", output, "", branch, commit, mainSHA, timestamp)
 			if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
-			} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			} else {
+				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+					})
+				}
+				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+				}
 			}
 		} else {
 			existing := findStageComment(item.Comments, stage.Name)
@@ -188,8 +202,16 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			} else {
 				if dbID, err := e.client.AddComment(owner, repo, item.Number, stageComment); err != nil {
 					e.logf(item.Number, "warn", "could not post stage comment: %v\n", err)
-				} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+				} else {
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+							DatabaseID: dbID, Body: stageComment, Author: e.cfg.User, CreatedAt: time.Now(),
+						})
+					}
+					// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+					if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+						e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+					}
 				}
 			}
 		}
@@ -208,6 +230,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		} else if prNumber > 0 {
 			threads := buildThreadEntries(comments)
 			prComment := formatReviewFeedbackComment(stage.Name, output, branch, commit, mainSHA, timestamp, threads, len(comments))
+			// no write-through: excluded — posts to prNumber (PR comment thread, not issue cache)
 			if _, err := e.client.AddComment(owner, repo, prNumber, prComment); err != nil {
 				e.logf(item.Number, "warn", "could not post review feedback summary to PR #%d: %v\n", prNumber, err)
 			} else {
@@ -230,6 +253,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			continue
 		}
 		if c.ReviewThreadID != "" {
+			// no write-through: excluded — AddPRReviewCommentReaction does not affect dispatch-relevant cache state
 			if err := e.client.AddPRReviewCommentReaction(owner, repo, c.DatabaseID, "rocket"); err != nil {
 				e.logf(item.Number, "warn", "could not add 🚀 to review thread comment %s: %v\n", c.ID, err)
 			}
@@ -242,6 +266,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 				resolvedThreads[c.ReviewThreadID] = true
 			}
 		} else {
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if err := e.client.AddCommentReaction(owner, repo, c.DatabaseID, "rocket"); err != nil {
 				e.logf(item.Number, "warn", "could not add 🚀 to comment %s: %v\n", c.ID, err)
 			}
@@ -311,6 +336,7 @@ func (e *Engine) markCommentsSeenByStage(item gh.ProjectItem, preStageComments [
 			continue
 		}
 		// This comment was seen by the stage — mark it so it won't trigger unblock
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 		if err := e.client.AddCommentReaction(owner, repo, c.DatabaseID, "rocket"); err != nil {
 			e.logf(item.Number, "warn", "could not add rocket to seen comment %s: %v\n", c.ID, err)
 		}

--- a/engine/dependencies.go
+++ b/engine/dependencies.go
@@ -3,7 +3,9 @@ package engine
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -48,6 +50,8 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 			if l == "fabrik:blocked" {
 				if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:blocked"); err != nil {
 					e.logf(item.Number, "warn", "could not remove fabrik:blocked label: %v\n", err)
+				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
 				}
 				break
 			}
@@ -80,11 +84,21 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 		comment := fmt.Sprintf("🏭 **Fabrik — blocked on dependencies**\n\nWaiting for the following issues to close: %s", strings.Join(waitingFor, ", "))
 		if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post blocked comment: %v\n", err)
-		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:blocked"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:blocked label: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
 		}
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -420,14 +420,26 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 		msg := fmt.Sprintf("🏭 **Fabrik — cannot clone repo**\n\nFailed to clone `%s/%s`:\n```\n%v\n```\nHuman intervention required. Fix the clone issue and remove `fabrik:paused` to retry.", owner, repo, err)
 		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
 			e.logf(item.Number, "warn", "could not post clone-failure comment: %v\n", commentErr)
-		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 		if labelErr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); labelErr != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", labelErr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 		}
 		if labelErr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); labelErr != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", labelErr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 		}
 		// Append a history entry so the TUI records the failure.
 		hist := tui.LoadHistory()

--- a/engine/engine_helpers_test.go
+++ b/engine/engine_helpers_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"github.com/verveguy/fabrik/boardcache"
+	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -42,6 +44,33 @@ func testEngine(client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
 		NewWorktreeManager("/tmp/test-repo"),
 	)
 }
+// testEngineWithCache creates an Engine with a live CacheImpl wired as readClient.
+// Returns the engine and the cache so tests can query cached state directly.
+// The cache is bootstrapped with a single item: owner/repo issue #1 in "Research".
+func testEngineWithCache(client *mockGitHubClient, claude *mockClaudeInvoker) (*Engine, *boardcache.CacheImpl) {
+	eng := testEngine(client, claude)
+
+	cache := boardcache.NewCacheImpl(client, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Title:     "Test Board",
+		OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{
+				ID:     "I_001",
+				ItemID: "PVTI_001",
+				Number: 1,
+				Title:  "Test Issue",
+				Repo:   "owner/repo",
+				Status: "Research",
+				Labels: []string{},
+			},
+		},
+	})
+	eng.readClient = cache
+	return eng, cache
+}
+
 func testStagesWithCleanup() []*stages.Stage {
 	ss := testStages()
 	return append(ss, &stages.Stage{

--- a/engine/item.go
+++ b/engine/item.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 )
@@ -386,6 +387,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				e.logf(item.Number, "unpause", "user commented on paused issue — unpausing\n")
 				if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 					e.logf(item.Number, "warn", "could not remove fabrik:paused label: %v\n", err)
+				} else {
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+					}
 				}
 				// Also clear any failed label so the stage retries cleanly
 				e.clearFailedStage(item, stage)
@@ -451,6 +456,8 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 			e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 		}
 
 		// Archive is handled by archiveDoneCompleteItems in the poll loop,
@@ -549,6 +556,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.mu.Lock()
 		e.lockedIssues[iKey] = true
 		e.mu.Unlock()
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
+		}
 	}
 
 	inProgressLabel := fmt.Sprintf("stage:%s:in_progress", stage.Name)
@@ -604,6 +614,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.logf(item.Number, "warn", "could not add in_progress label: %v\n", err)
 	} else {
 		inProgressAdded = true
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), inProgressLabel)
+		}
 	}
 
 	// Ensure the WorktreeManager for this item's repo is ready.
@@ -759,6 +772,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	if output != "" {
 		if updatedBody := extractUpdatedBody(output); updatedBody != "" {
 			e.logf(item.Number, "edit", "updating issue body from stage output\n")
+			// no write-through: excluded — issue body is not read from cache for dispatch decisions
 			if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
 				e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
 			}
@@ -789,8 +803,16 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			comment := formatOutputComment(stage.Name, postOutput, footer, branch, commit, mainSHA, timestamp)
 			if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
-			} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			} else {
+				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+					})
+				}
+				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+				}
 			}
 		}
 	}
@@ -829,8 +851,16 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		warnComment := fmt.Sprintf("🏭 **Fabrik — empty stage output**\n\nStage **%s** ran without error but produced no output.", stage.Name)
 		if dbID, commentErr := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, warnComment); commentErr != nil {
 			e.logf(item.Number, "warn", "could not post empty-output warning: %v\n", commentErr)
-		} else if reactErr := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: warnComment, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 	}
 
@@ -891,6 +921,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			if removeErr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:extend-turns"); removeErr != nil &&
 				!errors.Is(removeErr, gh.ErrNotFound) {
 				e.logf(item.Number, "warn", "could not remove extend-turns label: %v\n", removeErr)
+			} else if removeErr == nil {
+				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:extend-turns")
+				}
 			}
 		}
 		// Post-stage: create draft PR and/or mark ready now that commits exist
@@ -947,6 +981,8 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 
 	e.addFailedLabel(owner, repo, item.Number, stage.Name)
@@ -957,8 +993,16 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	)
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 		e.logf(item.Number, "warn", "could not post escalation comment: %v\n", err)
-	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
 	}
 
 	stageKey := issueKey(item, e.defaultRepo()) + "-" + stage.Name
@@ -978,6 +1022,10 @@ func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, failedLabel); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
 		e.logf(item.Number, "warn", "could not remove failed label: %v\n", err)
+	} else if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), failedLabel)
+		}
 	}
 
 	iKey := issueKey(item, e.defaultRepo())
@@ -1002,9 +1050,13 @@ func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add awaiting-input label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 	}
 }
 
@@ -1018,10 +1070,18 @@ func (e *Engine) unblockAwaitingInput(item gh.ProjectItem, stage *stages.Stage, 
 	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:paused"); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
 		e.logf(item.Number, "warn", "could not remove paused label: %v\n", err)
+	} else if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+		}
 	}
 	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
 		e.logf(item.Number, "warn", "could not remove awaiting-input label: %v\n", err)
+	} else if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+		}
 	}
 
 	e.mu.Lock()
@@ -1135,8 +1195,16 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 		body := fmt.Sprintf("🏭 **Fabrik — base branch not found**\n\nFabrik could not find branch `%s` on the remote (from `base:%s` label). Falling back to the repository default branch.", candidate, candidate)
 		if dbID, err := e.client.AddComment(owner, repo, item.Number, body); err != nil {
 			e.logf(item.Number, "warn", "could not post base branch fallback comment: %v\n", err)
-		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: body, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 	}
 	return wm.DefaultBaseBranch()
@@ -1152,6 +1220,10 @@ func (e *Engine) removeLockLabel(owner, repo string, issueNumber int, label stri
 	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, label); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
 		e.logf(issueNumber, "warn", "could not remove lock label: %v\n", err)
+	} else if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
+		}
 	}
 }
 
@@ -1160,6 +1232,10 @@ func (e *Engine) removeInProgressLabel(owner, repo string, issueNumber int, stag
 	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, label); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
 		e.logf(issueNumber, "warn", "could not remove in_progress label: %v\n", err)
+	} else if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
+		}
 	}
 }
 
@@ -1167,6 +1243,8 @@ func (e *Engine) addFailedLabel(owner, repo string, issueNumber int, stageName s
 	label := fmt.Sprintf("stage:%s:failed", stageName)
 	if err := e.client.AddLabelToIssue(owner, repo, issueNumber, label); err != nil {
 		e.logf(issueNumber, "warn", "could not add failed label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
 	}
 }
 
@@ -1175,6 +1253,10 @@ func (e *Engine) removeFailedLabel(owner, repo string, issueNumber int, stageNam
 	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, label); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
 		e.logf(issueNumber, "warn", "could not remove failed label: %v\n", err)
+	} else if err == nil {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
+		}
 	}
 }
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -1213,6 +1213,8 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 func (e *Engine) removeEditingLabel(owner, repo string, issueNumber int) {
 	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, "fabrik:editing"); err != nil {
 		e.logf(issueNumber, "warn", "could not remove editing label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:editing")
 	}
 }
 

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -80,6 +81,8 @@ func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage)
 	if !alreadyLabeled {
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
 		}
 	}
 	return true, true
@@ -91,6 +94,8 @@ func (e *Engine) removeRebaseNeededLabel(owner, repo string, item gh.ProjectItem
 		if l == "fabrik:rebase-needed" {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:rebase-needed"); err != nil {
 				e.logf(item.Number, "warn", "could not remove fabrik:rebase-needed label: %v\n", err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
 			}
 			return
 		}
@@ -247,13 +252,25 @@ func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.Projec
 	)
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post rebase cycle limit comment: %v\n", err)
-	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 	}
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -515,6 +515,9 @@ func (e *Engine) cleanupLockedIssues() {
 			e.logf(num, "warn", "could not remove lock label during shutdown: %v\n", err)
 		} else {
 			e.logf(num, "shutdown", "removed lock label\n")
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, num), lockLabel)
+			}
 		}
 		e.mu.Lock()
 		delete(e.lockedIssues, key)
@@ -549,6 +552,9 @@ func (e *Engine) cleanupClosedIssueLocks(board *gh.ProjectBoard) {
 			}
 		} else {
 			e.logf(num, "poll", "removed stale lock label from closed issue\n")
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
+			}
 		}
 	}
 }

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 )
 
@@ -39,6 +41,7 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) int {
 	seedBody := e.buildSeedBody(item, workDir)
 
 	head := fmt.Sprintf("fabrik/issue-%d", item.Number)
+	// no write-through: excluded — CreateDraftPR affects PR state, not issue/label cache
 	prNum, err := e.client.CreateDraftPR(owner, repo, item.Title, head, baseBranch, seedBody, item.Number)
 	if err != nil {
 		e.logf(item.Number, "warn", "could not create draft PR: %v\n", err)
@@ -125,6 +128,7 @@ func (e *Engine) updatePRVerification(item gh.ProjectItem, prNumber int, summary
 		return
 	}
 
+	// no write-through: excluded — issue body is not read from cache for dispatch decisions
 	if err := e.client.UpdateIssueBody(owner, repo, prNumber, updatedBody); err != nil {
 		e.logf(item.Number, "warn", "could not update PR #%d Verification section: %v\n", prNumber, err)
 		return
@@ -149,6 +153,7 @@ func (e *Engine) ensurePRLinksIssue(item gh.ProjectItem, prNumber int) {
 	// Self-heal unclosed code fences that could hide Closes #N from GitHub's parser.
 	balanced := balanceFences(body)
 	if balanced != body {
+		// no write-through: excluded — issue body is not read from cache for dispatch decisions
 		if err := e.client.UpdateIssueBody(owner, repo, prNumber, balanced); err != nil {
 			e.logf(item.Number, "warn", "could not update PR #%d body to close fence: %v\n", prNumber, err)
 			return
@@ -162,6 +167,7 @@ func (e *Engine) ensurePRLinksIssue(item gh.ProjectItem, prNumber int) {
 
 	// Append closing keyword
 	updatedBody := balanced + "\n\n" + closingKeyword
+	// no write-through: excluded — issue body is not read from cache for dispatch decisions
 	if err := e.client.UpdateIssueBody(owner, repo, prNumber, updatedBody); err != nil {
 		e.logf(item.Number, "warn", "could not update PR #%d body: %v\n", prNumber, err)
 		return
@@ -195,6 +201,7 @@ func (e *Engine) markPRReady(item gh.ProjectItem, knownPR int) {
 		return
 	}
 
+	// no write-through: excluded — MarkPRReady affects PR state, not issue/label cache
 	if err := e.client.MarkPRReady(owner, repo, prNumber); err != nil {
 		e.logf(item.Number, "warn", "could not mark PR #%d ready: %v\n", prNumber, err)
 		return
@@ -212,11 +219,13 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 
 	if prNumber > 0 {
 		// Post detailed output on the PR
+		// no write-through: excluded — posts to prNumber (PR comment thread, not issue cache)
 		comment := formatOutputComment(stageName, output, footer, branch, commit, mainSHA, timestamp)
 		if dbID, err := e.client.AddComment(owner, repo, prNumber, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post to PR #%d: %v\n", prNumber, err)
 		} else {
 			e.logf(item.Number, "post", "detailed %s output posted to PR #%d\n", stageName, prNumber)
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
 			}
@@ -226,8 +235,16 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 		summary := formatPRSummaryComment(stageName, prNumber, output, branch, commit, mainSHA, timestamp)
 		if dbID, err := e.client.AddComment(owner, repo, item.Number, summary); err != nil {
 			e.logf(item.Number, "warn", "could not post summary: %v\n", err)
-		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: summary, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 	} else {
 		// No PR found — fall back to posting on the issue
@@ -235,8 +252,16 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 		comment := formatOutputComment(stageName, output, footer, branch, commit, mainSHA, timestamp)
 		if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post comment: %v\n", err)
-		} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
 	}
 }

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -137,6 +138,8 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 					if l == botRepromptedLabel || l == "fabrik:awaiting-review" {
 						if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, l); err != nil {
 							e.logf(item.Number, "warn", "phase 2: could not remove %s: %v\n", l, err)
+						} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+							cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
 						}
 					}
 				}
@@ -172,8 +175,10 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 							e.logf(item.Number, "warn", "phase 1: could not re-add review request for %s: %v\n", login, err)
 						}
 						msg := fmt.Sprintf("🏭 **Fabrik — review re-prompt**\n\n@%s just checking in — could you take a look at this PR?", botMentionHandle(login))
+						// no write-through: excluded — posts to item.LinkedPRNumber (PR comment thread, not issue cache)
 						if dbID, err := e.client.AddComment(owner, repo, item.LinkedPRNumber, msg); err != nil {
 							e.logf(item.Number, "warn", "phase 1: could not post re-prompt comment for %s: %v\n", login, err)
+							// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 						} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 							e.logf(item.Number, "warn", "phase 1: could not add 🚀 to re-prompt comment: %v\n", reactErr)
 						}
@@ -181,6 +186,8 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 					}
 					if err := e.client.AddLabelToIssue(owner, repo, item.Number, botRepromptedLabel); err != nil {
 						e.logf(item.Number, "warn", "phase 1: could not add %s: %v\n", botRepromptedLabel, err)
+					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), botRepromptedLabel)
 					}
 					e.logf(item.Number, "review-gate", "phase 1: re-prompted bot reviewer(s): %s\n", strings.Join(repromptedLogins, ", "))
 					return true, false
@@ -224,6 +231,8 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 	if !alreadyWaiting {
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:awaiting-review label: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 		}
 	}
 
@@ -237,11 +246,15 @@ func (e *Engine) removeAwaitingReviewLabel(owner, repo string, item gh.ProjectIt
 		if l == "fabrik:awaiting-review" {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
 				e.logf(item.Number, "warn", "could not remove fabrik:awaiting-review label: %v\n", err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 			}
 		}
 		if l == botRepromptedLabel {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, l); err != nil {
 				e.logf(item.Number, "warn", "could not remove %s label: %v\n", l, err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
 			}
 		}
 	}
@@ -352,14 +365,26 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post review timeout comment: %v\n", err)
-	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 	}
 }
 
@@ -476,14 +501,26 @@ func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.Projec
 	)
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
 		e.logf(item.Number, "warn", "could not post review cycle limit comment: %v\n", err)
-	} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-		e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 	}
 }
 

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -362,6 +362,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 		// R5: len(checkRuns) == 0 — no CI configured; gate clears.
 	}
 
+	// no write-through: excluded — MergePR affects PR state, not issue/label cache
 	if err := e.client.MergePR(owner, repo, pr.Number); err != nil {
 		if errors.Is(err, gh.ErrNotMergeable) {
 			// Apply fabrik:rebase-needed idempotently.
@@ -441,6 +442,7 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 	}
 
 	e.logf(item.Number, "advance", "moving decomposed issue to Done\n")
+	// write-through: already covered by cacheImpl.UpdateItemStatus call in the else block below
 	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
 		e.logf(item.Number, "warn", "could not move issue to Done: %v\n", err)
 	} else {
@@ -468,6 +470,7 @@ func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem,
 	}
 
 	e.logf(item.Number, "advance", "moving to stage %q\n", next.Name)
+	// write-through: already covered by cacheImpl.UpdateItemStatus call in the else block below
 	err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID)
 	if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -91,6 +91,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 				completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); lerr != nil {
 					e.logf(item.Number, "warn", "could not add completion label: %v\n", lerr)
+				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 				}
 				e.logf(item.Number, "rebase-reinvoke", "PR merge deferred — rebase dispatched\n")
 			} else {
@@ -116,6 +118,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 		if !alreadyAwaitingCI {
 			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
 				e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 			}
 		}
 		// Also seed fabrik:awaiting-review optimistically (Path 1 idempotent), so
@@ -131,6 +135,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 			if !alreadyAwaitingReview {
 				if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:awaiting-review label: %v\n", err)
+				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 				}
 			}
 		}
@@ -141,6 +147,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 	}
 
 	// fabrik:yolo or fabrik:cruise label overrides stage.AutoAdvance — if the user
@@ -176,6 +184,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 			if !alreadyWaiting {
 				if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:awaiting-review label: %v\n", err)
+				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 				}
 				e.logf(item.Number, "awaiting-review", "waiting for PR reviewers before advancing\n")
 			}
@@ -275,6 +285,8 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 				e.logf(item.Number, "ci-gate", "merge blocked — CI failed: %s\n", strings.Join(names, ", "))
 				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); lerr != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci: %v\n", lerr)
+				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 				}
 				// Clean up pending timer since we now have a definitive failure state.
 				e.mu.Lock()
@@ -315,14 +327,26 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 						pr.Number, timeout, strings.Join(names, ", "))
 					if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
 						e.logf(item.Number, "warn", "could not post CI timeout comment: %v\n", cerr)
-					} else if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-						e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+					} else {
+						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+							cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+								DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+							})
+						}
+						// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+						if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+							e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+						}
 					}
 					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); lerr != nil {
 						e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", lerr)
+					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 					}
 					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); lerr != nil {
 						e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", lerr)
+					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 					}
 					return fmt.Errorf("merge guard: CI wait timeout elapsed after %s", timeout)
 				}
@@ -351,6 +375,8 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 			if !alreadyLabeled {
 				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); lerr != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", lerr)
+				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
 				}
 			}
 			// inFlight guard: if a rebase goroutine is already running, skip
@@ -398,6 +424,8 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 	}
 
 	if e.statusField == nil {

--- a/engine/write_through_test.go
+++ b/engine/write_through_test.go
@@ -38,24 +38,40 @@ func TestLabelWriteThrough(t *testing.T) {
 	}
 }
 
-// TestLockLabelWriteThrough verifies that removeLockLabel immediately updates the cache.
+// TestLockLabelWriteThrough verifies both the add and remove write-through paths
+// for lock-style labels.
 func TestLockLabelWriteThrough(t *testing.T) {
 	client := &mockGitHubClient{}
 	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
 
-	// Seed the lock label into the cache first via ApplyLabelAdded.
-	lockLabel := "fabrik:locked:testuser"
-	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), lockLabel)
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := testStages()[0]
+
+	// Acquisition path: blockOnInput calls AddLabelToIssue for fabrik:paused and
+	// fabrik:awaiting-input using the same write-through pattern as processItem's
+	// lock acquire (direct AddLabelToIssue → cache.ApplyLabelAdded on success).
+	eng.blockOnInput(item, stage)
 
 	labels, err := cache.FetchLabels("owner", "repo", 1)
 	if err != nil {
-		t.Fatalf("FetchLabels before remove: %v", err)
+		t.Fatalf("FetchLabels after blockOnInput: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("add write-through: expected fabrik:paused in cache after blockOnInput, got %v", labels)
+	}
+
+	// Removal path: seed the lock label, then verify removeLockLabel updates the cache.
+	lockLabel := "fabrik:locked:testuser"
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), lockLabel)
+
+	labels, err = cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels before removeLockLabel: %v", err)
 	}
 	if !containsLabel(labels, lockLabel) {
 		t.Fatalf("precondition: expected lock label in cache, got %v", labels)
 	}
 
-	// removeLockLabel → cache should immediately drop the lock label.
 	eng.removeLockLabel("owner", "repo", 1, lockLabel)
 
 	labels, err = cache.FetchLabels("owner", "repo", 1)
@@ -63,7 +79,7 @@ func TestLockLabelWriteThrough(t *testing.T) {
 		t.Fatalf("FetchLabels after removeLockLabel: %v", err)
 	}
 	if containsLabel(labels, lockLabel) {
-		t.Errorf("expected lock label absent from cache after removeLockLabel, got %v", labels)
+		t.Errorf("removal write-through: expected lock label absent after removeLockLabel, got %v", labels)
 	}
 }
 
@@ -130,12 +146,14 @@ func TestWriteThroughOnFailure(t *testing.T) {
 	}
 }
 
-// TestAdvanceLoopRegression verifies the core bug: after advanceToNextStage succeeds,
-// the cache reflects the new status immediately — preventing re-dispatch on the next poll cycle.
-// (advanceToNextStage already had UpdateItemStatus write-through; this test is a non-regression guard.)
+// TestAdvanceLoopRegression verifies the core advance-loop bug class: after
+// advanceToNextStage succeeds, FetchProjectBoard immediately returns the new
+// Status — so the catch-up loop on the next poll sees the updated column and
+// does not re-dispatch. Without write-through, the cache would still show the
+// old Status and the catch-up loop would fire again every 15 seconds.
 func TestAdvanceLoopRegression(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng, _ := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{
 		FieldID: "FIELD_1",
 		Options: map[string]string{
@@ -145,25 +163,40 @@ func TestAdvanceLoopRegression(t *testing.T) {
 	}
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Repo: "owner/repo"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_001", Repo: "owner/repo"}
 
-	// advanceToNextStage from Research → Plan; UpdateProjectItemStatus should be called once.
+	// Precondition: cache shows item in "Research".
+	b0, err := cache.FetchProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard (before): %v", err)
+	}
+	if len(b0.Items) == 0 || b0.Items[0].Status != "Research" {
+		t.Fatalf("precondition: expected Status=Research, got %+v", b0.Items)
+	}
+
 	from := testStages()[0] // Research
 	if err := eng.advanceToNextStage(board, item, from); err != nil {
 		t.Fatalf("advanceToNextStage: %v", err)
 	}
-	if len(client.updateStatusCalls) != 1 {
-		t.Fatalf("expected 1 UpdateProjectItemStatus call, got %d", len(client.updateStatusCalls))
-	}
 
-	// Calling again immediately should still call UpdateProjectItemStatus (stage hasn't changed
-	// in the live board; the cache write-through prevents re-reading stale status mid-cycle).
-	// This test guards against the "advance fires twice on the same item" regression.
-	if err := eng.advanceToNextStage(board, item, from); err != nil {
-		t.Fatalf("advanceToNextStage (2nd call): %v", err)
+	// The cache must immediately reflect the new Status. If it did not, the
+	// catch-up loop would still see Status="Research" and re-advance, looping
+	// every poll cycle — the advance-loop bug observed on issues #501 and #506.
+	b1, err := cache.FetchProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard (after): %v", err)
 	}
-	if len(client.updateStatusCalls) != 2 {
-		t.Fatalf("expected 2 total UpdateProjectItemStatus calls, got %d", len(client.updateStatusCalls))
+	var found bool
+	for _, pi := range b1.Items {
+		if pi.Number == 1 {
+			found = true
+			if pi.Status != "Plan" {
+				t.Errorf("advance-loop regression: expected Status=Plan after advanceToNextStage, got %q — stale cache would cause re-dispatch loop", pi.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("item not found in FetchProjectBoard result after advance")
 	}
 }
 

--- a/engine/write_through_test.go
+++ b/engine/write_through_test.go
@@ -1,0 +1,186 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/verveguy/fabrik/boardcache"
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// TestLabelWriteThrough verifies that successful label mutations are immediately
+// reflected in the in-memory cache without waiting for webhook echo or Reconcile.
+func TestLabelWriteThrough(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+
+	// addFailedLabel → cache should immediately contain "stage:Research:failed"
+	eng.addFailedLabel("owner", "repo", 1, "Research")
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "stage:Research:failed") {
+		t.Errorf("expected 'stage:Research:failed' in cache after addFailedLabel, got %v", labels)
+	}
+
+	// removeFailedLabel → cache should immediately drop "stage:Research:failed"
+	eng.removeFailedLabel("owner", "repo", 1, "Research")
+
+	labels, err = cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels after remove: %v", err)
+	}
+	if containsLabel(labels, "stage:Research:failed") {
+		t.Errorf("expected 'stage:Research:failed' absent from cache after removeFailedLabel, got %v", labels)
+	}
+}
+
+// TestLockLabelWriteThrough verifies that removeLockLabel immediately updates the cache.
+func TestLockLabelWriteThrough(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+
+	// Seed the lock label into the cache first via ApplyLabelAdded.
+	lockLabel := "fabrik:locked:testuser"
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), lockLabel)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels before remove: %v", err)
+	}
+	if !containsLabel(labels, lockLabel) {
+		t.Fatalf("precondition: expected lock label in cache, got %v", labels)
+	}
+
+	// removeLockLabel → cache should immediately drop the lock label.
+	eng.removeLockLabel("owner", "repo", 1, lockLabel)
+
+	labels, err = cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels after removeLockLabel: %v", err)
+	}
+	if containsLabel(labels, lockLabel) {
+		t.Errorf("expected lock label absent from cache after removeLockLabel, got %v", labels)
+	}
+}
+
+// TestCommentWriteThrough verifies that a successful issue comment post is immediately
+// reflected in the cache so dispatch can see the new comment without a Reconcile round-trip.
+func TestCommentWriteThrough(t *testing.T) {
+	client := &mockGitHubClient{
+		// Return a fixed database ID so we can verify write-through stored the right comment.
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 9001, nil
+		},
+	}
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+
+	// Warm up the deep-fetch cache so FetchItemDetails returns from cache (not fallback).
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if err := cache.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails warm-up: %v", err)
+	}
+
+	// postOutputToPR with no open PR falls back to posting on the issue.
+	// No PR → FindPRForIssue returns 0 (mock default).
+	eng.postOutputToPR(
+		gh.ProjectItem{Number: 1, Repo: "owner/repo", Title: "Test"},
+		"Research",
+		"Claude output here",
+		"",
+		"fabrik/issue-1",
+		"abc1234",
+		"",
+		time.Now().Format(time.RFC3339),
+	)
+
+	// FetchItemDetails should now return from cache and include the written comment.
+	item2 := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if err := cache.FetchItemDetails(&item2); err != nil {
+		t.Fatalf("FetchItemDetails after postOutputToPR: %v", err)
+	}
+	if !containsCommentByID(item2.Comments, 9001) {
+		t.Errorf("expected comment with DatabaseID 9001 in cache, got %v", item2.Comments)
+	}
+}
+
+// TestWriteThroughOnFailure verifies that a failed GitHub mutation leaves the cache unchanged.
+func TestWriteThroughOnFailure(t *testing.T) {
+	apiErr := errors.New("github: rate limit exceeded")
+	client := &mockGitHubClient{
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			return apiErr
+		},
+	}
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+
+	// addFailedLabel will call AddLabelToIssue which returns an error.
+	eng.addFailedLabel("owner", "repo", 1, "Implement")
+
+	// Cache should NOT contain the label since the API call failed.
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if containsLabel(labels, "stage:Implement:failed") {
+		t.Errorf("expected cache unchanged on API failure, but found 'stage:Implement:failed' in %v", labels)
+	}
+}
+
+// TestAdvanceLoopRegression verifies the core bug: after advanceToNextStage succeeds,
+// the cache reflects the new status immediately — preventing re-dispatch on the next poll cycle.
+// (advanceToNextStage already had UpdateItemStatus write-through; this test is a non-regression guard.)
+func TestAdvanceLoopRegression(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, _ := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng.statusField = &gh.StatusField{
+		FieldID: "FIELD_1",
+		Options: map[string]string{
+			"Research": "OPT_1",
+			"Plan":     "OPT_2",
+		},
+	}
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Repo: "owner/repo"}
+
+	// advanceToNextStage from Research → Plan; UpdateProjectItemStatus should be called once.
+	from := testStages()[0] // Research
+	if err := eng.advanceToNextStage(board, item, from); err != nil {
+		t.Fatalf("advanceToNextStage: %v", err)
+	}
+	if len(client.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateProjectItemStatus call, got %d", len(client.updateStatusCalls))
+	}
+
+	// Calling again immediately should still call UpdateProjectItemStatus (stage hasn't changed
+	// in the live board; the cache write-through prevents re-reading stale status mid-cycle).
+	// This test guards against the "advance fires twice on the same item" regression.
+	if err := eng.advanceToNextStage(board, item, from); err != nil {
+		t.Fatalf("advanceToNextStage (2nd call): %v", err)
+	}
+	if len(client.updateStatusCalls) != 2 {
+		t.Fatalf("expected 2 total UpdateProjectItemStatus calls, got %d", len(client.updateStatusCalls))
+	}
+}
+
+func containsLabel(labels []string, target string) bool {
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCommentByID(comments []gh.Comment, dbID int) bool {
+	for _, c := range comments {
+		if c.DatabaseID == dbID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Extend the existing Layer 0 write-through convention — documented in `docs/state-machine.md` using the `cacheImpl` type-assertion pattern — to cover all GitHub mutation call sites in `engine/`: `AddLabelToIssue`, `RemoveLabelFromIssue`, `AddComment`, and related calls. Each mutation site should update the cache immediately after the GitHub API call succeeds, using `CacheImpl` methods.

## Problem

When fabrik calls a GitHub mutation API itself (label add, status update, lock add, comment post), the local cache is **not updated** until either a webhook event echoes back or the next periodic Reconcile runs. In user mode (no `projects_v2_item` webhook delivery, no App-installed webhook, repo-only webhooks), the cache stays stale until Reconcile — up to 60 minutes.

This causes the **advance-loop class of bug**: `engine.advanceToNextStage` calls `UpdateProjectItemStatus`, GitHub processes it, but local cache still says the old Status. Next poll, the catch-up loop sees `stage:X:complete` + cached `Status="OldColumn"` and tries to advance again. Repeats every 15 seconds.

Concretely observed on **#501** and **#506** (logs preserved in those issues).

**Current state**: The Status write-through for `UpdateProjectItemStatus` is already implemented in `engine/stages.go` using `cacheImpl.UpdateItemStatus(...)`. Labels, comments, and lock paths have no write-through yet.

## Approach

### Approach

Extend the existing Layer 0 write-through convention to cover label and comment mutations. The pattern is already established in `engine/stages.go` for `UpdateItemStatus`: call the GitHub API, then on `nil` error, type-assert `e.readClient` to `*boardcache.CacheImpl` and call a write-through method. This PR adds three new `CacheImpl` methods (`ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded`) and wires them into every `AddLabelToIssue`, `RemoveLabelFromIssue`, and issue-targeted `AddComment` call site across `engine/`.

The `internal/itemstate` `Local*` mutation types already exist and are handled by `store.go` — only the `CacheImpl` wrapper methods are missing. No `store.go` changes needed.

Write-through is applied **inside the existing private helpers** where they exist (`ensureLabelOnIssue`, `removeLabelFromIssueIfExists`, `removeLabelFromIssue` in `item.go`), and at direct call sites elsewhere. This avoids patching each call site individually for those helpers.

No new ADR is warranted — this extends an explicitly anticipated pattern documented in ADR-035. The docs update is to `docs/state-machine.md` only.

---

### New/Modified Files

| File | Change |
|------|--------|
| `boardcache/boardcache.go` | Add `ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded` methods |
| `boardcache/boardcache_test.go` | Add unit tests for new `CacheImpl` methods including concurrency test |
| `engine/engine_helpers_test.go` | Add `testEngineWithCache` helper for write-through tests |
| `engine/write_through_test.go` | New file: all 5 write-through regression tests |
| `engine/stages.go` | Add write-through at 10 label sites + 1 comment site; add exclusion comments |
| `engine/item.go` | Add write-through inside helpers `ensureLabelOnIssue`, `removeLabelFromIssueIfExists`, `removeLabelFromIssue`; add write-through at direct call sites (lock acquire/release, `blockOnInput`, `unblockAwaitingInput`, etc.); add exclusion comments |
| `engine/ci.go` | Add write-through at 7 label sites + 2 comment sites; add exclusion comments |
| `engine/comments.go` | Add write-through at 1 label site + 2 comment sites; add exclusion comment for PR-targeted `AddComment` |
| `engine/reviews.go` | Add write-through at 7 label sites + 2 comment sites; add exclusion comments for PR bot re-prompt `AddComment` |
| `engine/poll.go` | Add write-through at 2 label (orphan-lock release) sites |
| `engine/merge_gate.go` | Add write-through at 3 label sites + 1 comment site |
| `engine/dependencies.go` | Add write-through at 1 label site + 1 comment site |
| `engine/engine.go` | Add write-through at 2 label sites + 1 comment site |
| `docs/state-machine.md` | Extend §D.7 Layer 0 section to cover label/comment write-through, list new methods, document exclusions |

---

### Key Decisions

- **Apply write-through inside helpers, not at each call site**: `ensureLabelOnIssue`, `removeLabelFromIssueIfExists`, and `removeLabelFromIssue` in `item.go` are the only engine-internal helpers that wrap `AddLabelToIssue`/`RemoveLabelFromIssue`. Applying write-through inside the helpers covers all their callers in one place without duplicating the pattern. The helper signatures already have `owner`, `repo`, `issueNumber` — enough to construct the `ItemKey`. Direct call sites in other files that bypass helpers still need individual patching.

- **Use `LocalLabelAdded/Removed` (not `LocalLockAcquired/Released`) for lock paths**: `LocalLockAcquired/Released` exist in `mutation.go` but the spec explicitly scopes this PR to label write-through. Lock acquisition/release goes through `AddLabelToIssue`/`RemoveLabelFromIssue`, so `ApplyLabelAdded`/`ApplyLabelRemoved` cover lock correctly. `LocalLockAcquired/Released` are deferred to a later phase.

- **`bumpLocalDeltaAt` only when Store reports changes**: Mirror `UpdateItemStatus` exactly — check `len(changes) == 0` after `store.Apply` and return early. Unconditional bump would spuriously freshen stale items, defeating the freshness signal.

- **No write-through for `LocalCommentAdded` idempotency**: `LocalCommentAdded` does a raw append (not idempotent by `DatabaseID`). This is acceptable because comment dedup for dispatch uses rocket-reaction checks, not `DatabaseID` uniqueness. A code comment on `ApplyCommentAdded` must document this transient-duplicate behavior.

- **`Author` field for `ApplyCommentAdded` is `e.cfg.User`**: All issue-targeted `AddComment` calls in scope post under the configured PAT identity. This is correct for all in-scope sites. PR-targeted comments are excluded and don't need this field.

- **`testEngineWithCache` creates a real `CacheImpl` in tests**: `NewWithDeps` always sets `readClient = NewGitHubAdapter(...)`, bypassing `CacheImpl`. Tests must directly assign `e.readClient = boardcache.NewCacheImpl(mock, logFn)` and bootstrap it with a test item. Since engine tests are `package engine` (in-package), `e.readClient` is accessible. Return both `*Engine` and `*boardcache.CacheImpl` from the helper so tests can query the cache directly.

---

### Task Checklist

- [ ] **Task 1**: Add `ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded` to `boardcache/boardcache.go` — mirror the `UpdateItemStatus` pattern: `parseItemKey` → `store.Apply(Local*)` → check `len(changes) == 0` → `bumpLocalDeltaAt`; document `LocalCommentAdded` non-idempotency in a comment on `ApplyCommentAdded`

- [ ] **Task 2**: Add unit tests for new `CacheImpl` methods in `boardcache/boardcache_test.go` — `TestApplyLabelAdded` (idempotent add), `TestApplyLabelRemoved` (removes; no-op when absent), `TestApplyCommentAdded` (appends), `TestWriteThroughNoopOnUnknownKey`, `TestConcurrentWriteThrough` (concurrent add+remove on same item, run with `-race`)

- [ ] **Task 3**: Add `testEngineWithCache` helper to `engine/engine_helpers_test.go` — returns `(*Engine, *boardcache.CacheImpl)` with a bootstrapped test item; also check whether `TestAdvanceLoopRegression` exists in `engine/stages_test.go` or `engine/advance_stage_test.go` and add it if absent (verifies `advanceToNextStage` write-through for Status)

- [ ] **Task 4**: Add write-through at all label sites in `engine/stages.go` (lines 92, 117, 132, 142, 177, 276, 321, 324, 352, 399) and at the comment site (line 316); add `// no write-through: excluded — already covered by UpdateItemStatus write-through` at the `UpdateProjectItemStatus` sites

- [ ] **Task 5**: Add write-through inside `engine/item.go` helpers (`ensureLabelOnIssue`, `removeLabelFromIssueIfExists`, `removeLabelFromIssue`); add write-through at remaining direct `AddLabelToIssue`/`RemoveLabelFromIssue` call sites (lock acquire line 545, `inProgressLabel` line 603, `pauseForRetries` lines 948, `blockOnInput` lines 1003/1006, `clearFailedStage` line 978, `unblockAwaitingInput` lines 1018/1022, `extend-turns` remove line 891, unpause line 387); add write-through at comment sites (lines 790, 830, 958, 1136)

- [ ] **Task 6**: Add write-through at all label sites in `engine/ci.go` (lines 165, 191, 177, 405, 408, 432, 435) and comment sites (lines 400, 427)

- [ ] **Task 7**: Add write-through at the label site in `engine/comments.go` (line 94) and included comment sites (lines 175, 189); add `// no write-through: excluded — posts to PR comment thread, not issue cache` at line 211

- [ ] **Task 8**: Add write-through at label sites in `engine/reviews.go` (lines 182, 225, 358, 361, 482, 485, and remove loop at 138/238/243) and comment sites (lines 353, 477); add exclusion comment at line 175 (`posts to item.LinkedPRNumber — PR comment, not issue cache`)

- [ ] **Task 9**: Add write-through at label/comment sites in `engine/poll.go` (lines 514, 546), `engine/merge_gate.go` (lines 81, 92, 253, 256, 248), `engine/dependencies.go` (lines 86, 49, 81), and `engine/engine.go` (lines 426, 429, 421)

- [ ] **Task 10**: Add exhaustive exclusion comments at all excluded `e.client.Add*`/`e.client.Remove*`/`e.client.Update*`/`e.client.Create*` sites that do NOT get write-through (`AddCommentReaction` all sites, `AddPRReviewCommentReaction`, `CreateDraftPR`, `MarkPRReady`, `UpdateIssueBody`, `MergePR`); comment format: `// no write-through: excluded — <reason>`; grep `e\.client\.(AddLabelToIssue|RemoveLabelFromIssue|AddComment|AddCommentReaction|AddPRReviewCommentReaction|CreateDraftPR|MarkPRReady|UpdateIssueBody|MergePR)` to confirm exhaustive coverage

- [ ] **Task 11**: Add `engine/write_through_test.go` with `TestLabelWriteThrough` (add+remove, using `testEngineWithCache`), `TestCommentWriteThrough`, `TestLockLabelWriteThrough`, `TestWriteThroughOnFailure` (mock returns error → cache unchanged)

- [ ] **Task 12**: Update `docs/state-machine.md` §D.7 "Layer 0 write-through convention" — extend to cover `ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded`; document the non-idempotency caveat for `LocalCommentAdded`; table of excluded mutation types with reasons

- [ ] **Task 13**: Run `go build ./...`, `go vet ./...`, `go test -race ./engine/... ./boardcache/...` and resolve any failures

---

### Risks

- **Missing a call site**: The exhaustive audit in Research covers 35+ label sites and 16+ comment sites. Task 10 has a mandatory grep step that mechanically verifies every `e.client.Add*/Remove*/Update*/Create*` site is either patched or commented as excluded. This is the primary mitigation.

- **`bumpLocalDeltaAt` unconditional bump**: If a new method bumps `localDeltaAt` even when `store.Apply` returns empty changes (item not in store), stale items appear fresh. The `if len(changes) == 0 { return }` guard in Task 1 mitigates this — it must mirror `UpdateItemStatus` exactly.

- **`removeLabelFromIssueIfExists` helper write-through signature**: The helper already has `owner`, `repo`, `issueNumber` — `boardcache.ItemKey(owner+"/"+repo, issueNumber)` yields the correct key. Verify this matches the `item.Repo` format used elsewhere (`owner/repo` — confirmed by `ItemKey` impl).

- **`TestWriteThroughOnFailure` test setup**: Must verify the mock returns an error AND that no write-through method is called. The simplest approach is to inspect the `CacheImpl` before and after the failed call — labels/comments should be identical. The `-race` flag in Task 13 catches any mutex misuse introduced in the new methods.

---
Used 13/50 turns, 9k input / 9k output tokens.

## Verification

Extended Fabrik's Layer 0 write-through cache convention to cover label and comment mutations across 9 engine files, closing the advance-loop bug class where repeated stage-advance attempts occurred because the cache showed stale state after self-driven mutations. Added `ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded` to `boardcache.CacheImpl` with existence guards, wired them at all relevant call sites, annotated all excluded sites, added 5 regression tests, and updated `docs/state-machine.md §D.7`.

---

Closes #515