### PR TITLE
Phase 3-D: webhook delta complete coverage (closes 'fabrik went deaf' bug class)

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -23,6 +23,7 @@ type ReadClient interface {
 	FetchStatusField(projectID string) (*gh.StatusField, error)
 	FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)
 	FetchPRsForSHA(owner, repo, sha string) ([]int, error)
+	FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error)
 	RateLimitStats() (rest, graphql gh.RateLimitStats)
 }
 
@@ -75,6 +76,10 @@ func (a *GitHubAdapter) FetchPRClosingIssues(owner, repo string, prNumber int) (
 
 func (a *GitHubAdapter) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
 	return a.client.FetchPRsForSHA(owner, repo, sha)
+}
+
+func (a *GitHubAdapter) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	return a.client.FetchProjectItem(owner, repo, issueNumber)
 }
 
 func (a *GitHubAdapter) RateLimitStats() (rest, graphql gh.RateLimitStats) {
@@ -608,6 +613,11 @@ func (c *CacheImpl) FetchPRClosingIssues(owner, repo string, prNumber int) ([]in
 // FetchPRsForSHA always delegates to GitHub — used by the auto-heal path in applyCheckRunCompleted.
 func (c *CacheImpl) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
 	return c.fallback.FetchPRsForSHA(owner, repo, sha)
+}
+
+// FetchProjectItem always delegates to GitHub — used by ensureIssueInStore for the fallback fetch path.
+func (c *CacheImpl) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	return c.fallback.FetchProjectItem(owner, repo, issueNumber)
 }
 
 // RateLimitStats always delegates to GitHub.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -16,21 +16,24 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockClient struct {
-	fetchItemDetailsCount      int
-	fetchCheckRunsCount        int
-	fetchLinkedPRCount         int
-	fetchLabelsCount           int
-	fetchPRClosingIssuesCount  int
-	fetchPRsForSHACount        int
+	fetchItemDetailsCount     int
+	fetchCheckRunsCount       int
+	fetchLinkedPRCount        int
+	fetchLabelsCount          int
+	fetchPRClosingIssuesCount int
+	fetchPRsForSHACount       int
+	fetchProjectItemCount     int
 
 	itemDetailsResult  *gh.ProjectItem
 	checkRunsResult    []gh.CheckRun
 	linkedPRResult     *gh.PRDetails
 	labelsResult       []string
 	projectBoardResult *gh.ProjectBoard
+	projectItemResult  *gh.ProjectItem
 
 	fetchPRClosingIssuesFn func(owner, repo string, prNumber int) ([]int, error)
 	fetchPRsForSHAFn       func(owner, repo, sha string) ([]int, error)
+	fetchProjectItemFn     func(owner, repo string, issueNumber int) (*gh.ProjectItem, error)
 }
 
 func (m *mockClient) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
@@ -92,6 +95,18 @@ func (m *mockClient) FetchPRClosingIssues(owner, repo string, prNumber int) ([]i
 	m.fetchPRClosingIssuesCount++
 	if m.fetchPRClosingIssuesFn != nil {
 		return m.fetchPRClosingIssuesFn(owner, repo, prNumber)
+	}
+	return nil, nil
+}
+
+func (m *mockClient) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	m.fetchProjectItemCount++
+	if m.fetchProjectItemFn != nil {
+		return m.fetchProjectItemFn(owner, repo, issueNumber)
+	}
+	if m.projectItemResult != nil {
+		cp := *m.projectItemResult
+		return &cp, nil
 	}
 	return nil, nil
 }

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -46,6 +46,15 @@ func (m *mockClient) FetchProjectBoard(owner, repo string, projectNum int, owner
 func (m *mockClient) FetchItemDetails(item *gh.ProjectItem) error {
 	m.fetchItemDetailsCount++
 	if m.itemDetailsResult != nil {
+		// Mirror the real FetchItemDetails behaviour: populate Number and Repo only
+		// when the caller hasn't already set them (e.g. projects_v2_item.created path
+		// passes a bare ProjectItem{ID: nodeID} with Number=0 and Repo="").
+		if item.Number == 0 && m.itemDetailsResult.Number > 0 {
+			item.Number = m.itemDetailsResult.Number
+		}
+		if item.Repo == "" && m.itemDetailsResult.Repo != "" {
+			item.Repo = m.itemDetailsResult.Repo
+		}
 		item.Body = m.itemDetailsResult.Body
 		item.Comments = cloneComments(m.itemDetailsResult.Comments)
 		item.LinkedPRNumber = m.itemDetailsResult.LinkedPRNumber
@@ -1590,4 +1599,121 @@ func TestConcurrentWriteThrough(t *testing.T) {
 	if count > 1 {
 		t.Errorf("want at most 1 'concurrent-label', got %d; labels=%v", count, labels)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional payload builders for Phase 3-D delta coverage tests
+// ---------------------------------------------------------------------------
+
+// issuesOpenedPayloadJSON builds an issues.opened payload with full issue data.
+func issuesOpenedPayloadJSON(repo string, issNum int, nodeID, title, body string, labels, assignees []string) []byte {
+	p := issuesPayload{Action: "opened"}
+	p.Repository.FullName = repo
+	p.Issue.Number = issNum
+	p.Issue.NodeID = nodeID
+	p.Issue.Title = title
+	p.Issue.Body = body
+	for _, l := range labels {
+		p.Issue.Labels = append(p.Issue.Labels, struct {
+			Name string `json:"name"`
+		}{Name: l})
+	}
+	for _, a := range assignees {
+		p.Issue.Assignees = append(p.Issue.Assignees, struct {
+			Login string `json:"login"`
+		}{Login: a})
+	}
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// issuesActionPayloadJSON builds a simple issues payload (closed/reopened/deleted/transferred)
+// with just repo and issue number.
+func issuesActionPayloadJSON(action, repo string, issNum int) []byte {
+	p := issuesPayload{Action: action}
+	p.Repository.FullName = repo
+	p.Issue.Number = issNum
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// issuesEditedPayloadJSON builds an issues.edited payload.
+func issuesEditedPayloadJSON(repo string, issNum int, title, body string) []byte {
+	p := issuesPayload{Action: "edited"}
+	p.Repository.FullName = repo
+	p.Issue.Number = issNum
+	p.Issue.Title = title
+	p.Issue.Body = body
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// issuesAssignedPayloadJSON builds an issues.assigned/unassigned payload with
+// the post-mutation full assignee list.
+func issuesAssignedPayloadJSON(action, repo string, issNum int, assignees []string) []byte {
+	p := issuesPayload{Action: action}
+	p.Repository.FullName = repo
+	p.Issue.Number = issNum
+	for _, a := range assignees {
+		p.Issue.Assignees = append(p.Issue.Assignees, struct {
+			Login string `json:"login"`
+		}{Login: a})
+	}
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// projectsV2ItemCreatedPayloadJSON builds a projects_v2_item.created payload.
+func projectsV2ItemCreatedPayloadJSON(contentNodeID, contentType string) []byte {
+	p := projectsV2ItemPayload{Action: "created"}
+	p.ProjectsV2Item.ContentNodeID = contentNodeID
+	p.ProjectsV2Item.ContentType = contentType
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// projectsV2ItemRemovedPayloadJSON builds a projects_v2_item.deleted or .archived payload.
+func projectsV2ItemRemovedPayloadJSON(action, itemID string) []byte {
+	p := projectsV2ItemPayload{Action: action}
+	p.ProjectsV2Item.ID = itemID
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// pullRequestDraftPayloadJSON builds a pull_request.ready_for_review or .converted_to_draft payload.
+func pullRequestDraftPayloadJSON(action, repo string, prNum int) []byte {
+	p := pullRequestPayload{Action: action}
+	p.Repository.FullName = repo
+	p.PullRequest.Number = prNum
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// pullRequestReviewRequestedPayloadJSON builds a pull_request.review_requested payload.
+// allReviewers is the full list after adding; singleLogin/singleType is the one being added.
+func pullRequestReviewRequestedPayloadJSON(repo string, prNum int, allLogins []string, singleLogin string) []byte {
+	p := pullRequestPayload{Action: "review_requested"}
+	p.Repository.FullName = repo
+	p.PullRequest.Number = prNum
+	for _, login := range allLogins {
+		p.PullRequest.RequestedReviewers = append(p.PullRequest.RequestedReviewers, struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		}{Login: login, Type: "User"})
+	}
+	p.RequestedReviewer.Login = singleLogin
+	p.RequestedReviewer.Type = "User"
+	b, _ := json.Marshal(p)
+	return b
+}
+
+// pullRequestReviewRequestRemovedPayloadJSON builds a pull_request.review_request_removed payload.
+func pullRequestReviewRequestRemovedPayloadJSON(repo string, prNum int, removedLogin string) []byte {
+	p := pullRequestPayload{Action: "review_request_removed"}
+	p.Repository.FullName = repo
+	p.PullRequest.Number = prNum
+	p.RequestedReviewer.Login = removedLogin
+	p.RequestedReviewer.Type = "User"
+	b, _ := json.Marshal(p)
+	return b
 }

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1664,8 +1664,10 @@ func issuesAssignedPayloadJSON(action, repo string, issNum int, assignees []stri
 }
 
 // projectsV2ItemCreatedPayloadJSON builds a projects_v2_item.created payload.
-func projectsV2ItemCreatedPayloadJSON(contentNodeID, contentType string) []byte {
+// boardItemID is the PVTI_xxx board-side item ID stored in projects_v2_item.id.
+func projectsV2ItemCreatedPayloadJSON(contentNodeID, contentType, boardItemID string) []byte {
 	p := projectsV2ItemPayload{Action: "created"}
+	p.ProjectsV2Item.ID = boardItemID
 	p.ProjectsV2Item.ContentNodeID = contentNodeID
 	p.ProjectsV2Item.ContentType = contentType
 	b, _ := json.Marshal(p)

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -484,7 +484,7 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		}
 		reviewers := make([]gh.ReviewRequest, 0, len(p.PullRequest.RequestedReviewers))
 		for _, r := range p.PullRequest.RequestedReviewers {
-			reviewers = append(reviewers, gh.ReviewRequest{Login: r.Login, IsBot: r.Type == "Bot"})
+			reviewers = append(reviewers, gh.ReviewRequest{Login: r.Login, IsBot: r.Type == "Bot" || gh.IsBotLogin(r.Login)})
 		}
 		c.store.Apply(itemstate.PRReviewRequested{
 			Repo:      issRepo,
@@ -955,6 +955,9 @@ func (c *CacheImpl) applyProjectsV2ItemDelta(payload []byte) {
 			c.logFn("[cache] applyProjectsV2ItemDelta(created): incomplete item for node %s (number=%d repo=%q)\n", nodeID, pi.Number, pi.Repo)
 			return
 		}
+		// Record the board-side item ID (PVTI_xxx) so that subsequent
+		// projects_v2_item.edited/deleted/archived events can resolve via itemIDToKey.
+		pi.ItemID = p.ProjectsV2Item.ID
 		_, changes, _ := c.store.Apply(itemstate.IssueOpened{Item: *pi})
 		if len(changes) == 0 {
 			return

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -2,6 +2,7 @@ package boardcache
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -227,6 +228,9 @@ func (c *CacheImpl) ensureIssueInStore(owner, fullRepo string, issNum int) error
 	pi, err := c.fallback.FetchProjectItem(owner, fullRepo[len(owner)+1:], issNum)
 	if err != nil {
 		return err
+	}
+	if pi == nil {
+		return fmt.Errorf("FetchProjectItem returned nil for %s#%d", fullRepo, issNum)
 	}
 	if pi.Repo == "" {
 		pi.Repo = fullRepo

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -63,7 +63,17 @@ type issuesPayload struct {
 		Name string `json:"name"`
 	} `json:"label"`
 	Issue struct {
-		Number int `json:"number"`
+		Number    int    `json:"number"`
+		NodeID    string `json:"node_id"`
+		Title     string `json:"title"`
+		Body      string `json:"body"`
+		State     string `json:"state"`
+		Labels    []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
 	} `json:"issue"`
 	Repository struct {
 		FullName string `json:"full_name"`
@@ -80,9 +90,19 @@ type pullRequestPayload struct {
 		Draft   bool   `json:"draft"`
 		Head    struct {
 			SHA string `json:"sha"`
+			Ref string `json:"ref"`
 		} `json:"head"`
-		MergeableState string `json:"mergeable_state"`
+		MergeableState     string `json:"mergeable_state"`
+		RequestedReviewers []struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"requested_reviewers"`
 	} `json:"pull_request"`
+	// RequestedReviewer is present in review_requested/review_request_removed events.
+	RequestedReviewer struct {
+		Login string `json:"login"`
+		Type  string `json:"type"`
+	} `json:"requested_reviewer"`
 	Repository struct {
 		FullName string `json:"full_name"`
 	} `json:"repository"`

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -18,19 +18,24 @@ func (c *CacheImpl) ApplyDelta(eventType string, payload []byte) {
 
 	switch eventType {
 	case "issue_comment":
-		c.applyIssueCommentCreated(payload)
+		c.applyIssueCommentDelta(payload)
 	case "issues":
 		c.applyIssuesDelta(payload)
 	case "pull_request":
 		c.applyPullRequestDelta(payload)
 	case "pull_request_review":
-		c.applyPullRequestReviewSubmitted(payload)
+		c.applyPullRequestReviewDelta(payload)
 	case "pull_request_review_comment":
-		c.applyPullRequestReviewCommentCreated(payload)
+		c.applyPullRequestReviewCommentDelta(payload)
 	case "check_run":
-		c.applyCheckRunCompleted(payload)
+		c.applyCheckRunDelta(payload)
+	case "check_suite":
+		// No-op: check_suite events are coarse-grained aggregates. Individual
+		// check run outcomes are tracked via check_run.completed, which provides
+		// the per-run Name, Conclusion, and SHA needed for the CI gate.
+		c.applyCheckSuite(payload)
 	case "projects_v2_item":
-		c.applyProjectsV2ItemEdited(payload)
+		c.applyProjectsV2ItemDelta(payload)
 	}
 }
 
@@ -204,15 +209,52 @@ func (c *CacheImpl) bumpLocalDeltaAt(key string) {
 	c.mu.Unlock()
 }
 
+// ensureIssueInStore guarantees the item (fullRepo, issNum) exists in the Store.
+// If the item is already present it is a fast no-op. On miss it fetches a minimal
+// ProjectItem from GitHub via FetchProjectItem and applies IssueOpened to the Store.
+//
+// This implements the "unknown-issue fallback" contract from ADR 034 §4: every
+// handler that would silently drop a delta for a missing item calls ensureIssueInStore
+// first so the item is populated before the delta is applied.
+//
+// Must be called WITHOUT holding c.mu (the network fetch must not hold any lock).
+func (c *CacheImpl) ensureIssueInStore(owner, fullRepo string, issNum int) error {
+	// Fast path: item already in Store.
+	if _, err := c.store.Get(fullRepo, issNum); err == nil {
+		return nil
+	}
+	// Miss: fetch from GitHub and populate.
+	pi, err := c.fallback.FetchProjectItem(owner, fullRepo[len(owner)+1:], issNum)
+	if err != nil {
+		return err
+	}
+	if pi.Repo == "" {
+		pi.Repo = fullRepo
+	}
+	c.store.Apply(itemstate.IssueOpened{Item: *pi})
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Delta functions
 // ---------------------------------------------------------------------------
 
-func (c *CacheImpl) applyIssueCommentCreated(payload []byte) {
+func (c *CacheImpl) applyIssueCommentDelta(payload []byte) {
 	var p issueCommentPayload
-	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "created" {
+	if err := json.Unmarshal(payload, &p); err != nil {
 		return
 	}
+	switch p.Action {
+	case "created":
+		// handled below
+	case "edited", "deleted":
+		// Comment edits and deletes are not tracked in the cache; the engine
+		// re-fetches comments via FetchItemDetails on the next poll cycle.
+		return
+	default:
+		return
+	}
+
 	fullRepo := p.Repository.FullName
 	issNum := p.Issue.Number
 	key := itemKey(fullRepo, issNum)
@@ -247,52 +289,144 @@ func (c *CacheImpl) applyIssuesDelta(payload []byte) {
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return
 	}
+
+	fullRepo := p.Repository.FullName
+	issNum := p.Issue.Number
+	key := itemKey(fullRepo, issNum)
+
+	owner, _, ok := splitRepo(fullRepo)
+	if !ok {
+		return
+	}
+
 	switch p.Action {
+	case "opened":
+		// Build a minimal ProjectItem from the webhook payload.
+		labels := make([]string, len(p.Issue.Labels))
+		for i, l := range p.Issue.Labels {
+			labels[i] = l.Name
+		}
+		assignees := make([]string, len(p.Issue.Assignees))
+		for i, a := range p.Issue.Assignees {
+			assignees[i] = a.Login
+		}
+		pi := gh.ProjectItem{
+			ID:        p.Issue.NodeID,
+			Number:    issNum,
+			Title:     p.Issue.Title,
+			Body:      p.Issue.Body,
+			Repo:      fullRepo,
+			Labels:    labels,
+			Assignees: assignees,
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueOpened{Item: pi})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
+	case "closed":
+		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
+			c.logFn("[cache] applyIssuesDelta(closed): ensure #%d: %v\n", issNum, err)
+			return
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueClosed{Repo: fullRepo, Number: issNum})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
+	case "reopened":
+		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
+			c.logFn("[cache] applyIssuesDelta(reopened): ensure #%d: %v\n", issNum, err)
+			return
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueReopened{Repo: fullRepo, Number: issNum})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
+	case "transferred", "deleted":
+		// Remove the item from the Store and clean up any PR linkage entries.
+		c.store.Remove(fullRepo, issNum)
+		c.mu.Lock()
+		for pk, ik := range c.prNumToKey {
+			if ik == key {
+				delete(c.prNumToKey, pk)
+				delete(c.linkedPRs, pk)
+			}
+		}
+		c.mu.Unlock()
+
+	case "edited":
+		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
+			c.logFn("[cache] applyIssuesDelta(edited): ensure #%d: %v\n", issNum, err)
+			return
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueEdited{
+			Repo:   fullRepo,
+			Number: issNum,
+			Title:  p.Issue.Title,
+			Body:   p.Issue.Body,
+		})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
+	case "assigned", "unassigned":
+		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
+			c.logFn("[cache] applyIssuesDelta(%s): ensure #%d: %v\n", p.Action, issNum, err)
+			return
+		}
+		assignees := make([]string, len(p.Issue.Assignees))
+		for i, a := range p.Issue.Assignees {
+			assignees[i] = a.Login
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueAssigneesUpdated{
+			Repo:      fullRepo,
+			Number:    issNum,
+			Assignees: assignees,
+		})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
 	case "labeled":
-		c.applyIssuesLabeled(p)
+		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
+			c.logFn("[cache] applyIssuesDelta(labeled): ensure #%d: %v\n", issNum, err)
+			return
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueLabeled{
+			Repo:   fullRepo,
+			Number: issNum,
+			Label:  p.Label.Name,
+		})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
 	case "unlabeled":
-		c.applyIssuesUnlabeled(p)
+		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
+			c.logFn("[cache] applyIssuesDelta(unlabeled): ensure #%d: %v\n", issNum, err)
+			return
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueUnlabeled{
+			Repo:   fullRepo,
+			Number: issNum,
+			Label:  p.Label.Name,
+		})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(key)
+
+	// milestoned, demilestoned, locked, unlocked, pinned, unpinned:
+	// no state in the engine's pipeline depends on these fields.
 	}
-}
-
-func (c *CacheImpl) applyIssuesLabeled(p issuesPayload) {
-	fullRepo := p.Repository.FullName
-	issNum := p.Issue.Number
-	key := itemKey(fullRepo, issNum)
-
-	if _, err := c.store.Get(fullRepo, issNum); err != nil {
-		return
-	}
-
-	_, changes, _ := c.store.Apply(itemstate.IssueLabeled{
-		Repo:   fullRepo,
-		Number: issNum,
-		Label:  p.Label.Name,
-	})
-	if len(changes) == 0 {
-		return // no-op (label already present or item missing)
-	}
-	c.bumpLocalDeltaAt(key)
-}
-
-func (c *CacheImpl) applyIssuesUnlabeled(p issuesPayload) {
-	fullRepo := p.Repository.FullName
-	issNum := p.Issue.Number
-	key := itemKey(fullRepo, issNum)
-
-	if _, err := c.store.Get(fullRepo, issNum); err != nil {
-		return
-	}
-
-	_, changes, _ := c.store.Apply(itemstate.IssueUnlabeled{
-		Repo:   fullRepo,
-		Number: issNum,
-		Label:  p.Label.Name,
-	})
-	if len(changes) == 0 {
-		return
-	}
-	c.bumpLocalDeltaAt(key)
 }
 
 func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
@@ -300,15 +434,88 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return
 	}
-	switch p.Action {
-	case "opened", "closed", "synchronize", "reopened":
-	default:
-		return
-	}
 
 	repo := p.Repository.FullName
 	prNum := p.PullRequest.Number
 	pk := prKey(repo, prNum)
+
+	switch p.Action {
+	case "opened", "closed", "synchronize", "reopened":
+		// SHA-tracking path — handled after this switch.
+
+	case "ready_for_review":
+		c.mu.Lock()
+		if pr, ok := c.linkedPRs[pk]; ok {
+			pr.Draft = false
+		}
+		issKey, _ := c.prNumToKey[pk]
+		c.mu.Unlock()
+		if issKey != "" {
+			c.bumpLocalDeltaAt(issKey)
+		}
+		return
+
+	case "converted_to_draft":
+		c.mu.Lock()
+		if pr, ok := c.linkedPRs[pk]; ok {
+			pr.Draft = true
+		}
+		issKey, _ := c.prNumToKey[pk]
+		c.mu.Unlock()
+		if issKey != "" {
+			c.bumpLocalDeltaAt(issKey)
+		}
+		return
+
+	case "review_requested":
+		c.mu.RLock()
+		issKey, issFound := c.prNumToKey[pk]
+		c.mu.RUnlock()
+		if !issFound {
+			return
+		}
+		issRepo, issNum, parseOK := parseItemKey(issKey)
+		if !parseOK {
+			return
+		}
+		reviewers := make([]gh.ReviewRequest, 0, len(p.PullRequest.RequestedReviewers))
+		for _, r := range p.PullRequest.RequestedReviewers {
+			reviewers = append(reviewers, gh.ReviewRequest{Login: r.Login, IsBot: r.Type == "Bot"})
+		}
+		c.store.Apply(itemstate.PRReviewRequested{
+			Repo:      issRepo,
+			Number:    issNum,
+			Reviewers: reviewers,
+		})
+		c.bumpLocalDeltaAt(issKey)
+		return
+
+	case "review_request_removed":
+		c.mu.RLock()
+		issKey, issFound := c.prNumToKey[pk]
+		c.mu.RUnlock()
+		if !issFound {
+			return
+		}
+		issRepo, issNum, parseOK := parseItemKey(issKey)
+		if !parseOK {
+			return
+		}
+		c.store.Apply(itemstate.PRReviewRequestRemoved{
+			Repo:   issRepo,
+			Number: issNum,
+			Login:  p.RequestedReviewer.Login,
+		})
+		c.bumpLocalDeltaAt(issKey)
+		return
+
+	// labeled, unlabeled, assigned, unassigned, edited: no engine pipeline state
+	// depends on PR-level labels/assignees/metadata. These are intentional no-ops.
+	default:
+		return
+	}
+
+	// --- SHA-tracking path (opened, closed, synchronize, reopened) ---
 	sha := p.PullRequest.Head.SHA
 	prDetails := &gh.PRDetails{
 		Number:         prNum,
@@ -386,9 +593,19 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, resolvedIssNum)
 }
 
-func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
+func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 	var p pullRequestReviewPayload
-	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "submitted" {
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return
+	}
+	switch p.Action {
+	case "submitted":
+		// handled below
+	case "edited", "dismissed":
+		// Review edits and dismissals do not change the set of pending reviewers
+		// or the overall approval state tracked by the engine.
+		return
+	default:
 		return
 	}
 	repo := p.Repository.FullName
@@ -470,9 +687,19 @@ func (c *CacheImpl) applyPullRequestReviewSubmitted(payload []byte) {
 	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, resolvedIssNum)
 }
 
-func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
+func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 	var p pullRequestReviewCommentPayload
-	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "created" {
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return
+	}
+	switch p.Action {
+	case "created":
+		// handled below
+	case "edited", "deleted":
+		// Comment edits and deletes are not tracked in the cache; the engine
+		// re-fetches review thread state via FetchItemDetails on the next poll cycle.
+		return
+	default:
 		return
 	}
 	repo := p.Repository.FullName
@@ -569,9 +796,20 @@ func (c *CacheImpl) applyPullRequestReviewCommentCreated(payload []byte) {
 	c.logFn("[cache] auto-heal: PR #%d → issue #%d; deep cache invalidated and delta re-applied\n", prNum, resolvedIssNum)
 }
 
-func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
+func (c *CacheImpl) applyCheckRunDelta(payload []byte) {
 	var p checkRunPayload
-	if err := json.Unmarshal(payload, &p); err != nil || p.Action != "completed" {
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return
+	}
+	switch p.Action {
+	case "completed":
+		// handled below
+	case "created", "rerequested", "requested_action":
+		// created: run started but has no outcome yet.
+		// rerequested/requested_action: administrative UX signals.
+		// The engine watches outcomes only (completed) for the CI gate.
+		return
+	default:
 		return
 	}
 	sha := p.CheckRun.HeadSHA
@@ -686,30 +924,73 @@ func (c *CacheImpl) applyCheckRunCompleted(payload []byte) {
 	c.logFn("[cache] auto-heal: check_run SHA %s → PR #%d → issue #%d; deep cache invalidated\n", sha, prNum, resolvedIssNum)
 }
 
-func (c *CacheImpl) applyProjectsV2ItemEdited(payload []byte) {
+// applyCheckSuite is a documented no-op. The comment in ApplyDelta's switch explains
+// why check_suite is skipped; this stub exists only so the call site compiles.
+func (c *CacheImpl) applyCheckSuite(_ []byte) {}
+
+func (c *CacheImpl) applyProjectsV2ItemDelta(payload []byte) {
 	var p projectsV2ItemPayload
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return
 	}
-	if p.Action != "edited" {
-		return
-	}
-	if p.Changes.FieldValue.FieldType != "single_select" {
-		return
-	}
-	newStatus := p.Changes.FieldValue.To.Name
-	if newStatus == "" {
-		return
-	}
-	itemID := p.ProjectsV2Item.ID
 
-	snap, changes, _ := c.store.Apply(itemstate.ProjectV2ItemEdited{
-		ItemID:    itemID,
-		NewStatus: newStatus,
-	})
-	if len(changes) == 0 {
-		return
+	switch p.Action {
+	case "created":
+		// An existing issue was added to the project board. The payload provides only
+		// content_node_id; fetch full item details from GraphQL to get number and repo.
+		nodeID := p.ProjectsV2Item.ContentNodeID
+		if nodeID == "" || p.ProjectsV2Item.ContentType != "Issue" {
+			return
+		}
+		pi := &gh.ProjectItem{ID: nodeID}
+		if err := c.fallback.FetchItemDetails(pi); err != nil {
+			c.logFn("[cache] applyProjectsV2ItemDelta(created): FetchItemDetails for node %s: %v\n", nodeID, err)
+			return
+		}
+		if pi.Number == 0 || pi.Repo == "" {
+			c.logFn("[cache] applyProjectsV2ItemDelta(created): incomplete item for node %s (number=%d repo=%q)\n", nodeID, pi.Number, pi.Repo)
+			return
+		}
+		_, changes, _ := c.store.Apply(itemstate.IssueOpened{Item: *pi})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(itemKey(pi.Repo, pi.Number))
+
+	case "edited":
+		if p.Changes.FieldValue.FieldType != "single_select" {
+			return
+		}
+		newStatus := p.Changes.FieldValue.To.Name
+		if newStatus == "" {
+			return
+		}
+		snap, changes, _ := c.store.Apply(itemstate.ProjectV2ItemEdited{
+			ItemID:    p.ProjectsV2Item.ID,
+			NewStatus: newStatus,
+		})
+		if len(changes) == 0 {
+			return
+		}
+		c.bumpLocalDeltaAt(itemKey(snap.Repo(), snap.Number()))
+
+	case "deleted", "archived":
+		// Remove the item from the Store and clean up any PR linkage entries.
+		repo, number, ok := c.store.RemoveByItemID(p.ProjectsV2Item.ID)
+		if !ok {
+			return
+		}
+		key := itemKey(repo, number)
+		c.mu.Lock()
+		for pk, ik := range c.prNumToKey {
+			if ik == key {
+				delete(c.prNumToKey, pk)
+				delete(c.linkedPRs, pk)
+			}
+		}
+		c.mu.Unlock()
+
+	// restored: item is back on the board; the next poll reconcile will re-add it.
+	// reordered: no position state in the engine.
 	}
-	key := itemKey(snap.Repo(), snap.Number())
-	c.bumpLocalDeltaAt(key)
 }

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -676,6 +676,25 @@ func TestPullRequestReviewRequestRemoved(t *testing.T) {
 	}
 }
 
+// TestPRLinkage_opened verifies that pull_request.opened for a PR with a
+// "Closes #N" body triggers the auto-heal path and populates LinkedPRNumber on
+// the linked issue's cached item.
+func TestPRLinkage_opened(t *testing.T) {
+	mc := &mockClient{
+		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {
+			return []int{1}, nil // PR #42 closes issue #1
+		},
+	}
+	c := seedCacheWithStalePRLink(t, mc) // item #1 with LinkedPRNumber=0
+
+	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha-link", "open", false, false))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || s.LinkedPR.Number != 42 {
+		t.Errorf("want LinkedPR.Number=42 after pull_request.opened auto-heal, got LinkedPR=%v", s.LinkedPR)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Phase 3-D: documented no-ops — verify no crash and no state change
 // ---------------------------------------------------------------------------

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -784,7 +784,7 @@ func TestProjectsV2ItemCreated(t *testing.T) {
 	c := NewCacheImpl(mc, nopLog)
 	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
 
-	payload := projectsV2ItemCreatedPayloadJSON("I_88", "Issue")
+	payload := projectsV2ItemCreatedPayloadJSON("I_88", "Issue", "PVTI_088")
 	c.ApplyDelta("projects_v2_item", payload)
 
 	s := testGetState(t, c, "owner/repo", 88)
@@ -794,6 +794,11 @@ func TestProjectsV2ItemCreated(t *testing.T) {
 	if mc.fetchItemDetailsCount != 1 {
 		t.Errorf("want exactly 1 FetchItemDetails call, got %d", mc.fetchItemDetailsCount)
 	}
+	// Verify the board item ID was stored so subsequent edited/deleted/archived
+	// events can be resolved through itemIDToKey.
+	if itemID, ok := c.GetItemID(itemKey("owner/repo", 88)); !ok || itemID != "PVTI_088" {
+		t.Errorf("want itemIDToKey[PVTI_088]=owner/repo#88; GetItemID returned (%q, %v)", itemID, ok)
+	}
 }
 
 func TestProjectsV2ItemCreatedNonIssueIgnored(t *testing.T) {
@@ -802,7 +807,7 @@ func TestProjectsV2ItemCreatedNonIssueIgnored(t *testing.T) {
 	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
 
 	// PullRequest content type must be ignored.
-	c.ApplyDelta("projects_v2_item", projectsV2ItemCreatedPayloadJSON("PR_123", "PullRequest"))
+	c.ApplyDelta("projects_v2_item", projectsV2ItemCreatedPayloadJSON("PR_123", "PullRequest", "PVTI_PR"))
 
 	if mc.fetchItemDetailsCount != 0 {
 		t.Errorf("PullRequest content_type should not trigger FetchItemDetails, got %d calls", mc.fetchItemDetailsCount)

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -7,6 +7,7 @@ package boardcache
 // behavioral tests in boardcache_test.go with focused Store-delegation checks.
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -390,6 +391,512 @@ func TestReconcileRemoveCleansUpPrNumToKey(t *testing.T) {
 	c.mu.RUnlock()
 	if afterReconcile {
 		t.Errorf("prNumToKey entry for PR #10 survived after item #1 removed by Reconcile")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3-D: issues.* delta handlers — per-action coverage
+// ---------------------------------------------------------------------------
+
+func TestIssuesOpened(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	payload := issuesOpenedPayloadJSON("owner/repo", 99, "I_99", "New Issue", "body text",
+		[]string{"enhancement"}, []string{"alice"})
+	c.ApplyDelta("issues", payload)
+
+	s := testGetState(t, c, "owner/repo", 99)
+	if s.Title != "New Issue" {
+		t.Errorf("Title: want %q, got %q", "New Issue", s.Title)
+	}
+	if s.Body != "body text" {
+		t.Errorf("Body: want %q, got %q", "body text", s.Body)
+	}
+	if !containsStr(s.Labels, "enhancement") {
+		t.Errorf("Labels: want [enhancement], got %v", s.Labels)
+	}
+	if !containsStr(s.Assignees, "alice") {
+		t.Errorf("Assignees: want [alice], got %v", s.Assignees)
+	}
+}
+
+func TestIssuesOpenedIdempotent(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	payload := issuesOpenedPayloadJSON("owner/repo", 99, "I_99", "Issue", "", []string{"bug"}, nil)
+	c.ApplyDelta("issues", payload)
+	c.ApplyDelta("issues", payload) // duplicate
+
+	s := testGetState(t, c, "owner/repo", 99)
+	count := 0
+	for _, l := range s.Labels {
+		if l == "bug" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("label 'bug' should appear exactly once after duplicate open, got %d", count)
+	}
+}
+
+func TestIssuesClosed(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("issues", issuesActionPayloadJSON("closed", "owner/repo", 1))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if !s.IsClosed {
+		t.Error("want IsClosed=true after issues.closed")
+	}
+}
+
+func TestIssuesReopened(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("issues", issuesActionPayloadJSON("closed", "owner/repo", 1))
+	c.ApplyDelta("issues", issuesActionPayloadJSON("reopened", "owner/repo", 1))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.IsClosed {
+		t.Error("want IsClosed=false after issues.reopened")
+	}
+}
+
+func TestIssuesEdited(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("issues", issuesEditedPayloadJSON("owner/repo", 1, "Updated Title", "Updated body"))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Title != "Updated Title" {
+		t.Errorf("Title: want %q, got %q", "Updated Title", s.Title)
+	}
+	if s.Body != "Updated body" {
+		t.Errorf("Body: want %q, got %q", "Updated body", s.Body)
+	}
+}
+
+func TestIssuesDeleted(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("issues", issuesActionPayloadJSON("deleted", "owner/repo", 1))
+
+	if _, err := c.store.Get("owner/repo", 1); err == nil {
+		t.Error("want ErrNotFound after issues.deleted, but item still in store")
+	}
+	// Item #2 must be unaffected.
+	if _, err := c.store.Get("owner/repo", 2); err != nil {
+		t.Errorf("item #2 should still be present after unrelated delete: %v", err)
+	}
+}
+
+func TestIssuesTransferred(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("issues", issuesActionPayloadJSON("transferred", "owner/repo", 1))
+
+	if _, err := c.store.Get("owner/repo", 1); err == nil {
+		t.Error("want ErrNotFound after issues.transferred, but item still in store")
+	}
+}
+
+func TestIssuesDeletedCleansPRLinkage(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+
+	c.ApplyDelta("issues", issuesActionPayloadJSON("deleted", "owner/repo", 1))
+
+	c.mu.RLock()
+	_, found := c.prNumToKey[prKey("owner/repo", 42)]
+	c.mu.RUnlock()
+	if found {
+		t.Error("prNumToKey entry for PR #42 should have been removed after issues.deleted")
+	}
+}
+
+func TestIssuesAssigned(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("issues", issuesAssignedPayloadJSON("assigned", "owner/repo", 1, []string{"alice", "bob"}))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if !containsStr(s.Assignees, "alice") || !containsStr(s.Assignees, "bob") {
+		t.Errorf("Assignees: want [alice bob], got %v", s.Assignees)
+	}
+}
+
+func TestIssuesUnassigned(t *testing.T) {
+	c := seedCache(t)
+	// Assign alice first.
+	c.ApplyDelta("issues", issuesAssignedPayloadJSON("assigned", "owner/repo", 1, []string{"alice"}))
+	// Unassign: full list is now empty.
+	c.ApplyDelta("issues", issuesAssignedPayloadJSON("unassigned", "owner/repo", 1, []string{}))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if containsStr(s.Assignees, "alice") {
+		t.Errorf("want alice removed after unassigned; Assignees: %v", s.Assignees)
+	}
+}
+
+// TestFabrikWentDeaf_IssuesLabeledBeforeOpened is the primary regression test for the
+// "fabrik went deaf" bug class. Without this PR's fix, the labeled delta for an
+// unknown issue is silently dropped. With the fix, ensureIssueInStore calls
+// FetchProjectItem, populates the cache, and then applies the label.
+//
+// This test MUST fail without the ensureIssueInStore fallback.
+func TestFabrikWentDeaf_IssuesLabeledBeforeOpened(t *testing.T) {
+	mc := &mockClient{
+		projectItemResult: &gh.ProjectItem{
+			Number: 99,
+			Title:  "Brand New Issue",
+			Repo:   "owner/repo",
+			Labels: nil, // no labels yet from GitHub
+		},
+	}
+	// Cache starts empty — issue #99 is NOT in the cache.
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	// Deliver labeled event BEFORE the item is in the cache (out-of-order delivery).
+	c.ApplyDelta("issues", issuesLabeledPayloadJSON("labeled", "owner/repo", 99, "fabrik:yolo"))
+
+	// The item should now be in the cache (populated via fallback) with the label applied.
+	s := testGetState(t, c, "owner/repo", 99)
+	if !containsStr(s.Labels, "fabrik:yolo") {
+		t.Errorf("want label 'fabrik:yolo' on issue #99 after fallback+labeled; got Labels=%v", s.Labels)
+	}
+	if mc.fetchProjectItemCount != 1 {
+		t.Errorf("want exactly 1 FetchProjectItem call (fallback), got %d", mc.fetchProjectItemCount)
+	}
+}
+
+func TestOutOfOrderIssuesLabeledBeforeOpened(t *testing.T) {
+	mc := &mockClient{
+		projectItemResult: &gh.ProjectItem{
+			Number: 77,
+			Title:  "OOO Issue",
+			Repo:   "owner/repo",
+		},
+	}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	// labeled arrives first (out of order).
+	c.ApplyDelta("issues", issuesLabeledPayloadJSON("labeled", "owner/repo", 77, "stage:Research"))
+
+	// opened arrives after — should be idempotent.
+	c.ApplyDelta("issues", issuesOpenedPayloadJSON("owner/repo", 77, "I_77", "OOO Issue", "", nil, nil))
+
+	s := testGetState(t, c, "owner/repo", 77)
+	if !containsStr(s.Labels, "stage:Research") {
+		t.Errorf("label 'stage:Research' should be present after out-of-order delivery; got %v", s.Labels)
+	}
+}
+
+func TestIssuesClosedFallbackFetch(t *testing.T) {
+	mc := &mockClient{
+		projectItemResult: &gh.ProjectItem{
+			Number: 55,
+			Title:  "Missing Issue",
+			Repo:   "owner/repo",
+		},
+	}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	// closed arrives but issue not in cache — should trigger fetch then close.
+	c.ApplyDelta("issues", issuesActionPayloadJSON("closed", "owner/repo", 55))
+
+	s := testGetState(t, c, "owner/repo", 55)
+	if !s.IsClosed {
+		t.Error("want IsClosed=true after fallback fetch + closed delta")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3-D: pull_request.* — draft and reviewer handlers
+// ---------------------------------------------------------------------------
+
+func TestPullRequestReadyForReview(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+	// Establish linkedPRs entry with Draft=true.
+	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha1", "open", false, true))
+
+	c.ApplyDelta("pull_request", pullRequestDraftPayloadJSON("ready_for_review", "owner/repo", 42))
+
+	c.mu.RLock()
+	pr := c.linkedPRs[prKey("owner/repo", 42)]
+	c.mu.RUnlock()
+	if pr == nil || pr.Draft {
+		t.Errorf("want Draft=false after ready_for_review; pr=%v", pr)
+	}
+}
+
+func TestPullRequestConvertedToDraft(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+	// Establish linkedPRs entry with Draft=false.
+	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha1", "open", false, false))
+
+	c.ApplyDelta("pull_request", pullRequestDraftPayloadJSON("converted_to_draft", "owner/repo", 42))
+
+	c.mu.RLock()
+	pr := c.linkedPRs[prKey("owner/repo", 42)]
+	c.mu.RUnlock()
+	if pr == nil || !pr.Draft {
+		t.Errorf("want Draft=true after converted_to_draft; pr=%v", pr)
+	}
+}
+
+func TestPullRequestReviewRequested(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+
+	payload := pullRequestReviewRequestedPayloadJSON("owner/repo", 42, []string{"alice"}, "alice")
+	c.ApplyDelta("pull_request", payload)
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || len(s.LinkedPR.ReviewRequests) != 1 {
+		t.Fatalf("want 1 review request; LinkedPR=%v", s.LinkedPR)
+	}
+	if s.LinkedPR.ReviewRequests[0].Login != "alice" {
+		t.Errorf("want reviewer alice, got %q", s.LinkedPR.ReviewRequests[0].Login)
+	}
+}
+
+func TestPullRequestReviewRequestRemoved(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+
+	// Add reviewer first.
+	c.ApplyDelta("pull_request", pullRequestReviewRequestedPayloadJSON("owner/repo", 42, []string{"alice"}, "alice"))
+	// Remove reviewer.
+	c.ApplyDelta("pull_request", pullRequestReviewRequestRemovedPayloadJSON("owner/repo", 42, "alice"))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR != nil && len(s.LinkedPR.ReviewRequests) != 0 {
+		t.Errorf("want 0 review requests after removal; got %v", s.LinkedPR.ReviewRequests)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3-D: documented no-ops — verify no crash and no state change
+// ---------------------------------------------------------------------------
+
+func TestIssueCommentEditedNoOp(t *testing.T) {
+	c := seedCache(t)
+	// First add a comment.
+	c.ApplyDelta("issue_comment", issueCommentPayloadJSON("created", "owner/repo", 1, "C1", 1, "original", "alice"))
+	// Edit the comment — must not panic or alter stored comments.
+	c.ApplyDelta("issue_comment", issueCommentPayloadJSON("edited", "owner/repo", 1, "C1", 1, "edited text", "alice"))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if len(s.Comments) != 1 || s.Comments[0].Body != "original" {
+		t.Errorf("comment edit should be a no-op; got %+v", s.Comments)
+	}
+}
+
+func TestPRReviewEditedNoOp(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+	// Submit a review.
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("submitted", "owner/repo", 42, 1001, "approved", "alice"))
+	// Edit the review — must be a no-op.
+	c.ApplyDelta("pull_request_review", pullRequestReviewPayloadJSON("edited", "owner/repo", 42, 1001, "approved", "alice"))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || len(s.LinkedPR.Reviews) != 1 {
+		t.Errorf("want exactly 1 review after edit no-op; got %v", s.LinkedPR)
+	}
+}
+
+func TestPRReviewCommentEditedNoOp(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+	c.ApplyDelta("pull_request_review_comment",
+		pullRequestReviewCommentPayloadJSON("created", "owner/repo", 42, 200, "RC_1", "original", "bob"))
+	c.ApplyDelta("pull_request_review_comment",
+		pullRequestReviewCommentPayloadJSON("edited", "owner/repo", 42, 200, "RC_1", "edited", "bob"))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || len(s.LinkedPR.ThreadComments) != 1 {
+		t.Errorf("want exactly 1 thread comment after edit no-op; got %v", s.LinkedPR)
+	}
+}
+
+func TestCheckRunCreatedNoOp(t *testing.T) {
+	c := seedCache(t)
+	before := testGetState(t, c, "owner/repo", 1)
+
+	// check_run.created must not alter any item state.
+	c.ApplyDelta("check_run", checkRunPayloadJSON("created", "owner/repo", 5555, "build", "in_progress", "", "sha_xyz"))
+
+	after := testGetState(t, c, "owner/repo", 1)
+	if after.Title != before.Title {
+		t.Errorf("check_run.created should be a no-op; Title changed from %q to %q", before.Title, after.Title)
+	}
+}
+
+func TestCheckSuiteNoOp(t *testing.T) {
+	c := seedCache(t)
+	before := testGetState(t, c, "owner/repo", 1)
+
+	// All check_suite actions must be no-ops.
+	for _, action := range []string{"completed", "requested", "rerequested"} {
+		payload, _ := json.Marshal(map[string]string{"action": action})
+		c.ApplyDelta("check_suite", payload)
+	}
+
+	after := testGetState(t, c, "owner/repo", 1)
+	if after.Title != before.Title {
+		t.Errorf("check_suite should be a no-op; state changed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3-D: projects_v2_item handlers
+// ---------------------------------------------------------------------------
+
+func TestProjectsV2ItemCreated(t *testing.T) {
+	mc := &mockClient{
+		itemDetailsResult: &gh.ProjectItem{
+			Number: 88,
+			Repo:   "owner/repo",
+			Title:  "Board Issue",
+		},
+	}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	payload := projectsV2ItemCreatedPayloadJSON("I_88", "Issue")
+	c.ApplyDelta("projects_v2_item", payload)
+
+	s := testGetState(t, c, "owner/repo", 88)
+	if s.Number != 88 {
+		t.Errorf("want Number=88, got %d", s.Number)
+	}
+	if mc.fetchItemDetailsCount != 1 {
+		t.Errorf("want exactly 1 FetchItemDetails call, got %d", mc.fetchItemDetailsCount)
+	}
+}
+
+func TestProjectsV2ItemCreatedNonIssueIgnored(t *testing.T) {
+	mc := &mockClient{}
+	c := NewCacheImpl(mc, nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "P", Title: "T", OwnerType: "organization"})
+
+	// PullRequest content type must be ignored.
+	c.ApplyDelta("projects_v2_item", projectsV2ItemCreatedPayloadJSON("PR_123", "PullRequest"))
+
+	if mc.fetchItemDetailsCount != 0 {
+		t.Errorf("PullRequest content_type should not trigger FetchItemDetails, got %d calls", mc.fetchItemDetailsCount)
+	}
+}
+
+func TestProjectsV2ItemDeleted(t *testing.T) {
+	c := seedCache(t)
+	// Item #1 has ItemID "PVTI_001" (set by seedCache via Bootstrap).
+	c.ApplyDelta("projects_v2_item", projectsV2ItemRemovedPayloadJSON("deleted", "PVTI_001"))
+
+	if _, err := c.store.Get("owner/repo", 1); err == nil {
+		t.Error("want item #1 removed after projects_v2_item.deleted")
+	}
+	// Item #2 must be unaffected.
+	if _, err := c.store.Get("owner/repo", 2); err != nil {
+		t.Errorf("item #2 should still be present: %v", err)
+	}
+}
+
+func TestProjectsV2ItemArchived(t *testing.T) {
+	c := seedCache(t)
+	c.ApplyDelta("projects_v2_item", projectsV2ItemRemovedPayloadJSON("archived", "PVTI_001"))
+
+	if _, err := c.store.Get("owner/repo", 1); err == nil {
+		t.Error("want item #1 removed after projects_v2_item.archived")
+	}
+}
+
+func TestProjectsV2ItemDeletedCleansPRLinkage(t *testing.T) {
+	c := seedCache(t)
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+	c.mu.Lock()
+	c.linkedPRs[prKey("owner/repo", 42)] = &gh.PRDetails{Number: 42}
+	c.mu.Unlock()
+
+	c.ApplyDelta("projects_v2_item", projectsV2ItemRemovedPayloadJSON("deleted", "PVTI_001"))
+
+	c.mu.RLock()
+	_, pkFound := c.prNumToKey[prKey("owner/repo", 42)]
+	_, lrFound := c.linkedPRs[prKey("owner/repo", 42)]
+	c.mu.RUnlock()
+	if pkFound || lrFound {
+		t.Error("prNumToKey and linkedPRs entries for PR #42 should be cleaned up after item deletion")
+	}
+}
+
+func TestProjectsV2ItemRestoredNoOp(t *testing.T) {
+	c := seedCache(t)
+	before := len(c.store.All())
+
+	// restored must not crash or duplicate items.
+	p := projectsV2ItemPayload{Action: "restored"}
+	p.ProjectsV2Item.ID = "PVTI_001"
+	payload, _ := json.Marshal(p)
+	c.ApplyDelta("projects_v2_item", payload)
+
+	if after := len(c.store.All()); after != before {
+		t.Errorf("projects_v2_item.restored must not change item count; before=%d after=%d", before, after)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3-D: cache pause drops deltas
+// ---------------------------------------------------------------------------
+
+func TestCachePauseDropsDelta(t *testing.T) {
+	c := seedCache(t)
+	c.Pause()
+
+	// Delta delivered while paused must be dropped.
+	c.ApplyDelta("issues", issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "during-pause"))
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if containsStr(s.Labels, "during-pause") {
+		t.Error("label applied while cache was paused; expected no-op")
+	}
+
+	c.Resume()
+	// Same delta delivered after resume must be applied.
+	c.ApplyDelta("issues", issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "during-pause"))
+
+	s = testGetState(t, c, "owner/repo", 1)
+	if !containsStr(s.Labels, "during-pause") {
+		t.Error("label should be applied after cache is resumed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3-D: concurrent delta — race detector clean
+// ---------------------------------------------------------------------------
+
+func TestConcurrentDeltaSameIssue(t *testing.T) {
+	c := seedCache(t)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			if idx%2 == 0 {
+				c.ApplyDelta("issues", issuesLabeledPayloadJSON("labeled", "owner/repo", 1, "concurrent-label"))
+			} else {
+				c.ApplyDelta("issues", issuesLabeledPayloadJSON("unlabeled", "owner/repo", 1, "concurrent-label"))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// After concurrent writes, item must still be accessible.
+	if _, err := c.store.Get("owner/repo", 1); err != nil {
+		t.Errorf("item #1 must be accessible after concurrent deltas: %v", err)
 	}
 }
 

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -124,6 +124,9 @@ func (m *testGitHubUpgradeClient) FetchPRClosingIssues(owner, repo string, prNum
 func (m *testGitHubUpgradeClient) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
 	return nil, nil
 }
+func (m *testGitHubUpgradeClient) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	return nil, nil
+}
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1334,7 +1334,7 @@ When a delta handler looks up an item that is not yet in the cache (e.g., `issue
 
 This resolves the "fabrik went deaf" bug class where webhooks for new issues were silently dropped because the issue had not yet been seen in a board reconcile.
 
-**Exception**: `issues.opened` itself creates the item from the webhook payload directly (no REST call needed — the payload contains full issue data). `issues.transferred` and `issues.deleted` remove the item rather than ensureing it.
+**Exception**: `issues.opened` itself creates the item from the webhook payload directly (no REST call needed — the payload contains full issue data). `issues.transferred` and `issues.deleted` remove the item rather than ensuring it.
 
 #### D.2.2 Webhook event coverage table
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1324,20 +1324,55 @@ If the bootstrap fetch fails (e.g., transient network error), the cache starts e
 
 ### D.2 Delta Application
 
-Every verified webhook payload is passed to `cacheImpl.ApplyDelta(eventType, payload []byte)` before the poll loop is woken. `ApplyDelta` is a no-op when `IsPaused()` returns true. Otherwise it dispatches to a typed handler:
+Every verified webhook payload is passed to `cacheImpl.ApplyDelta(eventType, payload []byte)` before the poll loop is woken. `ApplyDelta` is a no-op when `IsPaused()` returns true. Otherwise it dispatches to a typed handler.
 
-| Event type | Handler | Effect |
-|------------|---------|--------|
-| `issue_comment.created` | `applyIssueCommentCreated` | Appends comment to `item.Comments`; idempotent by NodeID |
-| `issues.labeled` | `applyIssuesLabeled` | Adds label to `item.Labels`; set-membership (no duplicates) |
-| `issues.unlabeled` | `applyIssuesUnlabeled` | Removes label from `item.Labels` |
-| `pull_request.opened/closed/synchronize` | `applyPullRequestDelta` | Upserts `linkedPRs[prKey]`; updates `shaToKey[sha]`; rotates old SHA on synchronize |
-| `pull_request_review.submitted` | `applyPullRequestReviewSubmitted` | Upserts review in `linkedPRs[prKey].Reviews` by DatabaseID |
-| `pull_request_review_comment.created` | `applyPullRequestReviewCommentCreated` | Appends to `LinkedPRReviewThreadComments`; idempotent by NodeID |
-| `check_run.completed` | `applyCheckRunCompleted` | Upserts check run in `checkRuns[sha]` by CheckRun.ID |
-| `projects_v2_item.edited` | `applyProjectsV2ItemEdited` | Updates `item.Status` via `itemIDToKey` reverse lookup |
+#### D.2.1 Unknown-item fallback
 
-All delta functions hold the write lock for their mutation only. They silently drop events for unknown items (e.g., items not yet on the board) rather than returning errors.
+When a delta handler looks up an item that is not yet in the cache (e.g., `issues.labeled` arrives before `issues.opened`), the handler calls `ensureIssueInStore(owner, fullRepo, issueNumber)`. This helper:
+1. Fast path: if the item is already in the Store, returns immediately.
+2. Miss path: calls `fallback.FetchProjectItem(owner, repo, issueNumber)` via REST GET `/repos/{owner}/{repo}/issues/{number}`, applies `IssueOpened{Item: *pi}` to the Store, then continues with the original delta.
+
+This resolves the "fabrik went deaf" bug class where webhooks for new issues were silently dropped because the issue had not yet been seen in a board reconcile.
+
+**Exception**: `issues.opened` itself creates the item from the webhook payload directly (no REST call needed — the payload contains full issue data). `issues.transferred` and `issues.deleted` remove the item rather than ensureing it.
+
+#### D.2.2 Webhook event coverage table
+
+All handlers hold the write lock for their mutation only. No lock is held during network calls (the `ensureIssueInStore` fallback fetch and `resolvePRLinkage` auto-heal are performed without holding `c.mu` — ADR 037 lock-ordering invariant).
+
+| Event type | Action | Handler decision | Cache mutation | Engine reaction |
+|------------|--------|-----------------|---------------|-----------------|
+| `issues` | `opened` | Create item from payload | `IssueOpened` (builds item from full webhook payload; no API call) | Item appears in next `FetchProjectBoard` |
+| `issues` | `closed` | Fallback if missing; update state | `IssueClosed` | `IsClosed=true`; `itemMayNeedWork` skips unless cleanup stage |
+| `issues` | `reopened` | Fallback if missing; update state | `IssueReopened` | `IsClosed=false`; re-enters dispatch |
+| `issues` | `transferred` | Remove item | `store.Remove` + `prNumToKey` cleanup | Item gone from next board fetch |
+| `issues` | `deleted` | Remove item | `store.Remove` + `prNumToKey` cleanup | Item gone from next board fetch |
+| `issues` | `edited` | Fallback if missing; update title+body | `IssueEdited` | `Title`/`Body` updated; next FetchItemDetails serves updated body |
+| `issues` | `assigned` | Fallback if missing; update assignees | `IssueAssigneesUpdated` (full list replace) | `Assignees` updated |
+| `issues` | `unassigned` | Fallback if missing; update assignees | `IssueAssigneesUpdated` (full list replace) | `Assignees` updated |
+| `issues` | `labeled` | Fallback if missing; add label | `IssueLabeled` | `Labels` updated; poll woken for next dispatch |
+| `issues` | `unlabeled` | Fallback if missing; remove label | `IssueUnlabeled` | `Labels` updated; poll woken |
+| `issues` | `milestoned`, `demilestoned`, `locked`, `unlocked`, `pinned`, `unpinned` | No-op | — | No engine state depends on these fields |
+| `issue_comment` | `created` | Guard: item must be in Store; append comment | `IssueCommentCreated` | Comment appears in next FetchItemDetails; poll woken for comment processing |
+| `issue_comment` | `edited`, `deleted` | No-op | — | Reaction-based state machine reads reactions not bodies; next deep-fetch heals |
+| `pull_request` | `opened`, `closed`, `reopened`, `synchronize` | Store PR details; resolve closing issue; update SHA | `PRHeadSHAUpdated`; `DeepFetchInvalidated` on auto-heal | `shaToKey` updated; CI gate can evaluate this SHA |
+| `pull_request` | `ready_for_review` | Update `linkedPRs[pk].Draft = false` | CacheImpl-local only (Draft not in Store per ADR 037) | PR no longer draft; review bots can see it |
+| `pull_request` | `converted_to_draft` | Update `linkedPRs[pk].Draft = true` | CacheImpl-local only | PR back to draft |
+| `pull_request` | `review_requested` | Look up linked issue via `prNumToKey`; replace reviewer list | `PRReviewRequested` (full list replace) | `LinkedPRReviewRequests` updated; review gate re-evaluated |
+| `pull_request` | `review_request_removed` | Look up linked issue via `prNumToKey`; remove one reviewer | `PRReviewRequestRemoved` (remove by login) | `LinkedPRReviewRequests` updated |
+| `pull_request` | `labeled`, `unlabeled`, `assigned`, `unassigned`, `edited` | No-op | — | PR-level labels/assignees/metadata not tracked; `Closes #N` linkage healed by next Reconcile |
+| `pull_request_review` | `submitted` | Route via `prNumToKey`; auto-heal if missing | `PRReviewSubmitted`; `PRHeadSHAUpdated` + `DeepFetchInvalidated` on auto-heal | `LinkedPRReviews` updated; review gate re-evaluated |
+| `pull_request_review` | `edited`, `dismissed` | No-op | — | Review state captured at submit; edits/dismissals don't affect Fabrik's approval tracking |
+| `pull_request_review_comment` | `created` | Route via `prNumToKey`; auto-heal if missing | `ReviewThreadCommentAdded`; `DeepFetchInvalidated` | Thread comment appears; review reinvoke path can see it |
+| `pull_request_review_comment` | `edited`, `deleted` | No-op | — | Thread comment content not decision-relevant; next deep-fetch heals |
+| `check_run` | `completed` | Upsert in `checkRuns[sha]`; index via `shaToKey`; auto-heal if SHA unknown | `CheckRunCompleted`; `PRHeadSHAUpdated` + `DeepFetchInvalidated` on auto-heal | CI gate evaluates conclusion; `LinkedPRCheckRuns` updated |
+| `check_run` | `created`, `rerequested`, `requested_action` | No-op | — | Only terminal state (`completed`) matters for CI gate |
+| `check_suite` | `completed`, `requested`, `rerequested` | No-op | — | Check suites are coarse aggregates; individual runs tracked via `check_run.completed` |
+| `projects_v2_item` | `created` | Call `FetchItemDetails` by `content_node_id`; apply as new item | `IssueOpened` | Item appears in board; triggers dispatch on next poll |
+| `projects_v2_item` | `edited` | Update `Status` via `itemIDToKey` reverse lookup | `ProjectV2ItemEdited` | `Status` updated; stage selection uses new column |
+| `projects_v2_item` | `deleted`, `archived` | Remove item; clean up `prNumToKey` | `store.Remove` + `prNumToKey`/`linkedPRs` cleanup | Item gone from next board fetch |
+| `projects_v2_item` | `restored` | No-op | — | Next Reconcile re-adds the item from the full board snapshot |
+| `projects_v2_item` | `reordered` | No-op | — | Column order not modeled in Fabrik's cache or engine |
 
 ### D.3 Cache Read Semantics
 

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -32,6 +32,7 @@ type GitHubClient interface {
 	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)
 	FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)
 	FetchPRsForSHA(owner, repo, sha string) ([]int, error)
+	FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error)
 	GetPRBase(owner, repo string, prNumber int) (string, error)
 	UpdatePRBase(owner, repo string, prNumber int, newBase string) error
 	CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -471,6 +471,10 @@ func (m *mockGitHubClient) FetchPRsForSHA(owner, repo, sha string) ([]int, error
 	return nil, nil
 }
 
+func (m *mockGitHubClient) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	return nil, nil
+}
+
 func (m *mockGitHubClient) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStats) {
 	if m.rateLimitStatsFn != nil {
 		return m.rateLimitStatsFn()

--- a/github/project.go
+++ b/github/project.go
@@ -577,6 +577,12 @@ query($id: ID!) {
 
 	node := result.Data.Node
 
+	// Populate item.Number from GraphQL response if it was zero (e.g., projects_v2_item.created
+	// provides only a node_id, so the caller sets item.Number=0 and we fill it in here).
+	if item.Number == 0 && node.Number > 0 {
+		item.Number = node.Number
+	}
+
 	// Populate scalar fields
 	item.Body = node.Body
 	item.URL = node.URL
@@ -1026,4 +1032,47 @@ query($id: ID!, $cursor: String) {
 	}
 
 	return out, nil
+}
+
+// FetchProjectItem fetches a minimal ProjectItem for an issue via REST GET
+// /repos/{owner}/{repo}/issues/{number}. Used by the boardcache fallback path
+// when a webhook event arrives for an issue not yet in the cache.
+func (c *Client) FetchProjectItem(owner, repo string, issueNumber int) (*ProjectItem, error) {
+	url := c.baseURL + "/repos/" + owner + "/" + repo + "/issues/" + strconv.Itoa(issueNumber)
+
+	var raw struct {
+		Number    int    `json:"number"`
+		Title     string `json:"title"`
+		Body      string `json:"body"`
+		State     string `json:"state"`
+		HTMLURL   string `json:"html_url"`
+		NodeID    string `json:"node_id"`
+		Labels    []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
+	}
+
+	if err := c.restGetJSON(url, &raw); err != nil {
+		return nil, fmt.Errorf("fetching project item for %s/%s#%d: %w", owner, repo, issueNumber, err)
+	}
+
+	pi := &ProjectItem{
+		ID:       raw.NodeID,
+		Number:   raw.Number,
+		Title:    raw.Title,
+		Body:     raw.Body,
+		IsClosed: raw.State == "closed",
+		URL:      raw.HTMLURL,
+		Repo:     owner + "/" + repo,
+	}
+	for _, l := range raw.Labels {
+		pi.Labels = append(pi.Labels, l.Name)
+	}
+	for _, a := range raw.Assignees {
+		pi.Assignees = append(pi.Assignees, a.Login)
+	}
+	return pi, nil
 }

--- a/github/project.go
+++ b/github/project.go
@@ -356,6 +356,7 @@ query($id: ID!) {
       number
       body
       url
+      repository { nameWithOwner }
       author { login }
       labels(first: 20) {
         nodes { name }
@@ -490,6 +491,9 @@ query($id: ID!) {
 				Number int    `json:"number"`
 				Body   string `json:"body"`
 				URL    string `json:"url"`
+				Repository *struct {
+					NameWithOwner string `json:"nameWithOwner"`
+				} `json:"repository"`
 				Author *struct {
 					Login string `json:"login"`
 				} `json:"author"`
@@ -581,6 +585,12 @@ query($id: ID!) {
 	// provides only a node_id, so the caller sets item.Number=0 and we fill it in here).
 	if item.Number == 0 && node.Number > 0 {
 		item.Number = node.Number
+	}
+
+	// Populate item.Repo when not yet set (e.g. projects_v2_item.created path where
+	// the caller constructs a bare ProjectItem with only ID set).
+	if item.Repo == "" && node.Repository != nil {
+		item.Repo = node.Repository.NameWithOwner
 	}
 
 	// Populate scalar fields

--- a/github/project.go
+++ b/github/project.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -345,11 +346,14 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 // FetchItemDetails populates the Comments, Labels, Body, URL, Author, Assignees,
 // and BlockedBy fields of a ProjectItem by fetching full item data via individual
 // node queries. This is the "deep" phase of the two-phase fetch approach.
+// If item.Number is zero (e.g., for projects_v2_item.created with only a node_id),
+// it is populated from the GraphQL response.
 func (c *Client) FetchItemDetails(item *ProjectItem) error {
 	query := `
 query($id: ID!) {
   node(id: $id) {
     ... on Issue {
+      number
       body
       url
       author { login }
@@ -483,6 +487,7 @@ query($id: ID!) {
 	var result struct {
 		Data struct {
 			Node *struct {
+				Number int    `json:"number"`
 				Body   string `json:"body"`
 				URL    string `json:"url"`
 				Author *struct {

--- a/github/types.go
+++ b/github/types.go
@@ -35,8 +35,11 @@ type ReviewRequest struct {
 	IsBot bool   // True if the reviewer is a bot (from __typename or login-pattern fallback)
 }
 
-// isBotLogin returns true if the login matches known bot patterns.
+// IsBotLogin returns true if the login matches known bot patterns.
 // Used as a fallback when the GraphQL __typename field is absent or not "Bot".
+func IsBotLogin(login string) bool { return isBotLogin(login) }
+
+// isBotLogin is the unexported implementation; call IsBotLogin from outside this package.
 func isBotLogin(login string) bool {
 	lower := strings.ToLower(login)
 	if strings.HasSuffix(lower, "[bot]") {

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -71,6 +71,49 @@ type IssueReopened struct {
 func (IssueReopened) isMutation() {}
 func (m IssueReopened) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// IssueEdited is emitted when an issue's title or body is changed.
+type IssueEdited struct {
+	Repo   string
+	Number int
+	Title  string
+	Body   string
+}
+
+func (IssueEdited) isMutation() {}
+func (m IssueEdited) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// IssueAssigneesUpdated is emitted when the assignee list changes (assigned or unassigned).
+// Assignees is the full post-mutation list from the webhook payload.
+type IssueAssigneesUpdated struct {
+	Repo      string
+	Number    int
+	Assignees []string
+}
+
+func (IssueAssigneesUpdated) isMutation() {}
+func (m IssueAssigneesUpdated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// PRReviewRequested is emitted when reviewers are added to the linked PR.
+// Reviewers is the full post-mutation list from the webhook payload.
+type PRReviewRequested struct {
+	Repo      string
+	Number    int // issue number
+	Reviewers []gh.ReviewRequest
+}
+
+func (PRReviewRequested) isMutation() {}
+func (m PRReviewRequested) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// PRReviewRequestRemoved is emitted when one reviewer is removed from the linked PR.
+type PRReviewRequestRemoved struct {
+	Repo   string
+	Number int // issue number
+	Login  string
+}
+
+func (PRReviewRequestRemoved) isMutation() {}
+func (m PRReviewRequestRemoved) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // IssueCommentCreated is emitted when a new comment is added to an issue.
 type IssueCommentCreated struct {
 	Repo    string

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -275,6 +275,25 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.IsClosed = false
 		return StateChanged
 
+	case IssueEdited:
+		item.Title = v.Title
+		item.Body = v.Body
+		return TitleBodyChanged
+
+	case IssueAssigneesUpdated:
+		item.Assignees = copyStrings(v.Assignees)
+		return AssigneesChanged
+
+	case PRReviewRequested:
+		ensureLinkedPR(item, 0)
+		item.LinkedPR.ReviewRequests = copyReviewRequests(v.Reviewers)
+		return LinkedPRChanged
+
+	case PRReviewRequestRemoved:
+		ensureLinkedPR(item, 0)
+		item.LinkedPR.ReviewRequests = removeReviewRequest(item.LinkedPR.ReviewRequests, v.Login)
+		return LinkedPRChanged
+
 	case IssueCommentCreated:
 		// Idempotent: skip if comment with this DatabaseID already exists.
 		for _, existing := range item.Comments {
@@ -872,6 +891,19 @@ func containsString(ss []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func removeReviewRequest(rrs []gh.ReviewRequest, login string) []gh.ReviewRequest {
+	out := rrs[:0:0]
+	for _, rr := range rrs {
+		if rr.Login != login {
+			out = append(out, rr)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func removeString(ss []string, s string) []string {

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -771,6 +771,32 @@ func (s *Store) Remove(repo string, number int) {
 	delete(s.items, key)
 }
 
+// RemoveByItemID removes the item identified by its project ItemID (board-side ID).
+// Returns the repo and number of the removed item, and ok=true, so callers can
+// clean up secondary state (e.g. prNumToKey entries). No-op and ok=false if the
+// ItemID is not in the index.
+func (s *Store) RemoveByItemID(itemID string) (repo string, number int, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key, found := s.itemIDToKey[itemID]
+	if !found {
+		return "", 0, false
+	}
+	item, exists := s.items[key]
+	if !exists {
+		delete(s.itemIDToKey, itemID)
+		return "", 0, false
+	}
+	repo = item.Repo
+	number = item.Number
+	if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
+		delete(s.shaToKey, item.LinkedPR.HeadSHA)
+	}
+	delete(s.itemIDToKey, itemID)
+	delete(s.items, key)
+	return repo, number, true
+}
+
 // Reset atomically replaces all Store state with the items in the given slice.
 // Existing items, indexes, and deep-fetch state are cleared. This is used by
 // Bootstrap to ensure a clean slate (unlike Reconcile, which preserves deep state).

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -253,7 +253,13 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	switch v := m.(type) {
 
 	case IssueOpened:
-		return applyProjectItem(item, v.Item)
+		// Merge labels: opened may arrive out-of-order, after labeled/unlabeled
+		// events have already been applied. Unioning preserves any labels added
+		// by subsequent delta events rather than overwriting them with the
+		// (stale) creation-time label list from the webhook payload.
+		merged := v.Item
+		merged.Labels = unionStrings(item.Labels, v.Item.Labels)
+		return applyProjectItem(item, merged)
 
 	case IssueLabeled:
 		if !containsString(item.Labels, v.Label) {
@@ -930,6 +936,18 @@ func removeReviewRequest(rrs []gh.ReviewRequest, login string) []gh.ReviewReques
 		return nil
 	}
 	return out
+}
+
+// unionStrings returns a slice containing all elements of existing plus any
+// elements from incoming that are not already present. Order is preserved.
+func unionStrings(existing, incoming []string) []string {
+	result := copyStrings(existing)
+	for _, s := range incoming {
+		if !containsString(result, s) {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 func removeString(ss []string, s string) []string {


### PR DESCRIPTION
## Summary

Audit every webhook event type fabrik subscribes to and add handlers for all missing actions. For any handler that looks up an item not in the cache, replace the silent `if !ok { return }` no-op with a fallback fetch that populates the cache from GitHub and then re-applies the delta. Add comprehensive tests covering every action, the unknown-issue fallback path, idempotency, out-of-order delivery, and concurrency.

## Problem

`boardcache/delta.go`'s `applyIssuesDelta` only handles `labeled` and `unlabeled` actions. `opened`, `closed`, `reopened`, `transferred`, `assigned`, `unassigned`, `edited` are silently dropped. Similar gaps exist throughout the other delta handlers.

When a new issue is opened on the project board:
1. `issues.opened` webhook fires.
2. `applyIssuesDelta` sees the action, dispatches to handler, no handler matches, returns silently.
3. The new issue is never added to the cache's `items` map.
4. Subsequent `issues.labeled` events for the same issue do `if !ok { return }` because the issue isn't in the cache.
5. The engine's `FetchProjectBoard` returns the cache view — without the new issue.
6. **Fabrik effectively cannot see the new issue** until the periodic 60-min Reconcile.

Concretely observed 2026-05-04 ("fabrik went deaf" — user filed multiple issues, fabrik did nothing).

## Approach

### Approach

**Chosen approach: Option A — add `FetchProjectItem` to `ReadClient`, wire as explicit fallback helper in delta handlers.**

The Store already has `FallbackFetcher` support (wired as nil today). Rather than wiring the Store fallback (which would silently make `store.Get()` trigger network I/O in any path), we implement `ensureIssueInStore` explicitly at the CacheImpl level — mirroring the existing `resolvePRLinkage` pattern. This keeps fallback fetch transparent to reviewers and matches ADR 034/036 intent.

**Key design decisions:**

1. **`FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error)`** added to `ReadClient`, `GitHubAdapter`, and `gh.Client`. Backed by a REST GET to `/repos/owner/repo/issues/N`. Returns a minimal `gh.ProjectItem` (Number, Title, Body, State, Labels, Assignees, URL, Repo). This is the fallback source for unknown-issue auto-heal.

2. **`issues.opened` creates from payload** — no API call. `issuesPayload.Issue` is expanded to include Title, Body, State, Labels, Assignees; the handler builds a `gh.ProjectItem` and applies `IssueOpened{Item: pi}`. For out-of-order events, `ensureIssueInStore` calls `FetchProjectItem`.

3. **`IssueEdited{Repo, Number, Title, Body}`** — follows GitHub event naming convention. Updates Title and Body in `applyToItem`.

4. **`IssueAssigneesUpdated{Repo, Number, Assignees []string}`** — replaces the full assignees slice (the webhook `issue.assignees` field provides the post-mutation full list for both `assigned` and `unassigned`). Simpler and more idempotent than individual add/remove mutations.

5. **`PRReviewRequested{Repo, Number, Reviewers []gh.ReviewRequest}`** and **`PRReviewRequestRemoved{Repo, Number, Login string}`** — `review_requested` replaces the full `LinkedPRReviewRequests` slice (full list in payload); `review_request_removed` removes one by login. Parallels `IssueLabeled`/`IssueUnlabeled` pattern.

6. **`projects_v2_item.created`** — payload has `content_node_id` (issue node ID) but no issue number. Call `FetchItemDetails` with `gh.ProjectItem{ID: content_node_id}` and **fix `FetchItemDetails` to set `item.Number` from the GraphQL response if it is zero**. Then apply `IssueOpened{Item: *item}`. (This is the only handler that uses `FetchItemDetails` rather than `FetchProjectItem`.)

7. **No-op decisions** (all documented with inline comments explaining why):
   - `pull_request.labeled`/`unlabeled`/`assigned`/`unassigned` — PR labels/assignees not tracked
   - `pull_request.edited` — `Closes #N` linkage drift healed by next Reconcile
   - `pull_request_review.edited`/`dismissed` — review state captured at `submitted`; edits/dismissals don't affect Fabrik's dispatch signals
   - `pull_request_review_comment.edited`/`deleted` — inline comment content not decision-relevant; next deep fetch heals
   - `issue_comment.edited`/`deleted` — reaction-based state machine reads reactions not comment bodies; creation time determines ordering
   - `check_run.created`/`rerequested`/`requested_action` — only terminal state (`completed`) matters for CI gate
   - `check_suite.*` — individual check runs tracked via `check_run.completed`; suite aggregates are redundant
   - `projects_v2_item.restored`/`reordered` — `restored`: next Reconcile re-adds; `reordered`: column order not modeled

8. **`projects_v2_item.archived`/`deleted`** — treated as removal: call `store.Remove(repo, num)` and clean up `prNumToKey` under `c.mu`. Follows the Reconcile removal pattern (`boardcache.go:301-316`).

9. **No new ADR** — decisions extend the existing ADR 034/036 patterns without introducing a new architectural principle. The fallback fetch at CacheImpl level (rather than Store level) is documented as a comment in `ensureIssueInStore`.

### New/Modified Files

| File | Change |
|------|--------|
| `boardcache/boardcache.go` | Add `FetchProjectItem` to `ReadClient` interface and `GitHubAdapter` |
| `boardcache/delta.go` | Expand payload structs; add `ensureIssueInStore`; implement all new handlers and document no-ops; add `case "check_suite"` |
| `boardcache/boardcache_test.go` | Add `FetchProjectItem` to `mockClient` |
| `boardcache/delta_test.go` | Add ~30 new tests covering all actions, fallback, idempotency, concurrency |
| `internal/itemstate/mutation.go` | Add `IssueEdited`, `IssueAssigneesUpdated`, `PRReviewRequested`, `PRReviewRequestRemoved` |
| `internal/itemstate/store.go` | Add `applyToItem` cases for the four new mutations |
| `github/project.go` | Add `FetchProjectItem` method; fix `FetchItemDetails` to set `item.Number` if 0 |
| `docs/state-machine.md` | Add §2.x Event Enumeration subsection |

### Key Decisions

- **Option A (explicit `FetchProjectItem` on ReadClient) over Option B (node_id + FetchItemDetails)**: Option B would require the node_id to be present in all webhook payloads (not guaranteed), uses an expensive deep-fetch path for simple population, and complicates mock setup. Option A adds one REST endpoint per fallback, which is minimal.
- **`ensureIssueInStore` helper over wiring Store FallbackFetcher**: Keeps fallback fetch transparent in delta handler code paths; avoids making `store.Get()` implicitly perform network I/O anywhere it's called.
- **`IssueAssigneesUpdated` (full-list replacement) over `IssueAssigned`/`IssueUnassigned`**: The webhook payload always includes the full post-mutation assignee list, so replacing is simpler and idempotent. Individual add/remove mutations would require careful ordering and state reconstruction.
- **`projects_v2_item.created` uses `FetchItemDetails` (not `FetchProjectItem`)**: This is the one handler with a node_id but no issue number. `FetchItemDetails` can look up the item by node_id via GraphQL. We accept the cost of fixing `FetchItemDetails` to populate `item.Number`.
- **`projects_v2_item.archived` removes the item**: Fabrik only processes active issues; archived items should not be dispatched. The next Reconcile confirms the item is gone.

### Task Checklist

- [ ] **Task 1**: Expand `issuesPayload.Issue` in `boardcache/delta.go` to add `Title`, `Body`, `State`, `Labels []struct{Name string}`, `Assignees []struct{Login string}`, `NodeID string`. Expand `pullRequestPayload.PullRequest` to add `RequestedReviewers []struct{Login, Type string}` and `HeadRef struct{Ref string}`.

- [ ] **Task 2**: Add `IssueEdited{Repo, Number, Title, Body string}`, `IssueAssigneesUpdated{Repo, Number, Assignees []string}`, `PRReviewRequested{Repo, Number, Reviewers []gh.ReviewRequest}`, `PRReviewRequestRemoved{Repo, Number, Login string}` to `internal/itemstate/mutation.go` (with `isMutation()` and `itemKey()` methods).

- [ ] **Task 3**: Add `applyToItem` cases in `internal/itemstate/store.go` for the four new mutations: `IssueEdited` updates Title+Body; `IssueAssigneesUpdated` replaces Assignees; `PRReviewRequested` replaces `item.LinkedPR.ReviewRequests` (creating `LinkedPR` if nil); `PRReviewRequestRemoved` removes one reviewer by Login.

- [ ] **Task 4**: Add `FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error)` to `ReadClient` interface and `GitHubAdapter` in `boardcache/boardcache.go`. Implement in `github/project.go` via REST GET `/repos/{owner}/{repo}/issues/{number}` returning a `gh.ProjectItem` with Number, Title, Body, State, Labels, Assignees, URL, Repo set. Also fix `FetchItemDetails` in `github/project.go` to set `item.Number` from the GraphQL response when it is zero. Update `mockClient` in `boardcache/boardcache_test.go` to add a `FetchProjectItem` method.

- [ ] **Task 5**: Add `ensureIssueInStore(owner, repo string, issNum int) error` helper to `boardcache/delta.go`. The helper calls `c.store.Get(repo, issNum)` — if found, returns nil. On miss, calls `c.fallback.FetchProjectItem(owner, repo, issNum)`, applies `IssueOpened{Item: *item}` to the Store, returns any error. This must NOT hold any lock during the fetch or Store call.

- [ ] **Task 6**: Implement all `issues.*` delta handlers in `boardcache/delta.go`. Replace the `applyIssuesDelta` switch with full coverage: `opened` (build `gh.ProjectItem` from expanded payload, apply `IssueOpened`); `closed`/`reopened` (call `ensureIssueInStore`, apply `IssueClosed`/`IssueReopened`); `transferred`/`deleted` (call `store.Remove`, clean up `prNumToKey` under `c.mu`); `edited` (call `ensureIssueInStore`, apply `IssueEdited`); `assigned`/`unassigned` (call `ensureIssueInStore`, apply `IssueAssigneesUpdated`). Fix the existing `labeled`/`unlabeled` handlers to call `ensureIssueInStore` instead of the silent `if err != nil { return }` guard.

- [ ] **Task 7**: Implement remaining `pull_request.*` handlers in `boardcache/delta.go`. Expand the `applyPullRequestDelta` switch to handle: `ready_for_review` / `converted_to_draft` (update `c.linkedPRs[pk].Draft` under `c.mu`; allocate `PRDetails` if missing); `review_requested` (build `[]gh.ReviewRequest` from `RequestedReviewers`, derive `IsBot` from `Type=="Bot"` or `isBotLogin`, apply `PRReviewRequested` to Store); `review_request_removed` (apply `PRReviewRequestRemoved` to Store). Add documented no-op comments for `labeled`, `unlabeled`, `assigned`, `unassigned`, `edited` (these already fall through the `default: return` but need explicit comment-documented no-ops in the switch).

- [ ] **Task 8**: Document no-ops for all remaining event types. In `applyPullRequestReviewSubmitted`: add `edited`/`dismissed` as documented no-op cases in the action filter. In `applyPullRequestReviewCommentCreated`: add `edited`/`deleted` cases. In `applyIssueCommentCreated`: add `edited`/`deleted` cases. In `applyCheckRunCompleted`: add `created`/`rerequested`/`requested_action` cases.

- [ ] **Task 9**: Add `case "check_suite"` to `ApplyDelta` in `boardcache/delta.go` with a no-op body and a comment explaining why (`check_suite` events are coarse-grained; individual check runs are tracked via `check_run.completed`). Add a new `applyCheckSuite` stub that documents all three actions (`completed`, `requested`, `rerequested`) as no-ops.

- [ ] **Task 10**: Implement `projects_v2_item.*` handlers in `boardcache/delta.go`. Expand `applyProjectsV2ItemEdited` (rename to `applyProjectsV2ItemDelta`) to handle: `created` (call `FetchItemDetails` with `gh.ProjectItem{ID: content_node_id}`, apply `IssueOpened{Item: *item}`); `deleted`/`archived` (call `store.Remove`, clean up `prNumToKey`); `restored` (documented no-op — next Reconcile re-adds); `reordered` (documented no-op — column order not modeled). Update `ApplyDelta` to call `applyProjectsV2ItemDelta` instead.

- [ ] **Task 11**: Tests for `issues.*` in `boardcache/delta_test.go`: one test per action (`opened`, `closed`, `reopened`, `edited`, `transferred`, `deleted`, `assigned`, `unassigned`, `labeled` existing, `unlabeled` existing). Include regression test `TestFabrikWentDeaf_IssuesLabeledBeforeOpened` that verifies `issues.labeled` for an unknown issue triggers fallback fetch. Include `TestIssuesOpenedIdempotent` (deliver twice, assert fields not doubled). Include `TestOutOfOrderIssuesLabeledBeforeOpened` (labeled before opened → correct final state).

- [ ] **Task 12**: Tests for `pull_request.*` in `boardcache/delta_test.go`: `TestPullRequestReadyForReview`, `TestPullRequestConvertedToDraft`, `TestPullRequestReviewRequested`, `TestPullRequestReviewRequestRemoved`, `TestPRLinkage_opened` (PR body `Closes #N` → `LinkedPRNumber` populated).

- [ ] **Task 13**: Tests for remaining event types in `boardcache/delta_test.go`: `TestCheckRunCompleted_ExistingLinkage` (existing), `TestCheckRunSuiteNoOp`, `TestProjectsV2ItemCreated`, `TestProjectsV2ItemDeleted`, `TestProjectsV2ItemArchived`, `TestProjectsV2ItemRestoredNoOp`. `TestCachePauseDropsDelta` (pause → deliver → no change; resume → deliver → applied). `TestConcurrentDeltaSameIssue` (race-detector test: 10 goroutines delivering deltas for the same issue). `TestNegativeCacheTTLPreserved` (PR miss within TTL doesn't re-attempt fallback).

- [ ] **Task 14**: Update `docs/state-machine.md` — add a new §2.x subsection **Webhook Event Enumeration** with a table mapping each event type → action → handler decision → cache mutation → engine reaction. Cover all 8 event types and ~30 actions. Reference that no-op decisions are documented with inline comments in `boardcache/delta.go`.

- [ ] **Task 15**: Run `go build ./...`, `go vet ./...`, `go test -race ./...`. Fix any compilation errors or race conditions.

### Risks

- **Lock-ordering violations**: Every new handler that calls `c.store.Get()` or `c.store.Apply()` must NOT hold `c.mu`. Reviewers must audit every new `c.store.*` call site — any holding `c.mu` reproduces the ADR 037 bug.
- **`FetchItemDetails` number population**: The fix to `FetchItemDetails` must correctly identify and set `item.Number` from the GraphQL response. If the GraphQL deep query doesn't return the issue number, a different query approach may be needed for `projects_v2_item.created`. Implementer should verify the GraphQL response shape before coding.
- **TOCTOU in `ensureIssueInStore`**: Two concurrent webhooks for the same unknown issue both trigger `FetchProjectItem`. The second `IssueOpened` apply is idempotent (no-op detection via `reflect.DeepEqual`). The delta re-application after both fetches results in both deltas applied — correct behavior.
- **`PRReviewRequested` full-list replace**: The `pull_request.review_requested` payload includes `pull_request.requested_reviewers` as the full list after adding. Using the full-list form means idempotent delivery doesn't cause duplicates. Confirm the payload field name against GitHub webhook docs during implementation.
- **mockClient update**: Any test that creates a `mockClient` without `FetchProjectItem` will fail to compile after Task 4. `boardcache_test.go` must be updated before any new delta tests that exercise the fallback path.

---
Used 16/50 turns, 8k input / 11k output tokens.

## Verification

Completed Phase 3-D implementation by fixing one failing test (`TestOutOfOrderIssuesLabeledBeforeOpened`) and updating docs. The fix adds union-semantics for labels in `IssueOpened` so late-arriving `opened` webhooks don't overwrite labels applied by prior `labeled` events. Also updated `docs/state-machine.md` §D.2 with the full webhook event coverage table (~30 actions across 8 event types) and documents the `ensureIssueInStore` fallback pattern. All tests pass with race detector.

---

Closes #516