### PR TITLE
Phase 3-E: consolidate per-item engine state into ItemState

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -568,8 +568,8 @@ Fabrik discovers PR comments through the `closedByPullRequestsReferences` GraphQ
 
 **Flow:**
 1. Find linked PR via `FindPRForIssue()` / `FetchLinkedPR()` (the latter also returns the head SHA needed for the per-check classification fallback).
-2. Query `FetchPRMergeableState()` (REST single-PR endpoint). If the result is `clean` or `unstable` (per `github.MergeableStateAccepted`), **skip the raw check_runs gate**: clear any stale `fabrik:awaiting-ci` label, drop the in-memory `ciMergePendingSince` entry, and proceed directly to step 4. Other states fall through to the per-check classification in step 3.
-3. **Per-check classification (fallback)**: fetch check runs via `FetchCheckRuns()`. Apply R1–R6 rules (no checks → R5 clears; failed → R3 applies `fabrik:awaiting-ci` and returns error; pending → R2 returns error and tracks `ciMergePendingSince` for the timeout; all green → R4 clears).
+2. Query `FetchPRMergeableState()` (REST single-PR endpoint). If the result is `clean` or `unstable` (per `github.MergeableStateAccepted`), **skip the raw check_runs gate**: clear any stale `fabrik:awaiting-ci` label, clear the `LinkedPRState.CIMergePendingSince` entry in the store, and proceed directly to step 4. Other states fall through to the per-check classification in step 3.
+3. **Per-check classification (fallback)**: fetch check runs via `FetchCheckRuns()`. Apply R1–R6 rules (no checks → R5 clears; failed → R3 applies `fabrik:awaiting-ci` and returns error; pending → R2 returns error and tracks `LinkedPRState.CIMergePendingSince` for the timeout; all green → R4 clears).
 4. Attempt merge via `MergePR()`. `MergePR` first checks the PR's `merged` field — if the PR was already merged (e.g., by a human), it returns nil immediately (no-op success). Otherwise it checks `mergeable` and attempts the merge.
 5. On `ErrNotMergeable`: apply `fabrik:rebase-needed` idempotently. Then:
    - **inFlight guard:** if a rebase goroutine is already running for this item, return a plain error (skip — prevents cycle-counter drift).
@@ -698,12 +698,12 @@ The CI gate has two paths that handle different timing scenarios:
 
 **Path 1: `attemptMergeOnValidate()` (Merge Guard)**
 - Embedded directly in the auto-merge path for Validate+yolo items
-- Uses in-memory `ciMergePendingSince` map (keyed by `issueKey`) to track how long CI has been pending
+- Uses `itemstate.Store` → `LinkedPRState.CIMergePendingSince` (via `CIMergePendingStarted`/`CIMergePendingCleared` mutations) to track how long CI has been pending
 - Fetches PR head SHA via `FetchLinkedPR()` (REST), then check run statuses via `FetchCheckRuns()` (REST)
-- **R5:** No check runs → gate clears (repo has no CI). The `prHasHadChecks` post-push delay guard applies to `checkCIGate()` (Path 2) only, not to this merge-guard path
-- **R4:** All checks green → clear `ciMergePendingSince`; clear `fabrik:awaiting-ci`; proceed to merge
+- **R5:** No check runs → gate clears (repo has no CI). The `LinkedPRState.HasHadChecks` post-push delay guard applies to `checkCIGate()` (Path 2) only, not to this merge-guard path
+- **R4:** All checks green → apply `CIMergePendingCleared`; clear `fabrik:awaiting-ci`; proceed to merge
 - **R3:** Any check failed → add `fabrik:awaiting-ci`; return error (advance skipped)
-- **R2:** Any check pending → start timer in `ciMergePendingSince` (first observation); return error (**R10c:** no label applied — avoids label churn for transient pending state)
+- **R2:** Any check pending → apply `CIMergePendingStarted` on first observation; return error (**R10c:** no label applied — avoids label churn for transient pending state)
 - **R6:** Pending elapsed ≥ `CIWaitTimeout` → post comment; add `fabrik:paused` + `fabrik:awaiting-input`; return error
 
 **Path 2: Catch-up loop Phase 1 (`checkCIGate()`)**
@@ -717,7 +717,7 @@ The CI gate has two paths that handle different timing scenarios:
 - **Gate cleared outcome:** When all checks pass (or no check runs exist — R5), `checkCIGate` calls `addCompleteLabelAndRemoveCI`: adds `stage:X:complete` and removes `fabrik:awaiting-ci`. This is the only place `stage:X:complete` is added for `wait_for_ci: true` stages (conjunctive gate invariant, ADR 032).
 
 **Two different timeout strategies:**
-- **Path 1** (merge guard): In-memory `ciMergePendingSince` map. Acceptable because merge-guard state is transient — engine restarts simply re-evaluate CI on the next poll.
+- **Path 1** (merge guard): `itemstate.Store` → `LinkedPRState.CIMergePendingSince`. Acceptable because merge-guard state is transient — engine restarts simply re-evaluate CI on the next poll (store is in-memory only; not persisted across restarts).
 - **Path 2** (catch-up loop): `FetchLabelAppliedAt` REST call on `fabrik:awaiting-ci`. Durable across restarts because the label itself persists. The label is present from the moment Claude emits FABRIK_STAGE_COMPLETE on a `wait_for_ci: true` stage, so timeout tracking is accurate from the start of the CI-await window.
 
 #### 6.4.2 CI Fix Reinvoke Mechanics
@@ -845,7 +845,7 @@ When Claude runs but does not output any completion marker, the engine enters a 
 - **State:** In-memory only (`processedSet[stageKey]` timestamp). No label is added for cooldown.
 - **Lock behavior:** The lock (`fabrik:locked:<user>` and `stage:<X>:in_progress`) is NOT released during cooldown. This prevents other instances from picking up the item.
 - **Resume behavior:** On retry, `resume=true` is passed to Claude (resumes the session rather than starting fresh)
-- **On restart:** Cooldown state is lost. The lock label is still present but `lockedIssues` in-memory map is empty — the shutdown cleanup removes lock labels. If the process crashes without cleanup, the lock label remains as a stale artifact until another instance or manual cleanup removes it.
+- **On restart:** Cooldown state is lost. The lock label is still present but the in-memory `ItemState.Lock` in the `itemstate.Store` is empty — the shutdown cleanup removes lock labels. If the process crashes without cleanup, the lock label remains as a stale artifact until another instance or manual cleanup removes it.
 - **Stage-complete exemption:** Items where `stage:X:complete` appears in the shallow label set are NOT subject to cooldown retry — they have no work to retry. When the cooldown-expired branch fires in `itemMayNeedWork()`, the engine checks for `stage:X:complete` in shallow labels before returning `true`; if present, it returns `false`. This prevents perpetual deep-fetch loops for terminal items (cruise+Validate complete, paused+complete, closed-with-stage-complete) where every poll after cooldown expiry would otherwise trigger a no-op deep-fetch indefinitely.
 
 ### 7.2 Failed Stage / Pause on Retry Limit
@@ -894,11 +894,11 @@ Closed issues are normally skipped by `itemMayNeedWork()` and `itemNeedsWork()`.
 | Paused-due-to-retries | `pausedDueToRetries[stageKey]` | `fabrik:paused` + `stage:<X>:failed` | Labels survive; in-memory flag lost but `processItem()` detects the failed label directly |
 | Review cycle count | `reviewCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
 | CI-fix cycle count | `ciFixCycleCount[stageKey]` | None | Lost — cycle count restarts from 0 |
-| CI merge pending since | `ciMergePendingSince[issueKey]` | None | Lost — merge guard re-evaluates CI fresh on next poll |
+| CI merge pending since | `itemstate.Store` → `LinkedPRState.CIMergePendingSince` | None | Lost — merge guard re-evaluates CI fresh on next poll |
 | Comment processed | `processedSet[key]` | ROCKET (🚀) reaction | Reaction survives restart; in-memory dedup is defense-in-depth |
-| Lock tracking | `lockedIssues[iKey]` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
+| Lock tracking | `itemstate.Store` → `ItemState.Lock` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
 | Last updatedAt | `seenUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |
-| Deep-fetch failure | `deepFetchFailureTime[iKey]` | None | Lost — failed items retried immediately |
+| Deep-fetch failure | `itemstate.Store` → `ItemState.LastDeepFetchFailureAt` | None | Lost — failed items retried immediately |
 
 ### 7.6 Invocation-Level Kill Mechanisms
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -897,7 +897,7 @@ Closed issues are normally skipped by `itemMayNeedWork()` and `itemNeedsWork()`.
 | CI merge pending since | `ciMergePendingSince[issueKey]` | None | Lost — merge guard re-evaluates CI fresh on next poll |
 | Comment processed | `processedSet[key]` | ROCKET (🚀) reaction | Reaction survives restart; in-memory dedup is defense-in-depth |
 | Lock tracking | `lockedIssues[iKey]` | `fabrik:locked:<user>` label | Label may survive if process crashes; `cleanupLockedIssues()` runs on graceful shutdown |
-| Last updatedAt | `lastUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |
+| Last updatedAt | `seenUpdatedAt[iKey]` | None | Lost — all items re-evaluated on first poll |
 | Deep-fetch failure | `deepFetchFailureTime[iKey]` | None | Lost — failed items retried immediately |
 
 ### 7.6 Invocation-Level Kill Mechanisms
@@ -1058,7 +1058,7 @@ Within a single `poll()` call:
 1. **Catch-up loop** runs first — processes items with `stage:<X>:complete` labels for yolo/cruise advancement, review gate evaluation, and review reinvoke dispatch
 2. **Dispatch loop** runs second — processes items that need stage invocations or comment processing
 
-The `advancedItems` map prevents items advanced by the catch-up loop from having their `lastUpdatedAt` re-cached (which would make them invisible on the next poll). The `inFlight` map prevents items dispatched by `dispatchReviewReinvoke()` in the catch-up loop from being double-dispatched by the dispatch loop.
+The `advancedItems` map prevents items advanced by the catch-up loop from having their `seenUpdatedAt` re-cached (which would make them invisible on the next poll). The `inFlight` map prevents items dispatched by `dispatchReviewReinvoke()` in the catch-up loop from being double-dispatched by the dispatch loop.
 
 ### 9.5 processedSet Mutex
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1062,7 +1062,29 @@ The `advancedItems` map prevents items advanced by the catch-up loop from having
 
 ### 9.5 processedSet Mutex
 
-`Engine.mu` (sync.Mutex) protects all in-memory state maps: `processedSet`, `lockedIssues`, `retryCount`, `pausedDueToRetries`, `reviewCycleCount`, `ciFixCycleCount`, `ciMergePendingSince`, `lastUpdatedAt`, `deepFetchFailureTime`, `lastUsage`, `lastCompleted`, `lastBlocked`, `totalTokens`, `lastReportedCost`. Critical sections are kept small — typically a single map read/write.
+`Engine.mu` (sync.Mutex) protects in-memory state that is not covered by its own synchronization primitive: `processedSet`, `retryCount`, `pausedDueToRetries`, `reviewCycleCount`, `ciFixCycleCount`, `rebaseCycleCount`, `seenUpdatedAt`, `totalTokens`, `lastReportedCost`. Critical sections are kept small — typically a single map read/write.
+
+Per-item engine state previously stored in `Engine.mu`-protected maps has been migrated to `itemstate.Store` (Phase 3-E; see ADR-036). Those fields — `Lock`, `LastTokenUsage`, `LastInvocationCompleted`, `LastInvocationBlocked`, `LastDeepFetchFailureAt`, `LinkedPR.HasHadChecks`, `LinkedPR.CIMergePendingSince` — are now read via `e.store.Get(repo, n)` (returning an immutable `Snapshot`) and written via `e.store.Apply(Mutation)`. The Store has its own internal mutex; no `Engine.mu` guard is needed for these fields.
+
+### 9.6 Engine Internal State (itemstate.Store)
+
+Per-item engine state lives in `Engine.store *itemstate.Store`, an engine-owned store separate from `CacheImpl`'s internal store. It is initialized with `itemstate.NewStore(nil)` in both `New()` and `NewWithDeps()`. Unification into a single store is deferred to a later phase (see ADR-036).
+
+The following fields are stored in `ItemState` / `LinkedPRState` and accessed exclusively through the store:
+
+| `ItemState` field | Mutation (write) | Snapshot accessor (read) | Former Engine map |
+|---|---|---|---|
+| `Lock` (`LockState`) | `LocalLockAcquired`, `LocalLockReleased` | `snap.Lock()` | `e.lockedIssues[iKey]` |
+| `LastTokenUsage` | `InvocationRecorded{Usage: ...}` | `snap.State().LastTokenUsage` | `e.lastUsage[iKey]` |
+| `LastInvocationCompleted` | `InvocationRecorded{Completed: ...}` | `snap.State().LastInvocationCompleted` | `e.lastCompleted[iKey]` |
+| `LastInvocationBlocked` | `InvocationRecorded{Blocked: ...}` | `snap.State().LastInvocationBlocked` | `e.lastBlocked[iKey]` |
+| `LastDeepFetchFailureAt` | `DeepFetchFailed{At: ...}` (set); `ItemDeepFetched` (clears) | `snap.State().LastDeepFetchFailureAt` | `e.deepFetchFailureTime[iKey]` |
+| `LinkedPR.HasHadChecks` | `PRChecksObserved` (REST path); `CheckRunCompleted` (webhook path) | `snap.LinkedPR().HasHadChecks` | `e.prHasHadChecks[iKey]` |
+| `LinkedPR.CIMergePendingSince` | `CIMergePendingStarted{At: ...}` (set); `CIMergePendingCleared` (clear) | `snap.LinkedPR().CIMergePendingSince` | `e.ciMergePendingSince[iKey]` |
+
+**`seenUpdatedAt` (deferred):** The map `e.seenUpdatedAt` (formerly `e.lastUpdatedAt`) tracks the last-seen `UpdatedAt` timestamp per issue. It is kept as a plain `Engine.mu`-protected map pending Phase 3-H, when change-feed observers will replace its purpose. It is intentionally excluded from `itemstate.Store` in this phase.
+
+See also: ADR-036 (`adrs/036-reactive-cache-single-owner.md`) for the full rationale and migration plan.
 
 ---
 

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
 )
@@ -40,7 +41,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 	}
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-	key := issueKey(item, e.defaultRepo())
+	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
 
 	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
@@ -76,17 +77,21 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 	}
 
 	if len(checkRuns) > 0 {
-		e.mu.Lock()
-		e.prHasHadChecks[key] = true
-		e.mu.Unlock()
+		e.store.Apply(itemstate.PRChecksObserved{
+			Repo:   itemRepo,
+			Number: item.Number,
+		})
 	}
 
 	// R5: no check runs found. If this PR has had checks before, we're likely in
 	// the post-push registration window — block and wait rather than clearing.
 	if len(checkRuns) == 0 {
-		e.mu.Lock()
-		hadChecks := e.prHasHadChecks[key]
-		e.mu.Unlock()
+		var hadChecks bool
+		if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
+			if lpr := snap.LinkedPR(); lpr != nil {
+				hadChecks = lpr.HasHadChecks
+			}
+		}
 		if hadChecks {
 			e.logf(item.Number, "ci-gate", "no check runs for SHA %s — likely post-push registration delay; waiting\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
 			return true, false, false
@@ -358,14 +363,14 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 		e.logf(item.Number, "ci-fix-reinvoke", "re-invoking stage %q via comment processing with CI failure context\n", stage.Name)
 		err := e.processComments(ctx, board, item, &ciFixStage, []gh.Comment{syntheticComment})
 
-		e.mu.Lock()
-		usage := e.lastUsage[iKey]
-		completed := e.lastCompleted[iKey]
-		blocked := e.lastBlocked[iKey]
-		delete(e.lastUsage, iKey)
-		delete(e.lastCompleted, iKey)
-		delete(e.lastBlocked, iKey)
-		e.mu.Unlock()
+		var usage TokenUsage
+		var completed, blocked bool
+		if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
+			st := snap.State()
+			usage = st.LastTokenUsage
+			completed = st.LastInvocationCompleted
+			blocked = st.LastInvocationBlocked
+		}
 		e.emitStructural(tui.JobCompletedEvent{
 			IssueNumber:    item.Number,
 			Repo:           itemRepo,

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -81,7 +82,7 @@ func TestCheckCIGate_PostPushDelay_BlocksGate(t *testing.T) {
 	}
 	eng := testEngineForMerge(client)
 	// Pre-seed: this issue has previously had check runs registered.
-	eng.prHasHadChecks["owner/repo#1"] = true
+	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 1})
 
 	tr := true
 	item := gh.ProjectItem{Number: 1}

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -140,26 +141,20 @@ func claudeLog(issueNumber int, tag, format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[#%d %s] "+format, append([]any{issueNumber, tag}, args...)...)
 }
 
-// TokenUsage holds token consumption data from a single Claude invocation.
-type TokenUsage struct {
-	InputTokens         int
-	OutputTokens        int
-	CacheCreationTokens int
-	CacheReadTokens     int
-	CostUSD             float64
-	TurnsUsed           int
-	MaxTurns            int
-}
+// TokenUsage is a type alias for itemstate.TokenUsage. Using an alias ensures
+// engine.TokenUsage and itemstate.TokenUsage are the same type with zero-cost
+// assignment between the two packages (Phase 3-E).
+type TokenUsage = itemstate.TokenUsage
 
-// add returns a new TokenUsage that is the sum of t and other.
-func (t TokenUsage) add(other TokenUsage) TokenUsage {
+// addTokenUsage returns a new TokenUsage that is the sum of a and b.
+func addTokenUsage(a, b TokenUsage) TokenUsage {
 	return TokenUsage{
-		InputTokens:         t.InputTokens + other.InputTokens,
-		OutputTokens:        t.OutputTokens + other.OutputTokens,
-		CacheCreationTokens: t.CacheCreationTokens + other.CacheCreationTokens,
-		CacheReadTokens:     t.CacheReadTokens + other.CacheReadTokens,
-		CostUSD:             t.CostUSD + other.CostUSD,
-		TurnsUsed:           t.TurnsUsed + other.TurnsUsed,
+		InputTokens:         a.InputTokens + b.InputTokens,
+		OutputTokens:        a.OutputTokens + b.OutputTokens,
+		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
+		CacheReadTokens:     a.CacheReadTokens + b.CacheReadTokens,
+		CostUSD:             a.CostUSD + b.CostUSD,
+		TurnsUsed:           a.TurnsUsed + b.TurnsUsed,
 	}
 }
 

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -133,8 +134,12 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		e.mu.Lock()
 		defer e.mu.Unlock()
 		e.totalTokens = addTokenUsage(e.totalTokens, usage)
-		e.lastUsage[issueKey(item, e.defaultRepo())] = usage
 	}()
+	e.store.Apply(itemstate.InvocationRecorded{
+		Repo:   itemOwnerRepoString(item, e.defaultRepo()),
+		Number: item.Number,
+		Usage:  usage,
+	})
 	if err != nil {
 		e.removeEditingLabel(owner, repo, item.Number)
 		if ctx.Err() != nil {
@@ -286,8 +291,13 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			defer e.mu.Unlock()
 			delete(e.retryCount, stageKey)
 			delete(e.pausedDueToRetries, stageKey)
-			e.lastCompleted[iKey] = true
 		}()
+		e.store.Apply(itemstate.InvocationRecorded{
+			Repo:      itemOwnerRepoString(item, e.defaultRepo()),
+			Number:    item.Number,
+			Completed: true,
+			Usage:     usage,
+		})
 		var prNumber int
 		if stage.CreateDraftPR {
 			prNumber = e.ensureDraftPR(item, baseBranch)

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -132,7 +132,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	func() {
 		e.mu.Lock()
 		defer e.mu.Unlock()
-		e.totalTokens = e.totalTokens.add(usage)
+		e.totalTokens = addTokenUsage(e.totalTokens, usage)
 		e.lastUsage[issueKey(item, e.defaultRepo())] = usage
 	}()
 	if err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -77,12 +77,7 @@ type Engine struct {
 	ciFixCycleCount      map[string]int        // key: "owner/repo#N-stageName"; CI-fix re-invocation cycle count per stage
 	rebaseCycleCount     map[string]int        // key: "owner/repo#N-stageName"; rebase re-invocation cycle count per stage
 	ciMergePendingSince  map[string]time.Time  // key: issueKey; when CI was first observed in_progress in the merge guard
-	prHasHadChecks       map[string]bool       // key: issueKey; true once FetchCheckRuns has returned non-empty for this issue
-	lastUsage            map[string]TokenUsage // key: issueKey; per-issue token usage from last processItem (for TUI)
-	lastCompleted        map[string]bool       // key: issueKey; per-issue stage completion from last processItem (for TUI)
-	lastBlocked          map[string]bool       // key: issueKey; per-issue blocked-on-input from last processItem (for TUI)
 	lastUpdatedAt        map[string]time.Time  // key: issueKey; tracks last-seen updatedAt per issue
-	deepFetchFailureTime map[string]time.Time  // key: issueKey; tracks when FetchItemDetails last failed
 	idleCount            int                   // consecutive idle polls; triggers self-upgrade at threshold
 	idleStart            time.Time             // when consecutive idle polls began; zero value = not idle
 	wakeCh               chan struct{}         // TUI sends on this to wake the poll loop immediately; nil if no TUI
@@ -132,18 +127,13 @@ func New(cfg Config) (*Engine, error) {
 		fabrikDir:            fabrikDir,
 		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
-		lastUsage:            make(map[string]TokenUsage),
-		lastCompleted:        make(map[string]bool),
-		lastBlocked:          make(map[string]bool),
 		lastUpdatedAt:        make(map[string]time.Time),
-		deepFetchFailureTime: make(map[string]time.Time),
 		retryCount:           make(map[string]int),
 		pausedDueToRetries:   make(map[string]bool),
 		reviewCycleCount:     make(map[string]int),
 		ciFixCycleCount:      make(map[string]int),
 		rebaseCycleCount:     make(map[string]int),
 		ciMergePendingSince:  make(map[string]time.Time),
-		prHasHadChecks:       make(map[string]bool),
 		sem:                  make(chan struct{}, cfg.MaxConcurrent),
 	}
 
@@ -197,18 +187,13 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		worktreeManagers:     wms,
 		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
-		lastUsage:            make(map[string]TokenUsage),
-		lastCompleted:        make(map[string]bool),
-		lastBlocked:          make(map[string]bool),
 		lastUpdatedAt:        make(map[string]time.Time),
-		deepFetchFailureTime: make(map[string]time.Time),
 		retryCount:           make(map[string]int),
 		pausedDueToRetries:   make(map[string]bool),
 		reviewCycleCount:     make(map[string]int),
 		ciFixCycleCount:      make(map[string]int),
 		rebaseCycleCount:     make(map[string]int),
 		ciMergePendingSince:  make(map[string]time.Time),
-		prHasHadChecks:       make(map[string]bool),
 		sem:                  make(chan struct{}, maxConcurrent),
 	}
 	if worktrees != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -76,8 +76,7 @@ type Engine struct {
 	reviewCycleCount     map[string]int        // key: "owner/repo#N-stageName"; review re-invocation cycle count per stage
 	ciFixCycleCount      map[string]int        // key: "owner/repo#N-stageName"; CI-fix re-invocation cycle count per stage
 	rebaseCycleCount     map[string]int        // key: "owner/repo#N-stageName"; rebase re-invocation cycle count per stage
-	ciMergePendingSince  map[string]time.Time  // key: issueKey; when CI was first observed in_progress in the merge guard
-	lastUpdatedAt        map[string]time.Time  // key: issueKey; tracks last-seen updatedAt per issue
+	seenUpdatedAt        map[string]time.Time  // key: issueKey; tracks last-seen updatedAt per issue (deferred to Phase 3-H)
 	idleCount            int                   // consecutive idle polls; triggers self-upgrade at threshold
 	idleStart            time.Time             // when consecutive idle polls began; zero value = not idle
 	wakeCh               chan struct{}         // TUI sends on this to wake the poll loop immediately; nil if no TUI
@@ -127,13 +126,12 @@ func New(cfg Config) (*Engine, error) {
 		fabrikDir:            fabrikDir,
 		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
-		lastUpdatedAt:        make(map[string]time.Time),
+		seenUpdatedAt:        make(map[string]time.Time),
 		retryCount:           make(map[string]int),
 		pausedDueToRetries:   make(map[string]bool),
 		reviewCycleCount:     make(map[string]int),
 		ciFixCycleCount:      make(map[string]int),
 		rebaseCycleCount:     make(map[string]int),
-		ciMergePendingSince:  make(map[string]time.Time),
 		sem:                  make(chan struct{}, cfg.MaxConcurrent),
 	}
 
@@ -187,13 +185,12 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		worktreeManagers:     wms,
 		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
-		lastUpdatedAt:        make(map[string]time.Time),
+		seenUpdatedAt:        make(map[string]time.Time),
 		retryCount:           make(map[string]int),
 		pausedDueToRetries:   make(map[string]bool),
 		reviewCycleCount:     make(map[string]int),
 		ciFixCycleCount:      make(map[string]int),
 		rebaseCycleCount:     make(map[string]int),
-		ciMergePendingSince:  make(map[string]time.Time),
 		sem:                  make(chan struct{}, maxConcurrent),
 	}
 	if worktrees != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -197,6 +197,7 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		client:               client,
 		claude:               claude,
 		worktreeManagers:     wms,
+		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
 		lockedIssues:         make(map[string]bool),
 		lastUsage:            make(map[string]TokenUsage),

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -69,7 +69,6 @@ type Engine struct {
 	mu                   sync.Mutex
 	store                *itemstate.Store      // per-item engine state (locks, invocation outcomes, deep-fetch, CI-gate); see ADR-036
 	processedSet         map[string]time.Time  // key: "owner/repo#N-stageName" or "owner/repo#N-comment-ID"
-	lockedIssues         map[string]bool       // key: "owner/repo#N"; issues with fabrik:locked added but not yet released
 	totalTokens          TokenUsage            // accumulated token usage since process start
 	lastReportedCost     float64               // cost at last [stats] report; skip repeat prints when unchanged
 	retryCount           map[string]int        // key: "owner/repo#N-stageName", value: failed attempt count
@@ -133,7 +132,6 @@ func New(cfg Config) (*Engine, error) {
 		fabrikDir:            fabrikDir,
 		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
-		lockedIssues:         make(map[string]bool),
 		lastUsage:            make(map[string]TokenUsage),
 		lastCompleted:        make(map[string]bool),
 		lastBlocked:          make(map[string]bool),
@@ -199,7 +197,6 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		worktreeManagers:     wms,
 		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
-		lockedIssues:         make(map[string]bool),
 		lastUsage:            make(map[string]TokenUsage),
 		lastCompleted:        make(map[string]bool),
 		lastBlocked:          make(map[string]bool),

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
 )
@@ -66,6 +67,7 @@ type Engine struct {
 	worktreeManagers     map[string]*WorktreeManager // key: "owner/repo"; one WM per discovered repo
 	fabrikDir            string                      // directory containing .fabrik/ (always os.Getwd() at startup)
 	mu                   sync.Mutex
+	store                *itemstate.Store      // per-item engine state (locks, invocation outcomes, deep-fetch, CI-gate); see ADR-036
 	processedSet         map[string]time.Time  // key: "owner/repo#N-stageName" or "owner/repo#N-comment-ID"
 	lockedIssues         map[string]bool       // key: "owner/repo#N"; issues with fabrik:locked added but not yet released
 	totalTokens          TokenUsage            // accumulated token usage since process start
@@ -129,6 +131,7 @@ func New(cfg Config) (*Engine, error) {
 		claude:               &RealClaudeInvoker{DebugOutput: cfg.DebugOutput},
 		worktreeManagers:     make(map[string]*WorktreeManager),
 		fabrikDir:            fabrikDir,
+		store:                itemstate.NewStore(nil),
 		processedSet:         make(map[string]time.Time),
 		lockedIssues:         make(map[string]bool),
 		lastUsage:            make(map[string]TokenUsage),

--- a/engine/engine_extra_test.go
+++ b/engine/engine_extra_test.go
@@ -5,8 +5,10 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/tui"
 )
 
@@ -51,11 +53,10 @@ func TestCleanupLockedIssues_RemovesLabels(t *testing.T) {
 	client := &mockGitHubClient{}
 	eng := testEngine(client, &mockClaudeInvoker{})
 
-	// Seed the lockedIssues map (keys are "owner/repo#N" format)
-	eng.mu.Lock()
-	eng.lockedIssues["owner/repo#10"] = true
-	eng.lockedIssues["owner/repo#11"] = true
-	eng.mu.Unlock()
+	// Seed locks in the store via LocalLockAcquired mutations.
+	now := time.Now()
+	eng.store.Apply(itemstate.LocalLockAcquired{Repo: "owner/repo", Number: 10, User: "testuser", AcquiredAt: now})
+	eng.store.Apply(itemstate.LocalLockAcquired{Repo: "owner/repo", Number: 11, User: "testuser", AcquiredAt: now})
 
 	eng.cleanupLockedIssues()
 
@@ -70,12 +71,11 @@ func TestCleanupLockedIssues_RemovesLabels(t *testing.T) {
 		}
 	}
 
-	// lockedIssues should be empty after cleanup
-	eng.mu.Lock()
-	remaining := len(eng.lockedIssues)
-	eng.mu.Unlock()
-	if remaining != 0 {
-		t.Errorf("lockedIssues should be empty after cleanup, got %d", remaining)
+	// Store should have no held locks after cleanup.
+	for _, snap := range eng.store.All() {
+		if lock := snap.Lock(); lock != nil && lock.HeldByThis {
+			t.Errorf("store still has held lock for %s#%d after cleanup", snap.Repo(), snap.Number())
+		}
 	}
 }
 

--- a/engine/engine_migration_test.go
+++ b/engine/engine_migration_test.go
@@ -1,0 +1,305 @@
+package engine
+
+// engine_migration_test.go — Phase 3-E integration tests
+//
+// Verifies that per-item engine state (formerly stored in Engine struct maps) now
+// lives correctly in itemstate.Store and is accessible via store.Get/store.Apply.
+// These tests correspond to the acceptance criteria in issue #517.
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
+)
+
+// TestMigration_LockAcquireReleaseRoundtrip verifies the lock acquire → read → release
+// cycle via the store: acquire sets HeldByThis=true, release clears it (Lock==nil).
+func TestMigration_LockAcquireReleaseRoundtrip(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	// Before acquire: item may not exist yet; if it does, no lock.
+	if snap0, err := eng.store.Get("owner/repo", 42); err == nil {
+		if snap0.Lock() != nil {
+			t.Fatal("expected no lock before acquire")
+		}
+	}
+
+	// Acquire.
+	eng.store.Apply(itemstate.LocalLockAcquired{
+		Repo:       "owner/repo",
+		Number:     42,
+		User:       "testuser",
+		AcquiredAt: time.Now(),
+	})
+
+	// After acquire: lock present, HeldByThis=true.
+	snap1, _ := eng.store.Get("owner/repo", 42)
+	lock1 := snap1.Lock()
+	if lock1 == nil {
+		t.Fatal("expected lock to be set after acquire")
+	}
+	if !lock1.HeldByThis {
+		t.Error("expected HeldByThis=true after LocalLockAcquired")
+	}
+
+	// Second Get returns same state.
+	snap2, _ := eng.store.Get("owner/repo", 42)
+	if lock2 := snap2.Lock(); lock2 == nil || !lock2.HeldByThis {
+		t.Error("second Get should still show held lock")
+	}
+
+	// Release.
+	eng.store.Apply(itemstate.LocalLockReleased{Repo: "owner/repo", Number: 42})
+
+	// After release: Lock==nil, HeldByThis effectively false.
+	snap3, _ := eng.store.Get("owner/repo", 42)
+	if snap3.Lock() != nil {
+		t.Error("expected Lock==nil after LocalLockReleased")
+	}
+}
+
+// TestMigration_LockDerivedField verifies HeldByThis transitions:
+// nil → set by self (HeldByThis=true) → released (Lock==nil).
+// (Other-user locks arrive via webhook IssueLabeled and are not emitted by LocalLockAcquired.)
+func TestMigration_LockDerivedField(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	// nil state.
+	snap, _ := eng.store.Get("owner/repo", 5)
+	if snap.Lock() != nil {
+		t.Fatal("initial lock should be nil")
+	}
+
+	// Set by self.
+	eng.store.Apply(itemstate.LocalLockAcquired{Repo: "owner/repo", Number: 5, User: "testuser", AcquiredAt: time.Now()})
+	snap, _ = eng.store.Get("owner/repo", 5)
+	if lock := snap.Lock(); lock == nil || !lock.HeldByThis {
+		t.Error("after self-acquire: Lock must be non-nil and HeldByThis=true")
+	}
+
+	// Release → nil.
+	eng.store.Apply(itemstate.LocalLockReleased{Repo: "owner/repo", Number: 5})
+	snap, _ = eng.store.Get("owner/repo", 5)
+	if snap.Lock() != nil {
+		t.Error("after release: Lock must be nil")
+	}
+}
+
+// TestMigration_TokenUsageUpdate verifies that InvocationRecorded stores
+// LastTokenUsage, LastInvocationCompleted, and LastInvocationBlocked atomically.
+func TestMigration_TokenUsageUpdate(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	usage := itemstate.TokenUsage{InputTokens: 100, OutputTokens: 200, CacheReadTokens: 50}
+	eng.store.Apply(itemstate.InvocationRecorded{
+		Repo:      "owner/repo",
+		Number:    10,
+		Usage:     usage,
+		Completed: true,
+		Blocked:   false,
+	})
+
+	snap, _ := eng.store.Get("owner/repo", 10)
+	st := snap.State()
+	if st.LastTokenUsage.InputTokens != 100 || st.LastTokenUsage.OutputTokens != 200 || st.LastTokenUsage.CacheReadTokens != 50 {
+		t.Errorf("unexpected LastTokenUsage: %+v", st.LastTokenUsage)
+	}
+	if !st.LastInvocationCompleted {
+		t.Error("expected LastInvocationCompleted=true")
+	}
+	if st.LastInvocationBlocked {
+		t.Error("expected LastInvocationBlocked=false")
+	}
+}
+
+// TestMigration_CompletionFlags verifies completed=true, blocked=false → correct snapshot.
+func TestMigration_CompletionFlags(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.store.Apply(itemstate.InvocationRecorded{
+		Repo:      "owner/repo",
+		Number:    11,
+		Completed: true,
+		Blocked:   false,
+	})
+
+	snap, _ := eng.store.Get("owner/repo", 11)
+	st := snap.State()
+	if !st.LastInvocationCompleted {
+		t.Error("expected LastInvocationCompleted=true")
+	}
+	if st.LastInvocationBlocked {
+		t.Error("expected LastInvocationBlocked=false")
+	}
+
+	// Overwrite with blocked invocation.
+	eng.store.Apply(itemstate.InvocationRecorded{
+		Repo:      "owner/repo",
+		Number:    11,
+		Completed: false,
+		Blocked:   true,
+	})
+	snap2, _ := eng.store.Get("owner/repo", 11)
+	st2 := snap2.State()
+	if st2.LastInvocationCompleted {
+		t.Error("expected LastInvocationCompleted=false after blocked invocation")
+	}
+	if !st2.LastInvocationBlocked {
+		t.Error("expected LastInvocationBlocked=true after blocked invocation")
+	}
+}
+
+// TestMigration_DeepFetchCooldown verifies the 10×PollSeconds cooldown semantics:
+// recent failure → itemMayNeedWork returns false; expired failure → returns true.
+func TestMigration_DeepFetchCooldown(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.PollSeconds = 1 // 10-second cooldown
+
+	item := gh.ProjectItem{Number: 51, Status: "Research", ItemID: "PVTI_51"}
+
+	// Recent failure: within cooldown.
+	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 51, At: time.Now()})
+	if eng.itemMayNeedWork(item) {
+		t.Error("item with recent deep-fetch failure should be skipped (within cooldown)")
+	}
+
+	// Expired failure: past 10×PollSeconds.
+	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 51, At: time.Now().Add(-20 * time.Second)})
+	if !eng.itemMayNeedWork(item) {
+		t.Error("item with expired deep-fetch failure cooldown should be retried")
+	}
+}
+
+// TestMigration_DeepFetchSuccessClears verifies that ItemDeepFetched zeros LastDeepFetchFailureAt.
+func TestMigration_DeepFetchSuccessClears(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 20, At: time.Now().Add(-time.Minute)})
+
+	snap1, _ := eng.store.Get("owner/repo", 20)
+	if snap1.State().LastDeepFetchFailureAt.IsZero() {
+		t.Fatal("expected LastDeepFetchFailureAt to be set after DeepFetchFailed")
+	}
+
+	eng.store.Apply(itemstate.ItemDeepFetched{
+		Repo:       "owner/repo",
+		Number:     20,
+		FreshState: gh.ProjectItem{Number: 20},
+	})
+
+	snap2, _ := eng.store.Get("owner/repo", 20)
+	if !snap2.State().LastDeepFetchFailureAt.IsZero() {
+		t.Error("expected LastDeepFetchFailureAt zeroed after ItemDeepFetched")
+	}
+}
+
+// TestMigration_PRChecksObservedMonotonic verifies HasHadChecks transitions false→true
+// when PRChecksObserved is applied and remains true on subsequent applications.
+func TestMigration_PRChecksObservedMonotonic(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	// Initially false.
+	snap0, _ := eng.store.Get("owner/repo", 30)
+	if lpr := snap0.LinkedPR(); lpr != nil && lpr.HasHadChecks {
+		t.Fatal("expected HasHadChecks=false initially")
+	}
+
+	// First PRChecksObserved: false→true.
+	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 30})
+	snap1, _ := eng.store.Get("owner/repo", 30)
+	lpr1 := snap1.LinkedPR()
+	if lpr1 == nil || !lpr1.HasHadChecks {
+		t.Fatal("expected HasHadChecks=true after PRChecksObserved")
+	}
+
+	// Second PRChecksObserved: stays true (monotonic).
+	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 30})
+	snap2, _ := eng.store.Get("owner/repo", 30)
+	lpr2 := snap2.LinkedPR()
+	if lpr2 == nil || !lpr2.HasHadChecks {
+		t.Error("expected HasHadChecks to remain true after second PRChecksObserved")
+	}
+}
+
+// TestMigration_CIMergePendingSetAndClear verifies CIMergePendingSince set/clear transitions.
+func TestMigration_CIMergePendingSetAndClear(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	// Initially zero.
+	snap0, _ := eng.store.Get("owner/repo", 40)
+	if lpr := snap0.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
+		t.Fatal("expected CIMergePendingSince zero initially")
+	}
+
+	// Set via CIMergePendingStarted.
+	pendingAt := time.Now().Add(-5 * time.Minute)
+	eng.store.Apply(itemstate.CIMergePendingStarted{Repo: "owner/repo", Number: 40, At: pendingAt})
+	snap1, _ := eng.store.Get("owner/repo", 40)
+	lpr1 := snap1.LinkedPR()
+	if lpr1 == nil {
+		t.Fatal("expected LinkedPR to be non-nil after CIMergePendingStarted")
+	}
+	if lpr1.CIMergePendingSince.IsZero() {
+		t.Error("expected CIMergePendingSince to be set after CIMergePendingStarted")
+	}
+	if !lpr1.CIMergePendingSince.Equal(pendingAt) {
+		t.Errorf("CIMergePendingSince = %v, want %v", lpr1.CIMergePendingSince, pendingAt)
+	}
+
+	// Clear via CIMergePendingCleared.
+	eng.store.Apply(itemstate.CIMergePendingCleared{Repo: "owner/repo", Number: 40})
+	snap2, _ := eng.store.Get("owner/repo", 40)
+	if lpr2 := snap2.LinkedPR(); lpr2 != nil && !lpr2.CIMergePendingSince.IsZero() {
+		t.Error("expected CIMergePendingSince zeroed after CIMergePendingCleared")
+	}
+}
+
+// TestMigration_SnapshotImmutability verifies that a snapshot taken before an Apply
+// is not affected by the subsequent mutation.
+func TestMigration_SnapshotImmutability(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 50})
+	snapBefore, _ := eng.store.Get("owner/repo", 50)
+
+	// Apply another mutation.
+	eng.store.Apply(itemstate.CIMergePendingStarted{Repo: "owner/repo", Number: 50, At: time.Now()})
+
+	// snapBefore should not see the new CIMergePendingSince.
+	if lpr := snapBefore.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
+		t.Error("earlier snapshot should not reflect mutations applied after it was taken")
+	}
+}
+
+// TestMigration_ConcurrentCompletions verifies that concurrent InvocationRecorded
+// applications for different issues are race-detector clean.
+func TestMigration_ConcurrentCompletions(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(num int) {
+			defer wg.Done()
+			eng.store.Apply(itemstate.InvocationRecorded{
+				Repo:      "owner/repo",
+				Number:    num,
+				Completed: true,
+				Usage:     itemstate.TokenUsage{InputTokens: num * 10},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	// All goroutines wrote their state; verify each is readable.
+	for i := 0; i < n; i++ {
+		snap, _ := eng.store.Get("owner/repo", i)
+		if !snap.State().LastInvocationCompleted {
+			t.Errorf("issue #%d: expected LastInvocationCompleted=true", i)
+		}
+	}
+}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 )
 
 func TestItemNeedsWork_SkipsPaused(t *testing.T) {
@@ -277,8 +278,8 @@ func TestConcurrentItemDispatch(t *testing.T) {
 			MaxConcurrent: maxConcurrent,
 			Stages:        nil, // no matching stage → processItem returns nil immediately
 		},
+		store:        itemstate.NewStore(nil),
 		processedSet: make(map[string]time.Time),
-		lockedIssues: make(map[string]bool),
 		sem:          make(chan struct{}, maxConcurrent),
 	}
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -467,8 +467,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 		e.mu.Lock()
 		e.processedSet[stageKey] = time.Now()
-		e.lastCompleted[iKey] = true
 		e.mu.Unlock()
+		e.store.Apply(itemstate.InvocationRecorded{
+			Repo:      itemOwnerRepoString(item, e.defaultRepo()),
+			Number:    item.Number,
+			Completed: true,
+		})
 
 		return nil
 	}
@@ -748,7 +752,6 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.mu.Lock()
 		defer e.mu.Unlock()
 		e.totalTokens = addTokenUsage(e.totalTokens, usage)
-		e.lastUsage[iKey] = usage
 	}()
 
 	// Restore any stashed changes now that the read-only stage has finished.
@@ -903,13 +906,14 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	blockedOnInput := err == nil && CheckBlockedOnInput(output)
 	decomposed := err == nil && CheckDecomposed(output)
 
-	// Store completion/blocked state for TUI event emission in poll.go.
-	func() {
-		e.mu.Lock()
-		defer e.mu.Unlock()
-		e.lastCompleted[iKey] = completed
-		e.lastBlocked[iKey] = blockedOnInput
-	}()
+	// Store completion/blocked/usage state for TUI event emission in poll.go.
+	e.store.Apply(itemstate.InvocationRecorded{
+		Repo:      itemOwnerRepoString(item, e.defaultRepo()),
+		Number:    item.Number,
+		Completed: completed,
+		Blocked:   blockedOnInput,
+		Usage:     usage,
+	})
 
 	if completed {
 		releaseLock()

--- a/engine/item.go
+++ b/engine/item.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -553,9 +554,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.logf(item.Number, "warn", "could not add lock label: %v\n", err)
 	} else {
 		lockAcquired = true
-		e.mu.Lock()
-		e.lockedIssues[iKey] = true
-		e.mu.Unlock()
+		e.store.Apply(itemstate.LocalLockAcquired{
+			Repo:       itemOwnerRepoString(item, e.defaultRepo()),
+			Number:     item.Number,
+			User:       e.cfg.User,
+			AcquiredAt: time.Now(),
+		})
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
 		}
@@ -571,9 +575,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	releaseLock := func() {
 		if lockAcquired {
 			e.removeLockLabel(owner, repo, item.Number, lockLabel)
-			e.mu.Lock()
-			delete(e.lockedIssues, iKey)
-			e.mu.Unlock()
+			e.store.Apply(itemstate.LocalLockReleased{
+				Repo:   itemOwnerRepoString(item, e.defaultRepo()),
+				Number: item.Number,
+			})
 		}
 		if inProgressAdded {
 			e.removeInProgressLabel(owner, repo, item.Number, stage.Name)

--- a/engine/item.go
+++ b/engine/item.go
@@ -705,7 +705,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		var invUsage TokenUsage
 		invOutput, completed, invUsage, err = e.claude.Invoke(ctx, stage, item, nil, resume, workDir, opts)
 		output += invOutput
-		usage = usage.add(invUsage)
+		usage = addTokenUsage(usage, invUsage)
 
 		hitLimit := !completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget
 		if !hitLimit || totalMultiple >= 3 {
@@ -742,7 +742,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	func() {
 		e.mu.Lock()
 		defer e.mu.Unlock()
-		e.totalTokens = e.totalTokens.add(usage)
+		e.totalTokens = addTokenUsage(e.totalTokens, usage)
 		e.lastUsage[iKey] = usage
 	}()
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -121,7 +121,7 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 	if !item.UpdatedAt.IsZero() {
 		iKey := issueKey(item, e.defaultRepo())
 		e.mu.Lock()
-		lastSeen, seen := e.lastUpdatedAt[iKey]
+		lastSeen, seen := e.seenUpdatedAt[iKey]
 		e.mu.Unlock()
 		if seen && !item.UpdatedAt.After(lastSeen) {
 			// Item unchanged — but still allow cooldown retries
@@ -889,12 +889,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// trigger the awaiting-input unblock logic on subsequent polls.
 	if claudeRan {
 		e.markCommentsSeenByStage(item, item.Comments)
-		// Evict lastUpdatedAt so the next poll re-evaluates this item, regardless
+		// Evict seenUpdatedAt so the next poll re-evaluates this item, regardless
 		// of what updatedAt was cached during the run. This handles the race where
 		// a concurrent poll cycle cached the item's updatedAt while the goroutine
 		// was in-flight, causing a comment posted during the run to be missed.
 		e.mu.Lock()
-		delete(e.lastUpdatedAt, iKey)
+		delete(e.seenUpdatedAt, iKey)
 		e.mu.Unlock()
 	}
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -200,14 +200,12 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 	// Without this, a persistent failure (e.g. deleted issue, permission error)
 	// would cause an API call on every poll cycle. The cooldown matches the
 	// processedSet cooldown used for failed stage retries.
-	iKey := issueKey(item, e.defaultRepo())
-	e.mu.Lock()
-	lastFailure, hadFailure := e.deepFetchFailureTime[iKey]
-	e.mu.Unlock()
-	if hadFailure {
-		cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
-		if time.Since(lastFailure) < cooldown {
-			return false
+	if snap, snapErr := e.store.Get(itemOwnerRepoString(item, e.defaultRepo()), item.Number); snapErr == nil {
+		if lastFailure := snap.State().LastDeepFetchFailureAt; !lastFailure.IsZero() {
+			cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
+			if time.Since(lastFailure) < cooldown {
+				return false
+			}
 		}
 	}
 

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
 )
@@ -49,7 +50,7 @@ func TestItemMayNeedWork_StaleButCooldownExpired(t *testing.T) {
 
 	// Record the last-seen timestamp so the "unchanged" path triggers
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#42"] = ts
+	eng.seenUpdatedAt["owner/repo#42"] = ts
 	// Record a processedSet entry from >cooldown ago
 	eng.processedSet["owner/repo#42-Research"] = time.Now().Add(-2 * time.Minute)
 	eng.mu.Unlock()
@@ -74,7 +75,7 @@ func TestItemMayNeedWork_StaleWithinCooldown(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#43"] = ts
+	eng.seenUpdatedAt["owner/repo#43"] = ts
 	eng.processedSet["owner/repo#43-Research"] = time.Now() // just processed
 	eng.mu.Unlock()
 
@@ -470,7 +471,7 @@ func TestItemNeedsWork_ClosedIssue_CleanupStage_Complete(t *testing.T) {
 }
 
 // TestPoll_DeepFetchFailureExcludesFromLastUpdatedAt verifies that when
-// FetchItemDetails fails for an item, lastUpdatedAt is NOT updated for that
+// FetchItemDetails fails for an item, seenUpdatedAt is NOT updated for that
 // item, so the next poll retries the deep-fetch.
 func TestPoll_DeepFetchFailureExcludesFromLastUpdatedAt(t *testing.T) {
 	now := time.Now()
@@ -495,19 +496,17 @@ func TestPoll_DeepFetchFailureExcludesFromLastUpdatedAt(t *testing.T) {
 		t.Fatalf("poll: %v", err)
 	}
 
-	// lastUpdatedAt must NOT be set for item #10 — failed deep-fetch must not cache.
+	// seenUpdatedAt must NOT be set for item #10 — failed deep-fetch must not cache.
 	eng.mu.Lock()
-	_, ok := eng.lastUpdatedAt["owner/repo#10"]
+	_, ok := eng.seenUpdatedAt["owner/repo#10"]
 	eng.mu.Unlock()
 	if ok {
-		t.Error("lastUpdatedAt should NOT be updated when FetchItemDetails fails")
+		t.Error("seenUpdatedAt should NOT be updated when FetchItemDetails fails")
 	}
 
-	// deepFetchFailureTime must be recorded.
-	eng.mu.Lock()
-	_, recorded := eng.deepFetchFailureTime["owner/repo#10"]
-	eng.mu.Unlock()
-	if !recorded {
+	// LastDeepFetchFailureAt must be recorded in the store.
+	snap, _ := eng.store.Get("owner/repo", 10)
+	if snap.State().LastDeepFetchFailureAt.IsZero() {
 		t.Error("deepFetchFailureTime should be recorded when FetchItemDetails fails")
 	}
 }
@@ -528,20 +527,16 @@ func TestPoll_DeepFetchSuccessClearsFailureTime(t *testing.T) {
 		// fetchItemDetailsFn nil = success (mock returns nil by default)
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
-	// Pre-seed a failure time.
-	eng.mu.Lock()
-	eng.deepFetchFailureTime["owner/repo#11"] = now.Add(-time.Minute)
-	eng.mu.Unlock()
+	// Pre-seed a failure time via the store.
+	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 11, At: now.Add(-time.Minute)})
 
 	ctx := t.Context()
 	if _, err := eng.poll(ctx); err != nil {
 		t.Fatalf("poll: %v", err)
 	}
 
-	eng.mu.Lock()
-	_, stillRecorded := eng.deepFetchFailureTime["owner/repo#11"]
-	eng.mu.Unlock()
-	if stillRecorded {
+	snapAfter, _ := eng.store.Get("owner/repo", 11)
+	if !snapAfter.State().LastDeepFetchFailureAt.IsZero() {
 		t.Error("deepFetchFailureTime should be cleared after a successful FetchItemDetails")
 	}
 }
@@ -564,7 +559,7 @@ func TestItemMayNeedWork_AwaitingInputRespectsCache(t *testing.T) {
 
 	// Record the last-seen timestamp so the "unchanged" path triggers.
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#50"] = ts
+	eng.seenUpdatedAt["owner/repo#50"] = ts
 	eng.mu.Unlock()
 
 	if eng.itemMayNeedWork(item) {
@@ -583,7 +578,7 @@ func TestItemMayNeedWork_DeepFetchFailureCooldown(t *testing.T) {
 		Number: 51,
 		Status: "Research",
 		ItemID: "PVTI_51",
-		// UpdatedAt zero — no lastUpdatedAt entry, so "unchanged" branch won't fire
+		// UpdatedAt zero — no seenUpdatedAt entry, so "unchanged" branch won't fire
 	}
 
 	// Record a very recent failure.
@@ -606,7 +601,7 @@ func TestItemMayNeedWork_DeepFetchFailureCooldown(t *testing.T) {
 }
 
 // TestProcessItem_EvictsLastUpdatedAtAfterStageRun verifies that processItem
-// deletes lastUpdatedAt[iKey] after a stage runs (claudeRan=true). This ensures
+// deletes seenUpdatedAt[iKey] after a stage runs (claudeRan=true). This ensures
 // the next poll re-evaluates the item, catching any comments that arrived during
 // the in-flight run.
 func TestProcessItem_EvictsLastUpdatedAtAfterStageRun(t *testing.T) {
@@ -645,21 +640,21 @@ func TestProcessItem_EvictsLastUpdatedAtAfterStageRun(t *testing.T) {
 		Repo:      "owner/repo",
 	}
 
-	// Pre-populate lastUpdatedAt as if a concurrent poll cached this item.
+	// Pre-populate seenUpdatedAt as if a concurrent poll cached this item.
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#60"] = ts
+	eng.seenUpdatedAt["owner/repo#60"] = ts
 	eng.mu.Unlock()
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	_ = eng.processItem(context.Background(), board, item)
 
-	// After processItem (with claudeRan), lastUpdatedAt must be evicted.
+	// After processItem (with claudeRan), seenUpdatedAt must be evicted.
 	eng.mu.Lock()
-	_, stillCached := eng.lastUpdatedAt["owner/repo#60"]
+	_, stillCached := eng.seenUpdatedAt["owner/repo#60"]
 	eng.mu.Unlock()
 
 	if stillCached {
-		t.Error("lastUpdatedAt should be evicted after a stage runs so next poll re-evaluates the item")
+		t.Error("seenUpdatedAt should be evicted after a stage runs so next poll re-evaluates the item")
 	}
 }
 
@@ -679,9 +674,9 @@ func TestItemMayNeedWork_AwaitingCI_BypassesUpdatedAtCache(t *testing.T) {
 		Labels:    []string{"fabrik:awaiting-ci"},
 	}
 
-	// Seed lastUpdatedAt so the "unchanged" path would normally trigger.
+	// Seed seenUpdatedAt so the "unchanged" path would normally trigger.
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#61"] = ts
+	eng.seenUpdatedAt["owner/repo#61"] = ts
 	eng.processedSet["owner/repo#61-Research"] = time.Now() // just processed — within cooldown
 	eng.mu.Unlock()
 
@@ -717,7 +712,7 @@ func TestItemMayNeedWork_AwaitingReview_CooldownPattern(t *testing.T) {
 
 	// Within cooldown: processedSet has a recent entry → must NOT re-admit yet.
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#67"] = ts
+	eng.seenUpdatedAt["owner/repo#67"] = ts
 	eng.processedSet["owner/repo#67-Research"] = time.Now() // just processed
 	eng.mu.Unlock()
 
@@ -756,7 +751,7 @@ func TestItemMayNeedWork_AwaitingReview_NotBypassedDirectly(t *testing.T) {
 	// No processedSet entry: cooldown retry path doesn't fire. Without unconditional
 	// bypass, the cache filter wins and we return false.
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#68"] = ts
+	eng.seenUpdatedAt["owner/repo#68"] = ts
 	eng.mu.Unlock()
 
 	if eng.itemMayNeedWork(item) {
@@ -782,7 +777,7 @@ func TestItemMayNeedWork_BlockedRespectsUpdatedAtCache(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#63"] = ts
+	eng.seenUpdatedAt["owner/repo#63"] = ts
 	eng.processedSet["owner/repo#63-Research"] = time.Now() // just processed — within cooldown
 	eng.mu.Unlock()
 
@@ -807,7 +802,7 @@ func TestItemMayNeedWork_NoSpecialLabel_RespectsUpdatedAtCache(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#62"] = ts
+	eng.seenUpdatedAt["owner/repo#62"] = ts
 	eng.processedSet["owner/repo#62-Research"] = time.Now()
 	eng.mu.Unlock()
 
@@ -833,7 +828,7 @@ func TestItemMayNeedWork_CompleteStageBypassed(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#70"] = ts
+	eng.seenUpdatedAt["owner/repo#70"] = ts
 	eng.processedSet["owner/repo#70-Research"] = time.Now().Add(-2 * time.Minute) // expired
 	eng.mu.Unlock()
 
@@ -859,7 +854,7 @@ func TestItemMayNeedWork_IncompleteStageStillRetried(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#71"] = ts
+	eng.seenUpdatedAt["owner/repo#71"] = ts
 	eng.processedSet["owner/repo#71-Research"] = time.Now().Add(-2 * time.Minute) // expired
 	eng.mu.Unlock()
 
@@ -887,7 +882,7 @@ func TestItemMayNeedWork_AwaitingReview_WithCompleteLabel(t *testing.T) {
 	}
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#69"] = ts
+	eng.seenUpdatedAt["owner/repo#69"] = ts
 	eng.processedSet["owner/repo#69-Research"] = time.Now().Add(-2 * time.Minute) // expired
 	eng.mu.Unlock()
 
@@ -1000,7 +995,7 @@ func TestPoll_DeferredRefresh_DoesNotRefreshIncompleteItem(t *testing.T) {
 
 	initial := time.Now().Add(-2 * time.Minute) // expired cooldown
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#80"] = ts // unchanged updatedAt → cooldown path
+	eng.seenUpdatedAt["owner/repo#80"] = ts // unchanged updatedAt → cooldown path
 	eng.processedSet["owner/repo#80-Research"] = initial
 	eng.mu.Unlock()
 
@@ -1049,7 +1044,7 @@ func TestPoll_DeferredRefresh_RefreshesTerminalItem(t *testing.T) {
 	eng.cfg.PollSeconds = 1 // cooldown = 10s
 
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#81"] = ts // unchanged updatedAt → cooldown path
+	eng.seenUpdatedAt["owner/repo#81"] = ts // unchanged updatedAt → cooldown path
 	eng.processedSet["owner/repo#81-Research"] = time.Now().Add(-2 * time.Minute)
 	eng.mu.Unlock()
 

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -581,19 +581,15 @@ func TestItemMayNeedWork_DeepFetchFailureCooldown(t *testing.T) {
 		// UpdatedAt zero — no seenUpdatedAt entry, so "unchanged" branch won't fire
 	}
 
-	// Record a very recent failure.
-	eng.mu.Lock()
-	eng.deepFetchFailureTime["owner/repo#51"] = time.Now()
-	eng.mu.Unlock()
+	// Record a very recent failure via the store.
+	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 51, At: time.Now()})
 
 	if eng.itemMayNeedWork(item) {
 		t.Error("item with recent deep-fetch failure should be skipped (within cooldown)")
 	}
 
 	// Simulate cooldown expiry by backdating the failure time.
-	eng.mu.Lock()
-	eng.deepFetchFailureTime["owner/repo#51"] = time.Now().Add(-20 * time.Second)
-	eng.mu.Unlock()
+	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 51, At: time.Now().Add(-20 * time.Second)})
 
 	if !eng.itemMayNeedWork(item) {
 		t.Error("item with expired deep-fetch failure cooldown should be retried")

--- a/engine/lock_then_verify_test.go
+++ b/engine/lock_then_verify_test.go
@@ -157,13 +157,10 @@ func TestLockThenVerify_CompetingLockLowerUser_YieldsAndReturnsNil(t *testing.T)
 		}
 	}
 
-	// lockedIssues map should be clean after loser path.
-	// issueKey format is "owner/repo#N" (no dash before #).
-	eng.mu.Lock()
-	_, stillLocked := eng.lockedIssues["owner/repo#12"]
-	eng.mu.Unlock()
-	if stillLocked {
-		t.Error("lockedIssues entry should be cleared after loser releases lock")
+	// Store should have no held lock for this issue after the loser path.
+	snap, _ := eng.store.Get("owner/repo", 12)
+	if lock := snap.Lock(); lock != nil && lock.HeldByThis {
+		t.Error("store lock should be cleared after loser releases lock")
 	}
 }
 

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -199,14 +199,14 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 		e.logf(item.Number, "rebase-reinvoke", "re-invoking stage %q via comment processing with rebase context\n", stage.Name)
 		err := e.processComments(ctx, board, item, &rebaseStage, []gh.Comment{syntheticComment})
 
-		e.mu.Lock()
-		usage := e.lastUsage[iKey]
-		completed := e.lastCompleted[iKey]
-		blocked := e.lastBlocked[iKey]
-		delete(e.lastUsage, iKey)
-		delete(e.lastCompleted, iKey)
-		delete(e.lastBlocked, iKey)
-		e.mu.Unlock()
+		var usage TokenUsage
+		var completed, blocked bool
+		if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
+			st := snap.State()
+			usage = st.LastTokenUsage
+			completed = st.LastInvocationCompleted
+			blocked = st.LastInvocationBlocked
+		}
 		e.emitStructural(tui.JobCompletedEvent{
 			IssueNumber:    item.Number,
 			Repo:           itemRepo,

--- a/engine/parse_claude_test.go
+++ b/engine/parse_claude_test.go
@@ -127,7 +127,7 @@ func TestTokenUsageFromResponse_MultiModel(t *testing.T) {
 func TestTokenUsageAdd(t *testing.T) {
 	a := TokenUsage{InputTokens: 10, OutputTokens: 5, CacheCreationTokens: 2, CacheReadTokens: 3, CostUSD: 0.001}
 	b := TokenUsage{InputTokens: 20, OutputTokens: 15, CacheCreationTokens: 8, CacheReadTokens: 7, CostUSD: 0.002}
-	got := a.add(b)
+	got := addTokenUsage(a, b)
 	if got.InputTokens != 30 {
 		t.Errorf("InputTokens = %d, want 30", got.InputTokens)
 	}
@@ -145,7 +145,7 @@ func TestTokenUsageAdd(t *testing.T) {
 	}
 	// Adding zero value leaves original unchanged
 	zero := TokenUsage{}
-	if a.add(zero) != a {
+	if addTokenUsage(a, zero) != a {
 		t.Error("adding zero TokenUsage should return original")
 	}
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1047,14 +1047,14 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 				StartedAt:   startTime,
 			})
 			err := e.processItem(ctx, board, item)
-			e.mu.Lock()
-			usage := e.lastUsage[iKey]
-			completed := e.lastCompleted[iKey]
-			blocked := e.lastBlocked[iKey]
-			delete(e.lastUsage, iKey)
-			delete(e.lastCompleted, iKey)
-			delete(e.lastBlocked, iKey)
-			e.mu.Unlock()
+			var usage TokenUsage
+			var completed, blocked bool
+			if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
+				st := snap.State()
+				usage = st.LastTokenUsage
+				completed = st.LastInvocationCompleted
+				blocked = st.LastInvocationBlocked
+			}
 			e.emitStructural(tui.JobCompletedEvent{
 				IssueNumber:    item.Number,
 				Repo:           itemRepo,

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -678,7 +678,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		for _, item := range deepFetchCandidates {
 			iKey := issueKey(item, e.defaultRepo())
 			if !item.UpdatedAt.IsZero() && !advancedItems[iKey] {
-				e.lastUpdatedAt[iKey] = item.UpdatedAt
+				e.seenUpdatedAt[iKey] = item.UpdatedAt
 			}
 			// Belt-and-suspenders: refresh processedSet for non-advanced *terminal*
 			// items that completed a full poll cycle without dispatching work. Only
@@ -750,7 +750,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 				Number: board.Items[i].Number,
 				At:     time.Now(),
 			})
-			// Skip appending to deepFetchCandidates so lastUpdatedAt is NOT updated.
+			// Skip appending to deepFetchCandidates so seenUpdatedAt is NOT updated.
 			// The next poll will retry the deep-fetch for this item.
 			continue
 		}
@@ -953,7 +953,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			if err := e.attemptMergeOnValidate(ctx, board, item, stage); err != nil {
 				if errors.Is(err, errRebaseDispatched) {
 					e.logf(item.Number, "rebase-reinvoke", "PR merge deferred — rebase dispatched during catch-up\n")
-					// Mark as dispatched so the defer does not re-cache lastUpdatedAt —
+					// Mark as dispatched so the defer does not re-cache seenUpdatedAt —
 					// mirrors Phase 1 dispatch behavior (review/rebase/CI-fix reinvokes).
 					// Without this, if the label add fails and GitHub doesn't bump
 					// updatedAt, itemMayNeedWork could filter the item on the next poll.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -743,19 +743,22 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			continue
 		}
 		e.logf(0, "poll", "deep-fetching details for #%d\n", board.Items[i].Number)
-		iKey := issueKey(board.Items[i], e.defaultRepo())
 		if err := e.readClient.FetchItemDetails(&board.Items[i]); err != nil {
 			e.logf(0, "warn", "could not fetch details for #%d: %v\n", board.Items[i].Number, err)
-			e.mu.Lock()
-			e.deepFetchFailureTime[iKey] = time.Now()
-			e.mu.Unlock()
+			e.store.Apply(itemstate.DeepFetchFailed{
+				Repo:   itemOwnerRepoString(board.Items[i], e.defaultRepo()),
+				Number: board.Items[i].Number,
+				At:     time.Now(),
+			})
 			// Skip appending to deepFetchCandidates so lastUpdatedAt is NOT updated.
 			// The next poll will retry the deep-fetch for this item.
 			continue
 		}
-		e.mu.Lock()
-		delete(e.deepFetchFailureTime, iKey)
-		e.mu.Unlock()
+		e.store.Apply(itemstate.ItemDeepFetched{
+			Repo:       itemOwnerRepoString(board.Items[i], e.defaultRepo()),
+			Number:     board.Items[i].Number,
+			FreshState: board.Items[i],
+		})
 		deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
 		deepFetched++
 	}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
 )
@@ -496,21 +497,23 @@ func (e *Engine) Run() error {
 // cleanupLockedIssues removes fabrik:locked labels for any issues that were locked
 // at shutdown time but never released (e.g., because the worker was killed mid-run).
 func (e *Engine) cleanupLockedIssues() {
-	e.mu.Lock()
-	keys := make([]string, 0, len(e.lockedIssues))
-	for key := range e.lockedIssues {
-		keys = append(keys, key)
-	}
-	e.mu.Unlock()
+	snaps := e.store.All()
+	lockLabel := fmt.Sprintf("fabrik:locked:%s", e.cfg.User)
 
-	if len(keys) == 0 {
+	var locked []itemstate.Snapshot
+	for _, snap := range snaps {
+		if lock := snap.Lock(); lock != nil && lock.HeldByThis {
+			locked = append(locked, snap)
+		}
+	}
+
+	if len(locked) == 0 {
 		return
 	}
-	lockLabel := fmt.Sprintf("fabrik:locked:%s", e.cfg.User)
-	e.logf(0, "shutdown", "removing lock labels from %d issue(s)\n", len(keys))
-	for _, key := range keys {
-		// Parse "owner/repo#N" back into components for the API call.
-		owner, repo, num := parseIssueKey(key, e.cfg.Owner, e.cfg.Repo)
+	e.logf(0, "shutdown", "removing lock labels from %d issue(s)\n", len(locked))
+	for _, snap := range locked {
+		owner, repo := parseOwnerRepo(snap.Repo())
+		num := snap.Number()
 		if err := e.client.RemoveLabelFromIssue(owner, repo, num, lockLabel); err != nil {
 			e.logf(num, "warn", "could not remove lock label during shutdown: %v\n", err)
 		} else {
@@ -519,9 +522,7 @@ func (e *Engine) cleanupLockedIssues() {
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, num), lockLabel)
 			}
 		}
-		e.mu.Lock()
-		delete(e.lockedIssues, key)
-		e.mu.Unlock()
+		e.store.Apply(itemstate.LocalLockReleased{Repo: snap.Repo(), Number: num})
 	}
 }
 

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -445,9 +445,9 @@ func TestYoloCatchup_SkipsNotDeepFetched(t *testing.T) {
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
 	eng.cfg.Yolo = true
-	// Pre-seed lastUpdatedAt so itemMayNeedWork sees this item as unchanged →
+	// Pre-seed seenUpdatedAt so itemMayNeedWork sees this item as unchanged →
 	// no deep-fetch → not in deepFetchedIDs → yolo catch-up must skip it.
-	eng.lastUpdatedAt["owner/repo#55"] = fixedTime
+	eng.seenUpdatedAt["owner/repo#55"] = fixedTime
 
 	ctx := context.Background()
 	if _, err := eng.poll(ctx); err != nil {
@@ -1180,8 +1180,8 @@ func TestItemMayNeedWork_WaitForCI_CompleteLabelOnly_FilteredByCache(t *testing.
 		UpdatedAt: fixedTime,
 		Labels:    []string{"stage:Validate:complete"}, // no fabrik:awaiting-ci
 	}
-	// Pre-seed lastUpdatedAt so the updatedAt cache returns false.
-	eng.lastUpdatedAt["owner/repo#99"] = fixedTime
+	// Pre-seed seenUpdatedAt so the updatedAt cache returns false.
+	eng.seenUpdatedAt["owner/repo#99"] = fixedTime
 
 	// Post-CI-clear: stage:Validate:complete only (no fabrik:awaiting-ci) is
 	// filtered by cache, just like non-CI-gated stages with a completion label.
@@ -1223,8 +1223,8 @@ func TestItemMayNeedWork_NoWaitForCI_CompleteLabel_FilteredByCache(t *testing.T)
 		UpdatedAt: fixedTime,
 		Labels:    []string{"stage:Validate:complete"},
 	}
-	// Pre-seed lastUpdatedAt so the updatedAt cache returns false.
-	eng.lastUpdatedAt["owner/repo#99"] = fixedTime
+	// Pre-seed seenUpdatedAt so the updatedAt cache returns false.
+	eng.seenUpdatedAt["owner/repo#99"] = fixedTime
 
 	if eng.itemMayNeedWork(item) {
 		t.Error("expected itemMayNeedWork to return false for non-wait_for_ci stage (filtered by cache), got true")
@@ -1277,7 +1277,7 @@ func TestPoll_CruiseValidateComplete_NoRepeatDeepFetch(t *testing.T) {
 
 	// Simulate the perpetual-loop trigger: stable updatedAt cached, processedSet expired.
 	eng.mu.Lock()
-	eng.lastUpdatedAt["owner/repo#732"] = fixedTime
+	eng.seenUpdatedAt["owner/repo#732"] = fixedTime
 	eng.processedSet["owner/repo#732-Validate"] = time.Now().Add(-2 * time.Minute)
 	eng.mu.Unlock()
 

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -450,14 +450,14 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 			stage.Name, len(syntheticComments))
 		err := e.processComments(ctx, board, item, stage, syntheticComments)
 
-		e.mu.Lock()
-		usage := e.lastUsage[iKey]
-		completed := e.lastCompleted[iKey]
-		blocked := e.lastBlocked[iKey]
-		delete(e.lastUsage, iKey)
-		delete(e.lastCompleted, iKey)
-		delete(e.lastBlocked, iKey)
-		e.mu.Unlock()
+		var usage TokenUsage
+		var completed, blocked bool
+		if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
+			st := snap.State()
+			usage = st.LastTokenUsage
+			completed = st.LastInvocationCompleted
+			blocked = st.LastInvocationBlocked
+		}
 		e.emitStructural(tui.JobCompletedEvent{
 			IssueNumber:    item.Number,
 			Repo:           itemRepo,

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -248,9 +249,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 			// Clear stale CI-await state so a stuck fabrik:awaiting-ci from
 			// the prior over-aggressive gate doesn't survive past the merge.
 			e.removeAwaitingCILabel(owner, repo, item)
-			e.mu.Lock()
-			delete(e.ciMergePendingSince, iKey)
-			e.mu.Unlock()
+			e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
 			bypassCheckRunsGate = true
 		}
 	}
@@ -289,9 +288,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 				}
 				// Clean up pending timer since we now have a definitive failure state.
-				e.mu.Lock()
-				delete(e.ciMergePendingSince, iKey)
-				e.mu.Unlock()
+				e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
 				return fmt.Errorf("merge blocked: CI checks failed")
 			}
 
@@ -307,19 +304,20 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 				if timeout <= 0 {
 					timeout = 30 * time.Minute
 				}
-				e.mu.Lock()
-				since, tracked := e.ciMergePendingSince[iKey]
-				if !tracked {
-					e.ciMergePendingSince[iKey] = time.Now()
-					since = e.ciMergePendingSince[iKey]
+				snap, _ := e.store.Get(owner+"/"+repo, item.Number)
+				var since time.Time
+				if lpr := snap.LinkedPR(); lpr != nil {
+					since = lpr.CIMergePendingSince
 				}
-				e.mu.Unlock()
+				if since.IsZero() {
+					now := time.Now()
+					e.store.Apply(itemstate.CIMergePendingStarted{Repo: owner + "/" + repo, Number: item.Number, At: now})
+					since = now
+				}
 
 				if time.Since(since) >= timeout {
 					// R6: timeout elapsed — pause issue.
-					e.mu.Lock()
-					delete(e.ciMergePendingSince, iKey)
-					e.mu.Unlock()
+					e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
 					msg := fmt.Sprintf("🏭 **Fabrik — CI wait timeout (merge guard)**\n\n"+
 						"Auto-merge blocked: CI checks for PR #%d have been in progress for longer than "+
 						"the configured timeout (%s). Fabrik has paused this issue for human review.\n\n"+
@@ -354,9 +352,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 			}
 
 			// R4: All checks green — clear pending timer and awaiting-ci label.
-			e.mu.Lock()
-			delete(e.ciMergePendingSince, iKey)
-			e.mu.Unlock()
+			e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
 			e.removeAwaitingCILabel(owner, repo, item)
 		}
 		// R5: len(checkRuns) == 0 — no CI configured; gate clears.

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 )
 
@@ -58,10 +59,7 @@ func TestAttemptMergeOnValidate_AllGreen_MergeProceeds(t *testing.T) {
 	}
 	eng := testEngineForMerge(client)
 	// Seed a stale pending timer to confirm it gets cleared on green.
-	iKey := "owner/repo#1"
-	eng.mu.Lock()
-	eng.ciMergePendingSince[iKey] = time.Now().Add(-1 * time.Minute)
-	eng.mu.Unlock()
+	eng.store.Apply(itemstate.CIMergePendingStarted{Repo: "owner/repo", Number: 1, At: time.Now().Add(-1 * time.Minute)})
 
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 	if err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"}); err != nil {
@@ -70,10 +68,8 @@ func TestAttemptMergeOnValidate_AllGreen_MergeProceeds(t *testing.T) {
 	if len(client.mergePRCalls) != 1 {
 		t.Fatalf("expected MergePR called once, got %d", len(client.mergePRCalls))
 	}
-	eng.mu.Lock()
-	_, still := eng.ciMergePendingSince[iKey]
-	eng.mu.Unlock()
-	if still {
+	snap, _ := eng.store.Get("owner/repo", 1)
+	if lpr := snap.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
 		t.Error("ciMergePendingSince should be cleared on all-green")
 	}
 }
@@ -158,21 +154,20 @@ func TestAttemptMergeOnValidate_CIPending_TracksTimer(t *testing.T) {
 	}
 	eng := testEngineForMerge(client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-	iKey := "owner/repo#1"
 
-	eng.mu.Lock()
-	_, before := eng.ciMergePendingSince[iKey]
-	eng.mu.Unlock()
-	if before {
+	snapBefore, _ := eng.store.Get("owner/repo", 1)
+	if lpr := snapBefore.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
 		t.Fatal("expected no pending entry before first call")
 	}
 
 	_ = eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
 
-	eng.mu.Lock()
-	_, after := eng.ciMergePendingSince[iKey]
-	eng.mu.Unlock()
-	if !after {
+	snapAfter, _ := eng.store.Get("owner/repo", 1)
+	var afterSince time.Time
+	if lpr := snapAfter.LinkedPR(); lpr != nil {
+		afterSince = lpr.CIMergePendingSince
+	}
+	if afterSince.IsZero() {
 		t.Error("expected ciMergePendingSince to be set after first pending observation")
 	}
 }
@@ -195,10 +190,7 @@ func TestAttemptMergeOnValidate_CIPendingTimeout_PausesIssue(t *testing.T) {
 	eng.cfg.CIWaitTimeout = 1 * time.Millisecond // tiny timeout for test
 
 	// Pre-seed as if first observed 1 second ago (well past 1ms timeout).
-	iKey := "owner/repo#1"
-	eng.mu.Lock()
-	eng.ciMergePendingSince[iKey] = time.Now().Add(-1 * time.Second)
-	eng.mu.Unlock()
+	eng.store.Apply(itemstate.CIMergePendingStarted{Repo: "owner/repo", Number: 1, At: time.Now().Add(-1 * time.Second)})
 
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -220,11 +212,9 @@ func TestAttemptMergeOnValidate_CIPendingTimeout_PausesIssue(t *testing.T) {
 	if !foundPaused {
 		t.Error("expected fabrik:paused label on CI timeout")
 	}
-	// ciMergePendingSince entry should be cleared after timeout.
-	eng.mu.Lock()
-	_, still := eng.ciMergePendingSince[iKey]
-	eng.mu.Unlock()
-	if still {
+	// CIMergePendingSince should be cleared after timeout.
+	snapTimeout, _ := eng.store.Get("owner/repo", 1)
+	if lpr := snapTimeout.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
 		t.Error("ciMergePendingSince should be deleted after timeout fires")
 	}
 }

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -400,6 +400,40 @@ type BaseBranchWarnRecorded struct {
 func (BaseBranchWarnRecorded) isMutation() {}
 func (m BaseBranchWarnRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// CIMergePendingStarted records that CI-gate merge polling has begun for the item's
+// linked PR. Sets LinkedPRState.CIMergePendingSince to At.
+// Replaces engine.ciMergePendingSince[iKey] = time.Now().
+type CIMergePendingStarted struct {
+	Repo   string
+	Number int
+	At     time.Time
+}
+
+func (CIMergePendingStarted) isMutation() {}
+func (m CIMergePendingStarted) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// CIMergePendingCleared records that CI-gate merge polling has ended for the item's
+// linked PR. Zeros LinkedPRState.CIMergePendingSince.
+// Replaces delete(engine.ciMergePendingSince, iKey).
+type CIMergePendingCleared struct {
+	Repo   string
+	Number int
+}
+
+func (CIMergePendingCleared) isMutation() {}
+func (m CIMergePendingCleared) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// PRChecksObserved records that the linked PR has had at least one CI check run
+// returned by FetchCheckRuns (REST path). Sets LinkedPRState.HasHadChecks = true.
+// Replaces engine.prHasHadChecks[iKey] = true.
+type PRChecksObserved struct {
+	Repo   string
+	Number int
+}
+
+func (PRChecksObserved) isMutation() {}
+func (m PRChecksObserved) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // itemKeyFor constructs the canonical "owner/repo#N" item key used throughout the Store.
 // Returns "" when repo is empty (indicating an invalid or unroutable mutation).
 func itemKeyFor(repo string, number int) string {

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -596,3 +596,99 @@ func TestNoOpCooldownSameValue(t *testing.T) {
 		t.Errorf("cooldown no-op produced change (changes=%d, fired=%d)", len(changes), fired)
 	}
 }
+
+// ---- CIMergePendingStarted / CIMergePendingCleared ----
+
+func TestApplyCIMergePendingStarted(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	at := time.Unix(12345, 0)
+	applyExpect(t, s, CIMergePendingStarted{Repo: testRepo, Number: 1, At: at}, LinkedPRChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LinkedPR == nil {
+		t.Fatal("LinkedPR is nil after CIMergePendingStarted")
+	}
+	if !st.LinkedPR.CIMergePendingSince.Equal(at) {
+		t.Errorf("CIMergePendingSince = %v; want %v", st.LinkedPR.CIMergePendingSince, at)
+	}
+}
+
+func TestApplyCIMergePendingCleared(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	at := time.Unix(12345, 0)
+	s.Apply(CIMergePendingStarted{Repo: testRepo, Number: 1, At: at})
+	applyExpect(t, s, CIMergePendingCleared{Repo: testRepo, Number: 1}, LinkedPRChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LinkedPR != nil && !st.LinkedPR.CIMergePendingSince.IsZero() {
+		t.Errorf("CIMergePendingSince not cleared: %v", st.LinkedPR.CIMergePendingSince)
+	}
+}
+
+func TestApplyCIMergePendingClearedWithNoLinkedPR(t *testing.T) {
+	// CIMergePendingCleared on an item with no LinkedPR should be a no-op (not panic).
+	s := newStoreWithItem(t, testRepo, 1)
+	_, changes, err := s.Apply(CIMergePendingCleared{Repo: testRepo, Number: 1})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// No-op: LinkedPR is nil so clearing is trivially done; we allow no changes.
+	_ = changes
+}
+
+// ---- PRChecksObserved ----
+
+func TestApplyPRChecksObserved(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, PRChecksObserved{Repo: testRepo, Number: 1}, LinkedPRChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LinkedPR == nil || !st.LinkedPR.HasHadChecks {
+		t.Error("HasHadChecks not set after PRChecksObserved")
+	}
+}
+
+func TestApplyPRChecksObservedIsMonotonic(t *testing.T) {
+	// Applying PRChecksObserved twice: second should be no-op (stays true).
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(PRChecksObserved{Repo: testRepo, Number: 1})
+
+	var fired int
+	s.Subscribe(ObserverFunc(func(c Change, snap Snapshot) { fired++ }))
+	_, changes, _ := s.Apply(PRChecksObserved{Repo: testRepo, Number: 1})
+	if len(changes) != 0 || fired != 0 {
+		t.Errorf("second PRChecksObserved was not a no-op (changes=%d, fired=%d)", len(changes), fired)
+	}
+}
+
+// ---- ItemDeepFetched clears LastDeepFetchFailureAt ----
+
+func TestItemDeepFetchedClearsFailureAt(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	at := time.Now()
+	s.Apply(DeepFetchFailed{Repo: testRepo, Number: 1, At: at})
+	if st := getItem(t, s, testRepo, 1); st.LastDeepFetchFailureAt.IsZero() {
+		t.Fatal("precondition: LastDeepFetchFailureAt not set")
+	}
+
+	fresh := testProjectItem(testRepo, 1)
+	s.Apply(ItemDeepFetched{Repo: testRepo, Number: 1, FreshState: fresh})
+	if st := getItem(t, s, testRepo, 1); !st.LastDeepFetchFailureAt.IsZero() {
+		t.Errorf("LastDeepFetchFailureAt not cleared by ItemDeepFetched: %v", st.LastDeepFetchFailureAt)
+	}
+}
+
+// ---- Snapshot immutability for LinkedPR fields ----
+
+func TestHeldSnapshotLinkedPRFieldsUnchanged(t *testing.T) {
+	// Verify that mutations to CIMergePendingSince and HasHadChecks do not affect
+	// a held Snapshot taken before the mutation.
+	s := newStoreWithItem(t, testRepo, 99)
+	held, _ := s.Get(testRepo, 99)
+	// held.LinkedPR() is nil at this point.
+
+	s.Apply(CIMergePendingStarted{Repo: testRepo, Number: 99, At: time.Unix(999, 0)})
+	s.Apply(PRChecksObserved{Repo: testRepo, Number: 99})
+
+	// Held snapshot should still have nil LinkedPR.
+	if lpr := held.LinkedPR(); lpr != nil {
+		t.Errorf("held snapshot LinkedPR became non-nil after mutations: %+v", lpr)
+	}
+}

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -324,6 +324,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case ItemDeepFetched:
 		flags := applyProjectItem(item, v.FreshState)
 		item.LastDeepFetchAt = time.Now()
+		item.LastDeepFetchFailureAt = time.Time{} // clear failure on success
 		return flags | DeepFetchChanged
 
 	case StageAttempted:
@@ -389,6 +390,25 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case DeepFetchFailed:
 		item.LastDeepFetchFailureAt = v.At
 		return DeepFetchChanged
+
+	case CIMergePendingStarted:
+		ensureLinkedPR(item, 0)
+		item.LinkedPR.CIMergePendingSince = v.At
+		return LinkedPRChanged
+
+	case CIMergePendingCleared:
+		if item.LinkedPR != nil {
+			item.LinkedPR.CIMergePendingSince = time.Time{}
+		}
+		return LinkedPRChanged
+
+	case PRChecksObserved:
+		ensureLinkedPR(item, 0)
+		if item.LinkedPR.HasHadChecks {
+			return 0 // already set; no-op
+		}
+		item.LinkedPR.HasHadChecks = true
+		return LinkedPRChanged
 
 	case BaseBranchWarnRecorded:
 		if item.BaseBranchWarned == nil {

--- a/internal/itemstate/store_test.go
+++ b/internal/itemstate/store_test.go
@@ -374,3 +374,117 @@ func TestSHAIndexMaintained(t *testing.T) {
 		t.Fatalf("CheckRunCompleted: err=%v changes=%d", err, len(changes))
 	}
 }
+
+// ---- Phase 3-E: new mutation handler tests ----
+
+// TestCIMergePendingStartedAndCleared verifies CIMergePendingStarted sets
+// CIMergePendingSince and CIMergePendingCleared zeroes it.
+func TestCIMergePendingStartedAndCleared(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 1)})
+
+	pendingAt := time.Now().Add(-5 * time.Minute)
+	_, _, err := s.Apply(CIMergePendingStarted{Repo: testRepo, Number: 1, At: pendingAt})
+	if err != nil {
+		t.Fatalf("CIMergePendingStarted: %v", err)
+	}
+
+	snap, _ := s.Get(testRepo, 1)
+	lpr := snap.LinkedPR()
+	if lpr == nil {
+		t.Fatal("expected LinkedPR non-nil after CIMergePendingStarted")
+	}
+	if !lpr.CIMergePendingSince.Equal(pendingAt) {
+		t.Errorf("CIMergePendingSince = %v, want %v", lpr.CIMergePendingSince, pendingAt)
+	}
+
+	// Snapshot immutability: a held snapshot must not see the clear.
+	snapHeld := snap
+
+	_, _, err = s.Apply(CIMergePendingCleared{Repo: testRepo, Number: 1})
+	if err != nil {
+		t.Fatalf("CIMergePendingCleared: %v", err)
+	}
+	snap2, _ := s.Get(testRepo, 1)
+	if lpr2 := snap2.LinkedPR(); lpr2 != nil && !lpr2.CIMergePendingSince.IsZero() {
+		t.Error("expected CIMergePendingSince zeroed after CIMergePendingCleared")
+	}
+
+	// Original snapshot must be unchanged.
+	if lprHeld := snapHeld.LinkedPR(); lprHeld == nil || lprHeld.CIMergePendingSince.IsZero() {
+		t.Error("held snapshot should still show the original CIMergePendingSince")
+	}
+}
+
+// TestPRChecksObservedMonotonic verifies HasHadChecks transitions false→true and stays true.
+func TestPRChecksObservedMonotonic(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 2)})
+
+	// Initially no linked PR: snap.LinkedPR() is nil.
+	snap0, _ := s.Get(testRepo, 2)
+	if lpr := snap0.LinkedPR(); lpr != nil && lpr.HasHadChecks {
+		t.Fatal("expected HasHadChecks=false initially")
+	}
+
+	_, _, err := s.Apply(PRChecksObserved{Repo: testRepo, Number: 2})
+	if err != nil {
+		t.Fatalf("PRChecksObserved: %v", err)
+	}
+
+	snap1, _ := s.Get(testRepo, 2)
+	lpr1 := snap1.LinkedPR()
+	if lpr1 == nil || !lpr1.HasHadChecks {
+		t.Fatal("expected HasHadChecks=true after PRChecksObserved")
+	}
+
+	// Second application: no-op (monotonic).
+	_, changes, _ := s.Apply(PRChecksObserved{Repo: testRepo, Number: 2})
+	if len(changes) != 0 {
+		t.Error("second PRChecksObserved should be a no-op (no change)")
+	}
+
+	snap2, _ := s.Get(testRepo, 2)
+	if lpr2 := snap2.LinkedPR(); lpr2 == nil || !lpr2.HasHadChecks {
+		t.Error("HasHadChecks should still be true after redundant PRChecksObserved")
+	}
+}
+
+// TestItemDeepFetchedClearsLastDeepFetchFailureAt verifies that applying ItemDeepFetched
+// zeroes the LastDeepFetchFailureAt field (set by a prior DeepFetchFailed).
+func TestItemDeepFetchedClearsLastDeepFetchFailureAt(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 3)})
+
+	failedAt := time.Now().Add(-time.Minute)
+	s.Apply(DeepFetchFailed{Repo: testRepo, Number: 3, At: failedAt})
+
+	snap1, _ := s.Get(testRepo, 3)
+	if snap1.State().LastDeepFetchFailureAt.IsZero() {
+		t.Fatal("expected LastDeepFetchFailureAt set after DeepFetchFailed")
+	}
+
+	freshItem := testProjectItem(testRepo, 3)
+	s.Apply(ItemDeepFetched{Repo: testRepo, Number: 3, FreshState: freshItem})
+
+	snap2, _ := s.Get(testRepo, 3)
+	if !snap2.State().LastDeepFetchFailureAt.IsZero() {
+		t.Error("expected LastDeepFetchFailureAt zeroed after ItemDeepFetched")
+	}
+}
+
+// TestLinkedPRSnapshotImmutabilityAfterCIMerge verifies that a snapshot taken
+// before CIMergePendingStarted is not retroactively mutated.
+func TestLinkedPRSnapshotImmutabilityAfterCIMerge(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 4)})
+
+	snapBefore, _ := s.Get(testRepo, 4)
+
+	s.Apply(CIMergePendingStarted{Repo: testRepo, Number: 4, At: time.Now()})
+
+	// snapBefore must not see the mutation.
+	if lpr := snapBefore.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
+		t.Error("snapshot taken before CIMergePendingStarted should not reflect the mutation")
+	}
+}


### PR DESCRIPTION
## Summary

Extend `ItemState` with the engine's 7 per-item maps (deferring `lastUpdatedAt`), add corresponding Mutation types and `Apply` handlers, redirect every engine read/write site to `store.Get`/`store.Apply`, and remove the old maps from `Engine`. The engine's observable behavior and public APIs are unchanged; only its internal state storage moves.

## Problem

Engine maintains 8 maps keyed by `iKey` ("owner/repo#N") that contain per-item state:

- `lockedIssues map[string]bool`
- `lastUsage map[string]TokenUsage`
- `lastCompleted map[string]bool`
- `lastBlocked map[string]bool`
- `lastUpdatedAt map[string]time.Time`
- `deepFetchFailureTime map[string]time.Time`
- `prHasHadChecks map[string]bool`
- `ciMergePendingSince map[string]time.Time`

Each has its own update path. Bugs frequently arise from updating one but not another. This PR moves them into `ItemState` fields (introduced by Phase 3-A), accessed via Store Snapshot.

## Approach

### Approach

This is a pure internal refactor: 7 engine maps are removed from the `Engine` struct and their read/write sites are redirected to `store.Get`/`store.Apply` calls against a new `*itemstate.Store` field on the Engine. Observable behavior is unchanged. The `ItemState` and `LinkedPRState` structs in `internal/itemstate/itemstate.go` already contain all required fields (added by Phase 3-A). Most required mutations and Apply handlers also exist; three are missing and must be added.

**Key decisions:**

1. **Engine-owned standalone Store (Option A)**: The engine gets its own `store *itemstate.Store` initialized with `itemstate.NewStore(nil)`. This is separate from `CacheImpl`'s internal store, which is acceptable for Phase 3-E — the engine store holds lock/invocation/deepFetch/CI state; board state continues through CacheImpl. Unification into a single store is a later phase.

2. **`ItemDeepFetched` handler clears `LastDeepFetchFailureAt`**: Rather than a new `DeepFetchSucceeded` mutation, modify the existing `ItemDeepFetched` Apply handler to zero `LastDeepFetchFailureAt`. This avoids proliferating mutation types for a behavior that's logically part of a successful deep fetch.

3. **Separate `CIMergePendingStarted` and `CIMergePendingCleared` mutations**: Matches Phase 3-A's naming convention (explicit past-tense verb phrases per event) and makes intent clear at each call site in `stages.go`.

4. **New `PRChecksObserved` mutation for REST path**: `CheckRunCompleted` (webhook path) already sets `HasHadChecks = true`. The REST path (`FetchCheckRuns` returns non-empty) needs its own mutation so `engine/ci.go` can set `HasHadChecks` without going through the webhook path.

5. **`engine.TokenUsage` becomes a type alias**: Change the struct declaration in `engine/claude.go` to `type TokenUsage = itemstate.TokenUsage`. This preserves all existing engine code as-is with zero-cost assignment, matching the intent documented in the `itemstate` comment.

6. **`lastUpdatedAt` renamed to `seenUpdatedAt`**: Explicit signal that this map is deferred to Phase 3-H. No semantic change.

7. **No new ADR**: The "separate stores during migration" decision is a transient implementation detail of an incremental migration already governed by ADR-036. A contributor reading ADR-036 and this PR description has all needed context.

### New/Modified Files

| File | Change |
|------|--------|
| `internal/itemstate/mutation.go` | Add `CIMergePendingStarted`, `CIMergePendingCleared`, `PRChecksObserved` mutations |
| `internal/itemstate/store.go` | Add Apply handlers for 3 new mutations; modify `ItemDeepFetched` handler to zero `LastDeepFetchFailureAt` |
| `internal/itemstate/store_test.go` | New tests for new mutation handlers + snapshot immutability for LinkedPR fields |
| `engine/engine.go` | Add `store *itemstate.Store` field; initialize in `New()` and `NewWithDeps()`; remove 7 maps; rename `lastUpdatedAt` → `seenUpdatedAt` |
| `engine/claude.go` | Change `TokenUsage` to type alias for `itemstate.TokenUsage` |
| `engine/item.go` | Redirect `lockedIssues` read/write sites; redirect `lastUsage`/`lastCompleted`/`lastBlocked` write sites; migrate `cleanupLockedIssues` |
| `engine/poll.go` | Redirect `deepFetchFailureTime` set/clear; redirect `lastUsage`/`lastCompleted`/`lastBlocked` read-then-delete → store reads |
| `engine/stages.go` | Redirect all 6 `ciMergePendingSince` read/write sites; audit `e.mu` removal |
| `engine/ci.go` | Redirect `prHasHadChecks` read/write; nil-check `snap.LinkedPR()` |
| `engine/comments.go` | Redirect `lastUsage`/`lastCompleted` write sites |
| `engine/merge_gate.go` | Redirect `lastUsage`/`lastCompleted`/`lastBlocked` read-then-delete → store reads |
| `engine/reviews.go` | Redirect `lastUsage`/`lastCompleted`/`lastBlocked` read-then-delete → store reads |
| `engine/engine_extra_test.go` | Migrate `lockedIssues` direct access to `store.Get` |
| `engine/item_extra_test.go` | Migrate `deepFetchFailureTime` direct access to `store.Apply`/`store.Get` |
| `engine/lock_then_verify_test.go` | Migrate `lockedIssues` check to `store.Get` |
| `engine/ci_test.go` | Migrate `prHasHadChecks` seed to `store.Apply(PRChecksObserved{...})` |
| `engine/stages_test.go` | Migrate `ciMergePendingSince` seed/check to `store.Apply`/`store.Get` |
| `engine/engine_test.go` | Remove `lockedIssues: make(map[string]bool)` from struct literal |
| `engine/engine_migration_test.go` | New file: integration tests per acceptance criteria |
| `docs/state-machine.md` | Add/update "Engine internal state" section |

### Key Decisions

- **No CacheImpl store exposure**: Rejected Option B (exposing `CacheImpl.store` via a `Store()` method) — it would introduce dual code paths for GitHubAdapter vs CacheImpl mode, complicating tests. Option A (engine-owned store) is simpler and sufficient for this phase.
- **Read-delete pattern becomes read-only**: The TUI JobCompleted event consumers in `poll.go`, `merge_gate.go`, `reviews.go`, `ci.go` currently read-then-delete from `lastUsage`/`lastCompleted`/`lastBlocked`. After migration, they simply read from the snapshot — the store retains state until overwritten by the next invocation. Tests asserting "zero after read" must be rewritten accordingly.
- **`e.mu` audit at each migrated site**: `store.Apply` has its own internal mutex. Where `e.mu` was held solely for a migrated map write, it can be dropped. Where `e.mu` still protects other shared fields in the same critical section, it must remain.

### Task Checklist

- [ ] **Task 1**: Add `CIMergePendingStarted`, `CIMergePendingCleared`, `PRChecksObserved` to `internal/itemstate/mutation.go` with `isMutation()` and `itemKey()` methods
- [ ] **Task 2**: Add Apply handlers for `CIMergePendingStarted`, `CIMergePendingCleared`, `PRChecksObserved` in `internal/itemstate/store.go`'s `applyToItem` switch; modify `ItemDeepFetched` case to zero `item.LastDeepFetchFailureAt`
- [ ] **Task 3**: Add unit tests in `internal/itemstate/store_test.go` for the 3 new mutation handlers and the `ItemDeepFetched` clear behavior; verify snapshot immutability for `LinkedPR` fields (take snapshot, apply mutation, verify original snapshot unchanged)
- [ ] **Task 4**: Make `engine.TokenUsage` a type alias (`type TokenUsage = itemstate.TokenUsage`) in `engine/claude.go`; add the `internal/itemstate` import; delete the duplicate struct body
- [ ] **Task 5**: Add `store *itemstate.Store` field to `Engine` struct in `engine/engine.go`; initialize with `itemstate.NewStore(nil)` in both `New()` and `NewWithDeps()`; add import
- [ ] **Task 6**: Redirect `lockedIssues` in `engine/item.go`: replace acquire write (`e.lockedIssues[iKey] = true`) with `e.store.Apply(LocalLockAcquired{...})`, release write with `e.store.Apply(LocalLockReleased{...})`; replace reads with `snap.Lock()` snapshot checks; migrate `cleanupLockedIssues` to iterate `e.store.All()` filtering `lock.HeldByThis`; remove `lockedIssues` from Engine struct and both constructors
- [ ] **Task 7**: Redirect `lastUsage`/`lastCompleted`/`lastBlocked` writes in `engine/item.go` and `engine/comments.go` to `e.store.Apply(InvocationRecorded{...})`; redirect read-then-delete consumers in `engine/poll.go`, `engine/merge_gate.go`, `engine/reviews.go` to `e.store.Get(repo, n)` snapshot reads (no delete); remove the three maps from Engine struct and both constructors
- [ ] **Task 8**: Redirect `deepFetchFailureTime` in `engine/poll.go`: replace `e.deepFetchFailureTime[iKey] = time.Now()` with `e.store.Apply(DeepFetchFailed{...})`; replace read sites with `snap.State().LastDeepFetchFailureAt`; the clear-on-success path is handled by the modified `ItemDeepFetched` handler (Task 2); remove `deepFetchFailureTime` from Engine struct and both constructors
- [ ] **Task 9**: Redirect `prHasHadChecks` in `engine/ci.go`: replace set (`e.prHasHadChecks[iKey] = true`) with `e.store.Apply(PRChecksObserved{...})`; replace read with `snap.LinkedPR()` nil-check then `.HasHadChecks`; remove `prHasHadChecks` from Engine struct and both constructors
- [ ] **Task 10**: Redirect all 6 `ciMergePendingSince` sites in `engine/stages.go`: sets → `e.store.Apply(CIMergePendingStarted{...})`, deletes → `e.store.Apply(CIMergePendingCleared{...})`, reads → `snap.LinkedPR()` nil-check then `.CIMergePendingSince`; audit and remove any `e.mu` guards that were solely protecting `ciMergePendingSince`; remove `ciMergePendingSince` from Engine struct and both constructors
- [ ] **Task 11**: Rename `e.lastUpdatedAt` → `e.seenUpdatedAt` throughout Engine struct, constructors, and all engine source files; no semantic change
- [ ] **Task 12**: Update test files with direct engine-map access: `engine/engine_test.go:281` (remove `lockedIssues` from struct literal), `engine/engine_extra_test.go:55-78` (seed/check via `store.Apply(LocalLockAcquired{...})`/`store.Get`), `engine/lock_then_verify_test.go:163-166` (check via `store.Get`), `engine/item_extra_test.go:508-545,591` (seed/read `deepFetchFailureTime` via `store.Apply(DeepFetchFailed{...})`/`store.Get`), `engine/ci_test.go:84` (seed via `store.Apply(PRChecksObserved{...})`), `engine/stages_test.go` (seed/check `ciMergePendingSince` via `store.Apply`/`store.Get`)
- [ ] **Task 13**: Add `engine/engine_migration_test.go` with integration tests covering all acceptance criteria: lock acquire/release cycle, token-usage update, completion/block flags, deep-fetch cooldown, `HasHadChecks` monotonic transition, `CIMergePendingSince` set/clear, lock derived-field transitions, concurrent completions (race-safe)
- [ ] **Task 14**: Update `docs/state-machine.md`: add or update "Engine internal state" section listing all migrated fields with their `ItemState`/`LinkedPRState` locations, access patterns (`store.Get`/`store.Apply`), and reference to ADR-036
- [ ] **Task 15**: Verify `go build ./...`, `go vet ./...`, and `go test -race ./...` all pass; confirm no data races under concurrent load

### Risks

- **`e.mu` partial removal**: Each `ciMergePendingSince` site in `stages.go` holds `e.mu` during the operation. After migration to `store.Apply`, if other fields in the same critical section still require `e.mu`, the lock must remain. Implement must audit each site individually — removing `e.mu` too aggressively is a data race; leaving it unnecessarily is harmless contention.

- **`snap.LinkedPR()` nil-check**: `ciMergePendingSince` and `prHasHadChecks` currently return zero values when absent (map miss). After migration, `snap.LinkedPR()` returns `nil` when no PR is linked. Every read site must nil-check before field access. Missing any nil-check is a nil-pointer panic in production.

- **Read-delete pattern tests**: Tests in `poll.go`, `merge_gate.go`, `reviews.go` that assert state is zero after "consumption" will fail — the store retains state. These tests must be rewritten to assert the correct current state rather than zero-after-delete. This is a semantic improvement but requires careful test review.

- **Import cycle check**: `engine` importing `internal/itemstate` is fine. No reverse import must be introduced. Verify the import graph compiles cleanly after Task 4 (TokenUsage alias introduces the first engine→itemstate import in `claude.go`).

---
Used 15/50 turns, 8k input / 7k output tokens.

## Verification

Phase 3-E migration of per-item engine state into `ItemState` is complete. All seven engine maps (`lockedIssues`, `lastUsage`, `lastCompleted`, `lastBlocked`, `deepFetchFailureTime`, `prHasHadChecks`, `ciMergePendingSince`) have been removed from the `Engine` struct and their read/write sites redirected to `store.Get`/`store.Apply`. `lastUpdatedAt` was renamed to `seenUpdatedAt` as planned. All tests pass including `go test -race ./...` clean, with 10 new engine migration integration tests and 4 new itemstate unit tests added.

---

Closes #517