### PR TITLE
SeedLabels seeds zero labels in multi-repo mode (empty cfg.Repo); also misses secondary repos in single-repo mode

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -71,6 +71,7 @@ type Engine struct {
 	totalTokens          TokenUsage            // accumulated token usage since process start
 	lastReportedCost     float64               // cost at last [stats] report; skip repeat prints when unchanged
 	seenUpdatedAt        map[string]time.Time  // key: issueKey; tracks last-seen updatedAt per issue (deferred to Phase 3-H)
+	seededRepos          map[string]bool       // key: "owner/repo"; in-memory guard to avoid re-seeding on every poll
 	idleCount            int                   // consecutive idle polls; triggers self-upgrade at threshold
 	idleStart            time.Time             // when consecutive idle polls began; zero value = not idle
 	wakeCh               chan struct{}         // TUI sends on this to wake the poll loop immediately; nil if no TUI
@@ -120,6 +121,7 @@ func New(cfg Config) (*Engine, error) {
 		fabrikDir:            fabrikDir,
 		store:                itemstate.NewStore(nil),
 		seenUpdatedAt:        make(map[string]time.Time),
+		seededRepos:          make(map[string]bool),
 		sem:                  make(chan struct{}, cfg.MaxConcurrent),
 	}
 
@@ -173,6 +175,7 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		worktreeManagers:     wms,
 		store:                itemstate.NewStore(nil),
 		seenUpdatedAt:        make(map[string]time.Time),
+		seededRepos:          make(map[string]bool),
 		sem:                  make(chan struct{}, maxConcurrent),
 	}
 	if worktrees != nil {

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -73,6 +73,8 @@ type mockGitHubClient struct {
 	addPRReviewCommentReactionCalls []prReviewCommentReactionCall
 	deleteReviewRequestCalls        []reviewRequestCall
 	addReviewRequestCalls           []reviewRequestCall
+	seedLabelsCalls                 []seedLabelsCall
+	seedLabelsFn                    func(owner, repo string, stageNames []string, lockedUser string) error
 }
 
 type reviewRequestCall struct {
@@ -95,6 +97,12 @@ type fetchLabelAppliedAtCall struct {
 
 type archiveProjectItemCall struct {
 	projectID, itemID string
+}
+
+type seedLabelsCall struct {
+	owner, repo string
+	stageNames  []string
+	lockedUser  string
 }
 
 type markPRReadyCall struct {
@@ -426,6 +434,13 @@ func (m *mockGitHubClient) ArchiveProjectItem(projectID, itemID string) error {
 }
 
 func (m *mockGitHubClient) SeedLabels(owner, repo string, stageNames []string, lockedUser string) error {
+	m.mu.Lock()
+	m.seedLabelsCalls = append(m.seedLabelsCalls, seedLabelsCall{owner, repo, stageNames, lockedUser})
+	fn := m.seedLabelsFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, stageNames, lockedUser)
+	}
 	return nil
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -752,11 +752,15 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			if already {
 				continue
 			}
-			parts := strings.SplitN(ownerRepo, "/", 2)
-			if len(parts) != 2 {
+			owner, repo := parseOwnerRepo(ownerRepo)
+			if owner == "" {
+				e.logf(0, "warn", "label seeding skipped: malformed repo %q\n", ownerRepo)
+				e.mu.Lock()
+				e.seededRepos[ownerRepo] = true
+				e.mu.Unlock()
 				continue
 			}
-			if err := e.client.SeedLabels(parts[0], parts[1], sn, e.cfg.User); err != nil {
+			if err := e.client.SeedLabels(owner, repo, sn, e.cfg.User); err != nil {
 				e.logf(0, "warn", "label seeding for %s failed (non-fatal): %v\n", ownerRepo, err)
 			}
 			e.mu.Lock()

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -282,12 +282,18 @@ func (e *Engine) Run() error {
 
 	// Seed all known Fabrik labels with descriptions and sensible default colors.
 	// Non-fatal: a seeding failure must not prevent the engine from polling.
+	// In multi-repo mode (cfg.Repo == ""), skip here; poll() seeds each discovered repo instead.
 	stageNames := make([]string, len(e.cfg.Stages))
 	for i, s := range e.cfg.Stages {
 		stageNames[i] = s.Name
 	}
-	if err := e.client.SeedLabels(e.cfg.Owner, e.cfg.Repo, stageNames, e.cfg.User); err != nil {
-		e.logf(0, "warn", "label seeding failed (non-fatal): %v\n", err)
+	if e.cfg.Repo != "" {
+		if err := e.client.SeedLabels(e.cfg.Owner, e.cfg.Repo, stageNames, e.cfg.User); err != nil {
+			e.logf(0, "warn", "label seeding failed (non-fatal): %v\n", err)
+		}
+		e.mu.Lock()
+		e.seededRepos[e.cfg.Owner+"/"+e.cfg.Repo] = true
+		e.mu.Unlock()
 	}
 
 	// Extract in-memory cache if configured (nil when board-cache=none).
@@ -729,6 +735,34 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			repos = append(repos, r)
 		}
 		e.logf(0, "poll", "repos on board: %v\n", repos)
+	}
+
+	// Seed labels on repos discovered for the first time this process run.
+	// seededRepos is guarded by e.mu; the poll loop is single-goroutine but
+	// lock for future-safety consistent with other Engine maps.
+	{
+		sn := make([]string, len(e.cfg.Stages))
+		for i, s := range e.cfg.Stages {
+			sn[i] = s.Name
+		}
+		for ownerRepo := range seenRepos {
+			e.mu.Lock()
+			already := e.seededRepos[ownerRepo]
+			e.mu.Unlock()
+			if already {
+				continue
+			}
+			parts := strings.SplitN(ownerRepo, "/", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			if err := e.client.SeedLabels(parts[0], parts[1], sn, e.cfg.User); err != nil {
+				e.logf(0, "warn", "label seeding for %s failed (non-fatal): %v\n", ownerRepo, err)
+			}
+			e.mu.Lock()
+			e.seededRepos[ownerRepo] = true
+			e.mu.Unlock()
+		}
 	}
 
 	var deepFetched int

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1485,3 +1485,74 @@ func TestRunReconciliationLoop_SkipsWhenProjectIDEmpty(t *testing.T) {
 		t.Errorf("FetchProjectItemStatusBatch should not be called when ProjectID is empty; got %d calls", n)
 	}
 }
+
+// TestSeedLabels_multiRepo verifies that in multi-repo mode (cfg.Repo == ""),
+// SeedLabels is called exactly once per discovered repo across two poll cycles,
+// and never called with an empty repo argument.
+func TestSeedLabels_multiRepo(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 1, Title: "Issue 1", Status: "Research", Repo: "owner/repo1"},
+			{Number: 2, Title: "Issue 2", Status: "Research", Repo: "owner/repo2"},
+		},
+	}
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return board, nil
+		},
+		fetchStatusFieldFn: func(projectID string) (*gh.StatusField, error) {
+			return &gh.StatusField{
+				FieldID: "F1",
+				Options: map[string]string{"Research": "OPT_1"},
+			}, nil
+		},
+	}
+
+	// Multi-repo mode: Owner set, Repo empty.
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		client,
+		&mockClaudeInvoker{},
+		nil,
+	)
+
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll 1: %v", err)
+	}
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll 2: %v", err)
+	}
+
+	client.mu.Lock()
+	calls := make([]seedLabelsCall, len(client.seedLabelsCalls))
+	copy(calls, client.seedLabelsCalls)
+	client.mu.Unlock()
+
+	// No call should have an empty repo.
+	for _, c := range calls {
+		if c.repo == "" {
+			t.Errorf("SeedLabels called with empty repo: %+v", c)
+		}
+	}
+
+	// Each unique owner/repo should be seeded exactly once across both poll cycles.
+	seen := make(map[string]int)
+	for _, c := range calls {
+		seen[c.owner+"/"+c.repo]++
+	}
+	for _, ownerRepo := range []string{"owner/repo1", "owner/repo2"} {
+		if seen[ownerRepo] != 1 {
+			t.Errorf("SeedLabels for %s called %d times, want 1", ownerRepo, seen[ownerRepo])
+		}
+	}
+}

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1493,8 +1493,8 @@ func TestSeedLabels_multiRepo(t *testing.T) {
 	board := &gh.ProjectBoard{
 		ProjectID: "PVT_1",
 		Items: []gh.ProjectItem{
-			{Number: 1, Title: "Issue 1", Status: "Research", Repo: "owner/repo1"},
-			{Number: 2, Title: "Issue 2", Status: "Research", Repo: "owner/repo2"},
+			{Number: 1, Title: "Issue 1", Status: "Done", Repo: "owner/repo1"},
+			{Number: 2, Title: "Issue 2", Status: "Done", Repo: "owner/repo2"},
 		},
 	}
 	client := &mockGitHubClient{

--- a/github/labels.go
+++ b/github/labels.go
@@ -182,13 +182,20 @@ func (c *Client) ensureLabel(owner, repo, name, description, color string) error
 	return nil
 }
 
+// ErrNoRepoConfigured is returned by SeedLabels when repo is empty.
+var ErrNoRepoConfigured = errors.New("repo must not be empty")
+
 // SeedLabels ensures all known Fabrik labels exist on the given repo and that
 // any label with an empty description is backfilled. It never changes an
 // existing label's color or non-empty description. stageNames is the list of
 // stage names from the loaded config; lockedUser is the current Fabrik user.
-// Returns the first error encountered, but callers should treat this as
-// non-fatal (log a warning and continue).
+// Returns ErrNoRepoConfigured when repo is empty. Per-label failures are logged
+// internally and do not cause an early return.
 func (c *Client) SeedLabels(owner, repo string, stageNames []string, lockedUser string) error {
+	if repo == "" {
+		return ErrNoRepoConfigured
+	}
+
 	// Collect all labels to seed.
 	defs := make([]labelDef, 0, len(staticLabelDefs)+len(stageNames)*3+1)
 	defs = append(defs, staticLabelDefs...)
@@ -220,7 +227,7 @@ func (c *Client) SeedLabels(owner, repo string, stageNames []string, lockedUser 
 
 	for _, d := range defs {
 		if err := c.seedOneLabel(owner, repo, d); err != nil {
-			return fmt.Errorf("seeding label %q: %w", d.name, err)
+			logf(0, "warn", "seeding label %q: %v\n", d.name, err)
 		}
 	}
 	return nil

--- a/github/labels.go
+++ b/github/labels.go
@@ -227,7 +227,7 @@ func (c *Client) SeedLabels(owner, repo string, stageNames []string, lockedUser 
 
 	for _, d := range defs {
 		if err := c.seedOneLabel(owner, repo, d); err != nil {
-			logf(0, "warn", "seeding label %q: %v\n", d.name, err)
+			logf(0, "warn", "seeding label %q on %s/%s: %v\n", d.name, owner, repo, err)
 		}
 	}
 	return nil

--- a/github/labels_test.go
+++ b/github/labels_test.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestSeedLabels_EmptyRepo verifies that SeedLabels returns ErrNoRepoConfigured
+// when repo is empty, without making any HTTP requests.
+func TestSeedLabels_EmptyRepo(t *testing.T) {
+	var requestCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	err := c.SeedLabels("owner", "", []string{"Research"}, "testuser")
+	if !errors.Is(err, ErrNoRepoConfigured) {
+		t.Fatalf("expected ErrNoRepoConfigured, got %v", err)
+	}
+	if n := atomic.LoadInt32(&requestCount); n != 0 {
+		t.Errorf("expected zero HTTP requests, got %d", n)
+	}
+}
+
+// TestSeedLabels_LogAndContinue verifies that a 5xx response on one label does
+// not prevent subsequent labels from being attempted.
+func TestSeedLabels_LogAndContinue(t *testing.T) {
+	var getCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			atomic.AddInt32(&getCount, 1)
+		}
+		w.WriteHeader(500)
+		w.Write([]byte(`{"message":"internal server error"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	// Pass no stage names so the label count is deterministic: staticLabelDefs + 1 locked.
+	err := c.SeedLabels("owner", "repo", nil, "testuser")
+	if err != nil {
+		t.Fatalf("expected nil error (log-and-continue), got %v", err)
+	}
+
+	want := int32(len(staticLabelDefs) + 1) // +1 for fabrik:locked:<user>
+	got := atomic.LoadInt32(&getCount)
+	if got != want {
+		t.Errorf("expected %d GET requests (one per label), got %d", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

Run `SeedLabels` against every managed repo Fabrik knows about, not just the bootstrap repo, and re-run it whenever the managed-repo set grows. In multi-repo mode (no bootstrap repo configured), seed labels from the project board's discovered repo set instead. Convert the per-label loop inside `SeedLabels` to log-and-continue rather than aborting on the first failure.

## Problem

`SeedLabels` (`github/labels.go:191`) is invoked at startup from `engine/poll.go:288`:

```go
e.client.SeedLabels(e.cfg.Owner, e.cfg.Repo, stageNames, e.cfg.User)
```

This has two failure modes in production:

### 1. Multi-repo mode: zero labels seeded anywhere

Project boards that span multiple repos use `repo:` empty (commented out) in `.fabrik/config.yaml` — this is the documented and recommended configuration for multi-repo mode. In that mode `e.cfg.Repo == ""`, and `SeedLabels` is called with an empty repo string. Every `seedOneLabel` request becomes a malformed URL like `https://api.github.com/repos/tenaciousvc//labels/fabrik%3Ayolo` (note double-slash). GitHub rejects it; `seedOneLabel` returns the error; `SeedLabels` aborts at the first label.

**Net result**: no labels are seeded *anywhere*. The only labels that exist on a multi-repo Fabrik project are the ones `AddLabelToIssue` → `ensureLabel` happens to create on-demand when the engine first applies them to an issue. Rarely-applied labels (`fabrik:extend-turns` — manual override; `fabrik:unrestricted` — opt-in; `fabrik:rebase-needed` — only when a PR fails to merge) often never get created until an operator manually picks them, by which point GitHub's autocomplete can't surface them and the user has to type the full string.

This is what bit the Fabrik PM project: `fabrik:extend-turns` was absent and had to be created manually before it could be applied. Same root cause applies to *any* multi-repo Fabrik instance.

### 2. Single-repo mode: only the bootstrap repo is seeded; secondary repos discovered later are skipped

Even when `repo:` is set explicitly, Fabrik may pick up additional managed repos via project-board scan and `UpdateRepos`. Those secondary repos never get seeded. The first time Fabrik applies, say, `fabrik:awaiting-review` to an issue in a secondary repo, `ensureLabel` creates it *without* the description-backfill PATCH path that `seedOneLabel` provides — so descriptions and colors drift across repos in the project.

## Approach

### Approach

Two independent fixes united by one new Engine field:

1. **`github/labels.go`**: Add `ErrNoRepoConfigured` sentinel and empty-repo early return; convert the per-label loop from abort-on-first-error to log-and-continue.
2. **`engine` layer**: Add a `seededRepos map[string]bool` field to Engine; guard the startup seed call against `e.cfg.Repo == ""`; inside `poll()` (after `seenRepos` is built), iterate discovered repos, check against `seededRepos`, and call `SeedLabels` for each new one.

**Hook location decision**: Research surfaced two options — place seeding in `doPollCycle` (spec's stated location) or in `poll()` itself. **Chosen: `poll()`**. Placing it in `poll()` makes it directly testable via `eng.poll()`, matching the existing test pattern in `poll_multirepo_test.go`. The testability benefit outweighs literal adherence to the spec's location suggestion. The spec's requirement ("seed after each poll cycle") is fully met either way.

**Startup bootstrap repo**: After the existing startup `SeedLabels` call (now guarded for empty repo), mark the bootstrap repo in `seededRepos` regardless of success, so `poll()` doesn't re-seed it every cycle. (Re-seeding is idempotent via GET-before-POST, but avoiding repeated GETs is cleaner.)

**`SeedLabels` signature**: Return type stays `error`. Returns `ErrNoRepoConfigured` only for the empty-repo sentinel; per-label failures are logged internally and never propagate. `engine/interfaces.go` needs no change.

**`seededRepos` concurrency**: The field is read/written in `poll()`, which runs on the single poll-loop goroutine. Guard with `e.mu` for future-safety, consistent with `processedSet`.

**`stageNames` in `poll()`**: Computed inline from `e.cfg.Stages` (immutable after construction). No closure capture needed.

**No ADR needed**: The `seededRepos` in-memory map follows the established Engine pattern (ADR-002, ADR-007 cover the rationale). No new architectural decisions.

**Documentation impact**: None. This is an internal bug fix with no new CLI flags, config fields, or user-visible behavior. `docs/state-machine.md` and `docs/stage-lifecycle.md` do not cover label seeding.

---

### New/Modified Files

| File | Change |
|------|--------|
| `github/labels.go` | Add `ErrNoRepoConfigured` var; add empty-repo guard to `SeedLabels`; convert per-label loop to log-and-continue |
| `engine/engine.go` | Add `seededRepos map[string]bool` field; initialize in `New()` and `NewWithDeps()` |
| `engine/poll.go` | Guard startup seed call (`if e.cfg.Repo != ""`); mark bootstrap repo in `seededRepos`; add post-`seenRepos` seeding block in `poll()` |
| `engine/interfaces.go` | No change (return type stays `error`) |
| `engine/mocks_test.go` | Add `seedLabelsCall` struct; add `seedLabelsCalls []seedLabelsCall` + `seedLabelsFn` to mock; upgrade `SeedLabels()` method |
| `github/labels_test.go` | New file: test `ErrNoRepoConfigured` on empty repo; test log-and-continue on 5xx |
| `engine/poll_test.go` | Add test: multi-repo discovery across poll cycles — exactly one `SeedLabels` call per repo, no empty-repo call |

---

### Key Decisions

- **Seeding in `poll()` not `doPollCycle()`**: Existing tests exercise `eng.poll()` directly; wrapping `Run()` in tests is complex. Testability wins over literal spec placement.
- **`ErrNoRepoConfigured` in `labels.go` not `rest.go`**: `rest.go` holds HTTP-level sentinels; this is a semantic guard. Same `var Err... = errors.New(...)` pattern.
- **Mark bootstrap repo in `seededRepos` regardless of startup-seed success**: Re-seeding is idempotent; avoiding repeated GET storms on every poll cycle is worth the minor leniency on startup failures. Operators already see the warning from the non-fatal handler.
- **Per-label failures log-and-continue, no return**: `SeedLabels` callers cannot act on individual label failures; the only actionable sentinel is `ErrNoRepoConfigured` (bad call-site bug). Logging per-label failures gives operator visibility without propagating noise.

---

### Task Checklist

- [ ] Task 1: `github/labels.go` — add `var ErrNoRepoConfigured = errors.New("repo must not be empty")` at package level; add `if repo == "" { return ErrNoRepoConfigured }` early return at top of `SeedLabels`; convert the `for _, d := range defs` loop from `return err` to `logf(0, "warn", "seeding label %q: %v\n", d.name, err); continue`
- [ ] Task 2: `engine/engine.go` — add `seededRepos map[string]bool` field to `Engine` struct; add `seededRepos: make(map[string]bool)` to both `New()` initializer and `NewWithDeps()` initializer
- [ ] Task 3: `engine/poll.go` startup — wrap the existing `SeedLabels` call at line 289 in `if e.cfg.Repo != ""` guard; after the call (on success or non-fatal skip), mark `e.cfg.Owner+"/"+e.cfg.Repo` in `e.seededRepos`
- [ ] Task 4: `engine/poll.go` `poll()` — after the `seenRepos` build loop (line ~727), before returning `pollResult`, iterate `seenRepos`; for each `ownerRepo` not in `e.seededRepos` (read/write under `e.mu`), call `e.client.SeedLabels(owner, repo, stageNames, e.cfg.User)` with a non-fatal warn on error, then set `e.seededRepos[ownerRepo] = true`; compute `stageNames` inline from `e.cfg.Stages`
- [ ] Task 5: `engine/mocks_test.go` — add `type seedLabelsCall struct { owner, repo string; stageNames []string; lockedUser string }`; add `seedLabelsCalls []seedLabelsCall` and `seedLabelsFn func(owner, repo string, stageNames []string, lockedUser string) error` fields to `mockGitHubClient`; rewrite `SeedLabels()` method to lock, append call, read fn, unlock, invoke fn (nil fn returns nil), matching the established pattern
- [ ] Task 6: `github/labels_test.go` (new file) — test 1: call `SeedLabels` with empty repo; assert returns `ErrNoRepoConfigured`; assert zero HTTP requests hit the test server; test 2: `httptest.NewServer` returning 500 for any label PUT/PATCH; call `SeedLabels` with N labels; assert server received N GET requests (all labels attempted despite errors)
- [ ] Task 7: `engine/poll_test.go` — add test `TestSeedLabels_multiRepo`: use `mockGitHubClient` with seeded board containing two repos; call `eng.poll()` twice; assert `seedLabelsCalls` contains exactly one entry per unique `owner/repo` and no entry has empty `repo`
- [ ] Task 8: Run `go test -race ./...` and `go vet ./...`; fix any issues

---

### Risks

- **`seenRepos` key format**: Verify that keys in `seenRepos` are `"owner/repo"` strings (consistent with `e.seededRepos` key format). Research confirms this (line 714–727). Mismatch would cause double-seeding but not correctness failures due to GET-before-POST idempotency.
- **`poll()` signature change**: Adding seeding to `poll()` adds GitHub calls to each poll cycle. For repos already in `seededRepos` the guard short-circuits immediately (no API calls). First-encounter cost is ~25 GETs per new repo — negligible.
- **Test board data**: `TestSeedLabels_multiRepo` needs a mock board with items in two distinct repos. Use the existing `mockGitHubClient.fetchProjectBoardFn` pattern to return a crafted `ProjectBoard`.

---
Used 13/50 turns, 6k input / 5k output tokens.

## Verification

Fixed `SeedLabels` to work correctly in multi-repo mode: added `ErrNoRepoConfigured` sentinel for empty-repo calls, converted the per-label loop from abort-on-first-error to log-and-continue, and added a `seededRepos` tracking map to the Engine that seeds labels on each newly-discovered repo after every poll cycle. The startup seed call is now guarded against empty `e.cfg.Repo`. All changes are tested: `github/labels_test.go` covers the sentinel and log-and-continue paths; `engine/poll_test.go` verifies exactly one `SeedLabels` call per repo and no empty-repo calls across two poll cycles.

---

Closes #524