### PR TITLE
feat(engine): Phase 3-G — WorkerHandle heartbeats and stale-lock detection (#519)

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -844,7 +844,7 @@ When Claude runs but does not output any completion marker, the engine enters a 
 - **State:** In-memory only (`CooldownAt("periodic-re-eval")` written to `itemstate.Store` via `CooldownRecorded` mutation). No label is added for cooldown.
 - **Lock behavior:** The lock (`fabrik:locked:<user>` and `stage:<X>:in_progress`) is NOT released during cooldown. This prevents other instances from picking up the item.
 - **Resume behavior:** On retry, `resume=true` is passed to Claude (resumes the session rather than starting fresh)
-- **On restart:** Cooldown state is lost. The lock label is still present but the in-memory `ItemState.Lock` in the `itemstate.Store` is empty — the shutdown cleanup removes lock labels. If the process crashes without cleanup, the lock label remains as a stale artifact until another instance or manual cleanup removes it.
+- **On restart:** Cooldown state is lost. The lock label is still present but the in-memory `ItemState.Lock` in the `itemstate.Store` is empty — the shutdown cleanup removes lock labels. If the process crashes without cleanup, the startup cleanup pass (§9.7) removes stale `fabrik:locked:<user>` and `stage:*:in_progress` labels after the first poll cycle populates the store.
 - **Stage-complete exemption:** Items where `stage:X:complete` appears in the shallow label set are NOT subject to cooldown retry — they have no work to retry. When the cooldown-expired branch fires in `itemMayNeedWork()`, the engine checks for `stage:X:complete` in shallow labels before returning `true`; if present, it returns `false`. This prevents perpetual deep-fetch loops for terminal items (cruise+Validate complete, paused+complete, closed-with-stage-complete) where every poll after cooldown expiry would otherwise trigger a no-op deep-fetch indefinitely.
 
 ### 7.2 Failed Stage / Pause on Retry Limit
@@ -1042,11 +1042,13 @@ No special handling. Each is independent. The engine only checks the in_progress
 
 ### 9.2 inFlight Map
 
-`Engine.inFlight` (`sync.Map`) tracks items currently being processed by worker goroutines. Key: `issueKey` string, Value: `bool` (isPR).
+`Engine.inFlight` (`sync.Map`) prevents double-dispatch of goroutines. Key: `issueKey` string, Value: `bool` (isPR).
 
 - **Set by:** dispatch loop (before goroutine launch), `dispatchReviewReinvoke()` (inside goroutine, before semaphore acquire), and `dispatchCIFixReinvoke()` (inside goroutine, before semaphore acquire)
 - **Cleared by:** goroutine defer (after `processItem()` or `processComments()` returns)
-- **Used by:** dispatch loop (skip already in-flight items) and catch-up loop (skip reinvoke/CI-fix dispatch if already in-flight)
+- **Used by:** dispatch loop only — to prevent launching a second goroutine for the same issue
+
+The semantic question "is a worker currently active for this issue?" is answered by `snap.Worker() != nil` (see §9.7), not by `inFlight`. The catch-up loop, CI-fix reinvoke guard, rebase reinvoke guard, and TUI idle display all use the store read. `inFlight` is retained solely as a goroutine-launch deduplication guard for the main dispatch loop.
 
 ### 9.3 Worktree Mutex
 
@@ -1090,10 +1092,98 @@ The following fields are stored in `ItemState` / `LinkedPRState` and accessed ex
 | `StageState.CIFixCycles` | `CIFixCycleIncremented` (increment); `EngineCyclesCleared` (reset) | `snap.CIFixCycles(stageName)` | `e.ciFixCycleCount[stageKey]` |
 | `StageState.RebaseCycles` | `RebaseCycleIncremented` (increment); `EngineCyclesCleared` (reset) | `snap.RebaseCycles(stageName)` | `e.rebaseCycleCount[stageKey]` |
 | `StageState.ProcessedComments` | `CommentProcessed{CommentID, At}` | `snap.CommentProcessed(commentID)` | `e.processedSet["…comment-ID"]` |
+| `Worker` (`*WorkerHandle`) | `LocalLockAcquired{Worker: &WorkerHandle{...}}` (set); `WorkerPIDSet{PID}` (update PID); `WorkerHeartbeat{At}` (update `LastSignAt`); `WorkerExited` (clear) | `snap.Worker()` | N/A (new in Phase 3-G) |
 
 **`seenUpdatedAt` (deferred):** The map `e.seenUpdatedAt` (formerly `e.lastUpdatedAt`) tracks the last-seen `UpdatedAt` timestamp per issue. It is kept as a plain `Engine.mu`-protected map pending Phase 3-H, when change-feed observers will replace its purpose. It is intentionally excluded from `itemstate.Store` in this phase.
 
 See also: ADR-036 (`adrs/036-reactive-cache-single-owner.md`) for the full rationale and migration plan.
+
+### 9.7 Worker Liveness (Heartbeat and Stale-Lock Recovery)
+
+Phase 3-G adds a heartbeat-based liveness system that allows the engine to detect and recover from stale `fabrik:locked:<user>` labels left by crashed worker processes.
+
+#### WorkerHandle Struct
+
+```go
+type WorkerHandle struct {
+    PID        int       // Claude subprocess PID (0 until cmd.Start() returns)
+    StageName  string    // name of the stage being invoked
+    StartedAt  time.Time // time LocalLockAcquired was applied
+    LastSignAt time.Time // time of the most recent WorkerHeartbeat mutation
+}
+```
+
+`ItemState.Worker` is non-nil while a worker goroutine is in flight; nil when no worker is active. `snap.Worker()` returns a deep copy (nil-safe).
+
+#### Heartbeat Protocol
+
+Every Claude-spawning dispatch path starts a heartbeat goroutine at dispatch time:
+
+| Dispatch site | File |
+|---|---|
+| `processItem()` — main stage invocation | `engine/item.go` |
+| `dispatchReviewReinvoke()` — review comment processing | `engine/reviews.go` |
+| `dispatchCIFixReinvoke()` — CI failure re-processing | `engine/ci.go` |
+| `dispatchRebaseReinvoke()` — rebase conflict re-processing | `engine/merge_gate.go` |
+
+**Lifecycle per dispatch path:**
+
+1. `store.Apply(LocalLockAcquired{Worker: &WorkerHandle{StageName, StartedAt, PID: 0}})` — Worker set with PID=0 (subprocess not yet started).
+2. A `done := make(chan struct{})` is created; `defer close(done)` is set on the dispatch goroutine.
+3. `go startHeartbeat(ctx, repo, number, done)` — heartbeat goroutine starts. It applies `WorkerHeartbeat{At: time.Now()}` every 30 seconds until `done` is closed or `ctx` is cancelled.
+4. Claude is invoked. After `cmd.Start()`, `opts.OnPIDReady(pid)` applies `WorkerPIDSet{PID: pid}` — the Claude subprocess PID is recorded in Worker.
+5. When the dispatch goroutine exits (defer): `close(done)` stops the heartbeat goroutine; `store.Apply(WorkerExited{})` sets `Worker = nil`.
+
+**No-op semantics:**
+- `WorkerHeartbeat` is a no-op when `Worker == nil` (race-safe: heartbeat may fire just after `WorkerExited`).
+- `WorkerPIDSet` is a no-op when `Worker == nil`.
+- `WorkerExited` is idempotent (safe to apply when already nil).
+
+#### Stale-Worker Detector (Runtime Crash Case)
+
+`startWorkerDetector(ctx)` launches a background goroutine in `Run()` that scans for stale workers every 30 seconds.
+
+**Detection criteria:** `Worker != nil` AND `time.Since(Worker.LastSignAt) > 2 minutes`.
+
+**PID=0 skip:** Workers with `PID == 0` (PID not yet set) are skipped regardless of heartbeat age — they are in the narrow window between `LocalLockAcquired` and `cmd.Start()`.
+
+**Signal-0 liveness check** (`os.FindProcess(pid)` + `process.Signal(syscall.Signal(0))`):
+
+| Outcome | Action |
+|---------|--------|
+| Signal-0 fails (PID dead) | `store.Apply(WorkerExited{})` + `RemoveLabel(fabrik:locked:<user>)` + `RemoveLabel(stage:<StageName>:in_progress)` + log cleanup message |
+| Signal-0 succeeds (PID alive) | Log warning only; do not remove labels or kill the process; re-check on next scan |
+
+`StageName` for label construction is taken from `Worker.StageName`, which was set at dispatch time.
+
+#### Startup Cleanup Pass (Restart Case)
+
+When a Fabrik process crashes, deferred cleanup never runs. On the next startup, stale `fabrik:locked:<user>` and `stage:*:in_progress` labels may remain on issues. The startup cleanup pass removes them.
+
+**Trigger:** Immediately after the first `doPollCycle()` completes (not a wall-clock timer). This guarantees the store is populated before the scan in both webhook and non-webhook modes.
+
+**Grace period:** Any lock acquired during the first poll cycle already has `Worker != nil` in the store (set by `LocalLockAcquired`). The scan skips these items — no artificial sleep is needed.
+
+**Detection:** Scan `store.All()` for items where:
+- `snap.Labels()` contains `"fabrik:locked:" + e.cfg.User` (raw label check — `Lock.HeldByThis` is nil on restart since no `LocalLockAcquired` was applied in this session), AND
+- `snap.Worker() == nil`
+
+**Cleanup per item:**
+1. `RemoveLabel(fabrik:locked:<user>)` from GitHub (with write-through to cache).
+2. For each label in `snap.Labels()` matching `strings.HasPrefix("stage:") && strings.HasSuffix(":in_progress")`: `RemoveLabel(label)` from GitHub (with write-through). `StageName` is unavailable; labels are identified by pattern.
+3. `store.Apply(WorkerExited{})` — no-op since `Worker` is already nil; applied for idempotency.
+4. Log the cleanup at `"startup"` tag.
+
+#### Updated `fabrik:locked:<user>` Label Lifecycle
+
+The lock label is now removed by four paths (previously two):
+
+| Path | Trigger | Function |
+|------|---------|----------|
+| Normal completion | Stage completes (any outcome) | `releaseLock()` |
+| Graceful shutdown | Engine receives SIGINT/SIGTERM | `cleanupLockedIssues()` |
+| **Stale-worker detector** | Worker PID dead + heartbeat stale > 2min | `cleanupStaleWorker()` |
+| **Startup cleanup** | Engine restart; Worker nil + lock label present | `runStartupCleanup()` |
 
 ---
 

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -361,7 +361,7 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 		})
 		done := make(chan struct{})
 		defer close(done)
-		go e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		e.startHeartbeat(ctx, itemRepo, item.Number, done)
 		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
 		onPIDReady := func(pid int) {
 			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -357,7 +357,7 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 			Number:     item.Number,
 			User:       e.cfg.User,
 			AcquiredAt: now,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now},
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
 		})
 		done := make(chan struct{})
 		defer close(done)

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -350,6 +350,23 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 			ciFixStage.CommentPrompt = ""
 		}
 
+		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
+		now := time.Now()
+		e.store.Apply(itemstate.LocalLockAcquired{
+			Repo:       itemRepo,
+			Number:     item.Number,
+			User:       e.cfg.User,
+			AcquiredAt: now,
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now},
+		})
+		done := make(chan struct{})
+		defer close(done)
+		go e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
+		onPIDReady := func(pid int) {
+			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
+		}
+
 		startTime := time.Now()
 		e.emitStructural(tui.JobStartedEvent{
 			IssueNumber: item.Number,
@@ -361,7 +378,7 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 		})
 
 		e.logf(item.Number, "ci-fix-reinvoke", "re-invoking stage %q via comment processing with CI failure context\n", stage.Name)
-		err := e.processComments(ctx, board, item, &ciFixStage, []gh.Comment{syntheticComment})
+		err := e.processComments(ctx, board, item, &ciFixStage, []gh.Comment{syntheticComment}, onPIDReady)
 
 		var usage TokenUsage
 		var completed, blocked bool

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -289,7 +289,7 @@ func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem
 	args := buildClaudeArgs(stage, sessFilePath, resume, opts.ModelOverride, effectiveBudget, hasUnrestrictedLabel(issue), workDir)
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
-	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv, stage.MaxWallTime, effectiveBudget)
+	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name, sessFilePath, ld, extraEnv, stage.MaxWallTime, effectiveBudget, opts.OnPIDReady)
 	usage.MaxTurns = effectiveBudget
 	if err != nil {
 		return output, completed, usage, err
@@ -318,7 +318,7 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 	args := buildClaudeArgs(stage, sessFilePath, true, opts.ModelOverride, limit, hasUnrestrictedLabel(issue), workDir) // resume existing session
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)
-	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review", sessFilePath, ld, extraEnv, stage.MaxWallTime, limit)
+	output, completed, usage, err := runClaude(ctx, args, prompt, workDir, issue.Number, stage.Name+"-comment-review", sessFilePath, ld, extraEnv, stage.MaxWallTime, limit, opts.OnPIDReady)
 	usage.MaxTurns = limit
 	return output, completed, usage, err
 }
@@ -459,7 +459,7 @@ type claudeResponse struct {
 	} `json:"usage"`
 }
 
-func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string, sessFilePath string, logDir string, extraEnv []string, maxWallTime time.Duration, maxTurns int) (string, bool, TokenUsage, error) {
+func runClaude(ctx context.Context, args []string, prompt string, workDir string, issueNumber int, label string, sessFilePath string, logDir string, extraEnv []string, maxWallTime time.Duration, maxTurns int, onPIDReady func(int)) (string, bool, TokenUsage, error) {
 	claudeLog(issueNumber, "claude", "invoking (%s) in %s\n", label, workDir)
 
 	// Set up stderr: in TUI mode discard; in plain mode forward to os.Stderr.
@@ -554,6 +554,9 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 	// cmd.Process is written once by cmd.Start and never modified again.
 	// Capture it here (same goroutine, post-Start) for the watchdog.
 	pid := cmd.Process.Pid
+	if onPIDReady != nil {
+		onPIDReady(pid)
+	}
 
 	// Inactivity watchdog: kills the process group if no stdout is received for
 	// claudeInactivityTimeout, indicating a stuck session regardless of wall time.

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -36,7 +36,7 @@ func (e *Engine) findNewComments(item gh.ProjectItem) []gh.Comment {
 
 // processComments handles new user comments on an issue.
 // Flow: 👀 reactions → editing label → invoke Claude → perform actions / update issue body → remove editing label → 🚀 reactions
-func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment) error {
+func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment, onPIDReady ...func(int)) error {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
 	// Merge any unresolved PR review thread comments into the working slice.
@@ -126,7 +126,11 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if effortOverride != "" {
 		e.logf(item.Number, "effort", "using effort override %q\n", effortOverride)
 	}
-	output, _, usage, err := e.claude.InvokeForComments(ctx, stage, item, comments, workDir, InvokeOptions{ModelOverride: modelOverride, EffortOverride: effortOverride, BaseBranch: baseBranch})
+	invokeOpts := InvokeOptions{ModelOverride: modelOverride, EffortOverride: effortOverride, BaseBranch: baseBranch}
+	if len(onPIDReady) > 0 && onPIDReady[0] != nil {
+		invokeOpts.OnPIDReady = onPIDReady[0]
+	}
+	output, _, usage, err := e.claude.InvokeForComments(ctx, stage, item, comments, workDir, invokeOpts)
 	func() {
 		e.mu.Lock()
 		defer e.mu.Unlock()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -84,6 +84,9 @@ type Engine struct {
 	logFile              *os.File              // persistent log file at .fabrik/fabrik.log; nil if not opened
 	logMu                sync.Mutex            // serializes concurrent writes to logFile
 	webhookMgr           *webhookManager       // nil when webhooks are disabled
+	// heartbeatIntervalOverride overrides the package-level heartbeatInterval constant
+	// when non-zero. Used by tests to reduce the heartbeat period to sub-millisecond.
+	heartbeatIntervalOverride time.Duration
 }
 
 func New(cfg Config) (*Engine, error) {

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -56,6 +56,9 @@ type InvokeOptions struct {
 	EffortOverride   string // from "effort:<level>" label, overrides stage.EffortLevel
 	BaseBranch       string // actual default base branch for the managed repo (e.g. "liminis", not always "main")
 	MaxTurnsOverride int    // when > 0, overrides stage.MaxTurns for this invocation; 0 means use stage.MaxTurns
+	// OnPIDReady, if non-nil, is called once after cmd.Start() with the Claude subprocess PID.
+	// Used by the heartbeat/liveness system to record the PID in the store.
+	OnPIDReady func(pid int)
 }
 
 // ClaudeInvoker defines the interface for invoking Claude Code.

--- a/engine/item.go
+++ b/engine/item.go
@@ -571,7 +571,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
 		}
 		workerDone = make(chan struct{})
-		go e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
+		e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
 	}
 	defer func() {
 		if workerDone != nil {

--- a/engine/item.go
+++ b/engine/item.go
@@ -554,20 +554,31 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// processItem return. This keeps the issue locked through cooldown
 	// retries so other instances don't pick it up.
 	lockAcquired := false
+	var workerDone chan struct{}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, lockLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add lock label: %v\n", err)
 	} else {
 		lockAcquired = true
+		workerStartedAt := time.Now()
 		e.store.Apply(itemstate.LocalLockAcquired{
-			Repo:       itemOwnerRepoString(item, e.defaultRepo()),
+			Repo:       repoStr,
 			Number:     item.Number,
 			User:       e.cfg.User,
-			AcquiredAt: time.Now(),
+			AcquiredAt: workerStartedAt,
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt},
 		})
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
 		}
+		workerDone = make(chan struct{})
+		go e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
 	}
+	defer func() {
+		if workerDone != nil {
+			close(workerDone)
+		}
+	}()
+	defer e.store.Apply(itemstate.WorkerExited{Repo: repoStr, Number: item.Number})
 
 	inProgressLabel := fmt.Sprintf("stage:%s:in_progress", stage.Name)
 	inProgressAdded := false
@@ -684,7 +695,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.logf(item.Number, "effort", "using effort override %q\n", effortOverride)
 	}
 	resume := !lastAttempt.IsZero() // resume session if we've processed this before
-	opts := InvokeOptions{ModelOverride: modelOverride, EffortOverride: effortOverride, BaseBranch: baseBranch}
+	opts := InvokeOptions{
+		ModelOverride:  modelOverride,
+		EffortOverride: effortOverride,
+		BaseBranch:     baseBranch,
+		OnPIDReady:     func(pid int) { e.store.Apply(itemstate.WorkerPIDSet{Repo: repoStr, Number: item.Number, PID: pid}) },
+	}
 
 	// Snapshot extend-turns presence before any FetchItemDetails re-fetches (which
 	// refresh item.Labels). Using a stable boolean ensures the first-budget calc and

--- a/engine/item.go
+++ b/engine/item.go
@@ -565,7 +565,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			Number:     item.Number,
 			User:       e.cfg.User,
 			AcquiredAt: workerStartedAt,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt},
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt, LastSignAt: workerStartedAt},
 		})
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -198,7 +198,7 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 		})
 		done := make(chan struct{})
 		defer close(done)
-		go e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		e.startHeartbeat(ctx, itemRepo, item.Number, done)
 		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
 		onPIDReady := func(pid int) {
 			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
 )
@@ -186,6 +187,23 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 			rebaseStage.CommentPrompt = ""
 		}
 
+		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
+		now := time.Now()
+		e.store.Apply(itemstate.LocalLockAcquired{
+			Repo:       itemRepo,
+			Number:     item.Number,
+			User:       e.cfg.User,
+			AcquiredAt: now,
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now},
+		})
+		done := make(chan struct{})
+		defer close(done)
+		go e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
+		onPIDReady := func(pid int) {
+			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
+		}
+
 		startTime := time.Now()
 		e.emitStructural(tui.JobStartedEvent{
 			IssueNumber: item.Number,
@@ -197,7 +215,7 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 		})
 
 		e.logf(item.Number, "rebase-reinvoke", "re-invoking stage %q via comment processing with rebase context\n", stage.Name)
-		err := e.processComments(ctx, board, item, &rebaseStage, []gh.Comment{syntheticComment})
+		err := e.processComments(ctx, board, item, &rebaseStage, []gh.Comment{syntheticComment}, onPIDReady)
 
 		var usage TokenUsage
 		var completed, blocked bool

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -194,7 +194,7 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 			Number:     item.Number,
 			User:       e.cfg.User,
 			AcquiredAt: now,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now},
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
 		})
 		done := make(chan struct{})
 		defer close(done)

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -450,14 +450,18 @@ func (e *Engine) Run() error {
 	}
 
 	// Run immediately on start, then on tick
-	if err := doPollCycle(); err != nil && ctx.Err() == nil {
-		e.logf(0, "warn", "poll error: %v\n", err)
+	firstPollErr := doPollCycle()
+	if firstPollErr != nil && ctx.Err() == nil {
+		e.logf(0, "warn", "poll error: %v\n", firstPollErr)
 	}
 
 	// One-time startup cleanup: remove stale fabrik:locked:<user> labels from items
 	// that have no active Worker in the store (restart case: prior crash left labels).
-	// Runs after the first poll cycle so the store is populated before the scan.
-	e.runStartupCleanup()
+	// Only runs after a successful first poll cycle so the store is populated.
+	// Skipped on poll failure to avoid scanning an empty/partial store.
+	if firstPollErr == nil {
+		e.runStartupCleanup()
+	}
 
 	// Start background stale-worker detector. Scans for workers whose heartbeat
 	// has gone stale and cleans up if the process is confirmed dead via signal 0.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -454,6 +454,15 @@ func (e *Engine) Run() error {
 		e.logf(0, "warn", "poll error: %v\n", err)
 	}
 
+	// One-time startup cleanup: remove stale fabrik:locked:<user> labels from items
+	// that have no active Worker in the store (restart case: prior crash left labels).
+	// Runs after the first poll cycle so the store is populated before the scan.
+	e.runStartupCleanup()
+
+	// Start background stale-worker detector. Scans for workers whose heartbeat
+	// has gone stale and cleans up if the process is confirmed dead via signal 0.
+	e.startWorkerDetector(ctx)
+
 	for {
 		if e.wakeCh != nil {
 			select {
@@ -883,17 +892,16 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		// have nothing to address; fall through to Phase 2.
 		if syntheticComments := e.buildReviewThreadComments(item); len(syntheticComments) > 0 {
 			iKey := issueKey(item, e.defaultRepo())
+			repoStr := itemOwnerRepoString(item, e.defaultRepo())
 			// Guard: if a goroutine from a previous poll cycle is still
 			// running dispatchReviewReinvoke for this item, skip the entire
 			// reinvoke path — including cycle-limit checks — to avoid
 			// pausing an item while valid work is still in progress. The
-			// goroutine clears inFlight when it exits; the next poll will
-			// re-evaluate.
-			if _, ok := e.inFlight.Load(iKey); ok {
+			// store Worker field is the semantic source of truth for in-flight state.
+			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
 				e.logf(item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
 				continue
 			}
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
 			var cycleCount int
 			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
 				cycleCount = snap.ReviewCycles(stage.Name)
@@ -917,11 +925,11 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		mergeBlocked, mergeConflict := e.checkMergeabilityGate(item, stage)
 		if mergeConflict {
 			iKey := issueKey(item, e.defaultRepo())
-			if _, ok := e.inFlight.Load(iKey); ok {
+			repoStr := itemOwnerRepoString(item, e.defaultRepo())
+			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
 				e.logf(item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
 				continue
 			}
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
 			var cycleCount int
 			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
 				cycleCount = snap.RebaseCycles(stage.Name)
@@ -950,11 +958,11 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		}
 		if ciFailure {
 			iKey := issueKey(item, e.defaultRepo())
-			if _, ok := e.inFlight.Load(iKey); ok {
+			repoStr := itemOwnerRepoString(item, e.defaultRepo())
+			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
 				e.logf(item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
 				continue
 			}
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
 			var cycleCount int
 			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
 				cycleCount = snap.CIFixCycles(stage.Name)
@@ -1157,16 +1165,12 @@ doneDispatching:
 		// If so, the engine is not truly idle — auto-upgrade must not run because
 		// checkAndUpgrade calls syscall.Exec which would kill in-flight workers.
 		var inFlightLabels []string
-		e.inFlight.Range(func(key, val any) bool {
-			if k, ok := key.(string); ok {
-				if isPR, _ := val.(bool); isPR {
-					inFlightLabels = append(inFlightLabels, "PR:"+k)
-				} else {
-					inFlightLabels = append(inFlightLabels, k)
-				}
+		for _, snap := range e.store.All() {
+			if snap.Worker() != nil {
+				k := snap.Repo() + "#" + fmt.Sprint(snap.Number())
+				inFlightLabels = append(inFlightLabels, k)
 			}
-			return true
-		})
+		}
 
 		if len(inFlightLabels) > 0 {
 			e.logf(0, "poll", "workers active\n")

--- a/engine/procattr_unix.go
+++ b/engine/procattr_unix.go
@@ -32,8 +32,11 @@ func killProcGroup(cmd *exec.Cmd) {
 
 // isProcessAlive returns true if the process with the given PID is alive.
 // Uses signal 0 (does not kill the process; only probes existence/permissions).
+// EPERM means the process exists but we lack permission — treat as alive.
+// ESRCH means no such process — treat as dead.
 func isProcessAlive(pid int) bool {
-	return syscall.Kill(pid, 0) == nil
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
 }
 
 // killProcGroupGraceful sends SIGTERM to the process group, waits 10 seconds for

--- a/engine/procattr_unix.go
+++ b/engine/procattr_unix.go
@@ -30,6 +30,12 @@ func killProcGroup(cmd *exec.Cmd) {
 	}
 }
 
+// isProcessAlive returns true if the process with the given PID is alive.
+// Uses signal 0 (does not kill the process; only probes existence/permissions).
+func isProcessAlive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
 // killProcGroupGraceful sends SIGTERM to the process group, waits 10 seconds for
 // a graceful shutdown, then sends SIGKILL. This reaps hung background children
 // (dangling pytest, tail -f, polling loops) in addition to the Claude CLI itself.

--- a/engine/procattr_windows.go
+++ b/engine/procattr_windows.go
@@ -13,3 +13,7 @@ func killProcGroup(cmd *exec.Cmd) {}
 
 // killProcGroupGraceful is a no-op on Windows.
 func killProcGroupGraceful(pid, issueNumber int, label string) {}
+
+// isProcessAlive returns true on Windows — process liveness via signal 0
+// is Unix-specific. The stale-lock detector is conservative on Windows.
+func isProcessAlive(pid int) bool { return true }

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
 )
@@ -435,6 +436,23 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 			return
 		}
 
+		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
+		now := time.Now()
+		e.store.Apply(itemstate.LocalLockAcquired{
+			Repo:       itemRepo,
+			Number:     item.Number,
+			User:       e.cfg.User,
+			AcquiredAt: now,
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now},
+		})
+		done := make(chan struct{})
+		defer close(done)
+		go e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
+		onPIDReady := func(pid int) {
+			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
+		}
+
 		startTime := time.Now()
 		e.emitStructural(tui.JobStartedEvent{
 			IssueNumber: item.Number,
@@ -447,7 +465,7 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 
 		e.logf(item.Number, "review-reinvoke", "re-invoking stage %q via comment processing with %d synthetic review comment(s)\n",
 			stage.Name, len(syntheticComments))
-		err := e.processComments(ctx, board, item, stage, syntheticComments)
+		err := e.processComments(ctx, board, item, stage, syntheticComments, onPIDReady)
 
 		var usage TokenUsage
 		var completed, blocked bool

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -443,7 +443,7 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 			Number:     item.Number,
 			User:       e.cfg.User,
 			AcquiredAt: now,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now},
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
 		})
 		done := make(chan struct{})
 		defer close(done)

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -447,7 +447,7 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 		})
 		done := make(chan struct{})
 		defer close(done)
-		go e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		e.startHeartbeat(ctx, itemRepo, item.Number, done)
 		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
 		onPIDReady := func(pid int) {
 			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -388,9 +388,18 @@ func TestCatchUpLoop_InFlightGuard(t *testing.T) {
 	eng := testEngineWithStages(client, stgs)
 	eng.cfg.MaxReviewCycles = 5
 
-	// Pre-store inFlight for this item to simulate a goroutine already running.
+	// Pre-populate the store Worker to simulate a goroutine already running.
+	// The review reinvoke catch-up loop uses store.Worker != nil as the semantic
+	// in-flight guard (not inFlight). Also set inFlight for the main dispatch guard.
 	iKey := "owner/repo#42"
 	eng.inFlight.Store(iKey, false)
+	eng.store.Apply(itemstate.LocalLockAcquired{
+		Repo:       "owner/repo",
+		Number:     42,
+		User:       "testuser",
+		Worker:     &itemstate.WorkerHandle{StageName: "Implement", StartedAt: time.Now()},
+		AcquiredAt: time.Now(),
+	})
 
 	ctx := context.Background()
 	if _, err := eng.poll(ctx); err != nil {

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -376,13 +376,12 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
 				}
 			}
-			// inFlight guard: if a rebase goroutine is already running, skip
-			// dispatch and cycle-limit check to avoid counter drift.
-			if _, ok := e.inFlight.Load(iKey); ok {
+			// Store Worker field is the semantic source of truth for in-flight state.
+			repoStr := itemOwnerRepoString(item, e.defaultRepo())
+			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
 				e.logf(item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
 				return fmt.Errorf("PR #%d not mergeable (rebase in-flight)", pr.Number)
 			}
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
 			var cycleCount int
 			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
 				cycleCount = snap.RebaseCycles(stage.Name)

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -218,7 +218,6 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 //   - All green → clear ciMergePendingSince; clear fabrik:awaiting-ci; proceed to merge
 func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) error {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-	iKey := issueKey(item, e.defaultRepo())
 
 	// Use FetchLinkedPR (REST) to get both the PR number and head SHA in one call.
 	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)

--- a/engine/worker_liveness.go
+++ b/engine/worker_liveness.go
@@ -1,0 +1,155 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/verveguy/fabrik/boardcache"
+	"github.com/verveguy/fabrik/internal/itemstate"
+)
+
+const (
+	heartbeatInterval      = 30 * time.Second
+	staleWorkerThreshold   = 2 * time.Minute
+	staleWorkerScanInterval = 30 * time.Second
+)
+
+// startHeartbeat runs a goroutine that sends WorkerHeartbeat mutations every
+// heartbeatInterval until done is closed or ctx is cancelled. The goroutine
+// exits cleanly when the dispatch goroutine's defer closes done.
+func (e *Engine) startHeartbeat(ctx context.Context, repo string, number int, done <-chan struct{}) {
+	go func() {
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				e.store.Apply(itemstate.WorkerHeartbeat{
+					Repo:   repo,
+					Number: number,
+					At:     time.Now(),
+				})
+			}
+		}
+	}()
+}
+
+// startWorkerDetector starts a background goroutine that scans for stale
+// workers (workers whose LastSignAt is older than staleWorkerThreshold).
+// For each stale worker, it verifies liveness via signal 0:
+//   - PID dead: removes lock and in-progress labels, clears Worker in store.
+//   - PID alive but heartbeat stale: logs a warning; does not remove labels.
+func (e *Engine) startWorkerDetector(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(staleWorkerScanInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				e.runWorkerDetectorScan()
+			}
+		}
+	}()
+}
+
+func (e *Engine) runWorkerDetectorScan() {
+	lockLabel := fmt.Sprintf("fabrik:locked:%s", e.cfg.User)
+	now := time.Now()
+	for _, snap := range e.store.All() {
+		w := snap.Worker()
+		if w == nil {
+			continue
+		}
+		if w.PID == 0 {
+			// PID not yet set — worker just started; skip this cycle.
+			continue
+		}
+		if now.Sub(w.LastSignAt) <= staleWorkerThreshold {
+			continue
+		}
+		// Stale heartbeat detected. Verify liveness via signal 0.
+		repo := snap.Repo()
+		number := snap.Number()
+		if isProcessAlive(w.PID) {
+			// Process is alive but heartbeat is stale. Log warning; do not kill.
+			e.logf(number, "worker-detector", "stale heartbeat for PID %d (stage %q) — process alive, waiting for natural exit\n", w.PID, w.StageName)
+		} else {
+			// Signal 0 failed — process is dead. Clean up.
+			e.logf(number, "worker-detector", "stale worker PID %d (stage %q) — process dead, cleaning up\n", w.PID, w.StageName)
+			e.cleanupStaleWorker(repo, number, lockLabel, w.StageName)
+		}
+	}
+}
+
+// cleanupStaleWorker removes the lock and in-progress labels for a dead worker
+// and clears the Worker entry in the store.
+func (e *Engine) cleanupStaleWorker(repo string, number int, lockLabel string, stageName string) {
+	e.store.Apply(itemstate.WorkerExited{Repo: repo, Number: number})
+
+	owner, repoName := parseOwnerRepo(repo)
+	e.removeLockLabel(owner, repoName, number, lockLabel)
+	e.removeInProgressLabel(owner, repoName, number, stageName)
+	e.logf(number, "worker-detector", "stale worker cleanup complete for stage %q\n", stageName)
+}
+
+// runStartupCleanup scans the store for items that have a fabrik:locked:<user>
+// label but no active Worker (Worker == nil). This catches the restart case where
+// a prior Fabrik instance crashed, leaving stale lock labels behind.
+//
+// Must be called after the store is populated by the first poll cycle.
+func (e *Engine) runStartupCleanup() {
+	lockLabel := fmt.Sprintf("fabrik:locked:%s", e.cfg.User)
+	var cleaned int
+	for _, snap := range e.store.All() {
+		if snap.Worker() != nil {
+			// Worker is active in this session — skip (grace period).
+			continue
+		}
+		hasLock := false
+		for _, l := range snap.Labels() {
+			if l == lockLabel {
+				hasLock = true
+				break
+			}
+		}
+		if !hasLock {
+			continue
+		}
+
+		repo := snap.Repo()
+		number := snap.Number()
+		owner, repoName := parseOwnerRepo(repo)
+
+		e.logf(number, "startup", "found stale lock label from prior crash — removing\n")
+		e.removeLockLabel(owner, repoName, number, lockLabel)
+
+		// Remove all stage:*:in_progress labels (StageName unavailable after restart).
+		for _, label := range snap.Labels() {
+			if strings.HasPrefix(label, "stage:") && strings.HasSuffix(label, ":in_progress") {
+				if err := e.client.RemoveLabelFromIssue(owner, repoName, number, label); err != nil {
+					e.logf(number, "warn", "could not remove stale in_progress label %q: %v\n", label, err)
+				} else {
+					e.logf(number, "startup", "removed stale label %q\n", label)
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repoName, number), label)
+					}
+				}
+			}
+		}
+
+		// No-op since Worker is already nil, but applied for idempotency.
+		e.store.Apply(itemstate.WorkerExited{Repo: repo, Number: number})
+		cleaned++
+	}
+	if cleaned > 0 {
+		e.logf(0, "startup", "startup cleanup: removed stale locks from %d issue(s)\n", cleaned)
+	}
+}

--- a/engine/worker_liveness.go
+++ b/engine/worker_liveness.go
@@ -20,8 +20,12 @@ const (
 // heartbeatInterval until done is closed or ctx is cancelled. The goroutine
 // exits cleanly when the dispatch goroutine's defer closes done.
 func (e *Engine) startHeartbeat(ctx context.Context, repo string, number int, done <-chan struct{}) {
+	interval := heartbeatInterval
+	if e.heartbeatIntervalOverride > 0 {
+		interval = e.heartbeatIntervalOverride
+	}
 	go func() {
-		ticker := time.NewTicker(heartbeatInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/engine/worker_liveness.go
+++ b/engine/worker_liveness.go
@@ -94,9 +94,12 @@ func (e *Engine) runWorkerDetectorScan() {
 }
 
 // cleanupStaleWorker removes the lock and in-progress labels for a dead worker
-// and clears the Worker entry in the store.
+// and clears the Worker and Lock entries in the store.
 func (e *Engine) cleanupStaleWorker(repo string, number int, lockLabel string, stageName string) {
 	e.store.Apply(itemstate.WorkerExited{Repo: repo, Number: number})
+	// Also release the lock state so cleanupLockedIssues() on graceful shutdown
+	// does not try to remove already-absent labels and log spurious warnings.
+	e.store.Apply(itemstate.LocalLockReleased{Repo: repo, Number: number})
 
 	owner, repoName := parseOwnerRepo(repo)
 	e.removeLockLabel(owner, repoName, number, lockLabel)

--- a/engine/worker_liveness_test.go
+++ b/engine/worker_liveness_test.go
@@ -172,45 +172,43 @@ func TestHeartbeatGoroutineCleanup(t *testing.T) {
 	e.heartbeatIntervalOverride = 5 * time.Millisecond
 
 	bootstrapItem(t, e, 3, nil)
-	setWorker(e, 3, os.Getpid(), "Plan", time.Now())
+	startedAt := time.Now()
+	setWorker(e, 3, os.Getpid(), "Plan", startedAt)
 
 	ctx := context.Background()
 	done := make(chan struct{})
 
-	// Start heartbeat and observe that after closing done, no more heartbeats fire.
+	// Start heartbeat and poll until at least one tick fires (up to 500ms).
 	e.startHeartbeat(ctx, "owner/repo", 3, done)
 
-	// Let at least one heartbeat fire.
-	time.Sleep(30 * time.Millisecond)
-
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		snap, _ := e.store.Get("owner/repo", 3)
+		if snap.Worker() != nil && snap.Worker().LastSignAt.After(startedAt) {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	snap, _ := e.store.Get("owner/repo", 3)
-	firstSignAt := snap.Worker().LastSignAt
+	if snap.Worker() == nil || !snap.Worker().LastSignAt.After(startedAt) {
+		t.Fatal("no heartbeat tick fired within 500ms")
+	}
 
 	// Close done to signal the goroutine to stop.
 	close(done)
 
-	// Give goroutine time to exit.
+	// Poll until the goroutine has exited: LastSignAt stops advancing.
+	// We check twice with a gap to confirm it truly stopped.
 	time.Sleep(20 * time.Millisecond)
-
-	// Record LastSignAt after stopping.
 	snap, _ = e.store.Get("owner/repo", 3)
 	stoppedAt := snap.Worker().LastSignAt
 
-	// Wait another tick interval to confirm no more heartbeats fire.
-	time.Sleep(30 * time.Millisecond)
-
+	// Wait two tick intervals and confirm no more heartbeats fired.
+	time.Sleep(20 * time.Millisecond)
 	snap, _ = e.store.Get("owner/repo", 3)
-	finalSignAt := snap.Worker().LastSignAt
-
-	// The heartbeat should have advanced at least once (first tick).
-	if !firstSignAt.IsZero() && firstSignAt.Equal(snap.Worker().StartedAt) {
-		t.Log("no heartbeat tick fired during the window (timing-sensitive, may be flaky)")
-	}
-
-	// After closing done, LastSignAt must not advance.
-	if !finalSignAt.Equal(stoppedAt) {
+	if snap.Worker().LastSignAt != stoppedAt {
 		t.Errorf("heartbeat goroutine still firing after done closed: stoppedAt=%v finalSignAt=%v",
-			stoppedAt, finalSignAt)
+			stoppedAt, snap.Worker().LastSignAt)
 	}
 }
 

--- a/engine/worker_liveness_test.go
+++ b/engine/worker_liveness_test.go
@@ -1,0 +1,484 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/verveguy/fabrik/github"
+	"github.com/verveguy/fabrik/internal/itemstate"
+)
+
+// bootstrapItem seeds the engine's store with a single issue so detector/cleanup
+// functions have something to scan.
+func bootstrapItem(t *testing.T, e *Engine, number int, labels []string) {
+	t.Helper()
+	e.store.Apply(itemstate.ItemDeepFetched{
+		Repo: "owner/repo",
+		Number: number,
+		FreshState: gh.ProjectItem{
+			ID:     "I_001",
+			ItemID: "PVTI_001",
+			Number: number,
+			Title:  "Test Issue",
+			Repo:   "owner/repo",
+			Status: "Implement",
+			Labels: labels,
+		},
+	})
+}
+
+// setWorker applies a LocalLockAcquired mutation to set the Worker field.
+func setWorker(e *Engine, number int, pid int, stageName string, lastSign time.Time) {
+	now := time.Now()
+	e.store.Apply(itemstate.LocalLockAcquired{
+		Repo:       "owner/repo",
+		Number:     number,
+		User:       e.cfg.User,
+		AcquiredAt: now,
+		Worker: &itemstate.WorkerHandle{
+			PID:        pid,
+			StageName:  stageName,
+			StartedAt:  now,
+			LastSignAt: lastSign,
+		},
+	})
+}
+
+// getWorker retrieves the Worker snapshot from the store.
+func getWorker(t *testing.T, e *Engine, number int) *itemstate.WorkerHandle {
+	t.Helper()
+	snap, err := e.store.Get("owner/repo", number)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	return snap.Worker()
+}
+
+// removeLabelsCalled returns all label names removed from the given issue.
+func removeLabelsCalled(client *mockGitHubClient, issueNumber int) []string {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	var labels []string
+	for _, c := range client.removeLabelCalls {
+		if c.issueNumber == issueNumber {
+			labels = append(labels, c.labelName)
+		}
+	}
+	return labels
+}
+
+// hasLabel checks if a label name appears in the removed calls.
+func hasRemovedLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCrashRecoveryRegression501 is the regression test for the operational bug
+// observed on issue #501 (2026-05-04). A worker goroutine is set up with a dead
+// PID and a stale heartbeat timestamp. The detector must identify it as dead,
+// remove the lock and in-progress labels from GitHub, and clear Worker in the store.
+func TestCrashRecoveryRegression501(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("crash recovery requires signal-0 support; not available on Windows")
+	}
+
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	// Start a real subprocess and kill it so we have a confirmed-dead PID.
+	cmd := exec.Command("sleep", "1000")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("could not start subprocess: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("could not kill subprocess: %v", err)
+	}
+	// Wait reaps the process so the PID is not a zombie and signal-0 returns ESRCH.
+	_ = cmd.Wait()
+
+	bootstrapItem(t, e, 1, []string{"fabrik:locked:testuser", "stage:Implement:in_progress"})
+	// Set Worker with the dead PID and a stale LastSignAt (>2 min ago).
+	staleTime := time.Now().Add(-5 * time.Minute)
+	setWorker(e, 1, pid, "Implement", staleTime)
+
+	// Verify setup: Worker is non-nil before scan.
+	if getWorker(t, e, 1) == nil {
+		t.Fatal("expected Worker to be non-nil before scan")
+	}
+
+	e.runWorkerDetectorScan()
+
+	// Worker must be nil after cleanup.
+	if w := getWorker(t, e, 1); w != nil {
+		t.Errorf("expected Worker == nil after detector cleanup, got PID=%d", w.PID)
+	}
+
+	// Both labels must have been removed.
+	removed := removeLabelsCalled(client, 1)
+	if !hasRemovedLabel(removed, "fabrik:locked:testuser") {
+		t.Errorf("expected lock label to be removed; got: %v", removed)
+	}
+	if !hasRemovedLabel(removed, "stage:Implement:in_progress") {
+		t.Errorf("expected in_progress label to be removed; got: %v", removed)
+	}
+}
+
+// TestWorkerHeartbeatUpdatesLastSignAt verifies that WorkerHeartbeat mutations
+// advance the LastSignAt timestamp in the store.
+func TestWorkerHeartbeatUpdatesLastSignAt(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 2, nil)
+	t0 := time.Now().Add(-1 * time.Minute)
+	setWorker(e, 2, 999, "Research", t0)
+
+	t1 := time.Now()
+	e.store.Apply(itemstate.WorkerHeartbeat{Repo: "owner/repo", Number: 2, At: t1})
+
+	w := getWorker(t, e, 2)
+	if w == nil {
+		t.Fatal("expected Worker non-nil")
+	}
+	if !w.LastSignAt.Equal(t1) {
+		t.Errorf("LastSignAt = %v, want %v", w.LastSignAt, t1)
+	}
+
+	// Second heartbeat advances timestamp further.
+	t2 := t1.Add(30 * time.Second)
+	e.store.Apply(itemstate.WorkerHeartbeat{Repo: "owner/repo", Number: 2, At: t2})
+
+	w = getWorker(t, e, 2)
+	if !w.LastSignAt.Equal(t2) {
+		t.Errorf("LastSignAt = %v after second heartbeat, want %v", w.LastSignAt, t2)
+	}
+}
+
+// TestHeartbeatGoroutineCleanup verifies that the heartbeat goroutine exits
+// cleanly when the done channel is closed, producing no goroutine leak.
+func TestHeartbeatGoroutineCleanup(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+	e.heartbeatIntervalOverride = 5 * time.Millisecond
+
+	bootstrapItem(t, e, 3, nil)
+	setWorker(e, 3, os.Getpid(), "Plan", time.Now())
+
+	ctx := context.Background()
+	done := make(chan struct{})
+
+	// Start heartbeat and observe that after closing done, no more heartbeats fire.
+	e.startHeartbeat(ctx, "owner/repo", 3, done)
+
+	// Let at least one heartbeat fire.
+	time.Sleep(30 * time.Millisecond)
+
+	snap, _ := e.store.Get("owner/repo", 3)
+	firstSignAt := snap.Worker().LastSignAt
+
+	// Close done to signal the goroutine to stop.
+	close(done)
+
+	// Give goroutine time to exit.
+	time.Sleep(20 * time.Millisecond)
+
+	// Record LastSignAt after stopping.
+	snap, _ = e.store.Get("owner/repo", 3)
+	stoppedAt := snap.Worker().LastSignAt
+
+	// Wait another tick interval to confirm no more heartbeats fire.
+	time.Sleep(30 * time.Millisecond)
+
+	snap, _ = e.store.Get("owner/repo", 3)
+	finalSignAt := snap.Worker().LastSignAt
+
+	// The heartbeat should have advanced at least once (first tick).
+	if !firstSignAt.IsZero() && firstSignAt.Equal(snap.Worker().StartedAt) {
+		t.Log("no heartbeat tick fired during the window (timing-sensitive, may be flaky)")
+	}
+
+	// After closing done, LastSignAt must not advance.
+	if !finalSignAt.Equal(stoppedAt) {
+		t.Errorf("heartbeat goroutine still firing after done closed: stoppedAt=%v finalSignAt=%v",
+			stoppedAt, finalSignAt)
+	}
+}
+
+// TestDetectorFalsePositivePrevention verifies that the detector does NOT remove
+// labels or clear Worker when the process is alive but the heartbeat is stale.
+func TestDetectorFalsePositivePrevention(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("signal-0 not applicable on Windows (always returns alive)")
+	}
+
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 4, []string{"fabrik:locked:testuser", "stage:Research:in_progress"})
+	// Use current process PID — always alive.
+	staleTime := time.Now().Add(-10 * time.Minute)
+	setWorker(e, 4, os.Getpid(), "Research", staleTime)
+
+	e.runWorkerDetectorScan()
+
+	// Worker must remain non-nil (process is alive).
+	if w := getWorker(t, e, 4); w == nil {
+		t.Error("detector incorrectly cleared Worker for alive process with stale heartbeat")
+	}
+
+	// No labels should have been removed.
+	removed := removeLabelsCalled(client, 4)
+	if len(removed) > 0 {
+		t.Errorf("detector incorrectly removed labels for alive process: %v", removed)
+	}
+}
+
+// TestDetectorRace_WorkerExitIdempotent verifies that WorkerExited is idempotent:
+// applying it twice leaves Worker nil without panicking or corrupting state.
+func TestDetectorRace_WorkerExitIdempotent(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 5, nil)
+	setWorker(e, 5, 12345, "Implement", time.Now())
+
+	// Apply WorkerExited twice — must be idempotent.
+	e.store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 5})
+	e.store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 5})
+
+	if w := getWorker(t, e, 5); w != nil {
+		t.Errorf("expected Worker == nil after double WorkerExited, got %+v", w)
+	}
+}
+
+// TestConcurrentWorkerSpawnExit spawns multiple goroutines that simultaneously
+// apply Worker mutations for different issues. The race detector must see no races.
+func TestConcurrentWorkerSpawnExit(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	const n = 20
+	for i := 1; i <= n; i++ {
+		bootstrapItem(t, e, i, nil)
+	}
+
+	var wg sync.WaitGroup
+	for i := 1; i <= n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			now := time.Now()
+			e.store.Apply(itemstate.LocalLockAcquired{
+				Repo:       "owner/repo",
+				Number:     i,
+				User:       "testuser",
+				AcquiredAt: now,
+				Worker: &itemstate.WorkerHandle{
+					PID:        i * 1000,
+					StageName:  "Implement",
+					StartedAt:  now,
+					LastSignAt: now,
+				},
+			})
+			e.store.Apply(itemstate.WorkerHeartbeat{
+				Repo:   "owner/repo",
+				Number: i,
+				At:     time.Now(),
+			})
+			e.store.Apply(itemstate.WorkerExited{
+				Repo:   "owner/repo",
+				Number: i,
+			})
+		}()
+	}
+	wg.Wait()
+
+	// All workers should be nil after exit.
+	for i := 1; i <= n; i++ {
+		if w := getWorker(t, e, i); w != nil {
+			t.Errorf("issue #%d: expected Worker == nil after WorkerExited, got %+v", i, w)
+		}
+	}
+}
+
+// TestStartupCleanupRemovesStaleLabels verifies that runStartupCleanup removes
+// fabrik:locked:<user> and stage:*:in_progress labels from items whose Worker is
+// nil in the store (the restart-after-crash case).
+func TestStartupCleanupRemovesStaleLabels(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	// Bootstrap item with stale lock label and in_progress label; no Worker applied.
+	bootstrapItem(t, e, 6, []string{
+		"fabrik:locked:testuser",
+		"stage:Implement:in_progress",
+	})
+
+	// Confirm Worker is nil (no LocalLockAcquired applied).
+	if w := getWorker(t, e, 6); w != nil {
+		t.Fatalf("expected Worker == nil before cleanup, got %+v", w)
+	}
+
+	e.runStartupCleanup()
+
+	// Both labels must have been removed.
+	removed := removeLabelsCalled(client, 6)
+	if !hasRemovedLabel(removed, "fabrik:locked:testuser") {
+		t.Errorf("expected lock label to be removed; got: %v", removed)
+	}
+	if !hasRemovedLabel(removed, "stage:Implement:in_progress") {
+		t.Errorf("expected in_progress label to be removed; got: %v", removed)
+	}
+}
+
+// TestStartupCleanupSkipsActiveWorkers verifies the startup grace period:
+// an item with a non-nil Worker (active in the current session) must NOT be
+// cleaned up by runStartupCleanup.
+func TestStartupCleanupSkipsActiveWorkers(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 7, []string{
+		"fabrik:locked:testuser",
+		"stage:Implement:in_progress",
+	})
+	// Simulate a lock acquired in the current session (Worker non-nil).
+	setWorker(e, 7, os.Getpid(), "Implement", time.Now())
+
+	e.runStartupCleanup()
+
+	// No labels should have been removed.
+	removed := removeLabelsCalled(client, 7)
+	if len(removed) > 0 {
+		t.Errorf("startup cleanup incorrectly removed labels for active worker: %v", removed)
+	}
+
+	// Worker must remain non-nil.
+	if w := getWorker(t, e, 7); w == nil {
+		t.Error("startup cleanup incorrectly cleared active Worker")
+	}
+}
+
+// TestWorkerHeartbeatNoOpWhenWorkerNil verifies that WorkerHeartbeat is a no-op
+// when Worker is nil — it must not create a new WorkerHandle.
+func TestWorkerHeartbeatNoOpWhenWorkerNil(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 8, nil)
+	// No Worker applied — store has Worker == nil.
+
+	e.store.Apply(itemstate.WorkerHeartbeat{
+		Repo:   "owner/repo",
+		Number: 8,
+		At:     time.Now(),
+	})
+
+	if w := getWorker(t, e, 8); w != nil {
+		t.Errorf("WorkerHeartbeat created WorkerHandle when Worker was nil; got %+v", w)
+	}
+}
+
+// TestWorkerPIDSetNoOpWhenWorkerNil verifies that WorkerPIDSet is a no-op
+// when Worker is nil — it must not create a new WorkerHandle.
+func TestWorkerPIDSetNoOpWhenWorkerNil(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 9, nil)
+
+	e.store.Apply(itemstate.WorkerPIDSet{
+		Repo:   "owner/repo",
+		Number: 9,
+		PID:    12345,
+	})
+
+	if w := getWorker(t, e, 9); w != nil {
+		t.Errorf("WorkerPIDSet created WorkerHandle when Worker was nil; got %+v", w)
+	}
+}
+
+// TestDetectorSkipsPIDZeroWorker verifies that the detector skips workers whose
+// PID is 0 (not yet set by OnPIDReady), even if the heartbeat is stale.
+func TestDetectorSkipsPIDZeroWorker(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 10, []string{"fabrik:locked:testuser"})
+	staleTime := time.Now().Add(-10 * time.Minute)
+	// PID=0 means OnPIDReady not yet called.
+	setWorker(e, 10, 0 /* PID zero */, "Implement", staleTime)
+
+	e.runWorkerDetectorScan()
+
+	// Worker must remain non-nil — PID=0 means skip.
+	if w := getWorker(t, e, 10); w == nil {
+		t.Error("detector incorrectly cleared Worker with PID=0 (should skip)")
+	}
+	removed := removeLabelsCalled(client, 10)
+	if len(removed) > 0 {
+		t.Errorf("detector removed labels for PID=0 worker: %v", removed)
+	}
+}
+
+// TestWorkerStoreReflectsDispatchPaths verifies that store.Get(...).Worker() != nil
+// correctly reflects worker state: non-nil after LocalLockAcquired, nil after
+// WorkerExited. This is the inFlight replacement semantic test (test #10 from spec).
+func TestWorkerStoreReflectsDispatchPaths(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 11, nil)
+
+	// Initially nil.
+	if w := getWorker(t, e, 11); w != nil {
+		t.Fatalf("expected Worker == nil initially, got %+v", w)
+	}
+
+	// After LocalLockAcquired with Worker: non-nil.
+	now := time.Now()
+	e.store.Apply(itemstate.LocalLockAcquired{
+		Repo:       "owner/repo",
+		Number:     11,
+		User:       "testuser",
+		AcquiredAt: now,
+		Worker:     &itemstate.WorkerHandle{StageName: "Implement", StartedAt: now, LastSignAt: now},
+	})
+	snap, err := e.store.Get("owner/repo", 11)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if snap.Worker() == nil {
+		t.Error("expected Worker != nil after LocalLockAcquired with Worker field")
+	}
+
+	// After WorkerExited: nil.
+	e.store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 11})
+	snap, _ = e.store.Get("owner/repo", 11)
+	if snap.Worker() != nil {
+		t.Errorf("expected Worker == nil after WorkerExited, got %+v", snap.Worker())
+	}
+
+	// LocalLockAcquired without Worker field: Worker stays nil.
+	e.store.Apply(itemstate.LocalLockAcquired{
+		Repo:       "owner/repo",
+		Number:     11,
+		User:       "testuser",
+		AcquiredAt: now,
+	})
+	snap, _ = e.store.Get("owner/repo", 11)
+	if snap.Worker() != nil {
+		t.Errorf("expected Worker == nil when LocalLockAcquired.Worker is nil, got %+v", snap.Worker())
+	}
+}

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -402,6 +402,17 @@ type WorkerHeartbeat struct {
 func (WorkerHeartbeat) isMutation() {}
 func (m WorkerHeartbeat) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// WorkerPIDSet records the Claude subprocess PID once cmd.Start() returns.
+// No-op if Worker is nil (e.g., WorkerExited arrived first).
+type WorkerPIDSet struct {
+	Repo   string
+	Number int
+	PID    int
+}
+
+func (WorkerPIDSet) isMutation() {}
+func (m WorkerPIDSet) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // WorkerExited clears the Worker handle when a Claude invocation finishes.
 type WorkerExited struct {
 	Repo   string

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -487,10 +487,15 @@ func TestChangeFlagsCoverage(t *testing.T) {
 		{StageStateChanged, "StageStateChanged", func(s *Store, n int) Mutation {
 			return StageAttempted{Repo: testRepo, Number: n, StageName: "S", At: time.Now()}
 		}},
-		{WorkerChanged, "WorkerChanged", func(s *Store, n int) Mutation {
+		{WorkerChanged, "WorkerChanged/Heartbeat", func(s *Store, n int) Mutation {
 			now := time.Now()
 			s.Apply(LocalLockAcquired{Repo: testRepo, Number: n, User: "u", AcquiredAt: now, Worker: &WorkerHandle{StageName: "X", StartedAt: now}})
 			return WorkerHeartbeat{Repo: testRepo, Number: n, At: now}
+		}},
+		{WorkerChanged, "WorkerChanged/PIDSet", func(s *Store, n int) Mutation {
+			now := time.Now()
+			s.Apply(LocalLockAcquired{Repo: testRepo, Number: n, User: "u", AcquiredAt: now, Worker: &WorkerHandle{StageName: "X", StartedAt: now}})
+			return WorkerPIDSet{Repo: testRepo, Number: n, PID: 12345}
 		}},
 		{CooldownChanged, "CooldownChanged", func(s *Store, n int) Mutation {
 			return CooldownRecorded{Repo: testRepo, Number: n, Reason: "r", Until: time.Now().Add(time.Minute)}

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -337,6 +337,8 @@ func TestApplyCooldownRecorded(t *testing.T) {
 
 func TestApplyWorkerHeartbeat(t *testing.T) {
 	s := newStoreWithItem(t, testRepo, 1)
+	now := time.Now()
+	s.Apply(LocalLockAcquired{Repo: testRepo, Number: 1, User: "u", AcquiredAt: now, Worker: &WorkerHandle{StageName: "X", StartedAt: now}})
 	at := time.Now()
 	applyExpect(t, s, WorkerHeartbeat{Repo: testRepo, Number: 1, At: at}, WorkerChanged)
 	st := getItem(t, s, testRepo, 1)
@@ -347,7 +349,8 @@ func TestApplyWorkerHeartbeat(t *testing.T) {
 
 func TestApplyWorkerExited(t *testing.T) {
 	s := newStoreWithItem(t, testRepo, 1)
-	s.Apply(WorkerHeartbeat{Repo: testRepo, Number: 1, At: time.Now()})
+	now := time.Now()
+	s.Apply(LocalLockAcquired{Repo: testRepo, Number: 1, User: "u", AcquiredAt: now, Worker: &WorkerHandle{StageName: "X", StartedAt: now}})
 	applyExpect(t, s, WorkerExited{Repo: testRepo, Number: 1}, WorkerChanged)
 	if getItem(t, s, testRepo, 1).Worker != nil {
 		t.Error("Worker not cleared")
@@ -485,7 +488,9 @@ func TestChangeFlagsCoverage(t *testing.T) {
 			return StageAttempted{Repo: testRepo, Number: n, StageName: "S", At: time.Now()}
 		}},
 		{WorkerChanged, "WorkerChanged", func(s *Store, n int) Mutation {
-			return WorkerHeartbeat{Repo: testRepo, Number: n, At: time.Now()}
+			now := time.Now()
+			s.Apply(LocalLockAcquired{Repo: testRepo, Number: n, User: "u", AcquiredAt: now, Worker: &WorkerHandle{StageName: "X", StartedAt: now}})
+			return WorkerHeartbeat{Repo: testRepo, Number: n, At: now}
 		}},
 		{CooldownChanged, "CooldownChanged", func(s *Store, n int) Mutation {
 			return CooldownRecorded{Repo: testRepo, Number: n, Reason: "r", Until: time.Now().Add(time.Minute)}

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -418,9 +418,16 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 
 	case WorkerHeartbeat:
 		if item.Worker == nil {
-			item.Worker = &WorkerHandle{}
+			return 0 // no-op: heartbeat for a worker that has already exited
 		}
 		item.Worker.LastSignAt = v.At
+		return WorkerChanged
+
+	case WorkerPIDSet:
+		if item.Worker == nil {
+			return 0 // no-op: worker already exited
+		}
+		item.Worker.PID = v.PID
 		return WorkerChanged
 
 	case WorkerExited:


### PR DESCRIPTION
## Summary

Implements Phase 3-G of the cache-refactor series: heartbeat-based liveness detection for workers, crash recovery via stale-lock cleanup, and replacement of semantic `inFlight` reads with the store's `Worker` field.

- **`WorkerHandle` plumbing**: All four Claude-spawning dispatch paths (`processItem`, `dispatchReviewReinvoke`, `dispatchCIFixReinvoke`, `dispatchRebaseReinvoke`) now register a `WorkerHandle` via `LocalLockAcquired{Worker: ...}` when a goroutine starts, and apply `WorkerExited` on exit.
- **Heartbeat goroutine**: Each dispatch goroutine starts a heartbeat goroutine that applies `WorkerHeartbeat` every 30s; the goroutine exits cleanly when the dispatch goroutine exits via a `done` channel.
- **PID plumbing**: `InvokeOptions.OnPIDReady` callback wires the Claude subprocess PID back into the store via a new `WorkerPIDSet` mutation, enabling signal-0 liveness checks.
- **Stale-worker detector**: A background goroutine (`startWorkerDetector`) scans every 30s for workers with stale heartbeats (>2 min). Dead processes trigger label removal and `WorkerExited`; alive-but-stale processes log a warning.
- **Startup cleanup**: `runStartupCleanup()` runs after the first poll cycle, removing `fabrik:locked:<self>` and `stage:*:in_progress` labels for items with no active Worker (restart-case crash recovery).
- **Semantic `inFlight` replacement**: All catch-up loop and rebase guards use `store.Get().Worker() != nil` instead of `inFlight.Load`; `inFlight` is retained only for main-dispatch deduplication.
- **Docs**: `docs/state-machine.md` §9.7 added covering WorkerHandle, heartbeat protocol, stale-worker detection, and updated `fabrik:locked:<user>` lifecycle.

## Key changes

| File | Change |
|------|--------|
| `internal/itemstate/store.go` | Fix `WorkerHeartbeat` no-op; add `WorkerPIDSet` handler |
| `internal/itemstate/mutation.go` | Add `WorkerPIDSet` mutation |
| `engine/interfaces.go` | Add `OnPIDReady func(pid int)` to `InvokeOptions` |
| `engine/claude.go` | Call `OnPIDReady` after `cmd.Start()` |
| `engine/item.go` | Heartbeat + `WorkerExited` defer + `OnPIDReady` wiring |
| `engine/reviews.go`, `ci.go`, `merge_gate.go` | Same heartbeat wiring for reinvoke dispatch paths |
| `engine/poll.go` | Replace semantic `inFlight.Load` reads; add detector + startup cleanup |
| `engine/stages.go` | Replace `inFlight.Load` at rebase guard |
| `engine/worker_liveness.go` | New: heartbeat, detector, startup cleanup |
| `engine/worker_liveness_test.go` | New: 10 tests covering all acceptance criteria |
| `docs/state-machine.md` | §9.7 Worker liveness section |

## How to test

1. `go test -race ./...` — all tests pass except `TestExecute_ConfigYAMLApplied` in `cmd/`, which is a pre-existing flaky test also failing on `main` (network timing issue unrelated to this PR).
2. `go vet ./...` — clean.
3. The crash recovery scenario (issue #501): kill a running Fabrik process with SIGKILL; on next startup, `runStartupCleanup()` removes the stale `fabrik:locked:<user>` label. At runtime, the stale-worker detector will clean up within 2 minutes via signal-0 verification.

Closes #519

🤖 Generated with [Claude Code](https://claude.ai/claude-code)