### PR TITLE
Layer 1 status refresh silently bails for new issues — itemID lookup misses when cache only has issues.opened delta

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -698,13 +698,17 @@ func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
 		c.logFn("[cache] UpdateItemStatus: key %q not found — no-op\n", key)
 		return
 	}
+	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
+	if _, err := c.store.Get(repo, number); err != nil {
+		return
+	}
 	_, changes, _ := c.store.Apply(itemstate.LocalStatusUpdated{
 		Repo:      repo,
 		Number:    number,
 		NewStatus: newStatus,
 	})
 	if len(changes) == 0 {
-		// Item not found in Store or status unchanged.
+		// Status unchanged.
 		return
 	}
 	now := time.Now()

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -820,6 +820,36 @@ func (c *CacheImpl) ApplyStatusBatch(updates map[string]string) {
 	}
 }
 
+// RegisterItemID sets the project-item node ID for an existing cache entry that
+// was added without one (e.g., via issues.opened before projects_v2_item.created).
+// No-op when key is not in the Store or itemID is empty. Safe for concurrent use.
+func (c *CacheImpl) RegisterItemID(key, itemID string) {
+	if itemID == "" {
+		return
+	}
+	repo, number, ok := parseItemKey(key)
+	if !ok {
+		c.logFn("[cache] RegisterItemID: key %q invalid — no-op\n", key)
+		return
+	}
+	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
+	if _, err := c.store.Get(repo, number); err != nil {
+		return
+	}
+	_, changes, _ := c.store.Apply(itemstate.ItemIDRegistered{
+		Repo:   repo,
+		Number: number,
+		ItemID: itemID,
+	})
+	if len(changes) == 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
+}
+
 // GetItemID returns the project-item node ID (PVTI_...) for the given cache key.
 // Returns ("", false) when the key is not present or has no ItemID.
 func (c *CacheImpl) GetItemID(key string) (string, bool) {

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1702,6 +1702,106 @@ func TestConcurrentWriteThrough(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// RegisterItemID
+// ---------------------------------------------------------------------------
+
+func TestRegisterItemID(t *testing.T) {
+	t.Run("populates itemID and GetItemID returns it", func(t *testing.T) {
+		// Bootstrap an item without an itemID (simulates issues.opened path).
+		c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+		board := &gh.ProjectBoard{
+			ProjectID: "PID", OwnerType: "organization",
+			Items: []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}},
+		}
+		c.Bootstrap(board)
+
+		key := ItemKey("owner/repo", 1)
+		// Item exists but has no itemID.
+		if id, ok := c.GetItemID(key); ok || id != "" {
+			t.Fatalf("expected no itemID before RegisterItemID, got %q ok=%v", id, ok)
+		}
+
+		c.RegisterItemID(key, "PVTI_new")
+
+		id, ok := c.GetItemID(key)
+		if !ok {
+			t.Fatal("GetItemID returned !ok after RegisterItemID")
+		}
+		if id != "PVTI_new" {
+			t.Errorf("GetItemID = %q, want %q", id, "PVTI_new")
+		}
+	})
+
+	t.Run("other fields remain intact after RegisterItemID", func(t *testing.T) {
+		c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+		board := &gh.ProjectBoard{
+			ProjectID: "PID", OwnerType: "organization",
+			Items: []gh.ProjectItem{
+				{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", Labels: []string{"bug"}},
+			},
+		}
+		c.Bootstrap(board)
+
+		key := ItemKey("owner/repo", 1)
+		c.RegisterItemID(key, "PVTI_xyz")
+
+		s := testGetState(t, c, "owner/repo", 1)
+		if s.ItemID != "PVTI_xyz" {
+			t.Errorf("ItemID = %q, want %q", s.ItemID, "PVTI_xyz")
+		}
+		if s.Status != "Research" {
+			t.Errorf("Status = %q, want %q", s.Status, "Research")
+		}
+		if len(s.Labels) != 1 || s.Labels[0] != "bug" {
+			t.Errorf("Labels = %v, want [bug]", s.Labels)
+		}
+	})
+
+	t.Run("no-op when key not in Store", func(t *testing.T) {
+		c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+		// Empty cache — no Bootstrap.
+		key := ItemKey("owner/repo", 99)
+		c.RegisterItemID(key, "PVTI_phantom") // must not create phantom entry
+		if _, ok := c.GetItemID(key); ok {
+			t.Error("RegisterItemID created a phantom Store entry for an unknown key")
+		}
+	})
+
+	t.Run("idempotent when called twice with same value", func(t *testing.T) {
+		c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+		board := &gh.ProjectBoard{
+			ProjectID: "PID", OwnerType: "organization",
+			Items: []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}},
+		}
+		c.Bootstrap(board)
+		key := ItemKey("owner/repo", 1)
+
+		c.RegisterItemID(key, "PVTI_same")
+		c.RegisterItemID(key, "PVTI_same") // second call — same value
+
+		id, ok := c.GetItemID(key)
+		if !ok || id != "PVTI_same" {
+			t.Errorf("after double call, GetItemID = %q ok=%v, want PVTI_same true", id, ok)
+		}
+	})
+
+	t.Run("no-op when itemID is empty", func(t *testing.T) {
+		c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+		board := &gh.ProjectBoard{
+			ProjectID: "PID", OwnerType: "organization",
+			Items: []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"}},
+		}
+		c.Bootstrap(board)
+		key := ItemKey("owner/repo", 1)
+
+		c.RegisterItemID(key, "") // empty — must be ignored
+		if id, ok := c.GetItemID(key); ok || id != "" {
+			t.Errorf("RegisterItemID(\"\") should be no-op, got %q ok=%v", id, ok)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Additional payload builders for Phase 3-D delta coverage tests
 // ---------------------------------------------------------------------------
 

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -127,6 +127,9 @@ func (m *testGitHubUpgradeClient) FetchPRsForSHA(owner, repo, sha string) ([]int
 func (m *testGitHubUpgradeClient) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
 	return nil, nil
 }
+func (m *testGitHubUpgradeClient) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {
+	return "", "", nil
+}
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1657,7 +1657,7 @@ In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub d
 | Layer | Mechanism | Latency | Cost |
 |-------|-----------|---------|------|
 | **0** Write-through | After any successful mutation call in the engine (status, labels, comments), the corresponding `CacheImpl` method is called immediately | Zero | Zero |
-| **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event on a known item, `FetchProjectItemStatus` fetches the current Status | Seconds (best-effort) | ~1–5 pts/event |
+| **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event, fetches the current Status: fast path (`FetchProjectItemStatus`) when the item's `itemID` is cached; fallback (`LookupIssueProjectItem`) when it isn't yet (e.g., brand-new issues arriving via `issues.opened` before `projects_v2_item.created`) | Seconds (best-effort) | ~1–5 pts/event |
 | **2** Periodic status sweep | `runReconciliationLoop` calls `FetchProjectItemStatusBatch` at `ProjectStatusPollSeconds` cadence (default 10 min) | Up to 10 min | O(⌈N/100⌉) per sweep |
 | **Bootstrap / stream-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and on webhook stream recovery | Minutes | Full board cost |
 
@@ -1697,3 +1697,5 @@ This is a no-op when `e.readClient` is a `GitHubAdapter` (cache-disabled mode), 
 **`CacheImpl` existence guard**: All three new write-through methods (`ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded`) call `c.store.Get(repo, number)` before applying the mutation. If the key is not present in the Store (i.e., was never bootstrapped), the method returns without creating a phantom Store entry.
 
 **Layer 1 scope**: Only `issues` and `issue_comment` event types trigger a per-event status fetch. `pull_request`, `pull_request_review`, `check_run`, and other event types are excluded from Layer 1 (finding the linked issue for a PR event requires an O(N) cache scan; `check_run` does not carry an item ID). Layer 2's periodic sweep covers these cases within its cadence.
+
+For new issues whose `itemID` is not yet in the cache (e.g., added via `issues.opened` before a `projects_v2_item.created` event is received), Layer 1 falls back to `LookupIssueProjectItem` to populate both `itemID` and current Status in one GraphQL query (`repository.issue.projectItems`). If `cache.ProjectID()` is empty (Bootstrap not yet complete), the fallback is skipped. After a successful fallback, subsequent Layer 1 calls for the same issue use the cheaper `FetchProjectItemStatus` fast path.

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -46,6 +46,7 @@ type GitHubClient interface {
 	RateLimitStats() (rest, graphql gh.RateLimitStats)
 	FetchProjectItemStatus(itemID string) (string, error)
 	FetchProjectItemStatusBatch(projectID string) (map[string]string, error)
+	LookupIssueProjectItem(projectID, repo string, issueNumber int) (itemID string, status string, err error)
 }
 
 // InvokeOptions bundles per-issue override parameters for Claude invocations.

--- a/engine/layer1_test.go
+++ b/engine/layer1_test.go
@@ -1,0 +1,210 @@
+package engine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/verveguy/fabrik/boardcache"
+	gh "github.com/verveguy/fabrik/github"
+)
+
+// issueEventPayload builds a minimal issues / issue_comment webhook payload
+// for use in Layer 1 status-refresh tests.
+func issueEventPayload(repo string, issueNum int) []byte {
+	b, _ := json.Marshal(map[string]interface{}{
+		"issue":      map[string]interface{}{"number": issueNum},
+		"repository": map[string]interface{}{"full_name": repo},
+	})
+	return b
+}
+
+// layer1Cache creates a CacheImpl backed by the engine's shared Store.
+// If projectID is non-empty, the cache is bootstrapped with a single item that
+// has no itemID (simulating the issues.opened-without-project-info path).
+func layer1Cache(eng *Engine, client *mockGitHubClient, projectID string, withItem bool) *boardcache.CacheImpl {
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	if !withItem {
+		// Bootstrap with projectID only — no items.
+		cache.Bootstrap(&gh.ProjectBoard{
+			ProjectID: projectID, OwnerType: "organization",
+		})
+		return cache
+	}
+	// Bootstrap with one item that has no itemID — simulates issues.opened path
+	// where the payload carries no project board info.
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: projectID, OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "", Number: 1, Repo: "owner/repo", Status: ""},
+		},
+	})
+	return cache
+}
+
+// TestLayer1StatusRefreshRegression is the mandatory regression test.
+// On current main this test FAILS because the silent bail at GetItemID !ok
+// prevents LookupIssueProjectItem from ever being called.
+func TestLayer1StatusRefreshRegression(t *testing.T) {
+	const newItemID = "PVTI_new"
+	const newStatus = "Research"
+
+	client := &mockGitHubClient{
+		lookupIssueProjectItemFn: func(projectID, repo string, issueNumber int) (string, string, error) {
+			return newItemID, newStatus, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	// Wire mayNeedWork observer so we can assert StatusChanged fires.
+	mwnObs := newMayNeedWorkObserver(&eng.mayNeedWorkMu, &eng.mayNeedWork)
+	unsub := eng.store.Subscribe(mwnObs)
+	defer unsub()
+
+	// Bootstrap issue #1 WITHOUT an itemID.
+	cache := layer1Cache(eng, client, "PVT_test", true)
+
+	key := boardcache.ItemKey("owner/repo", 1)
+	if _, ok := cache.GetItemID(key); ok {
+		t.Fatal("precondition: issue should not have itemID before the call")
+	}
+
+	eng.applyLayer1StatusRefresh("issues", issueEventPayload("owner/repo", 1), cache)
+
+	// Assert LookupIssueProjectItem was called with correct args.
+	client.mu.Lock()
+	calls := client.lookupIssueProjectItemCalls
+	fpCalls := client.fetchProjectItemStatusCalls
+	client.mu.Unlock()
+
+	if len(calls) != 1 {
+		t.Fatalf("LookupIssueProjectItem call count = %d, want 1", len(calls))
+	}
+	if calls[0].projectID != "PVT_test" {
+		t.Errorf("call.projectID = %q, want %q", calls[0].projectID, "PVT_test")
+	}
+	if calls[0].repo != "owner/repo" {
+		t.Errorf("call.repo = %q, want %q", calls[0].repo, "owner/repo")
+	}
+	if calls[0].issueNumber != 1 {
+		t.Errorf("call.issueNumber = %d, want 1", calls[0].issueNumber)
+	}
+	if len(fpCalls) != 0 {
+		t.Errorf("FetchProjectItemStatus called %d times, want 0 (fast path not taken)", len(fpCalls))
+	}
+
+	// Assert cache now has the itemID.
+	id, ok := cache.GetItemID(key)
+	if !ok || id != newItemID {
+		t.Errorf("GetItemID = %q ok=%v, want %q true", id, ok, newItemID)
+	}
+
+	// Assert cache has the correct status (via shared Store).
+	snap, err := eng.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if snap.State().Status != newStatus {
+		t.Errorf("item Status = %q, want %q", snap.State().Status, newStatus)
+	}
+
+	// Assert StatusChanged observer fired (item appears in mayNeedWork).
+	eng.mayNeedWorkMu.Lock()
+	inSet := eng.mayNeedWork[key]
+	eng.mayNeedWorkMu.Unlock()
+	if !inSet {
+		t.Error("StatusChanged observer did not fire: item not in mayNeedWork")
+	}
+}
+
+// TestLayer1StatusRefreshFastPath is the no-regression test.
+// When the cache already has an itemID, Layer 1 must use FetchProjectItemStatus
+// and must NOT call LookupIssueProjectItem.
+func TestLayer1StatusRefreshFastPath(t *testing.T) {
+	const existingItemID = "PVTI_existing"
+	const newStatus = "Plan"
+
+	client := &mockGitHubClient{
+		fetchProjectItemStatusFn: func(itemID string) (string, error) {
+			return newStatus, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	// Bootstrap with an item that already has an itemID (normal post-Bootstrap state).
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_test", OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: existingItemID, Number: 1, Repo: "owner/repo", Status: "Research"},
+		},
+	})
+
+	eng.applyLayer1StatusRefresh("issues", issueEventPayload("owner/repo", 1), cache)
+
+	client.mu.Lock()
+	fpCalls := client.fetchProjectItemStatusCalls
+	lookupCalls := client.lookupIssueProjectItemCalls
+	client.mu.Unlock()
+
+	if len(fpCalls) != 1 {
+		t.Fatalf("FetchProjectItemStatus call count = %d, want 1", len(fpCalls))
+	}
+	if fpCalls[0] != existingItemID {
+		t.Errorf("FetchProjectItemStatus called with %q, want %q", fpCalls[0], existingItemID)
+	}
+	if len(lookupCalls) != 0 {
+		t.Errorf("LookupIssueProjectItem called %d times, want 0 (should take fast path)", len(lookupCalls))
+	}
+}
+
+// TestLayer1StatusRefreshSkipWhenNotOnBoard verifies that when
+// LookupIssueProjectItem returns ("", "", nil) — the issue is not on fabrik's
+// project — Layer 1 silently returns without updating the cache.
+func TestLayer1StatusRefreshSkipWhenNotOnBoard(t *testing.T) {
+	client := &mockGitHubClient{
+		lookupIssueProjectItemFn: func(projectID, repo string, issueNumber int) (string, string, error) {
+			return "", "", nil // issue not on the project
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	cache := layer1Cache(eng, client, "PVT_test", true)
+
+	key := boardcache.ItemKey("owner/repo", 1)
+
+	eng.applyLayer1StatusRefresh("issues", issueEventPayload("owner/repo", 1), cache)
+
+	// Cache should still have no itemID.
+	if id, ok := cache.GetItemID(key); ok || id != "" {
+		t.Errorf("GetItemID = %q ok=%v, want empty and false", id, ok)
+	}
+
+	// Status should remain empty.
+	snap, err := eng.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if snap.State().Status != "" {
+		t.Errorf("Status = %q, want empty", snap.State().Status)
+	}
+}
+
+// TestLayer1StatusRefreshEmptyProjectID verifies that when cache.ProjectID()
+// returns "" (Bootstrap not yet complete), Layer 1 skips the fallback call
+// entirely. This guards against useless API calls during the startup window.
+func TestLayer1StatusRefreshEmptyProjectID(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	// Bootstrap with empty projectID — simulates pre-Bootstrap or mid-startup state.
+	cache := layer1Cache(eng, client, "" /* empty projectID */, true)
+
+	eng.applyLayer1StatusRefresh("issues", issueEventPayload("owner/repo", 1), cache)
+
+	client.mu.Lock()
+	lookupCalls := client.lookupIssueProjectItemCalls
+	client.mu.Unlock()
+
+	if len(lookupCalls) != 0 {
+		t.Errorf("LookupIssueProjectItem called %d times with empty projectID, want 0", len(lookupCalls))
+	}
+}

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -45,11 +45,15 @@ type mockGitHubClient struct {
 	addReviewRequestFn              func(owner, repo string, prNumber int, reviewers []string) error
 	fetchProjectItemStatusFn        func(itemID string) (string, error)
 	fetchProjectItemStatusBatchFn   func(projectID string) (map[string]string, error)
+	lookupIssueProjectItemFn        func(projectID, repo string, issueNumber int) (string, string, error)
 	fetchPRClosingIssuesFn          func(owner, repo string, prNumber int) ([]int, error)
 	fetchPRsForSHAFn                func(owner, repo, sha string) ([]int, error)
 
 	// Track call counts for FetchProjectItemStatus
 	fetchProjectItemStatusCalls []string
+
+	// Track calls for LookupIssueProjectItem
+	lookupIssueProjectItemCalls []lookupIssueProjectItemCall
 
 	// Track calls for FetchLabelAppliedAt
 	fetchLabelAppliedAtCalls []fetchLabelAppliedAtCall
@@ -81,6 +85,12 @@ type reviewRequestCall struct {
 	owner, repo string
 	prNumber    int
 	reviewers   []string
+}
+
+type lookupIssueProjectItemCall struct {
+	projectID   string
+	repo        string
+	issueNumber int
 }
 
 type prReviewCommentReactionCall struct {
@@ -516,6 +526,17 @@ func (m *mockGitHubClient) FetchProjectItemStatusBatch(projectID string) (map[st
 		return fn(projectID)
 	}
 	return map[string]string{}, nil
+}
+
+func (m *mockGitHubClient) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {
+	m.mu.Lock()
+	m.lookupIssueProjectItemCalls = append(m.lookupIssueProjectItemCalls, lookupIssueProjectItemCall{projectID, repo, issueNumber})
+	fn := m.lookupIssueProjectItemFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(projectID, repo, issueNumber)
+	}
+	return "", "", nil
 }
 
 // mockClaudeInvoker implements ClaudeInvoker for testing.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1570,6 +1570,26 @@ func (e *Engine) applyLayer1StatusRefresh(eventType string, payload []byte, cach
 	key := boardcache.ItemKey(ev.Repository.FullName, ev.Issue.Number)
 	itemID, ok := cache.GetItemID(key)
 	if !ok {
+		// Fallback: issue is in the cache but has no itemID yet (e.g., arrived via
+		// issues.opened before a projects_v2_item.created event). Perform a single
+		// GraphQL lookup to populate both itemID and Status in one call.
+		// If Bootstrap hasn't completed yet, projectID is empty — skip to avoid a
+		// useless API call with an empty project ID during the startup window.
+		projectID := cache.ProjectID()
+		if projectID == "" {
+			return
+		}
+		fetchedItemID, fetchedStatus, err := e.client.LookupIssueProjectItem(projectID, ev.Repository.FullName, ev.Issue.Number)
+		if err != nil {
+			e.logf(ev.Issue.Number, "warn", "layer1 fallback lookup failed for %s#%d: %v\n", ev.Repository.FullName, ev.Issue.Number, err)
+			return
+		}
+		if fetchedItemID == "" {
+			// Issue is not on the project fabrik manages — silently skip.
+			return
+		}
+		cache.RegisterItemID(key, fetchedItemID)
+		cache.UpdateItemStatus(key, fetchedStatus)
 		return
 	}
 	status, err := e.client.FetchProjectItemStatus(itemID)

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1542,9 +1542,15 @@ func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.Ca
 
 // applyLayer1StatusRefresh handles the Layer 1 opportunistic per-event Status
 // refresh. Called from the deltaFn closure after ApplyDelta. For issue and
-// issue_comment events on a known cache item, it fetches the current Status
-// from GitHub and updates the cache immediately. All errors are best-effort:
-// logged as warnings and never returned.
+// issue_comment events, it fetches the current Status from GitHub and updates
+// the cache immediately. Two paths:
+//   - Fast path: cache has the item's itemID → calls FetchProjectItemStatus.
+//   - Fallback path: cache lacks itemID (brand-new issue, issues.opened before
+//     projects_v2_item.created) → calls LookupIssueProjectItem to populate
+//     both itemID and Status in one query. Skipped when cache.ProjectID() == ""
+//     (Bootstrap not yet complete).
+//
+// All errors are best-effort: logged as warnings and never returned.
 func (e *Engine) applyLayer1StatusRefresh(eventType string, payload []byte, cache *boardcache.CacheImpl) {
 	if cache.IsPaused() {
 		return

--- a/github/project.go
+++ b/github/project.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -1085,4 +1086,85 @@ func (c *Client) FetchProjectItem(owner, repo string, issueNumber int) (*Project
 		pi.Assignees = append(pi.Assignees, a.Login)
 	}
 	return pi, nil
+}
+
+// LookupIssueProjectItem fetches the project-item node ID and current Status for
+// a given issue, filtered to the specified projectID. It queries
+// repository.issue.projectItems (first: 20), iterating nodes until one whose
+// project.id matches projectID is found. Returns ("", "", nil) when the issue is
+// not in the specified project. Returns an error on any GraphQL failure.
+//
+// Note: first:20 covers issues in up to 20 GitHub Projects. Issues belonging to
+// more than 20 projects are not supported (vanishingly rare in practice).
+func (c *Client) LookupIssueProjectItem(projectID, repo string, issueNumber int) (itemID string, status string, err error) {
+	slash := strings.LastIndex(repo, "/")
+	if slash < 0 {
+		return "", "", fmt.Errorf("LookupIssueProjectItem: invalid repo %q (expected owner/name)", repo)
+	}
+	owner := repo[:slash]
+	repoName := repo[slash+1:]
+
+	query := `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      projectItems(first: 20) {
+        nodes {
+          id
+          project {
+            id
+          }
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	vars := map[string]interface{}{
+		"owner":  owner,
+		"repo":   repoName,
+		"number": issueNumber,
+	}
+
+	var result struct {
+		Data struct {
+			Repository *struct {
+				Issue *struct {
+					ProjectItems struct {
+						Nodes []struct {
+							ID      string `json:"id"`
+							Project struct {
+								ID string `json:"id"`
+							} `json:"project"`
+							FieldValueByName *struct {
+								Name string `json:"name"`
+							} `json:"fieldValueByName"`
+						} `json:"nodes"`
+					} `json:"projectItems"`
+				} `json:"issue"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return "", "", fmt.Errorf("LookupIssueProjectItem for %s#%d: %w", repo, issueNumber, err)
+	}
+	if result.Data.Repository == nil || result.Data.Repository.Issue == nil {
+		return "", "", nil
+	}
+	for _, node := range result.Data.Repository.Issue.ProjectItems.Nodes {
+		if node.Project.ID == projectID {
+			st := ""
+			if node.FieldValueByName != nil {
+				st = node.FieldValueByName.Name
+			}
+			return node.ID, st, nil
+		}
+	}
+	return "", "", nil
 }

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -56,4 +57,202 @@ func makeItem(id, itemID, title string) map[string]interface{} {
 			"assignees": map[string]interface{}{"nodes": []interface{}{}},
 		},
 	}
+}
+
+// makeLookupServer creates an httptest server that serves a single GraphQL response
+// at POST /graphql. The handler calls respFn to build the JSON response body.
+func makeLookupServer(t *testing.T, respFn func() interface{}) (*httptest.Server, *Client) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body := respFn()
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			panic(fmt.Sprintf("makeLookupServer: encode: %v", err))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, NewClientWithBaseURL("token", srv.URL)
+}
+
+func TestLookupIssueProjectItem(t *testing.T) {
+	t.Run("happy path returns itemID and status", func(t *testing.T) {
+		_, client := makeLookupServer(t, func() interface{} {
+			return map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"issue": map[string]interface{}{
+							"projectItems": map[string]interface{}{
+								"nodes": []interface{}{
+									map[string]interface{}{
+										"id": "PVTI_abc",
+										"project": map[string]interface{}{
+											"id": "PVT_target",
+										},
+										"fieldValueByName": map[string]interface{}{
+											"name": "Research",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		itemID, status, err := client.LookupIssueProjectItem("PVT_target", "owner/repo", 42)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if itemID != "PVTI_abc" {
+			t.Errorf("itemID = %q, want %q", itemID, "PVTI_abc")
+		}
+		if status != "Research" {
+			t.Errorf("status = %q, want %q", status, "Research")
+		}
+	})
+
+	t.Run("multi-project filtering returns only the matching project item", func(t *testing.T) {
+		_, client := makeLookupServer(t, func() interface{} {
+			return map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"issue": map[string]interface{}{
+							"projectItems": map[string]interface{}{
+								"nodes": []interface{}{
+									map[string]interface{}{
+										"id": "PVTI_wrong",
+										"project": map[string]interface{}{
+											"id": "PVT_other",
+										},
+										"fieldValueByName": map[string]interface{}{
+											"name": "Done",
+										},
+									},
+									map[string]interface{}{
+										"id": "PVTI_correct",
+										"project": map[string]interface{}{
+											"id": "PVT_target",
+										},
+										"fieldValueByName": map[string]interface{}{
+											"name": "Plan",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		itemID, status, err := client.LookupIssueProjectItem("PVT_target", "owner/repo", 7)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if itemID != "PVTI_correct" {
+			t.Errorf("itemID = %q, want %q", itemID, "PVTI_correct")
+		}
+		if status != "Plan" {
+			t.Errorf("status = %q, want %q", status, "Plan")
+		}
+	})
+
+	t.Run("issue not on project returns empty strings and no error", func(t *testing.T) {
+		_, client := makeLookupServer(t, func() interface{} {
+			return map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"issue": map[string]interface{}{
+							"projectItems": map[string]interface{}{
+								"nodes": []interface{}{
+									map[string]interface{}{
+										"id": "PVTI_other",
+										"project": map[string]interface{}{
+											"id": "PVT_other",
+										},
+										"fieldValueByName": nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		itemID, status, err := client.LookupIssueProjectItem("PVT_target", "owner/repo", 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if itemID != "" {
+			t.Errorf("itemID = %q, want empty", itemID)
+		}
+		if status != "" {
+			t.Errorf("status = %q, want empty", status)
+		}
+	})
+
+	t.Run("GraphQL error returns non-nil error", func(t *testing.T) {
+		_, client := makeLookupServer(t, func() interface{} {
+			return map[string]interface{}{
+				"errors": []interface{}{
+					map[string]interface{}{"message": "some graphql error"},
+				},
+			}
+		})
+
+		_, _, err := client.LookupIssueProjectItem("PVT_target", "owner/repo", 1)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("no status field value returns empty status", func(t *testing.T) {
+		_, client := makeLookupServer(t, func() interface{} {
+			return map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"issue": map[string]interface{}{
+							"projectItems": map[string]interface{}{
+								"nodes": []interface{}{
+									map[string]interface{}{
+										"id": "PVTI_nostatus",
+										"project": map[string]interface{}{
+											"id": "PVT_target",
+										},
+										"fieldValueByName": nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		itemID, status, err := client.LookupIssueProjectItem("PVT_target", "owner/repo", 5)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if itemID != "PVTI_nostatus" {
+			t.Errorf("itemID = %q, want %q", itemID, "PVTI_nostatus")
+		}
+		if status != "" {
+			t.Errorf("status = %q, want empty", status)
+		}
+	})
+
+	t.Run("invalid repo format returns error", func(t *testing.T) {
+		// No server needed — should fail before making any HTTP call.
+		client := NewClientWithBaseURL("token", "http://localhost:0")
+		_, _, err := client.LookupIssueProjectItem("PVT_target", "noslash", 1)
+		if err == nil {
+			t.Fatal("expected error for invalid repo, got nil")
+		}
+	})
 }

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -171,12 +171,13 @@ func (m CheckRunCompleted) itemKey() string {
 	return ""
 }
 
-// ---- Self-mutations (write-through from fabrik's own GitHub mutations) ----
+// ---- Cache enrichment mutations (populated from read-side lookups) ----
 
 // ItemIDRegistered sets the project-item node ID for an existing Store entry that
 // was added without one (e.g., via issues.opened before projects_v2_item.created).
-// Returns ChangeFlags(0) — the itemIDToKey reverse index is updated via
-// reflect.DeepEqual detection in applySingleItem regardless of the returned flags.
+// This is triggered by the Layer 1 fallback GraphQL lookup, not by a Fabrik-initiated
+// GitHub mutation. Returns ChangeFlags(0) — the itemIDToKey reverse index is updated
+// via reflect.DeepEqual detection in applySingleItem regardless of the returned flags.
 // Dispatch is triggered only by the subsequent UpdateItemStatus call, not by this.
 type ItemIDRegistered struct {
 	Repo   string
@@ -186,6 +187,8 @@ type ItemIDRegistered struct {
 
 func (ItemIDRegistered) isMutation() {}
 func (m ItemIDRegistered) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// ---- Self-mutations (write-through from fabrik's own GitHub mutations) ----
 
 // LocalStatusUpdated is applied after fabrik calls UpdateProjectItemStatus.
 type LocalStatusUpdated struct {

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -173,6 +173,20 @@ func (m CheckRunCompleted) itemKey() string {
 
 // ---- Self-mutations (write-through from fabrik's own GitHub mutations) ----
 
+// ItemIDRegistered sets the project-item node ID for an existing Store entry that
+// was added without one (e.g., via issues.opened before projects_v2_item.created).
+// Returns ChangeFlags(0) — the itemIDToKey reverse index is updated via
+// reflect.DeepEqual detection in applySingleItem regardless of the returned flags.
+// Dispatch is triggered only by the subsequent UpdateItemStatus call, not by this.
+type ItemIDRegistered struct {
+	Repo   string
+	Number int
+	ItemID string
+}
+
+func (ItemIDRegistered) isMutation() {}
+func (m ItemIDRegistered) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // LocalStatusUpdated is applied after fabrik calls UpdateProjectItemStatus.
 type LocalStatusUpdated struct {
 	Repo      string

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -328,6 +328,14 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.Comments = append(item.Comments, v.Comment)
 		return CommentsChanged
 
+	case ItemIDRegistered:
+		if item.ItemID != v.ItemID {
+			item.ItemID = v.ItemID
+		}
+		// Return 0: updateIndexes fires via reflect.DeepEqual detection when ItemID changed.
+		// Dispatch is triggered only by the subsequent UpdateItemStatus call.
+		return 0
+
 	case LocalLockAcquired:
 		item.Lock = &LockState{
 			HolderUser: v.User,


### PR DESCRIPTION
## Summary

Replace the silent-bail in `applyLayer1StatusRefresh` with a fallback GraphQL lookup when the cache lacks an `itemID` for an issue. A single `Issue → projectItems` GraphQL query returns both the project item node ID and current Status in one call, populating the cache fully. After the fallback path, subsequent Layer 1 calls use the existing (cheaper) `FetchProjectItemStatus(itemID)` fast path.

## Problem

PR #510 added Layer 1 (opportunistic per-event Status refresh) as the mitigation for non-delivery of `projects_v2_item` events to repo-level webhooks. The intent: when ANY webhook event arrives for a known issue, also fetch its current Status from GitHub and update the cache, so column moves are visible without waiting for the 60-min reconciliation.

The implementation has a silent-no-op gap that defeats the mitigation **for the most important case: brand-new issues.**

`engine/poll.go:1570-1574`:

```go
key := boardcache.ItemKey(ev.Repository.FullName, ev.Issue.Number)
itemID, ok := cache.GetItemID(key)
if !ok {
    return  // silent bail
}
```

When a brand-new issue arrives:

1. `issues.opened` webhook delivers the issue. Payload **does not** include project-item information — that's a different event type (`projects_v2_item.created`), and `projects_v2_item` events aren't delivered to repo-level webhooks at all.
2. `applyIssuesDelta` adds the issue to the cache with labels and body but **no `itemID`** (because the payload didn't carry it and `FetchProjectItem` is a REST call that doesn't return project board info).
3. Layer 1 fires post-delta: `cache.GetItemID(key)` returns `!ok` → silent return.
4. Cache continues to hold the issue with `Status=""` (empty).
5. `itemNeedsWork` calls `stages.FindStage(stages, "")` → returns nil → dispatch skips the issue.
6. Issue is invisible to fabrik until the 60-min reconciliation timer fires.

## Approach

### Approach

The fix adds a fallback GraphQL lookup path to `applyLayer1StatusRefresh` when `GetItemID` returns `!ok`. The fallback path:
1. Guards against pre-Bootstrap invocation by checking `cache.ProjectID() != ""`
2. Calls `e.client.LookupIssueProjectItem(projectID, repo, issueNum)` — a new GraphQL query starting from `repository.issue.projectItems`
3. If the issue is not on fabrik's project, returns without updating the cache
4. On success: calls `cache.RegisterItemID(key, itemID)` (new `CacheImpl` method) then `cache.UpdateItemStatus(key, status)` — the latter fires the existing `StatusChanged` → `wakeChObserver` → `mayNeedWork` chain

The underlying infrastructure changes are layered bottom-up: a new `ItemIDRegistered` mutation type in `internal/itemstate`, `RegisterItemID` on `CacheImpl`, `LookupIssueProjectItem` on `GitHubClient`, then the fix in `engine/poll.go`.

### New/Modified Files

| File | Change |
|------|--------|
| `internal/itemstate/mutation.go` | Add `ItemIDRegistered{Repo, Number, ItemID}` mutation type |
| `internal/itemstate/store.go` | Add `case ItemIDRegistered:` in `applyToItem` |
| `boardcache/boardcache.go` | Add `RegisterItemID(key, itemID string)` method |
| `engine/interfaces.go` | Add `LookupIssueProjectItem(projectID, repo string, issueNumber int) (itemID string, status string, err error)` to `GitHubClient` |
| `github/project.go` | Implement `LookupIssueProjectItem` |
| `engine/mocks_test.go` | Add `lookupIssueProjectItemFn`, call tracking slice, `LookupIssueProjectItem` method |
| `engine/poll.go` | Replace silent bail in `applyLayer1StatusRefresh` with fallback path |
| `engine/layer1_test.go` | New file: all four Layer 1 engine-level tests |
| `boardcache/boardcache_test.go` | Add `TestRegisterItemID` unit tests |
| `github/project_test.go` | Add `TestLookupIssueProjectItem` tests (httptest mock server) |
| `docs/state-machine.md` | Update Layer 1 table row and scope paragraph |

### Key Decisions

**`ItemIDRegistered` returns `ChangeFlags = 0`**: The `reflect.DeepEqual` check in `applySingleItem` detects the ItemID field change and triggers `updateIndexes` regardless of the returned flags — the reverse index is updated. Returning 0 prevents a spurious dispatch wakeup from ItemID registration alone; dispatch should only fire from the subsequent `UpdateItemStatus` call. An alternative `ItemIDChanged` flag was considered but rejected as it would be unused in any observer filter.

**Two separate `Store.Apply` calls in the fallback path**: `RegisterItemID` (updates `itemIDToKey`) and `UpdateItemStatus` (fires `StatusChanged`) are called in sequence. This keeps each mutation's semantics clean: ItemID registration is a bookkeeping update; the Status update is the dispatch-triggering event. Combining them into a single mutation would duplicate the `LocalStatusUpdated` logic and bypass the existing observer chain.

**`first: 20` for `projectItems`, no pagination**: Issues belonging to >20 GitHub Projects is vanishingly rare. Full pagination would add complexity with no practical benefit. A code comment documents the limit. If a future issue requires higher coverage, the `first` value can be bumped or pagination added.

**`cache.ProjectID() != ""` guard**: If Bootstrap hasn't completed when the webhook arrives, `ProjectID()` returns `""`. The fallback is skipped. The next webhook after Bootstrap completes will either hit the fast path (if Reconcile populated the itemID) or trigger the fallback again correctly.

**No ADR warranted**: This is a targeted bug fix extending ADR 035's four-layer strategy using patterns already established in ADR 034 (event-sourced mutations) and ADR 036 (single owner for item state). No new architectural constraints are introduced that would constrain future contributors in ways not already captured by existing ADRs.

### Task Checklist

- [ ] **Task 1**: Add `ItemIDRegistered{Repo, Number, ItemID string}` mutation type to `internal/itemstate/mutation.go`, following the struct + `isMutation()` + `itemKey()` pattern of adjacent types (e.g., `LocalLabelAdded`)
- [ ] **Task 2**: Add `case ItemIDRegistered:` in `Store.applyToItem` (`internal/itemstate/store.go`) — set `item.ItemID = v.ItemID` only when different; return `ChangeFlags(0)`; the `reflect.DeepEqual` check in `applySingleItem` triggers `updateIndexes` which updates `itemIDToKey`
- [ ] **Task 3**: Add `RegisterItemID(key, itemID string)` to `CacheImpl` (`boardcache/boardcache.go`) — parse key, guard with `c.store.Get(repo, number)` to prevent phantom entry creation, apply `itemstate.ItemIDRegistered`, update `c.localDeltaAt[key]` under `c.mu`; follow the `ApplyLabelAdded` pattern exactly
- [ ] **Task 4**: Add `LookupIssueProjectItem(projectID, repo string, issueNumber int) (itemID string, status string, err error)` to the `GitHubClient` interface in `engine/interfaces.go`
- [ ] **Task 5**: Implement `LookupIssueProjectItem` in `github/project.go` — split `repo` at `"/"` to extract owner/name; query `repository(owner, name).issue(number).projectItems(first: 20)` returning `nodes { id, project { id }, fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } } }`; iterate nodes, match `node.project.id == projectID`, return matched `(id, status)`; return `("", "", nil)` if no match
- [ ] **Task 6**: Add `TestLookupIssueProjectItem` tests to `github/project_test.go` using `httptest.NewServer`: (a) happy path returns correct itemID+status; (b) multi-project filtering — nodes include two items with different project IDs, assert only the matching one is returned; (c) issue not on project returns `("", "", nil)`; (d) GraphQL error returns non-nil error
- [ ] **Task 7**: Add `TestRegisterItemID` tests to `boardcache/boardcache_test.go`: (a) after bootstrap with `ItemID=""`, `RegisterItemID` populates itemID and `GetItemID` returns it; (b) subsequent `Get` still has all other fields intact; (c) `RegisterItemID` is no-op when key not in Store (no phantom entry created); (d) calling `RegisterItemID` twice with same value is idempotent
- [ ] **Task 8**: Add `lookupIssueProjectItemFn func(projectID, repo string, issueNumber int) (string, string, error)` field, a `lookupIssueProjectItemCalls` tracking slice, and `LookupIssueProjectItem` method to `mockGitHubClient` in `engine/mocks_test.go` to satisfy the updated `GitHubClient` interface
- [ ] **Task 9**: Replace the silent bail in `applyLayer1StatusRefresh` (`engine/poll.go:1570-1574`) with the fallback path: when `!ok`, check `cache.ProjectID() != ""`; call `e.client.LookupIssueProjectItem(projectID, repo, issueNum)`; on error log warning and return; on empty `itemID` return silently; on success call `cache.RegisterItemID(key, itemID)` then `cache.UpdateItemStatus(key, status)` and return
- [ ] **Task 10**: Add Layer 1 engine-level tests to new file `engine/layer1_test.go`: (a) **mandatory regression test** — bootstrap issue with `ItemID=""`, call `applyLayer1StatusRefresh`, assert `lookupIssueProjectItemFn` called, assert `cache.GetItemID` returns the new itemID, assert `cache.Get` shows the correct Status, assert `StatusChanged` observer fired; this test **must fail on current main**; (b) **no-regression fast path** — issue has `ItemID` set, assert `FetchProjectItemStatus` called, `LookupIssueProjectItem` not called; (c) **skip-when-not-on-board** — `LookupIssueProjectItem` returns `("", "", nil)`, assert cache unchanged; (d) **empty-projectID guard** — `cache.ProjectID()` returns `""`, assert `LookupIssueProjectItem` not called at all
- [ ] **Task 11**: Update `docs/state-machine.md` Layer 1 table row (line 1660) and scope paragraph (line 1699): change "on a known item" to reflect the fallback path for new issues; add a sentence to the scope paragraph: "For new issues whose `itemID` is not yet in the cache (e.g., added via `issues.opened` before a `projects_v2_item.created` event), Layer 1 falls back to `LookupIssueProjectItem` to populate both `itemID` and current Status in one query. If `cache.ProjectID()` is empty (Bootstrap not yet complete), the fallback is skipped."

### Risks

- **GraphQL schema validity**: The query shape `repository.issue.projectItems(first: 20)` with `fieldValueByName` and `project { id }` on each node is new and untested against the live GitHub API. The `github/project_test.go` tests use an httptest mock server, so they do not validate the schema. If `Issue.projectItems` doesn't support `fieldValueByName` or `project { id }` in the API version fabrik targets, the query will fail at runtime. Implement should cross-check against the GitHub GraphQL schema explorer before finalizing the query.

- **`applySingleItem` no-op detection with `ChangeFlags = 0`**: The existing `applySingleItem` notifies observers even when `ChangeFlags = 0` if the `reflect.DeepEqual` check detects a change. This means registering a previously-empty `ItemID` does notify observers — but `wakeChObserver` and `mayNeedWorkObserver` both filter on `change.Fields & wakeChFlags == 0` and skip. This is correct behavior. Implement should verify this flow doesn't trigger unexpected observer side effects.

- **`UpdateItemStatus` with empty status string**: If `LookupIssueProjectItem` returns `(itemID, "", nil)` (issue is on the board but has no Status column value), `UpdateItemStatus` is still called with `""`. This sets Status = "" (no change from the pre-fix state). The issue will not dispatch (no matching stage for empty status). This is acceptable — the issue genuinely has no board column. Document as a known limitation in a code comment.

---
Used 19/50 turns, 7k input / 9k output tokens.

## Verification

Implemented the Layer 1 fallback path for new issues whose `itemID` is not yet in the cache. The fix adds a `ItemIDRegistered` mutation type in `internal/itemstate`, a `RegisterItemID` method on `CacheImpl`, a new `LookupIssueProjectItem` GraphQL method on `github.Client` and `GitHubClient`, and replaces the silent bail in `applyLayer1StatusRefresh` with a fallback that populates both `itemID` and `Status` in one query when the cache lacks an `itemID`. All 11 acceptance-criteria test cases are covered (regression, fast-path, not-on-board, empty-projectID guard), `docs/state-machine.md` is updated, and the full test suite (`go test -race ./...`) passes cleanly across all packages.

---

Closes #540