### PR TITLE
fix(engine): add AssigneesChanged to wakeChFlags

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -149,7 +149,7 @@ Each active stage column has the same set of reachable sub-states:
 
 ## 2. Event Enumeration
 
-Eleven distinct event types drive state transitions (§2.1–2.11), plus one TUI display event (§2.12) that does not drive transitions:
+Twelve distinct event types drive state transitions (§2.1–2.11, §2.13), plus one TUI display event (§2.12) that does not drive transitions:
 
 ### 2.1 Poll Tick
 
@@ -296,6 +296,16 @@ Eleven distinct event types drive state transitions (§2.1–2.11), plus one TUI
 - First invocation without `fabrik:extend-turns`: `stage.MaxTurns`
 - First invocation with `fabrik:extend-turns`: `2 × stage.MaxTurns`
 - Extension loop second iteration: `stage.MaxTurns` (per-invocation limit, not cumulative)
+
+### 2.13 Manual Assignee Change
+
+**Webhook event:** `issues.assigned` / `issues.unassigned`
+
+**Detection:** `applyIssuesDelta` (boardcache/delta.go:382) applies `IssueAssigneesUpdated`, which emits the `AssigneesChanged` flag. The `mayNeedWorkObserver` and `wakeChObserver` (engine/observers.go) include `AssigneesChanged` in `wakeChFlags`, so the assignment fires both a wake signal and a `mayNeedWork` cycleSet entry.
+
+**Effect:** Dispatcher re-evaluates the item on the next poll cycle. The engine does not currently filter dispatch on assignee — assignee changes do not change what work happens, only that the item is re-considered. Future assignee-as-dispatch-filter work (planned, not yet filed) will give this event additional dispatch semantics.
+
+**Why:** Assignment is a strong "please look at this" signal from the user, and is the mechanical underpinning of multi-user shared boards (each fabrik instance picking up only items assigned to its `cfg.User`).
 
 ---
 
@@ -1232,10 +1242,10 @@ All ChangeFlags are produced by the single shared store. Field ownership is by m
 The `wakeChObserver` is registered once on the shared store. It fires a non-blocking send on `wakeCh` when `Change.Fields & wakeChFlags != 0`:
 
 ```
-wakeChFlags = StatusChanged | LabelsChanged | CommentsChanged | LockChanged | LinkedPRChanged
+wakeChFlags = StatusChanged | LabelsChanged | CommentsChanged | LockChanged | LinkedPRChanged | AssigneesChanged
 ```
 
-Changes that do NOT fire `wakeCh`: `InvocationChanged`, `StageStateChanged`, `WorkerChanged`, `CooldownChanged`, `AssigneesChanged`, `TitleBodyChanged`, `StateChanged`, `BlockedByChanged`, `DeepFetchChanged`, `BaseBranchChanged`, `ItemRemoved`.
+Changes that do NOT fire `wakeCh`: `InvocationChanged`, `StageStateChanged`, `WorkerChanged`, `CooldownChanged`, `TitleBodyChanged`, `StateChanged`, `BlockedByChanged`, `DeepFetchChanged`, `BaseBranchChanged`, `ItemRemoved`.
 
 The unconditional `wakeCh <- struct{}{}` send that previously lived in the webhook handler has been removed. The observer path is the sole mechanism. Because all mutation types flow through the single shared store, the single `wakeChObserver` registration is sufficient — no per-source registration is needed.
 

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -18,7 +18,8 @@ const wakeChFlags = itemstate.StatusChanged |
 	itemstate.LabelsChanged |
 	itemstate.CommentsChanged |
 	itemstate.LockChanged |
-	itemstate.LinkedPRChanged
+	itemstate.LinkedPRChanged |
+	itemstate.AssigneesChanged
 
 // newWakeChObserver returns an Observer that sends a non-blocking wake signal on
 // wakeCh whenever a Change includes any of the wakeChFlags. This replaces the

--- a/engine/observers_test.go
+++ b/engine/observers_test.go
@@ -56,6 +56,20 @@ func TestWakeChObserver_SendsOnLabelsChanged(t *testing.T) {
 	}
 }
 
+func TestWakeChObserver_SendsOnAssigneesChanged(t *testing.T) {
+	wakeCh := make(chan struct{}, 1)
+	store := newTestStore()
+	unsub := store.Subscribe(newWakeChObserver(wakeCh))
+	defer unsub()
+
+	store.Apply(itemstate.IssueAssigneesUpdated{Repo: "owner/repo", Number: 1, Assignees: []string{"user1"}})
+	select {
+	case <-wakeCh:
+	default:
+		t.Fatal("expected wake signal on AssigneesChanged")
+	}
+}
+
 func TestWakeChObserver_SkipsInvocationChanged(t *testing.T) {
 	wakeCh := make(chan struct{}, 1)
 	store := newTestStore()
@@ -147,6 +161,23 @@ func TestMayNeedWorkObserver_KeyFormat(t *testing.T) {
 	mu.Unlock()
 	if !ok {
 		t.Fatalf("expected key %q in set", want)
+	}
+}
+
+func TestMayNeedWorkObserver_PopulatesKeyOnAssigneesChanged(t *testing.T) {
+	var mu sync.Mutex
+	set := make(map[string]bool)
+	store := newTestStore()
+	unsub := store.Subscribe(newMayNeedWorkObserver(&mu, &set))
+	defer unsub()
+
+	store.Apply(itemstate.IssueAssigneesUpdated{Repo: "owner/repo", Number: 1, Assignees: []string{"user1"}})
+
+	mu.Lock()
+	ok := set["owner/repo#1"]
+	mu.Unlock()
+	if !ok {
+		t.Fatalf("expected key %q in mayNeedWork set", "owner/repo#1")
 	}
 }
 


### PR DESCRIPTION
## Summary

Assignment/unassignment webhook events were silently dropped: `applyIssuesDelta` correctly applied `IssueAssigneesUpdated` but neither `wakeChObserver` nor `mayNeedWorkObserver` reacted because `AssigneesChanged` was absent from the `wakeChFlags` bitmask in `engine/observers.go`. The entire data pipeline already worked end-to-end — only the final flag check was missing.

## Key Changes

- **`engine/observers.go`**: Appended `| itemstate.AssigneesChanged` to the `wakeChFlags` constant (one line).
- **`engine/observers_test.go`**: Added `TestWakeChObserver_SendsOnAssigneesChanged` and `TestMayNeedWorkObserver_PopulatesKeyOnAssigneesChanged` following the existing observer test patterns.
- **`docs/state-machine.md`**: Updated the event count intro (Eleven → Twelve), added §2.13 "Manual Assignee Change" subsection, updated the `wakeChFlags` formula display, and removed `AssigneesChanged` from the "does NOT fire" exclusion list.

## How to Test

1. `go test -race ./engine/... ./internal/itemstate/...` — new tests pass, no races.
2. Simulate an `issues.assigned` webhook in a running Fabrik instance — the assigned item should now appear in the next poll cycle's deep-fetch set instead of being silently skipped.

## Notes

The engine does not yet filter dispatch on assignee; this PR only ensures assignment events trigger re-evaluation. The actual assignee-as-dispatch-filter feature is a separate, larger issue. The pre-existing `TestExecute_ConfigYAMLApplied` failure in `cmd/` is unrelated to this change (it also fails on the base commit).

Closes #543