### PR TITLE
fix: Store.Reset emits observer Changes for bootstrap-loaded items

### DIFF
--- a/adrs/036-reactive-cache-single-owner.md
+++ b/adrs/036-reactive-cache-single-owner.md
@@ -149,6 +149,27 @@ foot-guns identified in Phase 4 make the split untenable: the `worker_liveness.g
 label read was already silently broken on any board running in in-memory cache mode.
 Unification restores the structural guarantee the ADR intended.
 
+### Bootstrap gap fixed (Phase 5 / issue #542)
+
+After Phase 5 F3 unification (see above), `Store.Reset` — the only path through which
+`Bootstrap` populates the shared store — silently mutated the item map without emitting
+any observer Changes. Because `engine.store` and `cacheImpl.store` are now the same
+instance, `e.store.Get(...)` succeeds for bootstrapped items, causing the poll
+prefilter's `notInStore` bypass to return false. Items bootstrapped at startup were
+therefore invisible to the dispatch loop until an independent `Apply` fired an observer
+Change — effectively breaking restart-resume for every in-progress issue when running
+in in-memory cache mode with webhooks enabled.
+
+The fix (issue #542) rewrites `Store.Reset` to follow the same batch-notify pattern
+used by `Apply` and `applyBoardReconciled`: accumulate all `(Change, Snapshot)` pairs
+under a single `s.mu` hold, release the lock, capture observers, then call each
+observer outside all locks. A new `ItemRemoved` ChangeFlags constant was added to
+`change.go` so that items present in the old map but absent from the new items slice
+emit a semantically distinct signal (rather than reusing `StateChanged`, which means
+issue open/closed). The existing `mayNeedWorkObserver` and `wakeChObserver` both use
+flag-based filtering; `ItemRemoved` does not match either observer's mask, so removed
+items are safely ignored by the dispatch loop.
+
 ## References
 
 - `docs/cache-refactor/01-state-inventory.md` — inventory of every existing state structure with read/write sites and known bugs.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -226,6 +226,49 @@ func TestBootstrapPopulatesItems(t *testing.T) {
 	}
 }
 
+// TestBootstrapNotifiesObserver verifies that Bootstrap fires observer notifications
+// for every item in the board, matching production ordering in engine/poll.go where
+// observers are subscribed before Bootstrap is called.
+func TestBootstrapNotifiesObserver(t *testing.T) {
+	store := itemstate.NewStore(nil)
+
+	var mu sync.Mutex
+	var received []itemstate.Change
+	// Subscribe BEFORE Bootstrap — matching production ordering in engine/poll.go.
+	store.Subscribe(itemstate.ObserverFunc(func(c itemstate.Change, _ itemstate.Snapshot) {
+		mu.Lock()
+		received = append(received, c)
+		mu.Unlock()
+	}))
+
+	mc := &mockClient{}
+	c := NewCacheImpl(mc, store, nopLog)
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PID",
+		Title:     "T",
+		OwnerType: "organization",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", Repo: "owner/repo", Number: 1, Status: "Research", Title: "Issue 1"},
+			{ID: "I_2", Repo: "owner/repo", Number: 2, Status: "Implement", Title: "Issue 2"},
+		},
+	}
+	c.Bootstrap(board)
+
+	mu.Lock()
+	got := len(received)
+	mu.Unlock()
+
+	if got != 2 {
+		t.Fatalf("expected 2 observer Changes after Bootstrap, got %d", got)
+	}
+	for _, ch := range received {
+		if ch.Fields == 0 {
+			t.Errorf("Change for #%d has zero Fields; want non-zero", ch.Number)
+		}
+	}
+}
+
 func TestNewCacheImplNilStorePanic(t *testing.T) {
 	defer func() {
 		r := recover()

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1225,6 +1225,7 @@ All ChangeFlags are produced by the single shared store. Field ownership is by m
 | `WorkerChanged` | Engine-side | `LocalLockAcquired` (with Worker), `WorkerPIDSet`, `WorkerHeartbeat`, `WorkerExited` |
 | `CooldownChanged` | Engine-side | `CooldownRecorded` |
 | `DeepFetchChanged` | Engine-side | `DeepFetchFailed`, `ItemDeepFetched` |
+| `ItemRemoved` | Reset | `Store.Reset` for items present in the old map but absent from the new items slice |
 
 #### wakeChFlags: Which Changes Wake the Poll Loop
 
@@ -1234,7 +1235,7 @@ The `wakeChObserver` is registered once on the shared store. It fires a non-bloc
 wakeChFlags = StatusChanged | LabelsChanged | CommentsChanged | LockChanged | LinkedPRChanged
 ```
 
-Changes that do NOT fire `wakeCh`: `InvocationChanged`, `StageStateChanged`, `WorkerChanged`, `CooldownChanged`, `AssigneesChanged`, `TitleBodyChanged`, `StateChanged`, `BlockedByChanged`, `DeepFetchChanged`, `BaseBranchChanged`.
+Changes that do NOT fire `wakeCh`: `InvocationChanged`, `StageStateChanged`, `WorkerChanged`, `CooldownChanged`, `AssigneesChanged`, `TitleBodyChanged`, `StateChanged`, `BlockedByChanged`, `DeepFetchChanged`, `BaseBranchChanged`, `ItemRemoved`.
 
 The unconditional `wakeCh <- struct{}{}` send that previously lived in the webhook handler has been removed. The observer path is the sole mechanism. Because all mutation types flow through the single shared store, the single `wakeChObserver` registration is sufficient — no per-source registration is needed.
 
@@ -1284,7 +1285,7 @@ In addition to `Store.Subscribe`, `CacheImpl` exposes `SubscribePause(fn func(bo
 
 #### Invariants
 
-- **I1 (Single fire)**: Each `Store.Apply` call produces at most one `Change` per observer registration. Observers are called in registration order.
+- **I1 (Single fire)**: Each `Store.Apply` call produces at most one `Change` per observer registration. `Store.Reset` produces one `Change` per item (add, update, or removal). Observers are called in registration order.
 - **I2 (Outside lock)**: Observers are called after the store's write-lock is released. Observers may safely call `store.Get` or other read methods without deadlock.
 - **I3 (Single registration)**: Each observer is registered exactly once on the shared store. Since `engine.store` and `cacheImpl.store` are the same pointer, calling both `e.store.Subscribe(obs)` and `cacheImpl.Subscribe(obs)` registers the observer twice, causing every Apply to fire it twice. Register once via `e.store.Subscribe`. See ADR-038 for the historical dual-store design that this replaced.
 - **I4 (Non-blocking wakeCh)**: The `wakeChObserver` always uses a non-blocking send. A full `wakeCh` (capacity 1) means a poll is already pending; dropping the signal is correct (burst coalescence).
@@ -1528,6 +1529,8 @@ When `--webhooks` and `--board-cache=in-memory` are both active (the default whe
 ### D.1 Bootstrap
 
 Immediately after `wm.Start()` succeeds (webhook manager listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` directly — bypassing the cache — and passes the result to `cacheImpl.Bootstrap(board)`. Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
+
+Bootstrap calls `Store.Reset`, which fires observer notifications for every item (one `Change` per item, with non-zero `Fields`). Observers (`wakeChObserver`, `mayNeedWorkObserver`) are registered in `Engine.Run()` **before** Bootstrap is called, so bootstrapped items are visible to the dispatch loop on the first poll cycle — no external webhook event is needed to unblock them.
 
 If the bootstrap fetch fails (e.g., transient network error), the cache starts empty and populates through fallback on the first cache miss. No data is lost; latency for the first deep-fetch is slightly higher.
 

--- a/internal/itemstate/change.go
+++ b/internal/itemstate/change.go
@@ -37,6 +37,11 @@ const (
 	InvocationChanged
 	// BaseBranchChanged indicates BaseBranchWarned map changed.
 	BaseBranchChanged
+	// ItemRemoved indicates the item was removed from the board during a Reset.
+	// This flag is distinct from StateChanged (issue open/closed) and is emitted
+	// only by Store.Reset for items present in the old map but absent from the
+	// new items slice.
+	ItemRemoved
 )
 
 // Change describes what fields a mutation altered. Delivered to every Observer

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -841,23 +841,36 @@ func (s *Store) RemoveByItemID(itemID string) (repo string, number int, ok bool)
 	return repo, number, true
 }
 
+// resetNotification holds a Change and Snapshot for deferred observer dispatch.
+type resetNotification struct {
+	change Change
+	snap   Snapshot
+}
+
 // Reset atomically replaces all Store state with the items in the given slice.
 // Existing items, indexes, and deep-fetch state are cleared. This is used by
 // Bootstrap to ensure a clean slate (unlike Reconcile, which preserves deep state).
+// Observers are notified outside the write lock, following the same pattern as Apply.
 func (s *Store) Reset(items []gh.ProjectItem) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+
+	oldItems := s.items
 	s.items = make(map[string]*ItemState, len(items))
 	s.shaToKey = make(map[string]string, len(items))
 	s.itemIDToKey = make(map[string]string, len(items))
+
+	newKeys := make(map[string]bool, len(items))
+	var notifications []resetNotification
+
 	for i := range items {
 		pi := items[i]
 		key := itemKeyFor(pi.Repo, pi.Number)
 		if key == "" {
 			continue
 		}
+		newKeys[key] = true
 		item := &ItemState{Repo: pi.Repo, Number: pi.Number}
-		applyProjectItem(item, pi)
+		flags := applyProjectItem(item, pi)
 		s.items[key] = item
 		if item.ItemID != "" {
 			s.itemIDToKey[item.ItemID] = key
@@ -865,6 +878,31 @@ func (s *Store) Reset(items []gh.ProjectItem) {
 		if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
 			s.shaToKey[item.LinkedPR.HeadSHA] = key
 		}
+		notifications = append(notifications, resetNotification{
+			change: Change{Repo: item.Repo, Number: item.Number, Fields: flags},
+			snap:   newSnapshot(*item),
+		})
+	}
+
+	// Synthesize removal Changes for items present in the old map but absent from the new slice.
+	for key, old := range oldItems {
+		if newKeys[key] {
+			continue
+		}
+		notifications = append(notifications, resetNotification{
+			change: Change{Repo: old.Repo, Number: old.Number, Fields: ItemRemoved},
+			snap:   newSnapshot(*old),
+		})
+	}
+
+	s.mu.Unlock()
+
+	if len(notifications) == 0 {
+		return
+	}
+	obs := s.captureObservers()
+	for _, n := range notifications {
+		s.notify(obs, n.change, n.snap)
 	}
 }
 

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -897,11 +897,8 @@ func (s *Store) Reset(items []gh.ProjectItem) {
 
 	s.mu.Unlock()
 
-	if len(notifications) == 0 {
-		return
-	}
-	obs := s.captureObservers()
 	for _, n := range notifications {
+		obs := s.captureObservers()
 		s.notify(obs, n.change, n.snap)
 	}
 }

--- a/internal/itemstate/store_test.go
+++ b/internal/itemstate/store_test.go
@@ -473,6 +473,184 @@ func TestItemDeepFetchedClearsLastDeepFetchFailureAt(t *testing.T) {
 	}
 }
 
+// ---- Reset observer tests ----
+
+// TestResetNotifiesObserversOnAdd verifies that Reset emits a Change for every
+// item in the new slice, with non-zero Fields.
+func TestResetNotifiesObserversOnAdd(t *testing.T) {
+	s := NewStore(nil)
+
+	var mu sync.Mutex
+	var received []Change
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {
+		mu.Lock()
+		received = append(received, c)
+		mu.Unlock()
+	}))
+
+	items := []gh.ProjectItem{
+		testProjectItem(testRepo, 10),
+		testProjectItem(testRepo, 11),
+		testProjectItem(testRepo, 12),
+	}
+	s.Reset(items)
+
+	mu.Lock()
+	got := len(received)
+	mu.Unlock()
+
+	if got != 3 {
+		t.Fatalf("expected 3 Changes from Reset, got %d", got)
+	}
+	for _, c := range received {
+		if c.Fields == 0 {
+			t.Errorf("Change for #%d has zero Fields; want non-zero", c.Number)
+		}
+		if c.Fields&ItemRemoved != 0 {
+			t.Errorf("Change for #%d has ItemRemoved set unexpectedly", c.Number)
+		}
+	}
+}
+
+// TestResetNotifiesObserversOnRemoval verifies that Reset emits ItemRemoved Changes
+// for items present in the old map but absent from the new slice.
+func TestResetNotifiesObserversOnRemoval(t *testing.T) {
+	s := NewStore(nil)
+
+	// Populate three items via Apply.
+	for _, n := range []int{20, 21, 22} {
+		s.Apply(IssueOpened{Item: testProjectItem(testRepo, n)})
+	}
+
+	var mu sync.Mutex
+	var received []Change
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {
+		mu.Lock()
+		received = append(received, c)
+		mu.Unlock()
+	}))
+
+	// Reset with only 2 of the 3 items — #22 is removed.
+	s.Reset([]gh.ProjectItem{
+		testProjectItem(testRepo, 20),
+		testProjectItem(testRepo, 21),
+	})
+
+	mu.Lock()
+	got := make([]Change, len(received))
+	copy(got, received)
+	mu.Unlock()
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 Changes (2 retained + 1 removed), got %d", len(got))
+	}
+
+	var removals, retained int
+	for _, c := range got {
+		if c.Fields&ItemRemoved != 0 {
+			removals++
+			if c.Number != 22 {
+				t.Errorf("ItemRemoved Change for unexpected item #%d", c.Number)
+			}
+		} else {
+			retained++
+		}
+	}
+	if removals != 1 {
+		t.Errorf("expected 1 ItemRemoved Change, got %d", removals)
+	}
+	if retained != 2 {
+		t.Errorf("expected 2 non-removal Changes, got %d", retained)
+	}
+}
+
+// TestResetObserverCalledOutsideLock verifies that observers can call Store.Get
+// inside the Reset callback without deadlocking.
+func TestResetObserverCalledOutsideLock(t *testing.T) {
+	s := NewStore(nil)
+
+	done := make(chan struct{}, 1)
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) {
+		// Would deadlock if called under the write lock.
+		s.Get(c.Repo, c.Number)
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}))
+
+	s.Reset([]gh.ProjectItem{testProjectItem(testRepo, 30)})
+
+	select {
+	case <-done:
+		// OK — observer completed without deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("deadlock: observer could not call Store.Get during Reset dispatch")
+	}
+}
+
+// TestConcurrentReset verifies no data race when Reset, Apply, Subscribe, and
+// Unsubscribe run concurrently.
+func TestConcurrentReset(t *testing.T) {
+	s := NewStore(nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Concurrent Resets.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				s.Reset([]gh.ProjectItem{testProjectItem(testRepo, n+100)})
+			}
+		}(i)
+	}
+
+	// Concurrent Applies.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				s.Apply(IssueLabeled{Repo: testRepo, Number: n + 100, Label: "x"})
+			}
+		}(i)
+	}
+
+	// Concurrent Subscribe/Unsubscribe.
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				cancel := s.Subscribe(ObserverFunc(func(Change, Snapshot) {}))
+				cancel()
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
 // TestLinkedPRSnapshotImmutabilityAfterCIMerge verifies that a snapshot taken
 // before CIMergePendingStarted is not retroactively mutated.
 func TestLinkedPRSnapshotImmutabilityAfterCIMerge(t *testing.T) {


### PR DESCRIPTION
## Summary

- `Store.Reset` was silently mutating the item map without notifying observers, so bootstrap-loaded items were invisible to the dispatch loop after every fabrik restart with `board_cache_mode: in-memory` and `webhooks: true`
- After Phase 5 F3 store unification, `e.store.Get()` succeeds for bootstrapped items, so the poll prefilter's `notInStore` bypass never fired — items stalled indefinitely unless an independent webhook event happened to arrive
- Fix rewrites `Reset` to follow the same batch-notify pattern as `Apply`: accumulate `(Change, Snapshot)` pairs under a single `s.mu` hold, release the lock, then notify observers outside all locks

## Key changes

- `internal/itemstate/change.go`: new `ItemRemoved` ChangeFlags constant for board-level removal (semantically distinct from `StateChanged` / issue open-closed)
- `internal/itemstate/store.go`: `Reset` rewritten with `resetNotification` helper struct, batch accumulation, single lock release, then `captureObservers` + `notify` per item
- `internal/itemstate/store_test.go`: four new tests — observer-on-add, observer-on-removal, outside-lock (deadlock guard), and concurrent Reset + Apply + Subscribe/Unsubscribe
- `boardcache/boardcache_test.go`: `TestBootstrapNotifiesObserver` end-to-end test subscribing before Bootstrap and asserting Changes fire for all board items
- `adrs/036-reactive-cache-single-owner.md`: addendum documenting the Bootstrap gap and its fix

## How to test

1. `go test -race -timeout 5m ./...` — all packages pass, no data races
2. `go vet ./...` — clean
3. Integration: restart fabrik with `board_cache_mode: in-memory` and active in-progress issues; verify the first poll cycle dispatches them without waiting for a webhook event

Closes #542