### PR TITLE
Log cleanup: poll log message says 'fetching project board' even when serving from in-memory cache (misleading)

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -439,6 +439,23 @@ func (c *CacheImpl) IsPaused() bool {
 	return c.paused
 }
 
+// IsBootstrapped returns true when the cache has been populated with at least
+// one item — i.e., Bootstrap has been called. Called outside c.mu per the
+// "NEVER hold mu while calling Store" invariant.
+func (c *CacheImpl) IsBootstrapped() bool {
+	return len(c.store.All()) > 0
+}
+
+// IsItemDeepFetched returns true when the cache holds deep-fetched details for
+// the given item (LastDeepFetchAt is non-zero). Called outside c.mu.
+func (c *CacheImpl) IsItemDeepFetched(repo string, number int) bool {
+	snap, err := c.store.Get(repo, number)
+	if err != nil {
+		return false
+	}
+	return !snap.State().LastDeepFetchAt.IsZero()
+}
+
 // Subscribe registers an observer on the underlying Store. The returned func
 // unsubscribes the observer. Safe to call from any goroutine.
 func (c *CacheImpl) Subscribe(o itemstate.Observer) func() {

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -439,11 +439,12 @@ func (c *CacheImpl) IsPaused() bool {
 	return c.paused
 }
 
-// IsBootstrapped returns true when the cache has been populated with at least
-// one item — i.e., Bootstrap has been called. Called outside c.mu per the
-// "NEVER hold mu while calling Store" invariant.
+// IsBootstrapped returns true when the Store contains at least one cached item.
+// Uses HasItems (O(1), non-allocating) rather than All to avoid a full snapshot
+// allocation that would otherwise duplicate the one inside FetchProjectBoard.
+// Called outside c.mu per the "NEVER hold mu while calling Store" invariant.
 func (c *CacheImpl) IsBootstrapped() bool {
-	return len(c.store.All()) > 0
+	return c.store.HasItems()
 }
 
 // IsItemDeepFetched returns true when the cache holds deep-fetched details for

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -680,7 +680,11 @@ type pollResult struct {
 
 func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	e.emitStructural(tui.PollStartedEvent{Owner: e.cfg.Owner, Repo: e.cfg.Repo, Project: e.cfg.ProjectNum})
-	e.logf(0, "poll", "fetching project board %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
+	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && cacheImpl.IsBootstrapped() && !cacheImpl.IsPaused() {
+		e.logf(0, "poll", "reading project board from cache: %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
+	} else {
+		e.logf(0, "poll", "fetching project board from GitHub: %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
+	}
 
 	board, err := e.readClient.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 	if err != nil {
@@ -874,7 +878,11 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
 			continue
 		}
-		e.logf(0, "poll", "deep-fetching details for #%d\n", board.Items[i].Number)
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && !cacheImpl.IsPaused() && cacheImpl.IsItemDeepFetched(board.Items[i].Repo, board.Items[i].Number) {
+			e.logf(0, "poll", "reading details for #%d from cache\n", board.Items[i].Number)
+		} else {
+			e.logf(0, "poll", "deep-fetching details for #%d from GitHub\n", board.Items[i].Number)
+		}
 		if err := e.readClient.FetchItemDetails(&board.Items[i]); err != nil {
 			e.logf(0, "warn", "could not fetch details for #%d: %v\n", board.Items[i].Number, err)
 			e.store.Apply(itemstate.DeepFetchFailed{

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1589,3 +1589,213 @@ func TestSeedLabels_multiRepo(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Poll log: 'from cache' vs 'from GitHub' wording (Tasks 4-8)
+// ---------------------------------------------------------------------------
+
+// collectPollLogs captures log messages emitted during a single poll call.
+// The channel is not closed after poll returns so that background goroutines
+// spawned by the dispatch loop can still send to it without panicking.
+// Poll-level log lines (board fetch, item deep-fetch) are emitted synchronously
+// before any goroutines are launched, so they are always in the buffer on return.
+func collectPollLogs(t *testing.T, eng *Engine) []string {
+	t.Helper()
+	events := make(chan tui.Event, 256)
+	eng.events = events
+	if _, err := eng.poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	// Non-blocking drain: read what's already buffered without closing the channel.
+	var msgs []string
+	for {
+		select {
+		case ev := <-events:
+			if le, ok := ev.(tui.LogEvent); ok {
+				msgs = append(msgs, le.Message)
+			}
+		default:
+			return msgs
+		}
+	}
+}
+
+// TestPoll_LogBoardFromGitHub verifies the board fetch log says "from GitHub"
+// when readClient is a pass-through GitHubAdapter (no-cache mode).
+func TestPoll_LogBoardFromGitHub(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{ProjectID: "PVT_1", Items: nil}, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	logs := collectPollLogs(t, eng)
+
+	var boardLog string
+	for _, m := range logs {
+		if strings.Contains(m, "project board") {
+			boardLog = m
+			break
+		}
+	}
+	if !strings.Contains(boardLog, "from GitHub") {
+		t.Errorf("board log = %q; want to contain \"from GitHub\"", boardLog)
+	}
+	if strings.Contains(boardLog, "from cache") {
+		t.Errorf("board log = %q; must not contain \"from cache\"", boardLog)
+	}
+}
+
+// TestPoll_LogBoardFromCache verifies the board fetch log says "from cache"
+// when readClient is a bootstrapped, unpaused CacheImpl.
+func TestPoll_LogBoardFromCache(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, _ := testEngineWithCache(client, &mockClaudeInvoker{})
+
+	logs := collectPollLogs(t, eng)
+
+	var boardLog string
+	for _, m := range logs {
+		if strings.Contains(m, "project board") {
+			boardLog = m
+			break
+		}
+	}
+	if !strings.Contains(boardLog, "from cache") {
+		t.Errorf("board log = %q; want to contain \"from cache\"", boardLog)
+	}
+	if strings.Contains(boardLog, "from GitHub") {
+		t.Errorf("board log = %q; must not contain \"from GitHub\"", boardLog)
+	}
+}
+
+// TestPoll_LogBoardBootstrapThenCache verifies the board log says "from GitHub"
+// before Bootstrap and "from cache" after Bootstrap.
+func TestPoll_LogBoardBootstrapThenCache(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_test",
+		Items: []gh.ProjectItem{
+			{Number: 1, ItemID: "PVTI_001", Status: "Research", Repo: "owner/repo"},
+		},
+	}
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return board, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	eng.readClient = cache
+
+	// Poll 1: cache not yet bootstrapped — must fetch from GitHub.
+	logs1 := collectPollLogs(t, eng)
+	var boardLog1 string
+	for _, m := range logs1 {
+		if strings.Contains(m, "project board") {
+			boardLog1 = m
+			break
+		}
+	}
+	if !strings.Contains(boardLog1, "from GitHub") {
+		t.Errorf("poll 1 board log = %q; want \"from GitHub\"", boardLog1)
+	}
+
+	// Simulate a webhook-triggered Bootstrap.
+	cache.Bootstrap(board)
+
+	// Poll 2: cache is now bootstrapped — must serve from cache.
+	logs2 := collectPollLogs(t, eng)
+	var boardLog2 string
+	for _, m := range logs2 {
+		if strings.Contains(m, "project board") {
+			boardLog2 = m
+			break
+		}
+	}
+	if !strings.Contains(boardLog2, "from cache") {
+		t.Errorf("poll 2 board log = %q; want \"from cache\"", boardLog2)
+	}
+}
+
+// TestPoll_LogItemFromGitHub verifies the item deep-fetch log says "from GitHub"
+// when the item is not yet in the cache (falls through to GitHub on cache miss).
+// Uses an unbootstrapped CacheImpl so the item is "notInStore" on first poll,
+// which bypasses the cycleSet requirement.
+func TestPoll_LogItemFromGitHub(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_test",
+		Items:     []gh.ProjectItem{{Number: 1, ItemID: "PVTI_001", Status: "Research", Repo: "owner/repo"}},
+	}
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return board, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	// Wire an unbootstrapped CacheImpl so FetchProjectBoard falls through to GitHub
+	// and the item is "notInStore" (passes the poll pre-filter on first poll).
+	eng.readClient = boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+
+	logs := collectPollLogs(t, eng)
+
+	var itemLog string
+	for _, m := range logs {
+		if strings.Contains(m, "details for") {
+			itemLog = m
+			break
+		}
+	}
+	if !strings.Contains(itemLog, "from GitHub") {
+		t.Errorf("item log = %q; want to contain \"from GitHub\"", itemLog)
+	}
+	if strings.Contains(itemLog, "from cache") {
+		t.Errorf("item log = %q; must not contain \"from cache\"", itemLog)
+	}
+}
+
+// TestPoll_LogItemFromCache verifies the item deep-fetch log says "from cache"
+// when the item's deep-fetch state is already populated in the store.
+// Registers the mayNeedWorkObserver before Bootstrap so Bootstrap's StatusChanged
+// notification populates cycleSet, letting the item reach the deep-fetch section.
+func TestPoll_LogItemFromCache(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_test",
+		Items:     []gh.ProjectItem{{Number: 1, ItemID: "PVTI_001", Status: "Research", Repo: "owner/repo"}},
+	}
+	client := &mockGitHubClient{}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+
+	// Register the mayNeedWorkObserver before Bootstrap so the StatusChanged
+	// notification from Bootstrap populates e.mayNeedWork → cycleSet on next poll.
+	eng.store.Subscribe(newMayNeedWorkObserver(&eng.mayNeedWorkMu, &eng.mayNeedWork))
+
+	// Bootstrap → store has item #1; StatusChanged fires → "owner/repo#1" in mayNeedWork.
+	cache.Bootstrap(board)
+
+	// Pre-populate LastDeepFetchAt so IsItemDeepFetched returns true.
+	eng.store.Apply(itemstate.ItemDeepFetched{
+		Repo:       "owner/repo",
+		Number:     1,
+		FreshState: gh.ProjectItem{Number: 1, Repo: "owner/repo", Status: "Research"},
+	})
+
+	eng.readClient = cache
+
+	logs := collectPollLogs(t, eng)
+
+	var itemLog string
+	for _, m := range logs {
+		if strings.Contains(m, "details for") {
+			itemLog = m
+			break
+		}
+	}
+	if !strings.Contains(itemLog, "from cache") {
+		t.Errorf("item log = %q; want to contain \"from cache\"", itemLog)
+	}
+	if strings.Contains(itemLog, "from GitHub") {
+		t.Errorf("item log = %q; must not contain \"from GitHub\"", itemLog)
+	}
+}

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1595,10 +1595,9 @@ func TestSeedLabels_multiRepo(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // collectPollLogs captures log messages emitted during a single poll call.
-// The channel is not closed after poll returns so that background goroutines
-// spawned by the dispatch loop can still send to it without panicking.
-// Poll-level log lines (board fetch, item deep-fetch) are emitted synchronously
-// before any goroutines are launched, so they are always in the buffer on return.
+// Waits for all dispatched worker goroutines to finish (via eng.wg) before
+// returning so that callers can safely reassign eng.events for a subsequent poll
+// without racing against goroutines that still read the field.
 func collectPollLogs(t *testing.T, eng *Engine) []string {
 	t.Helper()
 	events := make(chan tui.Event, 256)
@@ -1606,7 +1605,8 @@ func collectPollLogs(t *testing.T, eng *Engine) []string {
 	if _, err := eng.poll(context.Background()); err != nil {
 		t.Fatalf("poll: %v", err)
 	}
-	// Non-blocking drain: read what's already buffered without closing the channel.
+	eng.wg.Wait() // drain background workers before caller touches eng.events again
+	// Non-blocking drain: read what's already buffered.
 	var msgs []string
 	for {
 		select {

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -782,6 +782,14 @@ func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 	return flags
 }
 
+// HasItems reports whether the Store contains at least one item. O(1) and
+// non-allocating. Safe to call concurrently with Apply.
+func (s *Store) HasItems() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.items) > 0
+}
+
 // All returns an immutable snapshot of every item currently in the Store.
 // The returned slice is a point-in-time snapshot; subsequent mutations do not
 // affect it. Safe to call concurrently with Apply.


### PR DESCRIPTION
## Summary

Change two `[poll]` log lines in `engine/poll.go` — the ones emitted before `FetchProjectBoard` and `FetchItemDetails` — so they explicitly say whether the call will be served from the in-memory cache or from GitHub. No other log lines need changing; no cache or fetch logic changes.

## Problem

When the in-memory board cache is enabled (`board_cache_mode: in-memory`), every poll cycle emits this log line:

```
[poll] fetching project board tenaciousvc/#1
[poll] found 125 items on board
```

The first line implies a GitHub fetch is happening. In practice, when the cache is bootstrapped and not paused, the call is **served from the in-memory cache** — no GraphQL request is made. The operator can't tell from the log line whether GraphQL was actually hit.

This matters because:

- During the cache-coherency cluster (PRs #485, #486, #495–#511, #527, #535, #538, etc.), the operator needed to know at-a-glance whether GraphQL load was real or being absorbed by the cache. Today the only signal is watching the rate-limit footer counter — indirect, easy to miss when troubleshooting.
- After the unified Store landed (#538), the architectural win is that idle polls stay completely off GraphQL. The log line doesn't surface that win.
- Future operators reading the log to debug performance or rate-limit issues will be misled about which calls actually hit the network.

## Approach

### Approach

Use the type-assertion pattern (Option A from research) — match what the engine already does in 5 places in `engine.go` for `ApplyCommentAdded`, `ApplyLabelAdded`, etc. This keeps the change tiny: two new query-only methods on `CacheImpl`, plus a one-time type assertion at each of the two `logf` call sites in `poll.go`.

No new interface, no new abstraction, no fetch logic changes. The TOCTOU gap (log printed just before the actual call) is explicitly acceptable per the spec.

`IsBootstrapped()` replicates the `len(c.store.All()) > 0` check already inside `FetchProjectBoard`, called outside `c.mu` per the established "NEVER hold mu while calling Store" invariant.

`IsItemDeepFetched(repo, number)` calls `c.store.Get(repo, number)` and checks `!s.LastDeepFetchAt.IsZero()`, replicating the cache-hit condition already inside `FetchItemDetails`.

### New/Modified Files

| File | Change |
|------|--------|
| `boardcache/boardcache.go` | Add `IsBootstrapped() bool` and `IsItemDeepFetched(repo string, number int) bool` to `CacheImpl` |
| `engine/poll.go` | Replace two `logf` calls (lines 683 and 877) with cache-aware conditional logs |
| `engine/poll_test.go` | Add 5 new tests covering board and item cache-hit / GitHub / bootstrap-then-cache paths |

### Key Decisions

- **Option A (type assertion) over Option B (new interface)**: `CacheImpl` is a concrete type already asserted against in 5+ engine sites. Adding a `CacheStatus` interface for two query-only methods would be an over-abstraction for a logging-only change. Option A is ~10 lines of new code total.

- **No change to `ReadClient` interface**: The query methods (`IsBootstrapped`, `IsItemDeepFetched`) belong on `CacheImpl` directly, not on the interface, because `GitHubAdapter` has no cache state to query. Keeping them off the interface means `GitHubAdapter` needs no changes and the "from GitHub" path fires automatically whenever the type assertion fails.

- **No ADR**: Both new methods are query-only reads that replicate internal conditions already expressed in `FetchProjectBoard` and `FetchItemDetails`. They add no new constraints for future contributors and follow patterns already documented in ADR 034/036. No ADR warranted.

- **No documentation updates**: The spec explicitly states `docs/state-machine.md` does not need updates. No user-facing docs or other engineering specs cover poll-level log wording. No doc changes required.

### Task Checklist

- [ ] Task 1: Add `IsBootstrapped() bool` and `IsItemDeepFetched(repo, number string) bool` to `CacheImpl` in `boardcache/boardcache.go` — query-only reads of store state, called outside `c.mu`
- [ ] Task 2: Replace `poll.go:683` (FetchProjectBoard pre-log) with a cache-aware conditional: type-assert `e.readClient` to `*boardcache.CacheImpl`, call `IsBootstrapped() && !IsPaused()` to choose "reading project board from cache: …" vs "fetching project board from GitHub: …"
- [ ] Task 3: Replace `poll.go:877` (FetchItemDetails pre-log) with a cache-aware conditional: type-assert `e.readClient` to `*boardcache.CacheImpl`, call `!IsPaused() && IsItemDeepFetched(repo, number)` to choose "reading details for #N from cache" vs "deep-fetching details for #N from GitHub"
- [ ] Task 4: Add `TestPoll_LogBoardFromGitHub` — engine with `GitHubAdapter` (no-cache mode); assert log contains "from GitHub" and does NOT contain "from cache"
- [ ] Task 5: Add `TestPoll_LogBoardFromCache` — engine with bootstrapped, unpaused `CacheImpl`; assert log contains "from cache" and does NOT contain "from GitHub"
- [ ] Task 6: Add `TestPoll_LogBoardBootstrapThenCache` — first poll with empty `CacheImpl` asserts "from GitHub"; call `cache.Bootstrap(board)` to simulate webhook; second poll asserts "from cache"
- [ ] Task 7: Add `TestPoll_LogItemFromGitHub` — bootstrapped `CacheImpl` with item not yet deep-fetched; assert deep-fetch log says "from GitHub"
- [ ] Task 8: Add `TestPoll_LogItemFromCache` — bootstrapped `CacheImpl` with item pre-deep-fetched (call `cache.FetchItemDetails` once against mock to populate `LastDeepFetchAt`); assert deep-fetch log says "from cache"

### Risks

- **Test setup for `TestPoll_LogItemFromCache`**: Seeding an item's deep-fetch state requires calling `cache.FetchItemDetails` against the mock before running poll (so `LastDeepFetchAt` is populated). The mock's `fetchItemDetailsFn` must return a minimal valid item. Follow the `seedTestCache` pattern at `poll_test.go:1342` — it is established and the approach is already proven.
- **No other risks**: This is a 2-line log change plus ~10 lines of accessor code.

---
Used 12/50 turns, 4k input / 5k output tokens.

## Verification

Logging-only change: the two `[poll]` log lines in `engine/poll.go` now say "reading project board from cache" / "fetching project board from GitHub" and "reading details for #N from cache" / "deep-fetching details for #N from GitHub" depending on whether the in-memory cache will serve the call. Two new query methods (`IsBootstrapped`, `IsItemDeepFetched`) added to `CacheImpl` in `boardcache/boardcache.go`; five new tests in `engine/poll_test.go` cover all cache-hit, cache-miss, and bootstrap-then-cache paths. No fetch logic or cache behaviour changed.

---

Closes #539