### PR TITLE
docs: document org-webhook migration path and mixed-owner caveat

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1658,6 +1658,7 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
   ```
   Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). No specific minimum version is pinned; any recent `gh` with extension support works.
 - **`gh auth login`** with a token that has `admin:repo_hook` write scope (classic PAT) or equivalent repo admin access. Fine-grained tokens may lack this scope.
+- **`admin:org` scope** for org-level webhook subscription (see [Multi-Repo Boards](#multi-repo-boards)). If your token lacks this scope, Fabrik falls back to per-repo subscriptions automatically. To add it: `gh auth refresh -h github.com -s admin:org`. (`admin:org_hook` is a narrower alternative that grants only the webhook management permission.)
 - **Repo admin access** on each repository on your board, or org-admin access for org-level subscription.
 
 If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
@@ -1734,6 +1735,8 @@ fabrik --webhooks --board-cache=none
 
 Fabrik attempts to subscribe to `projects_v2_item` events, which fire when an issue is moved between board columns. If `gh webhook forward` does not support this event type for your installation, Fabrik logs a warning and continues without it. In this case, board-column changes are caught by the periodic status sweep within `--status-poll` seconds (default 10 minutes), or within 5 minutes if the stream is unhealthy (full reconcile on recovery). All other event types continue to work normally.
 
+**Per-repo webhooks never deliver `projects_v2_item` events.** This is a GitHub platform constraint, not a Fabrik limitation. GitHub only sends board-column events to org-level webhook subscriptions. If Fabrik is in per-repo mode (either because org-level subscription failed, or because the board spans multiple owners — see [Multi-Repo Boards](#multi-repo-boards)), `projects_v2_item` events will never arrive regardless of configuration. Board-column changes in per-repo mode are caught exclusively by the periodic status sweep.
+
 ### Security
 
 - The HTTP listener binds exclusively to `127.0.0.1` and is never reachable from outside your machine.
@@ -1748,7 +1751,17 @@ On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 1. If your token has org-admin access, Fabrik uses `--org=<org>` to subscribe to all repos in the org with one subscription — no restarts needed when new repos appear.
 2. Otherwise, Fabrik subscribes per-repo. When a new repo appears on the board, the subprocess is briefly restarted with the updated repo list (the safety-net poll covers any events missed during the restart).
 
+**Mixed-owner boards disable org mode entirely.** Org-level subscription requires every managed repo on the board to share the same owner. If your board spans two orgs or users (for example, during a repo migration), Fabrik silently falls back to per-repo webhooks for *all* repos — even if your token has admin access to both orgs. As noted above, per-repo webhooks never deliver `projects_v2_item` events, so board-column changes in this configuration are caught only by the periodic status sweep. To avoid this: migrate all repos to the target org simultaneously, or run two separate Fabrik instances (one per org) during the transition.
+
 > **Startup delay on multi-repo boards**: Webhook subscriptions are established after the first board poll completes (up to one poll interval, typically 30 seconds). During this window the TUI shows the blue "starting up" indicator and the safety-net poll is in effect. This is expected — the webhook manager waits until the repo list is known before subscribing.
+
+### Migration / Permission Changes
+
+Fabrik's org-mode detection runs once at startup. The result is held for the lifetime of the process — there is no in-session re-probe.
+
+- **You just gained org-admin access** (or migrated repos to a new org you own): no state needs clearing. Restart Fabrik and it will detect org-level subscription automatically on the next startup.
+- **You lost org-admin access mid-session**: the current session continues attempting org-level subscription until the first probe fails with an auth error, at which point it falls back to per-repo mode for the remainder of the session. Restart Fabrik to immediately settle into per-repo mode without waiting for the probe to fail.
+- **Per-repo mode confirmed at startup**: org-level subscription was probed and declined (auth error or token lacks `admin:org`). Fabrik will not retry org mode until restarted.
 
 ### Troubleshooting Webhook Mode
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1656,7 +1656,7 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
   ```bash
   gh extension install cli/gh-webhook
   ```
-  Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). No specific minimum version is pinned; any recent `gh` with extension support works.
+  Verify installation: `gh webhook --help` (should print usage, not `unknown command "webhook"`). Fabrik requires `gh` ≥ 2.32.0, enforced at startup with a clear error if the version is too old.
 - **`gh auth login`** with a token that has `admin:repo_hook` write scope (classic PAT) or equivalent repo admin access. Fine-grained tokens may lack this scope.
 - **`admin:org` scope** for org-level webhook subscription (see [Multi-Repo Boards](#multi-repo-boards)). If your token lacks this scope, Fabrik falls back to per-repo subscriptions automatically. To add it: `gh auth refresh -h github.com -s admin:org`. (`admin:org_hook` is a narrower alternative that grants only the webhook management permission.)
 - **Repo admin access** on each repository on your board, or org-admin access for org-level subscription.
@@ -1748,7 +1748,7 @@ Fabrik attempts to subscribe to `projects_v2_item` events, which fire when an is
 
 On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 
-1. If your token has org-admin access, Fabrik uses `--org=<org>` to subscribe to all repos in the org with one subscription — no restarts needed when new repos appear.
+1. If your token has org-admin access, Fabrik uses `--org=<org>` to subscribe to all repos in the org with one subscription. New repos in that org are covered automatically — when a new repo appears, the subprocess is briefly restarted, but the org-level subscription covers all repos in the org so no events are missed.
 2. Otherwise, Fabrik subscribes per-repo. When a new repo appears on the board, the subprocess is briefly restarted with the updated repo list (the safety-net poll covers any events missed during the restart).
 
 **Mixed-owner boards disable org mode entirely.** Org-level subscription requires every managed repo on the board to share the same owner. If your board spans two orgs or users (for example, during a repo migration), Fabrik silently falls back to per-repo webhooks for *all* repos — even if your token has admin access to both orgs. As noted above, per-repo webhooks never deliver `projects_v2_item` events, so board-column changes in this configuration are caught only by the periodic status sweep. To avoid this: migrate all repos to the target org simultaneously, or run two separate Fabrik instances (one per org) during the transition.
@@ -1757,11 +1757,11 @@ On multi-repo boards, Fabrik uses a single `gh webhook forward` subprocess:
 
 ### Migration / Permission Changes
 
-Fabrik's org-mode detection runs once at startup. The result is held for the lifetime of the process — there is no in-session re-probe.
+Fabrik probes org mode each time the webhook subprocess starts or restarts. If the probe fails with a permission error (the subprocess exits within 10 seconds with an auth-shaped error), org mode is disabled for the rest of the session — Fabrik switches to per-repo subscriptions and does not retry. A Fabrik restart always clears this sticky state and re-probes org mode from scratch.
 
 - **You just gained org-admin access** (or migrated repos to a new org you own): no state needs clearing. Restart Fabrik and it will detect org-level subscription automatically on the next startup.
-- **You lost org-admin access mid-session**: the current session continues attempting org-level subscription until the first probe fails with an auth error, at which point it falls back to per-repo mode for the remainder of the session. Restart Fabrik to immediately settle into per-repo mode without waiting for the probe to fail.
-- **Per-repo mode confirmed at startup**: org-level subscription was probed and declined (auth error or token lacks `admin:org`). Fabrik will not retry org mode until restarted.
+- **You lost org-admin access mid-session**: the running subprocess continues in org mode until it exits or restarts. On the next restart cycle, the probe fails with a permission error and Fabrik falls back to per-repo mode for the remainder of the session. Restart Fabrik to immediately settle into per-repo mode.
+- **Per-repo mode after a permission failure**: a prior org-mode probe failed with an auth error (token lacks `admin:org` or org-admin access). Fabrik will not retry org mode until restarted.
 
 ### Troubleshooting Webhook Mode
 


### PR DESCRIPTION
## Summary

Extend USER_GUIDE.md §10 with four targeted documentation additions: (1) a "Migration / Permission Changes" subsection explaining how `orgModeFailed` lifetime and restart semantics work; (2) expanded "Multi-Repo Boards" copy documenting the mixed-owner caveat and its consequences; (3) a `admin:org` / `admin:org_hook` scope callout added to the prerequisites; (4) an explicit statement in the `projects_v2_item` section that per-repo webhooks never deliver board-column events (GitHub limitation). ADR 032 already captures the design rationale; no ADR changes needed.

## Problem

USER_GUIDE.md §10 "Webhook Mode" covers the steady-state behavior for multi-repo boards and org-mode webhook subscriptions, but omits several operational details that users regularly need: what happens to org-mode state across Fabrik restarts, the undocumented hard constraint that mixed-owner boards disable org mode entirely, the missing `admin:org` scope callout in the prerequisites, and the fact that per-repo webhooks never deliver `projects_v2_item` events (a GitHub platform constraint, not a Fabrik choice).

These gaps cause avoidable debugging sessions — users granting org-admin find themselves restarting unnecessarily (or not restarting when they should), running mixed-owner boards during migration and being surprised by silent fallback, and struggling with missing scope errors that a single hint would prevent.

## Approach

### Approach

This is a documentation-only change to `docs/USER_GUIDE.md §10`. All four requirements target independent, non-overlapping locations in the file. The edits will be applied in document order (top to bottom) to make the diff easy to read and to avoid positional conflicts between edits.

No ADR changes, no code changes, and no other files require modification. `docs/troubleshooting.md` is a redirect shim with no webhook content to update — it is explicitly out of scope. ADR 032 already captures the design rationale for all behaviors being documented; the new USER_GUIDE.md text should state facts, not repeat rationale.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Four targeted additions to §10 "Webhook Mode" |

### Key Decisions

- **Document order for edits**: Apply changes top-to-bottom (Req 3 → Req 4 → Req 2 → Req 1) to keep the diff coherent and avoid offset confusion between edits.
- **No ADR**: ADR 032 covers the design rationale. The new USER_GUIDE.md content states operational facts only; no new design decision is being recorded.
- **Req 4 framing**: Two separate reasons can cause missing `projects_v2_item` events — (a) `gh webhook forward` not supporting the event type for a given installation, and (b) per-repo webhooks never delivering these events by GitHub platform design. The new text must distinguish these clearly. The existing sentence covers (a); a new sentence states (b) as a platform fact.
- **Req 1 insertion point**: Insert between the existing startup-delay blockquote (`> **Startup delay...**`) and the `### Troubleshooting Webhook Mode` heading, at line ~1752. The new subsection heading is `### Migration / Permission Changes` at the `###` level, consistent with sibling subsections.
- **Req 2 scope**: Extend the numbered list in Multi-Repo Boards and add one or two sentences after it covering the mixed-owner constraint, its silent fallback consequence, and the migration recommendation. Keep it concise — the existing numbered list already establishes the context.
- **Req 3 scope**: Add a new bullet point to the Prerequisites list that calls out `admin:org` / `admin:org_hook` for org-level subscription, with the concrete `gh auth refresh` hint on the same bullet. This sits naturally after the existing `admin:repo_hook` bullet.

### Task Checklist

- [ ] Task 1 — Add `admin:org`/`admin:org_hook` scope callout to Prerequisites (Req 3): Add a new bullet after line 1661 stating that org-level webhook subscription requires `admin:org` scope (or `admin:org_hook`), with the hint `gh auth refresh -h github.com -s admin:org`.
- [ ] Task 2 — Extend `projects_v2_item` subsection with GitHub platform limitation (Req 4): Append to the existing paragraph at line 1735 an explicit statement that per-repo webhooks *never* deliver `projects_v2_item` events — this is a GitHub platform limitation, not a Fabrik gap — and that users in per-repo mode should expect board-column changes to arrive only via the status sweep.
- [ ] Task 3 — Extend Multi-Repo Boards subsection with mixed-owner caveat (Req 2): After the existing numbered list (line ~1749), add a paragraph stating that `detectOrgMode` requires every managed repo to share the same owner; that a mixed-owner board silently falls back to per-repo webhooks for all repos (even when the token has admin on both orgs); that this means `projects_v2_item` events are not delivered and board-column changes rely on the status sweep; and that the recommended approach is to migrate all repos simultaneously or run two separate Fabrik instances.
- [ ] Task 4 — Insert "Migration / Permission Changes" subsection (Req 1): Insert a new `### Migration / Permission Changes` subsection between the startup-delay blockquote (after Multi-Repo Boards, ~line 1751) and the `### Troubleshooting Webhook Mode` heading (~line 1753). Content: `orgModeFailed` is a process-lifetime flag; restart always re-probes; gaining org-admin requires only a restart; losing org-admin mid-session has no effect until the first probe fails (restart to settle quickly into per-repo mode).

### Risks

- **Positional drift**: The research identified line numbers from a specific commit. If main has advanced since research ran, line numbers may have shifted slightly. The implementer should verify context strings when making each edit rather than relying solely on line numbers.
- **Tone drift**: The existing §10 prose is terse and factual. New content that over-explains (e.g., quoting `orgModeFailed` field names directly, or repeating ADR rationale) will feel inconsistent. Implementer should use plain-language operational descriptions rather than internal field names where possible — exception: `orgModeFailed` is acceptable once in the Migration subsection since it is meaningful to users who have read the ADR.

---
Used 6/50 turns, 4k input / 2k output tokens.

## Verification

Extended USER_GUIDE.md §10 with four targeted additions: (1) a `Migration / Permission Changes` subsection explaining `orgModeFailed` process-lifetime semantics and restart behavior; (2) a mixed-owner caveat in Multi-Repo Boards documenting the silent fallback to per-repo webhooks and its consequences; (3) an `admin:org`/`admin:org_hook` scope callout with `gh auth refresh` hint in Prerequisites; (4) an explicit statement in the `projects_v2_item` subsection that per-repo webhooks never deliver board-column events (GitHub platform constraint). One commit pushed to `fabrik/issue-541`.

---

Closes #541