### PR TITLE
fabrik:extend-turns has no effect on comment processing — silent UX gap

### DIFF
--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -81,7 +81,7 @@ These labels do not define distinct states but influence transition behavior:
 | `fabrik:yolo` | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` |
 | `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
-| `fabrik:extend-turns` | Pre-grants a 2× turn budget for every stage invocation while present; persists across stages; removed only at the Done cleanup stage or manually; no-op when `max_turns == 0` |
+| `fabrik:extend-turns` | Pre-grants a 2× turn budget for every stage invocation and comment processing invocation while present; persists across stages; removed only at the Done cleanup stage or manually; no-op when `max_turns == 0` (stage) or always applies for comments since `commentMaxTurns` is never 0 |
 | `model:<name>` | Selects a specific model for this issue (e.g., `model:opus`) |
 | `effort:<level>` | Overrides stage effort level (`low`, `medium`, `high`, `max`); highest wins |
 | `base:<branch>` | Overrides worktree base branch; falls back to default if not on remote; updates PR base if PR exists |
@@ -141,7 +141,7 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
 | `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
 | `fabrik:unrestricted` | User (manual) | Any time | User (manual) | Any time | Passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` |
-| `fabrik:extend-turns` | User (manual) | Any time | `processItem` cleanup branch or User (manual) | At Done cleanup stage completion; or manual removal | Pre-grants 2× `stage.MaxTurns` budget for every invocation while present; persists across all intermediate stages; no-op when `max_turns == 0` (unlimited); subsequent extensions beyond 2× still require progress detection |
+| `fabrik:extend-turns` | User (manual) | Any time | `processItem` cleanup branch or User (manual) | At Done cleanup stage completion; or manual removal | Pre-grants 2× `stage.MaxTurns` budget for every stage invocation while present; no-op for stage path when `max_turns == 0` (unlimited); also pre-grants 2× `commentMaxTurns(stage)` budget for every comment processing invocation (comment budget is never 0); subsequent extensions beyond 2× require progress detection for both paths; persists across all intermediate stages |
 | `model:<name>` | User (manual) | Any time | User (manual) | Any time | Selects Claude model; first label wins if multiple present |
 | `effort:<level>` | User (manual) | Any time | User (manual) | Any time | Overrides stage effort level; highest-ranked wins if multiple present |
 | `base:<branch>` | User (manual) | Before Research (recommended) | User (manual) | Any time | Overrides worktree base branch; falls back to default if branch not found on remote; if a PR exists, its base branch is updated to match on each stage invocation |
@@ -545,7 +545,41 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
 | 11 | If FABRIK_STAGE_COMPLETE was detected: handle completion | `handleStageComplete()` | Same completion flow as a normal stage invocation (advance, PR ops, etc.) |
 
-### 4.3 Comment Processing Entry Points
+### 4.3 Turn Limit Extension
+
+When Claude exits a comment processing invocation due to `comment_max_turns` (i.e., `invUsage.TurnsUsed >= currentBudget` and `!invCompleted && err == nil`), the engine evaluates whether to extend before returning partial output.
+
+**Extension trigger condition:** `!invCompleted && err == nil && currentBudget > 0 && invUsage.TurnsUsed >= currentBudget`
+
+Note: `currentBudget > 0` is only satisfied when `fabrik:extend-turns` is present (label absent → `currentBudget = 0` → no extension possible).
+
+**Hard cap:** 3× `commentMaxTurns(stage)` total across all invocations. When `totalMultiple >= 3`, no further extension is attempted.
+
+**`commentMaxTurns(stage)`:** Returns `CommentMaxTurns` if set, else `MaxTurns`, else `50`. This value is always > 0 (unlike `stage.MaxTurns` which can be 0 for unlimited).
+
+**Per-stage progress signals:** Same signals as the stage invocation path — see §3 Turn Limit Extension table. For no-signal stages (Research, Specify, Plan, Done), `detectProgress` returns `false` immediately, so `fabrik:extend-turns` grants the 2× pre-budget for the first invocation but no further extension.
+
+**Extension loop behavior (within a single `processComments` call):**
+
+1. `hadExtendTurnsLabel` snapshotted before the loop. If present: `currentBudget = 2 × commentMaxTurns(stage)`, `totalMultiple = 2`. If absent: `currentBudget = 0`, `totalMultiple = 1`.
+2. `snapshotBaseline` called before the loop (same function as stage path).
+3. `InvokeForComments` called with `opts.MaxTurnsOverride = currentBudget`. Session resume is handled internally by `InvokeClaudeForComments` — no loop-level session management needed.
+4. If limit hit AND `totalMultiple < 3`: call `detectProgress`. If progress → `totalMultiple++`, `currentBudget = commentMaxTurns(stage)`, re-invoke. If no progress or error → return partial output.
+5. Output accumulated across all invocations before posting as a single comment.
+6. Usage totals (tokens, turns) and `InvocationRecorded` store event applied once after loop completes.
+
+**`fabrik:extend-turns` label:** When present, the first comment processing invocation receives `2 × commentMaxTurns(stage)` as its budget (pre-granted, no progress check required for the first turn-limit hit).
+
+**Log tag:** `[#N extend-turns]` — same tag as stage path. Emitted on each `detectProgress` call. When extension is granted, an additional line logs the new budget multiple and cumulative turns used. `[#N stats]` emitted after loop with final accumulated usage.
+
+| Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
+|--------------|-------|-------|-----------------|--------------|----------------|--------------|
+| Comment Processing, In Progress | Turn limit hit | `totalMultiple < 3`; progress detected | Comment Processing, In Progress (extension) | | | `totalMultiple++`; `currentBudget = commentMaxTurns(stage)`; output accumulated; `InvocationRecorded` deferred |
+| Comment Processing, In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Comment Processing, Complete (partial) | | | Hard cap reached; partial output posted; `InvocationRecorded` applied |
+| Comment Processing, In Progress | Turn limit hit | No progress detected or progress check failed | Comment Processing, Complete (partial) | | | No extension; partial output posted |
+| Comment Processing, In Progress | FABRIK_STAGE_COMPLETE (any extension) | `invCompleted = true` | Comment Processing, Complete | | | Normal comment completion flow; output posted |
+
+### 4.4 Comment Processing Entry Points
 
 Comments can trigger processing through three paths in `processItem()`:
 
@@ -553,7 +587,7 @@ Comments can trigger processing through three paths in `processItem()`:
 2. **Paused unpause:** `fabrik:paused` present + new comments → remove `fabrik:paused`, `clearFailedStage()` → fall through → `processComments()`
 3. **Normal comment processing:** Item is not paused → `findNewComments()` finds comments → `processComments()`
 
-### 4.4 markCommentsSeenByStage
+### 4.5 markCommentsSeenByStage
 
 After a stage invocation (not comment processing), `markCommentsSeenByStage()` adds ROCKET reactions to all pre-existing comments that were included in the prompt as context. This prevents those comments from triggering the awaiting-input unblock logic on subsequent polls.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -551,7 +551,7 @@ When Claude exits a comment processing invocation due to `comment_max_turns` (i.
 
 **Extension trigger condition:** `!invCompleted && err == nil && currentBudget > 0 && invUsage.TurnsUsed >= currentBudget`
 
-Note: `currentBudget > 0` is only satisfied when `fabrik:extend-turns` is present (label absent → `currentBudget = 0` → no extension possible).
+Note: `currentBudget > 0` is only satisfied when `fabrik:extend-turns` is present (label absent → `currentBudget = 0` → no extension possible). **This differs from stage invocations (§3)**, where the progress-based extension loop fires whenever `stage.MaxTurns > 0` is hit — the label only pre-grants the 2× first budget there. Comment processing is intentionally label-gated: extending comment-review turns is a new opt-in capability, and changing no-label behavior would silently extend comment budgets for all existing issues.
 
 **Hard cap:** 3× `commentMaxTurns(stage)` total across all invocations. When `totalMultiple >= 3`, no further extension is attempted.
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -315,6 +315,9 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 
 	prompt := buildCommentReviewPrompt(stage, issue, comments, opts.BaseBranch)
 	limit := commentMaxTurns(stage)
+	if opts.MaxTurnsOverride > 0 {
+		limit = opts.MaxTurnsOverride
+	}
 	args := buildClaudeArgs(stage, sessFilePath, true, opts.ModelOverride, limit, hasUnrestrictedLabel(issue), workDir) // resume existing session
 
 	extraEnv := buildClaudeEnv(stage, opts.EffortOverride)

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -130,7 +130,66 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if len(onPIDReady) > 0 && onPIDReady[0] != nil {
 		invokeOpts.OnPIDReady = onPIDReady[0]
 	}
-	output, _, usage, err := e.claude.InvokeForComments(ctx, stage, item, comments, workDir, invokeOpts)
+
+	// Snapshot extend-turns label before loop (stable across any mid-loop FetchItemDetails re-fetch).
+	hadExtendTurnsLabel := hasExtendTurnsLabel(item)
+
+	// Determine initial turn budget. Label absent → MaxTurnsOverride=0 (InvokeClaudeForComments uses
+	// commentMaxTurns naturally). Label present → 2× pre-granted budget (no progress check for first hit).
+	base := commentMaxTurns(stage)
+	firstBudget := 0
+	totalMultiple := 1
+	if hadExtendTurnsLabel && base > 0 {
+		firstBudget = 2 * base
+		totalMultiple = 2
+	}
+	baseline := snapshotBaseline(stage, item, workDir)
+
+	// Extension loop: InvokeForComments resumes the existing session internally.
+	// Hard cap is 3× commentMaxTurns across all invocations.
+	var output string
+	var usage TokenUsage
+	currentBudget := firstBudget
+	for {
+		invokeOpts.MaxTurnsOverride = currentBudget
+		var invOutput string
+		var invCompleted bool
+		var invUsage TokenUsage
+		invOutput, invCompleted, invUsage, err = e.claude.InvokeForComments(ctx, stage, item, comments, workDir, invokeOpts)
+		output += invOutput
+		usage = addTokenUsage(usage, invUsage)
+
+		hitLimit := !invCompleted && err == nil && currentBudget > 0 && invUsage.TurnsUsed >= currentBudget
+		if !hitLimit || totalMultiple >= 3 {
+			break
+		}
+		issueLogf := func(tag, format string, args ...any) {
+			e.logf(item.Number, tag, format, args...)
+		}
+		hasProgress, progressErr := detectProgress(ctx, stage, &item, baseline, workDir, e.client, issueLogf)
+		if progressErr != nil {
+			e.logf(item.Number, "extend-turns", "comment progress check failed: %v\n", progressErr)
+			break
+		}
+		if !hasProgress {
+			break
+		}
+		totalMultiple++
+		currentBudget = base
+		e.logf(item.Number, "extend-turns", "extending comment review to %d× budget (%d turns used)\n", totalMultiple, usage.TurnsUsed)
+	}
+	// Report cumulative budget across all extensions.
+	usage.MaxTurns = totalMultiple * base
+
+	if usage.TurnsUsed > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
+		if usage.MaxTurns > 0 {
+			e.logf(item.Number, "stats", "used %d/%d turns, %dk input / %dk output tokens\n",
+				usage.TurnsUsed, usage.MaxTurns, usage.InputTokens/1000, usage.OutputTokens/1000)
+		} else {
+			e.logf(item.Number, "stats", "used %d turns, %dk input / %dk output tokens\n",
+				usage.TurnsUsed, usage.InputTokens/1000, usage.OutputTokens/1000)
+		}
+	}
 	func() {
 		e.mu.Lock()
 		defer e.mu.Unlock()

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -159,6 +159,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		output += invOutput
 		usage = addTokenUsage(usage, invUsage)
 
+		// hitLimit uses currentBudget > 0 (not base > 0) so that extension only fires
+		// when fabrik:extend-turns is present. Unlike the stage path, comment-review
+		// extension is intentionally label-gated: no silent budget expansion without opt-in.
 		hitLimit := !invCompleted && err == nil && currentBudget > 0 && invUsage.TurnsUsed >= currentBudget
 		if !hitLimit || totalMultiple >= 3 {
 			break

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -336,3 +336,195 @@ func TestIsReviewReinvoke_EmptySlice_ReturnsFalse(t *testing.T) {
 		t.Error("expected false for empty slice")
 	}
 }
+
+// ── fabrik:extend-turns in comment processing ─────────────────────────────────
+
+// TestCommentProcessingExtendTurnsLabelAbsent verifies that when fabrik:extend-turns
+// is absent, MaxTurnsOverride=0 is passed to InvokeForComments (base budget used).
+func TestCommentProcessingExtendTurnsLabelAbsent(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(s *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "comment output", false, TokenUsage{TurnsUsed: 3}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", CommentMaxTurns: 5}
+	item := gh.ProjectItem{
+		Number: 30,
+		Body:   "spec",
+		// No fabrik:extend-turns label
+	}
+	userComments := []gh.Comment{
+		{ID: "C_1", DatabaseID: 800, Author: "testuser", Body: "please research"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	calls := claude.forCommentsCalls
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 InvokeForComments call, got %d", len(calls))
+	}
+	if calls[0].opts.MaxTurnsOverride != 0 {
+		t.Errorf("MaxTurnsOverride = %d, want 0 (label absent → base budget)", calls[0].opts.MaxTurnsOverride)
+	}
+}
+
+// TestCommentProcessingExtendTurnsLabelPresent verifies that when fabrik:extend-turns
+// is present, the first InvokeForComments call uses 2× commentMaxTurns as MaxTurnsOverride.
+func TestCommentProcessingExtendTurnsLabelPresent(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(s *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "comment output", false, TokenUsage{TurnsUsed: 3}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", CommentMaxTurns: 5}
+	item := gh.ProjectItem{
+		Number: 31,
+		Body:   "spec",
+		Labels: []string{"fabrik:extend-turns"},
+	}
+	userComments := []gh.Comment{
+		{ID: "C_2", DatabaseID: 801, Author: "testuser", Body: "please research"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	calls := claude.forCommentsCalls
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 InvokeForComments call, got %d", len(calls))
+	}
+	wantOverride := 2 * commentMaxTurns(stage) // 2 × 5 = 10
+	if calls[0].opts.MaxTurnsOverride != wantOverride {
+		t.Errorf("MaxTurnsOverride = %d, want %d (2× commentMaxTurns)", calls[0].opts.MaxTurnsOverride, wantOverride)
+	}
+}
+
+// TestCommentProcessingExtendTurnsProgressDetected verifies the full 2×→3× loop:
+// label present, first invocation hits limit, progress detected → second invocation at 3× total.
+// Uses Validate stage: detectProgress checks comment count via FetchItemDetails mock.
+func TestCommentProcessingExtendTurnsProgressDetected(t *testing.T) {
+	skipIfNoGit(t)
+
+	const commentMaxTurnsVal = 5
+	budget2x := 2 * commentMaxTurnsVal // 10
+	budget1x := commentMaxTurnsVal     // 5 (second slot)
+
+	var callCount int
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			// Simulate progress: add a new comment on re-fetch.
+			item.Comments = append(item.Comments, gh.Comment{Body: "new comment"})
+			return nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(s *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			if callCount == 1 {
+				// Hit the budget without completing.
+				return "partial output", false, TokenUsage{TurnsUsed: opts.MaxTurnsOverride}, nil
+			}
+			return "final output", true, TokenUsage{TurnsUsed: 3}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Validate", CommentMaxTurns: commentMaxTurnsVal}
+	item := gh.ProjectItem{
+		Number: 32,
+		Body:   "spec",
+		Labels: []string{"fabrik:extend-turns"},
+		// No comments initially → baseline commentCount=0; FetchItemDetails adds one.
+	}
+	userComments := []gh.Comment{
+		{ID: "C_3", DatabaseID: 802, Author: "testuser", Body: "please validate"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	calls := claude.forCommentsCalls
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 InvokeForComments calls (2×→3× extension), got %d", len(calls))
+	}
+	if calls[0].opts.MaxTurnsOverride != budget2x {
+		t.Errorf("first call MaxTurnsOverride = %d, want %d (2× budget)", calls[0].opts.MaxTurnsOverride, budget2x)
+	}
+	if calls[1].opts.MaxTurnsOverride != budget1x {
+		t.Errorf("second call MaxTurnsOverride = %d, want %d (1× extension)", calls[1].opts.MaxTurnsOverride, budget1x)
+	}
+}
+
+// TestCommentProcessingExtendTurnsNoProgress verifies that when label is present, budget is
+// hit, but no progress is detected, there is no re-invoke.
+// Uses Research stage: detectProgress always returns false for no-signal stages.
+func TestCommentProcessingExtendTurnsNoProgress(t *testing.T) {
+	skipIfNoGit(t)
+
+	const commentMaxTurnsVal = 5
+	budget2x := 2 * commentMaxTurnsVal // 10
+
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(s *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Hit the budget without completing; no progress signal for Research stage.
+			return "partial output", false, TokenUsage{TurnsUsed: opts.MaxTurnsOverride}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", CommentMaxTurns: commentMaxTurnsVal}
+	item := gh.ProjectItem{
+		Number: 33,
+		Body:   "spec",
+		Labels: []string{"fabrik:extend-turns"},
+	}
+	userComments := []gh.Comment{
+		{ID: "C_4", DatabaseID: 803, Author: "testuser", Body: "please research"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	calls := claude.forCommentsCalls
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 InvokeForComments call (no re-invoke on no-progress), got %d", len(calls))
+	}
+	if calls[0].opts.MaxTurnsOverride != budget2x {
+		t.Errorf("MaxTurnsOverride = %d, want %d (2× budget pre-granted)", calls[0].opts.MaxTurnsOverride, budget2x)
+	}
+}

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -542,15 +542,24 @@ func (m *mockGitHubClient) LookupIssueProjectItem(projectID, repo string, issueN
 // mockClaudeInvoker implements ClaudeInvoker for testing.
 // mu protects calls for concurrent-safe access.
 type mockClaudeInvoker struct {
-	mu       sync.Mutex
-	invokeFn func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error)
-	calls    []claudeInvokeCall
+	mu                  sync.Mutex
+	invokeFn            func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error)
+	calls               []claudeInvokeCall
+	invokeForCommentsFn func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error)
+	forCommentsCalls    []commentInvokeCall
 }
 
 type claudeInvokeCall struct {
 	stageName string
 	issueNum  int
 	resume    bool
+	workDir   string
+	opts      InvokeOptions
+}
+
+type commentInvokeCall struct {
+	stageName string
+	issueNum  int
 	workDir   string
 	opts      InvokeOptions
 }
@@ -567,8 +576,16 @@ func (m *mockClaudeInvoker) Invoke(ctx context.Context, stage *stages.Stage, iss
 }
 
 func (m *mockClaudeInvoker) InvokeForComments(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
-	if m.invokeFn != nil {
-		return m.invokeFn(stage, issue, comments, false, workDir, opts)
+	m.mu.Lock()
+	m.forCommentsCalls = append(m.forCommentsCalls, commentInvokeCall{stage.Name, issue.Number, workDir, opts})
+	fn := m.invokeForCommentsFn
+	fallback := m.invokeFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(stage, issue, comments, workDir, opts)
+	}
+	if fallback != nil {
+		return fallback(stage, issue, comments, false, workDir, opts)
 	}
 	return "mock comment output", false, TokenUsage{}, nil
 }


### PR DESCRIPTION
## Summary

Extend the `fabrik:extend-turns` label to cover comment processing, mirroring the existing stage-invocation behavior in `engine/item.go`. When the label is present, comment processing should: (1) pre-grant a 2× turn budget on the first invocation, and (2) run a progress-based extension loop (up to 3× total) if the budget is hit without completing. Add log visibility so the user can see when extensions fire or are exhausted.

## Problem

The `fabrik:extend-turns` label is implemented only for stage invocations (`engine/item.go`). Comment processing (`engine/comments.go`) ignores it entirely — no `hasExtendTurnsLabel` check, no budget override, no extension loop. Users who add the label to an issue stuck in comment-processing turn-exhaustion get no feedback and no behavior change.

This bit a real workflow on issue #544: a Review-comment-review hit the comment turn limit, the user added `fabrik:extend-turns` expecting it to help, and it had no effect. The label's name strongly implies "extend turns for any work on this issue"; the actual behavior is "extend turns for stage invocations only." The asymmetry is invisible to users.

## Approach

### Approach

Mirror the stage-invocation extension loop from `engine/item.go:651–701` into the comment-processing path in `engine/comments.go`. The design is not novel — ADR 030 already defines the 2×/3× budgeting semantics and the `fabrik:extend-turns` label contract. This PR applies that design to the second code path that was missed at initial implementation.

The four code changes are mechanical and isolated:
1. Fix `InvokeClaudeForComments` to respect `opts.MaxTurnsOverride` (one guard, two lines).
2. Extend `mockClaudeInvoker` to track `InvokeForComments` calls separately (required for new tests).
3. Wrap the `InvokeForComments` call site in `comments.go` with the extension loop (mirrors the stage path exactly).
4. Add four focused tests in `comments_test.go`.
5. Update `docs/state-machine.md` in the same commit as code changes (two sections).

**Stats footer decision:** The posted comment will keep its existing empty footer (`""`). The spec requires only `[#N extend-turns]` and `[#N stats]` *log output* — no change to the comment body format. This keeps scope minimal and matches the spec literally.

**No ADR needed:** ADR 030 already documents this pattern. Extending it to comment processing is additive, not a new architectural decision.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/claude.go` | Add `MaxTurnsOverride` guard in `InvokeClaudeForComments` (2 lines) |
| `engine/mocks_test.go` | Add `invokeForCommentsFn` field + `forCommentsCalls` slice to `mockClaudeInvoker` |
| `engine/comments.go` | Add extension loop around `InvokeForComments` call site; move usage/stats after loop |
| `engine/comments_test.go` | Four new tests covering the four acceptance scenarios |
| `docs/state-machine.md` | Update §1 quick-labels table; update §1.4 detailed table; add §4.3 Turn Limit Extension subsection (renumbering §4.3–§4.4 to §4.4–§4.5) |

### Key Decisions

- **`hadExtendTurnsLabel` snapshotted before the loop, not re-read per iteration.** Same rationale as the stage path: a mid-loop `FetchItemDetails` could change `item.Labels`; the first-budget calculation must be stable.
- **`firstBudget = 2 × commentMaxTurns(stage)` when label present.** `commentMaxTurns` never returns 0 (floor is 50), so no `> 0` guard on the multiply is needed — but include it anyway for consistency with the stage path and future-proofing.
- **`totalMultiple` tracks budget tier relative to `commentMaxTurns(stage)`.** After the loop: `usage.MaxTurns = totalMultiple * commentMaxTurns(stage)`. This parallels line 701 in the stage path (`totalMultiple * stage.MaxTurns`).
- **Usage accumulation and `InvocationRecorded` move to after the loop.** They currently fire immediately after the single `InvokeForComments` call. The loop accumulates `invUsage` per iteration into a total `usage`, then applies the store event once with accumulated totals.
- **No stats footer added to the posted comment.** The spec requires log output only. The `formatStatsFooter` call is not added — scope is strictly what the spec asks for.
- **Mock needs per-call opts recording.** `InvokeForComments` currently delegates to `invokeFn` and records nothing. Tests need to assert `opts.MaxTurnsOverride` per call and simulate multi-call scenarios (progress detected → second invocation). Add `invokeForCommentsFn func(...)` for per-call return control, and `forCommentsCalls []commentInvokeCall` for recording. Existing tests that don't set `invokeForCommentsFn` fall through to the default `"mock comment output"` return — backward-compatible.

### Task Checklist

- [ ] **Task 1:** `engine/claude.go` — In `InvokeClaudeForComments`, after `limit := commentMaxTurns(stage)`, add: `if opts.MaxTurnsOverride > 0 { limit = opts.MaxTurnsOverride }`. Update the `usage.MaxTurns = limit` line at the end is already correct — no change needed there.
- [ ] **Task 2:** `engine/mocks_test.go` — Add `commentInvokeCall` struct (fields: `stageName string`, `issueNum int`, `workDir string`, `opts InvokeOptions`). Add `invokeForCommentsFn func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error)` and `forCommentsCalls []commentInvokeCall` fields to `mockClaudeInvoker`. Update `InvokeForComments` to record call + opts into `forCommentsCalls` and dispatch to `invokeForCommentsFn` when set, otherwise fall through to existing `invokeFn`-then-default behavior.
- [ ] **Task 3:** `engine/comments.go` — Replace the single `InvokeForComments` call (line 133) with an extension loop matching the stage path:
  - Before the loop: snapshot `hadExtendTurnsLabel := hasExtendTurnsLabel(item)`; compute `firstBudget` (1× base, 2× if label+budget>0); set `totalMultiple`; call `snapshotBaseline`.
  - Loop: call `InvokeForComments` with `opts.MaxTurnsOverride = currentBudget`; accumulate `output` and `usage`; check `hitLimit`; call `detectProgress` with a bound `issueLogf` closure; extend or break; log `[#N extend-turns]` on each extension.
  - After loop: set `usage.MaxTurns = totalMultiple * commentMaxTurns(stage)`; emit `[#N stats]` logf; then `e.totalTokens` update and `e.store.Apply(InvocationRecorded{...})`.
  - The existing error handling, `checkCompletion`, `stripMarkers`, and posting code below remain unchanged.
- [ ] **Task 4a:** `engine/comments_test.go` — Add test `TestCommentProcessingExtendTurnsLabelAbsent`: label absent → mock returns base budget; assert `forCommentsCalls[0].opts.MaxTurnsOverride == 0` (engine passes override=0, which means `InvokeClaudeForComments` uses base budget).
- [ ] **Task 4b:** `engine/comments_test.go` — Add test `TestCommentProcessingExtendTurnsLabelPresent`: label present, single invocation completes without hitting limit; assert `forCommentsCalls[0].opts.MaxTurnsOverride == 2*commentMaxTurns(stage)`.
- [ ] **Task 4c:** `engine/comments_test.go` — Add test `TestCommentProcessingExtendTurnsProgressDetected`: label present; first invocation returns `completed=false` + `TurnsUsed >= 2× base` (hits limit); `detectProgress` logic requires a git commit change — simulate by using an Implement stage with snapshotted baseline; second invocation completes. Assert two `forCommentsCalls` entries with correct `MaxTurnsOverride` values (2× then 3×). *(Note: if `detectProgress` for Implement checks `gitHeadSHA`, the test will need a real git worktree. Check `extend_test.go` for the pattern used there — use `skipIfNoGit` guard and `t.TempDir()` with `git init` if needed, or mock the progress check via a stage that has no progress signal and accept the 2×-only behavior in the test.)*
- [ ] **Task 4d:** `engine/comments_test.go` — Add test `TestCommentProcessingExtendTurnsNoProgress`: label present; first invocation hits limit; progress check returns false; assert only one `forCommentsCalls` entry (no re-invoke).
- [ ] **Task 5:** `docs/state-machine.md`:
  - Update the §1 quick-labels table row (line 84): change `fabrik:extend-turns` description to cover both stage and comment processing scope.
  - Update the §1.4 detailed table row (line 144): extend the "Effects while present" cell to include `commentMaxTurns(stage)` budget for comment processing.
  - Insert a new "**### 4.3 Turn Limit Extension**" subsection after the end of §4.2 (before current §4.3), mirroring the §3 "Turn Limit Extension" section but referencing `commentMaxTurns(stage)` instead of `stage.MaxTurns`. Include: trigger condition, hard cap (3× `commentMaxTurns(stage)`), behavior for no-signal stages (Research/Specify/Plan: 2× pre-grant only, no further extension), and a state-transition table (4 rows) parallel to the one at lines 472–477. Renumber current §4.3 → §4.4 and §4.4 → §4.5.

### Risks

- **Task 4c git dependency:** `detectProgress` for Implement requires a live git repo with a HEAD SHA. Tests will need either `skipIfNoGit` + a scratch git repo, or a stage with no progress signal (e.g., a Plan-type stage where `detectProgress` always returns false). The simpler path: test task 4c with a Research/Plan stage (no progress signal → `detectProgress` returns `false` immediately → only 2× granted, no 3× extension). This avoids git setup while still exercising the loop. For a true 2→3× extension test, follow the `extend_test.go` integration pattern. The spec requires testing "label present + budget hit + progress detected → re-invoke at 3× budget" — use a `git init` scratch worktree with a committed SHA change, guarded by `skipIfNoGit`.
- **Usage/stats move:** Moving `e.totalTokens` and `InvocationRecorded` out of their current position changes when they fire. This is correct behavior (accumulate across all extensions), but requires careful review that no code between the old and new positions relies on them having already fired.
- **`completed` variable name collision:** `comments.go` already declares `completed` at line 161 (`completed := checkCompletion(stage, output)`). The per-invocation `completed` bool from `InvokeForComments` must use a distinct name (e.g., `invCompleted`) inside the loop to avoid shadowing.

---
Used 16/50 turns, 5k input / 5k output tokens.

## Verification

Implemented `fabrik:extend-turns` support for comment processing: `InvokeClaudeForComments` now respects `opts.MaxTurnsOverride`, `processComments` wraps the invoke call with a 2×→3× extension loop matching the stage path, and four new tests cover all acceptance scenarios. `docs/state-machine.md` updated with §4.3 Turn Limit Extension and revised §1/§1.4 label rows. All 148 engine tests pass.

---

Closes #551