### PR TITLE
Add shortcut to invoke abtop from fabrik TUI https://github.com/graykode/abtop

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1474,6 +1474,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `n` / `N` | Cancel quit or clear-all confirmation dialogs |
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
+| `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `?` | Toggle help panel (keybindings and labels reference) |
 | `q` | Quit |

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -111,6 +111,17 @@ func openResumeInlineCmd(pluginDir, repo string, issueNumber int, stageName, sta
 	})
 }
 
+// openAbtopInlineCmd returns a tea.Cmd that suspends the TUI and launches abtop
+// inline in the current terminal via tea.ExecProcess.
+// The TUI is restored automatically when the user exits abtop.
+// The caller must verify abtop is in PATH before calling this function.
+func openAbtopInlineCmd() tea.Cmd {
+	cmd := exec.Command("abtop")
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return abtopFinishedMsg{Err: err}
+	})
+}
+
 // worktreePathForIssue returns the absolute path to the issue's git worktree.
 // Path: <rootDir>/.fabrik/worktrees/<owner>-<repo>/issue-N
 func worktreePathForIssue(rootDir, repo string, issueNumber int) string {

--- a/tui/commands_test.go
+++ b/tui/commands_test.go
@@ -1,6 +1,10 @@
 package tui
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -73,5 +77,41 @@ func TestUpdate_LKey_Returns_WatchCmd(t *testing.T) {
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
 	if cmd == nil {
 		t.Error("expected non-nil cmd (tea.ExecProcess) from l key with active job")
+	}
+}
+
+// TestUpdate_AKey_NoAbtop_SetsStatusMsg verifies that pressing 'a' when abtop is not in
+// PATH sets an error status message and returns a nil cmd (no subprocess launched).
+func TestUpdate_AKey_NoAbtop_SetsStatusMsg(t *testing.T) {
+	t.Setenv("PATH", "")
+	m := New(30, ProjectInfo{}, "", nil)
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	if cmd != nil {
+		t.Error("expected nil cmd when abtop is not in PATH")
+	}
+	got := result.(Model).header.statusMsg
+	want := "abtop not found in PATH — install from github.com/graykode/abtop"
+	if got != want {
+		t.Errorf("status message = %q, want %q", got, want)
+	}
+}
+
+// TestUpdate_AKey_AbtopFound_ReturnsExecCmd verifies that pressing 'a' when abtop is
+// found in PATH returns a non-nil tea.ExecProcess cmd.
+func TestUpdate_AKey_AbtopFound_ReturnsExecCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix executable permissions")
+	}
+	dir := t.TempDir()
+	abtopPath := filepath.Join(dir, "abtop")
+	if err := os.WriteFile(abtopPath, []byte{}, 0755); err != nil {
+		t.Fatalf("create fake abtop: %v", err)
+	}
+	t.Setenv("PATH", fmt.Sprintf("%s%c%s", dir, os.PathListSeparator, os.Getenv("PATH")))
+
+	m := New(30, ProjectInfo{}, "", nil)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	if cmd == nil {
+		t.Error("expected non-nil cmd (tea.ExecProcess) when abtop is found in PATH")
 	}
 }

--- a/tui/help.go
+++ b/tui/help.go
@@ -33,6 +33,7 @@ KEYBOARD SHORTCUTS
     C          Clear all history (with confirmation)
 
   Global
+    a          Open abtop AI session monitor
     w          Wake: reset idle backoff and poll immediately
     ?          Toggle this help panel
     q          Quit

--- a/tui/model.go
+++ b/tui/model.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -64,6 +65,9 @@ type watchExitMsg struct{ Err error }
 
 // claudeResumeFinishedMsg is returned by tea.ExecProcess when the claude --resume subprocess exits.
 type claudeResumeFinishedMsg struct{ Err error }
+
+// abtopFinishedMsg is returned by tea.ExecProcess when the abtop subprocess exits.
+type abtopFinishedMsg struct{ Err error }
 
 // pane identifies which TUI section has focus.
 type pane int
@@ -305,6 +309,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
+		case "a":
+			if _, err := exec.LookPath("abtop"); err != nil {
+				m.header.SetStatusMsg("abtop not found in PATH — install from github.com/graykode/abtop")
+				return m, nil
+			}
+			return m, openAbtopInlineCmd()
+
 		case "c", "C":
 			if m.focusPane == paneHistory {
 				comp, cmd := m.history.Update(msg)
@@ -354,6 +365,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case claudeResumeFinishedMsg:
+		return m, nil
+
+	case abtopFinishedMsg:
 		return m, nil
 
 	case TickEvent:

--- a/tui/model.go
+++ b/tui/model.go
@@ -368,6 +368,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case abtopFinishedMsg:
+		if ev.Err != nil {
+			m.header.SetStatusMsg(fmt.Sprintf("abtop error: %v", ev.Err))
+		}
 		return m, nil
 
 	case TickEvent:


### PR DESCRIPTION
## Summary

Add an `a` keyboard shortcut to the Fabrik main TUI dashboard that suspends the current view, launches `abtop` inline in the same terminal using the existing `tea.ExecProcess` pattern, and restores the Fabrik TUI when the user exits abtop. If `abtop` is not installed, a status line error message is shown.

## Problem

When running the Fabrik TUI dashboard, operators have no quick way to inspect the resource usage of the Claude Code processes Fabrik is managing — token consumption, context window utilization, rate limit status, and session metadata. `abtop` (https://github.com/graykode/abtop) is a purpose-built real-time monitor for AI coding agent sessions ("htop for Claude Code"), but there's no integration with Fabrik's TUI. Users must alt-tab to a separate terminal and launch abtop manually.

## Approach

### Approach

This is a small, well-scoped addition following the established `tea.ExecProcess` pattern mandated by ADR 015. The implementation mirrors `openResumeInlineCmd` / `openWatchInlineCmd` almost identically.

The `exec.LookPath("abtop")` check lives in the `"a"` case of `Model.Update()` in `model.go`, not inside `openAbtopInlineCmd`. Reason: the not-found path needs to call `m.header.SetStatusMsg(...)` and return `nil`, which requires model state access — placing the check in the command constructor would require an awkward return-value encoding to propagate the error back. Keeping `openAbtopInlineCmd` as a pure `tea.ExecProcess` constructor (no conditional logic) stays consistent with the two existing constructors.

`abtopFinishedMsg` is declared in `model.go` alongside `watchExitMsg` and `claudeResumeFinishedMsg` (same file, same pattern). The handler is a no-op, same as those two.

No new ADR is needed. ADR 015 already mandates `tea.ExecProcess` for exactly this pattern. The LookPath-at-keypress constraint is explicitly specified and self-evident.

### New/Modified Files

| File | Change |
|------|--------|
| `tui/model.go` | Add `abtopFinishedMsg` type; add no-op handler in `Update()`; add `"a"` key case with LookPath check |
| `tui/commands.go` | Add `openAbtopInlineCmd()` |
| `tui/help.go` | Add `a` entry under "Global" section in `helpContent` |
| `docs/USER_GUIDE.md` | Add `a` row to §7 keyboard shortcuts table (required by the cross-reference comment in `help.go`) |
| `tui/commands_test.go` | Add `TestUpdate_AKey_NoAbtop_SetsStatusMsg` and `TestUpdate_AKey_AbtopFound_ReturnsExecCmd` |

### Key Decisions

- **LookPath in `Update()`, not in `openAbtopInlineCmd`**: Command constructors in this codebase are pure — they build and return a `tea.Cmd`, with no conditional paths. Status message mutation (`m.header.SetStatusMsg`) requires model access, so the not-found path belongs in `Update()`. `openAbtopInlineCmd` remains unconditional.

- **No args to `abtop`**: `exec.Command("abtop")` with no arguments, per spec. Avoids version coupling.

- **No `cmd.Dir` override**: Unlike `openResumeInlineCmd`, abtop doesn't need a specific working directory. It discovers Claude sessions from process metadata and filesystem, not CWD.

- **Error message text**: `"abtop not found in PATH — install from github.com/graykode/abtop"` — actionable and matches the existing error message style in the TUI.

- **No new ADR**: ADR 015 already covers this pattern explicitly. No decisions meet the bar for a new ADR.

### Task Checklist

- [ ] Task 1: `tui/model.go` — Add `abtopFinishedMsg` struct alongside `watchExitMsg` and `claudeResumeFinishedMsg`; add `case abtopFinishedMsg: return m, nil` in `Update()` alongside the other two exit handlers (lines 353–357)
- [ ] Task 2: `tui/commands.go` — Add `openAbtopInlineCmd()` function returning `tea.ExecProcess(exec.Command("abtop"), func(err error) tea.Msg { return abtopFinishedMsg{Err: err} })`
- [ ] Task 3: `tui/model.go` — Add `"a"` case in the `switch ev.String()` block (after the `"w"` case, before `"c"/"C"`): call `exec.LookPath("abtop")`; on error, call `m.header.SetStatusMsg("abtop not found in PATH — install from github.com/graykode/abtop")` and return `m, nil`; on success, return `m, openAbtopInlineCmd()`
- [ ] Task 4: `tui/help.go` + `docs/USER_GUIDE.md` — Add `a    Open abtop AI session monitor` under the "Global" section of `helpContent` in `help.go`; add matching `a` row to the TUI keyboard shortcuts table in `docs/USER_GUIDE.md` §7 (the `help.go` comment at line 12–13 requires both stay in sync)
- [ ] Task 5: `tui/commands_test.go` — Add `TestUpdate_AKey_NoAbtop_SetsStatusMsg`: set `t.Setenv("PATH", "")` to ensure LookPath fails, send `tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")}` to `Update()`, assert returned cmd is nil and `m.header` status message is set to the not-found string; add `TestUpdate_AKey_AbtopFound_ReturnsExecCmd`: write a zero-byte executable named `abtop` to `t.TempDir()`, set `PATH` to that dir, send the `"a"` key, assert returned cmd is non-nil

### Risks

- **Test PATH isolation**: `t.Setenv("PATH", ...)` restores the original value after the test, but `exec.LookPath` is a process-global call. Tests must not be run in parallel if they mutate PATH — ensure test functions do not call `t.Parallel()`.
- **`abtop` binary name on Windows**: The spec says cross-platform support is in scope for abtop itself, but Fabrik's TUI is primarily a Linux/macOS tool. `exec.LookPath` on Windows appends `.exe` automatically, so `exec.LookPath("abtop")` will find `abtop.exe` if present — no special handling needed.

---
Used 9/50 turns, 3k input / 5k output tokens.

## Verification

Added an `a` keyboard shortcut to the Fabrik main TUI dashboard that suspends the view and launches `abtop` inline via `tea.ExecProcess`, following the same pattern as the existing `l` (watch) and `r` (resume) shortcuts. When `abtop` is not in PATH, a transient status line error message is shown instead. The shortcut is documented in the help panel (`?`) and `docs/USER_GUIDE.md`, and two tests cover both the not-found and found paths.

---

Closes #553