### PR TITLE
Phase 5 F5 close-out: observer-registration discipline superseded by store unification

### DIFF
--- a/docs/cache-refactor/04-phase4-audit.md
+++ b/docs/cache-refactor/04-phase4-audit.md
@@ -16,9 +16,9 @@ The reactive plumbing (wakeCh, mayNeedWork set, TUI events) is wired correctly t
 - **F2**: Finish migrating `boardcache.linkedPRs` and `prNumToKey` into Store. (TODO present in code at `boardcache/boardcache.go:207`.)
 - **F3**: Decide and document the two-store split — either unify or make the split explicit with API guards (so `e.store.Get(...).Status()` can't return a stale-by-design empty value).
 - **F4**: Audit `boardcache.checkRuns` retention strategy; the comment at `boardcache/boardcache.go:200-203` notes Store silently drops `CheckRunCompleted` for unlinked SHAs and CacheImpl mirrors them. Validate this is correct or move check-run state into Store-level negative-cache + per-item.
-- **F5**: Tighten observer-registration discipline so future observers can't be registered on only one store when they should fire from both.
+- **F5**: ~~Tighten observer-registration discipline~~ — **Superseded by F3** (PR #538, issue #537). F3 unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance. With only one store, there is no "which store" registration choice to make; the mis-registration risk is structurally eliminated.
 
-Severity: F1 is a duplication that's likely benign in practice (both maps tracked together) but it's the exact "double source of truth" that motivated this refactor and should be eliminated. F2/F3/F4 are technical-debt cleanups. F5 is preventive.
+Severity: F1 is a duplication that's likely benign in practice (both maps tracked together) but it's the exact "double source of truth" that motivated this refactor and should be eliminated. F2/F3/F4 are technical-debt cleanups. F5 is superseded (resolved structurally by F3's store unification).
 
 The architecture is in a much, much better place than 24 hours ago. The remaining items don't block re-enabling the cache+webhooks in `dev` config — they're follow-up improvements.
 
@@ -109,7 +109,7 @@ Phase 5 issue F3 captures the choice.
 
 The mayNeedWork drain pattern (`engine/poll.go:823-831`) atomically swaps the map with a fresh empty one under lock — no missed events, no double-processing.
 
-Issue: this dual-store registration is **not enforced**. A future observer that should fire from both stores could be accidentally registered on only one. No type-system or test guard against this. Phase 5 F5.
+**F5 superseded:** The dual-store registration concern captured as Phase 5 F5 is no longer applicable. F3 (PR #538, issue #537) unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance. All observers now register on `e.store`, which is the same instance held by `cacheImpl`. There is no "which store" choice; the mis-registration risk is structurally eliminated.
 
 ## §3 Per-reader audit findings
 
@@ -205,13 +205,11 @@ Worker liveness label reads need fixing either way: route to cacheImpl.
 
 **Tests:** existing tests cover the dual-track flow. Add a test for "CheckRunCompleted arrives before linkage; subsequent linkage causes pre-linkage runs to be replayed."
 
-### F5 — observer-registration discipline
+### F5 — observer-registration discipline (**Superseded by F3**)
 
-**Problem:** `engine/poll.go:310-360` correctly registers each observer on the right store(s), but the choice is hand-coded per observer. Future observers could be mis-registered (e.g. only on `engine.store` when they should fire from both).
+**Superseded:** F3 (PR #538, issue #537) unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance — engine creates it and passes it to `NewCacheImpl`. With only one `Store`, the registration discipline concern is structurally eliminated: there is no "which store" choice to make. Every observer subscribes once on `e.store` (see `engine/poll.go:305-345`).
 
-**Fix:** introduce an `Observer.RequiredStores()` method (or struct field) that documents which stores the observer needs to subscribe to; have the registration site enforce it. Or: introduce a wrapper "broadcast subscribe" that registers on every Store the engine knows about, with per-observer filters via Change flags.
-
-**Tests:** test that an observer with `Stores: [Engine, Cache]` is correctly invoked from both; with `Stores: [Engine]` not invoked from cache.
+The proposed fixes (`Observer.RequiredStores()` method, broadcast-subscribe wrapper) were **not adopted** and are now dead architecture given the single-Store reality. No implementation required.
 
 ## §5 What did NOT need fixing
 

--- a/docs/cache-refactor/04-phase4-audit.md
+++ b/docs/cache-refactor/04-phase4-audit.md
@@ -16,7 +16,7 @@ The reactive plumbing (wakeCh, mayNeedWork set, TUI events) is wired correctly t
 - **F2**: Finish migrating `boardcache.linkedPRs` and `prNumToKey` into Store. (TODO present in code at `boardcache/boardcache.go:207`.)
 - **F3**: Decide and document the two-store split — either unify or make the split explicit with API guards (so `e.store.Get(...).Status()` can't return a stale-by-design empty value).
 - **F4**: Audit `boardcache.checkRuns` retention strategy; the comment at `boardcache/boardcache.go:200-203` notes Store silently drops `CheckRunCompleted` for unlinked SHAs and CacheImpl mirrors them. Validate this is correct or move check-run state into Store-level negative-cache + per-item.
-- **F5**: ~~Tighten observer-registration discipline~~ — **Superseded by F3** (PR #538, issue #537). F3 unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance. With only one store, there is no "which store" registration choice to make; the mis-registration risk is structurally eliminated.
+- **F5**: ~~Tighten observer-registration discipline~~ — **Superseded by F3** (PR #538, issue #537). Post-Phase-4, F3 unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance. With only one store, there is no "which store" registration choice to make; the mis-registration risk is structurally eliminated.
 
 Severity: F1 is a duplication that's likely benign in practice (both maps tracked together) but it's the exact "double source of truth" that motivated this refactor and should be eliminated. F2/F3/F4 are technical-debt cleanups. F5 is superseded (resolved structurally by F3's store unification).
 
@@ -109,7 +109,7 @@ Phase 5 issue F3 captures the choice.
 
 The mayNeedWork drain pattern (`engine/poll.go:823-831`) atomically swaps the map with a fresh empty one under lock — no missed events, no double-processing.
 
-**F5 superseded:** The dual-store registration concern captured as Phase 5 F5 is no longer applicable. F3 (PR #538, issue #537) unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance. All observers now register on `e.store`, which is the same instance held by `cacheImpl`. There is no "which store" choice; the mis-registration risk is structurally eliminated.
+**F5 superseded:** The dual-store registration concern captured as Phase 5 F5 is no longer applicable. F3 (PR #538, issue #537) unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance. All Store observers now register on `e.store`, which is the same instance held by `cacheImpl`. There is no "which store" choice; the mis-registration risk is structurally eliminated. (`SubscribePause`, used by `WebhookHealthObserver`, is a separate CacheImpl mechanism unrelated to Store observer registration.)
 
 ## §3 Per-reader audit findings
 
@@ -207,7 +207,7 @@ Worker liveness label reads need fixing either way: route to cacheImpl.
 
 ### F5 — observer-registration discipline (**Superseded by F3**)
 
-**Superseded:** F3 (PR #538, issue #537) unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance — engine creates it and passes it to `NewCacheImpl`. With only one `Store`, the registration discipline concern is structurally eliminated: there is no "which store" choice to make. Every observer subscribes once on `e.store` (see `engine/poll.go:305-345`).
+**Superseded:** F3 (PR #538, issue #537) unified `engine.store` and `cacheImpl.store` into a single shared `*itemstate.Store` instance — engine creates it and passes it to `NewCacheImpl`. With only one `Store`, the registration discipline concern is structurally eliminated: there is no "which store" choice to make. Every Store observer subscribes once on `e.store`.
 
 The proposed fixes (`Observer.RequiredStores()` method, broadcast-subscribe wrapper) were **not adopted** and are now dead architecture given the single-Store reality. No implementation required.
 


### PR DESCRIPTION
## Summary

Update `docs/cache-refactor/04-phase4-audit.md` to mark F5 as superseded by F3's store unification, with a brief explanation of why the structural concern no longer applies. No code changes are required or appropriate.

## Problem

`docs/cache-refactor/04-phase4-audit.md` §4 F5 describes a preventive concern about observer-registration discipline: future observers added to `engine/poll.go` could be mis-registered on only one `itemstate.Store` when they should fire from both, because the registration choice was hand-coded with no enforcement mechanism.

This concern was valid when two separate `itemstate.Store` instances existed (one on Engine, one on CacheImpl). It is now structurally moot: PR #538 (issue #537, Phase 5 F3) unified those two stores into a single shared instance. There is no longer a "which store" choice to make — every observer registers once on the single shared store.

The audit document still describes F5 as an open preventive issue, and §2's inline note still flags it as an unresolved concern. Both need to reflect the supersedure.

## Approach

### Approach

This is a pure documentation update with no code changes. The research found three specific locations in `docs/cache-refactor/04-phase4-audit.md` that still describe F5 as an open preventive issue. Each location gets a targeted edit replacing the open-issue framing with a supersedure note explaining that F3's store unification (PR #538, issue #537) eliminated the structural condition F5 was guarding against.

No new files. No architectural decisions. No ADR warranted — the F3 decision is already recorded in ADR-036; this is just synchronizing the audit doc's F5 entry to match the implemented outcome.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/cache-refactor/04-phase4-audit.md` | Three targeted edits: §0 F5 bullet, §2 closing note, §4 F5 spec block |

### Key Decisions

- **Only edit the three flagged locations, nothing else.** The rest of the audit document (§1.3's two-store description, §2's observer-registration details for non-F5 observers, §3's per-reader findings) still accurately describes Phase 4 findings and should not be touched. F5's supersedure is scoped to the three locations the spec identified.

- **Mark the §4 F5 block as superseded in-place rather than deleting it.** Deleting the spec block would remove historical context about what was proposed. Replacing the "Problem/Fix/Tests" framing with a "Superseded" outcome note preserves the record while accurately communicating the disposition.

- **No ADR needed.** The implementation decision (store unification) that makes F5 moot is already captured in ADR-036's addendum. This task is housekeeping documentation, not a new architectural decision.

### Task Checklist

- [ ] Edit §0: Update the F5 bullet in the Phase 5 backlog list (lines 19–21) to note supersedure by F3 (PR #538, issue #537), with a one-sentence explanation that the single shared Store instance eliminates the mis-registration risk.
- [ ] Edit §2: Replace the closing note at lines 111–112 that flags F5 as an unresolved concern with a supersedure note explaining that F3's store unification resolved the concern structurally.
- [ ] Edit §4: Replace the F5 spec block (lines 208–215) with a superseded-by-F3 outcome block, noting that the proposed `Observer.RequiredStores()` method and broadcast-subscribe wrapper were not adopted (superseded, not implemented).
- [ ] Commit the three-edit change with message referencing issue #564 and F3/PR #538.

### Risks

None. Single internal doc file, no consumers, no code changes.

---
Used 6/50 turns, 2k input / 1k output tokens.

## Verification

Updated `docs/cache-refactor/04-phase4-audit.md` in three places to mark Phase 5 issue F5 as superseded by F3's store unification (PR #538, issue #537): the §0 backlog bullet now notes the structural elimination of the mis-registration risk, the §2 closing note replaces the open-concern framing with a supersedure explanation, and the §4 F5 spec block replaces the Problem/Fix/Tests proposal with a superseded outcome noting that `Observer.RequiredStores()` and the broadcast-subscribe wrapper were not adopted. No code changes.

---

Closes #564