### PR TITLE
feat(boardcache): Phase 5 F2 — migrate linkedPRs and prNumToKey into Store

### DIFF
--- a/adrs/036-reactive-cache-single-owner.md
+++ b/adrs/036-reactive-cache-single-owner.md
@@ -102,6 +102,7 @@ The migration PRs (Phase 3-A through 3-H) are tracked as separate fabrik issues,
 - Phase 2 design: complete (`docs/cache-refactor/02-design.md`).
 - Phase 3-A through 3-H: filed as fabrik issues; pipeline executing.
 - Phase 4 audit: complete (`docs/cache-refactor/04-phase4-audit.md`).
+- Phase 5 F2 (linkedPRs / prNumToKey migration): complete (issue #562). See addendum below.
 - Phase 5 F3 (store unification): complete (issue #537, PR #538). See addendum below.
 - Phase 5 F4 (worker lifecycle migration): complete (issue #544). See addendum below.
 
@@ -204,6 +205,42 @@ After Fix B, every state transition that gates dispatch flows through `Store.App
 | Lock / worker PID | Store | Store |
 | Invocation outcomes, stage state | Store | Store |
 | **Worker lifecycle (in-flight guard)** | **sync.Map (bypass)** | **Store (WorkerEntered/WorkerExited)** |
+
+## Addendum — Phase 5 F2: linkedPRs / prNumToKey Migration (2026-05-05)
+
+### Remaining bypass
+
+After Phase 5 F4 (worker lifecycle migration), two `CacheImpl`-owned maps still lived outside the Store:
+
+- `linkedPRs map[string]*gh.PRDetails` — full PR detail objects (Title, State, Merged, Draft, HeadSHA, MergeableState) keyed by `prKey(repo, prNum)`. Mutations to this map (in `applyPullRequestDelta`, `FetchLinkedPR`, `ready_for_review`, `converted_to_draft`) fired no Store observers.
+- `prNumToKey map[string]string` — reverse-index from `prKey(repo, prNum)` to `itemKey`, used by delta handlers to route PR/review/check-run webhook events to the correct issue. Likewise invisible to the observer pipeline.
+
+The consequence: any future dispatch logic wanting to react to PR-detail changes (e.g., Draft toggled, PR closed) could not see those changes via the `wakeChFlags` pipeline. `FetchLinkedPR` reconstructed `*gh.PRDetails` from `c.linkedPRs`, a structure that had no Store-aware lifecycle.
+
+### Resolution
+
+Issue #562 completed the migration:
+
+1. **`LinkedPRState` extended** — four new fields (`Title string`, `State string`, `Merged bool`, `Draft bool`) added to `internal/itemstate/itemstate.go`, matching the fields in `gh.PRDetails` that were absent from the Store.
+
+2. **`PRDetailsUpdated` mutation added** — new type in `internal/itemstate/mutation.go` carrying `Repo`, `Number` (issue number), `PRNumber`, `Title`, `State`, `Merged`, `Draft`. Emits `LinkedPRChanged` (already in `wakeChFlags`). Every write site that previously mutated `c.linkedPRs` now calls `store.Apply(PRDetailsUpdated{...})`.
+
+3. **`prToKey` reverse-index in Store** — `internal/itemstate/store.go` gains a `prToKey map[string]string` field (keyed `"owner/repo#pr<N>"`) following the same lifecycle as `shaToKey` and `itemIDToKey`. Maintained by `updateIndexes` after every `Apply`; cleaned up by `Store.Remove`/`RemoveByItemID`. Exposed via `store.GetByPRKey(repo, prNum) (string, bool)`. All delta handlers that previously read `c.prNumToKey[pk]` now call `store.GetByPRKey`.
+
+4. **`CacheImpl` maps removed** — `linkedPRs` and `prNumToKey` fields deleted from the struct. `NewCacheImpl`, `Bootstrap`, `Reconcile`, `FetchItemDetails`, `FetchLinkedPR`, and all six delta-handler functions updated. `FetchLinkedPR` now uses `snap.LinkedPR().Title != ""` as the cache-hit sentinel and reconstructs `*gh.PRDetails` from the Store snapshot.
+
+### Structural invariant restored
+
+After F2, every per-item state mutation in both the engine and boardcache flows through `Store.Apply`. The `prToKey` index is an internal implementation detail of the Store (not engine state), consistent with `shaToKey` and `itemIDToKey`.
+
+| State structure | Pre-F2 | Post-F2 |
+|----------------|--------|---------|
+| Item status / labels / comments | Store | Store |
+| Lock / worker PID | Store | Store |
+| Invocation outcomes, stage state | Store | Store |
+| Worker lifecycle (in-flight guard) | Store (post-F4) | Store |
+| **PR detail fields (Title, State, Merged, Draft)** | **`CacheImpl.linkedPRs` (bypass)** | **Store (`PRDetailsUpdated`)** |
+| **PR→issue routing index** | **`CacheImpl.prNumToKey` (bypass)** | **`Store.prToKey` (index)** |
 
 ## References
 

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -167,9 +167,9 @@ func snapshotToProjectItem(snap itemstate.Snapshot) gh.ProjectItem {
 // fallback ReadClient on cache miss.
 //
 // Internal ownership split:
-//   - store owns: items, shaToKey, itemIDToKey
+//   - store owns: items, shaToKey, itemIDToKey, prToKey
 //   - CacheImpl owns: paused, recentMissCache, projectID/Title/OwnerType,
-//     linkedPRs, checkRuns, prNumToKey, localDeltaAt
+//     checkRuns, localDeltaAt
 //
 // Locking invariant: mu guards CacheImpl-local fields only. Store has its own
 // internal mutex. NEVER hold mu while calling any Store method — this prevents
@@ -203,20 +203,12 @@ type CacheImpl struct {
 	// is resolved.
 	checkRuns map[string][]gh.CheckRun
 
-	// linkedPRs stores full PR details keyed by prKey(repo, prNum).
-	// TODO(phase3-x): migrate to Store when LinkedPRState gains Title/State/Merged/Draft.
-	linkedPRs map[string]*gh.PRDetails
-
-	// prNumToKey maps prKey(repo, prNum) → issue itemKey.
-	// Replaces the linear scan of Store items for PR-number → issue lookups in delta handlers.
-	prNumToKey map[string]string
-
 	// localDeltaAt records the last time a webhook bumped an item.
 	// FetchProjectBoard uses max(ItemState.UpdatedAt, localDeltaAt[key]) so that
 	// webhook-driven changes are visible to itemMayNeedWork before the next Reconcile.
 	localDeltaAt map[string]time.Time
 
-	// store owns per-item state (items, shaToKey, itemIDToKey).
+	// store owns per-item state (items, shaToKey, itemIDToKey, prToKey).
 	store *itemstate.Store
 
 	fallback ReadClient
@@ -231,8 +223,6 @@ func NewCacheImpl(fallback ReadClient, store *itemstate.Store, logFn func(format
 	}
 	return &CacheImpl{
 		checkRuns:       make(map[string][]gh.CheckRun),
-		linkedPRs:       make(map[string]*gh.PRDetails),
-		prNumToKey:      make(map[string]string),
 		localDeltaAt:    make(map[string]time.Time),
 		recentMissCache: make(map[string]time.Time),
 		store:           store,
@@ -252,10 +242,9 @@ func (c *CacheImpl) Bootstrap(board *gh.ProjectBoard) {
 	c.projectID = board.ProjectID
 	c.projectTitle = board.Title
 	c.projectOwnerType = board.OwnerType
-	// Reset CacheImpl-local maps so they're consistent with the fresh Store state.
-	c.prNumToKey = make(map[string]string)
+	// Reset CacheImpl-local maps. linkedPRs and prNumToKey have been migrated to the
+	// Store (PRDetailsUpdated + prToKey index), so Store.Reset above handles them.
 	c.localDeltaAt = make(map[string]time.Time)
-	c.linkedPRs = make(map[string]*gh.PRDetails)
 	c.checkRuns = make(map[string][]gh.CheckRun)
 	c.mu.Unlock()
 
@@ -316,18 +305,12 @@ func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
 	}
 
 	// Remove items no longer on the board.
+	// Store.Remove handles cleanup of the prToKey index automatically.
 	for _, snap := range c.store.All() {
 		key := itemKey(snap.Repo(), snap.Number())
 		if !newKeys[key] {
 			drifted++
 			c.store.Remove(snap.Repo(), snap.Number())
-			// Clean up CacheImpl-side prNumToKey so stale PR numbers don't resurrect ghost items.
-			if lpr := snap.LinkedPR(); lpr != nil && lpr.Number != 0 {
-				pk := prKey(snap.Repo(), lpr.Number)
-				c.mu.Lock()
-				delete(c.prNumToKey, pk)
-				c.mu.Unlock()
-			}
 		}
 	}
 
@@ -539,22 +522,14 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 	}
 
 	// Write back to Store via ItemDeepFetched.
+	// ItemDeepFetched → applyProjectItem → ensureLinkedPR sets lpr.Number = pi.LinkedPRNumber,
+	// which then triggers updateIndexes to populate the prToKey index automatically.
+	// No explicit prNumToKey backfill needed.
 	c.store.Apply(itemstate.ItemDeepFetched{
 		Repo:       item.Repo,
 		Number:     item.Number,
 		FreshState: *item,
 	})
-	// If FetchItemDetails learned a LinkedPRNumber, backfill prNumToKey so that
-	// future PR review/comment deltas can route via the normal (non-auto-heal) path.
-	if item.LinkedPRNumber != 0 {
-		pk := prKey(item.Repo, item.LinkedPRNumber)
-		issKey := itemKey(item.Repo, item.Number)
-		c.mu.Lock()
-		if _, exists := c.prNumToKey[pk]; !exists {
-			c.prNumToKey[pk] = issKey
-		}
-		c.mu.Unlock()
-	}
 	return nil
 }
 
@@ -588,7 +563,6 @@ func (c *CacheImpl) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, erro
 // FetchLinkedPR returns cached PR details for an issue; falls back to GitHub on miss.
 func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 	fullRepo := owner + "/" + repo
-	issKey := itemKey(fullRepo, issueNumber)
 
 	c.mu.RLock()
 	paused := c.paused
@@ -598,7 +572,7 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		return c.fallback.FetchLinkedPR(owner, repo, issueNumber)
 	}
 
-	// Get LinkedPRNumber from Store (Store has its own mutex; no c.mu held).
+	// Get LinkedPR state from Store (Store has its own mutex; no c.mu held).
 	var linkedPRNum int
 	snap, snapErr := c.store.Get(fullRepo, issueNumber)
 	if snapErr == nil {
@@ -607,15 +581,19 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		}
 	}
 
-	if linkedPRNum != 0 {
-		pk := prKey(fullRepo, linkedPRNum)
-		c.mu.RLock()
-		if pr, ok := c.linkedPRs[pk]; ok {
-			prCopy := *pr
-			c.mu.RUnlock()
-			return &prCopy, nil
+	// Cache-hit: PR details are in the Store (Title is non-empty once PRDetailsUpdated fires).
+	if linkedPRNum != 0 && snapErr == nil {
+		if lpr := snap.LinkedPR(); lpr != nil && lpr.Title != "" {
+			return &gh.PRDetails{
+				Number:         lpr.Number,
+				Title:          lpr.Title,
+				State:          lpr.State,
+				Merged:         lpr.Merged,
+				Draft:          lpr.Draft,
+				HeadSHA:        lpr.HeadSHA,
+				MergeableState: lpr.MergeableState,
+			}, nil
 		}
-		c.mu.RUnlock()
 	}
 
 	c.logFn("[cache] miss: FetchLinkedPR #%d — fetching from GitHub\n", issueNumber)
@@ -624,14 +602,20 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		return nil, err
 	}
 	if pr != nil {
-		pk := prKey(fullRepo, pr.Number)
-		c.mu.Lock()
-		c.linkedPRs[pk] = pr
-		c.mu.Unlock()
-		// If the item had no LinkedPRNumber in Store, update it without touching deep-fetch state.
-		// Original behavior: only set LinkedPRNumber; do not change LastDeepFetchAt.
+		// Write PR details into the Store via PRDetailsUpdated. This fires LinkedPRChanged
+		// so observers see the change, and updates the prToKey reverse index automatically.
+		c.store.Apply(itemstate.PRDetailsUpdated{
+			Repo:     fullRepo,
+			Number:   issueNumber,
+			PRNumber: pr.Number,
+			Title:    pr.Title,
+			State:    pr.State,
+			Merged:   pr.Merged,
+			Draft:    pr.Draft,
+		})
+		// If the item had no LinkedPRNumber in Store, also register the PR linkage
+		// without touching deep-fetch state. prToKey is maintained by PRDetailsUpdated above.
 		if linkedPRNum == 0 && snapErr == nil {
-			// Preserve existing HeadSHA if any (LinkedPR may already have a SHA from a webhook).
 			existingSHA := ""
 			if s := snap.State(); s.LinkedPR != nil {
 				existingSHA = s.LinkedPR.HeadSHA
@@ -642,11 +626,6 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 				LinkedPRNum: pr.Number,
 				SHA:         existingSHA,
 			})
-			// Also update prNumToKey.
-			pk2 := prKey(fullRepo, pr.Number)
-			c.mu.Lock()
-			c.prNumToKey[pk2] = issKey
-			c.mu.Unlock()
 		}
 	}
 	return pr, nil

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -165,15 +165,10 @@ func testIsDeepFetched(c *CacheImpl, repo string, number int) bool {
 	return !snap.State().LastDeepFetchAt.IsZero()
 }
 
-// testSetLinkedPR sets up item (repo, issNum) as linked to prNum in both the
-// Store and c.prNumToKey, so delta handlers can route events by PR number.
+// testSetLinkedPR sets up item (repo, issNum) as linked to prNum in the Store
+// so delta handlers can route events by PR number via store.GetByPRKey.
 func testSetLinkedPR(c *CacheImpl, repo string, issNum, prNum int) {
-	pk := prKey(repo, prNum)
-	ik := itemKey(repo, issNum)
 	c.store.Apply(itemstate.PRHeadSHAUpdated{Repo: repo, Number: issNum, LinkedPRNum: prNum})
-	c.mu.Lock()
-	c.prNumToKey[pk] = ik
-	c.mu.Unlock()
 }
 
 // ---------------------------------------------------------------------------
@@ -465,6 +460,7 @@ func pullRequestPayloadJSON(action, repo string, prNum int, sha, state string, m
 	p := pullRequestPayload{Action: action}
 	p.Repository.FullName = repo
 	p.PullRequest.Number = prNum
+	p.PullRequest.Title = "Test PR Title"
 	p.PullRequest.Head.SHA = sha
 	p.PullRequest.State = state
 	p.PullRequest.Merged = merged
@@ -481,20 +477,15 @@ func TestDeltaPullRequestOpened(t *testing.T) {
 	payload := pullRequestPayloadJSON("opened", "owner/repo", 42, "sha123", "open", false, false)
 	c.ApplyDelta("pull_request", payload)
 
-	c.mu.RLock()
-	pr, ok := c.linkedPRs[prKey("owner/repo", 42)]
-	c.mu.RUnlock()
-
-	if !ok || pr == nil {
-		t.Error("expected linkedPRs entry for PR #42")
-	}
-	if pr != nil && pr.HeadSHA != "sha123" {
-		t.Errorf("expected HeadSHA sha123, got %q", pr.HeadSHA)
-	}
-	// Verify SHA is indexed in Store by checking item's LinkedPR.HeadSHA.
 	s := testGetState(t, c, "owner/repo", 1)
-	if s.LinkedPR == nil || s.LinkedPR.HeadSHA != "sha123" {
-		t.Errorf("expected item #1's LinkedPR.HeadSHA=sha123, got %v", s.LinkedPR)
+	if s.LinkedPR == nil || s.LinkedPR.Number != 42 {
+		t.Fatalf("expected LinkedPR.Number=42 after pull_request.opened, got %v", s.LinkedPR)
+	}
+	if s.LinkedPR.HeadSHA != "sha123" {
+		t.Errorf("expected HeadSHA sha123, got %q", s.LinkedPR.HeadSHA)
+	}
+	if s.LinkedPR.Title == "" {
+		t.Errorf("expected non-empty LinkedPR.Title after pull_request.opened")
 	}
 }
 

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1591,6 +1591,47 @@ func TestCacheImplSubscribeUnsubscribeStopsCalls(t *testing.T) {
 	}
 }
 
+// TestPullRequestDeltaFiresLinkedPRChangedObserver verifies the end-to-end
+// path: a pull_request "opened" webhook delta emits LinkedPRChanged via the
+// Store observer, and the resulting snapshot has LinkedPR.Title populated.
+// Mirrors TestCacheImplSubscribeReceivesChanges but exercises the PR-details
+// mutation path introduced in Phase 5 F2 (issue #562).
+func TestPullRequestDeltaFiresLinkedPRChangedObserver(t *testing.T) {
+	c := seedCache(t)
+	// Establish PR linkage: item #1 → PR #42.
+	testSetLinkedPR(c, "owner/repo", 1, 42)
+
+	var mu sync.Mutex
+	var seenLinkedPRChanged bool
+	var titleAfterChange string
+	unsub := c.Subscribe(itemstate.ObserverFunc(func(ch itemstate.Change, snap itemstate.Snapshot) {
+		if ch.Fields&itemstate.LinkedPRChanged != 0 {
+			mu.Lock()
+			seenLinkedPRChanged = true
+			if lpr := snap.LinkedPR(); lpr != nil {
+				titleAfterChange = lpr.Title
+			}
+			mu.Unlock()
+		}
+	}))
+	defer unsub()
+
+	// "opened" delta carries title/state/draft and updates LinkedPR details.
+	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha-abc", "open", false, false))
+
+	mu.Lock()
+	saw := seenLinkedPRChanged
+	title := titleAfterChange
+	mu.Unlock()
+
+	if !saw {
+		t.Error("want LinkedPRChanged observer fired after pull_request.opened delta; got none")
+	}
+	if title == "" {
+		t.Error("want non-empty LinkedPR.Title in observer snapshot; got empty")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // SubscribePause tests
 // ---------------------------------------------------------------------------

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -453,7 +453,7 @@ func TestDeltaIssuesUnlabeled(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Delta: pull_request — update linkedPRs and SHA index in Store
+// Delta: pull_request — update PR details (LinkedPRState) and SHA index in Store
 // ---------------------------------------------------------------------------
 
 func pullRequestPayloadJSON(action, repo string, prNum int, sha, state string, merged, draft bool) []byte {

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -441,40 +441,77 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 
 	repo := p.Repository.FullName
 	prNum := p.PullRequest.Number
-	pk := prKey(repo, prNum)
 
 	switch p.Action {
 	case "opened", "closed", "synchronize", "reopened":
 		// SHA-tracking path — handled after this switch.
 
 	case "ready_for_review":
-		c.mu.Lock()
-		if pr, ok := c.linkedPRs[pk]; ok {
-			pr.Draft = false
+		// Look up linked issue via Store's prToKey index (no c.mu held).
+		// Requires PR linkage to be established first via PRHeadSHAUpdated.
+		issKey, issFound := c.store.GetByPRKey(repo, prNum)
+		if !issFound {
+			return
 		}
-		issKey, _ := c.prNumToKey[pk]
-		c.mu.Unlock()
-		if issKey != "" {
-			c.bumpLocalDeltaAt(issKey)
+		issRepo, issNum, parseOK := parseItemKey(issKey)
+		if !parseOK {
+			return
 		}
+		// Read current PR details and apply updated Draft=false.
+		snap, snapErr := c.store.Get(issRepo, issNum)
+		if snapErr != nil {
+			return
+		}
+		lpr := snap.LinkedPR()
+		if lpr == nil {
+			return
+		}
+		c.store.Apply(itemstate.PRDetailsUpdated{
+			Repo:     issRepo,
+			Number:   issNum,
+			PRNumber: lpr.Number,
+			Title:    lpr.Title,
+			State:    lpr.State,
+			Merged:   lpr.Merged,
+			Draft:    false,
+		})
+		c.bumpLocalDeltaAt(issKey)
 		return
 
 	case "converted_to_draft":
-		c.mu.Lock()
-		if pr, ok := c.linkedPRs[pk]; ok {
-			pr.Draft = true
+		// Look up linked issue via Store's prToKey index (no c.mu held).
+		// Requires PR linkage to be established first via PRHeadSHAUpdated.
+		issKey, issFound := c.store.GetByPRKey(repo, prNum)
+		if !issFound {
+			return
 		}
-		issKey, _ := c.prNumToKey[pk]
-		c.mu.Unlock()
-		if issKey != "" {
-			c.bumpLocalDeltaAt(issKey)
+		issRepo, issNum, parseOK := parseItemKey(issKey)
+		if !parseOK {
+			return
 		}
+		// Read current PR details and apply updated Draft=true.
+		snap, snapErr := c.store.Get(issRepo, issNum)
+		if snapErr != nil {
+			return
+		}
+		lpr := snap.LinkedPR()
+		if lpr == nil {
+			return
+		}
+		c.store.Apply(itemstate.PRDetailsUpdated{
+			Repo:     issRepo,
+			Number:   issNum,
+			PRNumber: lpr.Number,
+			Title:    lpr.Title,
+			State:    lpr.State,
+			Merged:   lpr.Merged,
+			Draft:    true,
+		})
+		c.bumpLocalDeltaAt(issKey)
 		return
 
 	case "review_requested":
-		c.mu.RLock()
-		issKey, issFound := c.prNumToKey[pk]
-		c.mu.RUnlock()
+		issKey, issFound := c.store.GetByPRKey(repo, prNum)
 		if !issFound {
 			return
 		}
@@ -495,9 +532,7 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		return
 
 	case "review_request_removed":
-		c.mu.RLock()
-		issKey, issFound := c.prNumToKey[pk]
-		c.mu.RUnlock()
+		issKey, issFound := c.store.GetByPRKey(repo, prNum)
 		if !issFound {
 			return
 		}
@@ -521,31 +556,28 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 
 	// --- SHA-tracking path (opened, closed, synchronize, reopened) ---
 	sha := p.PullRequest.Head.SHA
-	prDetails := &gh.PRDetails{
-		Number:         prNum,
-		Title:          p.PullRequest.Title,
-		State:          p.PullRequest.State,
-		Merged:         p.PullRequest.Merged,
-		Draft:          p.PullRequest.Draft,
-		HeadSHA:        sha,
-		MergeableState: p.PullRequest.MergeableState,
-	}
 
 	owner, repoName, ok := splitRepo(repo)
 	if !ok {
 		return
 	}
 
-	// Always store/update PR details regardless of whether we find a linked issue.
-	c.mu.Lock()
-	c.linkedPRs[pk] = prDetails
-	issKey, issFound := c.prNumToKey[pk]
-	c.mu.Unlock()
+	// Look up linked issue via Store's prToKey index (no c.mu held).
+	issKey, issFound := c.store.GetByPRKey(repo, prNum)
 
 	if issFound {
 		// Normal path: linked issue is already known.
 		issRepo, issNum2, parseOK := parseItemKey(issKey)
 		if parseOK {
+			c.store.Apply(itemstate.PRDetailsUpdated{
+				Repo:     issRepo,
+				Number:   issNum2,
+				PRNumber: prNum,
+				Title:    p.PullRequest.Title,
+				State:    p.PullRequest.State,
+				Merged:   p.PullRequest.Merged,
+				Draft:    p.PullRequest.Draft,
+			})
 			c.store.Apply(itemstate.PRHeadSHAUpdated{
 				Repo:   issRepo,
 				Number: issNum2,
@@ -577,15 +609,24 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		c.logFn("[cache] dropped pull_request delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	// Confirm item still in Store before updating prNumToKey.
+	// Confirm item still in Store before proceeding.
 	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return
 	}
-	c.prNumToKey[pk] = key
 	c.mu.Unlock()
+	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
+	c.store.Apply(itemstate.PRDetailsUpdated{
+		Repo:     repo,
+		Number:   resolvedIssNum,
+		PRNumber: prNum,
+		Title:    p.PullRequest.Title,
+		State:    p.PullRequest.State,
+		Merged:   p.PullRequest.Merged,
+		Draft:    p.PullRequest.Draft,
+	})
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
 		Number:      resolvedIssNum,
@@ -614,7 +655,6 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 	}
 	repo := p.Repository.FullName
 	prNum := p.PullRequest.Number
-	pk := prKey(repo, prNum)
 
 	owner, repoName, ok := splitRepo(repo)
 	if !ok {
@@ -628,10 +668,8 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 		DatabaseID: p.Review.DatabaseID,
 	}
 
-	// Normal path: look up issue via prNumToKey.
-	c.mu.RLock()
-	issKey, issFound := c.prNumToKey[pk]
-	c.mu.RUnlock()
+	// Normal path: look up issue via Store's prToKey index (no c.mu held).
+	issKey, issFound := c.store.GetByPRKey(repo, prNum)
 
 	if issFound {
 		issRepo, issNum, parseOK := parseItemKey(issKey)
@@ -673,8 +711,8 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 		c.mu.Unlock()
 		return
 	}
-	c.prNumToKey[pk] = key
 	c.mu.Unlock()
+	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
@@ -733,10 +771,8 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 		comment.OriginalLine = *p.Comment.OriginalLine
 	}
 
-	// Normal path: look up issue via prNumToKey.
-	c.mu.RLock()
-	issKey, issFound := c.prNumToKey[pk]
-	c.mu.RUnlock()
+	// Normal path: look up issue via Store's prToKey index (no c.mu held).
+	issKey, issFound := c.store.GetByPRKey(repo, prNum)
 
 	if issFound {
 		issRepo, issNum, parseOK := parseItemKey(issKey)
@@ -782,8 +818,8 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 		c.mu.Unlock()
 		return
 	}
-	c.prNumToKey[pk] = key
 	c.mu.Unlock()
+	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -352,16 +352,8 @@ func (c *CacheImpl) applyIssuesDelta(payload []byte) {
 		c.bumpLocalDeltaAt(key)
 
 	case "transferred", "deleted":
-		// Remove the item from the Store and clean up any PR linkage entries.
+		// Remove the item from the Store. Store.Remove handles prToKey index cleanup.
 		c.store.Remove(fullRepo, issNum)
-		c.mu.Lock()
-		for pk, ik := range c.prNumToKey {
-			if ik == key {
-				delete(c.prNumToKey, pk)
-				delete(c.linkedPRs, pk)
-			}
-		}
-		c.mu.Unlock()
 
 	case "edited":
 		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
@@ -746,7 +738,6 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 	}
 	repo := p.Repository.FullName
 	prNum := p.PullRequest.Number
-	pk := prKey(repo, prNum)
 
 	owner, repoName, ok := splitRepo(repo)
 	if !ok {
@@ -944,9 +935,8 @@ func (c *CacheImpl) applyCheckRunDelta(payload []byte) {
 		c.mu.Unlock()
 		return
 	}
-	pk := prKey(repo, prNum)
-	c.prNumToKey[pk] = key
 	c.mu.Unlock()
+	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	// Update Store: set LinkedPRNum + SHA (updates shaToKey index), invalidate deep cache.
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
@@ -1018,20 +1008,11 @@ func (c *CacheImpl) applyProjectsV2ItemDelta(payload []byte) {
 		c.bumpLocalDeltaAt(itemKey(snap.Repo(), snap.Number()))
 
 	case "deleted", "archived":
-		// Remove the item from the Store and clean up any PR linkage entries.
-		repo, number, ok := c.store.RemoveByItemID(p.ProjectsV2Item.ID)
+		// Remove the item from the Store. Store.RemoveByItemID handles prToKey index cleanup.
+		_, _, ok := c.store.RemoveByItemID(p.ProjectsV2Item.ID)
 		if !ok {
 			return
 		}
-		key := itemKey(repo, number)
-		c.mu.Lock()
-		for pk, ik := range c.prNumToKey {
-			if ik == key {
-				delete(c.prNumToKey, pk)
-				delete(c.linkedPRs, pk)
-			}
-		}
-		c.mu.Unlock()
 
 	// restored: item is back on the board; the next poll reconcile will re-add it.
 	// reordered: no position state in the engine.

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -319,11 +319,11 @@ func TestStoreDelegationNegativeCacheTTLExpiry(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 11. FetchItemDetails backfills prNumToKey so PR review/comment deltas route
+// 11. FetchItemDetails backfills store.prToKey so PR review/comment deltas route
 //     without auto-heal after the first deep fetch.
 // ---------------------------------------------------------------------------
 
-func TestFetchItemDetailsBackfillsPrNumToKey(t *testing.T) {
+func TestFetchItemDetailsBackfillsPrToKey(t *testing.T) {
 	mc := &mockClient{
 		itemDetailsResult: &gh.ProjectItem{
 			Body:           "body",
@@ -362,7 +362,7 @@ func TestFetchItemDetailsBackfillsPrNumToKey(t *testing.T) {
 // 12. Reconcile item removal cleans up stale prToKey entries.
 // ---------------------------------------------------------------------------
 
-func TestReconcileRemoveCleansUpPrNumToKey(t *testing.T) {
+func TestReconcileRemoveCleansUpPrToKey(t *testing.T) {
 	c := seedCache(t)
 	// Establish PR linkage for item #1 → PR #10.
 	testSetLinkedPR(c, "owner/repo", 1, 10)

--- a/boardcache/delta_test.go
+++ b/boardcache/delta_test.go
@@ -347,22 +347,19 @@ func TestFetchItemDetailsBackfillsPrNumToKey(t *testing.T) {
 		t.Fatalf("want LinkedPRNumber 42, got %d", item.LinkedPRNumber)
 	}
 
-	// prNumToKey must be backfilled so PR deltas can route by PR number.
-	pk := prKey("owner/repo", 42)
-	c.mu.RLock()
-	issKey, found := c.prNumToKey[pk]
-	c.mu.RUnlock()
+	// prToKey in Store must be backfilled so PR deltas can route by PR number.
+	issKey, found := c.store.GetByPRKey("owner/repo", 42)
 	if !found {
-		t.Errorf("prNumToKey not backfilled after FetchItemDetails with LinkedPRNumber=42")
+		t.Errorf("store.prToKey not backfilled after FetchItemDetails with LinkedPRNumber=42")
 	}
 	wantKey := itemKey("owner/repo", 1)
 	if issKey != wantKey {
-		t.Errorf("prNumToKey: want %q, got %q", wantKey, issKey)
+		t.Errorf("store.prToKey: want %q, got %q", wantKey, issKey)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// 12. Reconcile item removal cleans up stale prNumToKey entries.
+// 12. Reconcile item removal cleans up stale prToKey entries.
 // ---------------------------------------------------------------------------
 
 func TestReconcileRemoveCleansUpPrNumToKey(t *testing.T) {
@@ -370,12 +367,8 @@ func TestReconcileRemoveCleansUpPrNumToKey(t *testing.T) {
 	// Establish PR linkage for item #1 → PR #10.
 	testSetLinkedPR(c, "owner/repo", 1, 10)
 
-	pk := prKey("owner/repo", 10)
-	c.mu.RLock()
-	_, beforeReconcile := c.prNumToKey[pk]
-	c.mu.RUnlock()
-	if !beforeReconcile {
-		t.Fatalf("prNumToKey for PR #10 not set before Reconcile")
+	if _, found := c.store.GetByPRKey("owner/repo", 10); !found {
+		t.Fatalf("store.prToKey for PR #10 not set before Reconcile")
 	}
 
 	// Reconcile with a board that no longer contains item #1.
@@ -386,11 +379,8 @@ func TestReconcileRemoveCleansUpPrNumToKey(t *testing.T) {
 		},
 	})
 
-	c.mu.RLock()
-	_, afterReconcile := c.prNumToKey[pk]
-	c.mu.RUnlock()
-	if afterReconcile {
-		t.Errorf("prNumToKey entry for PR #10 survived after item #1 removed by Reconcile")
+	if _, found := c.store.GetByPRKey("owner/repo", 10); found {
+		t.Errorf("store.prToKey entry for PR #10 survived after item #1 removed by Reconcile")
 	}
 }
 
@@ -503,11 +493,8 @@ func TestIssuesDeletedCleansPRLinkage(t *testing.T) {
 
 	c.ApplyDelta("issues", issuesActionPayloadJSON("deleted", "owner/repo", 1))
 
-	c.mu.RLock()
-	_, found := c.prNumToKey[prKey("owner/repo", 42)]
-	c.mu.RUnlock()
-	if found {
-		t.Error("prNumToKey entry for PR #42 should have been removed after issues.deleted")
+	if _, found := c.store.GetByPRKey("owner/repo", 42); found {
+		t.Error("store.prToKey entry for PR #42 should have been removed after issues.deleted")
 	}
 }
 
@@ -616,32 +603,28 @@ func TestIssuesClosedFallbackFetch(t *testing.T) {
 func TestPullRequestReadyForReview(t *testing.T) {
 	c := seedCache(t)
 	testSetLinkedPR(c, "owner/repo", 1, 42)
-	// Establish linkedPRs entry with Draft=true.
+	// Establish PR details with Draft=true via opened delta.
 	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha1", "open", false, true))
 
 	c.ApplyDelta("pull_request", pullRequestDraftPayloadJSON("ready_for_review", "owner/repo", 42))
 
-	c.mu.RLock()
-	pr := c.linkedPRs[prKey("owner/repo", 42)]
-	c.mu.RUnlock()
-	if pr == nil || pr.Draft {
-		t.Errorf("want Draft=false after ready_for_review; pr=%v", pr)
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || s.LinkedPR.Draft {
+		t.Errorf("want Draft=false after ready_for_review; LinkedPR=%v", s.LinkedPR)
 	}
 }
 
 func TestPullRequestConvertedToDraft(t *testing.T) {
 	c := seedCache(t)
 	testSetLinkedPR(c, "owner/repo", 1, 42)
-	// Establish linkedPRs entry with Draft=false.
+	// Establish PR details with Draft=false via opened delta.
 	c.ApplyDelta("pull_request", pullRequestPayloadJSON("opened", "owner/repo", 42, "sha1", "open", false, false))
 
 	c.ApplyDelta("pull_request", pullRequestDraftPayloadJSON("converted_to_draft", "owner/repo", 42))
 
-	c.mu.RLock()
-	pr := c.linkedPRs[prKey("owner/repo", 42)]
-	c.mu.RUnlock()
-	if pr == nil || !pr.Draft {
-		t.Errorf("want Draft=true after converted_to_draft; pr=%v", pr)
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || !s.LinkedPR.Draft {
+		t.Errorf("want Draft=true after converted_to_draft; LinkedPR=%v", s.LinkedPR)
 	}
 }
 
@@ -840,18 +823,11 @@ func TestProjectsV2ItemArchived(t *testing.T) {
 func TestProjectsV2ItemDeletedCleansPRLinkage(t *testing.T) {
 	c := seedCache(t)
 	testSetLinkedPR(c, "owner/repo", 1, 42)
-	c.mu.Lock()
-	c.linkedPRs[prKey("owner/repo", 42)] = &gh.PRDetails{Number: 42}
-	c.mu.Unlock()
 
 	c.ApplyDelta("projects_v2_item", projectsV2ItemRemovedPayloadJSON("deleted", "PVTI_001"))
 
-	c.mu.RLock()
-	_, pkFound := c.prNumToKey[prKey("owner/repo", 42)]
-	_, lrFound := c.linkedPRs[prKey("owner/repo", 42)]
-	c.mu.RUnlock()
-	if pkFound || lrFound {
-		t.Error("prNumToKey and linkedPRs entries for PR #42 should be cleaned up after item deletion")
+	if _, found := c.store.GetByPRKey("owner/repo", 42); found {
+		t.Error("store.prToKey entry for PR #42 should be cleaned up after item deletion")
 	}
 }
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1274,7 +1274,7 @@ There is exactly one `*itemstate.Store` instance. `Engine.New()` creates it and 
 
 Because both categories write to the same store, any `store.Get(...)` returns a Snapshot with all field groups populated. `CacheImpl.Subscribe` is a thin wrapper over `c.store.Subscribe`; since `c.store` is the shared store, engine code should call `e.store.Subscribe` directly rather than going through `cacheImpl.Subscribe` to avoid double-registration.
 
-**Boundary note**: `CacheImpl` also holds `linkedPRs map[string]*gh.PRDetails` and `checkRuns map[string][]gh.CheckRun` as private maps **outside** `itemstate.Store`. These serve the `ReadClient` interface (`GetLinkedPR`, `GetCheckRuns`) and are populated by CacheImpl's delta/reconcile logic. They are cache-layer storage, not engine state — `snap.LinkedPR()` returns `LinkedPRState` (head SHA, mergeable, reviews, HasHadChecks, etc.), not the full `gh.PRDetails` object from `linkedPRs`.
+**Boundary note**: `CacheImpl` holds `checkRuns map[string][]gh.CheckRun` as a private map **outside** `itemstate.Store` (F4, tracked separately). This serves the `ReadClient` interface and is populated by CacheImpl's delta/reconcile logic. The previously separate `linkedPRs` map was removed in Phase 5 F2 (issue #562) — PR detail fields (Title, State, Merged, Draft) are now in `LinkedPRState` via `PRDetailsUpdated`, and `FetchLinkedPR` reconstructs `*gh.PRDetails` from the Store snapshot.
 
 #### ChangeFlags and Their Trigger Mutations
 
@@ -1653,7 +1653,7 @@ All handlers hold the write lock for their mutation only. No lock is held during
 | `check_suite` | `completed`, `requested`, `rerequested` | No-op | — | Check suites are coarse aggregates; individual runs tracked via `check_run.completed` |
 | `projects_v2_item` | `created` | Call `FetchItemDetails` by `content_node_id`; apply as new item | `IssueOpened` | Item appears in board; triggers dispatch on next poll |
 | `projects_v2_item` | `edited` | Update `Status` via `itemIDToKey` reverse lookup | `ProjectV2ItemEdited` | `Status` updated; stage selection uses new column |
-| `projects_v2_item` | `deleted`, `archived` | Remove item; clean up `prNumToKey` | `store.Remove` + `prNumToKey`/`linkedPRs` cleanup | Item gone from next board fetch |
+| `projects_v2_item` | `deleted`, `archived` | Remove item | `store.RemoveByItemID` (cleans `prToKey` index automatically) | Item gone from next board fetch |
 | `projects_v2_item` | `restored` | No-op | — | Next Reconcile re-adds the item from the full board snapshot |
 | `projects_v2_item` | `reordered` | No-op | — | Column order not modeled in Fabrik's cache or engine |
 
@@ -1666,7 +1666,7 @@ All handlers hold the write lock for their mutation only. No lock is held during
 | `FetchProjectBoard` | Returns reconstructed board from `items` map; falls back to GitHub when cache is empty |
 | `FetchItemDetails` | Serves deep fields from cache when `deepFetched[key]` is true; falls back to GitHub and populates on miss; logs `[cache] miss for #N — fetching from GitHub` |
 | `FetchCheckRuns` | Serves from `checkRuns[sha]`; falls back and caches on miss |
-| `FetchLinkedPR` | Looks up `linkedPRs[prKey]` via `item.LinkedPRNumber`; falls back on miss |
+| `FetchLinkedPR` | Cache hit when `snap.LinkedPR().Title != ""` (set by `PRDetailsUpdated`); reconstructs `*gh.PRDetails` from Store snapshot; falls back to GitHub REST on miss and applies `PRDetailsUpdated` write-back |
 | `FetchPRMergeable` | Always delegates to fallback (mergeability changes without webhook events) |
 | `FetchPRMergeableState` | Always delegates to fallback |
 | `FetchLabels` | Serves from `item.Labels` when item is cached; falls back on miss |

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1139,7 +1139,7 @@ Per-item engine state previously stored in `Engine.mu`-protected maps has been m
 
 Per-item state lives in a single shared `*itemstate.Store` instance. The Engine creates it (`sharedStore := itemstate.NewStore(nil)` in `New()`), assigns it to `eng.store`, and passes it to `boardcache.NewCacheImpl`. All mutations — engine-side (locks, invocations, stage state) and webhook/reconcile-side (status, labels, comments, linked-PR fields) — flow through `sharedStore.Apply`. `NewWithDeps` (test factory) constructs its own independent store because it never creates a `CacheImpl`.
 
-Note: `CacheImpl` retains two private maps that are **not** in `itemstate.Store`: `linkedPRs map[string]*gh.PRDetails` (full PR detail objects for `ReadClient` interface serving) and `checkRuns map[string][]gh.CheckRun` (check-run lists keyed by commit SHA). These are cache-layer storage for board reads; the `itemstate.Store` holds the per-item *state fields* derived from PR mutations (`LinkedPRState`: head SHA, mergeable, reviews, HasHadChecks, etc.).
+Note: `CacheImpl` retains one private map that is **not** in `itemstate.Store`: `checkRuns map[string][]gh.CheckRun` (check-run lists keyed by commit SHA). The previously separate `linkedPRs map[string]*gh.PRDetails` and `prNumToKey map[string]string` maps were removed in Phase 5 F2 (issue #562) and migrated into `itemstate.Store`: PR detail fields (Title, State, Merged, Draft) are now stored in `LinkedPRState` via `PRDetailsUpdated` mutations, and the PR→issue reverse-index is `store.prToKey` (populated by `PRHeadSHAUpdated` / `PRDetailsUpdated`; queried via `store.GetByPRKey`).
 
 Field ownership is by **mutation type**, not by store identity: a reader calling `store.Get("owner/repo", 1)` receives a Snapshot with all field groups populated regardless of which code path applied each mutation. This is the single-Store design originally proposed in ADR-036 and completed in Phase 5 F3 (issue #537).
 
@@ -1154,6 +1154,8 @@ The following fields are stored in `ItemState` / `LinkedPRState` and accessed ex
 | `LastDeepFetchFailureAt` | `DeepFetchFailed{At: ...}` (set); `ItemDeepFetched` (clears) | `snap.State().LastDeepFetchFailureAt` | `e.deepFetchFailureTime[iKey]` |
 | `LinkedPR.HasHadChecks` | `PRChecksObserved` (REST path); `CheckRunCompleted` (webhook path) | `snap.LinkedPR().HasHadChecks` | `e.prHasHadChecks[iKey]` |
 | `LinkedPR.CIMergePendingSince` | `CIMergePendingStarted{At: ...}` (set); `CIMergePendingCleared` (clear) | `snap.LinkedPR().CIMergePendingSince` | `e.ciMergePendingSince[iKey]` |
+| `LinkedPR.Number`, `LinkedPR.HeadSHA` | `PRHeadSHAUpdated{LinkedPRNum, HeadSHA}` | `snap.LinkedPR().Number`, `snap.LinkedPR().HeadSHA` | `c.prNumToKey[pk]` (routing), `c.linkedPRs[pk].HeadSHA` (Phase 5 F2: migrated in #562) |
+| `LinkedPR.Title`, `LinkedPR.State`, `LinkedPR.Merged`, `LinkedPR.Draft` | `PRDetailsUpdated{Title, State, Merged, Draft}` | `snap.LinkedPR().Title`, etc. | `c.linkedPRs[pk].*` (Phase 5 F2: migrated in #562) |
 | `StageState.LastAttemptAt` | `StageAttempted{StageName, At}` (set); `StageLastAttemptCleared` (clear) | `snap.LastAttemptAt(stageName)` | `e.processedSet[stageKey]` (invocation timestamp) |
 | `ItemState.CooldownAt` | `CooldownRecorded{Reason, Until}` | `snap.CooldownAt(reason)` | `e.processedSet[stageKey]` (cooldown timestamp; same key, different semantic — now split) |
 | `StageState.Attempts` | `StageRetryIncremented` (increment); `StageRetryCleared` (reset) | `snap.Attempts(stageName)` | `e.retryCount[stageKey]` |
@@ -1626,8 +1628,8 @@ All handlers hold the write lock for their mutation only. No lock is held during
 | `issues` | `opened` | Create item from payload | `IssueOpened` (builds item from full webhook payload; no API call) | Item appears in next `FetchProjectBoard` |
 | `issues` | `closed` | Fallback if missing; update state | `IssueClosed` | `IsClosed=true`; `itemMayNeedWork` skips unless cleanup stage |
 | `issues` | `reopened` | Fallback if missing; update state | `IssueReopened` | `IsClosed=false`; re-enters dispatch |
-| `issues` | `transferred` | Remove item | `store.Remove` + `prNumToKey` cleanup | Item gone from next board fetch |
-| `issues` | `deleted` | Remove item | `store.Remove` + `prNumToKey` cleanup | Item gone from next board fetch |
+| `issues` | `transferred` | Remove item | `store.Remove` (cleans `prToKey` index automatically) | Item gone from next board fetch |
+| `issues` | `deleted` | Remove item | `store.Remove` (cleans `prToKey` index automatically) | Item gone from next board fetch |
 | `issues` | `edited` | Fallback if missing; update title+body | `IssueEdited` | `Title`/`Body` updated; next FetchItemDetails serves updated body |
 | `issues` | `assigned` | Fallback if missing; update assignees | `IssueAssigneesUpdated` (full list replace) | `Assignees` updated |
 | `issues` | `unassigned` | Fallback if missing; update assignees | `IssueAssigneesUpdated` (full list replace) | `Assignees` updated |
@@ -1636,15 +1638,15 @@ All handlers hold the write lock for their mutation only. No lock is held during
 | `issues` | `milestoned`, `demilestoned`, `locked`, `unlocked`, `pinned`, `unpinned` | No-op | — | No engine state depends on these fields |
 | `issue_comment` | `created` | Guard: item must be in Store; append comment | `IssueCommentCreated` | Comment appears in next FetchItemDetails; poll woken for comment processing |
 | `issue_comment` | `edited`, `deleted` | No-op | — | Reaction-based state machine reads reactions not bodies; next deep-fetch heals |
-| `pull_request` | `opened`, `closed`, `reopened`, `synchronize` | Store PR details; resolve closing issue; update SHA | `PRHeadSHAUpdated`; `DeepFetchInvalidated` on auto-heal | `shaToKey` updated; CI gate can evaluate this SHA |
-| `pull_request` | `ready_for_review` | Update `linkedPRs[pk].Draft = false` | CacheImpl-local only (Draft not in Store per ADR 037) | PR no longer draft; review bots can see it |
-| `pull_request` | `converted_to_draft` | Update `linkedPRs[pk].Draft = true` | CacheImpl-local only | PR back to draft |
-| `pull_request` | `review_requested` | Look up linked issue via `prNumToKey`; replace reviewer list | `PRReviewRequested` (full list replace) | `LinkedPRReviewRequests` updated; review gate re-evaluated |
-| `pull_request` | `review_request_removed` | Look up linked issue via `prNumToKey`; remove one reviewer | `PRReviewRequestRemoved` (remove by login) | `LinkedPRReviewRequests` updated |
+| `pull_request` | `opened`, `closed`, `reopened`, `synchronize` | Store PR details; resolve closing issue; update SHA | `PRHeadSHAUpdated` + `PRDetailsUpdated`; `DeepFetchInvalidated` on auto-heal | `shaToKey` + `prToKey` updated; CI gate can evaluate this SHA; `LinkedPR.Title/State/Merged/Draft` populated |
+| `pull_request` | `ready_for_review` | Look up linked issue via `store.GetByPRKey`; read current `LinkedPR` snapshot; apply `Draft=false` | `PRDetailsUpdated{Draft: false}` (preserves Title/State/Merged from snapshot) | `LinkedPR.Draft=false`; PR no longer draft; review bots can see it |
+| `pull_request` | `converted_to_draft` | Look up linked issue via `store.GetByPRKey`; read current `LinkedPR` snapshot; apply `Draft=true` | `PRDetailsUpdated{Draft: true}` (preserves Title/State/Merged from snapshot) | `LinkedPR.Draft=true`; PR back to draft |
+| `pull_request` | `review_requested` | Look up linked issue via `store.GetByPRKey`; replace reviewer list | `PRReviewRequested` (full list replace) | `LinkedPRReviewRequests` updated; review gate re-evaluated |
+| `pull_request` | `review_request_removed` | Look up linked issue via `store.GetByPRKey`; remove one reviewer | `PRReviewRequestRemoved` (remove by login) | `LinkedPRReviewRequests` updated |
 | `pull_request` | `labeled`, `unlabeled`, `assigned`, `unassigned`, `edited` | No-op | — | PR-level labels/assignees/metadata not tracked; `Closes #N` linkage healed by next Reconcile |
-| `pull_request_review` | `submitted` | Route via `prNumToKey`; auto-heal if missing | `PRReviewSubmitted`; `PRHeadSHAUpdated` + `DeepFetchInvalidated` on auto-heal | `LinkedPRReviews` updated; review gate re-evaluated |
+| `pull_request_review` | `submitted` | Route via `store.GetByPRKey`; auto-heal if missing | `PRReviewSubmitted`; `PRHeadSHAUpdated` + `DeepFetchInvalidated` on auto-heal | `LinkedPRReviews` updated; review gate re-evaluated |
 | `pull_request_review` | `edited`, `dismissed` | No-op | — | Review state captured at submit; edits/dismissals don't affect Fabrik's approval tracking |
-| `pull_request_review_comment` | `created` | Route via `prNumToKey`; auto-heal if missing | `ReviewThreadCommentAdded`; `DeepFetchInvalidated` | Thread comment appears; review reinvoke path can see it |
+| `pull_request_review_comment` | `created` | Route via `store.GetByPRKey`; auto-heal if missing | `ReviewThreadCommentAdded`; `DeepFetchInvalidated` | Thread comment appears; review reinvoke path can see it |
 | `pull_request_review_comment` | `edited`, `deleted` | No-op | — | Thread comment content not decision-relevant; next deep-fetch heals |
 | `check_run` | `completed` | Upsert in `checkRuns[sha]`; index via `shaToKey`; auto-heal if SHA unknown | `CheckRunCompleted`; `PRHeadSHAUpdated` + `DeepFetchInvalidated` on auto-heal | CI gate evaluates conclusion; `LinkedPRCheckRuns` updated |
 | `check_run` | `created`, `rerequested`, `requested_action` | No-op | — | Only terminal state (`completed`) matters for CI gate |

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1154,8 +1154,8 @@ The following fields are stored in `ItemState` / `LinkedPRState` and accessed ex
 | `LastDeepFetchFailureAt` | `DeepFetchFailed{At: ...}` (set); `ItemDeepFetched` (clears) | `snap.State().LastDeepFetchFailureAt` | `e.deepFetchFailureTime[iKey]` |
 | `LinkedPR.HasHadChecks` | `PRChecksObserved` (REST path); `CheckRunCompleted` (webhook path) | `snap.LinkedPR().HasHadChecks` | `e.prHasHadChecks[iKey]` |
 | `LinkedPR.CIMergePendingSince` | `CIMergePendingStarted{At: ...}` (set); `CIMergePendingCleared` (clear) | `snap.LinkedPR().CIMergePendingSince` | `e.ciMergePendingSince[iKey]` |
-| `LinkedPR.Number`, `LinkedPR.HeadSHA` | `PRHeadSHAUpdated{LinkedPRNum, HeadSHA}` | `snap.LinkedPR().Number`, `snap.LinkedPR().HeadSHA` | `c.prNumToKey[pk]` (routing), `c.linkedPRs[pk].HeadSHA` (Phase 5 F2: migrated in #562) |
-| `LinkedPR.Title`, `LinkedPR.State`, `LinkedPR.Merged`, `LinkedPR.Draft` | `PRDetailsUpdated{Title, State, Merged, Draft}` | `snap.LinkedPR().Title`, etc. | `c.linkedPRs[pk].*` (Phase 5 F2: migrated in #562) |
+| `LinkedPR.Number`, `LinkedPR.HeadSHA` | `PRHeadSHAUpdated{LinkedPRNum, SHA}` | `snap.LinkedPR().Number`, `snap.LinkedPR().HeadSHA` | CacheImpl: `c.prNumToKey[pk]` (routing), `c.linkedPRs[pk].HeadSHA` (Phase 5 F2: migrated in #562) |
+| `LinkedPR.Title`, `LinkedPR.State`, `LinkedPR.Merged`, `LinkedPR.Draft` | `PRDetailsUpdated{Title, State, Merged, Draft}` | `snap.LinkedPR().Title`, etc. | CacheImpl: `c.linkedPRs[pk].*` (Phase 5 F2: migrated in #562) |
 | `StageState.LastAttemptAt` | `StageAttempted{StageName, At}` (set); `StageLastAttemptCleared` (clear) | `snap.LastAttemptAt(stageName)` | `e.processedSet[stageKey]` (invocation timestamp) |
 | `ItemState.CooldownAt` | `CooldownRecorded{Reason, Until}` | `snap.CooldownAt(reason)` | `e.processedSet[stageKey]` (cooldown timestamp; same key, different semantic — now split) |
 | `StageState.Attempts` | `StageRetryIncremented` (increment); `StageRetryCleared` (reset) | `snap.Attempts(stageName)` | `e.retryCount[stageKey]` |

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -102,6 +102,12 @@ type ItemState struct {
 // LinkedPRState holds the state of the closing pull request for an issue.
 type LinkedPRState struct {
 	Number int
+	// Title, State ("open"/"closed"), Merged, and Draft mirror gh.PRDetails fields
+	// that were previously stored only in CacheImpl.linkedPRs. Populated by PRDetailsUpdated.
+	Title  string
+	State  string
+	Merged bool
+	Draft  bool
 	// Mergeable is nil when unknown; true/false once GitHub resolves mergeability.
 	Mergeable      *bool
 	MergeableState string // "clean", "unstable", "blocked", etc.

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -299,6 +299,23 @@ type PRHeadSHAUpdated struct {
 func (PRHeadSHAUpdated) isMutation() {}
 func (m PRHeadSHAUpdated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// PRDetailsUpdated sets LinkedPR.Title, State, Merged, and Draft for the given item.
+// These four fields were previously stored only in CacheImpl.linkedPRs; this mutation
+// moves them into the Store so PR-detail changes are observable via LinkedPRChanged.
+// PRNumber also ensures the prToKey reverse index is current.
+type PRDetailsUpdated struct {
+	Repo     string
+	Number   int // issue number
+	PRNumber int
+	Title    string
+	State    string
+	Merged   bool
+	Draft    bool
+}
+
+func (PRDetailsUpdated) isMutation() {}
+func (m PRDetailsUpdated) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // ReviewThreadCommentAdded appends an inline review-thread comment to an item's
 // LinkedPR.ThreadComments, idempotent by NodeID. Uses the ISSUE number (not the
 // PR number) as the routing key. Used by boardcache delta handlers.

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -3,6 +3,7 @@ package itemstate
 import (
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,7 @@ type Store struct {
 	// Reverse-lookup indexes maintained on every Apply that touches the relevant fields.
 	shaToKey    map[string]string // LinkedPR.HeadSHA → itemKey
 	itemIDToKey map[string]string // ItemState.ItemID → itemKey
+	prToKey     map[string]string // prKeyFor(repo, prNum) → itemKey
 
 	observerMu sync.RWMutex
 	observers  []observerEntry
@@ -83,6 +85,7 @@ func NewStore(fallback FallbackFetcher, opts ...StoreOption) *Store {
 		items:       make(map[string]*ItemState),
 		shaToKey:    make(map[string]string),
 		itemIDToKey: make(map[string]string),
+		prToKey:     make(map[string]string),
 		fallback:    fallback,
 		logger:      o.logger,
 	}
@@ -519,6 +522,15 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.LinkedPR.HeadSHA = v.SHA
 		return LinkedPRChanged
 
+	case PRDetailsUpdated:
+		ensureLinkedPR(item, v.PRNumber)
+		item.LinkedPR.Number = v.PRNumber
+		item.LinkedPR.Title = v.Title
+		item.LinkedPR.State = v.State
+		item.LinkedPR.Merged = v.Merged
+		item.LinkedPR.Draft = v.Draft
+		return LinkedPRChanged
+
 	case ReviewThreadCommentAdded:
 		ensureLinkedPR(item, 0)
 		// Idempotent by NodeID.
@@ -675,6 +687,26 @@ func (s *Store) updateIndexes(before, after ItemState, key string) {
 	} else if afterSHA != "" {
 		s.shaToKey[afterSHA] = key
 	}
+
+	// PR-number index: maps prKeyFor(repo, prNum) → itemKey.
+	beforePRNum := 0
+	afterPRNum := 0
+	if before.LinkedPR != nil {
+		beforePRNum = before.LinkedPR.Number
+	}
+	if after.LinkedPR != nil {
+		afterPRNum = after.LinkedPR.Number
+	}
+	if beforePRNum != afterPRNum {
+		if beforePRNum != 0 {
+			delete(s.prToKey, prKeyFor(before.Repo, beforePRNum))
+		}
+		if afterPRNum != 0 {
+			s.prToKey[prKeyFor(after.Repo, afterPRNum)] = key
+		}
+	} else if afterPRNum != 0 {
+		s.prToKey[prKeyFor(after.Repo, afterPRNum)] = key
+	}
 }
 
 // ---- helpers ----
@@ -808,7 +840,7 @@ func (s *Store) All() []Snapshot {
 }
 
 // Remove deletes the item identified by (repo, number) from the Store and
-// updates the shaToKey and itemIDToKey indexes accordingly.
+// updates the shaToKey, itemIDToKey, and prToKey indexes accordingly.
 // No-op when the item is not present.
 func (s *Store) Remove(repo string, number int) {
 	key := itemKeyFor(repo, number)
@@ -824,13 +856,15 @@ func (s *Store) Remove(repo string, number int) {
 	if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
 		delete(s.shaToKey, item.LinkedPR.HeadSHA)
 	}
+	if item.LinkedPR != nil && item.LinkedPR.Number != 0 {
+		delete(s.prToKey, prKeyFor(item.Repo, item.LinkedPR.Number))
+	}
 	delete(s.items, key)
 }
 
 // RemoveByItemID removes the item identified by its project ItemID (board-side ID).
-// Returns the repo and number of the removed item, and ok=true, so callers can
-// clean up secondary state (e.g. prNumToKey entries). No-op and ok=false if the
-// ItemID is not in the index.
+// Updates shaToKey, itemIDToKey, and prToKey indexes accordingly.
+// No-op and ok=false if the ItemID is not in the index.
 func (s *Store) RemoveByItemID(itemID string) (repo string, number int, ok bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -848,9 +882,23 @@ func (s *Store) RemoveByItemID(itemID string) (repo string, number int, ok bool)
 	if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
 		delete(s.shaToKey, item.LinkedPR.HeadSHA)
 	}
+	if item.LinkedPR != nil && item.LinkedPR.Number != 0 {
+		delete(s.prToKey, prKeyFor(item.Repo, item.LinkedPR.Number))
+	}
 	delete(s.itemIDToKey, itemID)
 	delete(s.items, key)
 	return repo, number, true
+}
+
+// GetByPRKey returns the item key for the issue that is closed by the given PR.
+// Returns ("", false) if no item in the Store has a LinkedPR.Number matching prNum
+// in the given repo. The returned key can be parsed with parseKey to extract
+// repo and number for a subsequent Get call.
+func (s *Store) GetByPRKey(repo string, prNum int) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key, ok := s.prToKey[prKeyFor(repo, prNum)]
+	return key, ok
 }
 
 // resetNotification holds a Change and Snapshot for deferred observer dispatch.
@@ -870,6 +918,7 @@ func (s *Store) Reset(items []gh.ProjectItem) {
 	s.items = make(map[string]*ItemState, len(items))
 	s.shaToKey = make(map[string]string, len(items))
 	s.itemIDToKey = make(map[string]string, len(items))
+	s.prToKey = make(map[string]string, len(items))
 
 	newKeys := make(map[string]bool, len(items))
 	var notifications []resetNotification
@@ -889,6 +938,9 @@ func (s *Store) Reset(items []gh.ProjectItem) {
 		}
 		if item.LinkedPR != nil && item.LinkedPR.HeadSHA != "" {
 			s.shaToKey[item.LinkedPR.HeadSHA] = key
+		}
+		if item.LinkedPR != nil && item.LinkedPR.Number != 0 {
+			s.prToKey[prKeyFor(item.Repo, item.LinkedPR.Number)] = key
 		}
 		notifications = append(notifications, resetNotification{
 			change: Change{Repo: item.Repo, Number: item.Number, Fields: flags},
@@ -1046,6 +1098,13 @@ func removeString(ss []string, s string) []string {
 		return nil
 	}
 	return out
+}
+
+// prKeyFor constructs the PR reverse-index key "owner/repo#pr<N>".
+// Same semantics as boardcache.prKey; duplicated here to keep the Store
+// package self-contained (boardcache is a separate package).
+func prKeyFor(repo string, prNum int) string {
+	return repo + "#pr" + strconv.Itoa(prNum)
 }
 
 // parseKey splits "owner/repo#N" into repo and number.

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -653,7 +653,7 @@ func (s *Store) applyCheckRunCompleted(v CheckRunCompleted) (Snapshot, []Change,
 	return snap, []Change{change}, nil
 }
 
-// updateIndexes keeps shaToKey and itemIDToKey consistent after a mutation.
+// updateIndexes keeps shaToKey, itemIDToKey, and prToKey consistent after a mutation.
 // Must be called with s.mu held for writing.
 func (s *Store) updateIndexes(before, after ItemState, key string) {
 	// ItemID index.

--- a/internal/itemstate/store_test.go
+++ b/internal/itemstate/store_test.go
@@ -666,3 +666,129 @@ func TestLinkedPRSnapshotImmutabilityAfterCIMerge(t *testing.T) {
 		t.Error("snapshot taken before CIMergePendingStarted should not reflect the mutation")
 	}
 }
+
+// ---- PRDetailsUpdated + prToKey index tests ----
+
+// TestPRDetailsUpdatedMutatesAndFiresObserver verifies that PRDetailsUpdated sets the
+// four new LinkedPRState fields (Title, State, Merged, Draft) and fires LinkedPRChanged.
+func TestPRDetailsUpdatedMutatesAndFiresObserver(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 10)})
+
+	var lastChange Change
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) { lastChange = c }))
+
+	_, changes, err := s.Apply(PRDetailsUpdated{
+		Repo:     testRepo,
+		Number:   10,
+		PRNumber: 42,
+		Title:    "feat: add caching",
+		State:    "open",
+		Merged:   false,
+		Draft:    true,
+	})
+	if err != nil {
+		t.Fatalf("PRDetailsUpdated: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected at least one change from PRDetailsUpdated")
+	}
+	if lastChange.Fields&LinkedPRChanged == 0 {
+		t.Errorf("Fields %b does not include LinkedPRChanged", lastChange.Fields)
+	}
+
+	snap, _ := s.Get(testRepo, 10)
+	lpr := snap.LinkedPR()
+	if lpr == nil {
+		t.Fatal("LinkedPR is nil after PRDetailsUpdated")
+	}
+	if lpr.Number != 42 {
+		t.Errorf("Number = %d; want 42", lpr.Number)
+	}
+	if lpr.Title != "feat: add caching" {
+		t.Errorf("Title = %q; want %q", lpr.Title, "feat: add caching")
+	}
+	if lpr.State != "open" {
+		t.Errorf("State = %q; want open", lpr.State)
+	}
+	if lpr.Merged {
+		t.Error("Merged should be false")
+	}
+	if !lpr.Draft {
+		t.Error("Draft should be true")
+	}
+}
+
+// TestPRDetailsUpdatedIsNoOpWhenFieldsUnchanged verifies that a duplicate PRDetailsUpdated
+// does not fire observers (invariant I6).
+func TestPRDetailsUpdatedIsNoOpWhenFieldsUnchanged(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 11)})
+	s.Apply(PRDetailsUpdated{Repo: testRepo, Number: 11, PRNumber: 7, Title: "T", State: "open"})
+
+	var count int
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) { count++ }))
+
+	_, changes, _ := s.Apply(PRDetailsUpdated{Repo: testRepo, Number: 11, PRNumber: 7, Title: "T", State: "open"})
+	if len(changes) != 0 {
+		t.Error("second identical PRDetailsUpdated should be a no-op")
+	}
+	if count != 0 {
+		t.Errorf("observer fired %d times; want 0 for no-op", count)
+	}
+}
+
+// TestGetByPRKeyReturnsMappedItemKey verifies that the prToKey index is populated
+// by PRDetailsUpdated and that GetByPRKey returns the correct item key.
+func TestGetByPRKeyReturnsMappedItemKey(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 12)})
+	s.Apply(PRDetailsUpdated{Repo: testRepo, Number: 12, PRNumber: 55, Title: "T", State: "open"})
+
+	key, ok := s.GetByPRKey(testRepo, 55)
+	if !ok {
+		t.Fatal("GetByPRKey returned false; expected true after PRDetailsUpdated")
+	}
+	want := itemKeyFor(testRepo, 12)
+	if key != want {
+		t.Errorf("key = %q; want %q", key, want)
+	}
+
+	// Unknown PR returns false.
+	if _, found := s.GetByPRKey(testRepo, 9999); found {
+		t.Error("GetByPRKey for unknown PR should return false")
+	}
+}
+
+// TestGetByPRKeyFalseAfterRemove verifies that Store.Remove clears the prToKey entry.
+func TestGetByPRKeyFalseAfterRemove(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 13)})
+	s.Apply(PRDetailsUpdated{Repo: testRepo, Number: 13, PRNumber: 99, Title: "T", State: "open"})
+
+	if _, ok := s.GetByPRKey(testRepo, 99); !ok {
+		t.Fatal("GetByPRKey returned false before Remove")
+	}
+
+	s.Remove(testRepo, 13)
+
+	if _, ok := s.GetByPRKey(testRepo, 99); ok {
+		t.Error("GetByPRKey should return false after Store.Remove")
+	}
+}
+
+// TestPRToKeyPopulatedByPRHeadSHAUpdated verifies that the prToKey index is also
+// maintained when LinkedPR.Number is set via PRHeadSHAUpdated.
+func TestPRToKeyPopulatedByPRHeadSHAUpdated(t *testing.T) {
+	s := NewStore(nil)
+	s.Apply(IssueOpened{Item: testProjectItem(testRepo, 14)})
+	s.Apply(PRHeadSHAUpdated{Repo: testRepo, Number: 14, LinkedPRNum: 77, SHA: "abc123"})
+
+	key, ok := s.GetByPRKey(testRepo, 77)
+	if !ok {
+		t.Fatal("GetByPRKey returned false after PRHeadSHAUpdated with LinkedPRNum")
+	}
+	if want := itemKeyFor(testRepo, 14); key != want {
+		t.Errorf("key = %q; want %q", key, want)
+	}
+}


### PR DESCRIPTION
## Summary

Removes `CacheImpl.linkedPRs` and `CacheImpl.prNumToKey` — the last two per-PR state maps that lived outside `itemstate.Store` — completing ADR 036's single-owner reactive cache invariant. PR detail fields (Title, State, Merged, Draft) are now store-backed via a new `PRDetailsUpdated` mutation, and the PR→issue routing index is now a `prToKey` reverse-index inside the Store.

## Key Changes

- **`internal/itemstate/itemstate.go`**: Added `Title`, `State`, `Merged`, `Draft` fields to `LinkedPRState`.
- **`internal/itemstate/mutation.go`**: New `PRDetailsUpdated` mutation type; emits `LinkedPRChanged` so all Store observers see PR-detail changes.
- **`internal/itemstate/store.go`**: Added `prToKey map[string]string` reverse-index (same lifecycle as `shaToKey`/`itemIDToKey`); new `GetByPRKey(repo, prNum)` accessor; `applyToItem` case for `PRDetailsUpdated`.
- **`boardcache/boardcache.go`**: Removed `linkedPRs` and `prNumToKey` fields. `FetchLinkedPR` now hits the Store snapshot (`snap.LinkedPR().Title != ""` cache-hit sentinel) and reconstructs `*gh.PRDetails` from it.
- **`boardcache/delta.go`**: All six delta handlers that previously read/wrote `c.prNumToKey` or `c.linkedPRs` updated to use `store.GetByPRKey` / `store.Apply(PRDetailsUpdated{...})`.
- **Docs**: `docs/state-machine.md` §9.6 updated; `adrs/036-reactive-cache-single-owner.md` has new F2 addendum.

## How to Test

```bash
go test -race ./boardcache/... ./internal/itemstate/...
```

Key new/updated tests:
- `TestPRDetailsUpdatedMutatesAndFiresObserver` — PRDetailsUpdated sets fields and fires LinkedPRChanged
- `TestGetByPRKeyReturnsMappedItemKey` — prToKey index populated by PRHeadSHAUpdated
- `TestPullRequestDeltaFiresLinkedPRChangedObserver` — end-to-end: pull_request.opened delta fires LinkedPRChanged observer with populated Title
- `TestPullRequestReadyForReview` / `TestPullRequestConvertedToDraft` — Draft field toggled via Store snapshot

Closes #562