### PR TITLE
fix(engine): defer WorkerExited at goroutine top in main dispatch (#544 follow-up)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3068,11 +3068,12 @@ No special handling. Each is independent. The engine only checks the in_progress
 
 **`Engine.inFlight` (`sync.Map`) has been removed (Fix B, issue #544).** The dispatch guard is now entirely Store-backed.
 
-The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is already running for an item. `WorkerEntered{Repo, Number, StageName, StartedAt}` is applied synchronously before `wg.Add(1)` and before the goroutine is launched, so the store guard is effective from the instant the goroutine is scheduled. The reinvoke dispatchers (`dispatchReviewReinvoke`, `dispatchCIFixReinvoke`, `dispatchRebaseReinvoke`) follow the same pattern. `WorkerExited` is deferred at the top of each goroutine.
+The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is already running for an item. `WorkerEntered{Repo, Number, StageName, StartedAt}` is applied synchronously before `wg.Add(1)` and before the goroutine is launched, so the store guard is effective from the instant the goroutine is scheduled. The reinvoke dispatchers (`dispatchReviewReinvoke`, `dispatchCIFixReinvoke`, `dispatchRebaseReinvoke`) follow the same pattern. `WorkerExited` is deferred **at the top of each goroutine** in all four dispatchers — main (`engine/poll.go`) and the three reinvoke dispatchers — so it fires on every exit path, including processItem's many early-return guards (paused, blocked, awaiting-input, locked-by-other, stage-complete, etc.).
 
 - **Set by:** dispatch loop applies `WorkerEntered` before goroutine launch; each reinvoke dispatcher applies `WorkerEntered` before goroutine launch
-- **Cleared by:** goroutine-top `defer store.Apply(WorkerExited{...})` — fires on any exit path including early return from context cancel or `ensureRepoReady` failure
-- **Read by:** `snap.Worker() != nil` — used by all dispatch guards (main loop, reinvoke catch-up guards), the idle display ("workers active" log), and auto-upgrade guard
+- **Cleared by:** goroutine-top `defer store.Apply(WorkerExited{...})` — fires on any exit path including processItem early-returns, context cancel, `ensureRepoReady` failure, panic-after-recover, or normal completion
+- **Read by:** `snap.Worker() != nil` — used by all dispatch guards (main loop, reinvoke catch-up guards), the idle display ("workers active" log), and **auto-upgrade guard** (auto-upgrade refuses to fire while any worker is in-flight, to avoid `syscall.Exec` killing live workers)
+- **Idempotent:** the `WorkerExited` mutation handler (`internal/itemstate/store.go`) returns 0 changes when `item.Worker == nil`, so a redundant defer (e.g. an inner `defer WorkerExited` inside `processItem` firing in addition to the goroutine-top defer) does not produce spurious observer notifications.
 
 Both mutations emit `WorkerChanged | WorkerLifecycleChanged` (§2.14). Only `WorkerLifecycleChanged` is in `wakeChFlags`, so worker entry and exit deterministically wake the poll loop. `WorkerHeartbeat` and `WorkerPIDSet` emit only `WorkerChanged` and do not trigger a wake.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3075,7 +3075,9 @@ The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is a
 - **Read by:** `snap.Worker() != nil` — used by all dispatch guards (main loop, reinvoke catch-up guards), the idle display ("workers active" log), and **auto-upgrade guard** (auto-upgrade refuses to fire while any worker is in-flight, to avoid `syscall.Exec` killing live workers)
 - **Idempotent:** the `WorkerExited` mutation handler (`internal/itemstate/store.go`) returns 0 changes when `item.Worker == nil`, so a redundant defer (e.g. an inner `defer WorkerExited` inside `processItem` firing in addition to the goroutine-top defer) does not produce spurious observer notifications.
 
-Both mutations emit `WorkerChanged | WorkerLifecycleChanged` (§2.14). Only `WorkerLifecycleChanged` is in `wakeChFlags`, so worker entry and exit deterministically wake the poll loop. `WorkerHeartbeat` and `WorkerPIDSet` emit only `WorkerChanged` and do not trigger a wake.
+Both mutations emit `WorkerChanged | WorkerLifecycleChanged` (§2.14). Only `WorkerLifecycleChanged` is in `wakeChFlags`, so worker entry and exit feed the wake pipeline. `WorkerHeartbeat` and `WorkerPIDSet` emit only `WorkerChanged` and do not feed the wake pipeline.
+
+> **Wake channel scope:** the wakeChObserver is registered only when a wake channel is configured (TUI mode or any other configuration that calls `SetWakeCh`). In headless / `--notui` runs, `WorkerLifecycleChanged` populates `mayNeedWork` for the next ticker-driven poll cycle but does not trigger an immediate wake. The dispatch re-evaluation guarantee is therefore "by the next scheduled poll" (≤ `PollSeconds`) when no wake channel is configured, and "within milliseconds" when one is.
 
 ### 9.3 Worktree Mutex
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3102,7 +3102,9 @@ Per-item engine state previously stored in `Engine.mu`-protected maps has been m
 
 Per-item state lives in a single shared `*itemstate.Store` instance. The Engine creates it (`sharedStore := itemstate.NewStore(nil)` in `New()`), assigns it to `eng.store`, and passes it to `boardcache.NewCacheImpl`. All mutations — engine-side (locks, invocations, stage state) and webhook/reconcile-side (status, labels, comments, linked-PR fields) — flow through `sharedStore.Apply`. `NewWithDeps` (test factory) constructs its own independent store because it never creates a `CacheImpl`.
 
-Note: `CacheImpl` retains one private map that is **not** in `itemstate.Store`: `checkRuns map[string][]gh.CheckRun` (check-run lists keyed by commit SHA). The previously separate `linkedPRs map[string]*gh.PRDetails` and `prNumToKey map[string]string` maps were removed in Phase 5 F2 (issue #562) and migrated into `itemstate.Store`: PR detail fields (Title, State, Merged, Draft) are now stored in `LinkedPRState` via `PRDetailsUpdated` mutations, and the PR→issue reverse-index is `store.prToKey` (populated by `PRHeadSHAUpdated` / `PRDetailsUpdated`; queried via `store.GetByPRKey`).
+**Phase 5 F2 (issue #562):** The previously separate `linkedPRs map[string]*gh.PRDetails` and `prNumToKey map[string]string` CacheImpl maps were migrated into `itemstate.Store`: PR detail fields (Title, State, Merged, Draft) are now stored in `LinkedPRState` via `PRDetailsUpdated` mutations, and the PR→issue reverse-index is `store.prToKey` (populated by `PRHeadSHAUpdated` / `PRDetailsUpdated`; queried via `store.GetByPRKey`).
+
+**Phase 5 F4 (issue #563):** The previously separate `checkRuns map[string][]gh.CheckRun` CacheImpl map (check-run lists keyed by commit SHA) was migrated into `itemstate.Store` as `pendingCheckRuns map[string][]gh.CheckRun`. This pre-linkage buffer holds check runs for SHAs not yet linked to any item. When `PRHeadSHAUpdated` fires (establishing the SHA→item mapping), the buffer is drained into `LinkedPR.CheckRuns` via upsert-by-ID. `FetchCheckRuns` now reads from `store.CheckRunsBySHA`, which returns the union of `pendingCheckRuns[sha]` and the linked item's `LinkedPR.CheckRuns`; on total miss it falls back to GitHub and populates the Store via `CheckRunCompleted` mutations. See §9.8 for `CheckRunChanged` flag semantics.
 
 Field ownership is by **mutation type**, not by store identity: a reader calling `store.Get("owner/repo", 1)` receives a Snapshot with all field groups populated regardless of which code path applied each mutation. This is the single-Store design originally proposed in ADR-036 and completed in Phase 5 F3 (issue #537).
 
@@ -3115,7 +3117,8 @@ The following fields are stored in `ItemState` / `LinkedPRState` and accessed ex
 | `LastInvocationCompleted` | `InvocationRecorded{Completed: ...}` | `snap.State().LastInvocationCompleted` | `e.lastCompleted[iKey]` |
 | `LastInvocationBlocked` | `InvocationRecorded{Blocked: ...}` | `snap.State().LastInvocationBlocked` | `e.lastBlocked[iKey]` |
 | `LastDeepFetchFailureAt` | `DeepFetchFailed{At: ...}` (set); `ItemDeepFetched` (clears) | `snap.State().LastDeepFetchFailureAt` | `e.deepFetchFailureTime[iKey]` |
-| `LinkedPR.HasHadChecks` | `PRChecksObserved` (REST path); `CheckRunCompleted` (webhook path) | `snap.LinkedPR().HasHadChecks` | `e.prHasHadChecks[iKey]` |
+| `LinkedPR.CheckRuns` | `CheckRunCompleted` (when SHA is already in `shaToKey`); `PRHeadSHAUpdated` drain (flushes `pendingCheckRuns[sha]`); fallback populate in `FetchCheckRuns` | `snap.LinkedPR().CheckRuns` | CacheImpl: `c.checkRuns[sha]` (Phase 5 F4: migrated to Store in #563) |
+| `LinkedPR.HasHadChecks` | `PRChecksObserved` (REST path); `CheckRunCompleted` and `PRHeadSHAUpdated` drain (webhook path) | `snap.LinkedPR().HasHadChecks` | `e.prHasHadChecks[iKey]` |
 | `LinkedPR.CIMergePendingSince` | `CIMergePendingStarted{At: ...}` (set); `CIMergePendingCleared` (clear) | `snap.LinkedPR().CIMergePendingSince` | `e.ciMergePendingSince[iKey]` |
 | `LinkedPR.Number`, `LinkedPR.HeadSHA` | `PRHeadSHAUpdated{LinkedPRNum, SHA}` | `snap.LinkedPR().Number`, `snap.LinkedPR().HeadSHA` | CacheImpl: `c.prNumToKey[pk]` (routing), `c.linkedPRs[pk].HeadSHA` (Phase 5 F2: migrated in #562) |
 | `LinkedPR.Title`, `LinkedPR.State`, `LinkedPR.Merged`, `LinkedPR.Draft` | `PRDetailsUpdated{Title, State, Merged, Draft}` | `snap.LinkedPR().Title`, etc. | CacheImpl: `c.linkedPRs[pk].*` (Phase 5 F2: migrated in #562) |
@@ -3237,7 +3240,7 @@ There is exactly one `*itemstate.Store` instance. `Engine.New()` creates it and 
 
 Because both categories write to the same store, any `store.Get(...)` returns a Snapshot with all field groups populated. `CacheImpl.Subscribe` is a thin wrapper over `c.store.Subscribe`; since `c.store` is the shared store, engine code should call `e.store.Subscribe` directly rather than going through `cacheImpl.Subscribe` to avoid double-registration.
 
-**Boundary note**: `CacheImpl` holds `checkRuns map[string][]gh.CheckRun` as a private map **outside** `itemstate.Store` (F4, tracked separately). This serves the `ReadClient` interface and is populated by CacheImpl's delta/reconcile logic. The previously separate `linkedPRs` map was removed in Phase 5 F2 (issue #562) — PR detail fields (Title, State, Merged, Draft) are now in `LinkedPRState` via `PRDetailsUpdated`, and `FetchLinkedPR` reconstructs `*gh.PRDetails` from the Store snapshot.
+**Boundary note**: After Phase 5 F4 (issue #563), **all** per-item and pre-linkage state lives in `itemstate.Store`. `CacheImpl` retains only `paused`, `recentMissCache`, `projectID/Title/OwnerType`, and `localDeltaAt` — none of which are per-item state. `checkRuns` was migrated to `Store.pendingCheckRuns` (Phase 5 F4, #563); `linkedPRs` was migrated to `LinkedPRState` via `PRDetailsUpdated` (Phase 5 F2, #562). `FetchLinkedPR` and `FetchCheckRuns` now reconstruct their results from Store snapshots.
 
 #### ChangeFlags and Their Trigger Mutations
 
@@ -3258,6 +3261,7 @@ All ChangeFlags are produced by the single shared store. Field ownership is by m
 | `CooldownChanged` | Engine-side | `CooldownRecorded` |
 | `DeepFetchChanged` | Engine-side | `DeepFetchFailed`, `ItemDeepFetched` |
 | `ItemRemoved` | Reset | `Store.Reset` for items present in the old map but absent from the new items slice |
+| `CheckRunChanged` | Webhook/reconcile | `CheckRunCompleted` when SHA is **not** yet in `shaToKey` — run buffered into `Store.pendingCheckRuns`; also emitted (combined with `LinkedPRChanged`) by `PRHeadSHAUpdated` when the buffer is drained. **Not in `wakeChFlags`**: the CI gate is catch-up-driven (the catch-up loop polls on every cycle), not wake-driven. The flag exists for observability (future TUI consumers) without forcing a poll wake. |
 
 #### wakeChFlags: Which Changes Wake the Poll Loop
 
@@ -3269,7 +3273,7 @@ wakeChFlags = StatusChanged | LabelsChanged | CommentsChanged | LockChanged | Li
 
 `AssigneesChanged` was added in issue #543 so that assignment webhooks wake the dispatcher. `WorkerLifecycleChanged` was added in Fix B (issue #544) so that `WorkerEntered` and `WorkerExited` mutations deterministically wake the poll loop. The broader `WorkerChanged` flag (which also covers `WorkerHeartbeat` and `WorkerPIDSet`) is intentionally **not** in `wakeChFlags` — heartbeats fire every 30s per active worker and would otherwise cause repeated deep-fetch cycles for items that cannot be dispatched. See §2.14.
 
-Changes that do NOT fire `wakeCh`: `InvocationChanged`, `StageStateChanged`, `CooldownChanged`, `WorkerChanged` (from heartbeats/PID-sets/lock-with-worker), `TitleBodyChanged`, `StateChanged`, `BlockedByChanged`, `DeepFetchChanged`, `BaseBranchChanged`, `ItemRemoved`.
+Changes that do NOT fire `wakeCh`: `InvocationChanged`, `StageStateChanged`, `CooldownChanged`, `WorkerChanged` (from heartbeats/PID-sets/lock-with-worker), `TitleBodyChanged`, `StateChanged`, `BlockedByChanged`, `DeepFetchChanged`, `BaseBranchChanged`, `ItemRemoved`, `CheckRunChanged` (CI gate is catch-up-driven; see §9.8 ChangeFlag table).
 
 The unconditional `wakeCh <- struct{}{}` send that previously lived in the webhook handler has been removed. The observer path is the sole mechanism for immediate wake — but `wakeChObserver` is only registered when `wakeCh != nil`. In headless runs (`--notui` or any configuration without a wake channel), `mayNeedWorkObserver` (always registered) alone populates the pre-filter set; `wakeCh` is never signalled and there is no immediate dispatcher wake. Because all mutation types flow through the single shared store, the single `wakeChObserver` registration (when present) is sufficient — no per-source registration is needed.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1115,7 +1115,9 @@ The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is a
 - **Read by:** `snap.Worker() != nil` — used by all dispatch guards (main loop, reinvoke catch-up guards), the idle display ("workers active" log), and **auto-upgrade guard** (auto-upgrade refuses to fire while any worker is in-flight, to avoid `syscall.Exec` killing live workers)
 - **Idempotent:** the `WorkerExited` mutation handler (`internal/itemstate/store.go`) returns 0 changes when `item.Worker == nil`, so a redundant defer (e.g. an inner `defer WorkerExited` inside `processItem` firing in addition to the goroutine-top defer) does not produce spurious observer notifications.
 
-Both mutations emit `WorkerChanged | WorkerLifecycleChanged` (§2.14). Only `WorkerLifecycleChanged` is in `wakeChFlags`, so worker entry and exit deterministically wake the poll loop. `WorkerHeartbeat` and `WorkerPIDSet` emit only `WorkerChanged` and do not trigger a wake.
+Both mutations emit `WorkerChanged | WorkerLifecycleChanged` (§2.14). Only `WorkerLifecycleChanged` is in `wakeChFlags`, so worker entry and exit feed the wake pipeline. `WorkerHeartbeat` and `WorkerPIDSet` emit only `WorkerChanged` and do not feed the wake pipeline.
+
+> **Wake channel scope:** the wakeChObserver is registered only when a wake channel is configured (TUI mode or any other configuration that calls `SetWakeCh`). In headless / `--notui` runs, `WorkerLifecycleChanged` populates `mayNeedWork` for the next ticker-driven poll cycle but does not trigger an immediate wake. The dispatch re-evaluation guarantee is therefore "by the next scheduled poll" (≤ `PollSeconds`) when no wake channel is configured, and "within milliseconds" when one is.
 
 ### 9.3 Worktree Mutex
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1108,11 +1108,12 @@ No special handling. Each is independent. The engine only checks the in_progress
 
 **`Engine.inFlight` (`sync.Map`) has been removed (Fix B, issue #544).** The dispatch guard is now entirely Store-backed.
 
-The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is already running for an item. `WorkerEntered{Repo, Number, StageName, StartedAt}` is applied synchronously before `wg.Add(1)` and before the goroutine is launched, so the store guard is effective from the instant the goroutine is scheduled. The reinvoke dispatchers (`dispatchReviewReinvoke`, `dispatchCIFixReinvoke`, `dispatchRebaseReinvoke`) follow the same pattern. `WorkerExited` is deferred at the top of each goroutine.
+The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is already running for an item. `WorkerEntered{Repo, Number, StageName, StartedAt}` is applied synchronously before `wg.Add(1)` and before the goroutine is launched, so the store guard is effective from the instant the goroutine is scheduled. The reinvoke dispatchers (`dispatchReviewReinvoke`, `dispatchCIFixReinvoke`, `dispatchRebaseReinvoke`) follow the same pattern. `WorkerExited` is deferred **at the top of each goroutine** in all four dispatchers — main (`engine/poll.go`) and the three reinvoke dispatchers — so it fires on every exit path, including processItem's many early-return guards (paused, blocked, awaiting-input, locked-by-other, stage-complete, etc.).
 
 - **Set by:** dispatch loop applies `WorkerEntered` before goroutine launch; each reinvoke dispatcher applies `WorkerEntered` before goroutine launch
-- **Cleared by:** goroutine-top `defer store.Apply(WorkerExited{...})` — fires on any exit path including early return from context cancel or `ensureRepoReady` failure
-- **Read by:** `snap.Worker() != nil` — used by all dispatch guards (main loop, reinvoke catch-up guards), the idle display ("workers active" log), and auto-upgrade guard
+- **Cleared by:** goroutine-top `defer store.Apply(WorkerExited{...})` — fires on any exit path including processItem early-returns, context cancel, `ensureRepoReady` failure, panic-after-recover, or normal completion
+- **Read by:** `snap.Worker() != nil` — used by all dispatch guards (main loop, reinvoke catch-up guards), the idle display ("workers active" log), and **auto-upgrade guard** (auto-upgrade refuses to fire while any worker is in-flight, to avoid `syscall.Exec` killing live workers)
+- **Idempotent:** the `WorkerExited` mutation handler (`internal/itemstate/store.go`) returns 0 changes when `item.Worker == nil`, so a redundant defer (e.g. an inner `defer WorkerExited` inside `processItem` firing in addition to the goroutine-top defer) does not produce spurious observer notifications.
 
 Both mutations emit `WorkerChanged | WorkerLifecycleChanged` (§2.14). Only `WorkerLifecycleChanged` is in `wakeChFlags`, so worker entry and exit deterministically wake the poll loop. `WorkerHeartbeat` and `WorkerPIDSet` emit only `WorkerChanged` and do not trigger a wake.
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1183,7 +1183,6 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		dispatched++
 		go func() {
 			defer e.wg.Done()
-			defer func() { <-e.sem }()
 			// WorkerExited must be deferred at the goroutine top level so it fires on
 			// every exit path, including processItem early-returns (paused, blocked,
 			// awaiting-input, locked-by-other, stage-complete, etc.). The defer inside
@@ -1191,7 +1190,14 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			// any of them would leak the Worker entry and permanently block re-dispatch
 			// via the snap.Worker() != nil guard. Same pattern as the reinvoke
 			// dispatchers in reviews.go, ci.go, and merge_gate.go.
+			//
+			// Ordering: WorkerExited must fire AFTER the semaphore release so the wake
+			// it triggers does not race a fresh dispatch into a still-occupied slot.
+			// Defers run LIFO; declaring WorkerExited BEFORE the sem-release defer
+			// means sem-release runs first on exit, then WorkerExited fires its wake
+			// against a freed slot.
 			defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
+			defer func() { <-e.sem }()
 			e.emitStructural(tui.JobStartedEvent{
 				IssueNumber: item.Number,
 				Repo:        itemRepo,

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1184,6 +1184,14 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		go func() {
 			defer e.wg.Done()
 			defer func() { <-e.sem }()
+			// WorkerExited must be deferred at the goroutine top level so it fires on
+			// every exit path, including processItem early-returns (paused, blocked,
+			// awaiting-input, locked-by-other, stage-complete, etc.). The defer inside
+			// processItem at item.go:533 is reached only after ~14 early-return guards;
+			// any of them would leak the Worker entry and permanently block re-dispatch
+			// via the snap.Worker() != nil guard. Same pattern as the reinvoke
+			// dispatchers in reviews.go, ci.go, and merge_gate.go.
+			defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
 			e.emitStructural(tui.JobStartedEvent{
 				IssueNumber: item.Number,
 				Repo:        itemRepo,

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1879,6 +1879,10 @@ func TestWorkerExitedWakesObserver(t *testing.T) {
 	obs := newWakeChObserver(wakeCh)
 	store.Subscribe(obs)
 
+	// Store.Apply + observer notification are synchronous, and the wakeChObserver's
+	// channel send is non-blocking. After Apply returns, the wake channel
+	// deterministically has a token or doesn't — no need for time.After timeouts.
+
 	// WorkerEntered must wake because WorkerLifecycleChanged is in wakeChFlags.
 	store.Apply(itemstate.WorkerEntered{
 		Repo:      "owner/repo",
@@ -1889,7 +1893,7 @@ func TestWorkerExitedWakesObserver(t *testing.T) {
 	select {
 	case <-wakeCh:
 		// expected
-	case <-time.After(100 * time.Millisecond):
+	default:
 		t.Error("wake channel did not fire after WorkerEntered")
 	}
 
@@ -1898,7 +1902,7 @@ func TestWorkerExitedWakesObserver(t *testing.T) {
 	select {
 	case <-wakeCh:
 		// expected
-	case <-time.After(100 * time.Millisecond):
+	default:
 		t.Error("wake channel did not fire after WorkerExited")
 	}
 
@@ -1910,7 +1914,7 @@ func TestWorkerExitedWakesObserver(t *testing.T) {
 	select {
 	case <-wakeCh:
 		t.Error("wake channel must not fire after WorkerHeartbeat (only WorkerLifecycleChanged is in wakeChFlags)")
-	case <-time.After(20 * time.Millisecond):
+	default:
 		// expected: heartbeat does not wake
 	}
 }
@@ -1988,12 +1992,17 @@ func TestWorkerExitedIdempotent(t *testing.T) {
 	wakeCh := make(chan struct{}, 4)
 	store.Subscribe(newWakeChObserver(wakeCh))
 
+	// Store.Apply is synchronous and the wakeChObserver's channel send is non-blocking,
+	// so after Apply returns the wake channel deterministically either has a token or
+	// doesn't. Use non-blocking selects rather than time.After to keep the test
+	// deterministic and fast.
+
 	// First WorkerExited: should fire wake (Worker was non-nil → cleared → wake).
 	store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 1})
 	select {
 	case <-wakeCh:
 		// expected
-	case <-time.After(50 * time.Millisecond):
+	default:
 		t.Fatal("first WorkerExited should fire wake")
 	}
 
@@ -2002,7 +2011,7 @@ func TestWorkerExitedIdempotent(t *testing.T) {
 	select {
 	case <-wakeCh:
 		t.Error("second WorkerExited should be a no-op (Worker already nil); spurious wake fired")
-	case <-time.After(20 * time.Millisecond):
+	default:
 		// expected: no wake
 	}
 }

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1914,3 +1914,95 @@ func TestWorkerExitedWakesObserver(t *testing.T) {
 		// expected: heartbeat does not wake
 	}
 }
+
+// TestDispatchGoroutineWorkerExitedOnEarlyReturn verifies the fix for the
+// stuck-Worker bug observed on #559 / #563: the main dispatch goroutine in
+// poll.go must defer WorkerExited at the goroutine's top level, so that
+// processItem's early-return paths (paused, blocked, awaiting-input,
+// locked-by-other, stage-complete, etc.) all release the Worker entry.
+//
+// Pre-fix, the only WorkerExited defer lived inside processItem itself
+// (item.go:533), reached only after ~14 early-return guards. Any of those
+// returns would leak a Worker entry, blocking re-dispatch via the
+// snap.Worker() != nil guard and also blocking auto-upgrade (which gates
+// on snap.Worker() != nil for any item).
+//
+// This test simulates the goroutine pattern from poll.go: WorkerEntered is
+// applied before goroutine launch, the goroutine runs a body that returns
+// early (without calling processItem's internal defer), and the
+// goroutine-level defer fires WorkerExited. After the goroutine completes,
+// snap.Worker() must be nil.
+func TestDispatchGoroutineWorkerExitedOnEarlyReturn(t *testing.T) {
+	store := itemstate.NewStore(nil)
+
+	// Mirror the dispatch site in poll.go: apply WorkerEntered before goroutine.
+	store.Apply(itemstate.WorkerEntered{
+		Repo:      "owner/repo",
+		Number:    42,
+		StageName: "Implement",
+		StartedAt: time.Now(),
+	})
+
+	snap, err := store.Get("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("store.Get after WorkerEntered: %v", err)
+	}
+	if snap.Worker() == nil {
+		t.Fatal("Worker should be set after WorkerEntered")
+	}
+
+	// Simulate the dispatch goroutine. The defer at the goroutine top must fire
+	// even when the inner work (processItem-equivalent) early-returns without
+	// running its own defer.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 42})
+		// Simulate processItem early-return — no inner WorkerExited fires here.
+		return
+	}()
+	<-done
+
+	snap, err = store.Get("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("store.Get after goroutine exit: %v", err)
+	}
+	if snap.Worker() != nil {
+		t.Errorf("Worker should be nil after goroutine exit; got %+v", snap.Worker())
+	}
+}
+
+// TestWorkerExitedIdempotent verifies that WorkerExited applied twice is a
+// no-op on the second call (returns 0 changes). This makes the redundant
+// defer at item.go:533 harmless — when processItem runs to completion and
+// fires its own WorkerExited, the goroutine-level defer in poll.go fires
+// WorkerExited again, but the second call should not produce spurious
+// observer notifications.
+func TestWorkerExitedIdempotent(t *testing.T) {
+	store := itemstate.NewStore(nil)
+	store.Apply(itemstate.WorkerEntered{
+		Repo: "owner/repo", Number: 1,
+		StageName: "X", StartedAt: time.Now(),
+	})
+
+	wakeCh := make(chan struct{}, 4)
+	store.Subscribe(newWakeChObserver(wakeCh))
+
+	// First WorkerExited: should fire wake (Worker was non-nil → cleared → wake).
+	store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 1})
+	select {
+	case <-wakeCh:
+		// expected
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("first WorkerExited should fire wake")
+	}
+
+	// Second WorkerExited: must be a no-op (Worker already nil → no flags → no wake).
+	store.Apply(itemstate.WorkerExited{Repo: "owner/repo", Number: 1})
+	select {
+	case <-wakeCh:
+		t.Error("second WorkerExited should be a no-op (Worker already nil); spurious wake fired")
+	case <-time.After(20 * time.Millisecond):
+		// expected: no wake
+	}
+}

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -454,7 +454,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 
 	case WorkerExited:
 		if item.Worker == nil {
-			return 0 // no-op: already exited (e.g. redundant defer in processItem after the goroutine-level defer fires)
+			return 0 // no-op when Worker is already nil (e.g. duplicate WorkerExited from nested defers — the inner processItem defer fires first per Go's LIFO order, then the goroutine-level defer in poll.go finds Worker already cleared)
 		}
 		item.Worker = nil
 		return WorkerChanged | WorkerLifecycleChanged

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -453,6 +453,9 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		return WorkerChanged
 
 	case WorkerExited:
+		if item.Worker == nil {
+			return 0 // no-op: already exited (e.g. redundant defer in processItem after the goroutine-level defer fires)
+		}
 		item.Worker = nil
 		return WorkerChanged | WorkerLifecycleChanged
 


### PR DESCRIPTION
## Summary

PR #549 (Fix B for #544) moved Worker lifecycle into the Store via `WorkerEntered`/`WorkerExited` mutations and updated the three reinvoke dispatchers to defer `WorkerExited` at the goroutine's top level. **The main dispatch goroutine in poll.go was overlooked** — it relied on `processItem`'s internal `defer WorkerExited` at item.go:533, which is reached only AFTER ~14 early-return guards (paused, blocked, awaiting-input, locked-by-other, stage-complete, etc.). Any of those returns leaked the Worker entry, leaving it permanently set in the Store.

## Live evidence

Observed today on issues #559 and #563:

- **#563**: processItem hit `checkDependencies` → `fabrik:blocked` early-return at item.go:333. Worker leaked. Subsequent dispatch attempts skipped via the `snap.Worker() != nil` guard. Stuck for 65+ minutes despite #562 (the blocker) having closed.
- **#559**: similar early-return after Review→Validate advance. Validate stage never invoked. PR #560 sat mergeable but unmerged.
- **Auto-upgrade also blocked**, since it gates on `snap.Worker() != nil` for any item — meaning fabrik couldn't even pick up a fix without a manual restart.

The TUI symptom for #563 was particularly visible: the active-pane showed "#563 Specify 62:04 elapsed" alongside the blocked-pane entry "#563 waiting for #562" — a stale `JobStartedEvent` from the original dispatch, never matched by `JobCompletedEvent` because the goroutine returned without ever applying `InvocationRecorded`.

## Diagnosis

Comparing the four dispatchers post-#549:

**poll.go (main dispatch) — broken:**
\`\`\`go
e.store.Apply(itemstate.WorkerEntered{...})
e.wg.Add(1)
go func() {
    defer e.wg.Done()
    defer func() { <-e.sem }()
    // ← no defer WorkerExited at top
    err := e.processItem(ctx, board, item)
    // processItem has defer WorkerExited at item.go:533, AFTER 14 early-return sites
}()
\`\`\`

**reviews.go / ci.go / merge_gate.go — correct:**
\`\`\`go
go func() {
    defer e.wg.Done()
    defer e.store.Apply(itemstate.WorkerExited{...})  // top-level — covers all paths
    ...
}()
\`\`\`

## Fix

### Part 1 — main dispatch goroutine

\`engine/poll.go\` at the dispatch goroutine: add \`defer e.store.Apply(itemstate.WorkerExited{...})\` immediately after \`defer e.wg.Done()\`, mirroring the reinvoke dispatchers.

### Part 2 — WorkerExited idempotence

\`internal/itemstate/store.go\`: \`WorkerExited\` handler returns 0 changes when \`item.Worker\` is already nil. This makes the redundant defer in processItem (item.go:533) harmless defense-in-depth instead of a source of spurious observer notifications.

\`\`\`go
case WorkerExited:
    if item.Worker == nil {
        return 0 // no-op: already exited
    }
    item.Worker = nil
    return WorkerChanged | WorkerLifecycleChanged
\`\`\`

### Tests

Added in \`engine/poll_test.go\`:

- **\`TestDispatchGoroutineWorkerExitedOnEarlyReturn\`** — simulates the goroutine pattern with a body that early-returns (mirroring processItem's many early-return sites), verifies Worker is cleared after goroutine exit.
- **\`TestWorkerExitedIdempotent\`** — verifies the second WorkerExited call on a Store where Worker is already nil produces no flags and no spurious wake.

Both tests pass with \`-race\`. Full suite clean: \`go test -race ./...\` passes (~145s for engine package).

### Docs

\`docs/state-machine.md\` §9.2 (Worker In-Flight Guard) updated to:
- Explicitly document that \`WorkerExited\` is deferred at the goroutine top in **all four** dispatchers (main + three reinvokes).
- Note that processItem early-returns are now covered exit paths.
- Document the auto-upgrade gate's dependency on \`snap.Worker() != nil\`.
- Document the idempotence guarantee.

\`docs/llms-full.txt\` regenerated.

## Why this matters operationally

This is the bug that was **silently swallowing every processItem early-return path** since #549 landed. Any issue that hit a "skip" condition during dispatch (paused, blocked, awaiting-input, locked-by-other, stage-complete-with-no-comments, etc.) would leak its Worker entry permanently. The dispatch guard then refuses re-dispatch forever, and auto-upgrade refuses to fire while any leaked Worker exists.

Manual restart was the only escape, and even the restart was sometimes blocked by the auto-upgrade-can't-fire-with-active-workers gate.

After this fix, the architectural invariant from ADR 036 — "every state mutation flows through Store.Apply, every Worker entry is reliably cleared" — finally holds for the main dispatch path too.

## Test plan

- [x] \`go test -race ./engine/...\` passes.
- [x] \`go test -race ./...\` passes.
- [x] \`go vet ./...\` passes (no new warnings).
- [x] \`docs/llms-full.txt\` matches \`scripts/generate-llms-full.sh\` output.
- [ ] After merge: restart fabrik; verify previously-stuck #559 / #563 dispatch normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)