### PR TITLE
Detect external project column moves within one poll cycle via cheap project.updatedAt gate

### DIFF
--- a/adrs/035-four-layer-status-reconciliation.md
+++ b/adrs/035-four-layer-status-reconciliation.md
@@ -96,3 +96,7 @@ The `ReadClient` interface (used by `GitHubAdapter` and `boardcache` tests) is n
 **Include PR events in Layer 1**: Rejected. Mapping a PR number to a cache key requires an O(N) scan of all cached items under read lock. The marginal coverage improvement (catching column moves that coincide only with PR events, not issue events) doesn't justify the complexity and latency. Layer 2's 10-minute sweep covers the gap.
 
 **Export `ItemKey` vs. inline format string**: Exporting chosen. The format `repo + "#" + strconv.Itoa(number)` is simple but must be consistent across packages. An exported helper prevents a silent divergence if the format ever changes and signals to callers that the format is stable and intentional.
+
+## Implementation Evolution
+
+**Issue #565 (2026-05-05)**: The Layer 2 mechanism was refactored from the `runReconciliationLoop` goroutine (a separate ticker at `ProjectStatusPollSeconds` cadence) to an in-poll `updatedAt` gate at the top of `Engine.poll()`. The gate calls `FetchProjectUpdatedAt` (~1 GraphQL point) every poll cycle (~15 s) and only fires `FetchProjectItemStatusBatch` + `ApplyStatusBatch` when the project's `updatedAt` timestamp has advanced. This eliminates the separate goroutine and reduces external-move detection latency from ≤10 min to ≤15 s. The four-layer architecture and the decision rationale above remain valid; only the Layer 2 mechanism changed. See `docs/state-machine.md §D.4` for the authoritative as-built description.

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -127,6 +127,9 @@ func (m *testGitHubUpgradeClient) FetchPRsForSHA(owner, repo, sha string) ([]int
 func (m *testGitHubUpgradeClient) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
 	return nil, nil
 }
+func (m *testGitHubUpgradeClient) FetchProjectUpdatedAt(projectID string) (time.Time, error) {
+	return time.Time{}, nil
+}
 func (m *testGitHubUpgradeClient) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {
 	return "", "", nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ type Config struct {
 	WebhookPort       int
 	WebhookEvents     string // comma-separated; empty means default event set
 	BoardCacheMode       string // "in-memory" or "none"; empty = auto (in-memory when webhooks enabled)
-	StatusPollSeconds    int    // Layer 2 status-only sweep cadence in seconds; 0 = use default (600)
+	StatusPollSeconds    int    // Layer 2 status-only sweep cadence in seconds; 0 = use default (15)
 }
 
 func Execute() error {
@@ -407,11 +407,11 @@ func Execute() error {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				cfg.StatusPollSeconds = n
 			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_STATUS_POLL=%q is invalid (must be a positive integer); using default 600\n", v)
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_STATUS_POLL=%q is invalid (must be a positive integer); using default 15\n", v)
 			}
 		} else if pc.StatusPoll != nil {
 			if *pc.StatusPoll <= 0 {
-				fmt.Fprintf(os.Stderr, "[warn] config.yaml status_poll=%d is invalid (must be a positive integer); using default 600\n", *pc.StatusPoll)
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml status_poll=%d is invalid (must be a positive integer); using default 15\n", *pc.StatusPoll)
 			} else {
 				cfg.StatusPollSeconds = *pc.StatusPoll
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func Execute() error {
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.StringVar(&cfg.BoardCacheMode, "board-cache", "", `Board cache mode: "in-memory" (cache board state; requires --webhooks) or "none" (always fetch from GitHub). Default: "in-memory" when --webhooks is enabled, "none" otherwise. Also FABRIK_BOARD_CACHE.`)
-	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Cadence in seconds for the periodic status-only board sweep (Layer 2; 0 = use default of 600; also FABRIK_STATUS_POLL)")
+	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Cadence in seconds for the periodic status-only board sweep (Layer 2; 0 = use default of 15; also FABRIK_STATUS_POLL)")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err
@@ -619,10 +619,11 @@ func claudeWaitDelay(seconds int) time.Duration {
 }
 
 // statusPollSeconds returns the configured ProjectStatusPollSeconds, defaulting
-// to 600 (10 min) when n is 0 (unset).
+// to 15 s when n is 0 (unset). The gate now runs every poll cycle so the default
+// matches the main poll cadence rather than the former goroutine ticker period.
 func statusPollSeconds(n int) int {
 	if n <= 0 {
-		return 600
+		return 15
 	}
 	return n
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func Execute() error {
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.StringVar(&cfg.BoardCacheMode, "board-cache", "", `Board cache mode: "in-memory" (cache board state; requires --webhooks) or "none" (always fetch from GitHub). Default: "in-memory" when --webhooks is enabled, "none" otherwise. Also FABRIK_BOARD_CACHE.`)
-	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Cadence in seconds for the periodic status-only board sweep (Layer 2; 0 = use default of 15; also FABRIK_STATUS_POLL)")
+	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1686,16 +1686,26 @@ Reconciliation operates at two levels:
 
 **Periodic status-only sweep (Layer 2)**
 
-A `runReconciliationLoop` goroutine ticks at `ProjectStatusPollSeconds` (default 600 s, configurable via `--status-poll` / `FABRIK_STATUS_POLL` / `config.yaml status_poll`). Each tick calls `e.client.FetchProjectItemStatusBatch(projectID)` — a lightweight GraphQL query returning only `itemNodeID → statusName` for every board item — and passes the result to `cacheImpl.ApplyStatusBatch(updates)`.
+At the top of every `poll()` cycle (~15 s), when the in-memory cache is bootstrapped (`cacheImpl != nil` and `cacheImpl.ProjectID() != ""`), the engine runs a two-step gate:
+
+1. **Gate step** — `e.client.FetchProjectUpdatedAt(projectID)`: fetches the single `updatedAt` field for the project node (`node(id:$id){ ...on ProjectV2 { updatedAt } }`). Cost: ~1 GraphQL point per poll cycle. If the returned timestamp equals `e.lastProjectUpdatedAt` (no project-level change since last cycle), the batch is skipped entirely.
+
+2. **Batch step** — fired only when the timestamp has advanced: `e.client.FetchProjectItemStatusBatch(projectID)` returns `itemNodeID → statusName` for every board item (paginated in pages of 100, no nested fields). The result is passed to `cacheImpl.ApplyStatusBatch(updates)`.
 
 `ApplyStatusBatch` holds the write lock for one pass:
 - For each `(itemID, newStatus)` pair, look up the cache key via `itemIDToKey`.
-- If the status differs from the cached value, update `Status` and `UpdatedAt`. Unchanged items are skipped.
+- If the status differs from the cached value, update `Status` and `UpdatedAt`. Unchanged items are skipped (no observer notifications).
 - Unknown item IDs (not yet bootstrapped) are silently skipped.
 
-This sweep is far cheaper than a full board fetch (no nested fields, no comments, no labels) and can run at 10-minute cadence without meaningful GraphQL budget pressure.
+After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new timestamp so the next poll cycle can compare correctly.
 
-The loop skips a tick and logs a warning if `cacheImpl.ProjectID()` is empty, which means the bootstrap has not yet completed.
+**First poll cycle**: `e.lastProjectUpdatedAt` starts at the zero value (`time.Time{}`). The first real `updatedAt` returned by GitHub is always later than zero, so the batch fires on the first cycle. This catches any Status drift that occurred before engine start.
+
+**GitHub API limitation**: GitHub's `ProjectV2.items` does not support a `since` filter or `orderBy: UPDATED_AT`. The full batch (`FetchProjectItemStatusBatch`) is the only way to identify which specific items changed once the gate fires. The Store's existing diff in `ApplyStatusBatch` de-dupes unchanged-Status items so no spurious observer notifications are emitted.
+
+**Gate placement**: The gate runs before `e.readClient.FetchProjectBoard(...)` in `poll()`, so the cache holds the latest Status values when the board is read and items are dispatched in the same cycle.
+
+**Gate inactive when**: `e.readClient` is not a `*boardcache.CacheImpl` (non-cache mode), or `cacheImpl.ProjectID()` is empty (bootstrap not yet complete).
 
 **Full reconcile — stream-recovery only**
 
@@ -1739,10 +1749,10 @@ In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub d
 |-------|-----------|---------|------|
 | **0** Write-through | After any successful mutation call in the engine (status, labels, comments), the corresponding `CacheImpl` method is called immediately | Zero | Zero |
 | **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event, fetches the current Status: fast path (`FetchProjectItemStatus`) when the item's `itemID` is cached; fallback (`LookupIssueProjectItem`) when it isn't yet (e.g., brand-new issues arriving via `issues.opened` before `projects_v2_item.created`) | Seconds (best-effort) | ~1–5 pts/event |
-| **2** Periodic status sweep | `runReconciliationLoop` calls `FetchProjectItemStatusBatch` at `ProjectStatusPollSeconds` cadence (default 10 min) | Up to 10 min | O(⌈N/100⌉) per sweep |
+| **2** Periodic status sweep | In-poll `updatedAt` gate: `FetchProjectUpdatedAt` (~1 pt) every poll cycle (~15 s); fires `FetchProjectItemStatusBatch` + `ApplyStatusBatch` only when project timestamp advances | Up to 15 s | ~1 pt/cycle idle; O(⌈N/100⌉) pts when gate fires |
 | **Bootstrap / stream-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and on webhook stream recovery | Minutes | Full board cost |
 
-**Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the Layer 2 cadence (`ProjectStatusPollSeconds`). If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own mutations.
+**Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the main poll cadence (~15 s) — Layer 2 runs at the top of every `poll()` cycle. If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own mutations.
 
 **Layer 0 write-through convention**: Every engine call site that mutates dispatch-relevant cache state **must** call the corresponding `CacheImpl` write-through method immediately after the API call succeeds. The safe type-assertion pattern used at every site:
 
@@ -1777,6 +1787,6 @@ This is a no-op when `e.readClient` is a `GitHubAdapter` (cache-disabled mode), 
 
 **`CacheImpl` existence guard**: All three new write-through methods (`ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyCommentAdded`) call `c.store.Get(repo, number)` before applying the mutation. If the key is not present in the Store (i.e., was never bootstrapped), the method returns without creating a phantom Store entry.
 
-**Layer 1 scope**: Only `issues` and `issue_comment` event types trigger a per-event status fetch. `pull_request`, `pull_request_review`, `check_run`, and other event types are excluded from Layer 1 (finding the linked issue for a PR event requires an O(N) cache scan; `check_run` does not carry an item ID). Layer 2's periodic sweep covers these cases within its cadence.
+**Layer 1 scope**: Only `issues` and `issue_comment` event types trigger a per-event status fetch. `pull_request`, `pull_request_review`, `check_run`, and other event types are excluded from Layer 1 (finding the linked issue for a PR event requires an O(N) cache scan; `check_run` does not carry an item ID). Layer 2's per-poll-cycle gate covers these cases within ~15 s.
 
 For new issues whose `itemID` is not yet in the cache (e.g., added via `issues.opened` before a `projects_v2_item.created` event is received), Layer 1 falls back to `LookupIssueProjectItem` to populate both `itemID` and current Status in one GraphQL query (`repository.issue.projectItems`). If `cache.ProjectID()` is empty (Bootstrap not yet complete), the fallback is skipped. After a successful fallback, subsequent Layer 1 calls for the same issue use the cheaper `FetchProjectItemStatus` fast path.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -43,7 +43,7 @@ type Config struct {
 	WebhookPort       int
 	WebhookEvents     []string
 	BoardCacheMode           string // "in-memory" or "none"; default "none" when webhooks off, "in-memory" when on
-	ProjectStatusPollSeconds int    // Layer 2 status-only sweep cadence in seconds; default 600 (10 min)
+	ProjectStatusPollSeconds int    // Layer 2 status-only sweep cadence in seconds; default 15 s (gate runs every poll cycle; field retained for config compatibility)
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -73,8 +73,9 @@ type Engine struct {
 	mayNeedWork    map[string]bool // key: issueKey; items that have changed since the last poll cycle
 	mayNeedWorkMu  sync.Mutex      // guards mayNeedWork
 	seededRepos          map[string]bool       // key: "owner/repo"; in-memory guard to avoid re-seeding on every poll
-	idleCount            int                   // consecutive idle polls; triggers self-upgrade at threshold
-	idleStart            time.Time             // when consecutive idle polls began; zero value = not idle
+	idleCount              int       // consecutive idle polls; triggers self-upgrade at threshold
+	idleStart              time.Time // when consecutive idle polls began; zero value = not idle
+	lastProjectUpdatedAt   time.Time // last seen project.updatedAt from FetchProjectUpdatedAt gate; zero = not yet checked
 	wakeCh               chan struct{}         // TUI sends on this to wake the poll loop immediately; nil if no TUI
 	sem                  chan struct{}         // semaphore bounding concurrent workers across poll cycles
 	wg                   sync.WaitGroup        // tracks in-flight workers for graceful shutdown

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -46,6 +46,7 @@ type GitHubClient interface {
 	RateLimitStats() (rest, graphql gh.RateLimitStats)
 	FetchProjectItemStatus(itemID string) (string, error)
 	FetchProjectItemStatusBatch(projectID string) (map[string]string, error)
+	FetchProjectUpdatedAt(projectID string) (time.Time, error)
 	LookupIssueProjectItem(projectID, repo string, issueNumber int) (itemID string, status string, err error)
 }
 

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -45,12 +45,16 @@ type mockGitHubClient struct {
 	addReviewRequestFn              func(owner, repo string, prNumber int, reviewers []string) error
 	fetchProjectItemStatusFn        func(itemID string) (string, error)
 	fetchProjectItemStatusBatchFn   func(projectID string) (map[string]string, error)
+	fetchProjectUpdatedAtFn         func(projectID string) (time.Time, error)
 	lookupIssueProjectItemFn        func(projectID, repo string, issueNumber int) (string, string, error)
 	fetchPRClosingIssuesFn          func(owner, repo string, prNumber int) ([]int, error)
 	fetchPRsForSHAFn                func(owner, repo, sha string) ([]int, error)
 
 	// Track call counts for FetchProjectItemStatus
 	fetchProjectItemStatusCalls []string
+
+	// Track call counts for FetchProjectItemStatusBatch (used by gate tests)
+	fetchProjectItemStatusBatchCalls int
 
 	// Track calls for LookupIssueProjectItem
 	lookupIssueProjectItemCalls []lookupIssueProjectItemCall
@@ -520,12 +524,23 @@ func (m *mockGitHubClient) FetchProjectItemStatus(itemID string) (string, error)
 
 func (m *mockGitHubClient) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
 	m.mu.Lock()
+	m.fetchProjectItemStatusBatchCalls++
 	fn := m.fetchProjectItemStatusBatchFn
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(projectID)
 	}
 	return map[string]string{}, nil
+}
+
+func (m *mockGitHubClient) FetchProjectUpdatedAt(projectID string) (time.Time, error) {
+	m.mu.Lock()
+	fn := m.fetchProjectUpdatedAtFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(projectID)
+	}
+	return time.Time{}, nil
 }
 
 func (m *mockGitHubClient) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -394,13 +394,6 @@ func (e *Engine) Run() error {
 		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {
 			e.webhookMgr = wm
 			defer wm.Stop()
-			if cacheImpl != nil {
-				cadence := time.Duration(e.cfg.ProjectStatusPollSeconds) * time.Second
-				if cadence <= 0 {
-					cadence = 600 * time.Second
-				}
-				go e.runReconciliationLoop(ctx, cacheImpl, cadence)
-			}
 		}
 	}
 
@@ -684,6 +677,26 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		e.logf(0, "poll", "reading project board from cache: %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
 	} else {
 		e.logf(0, "poll", "fetching project board from GitHub: %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
+	}
+
+	// Layer 2 gate: check project.updatedAt before the board read so the cache
+	// holds fresh Status values when poll() processes items this cycle.
+	// Only active when the in-memory cache is bootstrapped (cacheImpl != nil and
+	// ProjectID is known); skipped on the very first cycle when cache is unset.
+	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && cacheImpl.ProjectID() != "" {
+		projectID := cacheImpl.ProjectID()
+		updatedAt, err := e.client.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			e.logf(0, "cache", "layer2 gate: FetchProjectUpdatedAt failed: %v\n", err)
+		} else if updatedAt.After(e.lastProjectUpdatedAt) {
+			updates, err := e.client.FetchProjectItemStatusBatch(projectID)
+			if err != nil {
+				e.logf(0, "cache", "layer2 status sweep failed: %v\n", err)
+			} else {
+				cacheImpl.ApplyStatusBatch(updates)
+				e.lastProjectUpdatedAt = updatedAt
+			}
+		}
 	}
 
 	board, err := e.readClient.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
@@ -1542,32 +1555,6 @@ func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
 	cache.Reconcile(board)
 }
 
-// runReconciliationLoop periodically fetches only the Status field for every
-// project item and applies any drift to the in-memory cache (Layer 2).
-// This replaces the former 60-min full-board reconcile for the periodic path;
-// reconcileCache (full board fetch) is preserved for stream-recovery only.
-func (e *Engine) runReconciliationLoop(ctx context.Context, cache *boardcache.CacheImpl, cadence time.Duration) {
-	ticker := time.NewTicker(cadence)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			projectID := cache.ProjectID()
-			if projectID == "" {
-				e.logf(0, "cache", "layer2 status sweep skipped: cache not yet bootstrapped\n")
-				continue
-			}
-			updates, err := e.client.FetchProjectItemStatusBatch(projectID)
-			if err != nil {
-				e.logf(0, "cache", "layer2 status sweep failed: %v\n", err)
-				continue
-			}
-			cache.ApplyStatusBatch(updates)
-		}
-	}
-}
 
 // applyLayer1StatusRefresh handles the Layer 1 opportunistic per-event Status
 // refresh. Called from the deltaFn closure after ApplyDelta. For issue and

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1555,7 +1555,6 @@ func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
 	cache.Reconcile(board)
 }
 
-
 // applyLayer1StatusRefresh handles the Layer 1 opportunistic per-event Status
 // refresh. Called from the deltaFn closure after ApplyDelta. For issue and
 // issue_comment events, it fetches the current Status from GitHub and updates

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -685,16 +685,19 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// ProjectID is known); skipped on the very first cycle when cache is unset.
 	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && cacheImpl.ProjectID() != "" {
 		projectID := cacheImpl.ProjectID()
-		updatedAt, err := e.client.FetchProjectUpdatedAt(projectID)
-		if err != nil {
-			e.logf(0, "cache", "layer2 gate: FetchProjectUpdatedAt failed: %v\n", err)
-		} else if updatedAt.After(e.lastProjectUpdatedAt) {
+		updatedAt, gateErr := e.client.FetchProjectUpdatedAt(projectID)
+		if gateErr != nil {
+			e.logf(0, "cache", "layer2 gate: FetchProjectUpdatedAt failed: %v; running batch as fallback\n", gateErr)
+		}
+		if gateErr != nil || updatedAt.After(e.lastProjectUpdatedAt) {
 			updates, err := e.client.FetchProjectItemStatusBatch(projectID)
 			if err != nil {
 				e.logf(0, "cache", "layer2 status sweep failed: %v\n", err)
 			} else {
 				cacheImpl.ApplyStatusBatch(updates)
-				e.lastProjectUpdatedAt = updatedAt
+				if gateErr == nil {
+					e.lastProjectUpdatedAt = updatedAt
+				}
 			}
 		}
 	}

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1514,6 +1514,43 @@ func TestPollGateFire(t *testing.T) {
 	}
 }
 
+// TestPollGateFire_AppliesStatusDrift verifies the behavioral contract: when the
+// gate fires, ApplyStatusBatch updates the cached item Status and the new Status
+// is visible to the subsequent board read in the same poll cycle.
+func TestPollGateFire_AppliesStatusDrift(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	client := &mockGitHubClient{
+		fetchProjectUpdatedAtFn: func(projectID string) (time.Time, error) {
+			return t1, nil
+		},
+		fetchProjectItemStatusBatchFn: func(projectID string) (map[string]string, error) {
+			return map[string]string{"PVTI_001": "Implement"}, nil
+		},
+	}
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	eng.wg.Wait()
+
+	// Gate fires (t1 > zero); batch returns drifted status; cache must reflect it.
+	board, err := cache.FetchProjectBoard("owner", "repo", 1, "")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	var got string
+	for _, item := range board.Items {
+		if item.Number == 1 {
+			got = item.Status
+		}
+	}
+	if got != "Implement" {
+		t.Errorf("want cached Status %q after gate-fired batch, got %q", "Implement", got)
+	}
+}
+
 // TestSeedLabels_multiRepo verifies that in multi-repo mode (cfg.Repo == ""),
 // SeedLabels is called exactly once per discovered repo across two poll cycles,
 // and never called with an empty repo argument.

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1437,85 +1437,80 @@ func TestLayer1StatusRefresh_SkipsNonIssueEvents(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Layer 2 — periodic status-field-only sweep
+// Layer 2 — updatedAt gate in poll loop
 // ---------------------------------------------------------------------------
 
-func TestRunReconciliationLoop_AppliesStatusDrift(t *testing.T) {
-	var batchCalls int32
+// TestPollGateMiss verifies that when project.updatedAt is unchanged between
+// two poll cycles, FetchProjectItemStatusBatch is called only once (on the
+// first cycle when timestamp advances from zero).
+func TestPollGateMiss(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	client := &mockGitHubClient{
-		fetchProjectItemStatusBatchFn: func(projectID string) (map[string]string, error) {
-			atomic.AddInt32(&batchCalls, 1)
-			return map[string]string{"PVTI_001": "Implement"}, nil
+		fetchProjectUpdatedAtFn: func(projectID string) (time.Time, error) {
+			return t1, nil // same timestamp on every call
 		},
 	}
-	cache := seedTestCache(t, client)
 	eng := testEngine(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{ProjectID: "PVT_1", Items: nil})
+	eng.readClient = cache
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go eng.runReconciliationLoop(ctx, cache, 50*time.Millisecond)
-
-	// Wait up to 500ms for the cache to reflect the drifted status.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		board, err := cache.FetchProjectBoard("owner", "repo", 1, "")
-		if err != nil {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-		for _, item := range board.Items {
-			if item.Number == 1 && item.Status == "Implement" {
-				cancel()
-				return
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll 1: %v", err)
 	}
-	cancel()
-	// Give the goroutine time to finish any in-flight ApplyStatusBatch.
-	time.Sleep(25 * time.Millisecond)
+	eng.wg.Wait()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll 2: %v", err)
+	}
+	eng.wg.Wait()
 
-	if atomic.LoadInt32(&batchCalls) == 0 {
-		t.Fatal("FetchProjectItemStatusBatch was never called within 500ms")
-	}
-
-	// Verify the cache reflects the drifted status.
-	board, err := cache.FetchProjectBoard("owner", "repo", 1, "")
-	if err != nil {
-		t.Fatalf("FetchProjectBoard after layer2 sweep: %v", err)
-	}
-	var gotStatus string
-	for _, item := range board.Items {
-		if item.Number == 1 {
-			gotStatus = item.Status
-		}
-	}
-	if gotStatus != "Implement" {
-		t.Errorf("want cached Status %q after Layer 2 sweep, got %q", "Implement", gotStatus)
+	client.mu.Lock()
+	calls := client.fetchProjectItemStatusBatchCalls
+	client.mu.Unlock()
+	// Gate fires on cycle 1 (t1 after zero), skips on cycle 2 (t1 == t1).
+	if calls != 1 {
+		t.Errorf("FetchProjectItemStatusBatch: want 1 call, got %d", calls)
 	}
 }
 
-func TestRunReconciliationLoop_SkipsWhenProjectIDEmpty(t *testing.T) {
-	var batchCalls int32
+// TestPollGateFire verifies that when project.updatedAt advances between two
+// poll cycles, FetchProjectItemStatusBatch is called on each cycle.
+func TestPollGateFire(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Minute)
+	var callIdx int
+	timestamps := []time.Time{t1, t2}
 	client := &mockGitHubClient{
-		fetchProjectItemStatusBatchFn: func(projectID string) (map[string]string, error) {
-			atomic.AddInt32(&batchCalls, 1)
-			return map[string]string{}, nil
+		fetchProjectUpdatedAtFn: func(projectID string) (time.Time, error) {
+			ts := timestamps[callIdx]
+			if callIdx < len(timestamps)-1 {
+				callIdx++
+			}
+			return ts, nil
 		},
 	}
-	// Cache with no Bootstrap call — ProjectID() returns "".
-	cache := boardcache.NewCacheImpl(client, itemstate.NewStore(nil), func(format string, args ...any) {})
 	eng := testEngine(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{ProjectID: "PVT_1", Items: nil})
+	eng.readClient = cache
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll 1: %v", err)
+	}
+	eng.wg.Wait()
+	if _, err := eng.poll(ctx); err != nil {
+		t.Fatalf("poll 2: %v", err)
+	}
+	eng.wg.Wait()
 
-	go eng.runReconciliationLoop(ctx, cache, 50*time.Millisecond)
-	time.Sleep(150 * time.Millisecond)
-	cancel()
-
-	if n := atomic.LoadInt32(&batchCalls); n != 0 {
-		t.Errorf("FetchProjectItemStatusBatch should not be called when ProjectID is empty; got %d calls", n)
+	client.mu.Lock()
+	calls := client.fetchProjectItemStatusBatchCalls
+	client.mu.Unlock()
+	// Gate fires on cycle 1 (t1 after zero) and cycle 2 (t2 after t1).
+	if calls != 2 {
+		t.Errorf("FetchProjectItemStatusBatch: want 2 calls, got %d", calls)
 	}
 }
 

--- a/github/project.go
+++ b/github/project.go
@@ -951,6 +951,9 @@ query($id: ID!) {
 	if result.Data.Node == nil {
 		return time.Time{}, fmt.Errorf("fetching project updatedAt for %s: node not found or not a ProjectV2", projectID)
 	}
+	if result.Data.Node.UpdatedAt == "" {
+		return time.Time{}, fmt.Errorf("fetching project updatedAt for %s: node is not a ProjectV2 (updatedAt field absent)", projectID)
+	}
 	t, err := parseTime(result.Data.Node.UpdatedAt)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parsing project updatedAt for %s: %w", projectID, err)

--- a/github/project.go
+++ b/github/project.go
@@ -923,6 +923,41 @@ func parseTime(s string) (time.Time, error) {
 	return time.Parse(time.RFC3339, s)
 }
 
+// FetchProjectUpdatedAt returns the updatedAt timestamp for the given project node ID.
+// Used as a cheap gate in the poll loop to skip the full status batch when the project
+// hasn't changed since the last cycle.
+func (c *Client) FetchProjectUpdatedAt(projectID string) (time.Time, error) {
+	query := `
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      updatedAt
+    }
+  }
+}`
+	vars := map[string]interface{}{"id": projectID}
+
+	var result struct {
+		Data struct {
+			Node *struct {
+				UpdatedAt string `json:"updatedAt"`
+			} `json:"node"`
+		} `json:"data"`
+	}
+
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return time.Time{}, fmt.Errorf("fetching project updatedAt for %s: %w", projectID, err)
+	}
+	if result.Data.Node == nil {
+		return time.Time{}, fmt.Errorf("fetching project updatedAt for %s: node not found or not a ProjectV2", projectID)
+	}
+	t, err := parseTime(result.Data.Node.UpdatedAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing project updatedAt for %s: %w", projectID, err)
+	}
+	return t, nil
+}
+
 // FetchProjectItemStatus fetches only the Status field value for a single project
 // item identified by its node ID (PVTI_...). Returns "" when no status is set.
 func (c *Client) FetchProjectItemStatus(itemID string) (string, error) {


### PR DESCRIPTION
## Summary

Add a one-field `project.updatedAt` GraphQL gate that Fabrik checks at the top of every poll cycle (~15 s). When the timestamp hasn't changed, nothing else happens (cost: ~1 GraphQL point). When it has, Fabrik runs the existing `FetchProjectItemStatusBatch` + `ApplyStatusBatch` diff path to identify and apply the changed items. This brings external-move detection latency from ≤10 min down to ≤15 s at negligible API cost.

The implementation uses the **"fold into main poll loop" variant**: the `project.updatedAt` check is added at the top of `Engine.poll()` rather than keeping `runReconciliationLoop` as a separate goroutine. This eliminates moving parts and matches the existing 15 s poll cadence without adding a second timer.

## Problem

External status changes — a user manually dragging an issue to a different column in the GitHub project board UI, another Fabrik instance advancing an issue, or any automation moving items — are currently invisible to Fabrik for up to **10 minutes**. This is the current Layer 2 sweep cadence (`ProjectStatusPollSeconds`, default 600 s). Fabrik's own mutations write through immediately (Layer 0, added in #544), but external moves wait for the next full status-batch poll.

The UX gap is pronounced: a user drags an issue to "Specify" and watches Fabrik sit idle for several minutes before it notices.

## Approach

### Approach

Fold the Layer 2 status sweep directly into the main `poll()` loop using a one-field `project.updatedAt` GraphQL gate. At the top of each `poll()` call, when in cache mode with a bootstrapped project, the engine checks whether the project's `updatedAt` timestamp has advanced since the last check. If it hasn't, the batch is skipped (cost: ~1 GraphQL point). If it has, `FetchProjectItemStatusBatch` + `ApplyStatusBatch` run to identify and apply changed statuses.

This eliminates the `runReconciliationLoop` goroutine entirely — one fewer timer, one fewer goroutine, and no concurrent writer for the status batch path. The gate runs on every poll cycle (every ~15 s), so `ProjectStatusPollSeconds` effectively becomes an unused knob post-implementation (see Key Decisions).

Call order within the modified `poll()`:

```
poll() called
  → [Gate] if cacheImpl != nil && cacheImpl.ProjectID() != "":
      → e.client.FetchProjectUpdatedAt(projectID)
      → if timestamp advanced from lastProjectUpdatedAt:
          → e.client.FetchProjectItemStatusBatch(projectID)
          → cacheImpl.ApplyStatusBatch(updates)
          → e.lastProjectUpdatedAt = newTimestamp
  → e.readClient.FetchProjectBoard(...)    [cache now holds fresh Status]
  → ... rest of poll unchanged
```

### New/Modified Files

| File | Change |
|------|--------|
| `github/project.go` | Add `FetchProjectUpdatedAt(projectID string) (time.Time, error)` method |
| `engine/interfaces.go` | Append `FetchProjectUpdatedAt` to `GitHubClient` interface |
| `engine/mocks_test.go` | Add `fetchProjectUpdatedAtFn` field + method + `fetchProjectItemStatusBatchCalls` counter to `mockGitHubClient` |
| `cmd/cmd_extra_test.go` | Add trivial stub `FetchProjectUpdatedAt` to `testGitHubUpgradeClient` |
| `engine/engine.go` | Add `lastProjectUpdatedAt time.Time` field to `Engine` struct |
| `engine/poll.go` | Add gate block at top of `poll()`; remove `runReconciliationLoop` goroutine launch from `Run()`; remove `runReconciliationLoop` function |
| `cmd/root.go` | Change `statusPollSeconds()` default from 600 → 15; update inline comment and flag help text |
| `engine/poll_test.go` | Add `TestPollGateMiss` and `TestPollGateFire` |
| `docs/state-machine.md` | Rewrite §D.4 Layer 2 description; update §D.7 table row and residual latency note |
| `adrs/035-four-layer-status-reconciliation.md` | Add implementation-evolution note |

### Key Decisions

- **`lastProjectUpdatedAt` on Engine struct, not poll-local**: It must survive across poll cycles. Precedent: `idleStart time.Time` already lives on the Engine struct for the same reason. No mutex needed — `poll()` is single-goroutine, and removing `runReconciliationLoop` eliminates the only other writer.

- **Gate uses `e.client`, not `e.readClient`**: `FetchProjectUpdatedAt` is not part of `boardcache.ReadClient` (and should not be — it's a real-API call, not a cache read). Consistent with how `runReconciliationLoop` called `e.client.FetchProjectItemStatusBatch`.

- **Gate fires unconditionally on first poll cycle**: `lastProjectUpdatedAt` starts as `time.Time{}` (zero). Any real `updatedAt` from GitHub is after the zero time, so the batch runs on cycle 1. This is correct — it catches drift that occurred before engine start.

- **`ProjectStatusPollSeconds` becomes an unused knob**: After removing `runReconciliationLoop`, the `--status-poll` flag and `cfg.ProjectStatusPollSeconds` field no longer control anything at runtime (the gate fires every poll cycle regardless). The spec says to keep the field and flag, and change the default to 15 — this is done. The field value is simply not consumed in the new code path. No deprecation notice needed; the spec accepted this ambiguity.

- **No ADR needed for this change**: The four-layer architecture is preserved (ADR 035's decision stands). The mechanism change (goroutine → in-poll gate) is an implementation evolution of ADR 035's Layer 2, not a new architectural decision. A short evolution note is added to ADR 035 instead.

- **Call tracker for `FetchProjectItemStatusBatch` in mock**: The gate tests assert whether the batch was or was not called. Rather than adding a generic counter field for every method, add a specific `fetchProjectItemStatusBatchCalls int` counter (accessed under `mu`) to `mockGitHubClient`. Same pattern as `lookupIssueProjectItemCalls`.

### Task Checklist

- [ ] Task 1: Add `FetchProjectUpdatedAt` to `github/project.go` — one-field GraphQL query `node(id:$id){ ...on ProjectV2 { updatedAt } }` using the existing `graphqlRequest` + `parseTime` pattern from `FetchProjectItemStatus`
- [ ] Task 2: Add `FetchProjectUpdatedAt(projectID string) (time.Time, error)` to `GitHubClient` interface in `engine/interfaces.go`
- [ ] Task 3: Add stub to `engine/mocks_test.go` — `fetchProjectUpdatedAtFn func(projectID string) (time.Time, error)` field on `mockGitHubClient`, corresponding method body (mutex + fn call pattern), and `fetchProjectItemStatusBatchCalls int` counter incremented in the existing `FetchProjectItemStatusBatch` method body
- [ ] Task 4: Add trivial stub to `cmd/cmd_extra_test.go` — `func (m *testGitHubUpgradeClient) FetchProjectUpdatedAt(projectID string) (time.Time, error) { return time.Time{}, nil }`
- [ ] Task 5: Add `lastProjectUpdatedAt time.Time` field to `Engine` struct in `engine/engine.go`, adjacent to `idleStart time.Time`
- [ ] Task 6: Modify `engine/poll.go` — (a) add gate block at top of `poll()` before `FetchProjectBoard` call; (b) remove the `runReconciliationLoop` goroutine launch block (lines 397–403 in `Run()`); (c) delete the `runReconciliationLoop` function body
- [ ] Task 7: Update `cmd/root.go` — change `statusPollSeconds()` default return from `600` to `15`; update the function comment; update flag help text at line ~135 from "600" to "15"
- [ ] Task 8: Add `TestPollGateMiss` and `TestPollGateFire` to `engine/poll_test.go` using `testEngineWithCache` — gate-miss asserts `fetchProjectItemStatusBatchCalls == 1` after two polls with identical timestamps; gate-fire asserts `fetchProjectItemStatusBatchCalls == 2` after two polls with advancing timestamps
- [ ] Task 9: Update `docs/state-machine.md` — rewrite §D.4 "Periodic status-only sweep (Layer 2)" to describe the in-poll gate pattern; update §D.7 table Layer 2 row (mechanism, cadence 10 min → 15 s); update §D.7 residual latency note
- [ ] Task 10: Add evolution note to `adrs/035-four-layer-status-reconciliation.md` — brief paragraph noting that the Layer 2 mechanism was refactored from `runReconciliationLoop` goroutine to an in-poll `updatedAt` gate in issue #565, and that `state-machine.md` §D.4 is the authoritative as-built description
- [ ] Task 11: Run `go test -race ./...` and `go vet ./...`; fix any failures

### Risks

- **Interface-change compile cascade**: Adding `FetchProjectUpdatedAt` to `GitHubClient` breaks compilation until all three implementors (`*github.Client`, `mockGitHubClient`, `testGitHubUpgradeClient`) are updated. Tasks 1–4 must all complete before any `go build` or `go test` attempt; if implementing incrementally, add a dummy stub early to stay in a compilable state.

- **Gate test setup complexity**: `poll()` does many things beyond the gate — board fetch, rate limit logging, item dispatch. Gate tests need a mock client that returns benign non-error responses for all other calls (empty board, no items). `testEngineWithCache` already provides reasonable defaults; the implementer should verify the helper returns a valid `ProjectBoard` with `ProjectID: "PVT_1"` set so the gate's `cacheImpl.ProjectID() != ""` guard is satisfied.

- **Gate placement ordering**: The gate block must come before `e.readClient.FetchProjectBoard(...)` so that `ApplyStatusBatch` runs before the board is read in this cycle. If placed after, the fresh status won't be visible to item processing in the same cycle. Verify placement is before line 689 of the current `poll.go`.

- **`ProjectStatusPollSeconds` field residual confusion**: After the change, the Config field exists but has no runtime effect. Future contributors reading the config struct may wonder why it exists. The doc updates in §D.4/§D.7 will note the gate runs on every poll cycle; this is sufficient without adding a code comment to the struct.

---
Used 15/50 turns, 5k input / 7k output tokens.

## Verification

Implemented the `project.updatedAt` gate folded into `Engine.poll()`, replacing the `runReconciliationLoop` goroutine. Added `FetchProjectUpdatedAt` to `github/project.go`, `GitHubClient` interface, and all mock stubs; added `lastProjectUpdatedAt` to the Engine struct; wired the two-step gate (FetchProjectUpdatedAt → FetchProjectItemStatusBatch when timestamp advances) at the top of `poll()` before the board read. Changed `statusPollSeconds()` default from 600 to 15, replaced old reconciliation loop tests with `TestPollGateMiss` and `TestPollGateFire`, and updated `docs/state-machine.md` §D.4/§D.7 and ADR 035. All tests pass with `go test -race ./...`.

---

Closes #565