### PR TITLE
docs: add 'Install the PM plugin' quick-start to USER_GUIDE.md

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1182,8 +1182,8 @@ After installing, your interactive Claude Code session gains:
 
 | Component | Description |
 |-----------|-------------|
-| `fabrik` skill | Auto-activates when `.fabrik/` is detected or Fabrik is mentioned. Provides ambient PM awareness — ask about board state, issue status, stuck items, etc. |
-| `fabrik-setup` skill | One-time onboarding walkthrough for setting up Fabrik from scratch in a new project. |
+| `fabrik` skill (qualified: `fabrik:fabrik`) | Auto-activates when `.fabrik/` is detected or Fabrik is mentioned. Provides ambient PM awareness — ask about board state, issue status, stuck items, etc. |
+| `fabrik-setup` skill (qualified: `fabrik:fabrik-setup`) | One-time onboarding walkthrough for setting up Fabrik from scratch in a new project. |
 | `/fabrik:status` command | Board snapshot: shows what's in each pipeline stage, which workers are running, and which worktrees have uncommitted changes. |
 
 #### Keeping the plugin up to date

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1160,6 +1160,46 @@ the sequence.
 
 ## 5. Plugin & Skills
 
+### Install the Fabrik PM Plugin
+
+The **Fabrik PM plugin** is a Claude Code plugin for your interactive session — not for the workers. It gives Claude ambient awareness of your Fabrik-managed project so you can ask questions like "what's on the board?", "why is #42 stuck?", or "what's in progress?" without leaving Claude Code.
+
+> **Distinct from the worker plugin**: `fabrik-workflows` is embedded in the Fabrik binary and deployed automatically to `.fabrik/plugin/` by `fabrik init` and `fabrik upgrade`. You do **not** install `fabrik-workflows` manually.
+
+#### Install
+
+Run these three commands in your Claude Code interactive session:
+
+```
+/plugin marketplace add tenaciousvc/fabrik
+/plugin install fabrik@fabrik
+/reload-plugins
+```
+
+#### What you get
+
+After installing, your interactive Claude Code session gains:
+
+| Component | Description |
+|-----------|-------------|
+| `fabrik` skill | Auto-activates when `.fabrik/` is detected or Fabrik is mentioned. Provides ambient PM awareness — ask about board state, issue status, stuck items, etc. |
+| `fabrik-setup` skill | One-time onboarding walkthrough for setting up Fabrik from scratch in a new project. |
+| `/fabrik:status` command | Board snapshot: shows what's in each pipeline stage, which workers are running, and which worktrees have uncommitted changes. |
+
+#### Keeping the plugin up to date
+
+When the Fabrik repo ships a newer version of the plugin, refresh your local install:
+
+```
+/plugin marketplace update fabrik
+/plugin install fabrik@fabrik
+/reload-plugins
+```
+
+Alternatively, enable auto-update via the plugin UI: `/plugin` → Marketplaces tab → select `fabrik` → Enable auto-update. When enabled, Claude Code updates the marketplace and reinstalls the plugin automatically at startup.
+
+---
+
 ### How Skills Work
 
 Each stage references a **skill** -- a markdown file that contains detailed methodology

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1158,6 +1158,46 @@ the sequence.
 
 ## 5. Plugin & Skills
 
+### Install the Fabrik PM Plugin
+
+The **Fabrik PM plugin** is a Claude Code plugin for your interactive session — not for the workers. It gives Claude ambient awareness of your Fabrik-managed project so you can ask questions like "what's on the board?", "why is #42 stuck?", or "what's in progress?" without leaving Claude Code.
+
+> **Distinct from the worker plugin**: `fabrik-workflows` is embedded in the Fabrik binary and deployed automatically to `.fabrik/plugin/` by `fabrik init` and `fabrik upgrade`. You do **not** install `fabrik-workflows` manually.
+
+#### Install
+
+Run these three commands in your Claude Code interactive session:
+
+```
+/plugin marketplace add tenaciousvc/fabrik
+/plugin install fabrik@fabrik
+/reload-plugins
+```
+
+#### What you get
+
+After installing, your interactive Claude Code session gains:
+
+| Component | Description |
+|-----------|-------------|
+| `fabrik` skill | Auto-activates when `.fabrik/` is detected or Fabrik is mentioned. Provides ambient PM awareness — ask about board state, issue status, stuck items, etc. |
+| `fabrik-setup` skill | One-time onboarding walkthrough for setting up Fabrik from scratch in a new project. |
+| `/fabrik:status` command | Board snapshot: shows what's in each pipeline stage, which workers are running, and which worktrees have uncommitted changes. |
+
+#### Keeping the plugin up to date
+
+When the Fabrik repo ships a newer version of the plugin, refresh your local install:
+
+```
+/plugin marketplace update fabrik
+/plugin install fabrik@fabrik
+/reload-plugins
+```
+
+Alternatively, enable auto-update via the plugin UI: `/plugin` → Marketplaces tab → select `fabrik` → Enable auto-update. When enabled, Claude Code updates the marketplace and reinstalls the plugin automatically at startup.
+
+---
+
 ### How Skills Work
 
 Each stage references a **skill** -- a markdown file that contains detailed methodology

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1180,8 +1180,8 @@ After installing, your interactive Claude Code session gains:
 
 | Component | Description |
 |-----------|-------------|
-| `fabrik` skill | Auto-activates when `.fabrik/` is detected or Fabrik is mentioned. Provides ambient PM awareness — ask about board state, issue status, stuck items, etc. |
-| `fabrik-setup` skill | One-time onboarding walkthrough for setting up Fabrik from scratch in a new project. |
+| `fabrik` skill (qualified: `fabrik:fabrik`) | Auto-activates when `.fabrik/` is detected or Fabrik is mentioned. Provides ambient PM awareness — ask about board state, issue status, stuck items, etc. |
+| `fabrik-setup` skill (qualified: `fabrik:fabrik-setup`) | One-time onboarding walkthrough for setting up Fabrik from scratch in a new project. |
 | `/fabrik:status` command | Board snapshot: shows what's in each pipeline stage, which workers are running, and which worktrees have uncommitted changes. |
 
 #### Keeping the plugin up to date


### PR DESCRIPTION
## Summary

Add a new **"Install the PM plugin"** subsection to `docs/USER_GUIDE.md` covering what the Fabrik PM plugin is, how to install it via the Claude Code marketplace, what the user gets after installing, how to update it, and the distinction from the worker-side `fabrik-workflows` plugin (which users should never install manually).

Also regenerate `docs/llms-full.txt` as required by the docs-drift CI gate.

## Problem

Since PR #571 shipped the Fabrik PM plugin (`plugin/fabrik/`) and published its marketplace entry at `tenaciousvc/fabrik`, there is no user-facing documentation explaining how to install it. Users who want Claude Code ambient awareness of their Fabrik-managed project have no guided path for getting the plugin installed into their interactive session.

This is a docs-only gap: the plugin exists, its install mechanism works, but `USER_GUIDE.md` does not mention it.

## Approach

### Approach

This is a docs-only change. Add a new `### Install the Fabrik PM Plugin` subsection to the top of Section 5 ("Plugin & Skills") in `docs/USER_GUIDE.md`, then regenerate `docs/llms-full.txt` using the existing script.

**Placement decision**: Section 5 "Plugin & Skills" at line 1163, inserted as a new subsection immediately before `### How Skills Work`. This creates a clear two-part structure within Section 5: (1) the PM plugin for the human's interactive session, (2) the worker-side plugin/skills system. Section 1 was rejected because it's focused on infrastructure setup and is already long — the plugin section is the natural home for plugin installation docs.

**Update UX correction**: The spec's example suggested `/plugin marketplace update tenaciousvc/fabrik` but research confirmed the correct form is `/plugin marketplace update fabrik` (takes the marketplace name, not `owner/repo`). The `owner/repo` format only applies to `marketplace add`. The plan documents the correct commands.

**`/reload-plugins` step**: Research confirmed that after install or reinstall, users need to run `/reload-plugins` or restart Claude Code to activate the plugin in the current session. This must be included.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add new `### Install the Fabrik PM Plugin` subsection at top of Section 5 (before `### How Skills Work`, line 1163) |
| `docs/llms-full.txt` | Regenerate by running `scripts/generate-llms-full.sh` from repo root |

### Key Decisions

- **Section 5 placement over Section 1**: PM plugin install is a plugin concern, not an infrastructure setup concern. Section 5 is the dedicated plugin section; inserting there keeps Section 1 focused on binary setup and worktree scaffolding.
- **Use marketplace name `fabrik` (not `owner/repo`) in the update command**: Research verified the update command takes the marketplace name. Spec's suggested form was wrong; we document the correct form.
- **Include `/reload-plugins` step**: Research found this is required to activate the plugin in the current session without restarting Claude Code. Omitting it would leave users wondering why the plugin isn't working after install.
- **No ADR needed**: This is a documentation change with no architectural decisions that would constrain future contributors in a non-obvious way.

### Task Checklist

- [ ] Task 1: Add `### Install the Fabrik PM Plugin` subsection to `docs/USER_GUIDE.md` at the top of Section 5 (before `### How Skills Work`), covering: what the PM plugin is, install commands, what the user gets (skills + command), update flow, and worker-plugin distinction bullet
- [ ] Task 2: Run `scripts/generate-llms-full.sh` from repo root to regenerate `docs/llms-full.txt`
- [ ] Task 3: Run `go test -race ./...` to confirm no regressions (docs-only change; expected to pass unchanged)
- [ ] Task 4: Commit `docs/USER_GUIDE.md` and `docs/llms-full.txt` together in a single commit on the `fabrik/issue-572` branch

### Subsection Content Specification

The new subsection must include exactly:

1. **What it is**: Fabrik PM plugin — a Claude Code plugin for the human's interactive session, providing ambient awareness of the Fabrik-managed project. Distinct from `fabrik-workflows`, which is for workers (auto-installed, never manually installed).

2. **Install commands** (code block, in order):
   ```
   /plugin marketplace add tenaciousvc/fabrik
   /plugin install fabrik@fabrik
   /reload-plugins
   ```

3. **What you get** after installing:
   - `fabrik` skill — auto-activates when `.fabrik/` is detected or Fabrik is mentioned; provides ambient PM awareness
   - `fabrik-setup` skill — one-time onboarding walkthrough
   - `/fabrik:status` command — board snapshot, running workers, dirty worktrees

4. **Keeping the plugin up to date**:
   ```
   /plugin marketplace update fabrik
   /plugin install fabrik@fabrik
   /reload-plugins
   ```
   Alternatively, enable auto-update: `/plugin` → Marketplaces tab → select `fabrik` → Enable auto-update.

5. **Worker plugin distinction** (one bullet): Users do **not** install `fabrik-workflows` — it is embedded in the Fabrik binary and deployed to `.fabrik/plugin/` automatically by `fabrik init` and `fabrik upgrade`.

### Risks

- **docs-drift CI gate**: Both `USER_GUIDE.md` and `llms-full.txt` must be committed in the same change set. Running the regeneration script after the doc edit and before committing is load-bearing. If `llms-full.txt` is stale or missing, the CI gate fails the PR.
- **Bitwise determinism**: `scripts/generate-llms-full.sh` is deterministic (no timestamps), so the regenerated file will diff cleanly against the old one. Run it exactly once from the repo root.

---
Used 6/50 turns, 3k input / 2k output tokens.

## Verification

Added a new "Install the Fabrik PM Plugin" subsection to Section 5 of `docs/USER_GUIDE.md` covering: what the PM plugin is and how it differs from the worker-side `fabrik-workflows` plugin, the three-command install flow (`/plugin marketplace add tenaciousvc/fabrik` + `/plugin install fabrik@fabrik` + `/reload-plugins`), what you get after installing (the `fabrik` and `fabrik-setup` skills plus `/fabrik:status`), and the correct update flow using the marketplace name form (`/plugin marketplace update fabrik`). Regenerated `docs/llms-full.txt` to keep the docs-drift CI gate green. All tests pass.

---

Closes #572