### PR TITLE
docs(CLAUDE.md): require regenerating docs/llms-full.txt when canonical doc pages change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,17 @@ go test -race ./...      # Run with race detector
 go vet ./...             # Lint
 ```
 
+## Documentation bundle (docs/llms-full.txt)
+
+When you modify any of the canonical doc pages — `docs/USER_GUIDE.md`, `docs/state-machine.md`, `docs/stage-lifecycle.md`, or `docs/positioning.md` — you MUST regenerate `docs/llms-full.txt` in the same commit:
+
+```bash
+bash scripts/generate-llms-full.sh
+git add docs/llms-full.txt
+```
+
+CI's `docs-drift` workflow (`.github/workflows/docs-drift.yml`) runs the regen and fails the PR if the committed bundle differs from the regen output. Forgetting the regen costs an extra round-trip; doing it consistently keeps PRs green on first push. This requirement applies to **every** stage (Specify, Research, Plan, Implement, Review, Validate) — wherever a doc edit happens, the bundle must follow.
+
 ## Architecture
 
 - `cmd/root.go` — CLI entry point, flag parsing, .env loading


### PR DESCRIPTION
## Summary

Adds a small section to \`CLAUDE.md\` documenting that workers must regenerate \`docs/llms-full.txt\` in the same commit whenever a canonical doc page changes. Closes #590.

## Why

Several PRs this week (#555, #568, #571, #587) hit the docs-drift CI failure because the Implement stage updated a doc but didn't regen the bundle. Each time, a follow-up commit was pushed manually to fix CI before merge.

## Why CLAUDE.md, not the workflow skills

The fabrik-workflows skills are generic SDLC mechanics for any project. Most projects don't have a llms-full.txt bundle or a generate script. Project-specific build/doc requirements belong in the project's CLAUDE.md, which fabrik passes to every worker invocation via the \`.fabrik-context/\` mechanism.

## Test plan

- [x] CLAUDE.md section added
- [ ] CI: \`Verify llms-full.txt is up to date\` should pass (this PR doesn't touch any canonical doc page; only CLAUDE.md, which is not in the bundle)
- [ ] Future doc-touching PRs from fabrik should now regenerate the bundle on their own commit