### PR TITLE
PushUnblockObserver misses dependents whose BlockedBy is populated AFTER the blocker closed (deep-fetch ordering)

### DIFF
--- a/adrs/041-push-unblock-engine-side-scan.md
+++ b/adrs/041-push-unblock-engine-side-scan.md
@@ -63,3 +63,13 @@ Two implementation variants were evaluated:
 - ADR-039 (`039-cycleset-excludes-worker-lifecycle.md`): `cycleSetFlags` excludes `WorkerLifecycleChanged`. `PushUnblockObserver` subscribes independently to `StateChanged` and never goes through `wakeChFlags` or `cycleSetFlags`.
 
 - Issue #540, #549, #569: prior push-based observer introductions (Layer 1 status fetch, worker exit, CI check runs). This ADR follows the same pattern.
+
+## Update (issue #588)
+
+The statement "BlockedByChanged is not used by the push path" in the Consequences section above is now superseded.
+
+`PushUnblockObserver.OnChange` was extended in issue #588 to also subscribe to `BlockedByChanged`. This fixes a deep-fetch ordering gap: after bootstrap every item has `BlockedBy = nil` (deep-fetch-only field, per ADR-017). If a blocker's `StateChanged` fires before the dependent's first `ItemDeepFetched`, the `store.All()` scan finds `BlockedBy = nil` and silently skips the dependent. When the dependent IS later deep-fetched and `BlockedBy` is populated, the store now emits `BlockedByChanged`, which triggers a second observer path that checks only the dependent item's blockers (O(k) rather than O(n)).
+
+Both triggers are idempotent — double-removal is handled by treating `ErrNotFound` as success. Neither `StateChanged` nor `BlockedByChanged` is in `wakeChFlags` or `cycleSetFlags`; the label removal remains a direct side effect only.
+
+See `docs/state-machine.md §2.5` for the current as-built description of both trigger paths.

--- a/adrs/041-push-unblock-engine-side-scan.md
+++ b/adrs/041-push-unblock-engine-side-scan.md
@@ -54,7 +54,7 @@ Two implementation variants were evaluated:
 
 - `StateChanged` events for issue closes will invoke `PushUnblockObserver.OnChange` for every close on the board. For each close, the observer scans all ~130 items typically held in the store (O(n) scan). This is cheap — the scan is a simple in-memory slice iteration with no I/O.
 
-- `BlockedByChanged` (already present in `change.go`) is not used by the push path. Variant B subscribes to `StateChanged` on the blocker; it does not rely on or emit `BlockedByChanged`.
+- `BlockedByChanged` (already present in `change.go`) is not used by the push path. Variant B subscribes to `StateChanged` on the blocker; it does not rely on or emit `BlockedByChanged`. **[Superseded by issue #588 — see Update section below.]**
 
 ## Cross-references
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2194,15 +2194,25 @@ Thirteen distinct event types drive state transitions (§2.1–2.11, §2.13, §2
 
 ### 2.5 Blocking Issue Closed
 
-**Trigger:** An issue listed in `item.BlockedBy` transitions to the CLOSED state.
+**Trigger:** An issue listed in `item.BlockedBy` transitions to the CLOSED state, OR a dependent item's `BlockedBy` slice is populated for the first time via deep-fetch while all listed blockers are already closed.
 
 **Primary code path (push-based): `PushUnblockObserver`**
 
-`PushUnblockObserver` is registered on `engine.store` and fires on every `StateChanged` event where `snap.IsClosed() == true`. When a blocker Y closes:
+`PushUnblockObserver` is registered on `engine.store` and fires on two distinct events. The dependent unblocks within seconds regardless of which event arrives first.
+
+**Trigger 1 — `StateChanged` (blocker closes):** When a blocker Y closes:
 
 1. The observer calls `store.All()` to scan all known items.
 2. For each item X that carries `fabrik:blocked` and has Y in its `BlockedBy` list, it checks every remaining blocker via `store.Get()` (fresher than `dep.State` from the last board fetch; falls back to `dep.State == "CLOSED"` if the blocker is not in the store).
 3. If all of X's blockers are now closed, the observer dispatches `removeBlockedIfResolved` on a goroutine, which removes `fabrik:blocked` via `RemoveLabelFromIssue` (3 attempts, exponential backoff, idempotent) and applies the cache write-through.
+
+**Trigger 2 — `BlockedByChanged` (dependent's `BlockedBy` first populated via deep-fetch):** `BlockedBy` is a deep-fetch-only field — after bootstrap every item has `BlockedBy = nil` until its first `ItemDeepFetched` mutation. If Trigger 1 fires before the dependent's first deep-fetch, the dependent's `BlockedBy` is empty and the scan silently skips it. When the dependent IS later deep-fetched, the Store emits `BlockedByChanged`, and the observer reacts:
+
+1. It reads the post-mutation snapshot of the dependent item X directly (no `store.All()` scan).
+2. If `BlockedBy` is empty, it returns immediately (no-op — covers bootstrap nil→nil transitions).
+3. If X carries `fabrik:blocked` and all listed blockers are closed in the store, it dispatches `removeBlockedIfResolved` on a goroutine.
+
+Both triggers are idempotent — double-removal races are handled correctly (`ErrNotFound` is treated as success by `removeBlockedIfResolved`).
 
 This path **bypasses `processItem` and `itemMayNeedWork` entirely**, so it works for items in any column — including Backlog, Done, or custom non-stage columns where `itemMayNeedWork` would return false. No comment is posted; the push path is a label-removal-only operation.
 
@@ -2210,7 +2220,7 @@ This path **bypasses `processItem` and `itemMayNeedWork` entirely**, so it works
 
 `processItem()` applies `CooldownRecorded{Reason: "dep-blocked"}` each time `checkDependencies()` returns true (blocked). This ensures the cooldown-retry path in `itemMayNeedWork()` re-evaluates blocked items after `10 × PollSeconds` even if the blocked item's own `updatedAt` never changes when its dependency closes. This path only fires for items whose Status maps to a configured stage column; it serves as defense-in-depth for missed webhook events.
 
-**Concurrency note:** `StateChanged` is not in `wakeChFlags` or `cycleSetFlags`, so `PushUnblockObserver` fires do not wake the poll loop or populate `mayNeedWork`. Label removal is a direct side effect dispatched on a goroutine to avoid blocking the store notification call path. Double-removal races (two blockers closing within milliseconds) are handled correctly — `ErrNotFound` is treated as success by `removeBlockedIfResolved`.
+**Concurrency note:** Neither `StateChanged` nor `BlockedByChanged` is in `wakeChFlags` or `cycleSetFlags`, so `PushUnblockObserver` fires do not wake the poll loop or populate `mayNeedWork`. Label removal is a direct side effect dispatched on a goroutine to avoid blocking the store notification call path. Double-removal races (two blockers closing within milliseconds, or both triggers firing for the same item) are handled correctly — `ErrNotFound` is treated as success by `removeBlockedIfResolved`.
 
 ### 2.6 Claude Output Markers
 
@@ -2399,7 +2409,7 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
 |--------------|-------|-------|-----------------|--------------|----------------|--------------|
 | Any column, Idle | Poll tick | Open blockers in `item.BlockedBy` | Same column, Blocked | `fabrik:blocked` | | Comment posted listing blockers (first time only); TUI event emitted |
-| Same column, Blocked | Blocker closes (StateChanged) | All of X's blockers now CLOSED (store-side view) | Same column, Idle | | `fabrik:blocked` | Push path: `PushUnblockObserver` fires immediately; works for any column including Backlog/Done; no comment posted |
+| Same column, Blocked | Blocker closes (`StateChanged`) OR dependent's `BlockedBy` first populated via deep-fetch (`BlockedByChanged`) | All of X's blockers now CLOSED (store-side view) | Same column, Idle | | `fabrik:blocked` | Push path: `PushUnblockObserver` fires immediately; `StateChanged` scans all items (O(n)); `BlockedByChanged` checks only the dependent item (O(k blockers)); works for any column including Backlog/Done; no comment posted |
 | Stage column, Blocked | Poll tick (dep-blocked cooldown retry) | All blockers now CLOSED (`dep.State` view) | Same column, Idle | | `fabrik:blocked` | Pull path (defense-in-depth): `processItem` → `checkDependencies`; only for items in stage columns |
 
 #### Awaiting Input (FABRIK_BLOCKED_ON_INPUT)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2209,7 +2209,7 @@ Thirteen distinct event types drive state transitions (§2.1–2.11, §2.13, §2
 **Trigger 2 — `BlockedByChanged` (dependent's `BlockedBy` first populated via deep-fetch):** `BlockedBy` is a deep-fetch-only field — after bootstrap every item has `BlockedBy = nil` until its first `ItemDeepFetched` mutation. If Trigger 1 fires before the dependent's first deep-fetch, the dependent's `BlockedBy` is empty and the scan silently skips it. When the dependent IS later deep-fetched, the Store emits `BlockedByChanged`, and the observer reacts:
 
 1. It reads the post-mutation snapshot of the dependent item X directly (no `store.All()` scan).
-2. If `BlockedBy` is empty, it returns immediately (no-op — covers bootstrap nil→nil transitions).
+2. If `BlockedBy` is empty after the mutation, it returns immediately (no-op — `BlockedByChanged` only fires when the slice actually changes, so this guards against a deep-fetch that clears or results in an empty dependency list).
 3. If X carries `fabrik:blocked` and all listed blockers are closed in the store, it dispatches `removeBlockedIfResolved` on a goroutine.
 
 Both triggers are idempotent — double-removal races are handled correctly (`ErrNotFound` is treated as success by `removeBlockedIfResolved`).

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -209,7 +209,7 @@ Thirteen distinct event types drive state transitions (§2.1–2.11, §2.13, §2
 **Trigger 2 — `BlockedByChanged` (dependent's `BlockedBy` first populated via deep-fetch):** `BlockedBy` is a deep-fetch-only field — after bootstrap every item has `BlockedBy = nil` until its first `ItemDeepFetched` mutation. If Trigger 1 fires before the dependent's first deep-fetch, the dependent's `BlockedBy` is empty and the scan silently skips it. When the dependent IS later deep-fetched, the Store emits `BlockedByChanged`, and the observer reacts:
 
 1. It reads the post-mutation snapshot of the dependent item X directly (no `store.All()` scan).
-2. If `BlockedBy` is empty, it returns immediately (no-op — covers bootstrap nil→nil transitions).
+2. If `BlockedBy` is empty after the mutation, it returns immediately (no-op — `BlockedByChanged` only fires when the slice actually changes, so this guards against a deep-fetch that clears or results in an empty dependency list).
 3. If X carries `fabrik:blocked` and all listed blockers are closed in the store, it dispatches `removeBlockedIfResolved` on a goroutine.
 
 Both triggers are idempotent — double-removal races are handled correctly (`ErrNotFound` is treated as success by `removeBlockedIfResolved`).

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -194,15 +194,25 @@ Thirteen distinct event types drive state transitions (§2.1–2.11, §2.13, §2
 
 ### 2.5 Blocking Issue Closed
 
-**Trigger:** An issue listed in `item.BlockedBy` transitions to the CLOSED state.
+**Trigger:** An issue listed in `item.BlockedBy` transitions to the CLOSED state, OR a dependent item's `BlockedBy` slice is populated for the first time via deep-fetch while all listed blockers are already closed.
 
 **Primary code path (push-based): `PushUnblockObserver`**
 
-`PushUnblockObserver` is registered on `engine.store` and fires on every `StateChanged` event where `snap.IsClosed() == true`. When a blocker Y closes:
+`PushUnblockObserver` is registered on `engine.store` and fires on two distinct events. The dependent unblocks within seconds regardless of which event arrives first.
+
+**Trigger 1 — `StateChanged` (blocker closes):** When a blocker Y closes:
 
 1. The observer calls `store.All()` to scan all known items.
 2. For each item X that carries `fabrik:blocked` and has Y in its `BlockedBy` list, it checks every remaining blocker via `store.Get()` (fresher than `dep.State` from the last board fetch; falls back to `dep.State == "CLOSED"` if the blocker is not in the store).
 3. If all of X's blockers are now closed, the observer dispatches `removeBlockedIfResolved` on a goroutine, which removes `fabrik:blocked` via `RemoveLabelFromIssue` (3 attempts, exponential backoff, idempotent) and applies the cache write-through.
+
+**Trigger 2 — `BlockedByChanged` (dependent's `BlockedBy` first populated via deep-fetch):** `BlockedBy` is a deep-fetch-only field — after bootstrap every item has `BlockedBy = nil` until its first `ItemDeepFetched` mutation. If Trigger 1 fires before the dependent's first deep-fetch, the dependent's `BlockedBy` is empty and the scan silently skips it. When the dependent IS later deep-fetched, the Store emits `BlockedByChanged`, and the observer reacts:
+
+1. It reads the post-mutation snapshot of the dependent item X directly (no `store.All()` scan).
+2. If `BlockedBy` is empty, it returns immediately (no-op — covers bootstrap nil→nil transitions).
+3. If X carries `fabrik:blocked` and all listed blockers are closed in the store, it dispatches `removeBlockedIfResolved` on a goroutine.
+
+Both triggers are idempotent — double-removal races are handled correctly (`ErrNotFound` is treated as success by `removeBlockedIfResolved`).
 
 This path **bypasses `processItem` and `itemMayNeedWork` entirely**, so it works for items in any column — including Backlog, Done, or custom non-stage columns where `itemMayNeedWork` would return false. No comment is posted; the push path is a label-removal-only operation.
 
@@ -210,7 +220,7 @@ This path **bypasses `processItem` and `itemMayNeedWork` entirely**, so it works
 
 `processItem()` applies `CooldownRecorded{Reason: "dep-blocked"}` each time `checkDependencies()` returns true (blocked). This ensures the cooldown-retry path in `itemMayNeedWork()` re-evaluates blocked items after `10 × PollSeconds` even if the blocked item's own `updatedAt` never changes when its dependency closes. This path only fires for items whose Status maps to a configured stage column; it serves as defense-in-depth for missed webhook events.
 
-**Concurrency note:** `StateChanged` is not in `wakeChFlags` or `cycleSetFlags`, so `PushUnblockObserver` fires do not wake the poll loop or populate `mayNeedWork`. Label removal is a direct side effect dispatched on a goroutine to avoid blocking the store notification call path. Double-removal races (two blockers closing within milliseconds) are handled correctly — `ErrNotFound` is treated as success by `removeBlockedIfResolved`.
+**Concurrency note:** Neither `StateChanged` nor `BlockedByChanged` is in `wakeChFlags` or `cycleSetFlags`, so `PushUnblockObserver` fires do not wake the poll loop or populate `mayNeedWork`. Label removal is a direct side effect dispatched on a goroutine to avoid blocking the store notification call path. Double-removal races (two blockers closing within milliseconds, or both triggers firing for the same item) are handled correctly — `ErrNotFound` is treated as success by `removeBlockedIfResolved`.
 
 ### 2.6 Claude Output Markers
 
@@ -399,7 +409,7 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
 |--------------|-------|-------|-----------------|--------------|----------------|--------------|
 | Any column, Idle | Poll tick | Open blockers in `item.BlockedBy` | Same column, Blocked | `fabrik:blocked` | | Comment posted listing blockers (first time only); TUI event emitted |
-| Same column, Blocked | Blocker closes (StateChanged) | All of X's blockers now CLOSED (store-side view) | Same column, Idle | | `fabrik:blocked` | Push path: `PushUnblockObserver` fires immediately; works for any column including Backlog/Done; no comment posted |
+| Same column, Blocked | Blocker closes (`StateChanged`) OR dependent's `BlockedBy` first populated via deep-fetch (`BlockedByChanged`) | All of X's blockers now CLOSED (store-side view) | Same column, Idle | | `fabrik:blocked` | Push path: `PushUnblockObserver` fires immediately; `StateChanged` scans all items (O(n)); `BlockedByChanged` checks only the dependent item (O(k blockers)); works for any column including Backlog/Done; no comment posted |
 | Stage column, Blocked | Poll tick (dep-blocked cooldown retry) | All blockers now CLOSED (`dep.State` view) | Same column, Idle | | `fabrik:blocked` | Pull path (defense-in-depth): `processItem` → `checkDependencies`; only for items in stage columns |
 
 #### Awaiting Input (FABRIK_BLOCKED_ON_INPUT)

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -138,18 +139,44 @@ func (o *StageChangeObserver) OnChange(change itemstate.Change, snap itemstate.S
 	})
 }
 
-// PushUnblockObserver fires whenever an issue transitions to CLOSED (StateChanged)
-// and scans the Store for items that (a) carry fabrik:blocked, (b) list the closing
-// issue in their BlockedBy slice, and (c) have all remaining blockers resolved.
-// For each such item it dispatches Remove on a goroutine — bypassing processItem
-// and itemMayNeedWork entirely. This is the push-based primary unblock path; the
-// existing pull-based checkDependencies cooldown-retry path remains as defense-in-depth.
+// PushUnblockObserver fires on two distinct events and removes fabrik:blocked when
+// all blockers are resolved:
 //
-// StateChanged is not in wakeChFlags or cycleSetFlags so this observer does not
-// trigger a poll wake — the label removal is a direct side effect only.
+//  1. StateChanged (blocker closes): scans Store.All() for items that carry
+//     fabrik:blocked and list the closing issue in their BlockedBy slice, then
+//     checks whether every remaining blocker is closed.
+//
+//  2. BlockedByChanged (dependent's BlockedBy first populated via deep-fetch):
+//     inspects only the changed item's own snapshot; if it carries fabrik:blocked
+//     and all listed blockers are already closed in the store, removes the label.
+//
+// This dual-trigger ensures the dependent unblocks within seconds regardless of
+// which event arrives first — the blocker's close or the dependent's first
+// deep-fetch. Neither StateChanged nor BlockedByChanged is in wakeChFlags or
+// cycleSetFlags, so this observer does not trigger a poll wake — label removal
+// is a direct side effect only.
 type PushUnblockObserver struct {
 	Store  *itemstate.Store
 	Remove func(owner, repo string, number int)
+}
+
+// allBlockersClosed checks whether every dep in blockedBy is closed, preferring
+// the store's view (fresher than dep.State from the last board fetch).
+func (o *PushUnblockObserver) allBlockersClosed(defaultRepo string, blockedBy []gh.Dependency) bool {
+	for _, dep := range blockedBy {
+		depRepo := dep.Repo
+		if depRepo == "" {
+			depRepo = defaultRepo
+		}
+		if depSnap, err := o.Store.Get(depRepo, dep.Number); err == nil {
+			if !depSnap.IsClosed() {
+				return false
+			}
+		} else if dep.State != "CLOSED" {
+			return false
+		}
+	}
+	return true
 }
 
 // OnChange implements itemstate.Observer.
@@ -157,20 +184,66 @@ func (o *PushUnblockObserver) OnChange(change itemstate.Change, snap itemstate.S
 	if o.Store == nil || o.Remove == nil {
 		return
 	}
-	if change.Fields&itemstate.StateChanged == 0 {
-		return
+
+	// Path 1: blocker closes → scan all items for dependents.
+	if change.Fields&itemstate.StateChanged != 0 && snap.IsClosed() {
+		closedRepo := change.Repo
+		closedNum := change.Number
+
+		for _, x := range o.Store.All() {
+			xState := x.State()
+
+			// Only consider items carrying fabrik:blocked.
+			hasBlocked := false
+			for _, l := range xState.Labels {
+				if l == "fabrik:blocked" {
+					hasBlocked = true
+					break
+				}
+			}
+			if !hasBlocked {
+				continue
+			}
+
+			// Skip if the closing issue is not in this item's BlockedBy list.
+			hasDep := false
+			for _, dep := range xState.BlockedBy {
+				depRepo := dep.Repo
+				if depRepo == "" {
+					depRepo = xState.Repo
+				}
+				if depRepo == closedRepo && dep.Number == closedNum {
+					hasDep = true
+					break
+				}
+			}
+			if !hasDep {
+				continue
+			}
+
+			if !o.allBlockersClosed(xState.Repo, xState.BlockedBy) {
+				continue
+			}
+
+			xOwner, xRepo := parseOwnerRepo(xState.Repo)
+			if xOwner == "" {
+				continue
+			}
+			xNum := xState.Number
+			go o.Remove(xOwner, xRepo, xNum)
+		}
 	}
-	if !snap.IsClosed() {
-		return
-	}
 
-	closedRepo := change.Repo
-	closedNum := change.Number
+	// Path 2: dependent's BlockedBy just populated via deep-fetch → check only this item.
+	if change.Fields&itemstate.BlockedByChanged != 0 {
+		xState := snap.State()
 
-	for _, x := range o.Store.All() {
-		xState := x.State()
+		// No-op if BlockedBy is empty (e.g., item has no blockers, or bootstrap nil→nil).
+		if len(xState.BlockedBy) == 0 {
+			return
+		}
 
-		// Only consider items carrying fabrik:blocked.
+		// Only act if the item carries fabrik:blocked.
 		hasBlocked := false
 		for _, l := range xState.Labels {
 			if l == "fabrik:blocked" {
@@ -179,51 +252,17 @@ func (o *PushUnblockObserver) OnChange(change itemstate.Change, snap itemstate.S
 			}
 		}
 		if !hasBlocked {
-			continue
+			return
 		}
 
-		// Skip if the closing issue is not in this item's BlockedBy list.
-		hasDep := false
-		for _, dep := range xState.BlockedBy {
-			depRepo := dep.Repo
-			if depRepo == "" {
-				depRepo = xState.Repo
-			}
-			if depRepo == closedRepo && dep.Number == closedNum {
-				hasDep = true
-				break
-			}
-		}
-		if !hasDep {
-			continue
-		}
-
-		// Check all blockers — prefer store's view (fresher than dep.State from last board fetch).
-		allClosed := true
-		for _, dep := range xState.BlockedBy {
-			depRepo := dep.Repo
-			if depRepo == "" {
-				depRepo = xState.Repo
-			}
-			if depSnap, err := o.Store.Get(depRepo, dep.Number); err == nil {
-				if !depSnap.IsClosed() {
-					allClosed = false
-					break
-				}
-			} else if dep.State != "CLOSED" {
-				allClosed = false
-				break
-			}
-		}
-		if !allClosed {
-			continue
+		if !o.allBlockersClosed(xState.Repo, xState.BlockedBy) {
+			return
 		}
 
 		xOwner, xRepo := parseOwnerRepo(xState.Repo)
 		if xOwner == "" {
-			continue
+			return
 		}
-		xNum := xState.Number
-		go o.Remove(xOwner, xRepo, xNum)
+		go o.Remove(xOwner, xRepo, xState.Number)
 	}
 }

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -252,7 +252,7 @@ func (o *PushUnblockObserver) OnChange(change itemstate.Change, snap itemstate.S
 			return
 		}
 
-		// No-op if BlockedBy is empty (e.g., item has no blockers, or bootstrap nil→nil).
+		// No-op if BlockedBy is empty after the mutation (e.g., blockers cleared on re-fetch).
 		if len(xState.BlockedBy) == 0 {
 			return
 		}

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -235,13 +235,10 @@ func (o *PushUnblockObserver) OnChange(change itemstate.Change, snap itemstate.S
 	}
 
 	// Path 2: dependent's BlockedBy just populated via deep-fetch → check only this item.
+	// Uses return (not continue) because there is nothing after this block; the two paths
+	// are independent and both idempotent if a single Change somehow carries both flags.
 	if change.Fields&itemstate.BlockedByChanged != 0 {
 		xState := snap.State()
-
-		// No-op if BlockedBy is empty (e.g., item has no blockers, or bootstrap nil→nil).
-		if len(xState.BlockedBy) == 0 {
-			return
-		}
 
 		// Only act if the item carries fabrik:blocked.
 		hasBlocked := false
@@ -252,6 +249,11 @@ func (o *PushUnblockObserver) OnChange(change itemstate.Change, snap itemstate.S
 			}
 		}
 		if !hasBlocked {
+			return
+		}
+
+		// No-op if BlockedBy is empty (e.g., item has no blockers, or bootstrap nil→nil).
+		if len(xState.BlockedBy) == 0 {
 			return
 		}
 

--- a/engine/observers_test.go
+++ b/engine/observers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
 	"github.com/verveguy/fabrik/tui"
@@ -395,4 +396,135 @@ func TestObservers_ConcurrentApplyIsRaceFree(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// --- PushUnblockObserver BlockedByChanged path ---
+
+// TestPushUnblockObserver_BlockedByChanged_UnblocksWhenAllBlockersClosed verifies
+// the deep-fetch ordering fix: B's BlockedBy is nil at bootstrap; when a deep-fetch
+// populates it with a closed blocker A, PushUnblockObserver removes fabrik:blocked.
+func TestPushUnblockObserver_BlockedByChanged_UnblocksWhenAllBlockersClosed(t *testing.T) {
+	store := newTestStore()
+
+	// Seed A (closed) and B (open + fabrik:blocked, BlockedBy=nil at bootstrap).
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{Number: 1, Repo: "owner/repo"}})
+	store.Apply(itemstate.IssueClosed{Repo: "owner/repo", Number: 1})
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Number: 2,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:blocked"},
+		// BlockedBy intentionally nil — simulates bootstrap state.
+	}})
+
+	removeCh := make(chan int, 1)
+	obs := &PushUnblockObserver{
+		Store:  store,
+		Remove: func(owner, repo string, n int) { removeCh <- n },
+	}
+	store.Subscribe(obs)
+
+	// Simulate B's first deep-fetch populating BlockedBy with A (now CLOSED).
+	store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 2,
+		FreshState: gh.ProjectItem{
+			Number: 2,
+			Repo:   "owner/repo",
+			Labels: []string{"fabrik:blocked"},
+			BlockedBy: []gh.Dependency{
+				{Number: 1, Repo: "owner/repo", State: "CLOSED"},
+			},
+		},
+	})
+
+	n, ok := waitForRemove(t, removeCh)
+	if !ok {
+		t.Fatal("timeout: Remove was not called after BlockedByChanged with all blockers closed")
+	}
+	if n != 2 {
+		t.Errorf("expected Remove called for issue 2, got %d", n)
+	}
+}
+
+// TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockerStillOpen verifies that
+// the BlockedByChanged path does NOT remove fabrik:blocked when the listed blocker
+// is still open in the store.
+func TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockerStillOpen(t *testing.T) {
+	store := newTestStore()
+
+	// Seed A (open) and B (open + fabrik:blocked, BlockedBy=nil at bootstrap).
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{Number: 1, Repo: "owner/repo"}})
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Number: 2,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:blocked"},
+	}})
+
+	removeCh := make(chan int, 1)
+	obs := &PushUnblockObserver{
+		Store:  store,
+		Remove: func(owner, repo string, n int) { removeCh <- n },
+	}
+	store.Subscribe(obs)
+
+	// Deep-fetch populates B's BlockedBy with A (still OPEN in store).
+	store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 2,
+		FreshState: gh.ProjectItem{
+			Number: 2,
+			Repo:   "owner/repo",
+			Labels: []string{"fabrik:blocked"},
+			BlockedBy: []gh.Dependency{
+				{Number: 1, Repo: "owner/repo", State: "OPEN"},
+			},
+		},
+	})
+
+	select {
+	case n := <-removeCh:
+		t.Errorf("Remove unexpectedly called for issue %d when blocker still open", n)
+	case <-time.After(100 * time.Millisecond):
+		// expected: no removal
+	}
+}
+
+// TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty verifies that
+// the BlockedByChanged path is a no-op when BlockedBy is empty or nil — covers
+// the bootstrap scenario where ItemDeepFetched fires for an item with no blockers.
+func TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty(t *testing.T) {
+	store := newTestStore()
+
+	// Seed B (open + fabrik:blocked, no blockers listed).
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Number: 2,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:blocked"},
+	}})
+
+	removeCh := make(chan int, 1)
+	obs := &PushUnblockObserver{
+		Store:  store,
+		Remove: func(owner, repo string, n int) { removeCh <- n },
+	}
+	store.Subscribe(obs)
+
+	// Deep-fetch with empty BlockedBy — no dependencies.
+	store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 2,
+		FreshState: gh.ProjectItem{
+			Number:    2,
+			Repo:      "owner/repo",
+			Labels:    []string{"fabrik:blocked"},
+			BlockedBy: nil,
+		},
+	})
+
+	select {
+	case n := <-removeCh:
+		t.Errorf("Remove unexpectedly called for issue %d when BlockedBy is empty", n)
+	case <-time.After(100 * time.Millisecond):
+		// expected: no removal
+	}
 }

--- a/engine/observers_test.go
+++ b/engine/observers_test.go
@@ -489,6 +489,50 @@ func TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockerStillOpen(t *testin
 	}
 }
 
+// TestPushUnblockObserver_BlockedByChanged_StorePreemptsDepState verifies that the
+// store's view of a blocker takes precedence over dep.State in the deep-fetch payload:
+// even if dep.State says "CLOSED", an open blocker in the store prevents unblocking.
+func TestPushUnblockObserver_BlockedByChanged_StorePreemptsDepState(t *testing.T) {
+	store := newTestStore()
+
+	// Seed A (open in store) and B (open + fabrik:blocked).
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{Number: 1, Repo: "owner/repo"}})
+	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Number: 2,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:blocked"},
+	}})
+
+	removeCh := make(chan int, 1)
+	obs := &PushUnblockObserver{
+		Store:  store,
+		Remove: func(owner, repo string, n int) { removeCh <- n },
+	}
+	store.Subscribe(obs)
+
+	// Deep-fetch says A is CLOSED in dep.State, but the store still has A open.
+	// The store view must win: no unblock should fire.
+	store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 2,
+		FreshState: gh.ProjectItem{
+			Number: 2,
+			Repo:   "owner/repo",
+			Labels: []string{"fabrik:blocked"},
+			BlockedBy: []gh.Dependency{
+				{Number: 1, Repo: "owner/repo", State: "CLOSED"},
+			},
+		},
+	})
+
+	select {
+	case n := <-removeCh:
+		t.Errorf("Remove unexpectedly called for issue %d: store open blocker should preempt dep.State=CLOSED", n)
+	case <-time.After(100 * time.Millisecond):
+		// expected: no removal; store's open view takes precedence
+	}
+}
+
 // TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty verifies that
 // the BlockedByChanged path is a no-op when BlockedBy is empty or nil — covers
 // the bootstrap scenario where ItemDeepFetched fires for an item with no blockers.

--- a/engine/observers_test.go
+++ b/engine/observers_test.go
@@ -534,16 +534,20 @@ func TestPushUnblockObserver_BlockedByChanged_StorePreemptsDepState(t *testing.T
 }
 
 // TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty verifies that
-// the BlockedByChanged path is a no-op when BlockedBy is empty or nil — covers
-// the bootstrap scenario where ItemDeepFetched fires for an item with no blockers.
+// the BlockedByChanged path is a no-op when the post-mutation BlockedBy is empty.
+// The item is seeded with a non-nil BlockedBy so the nil→empty deep-fetch actually
+// emits BlockedByChanged; the observer must return without calling Remove.
 func TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty(t *testing.T) {
 	store := newTestStore()
 
-	// Seed B (open + fabrik:blocked, no blockers listed).
+	// Seed B with a non-nil BlockedBy so the subsequent deep-fetch triggers BlockedByChanged.
 	store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
 		Number: 2,
 		Repo:   "owner/repo",
 		Labels: []string{"fabrik:blocked"},
+		BlockedBy: []gh.Dependency{
+			{Number: 1, Repo: "owner/repo", State: "OPEN"},
+		},
 	}})
 
 	removeCh := make(chan int, 1)
@@ -553,7 +557,8 @@ func TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty(t *testing.
 	}
 	store.Subscribe(obs)
 
-	// Deep-fetch with empty BlockedBy — no dependencies.
+	// Deep-fetch clears BlockedBy to an empty slice — triggers BlockedByChanged (non-nil→empty).
+	// The observer must return early because len(BlockedBy)==0.
 	store.Apply(itemstate.ItemDeepFetched{
 		Repo:   "owner/repo",
 		Number: 2,
@@ -561,7 +566,7 @@ func TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty(t *testing.
 			Number:    2,
 			Repo:      "owner/repo",
 			Labels:    []string{"fabrik:blocked"},
-			BlockedBy: nil,
+			BlockedBy: []gh.Dependency{},
 		},
 	})
 


### PR DESCRIPTION
## Summary

`BlockedBy` is a deep-fetch-only field — it is not populated in the bootstrap board query, only in `FetchItemDetails`. After bootstrap, every item has `BlockedBy = nil` until its first lazy deep-fetch. If a blocker's `StateChanged` event fires before the dependent has been deep-fetched, the observer's walk finds no match and silently skips the dependent. When the dependent IS later deep-fetched and `BlockedBy` is populated, no observer currently re-checks.

The fix is to make `PushUnblockObserver` also subscribe to `BlockedByChanged` events. When an item's `BlockedBy` is first populated via deep-fetch and the item carries `fabrik:blocked`, the observer checks whether all blockers are already CLOSED in the Store. If so, it removes `fabrik:blocked` immediately — bypassing the poll cycle entirely.

The `BlockedByChanged` flag already exists in `internal/itemstate/change.go` and the Store already emits it when `BlockedBy` changes. No new infrastructure is needed.

## Problem

`PushUnblockObserver` (added by #580) fires only on `StateChanged` events for closing issues. It walks `Store.All()` looking for items that (a) carry `fabrik:blocked` and (b) list the closing issue in their `BlockedBy` slice. The observer silently misses any dependent whose `BlockedBy` slice is empty at the moment the closing issue's `StateChanged` fires — even when the dependent's `BlockedBy` gets populated moments later by a deep-fetch.

This created a real incident: issue #584 (dependent) remained `fabrik:blocked` for ~50 minutes after its blocker (#583) closed, because #584's `BlockedBy` slice was empty when the `StateChanged` fired on bootstrap.

## Approach

### Approach

Extend `PushUnblockObserver.OnChange` in `engine/observers.go` to handle two distinct events: the existing `StateChanged` (blocker closes, scan all items) and the new `BlockedByChanged` (dependent's `BlockedBy` just populated via deep-fetch, check only that item). The two paths are independent conditional blocks — the `StateChanged` path is preserved exactly as-is; the `BlockedByChanged` path uses `snap.State()` directly (the post-mutation dependent snapshot) and calls `store.Get` for each listed blocker, identical to the inner loop in the existing path. No new infrastructure is needed; `BlockedByChanged` already exists in `internal/itemstate/change.go` and the Store already emits it when `BlockedBy` changes.

The current function structure uses a function-level early return (`if change.Fields&itemstate.StateChanged == 0 { return }`) that must be restructured into two independent `if`-blocks so both paths can run independently. A single event can theoretically carry both flags; both paths are idempotent so double-execution is harmless.

No new ADR is warranted. The change is an extension to an existing observer within the scope ADR-041 describes. ADR-041 contains a statement that becomes stale ("BlockedByChanged is not used by the push path") — it will receive an addendum note. The authoritative as-built description lives in `docs/state-machine.md` §2.5.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/observers.go` | Restructure `OnChange` guard logic; add `BlockedByChanged` conditional block (~30 lines); update the leading comment on `PushUnblockObserver` |
| `engine/observers_test.go` | Add three new `TestPushUnblockObserver_BlockedByChanged_*` tests (~70 lines) |
| `docs/state-machine.md` | Update §2.5 prose to document dual-trigger; update §3 "Dependency Blocking" transition table row |
| `adrs/041-push-unblock-engine-side-scan.md` | Add update addendum noting `BlockedByChanged` is now used |

### Key Decisions

- **Two independent `if`-blocks, not `if/else if`**: Both `StateChanged` and `BlockedByChanged` can appear on the same change event (unlikely in practice but possible). Both paths are idempotent, so letting both run is correct and simpler than a combined guard.

- **No `store.All()` scan in the `BlockedByChanged` path**: The event fires on the dependent item itself, so `snap.State()` already gives the dependent's post-mutation state. This is O(k blockers) rather than O(n all items), consistent with the principle of using the narrowest scan possible.

- **Use `store.Get()` to check blocker liveness (not `dep.State`)**: The Store may have a more recent view of the blocker than the just-fetched `dep.State` field (e.g., blocker closed via webhook after the deep-fetch started). This matches the pattern in the existing `StateChanged` path's inner loop.

- **Guard on `len(xState.BlockedBy) == 0`**: After bootstrap every item has `BlockedBy = nil`. `ItemDeepFetched` for an item with no dependencies may emit `BlockedByChanged` with an empty slice (nil→[]). Both nil and empty slice must be no-ops.

- **Update ADR-041 with addendum, not a new ADR**: ADR-041 recorded the *decision* not to use `BlockedByChanged`; we're reversing that for one specific ordering gap. A brief addendum in the existing ADR preserves the decision history without fragmenting context across two ADRs.

### Task Checklist

- [ ] **Task 1: Restructure `PushUnblockObserver.OnChange` in `engine/observers.go`** — Remove the function-level early return (`if change.Fields&itemstate.StateChanged == 0 { return }` and the subsequent `if !snap.IsClosed() { return }`). Wrap the existing `StateChanged` store-scan logic in `if change.Fields&itemstate.StateChanged != 0 && snap.IsClosed() { ... }`. Add the new `BlockedByChanged` block after it: guard on `len(xState.BlockedBy) == 0` and `fabrik:blocked` label; reuse the same all-blockers-closed inner loop; dispatch `go o.Remove(xOwner, xRepo, xState.Number)`. Update the `PushUnblockObserver` struct doc comment to mention both triggers.

- [ ] **Task 2: Add `TestPushUnblockObserver_BlockedByChanged_UnblocksWhenAllBlockersClosed` to `engine/observers_test.go`** — Seed store with item A (closed, via `IssueClosed`) and item B (open+`fabrik:blocked`, via `IssueOpened` with `BlockedBy: nil`). Subscribe `PushUnblockObserver`. Apply `ItemDeepFetched` for B with `FreshState.BlockedBy = [{Number: A, Repo: "owner/repo", State: "CLOSED"}]` and `FreshState.Labels = ["fabrik:blocked"]`. Assert `Remove` is called for B within 1 second (`waitForRemove` helper already exists in `dependencies_test.go` — use the same pattern or a local helper).

- [ ] **Task 3: Add `TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockerStillOpen` to `engine/observers_test.go`** — Same setup but seed A as open (not closed). Apply deep-fetch populating B's `BlockedBy` with A (still open). Assert `Remove` is NOT called within 100ms.

- [ ] **Task 4: Add `TestPushUnblockObserver_BlockedByChanged_NoOpWhenBlockedByEmpty` to `engine/observers_test.go`** — Seed B with `fabrik:blocked` and no blockers. Apply `ItemDeepFetched` with `FreshState.BlockedBy = nil` (or `[]gh.Dependency{}`). Assert `Remove` is NOT called. This covers the bootstrap scenario where `BlockedByChanged` fires with an empty list.

- [ ] **Task 5: Update `docs/state-machine.md` §2.5** — Revise the `PushUnblockObserver` description to document dual-trigger behavior: `StateChanged` (blocker closes, scan all items) and `BlockedByChanged` (dependent's `BlockedBy` first populated via deep-fetch, check only that item). Add the sentence required by the spec: "the dependent unblocks within seconds regardless of which event arrives first." Update the concurrency note to mention `BlockedByChanged` is also not in `wakeChFlags`.

- [ ] **Task 6: Update the "Dependency Blocking" transition table in `docs/state-machine.md` §3** — The second row ("Blocker closes") currently references only `StateChanged`. Update the Event column to mention both `StateChanged` and `BlockedByChanged`; update the Side Effects column to describe both trigger paths and their scopes.

- [ ] **Task 7: Add update addendum to `adrs/041-push-unblock-engine-side-scan.md`** — Append a brief `## Update (issue #588)` section noting that `BlockedByChanged` is now used by `PushUnblockObserver` to fix the deep-fetch ordering gap, referencing `state-machine.md §2.5` for the current as-built description.

- [ ] **Task 8: Run `go test -race ./...` and verify all tests pass** — Confirm both new `BlockedByChanged` tests and all existing `PushUnblockObserver` tests in `engine/dependencies_test.go` pass clean with the race detector.

### Risks

- **Restructuring the early return introduces regression risk**: The existing `StateChanged` path must be preserved exactly. The only structural change is wrapping the existing code in `if change.Fields&itemstate.StateChanged != 0 && snap.IsClosed()`. Carefully verify that the `snap.IsClosed()` check (previously a separate early return) is folded into the condition correctly so the store scan still only runs on closing events.

- **Test placement inconsistency**: Existing `PushUnblockObserver` tests live in `engine/dependencies_test.go`; new tests go in `engine/observers_test.go` per spec. Both files are `package engine`, so there is no compilation issue. The inconsistency is a pre-existing quirk acknowledged in Research; it's not a blocker and the spec explicitly places new tests in `observers_test.go`.

- **Companion issue #589**: This fix does not depend on #589 technically. However, the spec notes they should land together for full defense-in-depth. If #589 is not yet merged at review time, flag it as a known gap in the PR description.

---
Used 13/50 turns, 5k input / 7k output tokens.

## Verification

Extended `PushUnblockObserver.OnChange` in `engine/observers.go` to fire on `BlockedByChanged` in addition to `StateChanged`, fixing the deep-fetch ordering gap where a blocker's close event fires before the dependent's first deep-fetch (leaving `BlockedBy = nil` and silently skipping the unblock). The new path checks only the dependent item's own snapshot (O(k blockers)) rather than scanning all items, and is a no-op when `BlockedBy` is empty. Added three new tests in `engine/observers_test.go` covering all `BlockedByChanged` scenarios; all 7 `PushUnblockObserver` tests pass with `go test -race ./...`. Updated `docs/state-machine.md` §2.5 and the §3 dependency blocking table to document the dual-trigger behavior, and added an addendum to ADR-041 superseding the prior "BlockedByChanged is not used" statement.

---

Closes #588