### PR TITLE
fabrik: spurious 404 on RemoveLabel for fabrik:blocked / fabrik:awaiting-ci when label not present

### DIFF
--- a/engine/ci.go
+++ b/engine/ci.go
@@ -182,7 +182,14 @@ func (e *Engine) removeAwaitingCILabel(owner, repo string, item gh.ProjectItem) 
 	for _, l := range item.Labels {
 		if l == "fabrik:awaiting-ci" {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
-				e.logf(item.Number, "warn", "could not remove fabrik:awaiting-ci label: %v\n", err)
+				if errors.Is(err, gh.ErrNotFound) {
+					// Label already absent on GitHub — desired end state achieved; sync cache.
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+					}
+				} else {
+					e.logf(item.Number, "warn", "could not remove fabrik:awaiting-ci label: %v\n", err)
+				}
 			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 			}

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -728,3 +728,31 @@ func TestCheckCIGate_MergeableStateBlocked_FallsThroughToCheckRuns(t *testing.T)
 		t.Errorf("expected blocked-pending for mergeable_state=blocked + in_progress checks, got blocked=%v ciFailure=%v", blocked, ciFailure)
 	}
 }
+
+// TestRemoveAwaitingCILabel_ErrNotFound verifies that a 404 from
+// RemoveLabelFromIssue is treated as success (label already absent) — exactly
+// one call, no warning logged, and cache write-through applied.
+func TestRemoveAwaitingCILabel_ErrNotFound(t *testing.T) {
+	var calls int
+	client := &mockGitHubClient{
+		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			if labelName == "fabrik:awaiting-ci" {
+				calls++
+				return gh.ErrNotFound
+			}
+			return nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{
+		Number: 1,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:awaiting-ci"},
+	}
+
+	eng.removeAwaitingCILabel("owner", "repo", item)
+
+	if calls != 1 {
+		t.Errorf("expected exactly 1 RemoveLabelFromIssue call for ErrNotFound, got %d", calls)
+	}
+}

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
+	"github.com/verveguy/fabrik/tui"
 )
 
 // ── checkCIGate ──────────────────────────────────────────────────────────────
@@ -738,12 +740,17 @@ func TestRemoveAwaitingCILabel_ErrNotFound(t *testing.T) {
 		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
 			if labelName == "fabrik:awaiting-ci" {
 				calls++
-				return gh.ErrNotFound
+				return fmt.Errorf("GitHub API returned 404: label not found: %w", gh.ErrNotFound)
 			}
 			return nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:awaiting-ci")
+
+	eventsCh := make(chan tui.Event, 16)
+	eng.events = eventsCh
+
 	item := gh.ProjectItem{
 		Number: 1,
 		Repo:   "owner/repo",
@@ -754,5 +761,24 @@ func TestRemoveAwaitingCILabel_ErrNotFound(t *testing.T) {
 
 	if calls != 1 {
 		t.Errorf("expected exactly 1 RemoveLabelFromIssue call for ErrNotFound, got %d", calls)
+	}
+
+	// No warn log should be emitted when ErrNotFound is returned.
+	close(eventsCh)
+	for ev := range eventsCh {
+		if le, ok := ev.(tui.LogEvent); ok && le.Tag == "warn" {
+			t.Errorf("unexpected warn log: %q", le.Message)
+		}
+	}
+
+	// Cache write-through applied: fabrik:awaiting-ci must be absent from cache.
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	for _, l := range labels {
+		if l == "fabrik:awaiting-ci" {
+			t.Error("expected fabrik:awaiting-ci to be removed from cache after ErrNotFound")
+		}
 	}
 }

--- a/engine/dependencies.go
+++ b/engine/dependencies.go
@@ -51,7 +51,14 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 		for _, l := range item.Labels {
 			if l == "fabrik:blocked" {
 				if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:blocked"); err != nil {
-					e.logf(item.Number, "warn", "could not remove fabrik:blocked label: %v\n", err)
+					if errors.Is(err, gh.ErrNotFound) {
+						// Label already absent on GitHub — desired end state achieved; sync cache.
+						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+							cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
+						}
+					} else {
+						e.logf(item.Number, "warn", "could not remove fabrik:blocked label: %v\n", err)
+					}
 				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
 				}

--- a/engine/dependencies_test.go
+++ b/engine/dependencies_test.go
@@ -618,3 +618,39 @@ func TestCheckDependencies_PullPath_Regression(t *testing.T) {
 		t.Errorf("expected pull-path to remove fabrik:blocked, got removeLabelCalls=%v", client.removeLabelCalls)
 	}
 }
+
+// TestCheckDependencies_RemoveBlocked_ErrNotFound verifies that a 404 from
+// RemoveLabelFromIssue is treated as success (label already absent) — exactly
+// one call, no warning logged, and cache write-through applied.
+func TestCheckDependencies_RemoveBlocked_ErrNotFound(t *testing.T) {
+	var calls int
+	client := &mockGitHubClient{
+		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			if labelName == "fabrik:blocked" {
+				calls++
+				return gh.ErrNotFound
+			}
+			return nil
+		},
+	}
+	eng := depTestEngine(client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 10,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:blocked"},
+		BlockedBy: []gh.Dependency{
+			{Number: 9, State: "CLOSED", Repo: "owner/repo"},
+		},
+	}
+	stage := &stages.Stage{Name: "Research"}
+
+	blocked := eng.checkDependencies(board, item, stage)
+
+	if blocked {
+		t.Error("expected not blocked when all deps CLOSED")
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 RemoveLabelFromIssue call for ErrNotFound, got %d", calls)
+	}
+}

--- a/engine/dependencies_test.go
+++ b/engine/dependencies_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/verveguy/fabrik/boardcache"
 	gh "github.com/verveguy/fabrik/github"
 	"github.com/verveguy/fabrik/internal/itemstate"
 	"github.com/verveguy/fabrik/stages"
+	"github.com/verveguy/fabrik/tui"
 )
 
 // depTestStages returns a two-stage pipeline for dependency gate tests.
@@ -628,15 +630,20 @@ func TestCheckDependencies_RemoveBlocked_ErrNotFound(t *testing.T) {
 		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
 			if labelName == "fabrik:blocked" {
 				calls++
-				return gh.ErrNotFound
+				return fmt.Errorf("GitHub API returned 404: label not found: %w", gh.ErrNotFound)
 			}
 			return nil
 		},
 	}
-	eng := depTestEngine(client)
+	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:blocked")
+
+	eventsCh := make(chan tui.Event, 16)
+	eng.events = eventsCh
+
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
-		Number: 10,
+		Number: 1,
 		Repo:   "owner/repo",
 		Labels: []string{"fabrik:blocked"},
 		BlockedBy: []gh.Dependency{
@@ -652,5 +659,24 @@ func TestCheckDependencies_RemoveBlocked_ErrNotFound(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("expected exactly 1 RemoveLabelFromIssue call for ErrNotFound, got %d", calls)
+	}
+
+	// No warn log should be emitted when ErrNotFound is returned.
+	close(eventsCh)
+	for ev := range eventsCh {
+		if le, ok := ev.(tui.LogEvent); ok && le.Tag == "warn" {
+			t.Errorf("unexpected warn log: %q", le.Message)
+		}
+	}
+
+	// Cache write-through applied: fabrik:blocked must be absent from cache.
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	for _, l := range labels {
+		if l == "fabrik:blocked" {
+			t.Error("expected fabrik:blocked to be removed from cache after ErrNotFound")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Treat `ErrNotFound` (HTTP 404) from `RemoveLabelFromIssue` as a no-op success — not an error — in `checkDependencies` and `removeAwaitingCILabel`. When GitHub returns 404 for a label DELETE, the label is already absent, which is exactly the desired end state. The cache should still be updated to reflect the label's absence. This eliminates spurious 404 warnings without changing any behavioral semantics.

## Problem

When the engine clears `fabrik:blocked` or `fabrik:awaiting-ci` from an issue, it calls the GitHub REST API. If the cached snapshot shows the label as present but GitHub has already removed it (stale snapshot from a prior cycle or concurrent operation), the REST DELETE returns 404 and the engine logs a spurious warning:

```
[#603 warn] could not remove fabrik:blocked label: GitHub API returned 404: {"message":"Label does not exist"...
[#603 warn] could not remove fabrik:awaiting-ci label: GitHub API returned 404: {"message":"Label does not exist"...
```

Observed twice on a single end-to-end run of #603 in smoke test #4 — once on push-unblock dispatch, once on Validate-complete.

The current code in `checkDependencies` and `removeAwaitingCILabel` already guards with a snapshot label check before calling `RemoveLabelFromIssue`. However, the snapshot can be stale: the label appears present in the local snapshot but was already removed on GitHub. When the DELETE hits GitHub and returns 404, the current error handler logs it as a warning — but the desired end state (label absent) has already been achieved, making the warning a false alarm.

By contrast, `removeBlockedIfResolved` (the push-based unblock path) already handles this correctly: it checks `errors.Is(err, gh.ErrNotFound)` and treats 404 as success (no warning, cache sync).

## Approach

### Approach

Apply the `ErrNotFound`-as-success pattern — already established in `removeBlockedIfResolved` — to the two call sites that currently log a spurious warning when GitHub returns 404. No new abstractions, no refactoring: the fix is a localized `errors.Is(err, gh.ErrNotFound)` branch inserted into the existing error handler at each site. Both files already import `"errors"`, `gh "github.com/verveguy/fabrik/github"`, and `"github.com/verveguy/fabrik/boardcache"`, so no import changes are needed.

The pattern: when `RemoveLabelFromIssue` returns an error that `errors.Is`-matches `gh.ErrNotFound`, write through to the cache (label is already absent on GitHub but still present in the local snapshot) and return/break without logging — identical to the 204 success path. For any other error, log the warning as before.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/dependencies.go` | Add `ErrNotFound` branch in `checkDependencies` label-removal block (lines 53–58) |
| `engine/ci.go` | Add `ErrNotFound` branch in `removeAwaitingCILabel` (lines 184–189) |
| `engine/dependencies_test.go` | Add `TestCheckDependencies_RemoveBlocked_ErrNotFound` |
| `engine/ci_test.go` | Add `TestRemoveAwaitingCILabel_ErrNotFound` |

### Key Decisions

- **Apply the fix to both sites independently, without a shared helper.** The spec explicitly calls out a shared helper as out of scope. The pattern is two lines at each site; a helper would add indirection with no benefit at this scale.

- **Use `boardcache.ItemKey(item.Repo, item.Number)` at both sites.** This matches the existing success-path cache write-through at each site — `checkDependencies` already uses `item.Repo` (which is already in `"owner/repo"` form), and `removeAwaitingCILabel` also uses `item.Repo`. Consistency with the surrounding code is more important than matching `removeBlockedIfResolved`'s `owner+"/"+repo` form (they are equivalent).

- **Write tests for both functions.** The spec requires "at least one"; covering both provides symmetry and guards against regression at each site independently.

- **No ADR required.** This fix applies an already-established pattern (`removeBlockedIfResolved`) and is not architecturally novel. No new contributor would need to discover this without reading the existing code — the pattern is already present in the same file.

- **No documentation updates required.** The Research stage confirmed no user-visible behavioral change: no new labels, config options, CLI commands, or markers introduced.

### Task Checklist

- [ ] **Fix `checkDependencies` in `engine/dependencies.go`**: in the `fabrik:blocked` removal block (after the `RemoveLabelFromIssue` call), insert `if errors.Is(err, gh.ErrNotFound)` branch that calls `cacheImpl.ApplyLabelRemoved` and `break`s without logging; move the existing `logf` warning to the `else` branch.
- [ ] **Add `TestCheckDependencies_RemoveBlocked_ErrNotFound` in `engine/dependencies_test.go`**: use `removeLabelFromIssueFn` mock to return `gh.ErrNotFound`; item has `fabrik:blocked` label and no open deps; assert exactly one `RemoveLabelFromIssue` call, cache reflects label removed, no warning emitted (model after `TestRemoveBlockedIfResolved_ErrNotFound`).
- [ ] **Fix `removeAwaitingCILabel` in `engine/ci.go`**: same pattern — insert `errors.Is(err, gh.ErrNotFound)` branch with cache sync and `return`; `else` branch logs warning as before.
- [ ] **Add `TestRemoveAwaitingCILabel_ErrNotFound` in `engine/ci_test.go`**: use `removeLabelFromIssueFn` mock to return `gh.ErrNotFound`; item has `fabrik:awaiting-ci` label; assert exactly one call, cache updated, no warning.
- [ ] **Run `go test -race ./engine/...`** and confirm all tests pass.

### Risks

None. The fix is purely defensive error-handling — the desired end state (label absent) is already achieved when GitHub returns 404. No behavioral semantics change.

---
Used 8/50 turns, 3k input / 3k output tokens.

## Verification

Fixed spurious 404 warnings in `checkDependencies` (`engine/dependencies.go`) and `removeAwaitingCILabel` (`engine/ci.go`) by treating `ErrNotFound` from `RemoveLabelFromIssue` as success — the desired end state (label absent) is already achieved when GitHub returns 404. Both sites now sync the cache write-through on 404, matching the pattern already established in `removeBlockedIfResolved`. Added `TestCheckDependencies_RemoveBlocked_ErrNotFound` and `TestRemoveAwaitingCILabel_ErrNotFound` to cover both fix sites; all 202 engine tests pass with `-race`.

---

Closes #607