### PR TITLE
fabrik: Implement stage posts output to issue before draft PR is created

### DIFF
--- a/engine/item.go
+++ b/engine/item.go
@@ -811,6 +811,13 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		postOutput = strings.TrimSpace(postOutput)
 	}
 
+	// When completing a stage that posts output to a PR and creates a draft PR,
+	// ensure the PR exists before posting so postOutputToPR can find it.
+	var prNumber int
+	if completed && stage.CreateDraftPR && stage.PostToPR {
+		prNumber = e.ensureDraftPR(item, baseBranch)
+	}
+
 	// Post Claude's output
 	if postOutput != "" {
 		footer := formatStatsFooter(usage, completed)
@@ -930,10 +937,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		// Clear retry tracking for this stage — no longer needed after success.
 		e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 		e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-		// Post-stage: create draft PR and/or mark ready now that commits exist
-		var prNumber int
+		// Post-stage: create draft PR and/or mark ready now that commits exist.
+		// prNumber may already be set if the early guard above ran (PostToPR + CreateDraftPR path).
 		if stage.CreateDraftPR {
-			prNumber = e.ensureDraftPR(item, baseBranch)
+			if prNumber == 0 {
+				prNumber = e.ensureDraftPR(item, baseBranch)
+			}
 			e.updatePRVerification(item, prNumber, extractSummary(output))
 		}
 		if stage.MarkPRReadyOnComplete {

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -858,6 +858,9 @@ func TestProcessItem_PostToPR_CreatesDraftPRBeforePosting(t *testing.T) {
 	// before the draft PR has been created — this is the bug: full stage output
 	// falls back to the issue instead of the PR.
 	var issueCommentBeforePR bool
+	// prCommentPosted is set when AddComment is called on the PR number,
+	// confirming output was actually routed to the PR.
+	var prCommentPosted bool
 
 	client := &mockGitHubClient{
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
@@ -875,6 +878,9 @@ func TestProcessItem_PostToPR_CreatesDraftPRBeforePosting(t *testing.T) {
 			if issueNumber == issueNum && !prExists {
 				// AddComment on the issue before the PR existed — this is the fallback bug.
 				issueCommentBeforePR = true
+			}
+			if issueNumber == prNum {
+				prCommentPosted = true
 			}
 			return issueNumber*10 + 1, nil
 		},
@@ -947,6 +953,9 @@ func TestProcessItem_PostToPR_CreatesDraftPRBeforePosting(t *testing.T) {
 	// by the time any AddComment on the issue number fires (summary, not fallback).
 	if issueCommentBeforePR {
 		t.Error("AddComment called on issue before draft PR was created — output fell back to issue instead of PR")
+	}
+	if !prCommentPosted {
+		t.Error("expected AddComment to be called on the PR — output was not posted to PR")
 	}
 }
 

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -821,6 +821,135 @@ func TestMarkPRReady_AllTransientExhausted(t *testing.T) {
 	}
 }
 
+// TestProcessItem_PostToPR_CreatesDraftPRBeforePosting verifies that when a stage
+// completes with both create_draft_pr and post_to_pr true, the draft PR is created
+// before postOutputToPR runs — so output is posted to the PR, not the issue fallback.
+func TestProcessItem_PostToPR_CreatesDraftPRBeforePosting(t *testing.T) {
+	skipIfNoGit(t)
+
+	const issueNum = 60
+	const prNum = 300
+
+	// Set up a repo with a real remote so ensureDraftPR can push the branch.
+	// initBareRepo creates a plain local repo; we use it as the "remote" and
+	// clone it so the working repo has origin configured.
+	remoteDir := initBareRepo(t)
+	workingDir := t.TempDir()
+	runCmd := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %s: %v", args, out, err)
+		}
+	}
+	runCmd("", "git", "clone", remoteDir, workingDir)
+	runCmd(workingDir, "git", "config", "user.email", "test@test.com")
+	runCmd(workingDir, "git", "config", "user.name", "Test")
+
+	wm := NewWorktreeManager(workingDir)
+
+	// prExists tracks whether the draft PR has been created yet.
+	// FindPRForIssue returns 0 until CreateDraftPR is called, simulating the bug
+	// scenario: no PR exists at stage start, PR is created by ensureDraftPR.
+	var prExists bool
+	var draftPRCreated bool
+	// issueCommentBeforePR is set when AddComment is called on the issue number
+	// before the draft PR has been created — this is the bug: full stage output
+	// falls back to the issue instead of the PR.
+	var issueCommentBeforePR bool
+
+	client := &mockGitHubClient{
+		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
+			if prExists {
+				return prNum, nil
+			}
+			return 0, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			draftPRCreated = true
+			prExists = true
+			return prNum, nil
+		},
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			if issueNumber == issueNum && !prExists {
+				// AddComment on the issue before the PR existed — this is the fallback bug.
+				issueCommentBeforePR = true
+			}
+			return issueNumber*10 + 1, nil
+		},
+		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
+			if issueNumber == prNum {
+				return "## Verification\n\n(Populated by Implement)\n\n---\n\nCloses #60", nil
+			}
+			return "issue body", nil
+		},
+		updateIssueBodyFn: func(owner, repo string, issueNumber int, body string) error {
+			return nil
+		},
+		fetchLabelsFn: func(owner, repo string, issueNumber int) ([]string, error) {
+			return nil, nil
+		},
+	}
+
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "Implementation done.\nFABRIK_STAGE_COMPLETE", true, TokenUsage{}, nil
+		},
+	}
+
+	stgs := []*stages.Stage{
+		{
+			Name:          "Implement",
+			Order:         1,
+			Prompt:        "implement it",
+			CreateDraftPR: true,
+			PostToPR:      true,
+			Completion:    stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+	statusOpts := make(map[string]string)
+	for _, s := range stgs {
+		statusOpts[s.Name] = "OPT_" + s.Name
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        stgs,
+		},
+		client,
+		claude,
+		wm,
+	)
+	eng.statusField = &gh.StatusField{FieldID: "FIELD_1", Options: statusOpts}
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: issueNum,
+		Title:  "My feature",
+		Status: "Implement",
+		ItemID: "PVTI_60",
+	}
+
+	eng.processItem(t.Context(), board, item)
+
+	if !draftPRCreated {
+		t.Fatal("expected CreateDraftPR to be called")
+	}
+
+	// The bug: full stage output posted to the issue before the PR existed.
+	// With the fix, ensureDraftPR runs before postOutputToPR, so prExists is true
+	// by the time any AddComment on the issue number fires (summary, not fallback).
+	if issueCommentBeforePR {
+		t.Error("AddComment called on issue before draft PR was created — output fell back to issue instead of PR")
+	}
+}
+
 func TestMarkPRReady_NonTransientNoRetry(t *testing.T) {
 	skipIfNoGit(t)
 	repoDir := initBareRepo(t)


### PR DESCRIPTION
## Summary

The engine's post-stage flow in `engine/item.go` posts Claude's output before creating the draft PR. When a stage is configured with both `post_to_pr: true` and `create_draft_pr: true` (as Implement is), the post step runs first, finds no open PR, and falls back to posting on the issue. The draft PR is created afterward. The fix is to reorder operations so the draft PR is created before output is posted when the stage completes.

## Problem

When the Implement stage completes, the engine sometimes posts output to the issue instead of the linked PR, despite the stage being configured with `post_to_pr: true`. The log shows the fallback message followed immediately by PR creation:

```
[#603 warn] no open PR found, posting on issue instead
[#603 worktree] pushed fabrik/issue-603 to origin
[#603 worktree] pushed fabrik/issue-603 to origin
[#603 pr] created draft PR #606
[#603 pr] updated PR #606 Verification section
[#603 pr] marked PR #606 ready-for-review
```

The Implement stage output (intended for the PR per `post_to_pr: true`) ends up on the issue instead. PR #606 is then created seconds later, leaving the issue cluttered with output that belongs on the PR.

Smoke test #4, issue #603 demonstrated this. Issue #602 (run earlier in the same smoke test) did NOT exhibit the bug — for #602, PR #604 was created before the post step ran. The behavior is order-sensitive but not yet deterministically reproducible outside that test.

## Approach

### Approach

The fix is a minimal, targeted reorder within `processItem` in `engine/item.go`. No new types, interfaces, or files are needed.

**The change in three steps:**

1. **Lift `var prNumber int`** out of the `if completed` block and declare it before the post-output block, so it is in scope for both the early guard and the existing completion logic.

2. **Add an early `ensureDraftPR` guard** immediately before the post-output block:
   ```go
   if completed && stage.CreateDraftPR && stage.PostToPR {
       prNumber = e.ensureDraftPR(item, baseBranch)
   }
   ```
   This guarantees the PR exists before `postOutputToPR` calls `FindPRForIssue`. The guard is strictly inside a `completed` check, so non-completing runs (max_turns, error, blocked) are unaffected.

3. **Guard the `ensureDraftPR` call in `if completed`** with `prNumber == 0` so the call is skipped when the PR was already created by the early guard:
   ```go
   if stage.CreateDraftPR {
       if prNumber == 0 {
           prNumber = e.ensureDraftPR(item, baseBranch)
       }
       e.updatePRVerification(item, prNumber, extractSummary(output))
   }
   ```

The `updatePRVerification` and `markPRReady` calls are unchanged in position and semantics. The `!PostToPR` path (post goes to issue by design) is unaffected.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/item.go` | Move `var prNumber int` before post-output block; add early `ensureDraftPR` guard; add `prNumber == 0` check in `if completed` |
| `engine/pr_test.go` | Add `TestProcessItem_PostToPR_CreatesDraftPRBeforePosting` |

### Key Decisions

- **Conditional early call, not unconditional move**: The early `ensureDraftPR` is guarded by `completed && stage.CreateDraftPR && stage.PostToPR`. If we moved it unconditionally (before the `completed` check), it would fire on non-completing runs, violating the spec requirement. The `PostToPR` condition is also required — for stages with `create_draft_pr: true` but `post_to_pr: false`, output goes to the issue by design and the existing order is correct.

- **`prNumber == 0` skip in `if completed`**: `ensureDraftPR` is idempotent, so calling it twice would be safe. The `== 0` guard avoids a redundant `FindPRForIssue` round-trip and makes the intent explicit: "only create if not already created."

- **No ADR warranted**: This is a bug fix to call ordering within a single function. No new abstractions, config options, or constraints are introduced. The fix is self-evident from reading the code.

- **Documentation impact**: None. This fixes internal engine sequencing. No new config options, labels, markers, or user-visible behaviors are introduced. `docs/state-machine.md` and `docs/stage-lifecycle.md` do not need updating — the fix brings the implementation in line with what a reader would already expect from those docs (PR exists before output is posted).

### Task Checklist

- [ ] Task 1: In `engine/item.go`, move `var prNumber int` to before the post-output block (~line 813) and add the early guard `if completed && stage.CreateDraftPR && stage.PostToPR { prNumber = e.ensureDraftPR(item, baseBranch) }` immediately before the `if postOutput != ""` block
- [ ] Task 2: In `engine/item.go`, remove the now-redundant `var prNumber int` from inside `if completed` (~line 934) and add `if prNumber == 0 {` guard around the existing `prNumber = e.ensureDraftPR(...)` call, keeping `e.updatePRVerification(...)` unconditional within `if stage.CreateDraftPR`
- [ ] Task 3: Add `TestProcessItem_PostToPR_CreatesDraftPRBeforePosting` in `engine/pr_test.go` — use a stateful mock where `FindPRForIssue` returns `0` on the first call (simulating no PR at post time) and `prNum` on subsequent calls (simulating PR created by `ensureDraftPR`); `createDraftPRFn` records it was called and returns `prNum`; verify that `createDraftPRFn` was called and `AddComment` was called with `prNum` (output posted to PR, not issue fallback)
- [ ] Task 4: Run `go test -race ./engine/...` and confirm all tests pass including the new one and the existing `TestProcessItem_ImplementStage_UpdatesVerificationOnComplete`

### Risks

- **`ensureDraftPR` pushes the branch internally** (`pr.go:38`): when called early, it pushes before the outer `wm.PushBranch` at `item.go:897`. The outer push then becomes a no-op (same HEAD). This is safe — identical to a double push of the same ref.
- **Existing test unaffected**: `TestProcessItem_ImplementStage_UpdatesVerificationOnComplete` has `PostToPR: false`, so the new early guard (`stage.PostToPR` is false) never fires for it. Its mock and assertions need no changes.
- **Race risk**: nil — `prNumber` is a local variable in `processItem`; no shared state is introduced.

---
Used 9/50 turns, 3k input / 7k output tokens.

## Verification

Fixed the ordering bug in `engine/item.go` where `postOutputToPR` ran before `ensureDraftPR` on completing `post_to_pr + create_draft_pr` stages, causing output to fall back to the issue. The fix lifts `var prNumber int` before the post-output block and adds an early `ensureDraftPR` guard so the PR always exists when `postOutputToPR` calls `FindPRForIssue`. Added `TestProcessItem_PostToPR_CreatesDraftPRBeforePosting` to catch this regression; all tests pass.

---

Closes #608