### PR TITLE
fix: webhook restart-loop circuit-breaker and session-level health tracking (#628)

### DIFF
--- a/engine/poll.go
+++ b/engine/poll.go
@@ -464,6 +464,9 @@ func (e *Engine) Run() error {
 			idleDuration = time.Since(e.idleStart)
 		}
 		webhookHealthy := e.webhookMgr != nil && e.webhookMgr.IsHealthyOrStartingUp()
+		if e.webhookMgr != nil && e.webhookMgr.IsDisabled() {
+			e.logf(0, "webhook", "poll-only mode active — webhook subscription disabled; restart Fabrik to retry\n")
+		}
 		effectiveInterval := computeEffectiveInterval(configuredInterval, idleDuration, rateLimitRatio, webhookHealthy)
 
 		// Notify webhook manager of any new repos discovered during this poll.

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -44,6 +44,14 @@ const (
 	// webhookRepoFailureThreshold is the number of consecutive auth-shaped quick exits
 	// required before a repo is quarantined for the session.
 	webhookRepoFailureThreshold = 3
+	// webhookEventStaleTimeout: if no verified event has arrived within this window
+	// (measured from sessionLastEventAt), the health monitor transitions to Unhealthy.
+	// Provides fast pausing (60s) during tight restart loops where startupTime resets
+	// would otherwise prevent the slower webhookHealthWindow check from firing.
+	webhookEventStaleTimeout = 60 * time.Second
+	// webhookPermanentFailureMax: consecutive HTTP 422 quick-exits before the
+	// circuit-breaker fires and switches to poll-only mode.
+	webhookPermanentFailureMax = 3
 )
 
 // defaultWebhookEvents is the canonical event list from the spec (R6).
@@ -75,6 +83,12 @@ type webhookManager struct {
 	// The caller is responsible for the cmd != nil check; killFn handles nil Process.
 	killFn func(*exec.Cmd)
 
+	// startSubprocessFn overrides startSubprocessInternal when non-nil (tests only).
+	startSubprocessFn func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error)
+
+	// probeTimeout overrides orgModeProbeTimeout when non-zero (tests only).
+	probeTimeout time.Duration
+
 	// listener — bound once before first subprocess start, reused across restarts
 	listener net.Listener
 	port     int
@@ -98,14 +112,21 @@ type webhookManager struct {
 
 	// health (protected by mu)
 	state         WebhookHealthState
-	startupTime   time.Time // when current subprocess started
-	lastEventTime time.Time // zero until first verified event received
+	startupTime   time.Time // when current subprocess started (resets on restart)
+	lastEventTime time.Time // zero until first verified event; resets on restart
+
+	// session-level health tracking — never reset on subprocess restart (protected by mu)
+	sessionFirstStartAt time.Time // set once when first subprocess starts
+	sessionLastEventAt  time.Time // set on every verified event; never cleared on restart
 
 	// secret rotation (protected by mu)
 	consecutiveFailures int
 	firstFailureAt      time.Time
 	rotateCycleCount    int
 	disabled            bool
+
+	// 422 circuit-breaker (protected by mu)
+	permanentFailureCount int // consecutive quick-exit runs with HTTP 422 stderr
 
 	// per-type event counters (protected by mu)
 	eventCounts map[string]int
@@ -356,6 +377,32 @@ func (wm *webhookManager) applyRepoAuthFailure(elapsed time.Duration, stderrCont
 	return quarantined
 }
 
+// effectiveProbeTimeout returns the probe timeout for org-mode and 422 detection.
+// Uses probeTimeout when set (tests only); falls back to orgModeProbeTimeout.
+func (wm *webhookManager) effectiveProbeTimeout() time.Duration {
+	if wm.probeTimeout > 0 {
+		return wm.probeTimeout
+	}
+	return orgModeProbeTimeout
+}
+
+// is422ShapedError returns true when the stderr output indicates an HTTP 422
+// Validation Failed response — a permanent configuration error (quota exhausted,
+// stale token, conflicting webhook). Used by the circuit-breaker in supervise()
+// to stop the restart loop after repeated permanent failures in per-repo mode.
+func is422ShapedError(s string) bool {
+	return strings.Contains(strings.ToLower(s), "422")
+}
+
+// IsDisabled returns true when the webhook manager has been permanently disabled
+// (circuit-breaker fired or HMAC rotation max-cycles reached). While disabled,
+// the engine operates in poll-only mode.
+func (wm *webhookManager) IsDisabled() bool {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	return wm.disabled
+}
+
 // containsEvent reports whether name is in the events slice.
 func containsEvent(events []string, name string) bool {
 	for _, e := range events {
@@ -603,7 +650,11 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 
 		args := buildGhArgs(org, repos, port, secret, events)
 		startedAt := time.Now()
-		cmd, stderrCh, err := wm.startSubprocessInternal(ctx, args)
+		startFn := wm.startSubprocessInternal
+		if wm.startSubprocessFn != nil {
+			startFn = wm.startSubprocessFn
+		}
+		cmd, stderrCh, err := startFn(ctx, args)
 		if err != nil {
 			wm.logFn(0, "webhook", "failed to start gh webhook forward: %v\n", err)
 			select {
@@ -623,6 +674,9 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 		wm.state = WebhookStreamStartingUp
 		wm.startupTime = time.Now()
 		wm.lastEventTime = time.Time{}
+		if wm.sessionFirstStartAt.IsZero() {
+			wm.sessionFirstStartAt = wm.startupTime
+		}
 		wm.mu.Unlock()
 		wm.emitCurrentState()
 
@@ -648,11 +702,13 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 		default:
 		}
 
+		probeTimeout := wm.effectiveProbeTimeout()
+
 		// Time-based convergent fallback for projects_v2_item in per-repo mode.
 		// If the subprocess exits quickly and projects_v2_item is still in the event
 		// list (meaning the stderr-based detection did not fire), drop it for the next
 		// restart to break any infinite crash-restart cycle.
-		if org == "" && elapsed < orgModeProbeTimeout {
+		if org == "" && elapsed < probeTimeout {
 			wm.mu.Lock()
 			if containsEvent(wm.events, "projects_v2_item") {
 				wm.events = filterOutEvent(wm.events, "projects_v2_item")
@@ -664,10 +720,40 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 			}
 		}
 
+		// 422 circuit-breaker: per-repo mode only.
+		// Quick exit with HTTP 422 stderr → permanent configuration error (quota, auth, conflict).
+		// Three consecutive such exits disable the webhook manager and switch to poll-only mode.
+		// Quick exits with non-422 stderr are transient crashes; they neither increment nor reset
+		// the counter. A durable run (elapsed >= orgModeProbeTimeout) resets the counter.
+		if org == "" {
+			if elapsed < probeTimeout && is422ShapedError(stderrContent) {
+				wm.mu.Lock()
+				wm.permanentFailureCount++
+				count := wm.permanentFailureCount
+				if count >= webhookPermanentFailureMax {
+					wm.disabled = true
+					wm.mu.Unlock()
+					wm.logFn(0, "webhook", "WARNING: webhook subscription permanently failed after %d consecutive HTTP 422 errors — "+
+						"switching to poll-only mode. Check 'gh auth status' and repo webhook quota, then restart Fabrik.\n",
+						webhookPermanentFailureMax)
+					if wm.healthChangeFn != nil {
+						wm.healthChangeFn(false)
+					}
+					return
+				}
+				wm.mu.Unlock()
+			} else if elapsed >= probeTimeout {
+				// Subprocess ran durably — reset the 422 circuit-breaker counter.
+				wm.mu.Lock()
+				wm.permanentFailureCount = 0
+				wm.mu.Unlock()
+			}
+		}
+
 		// Detect org mode rejection: combine time-based and stderr content signals.
 		// A quick exit with an auth-shaped error → permanent per-repo fallback.
 		// A quick exit without an auth error → transient crash; retry org mode with backoff.
-		if org != "" && elapsed < orgModeProbeTimeout {
+		if org != "" && elapsed < probeTimeout {
 			if isAuthShapedError(stderrContent) {
 				wm.logFn(0, "webhook", "org-level webhook failed (permission error, %v) — falling back to per-repo subscription\n", elapsed.Round(time.Millisecond))
 				wm.mu.Lock()
@@ -791,11 +877,21 @@ func (wm *webhookManager) checkHealthTransitions() {
 		if !wm.lastEventTime.IsZero() {
 			// Event received; HTTP handler already set state to Healthy.
 			// This is a no-op catch.
-		} else if !wm.startupTime.IsZero() && now.Sub(wm.startupTime) > webhookStartupGrace+webhookHealthWindow {
+		} else if !wm.sessionLastEventAt.IsZero() && now.Sub(wm.sessionLastEventAt) > webhookEventStaleTimeout {
+			// R-B4: cross-restart stale check — fires faster than the grace+window path
+			// when the subprocess is in a tight restart loop (each restart resets startupTime).
+			newState = WebhookStreamUnhealthy
+		} else if !wm.sessionFirstStartAt.IsZero() && now.Sub(wm.sessionFirstStartAt) > webhookStartupGrace+webhookHealthWindow {
+			// R-B3: use sessionFirstStartAt (not startupTime) so subprocess restarts
+			// don't reset the timer; this is the fix for the Bug B root cause.
 			newState = WebhookStreamUnhealthy
 		}
 	case WebhookStreamHealthy:
-		if !wm.lastEventTime.IsZero() && now.Sub(wm.lastEventTime) > webhookHealthWindow {
+		if !wm.sessionLastEventAt.IsZero() && now.Sub(wm.sessionLastEventAt) > webhookEventStaleTimeout {
+			// R-B4: 60s stale check applies to Healthy state too, providing faster
+			// detection when the stream goes quiet during or after a restart loop.
+			newState = WebhookStreamUnhealthy
+		} else if !wm.lastEventTime.IsZero() && now.Sub(wm.lastEventTime) > webhookHealthWindow {
 			newState = WebhookStreamUnhealthy
 		}
 	}
@@ -942,7 +1038,9 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	if prevState != WebhookStreamHealthy {
 		wm.state = WebhookStreamHealthy
 	}
-	wm.lastEventTime = time.Now()
+	now := time.Now()
+	wm.lastEventTime = now
+	wm.sessionLastEventAt = now // never reset on subprocess restart
 	wm.mu.Unlock()
 	if prevState != WebhookStreamHealthy {
 		wm.logFn(0, "webhook", "health state: %s → %s\n", prevState, WebhookStreamHealthy)

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -732,7 +732,13 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 				count := wm.permanentFailureCount
 				if count >= webhookPermanentFailureMax {
 					wm.disabled = true
+					prevState := wm.state
+					wm.state = WebhookStreamUnhealthy
 					wm.mu.Unlock()
+					if prevState != WebhookStreamUnhealthy {
+						wm.logFn(0, "webhook", "health state: %s → %s\n", prevState, WebhookStreamUnhealthy)
+						wm.emitCurrentState()
+					}
 					wm.logFn(0, "webhook", "WARNING: webhook subscription permanently failed after %d consecutive HTTP 422 errors — "+
 						"switching to poll-only mode. Check 'gh auth status' and repo webhook quota, then restart Fabrik.\n",
 						webhookPermanentFailureMax)
@@ -881,9 +887,11 @@ func (wm *webhookManager) checkHealthTransitions() {
 			// R-B4: cross-restart stale check — fires faster than the grace+window path
 			// when the subprocess is in a tight restart loop (each restart resets startupTime).
 			newState = WebhookStreamUnhealthy
-		} else if !wm.sessionFirstStartAt.IsZero() && now.Sub(wm.sessionFirstStartAt) > webhookStartupGrace+webhookHealthWindow {
+		} else if wm.sessionLastEventAt.IsZero() && !wm.sessionFirstStartAt.IsZero() && now.Sub(wm.sessionFirstStartAt) > webhookStartupGrace+webhookHealthWindow {
 			// R-B3: use sessionFirstStartAt (not startupTime) so subprocess restarts
-			// don't reset the timer; this is the fix for the Bug B root cause.
+			// don't reset the timer. Gate on sessionLastEventAt.IsZero() per spec:
+			// this path only fires when no event has ever been received in this session
+			// (if events were received but went stale, R-B4 above handles it).
 			newState = WebhookStreamUnhealthy
 		}
 	case WebhookStreamHealthy:

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -869,6 +869,7 @@ func TestCircuitBreaker422(t *testing.T) {
 		wm.mu.Lock()
 		disabled := wm.disabled
 		count := wm.permanentFailureCount
+		state := wm.state
 		wm.mu.Unlock()
 
 		if !disabled {
@@ -876,6 +877,9 @@ func TestCircuitBreaker422(t *testing.T) {
 		}
 		if count != webhookPermanentFailureMax {
 			t.Errorf("permanentFailureCount = %d, want %d", count, webhookPermanentFailureMax)
+		}
+		if state != WebhookStreamUnhealthy {
+			t.Errorf("state = %q after circuit-breaker, want %q", state, WebhookStreamUnhealthy)
 		}
 		if healthChangeFalseCalls != 1 {
 			t.Errorf("healthChangeFn(false) called %d times, want 1", healthChangeFalseCalls)
@@ -1081,6 +1085,31 @@ func TestHealthTransition_StartingUp_UsesSessionFirstStartAt(t *testing.T) {
 	wm.mu.Unlock()
 	if state == WebhookStreamUnhealthy {
 		t.Error("state should NOT be Unhealthy when only startupTime is old but sessionFirstStartAt is recent — the fix uses sessionFirstStartAt")
+	}
+}
+
+// TestHealthTransition_StartingUp_SkipsGraceWindowWhenEventsReceived verifies that
+// the sessionFirstStartAt grace+window path (R-B3) does NOT fire when events have
+// been received (sessionLastEventAt != zero), even if sessionFirstStartAt is old.
+// Without the sessionLastEventAt.IsZero() guard, this would incorrectly transition
+// to Unhealthy after ~10m even on a healthy-then-restarting stream.
+func TestHealthTransition_StartingUp_SkipsGraceWindowWhenEventsReceived(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	wm.mu.Lock()
+	wm.state = WebhookStreamStartingUp
+	// sessionFirstStartAt is old enough to trigger the grace+window path.
+	wm.sessionFirstStartAt = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
+	// But we have received events recently (within the 60s stale threshold).
+	wm.sessionLastEventAt = time.Now().Add(-10 * time.Second)
+	wm.mu.Unlock()
+
+	wm.checkHealthTransitions()
+
+	wm.mu.Lock()
+	state := wm.state
+	wm.mu.Unlock()
+	if state == WebhookStreamUnhealthy {
+		t.Error("state should NOT be Unhealthy when sessionFirstStartAt is old but events were received (sessionLastEventAt != zero)")
 	}
 }
 

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -239,8 +240,9 @@ func TestHealthStateTransitions(t *testing.T) {
 		wm, _ := newTestWebhookManager(t)
 		wm.mu.Lock()
 		wm.state = WebhookStreamStartingUp
-		// Set startup time far in the past so grace + health window have both elapsed.
-		wm.startupTime = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
+		// Set sessionFirstStartAt far in the past — the fix uses sessionFirstStartAt
+		// (not startupTime) so subprocess restarts don't reset the timer.
+		wm.sessionFirstStartAt = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
 		wm.mu.Unlock()
 
 		wm.checkHealthTransitions()
@@ -627,6 +629,32 @@ func TestIsProjectsV2ItemRejection(t *testing.T) {
 	}
 }
 
+// TestIs422ShapedError verifies 422 detection in stderr output (case-insensitive).
+func TestIs422ShapedError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"full 422 error", "Error: error creating webhook: HTTP 422: Validation Failed (https://api.github.com/repos/tenaciousvc/fabrik/hooks)", true},
+		{"422 uppercase", "HTTP 422 ERROR", true},
+		{"422 mixed case", "Http 422 Failed", true},
+		{"403 not 422", "HTTP 403 Forbidden", false},
+		{"404 not 422", "HTTP 404 Not Found", false},
+		{"empty string", "", false},
+		{"unrelated error", "connection reset by peer", false},
+		{"rate limited", "HTTP 429 Too Many Requests", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := is422ShapedError(tc.in)
+			if got != tc.want {
+				t.Errorf("is422ShapedError(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestApplyRepoAuthFailure_Quarantine verifies that three consecutive auth-shaped
 // quick exits quarantine all repos in the subscription set.
 func TestApplyRepoAuthFailure_Quarantine(t *testing.T) {
@@ -767,4 +795,351 @@ func TestUpdateRepos_NonQuarantinedRepoAdded(t *testing.T) {
 	if killCount != 1 {
 		t.Errorf("killFn called %d times for new-repo update, want 1", killCount)
 	}
+}
+
+// TestIsDisabled verifies IsDisabled() reflects the disabled field correctly.
+func TestIsDisabled(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	if wm.IsDisabled() {
+		t.Error("IsDisabled() = true initially, want false")
+	}
+	wm.mu.Lock()
+	wm.disabled = true
+	wm.mu.Unlock()
+	if !wm.IsDisabled() {
+		t.Error("IsDisabled() = false after setting disabled=true, want true")
+	}
+}
+
+// fake422Subprocess returns a startSubprocessFn that exits immediately and sends
+// the given stderr string on the channel. Suitable for testing fast-exit scenarios.
+func fake422Subprocess(t *testing.T, stderrOutput string) func(context.Context, []string) (*exec.Cmd, <-chan string, error) {
+	t.Helper()
+	return func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+		cmd := exec.CommandContext(ctx, "sh", "-c", "exit 1")
+		if err := cmd.Start(); err != nil {
+			return nil, nil, fmt.Errorf("starting fake subprocess: %w", err)
+		}
+		ch := make(chan string, 1)
+		ch <- stderrOutput
+		return cmd, ch, nil
+	}
+}
+
+// TestCircuitBreaker422 verifies the HTTP 422 permanent-failure circuit-breaker.
+func TestCircuitBreaker422(t *testing.T) {
+	t.Run("three consecutive 422s disable the manager", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		// Use a short probe timeout so the fake fast-exiting subprocess counts as a quick exit.
+		wm.probeTimeout = 50 * time.Millisecond
+		// Force per-repo mode (orgModeFailed=true bypasses detectOrgMode so org=="").
+		// The 422 circuit-breaker only fires in per-repo mode (gated on org=="").
+		wm.mu.Lock()
+		wm.orgModeFailed = true
+		wm.mu.Unlock()
+
+		healthChangeFalseCalls := 0
+		wm.healthChangeFn = func(healthy bool) {
+			if !healthy {
+				healthChangeFalseCalls++
+			}
+		}
+
+		callCount := 0
+		wm.startSubprocessFn = func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+			callCount++
+			return fake422Subprocess(t, "Error: error creating webhook: HTTP 422: Validation Failed")(ctx, args)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			wm.supervise(ctx)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("supervise did not return after circuit-breaker fired")
+		}
+
+		wm.mu.Lock()
+		disabled := wm.disabled
+		count := wm.permanentFailureCount
+		wm.mu.Unlock()
+
+		if !disabled {
+			t.Error("manager should be disabled after 3 consecutive 422 failures")
+		}
+		if count != webhookPermanentFailureMax {
+			t.Errorf("permanentFailureCount = %d, want %d", count, webhookPermanentFailureMax)
+		}
+		if healthChangeFalseCalls != 1 {
+			t.Errorf("healthChangeFn(false) called %d times, want 1", healthChangeFalseCalls)
+		}
+		if callCount != webhookPermanentFailureMax {
+			t.Errorf("startSubprocessFn called %d times, want %d", callCount, webhookPermanentFailureMax)
+		}
+	})
+
+	t.Run("non-422 quick exits do not increment counter", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.probeTimeout = 50 * time.Millisecond
+		wm.mu.Lock()
+		wm.orgModeFailed = true
+		wm.mu.Unlock()
+
+		wm.startSubprocessFn = fake422Subprocess(t, "connection reset by peer")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+
+		go wm.supervise(ctx)
+		<-ctx.Done()
+
+		wm.mu.Lock()
+		count := wm.permanentFailureCount
+		disabled := wm.disabled
+		wm.mu.Unlock()
+
+		if count != 0 {
+			t.Errorf("permanentFailureCount = %d after non-422 failures, want 0", count)
+		}
+		if disabled {
+			t.Error("manager should not be disabled by non-422 failures")
+		}
+	})
+
+	t.Run("durable run resets the counter", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		probeTimeout := 30 * time.Millisecond
+		wm.probeTimeout = probeTimeout
+
+		// Pre-seed counter to just below the threshold; force per-repo mode.
+		wm.mu.Lock()
+		wm.permanentFailureCount = webhookPermanentFailureMax - 1
+		wm.orgModeFailed = true
+		wm.mu.Unlock()
+
+		callCount := 0
+		wm.startSubprocessFn = func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+			callCount++
+			var cmd *exec.Cmd
+			if callCount == 1 {
+				// First call: sleep longer than probeTimeout to simulate a durable run.
+				sleepMs := (probeTimeout + 20*time.Millisecond).Milliseconds()
+				cmd = exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf("sleep 0.%03d; exit 0", sleepMs))
+			} else {
+				// Subsequent calls: exit immediately.
+				cmd = exec.CommandContext(ctx, "sh", "-c", "exit 1")
+			}
+			if err := cmd.Start(); err != nil {
+				return nil, nil, err
+			}
+			ch := make(chan string, 1)
+			ch <- "Error: HTTP 422: Validation Failed"
+			return cmd, ch, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		go wm.supervise(ctx)
+
+		// Wait for the durable subprocess to finish and counter to reset.
+		time.Sleep(probeTimeout + 100*time.Millisecond)
+
+		wm.mu.Lock()
+		disabled := wm.disabled
+		wm.mu.Unlock()
+
+		if disabled {
+			t.Error("manager should not be disabled: durable run should have reset the counter before the threshold was reached")
+		}
+	})
+}
+
+// TestSessionLastEventAt_NotResetOnRestart verifies that sessionLastEventAt persists
+// across subprocess restarts, while lastEventTime is cleared as supervise() does.
+func TestSessionLastEventAt_NotResetOnRestart(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	secret, _ := generateSecret()
+	wm.mu.Lock()
+	wm.state = WebhookStreamStartingUp
+	wm.startupTime = time.Now()
+	wm.secret = secret
+	wm.mu.Unlock()
+
+	// Send a valid webhook to set both lastEventTime and sessionLastEventAt.
+	body := []byte(`{"action":"created","repository":{"full_name":"myorg/myrepo"}}`)
+	req := signedRequest(t, body, secret)
+	rr := httptest.NewRecorder()
+	wm.handleWebhook(rr, req)
+
+	wm.mu.Lock()
+	sessionEventAt := wm.sessionLastEventAt
+	lastEventAt := wm.lastEventTime
+	wm.mu.Unlock()
+
+	if sessionEventAt.IsZero() {
+		t.Fatal("sessionLastEventAt should be set after verified event")
+	}
+	if lastEventAt.IsZero() {
+		t.Fatal("lastEventTime should be set after verified event")
+	}
+
+	// Simulate subprocess restart — supervise() resets lastEventTime but not sessionLastEventAt.
+	wm.mu.Lock()
+	wm.state = WebhookStreamStartingUp
+	wm.startupTime = time.Now()
+	wm.lastEventTime = time.Time{}
+	wm.mu.Unlock()
+
+	wm.mu.Lock()
+	sessionEventAfterRestart := wm.sessionLastEventAt
+	lastEventAfterRestart := wm.lastEventTime
+	wm.mu.Unlock()
+
+	if sessionEventAfterRestart.IsZero() {
+		t.Error("sessionLastEventAt was reset on subprocess restart — should persist across restarts")
+	}
+	if !sessionEventAfterRestart.Equal(sessionEventAt) {
+		t.Errorf("sessionLastEventAt changed on restart: was %v, now %v", sessionEventAt, sessionEventAfterRestart)
+	}
+	if !lastEventAfterRestart.IsZero() {
+		t.Error("lastEventTime should be zero after restart simulation")
+	}
+}
+
+// TestSessionFirstStartAt_SetOnce verifies sessionFirstStartAt is set on first subprocess
+// start and not overwritten on subsequent starts.
+func TestSessionFirstStartAt_SetOnce(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+
+	wm.mu.Lock()
+	if !wm.sessionFirstStartAt.IsZero() {
+		t.Fatal("sessionFirstStartAt should start as zero")
+	}
+	wm.mu.Unlock()
+
+	// Simulate first subprocess start (mirrors supervise() logic).
+	firstStartTime := time.Now()
+	wm.mu.Lock()
+	wm.startupTime = firstStartTime
+	wm.lastEventTime = time.Time{}
+	if wm.sessionFirstStartAt.IsZero() {
+		wm.sessionFirstStartAt = wm.startupTime
+	}
+	wm.mu.Unlock()
+
+	wm.mu.Lock()
+	firstAt := wm.sessionFirstStartAt
+	wm.mu.Unlock()
+
+	if firstAt.IsZero() {
+		t.Fatal("sessionFirstStartAt should be set after first subprocess start")
+	}
+
+	// Simulate second subprocess start.
+	time.Sleep(time.Millisecond)
+	wm.mu.Lock()
+	wm.startupTime = time.Now()
+	wm.lastEventTime = time.Time{}
+	if wm.sessionFirstStartAt.IsZero() {
+		wm.sessionFirstStartAt = wm.startupTime
+	}
+	wm.mu.Unlock()
+
+	wm.mu.Lock()
+	secondAt := wm.sessionFirstStartAt
+	wm.mu.Unlock()
+
+	if !secondAt.Equal(firstAt) {
+		t.Errorf("sessionFirstStartAt changed on second subprocess start: was %v, now %v", firstAt, secondAt)
+	}
+}
+
+// TestHealthTransition_StartingUp_UsesSessionFirstStartAt verifies that the
+// StartingUp→Unhealthy transition uses sessionFirstStartAt (not startupTime),
+// confirming the Bug B fix: subprocess restarts no longer reset the health timer.
+func TestHealthTransition_StartingUp_UsesSessionFirstStartAt(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	wm.mu.Lock()
+	wm.state = WebhookStreamStartingUp
+	// Set startupTime far in the past — old code would have triggered Unhealthy.
+	wm.startupTime = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
+	// sessionFirstStartAt is recent — should NOT trigger Unhealthy.
+	wm.sessionFirstStartAt = time.Now()
+	wm.mu.Unlock()
+
+	wm.checkHealthTransitions()
+
+	wm.mu.Lock()
+	state := wm.state
+	wm.mu.Unlock()
+	if state == WebhookStreamUnhealthy {
+		t.Error("state should NOT be Unhealthy when only startupTime is old but sessionFirstStartAt is recent — the fix uses sessionFirstStartAt")
+	}
+}
+
+// TestHealthTransition_SessionStale60s verifies that stale sessionLastEventAt
+// triggers Unhealthy faster than the 10-minute webhookHealthWindow — both from
+// StartingUp and Healthy states.
+func TestHealthTransition_SessionStale60s(t *testing.T) {
+	t.Run("stale sessionLastEventAt triggers unhealthy from StartingUp", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamStartingUp
+		wm.startupTime = time.Now()
+		wm.sessionFirstStartAt = time.Now()
+		wm.sessionLastEventAt = time.Now().Add(-(webhookEventStaleTimeout + time.Second))
+		wm.mu.Unlock()
+
+		wm.checkHealthTransitions()
+
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamUnhealthy {
+			t.Errorf("state = %q, want %q when sessionLastEventAt is stale (StartingUp)", state, WebhookStreamUnhealthy)
+		}
+	})
+
+	t.Run("stale sessionLastEventAt triggers unhealthy from Healthy", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamHealthy
+		wm.lastEventTime = time.Now().Add(-1 * time.Minute) // within 10-min window
+		wm.sessionLastEventAt = time.Now().Add(-(webhookEventStaleTimeout + time.Second))
+		wm.mu.Unlock()
+
+		wm.checkHealthTransitions()
+
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamUnhealthy {
+			t.Errorf("state = %q, want %q when sessionLastEventAt is stale (Healthy)", state, WebhookStreamUnhealthy)
+		}
+	})
+
+	t.Run("fresh sessionLastEventAt keeps Healthy state", func(t *testing.T) {
+		wm, _ := newTestWebhookManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamHealthy
+		wm.lastEventTime = time.Now().Add(-1 * time.Minute) // within 10-min window
+		wm.sessionLastEventAt = time.Now().Add(-10 * time.Second) // fresh (< 60s)
+		wm.mu.Unlock()
+
+		wm.checkHealthTransitions()
+
+		wm.mu.Lock()
+		state := wm.state
+		wm.mu.Unlock()
+		if state != WebhookStreamHealthy {
+			t.Errorf("state = %q, want %q when sessionLastEventAt is fresh", state, WebhookStreamHealthy)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- **Bug A**: HTTP 422 errors from `gh webhook forward` caused an unbounded restart loop with no operator signal. Added a circuit-breaker that detects 3 consecutive per-repo 422 quick-exits, disables the webhook manager, logs a loud warning, and pauses the cache.
- **Bug B**: Every subprocess restart reset `startupTime` and `lastEventTime`, preventing the health monitor's grace+window timer from firing during a tight restart loop. Added `sessionFirstStartAt` (set once) and `sessionLastEventAt` (updated on every verified event, never reset on restart) so the health monitor correctly transitions to Unhealthy even during a crash loop.

## Key Changes

**`engine/webhook.go`**:
- `is422ShapedError()` helper — detects HTTP 422 in stderr (follows `isAuthShapedError()` pattern)
- `permanentFailureCount` field + circuit-breaker logic in `supervise()` — 3 consecutive per-repo 422 quick-exits → `disabled = true`, `healthChangeFn(false)`, return
- `sessionFirstStartAt` / `sessionLastEventAt` — never-reset fields for cross-restart health tracking
- `checkHealthTransitions()` updated to use `sessionFirstStartAt` for StartingUp→Unhealthy timer; added 60s `sessionLastEventAt` stale check to both StartingUp and Healthy cases
- `handleWebhook()` sets `sessionLastEventAt` alongside `lastEventTime`
- `IsDisabled()` method for poll.go to query manager state
- `startSubprocessFn` / `probeTimeout` injection fields for unit testing

**`engine/poll.go`**:
- Log `"[webhook] poll-only mode active — webhook subscription disabled; restart Fabrik to retry"` each poll cycle when `IsDisabled()`

**`engine/webhook_test.go`**:
- `TestIs422ShapedError` — table-driven helper test
- `TestCircuitBreaker422` — 3 subtests via `startSubprocessFn` injection: 3×422→disabled, non-422 no-increment, durable-run resets counter
- `TestIsDisabled` — method coverage
- `TestSessionLastEventAt_NotResetOnRestart` / `TestSessionFirstStartAt_SetOnce` — field lifecycle tests
- `TestHealthTransition_StartingUp_UsesSessionFirstStartAt` — confirms the Bug B fix (old startupTime-only logic would have incorrectly NOT triggered Unhealthy)
- `TestHealthTransition_SessionStale60s` — 60s stale check from both StartingUp and Healthy
- Updated `TestHealthStateTransitions` to use `sessionFirstStartAt` (required by the fix)

## How to Test

1. Trigger a 422 loop (exhaust webhook quota or revoke token): confirm Fabrik logs the WARNING and stops restarting after 3 failures
2. Restart Fabrik: circuit-breaker resets automatically (no persistent state)
3. Run `go test ./engine/... -race -timeout 300s` — all pass

Closes #628