### PR TITLE
fabrik: mutation echo-check for fast webhook failure detection (Plan B)

### DIFF
--- a/adrs/042-mutation-echo-check.md
+++ b/adrs/042-mutation-echo-check.md
@@ -1,0 +1,91 @@
+# ADR 042: Mutation Echo-Check for Webhook Health Detection
+
+## Status
+
+Accepted
+
+## Context
+
+Fabrik's webhook-based board cache can enter a silent failure mode where GitHub webhooks stop arriving but Fabrik continues operating on stale cached state. The existing time-based health monitor (`webhookHealthWindow` = 10 min, `webhookEventStaleTimeout` = 5 min) only detects this after several minutes of silence.
+
+During an active pipeline run, Fabrik issues many GitHub mutations (label adds/removes, comment posts, PR creates, status updates). Each successful mutation should produce a corresponding webhook event within a few seconds under normal conditions. If multiple expected echoes fail to arrive, the webhook stream has almost certainly failed.
+
+This ADR documents the design of the mutation echo-check (Plan B) that detects silent stream failures within seconds during active mutation periods. It complements the slow-cadence periodic reconcile (Plan A, ADR 036) which catches failures during quiet periods.
+
+## Decision
+
+Add an echo-check subsystem to `webhookManager` that:
+
+1. Records a pending entry in `pendingEchoes` for each successful tracked mutation.
+2. Clears the entry when the corresponding inbound webhook arrives via `MatchEcho`.
+3. A background sweep goroutine runs every 5 seconds and counts unmatched entries older than `webhookEchoTimeout` (15s) as misses.
+4. When K = 3 misses accumulate within a rolling W = 60s window, `healthChangeFn(false)` is called — the same path used by the existing time-based health checks.
+
+## Key Design Choices
+
+### Self-signal via Fabrik's own mutations
+
+Using Fabrik's own mutations as the health signal is sound because: (a) under a healthy webhook stream, Fabrik's mutations reliably produce webhook events (documented in ADR 032 §Self-feedback); (b) the K=3 threshold in a 60s window provides substantial margin against transient GitHub delivery lag (~2–10s typical, 15s cap); (c) the signal volume is highest exactly when false negatives are most costly (active pipeline runs).
+
+### Rolling-window miss threshold (not consecutive)
+
+A rolling time window is used instead of "K consecutive misses" because Fabrik issues many concurrent mutations for different issues. The "consecutive" semantics break down when mutations are interleaved — e.g., an echo from issue A arrives between misses from issue B. Rolling-window misses are well-defined regardless of interleaving.
+
+**Implementation:** Append each miss's timestamp to `missHistory`. On each append, prune entries older than `now - W`. If `len(missHistory) >= K`, fire. Successful `MatchEcho` calls remove the specific `pendingEchoes` entry before the sweep can count it as a miss; they do NOT retroactively remove past miss timestamps. Past misses age out of the rolling window naturally.
+
+### `matchEchoFn` injection to avoid circular import
+
+`boardcache` cannot import `engine` (engine → boardcache is the existing direction). `MatchEcho` is wired into `CacheImpl` via a `matchEchoFn func(string, string, string)` function field set from `poll.go` after `webhookManager` is constructed. This is the same dependency-injection pattern established in ADR 036.
+
+### Suppression during startup
+
+Echo registration and sweep are no-ops while the webhook manager is in `WebhookStreamStartingUp` state. Mutations during the startup grace period have no expected echo because the webhook subscription may not yet be established.
+
+### `missHistory` cleared on recovery
+
+When any verified inbound webhook event flips the stream back to `Healthy`, `missHistory` is cleared in the same `wm.mu` lock block. Without this, stale miss timestamps from before the recovery could immediately re-trigger the threshold after a brief recovery.
+
+### `projects_v2_item` conditional (R7)
+
+`UpdateProjectItemStatus` mutations are excluded from echo registration when `projects_v2_item` is not in `wm.events` at registration time. The `wm.events` slice is mutated by the subprocess stderr handler goroutine when GitHub rejects the event type, so the check must be done under `wm.mu`. This is handled by `RegisterEchoIfSubscribed`, which atomically checks event subscription and registers.
+
+## Constants
+
+All three constants are defined as package-level `var` (not `const`) in `engine/webhook.go` so tests can override them without real tickers:
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `webhookEchoTimeout` | 15s | GitHub typical delivery < 2s, up to 10s under load; 5s margin |
+| `webhookEchoMissThreshold` | 3 | Three independent misses is far past statistical fluke |
+| `webhookEchoWindow` | 60s | Covers a stage's mutation burst; old misses age out within a minute |
+
+## Tracked Mutations
+
+| Mutation | Expected event | Action | Key format |
+|----------|---------------|--------|------------|
+| `AddLabelToIssue` | `issues` | `labeled` | `owner/repo#N+labelName` |
+| `RemoveLabelFromIssue` | `issues` | `unlabeled` | `owner/repo#N+labelName` |
+| `AddComment` | `issue_comment` | `created` | `owner/repo#N` |
+| `UpdateIssueBody` | `issues` | `edited` | `owner/repo#N` |
+| `CreateDraftPR` | `pull_request` | `opened` | `owner/repo#pr<prNum>` |
+| `MarkPRReady` | `pull_request` | `ready_for_review` | `owner/repo#pr<prNum>` |
+| `MergePR` | `pull_request` | `closed` | `owner/repo#pr<prNum>` |
+| `UpdateProjectItemStatus` | `projects_v2_item` | `edited` | `itemID` (R7 conditional) |
+
+## Consequences
+
+**Benefits:**
+- Silent webhook stream failures detected within seconds during active pipeline runs (previously took up to 10 minutes).
+- Complements Plan A (reconcile loop) for full coverage: Plan B is fast during active periods, Plan A is the safety net during quiet periods.
+- No new external dependencies; entirely in-memory state.
+
+**Drawbacks / risks:**
+- False positives under sustained GitHub webhook delivery lag > 15s (rare but possible under infrastructure stress). K=3 threshold mitigates but does not eliminate.
+- ~25 call sites across 5 engine files must be kept in sync as new mutation APIs are added. Missing a call site leaves a mutation type unmonitored.
+- Composite map key `eventType:action:key` uses last-write-wins for concurrent mutations to the same entity. Earlier entries may be overwritten; acceptable since the goal is stream-failure detection, not per-mutation tracking.
+
+## Related ADRs
+
+- [ADR-032: Webhook-Driven Event Delivery](032-webhook-event-delivery.md) — foundational webhook architecture; §Self-feedback loop establishes that Fabrik's own mutations produce webhook events.
+- [ADR-034: BoardCache Event-Sourced Delta](034-boardcache-event-sourced-delta.md) — defines `ApplyDelta` as the entry point where `MatchEcho` is called.
+- [ADR-036: Reactive Cache Single Owner](036-reactive-cache-single-owner.md) — establishes the `matchEchoFn` dependency-injection pattern.

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -204,8 +204,15 @@ type CacheImpl struct {
 	// store owns per-item state (items, shaToKey, itemIDToKey, prToKey, pendingCheckRuns).
 	store *itemstate.Store
 
-	fallback ReadClient
-	logFn    func(format string, args ...any)
+	fallback     ReadClient
+	logFn        func(format string, args ...any)
+	matchEchoFn  func(eventType, action, key string) // injected by engine; nil when cache disabled
+}
+
+// SetMatchEchoFn injects the MatchEcho function from the webhook manager.
+// Called once at startup in poll.go after the webhookManager is constructed.
+func (c *CacheImpl) SetMatchEchoFn(fn func(eventType, action, key string)) {
+	c.matchEchoFn = fn
 }
 
 // NewCacheImpl creates an empty cache backed by fallback for misses.

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -263,6 +263,10 @@ func (c *CacheImpl) applyIssueCommentDelta(payload []byte) {
 	issNum := p.Issue.Number
 	key := itemKey(fullRepo, issNum)
 
+	if c.matchEchoFn != nil {
+		c.matchEchoFn("issue_comment", "created", key)
+	}
+
 	createdAt, _ := time.Parse(time.RFC3339, p.Comment.CreatedAt)
 	comment := gh.Comment{
 		ID:         p.Comment.NodeID,
@@ -356,6 +360,9 @@ func (c *CacheImpl) applyIssuesDelta(payload []byte) {
 		c.store.Remove(fullRepo, issNum)
 
 	case "edited":
+		if c.matchEchoFn != nil {
+			c.matchEchoFn("issues", "edited", key)
+		}
 		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
 			c.logFn("[cache] applyIssuesDelta(edited): ensure #%d: %v\n", issNum, err)
 			return
@@ -391,6 +398,9 @@ func (c *CacheImpl) applyIssuesDelta(payload []byte) {
 		c.bumpLocalDeltaAt(key)
 
 	case "labeled":
+		if c.matchEchoFn != nil {
+			c.matchEchoFn("issues", "labeled", key+"+"+p.Label.Name)
+		}
 		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
 			c.logFn("[cache] applyIssuesDelta(labeled): ensure #%d: %v\n", issNum, err)
 			return
@@ -406,6 +416,9 @@ func (c *CacheImpl) applyIssuesDelta(payload []byte) {
 		c.bumpLocalDeltaAt(key)
 
 	case "unlabeled":
+		if c.matchEchoFn != nil {
+			c.matchEchoFn("issues", "unlabeled", key+"+"+p.Label.Name)
+		}
 		if err := c.ensureIssueInStore(owner, fullRepo, issNum); err != nil {
 			c.logFn("[cache] applyIssuesDelta(unlabeled): ensure #%d: %v\n", issNum, err)
 			return
@@ -439,6 +452,9 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		// SHA-tracking path — handled after this switch.
 
 	case "ready_for_review":
+		if c.matchEchoFn != nil {
+			c.matchEchoFn("pull_request", "ready_for_review", prKey(repo, prNum))
+		}
 		// Look up linked issue via Store's prToKey index (no c.mu held).
 		// Requires PR linkage to be established first via PRHeadSHAUpdated.
 		issKey, issFound := c.store.GetByPRKey(repo, prNum)
@@ -547,6 +563,10 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	}
 
 	// --- SHA-tracking path (opened, closed, synchronize, reopened) ---
+	// Echo-match for opened and closed PR mutations (synchronize/reopened are not tracked).
+	if c.matchEchoFn != nil && (p.Action == "opened" || p.Action == "closed") {
+		c.matchEchoFn("pull_request", p.Action, prKey(repo, prNum))
+	}
 	sha := p.PullRequest.Head.SHA
 
 	owner, repoName, ok := splitRepo(repo)
@@ -996,6 +1016,9 @@ func (c *CacheImpl) applyProjectsV2ItemDelta(payload []byte) {
 		c.bumpLocalDeltaAt(itemKey(pi.Repo, pi.Number))
 
 	case "edited":
+		if c.matchEchoFn != nil {
+			c.matchEchoFn("projects_v2_item", "edited", p.ProjectsV2Item.ID)
+		}
 		if p.Changes.FieldValue.FieldType != "single_select" {
 			return
 		}

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3089,6 +3089,20 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 - `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
 - `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace and waits for a new first event.
 
+**Mutation echo-check (Plan B fast failure detection).** In addition to the time-based health transitions above, the engine detects silent webhook stream failures within seconds during active mutation periods via an echo-check mechanism (`pendingEchoes`, `missHistory`, and `doEchoSweep` in `engine/webhook.go`):
+
+- **Registration:** After each successful tracked mutation (`AddLabelToIssue`, `RemoveLabelFromIssue`, `AddComment`, `UpdateIssueBody`, `CreateDraftPR`, `MarkPRReady`, `MergePR`, `UpdateProjectItemStatus`), the engine records a `(eventType, action, discriminatingKey, timestamp)` entry in `pendingEchoes`. Registration is suppressed during `WebhookStreamStartingUp` and when the board cache is disabled (`healthChangeFn == nil`). `UpdateProjectItemStatus` is additionally suppressed when `projects_v2_item` is not in the current `wm.events` subscription set (R7 conditional).
+
+- **Matching:** `CacheImpl.ApplyDelta` calls `wm.MatchEcho(eventType, action, key)` for each incoming webhook event before applying the delta to the store. A match removes the corresponding `pendingEchoes` entry, preventing it from counting as a miss.
+
+- **Sweep:** A background goroutine (started alongside `runHealthMonitor` in `webhookManager.Start()`) calls `doEchoSweep()` every 5 seconds. Entries in `pendingEchoes` older than `webhookEchoTimeout` (15s) with no match are echo misses — removed from `pendingEchoes` and their timestamp appended to `missHistory`.
+
+- **Rolling-window threshold:** On each miss append, `missHistory` entries older than `webhookEchoWindow` (60s) are pruned. If `len(missHistory) >= webhookEchoMissThreshold` (3), `healthChangeFn(false)` is called and `missHistory` is cleared to prevent repeated firing. Named constants (overridable in tests): `webhookEchoTimeout = 15s`, `webhookEchoMissThreshold = 3`, `webhookEchoWindow = 60s`.
+
+- **Recovery:** Any verified inbound webhook event arriving at `handleWebhook` transitions the stream back to `Healthy` via the existing recovery path. `missHistory` is cleared in the same lock block to prevent stale miss counts from immediately re-triggering the threshold after recovery.
+
+- **Design rationale:** [ADR-042: Mutation Echo-Check for Webhook Health Detection](../adrs/042-mutation-echo-check.md)
+
 **Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
 
 **References:** [ADR-032: Webhook-Driven Event Delivery](../adrs/032-webhook-event-delivery.md)

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1062,6 +1062,20 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 - `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
 - `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace and waits for a new first event.
 
+**Mutation echo-check (Plan B fast failure detection).** In addition to the time-based health transitions above, the engine detects silent webhook stream failures within seconds during active mutation periods via an echo-check mechanism (`pendingEchoes`, `missHistory`, and `doEchoSweep` in `engine/webhook.go`):
+
+- **Registration:** After each successful tracked mutation (`AddLabelToIssue`, `RemoveLabelFromIssue`, `AddComment`, `UpdateIssueBody`, `CreateDraftPR`, `MarkPRReady`, `MergePR`, `UpdateProjectItemStatus`), the engine records a `(eventType, action, discriminatingKey, timestamp)` entry in `pendingEchoes`. Registration is suppressed during `WebhookStreamStartingUp` and when the board cache is disabled (`healthChangeFn == nil`). `UpdateProjectItemStatus` is additionally suppressed when `projects_v2_item` is not in the current `wm.events` subscription set (R7 conditional).
+
+- **Matching:** `CacheImpl.ApplyDelta` calls `wm.MatchEcho(eventType, action, key)` for each incoming webhook event before applying the delta to the store. A match removes the corresponding `pendingEchoes` entry, preventing it from counting as a miss.
+
+- **Sweep:** A background goroutine (started alongside `runHealthMonitor` in `webhookManager.Start()`) calls `doEchoSweep()` every 5 seconds. Entries in `pendingEchoes` older than `webhookEchoTimeout` (15s) with no match are echo misses — removed from `pendingEchoes` and their timestamp appended to `missHistory`.
+
+- **Rolling-window threshold:** On each miss append, `missHistory` entries older than `webhookEchoWindow` (60s) are pruned. If `len(missHistory) >= webhookEchoMissThreshold` (3), `healthChangeFn(false)` is called and `missHistory` is cleared to prevent repeated firing. Named constants (overridable in tests): `webhookEchoTimeout = 15s`, `webhookEchoMissThreshold = 3`, `webhookEchoWindow = 60s`.
+
+- **Recovery:** Any verified inbound webhook event arriving at `handleWebhook` transitions the stream back to `Healthy` via the existing recovery path. `missHistory` is cleared in the same lock block to prevent stale miss counts from immediately re-triggering the threshold after recovery.
+
+- **Design rationale:** [ADR-042: Mutation Echo-Check for Webhook Health Detection](../adrs/042-mutation-echo-check.md)
+
 **Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
 
 **References:** [ADR-032: Webhook-Driven Event Delivery](../adrs/032-webhook-event-delivery.md)

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -249,6 +249,8 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		// no write-through: excluded — issue body is not read from cache for dispatch decisions
 		if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
 			e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
+		} else if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(item.Repo, item.Number))
 		}
 		output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 	}
@@ -275,6 +277,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 					})
 				}
+				if e.webhookMgr != nil {
+					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+				}
 				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
@@ -296,6 +301,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 						cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
 							DatabaseID: dbID, Body: stageComment, Author: e.cfg.User, CreatedAt: time.Now(),
 						})
+					}
+					if e.webhookMgr != nil {
+						e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
 					}
 					// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 					if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -119,7 +119,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:editing")
 		}
 		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:editing")
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:editing")
 		}
 	}
 
@@ -255,7 +255,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
 			e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
 		} else if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(item.Repo, item.Number))
+			e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, item.Number))
 		}
 		output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 	}
@@ -283,7 +283,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 					})
 				}
 				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 				}
 				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -308,7 +308,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 						})
 					}
 					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+						e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 					}
 					// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 					if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -114,8 +114,13 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	// Step 2: Add editing label
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:editing"); err != nil {
 		return fmt.Errorf("adding editing label: %w", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:editing")
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:editing")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:editing")
+		}
 	}
 
 	// Step 3: Ensure worktree
@@ -331,6 +336,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			if _, err := e.client.AddComment(owner, repo, prNumber, prComment); err != nil {
 				e.logf(item.Number, "warn", "could not post review feedback summary to PR #%d: %v\n", prNumber, err)
 			} else {
+				if e.webhookMgr != nil {
+					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, prNumber))
+				}
 				e.logf(item.Number, "post", "review feedback summary posted to PR #%d (%d thread(s))\n", prNumber, len(threads))
 			}
 		} else {

--- a/engine/item.go
+++ b/engine/item.go
@@ -547,6 +547,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
 		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+lockLabel)
+		}
 		workerDone = make(chan struct{})
 		e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
 	}
@@ -630,6 +633,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		inProgressAdded = true
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), inProgressLabel)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+inProgressLabel)
 		}
 	}
 
@@ -987,8 +993,13 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+		}
 	}
 
 	e.addFailedLabel(owner, repo, item.Number, stage.Name)
@@ -1049,13 +1060,23 @@ func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+		}
 	}
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 		e.logf(item.Number, "warn", "could not add awaiting-input label: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
+		}
 	}
 }
 
@@ -1073,6 +1094,9 @@ func (e *Engine) unblockAwaitingInput(item gh.ProjectItem, stage *stages.Stage) 
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+		}
 	}
 	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil &&
 		!errors.Is(err, gh.ErrNotFound) {
@@ -1080,6 +1104,9 @@ func (e *Engine) unblockAwaitingInput(item gh.ProjectItem, stage *stages.Stage) 
 	} else if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
 		}
 	}
 
@@ -1275,6 +1302,9 @@ func (e *Engine) removeLockLabel(owner, repo string, issueNumber int, label stri
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
 		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
+		}
 	}
 }
 
@@ -1287,6 +1317,9 @@ func (e *Engine) removeInProgressLabel(owner, repo string, issueNumber int, stag
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
 		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
+		}
 	}
 }
 
@@ -1294,8 +1327,13 @@ func (e *Engine) addFailedLabel(owner, repo string, issueNumber int, stageName s
 	label := fmt.Sprintf("stage:%s:failed", stageName)
 	if err := e.client.AddLabelToIssue(owner, repo, issueNumber, label); err != nil {
 		e.logf(issueNumber, "warn", "could not add failed label: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
+		}
 	}
 }
 
@@ -1307,6 +1345,9 @@ func (e *Engine) removeFailedLabel(owner, repo string, issueNumber int, stageNam
 	} else if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
 		}
 	}
 }

--- a/engine/item.go
+++ b/engine/item.go
@@ -425,7 +425,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 			}
 			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
 			}
 		}
 
@@ -443,7 +443,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:extend-turns")
 			}
 			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:extend-turns")
+				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:extend-turns")
 			}
 		}
 
@@ -853,7 +853,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 					})
 				}
 				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 				}
 				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -908,7 +908,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				})
 			}
 			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, dbID, "rocket"); reactErr != nil {
@@ -1036,7 +1036,7 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 			})
 		}
 		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 		}
 		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -1064,7 +1064,7 @@ func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), failedLabel)
 		}
 		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+failedLabel)
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+failedLabel)
 		}
 	}
 
@@ -1256,7 +1256,7 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 				})
 			}
 			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {

--- a/engine/item.go
+++ b/engine/item.go
@@ -349,6 +349,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 					}
+					if e.webhookMgr != nil {
+						e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+					}
 				}
 				// Also clear any failed label so the stage retries cleanly
 				e.clearFailedStage(item, stage)
@@ -417,8 +420,13 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 			e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+			}
 		}
 
 		// Remove fabrik:extend-turns at cleanup (Done) stage — this is the designated
@@ -433,6 +441,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		} else if removeErr == nil {
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:extend-turns")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:extend-turns")
 			}
 		}
 
@@ -798,6 +809,8 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			// no write-through: excluded — issue body is not read from cache for dispatch decisions
 			if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
 				e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
+			} else if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, item.Number))
 			}
 			output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 		}
@@ -838,6 +851,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
 						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 					})
+				}
+				if e.webhookMgr != nil {
+					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
 				}
 				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -890,6 +906,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
 					DatabaseID: dbID, Body: warnComment, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
 			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, dbID, "rocket"); reactErr != nil {
@@ -1016,6 +1035,9 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 			})
 		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+		}
 		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
@@ -1040,6 +1062,9 @@ func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	} else if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), failedLabel)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+failedLabel)
 		}
 	}
 
@@ -1230,6 +1255,9 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 					DatabaseID: dbID, Body: body, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
@@ -1271,6 +1299,9 @@ func (e *Engine) removeEditingLabel(owner, repo string, issueNumber int) {
 		if err == nil {
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:editing")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+"fabrik:editing")
 			}
 			return
 		}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -391,6 +391,10 @@ func (e *Engine) Run() error {
 			deltaFn,
 			healthChangeFn,
 		)
+		// Inject MatchEcho so ApplyDelta can clear pending echo entries on incoming webhooks.
+		if cacheImpl != nil {
+			cacheImpl.SetMatchEchoFn(wm.MatchEcho)
+		}
 		// Bootstrap the cache before accepting webhook events so no delta is
 		// dropped into an empty cache during the startup window.
 		if cacheImpl != nil {

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -58,6 +58,9 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) int {
 	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 		cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
 	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("pull_request", "opened", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNum))
+	}
 	return prNum
 }
 
@@ -217,6 +220,9 @@ func (e *Engine) markPRReady(item gh.ProjectItem, knownPR int) {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		err := e.client.MarkPRReady(owner, repo, prNumber)
 		if err == nil {
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("pull_request", "ready_for_review", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNumber))
+			}
 			e.logf(item.Number, "pr", "marked PR #%d ready-for-review\n", prNumber)
 			return
 		}

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -283,7 +283,7 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 				})
 			}
 			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -303,7 +303,7 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 				})
 			}
 			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -146,6 +146,9 @@ func (e *Engine) updatePRVerification(item gh.ProjectItem, prNumber int, summary
 		e.logf(item.Number, "warn", "could not update PR #%d Verification section: %v\n", prNumber, err)
 		return
 	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, prNumber))
+	}
 	e.logf(item.Number, "pr", "updated PR #%d Verification section\n", prNumber)
 }
 
@@ -171,6 +174,9 @@ func (e *Engine) ensurePRLinksIssue(item gh.ProjectItem, prNumber int) {
 			e.logf(item.Number, "warn", "could not update PR #%d body to close fence: %v\n", prNumber, err)
 			return
 		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, prNumber))
+		}
 		e.logf(item.Number, "pr", "balanced unclosed code fence in PR #%d body\n", prNumber)
 	}
 
@@ -184,6 +190,9 @@ func (e *Engine) ensurePRLinksIssue(item gh.ProjectItem, prNumber int) {
 	if err := e.client.UpdateIssueBody(owner, repo, prNumber, updatedBody); err != nil {
 		e.logf(item.Number, "warn", "could not update PR #%d body: %v\n", prNumber, err)
 		return
+	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, prNumber))
 	}
 	e.logf(item.Number, "pr", "added '%s' to PR #%d body\n", closingKeyword, prNumber)
 }
@@ -253,6 +262,9 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 		if dbID, err := e.client.AddComment(owner, repo, prNumber, comment); err != nil {
 			e.logf(item.Number, "warn", "could not post to PR #%d: %v\n", prNumber, err)
 		} else {
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, prNumber))
+			}
 			e.logf(item.Number, "post", "detailed %s output posted to PR #%d\n", stageName, prNumber)
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -270,6 +282,9 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 					DatabaseID: dbID, Body: summary, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
@@ -286,6 +301,9 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
 					DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
 			}
 			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -97,7 +97,7 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 					}
 					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
 					}
 				}
 				e.logf(item.Number, "rebase-reinvoke", "PR merge deferred — rebase dispatched\n")
@@ -129,7 +129,7 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 				}
 				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-ci")
+					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-ci")
 				}
 			}
 		}
@@ -148,7 +148,7 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 		}
 		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
 		}
 	}
 
@@ -190,7 +190,7 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 					}
 					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-review")
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-review")
 					}
 				}
 				e.logf(item.Number, "awaiting-review", "waiting for PR reviewers before advancing\n")
@@ -293,7 +293,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 					}
 					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-ci")
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-ci")
 					}
 				}
 				// Clean up pending timer since we now have a definitive failure state.
@@ -341,7 +341,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 							})
 						}
 						if e.webhookMgr != nil {
-							e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+							e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 						}
 						// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 						if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
@@ -355,7 +355,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 							cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
 						}
 						if e.webhookMgr != nil {
-							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:paused")
+							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
 						}
 					}
 					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); lerr != nil {
@@ -365,7 +365,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 							cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 						}
 						if e.webhookMgr != nil {
-							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-input")
+							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
 						}
 					}
 					return fmt.Errorf("merge guard: CI wait timeout elapsed after %s", timeout)
@@ -399,7 +399,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
 					}
 					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:rebase-needed")
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:rebase-needed")
 					}
 				}
 			}
@@ -454,7 +454,7 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 		}
 		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
 		}
 	}
 

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -92,8 +92,13 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 				completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); lerr != nil {
 					e.logf(item.Number, "warn", "could not add completion label: %v\n", lerr)
-				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+				} else {
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+					}
+					if e.webhookMgr != nil {
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+					}
 				}
 				e.logf(item.Number, "rebase-reinvoke", "PR merge deferred — rebase dispatched\n")
 			} else {
@@ -133,8 +138,13 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+		}
 	}
 
 	// fabrik:yolo or fabrik:cruise label overrides stage.AutoAdvance — if the user
@@ -385,6 +395,9 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 		return fmt.Errorf("auto-merge failed: %w", err)
 	}
 
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("pull_request", "closed", fmt.Sprintf("%s/%s#pr%d", owner, repo, pr.Number))
+	}
 	e.removeRebaseNeededLabel(owner, repo, item)
 	e.logf(item.Number, "info", "auto-merged PR #%d\n", pr.Number)
 	return nil
@@ -403,8 +416,13 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+completeLabel)
+		}
 	}
 
 	if e.statusField == nil {
@@ -426,6 +444,9 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Done")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 		}
 	}
 }
@@ -453,6 +474,9 @@ func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem,
 	if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), next.Name)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 		}
 	}
 	return err

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -124,8 +124,13 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 		if !alreadyAwaitingCI {
 			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
 				e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+			} else {
+				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+				}
+				if e.webhookMgr != nil {
+					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-ci")
+				}
 			}
 		}
 		// fabrik:awaiting-review is NOT seeded here when wait_for_ci: true.
@@ -180,8 +185,13 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 			if !alreadyWaiting {
 				if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:awaiting-review label: %v\n", err)
-				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
+				} else {
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
+					}
+					if e.webhookMgr != nil {
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-review")
+					}
 				}
 				e.logf(item.Number, "awaiting-review", "waiting for PR reviewers before advancing\n")
 			}
@@ -278,8 +288,13 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 				e.logf(item.Number, "ci-gate", "merge blocked — CI failed: %s\n", strings.Join(names, ", "))
 				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); lerr != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci: %v\n", lerr)
-				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+				} else {
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+					}
+					if e.webhookMgr != nil {
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-ci")
+					}
 				}
 				// Clean up pending timer since we now have a definitive failure state.
 				e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
@@ -325,6 +340,9 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 								DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
 							})
 						}
+						if e.webhookMgr != nil {
+							e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(item.Repo, item.Number))
+						}
 						// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
 						if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
 							e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
@@ -332,13 +350,23 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 					}
 					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); lerr != nil {
 						e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", lerr)
-					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+					} else {
+						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+							cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+						}
+						if e.webhookMgr != nil {
+							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:paused")
+						}
 					}
 					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); lerr != nil {
 						e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", lerr)
-					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+					} else {
+						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+							cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+						}
+						if e.webhookMgr != nil {
+							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:awaiting-input")
+						}
 					}
 					return fmt.Errorf("merge guard: CI wait timeout elapsed after %s", timeout)
 				}
@@ -366,8 +394,13 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 			if !alreadyLabeled {
 				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); lerr != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", lerr)
-				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
+				} else {
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
+					}
+					if e.webhookMgr != nil {
+						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(item.Repo, item.Number)+"+"+"fabrik:rebase-needed")
+					}
 				}
 			}
 			// Store Worker field is the semantic source of truth for in-flight state.

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -951,8 +951,9 @@ func echoKey(eventType, action, key string) string {
 }
 
 // RegisterEcho records a pending echo entry for a successful outgoing mutation.
-// No-op when the webhook stream is starting up, board cache is disabled (healthChangeFn == nil),
-// or for projects_v2_item when that event type is not currently subscribed.
+// No-op when the webhook stream is starting up or the board cache is disabled
+// (healthChangeFn == nil). For projects_v2_item conditional registration use
+// RegisterEchoIfSubscribed instead.
 func (wm *webhookManager) RegisterEcho(eventType, action, key string) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
@@ -990,6 +991,12 @@ func (wm *webhookManager) MatchEcho(eventType, action, key string) {
 func (wm *webhookManager) doEchoSweep() {
 	now := time.Now()
 	wm.mu.Lock()
+	// Suppress sweeping during startup: entries registered just before a restart
+	// would fire as false misses during the grace period.
+	if wm.state == WebhookStreamStartingUp {
+		wm.mu.Unlock()
+		return
+	}
 	var newMisses int
 	for k, registeredAt := range wm.pendingEchoes {
 		if now.Sub(registeredAt) >= webhookEchoTimeout {
@@ -1012,6 +1019,8 @@ func (wm *webhookManager) doEchoSweep() {
 	shouldFire := newMisses > 0 && wm.healthChangeFn != nil && len(wm.missHistory) >= webhookEchoMissThreshold
 	if shouldFire {
 		wm.missHistory = wm.missHistory[:0]
+		// Transition to Unhealthy so handleWebhook's recovery path fires on the next event.
+		wm.state = WebhookStreamUnhealthy
 	}
 	wm.mu.Unlock()
 

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -54,6 +54,16 @@ const (
 	webhookPermanentFailureMax = 3
 )
 
+// Echo-check constants — package-level vars (not const) so tests can override them.
+// webhookEchoTimeout: how long to wait for a matching inbound webhook after a mutation.
+// webhookEchoMissThreshold: how many misses within webhookEchoWindow triggers Unhealthy.
+// webhookEchoWindow: rolling time window for miss-history pruning.
+var (
+	webhookEchoTimeout       = 15 * time.Second
+	webhookEchoMissThreshold = 3
+	webhookEchoWindow        = 60 * time.Second
+)
+
 // defaultWebhookEvents is the canonical event list from the spec (R6).
 var defaultWebhookEvents = []string{
 	"issue_comment",
@@ -130,6 +140,12 @@ type webhookManager struct {
 
 	// per-type event counters (protected by mu)
 	eventCounts map[string]int
+
+	// echo-check state (protected by mu)
+	// pendingEchoes maps composite-key → registration timestamp.
+	// missHistory records timestamps of echo misses for rolling-window detection.
+	pendingEchoes map[string]time.Time
+	missHistory   []time.Time
 }
 
 func newWebhookManager(
@@ -160,6 +176,7 @@ func newWebhookManager(
 		unsubscribableRepos: make(map[string]bool),
 		stopCh:             make(chan struct{}),
 		repoReadyCh:        make(chan struct{}),
+		pendingEchoes:      make(map[string]time.Time),
 		killFn: func(cmd *exec.Cmd) {
 			if cmd != nil && cmd.Process != nil {
 				killProcGroup(cmd)
@@ -499,6 +516,7 @@ func (wm *webhookManager) Start(ctx context.Context, port int) error {
 
 	go wm.supervise(ctx)
 	go wm.runHealthMonitor(ctx)
+	go wm.runEchoSweep(ctx)
 
 	wm.logFn(0, "webhook", "webhook listener started on port %d\n", actualPort)
 	return nil
@@ -927,6 +945,97 @@ func (wm *webhookManager) checkHealthTransitions() {
 	wm.mu.Unlock()
 }
 
+// echoKey builds the composite key used in pendingEchoes: "eventType:action:discriminatingKey".
+func echoKey(eventType, action, key string) string {
+	return eventType + ":" + action + ":" + key
+}
+
+// RegisterEcho records a pending echo entry for a successful outgoing mutation.
+// No-op when the webhook stream is starting up, board cache is disabled (healthChangeFn == nil),
+// or for projects_v2_item when that event type is not currently subscribed.
+func (wm *webhookManager) RegisterEcho(eventType, action, key string) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	if wm.state == WebhookStreamStartingUp || wm.healthChangeFn == nil {
+		return
+	}
+	wm.pendingEchoes[echoKey(eventType, action, key)] = time.Now()
+}
+
+// RegisterEchoIfSubscribed registers an echo entry only when eventType is in wm.events.
+// Used for projects_v2_item (R7) where the event may have been dynamically removed.
+func (wm *webhookManager) RegisterEchoIfSubscribed(eventType, action, key string) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	if wm.state == WebhookStreamStartingUp || wm.healthChangeFn == nil {
+		return
+	}
+	if !containsEvent(wm.events, eventType) {
+		return
+	}
+	wm.pendingEchoes[echoKey(eventType, action, key)] = time.Now()
+}
+
+// MatchEcho removes the pending echo entry for an inbound webhook that matched a mutation.
+// Called from CacheImpl.ApplyDelta via the injected matchEchoFn.
+func (wm *webhookManager) MatchEcho(eventType, action, key string) {
+	wm.mu.Lock()
+	delete(wm.pendingEchoes, echoKey(eventType, action, key))
+	wm.mu.Unlock()
+}
+
+// doEchoSweep scans pendingEchoes for stale entries, records misses, and fires
+// healthChangeFn(false) when the rolling-window miss threshold is reached.
+// Safe to call from tests directly (no ticker dependency).
+func (wm *webhookManager) doEchoSweep() {
+	now := time.Now()
+	wm.mu.Lock()
+	var newMisses int
+	for k, registeredAt := range wm.pendingEchoes {
+		if now.Sub(registeredAt) >= webhookEchoTimeout {
+			delete(wm.pendingEchoes, k)
+			wm.missHistory = append(wm.missHistory, registeredAt)
+			newMisses++
+		}
+	}
+	if newMisses > 0 {
+		// Prune miss-history entries older than webhookEchoWindow.
+		cutoff := now.Add(-webhookEchoWindow)
+		live := wm.missHistory[:0]
+		for _, t := range wm.missHistory {
+			if t.After(cutoff) {
+				live = append(live, t)
+			}
+		}
+		wm.missHistory = live
+	}
+	shouldFire := newMisses > 0 && wm.healthChangeFn != nil && len(wm.missHistory) >= webhookEchoMissThreshold
+	if shouldFire {
+		wm.missHistory = wm.missHistory[:0]
+	}
+	wm.mu.Unlock()
+
+	if shouldFire {
+		wm.healthChangeFn(false)
+	}
+}
+
+// runEchoSweep is the goroutine that periodically calls doEchoSweep.
+func (wm *webhookManager) runEchoSweep(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-wm.stopCh:
+			return
+		case <-ticker.C:
+			wm.doEchoSweep()
+		}
+	}
+}
+
 // emitCurrentState emits a WebhookStatusEvent with the current state and event counts.
 func (wm *webhookManager) emitCurrentState() {
 	if wm.emitFn == nil {
@@ -1055,6 +1164,9 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	prevState := wm.state
 	if prevState != WebhookStreamHealthy {
 		wm.state = WebhookStreamHealthy
+		// Clear stale miss history on recovery so old misses don't immediately
+		// re-trigger the echo-miss threshold after stream recovery (R10).
+		wm.missHistory = wm.missHistory[:0]
 	}
 	now := time.Now()
 	wm.lastEventTime = now

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -1153,6 +1153,231 @@ func TestHealthTransition_StartingUp_SkipsGraceWindowWhenEventsReceived(t *testi
 	}
 }
 
+// TestEchoCheck covers the mutation echo-check subsystem (R12a–R12g).
+// Tests call doEchoSweep() directly and backdate pendingEchoes timestamps
+// to simulate aging without real tickers.
+func TestEchoCheck(t *testing.T) {
+	// newEchoManager creates a webhookManager pre-wired for echo-check tests:
+	// state=Healthy, healthChangeFn recording false calls, events containing
+	// "projects_v2_item" so R7 conditional tests can remove it.
+	newEchoManager := func(t *testing.T) (*webhookManager, *int) {
+		t.Helper()
+		wm, _ := newTestWebhookManager(t)
+		falseCalls := 0
+		wm.healthChangeFn = func(healthy bool) {
+			if !healthy {
+				falseCalls++
+			}
+		}
+		wm.mu.Lock()
+		wm.state = WebhookStreamHealthy
+		// Ensure "projects_v2_item" is in wm.events so R7 tests can remove it.
+		found := false
+		for _, ev := range wm.events {
+			if ev == "projects_v2_item" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			wm.events = append(wm.events, "projects_v2_item")
+		}
+		wm.mu.Unlock()
+		return wm, &falseCalls
+	}
+
+	t.Run("(a) register → match → no miss", func(t *testing.T) {
+		wm, falseCalls := newEchoManager(t)
+		wm.RegisterEcho("issues", "labeled", "owner/repo#1+test-label")
+		wm.MatchEcho("issues", "labeled", "owner/repo#1+test-label")
+
+		// Backdate any remaining entries past the timeout (there should be none).
+		wm.mu.Lock()
+		for k := range wm.pendingEchoes {
+			wm.pendingEchoes[k] = time.Now().Add(-(webhookEchoTimeout + time.Second))
+		}
+		wm.mu.Unlock()
+
+		wm.doEchoSweep()
+
+		wm.mu.Lock()
+		misses := len(wm.missHistory)
+		wm.mu.Unlock()
+
+		if misses != 0 {
+			t.Errorf("missHistory len = %d after matched echo, want 0", misses)
+		}
+		if *falseCalls != 0 {
+			t.Errorf("healthChangeFn(false) called %d times, want 0", *falseCalls)
+		}
+	})
+
+	t.Run("(b) register → no match within timeout → miss appended", func(t *testing.T) {
+		wm, falseCalls := newEchoManager(t)
+		wm.RegisterEcho("issues", "labeled", "owner/repo#2+another-label")
+
+		// Backdate the entry to simulate timeout elapsed.
+		wm.mu.Lock()
+		for k := range wm.pendingEchoes {
+			wm.pendingEchoes[k] = time.Now().Add(-(webhookEchoTimeout + time.Second))
+		}
+		wm.mu.Unlock()
+
+		wm.doEchoSweep()
+
+		wm.mu.Lock()
+		misses := len(wm.missHistory)
+		echoesRemaining := len(wm.pendingEchoes)
+		wm.mu.Unlock()
+
+		if misses != 1 {
+			t.Errorf("missHistory len = %d after timed-out echo, want 1", misses)
+		}
+		if echoesRemaining != 0 {
+			t.Errorf("pendingEchoes len = %d after sweep, want 0", echoesRemaining)
+		}
+		if *falseCalls != 0 {
+			t.Errorf("healthChangeFn(false) called %d times after 1 miss (threshold=3), want 0", *falseCalls)
+		}
+	})
+
+	t.Run("(c) 3 misses within window → healthChangeFn(false) called, missHistory cleared", func(t *testing.T) {
+		wm, falseCalls := newEchoManager(t)
+		// Register 3 distinct echoes.
+		wm.RegisterEcho("issues", "labeled", "owner/repo#3+label-a")
+		wm.RegisterEcho("issues", "labeled", "owner/repo#3+label-b")
+		wm.RegisterEcho("issues", "labeled", "owner/repo#3+label-c")
+
+		// Backdate all 3 past webhookEchoTimeout but within webhookEchoWindow.
+		staleAge := webhookEchoTimeout + time.Second
+		wm.mu.Lock()
+		for k := range wm.pendingEchoes {
+			wm.pendingEchoes[k] = time.Now().Add(-staleAge)
+		}
+		wm.mu.Unlock()
+
+		wm.doEchoSweep()
+
+		if *falseCalls != 1 {
+			t.Errorf("healthChangeFn(false) called %d times after 3 misses, want 1", *falseCalls)
+		}
+		wm.mu.Lock()
+		misses := len(wm.missHistory)
+		wm.mu.Unlock()
+		if misses != 0 {
+			t.Errorf("missHistory len = %d after threshold fire, want 0 (cleared)", misses)
+		}
+	})
+
+	t.Run("(d) 2 old misses age out + 1 new miss → threshold NOT reached", func(t *testing.T) {
+		wm, falseCalls := newEchoManager(t)
+		// Pre-populate missHistory with 2 entries older than webhookEchoWindow.
+		oldTimestamp := time.Now().Add(-(webhookEchoWindow + 2*time.Second))
+		wm.mu.Lock()
+		wm.missHistory = []time.Time{oldTimestamp, oldTimestamp}
+		wm.mu.Unlock()
+
+		// Register 1 echo and backdate it past webhookEchoTimeout but within window.
+		wm.RegisterEcho("issues", "edited", "owner/repo#4")
+		staleAge := webhookEchoTimeout + time.Second
+		wm.mu.Lock()
+		for k := range wm.pendingEchoes {
+			wm.pendingEchoes[k] = time.Now().Add(-staleAge)
+		}
+		wm.mu.Unlock()
+
+		wm.doEchoSweep()
+
+		if *falseCalls != 0 {
+			t.Errorf("healthChangeFn(false) called %d times after old misses aged out + 1 new miss, want 0", *falseCalls)
+		}
+		wm.mu.Lock()
+		misses := len(wm.missHistory)
+		wm.mu.Unlock()
+		// Only the 1 new miss survives (the 2 old ones were pruned).
+		if misses != 1 {
+			t.Errorf("missHistory len = %d after pruning old misses, want 1", misses)
+		}
+	})
+
+	t.Run("(e) registration suppressed during WebhookStreamStartingUp", func(t *testing.T) {
+		wm, _ := newEchoManager(t)
+		wm.mu.Lock()
+		wm.state = WebhookStreamStartingUp
+		wm.mu.Unlock()
+
+		wm.RegisterEcho("issues", "labeled", "owner/repo#5+startup-label")
+		wm.RegisterEchoIfSubscribed("projects_v2_item", "edited", "PVTI_startup")
+
+		wm.mu.Lock()
+		echoes := len(wm.pendingEchoes)
+		wm.mu.Unlock()
+
+		if echoes != 0 {
+			t.Errorf("pendingEchoes len = %d during StartingUp, want 0 (suppressed)", echoes)
+		}
+	})
+
+	t.Run("(f) projects_v2_item echo not registered when absent from wm.events", func(t *testing.T) {
+		wm, _ := newEchoManager(t)
+		// Remove "projects_v2_item" from wm.events.
+		wm.mu.Lock()
+		filtered := wm.events[:0]
+		for _, ev := range wm.events {
+			if ev != "projects_v2_item" {
+				filtered = append(filtered, ev)
+			}
+		}
+		wm.events = filtered
+		wm.mu.Unlock()
+
+		wm.RegisterEchoIfSubscribed("projects_v2_item", "edited", "PVTI_xyz")
+
+		wm.mu.Lock()
+		echoes := len(wm.pendingEchoes)
+		wm.mu.Unlock()
+
+		if echoes != 0 {
+			t.Errorf("pendingEchoes len = %d when projects_v2_item absent from events, want 0", echoes)
+		}
+	})
+
+	t.Run("(g) MergePR and UpdateIssueBody echoes matched correctly", func(t *testing.T) {
+		wm, _ := newEchoManager(t)
+
+		// MergePR echo: pull_request closed
+		wm.RegisterEcho("pull_request", "closed", "owner/repo#pr42")
+		wm.MatchEcho("pull_request", "closed", "owner/repo#pr42")
+
+		wm.mu.Lock()
+		echoesAfterMerge := len(wm.pendingEchoes)
+		wm.mu.Unlock()
+		if echoesAfterMerge != 0 {
+			t.Errorf("pendingEchoes len = %d after MergePR MatchEcho, want 0", echoesAfterMerge)
+		}
+
+		// UpdateIssueBody echo: issues edited
+		wm.RegisterEcho("issues", "edited", "owner/repo#7")
+		wm.MatchEcho("issues", "edited", "owner/repo#7")
+
+		wm.mu.Lock()
+		echoesAfterEdit := len(wm.pendingEchoes)
+		wm.mu.Unlock()
+		if echoesAfterEdit != 0 {
+			t.Errorf("pendingEchoes len = %d after UpdateIssueBody MatchEcho, want 0", echoesAfterEdit)
+		}
+
+		// Sweep should produce no misses.
+		wm.doEchoSweep()
+		wm.mu.Lock()
+		misses := len(wm.missHistory)
+		wm.mu.Unlock()
+		if misses != 0 {
+			t.Errorf("missHistory len = %d after matched echoes, want 0", misses)
+		}
+	})
+}
+
 // TestHealthTransition_SessionStale verifies that stale sessionLastEventAt
 // triggers Unhealthy faster than the 10-minute webhookHealthWindow — both from
 // StartingUp and Healthy states.


### PR DESCRIPTION
## Summary

When fabrik issues a GitHub mutation (label add/remove, comment post, issue body update, PR create, PR ready-for-review, PR merge, project status update), it records a pending echo entry in `webhookManager`. The corresponding webhook event should arrive within `webhookEchoTimeout` (15 s). If it does not, that is a miss. K = 3 misses within a rolling 60 s window → mark the webhook stream Unhealthy (same `healthChangeFn(false)` path used by existing health checks). Recovery is the same as today: any verified inbound event flips Healthy via `handleWebhook`.

## Problem

Fabrik's webhook-based board cache can enter a silent failure mode where GitHub webhooks stop arriving but fabrik continues operating, making decisions on stale cached state. The existing time-based health monitor (`webhookEventStaleTimeout` = 5 min, `webhookHealthWindow` = 10 min) only detects this after several minutes of silence — which is too slow when fabrik itself is actively mutating GitHub state (adding labels, posting comments, creating PRs). During an active pipeline run, fabrik may take many actions on stale data before the health monitor fires.

This issue adds a **mutation echo-check** (Plan B) to detect silent webhook stream failure within seconds during active periods. Complements the slow-cadence periodic reconcile (Plan A, the existing `Reconcile()` loop in `poll.go`, tracked as #641) which catches failures during quiet periods.

## Approach

### Approach

Implement the mutation echo-check in three coordinated layers:

1. **`webhookManager` core** (`engine/webhook.go`): add `pendingEchoes`, `missHistory`, `RegisterEcho`, `MatchEcho`, `doEchoSweep`, and sweep goroutine.
2. **`CacheImpl` bridge** (`boardcache/boardcache.go`, `boardcache/delta.go`): inject `matchEchoFn` as a function field to avoid the `engine→boardcache→engine` circular import; call it in each echo-relevant typed handler inside `ApplyDelta`.
3. **Engine call sites** (`engine/item.go`, `engine/pr.go`, `engine/comments.go`, `engine/stages.go`): call `RegisterEcho` after each successful tracked mutation.

**Key design decisions** are documented below. No alternatives are left open — the spec and research resolved all architectural choices.

**`AddComment` on PR vs. issue (resolving research open question):** All `AddComment` call sites register with key `owner/repo#N` where N is whatever number was passed. GitHub sends `issue_comment.created` with `issue.number == N` regardless of whether N is an issue or PR number. `MatchEcho` in `ApplyDelta` constructs the same key from the payload's `issue.number`. No special-casing needed.

---

### New/Modified Files

| File | Change |
|------|--------|
| `engine/webhook.go` | Add echo constants, struct fields, `RegisterEcho`, `MatchEcho`, `doEchoSweep`, sweep goroutine start, `missHistory` clear on recovery |
| `boardcache/boardcache.go` | Add `matchEchoFn` field and `SetMatchEchoFn` setter to `CacheImpl` |
| `boardcache/delta.go` | Call `c.matchEchoFn(...)` in each echo-relevant typed handler before store mutation |
| `engine/poll.go` | Wire `cacheImpl.SetMatchEchoFn(wm.MatchEcho)` after `wm` construction, before `wm.Start()` |
| `engine/item.go` | Add `RegisterEcho` to `removeLockLabel`, `removeInProgressLabel`, `addFailedLabel`, `removeFailedLabel`, and all remaining inline `AddLabelToIssue`/`RemoveLabelFromIssue` call sites |
| `engine/pr.go` | Add `RegisterEcho` to `ensureDraftPR` (using returned `prNum`) and `markPRReady` |
| `engine/comments.go` | Add `RegisterEcho` after `UpdateIssueBody` (line 250) and `AddComment` (lines 270, 292) |
| `engine/stages.go` | Add `RegisterEcho` after `MergePR` (line 346) and `UpdateProjectItemStatus` (lines 424/452) with R7 conditional |
| `engine/webhook_test.go` | Add unit tests covering R12a–R12g |
| `docs/state-machine.md` | Add echo-miss → Unhealthy path to the webhook health state section |
| `docs/llms-full.txt` | Regenerate after updating `state-machine.md` |

---

### Key Decisions

- **Echo state in `webhookManager`, not a separate struct**: All health-transition logic lives in one place under a single `wm.mu`. The sweep goroutine follows the exact same pattern as `runHealthMonitor` (5-second ticker, separate method, started alongside in `Start()`). Consistent with existing conventions; no new synchronization primitives needed.

- **`matchEchoFn` injected via `SetMatchEchoFn` (not a direct import)**: `boardcache` cannot import `engine` — circular. The function field pattern (`matchEchoFn func(string, string, string)`) is the same dependency-injection approach used in ADR 036 for other cross-package wiring. `SetMatchEchoFn` is called in `poll.go` after `wm` is constructed and before `wm.Start()`.

- **Composite map key `eventType+":"+action+":"+discriminatingKey`**: Last-write wins per slot. Two concurrent label-adds on the same issue+label overwrite each other (fresher timestamp), but key uniqueness per label (`+label` suffix) keeps most concurrent mutations distinct. Acceptable for stream-failure detection where per-mutation tracking is not the goal.

- **Package-level `var` (not `const`) for `webhookEchoTimeout`, `webhookEchoMissThreshold`, `webhookEchoWindow`**: Consistent with `lockVerifyDelay`, `editingLabelRetryDelay` — allows tests to override without real tickers. Tests call `wm.doEchoSweep()` directly and backdate timestamps to simulate aging.

- **`doEchoSweep` locking discipline**: Under `wm.mu`: scan `pendingEchoes`, remove stale entries, append miss timestamps to `missHistory`, prune old misses. Release `wm.mu` before calling `healthChangeFn(false)`. Mirrors `checkHealthTransitions` (lines 909–927 of `webhook.go`).

- **`missHistory` cleared on recovery**: In `handleWebhook`, inside the `wm.mu` lock block where `sessionLastEventAt` is updated, clear `wm.missHistory = wm.missHistory[:0]` when `prevState != WebhookStreamHealthy`. Prevents stale miss timestamps from immediately re-triggering the threshold after recovery (R10).

- **`projects_v2_item` registration under `wm.mu`** (R7): The R7 check reads `wm.events` (mutated by the stderr handler goroutine) — must hold `wm.mu` during the read. `RegisterEcho` already runs under `wm.mu` for the state check, so R7's conditional simply adds a `containsEvent(wm.events, "projects_v2_item")` guard inside that lock.

- **ADR warranted**: The mutation echo-check is a new health-transition trigger category (not covered by ADR 032 or 036). An ADR should document why we use Fabrik's own mutation→echo self-signal for health detection, the rolling-window miss threshold design choice, and the `matchEchoFn` injection pattern. The next ADR number should be determined at implementation time by checking the highest-numbered file in `adrs/`.

---

### Task Checklist

- [ ] **T1: Add echo state to `webhookManager`** — add package-level vars `webhookEchoTimeout = 15s`, `webhookEchoMissThreshold = 3`, `webhookEchoWindow = 60s`; add fields `pendingEchoes map[string]time.Time` and `missHistory []time.Time` to the struct; initialize in `newWebhookManager` with `make(map[string]time.Time)`

- [ ] **T2: Add `RegisterEcho` and `MatchEcho` methods** — `RegisterEcho(eventType, action, key string)` no-ops when `wm.state == WebhookStreamStartingUp` or `wm.healthChangeFn == nil`, otherwise stores `pendingEchoes[composite(eventType,action,key)] = time.Now()` under `wm.mu`; `MatchEcho(eventType, action, key string)` deletes the entry under `wm.mu`

- [ ] **T3: Add `doEchoSweep` method and sweep goroutine** — `doEchoSweep()` holds `wm.mu` to scan `pendingEchoes` for entries older than `webhookEchoTimeout`, removes them, appends their timestamp to `missHistory`, prunes `missHistory` entries older than `webhookEchoWindow`, then releases `wm.mu` before calling `healthChangeFn(false)` if `len(missHistory) >= webhookEchoMissThreshold` (clearing `missHistory` first under lock); start `go wm.runEchoSweep(ctx)` alongside `go wm.runHealthMonitor(ctx)` in `Start()`

- [ ] **T4: Clear `missHistory` on recovery in `handleWebhook`** — inside the `wm.mu.Lock()` block where `sessionLastEventAt` is set, add `if prevState != WebhookStreamHealthy { wm.missHistory = wm.missHistory[:0] }` before `wm.mu.Unlock()`

- [ ] **T5: Add `matchEchoFn` field and `SetMatchEchoFn` setter to `CacheImpl`** — add `matchEchoFn func(eventType, action, key string)` field to `CacheImpl` struct in `boardcache/boardcache.go`; add `SetMatchEchoFn(fn func(string, string, string))` method

- [ ] **T6: Wire `MatchEcho` calls in `ApplyDelta` typed handlers** — in `boardcache/delta.go`, at the start of each echo-relevant handler, parse the payload to extract the discriminating key, then call `c.matchEchoFn(eventType, action, key)` if non-nil:
  - `applyIssueCommentDelta`: action=`created` → key=`repo#issueNum`
  - `applyIssuesDelta`: action=`labeled`→key=`repo#N+labelName`, `unlabeled`→same, `edited`→key=`repo#N`
  - `applyPullRequestDelta`: action=`opened`→key=`repo#prPRNum`, `ready_for_review`→same, `closed`→same
  - `applyProjectsV2ItemDelta`: action=`edited` → key=`projectsV2Item.ID`

- [ ] **T7: Wire `SetMatchEchoFn` in `poll.go`** — after `wm := newWebhookManager(...)` and before `wm.Start(...)`, add: `if cacheImpl != nil { cacheImpl.SetMatchEchoFn(wm.MatchEcho) }`

- [ ] **T8: Add `RegisterEcho` to label mutation call sites** — for each call site that successfully calls `e.client.AddLabelToIssue` or `e.client.RemoveLabelFromIssue`, add `e.webhookMgr.RegisterEcho(...)` (nil-guarded) in the `err == nil` branch; prioritize the centralized helpers first: `removeLockLabel` (item.go:1270), `removeInProgressLabel` (item.go:1281), `addFailedLabel` (item.go:1293), `removeFailedLabel` (item.go:1302); then handle inline call sites in item.go (lines 536, 627, 988, 1050, 1055, 1069, 1077) and stages.go (line 430)

- [ ] **T9: Add `RegisterEcho` to PR, comment, and status mutations** —
  - `ensureDraftPR` in pr.go: after successful `CreateDraftPR` returns `prNum`, call `e.webhookMgr.RegisterEcho("pull_request", "opened", owner+"/"+repo+"#pr"+strconv.Itoa(prNum))`
  - `markPRReady` in pr.go (line 218): on the `err == nil` return path, call `RegisterEcho("pull_request", "ready_for_review", ...)`
  - `postIssueComment` / `postSummaryComment` in comments.go (lines 270, 292): call `RegisterEcho("issue_comment", "created", owner+"/"+repo+"#"+strconv.Itoa(N))` after successful `AddComment`
  - `UpdateIssueBody` in comments.go (line 250): call `RegisterEcho("issues", "edited", ...)` after success
  - `MergePR` in stages.go (line 346): call `RegisterEcho("pull_request", "closed", ...)` after success
  - `UpdateProjectItemStatus` in stages.go (lines 424, 452): under `wm.mu`, check `containsEvent(wm.events, "projects_v2_item")` before calling `RegisterEcho("projects_v2_item", "edited", itemID)`

- [ ] **T10: Write unit tests in `engine/webhook_test.go`** — add `TestEchoCheck` with subtests covering all R12 cases:
  - (a) register → match → no miss
  - (b) register → no match within timeout → miss appended
  - (c) 3 misses in window → `healthChangeFn(false)` called, `missHistory` cleared
  - (d) 2 misses + 61s elapses + 1 miss → threshold NOT reached (old misses aged out)
  - (e) registration suppressed during `WebhookStreamStartingUp`
  - (f) `projects_v2_item` echo not registered when absent from `wm.events`
  - (g) `MergePR` and `UpdateIssueBody` echoes matched correctly via `MatchEcho`

  Tests backdating timestamps directly (no real tickers); override `webhookEchoTimeout`/`webhookEchoWindow` package-level vars; call `wm.doEchoSweep()` directly

- [ ] **T11: Update `docs/state-machine.md` and regenerate `docs/llms-full.txt`** — in the "Webhook stream health states" section (around line 1051), add a subsection documenting the echo-miss → Unhealthy path: constants, rolling-window algorithm, suppression during startup, and how `missHistory` is cleared on recovery; run `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt`

- [ ] **T12: Create ADR NNN: Mutation Echo-Check for Webhook Health Detection** — check highest-numbered file in `adrs/` at implementation time for N; document: why self-signal via Fabrik's own mutation→webhook echo is sound health evidence during active periods; rolling-window miss threshold rationale (vs. consecutive); `matchEchoFn` injection to avoid circular import; relationship to Plan A (Reconcile loop, #641)

---

### Risks

- **Call site count**: ~25 tracked mutation call sites across 5 engine files. Missing one leaves a mutation type unmonitored — silent gap. T8 and T9 enumerate all sites; the implementer should use grep to verify exhaustiveness after each file before committing.

- **`wm.mu` deadlock in `doEchoSweep`**: `healthChangeFn(false)` must be called after releasing `wm.mu`. The pattern in `checkHealthTransitions` (unlock before calling `healthChangeFn`) must be replicated exactly. A common error is holding the lock across the `healthChangeFn` call — race detector tests will not necessarily catch this; deadlock testing requires a `healthChangeFn` that acquires `wm.mu` internally.

- **`projects_v2_item` R7 race**: `wm.events` is mutated by the stderr handler goroutine. T9's R7 check must read `wm.events` under `wm.mu`. Since `RegisterEcho` already acquires `wm.mu` for the startup-state check, the `containsEvent` read happens inside the same lock acquisition — straightforward, but easy to miss.

- **False positive under GitHub infrastructure degradation**: With K=3 and W=60s, prolonged GitHub webhook delivery lag (>15s per event) could trigger false Unhealthy transitions. This is a known trade-off documented in the spec; no mitigation beyond the chosen constants is in scope for this issue.

- **`doEchoSweep` must check `wm.healthChangeFn != nil`**: When the board cache is disabled, `healthChangeFn` is nil. `RegisterEcho` already guards on this, but `doEchoSweep` must also nil-check before calling it to avoid a panic.

---
Used 24/50 turns, 8k input / 10k output tokens.

## Verification

Implemented the mutation echo-check (Plan B) across all 7 planned tasks: added `pendingEchoes`/`missHistory` state, `RegisterEcho`/`MatchEcho`/`doEchoSweep` methods and sweep goroutine to `webhookManager`; injected `matchEchoFn` into `CacheImpl` to avoid the circular import; wired `MatchEcho` calls into all 6 echo-relevant `ApplyDelta` typed handlers; added `RegisterEcho` to ~25 mutation call sites across `item.go`, `stages.go`, `pr.go`, and `comments.go`; wrote 7 unit tests covering R12a–R12g; updated `docs/state-machine.md` with the echo-miss → Unhealthy subsection; and created ADR 042 documenting the design rationale. All tests pass, `go vet` is clean.

---

Closes #642