### PR TITLE
docs: document GitHub's single-user constraint on 'gh webhook forward' per repo/org

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1705,7 +1705,7 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
 If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
 
 > [!WARNING]
-> **Single-user constraint:** GitHub allows only one active `gh webhook forward` subscription per repository or organization at a time. If a second Fabrik instance (or any other tool) attempts to subscribe while one is already active, GitHub returns an HTTP 422 `Hook already exists` error. Fabrik logs this and falls back to poll-only mode for that instance — it will not receive real-time events.
+> **Single-user constraint:** GitHub allows only one active `gh webhook forward` subscription per repository or organization at a time. If a second Fabrik instance (or any other tool) attempts to subscribe while one is already active, GitHub returns an HTTP 422 `Hook already exists` error. Fabrik retries the subscription a few times and, after repeated 422 failures, permanently falls back to poll-only mode for that instance — it will not receive real-time events.
 >
 > **Operator guidance:** Coordinate across your team so that only one Fabrik instance runs with `--webhooks` at a time. Other instances can run in poll-only mode (omit `--webhooks`) and will still process issues, just without real-time event delivery. For the longer-term solution that lets multiple operators share a board without conflicting webhook subscriptions, see issue #543 (planned per-user assignee filter).
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1999,13 +1999,19 @@ Then restart Fabrik. The extension is a one-time install and persists across `gh
 
 ### `Hook already exists` (HTTP 422 from `gh webhook forward`)
 
-**Symptom:** Fabrik logs a line like:
+**Symptom:** After each restart attempt, Fabrik echoes the `gh` error to the log:
 
 ```
-[webhook] failed to subscribe repo <owner>/<repo>: HTTP 422 — {"message":"Hook already exists"}
+[webhook] [gh] Error: error creating webhook: HTTP 422: Hook already exists (https://api.github.com/repos/<owner>/<repo>/hooks)
 ```
 
-Fabrik then continues in poll-only mode with no real-time events for that repo.
+After three consecutive 422 failures, Fabrik emits:
+
+```
+[webhook] WARNING: webhook subscription permanently failed after 3 consecutive HTTP 422 errors — switching to poll-only mode. Check 'gh auth status' and repo webhook quota, then restart Fabrik.
+```
+
+Fabrik then continues in poll-only mode for the remainder of the session with no real-time events.
 
 **Cause:** GitHub enforces a single-user constraint on `gh webhook forward`: only one active subscription can exist per repository or organization at a time. A second Fabrik instance (or another tool) that tries to subscribe while one is already active receives this 422 error.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1704,6 +1704,11 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
 
 If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
 
+> [!WARNING]
+> **Single-user constraint:** GitHub allows only one active `gh webhook forward` subscription per repository or organization at a time. If a second Fabrik instance (or any other tool) attempts to subscribe while one is already active, GitHub returns an HTTP 422 `Hook already exists` error. Fabrik logs this and falls back to poll-only mode for that instance — it will not receive real-time events.
+>
+> **Operator guidance:** Coordinate across your team so that only one Fabrik instance runs with `--webhooks` at a time. Other instances can run in poll-only mode (omit `--webhooks`) and will still process issues, just without real-time event delivery. For the longer-term solution that lets multiple operators share a board without conflicting webhook subscriptions, see issue #543 (planned per-user assignee filter).
+
 ### Enabling Webhook Mode
 
 Three equivalent ways to enable:
@@ -1991,6 +1996,22 @@ gh webhook --help   # verify: should print usage
 ```
 
 Then restart Fabrik. The extension is a one-time install and persists across `gh` upgrades.
+
+### `Hook already exists` (HTTP 422 from `gh webhook forward`)
+
+**Symptom:** Fabrik logs a line like:
+
+```
+[webhook] failed to subscribe repo <owner>/<repo>: HTTP 422 — {"message":"Hook already exists"}
+```
+
+Fabrik then continues in poll-only mode with no real-time events for that repo.
+
+**Cause:** GitHub enforces a single-user constraint on `gh webhook forward`: only one active subscription can exist per repository or organization at a time. A second Fabrik instance (or another tool) that tries to subscribe while one is already active receives this 422 error.
+
+**Fix:** Coordinate across your team so that only one Fabrik instance runs with `--webhooks` at a time. All other instances should run in poll-only mode (omit the `--webhooks` flag). They will still process issues on their normal poll interval — they just won't receive real-time event notifications.
+
+For a longer-term solution that allows multiple operators to share a board without conflicting over the webhook subscription, see issue #543 (planned per-user assignee filter).
 
 ### Plugin Not Loading
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1702,6 +1702,11 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
 
 If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
 
+> [!WARNING]
+> **Single-user constraint:** GitHub allows only one active `gh webhook forward` subscription per repository or organization at a time. If a second Fabrik instance (or any other tool) attempts to subscribe while one is already active, GitHub returns an HTTP 422 `Hook already exists` error. Fabrik logs this and falls back to poll-only mode for that instance — it will not receive real-time events.
+>
+> **Operator guidance:** Coordinate across your team so that only one Fabrik instance runs with `--webhooks` at a time. Other instances can run in poll-only mode (omit `--webhooks`) and will still process issues, just without real-time event delivery. For the longer-term solution that lets multiple operators share a board without conflicting webhook subscriptions, see issue #543 (planned per-user assignee filter).
+
 ### Enabling Webhook Mode
 
 Three equivalent ways to enable:
@@ -1989,6 +1994,22 @@ gh webhook --help   # verify: should print usage
 ```
 
 Then restart Fabrik. The extension is a one-time install and persists across `gh` upgrades.
+
+### `Hook already exists` (HTTP 422 from `gh webhook forward`)
+
+**Symptom:** Fabrik logs a line like:
+
+```
+[webhook] failed to subscribe repo <owner>/<repo>: HTTP 422 — {"message":"Hook already exists"}
+```
+
+Fabrik then continues in poll-only mode with no real-time events for that repo.
+
+**Cause:** GitHub enforces a single-user constraint on `gh webhook forward`: only one active subscription can exist per repository or organization at a time. A second Fabrik instance (or another tool) that tries to subscribe while one is already active receives this 422 error.
+
+**Fix:** Coordinate across your team so that only one Fabrik instance runs with `--webhooks` at a time. All other instances should run in poll-only mode (omit the `--webhooks` flag). They will still process issues on their normal poll interval — they just won't receive real-time event notifications.
+
+For a longer-term solution that allows multiple operators to share a board without conflicting over the webhook subscription, see issue #543 (planned per-user assignee filter).
 
 ### Plugin Not Loading
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1703,7 +1703,7 @@ Events are translated into immediate poll wakeups — the existing board-fetch a
 If any prerequisite is missing, Fabrik logs a clear warning and falls back to polling-only mode. Webhook mode failure is always non-fatal.
 
 > [!WARNING]
-> **Single-user constraint:** GitHub allows only one active `gh webhook forward` subscription per repository or organization at a time. If a second Fabrik instance (or any other tool) attempts to subscribe while one is already active, GitHub returns an HTTP 422 `Hook already exists` error. Fabrik logs this and falls back to poll-only mode for that instance — it will not receive real-time events.
+> **Single-user constraint:** GitHub allows only one active `gh webhook forward` subscription per repository or organization at a time. If a second Fabrik instance (or any other tool) attempts to subscribe while one is already active, GitHub returns an HTTP 422 `Hook already exists` error. Fabrik retries the subscription a few times and, after repeated 422 failures, permanently falls back to poll-only mode for that instance — it will not receive real-time events.
 >
 > **Operator guidance:** Coordinate across your team so that only one Fabrik instance runs with `--webhooks` at a time. Other instances can run in poll-only mode (omit `--webhooks`) and will still process issues, just without real-time event delivery. For the longer-term solution that lets multiple operators share a board without conflicting webhook subscriptions, see issue #543 (planned per-user assignee filter).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1997,13 +1997,19 @@ Then restart Fabrik. The extension is a one-time install and persists across `gh
 
 ### `Hook already exists` (HTTP 422 from `gh webhook forward`)
 
-**Symptom:** Fabrik logs a line like:
+**Symptom:** After each restart attempt, Fabrik echoes the `gh` error to the log:
 
 ```
-[webhook] failed to subscribe repo <owner>/<repo>: HTTP 422 — {"message":"Hook already exists"}
+[webhook] [gh] Error: error creating webhook: HTTP 422: Hook already exists (https://api.github.com/repos/<owner>/<repo>/hooks)
 ```
 
-Fabrik then continues in poll-only mode with no real-time events for that repo.
+After three consecutive 422 failures, Fabrik emits:
+
+```
+[webhook] WARNING: webhook subscription permanently failed after 3 consecutive HTTP 422 errors — switching to poll-only mode. Check 'gh auth status' and repo webhook quota, then restart Fabrik.
+```
+
+Fabrik then continues in poll-only mode for the remainder of the session with no real-time events.
 
 **Cause:** GitHub enforces a single-user constraint on `gh webhook forward`: only one active subscription can exist per repository or organization at a time. A second Fabrik instance (or another tool) that tries to subscribe while one is already active receives this 422 error.
 


### PR DESCRIPTION
## Summary

Add a prominent documentation note in `docs/USER_GUIDE.md` covering the single-user webhook forwarding constraint. The note should appear in two places: (1) in the Prerequisites section as a proactive warning before operators enable webhook mode, and (2) in the Troubleshooting section as a named entry for the `Hook already exists` error. Also regenerate `docs/llms-full.txt` per the standard contract.

## Problem

`docs/USER_GUIDE.md` does not document GitHub's constraint that only one user can run `gh webhook forward` against a given repo/org at a time. Operators running multiple fabrik instances (e.g. on different machines, or alongside a teammate) hit cryptic `Hook already exists` HTTP 422 errors with no guidance on the cause or resolution.

GitHub documents this directly:

> Only one person can use webhook forwarding at a time for each repository and organization. If you try to set up webhook forwarding and someone else is already working with that organization or repository, you'll receive a `Hook already exists` error.

## Approach

### Approach

This is a pure documentation change with two targeted insertions into `docs/USER_GUIDE.md` and a mandatory `docs/llms-full.txt` regeneration. No code changes. No design decisions required — the spec fully specifies insertion points, content, and format.

**Note format chosen:** GitHub-flavored `> [!WARNING]` admonition for the Prerequisites callout. This renders as a styled yellow/orange alert box in GitHub's markdown renderer, giving maximum visual prominence — appropriate for an operational constraint that can cause silent fallback to polling. The Troubleshooting entry follows the existing `**Symptom:** / **Cause:** / **Fix:**` convention already established in the section.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add single-user warning after line 1705 (Prerequisites section) and add new Troubleshooting entry after line 1993 |
| `docs/llms-full.txt` | Regenerated via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **`> [!WARNING]` over bold paragraph**: GitHub renders this as a visually distinct admonition block. The constraint causes silent fallback to polling — operators may not notice without a prominent visual cue.
- **Place note after "If any prerequisite is missing..." (line 1705)**, not before it: the fallback sentence is a general safety net note; the single-user constraint is a distinct operational constraint that deserves its own callout at the same visual level, not buried inside the fallback sentence.
- **Troubleshooting entry heading**: `### \`Hook already exists\` (HTTP 422 from \`gh webhook forward\`)` — this follows the existing pattern of using the exact log/error text as the heading (`### \`unknown command 'webhook' for 'gh'\``), making it easy to find by searching.
- **No ADR**: This documents a GitHub API constraint, not a Fabrik design decision. ADR 032 covers the webhook implementation design; the single-user constraint is external behavior, not Fabrik's architectural choice.

### Task Checklist

- [ ] Task 1: Insert single-user constraint `> [!WARNING]` callout in the Prerequisites subsection of `docs/USER_GUIDE.md` — after "If any prerequisite is missing..." (line 1705), before `### Enabling Webhook Mode` (line 1707). Content: GitHub allows only one active `gh webhook forward` subscriber per repo/org; a second instance fails with HTTP 422 `Hook already exists` and falls back to poll-only mode; coordinate so only one instance holds the webhook subscription, or see issue #543 for the planned per-user assignee filter.
- [ ] Task 2: Insert new Troubleshooting entry in `docs/USER_GUIDE.md` — after the `unknown command 'webhook' for 'gh'` entry closes (line 1993), before `### Plugin Not Loading` (line 1995). Heading: `### \`Hook already exists\` (HTTP 422 from \`gh webhook forward\`)`. Follow **Symptom** / **Cause** / **Fix** format. Fix guidance: coordinate so only one Fabrik instance runs with `--webhooks` at a time; other instances can run poll-only (omit `--webhooks`); longer-term: see issue #543.
- [ ] Task 3: Run `bash scripts/generate-llms-full.sh` from repo root to regenerate `docs/llms-full.txt` and stage it.
- [ ] Task 4: Commit all changes (`docs/USER_GUIDE.md` + `docs/llms-full.txt`) on the `fabrik/issue-644` branch with a clear commit message.

### Risks

- **`docs-drift` CI failure if Task 3 is skipped**: Regenerating `docs/llms-full.txt` is a hard requirement enforced by CI. Running the script and staging the output in the same commit as the USER_GUIDE edits avoids this. Risk is low — the script is idempotent and straightforward.
- **Line number drift**: The research identified insertion points by line number (1705, 1993). If main has diverged, the worktree rebase may shift these. Implement should locate insertion points by surrounding content (the adjacent headings and sentences), not hardcoded line numbers.

---
Used 7/50 turns, 2k input / 2k output tokens.

## Verification

Added two documentation additions to `docs/USER_GUIDE.md`: a `> [!WARNING]` admonition in the Webhook Mode Prerequisites section explaining GitHub's single-user `gh webhook forward` constraint and the HTTP 422 fallback behavior, and a new Troubleshooting entry titled `` `Hook already exists` (HTTP 422 from `gh webhook forward`) `` with Symptom/Cause/Fix format pointing operators to coordinate webhook ownership and referencing issue #543. Regenerated `docs/llms-full.txt` and committed both files in a single commit on `fabrik/issue-644`.

---

Closes #644