### PR TITLE
feat: clean up orphaned forwarding hooks before each gh webhook forward launch

### DIFF
--- a/adrs/032-webhook-event-delivery.md
+++ b/adrs/032-webhook-event-delivery.md
@@ -180,3 +180,47 @@ The phrase list in the `projects_v2_item` rejection detector was extended to inc
 
 - `engine/webhook.go`: `webhookRepoFailureThreshold` constant; `repoFailureCounts` and `unsubscribableRepos` fields on `webhookManager`; `isProjectsV2ItemRejection` helper; `applyRepoAuthFailure` method; zero-repo guard and attribution call in `supervise`; quarantine filtering in `UpdateRepos`.
 - `engine/webhook_test.go`: `TestIsProjectsV2ItemRejection`, `TestApplyRepoAuthFailure_*`, `TestUpdateRepos_Quarantine*`.
+
+---
+
+## Amendment: Orphan Hook Cleanup at Subprocess Launch (Issue #643, 2026-05-07)
+
+### Problem
+
+When `gh webhook forward` exits unexpectedly (WebSocket abnormal closure, 500 from GitHub's WS server, network blip), the hook it registered at GitHub remains active. The next restart attempt creates a new hook registration, which GitHub rejects with HTTP 422 ("Hook already exists") because only one forwarding hook per repo is allowed at a time. Three consecutive 422s trigger the existing circuit-breaker (see below), switching Fabrik to poll-only mode and requiring a manual restart.
+
+Observed sequence from production (smoke #7, 2026-05-07):
+
+```
+[webhook] [gh] Error: error receiving json event: websocket: close 1006 (abnormal closure)
+[webhook] gh webhook forward exited: exit status 1 — restarting in 1s
+[webhook] [gh] Error: error creating webhook: HTTP 422: Validation Failed   ← orphan hook collision
+[webhook] WARNING: webhook subscription permanently failed after 3 consecutive HTTP 422 errors
+```
+
+### Design: Cleanup Before Each Subprocess Launch
+
+Before launching (or relaunching) `gh webhook forward`, Fabrik deletes any orphaned forwarding hooks it previously created at GitHub. The cleanup is a REST LIST + DELETE sequence inserted at the top of each `supervise()` loop iteration, after the lock-protected repos snapshot and the zero-repo guard, but before `buildGhArgs` / `startFn`.
+
+**Discriminator**: `gh webhook forward` registers hooks with `config.url = "https://webhook-forwarder.github.com/hook"` (`webhookForwarderURL` constant). Only hooks matching this URL are eligible for deletion; all other hooks are left untouched.
+
+**Error handling (non-fatal)**: If the LIST request fails (403, network error, 404) or any DELETE fails with a non-404 status, `cleanupFn` returns an error. The supervisor logs a warning and proceeds with subprocess launch regardless — the circuit-breaker remains as defense-in-depth. A 404 on DELETE is treated as success (hook already gone; idempotent).
+
+**Counter reset (R9)**: After `cleanupFn` returns `nil` (orphans deleted or none found), `permanentFailureCount` is reset to zero under `wm.mu` before the subprocess starts. Prior 422s were caused by the orphan and are no longer evidence of a permanent failure. If cleanup itself fails, the counter is not reset.
+
+**Scope**: Per-repo mode only (`GET /repos/{owner}/{repo}/hooks`, `DELETE /repos/{owner}/{repo}/hooks/<id>`). Org-mode cleanup (`/orgs/{org}/hooks`) is deferred; most fabrik tokens lack `admin:org` scope, as evidenced by 404 responses on every `/orgs/…` attempt. The PR for this issue documents this non-coverage explicitly.
+
+### Injection Pattern
+
+The cleanup function is injected as `cleanupFn func(repos []string) error` — a new field on `webhookManager` and a new final parameter to `newWebhookManager`. This matches the existing injection pattern for `killFn`, `startSubprocessFn`, `deltaFn`, and `healthChangeFn`. Tests that don't need cleanup pass `nil`; production wires a closure over `e.client.DeleteForwardingHooks`.
+
+The `DeleteForwardingHooks(owner, repo string) error` method lives in a new `github/hooks.go` file. It uses the existing `restGetJSON` and `restDelete` helpers.
+
+### Implementation Files
+
+- `github/hooks.go`: `webhookForwarderURL` constant; `repoHook` unexported type; `DeleteForwardingHooks` method.
+- `github/hooks_test.go`: `TestDeleteForwardingHooks_*` — five cases covering no-match, one-match, multi-match, GET failure, and 404-on-DELETE.
+- `engine/webhook.go`: `cleanupFn` field on `webhookManager`; updated `newWebhookManager` signature; cleanup call in `supervise()` with logging and `permanentFailureCount` reset.
+- `engine/webhook_test.go`: `TestSupervise_CleanupCalledBeforeEachSubprocess` (R8) — verifies ordering via a shared event sequence.
+- `engine/interfaces.go`: `DeleteForwardingHooks` added to `GitHubClient` interface.
+- `engine/poll.go`: `cleanupFn` closure wired at the `newWebhookManager` call site.

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -133,6 +133,7 @@ func (m *testGitHubUpgradeClient) FetchProjectUpdatedAt(projectID string) (time.
 func (m *testGitHubUpgradeClient) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {
 	return "", "", nil
 }
+func (m *testGitHubUpgradeClient) DeleteForwardingHooks(owner, repo string) error { return nil }
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -44,6 +44,7 @@ type GitHubClient interface {
 	FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error)
 	SeedLabels(owner, repo string, stageNames []string, lockedUser string) error
 	RateLimitStats() (rest, graphql gh.RateLimitStats)
+	DeleteForwardingHooks(owner, repo string) error
 	FetchProjectItemStatus(itemID string) (string, error)
 	FetchProjectItemStatusBatch(projectID string) (map[string]string, error)
 	FetchProjectUpdatedAt(projectID string) (time.Time, error)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -504,6 +504,10 @@ func (m *mockGitHubClient) FetchProjectItem(owner, repo string, issueNumber int)
 	return nil, nil
 }
 
+func (m *mockGitHubClient) DeleteForwardingHooks(owner, repo string) error {
+	return nil
+}
+
 func (m *mockGitHubClient) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStats) {
 	if m.rateLimitStatsFn != nil {
 		return m.rateLimitStatsFn()

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -383,16 +383,21 @@ func (e *Engine) Run() error {
 			}
 		}
 		cleanupFn := func(repos []string) error {
+			var firstErr error
 			for _, r := range repos {
 				owner, repo := parseOwnerRepo(r)
 				if owner == "" {
+					e.logf(0, "webhook", "skipping malformed repo in cleanup: %q\n", r)
 					continue
 				}
 				if err := e.client.DeleteForwardingHooks(owner, repo); err != nil {
-					return err
+					e.logf(0, "webhook", "orphan hook cleanup failed for %s/%s: %v\n", owner, repo, err)
+					if firstErr == nil {
+						firstErr = err
+					}
 				}
 			}
-			return nil
+			return firstErr
 		}
 		wm := newWebhookManager(
 			e.logf,

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -382,6 +382,18 @@ func (e *Engine) Run() error {
 				}
 			}
 		}
+		cleanupFn := func(repos []string) error {
+			for _, r := range repos {
+				owner, repo := parseOwnerRepo(r)
+				if owner == "" {
+					continue
+				}
+				if err := e.client.DeleteForwardingHooks(owner, repo); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 		wm := newWebhookManager(
 			e.logf,
 			e.wakeCh,
@@ -390,6 +402,7 @@ func (e *Engine) Run() error {
 			e.cfg.WebhookEvents,
 			deltaFn,
 			healthChangeFn,
+			cleanupFn,
 		)
 		// Inject MatchEcho so ApplyDelta can clear pending echo entries on incoming webhooks.
 		if cacheImpl != nil {

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -96,9 +96,7 @@ type webhookManager struct {
 	// startSubprocessFn overrides startSubprocessInternal when non-nil (tests only).
 	startSubprocessFn func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error)
 
-	// cleanupFn deletes orphaned gh webhook forward hooks registered at GitHub
-	// in prior sessions. Called before each subprocess launch. Non-fatal: if nil
-	// or if it returns an error, the supervisor proceeds without cleanup.
+	// cleanupFn deletes orphaned gh-forward hooks before each subprocess launch; nil or error is non-fatal.
 	cleanupFn func(repos []string) error
 
 	// probeTimeout overrides orgModeProbeTimeout when non-zero (tests only).
@@ -675,12 +673,7 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 			continue
 		}
 
-		// Orphan cleanup: delete any gh webhook forward hooks registered in prior
-		// sessions before starting a new subprocess. This prevents HTTP 422
-		// "Hook already exists" errors caused by orphaned hooks from crashed sessions.
-		// Non-fatal: if cleanup fails or cleanupFn is nil, the supervisor proceeds.
-		// On success, permanentFailureCount is reset — prior 422s were caused by the
-		// orphan and are no longer evidence of a permanent failure (R9).
+		// Delete orphaned forwarding hooks; on success reset the 422 counter (R9 — prior 422s were from the orphan).
 		if wm.cleanupFn != nil {
 			if err := wm.cleanupFn(repos); err != nil {
 				wm.logFn(0, "webhook", "WARNING: orphan webhook cleanup failed: %v — proceeding\n", err)

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -96,6 +96,11 @@ type webhookManager struct {
 	// startSubprocessFn overrides startSubprocessInternal when non-nil (tests only).
 	startSubprocessFn func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error)
 
+	// cleanupFn deletes orphaned gh webhook forward hooks registered at GitHub
+	// in prior sessions. Called before each subprocess launch. Non-fatal: if nil
+	// or if it returns an error, the supervisor proceeds without cleanup.
+	cleanupFn func(repos []string) error
+
 	// probeTimeout overrides orgModeProbeTimeout when non-zero (tests only).
 	probeTimeout time.Duration
 
@@ -156,6 +161,7 @@ func newWebhookManager(
 	events []string,
 	deltaFn func(string, []byte),
 	healthChangeFn func(bool),
+	cleanupFn func([]string) error,
 ) *webhookManager {
 	evts := events
 	if len(evts) == 0 {
@@ -168,6 +174,7 @@ func newWebhookManager(
 		emitFn:             emitFn,
 		deltaFn:            deltaFn,
 		healthChangeFn:     healthChangeFn,
+		cleanupFn:          cleanupFn,
 		repos:              copyRepoSet(repos),
 		events:             evts,
 		state:              WebhookStreamUnhealthy, // becomes StartingUp when subprocess launches
@@ -666,6 +673,22 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 			case <-time.After(webhookMaxRestartBackoff):
 			}
 			continue
+		}
+
+		// Orphan cleanup: delete any gh webhook forward hooks registered in prior
+		// sessions before starting a new subprocess. This prevents HTTP 422
+		// "Hook already exists" errors caused by orphaned hooks from crashed sessions.
+		// Non-fatal: if cleanup fails or cleanupFn is nil, the supervisor proceeds.
+		// On success, permanentFailureCount is reset — prior 422s were caused by the
+		// orphan and are no longer evidence of a permanent failure (R9).
+		if wm.cleanupFn != nil {
+			if err := wm.cleanupFn(repos); err != nil {
+				wm.logFn(0, "webhook", "WARNING: orphan webhook cleanup failed: %v — proceeding\n", err)
+			} else {
+				wm.mu.Lock()
+				wm.permanentFailureCount = 0
+				wm.mu.Unlock()
+			}
 		}
 
 		args := buildGhArgs(org, repos, port, secret, events)

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -203,6 +204,7 @@ func newTestWebhookManager(t *testing.T) (*webhookManager, chan tui.Event) {
 		map[string]bool{"myorg/myrepo": true},
 		nil,
 		deltaFn,
+		nil,
 		nil,
 	)
 	return wm, events
@@ -1436,4 +1438,64 @@ func TestHealthTransition_SessionStale(t *testing.T) {
 			t.Errorf("state = %q, want %q when sessionLastEventAt is fresh", state, WebhookStreamHealthy)
 		}
 	})
+}
+
+// TestSupervise_CleanupCalledBeforeEachSubprocess verifies R8: the cleanupFn is
+// invoked before each gh webhook forward subprocess launch, including the initial
+// start and each subsequent restart. Call ordering is verified by recording
+// "cleanup" and "subprocess" events into a shared slice and checking that cleanup
+// always precedes its paired subprocess start.
+func TestSupervise_CleanupCalledBeforeEachSubprocess(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	wm.probeTimeout = 30 * time.Millisecond
+	wm.mu.Lock()
+	wm.orgModeFailed = true // force per-repo mode so cleanup runs
+	wm.mu.Unlock()
+
+	var mu sync.Mutex
+	var events []string
+
+	wm.cleanupFn = func(repos []string) error {
+		mu.Lock()
+		events = append(events, "cleanup")
+		mu.Unlock()
+		return nil
+	}
+
+	wm.startSubprocessFn = func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+		mu.Lock()
+		events = append(events, "subprocess")
+		mu.Unlock()
+		cmd := exec.CommandContext(ctx, "sh", "-c", "exit 1")
+		if err := cmd.Start(); err != nil {
+			return nil, nil, fmt.Errorf("starting fake subprocess: %w", err)
+		}
+		ch := make(chan string, 1)
+		ch <- "" // empty stderr — not a 422 error, so circuit-breaker does not fire
+		return cmd, ch, nil
+	}
+
+	// Run supervise for long enough to get at least 2 cleanup+subprocess pairs.
+	// First restart backoff is 1 s, so 3 s is enough for 2 iterations.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go wm.supervise(ctx)
+	<-ctx.Done()
+
+	mu.Lock()
+	evts := make([]string, len(events))
+	copy(evts, events)
+	mu.Unlock()
+
+	if len(evts) < 4 {
+		t.Fatalf("got %d events, want at least 4 (2× cleanup+subprocess pairs): %v", len(evts), evts)
+	}
+
+	// Verify cleanup always immediately precedes its paired subprocess start.
+	for i := 0; i+1 < len(evts); i += 2 {
+		if evts[i] != "cleanup" || evts[i+1] != "subprocess" {
+			t.Errorf("events[%d:%d] = %v, want [cleanup subprocess]", i, i+2, evts[i:i+2])
+		}
+	}
 }

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -1499,3 +1499,75 @@ func TestSupervise_CleanupCalledBeforeEachSubprocess(t *testing.T) {
 		}
 	}
 }
+
+// TestSupervise_CleanupSuccessResetsCounter verifies R9(a): when cleanupFn returns nil,
+// permanentFailureCount is reset to 0 before the next subprocess is launched.
+func TestSupervise_CleanupSuccessResetsCounter(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	wm.mu.Lock()
+	wm.orgModeFailed = true
+	wm.permanentFailureCount = 2 // pre-set to non-zero
+	wm.mu.Unlock()
+
+	counterAtStart := make(chan int, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wm.cleanupFn = func(repos []string) error { return nil }
+
+	wm.startSubprocessFn = func(fctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+		wm.mu.Lock()
+		count := wm.permanentFailureCount
+		wm.mu.Unlock()
+		counterAtStart <- count
+		cancel()
+		return nil, nil, fmt.Errorf("test stop")
+	}
+
+	go wm.supervise(ctx)
+
+	select {
+	case count := <-counterAtStart:
+		if count != 0 {
+			t.Errorf("permanentFailureCount = %d after successful cleanup, want 0", count)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for subprocess start")
+	}
+}
+
+// TestSupervise_CleanupFailurePreservesCounter verifies R9(b): when cleanupFn returns
+// an error, permanentFailureCount is not reset and retains its prior value.
+func TestSupervise_CleanupFailurePreservesCounter(t *testing.T) {
+	wm, _ := newTestWebhookManager(t)
+	wm.mu.Lock()
+	wm.orgModeFailed = true
+	wm.permanentFailureCount = 2
+	wm.mu.Unlock()
+
+	counterAtStart := make(chan int, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wm.cleanupFn = func(repos []string) error { return fmt.Errorf("cleanup failed") }
+
+	wm.startSubprocessFn = func(fctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
+		wm.mu.Lock()
+		count := wm.permanentFailureCount
+		wm.mu.Unlock()
+		counterAtStart <- count
+		cancel()
+		return nil, nil, fmt.Errorf("test stop")
+	}
+
+	go wm.supervise(ctx)
+
+	select {
+	case count := <-counterAtStart:
+		if count != 2 {
+			t.Errorf("permanentFailureCount = %d after cleanup failure, want 2 (unchanged)", count)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for subprocess start")
+	}
+}

--- a/github/hooks.go
+++ b/github/hooks.go
@@ -1,0 +1,41 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+)
+
+// webhookForwarderURL is the config.url value that gh webhook forward registers
+// at GitHub. Only webhooks with this URL are treated as orphaned forwarding hooks
+// eligible for cleanup.
+const webhookForwarderURL = "https://webhook-forwarder.github.com/hook"
+
+type repoHook struct {
+	ID     int `json:"id"`
+	Config struct {
+		URL string `json:"url"`
+	} `json:"config"`
+}
+
+// DeleteForwardingHooks lists all webhooks for owner/repo and deletes any created
+// by gh webhook forward (identified by config.url matching webhookForwarderURL).
+// It is idempotent: if no matching hooks exist, it is a no-op. 404 on DELETE is
+// treated as success (hook already gone). Non-forwarding hooks are left untouched.
+func (c *Client) DeleteForwardingHooks(owner, repo string) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/hooks", c.baseURL, owner, repo)
+	var hooks []repoHook
+	if err := c.restGetJSON(url, &hooks); err != nil {
+		return fmt.Errorf("listing hooks for %s/%s: %w", owner, repo, err)
+	}
+
+	for _, h := range hooks {
+		if h.Config.URL != webhookForwarderURL {
+			continue
+		}
+		delURL := fmt.Sprintf("%s/repos/%s/%s/hooks/%d", c.baseURL, owner, repo, h.ID)
+		if err := c.restDelete(delURL); err != nil && !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("deleting forwarding hook %d for %s/%s: %w", h.ID, owner, repo, err)
+		}
+	}
+	return nil
+}

--- a/github/hooks.go
+++ b/github/hooks.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 )
 
-// webhookForwarderURL is the config.url value that gh webhook forward registers
-// at GitHub. Only webhooks with this URL are treated as orphaned forwarding hooks
-// eligible for cleanup.
+// webhookForwarderURL is the config.url that gh webhook forward registers at GitHub.
 const webhookForwarderURL = "https://webhook-forwarder.github.com/hook"
 
 type repoHook struct {
@@ -17,10 +15,7 @@ type repoHook struct {
 	} `json:"config"`
 }
 
-// DeleteForwardingHooks lists all webhooks for owner/repo and deletes any created
-// by gh webhook forward (identified by config.url matching webhookForwarderURL).
-// It is idempotent: if no matching hooks exist, it is a no-op. 404 on DELETE is
-// treated as success (hook already gone). Non-forwarding hooks are left untouched.
+// DeleteForwardingHooks deletes repo hooks matching webhookForwarderURL; 404 on DELETE is success.
 func (c *Client) DeleteForwardingHooks(owner, repo string) error {
 	url := fmt.Sprintf("%s/repos/%s/%s/hooks", c.baseURL, owner, repo)
 	var hooks []repoHook

--- a/github/hooks.go
+++ b/github/hooks.go
@@ -17,7 +17,7 @@ type repoHook struct {
 
 // DeleteForwardingHooks deletes repo hooks matching webhookForwarderURL; 404 on DELETE is success.
 func (c *Client) DeleteForwardingHooks(owner, repo string) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/hooks", c.baseURL, owner, repo)
+	url := fmt.Sprintf("%s/repos/%s/%s/hooks?per_page=100", c.baseURL, owner, repo)
 	var hooks []repoHook
 	if err := c.restGetJSON(url, &hooks); err != nil {
 		return fmt.Errorf("listing hooks for %s/%s: %w", owner, repo, err)

--- a/github/hooks_test.go
+++ b/github/hooks_test.go
@@ -1,0 +1,139 @@
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// hookWithURL builds a repoHook JSON object for the given id and config.url.
+func hookJSON(id int, configURL string) repoHook {
+	h := repoHook{ID: id}
+	h.Config.URL = configURL
+	return h
+}
+
+// TestDeleteForwardingHooks_NoMatchingHooks verifies that when no hooks match
+// webhookForwarderURL, zero DELETE requests are made.
+func TestDeleteForwardingHooks_NoMatchingHooks(t *testing.T) {
+	deleteCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deleteCount++
+		}
+		if r.Method == "GET" {
+			hooks := []repoHook{
+				hookJSON(1, "https://example.com/other-hook"),
+				hookJSON(2, "https://ci.example.com/webhook"),
+			}
+			json.NewEncoder(w).Encode(hooks)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	if err := c.DeleteForwardingHooks("owner", "repo"); err != nil {
+		t.Fatalf("DeleteForwardingHooks: %v", err)
+	}
+	if deleteCount != 0 {
+		t.Errorf("DELETE called %d times, want 0", deleteCount)
+	}
+}
+
+// TestDeleteForwardingHooks_OneMatchingHook verifies that one matching hook results
+// in exactly one DELETE request.
+func TestDeleteForwardingHooks_OneMatchingHook(t *testing.T) {
+	var deletedIDs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			hooks := []repoHook{
+				hookJSON(1, "https://example.com/other"),
+				hookJSON(42, webhookForwarderURL),
+			}
+			json.NewEncoder(w).Encode(hooks)
+		case "DELETE":
+			deletedIDs = append(deletedIDs, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	if err := c.DeleteForwardingHooks("owner", "repo"); err != nil {
+		t.Fatalf("DeleteForwardingHooks: %v", err)
+	}
+	if len(deletedIDs) != 1 {
+		t.Fatalf("DELETE called %d times, want 1; paths: %v", len(deletedIDs), deletedIDs)
+	}
+	want := "/repos/owner/repo/hooks/42"
+	if deletedIDs[0] != want {
+		t.Errorf("DELETE path = %q, want %q", deletedIDs[0], want)
+	}
+}
+
+// TestDeleteForwardingHooks_MultipleMatchingHooks verifies that all matching hooks
+// are deleted when multiple forwarding hooks exist.
+func TestDeleteForwardingHooks_MultipleMatchingHooks(t *testing.T) {
+	deleteCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			hooks := []repoHook{
+				hookJSON(10, webhookForwarderURL),
+				hookJSON(20, "https://other.example.com/hook"),
+				hookJSON(30, webhookForwarderURL),
+			}
+			json.NewEncoder(w).Encode(hooks)
+		case "DELETE":
+			deleteCount++
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	if err := c.DeleteForwardingHooks("owner", "repo"); err != nil {
+		t.Fatalf("DeleteForwardingHooks: %v", err)
+	}
+	if deleteCount != 2 {
+		t.Errorf("DELETE called %d times, want 2", deleteCount)
+	}
+}
+
+// TestDeleteForwardingHooks_GETFails verifies that a GET failure propagates as an error.
+func TestDeleteForwardingHooks_GETFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	err := c.DeleteForwardingHooks("owner", "repo")
+	if err == nil {
+		t.Fatal("expected error when GET fails, got nil")
+	}
+}
+
+// TestDeleteForwardingHooks_DELETE404TreatedAsSuccess verifies that a 404 on DELETE
+// is not returned as an error (hook already gone — idempotent).
+func TestDeleteForwardingHooks_DELETE404TreatedAsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			hooks := []repoHook{hookJSON(99, webhookForwarderURL)}
+			json.NewEncoder(w).Encode(hooks)
+		case "DELETE":
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message":"Not Found"}`))
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	if err := c.DeleteForwardingHooks("owner", "repo"); err != nil {
+		t.Fatalf("DeleteForwardingHooks: got error on 404 DELETE, want nil: %v", err)
+	}
+}

--- a/github/hooks_test.go
+++ b/github/hooks_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// hookWithURL builds a repoHook JSON object for the given id and config.url.
+// hookJSON builds a repoHook with the given id and config.url.
 func hookJSON(id int, configURL string) repoHook {
 	h := repoHook{ID: id}
 	h.Config.URL = configURL


### PR DESCRIPTION
## Summary

- Adds `DeleteForwardingHooks(owner, repo string) error` to the `github` package — lists repo hooks via REST and deletes any with `config.url == "https://webhook-forwarder.github.com/hook"` (the URL `gh webhook forward` registers). 404 on DELETE is treated as success (idempotent).
- Injects a `cleanupFn func([]string) error` callback into `webhookManager` (new final parameter to `newWebhookManager`), called at the top of the `supervise()` loop before each subprocess launch. On success, `permanentFailureCount` is reset to zero — prior 422s were caused by the orphan and are no longer evidence of a permanent failure (R9).
- Cleanup failure is non-fatal: a warning is logged and the supervisor proceeds; the 422 circuit-breaker remains as defense-in-depth.

**Org-mode cleanup is not included.** Most fabrik tokens lack `admin:org` scope; org-level orphan cleanup is tracked as a follow-up. Per-repo orphans are the source of the reproduction failure.

## Key changes

| File | Change |
|------|--------|
| `github/hooks.go` | New `webhookForwarderURL` constant and `DeleteForwardingHooks` method |
| `github/hooks_test.go` | Five test cases: no-match, one-match, multi-match, GET-fail, 404-DELETE |
| `engine/webhook.go` | `cleanupFn` field; updated `newWebhookManager` signature; cleanup call + counter reset in `supervise()` |
| `engine/webhook_test.go` | `TestSupervise_CleanupCalledBeforeEachSubprocess` (R8) — verifies cleanup precedes each subprocess start |
| `engine/interfaces.go` | `DeleteForwardingHooks` added to `GitHubClient` interface |
| `engine/poll.go` | `cleanupFn` closure wired at `newWebhookManager` call site |
| `adrs/032-webhook-event-delivery.md` | Amendment 3: orphan cleanup mechanic |

## How to test

1. Start fabrik with `--webhooks` on a repo where you have `admin:repo_hook` scope.
2. Kill fabrik without letting it clean up (e.g. `kill -9`), leaving an orphaned hook visible at `gh api repos/OWNER/REPO/hooks`.
3. Restart fabrik — verify the orphaned hook is deleted before the new subprocess launches (log: no 422 errors), and the hook list shows only one active entry after startup.
4. Run the unit tests: `go test ./github/... ./engine/... -run TestDeleteForwarding -run TestSupervise_Cleanup`

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)