### PR TITLE
feat: replace event-silence webhook health with periodic light reconcile (#641)

### DIFF
--- a/adrs/043-reconcile-driven-webhook-health.md
+++ b/adrs/043-reconcile-driven-webhook-health.md
@@ -26,7 +26,7 @@ The `reconcileTicker` goroutine runs in `engine/poll.go:Run()` at a configurable
 
 1. Snapshots the current cache items (under lock).
 2. Calls `c.fallback.FetchProjectBoard(...)` to fetch a shallow live snapshot from GitHub (without holding the lock).
-3. Compares each item on `status`, `len(labels)`, and `updatedAt`.
+3. Compares each item on `status` and `updatedAt` (label count is excluded — the board query returns at most 30 labels while the cache may hold the full deep-fetched set; label mutations are captured by `updatedAt`).
 4. Returns `(driftCount int, driftedKeys []string, freshBoard *gh.ProjectBoard, err error)`.
 
 The `reconcileTicker` goroutine acts on the result:
@@ -74,7 +74,7 @@ Each `LightReconcile` tick costs one `FetchProjectBoard` GraphQL call. At the de
 - **Drift is detected within one reconcile interval** (≤ 3 minutes by default) regardless of whether a webhook event arrived.
 - **Network errors during reconcile are silent.** A transient GitHub API failure during `LightReconcile` logs a warning and makes no state change — it does not flip health to unhealthy, avoiding the false-positive regression introduced by a different mechanism.
 - **Drift window briefly sets state to `Unhealthy` then immediately back to `Healthy`** within the same tick. If `IsHealthyOrStartingUp()` is sampled in this window, the poll loop uses the 5-minute idle cap for one cycle. This is acceptable and mirrors the existing Pause/Reconcile/Resume window.
-- **Startup latency**: The engine operates with the shorter idle cap (5 minutes) for up to ~3 minutes at startup, until the first reconcile tick confirms no drift and transitions to `Healthy`. Previously, the first verified webhook event could trigger a `Healthy` transition within seconds. This is a minor startup regression accepted as a tradeoff for correctness.
+- **Startup latency**: The 5-minute idle cap applies only in the brief window before the subprocess launches (state = `Unhealthy`). Once the subprocess starts and state becomes `StartingUp`, `IsHealthyOrStartingUp()` returns `true` and the 60-minute idle cap applies immediately. The engine stays in `StartingUp` (60-minute cap) until the first reconcile tick (~3 minutes), at which point it transitions to `Healthy`. Previously, the first verified webhook event could instantly transition from `StartingUp` to `Healthy`; under the new model this takes up to one reconcile interval. This is a minor startup regression accepted as a tradeoff for correctness.
 - **422 circuit-breaker no longer immediately pauses the cache.** The circuit-breaker in `supervise()` still sets `wm.disabled = true` and `wm.state = WebhookStreamUnhealthy`, but no longer calls `cacheImpl.Pause()` directly. The cache continues serving from its in-memory state until the next reconcile tick; if the board is truly unchanged (as expected when webhooks are merely disabled), the tick finds no drift and health remains or recovers to `Healthy`.
 
 ## Cross-references

--- a/adrs/043-reconcile-driven-webhook-health.md
+++ b/adrs/043-reconcile-driven-webhook-health.md
@@ -1,0 +1,84 @@
+# ADR-043: Reconcile-driven webhook health detection
+
+**Status:** Accepted  
+**Issue:** #641  
+**Date:** 2026-05-07
+
+## Context
+
+The original webhook health model (ADR-032) used an event-silence heuristic: if no verified webhook event arrived within `webhookHealthWindow` (10 minutes), the stream was declared `Unhealthy`, triggering a full `Reconcile` + `Pause`/`Resume` cycle.
+
+This conflated two fundamentally different conditions:
+
+- **Idle board with healthy webhooks**: GitHub produces no events when nothing changes. The heuristic marks the stream unhealthy after 10 minutes of board inactivity even when the cache is perfectly coherent — producing a false-unhealthy transition that burns a GraphQL call for a full `FetchProjectBoard` + `Reconcile`.
+
+- **Dead webhook stream with active board**: Webhook silence AND cache staleness — the true unhealthy case.
+
+The threshold was raised from 60 s to 5 minutes in #638, and a startup grace window (`webhookStartupGrace = 30s`) was added. These tuned the symptom but did not fix the root cause: **event silence is not the same as cache staleness**.
+
+Additionally, the `healthChangeFn` callback (ADR-034) created an indirect coupling between the `webhookManager` struct and the cache Pause/Reconcile/Resume sequence — a callback injected at construction time that made the health-to-cache wiring non-obvious.
+
+## Decision
+
+**Replace event-silence health detection with a periodic light-reconcile loop.**
+
+The `reconcileTicker` goroutine runs in `engine/poll.go:Run()` at a configurable cadence (default: 3 minutes). On each tick it calls `cacheImpl.LightReconcile(...)`, which:
+
+1. Snapshots the current cache items (under lock).
+2. Calls `c.fallback.FetchProjectBoard(...)` to fetch a shallow live snapshot from GitHub (without holding the lock).
+3. Compares each item on `status`, `len(labels)`, and `updatedAt`.
+4. Returns `(driftCount int, driftedKeys []string, freshBoard *gh.ProjectBoard, err error)`.
+
+The `reconcileTicker` goroutine acts on the result:
+
+| Result | Action |
+|--------|--------|
+| No drift | `wm.transitionHealthState(Healthy, "")` |
+| Drift detected | `transitionHealthState(Unhealthy, ...)` → `Pause()` → `Reconcile(freshBoard)` → `Resume()` → `transitionHealthState(Healthy, "drift reconciled")` |
+| Network error | Log warning; no state change |
+
+The `freshBoard` returned by `LightReconcile` is passed directly to `Reconcile()` on drift — no second API call is needed.
+
+`healthChangeFn` and the `runHealthMonitor` / `checkHealthTransitions` functions are removed. The `reconcileTicker` goroutine owns the Pause/Reconcile/Resume sequence directly.
+
+## What changed
+
+**Removed:**
+- `runHealthMonitor` and `checkHealthTransitions` functions from `engine/webhook.go`
+- `healthChangeFn` field, constructor parameter, and closure from `webhookManager` / `poll.go`
+- Event-silence constants: `webhookEventStaleTimeout`, `webhookHealthWindow`, `webhookStartupGrace`
+- Session-level health fields: `lastEventTime`, `sessionFirstStartAt`, `sessionLastEventAt`
+- `handleWebhook` no longer sets `wm.state = WebhookStreamHealthy` on verified events
+
+**Added:**
+- `boardcache.LightReconcile()` — shallow drift-detection method on `*CacheImpl`
+- `reconcileTicker` goroutine in `engine/poll.go:Run()` (started only when `cacheImpl != nil && webhookMgr != nil`)
+- `wm.transitionHealthState(newState, reason)` — compact helper that acquires `wm.mu`, updates state if changed, logs the transition, and calls `emitCurrentState()`
+- `lightReconcileInterval = 3 * time.Minute` constant in `engine/webhook.go`
+- `--reconcile-interval` flag and `FABRIK_RECONCILE_INTERVAL` env var (int seconds; 0 → 180 s default)
+- `ReconcileInterval time.Duration` in `engine.Config`
+
+## Startup behavior
+
+`WebhookStreamStartingUp` is retained with **pessimistic behavior**: health stays `StartingUp` until the first `reconcileTicker` tick completes (no drift → transitions to `Healthy`; drift → reconciles and then transitions to `Healthy`). `IsHealthyOrStartingUp()` returns `true` for `StartingUp`, so the 60-minute idle cap applies as soon as the subprocess launches. The first tick (~3 minutes after launch) resolves the state.
+
+The `webhookStartupGrace` constant is removed; `StartingUp` naturally persists until the first tick.
+
+## API cost
+
+Each `LightReconcile` tick costs one `FetchProjectBoard` GraphQL call. At the default 3-minute cadence: **20 calls/hour** — negligible against the 5000-point/hour budget. At 5-minute cadence: 12 calls/hour.
+
+## Consequences
+
+- **Idle boards no longer trigger false-unhealthy transitions.** Hours of webhook silence on a quiet board produce no health state change, no Pause, and no unnecessary GraphQL spend.
+- **Drift is detected within one reconcile interval** (≤ 3 minutes by default) regardless of whether a webhook event arrived.
+- **Network errors during reconcile are silent.** A transient GitHub API failure during `LightReconcile` logs a warning and makes no state change — it does not flip health to unhealthy, avoiding the false-positive regression introduced by a different mechanism.
+- **Drift window briefly sets state to `Unhealthy` then immediately back to `Healthy`** within the same tick. If `IsHealthyOrStartingUp()` is sampled in this window, the poll loop uses the 5-minute idle cap for one cycle. This is acceptable and mirrors the existing Pause/Reconcile/Resume window.
+- **Startup latency**: The engine operates with the shorter idle cap (5 minutes) for up to ~3 minutes at startup, until the first reconcile tick confirms no drift and transitions to `Healthy`. Previously, the first verified webhook event could trigger a `Healthy` transition within seconds. This is a minor startup regression accepted as a tradeoff for correctness.
+- **422 circuit-breaker no longer immediately pauses the cache.** The circuit-breaker in `supervise()` still sets `wm.disabled = true` and `wm.state = WebhookStreamUnhealthy`, but no longer calls `cacheImpl.Pause()` directly. The cache continues serving from its in-memory state until the next reconcile tick; if the board is truly unchanged (as expected when webhooks are merely disabled), the tick finds no drift and health remains or recovers to `Healthy`.
+
+## Cross-references
+
+- [ADR-032: Webhook-Driven Event Delivery](032-webhook-event-delivery.md) — established the three-state health model; this ADR supersedes its health-detection and state-transition sections while retaining the three states (`StartingUp`/`Healthy`/`Unhealthy`) and their idle-cap semantics.
+- [ADR-034: Board-Cache Event-Sourced Delta](034-boardcache-event-sourced-delta.md) — established `healthChangeFn` as the bridge from webhook health to cache Pause/Resume; the `healthChangeFn` callback is removed by this ADR.
+- [Issue #638](https://github.com/tenaciousvc/fabrik/issues/638) — raised `webhookEventStaleTimeout` from 60 s to 5 min (treated the symptom; this ADR fixes the root cause).

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -916,8 +916,13 @@ func (c *CacheImpl) ProjectID() string {
 }
 
 // LightReconcile fetches a fresh shallow board snapshot from GitHub and compares
-// it against the current cache state on three fields: status, label count, and
-// updatedAt. Returns the number of drifted items, their keys, and the fresh board
+// it against the current cache state on two fields: status and updatedAt.
+// Label count is intentionally excluded: the board query returns at most 30 labels
+// (shallow), while the cache may hold the full deep-fetched set; comparing counts
+// would produce persistent false-positive drift for issues with >30 labels. Label
+// mutations are captured by updatedAt, so the two-field check is sufficient.
+//
+// Returns the number of drifted items, their keys, and the fresh board
 // (to avoid a double-fetch when the caller passes it to Reconcile on drift).
 //
 // On network error the method returns a non-nil err, nil freshBoard, and 0 drift.
@@ -928,7 +933,6 @@ func (c *CacheImpl) ProjectID() string {
 func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType string) (driftCount int, driftedKeys []string, freshBoard *gh.ProjectBoard, err error) {
 	type entry struct {
 		status    string
-		labelLen  int
 		updatedAt time.Time
 	}
 
@@ -939,7 +943,6 @@ func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType
 		s := snap.State()
 		cached[itemKey(snap.Repo(), snap.Number())] = entry{
 			status:    s.Status,
-			labelLen:  len(s.Labels),
 			updatedAt: s.UpdatedAt,
 		}
 	}
@@ -961,9 +964,7 @@ func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType
 			driftedKeys = append(driftedKeys, key)
 			continue
 		}
-		if e.status != pi.Status ||
-			e.labelLen != len(pi.Labels) ||
-			!e.updatedAt.Equal(pi.UpdatedAt) {
+		if e.status != pi.Status || !e.updatedAt.Equal(pi.UpdatedAt) {
 			driftCount++
 			driftedKeys = append(driftedKeys, key)
 		}

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -204,13 +204,12 @@ type CacheImpl struct {
 	// store owns per-item state (items, shaToKey, itemIDToKey, prToKey, pendingCheckRuns).
 	store *itemstate.Store
 
-	fallback     ReadClient
-	logFn        func(format string, args ...any)
-	matchEchoFn  func(eventType, action, key string) // injected by engine; nil when cache disabled
+	fallback    ReadClient
+	logFn       func(format string, args ...any)
+	matchEchoFn func(eventType, action, key string) // injected by engine; nil when cache disabled
 }
 
 // SetMatchEchoFn injects the MatchEcho function from the webhook manager.
-// Called once at startup in poll.go after the webhookManager is constructed.
 func (c *CacheImpl) SetMatchEchoFn(fn func(eventType, action, key string)) {
 	c.matchEchoFn = fn
 }
@@ -914,6 +913,71 @@ func (c *CacheImpl) ProjectID() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.projectID
+}
+
+// LightReconcile fetches a fresh shallow board snapshot from GitHub and compares
+// it against the current cache state on three fields: status, label count, and
+// updatedAt. Returns the number of drifted items, their keys, and the fresh board
+// (to avoid a double-fetch when the caller passes it to Reconcile on drift).
+//
+// On network error the method returns a non-nil err, nil freshBoard, and 0 drift.
+// The caller should log a warning and make no health state change.
+//
+// LightReconcile must not hold c.mu during the FetchProjectBoard call, following
+// the "NEVER hold mu while calling Store" invariant and avoiding slow I/O under lock.
+func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType string) (driftCount int, driftedKeys []string, freshBoard *gh.ProjectBoard, err error) {
+	type entry struct {
+		status    string
+		labelLen  int
+		updatedAt time.Time
+	}
+
+	// Snapshot current cache items. Store.All() handles its own locking.
+	snaps := c.store.All()
+	cached := make(map[string]entry, len(snaps))
+	for _, snap := range snaps {
+		s := snap.State()
+		cached[itemKey(snap.Repo(), snap.Number())] = entry{
+			status:    s.Status,
+			labelLen:  len(s.Labels),
+			updatedAt: s.UpdatedAt,
+		}
+	}
+
+	// Fetch fresh board from GitHub (no lock held).
+	freshBoard, err = c.fallback.FetchProjectBoard(owner, repo, projectNum, ownerType)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	freshKeys := make(map[string]bool, len(freshBoard.Items))
+	for i := range freshBoard.Items {
+		pi := &freshBoard.Items[i]
+		key := itemKey(pi.Repo, pi.Number)
+		freshKeys[key] = true
+		e, inCache := cached[key]
+		if !inCache {
+			driftCount++
+			driftedKeys = append(driftedKeys, key)
+			continue
+		}
+		if e.status != pi.Status ||
+			e.labelLen != len(pi.Labels) ||
+			!e.updatedAt.Equal(pi.UpdatedAt) {
+			driftCount++
+			driftedKeys = append(driftedKeys, key)
+		}
+	}
+
+	// Items in the cache that are no longer on the fresh board are also drift.
+	for key := range cached {
+		if !freshKeys[key] {
+			driftCount++
+			driftedKeys = append(driftedKeys, key)
+		}
+	}
+
+	return driftCount, driftedKeys, freshBoard, nil
 }
 
 // copyDeepFieldsFromState overlays deep fields from an ItemState onto a *gh.ProjectItem.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -2046,12 +2046,15 @@ func TestLightReconcile_DriftDetected(t *testing.T) {
 	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
 	c.Bootstrap(seedBoard)
 
-	// Fresh board: item 1 has drifted status; item 2 has new label; item 3 is new.
+	// Fresh board: item 1 has drifted status+updatedAt; item 2 has only a label
+	// change (same updatedAt — GitHub always bumps updatedAt on label mutations, but
+	// label-count is no longer compared to avoid false positives from shallow queries);
+	// item 3 is new.
 	mc.projectBoardResult = &gh.ProjectBoard{
 		ProjectID: "PID",
 		Items: []gh.ProjectItem{
 			{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Plan", Labels: []string{"l1"}, UpdatedAt: t2},       // status + updatedAt drifted
-			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: []string{"new-label"}, UpdatedAt: t1}, // label count drifted
+			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: []string{"new-label"}, UpdatedAt: t1}, // label only, same updatedAt — NOT drift
 			{ID: "I_3", Number: 3, Repo: "owner/repo", Status: "Implement", Labels: nil, UpdatedAt: t1},              // new item
 		},
 	}
@@ -2060,21 +2063,26 @@ func TestLightReconcile_DriftDetected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LightReconcile returned unexpected error: %v", err)
 	}
-	if driftCount != 3 {
-		t.Errorf("driftCount = %d, want 3; drifted keys: %v", driftCount, driftedKeys)
+	// item 2's label change has the same updatedAt — not detected as drift (label-count
+	// comparison was dropped to avoid shallow-vs-deep representation false positives).
+	if driftCount != 2 {
+		t.Errorf("driftCount = %d, want 2; drifted keys: %v", driftCount, driftedKeys)
 	}
 	if freshBoard == nil {
 		t.Error("freshBoard should not be nil on success")
 	}
-	// Verify all three keys appear in driftedKeys.
+	// Verify items 1 and 3 appear in driftedKeys; item 2 should NOT.
 	seen := make(map[string]bool)
 	for _, k := range driftedKeys {
 		seen[k] = true
 	}
-	for _, want := range []string{"owner/repo#1", "owner/repo#2", "owner/repo#3"} {
+	for _, want := range []string{"owner/repo#1", "owner/repo#3"} {
 		if !seen[want] {
 			t.Errorf("driftedKeys missing %q; got %v", want, driftedKeys)
 		}
+	}
+	if seen["owner/repo#2"] {
+		t.Errorf("driftedKeys should not contain owner/repo#2 (same updatedAt); got %v", driftedKeys)
 	}
 }
 

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -2,6 +2,7 @@ package boardcache
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -24,12 +25,13 @@ type mockClient struct {
 	fetchPRsForSHACount       int
 	fetchProjectItemCount     int
 
-	itemDetailsResult  *gh.ProjectItem
-	checkRunsResult    []gh.CheckRun
-	linkedPRResult     *gh.PRDetails
-	labelsResult       []string
-	projectBoardResult *gh.ProjectBoard
-	projectItemResult  *gh.ProjectItem
+	itemDetailsResult    *gh.ProjectItem
+	checkRunsResult      []gh.CheckRun
+	linkedPRResult       *gh.PRDetails
+	labelsResult         []string
+	projectBoardResult   *gh.ProjectBoard
+	projectBoardErr      error // returned by FetchProjectBoard when non-nil
+	projectItemResult    *gh.ProjectItem
 
 	fetchPRClosingIssuesFn func(owner, repo string, prNumber int) ([]int, error)
 	fetchPRsForSHAFn       func(owner, repo, sha string) ([]int, error)
@@ -37,6 +39,9 @@ type mockClient struct {
 }
 
 func (m *mockClient) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	if m.projectBoardErr != nil {
+		return nil, m.projectBoardErr
+	}
 	if m.projectBoardResult != nil {
 		return m.projectBoardResult, nil
 	}
@@ -1990,4 +1995,136 @@ func pullRequestReviewRequestRemovedPayloadJSON(repo string, prNum int, removedL
 	p.RequestedReviewer.Type = "User"
 	b, _ := json.Marshal(p)
 	return b
+}
+
+// ---------------------------------------------------------------------------
+// LightReconcile tests
+// ---------------------------------------------------------------------------
+
+func TestLightReconcile_NoDrift(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second)
+	mc := &mockClient{
+		projectBoardResult: &gh.ProjectBoard{
+			ProjectID: "PID",
+			Items: []gh.ProjectItem{
+				{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", Labels: []string{"l1"}, UpdatedAt: t1},
+				{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: nil, UpdatedAt: t1},
+			},
+		},
+	}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	c.Bootstrap(mc.projectBoardResult)
+
+	driftCount, driftedKeys, freshBoard, err := c.LightReconcile("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("LightReconcile returned unexpected error: %v", err)
+	}
+	if driftCount != 0 {
+		t.Errorf("driftCount = %d, want 0; drifted keys: %v", driftCount, driftedKeys)
+	}
+	if len(driftedKeys) != 0 {
+		t.Errorf("driftedKeys = %v, want empty", driftedKeys)
+	}
+	if freshBoard == nil {
+		t.Error("freshBoard should not be nil on success")
+	}
+}
+
+func TestLightReconcile_DriftDetected(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second)
+	t2 := t1.Add(time.Second)
+
+	// Seed the cache with two items.
+	seedBoard := &gh.ProjectBoard{
+		ProjectID: "PID",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", Labels: []string{"l1"}, UpdatedAt: t1},
+			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: nil, UpdatedAt: t1},
+		},
+	}
+	mc := &mockClient{}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	c.Bootstrap(seedBoard)
+
+	// Fresh board: item 1 has drifted status; item 2 has new label; item 3 is new.
+	mc.projectBoardResult = &gh.ProjectBoard{
+		ProjectID: "PID",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Plan", Labels: []string{"l1"}, UpdatedAt: t2},       // status + updatedAt drifted
+			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: []string{"new-label"}, UpdatedAt: t1}, // label count drifted
+			{ID: "I_3", Number: 3, Repo: "owner/repo", Status: "Implement", Labels: nil, UpdatedAt: t1},              // new item
+		},
+	}
+
+	driftCount, driftedKeys, freshBoard, err := c.LightReconcile("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("LightReconcile returned unexpected error: %v", err)
+	}
+	if driftCount != 3 {
+		t.Errorf("driftCount = %d, want 3; drifted keys: %v", driftCount, driftedKeys)
+	}
+	if freshBoard == nil {
+		t.Error("freshBoard should not be nil on success")
+	}
+	// Verify all three keys appear in driftedKeys.
+	seen := make(map[string]bool)
+	for _, k := range driftedKeys {
+		seen[k] = true
+	}
+	for _, want := range []string{"owner/repo#1", "owner/repo#2", "owner/repo#3"} {
+		if !seen[want] {
+			t.Errorf("driftedKeys missing %q; got %v", want, driftedKeys)
+		}
+	}
+}
+
+func TestLightReconcile_RemovedItemIsDrift(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second)
+
+	// Seed cache with two items.
+	seedBoard := &gh.ProjectBoard{
+		ProjectID: "PID",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", UpdatedAt: t1},
+			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", UpdatedAt: t1},
+		},
+	}
+	mc := &mockClient{}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	c.Bootstrap(seedBoard)
+
+	// Fresh board: item 2 is gone.
+	mc.projectBoardResult = &gh.ProjectBoard{
+		ProjectID: "PID",
+		Items:     []gh.ProjectItem{{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", UpdatedAt: t1}},
+	}
+
+	driftCount, driftedKeys, _, err := c.LightReconcile("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("LightReconcile returned unexpected error: %v", err)
+	}
+	if driftCount != 1 {
+		t.Errorf("driftCount = %d, want 1; drifted keys: %v", driftCount, driftedKeys)
+	}
+}
+
+func TestLightReconcile_NetworkError(t *testing.T) {
+	mc := &mockClient{
+		projectBoardErr: errors.New("simulated network error"),
+	}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+
+	driftCount, driftedKeys, freshBoard, err := c.LightReconcile("owner", "repo", 1, "organization")
+	if err == nil {
+		t.Fatal("LightReconcile should return an error on network failure")
+	}
+	if driftCount != 0 {
+		t.Errorf("driftCount = %d on error, want 0", driftCount)
+	}
+	if len(driftedKeys) != 0 {
+		t.Errorf("driftedKeys = %v on error, want nil", driftedKeys)
+	}
+	if freshBoard != nil {
+		t.Errorf("freshBoard = %v on error, want nil", freshBoard)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -341,10 +341,10 @@ func Execute() error {
 	}
 	if !explicitFlags["reconcile-interval"] {
 		if v := os.Getenv("FABRIK_RECONCILE_INTERVAL"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.ReconcileInterval = n
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				cfg.ReconcileInterval = n // 0 → use engine default (lightReconcileInterval = 3 min)
 			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_RECONCILE_INTERVAL=%q is invalid (must be a positive integer of seconds); using default 180\n", v)
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_RECONCILE_INTERVAL=%q is invalid (must be a non-negative integer of seconds; 0 = use default 180); using default 180\n", v)
 			}
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ type Config struct {
 	WebhookEvents     string // comma-separated; empty means default event set
 	BoardCacheMode       string // "in-memory" or "none"; empty = auto (in-memory when webhooks enabled)
 	StatusPollSeconds    int    // Layer 2 status-only sweep cadence in seconds; 0 = use default (15)
+	ReconcileInterval    int    // seconds; 0 means use default (180 = 3 min); also FABRIK_RECONCILE_INTERVAL
 }
 
 func Execute() error {
@@ -133,6 +134,7 @@ func Execute() error {
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.StringVar(&cfg.BoardCacheMode, "board-cache", "", `Board cache mode: "in-memory" (cache board state; requires --webhooks) or "none" (always fetch from GitHub). Default: "in-memory" when --webhooks is enabled, "none" otherwise. Also FABRIK_BOARD_CACHE.`)
 	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
+	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile health checks when webhooks and board cache are enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL)")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err
@@ -334,6 +336,15 @@ func Execute() error {
 				// n == 0: silently use default (same semantics as --claude-wait-delay 0)
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_CLAUDE_WAIT_DELAY=%q is invalid (must be 0 or a positive integer of seconds); using default 30\n", v)
+			}
+		}
+	}
+	if !explicitFlags["reconcile-interval"] {
+		if v := os.Getenv("FABRIK_RECONCILE_INTERVAL"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.ReconcileInterval = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_RECONCILE_INTERVAL=%q is invalid (must be a positive integer of seconds); using default 180\n", v)
 			}
 		}
 	}
@@ -547,6 +558,7 @@ func Execute() error {
 		WebhookEvents:     webhookEvents,
 		BoardCacheMode:           cfg.BoardCacheMode,
 		ProjectStatusPollSeconds: statusPollSeconds(cfg.StatusPollSeconds),
+		ReconcileInterval:        reconcileIntervalDuration(cfg.ReconcileInterval),
 		ReadyCh:                  testReadyCh,
 	})
 	if err != nil {
@@ -626,6 +638,16 @@ func statusPollSeconds(n int) int {
 		return 15
 	}
 	return n
+}
+
+// reconcileIntervalDuration converts a ReconcileInterval config value (seconds)
+// to a time.Duration. When seconds is 0 (unset), returns 0 so the engine falls
+// back to its lightReconcileInterval default (3 minutes).
+func reconcileIntervalDuration(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // buildProjectInfo assembles the TUI footer metadata from the active config.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3079,29 +3079,17 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 
 | State | Meaning | Idle cap used | TUI indicator |
 |-------|---------|---------------|---------------|
-| `WebhookStreamStartingUp` | Subprocess launched; no verified event received yet. The state persists until the first event arrives or `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) elapses with no event. | 60 min | Blue ○ |
-| `WebhookStreamHealthy` | At least one event received within the last health window (10 min) | 60 min | Green ● |
-| `WebhookStreamUnhealthy` | No first event received before `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch, or health window (10 min) elapsed since last event | 5 min | Yellow ◌ |
+| `WebhookStreamStartingUp` | Subprocess launched; no reconcile tick has completed yet. State persists until the first `reconcileTicker` tick confirms no drift. | 60 min | Blue ○ |
+| `WebhookStreamHealthy` | Most recent `reconcileTicker` tick found no drift between in-memory cache and GitHub | 60 min | Green ● |
+| `WebhookStreamUnhealthy` | Most recent `reconcileTicker` tick found drift; Pause/Reconcile/Resume in progress | 5 min | Yellow ◌ |
 
-**State transitions:**
-- `StartingUp → Healthy`: first verified webhook event received at any point after subprocess launch.
-- `StartingUp → Unhealthy`: no verified event received for `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch.
-- `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
-- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace and waits for a new first event.
+**State transitions (reconcile-driven — webhooks no longer drive health state):**
+- `StartingUp → Healthy`: first `reconcileTicker` tick completes with no drift (or drift is reconciled).
+- `StartingUp/Healthy → Unhealthy`: `reconcileTicker` tick finds drift between cache and GitHub; triggers Pause → Reconcile(freshBoard) → Resume.
+- `Unhealthy → Healthy`: immediately after Reconcile+Resume completes successfully within the same tick.
+- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets state; next tick re-evaluates.
 
-**Mutation echo-check (Plan B fast failure detection).** In addition to the time-based health transitions above, the engine detects silent webhook stream failures within seconds during active mutation periods via an echo-check mechanism (`pendingEchoes`, `missHistory`, and `doEchoSweep` in `engine/webhook.go`):
-
-- **Registration:** After each successful tracked mutation (`AddLabelToIssue`, `RemoveLabelFromIssue`, `AddComment`, `UpdateIssueBody`, `CreateDraftPR`, `MarkPRReady`, `MergePR`, `UpdateProjectItemStatus`), the engine records a `(eventType, action, discriminatingKey, timestamp)` entry in `pendingEchoes`. Registration is suppressed during `WebhookStreamStartingUp` and when the board cache is disabled (`healthChangeFn == nil`). `UpdateProjectItemStatus` is additionally suppressed when `projects_v2_item` is not in the current `wm.events` subscription set (R7 conditional).
-
-- **Matching:** `CacheImpl.ApplyDelta` calls `wm.MatchEcho(eventType, action, key)` for each incoming webhook event before applying the delta to the store. A match removes the corresponding `pendingEchoes` entry, preventing it from counting as a miss.
-
-- **Sweep:** A background goroutine (started alongside `runHealthMonitor` in `webhookManager.Start()`) calls `doEchoSweep()` every 5 seconds. Entries in `pendingEchoes` older than `webhookEchoTimeout` (15s) with no match are echo misses — removed from `pendingEchoes` and their timestamp appended to `missHistory`.
-
-- **Rolling-window threshold:** On each miss append, `missHistory` entries older than `webhookEchoWindow` (60s) are pruned. If `len(missHistory) >= webhookEchoMissThreshold` (3), `healthChangeFn(false)` is called and `missHistory` is cleared to prevent repeated firing. Named constants (overridable in tests): `webhookEchoTimeout = 15s`, `webhookEchoMissThreshold = 3`, `webhookEchoWindow = 60s`.
-
-- **Recovery:** Any verified inbound webhook event arriving at `handleWebhook` transitions the stream back to `Healthy` via the existing recovery path. `missHistory` is cleared in the same lock block to prevent stale miss counts from immediately re-triggering the threshold after recovery.
-
-- **Design rationale:** [ADR-042: Mutation Echo-Check for Webhook Health Detection](../adrs/042-mutation-echo-check.md)
+Webhooks continue to apply deltas to the cache via `ApplyDelta` but no longer drive health state. Event silence does not produce health transitions — only `LightReconcile` drift detection does.
 
 **Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
 
@@ -3814,9 +3802,9 @@ After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new ti
 
 **Gate inactive when**: `e.readClient` is not a `*boardcache.CacheImpl` (non-cache mode), or `cacheImpl.ProjectID()` is empty (bootstrap not yet complete).
 
-**Full reconcile — stream-recovery only**
+**Full reconcile — drift-recovery only**
 
-`reconcileCache` (which calls `e.client.FetchProjectBoard(...)` and `cacheImpl.Reconcile(board)`) is preserved but is **no longer called by the periodic loop**. It is called only on webhook stream recovery (see §D.5).
+`LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. `reconcileCache` (the older full-fetch-and-reconcile helper) is retained but is no longer called by the engine.
 
 `Reconcile` performs a deep partial update:
 - For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.
@@ -3826,18 +3814,23 @@ After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new ti
 
 ### D.5 Stream-Health Failover
 
-The `healthChangeFn` callback injected into `webhookManager` is called on health state transitions:
+Health transitions are driven by the `reconcileTicker` goroutine (`engine/poll.go`), which calls `cacheImpl.LightReconcile(...)` on each tick (default: every 3 minutes, configurable via `--reconcile-interval` / `FABRIK_RECONCILE_INTERVAL`):
 
-| Transition | Action |
-|------------|--------|
-| Any → `WebhookStreamUnhealthy` (from `checkHealthTransitions`) | `cacheImpl.Pause()` |
-| Any → `WebhookStreamHealthy` (from `handleWebhook` on first recovery event) | `reconcileCache()` inline → `cacheImpl.Resume()` |
+| `LightReconcile` result | Action |
+|-------------------------|--------|
+| No drift | `wm.transitionHealthState(Healthy, "")` — no-op if already healthy; logs if recovering from unhealthy |
+| Drift detected | `wm.transitionHealthState(Unhealthy, reason)` → `cacheImpl.Pause()` → `cacheImpl.Reconcile(freshBoard)` → `cacheImpl.Resume()` → `wm.transitionHealthState(Healthy, "drift reconciled")` |
+| Network error | Log warning; no state change (treat as "unable to determine", not drift) |
 
 When `IsPaused()` is true:
 - `ApplyDelta` is a no-op (deltas are dropped rather than applied to a potentially stale cache).
 - All `CacheImpl` read methods fall through to the `fallback` ReadClient (live GitHub API), so correctness is preserved at the cost of increased GraphQL usage.
 
-On recovery, `reconcileCache()` fetches a fresh board snapshot before `Resume()` so the cache is coherent immediately when `IsPaused()` returns false.
+On drift recovery, `LightReconcile` returns the fresh board it already fetched; this is passed directly to `cacheImpl.Reconcile(freshBoard)` before `Resume()`, so the cache is coherent immediately when `IsPaused()` returns false.
+
+**API cost:** Each `LightReconcile` tick costs ~1 GraphQL call (`FetchProjectBoard`). At the default 3-minute cadence: ≤ 20 calls/hour — negligible against the 5000-point/hour budget.
+
+**`healthChangeFn` removed (issue #641):** The callback-based `healthChangeFn` pattern (ADR-034) has been replaced. The `reconcileTicker` goroutine owns the full Pause/Reconcile/Resume sequence directly; no indirection through a closure is required.
 
 ### D.6 Cache Mode Selection
 
@@ -3857,7 +3850,7 @@ In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub d
 | **0** Write-through | After any successful mutation call in the engine (status, labels, comments), the corresponding `CacheImpl` method is called immediately | Zero | Zero |
 | **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event, fetches the current Status: fast path (`FetchProjectItemStatus`) when the item's `itemID` is cached; fallback (`LookupIssueProjectItem`) when it isn't yet (e.g., brand-new issues arriving via `issues.opened` before `projects_v2_item.created`) | Seconds (best-effort) | ~1–5 pts/event |
 | **2** Periodic status sweep | In-poll `updatedAt` gate: `FetchProjectUpdatedAt` (~1 pt) every poll cycle (~15 s); fires `FetchProjectItemStatusBatch` + `ApplyStatusBatch` only when project timestamp advances | Up to 15 s | ~1 pt/cycle idle; O(⌈N/100⌉) pts when gate fires |
-| **Bootstrap / stream-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and on webhook stream recovery | Minutes | Full board cost |
+| **Bootstrap / drift-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and when `reconcileTicker` detects drift | Minutes | Full board cost |
 
 **Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the main poll cadence (~15 s) — Layer 2 runs at the top of every `poll()` cycle. If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own mutations.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3081,7 +3081,7 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 |-------|---------|---------------|---------------|
 | `WebhookStreamStartingUp` | Subprocess launched; no reconcile tick has completed yet. State persists until the first `reconcileTicker` tick confirms no drift. | 60 min | Blue ○ |
 | `WebhookStreamHealthy` | Most recent `reconcileTicker` tick found no drift between in-memory cache and GitHub | 60 min | Green ● |
-| `WebhookStreamUnhealthy` | Most recent `reconcileTicker` tick found drift; Pause/Reconcile/Resume in progress | 5 min | Yellow ◌ |
+| `WebhookStreamUnhealthy` | Cache is known to be out of sync (most recent `reconcileTicker` tick found drift, Pause/Reconcile/Resume in progress), OR subprocess failed to start / was permanently disabled by the 422 circuit-breaker | 5 min | Yellow ◌ |
 
 **State transitions (reconcile-driven — webhooks no longer drive health state):**
 - `StartingUp → Healthy`: first `reconcileTicker` tick completes with no drift (or drift is reconciled).

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1052,29 +1052,17 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 
 | State | Meaning | Idle cap used | TUI indicator |
 |-------|---------|---------------|---------------|
-| `WebhookStreamStartingUp` | Subprocess launched; no verified event received yet. The state persists until the first event arrives or `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) elapses with no event. | 60 min | Blue ○ |
-| `WebhookStreamHealthy` | At least one event received within the last health window (10 min) | 60 min | Green ● |
-| `WebhookStreamUnhealthy` | No first event received before `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch, or health window (10 min) elapsed since last event | 5 min | Yellow ◌ |
+| `WebhookStreamStartingUp` | Subprocess launched; no reconcile tick has completed yet. State persists until the first `reconcileTicker` tick confirms no drift. | 60 min | Blue ○ |
+| `WebhookStreamHealthy` | Most recent `reconcileTicker` tick found no drift between in-memory cache and GitHub | 60 min | Green ● |
+| `WebhookStreamUnhealthy` | Most recent `reconcileTicker` tick found drift; Pause/Reconcile/Resume in progress | 5 min | Yellow ◌ |
 
-**State transitions:**
-- `StartingUp → Healthy`: first verified webhook event received at any point after subprocess launch.
-- `StartingUp → Unhealthy`: no verified event received for `webhookStartupGrace` (30s) + `webhookHealthWindow` (10 min) after subprocess launch.
-- `Healthy → Unhealthy`: no event received for `webhookHealthWindow` (10 min).
-- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets grace and waits for a new first event.
+**State transitions (reconcile-driven — webhooks no longer drive health state):**
+- `StartingUp → Healthy`: first `reconcileTicker` tick completes with no drift (or drift is reconciled).
+- `StartingUp/Healthy → Unhealthy`: `reconcileTicker` tick finds drift between cache and GitHub; triggers Pause → Reconcile(freshBoard) → Resume.
+- `Unhealthy → Healthy`: immediately after Reconcile+Resume completes successfully within the same tick.
+- `* → StartingUp`: subprocess restart (secret rotation, crash recovery) resets state; next tick re-evaluates.
 
-**Mutation echo-check (Plan B fast failure detection).** In addition to the time-based health transitions above, the engine detects silent webhook stream failures within seconds during active mutation periods via an echo-check mechanism (`pendingEchoes`, `missHistory`, and `doEchoSweep` in `engine/webhook.go`):
-
-- **Registration:** After each successful tracked mutation (`AddLabelToIssue`, `RemoveLabelFromIssue`, `AddComment`, `UpdateIssueBody`, `CreateDraftPR`, `MarkPRReady`, `MergePR`, `UpdateProjectItemStatus`), the engine records a `(eventType, action, discriminatingKey, timestamp)` entry in `pendingEchoes`. Registration is suppressed during `WebhookStreamStartingUp` and when the board cache is disabled (`healthChangeFn == nil`). `UpdateProjectItemStatus` is additionally suppressed when `projects_v2_item` is not in the current `wm.events` subscription set (R7 conditional).
-
-- **Matching:** `CacheImpl.ApplyDelta` calls `wm.MatchEcho(eventType, action, key)` for each incoming webhook event before applying the delta to the store. A match removes the corresponding `pendingEchoes` entry, preventing it from counting as a miss.
-
-- **Sweep:** A background goroutine (started alongside `runHealthMonitor` in `webhookManager.Start()`) calls `doEchoSweep()` every 5 seconds. Entries in `pendingEchoes` older than `webhookEchoTimeout` (15s) with no match are echo misses — removed from `pendingEchoes` and their timestamp appended to `missHistory`.
-
-- **Rolling-window threshold:** On each miss append, `missHistory` entries older than `webhookEchoWindow` (60s) are pruned. If `len(missHistory) >= webhookEchoMissThreshold` (3), `healthChangeFn(false)` is called and `missHistory` is cleared to prevent repeated firing. Named constants (overridable in tests): `webhookEchoTimeout = 15s`, `webhookEchoMissThreshold = 3`, `webhookEchoWindow = 60s`.
-
-- **Recovery:** Any verified inbound webhook event arriving at `handleWebhook` transitions the stream back to `Healthy` via the existing recovery path. `missHistory` is cleared in the same lock block to prevent stale miss counts from immediately re-triggering the threshold after recovery.
-
-- **Design rationale:** [ADR-042: Mutation Echo-Check for Webhook Health Detection](../adrs/042-mutation-echo-check.md)
+Webhooks continue to apply deltas to the cache via `ApplyDelta` but no longer drive health state. Event silence does not produce health transitions — only `LightReconcile` drift detection does.
 
 **Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
 
@@ -1787,9 +1775,9 @@ After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new ti
 
 **Gate inactive when**: `e.readClient` is not a `*boardcache.CacheImpl` (non-cache mode), or `cacheImpl.ProjectID()` is empty (bootstrap not yet complete).
 
-**Full reconcile — stream-recovery only**
+**Full reconcile — drift-recovery only**
 
-`reconcileCache` (which calls `e.client.FetchProjectBoard(...)` and `cacheImpl.Reconcile(board)`) is preserved but is **no longer called by the periodic loop**. It is called only on webhook stream recovery (see §D.5).
+`LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. `reconcileCache` (the older full-fetch-and-reconcile helper) is retained but is no longer called by the engine.
 
 `Reconcile` performs a deep partial update:
 - For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.
@@ -1799,18 +1787,23 @@ After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new ti
 
 ### D.5 Stream-Health Failover
 
-The `healthChangeFn` callback injected into `webhookManager` is called on health state transitions:
+Health transitions are driven by the `reconcileTicker` goroutine (`engine/poll.go`), which calls `cacheImpl.LightReconcile(...)` on each tick (default: every 3 minutes, configurable via `--reconcile-interval` / `FABRIK_RECONCILE_INTERVAL`):
 
-| Transition | Action |
-|------------|--------|
-| Any → `WebhookStreamUnhealthy` (from `checkHealthTransitions`) | `cacheImpl.Pause()` |
-| Any → `WebhookStreamHealthy` (from `handleWebhook` on first recovery event) | `reconcileCache()` inline → `cacheImpl.Resume()` |
+| `LightReconcile` result | Action |
+|-------------------------|--------|
+| No drift | `wm.transitionHealthState(Healthy, "")` — no-op if already healthy; logs if recovering from unhealthy |
+| Drift detected | `wm.transitionHealthState(Unhealthy, reason)` → `cacheImpl.Pause()` → `cacheImpl.Reconcile(freshBoard)` → `cacheImpl.Resume()` → `wm.transitionHealthState(Healthy, "drift reconciled")` |
+| Network error | Log warning; no state change (treat as "unable to determine", not drift) |
 
 When `IsPaused()` is true:
 - `ApplyDelta` is a no-op (deltas are dropped rather than applied to a potentially stale cache).
 - All `CacheImpl` read methods fall through to the `fallback` ReadClient (live GitHub API), so correctness is preserved at the cost of increased GraphQL usage.
 
-On recovery, `reconcileCache()` fetches a fresh board snapshot before `Resume()` so the cache is coherent immediately when `IsPaused()` returns false.
+On drift recovery, `LightReconcile` returns the fresh board it already fetched; this is passed directly to `cacheImpl.Reconcile(freshBoard)` before `Resume()`, so the cache is coherent immediately when `IsPaused()` returns false.
+
+**API cost:** Each `LightReconcile` tick costs ~1 GraphQL call (`FetchProjectBoard`). At the default 3-minute cadence: ≤ 20 calls/hour — negligible against the 5000-point/hour budget.
+
+**`healthChangeFn` removed (issue #641):** The callback-based `healthChangeFn` pattern (ADR-034) has been replaced. The `reconcileTicker` goroutine owns the full Pause/Reconcile/Resume sequence directly; no indirection through a closure is required.
 
 ### D.6 Cache Mode Selection
 
@@ -1830,7 +1823,7 @@ In user mode (PAT-based, repo-level webhooks via `gh webhook forward`), GitHub d
 | **0** Write-through | After any successful mutation call in the engine (status, labels, comments), the corresponding `CacheImpl` method is called immediately | Zero | Zero |
 | **1** Per-event refresh | After `ApplyDelta` for an `issues` or `issue_comment` event, fetches the current Status: fast path (`FetchProjectItemStatus`) when the item's `itemID` is cached; fallback (`LookupIssueProjectItem`) when it isn't yet (e.g., brand-new issues arriving via `issues.opened` before `projects_v2_item.created`) | Seconds (best-effort) | ~1–5 pts/event |
 | **2** Periodic status sweep | In-poll `updatedAt` gate: `FetchProjectUpdatedAt` (~1 pt) every poll cycle (~15 s); fires `FetchProjectItemStatusBatch` + `ApplyStatusBatch` only when project timestamp advances | Up to 15 s | ~1 pt/cycle idle; O(⌈N/100⌉) pts when gate fires |
-| **Bootstrap / stream-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and on webhook stream recovery | Minutes | Full board cost |
+| **Bootstrap / drift-recovery** | Full `FetchProjectBoard` + `Reconcile` on startup and when `reconcileTicker` detects drift | Minutes | Full board cost |
 
 **Residual latency**: For external column moves (user moves issue on the board), the upper bound on detection latency is the main poll cadence (~15 s) — Layer 2 runs at the top of every `poll()` cycle. If the column move happens to coincide with any other issue activity (a comment, label change, etc.), Layer 1 may catch it sooner. Layer 0 applies only to Fabrik's own mutations.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1054,7 +1054,7 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 |-------|---------|---------------|---------------|
 | `WebhookStreamStartingUp` | Subprocess launched; no reconcile tick has completed yet. State persists until the first `reconcileTicker` tick confirms no drift. | 60 min | Blue ○ |
 | `WebhookStreamHealthy` | Most recent `reconcileTicker` tick found no drift between in-memory cache and GitHub | 60 min | Green ● |
-| `WebhookStreamUnhealthy` | Most recent `reconcileTicker` tick found drift; Pause/Reconcile/Resume in progress | 5 min | Yellow ◌ |
+| `WebhookStreamUnhealthy` | Cache is known to be out of sync (most recent `reconcileTicker` tick found drift, Pause/Reconcile/Resume in progress), OR subprocess failed to start / was permanently disabled by the 422 circuit-breaker | 5 min | Yellow ◌ |
 
 **State transitions (reconcile-driven — webhooks no longer drive health state):**
 - `StartingUp → Healthy`: first `reconcileTicker` tick completes with no drift (or drift is reconciled).

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -30,7 +30,8 @@ type Config struct {
 	PollSeconds       int
 	MaxConcurrent     int
 	MaxRetries        int
-	ReviewWaitTimeout time.Duration // How long to wait for PR reviewers before auto-advancing anyway (default 15m)
+	ReviewWaitTimeout   time.Duration // How long to wait for PR reviewers before auto-advancing anyway (default 15m)
+	ReconcileInterval   time.Duration // Reconcile ticker cadence (0 = use lightReconcileInterval default of 3m)
 	MaxReviewCycles   int           // Max review re-invocation cycles per issue before pausing (default 5)
 	CIWaitTimeout     time.Duration // How long to wait for CI in the merge guard before pausing (default 30m)
 	MaxCiFixCycles    int           // Max CI-fix re-invocation cycles per issue before pausing (default 5)

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -367,19 +367,10 @@ func (e *Engine) Run() error {
 			initialRepos = map[string]bool{e.cfg.Owner + "/" + e.cfg.Repo: true}
 		}
 		var deltaFn func(string, []byte)
-		var healthChangeFn func(bool)
 		if cacheImpl != nil {
 			deltaFn = func(eventType string, payload []byte) {
 				cacheImpl.ApplyDelta(eventType, payload)
 				e.applyLayer1StatusRefresh(eventType, payload, cacheImpl)
-			}
-			healthChangeFn = func(healthy bool) {
-				if healthy {
-					e.reconcileCache(cacheImpl)
-					cacheImpl.Resume()
-				} else {
-					cacheImpl.Pause()
-				}
 			}
 		}
 		cleanupFn := func(repos []string) error {
@@ -406,7 +397,6 @@ func (e *Engine) Run() error {
 			initialRepos,
 			e.cfg.WebhookEvents,
 			deltaFn,
-			healthChangeFn,
 			cleanupFn,
 		)
 		// Inject MatchEcho so ApplyDelta can clear pending echo entries on incoming webhooks.
@@ -426,6 +416,41 @@ func (e *Engine) Run() error {
 		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {
 			e.webhookMgr = wm
 			defer wm.Stop()
+
+			if cacheImpl != nil {
+				reconcileInterval := e.cfg.ReconcileInterval
+				if reconcileInterval <= 0 {
+					reconcileInterval = lightReconcileInterval
+				}
+				go func() {
+					ticker := time.NewTicker(reconcileInterval)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-ticker.C:
+							driftCount, driftedKeys, freshBoard, err := cacheImpl.LightReconcile(
+								e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType,
+							)
+							if err != nil {
+								e.logf(0, "reconcile", "light reconcile failed (no health state change): %v\n", err)
+								continue
+							}
+							if driftCount == 0 {
+								wm.transitionHealthState(WebhookStreamHealthy, "")
+							} else {
+								e.logf(0, "reconcile", "light reconcile: %d item(s) drifted (%v) — reconciling cache\n", driftCount, driftedKeys)
+								wm.transitionHealthState(WebhookStreamUnhealthy, fmt.Sprintf("%d item(s) drifted", driftCount))
+								cacheImpl.Pause()
+								cacheImpl.Reconcile(freshBoard)
+								cacheImpl.Resume()
+								wm.transitionHealthState(WebhookStreamHealthy, "drift reconciled")
+							}
+						}
+					}
+				}()
+			}
 		}
 	}
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -440,7 +440,11 @@ func (e *Engine) Run() error {
 							if driftCount == 0 {
 								wm.transitionHealthState(WebhookStreamHealthy, "")
 							} else {
-								e.logf(0, "reconcile", "light reconcile: %d item(s) drifted (%v) — reconciling cache\n", driftCount, driftedKeys)
+								keyStr := fmt.Sprintf("%v", driftedKeys)
+								if len(driftedKeys) > 5 {
+									keyStr = fmt.Sprintf("%v … %d more", driftedKeys[:5], len(driftedKeys)-5)
+								}
+								e.logf(0, "reconcile", "light reconcile: %d item(s) drifted (%s) — reconciling cache\n", driftCount, keyStr)
 								wm.transitionHealthState(WebhookStreamUnhealthy, fmt.Sprintf("%d item(s) drifted", driftCount))
 								cacheImpl.Pause()
 								cacheImpl.Reconcile(freshBoard)

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -946,7 +946,9 @@ func (wm *webhookManager) doEchoSweep() {
 	wm.mu.Unlock()
 
 	if shouldFire {
-		// Transition to Unhealthy; the reconcileTicker will restore Healthy on the next no-drift tick.
+		// Transition to Unhealthy — the idle cap drops to 5 min and the board is polled more aggressively.
+		// Intentionally no cacheImpl.Pause() here: the cache continues serving webhook deltas while the
+		// reconcileTicker confirms drift (≤ one interval, default 3 min) and triggers Pause/Reconcile/Resume.
 		wm.transitionHealthState(WebhookStreamUnhealthy, "echo-check miss threshold")
 	}
 }

--- a/engine/webhook.go
+++ b/engine/webhook.go
@@ -32,9 +32,9 @@ const (
 // Internal constants — not user-configurable in v1.
 const (
 	webhookIdleCap           = 60 * time.Minute
-	webhookHealthWindow      = 10 * time.Minute
-	webhookStartupGrace      = 30 * time.Second
 	webhookMaxRestartBackoff = 60 * time.Second
+	// lightReconcileInterval is the default cadence for the reconcileTicker goroutine in poll.go.
+	lightReconcileInterval = 3 * time.Minute
 	webhookRotationFailures  = 5
 	webhookRotationWindow    = 2 * time.Minute
 	webhookRotationMaxCycles = 2
@@ -44,11 +44,6 @@ const (
 	// webhookRepoFailureThreshold is the number of consecutive auth-shaped quick exits
 	// required before a repo is quarantined for the session.
 	webhookRepoFailureThreshold = 3
-	// webhookEventStaleTimeout: if no verified event has arrived within this window
-	// (measured from sessionLastEventAt), the health monitor transitions to Unhealthy.
-	// Provides fast pausing during tight restart loops where lastEventTime resets
-	// on each restart would otherwise prevent the slower webhookHealthWindow check from firing.
-	webhookEventStaleTimeout = 5 * time.Minute
 	// webhookPermanentFailureMax: consecutive HTTP 422 quick-exits before the
 	// circuit-breaker fires and switches to poll-only mode.
 	webhookPermanentFailureMax = 3
@@ -86,8 +81,7 @@ type webhookManager struct {
 	logFn         func(issueNumber int, tag, format string, args ...any)
 	wakeCh        chan struct{}
 	emitFn        func(tui.Event)
-	deltaFn       func(eventType string, payload []byte) // nil when board cache disabled
-	healthChangeFn func(healthy bool)                    // nil when board cache disabled
+	deltaFn func(eventType string, payload []byte) // nil when board cache disabled
 
 	// killFn terminates a subprocess. Defaults to killProcGroup; overridable in tests.
 	// The caller is responsible for the cmd != nil check; killFn handles nil Process.
@@ -124,13 +118,7 @@ type webhookManager struct {
 	repoReady   bool // whether repoReadyCh has been closed (protected by mu)
 
 	// health (protected by mu)
-	state         WebhookHealthState
-	startupTime   time.Time // when current subprocess started (resets on restart)
-	lastEventTime time.Time // zero until first verified event; resets on restart
-
-	// session-level health tracking — never reset on subprocess restart (protected by mu)
-	sessionFirstStartAt time.Time // set once when first subprocess starts
-	sessionLastEventAt  time.Time // set on every verified event; never cleared on restart
+	state WebhookHealthState
 
 	// secret rotation (protected by mu)
 	consecutiveFailures int
@@ -158,7 +146,6 @@ func newWebhookManager(
 	repos map[string]bool,
 	events []string,
 	deltaFn func(string, []byte),
-	healthChangeFn func(bool),
 	cleanupFn func([]string) error,
 ) *webhookManager {
 	evts := events
@@ -171,7 +158,6 @@ func newWebhookManager(
 		wakeCh:             wakeCh,
 		emitFn:             emitFn,
 		deltaFn:            deltaFn,
-		healthChangeFn:     healthChangeFn,
 		cleanupFn:          cleanupFn,
 		repos:              copyRepoSet(repos),
 		events:             evts,
@@ -520,7 +506,6 @@ func (wm *webhookManager) Start(ctx context.Context, port int) error {
 	wm.mu.Unlock()
 
 	go wm.supervise(ctx)
-	go wm.runHealthMonitor(ctx)
 	go wm.runEchoSweep(ctx)
 
 	wm.logFn(0, "webhook", "webhook listener started on port %d\n", actualPort)
@@ -708,11 +693,6 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 		wm.mu.Lock()
 		wm.currentCmd = cmd
 		wm.state = WebhookStreamStartingUp
-		wm.startupTime = time.Now()
-		wm.lastEventTime = time.Time{}
-		if wm.sessionFirstStartAt.IsZero() {
-			wm.sessionFirstStartAt = wm.startupTime
-		}
 		wm.mu.Unlock()
 		wm.emitCurrentState()
 
@@ -778,9 +758,6 @@ func (wm *webhookManager) supervise(ctx context.Context) {
 					wm.logFn(0, "webhook", "WARNING: webhook subscription permanently failed after %d consecutive HTTP 422 errors — "+
 						"switching to poll-only mode. Check 'gh auth status' and repo webhook quota, then restart Fabrik.\n",
 						webhookPermanentFailureMax)
-					if wm.healthChangeFn != nil {
-						wm.healthChangeFn(false)
-					}
 					return
 				}
 				wm.mu.Unlock()
@@ -892,88 +869,18 @@ func (wm *webhookManager) startSubprocessInternal(ctx context.Context, args []st
 	return cmd, stderrCh, nil
 }
 
-// runHealthMonitor periodically checks time-based health state transitions.
-func (wm *webhookManager) runHealthMonitor(ctx context.Context) {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-wm.stopCh:
-			return
-		case <-ticker.C:
-			wm.checkHealthTransitions()
-		}
-	}
-}
-
-func (wm *webhookManager) checkHealthTransitions() {
-	wm.mu.Lock()
-	now := time.Now()
-	state := wm.state
-	var newState WebhookHealthState
-
-	switch state {
-	case WebhookStreamStartingUp:
-		if !wm.lastEventTime.IsZero() {
-			// Event received; HTTP handler already set state to Healthy.
-			// This is a no-op catch.
-		} else if !wm.sessionLastEventAt.IsZero() && now.Sub(wm.sessionLastEventAt) > webhookEventStaleTimeout {
-			// R-B4: cross-restart stale check — fires faster than the grace+window path
-			// when the subprocess is in a tight restart loop (each restart resets lastEventTime).
-			newState = WebhookStreamUnhealthy
-		} else if wm.sessionLastEventAt.IsZero() && !wm.sessionFirstStartAt.IsZero() && now.Sub(wm.sessionFirstStartAt) > webhookStartupGrace+webhookHealthWindow {
-			// R-B3: use sessionFirstStartAt (not startupTime) so subprocess restarts
-			// don't reset the timer. Gate on sessionLastEventAt.IsZero() per spec:
-			// this path only fires when no event has ever been received in this session
-			// (if events were received but went stale, R-B4 above handles it).
-			newState = WebhookStreamUnhealthy
-		}
-	case WebhookStreamHealthy:
-		if !wm.sessionLastEventAt.IsZero() && now.Sub(wm.sessionLastEventAt) > webhookEventStaleTimeout {
-			// R-B4: stale check (webhookEventStaleTimeout) applies to Healthy state too, providing faster
-			// detection when the stream goes quiet during or after a restart loop.
-			newState = WebhookStreamUnhealthy
-		} else if !wm.lastEventTime.IsZero() && now.Sub(wm.lastEventTime) > webhookHealthWindow {
-			newState = WebhookStreamUnhealthy
-		}
-	}
-
-	if newState != "" && newState != state {
-		wm.state = newState
-		var elapsed time.Duration
-		if newState == WebhookStreamUnhealthy && !wm.sessionLastEventAt.IsZero() {
-			elapsed = now.Sub(wm.sessionLastEventAt)
-		}
-		wm.mu.Unlock()
-		if elapsed > 0 {
-			wm.logFn(0, "webhook", "health state: %s → %s (no events for %s)\n", state, newState, elapsed)
-		} else {
-			wm.logFn(0, "webhook", "health state: %s → %s\n", state, newState)
-		}
-		wm.emitCurrentState()
-		if newState == WebhookStreamUnhealthy && wm.healthChangeFn != nil {
-			wm.healthChangeFn(false)
-		}
-		return
-	}
-	wm.mu.Unlock()
-}
-
 // echoKey builds the composite key used in pendingEchoes: "eventType:action:discriminatingKey".
 func echoKey(eventType, action, key string) string {
 	return eventType + ":" + action + ":" + key
 }
 
 // RegisterEcho records a pending echo entry for a successful outgoing mutation.
-// No-op when the webhook stream is starting up or the board cache is disabled
-// (healthChangeFn == nil). For projects_v2_item conditional registration use
-// RegisterEchoIfSubscribed instead.
+// No-op when the webhook stream is starting up.
+// For projects_v2_item conditional registration use RegisterEchoIfSubscribed instead.
 func (wm *webhookManager) RegisterEcho(eventType, action, key string) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
-	if wm.state == WebhookStreamStartingUp || wm.healthChangeFn == nil {
+	if wm.state == WebhookStreamStartingUp {
 		return
 	}
 	wm.pendingEchoes[echoKey(eventType, action, key)] = time.Now()
@@ -984,7 +891,7 @@ func (wm *webhookManager) RegisterEcho(eventType, action, key string) {
 func (wm *webhookManager) RegisterEchoIfSubscribed(eventType, action, key string) {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
-	if wm.state == WebhookStreamStartingUp || wm.healthChangeFn == nil {
+	if wm.state == WebhookStreamStartingUp {
 		return
 	}
 	if !containsEvent(wm.events, eventType) {
@@ -1001,8 +908,8 @@ func (wm *webhookManager) MatchEcho(eventType, action, key string) {
 	wm.mu.Unlock()
 }
 
-// doEchoSweep scans pendingEchoes for stale entries, records misses, and fires
-// healthChangeFn(false) when the rolling-window miss threshold is reached.
+// doEchoSweep scans pendingEchoes for stale entries, records misses, and
+// transitions to Unhealthy when the rolling-window miss threshold is reached.
 // Safe to call from tests directly (no ticker dependency).
 func (wm *webhookManager) doEchoSweep() {
 	now := time.Now()
@@ -1032,16 +939,15 @@ func (wm *webhookManager) doEchoSweep() {
 		}
 		wm.missHistory = live
 	}
-	shouldFire := newMisses > 0 && wm.healthChangeFn != nil && len(wm.missHistory) >= webhookEchoMissThreshold
+	shouldFire := newMisses > 0 && len(wm.missHistory) >= webhookEchoMissThreshold
 	if shouldFire {
 		wm.missHistory = wm.missHistory[:0]
-		// Transition to Unhealthy so handleWebhook's recovery path fires on the next event.
-		wm.state = WebhookStreamUnhealthy
 	}
 	wm.mu.Unlock()
 
 	if shouldFire {
-		wm.healthChangeFn(false)
+		// Transition to Unhealthy; the reconcileTicker will restore Healthy on the next no-drift tick.
+		wm.transitionHealthState(WebhookStreamUnhealthy, "echo-check miss threshold")
 	}
 }
 
@@ -1077,6 +983,25 @@ func (wm *webhookManager) emitCurrentState() {
 		State:       state,
 		EventCounts: counts,
 	})
+}
+
+// transitionHealthState updates wm.state to newState if it differs, logs the transition,
+// and calls emitCurrentState. No-op if state is unchanged.
+func (wm *webhookManager) transitionHealthState(newState WebhookHealthState, reason string) {
+	wm.mu.Lock()
+	prev := wm.state
+	if prev == newState {
+		wm.mu.Unlock()
+		return
+	}
+	wm.state = newState
+	wm.mu.Unlock()
+	if reason != "" {
+		wm.logFn(0, "webhook", "health state: %s → %s (%s)\n", prev, newState, reason)
+	} else {
+		wm.logFn(0, "webhook", "health state: %s → %s\n", prev, newState)
+	}
+	wm.emitCurrentState()
 }
 
 // minWebhookPayload is the minimal set of fields read from each incoming webhook payload.
@@ -1186,29 +1111,13 @@ func (wm *webhookManager) handleWebhook(w http.ResponseWriter, r *http.Request) 
 	// Update state and counters.
 	wm.mu.Lock()
 	wm.eventCounts[eventType]++
-	prevState := wm.state
-	if prevState != WebhookStreamHealthy {
-		wm.state = WebhookStreamHealthy
-		// Clear stale miss history on recovery so old misses don't immediately
-		// re-trigger the echo-miss threshold after stream recovery (R10).
+	// Clear stale miss history on incoming events to prevent echo-miss false positives (R10).
+	if len(wm.missHistory) > 0 {
 		wm.missHistory = wm.missHistory[:0]
 	}
-	now := time.Now()
-	wm.lastEventTime = now
-	wm.sessionLastEventAt = now // never reset on subprocess restart
 	wm.mu.Unlock()
-	if prevState != WebhookStreamHealthy {
-		wm.logFn(0, "webhook", "health state: %s → %s\n", prevState, WebhookStreamHealthy)
-	}
 
 	wm.emitCurrentState()
-
-	// On recovery from unhealthy/starting-up, reconcile and resume the cache first
-	// so the delta applied below lands on coherent state rather than being dropped
-	// because the cache is still paused.
-	if prevState != WebhookStreamHealthy && wm.healthChangeFn != nil {
-		wm.healthChangeFn(true)
-	}
 
 	// Apply cache delta after any recovery reconciliation, so the cache is fresh
 	// when the poll loop wakes. The wakeChObserver registered on the cache store

--- a/engine/webhook_test.go
+++ b/engine/webhook_test.go
@@ -205,91 +205,8 @@ func newTestWebhookManager(t *testing.T) (*webhookManager, chan tui.Event) {
 		nil,
 		deltaFn,
 		nil,
-		nil,
 	)
 	return wm, events
-}
-
-// TestHealthStateTransitions exercises the time-based health state machine.
-func TestHealthStateTransitions(t *testing.T) {
-	t.Run("startup grace → healthy on first verified event", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamStartingUp
-		wm.startupTime = time.Now()
-		secret, _ := generateSecret()
-		wm.secret = secret
-		wm.mu.Unlock()
-
-		// Simulate a valid webhook POST.
-		body := []byte(`{"action":"created","repository":{"full_name":"myorg/myrepo"}}`)
-		req := signedRequest(t, body, secret)
-		rr := httptest.NewRecorder()
-		wm.handleWebhook(rr, req)
-
-		if rr.Code != http.StatusOK {
-			t.Fatalf("expected 200, got %d", rr.Code)
-		}
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamHealthy {
-			t.Errorf("state = %q, want %q", state, WebhookStreamHealthy)
-		}
-	})
-
-	t.Run("starting up → unhealthy after grace + health window", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamStartingUp
-		// Set sessionFirstStartAt far in the past — the fix uses sessionFirstStartAt
-		// (not startupTime) so subprocess restarts don't reset the timer.
-		wm.sessionFirstStartAt = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
-		wm.mu.Unlock()
-
-		wm.checkHealthTransitions()
-
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamUnhealthy {
-			t.Errorf("state = %q, want %q", state, WebhookStreamUnhealthy)
-		}
-	})
-
-	t.Run("healthy → unhealthy after health window with no events", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamHealthy
-		wm.lastEventTime = time.Now().Add(-(webhookHealthWindow + time.Second))
-		wm.mu.Unlock()
-
-		wm.checkHealthTransitions()
-
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamUnhealthy {
-			t.Errorf("state = %q, want %q", state, WebhookStreamUnhealthy)
-		}
-	})
-
-	t.Run("healthy stays healthy within health window", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamHealthy
-		wm.lastEventTime = time.Now().Add(-1 * time.Minute) // within 10 min window
-		wm.mu.Unlock()
-
-		wm.checkHealthTransitions()
-
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamHealthy {
-			t.Errorf("state = %q, want %q (should stay healthy)", state, WebhookStreamHealthy)
-		}
-	})
 }
 
 // TestSecretRotationTrigger verifies that 5 consecutive HMAC failures within 2 min
@@ -396,7 +313,6 @@ func TestHandleWebhookIncrementsCounters(t *testing.T) {
 	secret, _ := generateSecret()
 	wm.mu.Lock()
 	wm.state = WebhookStreamStartingUp
-	wm.startupTime = time.Now()
 	wm.secret = secret
 	wm.mu.Unlock()
 
@@ -542,7 +458,6 @@ func TestHandleWebhookBurstCoalescence(t *testing.T) {
 	secret, _ := generateSecret()
 	wm.mu.Lock()
 	wm.state = WebhookStreamStartingUp
-	wm.startupTime = time.Now()
 	wm.secret = secret
 	wm.mu.Unlock()
 
@@ -880,13 +795,6 @@ func TestCircuitBreaker422(t *testing.T) {
 		wm.orgModeFailed = true
 		wm.mu.Unlock()
 
-		healthChangeFalseCalls := 0
-		wm.healthChangeFn = func(healthy bool) {
-			if !healthy {
-				healthChangeFalseCalls++
-			}
-		}
-
 		callCount := 0
 		wm.startSubprocessFn = func(ctx context.Context, args []string) (*exec.Cmd, <-chan string, error) {
 			callCount++
@@ -922,9 +830,6 @@ func TestCircuitBreaker422(t *testing.T) {
 		}
 		if state != WebhookStreamUnhealthy {
 			t.Errorf("state = %q after circuit-breaker, want %q", state, WebhookStreamUnhealthy)
-		}
-		if healthChangeFalseCalls != 1 {
-			t.Errorf("healthChangeFn(false) called %d times, want 1", healthChangeFalseCalls)
 		}
 		if callCount != webhookPermanentFailureMax {
 			t.Errorf("startSubprocessFn called %d times, want %d", callCount, webhookPermanentFailureMax)
@@ -1007,170 +912,16 @@ func TestCircuitBreaker422(t *testing.T) {
 	})
 }
 
-// TestSessionLastEventAt_NotResetOnRestart verifies that sessionLastEventAt persists
-// across subprocess restarts, while lastEventTime is cleared as supervise() does.
-func TestSessionLastEventAt_NotResetOnRestart(t *testing.T) {
-	wm, _ := newTestWebhookManager(t)
-	secret, _ := generateSecret()
-	wm.mu.Lock()
-	wm.state = WebhookStreamStartingUp
-	wm.startupTime = time.Now()
-	wm.secret = secret
-	wm.mu.Unlock()
-
-	// Send a valid webhook to set both lastEventTime and sessionLastEventAt.
-	body := []byte(`{"action":"created","repository":{"full_name":"myorg/myrepo"}}`)
-	req := signedRequest(t, body, secret)
-	rr := httptest.NewRecorder()
-	wm.handleWebhook(rr, req)
-
-	wm.mu.Lock()
-	sessionEventAt := wm.sessionLastEventAt
-	lastEventAt := wm.lastEventTime
-	wm.mu.Unlock()
-
-	if sessionEventAt.IsZero() {
-		t.Fatal("sessionLastEventAt should be set after verified event")
-	}
-	if lastEventAt.IsZero() {
-		t.Fatal("lastEventTime should be set after verified event")
-	}
-
-	// Simulate subprocess restart — supervise() resets lastEventTime but not sessionLastEventAt.
-	wm.mu.Lock()
-	wm.state = WebhookStreamStartingUp
-	wm.startupTime = time.Now()
-	wm.lastEventTime = time.Time{}
-	wm.mu.Unlock()
-
-	wm.mu.Lock()
-	sessionEventAfterRestart := wm.sessionLastEventAt
-	lastEventAfterRestart := wm.lastEventTime
-	wm.mu.Unlock()
-
-	if sessionEventAfterRestart.IsZero() {
-		t.Error("sessionLastEventAt was reset on subprocess restart — should persist across restarts")
-	}
-	if !sessionEventAfterRestart.Equal(sessionEventAt) {
-		t.Errorf("sessionLastEventAt changed on restart: was %v, now %v", sessionEventAt, sessionEventAfterRestart)
-	}
-	if !lastEventAfterRestart.IsZero() {
-		t.Error("lastEventTime should be zero after restart simulation")
-	}
-}
-
-// TestSessionFirstStartAt_SetOnce verifies sessionFirstStartAt is set on first subprocess
-// start and not overwritten on subsequent starts.
-func TestSessionFirstStartAt_SetOnce(t *testing.T) {
-	wm, _ := newTestWebhookManager(t)
-
-	wm.mu.Lock()
-	if !wm.sessionFirstStartAt.IsZero() {
-		t.Fatal("sessionFirstStartAt should start as zero")
-	}
-	wm.mu.Unlock()
-
-	// Simulate first subprocess start (mirrors supervise() logic).
-	firstStartTime := time.Now()
-	wm.mu.Lock()
-	wm.startupTime = firstStartTime
-	wm.lastEventTime = time.Time{}
-	if wm.sessionFirstStartAt.IsZero() {
-		wm.sessionFirstStartAt = wm.startupTime
-	}
-	wm.mu.Unlock()
-
-	wm.mu.Lock()
-	firstAt := wm.sessionFirstStartAt
-	wm.mu.Unlock()
-
-	if firstAt.IsZero() {
-		t.Fatal("sessionFirstStartAt should be set after first subprocess start")
-	}
-
-	// Simulate second subprocess start.
-	time.Sleep(time.Millisecond)
-	wm.mu.Lock()
-	wm.startupTime = time.Now()
-	wm.lastEventTime = time.Time{}
-	if wm.sessionFirstStartAt.IsZero() {
-		wm.sessionFirstStartAt = wm.startupTime
-	}
-	wm.mu.Unlock()
-
-	wm.mu.Lock()
-	secondAt := wm.sessionFirstStartAt
-	wm.mu.Unlock()
-
-	if !secondAt.Equal(firstAt) {
-		t.Errorf("sessionFirstStartAt changed on second subprocess start: was %v, now %v", firstAt, secondAt)
-	}
-}
-
-// TestHealthTransition_StartingUp_UsesSessionFirstStartAt verifies that the
-// StartingUp→Unhealthy transition uses sessionFirstStartAt (not startupTime),
-// confirming the Bug B fix: subprocess restarts no longer reset the health timer.
-func TestHealthTransition_StartingUp_UsesSessionFirstStartAt(t *testing.T) {
-	wm, _ := newTestWebhookManager(t)
-	wm.mu.Lock()
-	wm.state = WebhookStreamStartingUp
-	// Set startupTime far in the past — old code would have triggered Unhealthy.
-	wm.startupTime = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
-	// sessionFirstStartAt is recent — should NOT trigger Unhealthy.
-	wm.sessionFirstStartAt = time.Now()
-	wm.mu.Unlock()
-
-	wm.checkHealthTransitions()
-
-	wm.mu.Lock()
-	state := wm.state
-	wm.mu.Unlock()
-	if state == WebhookStreamUnhealthy {
-		t.Error("state should NOT be Unhealthy when only startupTime is old but sessionFirstStartAt is recent — the fix uses sessionFirstStartAt")
-	}
-}
-
-// TestHealthTransition_StartingUp_SkipsGraceWindowWhenEventsReceived verifies that
-// the sessionFirstStartAt grace+window path (R-B3) does NOT fire when events have
-// been received (sessionLastEventAt != zero), even if sessionFirstStartAt is old.
-// Without the sessionLastEventAt.IsZero() guard, this would incorrectly transition
-// to Unhealthy after ~10m even on a healthy-then-restarting stream.
-func TestHealthTransition_StartingUp_SkipsGraceWindowWhenEventsReceived(t *testing.T) {
-	wm, _ := newTestWebhookManager(t)
-	wm.mu.Lock()
-	wm.state = WebhookStreamStartingUp
-	// sessionFirstStartAt is old enough to trigger the grace+window path.
-	wm.sessionFirstStartAt = time.Now().Add(-(webhookStartupGrace + webhookHealthWindow + time.Second))
-	// But we have received events recently (within the webhookEventStaleTimeout threshold).
-	wm.sessionLastEventAt = time.Now().Add(-10 * time.Second)
-	wm.mu.Unlock()
-
-	wm.checkHealthTransitions()
-
-	wm.mu.Lock()
-	state := wm.state
-	wm.mu.Unlock()
-	if state == WebhookStreamUnhealthy {
-		t.Error("state should NOT be Unhealthy when sessionFirstStartAt is old but events were received (sessionLastEventAt != zero)")
-	}
-}
-
 // TestEchoCheck covers the mutation echo-check subsystem (R12a–R12g).
 // Tests call doEchoSweep() directly and backdate pendingEchoes timestamps
 // to simulate aging without real tickers.
 func TestEchoCheck(t *testing.T) {
 	// newEchoManager creates a webhookManager pre-wired for echo-check tests:
-	// state=Healthy, healthChangeFn recording false calls, events containing
-	// "projects_v2_item" so R7 conditional tests can remove it.
-	newEchoManager := func(t *testing.T) (*webhookManager, *int) {
+	// state=Healthy, events containing "projects_v2_item" so R7 conditional tests can remove it.
+	// Returns the manager; callers check wm.state directly to verify health transitions.
+	newEchoManager := func(t *testing.T) *webhookManager {
 		t.Helper()
 		wm, _ := newTestWebhookManager(t)
-		falseCalls := 0
-		wm.healthChangeFn = func(healthy bool) {
-			if !healthy {
-				falseCalls++
-			}
-		}
 		wm.mu.Lock()
 		wm.state = WebhookStreamHealthy
 		// Ensure "projects_v2_item" is in wm.events so R7 tests can remove it.
@@ -1185,11 +936,11 @@ func TestEchoCheck(t *testing.T) {
 			wm.events = append(wm.events, "projects_v2_item")
 		}
 		wm.mu.Unlock()
-		return wm, &falseCalls
+		return wm
 	}
 
 	t.Run("(a) register → match → no miss", func(t *testing.T) {
-		wm, falseCalls := newEchoManager(t)
+		wm := newEchoManager(t)
 		wm.RegisterEcho("issues", "labeled", "owner/repo#1+test-label")
 		wm.MatchEcho("issues", "labeled", "owner/repo#1+test-label")
 
@@ -1204,18 +955,19 @@ func TestEchoCheck(t *testing.T) {
 
 		wm.mu.Lock()
 		misses := len(wm.missHistory)
+		state := wm.state
 		wm.mu.Unlock()
 
 		if misses != 0 {
 			t.Errorf("missHistory len = %d after matched echo, want 0", misses)
 		}
-		if *falseCalls != 0 {
-			t.Errorf("healthChangeFn(false) called %d times, want 0", *falseCalls)
+		if state != WebhookStreamHealthy {
+			t.Errorf("state = %q after matched echo, want %q (no health transition)", state, WebhookStreamHealthy)
 		}
 	})
 
 	t.Run("(b) register → no match within timeout → miss appended", func(t *testing.T) {
-		wm, falseCalls := newEchoManager(t)
+		wm := newEchoManager(t)
 		wm.RegisterEcho("issues", "labeled", "owner/repo#2+another-label")
 
 		// Backdate the entry to simulate timeout elapsed.
@@ -1230,6 +982,7 @@ func TestEchoCheck(t *testing.T) {
 		wm.mu.Lock()
 		misses := len(wm.missHistory)
 		echoesRemaining := len(wm.pendingEchoes)
+		state := wm.state
 		wm.mu.Unlock()
 
 		if misses != 1 {
@@ -1238,13 +991,13 @@ func TestEchoCheck(t *testing.T) {
 		if echoesRemaining != 0 {
 			t.Errorf("pendingEchoes len = %d after sweep, want 0", echoesRemaining)
 		}
-		if *falseCalls != 0 {
-			t.Errorf("healthChangeFn(false) called %d times after 1 miss (threshold=3), want 0", *falseCalls)
+		if state != WebhookStreamHealthy {
+			t.Errorf("state = %q after 1 miss (threshold=3), want %q (no transition yet)", state, WebhookStreamHealthy)
 		}
 	})
 
-	t.Run("(c) 3 misses within window → healthChangeFn(false) called, missHistory cleared", func(t *testing.T) {
-		wm, falseCalls := newEchoManager(t)
+	t.Run("(c) 3 misses within window → Unhealthy transition, missHistory cleared", func(t *testing.T) {
+		wm := newEchoManager(t)
 		// Register 3 distinct echoes.
 		wm.RegisterEcho("issues", "labeled", "owner/repo#3+label-a")
 		wm.RegisterEcho("issues", "labeled", "owner/repo#3+label-b")
@@ -1260,19 +1013,20 @@ func TestEchoCheck(t *testing.T) {
 
 		wm.doEchoSweep()
 
-		if *falseCalls != 1 {
-			t.Errorf("healthChangeFn(false) called %d times after 3 misses, want 1", *falseCalls)
-		}
 		wm.mu.Lock()
+		state := wm.state
 		misses := len(wm.missHistory)
 		wm.mu.Unlock()
+		if state != WebhookStreamUnhealthy {
+			t.Errorf("state = %q after 3 misses, want %q (threshold fired)", state, WebhookStreamUnhealthy)
+		}
 		if misses != 0 {
 			t.Errorf("missHistory len = %d after threshold fire, want 0 (cleared)", misses)
 		}
 	})
 
 	t.Run("(d) 2 old misses age out + 1 new miss → threshold NOT reached", func(t *testing.T) {
-		wm, falseCalls := newEchoManager(t)
+		wm := newEchoManager(t)
 		// Pre-populate missHistory with 2 entries older than webhookEchoWindow.
 		oldTimestamp := time.Now().Add(-(webhookEchoWindow + 2*time.Second))
 		wm.mu.Lock()
@@ -1290,12 +1044,13 @@ func TestEchoCheck(t *testing.T) {
 
 		wm.doEchoSweep()
 
-		if *falseCalls != 0 {
-			t.Errorf("healthChangeFn(false) called %d times after old misses aged out + 1 new miss, want 0", *falseCalls)
-		}
 		wm.mu.Lock()
+		state := wm.state
 		misses := len(wm.missHistory)
 		wm.mu.Unlock()
+		if state != WebhookStreamHealthy {
+			t.Errorf("state = %q after old misses aged out + 1 new miss, want %q (threshold not reached)", state, WebhookStreamHealthy)
+		}
 		// Only the 1 new miss survives (the 2 old ones were pruned).
 		if misses != 1 {
 			t.Errorf("missHistory len = %d after pruning old misses, want 1", misses)
@@ -1303,7 +1058,7 @@ func TestEchoCheck(t *testing.T) {
 	})
 
 	t.Run("(e) registration suppressed during WebhookStreamStartingUp", func(t *testing.T) {
-		wm, _ := newEchoManager(t)
+		wm := newEchoManager(t)
 		wm.mu.Lock()
 		wm.state = WebhookStreamStartingUp
 		wm.mu.Unlock()
@@ -1321,7 +1076,7 @@ func TestEchoCheck(t *testing.T) {
 	})
 
 	t.Run("(f) projects_v2_item echo not registered when absent from wm.events", func(t *testing.T) {
-		wm, _ := newEchoManager(t)
+		wm := newEchoManager(t)
 		// Remove "projects_v2_item" from wm.events.
 		wm.mu.Lock()
 		filtered := wm.events[:0]
@@ -1345,7 +1100,7 @@ func TestEchoCheck(t *testing.T) {
 	})
 
 	t.Run("(g) MergePR and UpdateIssueBody echoes matched correctly", func(t *testing.T) {
-		wm, _ := newEchoManager(t)
+		wm := newEchoManager(t)
 
 		// MergePR echo: pull_request closed
 		wm.RegisterEcho("pull_request", "closed", "owner/repo#pr42")
@@ -1376,66 +1131,6 @@ func TestEchoCheck(t *testing.T) {
 		wm.mu.Unlock()
 		if misses != 0 {
 			t.Errorf("missHistory len = %d after matched echoes, want 0", misses)
-		}
-	})
-}
-
-// TestHealthTransition_SessionStale verifies that stale sessionLastEventAt
-// triggers Unhealthy faster than the 10-minute webhookHealthWindow — both from
-// StartingUp and Healthy states.
-func TestHealthTransition_SessionStale(t *testing.T) {
-	t.Run("stale sessionLastEventAt triggers unhealthy from StartingUp", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamStartingUp
-		wm.startupTime = time.Now()
-		wm.sessionFirstStartAt = time.Now()
-		wm.sessionLastEventAt = time.Now().Add(-(webhookEventStaleTimeout + time.Second))
-		wm.mu.Unlock()
-
-		wm.checkHealthTransitions()
-
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamUnhealthy {
-			t.Errorf("state = %q, want %q when sessionLastEventAt is stale (StartingUp)", state, WebhookStreamUnhealthy)
-		}
-	})
-
-	t.Run("stale sessionLastEventAt triggers unhealthy from Healthy", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamHealthy
-		wm.lastEventTime = time.Now().Add(-1 * time.Minute) // within 10-min window
-		wm.sessionLastEventAt = time.Now().Add(-(webhookEventStaleTimeout + time.Second))
-		wm.mu.Unlock()
-
-		wm.checkHealthTransitions()
-
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamUnhealthy {
-			t.Errorf("state = %q, want %q when sessionLastEventAt is stale (Healthy)", state, WebhookStreamUnhealthy)
-		}
-	})
-
-	t.Run("fresh sessionLastEventAt keeps Healthy state", func(t *testing.T) {
-		wm, _ := newTestWebhookManager(t)
-		wm.mu.Lock()
-		wm.state = WebhookStreamHealthy
-		wm.lastEventTime = time.Now().Add(-1 * time.Minute) // within 10-min window
-		wm.sessionLastEventAt = time.Now().Add(-10 * time.Second) // fresh (< webhookEventStaleTimeout)
-		wm.mu.Unlock()
-
-		wm.checkHealthTransitions()
-
-		wm.mu.Lock()
-		state := wm.state
-		wm.mu.Unlock()
-		if state != WebhookStreamHealthy {
-			t.Errorf("state = %q, want %q when sessionLastEventAt is fresh", state, WebhookStreamHealthy)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Replaces the time-based `webhookEventStaleTimeout` heuristic with a **periodic `LightReconcile` loop** that compares the in-memory cache against GitHub on every tick (default 3 min)
- Health transitions are now driven by actual cache drift vs. GitHub state — not by event silence
- Removes `runHealthMonitor`, `checkHealthTransitions`, `healthChangeFn`, and all event-silence constants; adds `LightReconcile` on `*CacheImpl` and a `reconcileTicker` goroutine in the engine
- Adds ADR-043 and updates `docs/state-machine.md` to document the new health model

## Key changes

**`boardcache/boardcache.go`** — New `LightReconcile(owner, repo string, projectNum int, ownerType string) (driftCount int, driftedKeys []string, freshBoard *gh.ProjectBoard, err error)` method. Snapshots cache items under lock, then calls `fallback.FetchProjectBoard` without lock, compares `status`/`len(labels)`/`updatedAt` per item. Returns the fresh board on drift so the caller can pass it directly to `Reconcile()` — no second API call.

**`engine/webhook.go`** — Removes `runHealthMonitor`, `checkHealthTransitions`, `healthChangeFn`, and the event-silence constants (`webhookEventStaleTimeout`, `webhookHealthWindow`, `webhookStartupGrace`). Adds `transitionHealthState(newState, reason)` helper (lock/compare/set/emit). `handleWebhook` no longer mutates `wm.state`. Echo-check (`doEchoSweep`) updated to call `transitionHealthState` instead of `healthChangeFn`.

**`engine/poll.go`** — Adds `reconcileTicker` goroutine (started only when `cacheImpl != nil && webhookMgr != nil`). On no-drift: transitions to `Healthy`. On drift: transitions to `Unhealthy` → `Pause()` → `Reconcile(freshBoard)` → `Resume()` → `Healthy`. On network error: logs warning, no state change.

**`cmd/root.go`** — Adds `--reconcile-interval` flag (seconds, default 0 → 180 s) and `FABRIK_RECONCILE_INTERVAL` env var following the `FABRIK_REVIEW_WAIT_TIMEOUT` pattern.

## How to test

1. Start Fabrik with webhooks enabled against a real board: `fabrik --webhooks ...`
2. Leave the board idle for > 5 minutes — previously this triggered a false-unhealthy transition. Verify the webhook state stays `Healthy` (no `reconciliation` log lines with drift, no Pause/Resume cycle).
3. Manually corrupt the cache (e.g., stop Fabrik, manually change a board item's status via the GitHub UI, restart) — verify the next reconcile tick logs drift and reconciles.
4. Run `go test ./boardcache/... -run TestLightReconcile -v` for unit coverage of the three cases (no-drift, drift, network error).

Closes #641