### PR TITLE
refactor: make CacheImpl the unified source of truth, remove --board-cache flag

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -28,7 +28,8 @@ type ReadClient interface {
 }
 
 // GitHubAdapter wraps a ReadClient with pass-through implementations.
-// When --board-cache=none, the engine sets e.readClient = NewGitHubAdapter(e.client).
+// Used as the fallback inside CacheImpl (cache miss → forward to GitHub) and
+// directly in NewWithDeps test wiring (engine tests bypass CacheImpl).
 type GitHubAdapter struct {
 	client ReadClient
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,7 +132,7 @@ func Execute() error {
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
-	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile health checks when webhooks and board cache are enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL)")
+	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile webhook-stream-health checks when --webhooks is enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL). Inactive without --webhooks — the per-poll Reconcile is the only freshener in that mode.")
 
 	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,6 @@ type Config struct {
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     string // comma-separated; empty means default event set
-	BoardCacheMode    string // "in-memory" or "none"; empty = auto (in-memory when webhooks enabled)
 	StatusPollSeconds int    // Layer 2 status-only sweep cadence in seconds; 0 = use default (15)
 	ReconcileInterval int    // seconds; 0 means use default (180 = 3 min); also FABRIK_RECONCILE_INTERVAL
 }
@@ -132,7 +131,6 @@ func Execute() error {
 	flag.BoolVar(&cfg.Webhooks, "webhooks", false, "Enable webhook-driven event delivery via gh webhook forward (requires gh ≥ 2.32.0; also FABRIK_WEBHOOKS)")
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
-	flag.StringVar(&cfg.BoardCacheMode, "board-cache", "", `Board cache mode: "in-memory" (cache board state; requires --webhooks) or "none" (always fetch from GitHub). Default: "in-memory" when --webhooks is enabled, "none" otherwise. Also FABRIK_BOARD_CACHE.`)
 	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
 	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile health checks when webhooks and board cache are enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL)")
 
@@ -408,11 +406,6 @@ func Execute() error {
 			cfg.WebhookEvents = v
 		}
 	}
-	if !explicitFlags["board-cache"] {
-		if v := os.Getenv("FABRIK_BOARD_CACHE"); v != "" {
-			cfg.BoardCacheMode = v
-		}
-	}
 	if !explicitFlags["status-poll"] {
 		if v := os.Getenv("FABRIK_STATUS_POLL"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
@@ -427,22 +420,6 @@ func Execute() error {
 				cfg.StatusPollSeconds = *pc.StatusPoll
 			}
 		}
-	}
-
-	// Apply board-cache default: "in-memory" when webhooks are enabled; "none" otherwise.
-	// Explicit --board-cache=in-memory without --webhooks is a configuration error.
-	if cfg.BoardCacheMode == "" {
-		if cfg.Webhooks {
-			cfg.BoardCacheMode = "in-memory"
-		} else {
-			cfg.BoardCacheMode = "none"
-		}
-	}
-	if cfg.BoardCacheMode == "in-memory" && !cfg.Webhooks {
-		return fmt.Errorf("--board-cache=in-memory requires --webhooks (no delta source without webhook events)")
-	}
-	if cfg.BoardCacheMode != "in-memory" && cfg.BoardCacheMode != "none" {
-		return fmt.Errorf("invalid --board-cache value %q: must be \"in-memory\" or \"none\"", cfg.BoardCacheMode)
 	}
 
 	if cfg.Owner == "" || cfg.ProjectNum == 0 {
@@ -556,7 +533,6 @@ func Execute() error {
 		Webhooks:                 cfg.Webhooks,
 		WebhookPort:              cfg.WebhookPort,
 		WebhookEvents:            webhookEvents,
-		BoardCacheMode:           cfg.BoardCacheMode,
 		ProjectStatusPollSeconds: statusPollSeconds(cfg.StatusPollSeconds),
 		ReconcileInterval:        reconcileIntervalDuration(cfg.ReconcileInterval),
 		ReadyCh:                  testReadyCh,

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1741,8 +1741,7 @@ webhooks: true
 | Enable webhooks | `--webhooks` | `FABRIK_WEBHOOKS` | `webhooks: true` | off |
 | Listener port | `--webhook-port=<N>` | `FABRIK_WEBHOOK_PORT` | `webhook_port: <N>` | 0 (OS-assigned) |
 | Event filter | `--webhook-events=<csv>` | `FABRIK_WEBHOOK_EVENTS` | `webhook_events: [...]` | all supported events |
-| Board cache | `--board-cache=<mode>` | `FABRIK_BOARD_CACHE` | `board_cache: <mode>` | `in-memory` when `--webhooks`, else `none` |
-| Reconcile interval | `--reconcile-interval=<N>` | `FABRIK_RECONCILE_INTERVAL` | — | 0 (180 s; only active with `--board-cache=in-memory`) |
+| Reconcile interval | `--reconcile-interval=<N>` | `FABRIK_RECONCILE_INTERVAL` | — | 0 (180 s) |
 
 By default, Fabrik subscribes to: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `check_suite`, and `projects_v2_item` (board column changes — see note below).
 
@@ -1779,27 +1778,20 @@ When `--webhooks` is enabled, gate clearance events (Copilot/Gemini review submi
 
 On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state full-board GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. A lightweight Layer 2 status gate checks the project `updatedAt` timestamp each poll cycle at very low GraphQL cost to catch board-column changes. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
 
-### In-Memory Board Cache (`--board-cache`)
+### In-Memory Board Cache
 
-When webhook mode is active, Fabrik maintains an in-memory board cache (`--board-cache=in-memory`, the default). Incoming webhook payloads are applied as typed state deltas to the cache before the poll loop wakes, so most reads are served from memory rather than GitHub's API.
+Fabrik always maintains an in-memory cache of board state — the cache is the unified source of truth for downstream engine logic and reactive observers (push-unblock, stage-change, etc.) regardless of whether webhooks are configured.
 
-**Cache modes:**
+**How the cache stays fresh:**
 
-| Mode | When | Behavior |
-|------|------|----------|
-| `in-memory` | `--webhooks` enabled (default) | Cache populated at startup; deltas from webhooks; Layer 2 status gate each poll cycle (~30 s); full reconcile on stream recovery; falls back to GitHub when stream is unhealthy |
-| `none` | `--webhooks` disabled (default), or explicit override | All reads go directly to GitHub API (original behavior) |
+| Mode | Refresh paths |
+|------|---------------|
+| Webhooks disabled | Every poll cycle: shallow board fetch from GitHub → `Reconcile` into the cache. Layer 2 status gate also runs each poll for project Status changes (which never flow over webhooks). |
+| Webhooks enabled | Webhook deltas (`issues`, `pull_request`, `issue_comment`, etc.) update the cache between polls. Every poll still does a shallow Reconcile as the drift-detection safety net for missed events. The light-reconcile loop (~3 min) drives stream-health classification. |
 
-**To disable the cache while keeping webhooks:**
-```bash
-fabrik --webhooks --board-cache=none
-```
+**Project Status note:** GitHub webhooks do not deliver project-board Status (column) changes for repo-level project subscriptions, and only conditionally for org-level subscriptions with the right permissions. The Layer 2 status gate (`updatedAt` check + lightweight status batch) runs each poll cycle regardless of webhook health and is the only authoritative delivery path for Status drift.
 
-**Stream-health failover:** If the webhook stream goes unhealthy (reconcile detected drift or echo-check miss threshold triggered), the cache pauses and all reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. This ensures correctness is never compromised by a degraded webhook stream.
-
-**Reconciliation:** Fabrik uses a two-level reconciliation strategy. The light reconcile loop (default every 3 minutes, configurable via `--reconcile-interval` / `FABRIK_RECONCILE_INTERVAL`) is the primary health driver: each tick fetches the full item list and compares it against the cached state. When no drift is found, the stream transitions to Healthy; when drift is detected, the stream transitions to Unhealthy and the cache is reconciled from GitHub. A Layer 2 status gate also runs each poll cycle (~30 s default): it fetches the project's `updatedAt` timestamp and, if it changed, applies a lightweight status batch (Stage/column field only) at very low GraphQL cost — this is the primary mechanism for catching board-column changes. A full board snapshot is fetched on stream recovery (webhook stream goes unhealthy then recovers), ensuring all cached fields are coherent after a gap in event delivery.
-
-> **Note:** `--board-cache=in-memory` requires `--webhooks`. Without a webhook stream, there is no delta source and the cache relies solely on the periodic status sweep — worse than the default polling behavior.
+**Stream-health failover (webhook mode):** If the webhook stream goes unhealthy (reconcile detected drift or echo-check miss threshold triggered), the cache pauses and reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. The per-poll Reconcile remains active throughout and continues to keep state correct.
 
 ### `projects_v2_item` (Board Column Changes)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1739,8 +1739,7 @@ webhooks: true
 | Enable webhooks | `--webhooks` | `FABRIK_WEBHOOKS` | `webhooks: true` | off |
 | Listener port | `--webhook-port=<N>` | `FABRIK_WEBHOOK_PORT` | `webhook_port: <N>` | 0 (OS-assigned) |
 | Event filter | `--webhook-events=<csv>` | `FABRIK_WEBHOOK_EVENTS` | `webhook_events: [...]` | all supported events |
-| Board cache | `--board-cache=<mode>` | `FABRIK_BOARD_CACHE` | `board_cache: <mode>` | `in-memory` when `--webhooks`, else `none` |
-| Reconcile interval | `--reconcile-interval=<N>` | `FABRIK_RECONCILE_INTERVAL` | — | 0 (180 s; only active with `--board-cache=in-memory`) |
+| Reconcile interval | `--reconcile-interval=<N>` | `FABRIK_RECONCILE_INTERVAL` | — | 0 (180 s) |
 
 By default, Fabrik subscribes to: `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `check_run`, `check_suite`, and `projects_v2_item` (board column changes — see note below).
 
@@ -1777,27 +1776,20 @@ When `--webhooks` is enabled, gate clearance events (Copilot/Gemini review submi
 
 On an active board that would poll every 30 seconds without webhooks, enabling webhook mode reduces steady-state full-board GraphQL polling to at most once every 60 minutes — roughly a 120× reduction in GraphQL points consumed while idle. A lightweight Layer 2 status gate checks the project `updatedAt` timestamp each poll cycle at very low GraphQL cost to catch board-column changes. During active periods, polls are triggered immediately by webhook events instead of waiting for the tick.
 
-### In-Memory Board Cache (`--board-cache`)
+### In-Memory Board Cache
 
-When webhook mode is active, Fabrik maintains an in-memory board cache (`--board-cache=in-memory`, the default). Incoming webhook payloads are applied as typed state deltas to the cache before the poll loop wakes, so most reads are served from memory rather than GitHub's API.
+Fabrik always maintains an in-memory cache of board state — the cache is the unified source of truth for downstream engine logic and reactive observers (push-unblock, stage-change, etc.) regardless of whether webhooks are configured.
 
-**Cache modes:**
+**How the cache stays fresh:**
 
-| Mode | When | Behavior |
-|------|------|----------|
-| `in-memory` | `--webhooks` enabled (default) | Cache populated at startup; deltas from webhooks; Layer 2 status gate each poll cycle (~30 s); full reconcile on stream recovery; falls back to GitHub when stream is unhealthy |
-| `none` | `--webhooks` disabled (default), or explicit override | All reads go directly to GitHub API (original behavior) |
+| Mode | Refresh paths |
+|------|---------------|
+| Webhooks disabled | Every poll cycle: shallow board fetch from GitHub → `Reconcile` into the cache. Layer 2 status gate also runs each poll for project Status changes (which never flow over webhooks). |
+| Webhooks enabled | Webhook deltas (`issues`, `pull_request`, `issue_comment`, etc.) update the cache between polls. Every poll still does a shallow Reconcile as the drift-detection safety net for missed events. The light-reconcile loop (~3 min) drives stream-health classification. |
 
-**To disable the cache while keeping webhooks:**
-```bash
-fabrik --webhooks --board-cache=none
-```
+**Project Status note:** GitHub webhooks do not deliver project-board Status (column) changes for repo-level project subscriptions, and only conditionally for org-level subscriptions with the right permissions. The Layer 2 status gate (`updatedAt` check + lightweight status batch) runs each poll cycle regardless of webhook health and is the only authoritative delivery path for Status drift.
 
-**Stream-health failover:** If the webhook stream goes unhealthy (reconcile detected drift or echo-check miss threshold triggered), the cache pauses and all reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. This ensures correctness is never compromised by a degraded webhook stream.
-
-**Reconciliation:** Fabrik uses a two-level reconciliation strategy. The light reconcile loop (default every 3 minutes, configurable via `--reconcile-interval` / `FABRIK_RECONCILE_INTERVAL`) is the primary health driver: each tick fetches the full item list and compares it against the cached state. When no drift is found, the stream transitions to Healthy; when drift is detected, the stream transitions to Unhealthy and the cache is reconciled from GitHub. A Layer 2 status gate also runs each poll cycle (~30 s default): it fetches the project's `updatedAt` timestamp and, if it changed, applies a lightweight status batch (Stage/column field only) at very low GraphQL cost — this is the primary mechanism for catching board-column changes. A full board snapshot is fetched on stream recovery (webhook stream goes unhealthy then recovers), ensuring all cached fields are coherent after a gap in event delivery.
-
-> **Note:** `--board-cache=in-memory` requires `--webhooks`. Without a webhook stream, there is no delta source and the cache relies solely on the periodic status sweep — worse than the default polling behavior.
+**Stream-health failover (webhook mode):** If the webhook stream goes unhealthy (reconcile detected drift or echo-check miss threshold triggered), the cache pauses and reads fall back to the live GitHub API. When the stream recovers, the cache reconciles from GitHub before resuming. The per-poll Reconcile remains active throughout and continues to keep state correct.
 
 ### `projects_v2_item` (Board Column Changes)
 
@@ -3729,15 +3721,21 @@ The engine uses two distinct in-memory stores (both in `itemstate.Store`) for co
 
 ## Appendix D: In-Memory Board Cache Lifecycle
 
-When `--webhooks` and `--board-cache=in-memory` are both active (the default when webhooks are enabled), the engine maintains an in-memory cache of board state in `boardcache.CacheImpl`. This appendix describes the cache lifecycle, delta semantics, reconciliation, and stream-health failover.
+The engine always maintains an in-memory cache of board state in `boardcache.CacheImpl`, wired as `e.readClient` for production runs (tests using `engine.NewWithDeps` bypass the cache and use `boardcache.GitHubAdapter` directly). The cache is the unified source of truth for downstream engine logic and reactive observers (`PushUnblockObserver`, `StageChangeObserver`, etc.) regardless of whether webhooks are configured. This appendix describes the cache lifecycle, delta semantics, reconciliation, and stream-health failover.
 
 ### D.1 Bootstrap
 
-Immediately after `wm.Start()` succeeds (webhook manager listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` directly — bypassing the cache — and passes the result to `cacheImpl.Bootstrap(board)`. Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
+The cache is bootstrapped from a fresh GitHub `FetchProjectBoard` call. Two paths can perform Bootstrap:
+
+1. **Webhook startup path** — when `--webhooks` is enabled, immediately after `wm.Start()` succeeds (listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` and passes the result to `cacheImpl.Bootstrap(board)`. This pre-bootstrap closes the gap between webhook subprocess start and the first poll cycle, so deltas don't land in an empty cache.
+
+2. **First-poll path** — every `poll()` cycle starts with a shallow `e.client.FetchProjectBoard(...)` call. If `cacheImpl.ProjectID() == ""` (cache not yet bootstrapped — e.g., webhooks disabled, or webhook-startup bootstrap failed), the result is passed to `cacheImpl.Bootstrap(board)`. On subsequent polls (cache already bootstrapped), the same fetch is passed to `cacheImpl.Reconcile(board)` instead — see D.4.
+
+Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
 
 Bootstrap calls `Store.Reset`, which fires observer notifications for every item (one `Change` per item, with non-zero `Fields`). `mayNeedWorkObserver` is always registered in `Engine.Run()` **before** Bootstrap is called and is the mechanism that makes bootstrapped items visible to the dispatch loop via the next ticker poll — no external webhook event is needed to unblock them. `wakeChObserver` is also registered before Bootstrap, but only when `wakeCh != nil`; in headless runs there is no wake channel and `wakeChObserver` is not registered, so visibility of bootstrapped items relies solely on `mayNeedWorkObserver` and the next ticker-driven poll (within `PollSeconds`).
 
-If the bootstrap fetch fails (e.g., transient network error), the cache starts empty and populates through fallback on the first cache miss. No data is lost; latency for the first deep-fetch is slightly higher.
+If a bootstrap fetch fails (e.g., transient network error), the cache stays unbootstrapped and the next poll cycle retries via the first-poll path. No data is lost.
 
 ### D.2 Delta Application
 
@@ -3835,7 +3833,13 @@ After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new ti
 
 **Gate inactive when**: `e.readClient` is not a `*boardcache.CacheImpl` (non-cache mode), or `cacheImpl.ProjectID()` is empty (bootstrap not yet complete).
 
-**Full reconcile — drift-recovery only**
+**Per-poll baseline reconcile**
+
+After the Layer 2 status gate above, every `poll()` cycle calls `e.client.FetchProjectBoard(...)` directly (bypassing the cache) and passes the result to `cacheImpl.Reconcile(board)` — or `cacheImpl.Bootstrap(board)` on the first poll when the cache hasn't been bootstrapped yet (see D.1). This is the universal baseline freshener: it flows shallow board state (notably `IsClosed`, `Status`, `Labels`, `UpdatedAt`) into the Store on every poll regardless of webhook configuration, firing observer notifications (`StateChanged`, `LabelsChanged`, `BlockedByChanged`, etc.) so reactive observers like `PushUnblockObserver` operate identically with or without webhooks.
+
+The per-poll Reconcile is what makes the cache the unified source of truth: without it, `PushUnblockObserver` and other Store-mutation observers were structurally dormant when webhooks were disabled, because no path in the polling-only loop wrote shallow board state into the Store.
+
+**Full reconcile — drift-recovery (webhook mode)**
 
 `LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. `reconcileCache` (the older full-fetch-and-reconcile helper) is retained but is no longer called by the engine.
 
@@ -3865,14 +3869,16 @@ On drift recovery, `LightReconcile` returns the fresh board it already fetched; 
 
 **`healthChangeFn` removed (issue #641):** The callback-based `healthChangeFn` pattern (ADR-034) has been replaced. The `reconcileTicker` goroutine owns the full Pause/Reconcile/Resume sequence directly; no indirection through a closure is required.
 
-### D.6 Cache Mode Selection
+### D.6 Cache Mode
 
-| `--board-cache` | `--webhooks` | Behavior |
-|-----------------|--------------|----------|
-| `in-memory` (default when webhooks on) | required | `CacheImpl` with delta/failover |
-| `none` | any | `GitHubAdapter` pass-through (no caching) |
+The `--board-cache` flag has been removed. `CacheImpl` is now wired unconditionally for production runs. The cache is freshened by:
 
-Specifying `--board-cache=in-memory` without `--webhooks` is a configuration error: without a webhook stream there is no delta source and the cache relies solely on the periodic status sweep — worse than direct polling.
+1. **Per-poll baseline Reconcile** (always active) — see D.4
+2. **Layer 2 status sweep** (always active) — see D.4 and D.7
+3. **Webhook deltas** (when `--webhooks` is enabled) — see D.2
+4. **Light-reconcile drift recovery** (when `--webhooks` is enabled) — see D.5
+
+Tests that need to bypass the cache use `engine.NewWithDeps`, which wires `boardcache.GitHubAdapter` directly. This bypasses the Store-mutation pipeline and silently disables observers, so it is intended only for unit tests that don't exercise Store-driven behavior.
 
 ### D.7 Status field reconciliation in user mode
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1669,15 +1669,21 @@ The engine uses two distinct in-memory stores (both in `itemstate.Store`) for co
 
 ## Appendix D: In-Memory Board Cache Lifecycle
 
-When `--webhooks` and `--board-cache=in-memory` are both active (the default when webhooks are enabled), the engine maintains an in-memory cache of board state in `boardcache.CacheImpl`. This appendix describes the cache lifecycle, delta semantics, reconciliation, and stream-health failover.
+The engine always maintains an in-memory cache of board state in `boardcache.CacheImpl`, wired as `e.readClient` for production runs (tests using `engine.NewWithDeps` bypass the cache and use `boardcache.GitHubAdapter` directly). The cache is the unified source of truth for downstream engine logic and reactive observers (`PushUnblockObserver`, `StageChangeObserver`, etc.) regardless of whether webhooks are configured. This appendix describes the cache lifecycle, delta semantics, reconciliation, and stream-health failover.
 
 ### D.1 Bootstrap
 
-Immediately after `wm.Start()` succeeds (webhook manager listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` directly — bypassing the cache — and passes the result to `cacheImpl.Bootstrap(board)`. Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
+The cache is bootstrapped from a fresh GitHub `FetchProjectBoard` call. Two paths can perform Bootstrap:
+
+1. **Webhook startup path** — when `--webhooks` is enabled, immediately after `wm.Start()` succeeds (listener bound and subprocess launched), the engine calls `e.client.FetchProjectBoard(...)` and passes the result to `cacheImpl.Bootstrap(board)`. This pre-bootstrap closes the gap between webhook subprocess start and the first poll cycle, so deltas don't land in an empty cache.
+
+2. **First-poll path** — every `poll()` cycle starts with a shallow `e.client.FetchProjectBoard(...)` call. If `cacheImpl.ProjectID() == ""` (cache not yet bootstrapped — e.g., webhooks disabled, or webhook-startup bootstrap failed), the result is passed to `cacheImpl.Bootstrap(board)`. On subsequent polls (cache already bootstrapped), the same fetch is passed to `cacheImpl.Reconcile(board)` instead — see D.4.
+
+Bootstrap populates `items`, `shaToKey`, and `itemIDToKey` from the full board snapshot. Deep fields (comments, linked PR data) are not populated at bootstrap; they are fetched lazily on first `FetchItemDetails` call.
 
 Bootstrap calls `Store.Reset`, which fires observer notifications for every item (one `Change` per item, with non-zero `Fields`). `mayNeedWorkObserver` is always registered in `Engine.Run()` **before** Bootstrap is called and is the mechanism that makes bootstrapped items visible to the dispatch loop via the next ticker poll — no external webhook event is needed to unblock them. `wakeChObserver` is also registered before Bootstrap, but only when `wakeCh != nil`; in headless runs there is no wake channel and `wakeChObserver` is not registered, so visibility of bootstrapped items relies solely on `mayNeedWorkObserver` and the next ticker-driven poll (within `PollSeconds`).
 
-If the bootstrap fetch fails (e.g., transient network error), the cache starts empty and populates through fallback on the first cache miss. No data is lost; latency for the first deep-fetch is slightly higher.
+If a bootstrap fetch fails (e.g., transient network error), the cache stays unbootstrapped and the next poll cycle retries via the first-poll path. No data is lost.
 
 ### D.2 Delta Application
 
@@ -1775,7 +1781,13 @@ After a successful batch step, `e.lastProjectUpdatedAt` is updated to the new ti
 
 **Gate inactive when**: `e.readClient` is not a `*boardcache.CacheImpl` (non-cache mode), or `cacheImpl.ProjectID()` is empty (bootstrap not yet complete).
 
-**Full reconcile — drift-recovery only**
+**Per-poll baseline reconcile**
+
+After the Layer 2 status gate above, every `poll()` cycle calls `e.client.FetchProjectBoard(...)` directly (bypassing the cache) and passes the result to `cacheImpl.Reconcile(board)` — or `cacheImpl.Bootstrap(board)` on the first poll when the cache hasn't been bootstrapped yet (see D.1). This is the universal baseline freshener: it flows shallow board state (notably `IsClosed`, `Status`, `Labels`, `UpdatedAt`) into the Store on every poll regardless of webhook configuration, firing observer notifications (`StateChanged`, `LabelsChanged`, `BlockedByChanged`, etc.) so reactive observers like `PushUnblockObserver` operate identically with or without webhooks.
+
+The per-poll Reconcile is what makes the cache the unified source of truth: without it, `PushUnblockObserver` and other Store-mutation observers were structurally dormant when webhooks were disabled, because no path in the polling-only loop wrote shallow board state into the Store.
+
+**Full reconcile — drift-recovery (webhook mode)**
 
 `LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. `reconcileCache` (the older full-fetch-and-reconcile helper) is retained but is no longer called by the engine.
 
@@ -1805,14 +1817,16 @@ On drift recovery, `LightReconcile` returns the fresh board it already fetched; 
 
 **`healthChangeFn` removed (issue #641):** The callback-based `healthChangeFn` pattern (ADR-034) has been replaced. The `reconcileTicker` goroutine owns the full Pause/Reconcile/Resume sequence directly; no indirection through a closure is required.
 
-### D.6 Cache Mode Selection
+### D.6 Cache Mode
 
-| `--board-cache` | `--webhooks` | Behavior |
-|-----------------|--------------|----------|
-| `in-memory` (default when webhooks on) | required | `CacheImpl` with delta/failover |
-| `none` | any | `GitHubAdapter` pass-through (no caching) |
+The `--board-cache` flag has been removed. `CacheImpl` is now wired unconditionally for production runs. The cache is freshened by:
 
-Specifying `--board-cache=in-memory` without `--webhooks` is a configuration error: without a webhook stream there is no delta source and the cache relies solely on the periodic status sweep — worse than direct polling.
+1. **Per-poll baseline Reconcile** (always active) — see D.4
+2. **Layer 2 status sweep** (always active) — see D.4 and D.7
+3. **Webhook deltas** (when `--webhooks` is enabled) — see D.2
+4. **Light-reconcile drift recovery** (when `--webhooks` is enabled) — see D.5
+
+Tests that need to bypass the cache use `engine.NewWithDeps`, which wires `boardcache.GitHubAdapter` directly. This bypasses the Store-mutation pipeline and silently disables observers, so it is intended only for unit tests that don't exercise Store-driven behavior.
 
 ### D.7 Status field reconciliation in user mode
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -43,8 +43,7 @@ type Config struct {
 	Webhooks                 bool
 	WebhookPort              int
 	WebhookEvents            []string
-	BoardCacheMode           string // "in-memory" or "none"; default "none" when webhooks off, "in-memory" when on
-	ProjectStatusPollSeconds int    // Layer 2 status-only sweep cadence in seconds; default 15 s (gate runs every poll cycle; field retained for config compatibility)
+	ProjectStatusPollSeconds int // Layer 2 status-only sweep cadence in seconds; default 15 s (gate runs every poll cycle; field retained for config compatibility)
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}
@@ -155,17 +154,13 @@ func New(cfg Config) (*Engine, error) {
 	// fabrik.log in both TUI and plain-text modes.
 	gh.Logf = eng.logf
 
-	// Initialize the read client: GitHubAdapter (pass-through) unless the in-memory
-	// board cache is enabled, in which case CacheImpl is created (bootstrap happens in Run()).
-	// The shared store is passed to CacheImpl so all mutations — engine-side and
-	// webhook-delta-side — flow through one Store instance.
+	// Initialize the read client. CacheImpl is the unified source of truth: the
+	// shared store is passed so all mutations — poll-driven Reconcile, engine-side,
+	// and (when enabled) webhook-delta-side — flow through one Store instance and
+	// reach the same observers (PushUnblockObserver, etc.).
 	adapter := boardcache.NewGitHubAdapter(eng.client)
-	if cfg.BoardCacheMode == "in-memory" {
-		cacheLogFn := func(format string, args ...any) { eng.logf(0, "cache", format, args...) }
-		eng.readClient = boardcache.NewCacheImpl(adapter, sharedStore, cacheLogFn)
-	} else {
-		eng.readClient = adapter
-	}
+	cacheLogFn := func(format string, args ...any) { eng.logf(0, "cache", format, args...) }
+	eng.readClient = boardcache.NewCacheImpl(adapter, sharedStore, cacheLogFn)
 
 	return eng, nil
 }
@@ -197,7 +192,10 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		}
 		wms[key] = worktrees
 	}
-	// Tests always use pass-through adapter (--board-cache=none behavior).
+	// Tests use the pass-through GitHub adapter directly so they exercise engine
+	// logic without going through CacheImpl's Reconcile/observer machinery — those
+	// are covered by boardcache's own tests. Production wiring (in New) always uses
+	// CacheImpl as the unified source of truth.
 	eng.readClient = boardcache.NewGitHubAdapter(client)
 	return eng
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -851,12 +851,25 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		case refreshErr != nil:
 			e.logf(0, "cache", "shallow refresh failed (using prior cache state): %v\n", refreshErr)
 		case freshBoard == nil || freshBoard.ProjectID == "":
-			// Empty/uninitialised fetch — treat as no-op rather than clobbering the
-			// cache's prior projectID and item set with an empty board.
-		case cacheImpl.ProjectID() == "":
-			cacheImpl.Bootstrap(freshBoard)
-		default:
+			// Empty/uninitialised fetch — no-op rather than clobbering prior cache state.
+		case len(freshBoard.Items) == 0 && cacheImpl.IsBootstrapped():
+			// Suspicious: fresh fetch came back with 0 items but cache has data.
+			// fetchProjectBoardOnce already retries on totalCount=0/nodes=0 indexer
+			// hiccups (see github/project.go projectBoardFetchAttempts), but a
+			// degraded response can still slip through. Reconciling a 0-item board
+			// against a populated cache would remove every cached item; skip this
+			// cycle and retry on the next poll instead.
+			e.logf(0, "cache", "shallow refresh returned 0 items while cache has data — skipping reconcile (treating as transient indexer hiccup)\n")
+		case cacheImpl.IsBootstrapped() || cacheImpl.ProjectID() != "":
+			// Already bootstrapped (or partially: projectID set without items).
+			// Reconcile is a partial update that preserves engine-side Store fields
+			// (locks, worker state, stage state, deep-fetched data). Bootstrap is
+			// strictly stronger — it calls Store.Reset which wipes those fields —
+			// and must only be used when the cache is truly virgin.
 			cacheImpl.Reconcile(freshBoard)
+		default:
+			// Truly virgin: no projectID and no items. Safe to Bootstrap.
+			cacheImpl.Bootstrap(freshBoard)
 		}
 	}
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -296,7 +296,9 @@ func (e *Engine) Run() error {
 		e.mu.Unlock()
 	}
 
-	// Extract in-memory cache if configured (nil when board-cache=none).
+	// In production wiring readClient is always *CacheImpl; the cast may return
+	// (nil, false) when called from tests that use the pass-through GitHub adapter
+	// directly via NewWithDeps. Code paths that depend on cacheImpl must check nil.
 	cacheImpl, _ := e.readClient.(*boardcache.CacheImpl)
 
 	// Register reactive observers. All returned unsubscribe funcs are collected
@@ -822,6 +824,39 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 					e.lastProjectUpdatedAt = updatedAt
 				}
 			}
+		}
+	}
+
+	// Universal baseline freshener: every poll, fetch the shallow board directly
+	// from GitHub and sync the cache via Bootstrap (first poll) or Reconcile
+	// (subsequent polls). This is what makes the cache the unified source of truth
+	// regardless of webhook state — without webhooks, this is the only path that
+	// flows IsClosed / Status / Label changes into the Store and fires Store
+	// observers (e.g., PushUnblockObserver). With webhooks, this remains as the
+	// drift-detection safety net for missed events.
+	//
+	// Future work (separate PR): track webhook health per-repo. Webhooks are either
+	// working for a repo or they are not — when healthy, the cache is authoritative
+	// for issue/PR/comment/review events in that repo, and the per-poll deep-fetch
+	// admit pass can be skipped entirely for items in that repo. Repos with
+	// disabled or unhealthy webhooks continue through the deep-fetch path.
+	//
+	// Important caveat: project Status changes do NOT flow over webhooks for
+	// repo-level projects (and only sometimes for org-level projects with the
+	// right permissions). The Layer 2 status sweep above must continue running
+	// regardless of webhook health — it is the only delivery path for Status.
+	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		freshBoard, refreshErr := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+		switch {
+		case refreshErr != nil:
+			e.logf(0, "cache", "shallow refresh failed (using prior cache state): %v\n", refreshErr)
+		case freshBoard == nil || freshBoard.ProjectID == "":
+			// Empty/uninitialised fetch — treat as no-op rather than clobbering the
+			// cache's prior projectID and item set with an empty board.
+		case cacheImpl.ProjectID() == "":
+			cacheImpl.Bootstrap(freshBoard)
+		default:
+			cacheImpl.Reconcile(freshBoard)
 		}
 	}
 

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1995,9 +1995,11 @@ func TestPoll_LogBoardBootstrapThenCache(t *testing.T) {
 }
 
 // TestPoll_LogItemFromGitHub verifies the item deep-fetch log says "from GitHub"
-// when the item is not yet in the cache (falls through to GitHub on cache miss).
-// Uses an unbootstrapped CacheImpl so the item is "notInStore" on first poll,
-// which bypasses the cycleSet requirement.
+// when the item's deep cache entry is empty, even though the shallow Bootstrap
+// has already populated the Store. The first poll's Bootstrap-or-Reconcile fires
+// StatusChanged through mayNeedWorkObserver → cycleSet, so the item passes the
+// pre-filter; IsItemDeepFetched is still false (deep state never populated), so
+// the deep-fetch falls through to GitHub.
 func TestPoll_LogItemFromGitHub(t *testing.T) {
 	board := &gh.ProjectBoard{
 		ProjectID: "PVT_test",
@@ -2009,9 +2011,12 @@ func TestPoll_LogItemFromGitHub(t *testing.T) {
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
-	// Wire an unbootstrapped CacheImpl so FetchProjectBoard falls through to GitHub
-	// and the item is "notInStore" (passes the poll pre-filter on first poll).
 	eng.readClient = boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+
+	// Register mayNeedWorkObserver before poll(): the per-poll Bootstrap fires
+	// StatusChanged which must populate mayNeedWork → cycleSet for the item to
+	// reach the deep-fetch section (matching production wiring in Run()).
+	eng.store.Subscribe(newMayNeedWorkObserver(&eng.mayNeedWorkMu, &eng.mayNeedWork))
 
 	logs := collectPollLogs(t, eng)
 


### PR DESCRIPTION
## Summary

The cache is now wired unconditionally and freshened by a shallow `FetchProjectBoard` + `Bootstrap`-or-`Reconcile` every poll cycle, regardless of whether webhooks are configured. Webhooks remain an optional acceleration: their deltas update the cache between polls, but the per-poll Reconcile is the universal baseline — it flows `IsClosed`/`Status`/`Labels` into the Store and fires Store observers (`PushUnblockObserver`, etc.) that were previously structurally dormant in non-webhook runs.

## Motivation

In a live test on this board:
- A blocker (#657) was closed at 02:14:51
- Its dependent (#658, with `fabrik:blocked`) stayed blocked
- The push-path observer (`PushUnblockObserver`) never fired
- The pull-path (`checkDependencies` in `processItem`) unblocked it ~150s later, after the `dep-blocked` cooldown expired

Root cause: with `--board-cache=none` (the auto-default when `--webhooks` was disabled), no path wrote shallow board state into the Store, so the `StateChanged` event for the blocker's close never fired. `PushUnblockObserver` was structurally dormant. The same pattern was visible in a webhook+cache project where `issues.closed` for an issue closed via PR merge silently never reached the cache — drift sat for ~2 hours until `light reconcile` rescued it.

The original architectural intent (per discussion):
> The cache is the source of truth for all downstream engine state changes. GraphQL polling populates the cache; webhooks optionally refresh the cache faster when available.

This PR restores that intent.

## Changes

- **`cmd/root.go`** — Drop `--board-cache` flag, `FABRIK_BOARD_CACHE` env var, the `--board-cache=in-memory requires --webhooks` validation, and the `BoardCacheMode` config field
- **`engine/engine.go`** — Drop `BoardCacheMode`; `New()` always constructs `CacheImpl`; `NewWithDeps` (test-only) still uses the pass-through `GitHubAdapter`
- **`engine/poll.go`** — In `poll()`, after the Layer 2 status gate, always do a shallow `FetchProjectBoard` from `e.client` (bypassing the cache) and pass the result to `Bootstrap` (first poll, when `projectID == ""`) or `Reconcile` (subsequent polls). Empty/uninitialised fetches are no-ops to avoid clobbering the cache's prior `projectID`/items
- **`engine/poll_test.go`** — `TestPoll_LogItemFromGitHub` now registers `mayNeedWorkObserver` before `poll()` so the per-poll Bootstrap populates `cycleSet` (the old "unbootstrapped cache + `notInStore` bypass" path no longer exists in production)
- **`docs/USER_GUIDE.md`, `docs/state-machine.md`, `docs/llms-full.txt`** — Updated to reflect the new architecture; `--board-cache` flag removed from option table; "In-Memory Board Cache" section rewritten around per-poll Reconcile; Appendix D Bootstrap / Reconcile / Cache-Mode sections rewritten

## Cost

Every poll now does one extra GraphQL call (the shallow `FetchProjectBoard`) in webhook mode. ~1 point — negligible compared to the deep-fetches that follow.

## Caveats

- **Project Status doesn't flow over webhooks** for repo-level projects (and only sometimes for org-level). The Layer 2 status sweep above the per-poll Reconcile remains the only authoritative delivery path for Status drift and continues to run every poll regardless of webhook health.

## Follow-up (separate PR)

Track webhook health per-repo. Webhooks are either working for a repo or they are not — when healthy, the cache is authoritative for issue/PR/comment/review events in that repo, and the per-poll deep-fetch admit pass can be skipped entirely for items in that repo. The Layer 2 status sweep must continue regardless.

## Test plan

- [x] `go build -o fabrik .`
- [x] `go test -race ./...` — all green
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [ ] Live verify: run with webhooks off, close a blocker, dependent unblocks within `PollSeconds*10` (cooldown) instead of staying blocked indefinitely
- [ ] Live verify: run with webhooks on, behavior matches prior cache+webhooks mode
- [ ] Live verify: project Status changes still propagate via Layer 2 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)