### PR TITLE
ci: publish fabrik plugin marketplace + sources to shadoworg/fabrik on release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "description": "The Fabrik plugin marketplace — ambient awareness of Fabrik (a GitHub-Project-driven SDLC pipeline orchestrator) for your interactive Claude Code session.",
   "owner": {
     "name": "Tenacious Ventures",
-    "url": "https://github.com/tenaciousvc/fabrik"
+    "url": "https://github.com/shadoworg/fabrik"
   },
   "plugins": [
     {
@@ -13,14 +13,14 @@
       "category": "development",
       "source": {
         "source": "git-subdir",
-        "url": "https://github.com/tenaciousvc/fabrik.git",
+        "url": "https://github.com/shadoworg/fabrik.git",
         "path": "plugin/fabrik",
         "ref": "main"
       },
       "homepage": "https://fabrik.shadoworg.dev",
       "author": {
         "name": "Tenacious Ventures",
-        "url": "https://github.com/tenaciousvc/fabrik"
+        "url": "https://github.com/shadoworg/fabrik"
       }
     }
   ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,46 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_RELEASE_TOKEN }}
 
+      - name: Publish plugin to shadoworg/fabrik
+        env:
+          GH_TOKEN: ${{ secrets.PUBLIC_REPO_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.ref_name }}"
+          SRC="${{ github.workspace }}"
+
+          if [ ! -f "$SRC/.claude-plugin/marketplace.json" ]; then
+            echo "Error: .claude-plugin/marketplace.json missing in source — nothing to publish."
+            exit 1
+          fi
+          if [ ! -d "$SRC/plugin/fabrik" ]; then
+            echo "Error: plugin/fabrik/ missing in source — nothing to publish."
+            exit 1
+          fi
+
+          WORK="$(mktemp -d)"
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/shadoworg/fabrik.git" "$WORK/shadoworg-fabrik"
+          cd "$WORK/shadoworg-fabrik"
+
+          git config user.name "fabrik-release-bot"
+          git config user.email "fabrik-release-bot@users.noreply.github.com"
+
+          mkdir -p .claude-plugin
+          cp "$SRC/.claude-plugin/marketplace.json" .claude-plugin/marketplace.json
+
+          rm -rf plugin/fabrik
+          mkdir -p plugin
+          cp -R "$SRC/plugin/fabrik" plugin/fabrik
+
+          git add .claude-plugin/marketplace.json plugin/fabrik
+          if git diff --cached --quiet; then
+            echo "No plugin changes to publish for ${VERSION}."
+          else
+            git commit -m "chore: publish fabrik plugin ${VERSION}"
+            git push origin main
+            echo "Plugin published to shadoworg/fabrik for ${VERSION}."
+          fi
+
       - name: Announce release on Discussions
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_REPO_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Two coupled changes that together let users install the fabrik plugin from the public release repo (`shadoworg/fabrik`) instead of the dev repo (`tenaciousvc/fabrik`):

1. **`.claude-plugin/marketplace.json`** — switch owner URL, plugin source URL, and author URL from `tenaciousvc/fabrik` (dev) to `shadoworg/fabrik` (public release).

2. **`.github/workflows/release.yml`** — new `Publish plugin to shadoworg/fabrik` step between `goreleaser` and the Discussion announcement that:
   - Clones `shadoworg/fabrik:main` using `PUBLIC_REPO_RELEASE_TOKEN`
   - Overwrites only `.claude-plugin/marketplace.json` and replaces `plugin/fabrik/` (other curated files in shadoworg — README, LICENSE, CONTRIBUTING.md, `community-skills/`, etc. — are untouched)
   - Commits as `fabrik-release-bot` with message `chore: publish fabrik plugin <tag>` and pushes to `main`
   - No-op when nothing changed
   - Runs after the binary release succeeds but before the announcement, so a sync failure prevents announcing a half-published release

## Why

`shadoworg/fabrik` is the public release repo where fabrik binaries get published; `tenaciousvc/fabrik` is the dev repo. Users running `/plugin marketplace add shadoworg/fabrik` in Claude Code expect the marketplace manifest and plugin source to live in the same repo as the binaries — they don't currently.

## Caveats

- **Token scope**: `PUBLIC_REPO_RELEASE_TOKEN` must have `contents: write` on `shadoworg/fabrik`. It already creates releases there, but pushing to the default branch may need a separate scope or branch protection bypass — worth a dry-run.
- **Branch protection**: `shadoworg/fabrik:main` may have branch protection rules (required reviews, linear history) that block bot pushes. If so, grant the bot bypass or relax the rule for this token.
- **Repo visibility**: `shadoworg/fabrik` is currently private — `/plugin marketplace add shadoworg/fabrik` will require auth until you flip it public.
- **Trigger cadence**: Publishes only on release-tag pushes, so plugin-only fixes still need a fabrik binary release to reach users.

## Test plan

- [ ] Verify `PUBLIC_REPO_RELEASE_TOKEN` has push access to `shadoworg/fabrik:main` (dry-run before next release tag)
- [ ] On next release tag: confirm `Publish plugin to shadoworg/fabrik` step succeeds and the bot commit lands at `shadoworg/fabrik:main`
- [ ] Confirm shadoworg's existing curated files (README, LICENSE, etc.) are untouched after the sync
- [ ] After flipping shadoworg/fabrik public: verify `/plugin marketplace add shadoworg/fabrik` resolves without auth and the plugin installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)