### PR TITLE
When checking and setting labels on the project board, set colors too

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1412,7 +1412,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 
 ### Fabrik-Managed Labels
 
-> Fabrik auto-seeds all managed labels on the configured repository at startup — creating them with their descriptions and colors if they do not already exist, so the GitHub UI shows meaningful hover text.
+> Fabrik auto-seeds all managed labels on the configured repository at startup — creating them if missing, and enforcing the correct color on existing labels, so the GitHub UI shows meaningful hover text and the board color scheme stays consistent.
 
 | Label | Purpose |
 |-------|---------|

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1410,7 +1410,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 
 ### Fabrik-Managed Labels
 
-> Fabrik auto-seeds all managed labels on the configured repository at startup — creating them with their descriptions and colors if they do not already exist, so the GitHub UI shows meaningful hover text.
+> Fabrik auto-seeds all managed labels on the configured repository at startup — creating them if missing, and enforcing the correct color on existing labels, so the GitHub UI shows meaningful hover text and the board color scheme stays consistent.
 
 | Label | Purpose |
 |-------|---------|

--- a/github/labels.go
+++ b/github/labels.go
@@ -17,27 +17,27 @@ type labelDef struct {
 }
 
 // staticLabelDefs lists every static and enumerated Fabrik label with its
-// description (≤100 chars) and a sensible default color for first creation.
-// Colors are never changed after a label is created.
+// description (≤100 chars) and color. Colors are enforced on existing labels
+// at startup via SeedLabels.
 var staticLabelDefs = []labelDef{
-	// --- behaviour labels (blue) ---
-	{"fabrik:yolo", "Auto-advance all stages and auto-merge the PR at Validate", "0075ca"},
-	{"fabrik:cruise", "Auto-advance all stages; stop at Validate without merging", "0075ca"},
-	{"fabrik:extend-turns", "Override: pre-grant 2× turn budget; auto-removed on stage success", "0075ca"},
+	// --- behaviour override labels (grey) ---
+	{"fabrik:yolo", "Auto-advance all stages and auto-merge the PR at Validate", "cfd3d7"},
+	{"fabrik:cruise", "Auto-advance all stages; stop at Validate without merging", "cfd3d7"},
+	{"fabrik:extend-turns", "Override: pre-grant 2× turn budget; auto-removed on stage success", "cfd3d7"},
 
-	// --- warning / waiting labels (yellow) ---
-	{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "e4e669"},
+	// --- error / intervention needed labels (red) ---
+	{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "d73a4a"},
+	{"fabrik:blocked", "Blocked by one or more open dependency issues", "d73a4a"},
+	{"fabrik:unrestricted", "Claude runs with --dangerously-skip-permissions for this issue", "d73a4a"},
+
+	// --- waiting labels (yellow) ---
 	{"fabrik:awaiting-input", "Stage blocked on FABRIK_BLOCKED_ON_INPUT; comment to unblock", "e4e669"},
 	{"fabrik:awaiting-review", "Validate complete; waiting for requested PR reviewers", "e4e669"},
 	{"fabrik:awaiting-ci", "CI gate active; waiting for CI checks to pass (checks may be running or have failed)", "e4e669"},
 	{"fabrik:rebase-needed", "Base branch advanced and PR no longer merges; engine is retrying a rebase invocation", "e4e669"},
 	{"fabrik:bot-reprompted", "Bot re-prompt sent; waiting for bot to respond (transient; removed at gate-cycle end)", "e4e669"},
 
-	// --- danger labels (red) ---
-	{"fabrik:blocked", "Blocked by one or more open dependency issues", "d73a4a"},
-	{"fabrik:unrestricted", "Claude runs with --dangerously-skip-permissions for this issue", "d73a4a"},
-
-	// --- neutral labels (grey) ---
+	// --- neutral / transient labels (grey) ---
 	{"fabrik:editing", "Issue is being edited by the user; processing deferred", "cfd3d7"},
 
 	// --- model override labels (purple) ---
@@ -71,7 +71,7 @@ func labelDefFor(name string) (description, color string) {
 			stageName := parts[1]
 			switch parts[2] {
 			case "in_progress":
-				return fmt.Sprintf("Fabrik is currently running the %s stage", stageName), "0e8a16"
+				return fmt.Sprintf("Fabrik is currently running the %s stage", stageName), "6f42c1"
 			case "complete":
 				return fmt.Sprintf("%s stage completed successfully", stageName), "0e8a16"
 			case "failed":
@@ -185,12 +185,12 @@ func (c *Client) ensureLabel(owner, repo, name, description, color string) error
 // ErrNoRepoConfigured is returned by SeedLabels when repo is empty.
 var ErrNoRepoConfigured = errors.New("repo must not be empty")
 
-// SeedLabels ensures all known Fabrik labels exist on the given repo and that
-// any label with an empty description is backfilled. It never changes an
-// existing label's color or non-empty description. stageNames is the list of
-// stage names from the loaded config; lockedUser is the current Fabrik user.
-// Returns ErrNoRepoConfigured when repo is empty. Per-label failures are logged
-// internally and do not cause an early return.
+// SeedLabels ensures all known Fabrik labels exist on the given repo. It
+// enforces the correct color on existing labels and backfills empty
+// descriptions. Non-empty descriptions are never overwritten. stageNames is the
+// list of stage names from the loaded config; lockedUser is the current Fabrik
+// user. Returns ErrNoRepoConfigured when repo is empty. Per-label failures are
+// logged internally and do not cause an early return.
 func (c *Client) SeedLabels(owner, repo string, stageNames []string, lockedUser string) error {
 	if repo == "" {
 		return ErrNoRepoConfigured
@@ -210,7 +210,7 @@ func (c *Client) SeedLabels(owner, repo string, stageNames []string, lockedUser 
 			labelDef{
 				fmt.Sprintf("stage:%s:in_progress", s),
 				fmt.Sprintf("Fabrik is currently running the %s stage", s),
-				"0e8a16",
+				"6f42c1",
 			},
 			labelDef{
 				fmt.Sprintf("stage:%s:complete", s),
@@ -233,14 +233,16 @@ func (c *Client) SeedLabels(owner, repo string, stageNames []string, lockedUser 
 	return nil
 }
 
-// seedOneLabel creates a label if it does not exist, or backfills its
-// description if it exists with an empty description. Color is never changed.
+// seedOneLabel creates a label if it does not exist, or enforces the correct
+// color on existing labels and backfills empty descriptions. Color is enforced
+// on existing labels; description is only backfilled when empty.
 func (c *Client) seedOneLabel(owner, repo string, d labelDef) error {
 	getURL := fmt.Sprintf("%s/repos/%s/%s/labels/%s", c.baseURL, owner, repo, url.PathEscape(d.name))
 
 	var existing struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
+		Color       string `json:"color"`
 	}
 	err := c.restGetJSON(getURL, &existing)
 	if err != nil {
@@ -260,11 +262,19 @@ func (c *Client) seedOneLabel(owner, repo string, d labelDef) error {
 		return err
 	}
 
-	// Label exists. Backfill description only if currently empty.
-	if existing.Description != "" {
+	// Label exists. Enforce color; backfill description only if currently empty.
+	needDesc := existing.Description == ""
+	needColor := existing.Color != d.color
+	if !needDesc && !needColor {
 		return nil
 	}
+	patch := map[string]string{}
+	if needDesc {
+		patch["description"] = d.description
+	}
+	if needColor {
+		patch["color"] = d.color
+	}
 	patchURL := fmt.Sprintf("%s/repos/%s/%s/labels/%s", c.baseURL, owner, repo, url.PathEscape(d.name))
-	patch := map[string]string{"description": d.description}
 	return c.restPatch(patchURL, patch)
 }

--- a/github/mutations_test.go
+++ b/github/mutations_test.go
@@ -307,7 +307,8 @@ func TestSeedLabels_CreateMissing(t *testing.T) {
 }
 
 // TestSeedLabels_BackfillEmpty: seedOneLabel PATCHes an existing label that has
-// an empty description. The PATCH body must NOT contain a color field.
+// an empty description and no color set. PATCH body must include both
+// description and color.
 func TestSeedLabels_BackfillEmpty(t *testing.T) {
 	var gotMethod []string
 	var patchBody map[string]interface{}
@@ -316,7 +317,7 @@ func TestSeedLabels_BackfillEmpty(t *testing.T) {
 		gotMethod = append(gotMethod, r.Method)
 		switch r.Method {
 		case http.MethodGet:
-			// Label exists with empty description
+			// Label exists with empty description and no color field (empty string).
 			w.WriteHeader(200)
 			json.NewEncoder(w).Encode(map[string]string{"name": "fabrik:paused", "description": ""})
 		case http.MethodPatch:
@@ -330,24 +331,24 @@ func TestSeedLabels_BackfillEmpty(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token", srv.URL)
-	d := labelDef{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "e4e669"}
+	d := labelDef{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "d73a4a"}
 	if err := c.seedOneLabel("owner", "repo", d); err != nil {
 		t.Fatalf("seedOneLabel: %v", err)
 	}
 	if len(gotMethod) != 2 || gotMethod[0] != "GET" || gotMethod[1] != "PATCH" {
 		t.Errorf("expected [GET PATCH], got %v", gotMethod)
 	}
-	// PATCH body must include description and must NOT include color.
+	// PATCH body must include both description and color.
 	if patchBody["description"] != "Stage failed or needs intervention; remove to resume" {
 		t.Errorf("PATCH description = %v", patchBody["description"])
 	}
-	if _, hasColor := patchBody["color"]; hasColor {
-		t.Error("PATCH body must not include color field")
+	if patchBody["color"] != "d73a4a" {
+		t.Errorf("PATCH color = %v, want d73a4a", patchBody["color"])
 	}
 }
 
 // TestSeedLabels_SkipNonEmpty: seedOneLabel does nothing when the label already
-// has a non-empty description (preserves user customisation).
+// has the correct color and a non-empty description (preserves user customisation).
 func TestSeedLabels_SkipNonEmpty(t *testing.T) {
 	var gotMethod []string
 
@@ -355,23 +356,115 @@ func TestSeedLabels_SkipNonEmpty(t *testing.T) {
 		gotMethod = append(gotMethod, r.Method)
 		switch r.Method {
 		case http.MethodGet:
-			// Label exists with a custom description
+			// Label exists with correct color and a custom non-empty description.
 			w.WriteHeader(200)
-			json.NewEncoder(w).Encode(map[string]string{"name": "fabrik:paused", "description": "user custom description"})
+			json.NewEncoder(w).Encode(map[string]string{
+				"name":        "fabrik:paused",
+				"description": "user custom description",
+				"color":       "d73a4a",
+			})
 		default:
-			t.Errorf("unexpected method: %s — should not PATCH when description is non-empty", r.Method)
+			t.Errorf("unexpected method: %s — should not PATCH when both color and description are correct", r.Method)
 			w.WriteHeader(500)
 		}
 	}))
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token", srv.URL)
-	d := labelDef{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "e4e669"}
+	d := labelDef{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "d73a4a"}
 	if err := c.seedOneLabel("owner", "repo", d); err != nil {
 		t.Fatalf("seedOneLabel: %v", err)
 	}
 	if len(gotMethod) != 1 || gotMethod[0] != "GET" {
 		t.Errorf("expected [GET] only, got %v", gotMethod)
+	}
+}
+
+// TestSeedLabels_ColorWrongDescOK: seedOneLabel PATCHes color when it is wrong
+// but description is already non-empty. PATCH body must include color only.
+func TestSeedLabels_ColorWrongDescOK(t *testing.T) {
+	var gotMethod []string
+	var patchBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = append(gotMethod, r.Method)
+		switch r.Method {
+		case http.MethodGet:
+			// Label exists with non-empty description but wrong color.
+			w.WriteHeader(200)
+			json.NewEncoder(w).Encode(map[string]string{
+				"name":        "fabrik:paused",
+				"description": "Stage failed or needs intervention; remove to resume",
+				"color":       "000000",
+			})
+		case http.MethodPatch:
+			json.NewDecoder(r.Body).Decode(&patchBody)
+			w.WriteHeader(200)
+		default:
+			t.Errorf("unexpected method: %s", r.Method)
+			w.WriteHeader(500)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	d := labelDef{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "d73a4a"}
+	if err := c.seedOneLabel("owner", "repo", d); err != nil {
+		t.Fatalf("seedOneLabel: %v", err)
+	}
+	if len(gotMethod) != 2 || gotMethod[0] != "GET" || gotMethod[1] != "PATCH" {
+		t.Errorf("expected [GET PATCH], got %v", gotMethod)
+	}
+	// PATCH body must include color but NOT description.
+	if patchBody["color"] != "d73a4a" {
+		t.Errorf("PATCH color = %v, want d73a4a", patchBody["color"])
+	}
+	if _, hasDesc := patchBody["description"]; hasDesc {
+		t.Error("PATCH body must not include description field when description is already correct")
+	}
+}
+
+// TestSeedLabels_BothWrong: seedOneLabel PATCHes both fields when label exists
+// with empty description and wrong color.
+func TestSeedLabels_BothWrong(t *testing.T) {
+	var gotMethod []string
+	var patchBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = append(gotMethod, r.Method)
+		switch r.Method {
+		case http.MethodGet:
+			// Label exists with empty description and wrong color.
+			w.WriteHeader(200)
+			json.NewEncoder(w).Encode(map[string]string{
+				"name":        "fabrik:paused",
+				"description": "",
+				"color":       "000000",
+			})
+		case http.MethodPatch:
+			json.NewDecoder(r.Body).Decode(&patchBody)
+			w.WriteHeader(200)
+		default:
+			t.Errorf("unexpected method: %s", r.Method)
+			w.WriteHeader(500)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	d := labelDef{"fabrik:paused", "Stage failed or needs intervention; remove to resume", "d73a4a"}
+	if err := c.seedOneLabel("owner", "repo", d); err != nil {
+		t.Fatalf("seedOneLabel: %v", err)
+	}
+	if len(gotMethod) != 2 || gotMethod[0] != "GET" || gotMethod[1] != "PATCH" {
+		t.Errorf("expected [GET PATCH], got %v", gotMethod)
+	}
+	// PATCH body must include both description and color.
+	if patchBody["description"] != "Stage failed or needs intervention; remove to resume" {
+		t.Errorf("PATCH description = %v", patchBody["description"])
+	}
+	if patchBody["color"] != "d73a4a" {
+		t.Errorf("PATCH color = %v, want d73a4a", patchBody["color"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Assign a consistent color palette to all Fabrik-managed labels, grouped by semantic category. Update `SeedLabels` / `seedOneLabel` to enforce correct colors on both new and existing labels, so that repos already using Fabrik are brought up to date on the next startup.

## Problem

Fabrik manages a set of labels on the GitHub Project board (via `SeedLabels` on startup) to track pipeline state. Labels are created with colors when first created, but the colors are never enforced or updated on existing labels. Additionally, the current color assignments don't follow a consistent semantic scheme — for example, `stage:*:in_progress` labels are green (same as `complete`), and `fabrik:yolo`/`fabrik:cruise` are blue even though they are behavioral overrides rather than status indicators.

This makes the board harder to read at a glance: there's no visual distinction between "things are running" and "things are done", and behavior-modifier labels are styled the same as GitHub's built-in blue labels.

## Approach

### Approach

This is a pure `github/labels.go` change (plus test updates and a one-line doc fix). The work splits into four logical units: correcting the color constants, extending `seedOneLabel` to enforce colors on existing labels, updating the test suite to match the new behavior, and updating the user guide.

The `seedOneLabel` rewrite is the core change. The approach:
- Extend the GET response struct to capture `Color` from the GitHub API response
- Compute `needDesc := existing.Description == ""` and `needColor := existing.Color != d.color`
- Return early (no PATCH) only when both are false
- Build the patch map with only the fields that need updating, issue a single PATCH

The GitHub Labels API PATCH endpoint accepts partial updates, so sending only `color`, only `description`, or both is supported without any changes to `rest.go`.

No ADR is warranted — the color enforcement is a straightforward behavioral extension of `seedOneLabel` with no non-obvious constraint on future contributors.

### New/Modified Files

| File | Change |
|------|--------|
| `github/labels.go` | Fix 4 color values in `staticLabelDefs`; fix `stage:*:in_progress` color in `labelDefFor` and `SeedLabels`; rewrite `seedOneLabel` to enforce color; update docstrings |
| `github/mutations_test.go` | Rewrite `TestSeedLabels_BackfillEmpty`; update `TestSeedLabels_SkipNonEmpty`; add `TestSeedLabels_ColorWrongDescOK` and `TestSeedLabels_BothCorrect` |
| `docs/USER_GUIDE.md` | Update line 1415 to mention retroactive color enforcement |
| `docs/llms-full.txt` | Regenerate after USER_GUIDE.md edit |

### Key Decisions

- **Single PATCH per label.** When both description and color need updating, they are combined into one PATCH call rather than two sequential PATCHes. The GitHub API supports this; the spec requires it. Two-call alternative was not considered.

- **Color comparison is case-sensitive lowercase.** GitHub returns colors as lowercase hex without `#` (e.g., `d73a4a`). Fabrik stores them the same way. No normalization is added — any future divergence would require investigation at that point, not now.

- **`TestSeedLabels_BackfillEmpty` is rewritten, not renamed.** The test name is still accurate after the change: it still covers the "backfill empty description" path, now also covering the simultaneous color fix. A rename or split would be cosmetic churn; the test comment is updated to reflect both behaviors.

- **`TestSeedLabels_SkipNonEmpty` now validates "both correct → no PATCH."** The mock GET response is updated to return the correct color for `fabrik:paused` (now `d73a4a`). This keeps the test's original intent: when the label already has the right data, nothing is changed.

### Task Checklist

- [ ] **Task 1**: Fix color constants in `github/labels.go` — update `staticLabelDefs` (`fabrik:yolo`, `fabrik:cruise`, `fabrik:extend-turns` from `0075ca` → `cfd3d7`; `fabrik:paused` from `e4e669` → `d73a4a`), fix `labelDefFor` (`stage:*:in_progress` from `0e8a16` → `6f42c1`), and fix the hardcoded `stage:*:in_progress` color string at line 212 of `SeedLabels` (`0e8a16` → `6f42c1`). Also update `staticLabelDefs` comment block headers to reflect the new groupings (grey/red/purple).
- [ ] **Task 2**: Rewrite `seedOneLabel` in `github/labels.go` to enforce color — add `Color string \`json:"color"\`` to the GET response struct; compute `needDesc` and `needColor`; build patch map with only the needed fields; return early only when both are false. Update the function comment to say "Color is enforced on existing labels; description is only backfilled when empty."
- [ ] **Task 3**: Update `SeedLabels` docstring in `github/labels.go` — remove "It never changes an existing label's color" and replace with "It enforces the correct color on existing labels and backfills empty descriptions."
- [ ] **Task 4**: Update `TestSeedLabels_BackfillEmpty` in `github/mutations_test.go` — use new color `d73a4a` in the labelDef, have mock GET return empty description and no color (so both need fixing), assert PATCH body contains both `description` and `color`, invert the "must not include color" assertion.
- [ ] **Task 5**: Update `TestSeedLabels_SkipNonEmpty` in `github/mutations_test.go` — have mock GET return `{"name": "fabrik:paused", "description": "user custom description", "color": "d73a4a"}` so both fields match; update labelDef to use new color `d73a4a`; verify only GET fires, no PATCH.
- [ ] **Task 6**: Add `TestSeedLabels_ColorWrongDescOK` in `github/mutations_test.go` — label has non-empty description but wrong color; mock GET returns correct non-empty description but wrong color `000000`; assert PATCH fires with `color` field only (no `description` field).
- [ ] **Task 7**: Add `TestSeedLabels_BothWrong` in `github/mutations_test.go` — label exists with empty description and wrong color; assert PATCH fires with both `description` and `color` fields (this overlaps partially with updated `BackfillEmpty`, but tests the explicit "both wrong" case from the spec explicitly).
- [ ] **Task 8**: Update `docs/USER_GUIDE.md` line 1415 — change "creating them with their descriptions and colors if they do not already exist" to "creating them if missing, and enforcing the correct color on existing labels, so the GitHub UI shows meaningful hover text and the board color scheme stays consistent."
- [ ] **Task 9**: Regenerate `docs/llms-full.txt` by running `bash scripts/generate-llms-full.sh` and staging the result.
- [ ] **Task 10**: Run `go test ./...` and `go vet ./...`; confirm all tests pass and no vet issues.

### Risks

- **`TestSeedLabels_CreateMissing` uses `"0075ca"` as the color in its labelDef** (line 291 of `mutations_test.go`). That test is for a label that doesn't exist (404 path), so the existing color constant `0075ca` in the test's labelDef is fine — it tests the create path, not the color-enforcement path. However, the `fabrik:yolo` label it uses now has color `cfd3d7` in `staticLabelDefs`. The test constructs the labelDef directly with a hardcoded `"0075ca"` which is independent of `staticLabelDefs`, so the test remains valid for what it tests (create path sends the requested color). No change needed there.

- **Ordering**: Tasks 1–3 are all `github/labels.go` changes and can be done in a single commit. Tasks 4–7 are all test changes and can be a second commit. Tasks 8–9 are the doc commit. Task 10 is the verification step, not a separate commit.

---
Used 8/50 turns, 4k input / 4k output tokens.

## Verification

Updated `github/labels.go` with a consistent semantic color palette: behavior-override labels (yolo/cruise/extend-turns) changed from blue to grey, `fabrik:paused` moved from yellow to red, and `stage:*:in_progress` changed from green to purple. `seedOneLabel` now retroactively enforces colors on existing labels (PATCH when color differs) while continuing to backfill empty descriptions, combining both fixes into a single PATCH call when needed. Test suite updated with four focused tests covering the new color-enforcement paths, and `docs/USER_GUIDE.md` updated to reflect the retroactive enforcement behavior.

---

Closes #659