### PR TITLE
fix: cache staleness gate via updatedAt + non-interactive git/ssh

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -468,12 +468,54 @@ func (c *CacheImpl) IsBootstrapped() bool {
 
 // IsItemDeepFetched returns true when the cache holds deep-fetched details for
 // the given item (LastDeepFetchAt is non-zero). Called outside c.mu.
+//
+// Note: this only reports whether a deep fetch ever happened; it does not check
+// freshness. Callers that need to know whether the cache is currently
+// authoritative should use IsItemCacheFresh.
 func (c *CacheImpl) IsItemDeepFetched(repo string, number int) bool {
 	snap, err := c.store.Get(repo, number)
 	if err != nil {
 		return false
 	}
 	return !snap.State().LastDeepFetchAt.IsZero()
+}
+
+// IsItemCacheFresh returns true when the cache has deep-fetched details for the
+// given item AND those details are not stale relative to the supplied
+// sourceUpdatedAt (typically pi.UpdatedAt from a fresh board read). When the
+// cache is stale, FetchItemDetails will fall through to a GraphQL deep-fetch.
+// Called outside c.mu.
+func (c *CacheImpl) IsItemCacheFresh(repo string, number int, sourceUpdatedAt time.Time) bool {
+	snap, err := c.store.Get(repo, number)
+	if err != nil {
+		return false
+	}
+	s := snap.State()
+	if s.LastDeepFetchAt.IsZero() {
+		return false
+	}
+	return !cacheIsStale(sourceUpdatedAt, s.LastSeenSourceUpdatedAt)
+}
+
+// cacheIsStale reports whether the cached deep state is stale relative to the
+// fresh board's source updatedAt. Returns true when sourceUpdatedAt is strictly
+// after lastSeen — i.e., something on GitHub has bumped updatedAt since we last
+// captured a deep fetch.
+//
+// Edge cases:
+//   - lastSeen is zero (legacy cache entries written before this field existed):
+//     treat as stale so the next FetchItemDetails refreshes once and populates
+//     LastSeenSourceUpdatedAt going forward.
+//   - sourceUpdatedAt is zero (board read did not populate it): treat as fresh
+//     to avoid a hot-loop refetch when no signal is available.
+func cacheIsStale(sourceUpdatedAt, lastSeen time.Time) bool {
+	if sourceUpdatedAt.IsZero() {
+		return false
+	}
+	if lastSeen.IsZero() {
+		return true
+	}
+	return sourceUpdatedAt.After(lastSeen)
 }
 
 // Subscribe registers an observer on the underlying Store. The returned func
@@ -532,7 +574,19 @@ func (c *CacheImpl) FetchProjectBoard(owner, repo string, projectNum int, ownerT
 // FetchItemDetails copies cached deep fields into the passed item pointer.
 // Deep fields: Body, URL, Author, Assignees, BlockedBy, Comments, LinkedPRNumber,
 // LinkedPRReviewRequests, LinkedPRReviews, LinkedPRReviewThreadComments, LinkedPRResolvedThreadCount.
-// Falls back to GitHub on cache miss and populates the cache with the result.
+//
+// Cache freshness contract: the cache is treated as authoritative only while the
+// fresh board's pi.UpdatedAt has not advanced past LastSeenSourceUpdatedAt (the
+// pi.UpdatedAt observed at the moment of the last successful deep fetch). When
+// the board's updatedAt is newer, the cache is stale and we fall through to a
+// real GraphQL fetch. pi.UpdatedAt is computed by FetchProjectBoard as
+// max(issue.updatedAt, projectItem.updatedAt, linkedPR.updatedAt), so PR-side
+// changes (new reviews, comments, draft toggles) bump it. Webhooks remain a
+// pure optimization that mutate the cache between polls; in their absence (or
+// when they're unhealthy), the board's updatedAt correctly forces a re-fetch.
+//
+// Falls back to GitHub on cache miss or when the cache is stale, and populates
+// the cache with the result.
 func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 	c.mu.RLock()
 	paused := c.paused
@@ -546,13 +600,19 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 	if err == nil {
 		s := snap.State()
 		if !s.LastDeepFetchAt.IsZero() {
-			// Cache hit — copy deep fields into item.
-			copyDeepFieldsFromState(item, s)
-			return nil
+			if !cacheIsStale(item.UpdatedAt, s.LastSeenSourceUpdatedAt) {
+				// Cache hit — copy deep fields into item.
+				copyDeepFieldsFromState(item, s)
+				return nil
+			}
+			c.logFn("[cache] stale for #%d (board updatedAt %s > last-seen %s) — refetching from GitHub\n",
+				item.Number, item.UpdatedAt.Format(time.RFC3339), s.LastSeenSourceUpdatedAt.Format(time.RFC3339))
+		} else {
+			c.logFn("[cache] miss for #%d — fetching from GitHub\n", item.Number)
 		}
+	} else {
+		c.logFn("[cache] miss for #%d — fetching from GitHub\n", item.Number)
 	}
-
-	c.logFn("[cache] miss for #%d — fetching from GitHub\n", item.Number)
 	if err := c.fallback.FetchItemDetails(item); err != nil {
 		return err
 	}

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -350,6 +350,140 @@ func TestFetchItemDetailsFallbackPopulatesCache(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// FetchItemDetails — staleness gate (item.UpdatedAt vs LastSeenSourceUpdatedAt)
+// ---------------------------------------------------------------------------
+
+// When the board's pi.UpdatedAt advances past LastSeenSourceUpdatedAt, the
+// cache must fall through to a real GraphQL fetch instead of serving frozen
+// deep state. This is the bug behind verveguy/fantasy#12: bot reviews landed
+// on the linked PR after the first deep-fetch and the cache served the empty
+// LinkedPRReviews slice forever, leaving the review gate permanently unmet.
+func TestFetchItemDetailsCacheStaleRefetches(t *testing.T) {
+	t0 := time.Date(2026, 5, 9, 2, 47, 0, 0, time.UTC)
+	t1 := t0.Add(7 * time.Minute) // simulates a PR review submitted later
+	mc := &mockClient{
+		itemDetailsResult: &gh.ProjectItem{
+			Number: 12, Repo: "owner/repo",
+			Body:           "body v1",
+			LinkedPRNumber: 33,
+		},
+	}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	board := &gh.ProjectBoard{
+		ProjectID: "PID", Title: "T", OwnerType: "user",
+		Items: []gh.ProjectItem{{
+			ID: "I_12", Number: 12, Repo: "owner/repo", Status: "Review",
+			UpdatedAt: t0,
+		}},
+	}
+	c.Bootstrap(board)
+
+	// First call: cache miss → fallback populates and records LastSeen=t0.
+	item := gh.ProjectItem{ID: "I_12", Number: 12, Repo: "owner/repo", Status: "Review", UpdatedAt: t0}
+	if err := c.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails(first): %v", err)
+	}
+	if mc.fetchItemDetailsCount != 1 {
+		t.Fatalf("first call: want 1 fallback, got %d", mc.fetchItemDetailsCount)
+	}
+
+	// Second call with same UpdatedAt: cache hit, no extra fallback.
+	item2 := gh.ProjectItem{ID: "I_12", Number: 12, Repo: "owner/repo", Status: "Review", UpdatedAt: t0}
+	if err := c.FetchItemDetails(&item2); err != nil {
+		t.Fatalf("FetchItemDetails(second): %v", err)
+	}
+	if mc.fetchItemDetailsCount != 1 {
+		t.Fatalf("second call (fresh): want 1 fallback, got %d", mc.fetchItemDetailsCount)
+	}
+
+	// Third call with bumped UpdatedAt: cache stale, fallback must be re-invoked.
+	mc.itemDetailsResult.Body = "body v2"
+	mc.itemDetailsResult.LinkedPRReviews = []gh.PRReview{{Author: "copilot", State: "COMMENTED"}}
+	item3 := gh.ProjectItem{ID: "I_12", Number: 12, Repo: "owner/repo", Status: "Review", UpdatedAt: t1}
+	if err := c.FetchItemDetails(&item3); err != nil {
+		t.Fatalf("FetchItemDetails(third): %v", err)
+	}
+	if mc.fetchItemDetailsCount != 2 {
+		t.Fatalf("third call (stale): want 2 fallback, got %d", mc.fetchItemDetailsCount)
+	}
+	if item3.Body != "body v2" {
+		t.Errorf("third call: stale data served, want body 'body v2', got %q", item3.Body)
+	}
+	if len(item3.LinkedPRReviews) != 1 || item3.LinkedPRReviews[0].State != "COMMENTED" {
+		t.Errorf("third call: stale reviews served, got %+v", item3.LinkedPRReviews)
+	}
+
+	// Fourth call with same UpdatedAt as third: now fresh again, no extra fallback.
+	item4 := gh.ProjectItem{ID: "I_12", Number: 12, Repo: "owner/repo", Status: "Review", UpdatedAt: t1}
+	if err := c.FetchItemDetails(&item4); err != nil {
+		t.Fatalf("FetchItemDetails(fourth): %v", err)
+	}
+	if mc.fetchItemDetailsCount != 2 {
+		t.Errorf("fourth call (re-fresh): want 2 fallback, got %d", mc.fetchItemDetailsCount)
+	}
+}
+
+// IsItemCacheFresh is the public probe used by the poll loop's log line. It
+// must agree with FetchItemDetails on what counts as a cache hit.
+func TestIsItemCacheFreshAgreesWithFetch(t *testing.T) {
+	t0 := time.Date(2026, 5, 9, 2, 47, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+	mc := &mockClient{itemDetailsResult: &gh.ProjectItem{Number: 5, Repo: "owner/repo"}}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	c.Bootstrap(&gh.ProjectBoard{ProjectID: "PID", OwnerType: "user", Items: []gh.ProjectItem{{
+		ID: "I_5", Number: 5, Repo: "owner/repo", Status: "Plan", UpdatedAt: t0,
+	}}})
+
+	// Pre-deep-fetch: never deep-fetched → not fresh.
+	if c.IsItemCacheFresh("owner/repo", 5, t0) {
+		t.Error("pre-fetch: want stale, got fresh")
+	}
+
+	// Populate cache.
+	item := gh.ProjectItem{ID: "I_5", Number: 5, Repo: "owner/repo", Status: "Plan", UpdatedAt: t0}
+	if err := c.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+
+	// Same UpdatedAt → fresh.
+	if !c.IsItemCacheFresh("owner/repo", 5, t0) {
+		t.Error("post-fetch same updatedAt: want fresh, got stale")
+	}
+	// Bumped UpdatedAt → stale.
+	if c.IsItemCacheFresh("owner/repo", 5, t1) {
+		t.Error("post-fetch bumped updatedAt: want stale, got fresh")
+	}
+	// Zero source updatedAt → fresh (no signal to invalidate).
+	if !c.IsItemCacheFresh("owner/repo", 5, time.Time{}) {
+		t.Error("zero source updatedAt: want fresh (no signal), got stale")
+	}
+}
+
+func TestCacheIsStale(t *testing.T) {
+	t0 := time.Date(2026, 5, 9, 2, 47, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+	cases := []struct {
+		name             string
+		source, lastSeen time.Time
+		wantStale        bool
+	}{
+		{"both zero", time.Time{}, time.Time{}, false},
+		{"source zero, lastSeen set", time.Time{}, t0, false},
+		{"source set, lastSeen zero (legacy)", t0, time.Time{}, true},
+		{"source equals lastSeen", t0, t0, false},
+		{"source before lastSeen", t0, t1, false},
+		{"source after lastSeen", t1, t0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cacheIsStale(tc.source, tc.lastSeen); got != tc.wantStale {
+				t.Errorf("cacheIsStale(%v, %v) = %v, want %v", tc.source, tc.lastSeen, got, tc.wantStale)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Delta: issue_comment.created — idempotent by DatabaseID
 // ---------------------------------------------------------------------------
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1066,7 +1066,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
 			continue
 		}
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && !cacheImpl.IsPaused() && cacheImpl.IsItemDeepFetched(board.Items[i].Repo, board.Items[i].Number) {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && !cacheImpl.IsPaused() && cacheImpl.IsItemCacheFresh(board.Items[i].Repo, board.Items[i].Number, board.Items[i].UpdatedAt) {
 			e.logf(0, "poll", "reading details for #%d from cache\n", board.Items[i].Number)
 		} else {
 			e.logf(0, "poll", "deep-fetching details for #%d from GitHub\n", board.Items[i].Number)

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -49,22 +49,49 @@ func NewWorktreeManagerForRepo(baseDir, worktreeRoot, rName string) *WorktreeMan
 	}
 }
 
+// buildCloneURL returns the git clone URL for a GitHub repo. Pure helper so
+// the URL-construction logic can be unit-tested without shelling out to git.
+func buildCloneURL(owner, repo string, useSSH bool) string {
+	if useSSH {
+		return fmt.Sprintf("git@github.com:%s/%s.git", owner, repo)
+	}
+	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+}
+
+// nonInteractiveGitEnv returns os.Environ() with GIT_TERMINAL_PROMPT and
+// GIT_SSH_COMMAND overrides that force git/ssh to fail fast instead of
+// blocking on interactive prompts (passphrase, host-key acceptance,
+// keyboard-interactive fallback). Fabrik runs as a daemon with no TTY, so an
+// interactive prompt would hang the engine indefinitely; this is also what
+// caused TestEnsureBareClone_SSHMode_UsesSSHURL to hang on dev machines with
+// an ssh-agent that prompts for a YubiKey/Touch ID tap.
+func nonInteractiveGitEnv() []string {
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10",
+	)
+}
+
 // ensureBareClone creates a bare clone of the target repo at
 // .fabrik/repos/<owner>-<repo>.git if it doesn't already exist.
 // Returns the path to the bare clone directory on success.
 // This is used for all repos — Fabrik always bare-clones managed repos.
 func ensureBareClone(baseDir, owner, repo string, useSSH bool) (string, error) {
 	bareDir := filepath.Join(baseDir, ".fabrik", "repos", owner+"-"+repo+".git")
+	env := nonInteractiveGitEnv()
+
 	if _, err := os.Stat(bareDir); err == nil {
 		// Repair: bare clones created before v0.0.22 are missing the fetch
 		// refspec. Add it idempotently so plain `git fetch origin` works.
 		repairCmd := exec.Command("git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
 		repairCmd.Dir = bareDir
+		repairCmd.Env = env
 		repairCmd.CombinedOutput() // best-effort
 
 		// Fetch latest with explicit refspec (belt-and-suspenders).
 		cmd := exec.Command("git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 		cmd.Dir = bareDir
+		cmd.Env = env
 		cmd.CombinedOutput() // best-effort
 
 		// Sync refs/remotes/origin/HEAD with the remote's current default
@@ -74,6 +101,7 @@ func ensureBareClone(baseDir, owner, repo string, useSSH bool) (string, error) {
 		// the wrong base and Closes #N auto-close to not fire.
 		refreshCmd := exec.Command("git", "remote", "set-head", "origin", "--auto")
 		refreshCmd.Dir = bareDir
+		refreshCmd.Env = env
 		refreshCmd.CombinedOutput() // best-effort
 		return bareDir, nil
 	}
@@ -82,13 +110,9 @@ func ensureBareClone(baseDir, owner, repo string, useSSH bool) (string, error) {
 		return "", fmt.Errorf("creating .fabrik/repos dir: %w", err)
 	}
 
-	var cloneURL string
-	if useSSH {
-		cloneURL = fmt.Sprintf("git@github.com:%s/%s.git", owner, repo)
-	} else {
-		cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
-	}
+	cloneURL := buildCloneURL(owner, repo, useSSH)
 	cmd := exec.Command("git", "clone", "--bare", cloneURL, bareDir)
+	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("cloning %s: %s: %w", cloneURL, strings.TrimSpace(string(out)), err)
 	}
@@ -97,11 +121,13 @@ func ensureBareClone(baseDir, owner, repo string, useSSH bool) (string, error) {
 	// subsequent `git fetch origin` updates refs/remotes/origin/*.
 	cfgCmd := exec.Command("git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
 	cfgCmd.Dir = bareDir
+	cfgCmd.Env = env
 	cfgCmd.CombinedOutput() // best-effort
 
 	// Initial fetch so refs/remotes/origin/* is populated before we set HEAD.
 	fetchCmd := exec.Command("git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 	fetchCmd.Dir = bareDir
+	fetchCmd.Env = env
 	fetchCmd.CombinedOutput() // best-effort
 
 	// Set refs/remotes/origin/HEAD to the remote's current default branch.
@@ -112,6 +138,7 @@ func ensureBareClone(baseDir, owner, repo string, useSSH bool) (string, error) {
 	// becomes stale if the remote's default branch changes later.
 	refreshCmd := exec.Command("git", "remote", "set-head", "origin", "--auto")
 	refreshCmd.Dir = bareDir
+	refreshCmd.Env = env
 	refreshCmd.CombinedOutput() // best-effort
 
 	return bareDir, nil

--- a/engine/worktree_extra_test.go
+++ b/engine/worktree_extra_test.go
@@ -1,10 +1,10 @@
 package engine
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -181,19 +181,32 @@ func TestEnsureBareClone_NewDir_ClonesFromLocal(t *testing.T) {
 	_ = srcDir
 }
 
-func TestEnsureBareClone_SSHMode_UsesSSHURL(t *testing.T) {
-	skipIfNoGit(t)
-	tmpDir := t.TempDir()
-
-	// With useSSH=true the clone URL should be git@github.com:owner/repo.git.
-	// The clone will fail (no network / no SSH key in CI), but the error message
-	// must reference the SSH URL, proving the correct URL was constructed.
-	_, err := ensureBareClone(tmpDir, "owner", "repo", true)
-	if err == nil {
-		t.Log("clone unexpectedly succeeded (real SSH access?)")
-		return
+// Test the URL-construction helper directly. The previous form of this test
+// shelled out to `git clone git@github.com:owner/repo.git` and grepped the
+// resulting error for the SSH URL. That worked in CI (no SSH credentials, so
+// git failed fast) but hung indefinitely on developer machines with an
+// ssh-agent that prompts for a YubiKey/Touch ID tap or passphrase: there's no
+// TTY under `go test`, so the SSH process blocks forever waiting for input
+// that will never arrive. Testing the pure helper avoids the network call
+// entirely. The non-interactive env vars set by ensureBareClone now also
+// prevent the hang in production code paths.
+func TestBuildCloneURL(t *testing.T) {
+	cases := []struct {
+		owner, repo string
+		useSSH      bool
+		want        string
+	}{
+		{"owner", "repo", true, "git@github.com:owner/repo.git"},
+		{"owner", "repo", false, "https://github.com/owner/repo.git"},
+		{"verveguy", "fantasy", true, "git@github.com:verveguy/fantasy.git"},
+		{"verveguy", "fantasy", false, "https://github.com/verveguy/fantasy.git"},
 	}
-	if !strings.Contains(err.Error(), "git@github.com:") {
-		t.Errorf("expected SSH clone URL in error, got: %v", err)
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s/%s ssh=%v", tc.owner, tc.repo, tc.useSSH), func(t *testing.T) {
+			if got := buildCloneURL(tc.owner, tc.repo, tc.useSSH); got != tc.want {
+				t.Errorf("buildCloneURL(%q, %q, %v) = %q, want %q",
+					tc.owner, tc.repo, tc.useSSH, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -70,6 +70,15 @@ type ItemState struct {
 	// A zero value means no deep fetch has occurred. Replaces boardcache.deepFetched[key].
 	LastDeepFetchAt time.Time
 
+	// LastSeenSourceUpdatedAt is the value of pi.UpdatedAt observed at the moment
+	// of the last successful deep fetch. The cache compares this against the fresh
+	// pi.UpdatedAt from each board read to decide whether the cached deep fields
+	// are still authoritative; a later board updatedAt forces a deep re-fetch.
+	// This is the "GraphQL fetching is primary; updatedAt makes the staleness check
+	// cheap" contract — webhooks remain an optimization that keeps the cache fresh
+	// between polls but never replace the polling refresh path.
+	LastSeenSourceUpdatedAt time.Time
+
 	// LastDeepFetchFailureAt is the time the most recent deep fetch attempt failed.
 	// Replaces engine.deepFetchFailureTime[iKey].
 	LastDeepFetchFailureAt time.Time

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -367,6 +367,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case ItemDeepFetched:
 		flags := applyProjectItem(item, v.FreshState)
 		item.LastDeepFetchAt = time.Now()
+		item.LastSeenSourceUpdatedAt = v.FreshState.UpdatedAt
 		item.LastDeepFetchFailureAt = time.Time{} // clear failure on success
 		return flags | DeepFetchChanged
 
@@ -522,6 +523,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 
 	case DeepFetchInvalidated:
 		item.LastDeepFetchAt = time.Time{}
+		item.LastSeenSourceUpdatedAt = time.Time{}
 		return DeepFetchChanged
 
 	case PRHeadSHAUpdated:


### PR DESCRIPTION
Two related fixes — both versions of the same theme: silent failures that look like "everything's fine, just keep waiting."

## 1. Cache staleness via updatedAt (`boardcache`)

**Bug.** Once an item was deep-fetched, `CacheImpl.FetchItemDetails` treated the cached deep state as authoritative for the lifetime of the process — there was no freshness check against the board's `pi.UpdatedAt`. The implicit assumption was "webhooks will mutate the cache between polls", which holds when the webhook stream is healthy but silently fails open when webhooks are absent (the configuration verveguy/fantasy runs).

**Symptom.** `verveguy/fantasy#12`, 2026-05-09:
- Review stage finished 02:53:46Z, engine set `fabrik:awaiting-review`
- gemini-code-assist (02:48:54Z, COMMENTED) and copilot-pull-request-reviewer (02:52:27Z, COMMENTED) had already submitted reviews, satisfying the gate predicate `outstanding == 0 && hasReviews`
- Every poll logged `[poll] reading details for #12 from cache` and `[awaiting-review] waiting for initial review submission` — the cached `LinkedPRReviews` was the empty pre-review snapshot. Two review-wait timeouts and two pauses later, the issue sat stuck for ~9.5 hours

**Fix.** Reframe webhooks as a pure optimization. GraphQL polling is the primary refresh path; the board read's `pi.UpdatedAt` — already computed as `max(issue, projectItem, linkedPR).updatedAt` — is the cheap staleness signal that decides whether the cached deep fields are still authoritative.

- `ItemState.LastSeenSourceUpdatedAt`: captured at `ItemDeepFetched` apply time, cleared by `DeepFetchInvalidated`
- `CacheImpl.FetchItemDetails`: serves from cache only while `pi.UpdatedAt ≤ LastSeenSourceUpdatedAt`; otherwise falls through to a real fallback fetch and repopulates
- `CacheImpl.IsItemCacheFresh(repo, number, sourceUpdatedAt)`: public probe so the poll log line accurately reflects which path was taken
- Legacy / zero-`LastSeenSourceUpdatedAt` cache entries are treated as stale on first lookup so they refresh once and start tracking the source updatedAt going forward

## 2. Non-interactive git/ssh in `ensureBareClone` (`engine/worktree.go`)

**Bug.** `ensureBareClone` shelled out to git without forcing non-interactive mode. On a dev machine with a working `ssh-agent` (e.g. one that prompts for a YubiKey/Touch ID tap or a passphrase), `git clone git@github.com:...` handed off to ssh, which then blocked forever waiting for input that has nowhere to land — Fabrik runs as a daemon with no TTY, and `go test` doesn't have one either.

**Symptom.** `TestEnsureBareClone_SSHMode_UsesSSHURL` hung indefinitely on every dev machine, leaving zombie `git clone` processes behind on each run (this PR was discovered while investigating the cache bug — the test had been hanging silently for who-knows-how-long).

**Fix.**
- `ensureBareClone` now sets `GIT_TERMINAL_PROMPT=0` and `GIT_SSH_COMMAND=ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10` on every git invocation. A missing SSH key, a required interactive auth step, or an unreachable host now errors out in seconds instead of blocking the engine
- Extracted `buildCloneURL(owner, repo, useSSH)` as a pure helper and replaced `TestEnsureBareClone_SSHMode_UsesSSHURL` with `TestBuildCloneURL`, which exercises the helper directly without shelling out. The original "force a real git clone to fail and grep the error string" pattern was fragile by design

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -timeout 240s ./...` — **all packages green**, including the engine suite that was previously hanging on `TestEnsureBareClone_SSHMode_UsesSSHURL`
- [x] New tests:
  - `TestFetchItemDetailsCacheStaleRefetches` — bumped `pi.UpdatedAt` after a deep-fetch forces a real refetch; same `pi.UpdatedAt` does not
  - `TestIsItemCacheFreshAgreesWithFetch` — the public probe used by the poll log agrees with `FetchItemDetails`
  - `TestCacheIsStale` — table test for the helper, including the legacy-entry (zero lastSeen) and zero-source cases
  - `TestBuildCloneURL` — table test for the URL-construction helper (replaces the network-dependent SSH URL test)
- [ ] Manual verification: deploy to fantasy fabrik, observe that #12 unsticks once the next poll deep-fetches the PR and sees the existing bot reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)