### PR TITLE
feat: SIGHUP handler triggers self-restart to clear in-memory cache

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2051,3 +2051,49 @@ If Claude doesn't seem to follow the skill instructions:
 - Check that the stage YAML has `skill:` set (not `prompt:`)
 - For development, use `--plugin-dir` to point at your working copy
 - Verify Claude Code version supports `--plugin-dir`
+
+### Recovering from Wedged State
+
+Cache-stale bugs can occasionally leave Fabrik's in-memory state stuck — an issue that should advance doesn't, or a label that should clear doesn't. The safest escape hatch is a SIGHUP restart, which drops all in-memory state and re-execs the same binary in place, without tearing down the terminal session or TUI.
+
+**How to trigger:**
+
+```bash
+# Find the PID (shown at startup: "[startup] fabrik PID: <N>")
+kill -HUP <fabrik-pid>
+
+# Or by name if only one instance is running
+pkill -HUP fabrik
+```
+
+**What happens:**
+
+1. Fabrik logs `[signal] received SIGHUP — restarting in place to clear in-memory state` to `fabrik.log`.
+2. In-flight Claude workers are cancelled (same drain as Ctrl-C).
+3. `fabrik:locked:<user>` labels are removed from any issues that were mid-run.
+4. The lockfile (`.fabrik/fabrik.lock`) is released.
+5. `syscall.Exec` replaces the process image in place — the PID stays the same, the parent shell and TUI remain attached, and a brief TUI redraw may occur.
+6. The new process starts with a clean in-memory cache, Store, observers, and `mayNeedWork` set.
+
+**What is cleared:**
+
+- In-memory board cache and item Store
+- Registered observers (wake-channel, mayNeedWork, invocation, stage-change, push-unblock)
+- `mayNeedWork` map
+
+**What is preserved:**
+
+- All GitHub-side state: labels, comments, PR status, stage history — these live on GitHub, not in memory
+- Rocket-reaction durability: comments that were fully processed before the SIGHUP already carry a 🚀 reaction; the new process skips them
+- Worktrees and uncommitted work in `.fabrik/worktrees/`
+
+**In-flight Claude runs:** Any Claude session interrupted by the SIGHUP drain did not emit `FABRIK_STAGE_COMPLETE`, so the new process will re-dispatch those stages. The rocket-reaction guard prevents double-posting of already-processed comments. Expect the interrupted stage to restart from its session file.
+
+**Log truncation:** `fabrik.log` is opened with `O_TRUNC` on each startup, so the pre-restart log is cleared. If you need the pre-restart log for diagnostics, copy it first:
+
+```bash
+cp .fabrik/fabrik.log .fabrik/fabrik-pre-restart.log
+kill -HUP <fabrik-pid>
+```
+
+**Windows:** SIGHUP is a Unix signal. This feature is silently absent on Windows.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2050,6 +2050,52 @@ If Claude doesn't seem to follow the skill instructions:
 - For development, use `--plugin-dir` to point at your working copy
 - Verify Claude Code version supports `--plugin-dir`
 
+### Recovering from Wedged State
+
+Cache-stale bugs can occasionally leave Fabrik's in-memory state stuck — an issue that should advance doesn't, or a label that should clear doesn't. The safest escape hatch is a SIGHUP restart, which drops all in-memory state and re-execs the same binary in place, without tearing down the terminal session or TUI.
+
+**How to trigger:**
+
+```bash
+# Find the PID (shown at startup: "[startup] fabrik PID: <N>")
+kill -HUP <fabrik-pid>
+
+# Or by name if only one instance is running
+pkill -HUP fabrik
+```
+
+**What happens:**
+
+1. Fabrik logs `[signal] received SIGHUP — restarting in place to clear in-memory state` to `fabrik.log`.
+2. In-flight Claude workers are cancelled (same drain as Ctrl-C).
+3. `fabrik:locked:<user>` labels are removed from any issues that were mid-run.
+4. The lockfile (`.fabrik/fabrik.lock`) is released.
+5. `syscall.Exec` replaces the process image in place — the PID stays the same, the parent shell and TUI remain attached, and a brief TUI redraw may occur.
+6. The new process starts with a clean in-memory cache, Store, observers, and `mayNeedWork` set.
+
+**What is cleared:**
+
+- In-memory board cache and item Store
+- Registered observers (wake-channel, mayNeedWork, invocation, stage-change, push-unblock)
+- `mayNeedWork` map
+
+**What is preserved:**
+
+- All GitHub-side state: labels, comments, PR status, stage history — these live on GitHub, not in memory
+- Rocket-reaction durability: comments that were fully processed before the SIGHUP already carry a 🚀 reaction; the new process skips them
+- Worktrees and uncommitted work in `.fabrik/worktrees/`
+
+**In-flight Claude runs:** Any Claude session interrupted by the SIGHUP drain did not emit `FABRIK_STAGE_COMPLETE`, so the new process will re-dispatch those stages. The rocket-reaction guard prevents double-posting of already-processed comments. Expect the interrupted stage to restart from its session file.
+
+**Log truncation:** `fabrik.log` is opened with `O_TRUNC` on each startup, so the pre-restart log is cleared. If you need the pre-restart log for diagnostics, copy it first:
+
+```bash
+cp .fabrik/fabrik.log .fabrik/fabrik-pre-restart.log
+kill -HUP <fabrik-pid>
+```
+
+**Windows:** SIGHUP is a Unix signal. This feature is silently absent on Windows.
+
 ---
 
 # Fabrik Issue State Machine

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
@@ -91,6 +92,12 @@ type Engine struct {
 	// upgradeCheckFn is called instead of checkAndUpgrade() when non-nil.
 	// Used by tests to observe the startup upgrade check without invoking the real upgrade path.
 	upgradeCheckFn func()
+	// sighupRequested is set by the SIGHUP handler goroutine to signal that the
+	// main loop should re-exec after draining workers (Unix only).
+	sighupRequested atomic.Bool
+	// sighupExecFn overrides syscall.Exec in tests to prevent the test process
+	// from actually being replaced. Production code leaves this nil.
+	sighupExecFn func(argv0 string, argv []string, envv []string) error
 }
 
 func New(cfg Config) (*Engine, error) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -149,6 +149,13 @@ func TestRun_ShutdownOnSignal(t *testing.T) {
 	eng := testEngine(client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 300 // long poll so we don't hit a second tick
 
+	// Provide a temp fabrikDir so Run() can create the lock file.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	eng.fabrikDir = dir
+
 	// Use ReadyCh so we only send SIGINT after signal.Notify is registered.
 	readyCh := make(chan struct{})
 	eng.cfg.ReadyCh = readyCh

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -244,6 +244,7 @@ func (e *Engine) Run() error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
+	registerSighupHandler(ctx, cancel, e)
 	if e.cfg.ReadyCh != nil {
 		close(e.cfg.ReadyCh)
 	}
@@ -590,11 +591,17 @@ func (e *Engine) Run() error {
 			case <-ctx.Done():
 				e.cleanupLockedIssues()
 				e.wg.Wait()
+				if e.sighupRequested.Load() {
+					performSighupRestart(e, lockFile)
+				}
 				return nil
 			case <-ticker.C:
 				if ctx.Err() != nil {
 					e.cleanupLockedIssues()
 					e.wg.Wait()
+					if e.sighupRequested.Load() {
+						performSighupRestart(e, lockFile)
+					}
 					return nil
 				}
 				if err := doPollCycle(); err != nil {
@@ -615,11 +622,17 @@ func (e *Engine) Run() error {
 			case <-ctx.Done():
 				e.cleanupLockedIssues()
 				e.wg.Wait()
+				if e.sighupRequested.Load() {
+					performSighupRestart(e, lockFile)
+				}
 				return nil
 			case <-ticker.C:
 				if ctx.Err() != nil {
 					e.cleanupLockedIssues()
 					e.wg.Wait()
+					if e.sighupRequested.Load() {
+						performSighupRestart(e, lockFile)
+					}
 					return nil
 				}
 				if err := doPollCycle(); err != nil {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -244,7 +244,10 @@ func (e *Engine) Run() error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
-	registerSighupHandler(ctx, cancel, e)
+	// restartDone is closed after performSighupRestart returns (exec failure path)
+	// so the SIGHUP goroutine stays alive for the full drain window.
+	restartDone := make(chan struct{})
+	registerSighupHandler(ctx, cancel, e, restartDone)
 	if e.cfg.ReadyCh != nil {
 		close(e.cfg.ReadyCh)
 	}
@@ -593,6 +596,7 @@ func (e *Engine) Run() error {
 				e.wg.Wait()
 				if e.sighupRequested.Load() {
 					performSighupRestart(e, lockFile)
+					close(restartDone) // reached only on exec failure
 				}
 				return nil
 			case <-ticker.C:
@@ -601,6 +605,7 @@ func (e *Engine) Run() error {
 					e.wg.Wait()
 					if e.sighupRequested.Load() {
 						performSighupRestart(e, lockFile)
+						close(restartDone) // reached only on exec failure
 					}
 					return nil
 				}
@@ -624,6 +629,7 @@ func (e *Engine) Run() error {
 				e.wg.Wait()
 				if e.sighupRequested.Load() {
 					performSighupRestart(e, lockFile)
+					close(restartDone) // reached only on exec failure
 				}
 				return nil
 			case <-ticker.C:
@@ -632,6 +638,7 @@ func (e *Engine) Run() error {
 					e.wg.Wait()
 					if e.sighupRequested.Load() {
 						performSighupRestart(e, lockFile)
+						close(restartDone) // reached only on exec failure
 					}
 					return nil
 				}

--- a/engine/sighup_test.go
+++ b/engine/sighup_test.go
@@ -1,0 +1,80 @@
+//go:build !windows
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+func TestRun_SighupRestart(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{}, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+	eng.cfg.PollSeconds = 300 // long poll so we don't hit a second tick
+
+	// Set up a temp fabrikDir so Run() can create the lock file.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	eng.fabrikDir = dir
+
+	// Use ReadyCh so we only send SIGHUP after signal.Notify is registered.
+	readyCh := make(chan struct{})
+	eng.cfg.ReadyCh = readyCh
+
+	// Override exec so the test process is not actually replaced.
+	var execCalled atomic.Bool
+	var capturedBin string
+	var capturedArgs []string
+	eng.sighupExecFn = func(argv0 string, argv []string, envv []string) error {
+		execCalled.Store(true)
+		capturedBin = argv0
+		capturedArgs = argv
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eng.Run()
+	}()
+
+	// Wait for Run to register signal handlers before sending SIGHUP.
+	<-readyCh
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(syscall.SIGHUP)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not shut down after SIGHUP in time")
+	}
+
+	if !execCalled.Load() {
+		t.Fatal("sighupExecFn was not called")
+	}
+	if capturedBin == "" {
+		t.Error("exec called with empty binary path")
+	}
+	if len(capturedArgs) == 0 {
+		t.Error("exec called with empty args")
+	}
+	// The flag should be set after the restart.
+	if !eng.sighupRequested.Load() {
+		t.Error("sighupRequested flag not set")
+	}
+	_ = capturedArgs
+}

--- a/engine/sighup_test.go
+++ b/engine/sighup_test.go
@@ -72,9 +72,7 @@ func TestRun_SighupRestart(t *testing.T) {
 	if len(capturedArgs) == 0 {
 		t.Error("exec called with empty args")
 	}
-	// The flag should be set after the restart.
 	if !eng.sighupRequested.Load() {
 		t.Error("sighupRequested flag not set")
 	}
-	_ = capturedArgs
 }

--- a/engine/sighup_unix.go
+++ b/engine/sighup_unix.go
@@ -14,7 +14,12 @@ import (
 // registerSighupHandler registers a SIGHUP signal handler. On receipt, it logs,
 // sets the sighupRequested flag, and cancels the context so the main loop drains
 // workers before re-execing. A second SIGHUP during the drain window force-exits.
-func registerSighupHandler(ctx context.Context, cancel context.CancelFunc, e *Engine) {
+// restartDone is closed by the caller after performSighupRestart returns (exec
+// failure path); on exec success the process is replaced before it can be closed.
+// Using restartDone instead of ctx.Done() in the second select keeps the goroutine
+// alive for the full drain window, because ctx.Done() fires immediately when
+// cancel() is called on the first SIGHUP.
+func registerSighupHandler(ctx context.Context, cancel context.CancelFunc, e *Engine, restartDone <-chan struct{}) {
 	sighupCh := make(chan os.Signal, 1)
 	signal.Notify(sighupCh, syscall.SIGHUP)
 	go func() {
@@ -35,7 +40,7 @@ func registerSighupHandler(ctx context.Context, cancel context.CancelFunc, e *En
 		case <-sighup2Ch:
 			fmt.Fprintln(os.Stderr, "\nSecond SIGHUP received during drain — force-quitting...")
 			os.Exit(1)
-		case <-ctx.Done():
+		case <-restartDone:
 			signal.Stop(sighup2Ch)
 		}
 	}()
@@ -49,10 +54,16 @@ func performSighupRestart(e *Engine, lockFile *os.File) {
 		e.webhookMgr.Stop()
 	}
 
-	// Release the lock explicitly before exec so the new process can acquire it.
-	// O_CLOEXEC would release it on exec anyway, but being explicit matches the spec.
+	// Release the lock explicitly before exec. O_CLOEXEC means the fd is also
+	// closed atomically at exec time, but doing it here makes the intent clear.
+	// There is a negligible window between this unlock and syscall.Exec during
+	// which another instance could theoretically acquire the lock; in practice
+	// this is harmless because exec is called immediately after and the PID is
+	// unchanged, so any competing instance would fail on its next poll cycle.
 	syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
-	lockFile.Close()
+	if err := lockFile.Close(); err != nil {
+		e.logf(0, "signal", "SIGHUP restart: could not close lock file: %v\n", err)
+	}
 
 	exe, err := os.Executable()
 	if err != nil {

--- a/engine/sighup_unix.go
+++ b/engine/sighup_unix.go
@@ -1,0 +1,78 @@
+//go:build !windows
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+// registerSighupHandler registers a SIGHUP signal handler. On receipt, it logs,
+// sets the sighupRequested flag, and cancels the context so the main loop drains
+// workers before re-execing. A second SIGHUP during the drain window force-exits.
+func registerSighupHandler(ctx context.Context, cancel context.CancelFunc, e *Engine) {
+	sighupCh := make(chan os.Signal, 1)
+	signal.Notify(sighupCh, syscall.SIGHUP)
+	go func() {
+		select {
+		case <-sighupCh:
+			e.logf(0, "signal", "received SIGHUP — restarting in place to clear in-memory state\n")
+			e.sighupRequested.Store(true)
+			cancel()
+		case <-ctx.Done():
+			signal.Stop(sighupCh)
+			return
+		}
+		signal.Stop(sighupCh)
+		// Listen for a second SIGHUP during the drain window and force-exit.
+		sighup2Ch := make(chan os.Signal, 1)
+		signal.Notify(sighup2Ch, syscall.SIGHUP)
+		select {
+		case <-sighup2Ch:
+			fmt.Fprintln(os.Stderr, "\nSecond SIGHUP received during drain — force-quitting...")
+			os.Exit(1)
+		case <-ctx.Done():
+			signal.Stop(sighup2Ch)
+		}
+	}()
+}
+
+// performSighupRestart stops the webhook manager, releases the lockfile, and
+// re-execs the current binary in place. On success, this function never returns.
+// On exec failure, it logs the error and returns so Run() can exit cleanly.
+func performSighupRestart(e *Engine, lockFile *os.File) {
+	if e.webhookMgr != nil {
+		e.webhookMgr.Stop()
+	}
+
+	// Release the lock explicitly before exec so the new process can acquire it.
+	// O_CLOEXEC would release it on exec anyway, but being explicit matches the spec.
+	syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN) //nolint:errcheck
+	lockFile.Close()
+
+	exe, err := os.Executable()
+	if err != nil {
+		e.logf(0, "signal", "SIGHUP restart: could not determine executable path: %v\n", err)
+		return
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		e.logf(0, "signal", "SIGHUP restart: could not resolve symlinks for executable: %v\n", err)
+		return
+	}
+
+	execFn := func(argv0 string, argv []string, envv []string) error {
+		return syscall.Exec(argv0, argv, envv)
+	}
+	if e.sighupExecFn != nil {
+		execFn = e.sighupExecFn
+	}
+
+	if err := execFn(exe, os.Args, os.Environ()); err != nil {
+		e.logf(0, "signal", "SIGHUP restart: exec failed: %v\n", err)
+	}
+}

--- a/engine/sighup_windows.go
+++ b/engine/sighup_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // registerSighupHandler is a no-op on Windows: SIGHUP is not a Windows signal.
-func registerSighupHandler(_ context.Context, _ context.CancelFunc, _ *Engine) {}
+func registerSighupHandler(_ context.Context, _ context.CancelFunc, _ *Engine, _ <-chan struct{}) {}
 
 // performSighupRestart is a no-op on Windows: SIGHUP is not a Windows signal.
 func performSighupRestart(_ *Engine, _ *os.File) {}

--- a/engine/sighup_windows.go
+++ b/engine/sighup_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package engine
+
+import (
+	"context"
+	"os"
+)
+
+// registerSighupHandler is a no-op on Windows: SIGHUP is not a Windows signal.
+func registerSighupHandler(_ context.Context, _ context.CancelFunc, _ *Engine) {}
+
+// performSighupRestart is a no-op on Windows: SIGHUP is not a Windows signal.
+func performSighupRestart(_ *Engine, _ *os.File) {}


### PR DESCRIPTION
## Summary

- Adds a SIGHUP handler to `engine.Run()` that drains in-flight workers and re-execs the same binary in place via `syscall.Exec`, clearing all in-memory state (cache, Store, observers, `mayNeedWork`) without disrupting the terminal session or TUI
- Operators trigger this with `kill -HUP <fabrik-pid>` or `pkill -HUP fabrik` as an escape hatch for wedged state machines
- Adds a "Recovering from wedged state" section to `USER_GUIDE.md`

## Key Changes

**`engine/sighup_unix.go`** (new, `//go:build !windows`):
- `registerSighupHandler(ctx, cancel, e)` — registers a separate `sighupCh`, logs the restart intent, sets `e.sighupRequested`, calls `cancel()`, and listens for a second SIGHUP to force-exit (matching double-SIGINT behavior)
- `performSighupRestart(e, lockFile)` — stops the webhook manager (`wm.Stop()`), releases the lockfile explicitly, resolves the binary via `os.Executable()` + `filepath.EvalSymlinks()`, then calls `syscall.Exec`

**`engine/sighup_windows.go`** (new, `//go:build windows`): no-op stubs

**`engine/engine.go`**: two new fields on `Engine` — `sighupRequested atomic.Bool` (set by the SIGHUP goroutine) and `sighupExecFn func(string, []string, []string) error` (test hook to intercept exec without replacing the test process)

**`engine/poll.go`**: calls `registerSighupHandler` after SIGINT setup; all four `ctx.Done()` drain paths check `sighupRequested.Load()` and call `performSighupRestart` if set

**`engine/sighup_test.go`** (new): `TestRun_SighupRestart` — sends `SIGHUP` after `ReadyCh` fires, verifies `sighupExecFn` was called with a non-empty binary path

**`engine/engine_test.go`**: fixed `TestRun_ShutdownOnSignal` to use a temp dir for `fabrikDir` (the test was blocking indefinitely without it)

**`docs/USER_GUIDE.md`** + **`docs/llms-full.txt`**: new "Recovering from wedged state" troubleshooting section

## How to Test

1. Start Fabrik: `./fabrik --project ...`
2. Note the PID from startup log or `pgrep fabrik`
3. Send SIGHUP: `kill -HUP <pid>`
4. Verify in `fabrik.log`: `[signal] received SIGHUP — restarting in place to clear in-memory state`
5. Verify Fabrik restarts with a fresh poll cycle; TUI stays attached; terminal session survives

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)