### PR TITLE
fix: Implement stage should commit per-task with proper Conventional Commit messages, not one boilerplate WIP commit

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4314,7 +4314,7 @@ When `FABRIK_BLOCKED_ON_INPUT` is detected (and Claude ran without error):
 
 ### Incomplete Path (No Marker)
 
-1. WIP commit (unless read-only): `git add -A && git commit -m "WIP: ..."`
+1. Partial-progress commit (unless read-only): `git add -A && git commit -m "chore: partial <StageName> stage progress (incomplete)"`
 2. Branch pushed
 3. Cooldown timer: `pollSeconds * 10` seconds
 4. Lock held through cooldown

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -289,7 +289,7 @@ When `FABRIK_BLOCKED_ON_INPUT` is detected (and Claude ran without error):
 
 ### Incomplete Path (No Marker)
 
-1. WIP commit (unless read-only): `git add -A && git commit -m "WIP: ..."`
+1. Partial-progress commit (unless read-only): `git add -A && git commit -m "chore: partial <StageName> stage progress (incomplete)"`
 2. Branch pushed
 3. Cooldown timer: `pollSeconds * 10` seconds
 4. Lock held through cooldown

--- a/engine/item.go
+++ b/engine/item.go
@@ -1426,8 +1426,8 @@ func (e *Engine) removeFailedLabel(owner, repo string, issueNumber int, stageNam
 	}
 }
 
-// commitWIP commits any uncommitted changes in the worktree as a WIP commit.
-// This preserves partial work when Claude hits max_turns or errors out.
+// commitWIP commits any uncommitted changes in the worktree as a partial-progress
+// commit. This preserves partial work when Claude hits max_turns or errors out.
 func (e *Engine) commitWIP(workDir string, issueNumber int, stageName string) {
 	dirty, err := isWorkingTreeDirty(workDir)
 	if err != nil || !dirty {
@@ -1438,7 +1438,7 @@ func (e *Engine) commitWIP(workDir string, issueNumber int, stageName string) {
 	addCmd := exec.Command("git", "add", "-A")
 	addCmd.Dir = workDir
 	if _, err := addCmd.CombinedOutput(); err != nil {
-		e.logf(issueNumber, "warn", "could not stage WIP changes: %v\n", err)
+		e.logf(issueNumber, "warn", "could not stage partial changes: %v\n", err)
 		return
 	}
 
@@ -1454,15 +1454,15 @@ func (e *Engine) commitWIP(workDir string, issueNumber int, stageName string) {
 	}
 
 	// Commit
-	msg := fmt.Sprintf("WIP: %s stage incomplete (partial progress)", stageName)
+	msg := fmt.Sprintf("chore: partial %s stage progress (incomplete)", stageName)
 	commitCmd := exec.Command("git", "commit", "-m", msg)
 	commitCmd.Dir = workDir
 	if _, err := commitCmd.CombinedOutput(); err != nil {
-		e.logf(issueNumber, "warn", "could not commit WIP: %v\n", err)
+		e.logf(issueNumber, "warn", "could not commit partial progress: %v\n", err)
 		return
 	}
 
-	e.logf(issueNumber, "info", "committed WIP changes for incomplete %s stage\n", stageName)
+	e.logf(issueNumber, "info", "committed partial progress for incomplete %s stage\n", stageName)
 }
 
 // progressBaseline captures observable progress signals at the start of a stage

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -294,8 +295,8 @@ func TestBlockOnInput_LabelErrors_LogsWarning(t *testing.T) {
 }
 
 // TestCommitWIP_ExcludesContextFiles verifies that commitWIP does not include
-// files under .fabrik-context/ in the WIP commit, even when they were previously
-// committed (making them tracked by git).
+// files under .fabrik-context/ in the partial-progress commit, even when they
+// were previously committed (making them tracked by git).
 func TestCommitWIP_ExcludesContextFiles(t *testing.T) {
 	skipIfNoGit(t)
 
@@ -353,18 +354,22 @@ func TestCommitWIP_ExcludesContextFiles(t *testing.T) {
 	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.commitWIP(workDir, 42, "Research")
 
-	// Verify the WIP commit was created.
+	// Verify the partial-progress commit was created.
 	logCmd := exec.Command("git", "log", "--oneline", "-1")
 	logCmd.Dir = workDir
 	logOut, err := logCmd.Output()
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
-	if !strings.Contains(string(logOut), "WIP") {
-		t.Errorf("expected WIP commit, got: %s", string(logOut))
+	if !strings.Contains(string(logOut), "chore: partial") {
+		t.Errorf("expected partial-progress commit, got: %s", string(logOut))
+	}
+	ccPattern := regexp.MustCompile(`(feat|fix|refactor|test|docs|chore|style|perf)(\([^)]+\))?: .+`)
+	if !ccPattern.MatchString(string(logOut)) {
+		t.Errorf("commit message does not match Conventional Commits format, got: %s", string(logOut))
 	}
 
-	// Verify the context file is NOT in the WIP commit.
+	// Verify the context file is NOT in the partial-progress commit.
 	showCmd := exec.Command("git", "show", "--name-only", "--format=", "HEAD")
 	showCmd.Dir = workDir
 	showOut, err := showCmd.Output()
@@ -373,10 +378,10 @@ func TestCommitWIP_ExcludesContextFiles(t *testing.T) {
 	}
 	filesInCommit := string(showOut)
 	if strings.Contains(filesInCommit, ".fabrik-context") {
-		t.Errorf(".fabrik-context files should not appear in WIP commit, got:\n%s", filesInCommit)
+		t.Errorf(".fabrik-context files should not appear in partial-progress commit, got:\n%s", filesInCommit)
 	}
 	if !strings.Contains(filesInCommit, "app.go") {
-		t.Errorf("app.go should appear in WIP commit, got:\n%s", filesInCommit)
+		t.Errorf("app.go should appear in partial-progress commit, got:\n%s", filesInCommit)
 	}
 
 	// Verify the context file change is preserved on disk (not lost).

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -355,18 +355,19 @@ func TestCommitWIP_ExcludesContextFiles(t *testing.T) {
 	eng.commitWIP(workDir, 42, "Research")
 
 	// Verify the partial-progress commit was created.
-	logCmd := exec.Command("git", "log", "--oneline", "-1")
+	logCmd := exec.Command("git", "log", "-1", "--pretty=%s")
 	logCmd.Dir = workDir
 	logOut, err := logCmd.Output()
 	if err != nil {
 		t.Fatalf("git log: %v", err)
 	}
-	if !strings.Contains(string(logOut), "chore: partial") {
-		t.Errorf("expected partial-progress commit, got: %s", string(logOut))
+	subject := strings.TrimSpace(string(logOut))
+	if !strings.Contains(subject, "chore: partial") {
+		t.Errorf("expected partial-progress commit, got: %s", subject)
 	}
-	ccPattern := regexp.MustCompile(`(feat|fix|refactor|test|docs|chore|style|perf)(\([^)]+\))?: .+`)
-	if !ccPattern.MatchString(string(logOut)) {
-		t.Errorf("commit message does not match Conventional Commits format, got: %s", string(logOut))
+	ccPattern := regexp.MustCompile(`^(feat|fix|refactor|test|docs|chore|style|perf)(\([^)]+\))?: .+$`)
+	if !ccPattern.MatchString(subject) {
+		t.Errorf("commit message does not match Conventional Commits format, got: %s", subject)
 	}
 
 	// Verify the context file is NOT in the partial-progress commit.

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -58,8 +58,9 @@ Commit after each Task in the plan — at minimum one commit per Task. Do not ac
 - Make review easier
 - Enable bisecting if something breaks
 
-**Use Conventional Commits format** for every commit. The pattern is:
-`(feat|fix|refactor|test|docs|chore|style|perf)[optional scope]: <description>`
+**Use Conventional Commits format** for every commit. The format is:
+`<type>: <description>` or `<type>(<scope>): <description>`
+where `<type>` is one of: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `style`, `perf`
 
 Good commit messages:
 - `feat(auth): add JWT token validation`
@@ -70,7 +71,7 @@ Good commit messages:
 - `chore: update default stage YAML with new completion field`
 
 Bad commit messages:
-- `WIP: Implement stage incomplete (partial progress)` — **explicitly prohibited**; this string is reserved for the engine's partial-progress fallback and must never appear in hand-written commits
+- `WIP: Implement stage incomplete (partial progress)` — **explicitly prohibited**; this is a legacy boilerplate string that must never appear in any commit
 - `WIP`
 - `Updates`
 - `Fix stuff`

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -51,22 +51,30 @@ Work through tasks in the order listed. For each task:
 5. Push to remote
 6. Check off the task in the Plan stage comment (see below)
 
-### Commit frequently
+### Commit frequently — one commit per Task, using Conventional Commits
 
-Commit after each logical unit of work — typically after each task or sub-task. Do not accumulate a large diff and commit at the end. Frequent commits:
+Commit after each Task in the plan — at minimum one commit per Task. Do not accumulate a large diff and commit at the end. Frequent commits:
 - Preserve progress if the session is interrupted
 - Make review easier
 - Enable bisecting if something breaks
 
+**Use Conventional Commits format** for every commit. The pattern is:
+`(feat|fix|refactor|test|docs|chore|style|perf)[optional scope]: <description>`
+
 Good commit messages:
-- `Add FetchItemDetails method for deep-fetching item comments`
-- `Update poll loop to use two-phase fetch`
-- `Fix race condition in worktree mutex handling`
+- `feat(auth): add JWT token validation`
+- `fix(worktree): handle missing remote branch gracefully`
+- `refactor(engine): extract progress detection into helper`
+- `test(item): add coverage for commitWIP exclusion of context files`
+- `docs: update stage-lifecycle to reflect new commit format`
+- `chore: update default stage YAML with new completion field`
 
 Bad commit messages:
+- `WIP: Implement stage incomplete (partial progress)` — **explicitly prohibited**; this string is reserved for the engine's partial-progress fallback and must never appear in hand-written commits
 - `WIP`
 - `Updates`
 - `Fix stuff`
+- Any message without a Conventional Commits type prefix
 
 ### Push regularly
 
@@ -161,7 +169,7 @@ Before signaling completion:
 
 **If you can't complete**: Don't output the completion marker. Describe what's blocking you. The engine will retry after a cooldown, and you'll resume your session.
 
-**If you hit max turns**: The engine will create a WIP commit of any uncommitted changes and push them. Your progress is preserved for the next attempt.
+**If you hit max turns**: The engine will create a partial-progress commit (`chore: partial <StageName> stage progress (incomplete)`) of any uncommitted changes and push them. Your progress is preserved for the next attempt.
 
 **Draft PR**: If the stage config has `create_draft_pr: true`, the engine creates a draft PR after you signal completion. Make sure your branch is pushed before completing.
 


### PR DESCRIPTION
## Summary

Change the Implement stage to commit incrementally — once per Task in the plan — with Conventional Commit messages (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, etc.). Additionally, update the engine's `commitWIP` fallback to use a Conventional Commit-compatible message so that even when max_turns is hit mid-task, the resulting commit message is meaningful rather than boilerplate.

## Problem

The Implement stage produces a misleading commit history. PR #674 (the SIGHUP handler) is the canonical example, but the same pattern is visible across multiple recent issues (`445ec91`, `a0fdca9`, and others on main).

What the Implement stage produces today:

```
PR #674 commits (in chronological order):
  22a95f5  WIP: Implement stage incomplete (partial progress)    ← 8 files, the entire feature
  f1eb70c  feat: add SIGHUP handler for in-place restart...     ← 0 files (empty commit)
  33d4512  fix: remove redundant blank identifier in sighup test
  bc54cbf  fix: address code review findings in SIGHUP handler
```

What lands on main after rebase-merge:

```
  445ec91  WIP: Implement stage incomplete (partial progress)   ← the actual feature
  347a4f9  fix: remove redundant blank identifier in sighup test
  7073ca7  fix: address code review findings in SIGHUP handler
```

The boilerplate `WIP: Implement stage incomplete (partial progress)` message survives, while the proper `feat: add SIGHUP handler…` commit gets silently dropped by rebase-merge because it was empty (all the changes were already in the WIP commit). So `git log` on main now has prominent features listed under a misleading "WIP" message, and `git blame` for those changes points at a "WIP: Implement stage incomplete" line that says nothing about what the change actually does.

There are two sources of WIP messages:

1. **Engine-side** (`engine/item.go`, `commitWIP`): The engine calls `commitWIP` when Claude ran but did not emit `FABRIK_STAGE_COMPLETE` (i.e., hit `max_turns` or errored). The commit message is hard-coded to `"WIP: %s stage incomplete (partial progress)"`. This is the primary source of the WIP commits on main.

2. **Skill-side**: The current `fabrik-implement` skill already discourages WIP commits and recommends per-task commits, but does not specify Conventional Commits format or explicitly prohibit the WIP message string.

## Approach

### Approach

This is a targeted 4-file change with no new abstractions. The work falls into two independent streams:

1. **Engine fix**: Change the `commitWIP` message in `engine/item.go` from `"WIP: %s stage incomplete (partial progress)"` to `"chore: partial %s stage progress (incomplete)"`, update the one test that asserts on "WIP", and add a Conventional Commits regex check.

2. **Skill + docs update**: Update `plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md` to mandate Conventional Commits format per task, then update `docs/stage-lifecycle.md` to reflect the new commit message format and regenerate `docs/llms-full.txt`.

The function signature for `commitWIP` does not change — `stageName` already provides what's needed to construct the new message. The trigger logic (`claudeRan && !completed && !stage.ReadOnly`) is left entirely untouched per scope constraints.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/item.go` | Line 1457: new commit message format; lines 1429/1441/1461/1465: update internal comments/log strings |
| `engine/item_extra_test.go` | Line 363: replace `strings.Contains(logOut, "WIP")` with check for new prefix; add regex assertion for CC format |
| `plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md` | Lines 54–70: add CC format mandate and prohibit engine WIP string; line 164: update description of fallback commit |
| `docs/stage-lifecycle.md` | Line 292: update `"WIP: ..."` placeholder to show CC format |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **New commit message: `"chore: partial %s stage progress (incomplete)"`** — uses `chore:` as the type (partial uncommitted work is not a feat/fix/test), includes the stage name for context, and the `(incomplete)` suffix mirrors the prior message's intent without using the prohibited "WIP" string. The spec explicitly suggests this format.

- **Engine log/comment strings**: Internal "WIP" references in comments (`// commitWIP commits...`) and log calls (`"could not commit WIP"`, `"committed WIP changes"`) will be updated to remove or replace "WIP" for consistency — these are cosmetic and risk-free.

- **Test update strategy**: The existing `TestCommitWIP_ExcludesContextFiles` test's primary assertion (context files excluded) is unchanged. The message assertion at line 363 changes to `strings.Contains(string(logOut), "chore: partial")` and a second assertion uses `regexp.MustCompile` to verify the full CC format `^(feat|fix|refactor|test|docs|chore|style|perf)(\([^)]+\))?: .+` against the commit subject. This satisfies the spec's requirement for a new CC-format test.

- **`docs/stage-lifecycle.md` and `docs/llms-full.txt` must be in the same commit** — the `docs-drift` CI workflow fails if the bundle diverges from the regenerated output. These two files are committed together.

- **No ADR needed**: This is a commit message format change. It doesn't introduce a new mechanism, interface, or non-obvious constraint that would trap a future contributor. The concept name "WIP commit" continues to appear in ADR 030 and USER_GUIDE.md as a mechanism name — those do not need updating per research findings.

### Task Checklist

- [ ] Task 1: In `engine/item.go`, change the commit message at line 1457 to `fmt.Sprintf("chore: partial %s stage progress (incomplete)", stageName)` and update internal comments/log strings at lines 1429, 1441, 1461, 1465 that reference "WIP" — commit as `fix: update commitWIP message to Conventional Commit format`
- [ ] Task 2: In `engine/item_extra_test.go`, update the assertion at line 363 to check `"chore: partial"` instead of `"WIP"`, and add a `regexp` assertion verifying the full CC format pattern against the commit subject — commit as `test: update commitWIP test for Conventional Commit format`
- [ ] Task 3: Run `go test -race ./...` and `go vet ./...` to confirm the engine change and updated test pass
- [ ] Task 4: In `plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md`, rewrite the "Commit frequently" section (lines 54–70) to name Conventional Commits format explicitly, update the good-examples list to use CC prefixes (`feat:`, `fix:`, `refactor:`, etc.), add explicit prohibition of the engine WIP string, and update line 164 to describe the fallback as `chore: partial <StageName> stage progress (incomplete)` — commit as `chore: mandate Conventional Commits format in fabrik-implement skill`
- [ ] Task 5: In `docs/stage-lifecycle.md`, update line 292 to replace `"WIP: ..."` with `"chore: partial <StageName> stage progress (incomplete)"`, then run `bash scripts/generate-llms-full.sh` and `git add docs/llms-full.txt`, and commit both files together as `docs: update stage-lifecycle to show commitWIP Conventional Commit format`

### Risks

- **`docs/llms-full.txt` drift**: If the Implement agent edits `docs/stage-lifecycle.md` without running the regen script, the `docs-drift` CI check will fail. Task 5 explicitly requires both steps in a single commit. The Implement agent must not split these into separate commits.
- **Test import for `regexp`**: The test file may not already import `regexp`. The Implement agent must verify imports and add `"regexp"` if absent — Go will refuse to compile otherwise.
- **`commitWIP` preserves partial work**: The only change is the `msg` string at line 1457. The `git add -A`, `.fabrik-context/` reset, and `git commit` mechanics are identical. No behavior change to the safety net itself.

---
Used 10/50 turns, 4k input / 3k output tokens.

## Verification

Changed `commitWIP` in `engine/item.go` to produce `chore: partial <StageName> stage progress (incomplete)` instead of the boilerplate `WIP: Implement stage incomplete (partial progress)`. Updated the `TestCommitWIP_ExcludesContextFiles` test to assert the new CC-format prefix and added a `regexp` assertion verifying the full Conventional Commits pattern. Updated the `fabrik-implement` skill to mandate per-Task commits using Conventional Commits format and explicitly prohibit the engine WIP string. Updated `docs/stage-lifecycle.md` and regenerated `docs/llms-full.txt`.

---

Closes #675