### PR TITLE
Update docs for v0.0.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,23 @@ Fabrik responds to natural language. Comment on an issue to steer the work:
 Each stage sees the full conversation history — previous stage outputs, user
 comments, and all — so context carries forward through the pipeline.
 
+### Awaiting Input Notifications
+
+When a stage needs user input (`FABRIK_BLOCKED_ON_INPUT`), Fabrik posts a
+`🏭 **Fabrik** — @<user>:` comment so GitHub delivers a mobile push notification
+to the configured operator. For pushes to arrive, Fabrik must run as a different
+account than the user being @mentioned — see
+[USER_GUIDE.md §Stages Waiting for Input](docs/USER_GUIDE.md#stages-waiting-for-input)
+for setup details and the self-mention caveat.
+
+### In-Place Restart
+
+Sending `SIGHUP` to the Fabrik process drains in-flight Claude runs, then
+re-execs the binary in place — no terminal disruption, no lost state. Use it
+to pick up a new binary after `go install` without restarting the session. See
+[USER_GUIDE.md §Recovering from Wedged State](docs/USER_GUIDE.md#recovering-from-wedged-state)
+for the full escape-hatch procedure.
+
 ## Default Pipeline
 
 The example stages implement a full SDLC pipeline:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -747,6 +747,18 @@ When the configured user posts a new comment:
 This is the intended mechanism for Q&A in stages like Specify — Claude asks a question,
 the configured user answers it in a comment, and the stage resumes automatically.
 
+When Fabrik adds `fabrik:awaiting-input`, it also posts a notification comment beginning
+with `🏭 **Fabrik** — @<user>:` so GitHub delivers a mobile push notification to the
+configured operator (set via `--user` / `FABRIK_USER`). This ensures you're alerted even
+if you're not actively watching the issue.
+
+> **Note:** GitHub does not deliver push notifications for activity an account performs on
+> itself. If Fabrik runs as the same GitHub account as the user being @mentioned, no push
+> arrives. To receive mobile pushes, run Fabrik as a dedicated bot account (a different
+> identity than the operator account you configure with `--user`). The `--filter-user`
+> flag ([#671](https://github.com/handarbeit/fabrik/issues/671)) will make this separation
+> easier once implemented.
+
 ### Dependency-Based Sequencing (Formations)
 
 Fabrik supports dependency-based sequencing of issues using GitHub's native "Blocked by" relationships. This enables **formations** — coordinated sets of issues that execute in parallel where possible and respect ordering constraints automatically.

--- a/docs/index.md
+++ b/docs/index.md
@@ -241,6 +241,20 @@ description: >-
           Blocks merge until CI passes and auto-fixes failing checks each cycle.
         </div>
       </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#stages-waiting-for-input" aria-label="Awaiting Input Notifications — open documentation">
+        <span class="feature-icon">🔔</span>
+        <div class="feature-title">Awaiting Input Notifications</div>
+        <div class="feature-desc">
+          Mentions the configured operator via @mention comment for mobile push when a stage needs user input.
+        </div>
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#recovering-from-wedged-state" aria-label="In-Place Restart — open documentation">
+        <span class="feature-icon">🔃</span>
+        <div class="feature-title">In-Place Restart</div>
+        <div class="feature-desc">
+          SIGHUP drains in-flight runs and re-execs the binary in place — pick up a new build without terminal disruption.
+        </div>
+      </a>
     </div>
 
     <div class="factory-callout">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -745,6 +745,18 @@ When the configured user posts a new comment:
 This is the intended mechanism for Q&A in stages like Specify — Claude asks a question,
 the configured user answers it in a comment, and the stage resumes automatically.
 
+When Fabrik adds `fabrik:awaiting-input`, it also posts a notification comment beginning
+with `🏭 **Fabrik** — @<user>:` so GitHub delivers a mobile push notification to the
+configured operator (set via `--user` / `FABRIK_USER`). This ensures you're alerted even
+if you're not actively watching the issue.
+
+> **Note:** GitHub does not deliver push notifications for activity an account performs on
+> itself. If Fabrik runs as the same GitHub account as the user being @mentioned, no push
+> arrives. To receive mobile pushes, run Fabrik as a dedicated bot account (a different
+> identity than the operator account you configure with `--user`). The `--filter-user`
+> flag ([#671](https://github.com/handarbeit/fabrik/issues/671)) will make this separation
+> easier once implemented.
+
 ### Dependency-Based Sequencing (Formations)
 
 Fabrik supports dependency-based sequencing of issues using GitHub's native "Blocked by" relationships. This enables **formations** — coordinated sets of issues that execute in parallel where possible and respect ordering constraints automatically.


### PR DESCRIPTION
## Summary

Update USER_GUIDE.md, README.md, and docs/index.md to document the @mention notification behavior (including the self-mention caveat) and the SIGHUP in-place restart, and confirm all org references are on `handarbeit`. Then regenerate `docs/llms-full.txt`.

## Problem

Fabrik v0.0.56 shipped two user-visible features — @mention notifications on awaiting-input comments and a SIGHUP in-place restart — plus an org migration from `tenaciousvc/shadoworg` to `handarbeit`. The USER_GUIDE.md, README.md, and marketing page (docs/index.md) need to reflect these changes so operators can discover and use them. Without these docs updates, the @mention feature is silent (the `--user` flag description mentions it, but the "Stages Waiting for Input" operational section doesn't), and the SIGHUP escape hatch is undiscoverable unless an operator reads the SIGHUP section that was added to USER_GUIDE.md.

## Approach

### Approach

This is a documentation-only task — three files need surgical edits, plus a `docs/llms-full.txt` regen. No code changes. The work is ordered by the CI constraint: USER_GUIDE.md and its `llms-full.txt` regen must land in the same commit; README.md and docs/index.md are not in the bundle and can commit freely.

The USER_GUIDE.md edit is the highest-risk item (large file, specific insertion point). It goes first so the regen can follow immediately in the same commit. README and index edits are independent and can commit after.

**Placement decisions:**

- **USER_GUIDE.md**: Insert after line 748 (end of "Stages Waiting for Input" body, before the "### Dependency-Based Sequencing" heading). Content: a prose paragraph describing the `🏭 **Fabrik** — @<user>:` notification comment, followed by a `> **Note:**` blockquote for the self-mention caveat + #671 reference. This matches the blockquote callout style used elsewhere in the guide.

- **README.md**: Add two new `###` subsections inside "How It Works" — `### Awaiting Input Notifications` and `### In-Place Restart` — placed after "Steering with Comments" (line 160–169) and before "## Default Pipeline". Each is 2–3 sentences with a cross-link to the USER_GUIDE anchor.

- **docs/index.md**: Append two new `<a class="feature-card">` entries inside the `<div class="features-grid">` block, after the last existing card (the "CI Gate" entry, line 237–243). Icon, title, short description, and `{{ '/USER_GUIDE' | relative_url }}#<anchor>` href following the existing card pattern.

**ADR assessment**: No ADRs needed — no architectural decisions, no code changes, no non-obvious constraints introduced.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add @mention notification paragraph + self-mention caveat blockquote after "Stages Waiting for Input" body (after line 748) |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` — committed in same commit as USER_GUIDE.md |
| `README.md` | Add `### Awaiting Input Notifications` and `### In-Place Restart` subsections inside "How It Works" |
| `docs/index.md` | Add two `<a class="feature-card">` entries to the features grid |

### Key Decisions

- **USER_GUIDE.md and llms-full.txt in one commit**: CI's `docs-drift` workflow diffs the committed bundle against a fresh regen. Any divergence fails the PR. Keeping the regen in the same commit as the USER_GUIDE.md edit guarantees the committed bundle always matches. README.md and docs/index.md are not in the bundle, so they can commit separately without risk.

- **Prose paragraph + blockquote caveat style**: The self-mention caveat warrants a callout rather than inline prose because it describes a counterintuitive platform behavior (GitHub doesn't ping you for your own actions). The `> **Note:**` blockquote pattern is already used throughout USER_GUIDE.md for similar edge-case callouts.

- **Two separate README subsections vs. one combined section**: Keeping SIGHUP and @mention as separate `###` sections makes them individually linkable and matches the README's existing pattern of focused single-concept subsections (Webhook Mode, Comment Processing, Review and Fix, etc.).

- **Feature card placement at end of grid**: Appending at the end of the grid preserves the existing ordering (pipeline flow first, operational features after) while adding new capability cards. No reordering or deletion needed.

### Task Checklist

- [x] Task 1: Grep `docs/USER_GUIDE.md`, `README.md`, and `docs/index.md` for `tenaciousvc` and `shadoworg` — confirm clean (research found these only in release-notes/ADR/migration scripts, not user-facing docs)
- [x] Task 2: Edit `docs/USER_GUIDE.md` — after line 748, insert @mention notification paragraph (`🏭 **Fabrik** — @<user>:` comment triggers mobile push) and `> **Note:**` blockquote for self-mention caveat with #671 reference
- [x] Task 3: Run `bash scripts/generate-llms-full.sh` and commit both `docs/USER_GUIDE.md` and `docs/llms-full.txt` together (required by CI docs-drift check)
- [x] Task 4: Edit `README.md` — add `### Awaiting Input Notifications` subsection (2–3 sentences, cross-link to `docs/USER_GUIDE.md#stages-waiting-for-input`) and `### In-Place Restart` subsection (2–3 sentences on SIGHUP drain/re-exec, cross-link to `docs/USER_GUIDE.md#recovering-from-wedged-state`), both after "Steering with Comments" and before "## Default Pipeline"
- [x] Task 5: Edit `docs/index.md` — append two `<a class="feature-card">` entries inside the features grid: one for @mention notifications (link `#stages-waiting-for-input`, icon 🔔, title "Awaiting Input Notifications") and one for SIGHUP restart (link `#recovering-from-wedged-state`, icon ↩️ or 🔃, title "In-Place Restart")
- [x] Task 6: Commit `README.md` and `docs/index.md` together

### Risks

- **llms-full.txt regen in wrong commit**: If USER_GUIDE.md and llms-full.txt land in separate commits, the intermediate commit will fail CI. Mitigation: Task 3 explicitly combines both files in a single `git add` + commit; the checklist enforces this ordering before any README/index work begins.

- **USER_GUIDE.md insertion point**: The section at lines 730–748 ends cleanly with a paragraph. Inserting between the paragraph and the next `###` heading is safe as long as the new content is separated by a blank line above and below. The implementer should verify the section structure with a quick Read before editing.

- **docs/index.md Jekyll URL format**: Feature card hrefs use `{{ '/USER_GUIDE' | relative_url }}#anchor`, not a raw URL. The two new cards must follow this exact template syntax; a raw `docs/USER_GUIDE.md#anchor` href would break the marketing site.

---
Used 9/50 turns, 3k input / 4k output tokens.

## Verification

Added @mention notification documentation to USER_GUIDE.md's "Stages Waiting for Input" section (with self-mention caveat and #671 reference) and regenerated llms-full.txt in the same commit. Added SIGHUP in-place restart and @mention notification entries to README.md (as new subsections) and docs/index.md (as two new feature cards). All three user-facing docs confirmed free of tenaciousvc/shadoworg references.

---

Closes #678