### PR TITLE
fix(plugin): stop embedding fabrik-workflows/README.md in the binary

### DIFF
--- a/plugin/embed.go
+++ b/plugin/embed.go
@@ -12,7 +12,12 @@ import "embed"
 // This is distinct from the user-facing `fabrik` plugin (plugin/fabrik/) which
 // is installed via Claude Code's plugin marketplace, not embedded.
 //
+// Only files Claude Code actually loads at runtime are embedded: the plugin
+// manifest and the SKILL.md files. The plugin's own README.md is developer
+// documentation that lives at plugin/fabrik-workflows/README.md in this repo
+// for source readers — it is not bundled into the binary and not extracted
+// into user projects, where it would just be clutter.
+//
 //go:embed fabrik-workflows/.claude-plugin/plugin.json
-//go:embed fabrik-workflows/README.md
 //go:embed fabrik-workflows/skills/*/SKILL.md
 var FabrikPlugin embed.FS


### PR DESCRIPTION
## Summary

The plugin's own \`README.md\` was listed alongside the plugin manifest and the SKILL.md files in the \`//go:embed\` directives in \`plugin/embed.go\`. Claude Code never loads the README at runtime — it's developer documentation about the plugin itself, intended for people reading the fabrik source tree.

## Side effect this fixes

\`RefreshPlugin\` (called from \`fabrik init\` and \`fabrik upgrade\`) walks the embedded FS and writes every entry into \`.fabrik/plugin/\` in the user's project. With the README in the embed directive, every fabrik-managed repo ended up with a 2 KB \`.fabrik/plugin/README.md\` describing the plugin's internals — pure clutter for users.

Verified on \`verveguy/fantasy\`: \`~/dev/fantasy/.fabrik/plugin/README.md\` exists, byte-identical to the source.

## The fix

One line removed from the embed directive in \`plugin/embed.go\`. Comment expanded to explain the policy: only runtime-loaded files (manifest + SKILL.md) are embedded; documentation stays in the source tree only.

## Note for existing user projects

\`RefreshPlugin\` overwrites destination files but does not delete files that no longer exist in the embedded source. So existing fabrik-managed repos will keep their stale \`.fabrik/plugin/README.md\` until manually removed. Nothing references it; \`rm .fabrik/plugin/README.md\` is safe.

A future enhancement could make \`RefreshPlugin\` mirror-style (delete destination files absent from source), but that's a separate concern and out of scope here.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test -race ./...\` all green
- [x] After this change, the embedded FS no longer contains \`fabrik-workflows/README.md\`
- [ ] Live verify: \`fabrik init\` in a fresh test repo does not create \`.fabrik/plugin/README.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)