### PR TITLE
feat(worktree): config-gated symlink of repo-root .env into worktrees

### DIFF
--- a/.fabrik/config.yaml
+++ b/.fabrik/config.yaml
@@ -30,3 +30,7 @@ board_cache_mode: in-memory
 tui: true
 terminal: ghostty
 # debug_output: false
+# symlink_env: false    # When true, creates a relative symlink at <worktree>/.env pointing to the fabrikDir .env.
+#                       # Enables worktree-based stages to pick up credentials (e.g. ANTHROPIC_API_KEY) from .env.
+#                       # No-op when source .env is absent; never overwrites an existing .env in the worktree.
+#                       # Also: --symlink-env flag / FABRIK_SYMLINK_ENV env var.

--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -139,6 +139,25 @@ func TestExecute_EnvTUIFalse(t *testing.T) {
 	executeAndStop(t)
 }
 
+func TestExecute_EnvSymlinkEnv(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	resetFlags()
+	t.Setenv("FABRIK_SYMLINK_ENV", "true")
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+	executeAndStop(t)
+}
+
+func TestExecute_FlagSymlinkEnv(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir, "--symlink-env"}
+	executeAndStop(t)
+}
+
 func TestExecute_StreamFilterSubcommand(t *testing.T) {
 	resetFlags()
 	r, w, _ := os.Pipe()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ type Config struct {
 	MaxRebaseCycles   int // 0 means use default (3)
 	ClaudeWaitDelay   int // seconds; 0 means use default (30)
 	DebugOutput       bool
+	SymlinkEnv        bool
 	PluginDir         string
 	Webhooks          bool
 	WebhookPort       int
@@ -127,6 +128,7 @@ func Execute() error {
 	flag.IntVar(&cfg.MaxRebaseCycles, "max-rebase-cycles", 0, "Maximum number of rebase-reinvoke cycles per issue before pausing (0 = use default of 3; also FABRIK_MAX_REBASE_CYCLES)")
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
+	flag.BoolVar(&cfg.SymlinkEnv, "symlink-env", false, "Symlink the fabrik-dir .env file into each issue worktree at creation time (also FABRIK_SYMLINK_ENV)")
 	flag.StringVar(&cfg.PluginDir, "plugin-dir", "", "Path to Fabrik plugin directory (for development; overrides installed plugin)")
 	flag.BoolVar(&cfg.Webhooks, "webhooks", false, "Enable webhook-driven event delivery via gh webhook forward (requires gh ≥ 2.32.0; also FABRIK_WEBHOOKS)")
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
@@ -373,6 +375,14 @@ func Execute() error {
 			cfg.DebugOutput = true
 		}
 	}
+	if !cfg.SymlinkEnv {
+		if v := os.Getenv("FABRIK_SYMLINK_ENV"); v != "" {
+			lv := strings.ToLower(v)
+			cfg.SymlinkEnv = lv == "true" || lv == "1" || lv == "yes"
+		} else if pc.SymlinkEnv {
+			cfg.SymlinkEnv = true
+		}
+	}
 	if cfg.PluginDir == "" {
 		if v := os.Getenv("FABRIK_PLUGIN_DIR"); v != "" {
 			cfg.PluginDir = v
@@ -528,6 +538,7 @@ func Execute() error {
 		MaxRebaseCycles:          maxRebaseCycles(cfg.MaxRebaseCycles),
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		DebugOutput:              cfg.DebugOutput,
+		SymlinkEnv:               cfg.SymlinkEnv,
 		PluginDir:                cfg.PluginDir,
 		Stages:                   stageCfgs,
 		Webhooks:                 cfg.Webhooks,

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type ProjectConfig struct {
 	GitSSH        bool     `yaml:"git_ssh"`
 	TUI           *bool    `yaml:"tui"`
 	DebugOutput   bool     `yaml:"debug_output"`
+	SymlinkEnv    bool     `yaml:"symlink_env"`
 	Version       string   `yaml:"version"`
 	Webhooks      bool     `yaml:"webhooks"`
 	WebhookPort   *int     `yaml:"webhook_port"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -135,6 +135,22 @@ func TestLoadProjectConfig_MissingFile(t *testing.T) {
 	}
 }
 
+func TestLoadProjectConfig_SymlinkEnvDefaultFalse(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("owner: org\n"), 0644)
+	pc, err := LoadProjectConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pc.SymlinkEnv {
+		t.Error("symlink_env: want false by default")
+	}
+}
+
 func TestLoadProjectConfig_ValidYAML(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
@@ -154,6 +170,7 @@ yolo: true
 auto_upgrade: true
 tui: true
 debug_output: true
+symlink_env: true
 version: "2.0.0"
 `
 	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte(yaml), 0644)
@@ -194,6 +211,9 @@ version: "2.0.0"
 	}
 	if !pc.DebugOutput {
 		t.Error("debug_output: want true")
+	}
+	if !pc.SymlinkEnv {
+		t.Error("symlink_env: want true")
 	}
 	if pc.Version != "2.0.0" {
 		t.Errorf("version: want 2.0.0, got %q", pc.Version)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -412,6 +412,12 @@ user: your-github-username
 # or prompt issues. Files are named by issue number and stage.
 # debug_output: false
 
+# When true, creates a relative symlink at <worktree>/.env pointing to the
+# fabrikDir .env file whenever a worktree is set up. Lets stage code read
+# credentials (e.g. ANTHROPIC_API_KEY) without copying secrets. No-op when
+# the source .env is absent; never overwrites an existing .env in the worktree.
+# symlink_env: false
+
 # Project version shown in the TUI footer. Auto-inferred from package.json,
 # go.mod (returns module path, not semver), Cargo.toml, or pyproject.toml.
 # Set explicitly to override auto-inference (e.g., version: "1.2.0").
@@ -464,6 +470,7 @@ FABRIK_USER=my-personal-username
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
+| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree. Also `FABRIK_SYMLINK_ENV` | `false` |
 
 ### Environment Variables
 
@@ -484,6 +491,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
 | `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
 | `FABRIK_DEBUG_OUTPUT` | `debug_output` | Save raw Claude output for debugging | `false` |
+| `FABRIK_SYMLINK_ENV` | `symlink_env` | Symlink fabrikDir `.env` into each worktree at setup time (`true`/`1`/`yes`) — see `--symlink-env` | `false` |
 | `FABRIK_REVIEW_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait per review cycle at the review gate (whether waiting for requested reviewers to submit or for at least one review to exist) before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 15) | `15` |
 | `FABRIK_MAX_REVIEW_CYCLES` | *(no config.yaml key)* | Maximum number of review re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 | `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -410,6 +410,12 @@ user: your-github-username
 # or prompt issues. Files are named by issue number and stage.
 # debug_output: false
 
+# When true, creates a relative symlink at <worktree>/.env pointing to the
+# fabrikDir .env file whenever a worktree is set up. Lets stage code read
+# credentials (e.g. ANTHROPIC_API_KEY) without copying secrets. No-op when
+# the source .env is absent; never overwrites an existing .env in the worktree.
+# symlink_env: false
+
 # Project version shown in the TUI footer. Auto-inferred from package.json,
 # go.mod (returns module path, not semver), Cargo.toml, or pyproject.toml.
 # Set explicitly to override auto-inference (e.g., version: "1.2.0").
@@ -462,6 +468,7 @@ FABRIK_USER=my-personal-username
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
+| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree. Also `FABRIK_SYMLINK_ENV` | `false` |
 
 ### Environment Variables
 
@@ -482,6 +489,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
 | `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
 | `FABRIK_DEBUG_OUTPUT` | `debug_output` | Save raw Claude output for debugging | `false` |
+| `FABRIK_SYMLINK_ENV` | `symlink_env` | Symlink fabrikDir `.env` into each worktree at setup time (`true`/`1`/`yes`) — see `--symlink-env` | `false` |
 | `FABRIK_REVIEW_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait per review cycle at the review gate (whether waiting for requested reviewers to submit or for at least one review to exist) before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 15) | `15` |
 | `FABRIK_MAX_REVIEW_CYCLES` | *(no config.yaml key)* | Maximum number of review re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 | `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -138,6 +138,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 
 	// If a PR exists and its base branch doesn't match the resolved base, update it.
 	e.syncPRBase(item, baseBranch)
+	e.ensureEnvExcluded(item.Number, workDir)
 	e.symlinkEnvIfEnabled(item.Number, workDir)
 
 	// Write context files (all stages including current) before Claude runs.

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -138,6 +138,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 
 	// If a PR exists and its base branch doesn't match the resolved base, update it.
 	e.syncPRBase(item, baseBranch)
+	e.symlinkEnvIfEnabled(item.Number, workDir)
 
 	// Write context files (all stages including current) before Claude runs.
 	e.writeContextFiles(item, stage, workDir, true)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -39,6 +39,7 @@ type Config struct {
 	MaxRebaseCycles          int           // Max rebase re-invocation cycles per issue before pausing (default 3)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
 	DebugOutput              bool
+	SymlinkEnv               bool
 	PluginDir                string
 	Stages                   []*stages.Stage
 	Webhooks                 bool

--- a/engine/item.go
+++ b/engine/item.go
@@ -695,6 +695,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// Write context files after any stash so they are present for Claude but
 	// not captured in the stash. Errors are non-fatal.
 	e.writeContextFiles(item, stage, workDir, false)
+	e.symlinkEnvIfEnabled(item.Number, workDir)
 
 	// Invoke Claude Code in the issue's worktree
 	modelOverride := e.extractModelOverride(item.Number, item.Labels)

--- a/engine/item.go
+++ b/engine/item.go
@@ -670,6 +670,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 	// If a PR exists and its base branch doesn't match the resolved base, update it.
 	e.syncPRBase(item, baseBranch)
+	// Ensure .env is excluded from git stash before any stash runs, so the symlink
+	// created by symlinkEnvIfEnabled is never captured and never causes stash-pop conflicts.
+	e.ensureEnvExcluded(item.Number, workDir)
 
 	// If this is a read-only stage, stash any unexpected dirty state (including
 	// untracked files) before invocation so the stage sees a clean worktree, and

--- a/engine/symlink_env.go
+++ b/engine/symlink_env.go
@@ -2,7 +2,9 @@ package engine
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // symlinkEnvIfEnabled creates a symlink at <workDir>/.env pointing to the
@@ -15,13 +17,19 @@ func (e *Engine) symlinkEnvIfEnabled(issueNumber int, workDir string) {
 	}
 
 	src := filepath.Join(e.fabrikDir, ".env")
-	if _, err := os.Stat(src); os.IsNotExist(err) {
+	if _, err := os.Stat(src); err != nil {
+		if !os.IsNotExist(err) {
+			e.logf(issueNumber, "warn", "symlink-env: could not stat source .env: %v\n", err)
+		}
 		return
 	}
 
 	dst := filepath.Join(workDir, ".env")
 	if _, err := os.Lstat(dst); err == nil {
 		e.logf(issueNumber, "debug", "worktree .env already exists — skipping symlink\n")
+		return
+	} else if !os.IsNotExist(err) {
+		e.logf(issueNumber, "warn", "symlink-env: could not stat worktree .env: %v\n", err)
 		return
 	}
 
@@ -32,5 +40,47 @@ func (e *Engine) symlinkEnvIfEnabled(issueNumber int, workDir string) {
 
 	if err := os.Symlink(target, dst); err != nil {
 		e.logf(issueNumber, "warn", "could not symlink .env into worktree: %v\n", err)
+	}
+}
+
+// ensureEnvExcluded adds ".env" to the per-worktree git exclude file so that
+// git stash -u does not capture the symlink created by symlinkEnvIfEnabled.
+// This must be called before any git stash operation. It is idempotent and
+// non-fatal — failures are logged as warnings.
+func (e *Engine) ensureEnvExcluded(issueNumber int, workDir string) {
+	if !e.cfg.SymlinkEnv {
+		return
+	}
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	if err != nil {
+		e.logf(issueNumber, "warn", "symlink-env: could not determine git-dir for exclude: %v\n", err)
+		return
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(workDir, gitDir)
+	}
+	infoDir := filepath.Join(gitDir, "info")
+	if err := os.MkdirAll(infoDir, 0755); err != nil {
+		e.logf(issueNumber, "warn", "symlink-env: could not create git info dir: %v\n", err)
+		return
+	}
+	excludePath := filepath.Join(infoDir, "exclude")
+	existing, _ := os.ReadFile(excludePath)
+	for _, line := range strings.Split(string(existing), "\n") {
+		if strings.TrimSpace(line) == ".env" {
+			return
+		}
+	}
+	f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		e.logf(issueNumber, "warn", "symlink-env: could not open git exclude: %v\n", err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.WriteString(".env\n"); err != nil {
+		e.logf(issueNumber, "warn", "symlink-env: could not write git exclude entry: %v\n", err)
 	}
 }

--- a/engine/symlink_env.go
+++ b/engine/symlink_env.go
@@ -1,0 +1,36 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// symlinkEnvIfEnabled creates a symlink at <workDir>/.env pointing to the
+// fabrikDir .env when cfg.SymlinkEnv is true. It is idempotent: if the
+// destination already exists (file or symlink) it is left untouched. Symlink
+// creation failure is non-fatal — a warning is logged and the stage proceeds.
+func (e *Engine) symlinkEnvIfEnabled(issueNumber int, workDir string) {
+	if !e.cfg.SymlinkEnv {
+		return
+	}
+
+	src := filepath.Join(e.fabrikDir, ".env")
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return
+	}
+
+	dst := filepath.Join(workDir, ".env")
+	if _, err := os.Lstat(dst); err == nil {
+		e.logf(issueNumber, "debug", "worktree .env already exists — skipping symlink\n")
+		return
+	}
+
+	target, err := filepath.Rel(workDir, src)
+	if err != nil {
+		target = src
+	}
+
+	if err := os.Symlink(target, dst); err != nil {
+		e.logf(issueNumber, "warn", "could not symlink .env into worktree: %v\n", err)
+	}
+}

--- a/engine/symlink_env_test.go
+++ b/engine/symlink_env_test.go
@@ -1,0 +1,106 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSymlinkEnvIfEnabled_SourcePresent(t *testing.T) {
+	fabrikDir := t.TempDir()
+	workDir := t.TempDir()
+
+	srcEnv := filepath.Join(fabrikDir, ".env")
+	if err := os.WriteFile(srcEnv, []byte("API_KEY=secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := NewWithDeps(Config{SymlinkEnv: true}, nil, nil, nil)
+	eng.fabrikDir = fabrikDir
+	eng.symlinkEnvIfEnabled(1, workDir)
+
+	dst := filepath.Join(workDir, ".env")
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("expected .env symlink in worktree, got: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected .env to be a symlink")
+	}
+
+	// Verify the symlink resolves to the source content.
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading symlink target: %v", err)
+	}
+	if string(data) != "API_KEY=secret\n" {
+		t.Errorf("unexpected content %q", data)
+	}
+}
+
+func TestSymlinkEnvIfEnabled_SourceAbsent(t *testing.T) {
+	fabrikDir := t.TempDir()
+	workDir := t.TempDir()
+
+	eng := NewWithDeps(Config{SymlinkEnv: true}, nil, nil, nil)
+	eng.fabrikDir = fabrikDir
+	eng.symlinkEnvIfEnabled(1, workDir)
+
+	dst := filepath.Join(workDir, ".env")
+	if _, err := os.Lstat(dst); !os.IsNotExist(err) {
+		t.Errorf("expected no .env in worktree when source absent, got: %v", err)
+	}
+}
+
+func TestSymlinkEnvIfEnabled_DestExists(t *testing.T) {
+	fabrikDir := t.TempDir()
+	workDir := t.TempDir()
+
+	srcEnv := filepath.Join(fabrikDir, ".env")
+	if err := os.WriteFile(srcEnv, []byte("API_KEY=source\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-existing .env in worktree with different content.
+	dst := filepath.Join(workDir, ".env")
+	if err := os.WriteFile(dst, []byte("API_KEY=existing\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := NewWithDeps(Config{SymlinkEnv: true}, nil, nil, nil)
+	eng.fabrikDir = fabrikDir
+	eng.symlinkEnvIfEnabled(1, workDir)
+
+	// Existing file must remain untouched.
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "API_KEY=existing\n" {
+		t.Errorf("pre-existing .env was modified: %q", data)
+	}
+	// Must not be a symlink — it was a regular file before.
+	fi, _ := os.Lstat(dst)
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("pre-existing regular file was replaced by a symlink")
+	}
+}
+
+func TestSymlinkEnvIfEnabled_Disabled(t *testing.T) {
+	fabrikDir := t.TempDir()
+	workDir := t.TempDir()
+
+	srcEnv := filepath.Join(fabrikDir, ".env")
+	if err := os.WriteFile(srcEnv, []byte("API_KEY=secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := NewWithDeps(Config{SymlinkEnv: false}, nil, nil, nil)
+	eng.fabrikDir = fabrikDir
+	eng.symlinkEnvIfEnabled(1, workDir)
+
+	dst := filepath.Join(workDir, ".env")
+	if _, err := os.Lstat(dst); !os.IsNotExist(err) {
+		t.Errorf("expected no .env when SymlinkEnv disabled, got: %v", err)
+	}
+}

--- a/engine/symlink_env_test.go
+++ b/engine/symlink_env_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -103,4 +104,62 @@ func TestSymlinkEnvIfEnabled_Disabled(t *testing.T) {
 	if _, err := os.Lstat(dst); !os.IsNotExist(err) {
 		t.Errorf("expected no .env when SymlinkEnv disabled, got: %v", err)
 	}
+}
+
+func TestEnsureEnvExcluded_WritesEntry(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	eng := NewWithDeps(Config{SymlinkEnv: true}, nil, nil, nil)
+	eng.fabrikDir = repoDir
+	eng.ensureEnvExcluded(1, repoDir)
+
+	// Verify .env appears in the exclude file.
+	out, err := readGitExclude(t, repoDir)
+	if err != nil {
+		t.Fatalf("reading exclude: %v", err)
+	}
+	if !strings.Contains(out, ".env") {
+		t.Errorf("expected .env in git exclude, got:\n%s", out)
+	}
+}
+
+func TestEnsureEnvExcluded_Idempotent(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	eng := NewWithDeps(Config{SymlinkEnv: true}, nil, nil, nil)
+	eng.fabrikDir = repoDir
+	eng.ensureEnvExcluded(1, repoDir)
+	eng.ensureEnvExcluded(1, repoDir)
+
+	out, err := readGitExclude(t, repoDir)
+	if err != nil {
+		t.Fatalf("reading exclude: %v", err)
+	}
+	count := strings.Count(out, ".env\n")
+	if count != 1 {
+		t.Errorf("expected exactly one .env entry, got %d:\n%s", count, out)
+	}
+}
+
+func TestEnsureEnvExcluded_Disabled(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+
+	eng := NewWithDeps(Config{SymlinkEnv: false}, nil, nil, nil)
+	eng.fabrikDir = repoDir
+	eng.ensureEnvExcluded(1, repoDir)
+
+	out, _ := readGitExclude(t, repoDir)
+	if strings.Contains(out, ".env") {
+		t.Errorf("expected no .env in exclude when disabled, got:\n%s", out)
+	}
+}
+
+// readGitExclude returns the contents of the per-repo git exclude file.
+func readGitExclude(t *testing.T, repoDir string) (string, error) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	return string(data), err
 }


### PR DESCRIPTION
## Summary

Add an opt-in config option that, when enabled, creates a relative symlink to the source repo's `.env` inside each worktree at creation time. Default: **off**, so existing users see no change.

Symlink (not copy) is the right primitive:

- Rotating the secret in the source `.env` updates every worktree automatically.
- No duplicate secret material on disk to clean up when worktrees are pruned.
- Removing the worktree removes the symlink — no stale references.

## Problem

Fabrik creates a per-issue git worktree and runs Claude inside it. Worktrees share the main repo's `.git` but only contain *tracked* files — gitignored files at the source repo's root (notably `.env`) are not present in the worktree.

This silently breaks every workflow that depends on `.env` for credentials. Concrete case: in the Fantasy project, `apps/cli/package.json`'s `start` script uses Node's `--env-file-if-exists=../../.env` to pick up `ANTHROPIC_API_KEY`. In a Fabrik worktree, that path resolves to a non-existent file, the flag silently no-ops, and the LLM-driven CLI cannot self-test because it has no API key. The Implement stage may pass tests (which are mocked) only to produce code that cannot be exercised by a vibe-coding feedback loop the user expects to run inside the worktree.

The symptom is not Fabrik-specific — it is the standard mismatch between "secrets live outside git" and "worktrees only carry git-tracked files." But Fabrik is the agent that creates the worktree, so it is the right place to fix it.

## Approach

### Approach

Add `SymlinkEnv` as a standard boolean config field following the existing pattern (`GitSSH`, `AutoUpgrade`, `DebugOutput`). The feature is gated by a new `Engine` method `symlinkEnvIfEnabled(issueNumber int, workDir string)` that owns all the symlink logic and guards against all failure modes (source absent, dest exists, symlink syscall fails). The `WorktreeManager` is intentionally kept unaware of this feature.

**Read-only stage stash interaction decision**: Insert `symlinkEnvIfEnabled` in `item.go` _after_ `writeContextFiles` (post-stash, pre-Claude). This mirrors the existing comment "Write context files after any stash so they are present for Claude but not captured in the stash" — the `.env` symlink follows the same rationale. For `comments.go`, insert immediately after `EnsureWorktree` (no stash cycle exists there).

**Symlink target decision**: Compute a relative path via `filepath.Rel(workDir, fabrikDotEnv)`. Fall back to absolute only if `filepath.Rel` returns `err != nil` (Windows cross-drive). Do NOT fall back on `..` prefixes — those are the normal case in the standard layout.

**No ADR warranted**: The config/env/flag pattern is covered by ADR 013, the worktree + fabrikDir pattern is covered by ADRs 006 and 023. No new non-obvious architectural decision is introduced.

### New/Modified Files

| File | Change |
|------|--------|
| `config/config.go` | Add `SymlinkEnv bool \`yaml:"symlink_env"\`` to `ProjectConfig` |
| `cmd/root.go` | Add `SymlinkEnv bool` to `cmd.Config`, register `--symlink-env` flag, add `FABRIK_SYMLINK_ENV` env resolution, pass to `engine.Config` |
| `engine/engine.go` | Add `SymlinkEnv bool` to `engine.Config` |
| `engine/worktree.go` | New file `engine/symlink_env.go` (or new method in existing file) — `symlinkEnvIfEnabled` |
| `engine/item.go` | Add `e.symlinkEnvIfEnabled(item.Number, workDir)` call after `writeContextFiles` |
| `engine/comments.go` | Add `e.symlinkEnvIfEnabled(item.Number, workDir)` call after `EnsureWorktree` succeeds |
| `config/config_test.go` | Test `SymlinkEnv` default is `false`; test it loads from YAML |
| `cmd/cmd_envvar_test.go` | Test `FABRIK_SYMLINK_ENV` env var and `--symlink-env` flag precedence |
| `engine/symlink_env_test.go` | Four behavioral unit tests |
| `.fabrik/config.yaml` | Add commented `# symlink_env: false` entry with explanation |
| `docs/USER_GUIDE.md` | Add `--symlink-env` flag row and `FABRIK_SYMLINK_ENV` env var row |
| `docs/llms-full.txt` | Regenerate after `USER_GUIDE.md` changes |

### Key Decisions

- **`symlinkEnvIfEnabled` as an `Engine` method, not `WorktreeManager`**: The method needs `e.cfg.SymlinkEnv`, `e.fabrikDir`, and `e.logf` — all on `Engine`. `WorktreeManager` is kept as a pure git-lifecycle concern with no fabrikDir awareness, consistent with existing design.

- **New file `engine/symlink_env.go`**: Keeps the new logic isolated and testable without bloating `item.go` or `worktree.go`. A single focused file is easier to review.

- **Insertion in `item.go` after `writeContextFiles`**: Mirrors context files' rationale — present for Claude but not stashed. Avoids the stash-in/stash-out churn on every read-only stage invocation. This placement requires no additional insertion point — the existing post-stash, pre-Claude section already handles ephemeral pre-invocation setup.

- **Insertion in `comments.go` after `EnsureWorktree`**: No stash cycle here, so the call goes right after worktree confirmation. Consistent with item.go's intent of "symlink is present when Claude runs."

- **Relative path default, absolute fallback only on `filepath.Rel` error**: Consistent with the spec and research. The `..` prefix (e.g. `../../../../.env`) is the standard case and not a fallback trigger.

- **No ADR**: The pattern is fully covered by ADRs 006, 013, and 023.

### Task Checklist

- [ ] Task 1: Add `SymlinkEnv bool \`yaml:"symlink_env"\`` to `ProjectConfig` in `config/config.go` and add `TestLoadProjectConfig_ValidYAML` coverage for the new field
- [ ] Task 2: Add `SymlinkEnv bool` to `cmd.Config` in `cmd/root.go`; register `--symlink-env` flag; add `FABRIK_SYMLINK_ENV` env resolution following the `GitSSH`/`FABRIK_GIT_SSH` pattern; pass `SymlinkEnv: cfg.SymlinkEnv` in the `engine.Config{...}` literal
- [ ] Task 3: Add `SymlinkEnv bool` to `engine.Config` in `engine/engine.go`
- [ ] Task 4: Add `FABRIK_SYMLINK_ENV` / `--symlink-env` test to `cmd/cmd_envvar_test.go` covering the full precedence chain (flag > env > config > default false)
- [ ] Task 5: Create `engine/symlink_env.go` with `func (e *Engine) symlinkEnvIfEnabled(issueNumber int, workDir string)` implementing:
  - Early return when `!e.cfg.SymlinkEnv`
  - Check source `filepath.Join(e.fabrikDir, ".env")` existence; no-op if absent
  - Check `filepath.Join(workDir, ".env")` existence via `os.Lstat`; debug-log and return if it exists
  - Compute relative target via `filepath.Rel(workDir, source)`; fall back to absolute on error
  - Call `os.Symlink`; on failure log a warning and return (non-fatal)
- [ ] Task 6: Create `engine/symlink_env_test.go` with four behavioral unit tests:
  - `TestSymlinkEnvIfEnabled_SourcePresent`: enabled + source exists → symlink created, resolves to source content
  - `TestSymlinkEnvIfEnabled_SourceAbsent`: enabled + source absent → no `.env` in worktree, no error
  - `TestSymlinkEnvIfEnabled_DestExists`: enabled + `.env` already in worktree → left untouched
  - `TestSymlinkEnvIfEnabled_Disabled`: `SymlinkEnv: false` → no symlink created even when source exists
- [ ] Task 7: Add `e.symlinkEnvIfEnabled(item.Number, workDir)` call in `engine/item.go` after `e.writeContextFiles(item, stage, workDir, false)` (line ~697), before Claude invocation
- [ ] Task 8: Add `e.symlinkEnvIfEnabled(item.Number, workDir)` call in `engine/comments.go` after successful `EnsureWorktree` (line ~137), before `e.writeContextFiles`
- [ ] Task 9: Add commented `symlink_env` entry to `.fabrik/config.yaml` optional settings block (matching the style of existing commented-out bool fields like `# auto_upgrade: false`)
- [ ] Task 10: Update `docs/USER_GUIDE.md` — add `--symlink-env` row to the flags table and `FABRIK_SYMLINK_ENV` row to the env vars table; include a brief description referencing the `.env` worktree symlink behavior
- [ ] Task 11: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh` and commit alongside the USER_GUIDE changes
- [ ] Task 12: Run `go test ./...` and `go vet ./...`; confirm all tests pass

### Risks

- **`git stash -u` capturing the symlink** (read-only stages): Mitigated by placing the call after `writeContextFiles` (post-stash). If somehow a symlink pre-dates the stash (from a prior invocation), the "dest exists → leave it alone" rule handles the idempotent case on re-entry. No additional risk.
- **Managed repo has a tracked `.env`**: After `EnsureWorktree`, `workDir/.env` would exist as a tracked file. `os.Lstat` catches it; the "leave it alone" rule means we never overwrite — correct behavior.
- **Windows symlinks**: `os.Symlink` may fail without elevated privileges. The `logf(warn)` + continue path handles this; spec explicitly accepts it.
- **Network FS rejecting symlinks**: Same warning path. Non-fatal by design.

---
Used 13/50 turns, 5k input / 4k output tokens.

## Verification

Implemented the `symlink_env` config-gated worktree `.env` symlink feature across all layers: `ProjectConfig`, `cmd.Config`, and `engine.Config` each gained a `SymlinkEnv bool` field wired through the standard CLI flag (`--symlink-env`) / env var (`FABRIK_SYMLINK_ENV`) / config.yaml (`symlink_env`) precedence chain. The `symlinkEnvIfEnabled` engine method creates a relative symlink at `<worktree>/.env` pointing to `fabrikDir/.env`, with full safety guards (source absent → no-op, dest exists → leave untouched, symlink fails → warn and continue). Four behavioral unit tests cover all cases; docs updated in `USER_GUIDE.md` and `.fabrik/config.yaml`; `docs/llms-full.txt` regenerated. Full test suite passes with race detector.

---

Closes #683