### PR TITLE
fabrik: skip deep-fetch for terminal Done items in probe-driven poll loop

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3870,6 +3870,27 @@ The probe loop:
 
 `FetchItemDetails` writes `ItemDeepFetched` to the Store, updating `LastSeenSourceUpdatedAt` to the new `effectiveUpdatedAt`. The candidates loop that runs later in the same poll cycle sees these items as fresh (via `IsItemCacheFresh`) and skips duplicate fetches.
 
+**Terminal-item skip**
+
+An item is **terminal** once Fabrik has confirmed it has nothing left to do: its status is a cleanup stage (e.g. `Done`), its labels include `stage:<StageName>:complete`, and no transient lifecycle label (`fabrik:awaiting-review`, `fabrik:awaiting-ci`, `fabrik:awaiting-input`, `fabrik:rebase-needed`, `fabrik:bot-reprompted`) or lock label (`fabrik:locked:*`) is present.
+
+Terminal state is stored as a `Terminal bool` field in `ItemState` and set/cleared via the `TerminalFlagSet` mutation.
+
+**When the flag is set**: after a successful `FetchItemDetails` call in either `runProbeAndDeepFetch` or the admit pass, if `isTerminalPredicate(labels, status, stages)` returns true. Logged once (first-time only) at `[poll] terminal flag set`.
+
+**When the flag is cleared**:
+- `applyProbeItem` clears `Terminal` whenever the item's `Status` changes (probe shows the item left the cleanup column).
+- `applyShallowItem` clears it on any status change during reconciliation.
+- `applyProjectV2ItemEdited` (Layer 2 status sweep) clears it when the board status changes.
+- `LocalStatusUpdated` clears it when the engine itself changes the item's status.
+- The probe loop's terminal gate and the admit pass terminal gate each clear the flag explicitly and log `[poll] terminal flag cleared (status drifted to ...)` when the probe shows the item in a non-cleanup stage.
+
+**Probe-loop skip**: the terminal gate in `runProbeAndDeepFetch` runs **before** `ProbeBoardItemUpdated` is applied (ordering constraint: the cached `Terminal` flag must be read before `applyProbeItem` would clear it on a status change). If `Terminal == true` and the probe's status is still a cleanup stage, the item is skipped without any deep-fetch. If `Terminal == true` but the probe shows a non-cleanup status, the flag is cleared and the item falls through to normal probe processing.
+
+**Admit-pass skip**: the same gate in the per-poll admit pass (before the `cycleSet` check) unconditionally skips items that are terminal and still in the cleanup stage. This guard is redundant for the normal probe path (where `runProbeAndDeepFetch` already handled the item) but covers non-cache and paused-cache modes.
+
+**Cold-start (startup scan)**: after `runStartupTransientLabelScan` removes stale transient labels, `runStartupTerminalScan` iterates all items in the Store and applies `TerminalFlagSet{Terminal: true}` to any that pass the terminal predicate. This uses bootstrap label data already present in the Store — no GitHub API call is needed. On a 362-item board with 340 terminal Done items, this eliminates ~340 deep-fetches on the first poll cycle.
+
 **`Reconcile` is now Bootstrap-path only**: `cacheImpl.Reconcile(board)` is only called during Bootstrap (first poll, unbootstrapped cache) and during drift-recovery in webhook mode (see below). It is no longer called on every poll cycle.
 
 **Full reconcile — drift-recovery (webhook mode)**

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1805,6 +1805,27 @@ The probe loop:
 
 `FetchItemDetails` writes `ItemDeepFetched` to the Store, updating `LastSeenSourceUpdatedAt` to the new `effectiveUpdatedAt`. The candidates loop that runs later in the same poll cycle sees these items as fresh (via `IsItemCacheFresh`) and skips duplicate fetches.
 
+**Terminal-item skip**
+
+An item is **terminal** once Fabrik has confirmed it has nothing left to do: its status is a cleanup stage (e.g. `Done`), its labels include `stage:<StageName>:complete`, and no transient lifecycle label (`fabrik:awaiting-review`, `fabrik:awaiting-ci`, `fabrik:awaiting-input`, `fabrik:rebase-needed`, `fabrik:bot-reprompted`) or lock label (`fabrik:locked:*`) is present.
+
+Terminal state is stored as a `Terminal bool` field in `ItemState` and set/cleared via the `TerminalFlagSet` mutation.
+
+**When the flag is set**: after a successful `FetchItemDetails` call in either `runProbeAndDeepFetch` or the admit pass, if `isTerminalPredicate(labels, status, stages)` returns true. Logged once (first-time only) at `[poll] terminal flag set`.
+
+**When the flag is cleared**:
+- `applyProbeItem` clears `Terminal` whenever the item's `Status` changes (probe shows the item left the cleanup column).
+- `applyShallowItem` clears it on any status change during reconciliation.
+- `applyProjectV2ItemEdited` (Layer 2 status sweep) clears it when the board status changes.
+- `LocalStatusUpdated` clears it when the engine itself changes the item's status.
+- The probe loop's terminal gate and the admit pass terminal gate each clear the flag explicitly and log `[poll] terminal flag cleared (status drifted to ...)` when the probe shows the item in a non-cleanup stage.
+
+**Probe-loop skip**: the terminal gate in `runProbeAndDeepFetch` runs **before** `ProbeBoardItemUpdated` is applied (ordering constraint: the cached `Terminal` flag must be read before `applyProbeItem` would clear it on a status change). If `Terminal == true` and the probe's status is still a cleanup stage, the item is skipped without any deep-fetch. If `Terminal == true` but the probe shows a non-cleanup status, the flag is cleared and the item falls through to normal probe processing.
+
+**Admit-pass skip**: the same gate in the per-poll admit pass (before the `cycleSet` check) unconditionally skips items that are terminal and still in the cleanup stage. This guard is redundant for the normal probe path (where `runProbeAndDeepFetch` already handled the item) but covers non-cache and paused-cache modes.
+
+**Cold-start (startup scan)**: after `runStartupTransientLabelScan` removes stale transient labels, `runStartupTerminalScan` iterates all items in the Store and applies `TerminalFlagSet{Terminal: true}` to any that pass the terminal predicate. This uses bootstrap label data already present in the Store — no GitHub API call is needed. On a 362-item board with 340 terminal Done items, this eliminates ~340 deep-fetches on the first poll cycle.
+
 **`Reconcile` is now Bootstrap-path only**: `cacheImpl.Reconcile(board)` is only called during Bootstrap (first poll, unbootstrapped cache) and during drift-recovery in webhook mode (see below). It is no longer called on every poll cycle.
 
 **Full reconcile — drift-recovery (webhook mode)**

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1040,15 +1040,18 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		// Items with an active CooldownAt but no other signal are suppressed.
 		item := board.Items[i]
 		iKey := issueKey(item, e.defaultRepo())
-		// Terminal skip: unconditionally skip items flagged terminal while still in
-		// a cleanup stage — external board activity (label-bot, PR comments, GitHub
-		// bookkeeping) bumps updatedAt but Fabrik has nothing left to do for them.
+		// Terminal skip: skip items flagged terminal while still in the same cleanup
+		// stage — external board activity (label-bot, PR comments, GitHub bookkeeping)
+		// bumps updatedAt but Fabrik has nothing left to do for them.
+		// item.Status == admitSnap.Status() guards against items that moved between two
+		// cleanup stages: in that case we must process normally to update the store.
 		if admitSnap, admitErr := e.store.Get(itemOwnerRepoString(item, e.defaultRepo()), item.Number); admitErr == nil {
 			if admitSnap.IsTerminal() {
-				if pst := stages.FindStage(e.cfg.Stages, item.Status); pst != nil && pst.CleanupWorktree {
-					continue // terminal + still in cleanup stage: skip entirely
+				if pst := stages.FindStage(e.cfg.Stages, item.Status); pst != nil && pst.CleanupWorktree && item.Status == admitSnap.Status() {
+					continue // terminal + still in same cleanup stage: skip entirely
 				}
-				// Status drifted out of the cleanup stage — clear the flag and fall through.
+				// Status changed (left cleanup or moved to a different cleanup stage) —
+				// clear the flag and fall through.
 				e.store.Apply(itemstate.TerminalFlagSet{
 					Repo:     itemOwnerRepoString(item, e.defaultRepo()),
 					Number:   item.Number,
@@ -1586,15 +1589,18 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 		}
 
 		// Terminal skip: if this item was previously identified as terminal and the
-		// probe still shows it in a cleanup stage, skip deep-fetch entirely — external
-		// activity on a closed Done item has no bearing on Fabrik's work. Must run
-		// BEFORE ProbeBoardItemUpdated so we read the cached Terminal flag; applyProbeItem
-		// would clear it on status change before we could react to pi.Status.
+		// probe still shows it in the same cleanup stage, skip deep-fetch entirely —
+		// external activity on a closed Done item has no bearing on Fabrik's work.
+		// Must run BEFORE ProbeBoardItemUpdated so we read the cached Terminal flag;
+		// applyProbeItem would clear it on status change before we could react to pi.Status.
+		// pi.Status == s.Status guards against items that moved between two cleanup stages:
+		// in that case we must apply the probe update so the store reflects the new status.
 		if s.Terminal {
-			if pst := stages.FindStage(e.cfg.Stages, pi.Status); pst != nil && pst.CleanupWorktree {
-				continue // still terminal — no deep-fetch needed
+			if pst := stages.FindStage(e.cfg.Stages, pi.Status); pst != nil && pst.CleanupWorktree && pi.Status == s.Status {
+				continue // still terminal in the same cleanup stage — no deep-fetch needed
 			}
-			// Status has left the cleanup stage — clear the flag and fall through.
+			// Status changed (left the cleanup stage or moved to a different one) — clear
+			// the flag and fall through to normal probe processing.
 			e.store.Apply(itemstate.TerminalFlagSet{Repo: repo, Number: pi.Number, Terminal: false})
 			e.logf(pi.Number, "poll", "terminal flag cleared (status drifted to %q)\n", pi.Status)
 		}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -583,6 +583,7 @@ func (e *Engine) Run() error {
 	if firstPollErr == nil {
 		e.runStartupCleanup()
 		e.runStartupTransientLabelScan()
+		e.runStartupTerminalScan()
 	}
 
 	// Start background stale-worker detector. Scans for workers whose heartbeat
@@ -1039,6 +1040,23 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		// Items with an active CooldownAt but no other signal are suppressed.
 		item := board.Items[i]
 		iKey := issueKey(item, e.defaultRepo())
+		// Terminal skip: unconditionally skip items flagged terminal while still in
+		// a cleanup stage — external board activity (label-bot, PR comments, GitHub
+		// bookkeeping) bumps updatedAt but Fabrik has nothing left to do for them.
+		if admitSnap, admitErr := e.store.Get(itemOwnerRepoString(item, e.defaultRepo()), item.Number); admitErr == nil {
+			if admitSnap.IsTerminal() {
+				if pst := stages.FindStage(e.cfg.Stages, item.Status); pst != nil && pst.CleanupWorktree {
+					continue // terminal + still in cleanup stage: skip entirely
+				}
+				// Status drifted out of the cleanup stage — clear the flag and fall through.
+				e.store.Apply(itemstate.TerminalFlagSet{
+					Repo:     itemOwnerRepoString(item, e.defaultRepo()),
+					Number:   item.Number,
+					Terminal: false,
+				})
+				e.logf(item.Number, "poll", "terminal flag cleared (status drifted to %q)\n", item.Status)
+			}
+		}
 		if !cycleSet[iKey] {
 			stage := stages.FindStage(e.cfg.Stages, item.Status)
 			isCleanup := stage != nil && stage.CleanupWorktree
@@ -1089,11 +1107,20 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			// The next poll will retry the deep-fetch for this item.
 			continue
 		}
+		admitRepo := itemOwnerRepoString(board.Items[i], e.defaultRepo())
+		admitPreSnap, admitPreErr := e.store.Get(admitRepo, board.Items[i].Number)
 		e.store.Apply(itemstate.ItemDeepFetched{
-			Repo:       itemOwnerRepoString(board.Items[i], e.defaultRepo()),
+			Repo:       admitRepo,
 			Number:     board.Items[i].Number,
 			FreshState: board.Items[i],
 		})
+		// After a successful deep-fetch, check if this item just became terminal.
+		if isTerminalPredicate(board.Items[i].Labels, board.Items[i].Status, e.cfg.Stages) {
+			if admitPreErr != nil || !admitPreSnap.IsTerminal() {
+				e.logf(board.Items[i].Number, "poll", "terminal flag set\n")
+			}
+			e.store.Apply(itemstate.TerminalFlagSet{Repo: admitRepo, Number: board.Items[i].Number, Terminal: true})
+		}
 		deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
 		deepFetched++
 	}
@@ -1558,6 +1585,20 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 			e.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: pi.Number})
 		}
 
+		// Terminal skip: if this item was previously identified as terminal and the
+		// probe still shows it in a cleanup stage, skip deep-fetch entirely — external
+		// activity on a closed Done item has no bearing on Fabrik's work. Must run
+		// BEFORE ProbeBoardItemUpdated so we read the cached Terminal flag; applyProbeItem
+		// would clear it on status change before we could react to pi.Status.
+		if s.Terminal {
+			if pst := stages.FindStage(e.cfg.Stages, pi.Status); pst != nil && pst.CleanupWorktree {
+				continue // still terminal — no deep-fetch needed
+			}
+			// Status has left the cleanup stage — clear the flag and fall through.
+			e.store.Apply(itemstate.TerminalFlagSet{Repo: repo, Number: pi.Number, Terminal: false})
+			e.logf(pi.Number, "poll", "terminal flag cleared (status drifted to %q)\n", pi.Status)
+		}
+
 		// Apply probe state (updates IsClosed, State, IsPR, Status, UpdatedAt;
 		// intentionally skips Labels to preserve webhook-driven label state).
 		e.store.Apply(itemstate.ProbeBoardItemUpdated{Repo: repo, Number: pi.Number, Item: pi})
@@ -1584,6 +1625,13 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 			continue
 		}
 		deepFetched++
+		// After a successful deep-fetch, check if this item is now terminal.
+		if isTerminalPredicate(minimal.Labels, minimal.Status, e.cfg.Stages) {
+			if !s.Terminal {
+				e.logf(pi.Number, "poll", "terminal flag set\n")
+			}
+			e.store.Apply(itemstate.TerminalFlagSet{Repo: repo, Number: pi.Number, Terminal: true})
+		}
 	}
 
 	// Remove items no longer on the board.
@@ -1598,6 +1646,39 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 	if deepFetched > 0 {
 		e.logf(0, "cache", "probe: deep-fetched %d item(s)\n", deepFetched)
 	}
+}
+
+// isTerminalPredicate reports whether an item with the given labels and board
+// status qualifies as terminal: it must be in a cleanup (Done) stage, carry the
+// stage:Name:complete label, and have no transient lifecycle or lock labels.
+// Terminal items have no remaining Fabrik work and may safely skip deep-fetch.
+func isTerminalPredicate(labels []string, status string, stagesCfg []*stages.Stage) bool {
+	st := stages.FindStage(stagesCfg, status)
+	if st == nil || !st.CleanupWorktree {
+		return false
+	}
+	completeLabel := "stage:" + st.Name + ":complete"
+	hasComplete := false
+	for _, l := range labels {
+		if l == completeLabel {
+			hasComplete = true
+			break
+		}
+	}
+	if !hasComplete {
+		return false
+	}
+	for _, l := range labels {
+		for _, tl := range transientLifecycleLabels {
+			if l == tl {
+				return false
+			}
+		}
+		if strings.HasPrefix(l, "fabrik:locked:") {
+			return false
+		}
+	}
+	return true
 }
 
 // runStartupTransientLabelScan is a one-shot recovery pass that runs after the
@@ -1651,6 +1732,32 @@ func (e *Engine) runStartupTransientLabelScan() {
 	board := &gh.ProjectBoard{Items: items}
 	e.cleanupClosedIssueLocks(board)
 	e.cleanupClosedIssueTransientLabels(board)
+}
+
+// runStartupTerminalScan marks terminal items in the Store after the first
+// successful poll. It uses bootstrap label data already present in the Store
+// (populated by FetchProjectBoard + Reset) so no GitHub API call is needed.
+// Must run after runStartupTransientLabelScan so stale transient labels have
+// been removed before the predicate is evaluated.
+func (e *Engine) runStartupTerminalScan() {
+	snaps := e.store.All()
+	var marked int
+	for _, snap := range snaps {
+		if snap.IsTerminal() {
+			continue // already set — no-op path
+		}
+		if isTerminalPredicate(snap.Labels(), snap.Status(), e.cfg.Stages) {
+			e.store.Apply(itemstate.TerminalFlagSet{
+				Repo:     snap.Repo(),
+				Number:   snap.Number(),
+				Terminal: true,
+			})
+			marked++
+		}
+	}
+	if marked > 0 {
+		e.logf(0, "startup", "terminal scan: marked %d item(s) as terminal\n", marked)
+	}
 }
 
 // checkAndUpgrade selects the upgrade path based on the running version:

--- a/engine/terminal_test.go
+++ b/engine/terminal_test.go
@@ -271,6 +271,71 @@ func TestIsTerminalPredicate_LockLabelPrefix(t *testing.T) {
 	}
 }
 
+// TestRunProbeAndDeepFetch_TerminalItem_MovedBetweenCleanupStages ensures that
+// when a terminal item's probe shows a different cleanup stage (not just
+// non-cleanup), the terminal flag is cleared and the probe update is applied.
+func TestRunProbeAndDeepFetch_TerminalItem_MovedBetweenCleanupStages(t *testing.T) {
+	var deepFetchCalls int
+
+	twoCleanupStages := []*stages.Stage{
+		{Name: "Research", Order: 1, Prompt: "p", Completion: stages.CompletionCriteria{Type: "claude"}},
+		{Name: "Done", Order: 90, CleanupWorktree: true},
+		{Name: "Archive", Order: 99, CleanupWorktree: true},
+	}
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				// Item moved from "Done" to "Archive" — both are cleanup stages.
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+					Status: "Archive", EffectiveUpdatedAt: time.Now()},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			// Return labels that do NOT satisfy the terminal predicate for "Archive"
+			// (no stage:Archive:complete) so the item is not re-terminalized after fetch.
+			item.Labels = []string{"stage:Archive:in_progress"}
+			item.Status = "Archive"
+			return nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner: "owner", Repo: "repo", ProjectNum: 1,
+			User: "testuser", Token: "token", MaxConcurrent: 5,
+			Stages: twoCleanupStages,
+		},
+		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"),
+	)
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo",
+				Status: "Done", IsClosed: true, Labels: []string{"stage:Done:complete"},
+				UpdatedAt: time.Now().Add(-time.Hour)},
+		},
+	})
+	eng.readClient = cache
+
+	// Mark terminal in "Done".
+	eng.store.Apply(itemstate.TerminalFlagSet{Repo: "owner/repo", Number: 1, Terminal: true})
+
+	eng.runProbeAndDeepFetch(cache)
+
+	// Terminal flag must have been cleared (status moved to different cleanup stage).
+	snap, _ := eng.store.Get("owner/repo", 1)
+	if snap.IsTerminal() {
+		t.Error("terminal flag should be cleared when item moves to a different cleanup stage")
+	}
+	// Deep-fetch must have fired.
+	if deepFetchCalls == 0 {
+		t.Error("expected FetchItemDetails called after terminal cleared on cleanup-stage move; got 0")
+	}
+}
+
 // TestRunStartupTerminalScan_UsesCleanupStageNotHardcodedDone ensures that
 // the terminal scan works for any cleanup stage name, not just "Done".
 func TestRunStartupTerminalScan_UsesCleanupStageNotHardcodedDone(t *testing.T) {

--- a/engine/terminal_test.go
+++ b/engine/terminal_test.go
@@ -1,0 +1,310 @@
+package engine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/boardcache"
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// ---- isTerminalPredicate unit tests (Task 11) ----
+
+func TestIsTerminalPredicate_CleanupCompleteNoTransient(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	labels := []string{"stage:Done:complete"}
+	if !isTerminalPredicate(labels, "Done", stagesCfg) {
+		t.Error("expected terminal=true for cleanup stage + complete label + no transient")
+	}
+}
+
+func TestIsTerminalPredicate_HasAwaitingCI(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	labels := []string{"stage:Done:complete", "fabrik:awaiting-ci"}
+	if isTerminalPredicate(labels, "Done", stagesCfg) {
+		t.Error("expected terminal=false when fabrik:awaiting-ci is present")
+	}
+}
+
+func TestIsTerminalPredicate_HasLockLabel(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	labels := []string{"stage:Done:complete", "fabrik:locked:bob"}
+	if isTerminalPredicate(labels, "Done", stagesCfg) {
+		t.Error("expected terminal=false when fabrik:locked:* is present")
+	}
+}
+
+func TestIsTerminalPredicate_NoCompleteLabel(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	labels := []string{"bug", "enhancement"}
+	if isTerminalPredicate(labels, "Done", stagesCfg) {
+		t.Error("expected terminal=false without stage:Done:complete label")
+	}
+}
+
+func TestIsTerminalPredicate_NonCleanupStage(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	labels := []string{"stage:Implement:complete"}
+	if isTerminalPredicate(labels, "Implement", stagesCfg) {
+		t.Error("expected terminal=false for non-cleanup stage")
+	}
+}
+
+func TestIsTerminalPredicate_UnknownStatus(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	labels := []string{"stage:Unknown:complete"}
+	if isTerminalPredicate(labels, "Unknown", stagesCfg) {
+		t.Error("expected terminal=false for unknown status")
+	}
+}
+
+func TestIsTerminalPredicate_AllTransientLabels(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	for _, tl := range transientLifecycleLabels {
+		labels := []string{"stage:Done:complete", tl}
+		if isTerminalPredicate(labels, "Done", stagesCfg) {
+			t.Errorf("expected terminal=false when transient label %q is present", tl)
+		}
+	}
+}
+
+// ---- runStartupTerminalScan tests (Task 12) ----
+
+func testEngineWithCleanup(client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
+	return NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStagesWithCleanup(),
+		},
+		client,
+		claude,
+		NewWorktreeManager("/tmp/test-repo"),
+	)
+}
+
+func TestRunStartupTerminalScan_MarksTerminalItems(t *testing.T) {
+	eng := testEngineWithCleanup(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	// Item 1: terminal — Done + stage:Done:complete + no transient labels.
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo:     "owner/repo",
+		Number:   1,
+		Status:   "Done",
+		IsClosed: true,
+		Labels:   []string{"stage:Done:complete"},
+	}})
+
+	// Item 2: not terminal — Done + stage:Done:complete but has transient label.
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo:     "owner/repo",
+		Number:   2,
+		Status:   "Done",
+		IsClosed: true,
+		Labels:   []string{"stage:Done:complete", "fabrik:awaiting-ci"},
+	}})
+
+	// Item 3: not terminal — non-Done stage.
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo:     "owner/repo",
+		Number:   3,
+		Status:   "Implement",
+		IsClosed: false,
+		Labels:   []string{"stage:Implement:complete"},
+	}})
+
+	eng.runStartupTerminalScan()
+
+	snap1, _ := eng.store.Get("owner/repo", 1)
+	if !snap1.IsTerminal() {
+		t.Error("item 1 (terminal): expected IsTerminal()=true after runStartupTerminalScan")
+	}
+
+	snap2, _ := eng.store.Get("owner/repo", 2)
+	if snap2.IsTerminal() {
+		t.Error("item 2 (has transient label): expected IsTerminal()=false")
+	}
+
+	snap3, _ := eng.store.Get("owner/repo", 3)
+	if snap3.IsTerminal() {
+		t.Error("item 3 (non-Done stage): expected IsTerminal()=false")
+	}
+}
+
+func TestRunStartupTerminalScan_IdempotentOnAlreadyTerminal(t *testing.T) {
+	eng := testEngineWithCleanup(&mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo:     "owner/repo",
+		Number:   1,
+		Status:   "Done",
+		IsClosed: true,
+		Labels:   []string{"stage:Done:complete"},
+	}})
+	eng.store.Apply(itemstate.TerminalFlagSet{Repo: "owner/repo", Number: 1, Terminal: true})
+
+	// Calling again should be a no-op — no panic, no duplicate logging side-effects.
+	eng.runStartupTerminalScan()
+
+	snap, _ := eng.store.Get("owner/repo", 1)
+	if !snap.IsTerminal() {
+		t.Error("item should still be terminal after second scan")
+	}
+}
+
+// ---- probe-loop terminal skip tests (Task 13) ----
+
+// testEngineWithCleanupCache creates an Engine with testStagesWithCleanup and a
+// live CacheImpl seeded with one item already in "Done" with stage:Done:complete.
+func testEngineWithCleanupCache(client *mockGitHubClient, claude *mockClaudeInvoker) (*Engine, *boardcache.CacheImpl) {
+	eng := testEngineWithCleanup(client, claude)
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{
+				ID:       "I_001",
+				ItemID:   "PVTI_001",
+				Number:   1,
+				Repo:     "owner/repo",
+				Status:   "Done",
+				IsClosed: true,
+				Labels:   []string{"stage:Done:complete"},
+				UpdatedAt: time.Now().Add(-time.Hour),
+			},
+		},
+	})
+	eng.readClient = cache
+	return eng, cache
+}
+
+func TestRunProbeAndDeepFetch_TerminalItem_SkipsDeepFetch(t *testing.T) {
+	var deepFetchCalls int
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				// EffectiveUpdatedAt is newer than T1 (would normally trigger deep-fetch).
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+					Status: "Done", EffectiveUpdatedAt: time.Now()},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			return nil
+		},
+	}
+	eng, cache := testEngineWithCleanupCache(client, &mockClaudeInvoker{})
+
+	// Mark item 1 as terminal (simulate prior deep-fetch that found it terminal).
+	eng.store.Apply(itemstate.TerminalFlagSet{Repo: "owner/repo", Number: 1, Terminal: true})
+
+	eng.runProbeAndDeepFetch(cache)
+
+	if deepFetchCalls != 0 {
+		t.Errorf("terminal item in Done: expected 0 FetchItemDetails calls; got %d", deepFetchCalls)
+	}
+
+	// Terminal flag must still be set after the skip.
+	snap, _ := eng.store.Get("owner/repo", 1)
+	if !snap.IsTerminal() {
+		t.Error("terminal flag should remain set after probe-loop skip")
+	}
+}
+
+func TestRunProbeAndDeepFetch_TerminalItem_StatusDrift_ClearsFlagAndDeepFetches(t *testing.T) {
+	var deepFetchCalls int
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				// Item now shows "Implement" — user dragged it out of Done.
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+					Status: "Implement", EffectiveUpdatedAt: time.Now()},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			item.Labels = []string{"stage:Implement:in_progress"} // populate labels
+			return nil
+		},
+	}
+	eng, cache := testEngineWithCleanupCache(client, &mockClaudeInvoker{})
+
+	// Pre-set terminal flag.
+	eng.store.Apply(itemstate.TerminalFlagSet{Repo: "owner/repo", Number: 1, Terminal: true})
+
+	eng.runProbeAndDeepFetch(cache)
+
+	// Status drifted out of Done → terminal flag should be cleared.
+	snap, _ := eng.store.Get("owner/repo", 1)
+	if snap.IsTerminal() {
+		t.Error("terminal flag should have been cleared when status left Done")
+	}
+
+	// Deep-fetch must have fired (item is no longer terminal).
+	if deepFetchCalls == 0 {
+		t.Error("expected FetchItemDetails called after terminal flag cleared; got 0 calls")
+	}
+}
+
+// TestIsTerminalPredicate_LockLabelPrefix verifies that any fabrik:locked:*
+// label (not just the engine user's own) blocks the predicate.
+func TestIsTerminalPredicate_LockLabelPrefix(t *testing.T) {
+	stagesCfg := testStagesWithCleanup()
+	lockVariants := []string{
+		"fabrik:locked:alice",
+		"fabrik:locked:bob",
+		"fabrik:locked:someone-else",
+	}
+	for _, lk := range lockVariants {
+		labels := []string{"stage:Done:complete", lk}
+		if isTerminalPredicate(labels, "Done", stagesCfg) {
+			t.Errorf("expected terminal=false for lock label %q", lk)
+		}
+	}
+}
+
+// TestRunStartupTerminalScan_UsesCleanupStageNotHardcodedDone ensures that
+// the terminal scan works for any cleanup stage name, not just "Done".
+func TestRunStartupTerminalScan_UsesCleanupStageNotHardcodedDone(t *testing.T) {
+	// Create an engine with a cleanup stage named "Archived" instead of "Done".
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages: []*stages.Stage{
+				{Name: "Research", Order: 1, Prompt: "p", Completion: stages.CompletionCriteria{Type: "claude"}},
+				{Name: "Archived", Order: 99, CleanupWorktree: true},
+			},
+		},
+		&mockGitHubClient{},
+		&mockClaudeInvoker{},
+		NewWorktreeManager("/tmp/test-repo"),
+	)
+
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo:     "owner/repo",
+		Number:   10,
+		Status:   "Archived",
+		IsClosed: true,
+		Labels:   []string{"stage:Archived:complete"},
+	}})
+
+	eng.runStartupTerminalScan()
+
+	snap, _ := eng.store.Get("owner/repo", 10)
+	if !snap.IsTerminal() {
+		t.Error("expected IsTerminal()=true for cleanup stage named 'Archived'")
+	}
+}

--- a/internal/itemstate/change.go
+++ b/internal/itemstate/change.go
@@ -51,6 +51,10 @@ const (
 	// the CI gate is catch-up-driven, not wake-driven. The flag exists for
 	// observability (e.g. future TUI consumers) without forcing a poll wake.
 	CheckRunChanged
+	// TerminalChanged indicates the Terminal flag was explicitly set or cleared via
+	// TerminalFlagSet. Store-internal clears (when status changes) piggyback on
+	// StatusChanged and do not emit TerminalChanged.
+	TerminalChanged
 )
 
 // Change describes what fields a mutation altered. Delivered to every Observer

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -65,9 +65,9 @@ type ItemState struct {
 	Worker *WorkerHandle
 
 	// Terminal is set by the engine after a deep-fetch confirms the item satisfies
-	// the terminal predicate (Done status + stage:Done:complete label + no transient
-	// lifecycle labels). While set, the poll loop skips deep-fetch entirely for this
-	// item. Cleared automatically when the item's status leaves Done.
+	// the terminal predicate (cleanup-stage status + stage:<Name>:complete label + no
+	// transient lifecycle labels). While set, the poll loop skips deep-fetch entirely
+	// for this item. Cleared automatically when the item's status changes.
 	Terminal bool
 
 	// -------- TUI / invocation mirror state --------

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -64,6 +64,12 @@ type ItemState struct {
 	// Worker is present when a worker is in-flight for this item.
 	Worker *WorkerHandle
 
+	// Terminal is set by the engine after a deep-fetch confirms the item satisfies
+	// the terminal predicate (Done status + stage:Done:complete label + no transient
+	// lifecycle labels). While set, the poll loop skips deep-fetch entirely for this
+	// item. Cleared automatically when the item's status leaves Done.
+	Terminal bool
+
 	// -------- TUI / invocation mirror state --------
 
 	// LastDeepFetchAt is the time of the last successful deep fetch for this item.

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -526,6 +526,19 @@ type BaseBranchWarnRecorded struct {
 func (BaseBranchWarnRecorded) isMutation()       {}
 func (m BaseBranchWarnRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// TerminalFlagSet sets or clears the Terminal flag on an item. When Terminal is
+// true, the poll loop skips deep-fetch for this item as long as its status
+// remains in a cleanup (Done) stage. When Terminal is false, normal deep-fetch
+// evaluation resumes.
+type TerminalFlagSet struct {
+	Repo     string
+	Number   int
+	Terminal bool
+}
+
+func (TerminalFlagSet) isMutation()       {}
+func (m TerminalFlagSet) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // CIMergePendingStarted records that CI-gate merge polling has begun for the item's
 // linked PR. Sets LinkedPRState.CIMergePendingSince to At.
 // Replaces engine.ciMergePendingSince[iKey] = time.Now().

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -94,7 +94,7 @@ func (s Snapshot) Labels() []string { return copyStrings(s.state.Labels) }
 func (s Snapshot) IsClosed() bool { return s.state.IsClosed }
 
 // IsTerminal reports whether the terminal flag is set for this item.
-// When true, the poll loop skips deep-fetch as long as status remains in Done.
+// When true, the poll loop skips deep-fetch as long as status remains in a cleanup stage.
 func (s Snapshot) IsTerminal() bool { return s.state.Terminal }
 
 // Worker returns the active WorkerHandle, or nil if no worker is in-flight.

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -93,6 +93,10 @@ func (s Snapshot) Labels() []string { return copyStrings(s.state.Labels) }
 // IsClosed reports whether the issue is closed.
 func (s Snapshot) IsClosed() bool { return s.state.IsClosed }
 
+// IsTerminal reports whether the terminal flag is set for this item.
+// When true, the poll loop skips deep-fetch as long as status remains in Done.
+func (s Snapshot) IsTerminal() bool { return s.state.Terminal }
+
 // Worker returns the active WorkerHandle, or nil if no worker is in-flight.
 func (s Snapshot) Worker() *WorkerHandle {
 	if s.state.Worker == nil {

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -321,8 +321,15 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		return CommentsChanged
 
 	case LocalStatusUpdated:
-		item.Status = v.NewStatus
+		if item.Status != v.NewStatus {
+			item.Status = v.NewStatus
+			item.Terminal = false
+		}
 		return StatusChanged
+
+	case TerminalFlagSet:
+		item.Terminal = v.Terminal
+		return TerminalChanged
 
 	case LocalLabelAdded:
 		if !containsString(item.Labels, v.Label) {
@@ -619,7 +626,10 @@ func (s *Store) applyProjectV2ItemEdited(v ProjectV2ItemEdited) (Snapshot, []Cha
 	}
 	item := s.items[key]
 	before := newSnapshot(*item).state
-	item.Status = v.NewStatus
+	if item.Status != v.NewStatus {
+		item.Status = v.NewStatus
+		item.Terminal = false
+	}
 	if reflect.DeepEqual(before, *item) {
 		snap := newSnapshot(*item)
 		s.mu.Unlock()
@@ -1084,6 +1094,7 @@ func applyShallowItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 
 	if item.Status != pi.Status {
 		item.Status = pi.Status
+		item.Terminal = false
 		flags |= StatusChanged
 	}
 
@@ -1120,6 +1131,7 @@ func applyProbeItem(item *ItemState, pi gh.BoardProbeItem) ChangeFlags {
 
 	if item.Status != pi.Status {
 		item.Status = pi.Status
+		item.Terminal = false
 		flags |= StatusChanged
 	}
 

--- a/internal/itemstate/store_test.go
+++ b/internal/itemstate/store_test.go
@@ -911,3 +911,91 @@ func TestCheckRunDrainOnPRHeadSHAUpdated(t *testing.T) {
 		t.Error("pendingCheckRuns entry should have been deleted after drain")
 	}
 }
+
+// ---- TerminalFlagSet mutation ----
+
+func TestTerminalFlagSet_SetsFlag(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	snap := applyExpect(t, s, TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true}, TerminalChanged)
+	if !snap.IsTerminal() {
+		t.Error("IsTerminal() = false after TerminalFlagSet{Terminal:true}; want true")
+	}
+	if !getItem(t, s, testRepo, 1).Terminal {
+		t.Error("store item Terminal = false after TerminalFlagSet{Terminal:true}; want true")
+	}
+}
+
+func TestTerminalFlagSet_IdempotentNoOp(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+
+	var observedChanges int
+	s.Subscribe(ObserverFunc(func(c Change, _ Snapshot) { observedChanges++ }))
+
+	// Applying the same value again must produce no observer notification.
+	_, changes, err := s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("idempotent TerminalFlagSet returned %d changes; want 0", len(changes))
+	}
+	if observedChanges != 0 {
+		t.Errorf("observer notified %d times; want 0", observedChanges)
+	}
+}
+
+func TestTerminalFlagSet_ClearsFlag(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+	applyExpect(t, s, TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: false}, TerminalChanged)
+	if getItem(t, s, testRepo, 1).Terminal {
+		t.Error("store item Terminal = true after TerminalFlagSet{Terminal:false}; want false")
+	}
+}
+
+func TestTerminalFlagClearedByLocalStatusUpdated(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+
+	// Changing status must clear the terminal flag.
+	s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Validate"})
+	if getItem(t, s, testRepo, 1).Terminal {
+		t.Error("Terminal flag not cleared by LocalStatusUpdated to different status")
+	}
+
+	// Same status → flag must remain (no-op path must not clear Terminal).
+	s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+	s.Apply(LocalStatusUpdated{Repo: testRepo, Number: 1, NewStatus: "Validate"})
+	if !getItem(t, s, testRepo, 1).Terminal {
+		t.Error("Terminal flag unexpectedly cleared by LocalStatusUpdated with unchanged status")
+	}
+}
+
+func TestTerminalFlagClearedByProbeBoardItemUpdated(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+
+	probe := gh.BoardProbeItem{
+		Repo:   testRepo,
+		Number: 1,
+		Status: "Review",
+	}
+	s.Apply(ProbeBoardItemUpdated{Repo: testRepo, Number: 1, Item: probe})
+	if getItem(t, s, testRepo, 1).Terminal {
+		t.Error("Terminal flag not cleared by ProbeBoardItemUpdated with new status")
+	}
+}
+
+func TestTerminalFlagClearedByProjectV2ItemEdited(t *testing.T) {
+	s := NewStore(nil)
+	pi := testProjectItem(testRepo, 1)
+	pi.ItemID = "PVTI_terminal_test"
+	s.Apply(IssueOpened{Item: pi})
+	s.Apply(TerminalFlagSet{Repo: testRepo, Number: 1, Terminal: true})
+
+	s.Apply(ProjectV2ItemEdited{ItemID: "PVTI_terminal_test", NewStatus: "Review"})
+	if getItem(t, s, testRepo, 1).Terminal {
+		t.Error("Terminal flag not cleared by ProjectV2ItemEdited with new status")
+	}
+}


### PR DESCRIPTION
## Summary

Add a `Terminal bool` flag to per-item Store state. Once set, the admit pass in `engine/poll.go` skips deep-fetch entirely for that item, regardless of `updatedAt` drift. The flag is set after a successful deep-fetch where the terminal predicate evaluates true, and cleared when the Layer 2 status sweep observes the item leaving Done. At engine startup, the existing `runStartupTransientLabelScan` is extended to also mark all closed Done items without transient labels as terminal, avoiding a cold-start flood of deep-fetches.

## Problem

After #685 ships, the probe is cheap, but the engine still deep-fetches Done items whenever their `updatedAt` drifts (user comments on a closed PR, label bot activity, GitHub-side bookkeeping, etc.). On a 362-item board where ~340 items are terminal Done items, this is dominant residual cost — and on engine restart, the cold-start catch-up deep-fetches every Done item once just to re-establish cache, blowing through GraphQL budget in minutes.

#687 (re-enable archive) addresses this by removing Done items from the board after a grace period. That's good for board UX but slow to take effect (24h grace) and complex to get right (needs proper completion-anchored timing). It does not help the immediate cost problem.

This issue is a strictly cheaper, faster lever: **never deep-fetch terminal items, regardless of `updatedAt` drift**.

## Approach

### Approach

The research fully specifies the implementation with no open design questions. The approach follows these principles:

1. **`internal/itemstate/` first** — add the `Terminal` field, `TerminalFlagSet` mutation, `TerminalChanged` flag, `IsTerminal()` snapshot accessor, and store-internal clearing on status change in four handlers.
2. **`engine/poll.go` second** — add the `isTerminalPredicate` helper, wire the terminal skip gate in `runProbeAndDeepFetch` (before `ProbeBoardItemUpdated` is applied, per research constraint 8), wire it in the admit pass, add terminal-flag-set after successful deep-fetch in both paths, and add `runStartupTerminalScan`.
3. **Tests alongside code** — store mutation tests + engine predicate and startup-scan tests.
4. **Docs** — update `docs/state-machine.md §D.4` to document the terminal-item skip; regenerate `docs/llms-full.txt`.

**Key ordering constraint in `runProbeAndDeepFetch`**: The terminal check reads `snap.State().Terminal` (cached) and `pi.Status` (probe). It must run AFTER linkage drift detection (which may invalidate the deep cache) but BEFORE `ProbeBoardItemUpdated` is applied (which would overwrite `snap.state.Terminal` in the store). The existing item path is: Get → linkage drift → [TERMINAL CHECK HERE] → ProbeBoardItemUpdated → stale check → FetchItemDetails.

**`CacheImpl.FetchItemDetails` applies `ItemDeepFetched` internally** when it performs a real GraphQL fetch. So `minimal.Labels` is populated and the store is updated by the time execution returns from `FetchItemDetails`. The terminal-flag-set after deep-fetch reads from `minimal.Labels` and the pre-fetch `snap.State().Terminal` for first-time logging.

**Admit-pass terminal-flag-set**: Items in a cleanup stage (Done) go through the cleanup-stage shortcut, not through `FetchItemDetails`. With the current predicate (requires cleanup stage), the admit-pass `FetchItemDetails` path never produces a terminal item. The code is included per the spec for defense-in-depth against future predicate changes.

**No ADR warranted**: This is a performance heuristic that builds directly on ADR-044 (probe loop). The terminal-skip behavior is self-documenting from the predicate function and two guard sites. The behavioral impact is captured in the `docs/state-machine.md §D.4` update.

### New/Modified Files

| File | Change |
|------|--------|
| `internal/itemstate/change.go` | Add `TerminalChanged ChangeFlags` constant |
| `internal/itemstate/itemstate.go` | Add `Terminal bool` field to `ItemState` (Engine state section, after `Worker`) |
| `internal/itemstate/mutation.go` | Add `TerminalFlagSet{Repo, Number, Terminal}` mutation type |
| `internal/itemstate/snapshot.go` | Add `IsTerminal() bool` accessor |
| `internal/itemstate/store.go` | Add `TerminalFlagSet` case in `applyToItem`; clear `item.Terminal = false` in `applyProjectV2ItemEdited`, `applyShallowItem`, `applyProbeItem`, and `LocalStatusUpdated` when status changes |
| `internal/itemstate/store_test.go` | Add tests for `TerminalFlagSet` mutation and store-internal clearing |
| `engine/poll.go` | Add `isTerminalPredicate` helper; terminal skip gate + flag-set in `runProbeAndDeepFetch`; terminal skip gate + flag-set in admit pass; add `runStartupTerminalScan`; call it from `Run()` |
| `engine/terminal_test.go` (new) | Tests for `isTerminalPredicate`, `runStartupTerminalScan`, probe-loop terminal skip |
| `docs/state-machine.md` | Update §D.4 to document terminal-item skip |
| `docs/llms-full.txt` | Regenerate after updating state-machine.md |

### Key Decisions

- **`isTerminalPredicate` in `engine/poll.go`**: The store cannot import `stages` (cycle). The predicate requires `stages.FindStage`, so it belongs in the engine package where `e.cfg.Stages` is accessible. Store-internal clearing uses data-driven logic only (status string change).

- **`item.Terminal = false` piggybacked on `StatusChanged`**: No separate `TerminalChanged` emission needed for store-internal clears. The terminal flag is a local optimization; observers only need to react to `StatusChanged`. `TerminalChanged` is reserved for explicit `TerminalFlagSet` mutations so callers who apply it can observe the change.

- **`runStartupTerminalScan` as a separate function**: Clean separation from `runStartupTransientLabelScan` (which has a focused purpose: remove stale labels). Separate function is also independently testable.

- **First-time logging**: Use pre-deep-fetch `snap.State().Terminal` as the "was it already set?" sentinel before calling `e.store.Apply(TerminalFlagSet{Terminal: true})`. If already true, apply is a no-op (idempotent) and no log is emitted.

- **No `IsClosed` check in terminal predicate**: The predicate checks board state only (status + labels). `runStartupTransientLabelScan` already cleans labels before `runStartupTerminalScan` runs, so transient-label interference at startup is already handled.

### Task Checklist

- [ ] Task 1: `internal/itemstate/change.go` — add `TerminalChanged ChangeFlags` constant after the existing constants
- [ ] Task 2: `internal/itemstate/itemstate.go` — add `Terminal bool` field to `ItemState` in the Engine state section (after `Worker *WorkerHandle`); add doc comment explaining it is set by the engine after verifying the item is fully done and skips deep-fetch
- [ ] Task 3: `internal/itemstate/mutation.go` — add `TerminalFlagSet{Repo string, Number int, Terminal bool}` mutation type with `isMutation()` and `itemKey()` implementations, following the pattern of `DeepFetchFailed`
- [ ] Task 4: `internal/itemstate/snapshot.go` — add `IsTerminal() bool { return s.state.Terminal }` accessor
- [ ] Task 5: `internal/itemstate/store.go` — (a) add `case TerminalFlagSet: item.Terminal = v.Terminal; return TerminalChanged` in `applyToItem`; (b) in `applyProjectV2ItemEdited`, change direct `item.Status = v.NewStatus` to conditional clear: `if item.Status != v.NewStatus { item.Status = v.NewStatus; item.Terminal = false }`; (c) in `applyShallowItem`, inside the `item.Status != pi.Status` branch, add `item.Terminal = false`; (d) in `applyProbeItem`, inside the `item.Status != pi.Status` branch, add `item.Terminal = false`; (e) in `applyToItem` `LocalStatusUpdated` case, before setting status, clear `item.Terminal = false` when status changes
- [ ] Task 6: `internal/itemstate/store_test.go` — add tests: (a) `TerminalFlagSet{Terminal:true}` sets flag and emits `TerminalChanged`; (b) repeated `TerminalFlagSet{Terminal:true}` is a no-op (idempotent — no change, no observer notification); (c) `TerminalFlagSet{Terminal:false}` clears flag; (d) `LocalStatusUpdated` to a different status clears `Terminal`; (e) `ProbeBoardItemUpdated` with different status clears `Terminal`; (f) `ProjectV2ItemEdited` with different status clears `Terminal`
- [ ] Task 7: `engine/poll.go` — add private `isTerminalPredicate(labels []string, status string, stagesCfg []*stages.Stage) bool` helper: (1) find stage by status via `stages.FindStage`, return false if not found or `!st.CleanupWorktree`; (2) verify `"stage:"+st.Name+":complete"` is in labels; (3) verify no label is in `transientLifecycleLabels` and no label has prefix `"fabrik:locked:"`
- [ ] Task 8: `engine/poll.go` — in `runProbeAndDeepFetch`, for the existing-item path: after linkage drift detection and before `ProbeBoardItemUpdated`, add terminal skip gate: if `s.Terminal` and `stages.FindStage(e.cfg.Stages, pi.Status)` is a cleanup stage → `continue`; if `s.Terminal` and NOT cleanup stage → `e.store.Apply(TerminalFlagSet{..., Terminal:false})` + log, then fall through; after a successful `FetchItemDetails`, evaluate `isTerminalPredicate(minimal.Labels, minimal.Status, e.cfg.Stages)` and if true (and `!s.Terminal` for first-time log), apply `TerminalFlagSet{..., Terminal:true}` and log
- [ ] Task 9: `engine/poll.go` — in the admit pass loop, immediately after `item := board.Items[i]` and `iKey := issueKey(...)`, add terminal skip gate: `store.Get` → if `IsTerminal()` and cleanup stage → `continue`; if `IsTerminal()` and not cleanup stage → `store.Apply(TerminalFlagSet{..., Terminal:false})` + log, fall through; after `store.Apply(ItemDeepFetched{...})` at line 1092, evaluate `isTerminalPredicate` and apply `TerminalFlagSet{Terminal:true}` + log if true and not already set
- [ ] Task 10: `engine/poll.go` — add `runStartupTerminalScan()` method: iterate `e.store.All()`, for each snap call `isTerminalPredicate(snap.Labels(), snap.Status(), e.cfg.Stages)`, apply `TerminalFlagSet{Terminal:true}` to matches, log the count; call it after `e.runStartupTransientLabelScan()` in `Run()` (line 585-586 area)
- [ ] Task 11: `engine/terminal_test.go` — unit tests for `isTerminalPredicate`: (a) cleanup stage + complete label + no transient → true; (b) cleanup stage + complete label + `fabrik:awaiting-ci` → false; (c) cleanup stage + complete label + `fabrik:locked:bob` → false; (d) cleanup stage + no complete label → false; (e) non-cleanup stage + complete label → false; (f) unknown status → false
- [ ] Task 12: `engine/terminal_test.go` — test for `runStartupTerminalScan`: set up engine with a store containing: a terminal item (Done + `stage:Done:complete` + `IsClosed` + no transient), an item with transient label, an item in non-Done stage; call `runStartupTerminalScan()`; verify only the terminal item has `Terminal=true`
- [ ] Task 13: `engine/terminal_test.go` — probe-loop terminal skip test: use `runProbeAndDeepFetch` mock path; verify (a) a pre-terminal-flagged item in Done skips deep-fetch when probe shows status=Done; (b) when probe shows item moved to non-Done, flag is cleared and deep-fetch proceeds
- [ ] Task 14: `docs/state-machine.md §D.4` — after the "Per-poll probe" paragraph, add a "Terminal-item skip" subsection documenting: the terminal predicate definition, when the flag is set/cleared, the startup scan behavior, and the expected cost impact on large boards
- [ ] Task 15: regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt`
- [ ] Task 16: `go test -race ./...` — verify all tests pass with no data races

### Risks

- **Probe-path ordering**: If the terminal check is accidentally placed AFTER `ProbeBoardItemUpdated`, the store's `Terminal` field would be cleared by `applyProbeItem` on a status change before the terminal check can react to it. The test in Task 13(b) would catch this regression.

- **`FetchItemDetails` populates `minimal.Labels`**: The terminal-flag-set in `runProbeAndDeepFetch` reads `minimal.Labels`. If `FetchItemDetails` fails to populate labels (e.g., the cache serves stale data without labels), `isTerminalPredicate` returns false and the flag isn't set — the item continues deep-fetching each poll until labels are populated. This is safe (conservative).

- **Startup scan ordering**: `runStartupTerminalScan` must run AFTER `runStartupTransientLabelScan` so stale transient labels have been removed from the store before the predicate is evaluated. The existing call site enforces this.

- **`applyProjectV2ItemEdited` no-op path**: The existing function sets `item.Status = v.NewStatus` unconditionally then uses `reflect.DeepEqual` for no-op detection. The change to a conditional set (`if item.Status != v.NewStatus { ... }`) preserves the `reflect.DeepEqual` idempotency check while correctly clearing `Terminal` only on actual status changes.

---
Used 24/50 turns, 6k input / 18k output tokens.

## Verification

(Populated by Implement on completion)

---

Closes #689