### PR TITLE
Update docs for v0.0.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ GitHub Project Board (source of truth)
 5. **Complete** — When Claude signals completion, the issue is labeled `stage:<name>:complete`.
 6. **Advance** — In yolo mode, the issue auto-advances to the next stage. Otherwise, a human moves it.
 
+> **Big-board efficiency (v0.0.57):** On large project boards, the per-poll GraphQL cost drops ~5–10× via a lightweight `updatedAt`-only probe that gates the full deep-fetch — only items that changed since the last poll trigger a full query. Terminal items (issues in a cleanup/Done column with `stage:<name>:complete` and no active lifecycle labels) are skipped entirely from both the probe and deep-fetch evaluation.
+
 ### Webhook Mode (Optional)
 
 Fabrik can receive GitHub events in near-real-time (within ~2 seconds) instead of waiting for the next poll tick by spawning `gh webhook forward` as a background subprocess. Enable with `--webhooks`. With the default in-memory board cache active, the webhook stream also drives a reconcile-based health check (default every 3 minutes) that reduces full-board polling to at most once every 60 minutes.
@@ -287,6 +289,7 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `--max-review-cycles` | Max re-invocation cycles per reviewer-gate session. Explicitly passing `0` uses the built-in default of `5` and bypasses `FABRIK_MAX_REVIEW_CYCLES`. When absent, `FABRIK_MAX_REVIEW_CYCLES` is consulted first; falls back to `5` if unset. | `0` |
 | `--max-rebase-cycles` | Maximum rebase re-invocation cycles per issue before pausing (0 = default 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` for debugging | `false` |
+| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` at worktree setup time. Enables stage code to read project secrets without copying them. Also `FABRIK_SYMLINK_ENV`. | `false` |
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides installed plugin) | `""` |
 | `--webhooks` | Enable real-time webhook event delivery via `gh webhook forward` (requires `cli/gh-webhook` extension; also `FABRIK_WEBHOOKS`) | `false` |
 | `--reconcile-interval` | Seconds between periodic light-reconcile health checks when webhooks are enabled (0 = default 180; also `FABRIK_RECONCILE_INTERVAL`) | `0` (180 s) |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -415,7 +415,8 @@ user: your-github-username
 # When true, creates a relative symlink at <worktree>/.env pointing to the
 # fabrikDir .env file whenever a worktree is set up. Lets stage code read
 # credentials (e.g. ANTHROPIC_API_KEY) without copying secrets. No-op when
-# the source .env is absent; never overwrites an existing .env in the worktree.
+# the source .env is absent; never overwrites an existing .env in the worktree;
+# also excluded from git stash via the worktree's git exclude file.
 # symlink_env: false
 
 # Project version shown in the TUI footer. Auto-inferred from package.json,
@@ -470,7 +471,7 @@ FABRIK_USER=my-personal-username
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
-| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree. Also `FABRIK_SYMLINK_ENV` | `false` |
+| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree; also excluded from git stash via the worktree's git exclude file. Also `FABRIK_SYMLINK_ENV` | `false` |
 
 ### Environment Variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -255,6 +255,13 @@ description: >-
           SIGHUP drains in-flight runs and re-execs the binary in place — pick up a new build without terminal disruption.
         </div>
       </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#command-line-flags" aria-label="Big-Board Efficiency — open documentation">
+        <span class="feature-icon">🚀</span>
+        <div class="feature-title">Big-Board Efficiency</div>
+        <div class="feature-desc">
+          Probe-driven polling cuts per-poll GraphQL cost ~5–10× on large boards; terminal Done items are skipped entirely.
+        </div>
+      </a>
     </div>
 
     <div class="factory-callout">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -413,7 +413,8 @@ user: your-github-username
 # When true, creates a relative symlink at <worktree>/.env pointing to the
 # fabrikDir .env file whenever a worktree is set up. Lets stage code read
 # credentials (e.g. ANTHROPIC_API_KEY) without copying secrets. No-op when
-# the source .env is absent; never overwrites an existing .env in the worktree.
+# the source .env is absent; never overwrites an existing .env in the worktree;
+# also excluded from git stash via the worktree's git exclude file.
 # symlink_env: false
 
 # Project version shown in the TUI footer. Auto-inferred from package.json,
@@ -468,7 +469,7 @@ FABRIK_USER=my-personal-username
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
-| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree. Also `FABRIK_SYMLINK_ENV` | `false` |
+| `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree; also excluded from git stash via the worktree's git exclude file. Also `FABRIK_SYMLINK_ENV` | `false` |
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary

Audit and update the three user-facing documentation targets — `USER_GUIDE.md`, `README.md`, and `docs/index.md` — to accurately reflect the v0.0.57 feature set. The primary additions are the `--symlink-env` flag entry in README.md's flags table and an efficiency-improvement callout in README.md and docs/index.md for big-board users.

## Problem

v0.0.57 shipped several user-visible features — a new `--symlink-env` configuration triple, a probe-driven poll architecture that dramatically reduces GraphQL cost on large boards, terminal-item skip for boards with many Done items, and a startup transient-label recovery scan. None of these appear in README.md or docs/index.md. The USER_GUIDE.md has the symlink-env config and new SIGHUP/notification sections already, but they need a final accuracy pass to confirm they match the shipped code.

## Approach

### Approach

This is a pure documentation task: four targeted edits across three files, plus one mandatory bundle regeneration. The research has already verified which sections are accurate (SIGHUP, @mention) and identified the two gaps in `USER_GUIDE.md`, the missing `--symlink-env` flag entry in `README.md`, and the absent efficiency callout in both `README.md` and `docs/index.md`.

All changes land in a single commit: `USER_GUIDE.md` must ship alongside the regenerated `docs/llms-full.txt` (CI's `docs-drift` check enforces this), so batching everything together is cleaner than two commits.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add git-stash-exclusion detail to config.yaml comment (line ~419) and flags table row (line ~473) |
| `README.md` | Insert `--symlink-env` row in Flags table; add probe-poll efficiency callout to "How It Works" |
| `docs/index.md` | Add 18th feature card: "Big-Board Efficiency" linking to `USER_GUIDE.md` |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` after `USER_GUIDE.md` edit |

### Key Decisions

- **Single commit** — `USER_GUIDE.md` and `docs/llms-full.txt` must be staged together or the `docs-drift` CI check fails. Including `README.md` and `docs/index.md` in the same commit is clean and has no downside.

- **No new USER_GUIDE section for probe polling** — The efficiency feature card in `docs/index.md` links to `{{ '/USER_GUIDE' | relative_url }}#command-line-flags` (or the closest existing relevant anchor). There's no requirement to add a dedicated USER_GUIDE polling section; README.md carries the human-readable description and the feature card links there.

- **`--symlink-env` position in README Flags table** — Insert after `--debug-output` (current second-to-last row before `--webhooks` / `--reconcile-interval`), consistent with the USER_GUIDE flags table ordering where `--symlink-env` appears last in the core flags block.

- **Efficiency callout placement in README.md** — Add after step 1 (Poll) in "How It Works", as a callout paragraph directly under the numbered list. This keeps the existing numbered steps intact while surfacing the efficiency story where readers naturally expect it.

- **No ADRs warranted** — All decisions document already-shipped code. ADR 044 already covers the probe-driven poll architecture decision.

### Task Checklist

- [ ] Task 1: `docs/USER_GUIDE.md` — add git-stash-exclusion line to config.yaml comment block (after "never overwrites an existing .env in the worktree", add "; also excluded from git stash via the worktree's git exclude file")
- [ ] Task 2: `docs/USER_GUIDE.md` — append the same stash-exclusion detail to the `--symlink-env` flag row description in the Command-Line Flags table (line ~473)
- [ ] Task 3: `README.md` — insert `--symlink-env` flag row into the Flags table after `--debug-output`, using the issue-spec description: "Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` at worktree setup time. Enables stage code to read project secrets without copying them. Also `FABRIK_SYMLINK_ENV`." Default: `false`
- [ ] Task 4: `README.md` — add probe-poll efficiency callout after the numbered "How It Works" steps, noting that v0.0.57 reduces per-poll GraphQL cost ~5–10× on large boards via an `updatedAt`-only probe that gates full deep-fetch, and terminal items (Done-column issues) are skipped entirely from evaluation
- [ ] Task 5: `docs/index.md` — add a new feature card (18th) to the features grid for "Big-Board Efficiency" with emoji ⚡ (or 🚀 if ⚡ is reused), a 1-sentence description of the probe-poll efficiency improvement, and `href="{{ '/USER_GUIDE' | relative_url }}#command-line-flags"` as the link target; follow the exact HTML structure of adjacent cards
- [ ] Task 6: Regenerate `docs/llms-full.txt` — run `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt`
- [ ] Task 7: Commit all changes — stage `docs/USER_GUIDE.md`, `README.md`, `docs/index.md`, `docs/llms-full.txt` and commit with a message summarizing the v0.0.57 doc additions

### Risks

- **`docs-drift` CI failure** — If `docs/llms-full.txt` is not regenerated in the same commit as `USER_GUIDE.md`, CI fails. Mitigated by Task 6 being an explicit checklist step immediately before the commit.
- **`docs/index.md` Jekyll/Liquid templating** — The feature card must use `{{ '/USER_GUIDE' | relative_url }}` link syntax and the exact HTML structure of adjacent cards (`<a class="feature-card">`, `<span class="feature-icon">`, `<div class="feature-title">`, `<div class="feature-desc">`). The implementer must copy the structure verbatim from an adjacent card — not invent a new pattern.
- **⚡ emoji collision** — The "Yolo Mode & Auto-Merge" card (line 161) already uses ⚡. Use 🚀 for the new efficiency card instead.

---
Used 9/50 turns, 4k input / 3k output tokens.

## Verification

Updated `docs/USER_GUIDE.md` (added git-stash-exclusion detail to the `symlink_env` config comment and `--symlink-env` flag row), `README.md` (added `--symlink-env` to the Flags table and a probe-poll efficiency callout under "How It Works"), and `docs/index.md` (added an 18th "Big-Board Efficiency" feature card). Regenerated `docs/llms-full.txt` and committed everything in a single commit (`a400a95`) pushed to `fabrik/issue-695`.

---

Closes #695