### PR TITLE
fabrik(tui): 'r' key should force a board refresh like SIGHUP

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1487,6 +1487,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
 | `w` | Wake: reset idle backoff and poll immediately |
+| `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |
 | `q` | Quit |
 
@@ -2025,6 +2026,10 @@ If Claude doesn't seem to follow the skill instructions:
 Cache-stale bugs can occasionally leave Fabrik's in-memory state stuck — an issue that should advance doesn't, or a label that should clear doesn't. The safest escape hatch is a SIGHUP restart, which drops all in-memory state and re-execs the same binary in place, without tearing down the terminal session or TUI.
 
 **How to trigger:**
+
+If you are using the TUI dashboard, press **`ctrl+r`** — this sends SIGHUP to the Fabrik process and triggers the same restart without leaving the TUI to open another terminal window.
+
+From the command line:
 
 ```bash
 # Find the PID (shown at startup: "[startup] fabrik PID: <N>")

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1485,6 +1485,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
 | `w` | Wake: reset idle backoff and poll immediately |
+| `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |
 | `q` | Quit |
 
@@ -2023,6 +2024,10 @@ If Claude doesn't seem to follow the skill instructions:
 Cache-stale bugs can occasionally leave Fabrik's in-memory state stuck — an issue that should advance doesn't, or a label that should clear doesn't. The safest escape hatch is a SIGHUP restart, which drops all in-memory state and re-execs the same binary in place, without tearing down the terminal session or TUI.
 
 **How to trigger:**
+
+If you are using the TUI dashboard, press **`ctrl+r`** — this sends SIGHUP to the Fabrik process and triggers the same restart without leaving the TUI to open another terminal window.
+
+From the command line:
 
 ```bash
 # Find the PID (shown at startup: "[startup] fabrik PID: <N>")

--- a/tui/active_test.go
+++ b/tui/active_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -336,5 +337,36 @@ func TestUpdate_TurnProgressEvent_ResetOnJobStarted(t *testing.T) {
 	}
 	if job.MaxTurns != 0 {
 		t.Errorf("MaxTurns = %d after new JobStartedEvent, want 0", job.MaxTurns)
+	}
+}
+
+// TestUpdate_CtrlR_ActivePane_ReturnsSighupCmd verifies that ctrl+r from the
+// active pane returns a non-nil cmd (the SIGHUP-sending command). The cmd is
+// not called to avoid sending a real SIGHUP to the test process.
+func TestUpdate_CtrlR_ActivePane_ReturnsSighupCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sendSighupCmd is a no-op on Windows")
+	}
+	m := New(30, ProjectInfo{}, "", nil)
+	m.focusPane = paneActive
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	if cmd == nil {
+		t.Error("expected non-nil cmd from ctrl+r in active pane")
+	}
+}
+
+// TestUpdate_CtrlR_HistoryPane_ReturnsSighupCmd verifies that ctrl+r from the
+// history pane returns a non-nil cmd (the SIGHUP-sending command).
+func TestUpdate_CtrlR_HistoryPane_ReturnsSighupCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sendSighupCmd is a no-op on Windows")
+	}
+	m := New(30, ProjectInfo{}, "", nil)
+	m.focusPane = paneHistory
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	if cmd == nil {
+		t.Error("expected non-nil cmd from ctrl+r in history pane")
 	}
 }

--- a/tui/help.go
+++ b/tui/help.go
@@ -35,6 +35,7 @@ KEYBOARD SHORTCUTS
   Global
     a          Open abtop AI session monitor
     w          Wake: reset idle backoff and poll immediately
+    ctrl+r     Force refresh (same as SIGHUP)
     ?          Toggle this help panel
     q          Quit
     ctrl+c     Force quit

--- a/tui/model.go
+++ b/tui/model.go
@@ -309,6 +309,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
+		case "ctrl+r":
+			m.header.SetStatusMsg("refreshing…")
+			return m, sendSighupCmd()
+
 		case "a":
 			if _, err := exec.LookPath("abtop"); err != nil {
 				m.header.SetStatusMsg("abtop not found in PATH — install from github.com/graykode/abtop")

--- a/tui/sighup_unix.go
+++ b/tui/sighup_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package tui
+
+import (
+	"os"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// sendSighupCmd returns a tea.Cmd that sends SIGHUP to the current process,
+// triggering the engine's drain-and-re-exec restart path.
+func sendSighupCmd() tea.Cmd {
+	return func() tea.Msg {
+		syscall.Kill(os.Getpid(), syscall.SIGHUP) //nolint:errcheck
+		return nil
+	}
+}

--- a/tui/sighup_windows.go
+++ b/tui/sighup_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// sendSighupCmd is a no-op on Windows: SIGHUP is not a Windows signal.
+func sendSighupCmd() tea.Cmd {
+	return nil
+}


### PR DESCRIPTION
## Summary

Wire `ctrl+r` in the TUI to trigger the same force-refresh semantics as SIGHUP, making the board refresh reachable without switching to another terminal window. `ctrl+r` is the conventional "refresh" binding (browsers, terminals) and is clearly distinct from `r` (which retains its existing "resume Claude session" meaning in the history pane). No existing keybinding is displaced.

## Problem

The TUI has a handler for the `r` key (`tui/model.go` `Update` path; covered by `TestUpdate_RKey_ActivePane_SetsStatusMsg` and `TestUpdate_RKey_ActivePane_NoJobs_NoOp` in `tui/active_test.go`) but it only partially works:

- **Active pane**: `r` on a selected in-progress job shows "stage in progress — use l to watch" and returns no command. With no jobs selected it is a no-op.
- **History pane**: `r` on a selected completed-entry opens an inline Claude session resume via `openResumeInlineCmd`. This is a live feature documented in `tui/help.go` and `docs/USER_GUIDE.md`.

SIGHUP already provides the in-place "force a fresh poll / clear cached state" mechanism (`engine/sighup_unix.go`: sets `sighupRequested`, cancels the engine context to drain workers, then re-execs the binary). That's available to anyone running Fabrik from a terminal, but it's a CLI-only escape hatch — when the user is interacting with the TUI, they can't easily issue a signal.

## Approach

### Approach

Wire `ctrl+r` in the TUI to send SIGHUP to the current process, triggering the existing drain-and-re-exec path. The implementation requires:

1. A platform-split `sendSighupCmd` tea.Cmd (new files `tui/sighup_unix.go` and `tui/sighup_windows.go` mirroring the `engine/sighup_*.go` pattern).
2. A new `"ctrl+r"` case in the global `switch ev.String()` in `tui/model.go:Update()`, before the pane-specific dispatch.
3. Documentation updates in `tui/help.go` and `docs/USER_GUIDE.md`.

**Help panel during `ctrl+r`**: `ctrl+r` is placed only in the main switch, not in the help-panel suppressor block. This means `ctrl+r` is silently swallowed when the help overlay is open, consistent with all non-ctrl+c keys. Adding it to the suppressor would require an extra case and test. The spec says "any TUI pane" meaning paneActive and paneHistory — the help overlay is not a pane.

**Platform split naming**: `tui/sighup_unix.go` + `tui/sighup_windows.go` (same naming convention as `engine/sighup_unix.go` / `engine/sighup_windows.go`). This keeps all SIGHUP-related platform code in files clearly named for that purpose, rather than splitting `commands.go` into per-platform variants.

**No ADR needed**: This is a straightforward extension of established patterns (engine SIGHUP split, tea.Cmd dispatch). No new architectural constraints are introduced.

### New/Modified Files

| File | Change |
|------|--------|
| `tui/sighup_unix.go` | New — `//go:build !windows`; `sendSighupCmd()` returning a tea.Cmd that calls `syscall.Kill(os.Getpid(), syscall.SIGHUP)` |
| `tui/sighup_windows.go` | New — `//go:build windows`; `sendSighupCmd()` no-op stub returning `nil` |
| `tui/model.go` | Add `"ctrl+r"` case in `Update()` global switch: set status msg `"refreshing…"` and return `sendSighupCmd()` |
| `tui/active_test.go` | Add two tests: `ctrl+r` from active pane returns non-nil cmd; `ctrl+r` from history pane returns non-nil cmd |
| `tui/help.go` | Add `ctrl+r` entry in the Global section of `helpContent` |
| `docs/USER_GUIDE.md` | Add `ctrl+r` row to keyboard shortcuts table; add cross-reference in "Recovering from Wedged State" section |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` after editing `docs/USER_GUIDE.md` |

### Key Decisions

- **`tui/sighup_unix.go` not `tui/commands_unix.go`**: Naming by concern (`sighup`) rather than by mechanism (`commands`) makes the build-tag split self-documenting and mirrors the engine package. Future SIGHUP-related TUI helpers (unlikely but possible) would land in the right file.
- **Status message is set in `model.go`, not inside `sendSighupCmd`**: tea.Cmd runs outside `Update()`; model state mutations must happen synchronously in `Update()` before the cmd is returned. The status message is set in the case body, then the cmd is returned — identical to how `w` key sets status before returning.
- **`ctrl+r` suppressed during help overlay**: Consistent with all non-ctrl+c keys. The spec's "any pane" clause covers paneActive and paneHistory, not the help overlay.
- **Tests check `cmd != nil` only**: Executing the returned cmd would send a real SIGHUP to the test process. This is consistent with `TestUpdate_AKey_AbtopFound_ReturnsExecCmd` in `commands_test.go`.

### Task Checklist

- [ ] **Task 1**: Create `tui/sighup_unix.go` — `//go:build !windows` file with `sendSighupCmd()` that returns a `tea.Cmd` calling `syscall.Kill(os.Getpid(), syscall.SIGHUP)` and returning `nil`
- [ ] **Task 2**: Create `tui/sighup_windows.go` — `//go:build windows` file with `sendSighupCmd()` no-op stub returning `nil` (a `tea.Cmd` that returns nil)
- [ ] **Task 3**: Add `"ctrl+r"` case to `tui/model.go` `Update()` global switch — sets `m.header.SetStatusMsg("refreshing…")` and returns `sendSighupCmd()`; place after `"w"` case (line ~301)
- [ ] **Task 4**: Add tests to `tui/active_test.go` — `TestUpdate_CtrlR_ActivePane_ReturnsSighupCmd` and `TestUpdate_CtrlR_HistoryPane_ReturnsSighupCmd`; use `tea.KeyMsg{Type: tea.KeyCtrlR}` to dispatch; assert `cmd != nil` and do not call `cmd()`
- [ ] **Task 5**: Add `ctrl+r` to `tui/help.go` Global section — new line `ctrl+r     Force refresh (same as SIGHUP)` after the `w` entry (before `?`)
- [ ] **Task 6**: Update `docs/USER_GUIDE.md` — add `ctrl+r` row to keyboard shortcuts table (line ~1491, after `w`); add one sentence cross-reference in the "Recovering from Wedged State" section noting `ctrl+r` as the TUI-accessible equivalent
- [ ] **Task 7**: Regenerate `docs/llms-full.txt` — run `bash scripts/generate-llms-full.sh` and `git add docs/llms-full.txt`
- [ ] **Task 8**: Run `go build ./...` and `go test ./tui/... -race` to verify clean compile and passing tests; run `go vet ./...`
- [ ] **Task 9**: Commit all changes on branch `fabrik/issue-690`

### Risks

- **Test SIGHUP leakage**: If a test accidentally calls `cmd()`, it sends a real SIGHUP to the `go test` process. Tests must only assert `cmd != nil`. The existing pattern in `commands_test.go` (abtop test) is the model to follow.
- **`docs/llms-full.txt` drift**: CI fails if `USER_GUIDE.md` is edited without regenerating `llms-full.txt`. Task 7 is explicitly ordered after Task 6 and must be part of the same commit.
- **`tui/sighup_windows.go` stub signature**: The stub must match the `!windows` function signature exactly (`func sendSighupCmd() tea.Cmd`), otherwise the build will fail even though Windows is unsupported in practice.

---
Used 11/50 turns, 5k input / 3k output tokens.

## Verification

Added `ctrl+r` keybinding to the TUI that sends SIGHUP to the current process, triggering the engine's existing drain-and-re-exec restart path. New platform-split files `tui/sighup_unix.go` / `tui/sighup_windows.go` provide `sendSighupCmd()`; `tui/model.go` handles the key with a "refreshing…" status message; two new tests verify the cmd is non-nil from both panes; `tui/help.go` and `docs/USER_GUIDE.md` document the binding. All committed and pushed to `fabrik/issue-690`.

---

Closes #690