### PR TITLE
fix(tui): release terminal before SIGHUP re-exec and force-quit exits

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -679,7 +679,7 @@ func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir
 	// Register terminal cleanup so force-quit paths (SIGHUP re-exec, second
 	// SIGTERM/SIGHUP) release alt-screen before replacing or exiting the process.
 	// Must be registered before eng.Run() starts the signal handlers.
-	eng.SetCleanupHook(func() { p.ReleaseTerminal() }) //nolint:errcheck
+	eng.SetCleanupHook(func() { _ = p.ReleaseTerminal() })
 
 	// Forward events from the engine's channel into bubbletea.
 	go func() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -676,6 +676,10 @@ func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir
 
 	tuiModel := tui.New(pollSeconds, info, pluginDir, wakeCh)
 	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
+	// Register terminal cleanup so force-quit paths (SIGHUP re-exec, second
+	// SIGTERM/SIGHUP) release alt-screen before replacing or exiting the process.
+	// Must be registered before eng.Run() starts the signal handlers.
+	eng.SetCleanupHook(func() { p.ReleaseTerminal() }) //nolint:errcheck
 
 	// Forward events from the engine's channel into bubbletea.
 	go func() {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -99,6 +99,11 @@ type Engine struct {
 	// sighupExecFn overrides syscall.Exec in tests to prevent the test process
 	// from actually being replaced. Production code leaves this nil.
 	sighupExecFn func(argv0 string, argv []string, envv []string) error
+	// cleanupHook is called before any syscall.Exec or os.Exit(1) on force-quit
+	// paths to release the terminal (e.g. p.ReleaseTerminal() in TUI mode).
+	// Nil in non-TUI mode. Set via SetCleanupHook; wrapped in sync.Once so
+	// concurrent force-quit goroutines can't call it simultaneously.
+	cleanupHook func()
 }
 
 func New(cfg Config) (*Engine, error) {
@@ -279,6 +284,18 @@ func (e *Engine) SetEvents(ch chan tui.Event) {
 		wm.logfFn = e.logf
 	}
 	e.mu.Unlock()
+}
+
+// SetCleanupHook registers fn to be called exactly once before any force-quit
+// path (SIGHUP re-exec, second SIGTERM, second SIGHUP). Wraps fn in sync.Once
+// so concurrent force-quit goroutines can't invoke it simultaneously. Must be
+// called before Run(). No-op when fn is nil.
+func (e *Engine) SetCleanupHook(fn func()) {
+	if fn == nil {
+		return
+	}
+	var once sync.Once
+	e.cleanupHook = func() { once.Do(fn) }
 }
 
 // emit sends an event to the channel without blocking. Dropped if the channel is full.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -268,6 +268,11 @@ func (e *Engine) Run() error {
 		select {
 		case <-sigCh:
 			fmt.Fprintln(os.Stderr, "\nForce-quitting...")
+			// Release the terminal before exiting so the shell is not left in
+			// alt-screen mode.
+			if fn := e.cleanupHook; fn != nil {
+				fn()
+			}
 			os.Exit(1)
 		case <-ctx.Done():
 		}

--- a/engine/sighup_test.go
+++ b/engine/sighup_test.go
@@ -33,12 +33,21 @@ func TestRun_SighupRestart(t *testing.T) {
 	readyCh := make(chan struct{})
 	eng.cfg.ReadyCh = readyCh
 
+	// seq is a monotonic counter; each hook records the value at call time so we
+	// can assert cleanup happened strictly before exec.
+	var seq atomic.Int32
+	var cleanupSeq, execSeq int32
+
+	// Set cleanupHook directly (bypassing SetCleanupHook) to capture order.
+	eng.cleanupHook = func() {
+		cleanupSeq = seq.Add(1)
+	}
+
 	// Override exec so the test process is not actually replaced.
-	var execCalled atomic.Bool
 	var capturedBin string
 	var capturedArgs []string
 	eng.sighupExecFn = func(argv0 string, argv []string, envv []string) error {
-		execCalled.Store(true)
+		execSeq = seq.Add(1)
 		capturedBin = argv0
 		capturedArgs = argv
 		return nil
@@ -63,7 +72,7 @@ func TestRun_SighupRestart(t *testing.T) {
 		t.Fatal("Run did not shut down after SIGHUP in time")
 	}
 
-	if !execCalled.Load() {
+	if execSeq == 0 {
 		t.Fatal("sighupExecFn was not called")
 	}
 	if capturedBin == "" {
@@ -74,5 +83,11 @@ func TestRun_SighupRestart(t *testing.T) {
 	}
 	if !eng.sighupRequested.Load() {
 		t.Error("sighupRequested flag not set")
+	}
+	if cleanupSeq == 0 {
+		t.Fatal("cleanupHook was not called before exec")
+	}
+	if cleanupSeq >= execSeq {
+		t.Errorf("cleanupHook must be called before exec: cleanupSeq=%d execSeq=%d", cleanupSeq, execSeq)
 	}
 }

--- a/engine/sighup_unix.go
+++ b/engine/sighup_unix.go
@@ -39,6 +39,12 @@ func registerSighupHandler(ctx context.Context, cancel context.CancelFunc, e *En
 		select {
 		case <-sighup2Ch:
 			fmt.Fprintln(os.Stderr, "\nSecond SIGHUP received during drain — force-quitting...")
+			// Release the terminal before exiting so the shell is not left in
+			// alt-screen mode. See also: #692 — any new os.Exit added there must
+			// invoke this hook too.
+			if fn := e.cleanupHook; fn != nil {
+				fn()
+			}
 			os.Exit(1)
 		case <-restartDone:
 			signal.Stop(sighup2Ch)
@@ -81,6 +87,13 @@ func performSighupRestart(e *Engine, lockFile *os.File) {
 	}
 	if e.sighupExecFn != nil {
 		execFn = e.sighupExecFn
+	}
+
+	// Release the terminal before replacing the process so the shell is not left
+	// in alt-screen mode. The new process re-enters alt-screen normally.
+	// NOTE: any new syscall.Exec added by issue #692 must also invoke this hook.
+	if fn := e.cleanupHook; fn != nil {
+		fn()
 	}
 
 	if err := execFn(exe, os.Args, os.Environ()); err != nil {


### PR DESCRIPTION
## Summary

- Adds a `cleanupHook func()` field to `Engine` and a `SetCleanupHook` method (wrapped in `sync.Once` for concurrent-call safety).
- `runTUI` in `cmd/root.go` registers `p.ReleaseTerminal` as the cleanup hook immediately after creating the Bubble Tea program, before starting the engine goroutine.
- Three previously broken signal paths now invoke the hook before replacing or exiting the process: SIGHUP re-exec (`performSighupRestart`), second SIGHUP during drain, and second SIGTERM during drain.

## Key Changes

- **`engine/engine.go`**: `cleanupHook func()` field; `SetCleanupHook(fn func())` wraps fn in `sync.Once` so concurrent goroutines can't call `ReleaseTerminal` simultaneously.
- **`engine/sighup_unix.go`**: `performSighupRestart` calls `cleanupHook` before `execFn`; second-SIGHUP force-exit calls `cleanupHook` before `os.Exit(1)`. Coordination comment added for issue #692.
- **`engine/poll.go`**: second-SIGTERM force-exit calls `cleanupHook` before `os.Exit(1)`.
- **`cmd/root.go`**: `eng.SetCleanupHook(func() { p.ReleaseTerminal() })` registered before `eng.Run()` goroutine starts.

## How to Test

1. Run `fabrik` in TUI mode (`fab run` or equivalent with a configured project board).
2. Send `SIGHUP` to the process: `kill -HUP <pid>`. The terminal should exit alt-screen cleanly before the process re-execs; the new process re-enters alt-screen normally.
3. Without the fix, the terminal would require `reset` to recover after SIGHUP.
4. Run `go test -race ./engine/... -run TestRun_SighupRestart` — passes and asserts cleanup fires before exec.

Closes #693