### PR TITLE
fabrik: SIGHUP restart triggers blocking plugin-upgrade prompt; move skills check off the startup path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -559,9 +559,17 @@ func Execute() error {
 	// Evaluate plugin skill staleness after engine.New() (so env vars are unset
 	// and the inheritance window is closed). For non-TUI, refresh silently. For
 	// TUI, the count is passed to tui.New() to drive the header badge.
+	// Guard with os.Stat so projects that haven't run `fabrik init` (no
+	// .fabrik/plugin/ dir) always report stale count 0 — diffingPluginFiles
+	// treats every missing on-disk file as diffing, which would produce a
+	// spuriously large count when the directory doesn't exist yet.
 	var skillsStaleCount int
-	if diffing, diffErr := diffingPluginFiles(".fabrik/plugin"); diffErr == nil {
-		skillsStaleCount = len(diffing)
+	if _, statErr := os.Stat(".fabrik/plugin"); statErr == nil {
+		if diffing, diffErr := diffingPluginFiles(".fabrik/plugin"); diffErr != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed: %v\n", diffErr)
+		} else {
+			skillsStaleCount = len(diffing)
+		}
 	}
 
 	// When TUI is enabled (and we have a real terminal), run the bubbletea

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -497,11 +497,15 @@ func Execute() error {
 		}
 	}
 
-	// Check whether on-disk plugin files match the embedded versions. This runs
-	// only in the main daemon path (all subcommands returned early above).
-	// If .fabrik/plugin/ does not exist (no fabrik init), the check is a no-op.
-	if err := checkPluginSkills(".fabrik/plugin"); err != nil {
-		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed: %v\n", err)
+	// If the process was re-exec'd by a SIGHUP restart, force non-interactive
+	// plugin skills refresh. The env var is unset immediately so Claude child
+	// processes do not inherit it. This mirrors the FABRIK_AUTO_UPGRADED pattern
+	// and must happen before engine.New() to close the inheritance window.
+	if os.Getenv("FABRIK_SIGHUP_RESTART") == "1" {
+		os.Unsetenv("FABRIK_SIGHUP_RESTART")
+		if err := checkPluginSkillsWithReader(".fabrik/plugin", false, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed after SIGHUP restart: %v\n", err)
+		}
 	}
 
 	// Parse webhook events from comma-separated string.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -556,12 +556,25 @@ func Execute() error {
 		return err
 	}
 
+	// Evaluate plugin skill staleness after engine.New() (so env vars are unset
+	// and the inheritance window is closed). For non-TUI, refresh silently. For
+	// TUI, the count is passed to tui.New() to drive the header badge.
+	var skillsStaleCount int
+	if diffing, diffErr := diffingPluginFiles(".fabrik/plugin"); diffErr == nil {
+		skillsStaleCount = len(diffing)
+	}
+
 	// When TUI is enabled (and we have a real terminal), run the bubbletea
 	// TUI. Otherwise fall through to plain-text mode.
 	if useTUI {
 		wakeCh := make(chan struct{}, 1)
 		eng.SetWakeCh(wakeCh)
-		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.PluginDir, wakeCh)
+		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.PluginDir, wakeCh, skillsStaleCount)
+	}
+	if skillsStaleCount > 0 {
+		if refreshErr := checkPluginSkillsWithReader(".fabrik/plugin", false, nil); refreshErr != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill refresh failed: %v\n", refreshErr)
+		}
 	}
 	return eng.Run()
 }
@@ -674,11 +687,11 @@ func buildProjectInfo(cfg *Config, pc config.ProjectConfig) tui.ProjectInfo {
 // runTUI wires the event channel, starts the bubbletea program, and runs the
 // engine. The engine handles SIGINT itself; bubbletea uses WithoutSignalHandler
 // so it doesn't interfere. When the engine exits, the TUI is quit.
-func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir string, wakeCh chan struct{}) error {
+func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir string, wakeCh chan struct{}, skillsStaleCount int) error {
 	events := make(chan tui.Event, 256)
 	eng.SetEvents(events)
 
-	tuiModel := tui.New(pollSeconds, info, pluginDir, wakeCh)
+	tuiModel := tui.New(pollSeconds, info, pluginDir, wakeCh, skillsStaleCount)
 	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
 	// Register terminal cleanup so force-quit paths (SIGHUP re-exec, second
 	// SIGTERM/SIGHUP) release alt-screen before replacing or exiting the process.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1486,6 +1486,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
+| `u` | Upgrade plugin skills (shows confirmation prompt when out of date; active stage invocations pick up new files on next run) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1484,6 +1484,7 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
+| `u` | Upgrade plugin skills (shows confirmation prompt when out of date; active stage invocations pick up new files on next run) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |

--- a/engine/sighup_test.go
+++ b/engine/sighup_test.go
@@ -46,10 +46,12 @@ func TestRun_SighupRestart(t *testing.T) {
 	// Override exec so the test process is not actually replaced.
 	var capturedBin string
 	var capturedArgs []string
+	var capturedEnv []string
 	eng.sighupExecFn = func(argv0 string, argv []string, envv []string) error {
 		execSeq = seq.Add(1)
 		capturedBin = argv0
 		capturedArgs = argv
+		capturedEnv = envv
 		return nil
 	}
 
@@ -89,5 +91,18 @@ func TestRun_SighupRestart(t *testing.T) {
 	}
 	if cleanupSeq >= execSeq {
 		t.Errorf("cleanupHook must be called before exec: cleanupSeq=%d execSeq=%d", cleanupSeq, execSeq)
+	}
+
+	// Verify FABRIK_SIGHUP_RESTART=1 is injected so cmd/root.go can detect
+	// a re-exec'd process and skip the interactive plugin skills prompt.
+	found := false
+	for _, kv := range capturedEnv {
+		if kv == "FABRIK_SIGHUP_RESTART=1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("exec env did not contain FABRIK_SIGHUP_RESTART=1")
 	}
 }

--- a/engine/sighup_unix.go
+++ b/engine/sighup_unix.go
@@ -91,12 +91,16 @@ func performSighupRestart(e *Engine, lockFile *os.File) {
 
 	// Release the terminal before replacing the process so the shell is not left
 	// in alt-screen mode. The new process re-enters alt-screen normally.
-	// NOTE: any new syscall.Exec added by issue #692 must also invoke this hook.
 	if fn := e.cleanupHook; fn != nil {
 		fn()
 	}
 
-	if err := execFn(exe, os.Args, os.Environ()); err != nil {
+	// FABRIK_SIGHUP_RESTART=1 mirrors FABRIK_AUTO_UPGRADED: detected at
+	// cmd/root.go startup to force non-interactive plugin skills refresh
+	// without prompting. Must be unset there before engine.New() so Claude
+	// child processes do not inherit it.
+	env := append(os.Environ(), "FABRIK_SIGHUP_RESTART=1")
+	if err := execFn(exe, os.Args, env); err != nil {
 		e.logf(0, "signal", "SIGHUP restart: exec failed: %v\n", err)
 	}
 }

--- a/tui/active_test.go
+++ b/tui/active_test.go
@@ -39,7 +39,7 @@ func TestActiveHeight(t *testing.T) {
 
 func TestUpdate_JobStartedAndCompleted(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	start := time.Now()
 
 	// JobStartedEvent adds to active
@@ -80,7 +80,7 @@ func TestUpdate_JobStartedAndCompleted(t *testing.T) {
 }
 
 func TestUpdate_LogEvent_UpdatesActiveJob(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	key7 := activeJobKey("", 7)
 	m.active.active[key7] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
 	m.active.activeNumToKey[7] = key7
@@ -102,7 +102,7 @@ func TestUpdate_LogEvent_UpdatesActiveJob(t *testing.T) {
 
 func TestUpdate_LogEvent_UnknownIssue(t *testing.T) {
 	// LogEvent for an issue not in active map should not panic
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	next, _ := m.Update(LogEvent{IssueNumber: 999, Tag: "warn", Message: "something\n"})
 	nm := next.(Model)
 	if _, ok := nm.active.active[activeJobKey("", 999)]; ok {
@@ -112,7 +112,7 @@ func TestUpdate_LogEvent_UnknownIssue(t *testing.T) {
 
 // TestUpdate_JK_ActivePane verifies j/k navigation in the active pane.
 func TestUpdate_JK_ActivePane(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.active.active[activeJobKey("", 1)] = &activeJob{StageName: "Research", StartedAt: time.Now()}
 	m.active.active[activeJobKey("", 2)] = &activeJob{StageName: "Plan", StartedAt: time.Now()}
 
@@ -130,7 +130,7 @@ func TestUpdate_JK_ActivePane(t *testing.T) {
 
 // TestUpdate_RKey_ActivePane_SetsStatusMsg verifies r on an active pane item sets statusMsg.
 func TestUpdate_RKey_ActivePane_SetsStatusMsg(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneActive
 	key7 := activeJobKey("", 7)
 	m.active.active[key7] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
@@ -148,7 +148,7 @@ func TestUpdate_RKey_ActivePane_SetsStatusMsg(t *testing.T) {
 }
 
 func TestUpdate_RKey_ActivePane_NoJobs_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneActive
 	// No active jobs: r is a no-op
 
@@ -160,7 +160,7 @@ func TestUpdate_RKey_ActivePane_NoJobs_NoOp(t *testing.T) {
 
 // TestViewActive_IsComment verifies the 💬 emoji appears for comment jobs.
 func TestViewActive_IsComment(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.active.active[activeJobKey("", 5)] = &activeJob{StageName: "Implement", IsComment: true, StartedAt: time.Now()}
@@ -172,7 +172,7 @@ func TestViewActive_IsComment(t *testing.T) {
 
 func TestUpdate_IssueBlockedEvent(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 
 	// IssueBlockedEvent adds to blocked map
 	next, _ := m.Update(IssueBlockedEvent{
@@ -208,7 +208,7 @@ func TestUpdate_IssueBlockedEvent(t *testing.T) {
 
 func TestViewActive_BlockedIssue(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 120
 	m.active.now = time.Now()
 
@@ -238,7 +238,7 @@ func TestViewActive_BlockedIssue(t *testing.T) {
 
 func TestViewActive_BlockedCountIncludedInHeader(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 120
 	m.active.now = time.Now()
 
@@ -289,7 +289,7 @@ func TestTurnBadge(t *testing.T) {
 
 // TestUpdate_TurnProgressEvent_UpdatesJob verifies that TurnProgressEvent updates the active job.
 func TestUpdate_TurnProgressEvent_UpdatesJob(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Research", StartedAt: time.Now()}
 	m.active.activeNumToKey[42] = key42
@@ -311,7 +311,7 @@ func TestUpdate_TurnProgressEvent_UpdatesJob(t *testing.T) {
 
 // TestUpdate_TurnProgressEvent_UnknownIssue verifies that an unknown issue number does not panic.
 func TestUpdate_TurnProgressEvent_UnknownIssue(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	// Should not panic for an issue not in the active map.
 	next, _ := m.Update(TurnProgressEvent{IssueNumber: 999, TurnsUsed: 5, MaxTurns: 30})
 	nm := next.(Model)
@@ -322,7 +322,7 @@ func TestUpdate_TurnProgressEvent_UnknownIssue(t *testing.T) {
 
 // TestUpdate_TurnProgressEvent_ResetOnJobStarted verifies that starting a new job resets turn state.
 func TestUpdate_TurnProgressEvent_ResetOnJobStarted(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	key5 := activeJobKey("", 5)
 	m.active.active[key5] = &activeJob{IssueNumber: 5, StageName: "Research", StartedAt: time.Now(), TurnsUsed: 10, MaxTurns: 30}
 	m.active.activeNumToKey[5] = key5

--- a/tui/active_test.go
+++ b/tui/active_test.go
@@ -347,7 +347,7 @@ func TestUpdate_CtrlR_ActivePane_ReturnsSighupCmd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sendSighupCmd is a no-op on Windows")
 	}
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneActive
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
@@ -362,7 +362,7 @@ func TestUpdate_CtrlR_HistoryPane_ReturnsSighupCmd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sendSighupCmd is a no-op on Windows")
 	}
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneHistory
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -10,7 +10,24 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	fabrikplugin "github.com/handarbeit/fabrik/plugin"
 )
+
+// pluginUpgradeResultMsg is returned by upgradePluginCmd when RefreshPlugin completes.
+type pluginUpgradeResultMsg struct {
+	Wrote int
+	Err   error
+}
+
+// upgradePluginCmd returns a tea.Cmd that calls fabrikplugin.RefreshPlugin() in
+// a background goroutine and delivers the result as a pluginUpgradeResultMsg.
+// It does not block the TUI event loop.
+func upgradePluginCmd() tea.Cmd {
+	return func() tea.Msg {
+		n, err := fabrikplugin.RefreshPlugin()
+		return pluginUpgradeResultMsg{Wrote: n, Err: err}
+	}
+}
 
 // tuiReadSessionID reads the Claude session ID for a given repo, issue and stage.
 // The path logic mirrors engine.ReadSessionID — keep in sync if either changes.

--- a/tui/commands_test.go
+++ b/tui/commands_test.go
@@ -69,7 +69,7 @@ func TestTuiReadSessionID_NotFound(t *testing.T) {
 
 // TestUpdate_LKey_Returns_WatchCmd verifies the l key returns a non-nil tea.ExecProcess cmd.
 func TestUpdate_LKey_Returns_WatchCmd(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneActive
 	m.active.active[activeJobKey("", 7)] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
 	m.active.activeNumToKey[7] = activeJobKey("", 7)
@@ -84,7 +84,7 @@ func TestUpdate_LKey_Returns_WatchCmd(t *testing.T) {
 // PATH sets an error status message and returns a nil cmd (no subprocess launched).
 func TestUpdate_AKey_NoAbtop_SetsStatusMsg(t *testing.T) {
 	t.Setenv("PATH", "")
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
 	if cmd != nil {
 		t.Error("expected nil cmd when abtop is not in PATH")
@@ -109,7 +109,7 @@ func TestUpdate_AKey_AbtopFound_ReturnsExecCmd(t *testing.T) {
 	}
 	t.Setenv("PATH", fmt.Sprintf("%s%c%s", dir, os.PathListSeparator, os.Getenv("PATH")))
 
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
 	if cmd == nil {
 		t.Error("expected non-nil cmd (tea.ExecProcess) when abtop is found in PATH")

--- a/tui/detail_test.go
+++ b/tui/detail_test.go
@@ -10,7 +10,7 @@ import (
 // TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel verifies enter in history pane toggles the detail panel.
 func TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -30,7 +30,7 @@ func TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel(t *testing.T) {
 
 // TestUpdate_EscapeKey_ClosesDetailPanel verifies escape closes the detail panel.
 func TestUpdate_EscapeKey_ClosesDetailPanel(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.detailPanel = true
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -45,7 +45,7 @@ func TestUpdate_EscapeKey_ClosesDetailPanel(t *testing.T) {
 
 // TestUpdate_EnterKey_ActivePane_TogglesDetailPanel verifies enter in active pane toggles the detail panel.
 func TestUpdate_EnterKey_ActivePane_TogglesDetailPanel(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneActive

--- a/tui/events.go
+++ b/tui/events.go
@@ -135,3 +135,12 @@ type StageChangedEvent struct {
 }
 
 func (StageChangedEvent) tuiEvent() {}
+
+// SkillsStaleEvent is emitted once after startup when the on-disk plugin skill
+// files differ from the embedded versions. Count is the number of diffing files;
+// zero means skills are up to date (used to clear the header badge after upgrade).
+type SkillsStaleEvent struct {
+	Count int
+}
+
+func (SkillsStaleEvent) tuiEvent() {}

--- a/tui/footer_test.go
+++ b/tui/footer_test.go
@@ -18,7 +18,7 @@ func TestFooterHeight(t *testing.T) {
 }
 
 func TestViewFooter_Content(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board", Version: "2.0.0"}, "", nil)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board", Version: "2.0.0"}, "", nil, 0)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -34,7 +34,7 @@ func TestViewFooter_Content(t *testing.T) {
 }
 
 func TestViewFooter_NoVersion(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -52,7 +52,7 @@ func TestViewFooter_Truncation(t *testing.T) {
 		CWD:        "~/very/long/path/to/a/deeply/nested/project/directory",
 		BoardTitle: "Some Long Board Name For Truncation Test",
 		Version:    "99.99.99",
-	}, "", nil)
+	}, "", nil, 0)
 	m.width = 30
 	footer := m.footer.View(m.width)
 
@@ -70,7 +70,7 @@ func TestViewFooter_Truncation(t *testing.T) {
 // TestViewFooter_RateLimitHidden verifies that the rate limit section is omitted
 // when no stats have been received (Limit==0).
 func TestViewFooter_RateLimitHidden(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0)
 	m.width = 120
 	// graphqlStats is zero-value (Limit==0) by default.
 	footer := m.footer.View(m.width)
@@ -89,7 +89,7 @@ func TestViewFooter_RateLimitHidden(t *testing.T) {
 // TestViewFooter_RateLimitShown verifies the rate limit section appears once
 // graphqlStats is populated, and contains the fraction and countdown.
 func TestViewFooter_RateLimitShown(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0)
 	m.width = 120
 	m.footer.now = time.Now()
 	m.footer.graphqlStats = RateLimitStats{
@@ -129,7 +129,7 @@ func TestViewFooter_RateLimitColors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{CWD: "~", BoardTitle: "My Board"}, "", nil)
+			m := New(30, ProjectInfo{CWD: "~", BoardTitle: "My Board"}, "", nil, 0)
 			m.width = 120
 			m.footer.now = now
 			m.footer.graphqlStats = RateLimitStats{
@@ -154,7 +154,7 @@ func TestViewFooter_TruncationWithRateLimit(t *testing.T) {
 		CWD:        "~/very/long/path/to/a/deeply/nested/project/directory",
 		BoardTitle: "Some Long Board Name For Truncation Test",
 		Version:    "99.99.99",
-	}, "", nil)
+	}, "", nil, 0)
 	m.width = 40
 	m.footer.now = now
 	m.footer.graphqlStats = RateLimitStats{
@@ -188,7 +188,7 @@ func TestViewFooter_OSC8Hyperlink(t *testing.T) {
 		CWD:        "~",
 		BoardTitle: "My Board",
 		BoardURL:   "https://github.com/orgs/acme/projects/1",
-	}, "", nil)
+	}, "", nil, 0)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -209,7 +209,7 @@ func TestViewFooter_PlainTextNoOSC8(t *testing.T) {
 		CWD:        "~",
 		BoardTitle: "My Board",
 		BoardURL:   "https://github.com/orgs/acme/projects/1",
-	}, "", nil)
+	}, "", nil, 0)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -224,7 +224,7 @@ func TestViewFooter_PlainTextNoOSC8(t *testing.T) {
 // TestViewFooter_NoTitleSlot verifies that no separator dot is shown when
 // BoardTitle is empty (footer is just CWD with no board title slot).
 func TestViewFooter_NoTitleSlot(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/project"}, "", nil)
+	m := New(30, ProjectInfo{CWD: "~/project"}, "", nil, 0)
 	m.width = 120
 	footer := m.footer.View(m.width)
 	plain := ansi.Strip(footer)

--- a/tui/header.go
+++ b/tui/header.go
@@ -18,6 +18,7 @@ type HeaderComponent struct {
 	fabrikVersion     string
 	statusLine        string
 	statusMsg         string
+	skillsStaleCount  int // number of plugin skill files differing from embedded; 0 = up to date
 }
 
 func (h HeaderComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
@@ -42,6 +43,8 @@ func (h HeaderComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 		if ev.IssueNumber == 0 {
 			h.statusLine = fmt.Sprintf("[%s] %s", ev.Tag, strings.TrimRight(ev.Message, "\n"))
 		}
+	case SkillsStaleEvent:
+		h.skillsStaleCount = ev.Count
 	}
 	return h, nil
 }
@@ -94,6 +97,11 @@ func (h HeaderComponent) View(width int) string {
 		left = title + status
 		leftWidth = lipgloss.Width(left)
 	}
+	if h.skillsStaleCount > 0 {
+		badge := dimStyle.Render("  [u] skills out of date")
+		left = left + badge
+		leftWidth = lipgloss.Width(left)
+	}
 	gap := max(width-4-leftWidth-timerWidth, 0)
 	return " " + left + strings.Repeat(" ", gap) + timerStr
 }
@@ -109,4 +117,10 @@ func (h HeaderComponent) HandleClick(x, y int) bool {
 // SetStatusMsg sets a transient status message shown in the header.
 func (h *HeaderComponent) SetStatusMsg(msg string) {
 	h.statusMsg = msg
+}
+
+// SetSkillsStaleCount sets the number of plugin skill files that differ from
+// the embedded versions. When n > 0, a persistent badge is shown in the header.
+func (h *HeaderComponent) SetSkillsStaleCount(n int) {
+	h.skillsStaleCount = n
 }

--- a/tui/header.go
+++ b/tui/header.go
@@ -74,12 +74,21 @@ func (h HeaderComponent) View(width int) string {
 		status = "  " + dimStyle.Render(displayStatus)
 	}
 
+	// Pre-compute badge so its width is factored into the truncation budget.
+	// Without this the badge can push the rendered line past the terminal width.
+	badge := ""
+	badgeWidth := 0
+	if h.skillsStaleCount > 0 {
+		badge = dimStyle.Render("  [u] skills out of date")
+		badgeWidth = lipgloss.Width(badge)
+	}
+
 	left := title + status
 	leftWidth := lipgloss.Width(left)
 	timerWidth := lipgloss.Width(timerStr)
 	available := width - 4
-	if leftWidth+timerWidth > available {
-		maxStatus := max(available-lipgloss.Width(title)-timerWidth-3, 0)
+	if leftWidth+timerWidth+badgeWidth > available {
+		maxStatus := max(available-lipgloss.Width(title)-timerWidth-badgeWidth-3, 0)
 		if maxStatus > 0 && displayStatus != "" {
 			s := displayStatus
 			for lipgloss.Width(s) > maxStatus {
@@ -97,10 +106,9 @@ func (h HeaderComponent) View(width int) string {
 		left = title + status
 		leftWidth = lipgloss.Width(left)
 	}
-	if h.skillsStaleCount > 0 {
-		badge := dimStyle.Render("  [u] skills out of date")
+	if badge != "" {
 		left = left + badge
-		leftWidth = lipgloss.Width(left)
+		leftWidth += badgeWidth
 	}
 	gap := max(width-4-leftWidth-timerWidth, 0)
 	return " " + left + strings.Repeat(" ", gap) + timerStr

--- a/tui/header_test.go
+++ b/tui/header_test.go
@@ -18,7 +18,7 @@ func TestHeaderHeight(t *testing.T) {
 // TestViewHeader_TimerAlwaysVisible verifies that when the status message is
 // long enough to trigger truncation, the timer string still appears in the output.
 func TestViewHeader_TimerAlwaysVisible(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 60
 	m.header.nextPollAt = time.Now().Add(90 * time.Second)
 
@@ -51,7 +51,7 @@ func TestViewHeader_WidthNeverExceedsTerminal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil)
+			m := New(30, ProjectInfo{}, "", nil, 0)
 			m.width = tc.width
 			m.header.nextPollAt = time.Now().Add(90 * time.Second)
 			m.header.statusLine = tc.statusLine
@@ -68,7 +68,7 @@ func TestViewHeader_WidthNeverExceedsTerminal(t *testing.T) {
 
 // TestViewHeader_WithStatusLine verifies statusLine content appears in the header.
 func TestViewHeader_WithStatusLine(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.header.statusLine = "some status"
 	header := m.header.View(m.width)
@@ -79,7 +79,7 @@ func TestViewHeader_WithStatusLine(t *testing.T) {
 
 // TestViewHeader_StatusLineTruncation verifies narrow headers truncate statusLine without panic.
 func TestViewHeader_StatusLineTruncation(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 25
 	m.header.statusLine = "a very very very very very very long status message"
 	header := m.header.View(m.width)
@@ -92,7 +92,7 @@ func TestViewHeader_StatusLineTruncation(t *testing.T) {
 // TestViewHeader_EffectiveInterval verifies that PollCompletedEvent with
 // EffectiveInterval updates the header timer to show the effective interval.
 func TestViewHeader_EffectiveInterval(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 
 	// Send a PollCompletedEvent with 2-minute effective interval.
@@ -117,7 +117,7 @@ func TestViewHeader_EffectiveInterval(t *testing.T) {
 // PollCompletedEvent sets the effective interval, a subsequent PollStartedEvent
 // uses that effective interval (not the configured one).
 func TestViewHeader_PollStartedUsesEffectiveInterval(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 
 	// Set effective interval via PollCompletedEvent.

--- a/tui/help.go
+++ b/tui/help.go
@@ -34,6 +34,7 @@ KEYBOARD SHORTCUTS
 
   Global
     a          Open abtop AI session monitor
+    u          Upgrade plugin skills (when out of date; confirms first)
     w          Wake: reset idle backoff and poll immediately
     ctrl+r     Force refresh (same as SIGHUP)
     ?          Toggle this help panel

--- a/tui/history_test.go
+++ b/tui/history_test.go
@@ -26,7 +26,7 @@ func redirectHistory(t *testing.T) {
 // TestUpdate_JK_HistoryPane verifies j/k navigation in the history pane.
 func TestUpdate_JK_HistoryPane(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -59,7 +59,7 @@ func TestUpdate_JK_HistoryPane(t *testing.T) {
 // TestUpdate_CKey_DeletesHistoryEntry verifies c removes the selected entry.
 func TestUpdate_CKey_DeletesHistoryEntry(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -80,7 +80,7 @@ func TestUpdate_CKey_DeletesHistoryEntry(t *testing.T) {
 
 // TestUpdate_CKey_EmptyHistory_NoOp verifies c is a no-op with no history.
 func TestUpdate_CKey_EmptyHistory_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneHistory
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
 	if cmd != nil {
@@ -92,7 +92,7 @@ func TestUpdate_CKey_EmptyHistory_NoOp(t *testing.T) {
 // viewport area scrolls the YOffset down, and navigating back up scrolls it up.
 func TestUpdate_ScrollToVisible(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -149,7 +149,7 @@ func TestUpdate_ScrollToVisible(t *testing.T) {
 // resets the viewport to the top regardless of the current selection position.
 func TestUpdate_JobCompletedScrollsToTop(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -183,7 +183,7 @@ func TestUpdate_JobCompletedScrollsToTop(t *testing.T) {
 // TestUpdate_CapitalC_ClearAll verifies two C presses clear all history.
 func TestUpdate_CapitalC_ClearAll(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -213,7 +213,7 @@ func TestUpdate_CapitalC_ClearAll(t *testing.T) {
 
 // TestUpdate_QuitDuringConfirmClear_Cancels verifies q cancels confirmClear state.
 func TestUpdate_QuitDuringConfirmClear_Cancels(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.history.SetConfirmClear(true)
 	m.focusPane = paneHistory
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
@@ -228,7 +228,7 @@ func TestUpdate_QuitDuringConfirmClear_Cancels(t *testing.T) {
 
 // TestUpdate_NKey_CancelsConfirmClear verifies n cancels the clear confirmation.
 func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.history.SetConfirmClear(true)
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
 	nm := next.(Model)
@@ -240,7 +240,7 @@ func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
 // TestViewHistory_ConfirmClear verifies the confirmation prompt is shown.
 func TestViewHistory_ConfirmClear(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -255,7 +255,7 @@ func TestViewHistory_ConfirmClear(t *testing.T) {
 // TestViewHistory_IsComment verifies the 💬 emoji appears for comment history entries.
 func TestViewHistory_IsComment(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.history.history = []HistoryEntry{{IssueNumber: 5, StageName: "Implement", IsComment: true, Success: true}}
@@ -270,7 +270,7 @@ func TestViewHistory_IsComment(t *testing.T) {
 // TestViewHistory_ConfirmQuit verifies the quit confirmation prompt is shown in viewHistory.
 func TestViewHistory_ConfirmQuit(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	key42 := activeJobKey("", 42)
@@ -393,7 +393,7 @@ func TestLoadHistory_Dedup(t *testing.T) {
 func TestJobCompletedEvent_Dedup(t *testing.T) {
 	redirectHistory(t)
 
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -124,7 +124,8 @@ const minHistoryRows = 5
 // info provides project metadata displayed in the footer.
 // pluginDir is the Fabrik plugin directory passed to claude --plugin-dir (may be empty).
 // wakeCh is an optional channel the TUI sends on to wake the engine poll loop (may be nil).
-func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct{}) Model {
+// skillsStaleCount is the number of plugin skill files that differ from embedded; 0 means up to date.
+func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct{}, skillsStaleCount int) Model {
 	interval := time.Duration(pollSeconds) * time.Second
 	now := time.Now()
 	spinnerFrames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -144,9 +145,10 @@ func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct
 		pluginDir: pluginDir,
 		wakeCh:    wakeCh,
 		header: HeaderComponent{
-			pollInterval:  interval,
-			now:           now,
-			fabrikVersion: info.FabrikVersion,
+			pollInterval:     interval,
+			now:              now,
+			fabrikVersion:    info.FabrikVersion,
+			skillsStaleCount: skillsStaleCount,
 		},
 		active:  active,
 		history: NewHistoryPaneComponent(info.Repo),

--- a/tui/model.go
+++ b/tui/model.go
@@ -416,6 +416,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Fan out to all components
 		comp, _ := m.header.Update(msg)
 		m.header = comp.(HeaderComponent)
+		// TickEvent clears statusMsg; re-show the upgrade confirmation prompt so
+		// it remains visible until the user responds with y/n/esc.
+		if m.confirmUpgrade {
+			m.header.SetStatusMsg(fmt.Sprintf(
+				"Upgrade %d plugin file(s)? Active invocations pick up changes on next run. [y/N]",
+				m.header.skillsStaleCount,
+			))
+		}
 		comp, _ = m.active.Update(msg)
 		m.active = comp.(ActivePaneComponent)
 		comp, _ = m.footer.Update(msg)

--- a/tui/model.go
+++ b/tui/model.go
@@ -483,6 +483,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.active = comp.(ActivePaneComponent)
 		return m, nil
 
+	case SkillsStaleEvent:
+		m.header.SetSkillsStaleCount(ev.Count)
+		return m, nil
+
+	case pluginUpgradeResultMsg:
+		m.confirmUpgrade = false
+		if ev.Err != nil {
+			m.header.SetStatusMsg(fmt.Sprintf("plugin upgrade failed: %v", ev.Err))
+		} else {
+			m.header.SetSkillsStaleCount(0)
+			m.header.SetStatusMsg(fmt.Sprintf("Plugin skills upgraded: %d file(s)", ev.Wrote))
+		}
+		return m, nil
+
 	}
 
 	return m, nil

--- a/tui/model.go
+++ b/tui/model.go
@@ -94,10 +94,11 @@ type Model struct {
 	height int
 
 	// focus and confirmation state
-	focusPane   pane
-	confirmQuit bool
-	detailPanel bool
-	helpPanel   bool
+	focusPane      pane
+	confirmQuit    bool
+	confirmUpgrade bool
+	detailPanel    bool
+	helpPanel      bool
 
 	// plugin directory
 	pluginDir string
@@ -219,6 +220,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "n", "N":
+			if m.confirmUpgrade {
+				m.confirmUpgrade = false
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
 			if m.history.ConfirmClear() {
 				m.history.SetConfirmClear(false)
 				m.updateLayout(false)
@@ -236,6 +242,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "esc":
+			if m.confirmUpgrade {
+				m.confirmUpgrade = false
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
 			if m.history.ConfirmClear() {
 				m.history.SetConfirmClear(false)
 				m.updateLayout(false)
@@ -312,6 +323,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+r":
 			m.header.SetStatusMsg("refreshing…")
 			return m, sendSighupCmd()
+
+		case "u":
+			if m.header.skillsStaleCount > 0 {
+				m.confirmUpgrade = true
+				m.header.SetStatusMsg(fmt.Sprintf(
+					"Upgrade %d plugin file(s)? Active invocations pick up changes on next run. [y/N]",
+					m.header.skillsStaleCount,
+				))
+			} else {
+				m.header.SetStatusMsg("plugin skills up to date")
+			}
+			return m, nil
+
+		case "y", "Y":
+			if m.confirmUpgrade {
+				m.confirmUpgrade = false
+				return m, upgradePluginCmd()
+			}
+			// Not confirming — forward to history viewport for scrolling.
+			var cmd tea.Cmd
+			m.history.historyVP, cmd = m.history.historyVP.Update(msg)
+			return m, cmd
 
 		case "a":
 			if _, err := exec.LookPath("abtop"); err != nil {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	if m.header.pollInterval != 30*time.Second {
 		t.Errorf("pollInterval = %v, want 30s", m.header.pollInterval)
 	}
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 
 func TestNew_StoresProjectInfo(t *testing.T) {
 	info := ProjectInfo{CWD: "~/foo", BoardTitle: "Acme Board", Version: "1.2.3"}
-	m := New(30, info, "", nil)
+	m := New(30, info, "", nil, 0)
 	if m.footer.projectInfo != info {
 		t.Errorf("projectInfo = %+v, want %+v", m.footer.projectInfo, info)
 	}
@@ -38,7 +38,7 @@ func TestNew_StoresProjectInfo(t *testing.T) {
 
 // TestInit verifies Init returns a non-nil cmd (the initial tick).
 func TestInit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	cmd := m.Init()
 	if cmd == nil {
 		t.Error("Init() should return a non-nil cmd")
@@ -46,7 +46,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestUpdate_TickEvent(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	initial := m.active.spinnerIdx
@@ -67,7 +67,7 @@ func TestUpdate_TickEvent(t *testing.T) {
 }
 
 func TestUpdate_PollStartedAndCompleted(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	before := time.Now()
 
 	next, _ := m.Update(PollStartedEvent{Owner: "o", Repo: "r", Project: 1})
@@ -85,7 +85,7 @@ func TestUpdate_PollStartedAndCompleted(t *testing.T) {
 }
 
 func TestUpdate_QuitKey(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	if cmd == nil {
 		t.Error("expected quit cmd from 'q' key")
@@ -99,7 +99,7 @@ func TestUpdate_QuitKey(t *testing.T) {
 
 // TestUpdate_TabKey_SwitchesPanes verifies tab toggles focus between panes.
 func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	if m.focusPane != paneActive {
@@ -124,7 +124,7 @@ func TestUpdate_RKey_HistoryPane_WithEntry_MissingWorktree(t *testing.T) {
 	redirectHistory(t)
 	// Chdir to a temp dir so worktree path won't accidentally exist.
 	t.Chdir(t.TempDir())
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneHistory
 	m.history.history = []HistoryEntry{
 		{IssueNumber: 42, StageName: "Research", StageModel: "sonnet", Success: true},
@@ -150,7 +150,7 @@ func TestUpdate_RKey_HistoryPane_WithWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(dir)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneHistory
 	m.history.history = []HistoryEntry{
 		{IssueNumber: 42, StageName: "Research", StageModel: "sonnet", Success: true},
@@ -164,7 +164,7 @@ func TestUpdate_RKey_HistoryPane_WithWorktree(t *testing.T) {
 }
 
 func TestUpdate_RKey_HistoryPane_NoEntries_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneHistory
 	m.history.history = nil
 
@@ -176,7 +176,7 @@ func TestUpdate_RKey_HistoryPane_NoEntries_NoOp(t *testing.T) {
 
 func TestUpdate_RKey_HistoryPane_ActiveIssue_SetsStatusMsg(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.focusPane = paneHistory
 	// Add issue 42 to both active map and history.
 	key42 := activeJobKey("", 42)
@@ -196,7 +196,7 @@ func TestUpdate_RKey_HistoryPane_ActiveIssue_SetsStatusMsg(t *testing.T) {
 }
 
 func TestUpdate_LogEvent_IssueZero_StatusLine(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	next, _ := m.Update(LogEvent{IssueNumber: 0, Tag: "poll", Message: "polling now\n"})
@@ -207,7 +207,7 @@ func TestUpdate_LogEvent_IssueZero_StatusLine(t *testing.T) {
 }
 
 func TestUpdate_QKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
 
@@ -222,7 +222,7 @@ func TestUpdate_QKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
 }
 
 func TestUpdate_QKey_WhenConfirmQuit_Quits(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.confirmQuit = true
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
@@ -238,7 +238,7 @@ func TestUpdate_QKey_WhenConfirmQuit_Quits(t *testing.T) {
 }
 
 func TestUpdate_NKey_CancelsConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.confirmQuit = true
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
@@ -252,7 +252,7 @@ func TestUpdate_NKey_CancelsConfirmQuit(t *testing.T) {
 }
 
 func TestUpdate_EscKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
 
@@ -267,7 +267,7 @@ func TestUpdate_EscKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
 }
 
 func TestUpdate_EscKey_WhenConfirmQuit_Cancels(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.confirmQuit = true
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
@@ -283,7 +283,7 @@ func TestUpdate_EscKey_WhenConfirmQuit_Cancels(t *testing.T) {
 }
 
 func TestUpdate_CtrlC_BypassesConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.confirmQuit = true
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
@@ -299,7 +299,7 @@ func TestUpdate_CtrlC_BypassesConfirmQuit(t *testing.T) {
 }
 
 func TestView_BeforeWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	// Before width is set, View should return a loading placeholder without panicking
 	v := m.View()
 	if !strings.Contains(v, "Loading") {
@@ -308,7 +308,7 @@ func TestView_BeforeWindowSize(t *testing.T) {
 }
 
 func TestView_AfterWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{BoardTitle: "Acme PM", CWD: "~/myproject"}, "", nil)
+	m := New(30, ProjectInfo{BoardTitle: "Acme PM", CWD: "~/myproject"}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	m.header.nextPollAt = time.Now().Add(30 * time.Second)
@@ -344,7 +344,7 @@ func TestLayoutHeightInvariant(t *testing.T) {
 
 	for _, n := range []int{0, 1, 7, 8, 15} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil)
+			m := New(30, ProjectInfo{}, "", nil, 0)
 			// Add n active jobs.
 			now := time.Now()
 			for i := 0; i < n; i++ {
@@ -385,7 +385,7 @@ func TestLayoutHeightInvariant_SmallTerminal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("h=%d,n=%d", tc.termHeight, tc.nActive), func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil)
+			m := New(30, ProjectInfo{}, "", nil, 0)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -426,7 +426,7 @@ func TestLayoutHeightInvariant_NarrowWithHint(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil)
+			m := New(30, ProjectInfo{}, "", nil, 0)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -466,7 +466,7 @@ func TestTuiEventMethods(t *testing.T) {
 // or esc closes it, and opening help closes the detail panel.
 func TestHelpPanelToggle(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 
@@ -495,7 +495,7 @@ func TestHelpPanelToggle(t *testing.T) {
 	}
 
 	// Pressing ? while detail panel is open closes detail and opens help.
-	m2 := New(30, ProjectInfo{}, "", nil)
+	m2 := New(30, ProjectInfo{}, "", nil, 0)
 	m2.width = 80
 	m2.height = 24
 	m2.detailPanel = true
@@ -513,7 +513,7 @@ func TestHelpPanelToggle(t *testing.T) {
 // would normally change model state (tab, enter, r, l) are suppressed.
 func TestHelpPanelSuppressKeys(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 	// Open help panel.
@@ -569,7 +569,7 @@ func TestLayoutHeightInvariant_ConfirmClear(t *testing.T) {
 
 	setup := func(t *testing.T) Model {
 		t.Helper()
-		m := New(30, ProjectInfo{}, "", nil)
+		m := New(30, ProjectInfo{}, "", nil, 0)
 		for i := 0; i < 3; i++ {
 			m.history.history = append(m.history.history, HistoryEntry{
 				IssueNumber: i + 1, StageName: "Research", Success: true, Completed: true,
@@ -661,7 +661,7 @@ func TestLayoutHeightInvariant_DetailPanel(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil)
+			m := New(30, ProjectInfo{}, "", nil, 0)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				key := fmt.Sprintf("issue-%d", i+1)
@@ -723,7 +723,7 @@ func TestLayoutHeightInvariant_WithHelp(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil)
+			m := New(30, ProjectInfo{}, "", nil, 0)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -757,7 +757,7 @@ func TestLayoutHeightInvariant_WithHelp(t *testing.T) {
 // and sets the status message to "waking up...".
 func TestUpdate_WKey_SendsOnWakeCh(t *testing.T) {
 	wakeCh := make(chan struct{}, 1)
-	m := New(30, ProjectInfo{}, "", wakeCh)
+	m := New(30, ProjectInfo{}, "", wakeCh, 0)
 	m.width = 80
 	m.height = 24
 	m.header.nextPollAt = time.Now().Add(5 * time.Minute)
@@ -782,7 +782,7 @@ func TestUpdate_WKey_SendsOnWakeCh(t *testing.T) {
 
 // TestUpdate_WKey_NilWakeCh_NoOp verifies that pressing w with no wakeCh is a no-op.
 func TestUpdate_WKey_NilWakeCh_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil)
+	m := New(30, ProjectInfo{}, "", nil, 0)
 	m.width = 80
 	m.height = 24
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -460,6 +460,7 @@ func TestTuiEventMethods(t *testing.T) {
 	JobStartedEvent{}.tuiEvent()
 	JobCompletedEvent{}.tuiEvent()
 	TickEvent{}.tuiEvent()
+	SkillsStaleEvent{}.tuiEvent()
 }
 
 // TestHelpPanelToggle verifies that pressing ? opens the help panel, pressing ?
@@ -791,5 +792,166 @@ func TestUpdate_WKey_NilWakeCh_NoOp(t *testing.T) {
 
 	if nm.header.statusMsg != "" {
 		t.Errorf("expected empty statusMsg with nil wakeCh, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUpdate_UKey_WhenStale_SetsConfirmUpgrade verifies that pressing u when
+// skillsStaleCount > 0 sets confirmUpgrade and shows a confirmation prompt.
+func TestUpdate_UKey_WhenStale_SetsConfirmUpgrade(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 3)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from u key (just shows prompt)")
+	}
+	if !nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=true after pressing u with stale skills")
+	}
+	if !strings.Contains(nm.header.statusMsg, "3") {
+		t.Errorf("statusMsg should mention file count, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg verifies that pressing u when
+// skillsStaleCount == 0 shows "up to date" message without setting confirmUpgrade.
+func TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from u key when up to date")
+	}
+	if nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=false when skills are up to date")
+	}
+	if nm.header.statusMsg != "plugin skills up to date" {
+		t.Errorf("statusMsg = %q, want %q", nm.header.statusMsg, "plugin skills up to date")
+	}
+}
+
+// TestUpdate_YKey_WhenConfirmUpgrade_DispatchesCmd verifies that pressing y
+// when confirmUpgrade is true clears the flag and returns the upgrade cmd.
+func TestUpdate_YKey_WhenConfirmUpgrade_DispatchesCmd(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 2)
+	m.confirmUpgrade = true
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	nm := next.(Model)
+
+	if cmd == nil {
+		t.Error("expected non-nil cmd (upgradePluginCmd) after pressing y")
+	}
+	if nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=false after pressing y")
+	}
+}
+
+// TestUpdate_NKey_CancelsConfirmUpgrade verifies that pressing n when
+// confirmUpgrade is true clears the flag and status message.
+func TestUpdate_NKey_CancelsConfirmUpgrade(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 2)
+	m.confirmUpgrade = true
+	m.header.statusMsg = "Upgrade 2 plugin file(s)? [y/N]"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from n key canceling upgrade")
+	}
+	if nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=false after pressing n")
+	}
+	if nm.header.statusMsg != "" {
+		t.Errorf("expected empty statusMsg after cancel, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUpdate_EscKey_CancelsConfirmUpgrade verifies that pressing esc when
+// confirmUpgrade is true clears the flag and status message.
+func TestUpdate_EscKey_CancelsConfirmUpgrade(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 2)
+	m.confirmUpgrade = true
+	m.header.statusMsg = "Upgrade 2 plugin file(s)? [y/N]"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from esc key canceling upgrade")
+	}
+	if nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=false after pressing esc")
+	}
+	if nm.header.statusMsg != "" {
+		t.Errorf("expected empty statusMsg after cancel, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUpdate_New_WithSkillsStaleCount initializes with a stale count and
+// verifies the header badge field is set.
+func TestUpdate_New_WithSkillsStaleCount(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 5)
+	if m.header.skillsStaleCount != 5 {
+		t.Errorf("skillsStaleCount = %d, want 5", m.header.skillsStaleCount)
+	}
+}
+
+// TestUpdate_SkillsStaleEvent updates the header badge count.
+func TestUpdate_SkillsStaleEvent(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0)
+
+	next, cmd := m.Update(SkillsStaleEvent{Count: 4})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from SkillsStaleEvent")
+	}
+	if nm.header.skillsStaleCount != 4 {
+		t.Errorf("skillsStaleCount = %d, want 4", nm.header.skillsStaleCount)
+	}
+}
+
+// TestUpdate_PluginUpgradeResultMsg_Success verifies a successful upgrade clears
+// the badge and shows a success message.
+func TestUpdate_PluginUpgradeResultMsg_Success(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 3)
+	m.confirmUpgrade = true
+
+	next, _ := m.Update(pluginUpgradeResultMsg{Wrote: 3, Err: nil})
+	nm := next.(Model)
+
+	if nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=false after successful upgrade")
+	}
+	if nm.header.skillsStaleCount != 0 {
+		t.Errorf("skillsStaleCount = %d, want 0 after upgrade", nm.header.skillsStaleCount)
+	}
+	if !strings.Contains(nm.header.statusMsg, "3") {
+		t.Errorf("statusMsg should mention count, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUpdate_PluginUpgradeResultMsg_Error verifies a failed upgrade retains the
+// badge and shows an error message.
+func TestUpdate_PluginUpgradeResultMsg_Error(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 2)
+	m.confirmUpgrade = true
+
+	next, _ := m.Update(pluginUpgradeResultMsg{Wrote: 0, Err: fmt.Errorf("disk full")})
+	nm := next.(Model)
+
+	if nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade=false after upgrade attempt")
+	}
+	if nm.header.skillsStaleCount != 2 {
+		t.Errorf("skillsStaleCount = %d, want 2 (badge retained on error)", nm.header.skillsStaleCount)
+	}
+	if !strings.Contains(nm.header.statusMsg, "disk full") {
+		t.Errorf("statusMsg should contain error, got %q", nm.header.statusMsg)
 	}
 }

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -814,6 +814,27 @@ func TestUpdate_UKey_WhenStale_SetsConfirmUpgrade(t *testing.T) {
 	}
 }
 
+// TestUpdate_TickEvent_ConfirmUpgrade_PromptPersists verifies that the upgrade
+// confirmation prompt is re-shown after a TickEvent clears statusMsg.
+func TestUpdate_TickEvent_ConfirmUpgrade_PromptPersists(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 2)
+	m.confirmUpgrade = true
+	m.header.SetStatusMsg("Upgrade 2 plugin file(s)? Active invocations pick up changes on next run. [y/N]")
+
+	next, _ := m.Update(TickEvent{At: time.Now()})
+	nm := next.(Model)
+
+	if !nm.confirmUpgrade {
+		t.Error("expected confirmUpgrade still true after tick")
+	}
+	if nm.header.statusMsg == "" {
+		t.Error("expected prompt to be re-shown after tick cleared statusMsg")
+	}
+	if !strings.Contains(nm.header.statusMsg, "2") {
+		t.Errorf("re-shown prompt should mention file count, got %q", nm.header.statusMsg)
+	}
+}
+
 // TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg verifies that pressing u when
 // skillsStaleCount == 0 shows "up to date" message without setting confirmUpgrade.
 func TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg(t *testing.T) {


### PR DESCRIPTION
## Summary

Two changes, in order of priority:

**Part 1 (minimal fix):** Mirror the `FABRIK_AUTO_UPGRADED` pattern. Set `FABRIK_SIGHUP_RESTART=1` in the environment before `syscall.Exec` in `engine/sighup_unix.go`. In `cmd/root.go`, when that var is set, unset it immediately and force the non-TTY path through `checkPluginSkills` — auto-refresh silently without prompting. This stops the daemon wedging on stdin after SIGHUP.

**Part 2 (architectural fix):** Remove `checkPluginSkills` from the startup-blocking path entirely. For TUI sessions, evaluate the diff after the poll loop starts and surface a persistent header warning with a `u` keybinding to trigger upgrade interactively. For non-TUI (headless/CI) sessions, keep the current silent auto-refresh behavior.

## Problem

SIGHUP triggers an in-place re-exec (`engine/sighup_unix.go`) to clear in-memory state. After re-exec, the new process hits `checkPluginSkills` at `cmd/root.go:503`. If `.fabrik/plugin/` files differ from the embedded set **and** the process has a TTY, it blocks on a stdin prompt:

```
Plugin skills on disk don't match this version of fabrik. Do you want to upgrade them? [y/N]
```

The user asked for "refresh state," not "upgrade plugin skills." The daemon wedges waiting on stdin the user has no expectation of. The auto-upgrade re-exec path already sidesteps this prompt via `FABRIK_AUTO_UPGRADED=1` (`cmd/root.go:493`); SIGHUP re-exec has no equivalent guard.

The deeper design problem: `checkPluginSkills` is on the startup-blocking path. A daemon should start fully and surface optional state-mutation prompts as a non-blocking notification — not gate startup on them. Currently:

- **Non-TTY** — silently auto-refreshes; user never learns plugin files were rewritten.
- **Interactive / TTY** — blocks at startup on a y/N prompt. Surprising on SIGHUP; mildly annoying on a normal start.

## Approach

### Approach

This is a two-part change. Part 1 is a targeted env-var guard (mirrors the existing `FABRIK_AUTO_UPGRADED` pattern exactly). Part 2 removes the blocking startup call and adds a TUI-native upgrade flow via a new keybinding.

**Key decisions made from research options:**

- **Badge placement**: Inline on the existing single header row (option a). Avoids updating `Height()` and the 10+ layout invariant tests. The badge text (`  [u] skills out of date`) gets truncated naturally at narrow widths, which is acceptable — the prompt appears in the header status when `u` is pressed.
- **Initial stale count delivery**: Pass `skillsStaleCount int` as a new parameter to `tui.New()` (option a). Simpler than a channel send, initializes state directly, no race between forwarding goroutine start and render.
- **SIGHUP test approach**: Extend `TestRun_SighupRestart` in `engine/sighup_test.go` to assert `FABRIK_SIGHUP_RESTART=1` is present in the captured `envv` (option b). Most targeted, follows the existing test structure.
- **`n`/`esc` handler order**: Cancel `confirmUpgrade` at the top of each handler, before all existing checks. Prevents `n` from being misinterpreted if both `confirmUpgrade` and another confirmation are simultaneously true.
- **`y`/`Y` handler**: Only acts when `m.confirmUpgrade` is true; falls through to the viewport scroll `default:` otherwise.
- **No ADR needed**: The env-var guard and TUI event patterns follow established conventions (existing ADR 015 covers the non-ExecProcess Cmd pattern; `FABRIK_AUTO_UPGRADED` is the direct prior art). No new architectural decisions here.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/sighup_unix.go` | Append `FABRIK_SIGHUP_RESTART=1` to env slice before exec |
| `cmd/root.go` | Detect/unset `FABRIK_SIGHUP_RESTART` before `engine.New()`; remove blocking `checkPluginSkills` call; add post-`engine.New()` stale count evaluation; pass count to `runTUI` |
| `engine/sighup_test.go` | Extend `TestRun_SighupRestart` to assert env var in captured exec call |
| `tui/events.go` | Add `SkillsStaleEvent{Count int}` |
| `tui/header.go` | Add `skillsStaleCount int` field; inline badge in `View()`; handle `SkillsStaleEvent` in `Update()`; add `SetSkillsStaleCount()` |
| `tui/commands.go` | Add `pluginUpgradeResultMsg` type; add `upgradePluginCmd()` background `tea.Cmd` |
| `tui/model.go` | Add `confirmUpgrade bool`; `u`/`y`/`Y` handlers; update `n`/`N` and `esc` handlers; handle `pluginUpgradeResultMsg` and `SkillsStaleEvent` in `Update()` |
| `tui/help.go` | Add `u` entry to Global keybindings section |
| `docs/USER_GUIDE.md` | Add `u` row to §7 Keyboard Shortcuts table |

### Key Decisions

- **`os.Unsetenv("FABRIK_SIGHUP_RESTART")` placement**: Must occur before `engine.New()` to prevent Claude child processes inheriting it. The call goes in the same block as the `FABRIK_AUTO_UPGRADED` guard (lines 493–498), immediately after the auto-upgraded block.
- **`checkPluginSkills` removal**: The startup-blocking call at line 503 is removed entirely. The SIGHUP guard (Part 1) handles the SIGHUP re-exec window; the post-`engine.New()` block (Part 2) handles normal startup.
- **`upgradePluginCmd()` as a background goroutine**: Calls `fabrikplugin.RefreshPlugin()` in a goroutine (standard bubbletea `tea.Cmd` pattern); returns `pluginUpgradeResultMsg`. No `tea.ExecProcess` — the operation is non-interactive and does not need TTY handoff.
- **`SkillsStaleEvent` handling in `Model.Update()`**: Calls `m.header.SetSkillsStaleCount(ev.Count)`. The `pluginUpgradeResultMsg` handler clears `confirmUpgrade`, calls `m.header.SetSkillsStaleCount(0)`, and shows a status message. On error, it shows an error status without clearing the badge.
- **`confirmUpgrade` prompt text**: `"Upgrade N plugin file(s)? Active invocations pick up changes on next run. [y/N]"` — shown via `m.header.SetStatusMsg()`. When `esc`/`n`/`N` cancel, `SetStatusMsg("")` clears it.

### Task Checklist

- [ ] **Task 1 — `engine/sighup_unix.go`: inject env var before exec.** Change `execFn(exe, os.Args, os.Environ())` to append `"FABRIK_SIGHUP_RESTART=1"` to a copy of `os.Environ()`. Add a comment: `// FABRIK_SIGHUP_RESTART=1 mirrors FABRIK_AUTO_UPGRADED: detected at cmd/root.go startup to force non-interactive plugin skills refresh without prompting.`
- [ ] **Task 2 — `cmd/root.go`: SIGHUP guard (Part 1).** After the `FABRIK_AUTO_UPGRADED` block (line 498), add a new block: if `os.Getenv("FABRIK_SIGHUP_RESTART") == "1"`, call `os.Unsetenv("FABRIK_SIGHUP_RESTART")` then `checkPluginSkillsWithReader(pluginDir, false, nil)` with stderr warning on error.
- [ ] **Task 3 — `engine/sighup_test.go`: assert env var in exec.** In `TestRun_SighupRestart` (after exec is captured), add a check that the captured `envv` slice contains `"FABRIK_SIGHUP_RESTART=1"`.
- [ ] **Task 4 — `tui/events.go`: add `SkillsStaleEvent`.** Add `type SkillsStaleEvent struct { Count int }` with `func (SkillsStaleEvent) tuiEvent() {}`.
- [ ] **Task 5 — `tui/header.go`: persistent badge for stale skills.** Add `skillsStaleCount int` field to `HeaderComponent`. In `Update()`, handle `SkillsStaleEvent` by setting `h.skillsStaleCount = ev.Count`. In `View()`, when `h.skillsStaleCount > 0`, append `  [u] skills out of date` (dim-styled) to the `left` string, before the gap calculation. Add `func (h *HeaderComponent) SetSkillsStaleCount(n int) { h.skillsStaleCount = n }`.
- [ ] **Task 6 — `tui/commands.go` + message type: `upgradePluginCmd()`.** Add `type pluginUpgradeResultMsg struct { Wrote int; Err error }`. Add `func upgradePluginCmd() tea.Cmd` that returns a function calling `fabrikplugin.RefreshPlugin()` and returning `pluginUpgradeResultMsg{Wrote: n, Err: err}`. Add import for `fabrikplugin "github.com/..."` (match existing upgrade.go import path).
- [ ] **Task 7 — `tui/model.go`: confirmation state and key handlers.** Add `confirmUpgrade bool` to `Model`. In the key handler switch: add `case "u":` (when `m.header.skillsStaleCount > 0`, set `m.confirmUpgrade = true` and call `m.header.SetStatusMsg(fmt.Sprintf("Upgrade %d plugin file(s)? Active invocations pick up changes on next run. [y/N]", m.header.skillsStaleCount))`; if count == 0, `m.header.SetStatusMsg("plugin skills up to date")`). Add `case "y", "Y":` (if `m.confirmUpgrade`, set `m.confirmUpgrade = false` and `return m, upgradePluginCmd()`). Prepend to `case "n", "N":` handler: if `m.confirmUpgrade`, clear it, call `m.header.SetStatusMsg("")`, return. Prepend to `case "esc":` handler: same. In `Update()`, handle `SkillsStaleEvent`: `m.header.SetSkillsStaleCount(ev.Count)`. Handle `pluginUpgradeResultMsg`: if `msg.Err != nil`, `m.header.SetStatusMsg(fmt.Sprintf("plugin upgrade failed: %v", msg.Err))`; else `m.header.SetSkillsStaleCount(0); m.header.SetStatusMsg(fmt.Sprintf("Plugin skills upgraded: %d file(s)", msg.Wrote))`.
- [ ] **Task 8 — `tui.New()`: add `skillsStaleCount` param.** Add `skillsStaleCount int` parameter to `tui.New()`. Initialize `header.skillsStaleCount: skillsStaleCount` in the returned `Model`. Update `runTUI` in `cmd/root.go` to accept `skillsStaleCount int` and pass to `tui.New()`.
- [ ] **Task 9 — `cmd/root.go`: remove blocking call; add post-`engine.New()` stale count.** Remove `checkPluginSkills(".fabrik/plugin")` at line 503. After `engine.New()` succeeds, add: `var skillsStaleCount int; if diffing, err := diffingPluginFiles(pluginDir); err == nil { skillsStaleCount = len(diffing) }`. For the non-TUI path: if `skillsStaleCount > 0`, call `checkPluginSkillsWithReader(pluginDir, false, nil)` (silent refresh). For the TUI path: pass `skillsStaleCount` to `runTUI`. (Note: `diffingPluginFiles` must be exported or the call moved to where it's accessible — it's in `cmd/upgrade.go`, same package, so it's accessible.)
- [ ] **Task 10 — `tui/help.go`: add `u` keybinding.** In the `Global` section of `helpContent`, add: `    u          Upgrade plugin skills (when out of date; shows confirmation)`. Keep within 72-char line limit.
- [ ] **Task 11 — `docs/USER_GUIDE.md` §7: document `u` keybinding.** Add a `u` row to the Keyboard Shortcuts table: "Upgrade plugin skills (when out of date; shows confirmation prompt)". Regenerate `docs/llms-full.txt` per CLAUDE.md instructions.

### Risks

- **`n`/`esc` ordering**: Both handlers must add the `confirmUpgrade` cancellation before their existing checks. Missing this leads to `confirmQuit` being triggered when the user cancels the upgrade prompt with `n`. The plan specifies "prepend" — the implementer must add the new check as the first `if` in each handler.
- **Badge truncation at narrow terminals**: The inline badge may be clipped when the terminal is very narrow. This is acceptable — the existing status line already truncates. The badge text is short (`  [u] skills out of date`).
- **`fabrikplugin` import in `tui/commands.go`**: The `tui` package currently doesn't import the `plugin` package. Adding this import introduces a new dependency. Check that it does not create an import cycle (it should not — `plugin` is a leaf package).
- **`tui.New()` signature change breaks callers**: Only one call site in `cmd/root.go`. Update it as part of Task 8.
- **`skillsStaleCount` field access in `tui/model.go`**: `m.header.skillsStaleCount` is a private field. Access from `Model.Update()` is valid (same package). The `case "u":` handler reads `m.header.skillsStaleCount` directly.

---
Used 15/50 turns, 7k input / 8k output tokens.

## Verification

Implemented both parts of the fix. Part 1: `FABRIK_SIGHUP_RESTART=1` is injected into the exec env before re-exec, detected and unset at startup, and `checkPluginSkillsWithReader(isTTY=false)` is called silently — SIGHUP restarts no longer block on stdin. Part 2: the blocking `checkPluginSkills()` startup call is removed; post-`engine.New()` the stale count drives either a silent headless refresh or a TUI header badge with a `u` keybinding that shows a confirmation prompt, runs `RefreshPlugin()` in a background goroutine, and clears the badge on success.

---

Closes #692