### PR TITLE
fabrik: force immediate probe when GraphQL budget recovers from exhaustion

### DIFF
--- a/engine/poll.go
+++ b/engine/poll.go
@@ -37,6 +37,13 @@ const rateLimitHealthyThreshold = 0.50
 // configured poll interval (e.g. 10× = 10 * PollSeconds).
 const rateLimitMaxBackoffMultiplier = 10
 
+// rateLimitNearZeroPercent is the threshold (as a percentage of Limit) below
+// which the previous remaining count is considered "near zero" for the
+// recovery wake signal. Budget transitions from near-zero to healthy happen
+// at the hourly reset boundary — not via gradual organic replenishment — so
+// this guard prevents spurious wakes from ordinary hysteresis crossings.
+const rateLimitNearZeroPercent = 1
+
 // maxIdleBackoff is the absolute maximum poll interval during idle backoff,
 // regardless of the configured poll interval.
 const maxIdleBackoff = 5 * time.Minute
@@ -68,6 +75,12 @@ func nextRateLimitLow(current bool, ratio float64) bool {
 		return false
 	}
 	return current
+}
+
+// isRateLimitNearZero reports whether remaining is at or near zero relative to
+// limit (within rateLimitNearZeroPercent). Returns false when limit is 0.
+func isRateLimitNearZero(remaining, limit int) bool {
+	return limit > 0 && remaining*100 <= limit*rateLimitNearZeroPercent
 }
 
 // effectiveIdleCap returns the idle backoff cap based on webhook stream health.
@@ -482,6 +495,7 @@ func (e *Engine) Run() error {
 	prevMultiplier := 1
 	rateLimitLow := false
 	rateLimitRatio := 1.0
+	lastRemainingCount := 0
 
 	// doPollCycle runs poll(), updates idle/backoff state, emits PollCompletedEvent,
 	// and resets the ticker to the effective interval. Returns the error from poll().
@@ -511,7 +525,17 @@ func (e *Engine) Run() error {
 			if newRateLimitLow && !rateLimitLow {
 				e.logf(0, "warn", "GraphQL rate limit low (%.0f%% remaining) — activating rate-limit backoff\n", ratio*100)
 			} else if !newRateLimitLow && rateLimitLow {
-				e.logf(0, "poll", "GraphQL rate limit recovered (%.0f%% remaining)\n", ratio*100)
+				if isRateLimitNearZero(lastRemainingCount, graphqlStats.Limit) {
+					e.logf(0, "info", "GraphQL rate limit recovered (%d/%d remaining) — triggering immediate probe\n", graphqlStats.Remaining, graphqlStats.Limit)
+					if e.wakeCh != nil {
+						select {
+						case e.wakeCh <- struct{}{}:
+						default:
+						}
+					}
+				} else {
+					e.logf(0, "poll", "GraphQL rate limit recovered (%.0f%% remaining)\n", ratio*100)
+				}
 			}
 			rateLimitLow = newRateLimitLow
 			if rateLimitLow {
@@ -519,6 +543,7 @@ func (e *Engine) Run() error {
 			} else {
 				rateLimitRatio = 1.0
 			}
+			lastRemainingCount = graphqlStats.Remaining
 		}
 
 		// Compute and apply effective interval.

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1402,6 +1402,41 @@ func TestNextRateLimitLow_NoActivationAboveThreshold(t *testing.T) {
 	}
 }
 
+// TestIsRateLimitNearZero_AtZero verifies that remaining=0 is always near zero.
+func TestIsRateLimitNearZero_AtZero(t *testing.T) {
+	if !isRateLimitNearZero(0, 5000) {
+		t.Error("expected true: remaining=0 must be near zero")
+	}
+}
+
+// TestIsRateLimitNearZero_AtBoundary verifies that remaining=50 with limit=5000 (exactly 1%) is near zero.
+func TestIsRateLimitNearZero_AtBoundary(t *testing.T) {
+	if !isRateLimitNearZero(50, 5000) {
+		t.Error("expected true: remaining=50 (1% of 5000) is at the near-zero boundary")
+	}
+}
+
+// TestIsRateLimitNearZero_JustAboveBoundary verifies that remaining=51 with limit=5000 (>1%) is not near zero.
+func TestIsRateLimitNearZero_JustAboveBoundary(t *testing.T) {
+	if isRateLimitNearZero(51, 5000) {
+		t.Error("expected false: remaining=51 (>1% of 5000) is just above the near-zero boundary")
+	}
+}
+
+// TestIsRateLimitNearZero_HealthyQuota verifies that a healthy remaining count is not near zero.
+func TestIsRateLimitNearZero_HealthyQuota(t *testing.T) {
+	if isRateLimitNearZero(1000, 5000) {
+		t.Error("expected false: remaining=1000 is well above the near-zero threshold")
+	}
+}
+
+// TestIsRateLimitNearZero_ZeroLimit verifies that limit=0 returns false (guards divide-by-zero).
+func TestIsRateLimitNearZero_ZeroLimit(t *testing.T) {
+	if isRateLimitNearZero(0, 0) {
+		t.Error("expected false: limit=0 must always return false")
+	}
+}
+
 // TestPollPreFilter_WaitForCI_CompleteLabelOnly_Skipped verifies that an item with
 // wait_for_ci: true and ONLY stage:X:complete (no fabrik:awaiting-ci) is filtered by
 // the poll pre-filter when not in cycleSet and no expired CooldownAt. In the

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -1430,7 +1430,7 @@ func TestIsRateLimitNearZero_HealthyQuota(t *testing.T) {
 	}
 }
 
-// TestIsRateLimitNearZero_ZeroLimit verifies that limit=0 returns false (guards divide-by-zero).
+// TestIsRateLimitNearZero_ZeroLimit verifies that limit=0 returns false (guards invalid/unknown limit).
 func TestIsRateLimitNearZero_ZeroLimit(t *testing.T) {
 	if isRateLimitNearZero(0, 0) {
 		t.Error("expected false: limit=0 must always return false")


### PR DESCRIPTION
## Summary

- Adds `isRateLimitNearZero(remaining, limit int) bool` pure helper (1% of Limit threshold) to `engine/poll.go`, following the `nextRateLimitLow` pattern
- Adds `lastRemainingCount int` closure-local in `Run()` to track the previous cycle's remaining count
- When `rateLimitLow → false` recovery is detected and the previous remaining was near zero (≤ 1% of Limit), sends a non-blocking wake on `e.wakeCh` and logs `[info] GraphQL rate limit recovered (N/M remaining) — triggering immediate probe`
- Five unit tests for `isRateLimitNearZero` covering zero, boundary, just-above-boundary, healthy, and zero-limit cases

Closes #706

## Test plan

- [ ] `go test -race -timeout 5m ./engine/...` — all engine tests pass
- [ ] `go vet ./...` — no vet issues
- [ ] `TestIsRateLimitNearZero_*` — five new unit tests pass, covering all boundary conditions
- [ ] Manual: run fabrik against a project that hits GraphQL exhaustion; verify immediate probe fires after hourly reset rather than waiting for next poll tick