### PR TITLE
fabrik(tui): surface rate-limit exhaustion as a prominent header banner with time-to-reset

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1470,7 +1470,9 @@ The interactive terminal dashboard is enabled by default when running in a real 
 
 The TUI shows a compact header with poll status, an In Progress pane showing active
 Claude sessions, a scrollable History pane with completed jobs, and a status bar
-(footer) displaying REST and GraphQL rate limit stats.
+(footer) displaying REST and GraphQL rate limit stats. When the GraphQL budget is
+exhausted or rate-limit-induced probe failures are detected, a prominent red alert
+banner appears immediately below the header with a countdown to when polling resumes.
 
 ### Keyboard Shortcuts
 
@@ -1651,6 +1653,20 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
 
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.
+
+#### Rate-Limit Exhaustion Alert Banner
+
+When the GraphQL budget hits zero or drops below 20% and probe failures begin,
+Fabrik suspends polling and displays a red alert banner immediately below the TUI
+header:
+
+```
+⚠ GraphQL rate limit exhausted — polling suspended. Resumes in 12m (14:30 local time).
+```
+
+The countdown ticks every second and shows the local time when the quota resets.
+Once the GraphQL budget recovers above 50%, the banner disappears automatically and
+polling resumes. You do not need to restart Fabrik — it recovers on its own.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1468,7 +1468,9 @@ The interactive terminal dashboard is enabled by default when running in a real 
 
 The TUI shows a compact header with poll status, an In Progress pane showing active
 Claude sessions, a scrollable History pane with completed jobs, and a status bar
-(footer) displaying REST and GraphQL rate limit stats.
+(footer) displaying REST and GraphQL rate limit stats. When the GraphQL budget is
+exhausted or rate-limit-induced probe failures are detected, a prominent red alert
+banner appears immediately below the header with a countdown to when polling resumes.
 
 ### Keyboard Shortcuts
 
@@ -1649,6 +1651,20 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
 
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.
+
+#### Rate-Limit Exhaustion Alert Banner
+
+When the GraphQL budget hits zero or drops below 20% and probe failures begin,
+Fabrik suspends polling and displays a red alert banner immediately below the TUI
+header:
+
+```
+⚠ GraphQL rate limit exhausted — polling suspended. Resumes in 12m (14:30 local time).
+```
+
+The countdown ticks every second and shows the local time when the quota resets.
+Once the GraphQL budget recovers above 50%, the banner disappears automatically and
+polling resumes. You do not need to restart Fabrik — it recovers on its own.
 
 ---
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1559,7 +1559,17 @@ func gitRevParse(dir, ref string) (string, error) {
 func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 	probeItems, _, err := e.client.ProbeProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 	if err != nil {
-		e.logf(0, "cache", "probe refresh failed (using prior cache state): %v\n", err)
+		_, graphqlStats := e.client.RateLimitStats()
+		if graphqlStats.Limit > 0 && (graphqlStats.Remaining == 0 || float64(graphqlStats.Remaining)/float64(graphqlStats.Limit) < rateLimitBackoffThreshold) {
+			retryStr := "retrying soon"
+			if !graphqlStats.Reset.IsZero() && graphqlStats.Reset.After(time.Now()) {
+				retryStr = fmt.Sprintf("retrying after %s (local)", graphqlStats.Reset.Local().Format("15:04"))
+			}
+			e.logf(0, "warn", "rate limited — polling suspended, %s\n", retryStr)
+			e.emitStructural(tui.RateLimitAlertEvent{Exhausted: true, Reset: graphqlStats.Reset})
+		} else {
+			e.logf(0, "cache", "probe refresh failed (using prior cache state): %v\n", err)
+		}
 		return
 	}
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -518,10 +518,12 @@ func (e *Engine) Run() error {
 		// Update rate-limit state using two-threshold hysteresis:
 		// activate when ratio drops below 20%; clear only when ratio rises above 50%.
 		// Activity detection does NOT reset rate-limit backoff — it is a separate concern.
+		var enteredRateLimitLow bool
 		_, graphqlStats := e.client.RateLimitStats()
 		if graphqlStats.Limit > 0 {
 			ratio := float64(graphqlStats.Remaining) / float64(graphqlStats.Limit)
 			newRateLimitLow := nextRateLimitLow(rateLimitLow, ratio)
+			enteredRateLimitLow = newRateLimitLow && !rateLimitLow
 			if newRateLimitLow && !rateLimitLow {
 				e.logf(0, "warn", "GraphQL rate limit low (%.0f%% remaining) — activating rate-limit backoff\n", ratio*100)
 			} else if !newRateLimitLow && rateLimitLow {
@@ -536,6 +538,7 @@ func (e *Engine) Run() error {
 				} else {
 					e.logf(0, "poll", "GraphQL rate limit recovered (%.0f%% remaining)\n", ratio*100)
 				}
+				e.emitStructural(tui.RateLimitAlertEvent{Exhausted: false})
 			}
 			rateLimitLow = newRateLimitLow
 			if rateLimitLow {
@@ -577,7 +580,7 @@ func (e *Engine) Run() error {
 		}
 
 		ticker.Reset(effectiveInterval)
-		if rateLimitLow {
+		if enteredRateLimitLow {
 			e.logf(0, "poll", "rate-limit backoff active — effective poll interval: %v\n", effectiveInterval)
 		}
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -518,12 +518,10 @@ func (e *Engine) Run() error {
 		// Update rate-limit state using two-threshold hysteresis:
 		// activate when ratio drops below 20%; clear only when ratio rises above 50%.
 		// Activity detection does NOT reset rate-limit backoff — it is a separate concern.
-		var enteredRateLimitLow bool
 		_, graphqlStats := e.client.RateLimitStats()
 		if graphqlStats.Limit > 0 {
 			ratio := float64(graphqlStats.Remaining) / float64(graphqlStats.Limit)
 			newRateLimitLow := nextRateLimitLow(rateLimitLow, ratio)
-			enteredRateLimitLow = newRateLimitLow && !rateLimitLow
 			if newRateLimitLow && !rateLimitLow {
 				e.logf(0, "warn", "GraphQL rate limit low (%.0f%% remaining) — activating rate-limit backoff\n", ratio*100)
 			} else if !newRateLimitLow && rateLimitLow {
@@ -580,9 +578,6 @@ func (e *Engine) Run() error {
 		}
 
 		ticker.Reset(effectiveInterval)
-		if enteredRateLimitLow {
-			e.logf(0, "poll", "rate-limit backoff active — effective poll interval: %v\n", effectiveInterval)
-		}
 
 		e.emitStructural(tui.PollCompletedEvent{
 			ItemCount:         result.ItemCount,
@@ -1568,7 +1563,7 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 			if !graphqlStats.Reset.IsZero() && graphqlStats.Reset.After(time.Now()) {
 				retryStr = fmt.Sprintf("retrying after %s (local)", graphqlStats.Reset.Local().Format("15:04"))
 			}
-			e.logf(0, "warn", "rate limited — polling suspended, %s\n", retryStr)
+			e.logf(0, "warn", "rate limited — polling suspended, %s: %v\n", retryStr, err)
 			e.emitStructural(tui.RateLimitAlertEvent{Exhausted: true, Reset: graphqlStats.Reset})
 		} else {
 			e.logf(0, "cache", "probe refresh failed (using prior cache state): %v\n", err)

--- a/tui/alert.go
+++ b/tui/alert.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// AlertBannerComponent renders a single high-visibility row when the GraphQL
+// budget is exhausted or probe failures attributable to rate limiting have been
+// observed. It implements the Component interface. Height() returns 1 when the
+// banner is visible and 0 otherwise, so the layout budget in model.go is correct.
+type AlertBannerComponent struct {
+	bannerActive bool
+	graphqlStats RateLimitStats
+	now          time.Time
+}
+
+// isVisible returns true when the banner should be shown.
+func (a AlertBannerComponent) isVisible() bool {
+	if a.graphqlStats.Limit == 0 {
+		return false
+	}
+	ratio := float64(a.graphqlStats.Remaining) / float64(a.graphqlStats.Limit)
+	if ratio > 0.50 {
+		return false
+	}
+	if a.graphqlStats.Remaining == 0 {
+		return true
+	}
+	return a.bannerActive
+}
+
+// Update handles events relevant to the alert banner.
+func (a AlertBannerComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case RateLimitAlertEvent:
+		if ev.Exhausted {
+			a.bannerActive = true
+			if !ev.Reset.IsZero() {
+				a.graphqlStats.Reset = ev.Reset
+			}
+		} else {
+			a.bannerActive = false
+		}
+	case PollCompletedEvent:
+		a.graphqlStats = ev.GraphQLStats
+	case TickEvent:
+		a.now = ev.At
+	}
+	return a, nil
+}
+
+// Height returns 1 when the banner is visible, 0 otherwise.
+func (a AlertBannerComponent) Height() int {
+	if a.isVisible() {
+		return 1
+	}
+	return 0
+}
+
+// View renders the alert banner at the given width.
+func (a AlertBannerComponent) View(width int) string {
+	if !a.isVisible() {
+		return ""
+	}
+	text := "⚠ GraphQL rate limit exhausted — polling suspended."
+	countdown := fmtBannerCountdown(a.graphqlStats.Reset, a.now)
+	if countdown != "" {
+		text += " " + countdown
+	}
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("196")).
+		Bold(true).
+		Width(width)
+	return style.Render(text)
+}

--- a/tui/alert.go
+++ b/tui/alert.go
@@ -70,9 +70,14 @@ func (a AlertBannerComponent) View(width int) string {
 	if countdown != "" {
 		text += " " + countdown
 	}
-	style := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("196")).
-		Bold(true).
-		Width(width)
-	return style.Render(text)
+	// Truncate to a single line so Height() == 1 is always accurate on
+	// narrow terminals where the text would otherwise wrap.
+	if width > 0 && lipgloss.Width(text) > width {
+		runes := []rune(text)
+		for len(runes) > 0 && lipgloss.Width(string(runes)+"…") > width {
+			runes = runes[:len(runes)-1]
+		}
+		text = string(runes) + "…"
+	}
+	return failStyle.Bold(true).Width(width).Render(text)
 }

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -80,6 +80,29 @@ func fmtRateLimitCountdown(reset time.Time, now time.Time) string {
 	return fmt.Sprintf("%ds", secs)
 }
 
+// fmtBannerCountdown formats the rate-limit reset time for the alert banner.
+// Returns "" when reset is zero (header was absent), "Resumes soon." when reset
+// is in the past, or "Resumes in Nm (HH:MM local time)." for a future reset.
+func fmtBannerCountdown(reset time.Time, now time.Time) string {
+	if reset.IsZero() {
+		return ""
+	}
+	remaining := reset.Sub(now)
+	if remaining <= 0 {
+		return "Resumes soon."
+	}
+	secs := int(remaining.Seconds())
+	var countdown string
+	if secs >= 3600 {
+		countdown = fmt.Sprintf("%dh", secs/3600)
+	} else if secs >= 60 {
+		countdown = fmt.Sprintf("%dm", secs/60)
+	} else {
+		countdown = fmt.Sprintf("%ds", secs)
+	}
+	return fmt.Sprintf("Resumes in %s (%s local time).", countdown, reset.Local().Format("15:04"))
+}
+
 // openWatchInlineCmd returns a tea.Cmd that suspends the TUI and launches
 // "fabrik watch <issueNumber>" in the current terminal via tea.ExecProcess.
 // The TUI is restored automatically when the user exits watch with q.

--- a/tui/commands_test.go
+++ b/tui/commands_test.go
@@ -59,6 +59,41 @@ func TestFmtRateLimitCountdown(t *testing.T) {
 	}
 }
 
+// TestFmtBannerCountdown verifies the banner countdown formatting helper.
+func TestFmtBannerCountdown(t *testing.T) {
+	now := time.Date(2026, 5, 11, 14, 0, 0, 0, time.UTC)
+
+	// Helper to build expected string: countdown + HH:MM derived from the reset's local time.
+	withTime := func(countdown string, reset time.Time) string {
+		return fmt.Sprintf("Resumes in %s (%s local time).", countdown, reset.Local().Format("15:04"))
+	}
+
+	resetSecs := now.Add(45 * time.Second)
+	resetMins := now.Add(3*time.Minute + 30*time.Second)
+	resetHours := now.Add(2*time.Hour + 30*time.Minute)
+
+	cases := []struct {
+		name  string
+		reset time.Time
+		want  string
+	}{
+		{"zero reset", time.Time{}, ""},
+		{"past reset", now.Add(-5 * time.Second), "Resumes soon."},
+		{"past reset zero delta", now, "Resumes soon."},
+		{"seconds", resetSecs, withTime("45s", resetSecs)},
+		{"minutes", resetMins, withTime("3m", resetMins)},
+		{"hours", resetHours, withTime("2h", resetHours)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fmtBannerCountdown(tc.reset, now)
+			if got != tc.want {
+				t.Errorf("fmtBannerCountdown(%v): got %q, want %q", tc.reset, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestTuiReadSessionID_NotFound verifies empty string for a missing session file.
 func TestTuiReadSessionID_NotFound(t *testing.T) {
 	id := tuiReadSessionID("", 99999, "SomeStageThatDoesNotExist")

--- a/tui/events.go
+++ b/tui/events.go
@@ -144,3 +144,14 @@ type SkillsStaleEvent struct {
 }
 
 func (SkillsStaleEvent) tuiEvent() {}
+
+// RateLimitAlertEvent is emitted by the engine when the GraphQL rate-limit state
+// transitions: Exhausted=true when a probe failure occurs while quota is low or
+// zero; Exhausted=false when quota recovers above rateLimitHealthyThreshold.
+// Reset is the time at which the quota is expected to reset (zero if unknown).
+type RateLimitAlertEvent struct {
+	Exhausted bool
+	Reset     time.Time
+}
+
+func (RateLimitAlertEvent) tuiEvent() {}

--- a/tui/model.go
+++ b/tui/model.go
@@ -108,6 +108,7 @@ type Model struct {
 
 	// components
 	header  HeaderComponent
+	alert   AlertBannerComponent
 	active  ActivePaneComponent
 	history HistoryPaneComponent
 	detail  DetailPanelComponent
@@ -150,6 +151,7 @@ func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct
 			fabrikVersion:    info.FabrikVersion,
 			skillsStaleCount: skillsStaleCount,
 		},
+		alert:   AlertBannerComponent{now: now},
 		active:  active,
 		history: NewHistoryPaneComponent(info.Repo),
 		footer: FooterComponent{
@@ -426,6 +428,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		comp, _ = m.active.Update(msg)
 		m.active = comp.(ActivePaneComponent)
+		comp, _ = m.alert.Update(msg)
+		m.alert = comp.(AlertBannerComponent)
 		comp, _ = m.footer.Update(msg)
 		m.footer = comp.(FooterComponent)
 		return m, tickCmd()
@@ -448,8 +452,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case PollCompletedEvent:
 		comp, _ := m.header.Update(msg)
 		m.header = comp.(HeaderComponent)
+		comp, _ = m.alert.Update(msg)
+		m.alert = comp.(AlertBannerComponent)
+		m.updateLayout(false)
 		comp, _ = m.footer.Update(msg)
 		m.footer = comp.(FooterComponent)
+		return m, nil
+
+	case RateLimitAlertEvent:
+		comp, _ := m.alert.Update(msg)
+		m.alert = comp.(AlertBannerComponent)
+		m.updateLayout(false)
 		return m, nil
 
 	case JobStartedEvent:
@@ -526,7 +539,7 @@ func (m *Model) updateLayout(scrollToTop bool) {
 		m.prepareDetailItem()
 		detailH = m.detail.Height()
 	}
-	totalAvail := m.height - m.header.Height() - activeH - detailH - m.footer.Height()
+	totalAvail := m.height - m.header.Height() - m.alert.Height() - activeH - detailH - m.footer.Height()
 
 	helpH := 0
 	if m.helpPanel {
@@ -594,6 +607,9 @@ func (m Model) View() string {
 	var sections []string
 
 	sections = append(sections, m.header.View(m.width))
+	if alertView := m.alert.View(m.width); alertView != "" {
+		sections = append(sections, alertView)
+	}
 	sections = append(sections, m.active.View(m.width))
 
 	if m.detailPanel {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -461,6 +461,77 @@ func TestTuiEventMethods(t *testing.T) {
 	JobCompletedEvent{}.tuiEvent()
 	TickEvent{}.tuiEvent()
 	SkillsStaleEvent{}.tuiEvent()
+	RateLimitAlertEvent{}.tuiEvent()
+}
+
+// TestUpdate_RateLimitAlertEvent_Exhausted verifies that after receiving a
+// RateLimitAlertEvent{Exhausted: true}, the alert banner becomes visible when
+// graphqlStats show low remaining quota.
+func TestUpdate_RateLimitAlertEvent_Exhausted(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0)
+	// First deliver stats that put ratio at 10% (below 20% threshold).
+	next, _ := m.Update(PollCompletedEvent{
+		GraphQLStats: RateLimitStats{Limit: 100, Remaining: 10},
+	})
+	m = next.(Model)
+
+	// Trigger alert — probe failure while rate limited.
+	next, _ = m.Update(RateLimitAlertEvent{Exhausted: true})
+	m = next.(Model)
+
+	if !m.alert.bannerActive {
+		t.Error("expected alert.bannerActive=true after RateLimitAlertEvent{Exhausted: true}")
+	}
+	if !m.alert.isVisible() {
+		t.Error("expected alert banner to be visible after Exhausted=true event with low quota")
+	}
+}
+
+// TestUpdate_RateLimitAlertEvent_Recovered verifies that after receiving a
+// RateLimitAlertEvent{Exhausted: false}, the banner's bannerActive flag is cleared.
+func TestUpdate_RateLimitAlertEvent_Recovered(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0)
+	// Manually set banner active with stats still low.
+	m.alert.bannerActive = true
+	m.alert.graphqlStats = RateLimitStats{Limit: 100, Remaining: 10}
+
+	// Recovery event.
+	next, _ := m.Update(RateLimitAlertEvent{Exhausted: false})
+	m = next.(Model)
+
+	if m.alert.bannerActive {
+		t.Error("expected alert.bannerActive=false after RateLimitAlertEvent{Exhausted: false}")
+	}
+}
+
+// TestUpdateLayout_AlertBannerHeightBudget verifies that the layout height
+// invariant holds when the alert banner is visible (banner takes 1 row).
+func TestUpdateLayout_AlertBannerHeightBudget(t *testing.T) {
+	redirectHistory(t)
+
+	const termWidth = 80
+	const termHeight = 24
+
+	m := New(30, ProjectInfo{}, "", nil, 0)
+	// Set stats so banner is visible (Remaining == 0).
+	m.alert.graphqlStats = RateLimitStats{Limit: 100, Remaining: 0}
+	m.alert.now = time.Now()
+
+	if !m.alert.isVisible() {
+		t.Fatal("precondition: alert banner should be visible with Remaining==0")
+	}
+	if m.alert.Height() != 1 {
+		t.Fatalf("precondition: alert Height() = %d, want 1", m.alert.Height())
+	}
+
+	// Apply window size — triggers updateLayout.
+	next, _ := m.Update(tea.WindowSizeMsg{Width: termWidth, Height: termHeight})
+	m = next.(Model)
+
+	got := lipgloss.Height(m.View())
+	if got != termHeight {
+		t.Errorf("with banner visible: View() height = %d, want %d (height budget not accounting for banner)", got, termHeight)
+	}
 }
 
 // TestHelpPanelToggle verifies that pressing ? opens the help panel, pressing ?


### PR DESCRIPTION
## Summary

Add a prominent TUI alert banner that appears whenever the GraphQL budget is exhausted (or so low that probe failures are occurring), displaying the countdown to reset so users immediately understand fabrik is suspended rather than broken. Improve the engine log line emitted on rate-limit-induced probe failures from a generic "probe refresh failed" to an actionable "rate limited, retrying after HH:MM."

## Problem

When the user-token GraphQL budget hits zero, `ProbeProjectBoard` and `FetchItemDetails` both fail. The probe-driven cache refresh path (`runProbeAndDeepFetch` at `engine/poll.go:1534`) bails out cleanly via:

```go
if err != nil {
    e.logf(0, "cache", "probe refresh failed (using prior cache state): %v\n", err)
    return
}
```

The user sees nothing happen — no new items detected, no PR activity processed, no stage advancement. They have no way to know fabrik is rate-limited rather than broken or hung. Symptom in the field: "fabrik went deaf, I had to restart it." Restart appears to fix things because (a) Bootstrap re-fetches the board cleanly, and (b) by the time the restart finishes, the budget often has reset.

The headers from GitHub already tell us *exactly* when the reset will occur. The engine already captures this in `RateLimitStats.Reset` (`github/client.go:37`) and already emits it to the TUI via `tui.RateLimitStats{Limit, Remaining, Reset}` (`engine/poll.go:562`). The footer already color-codes rate limit display in red when below 20%. We just don't surface the exhausted/suspended state prominently enough for the user to notice.

## Approach

### Approach

Add a dedicated `AlertBannerComponent` to the TUI that renders a single high-visibility row when the GraphQL budget is exhausted or probe failures attributable to rate limiting are occurring. The banner sits between the header and the active pane — the most prominent position. It implements the existing `Component` interface and is wired into `Model` following the same pattern as the conditional `SkillsStaleEvent` height tracking in the header.

The banner's visibility is computed from two sources:
1. **`graphqlStats.Remaining == 0`** — derived from `PollCompletedEvent.GraphQLStats` already flowing through the TUI. No new engine signal needed for this case.
2. **Probe failure observed while low on quota** — driven by a new `RateLimitAlertEvent{Exhausted: true}` emitted from `runProbeAndDeepFetch` when a probe fails and `Remaining == 0` (or ratio < 20%). Cleared by `RateLimitAlertEvent{Exhausted: false}` on recovery in `doPollCycle`.

Recovery hides the banner when `Remaining/Limit > 50%` (the existing `rateLimitHealthyThreshold`), computed in `isVisible()` from the latest `PollCompletedEvent` stats.

The stretch goal (suppress per-cycle backoff log line) is included — it's a one-line guard change at the same call site as the other engine modifications.

No ADR is needed: this follows established patterns (Component interface, Elm-architecture event routing, `emitStructural` for visible state).

### New / Modified Files

| File | Change |
|------|--------|
| `tui/events.go` | Add `RateLimitAlertEvent{Exhausted bool, Reset time.Time}` |
| `tui/alert.go` | New — `AlertBannerComponent` implementing `Component` |
| `tui/commands.go` | Add `fmtBannerCountdown(reset, now time.Time) string` helper |
| `tui/commands_test.go` | Tests for `fmtBannerCountdown` |
| `tui/model.go` | Add `alert AlertBannerComponent`; wire into `New()`, `Update()`, `updateLayout()`, `View()` |
| `tui/model_test.go` | Tests for `RateLimitAlertEvent` routing and layout height budget |
| `engine/poll.go` | Emit `RateLimitAlertEvent` from `runProbeAndDeepFetch`; emit recovery event in `doPollCycle`; improve log line; suppress per-cycle backoff log |
| `docs/USER_GUIDE.md` | Update TUI and Rate Limit Monitoring sections to mention alert banner |
| `docs/llms-full.txt` | Regenerate after USER_GUIDE.md update |

### Key Decisions

- **Banner placement: between header and active pane.** The header row is already 1 line; adding alert content there crowds the poll-timer and badge. A dedicated row immediately below the header is the most unmissable position. The `SkillsStaleEvent` badge precedent (conditional height in a component) extends naturally to a full component row.

- **TUI handles `Remaining == 0` from `PollCompletedEvent`, no duplicate engine emit.** The `AlertBannerComponent.isVisible()` method checks `graphqlStats.Remaining == 0` from the stats already flowing via `PollCompletedEvent`. This eliminates the risk of double-emit from two engine sites. The `RateLimitAlertEvent` is only needed for the "probe failure + low ratio" case (not `Remaining == 0`) and for the recovery signal.

- **`fmtBannerCountdown` as a new helper, not an overload of `fmtRateLimitCountdown`.** The banner format requires `"Resumes in Nm (HH:MM local time)."` while the footer uses `"Nm"`. A new function avoids signature churn and keeps footer tests unaffected. Returns `"Resumes soon."` when reset is past, `""` when reset is zero.

- **Styling: `failStyle.Copy().Bold(true).Width(width)`.** Red bold text on a full-width row is unmissable, consistent with the existing `failStyle` usage in the footer, and avoids inverse-video compatibility issues across terminal themes.

- **Stretch goal included.** The per-cycle backoff log at `poll.go:556` is suppressed by checking `newRateLimitLow && !rateLimitLow` (first cycle only). Same transition-detection block handles both entry log and backoff log, making this a 2-line change with no new state.

### Task Checklist

- [ ] Task 1: Add `RateLimitAlertEvent{Exhausted bool, Reset time.Time}` to `tui/events.go`
- [ ] Task 2: Add `fmtBannerCountdown(reset, now time.Time) string` to `tui/commands.go`; add test cases in `tui/commands_test.go` covering past reset (`"Resumes soon."`), zero reset (`""`), future minutes, future hours
- [ ] Task 3: Create `tui/alert.go` with `AlertBannerComponent` — fields `bannerActive bool`, `graphqlStats RateLimitStats`, `now time.Time`; implement `Component` interface; `isVisible()` logic: return false when `Limit == 0`, false when `Remaining/Limit > 0.50`, true when `Remaining == 0`, else `bannerActive`; `View()` composes `"⚠ GraphQL rate limit exhausted — polling suspended."` + `fmtBannerCountdown(...)` rendered with `failStyle.Copy().Bold(true).Width(width)`; handle `RateLimitAlertEvent`, `PollCompletedEvent`, `TickEvent` in `Update()`
- [ ] Task 4: Wire `AlertBannerComponent` into `tui/model.go`: add `alert AlertBannerComponent` field; initialize in `New()`; fan-out `RateLimitAlertEvent`, `PollCompletedEvent`, `TickEvent` to `m.alert` in `Update()`; subtract `m.alert.Height()` from `totalAvail` in `updateLayout()`; insert `m.alert.View(m.width)` in `View()` between header and active
- [ ] Task 5: Add tests in `tui/model_test.go`: `TestUpdate_RateLimitAlertEvent_Exhausted` (banner visible after `{Exhausted: true}`), `TestUpdate_RateLimitAlertEvent_Recovered` (banner hidden after `{Exhausted: false}`), `TestUpdateLayout_AlertBannerHeightBudget` (verify `updateLayout` accounts for banner Height)
- [ ] Task 6: Update `engine/poll.go` — `runProbeAndDeepFetch`: after probe failure, call `e.client.RateLimitStats()`, check if `graphqlStats.Limit > 0 && (graphqlStats.Remaining == 0 || float64(graphqlStats.Remaining)/float64(graphqlStats.Limit) < rateLimitBackoffThreshold)`; if so, replace the `[cache]` log with `[warn] rate limited — polling suspended, retrying after HH:MM (local)` (or `retrying soon` when reset is zero/past); emit `e.emitStructural(tui.RateLimitAlertEvent{Exhausted: true, Reset: graphqlStats.Reset})`
- [ ] Task 7: Update `engine/poll.go` — `doPollCycle`: on `rateLimitLow` `true→false` transition (line 514), emit `e.emitStructural(tui.RateLimitAlertEvent{Exhausted: false})`; guard the per-cycle backoff log at line 556 to only fire on the first cycle (`newRateLimitLow && !rateLimitLow`) by merging it into the existing entry log at line 512
- [ ] Task 8: Update `docs/USER_GUIDE.md` — in the TUI section "What's Displayed" (§ around line 1471), add mention of the alert banner row; in "Rate Limit Monitoring" (§ around line 1627), add a subsection describing the banner trigger conditions and auto-dismissal; run `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt`

### Risks

- **Layout height budget off-by-one**: If `m.alert.Height()` is not subtracted in `updateLayout()`, the history pane will render one row over the terminal boundary. Task 5's `TestUpdateLayout_AlertBannerHeightBudget` test directly catches this regression.

- **Banner persists if engine never emits recovery event**: If the engine fails to emit `{Exhausted: false}` (e.g., process crash during rate-limit), the banner stays visible on restart until `PollCompletedEvent` delivers `Remaining/Limit > 0.50`. This is safe — the banner disappears on the first successful poll after restart. No special handling needed.

- **`runProbeAndDeepFetch` rate-limit check on non-rate-limit failures**: The log improvement and `RateLimitAlertEvent` emission in Task 6 are guarded by `graphqlStats.Limit > 0 && (Remaining == 0 || ratio < 20%)`. Non-rate-limit probe failures (e.g., network errors) where `graphqlStats.Limit == 0` fall through to the existing `[cache]` log. This correctly separates the two failure modes.

- **`emitStructural` blocks if channel full**: `emitStructural` is a blocking send. It's appropriate here (recovery/alert events are infrequent, low-frequency state changes), but callers inside `runProbeAndDeepFetch` (called from `e.poll()` inside `doPollCycle`) should not hold any locks at that point. Research confirms no locks are held at that call site.

---
Used 17/50 turns, 6k input / 10k output tokens.

## Verification

Implemented the rate-limit exhaustion alert banner across 8 commits: added `RateLimitAlertEvent` to the TUI event system, a new `AlertBannerComponent` (with `fmtBannerCountdown` helper) that shows a red full-width banner between the header and active pane when the GraphQL budget is exhausted or probe failures are rate-limit-induced, and wired it into `Model` with correct layout height accounting. On the engine side, `runProbeAndDeepFetch` now detects rate-limit failures specifically (vs generic network errors) and emits a `[warn]` log with reset time plus `RateLimitAlertEvent{Exhausted: true}`; `doPollCycle` emits the recovery event on the `rateLimitLow` true→false transition and suppresses the per-cycle backoff log to entry-only. Docs updated and `llms-full.txt` regenerated.

---

Closes #705