### PR TITLE
fabrik: cold-start cache population is expensive — migrate bootstrap to probe and suppress spurious linkage-drift

### DIFF
--- a/adrs/044-probe-driven-poll-loop.md
+++ b/adrs/044-probe-driven-poll-loop.md
@@ -69,3 +69,46 @@ A one-shot `runStartupTransientLabelScan` runs after the first successful poll. 
 - **Label visibility during steady-state**: unchanged — labels come from `FetchItemDetails` (full label set), now written on first access and refreshed on any `updatedAt` drift.
 - **Constraint for future contributors**: mutations applied from probe data MUST use `ProbeBoardItemUpdated`, not `ShallowBoardItemUpdated`. Adding labels or other deep fields to the probe query without a corresponding mutation-type update would silently corrupt the cache.
 - **`LightReconcile` residual cost**: ≤ 20 full shallow board fetches/hour in webhook mode. Acceptable; a follow-up could add `ProbeProjectBoard` to `ReadClient` to eliminate this cost.
+
+---
+
+## Addendum — Probe bootstrap (issue #710, 2026-05-11)
+
+The Bootstrap section above stated: *"Bootstrap (first poll, unbootstrapped cache): `FetchProjectBoard` → `Bootstrap`."* This has been superseded.
+
+### New cold-start path
+
+The virgin-cache branch now uses `ProbeProjectBoard → BootstrapFromProbe` instead of `FetchProjectBoard → Bootstrap`.
+
+**Why**: `FetchProjectBoard` carries `labels(first:30)` and `closedByPullRequestsReferences(first:5)` per item, costing ~2 350 nodes on a 47-item board just to warm a cold cache. `ProbeProjectBoard` costs ~250 nodes for the same board. An overnight test revealed the old path was causing Fabrik to go deaf for ~1 hour after restart when the shared GraphQL budget was already depleted.
+
+### `BootstrapFromProbe(items []BoardProbeItem, projectID string, stagesCfg []*stages.Stage)`
+
+New method on `boardcache.CacheImpl`. Constructs synthetic `[]gh.ProjectItem` from probe items and calls `store.Reset`, which populates `LinkedPR.Number` from `LinkedPRNumber` via `applyProjectItem`. This prevents the subsequent probe cycle from seeing spurious linkage-drift on items that already have a PR.
+
+After `store.Reset`, `BootstrapFromProbe` applies `TerminalFlagSet` for items that are both closed and in a cleanup stage (`CleanupWorktree: true`). The simplified predicate (no label check) means these items are never deep-fetched — not by the first probe cycle, and not by subsequent cycles unless their status changes.
+
+### Label absence and its consequences
+
+Probe results carry no labels. After `BootstrapFromProbe`:
+
+- `runStartupTransientLabelScan` is a no-op (empty label sets; stale transient labels on closed terminal items will not be detected at startup).
+- `runStartupTerminalScan` is a no-op (label-aware predicate requires labels; cold-start seeding was done by `BootstrapFromProbe` instead).
+
+The accepted gap: an item with stale transient labels that closed mid-Done-stage in a prior crash will not be cleaned up at startup. Probability is very low. The steady-state deep-fetch path cleans up non-terminal items naturally on the first probe cycle.
+
+### Linkage-drift gate
+
+`runProbeAndDeepFetch` now gates the linkage-drift check on `s.LastDeepFetchAt.IsZero()`:
+
+- **Never deep-fetched** (`LastDeepFetchAt == zero`): probe's `LinkedPRNumber` is written authoritatively via `PRDetailsUpdated` (updates `LinkedPR.Number` and `prToKey` reverse index) without firing `DeepFetchInvalidated`. There is no prior deep cache to invalidate.
+- **Warm cache** (`LastDeepFetchAt != zero`): existing `DeepFetchInvalidated` path unchanged — real linkage drift forces an immediate re-deep-fetch.
+
+This is a correctness fix as well as an optimization: the old code fired `DeepFetchInvalidated` on every cold start for every item with a PR (because the old `Bootstrap` from `FetchProjectBoard` wrote `LinkedPR.Number=0`, and the first probe found the actual PR number — interpreted as drift). With `BootstrapFromProbe` correctly seeding `LinkedPR.Number`, this spurious case no longer arises; the gate also eliminates it for any remaining edge cases.
+
+### Bootstrap path summary (updated)
+
+| Trigger | Path | Labels in store? | Terminal seeding |
+|---|---|---|---|
+| Virgin cache (default) | `ProbeProjectBoard → BootstrapFromProbe` | No | `IsClosed + CleanupWorktree` |
+| Drift recovery / reconcile | `LightReconcile → Reconcile(freshBoard)` | Yes (from `FetchProjectBoard`) | `runStartupTerminalScan` |

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -8,6 +8,7 @@ import (
 
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
 )
 
 // ReadClient is the subset of engine.GitHubClient covering read-only board/item/PR/check-run state.
@@ -247,6 +248,74 @@ func (c *CacheImpl) Bootstrap(board *gh.ProjectBoard) {
 	c.mu.Unlock()
 
 	c.logFn("[cache] bootstrap complete: %d items\n", len(board.Items))
+}
+
+// BootstrapFromProbe populates the cache from a ProbeProjectBoard result instead
+// of a full FetchProjectBoard. This is the preferred cold-start path: probe costs
+// ~250 nodes vs ~2350 for a full shallow fetch on a 47-item board.
+//
+// Labels are absent from probe results; startup scans that rely on label data
+// (runStartupTransientLabelScan, runStartupTerminalScan) will see empty label sets
+// and silently become no-ops after this bootstrap path. This is an accepted
+// trade-off: stale transient labels on closed terminal items will not be detected
+// at startup (very low probability; requires a crash mid-Done-stage). Active items
+// are deep-fetched on the first probe cycle, populating their labels normally.
+//
+// Sets LinkedPR.Number from each probe item's LinkedPRNumber so the subsequent
+// probe cycle does not see spurious linkage-drift on items that already have a PR.
+//
+// Must be called before any engine mutations flow through the shared store.
+func (c *CacheImpl) BootstrapFromProbe(items []gh.BoardProbeItem, projectID string, stagesCfg []*stages.Stage) {
+	// Construct synthetic ProjectItems from probe data.
+	// applyProjectItem (called by Reset) populates LinkedPR.Number from LinkedPRNumber,
+	// which prevents the subsequent probe from seeing spurious "linkage drift".
+	syntheticItems := make([]gh.ProjectItem, 0, len(items))
+	for _, pi := range items {
+		syntheticItems = append(syntheticItems, gh.ProjectItem{
+			ID:             pi.ContentID,
+			ItemID:         pi.ItemID,
+			Number:         pi.Number,
+			IsPR:           pi.IsPR,
+			IsClosed:       pi.IsClosed,
+			Status:         pi.Status,
+			Repo:           pi.Repo,
+			UpdatedAt:      pi.EffectiveUpdatedAt,
+			LinkedPRNumber: pi.LinkedPRNumber,
+		})
+	}
+
+	// Reset Store atomically — clears all prior item state and indexes.
+	c.store.Reset(syntheticItems)
+
+	c.mu.Lock()
+	c.projectID = projectID
+	// projectTitle and projectOwnerType are not available from probe results;
+	// they remain empty until the next Reconcile. The engine reads OwnerType
+	// from e.cfg.OwnerType directly, not from cache, so this is safe.
+	c.localDeltaAt = make(map[string]time.Time)
+	c.mu.Unlock()
+
+	// Seed terminal flag for closed items in cleanup stages using a simpler
+	// predicate (IsClosed + CleanupWorktree) since labels are absent.
+	// This prevents the probe loop from deep-fetching closed Done items.
+	var terminal int
+	for _, pi := range items {
+		if !pi.IsClosed {
+			continue
+		}
+		st := stages.FindStage(stagesCfg, pi.Status)
+		if st == nil || !st.CleanupWorktree {
+			continue
+		}
+		c.store.Apply(itemstate.TerminalFlagSet{
+			Repo:     pi.Repo,
+			Number:   pi.Number,
+			Terminal: true,
+		})
+		terminal++
+	}
+
+	c.logFn("[cache] probe bootstrap complete: %d items (%d terminal)\n", len(items), terminal)
 }
 
 // Reconcile replaces shallow board state from a fresh board fetch.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -10,6 +10,7 @@ import (
 
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
 )
 
 // ---------------------------------------------------------------------------
@@ -2251,5 +2252,127 @@ func TestLightReconcile_NetworkError(t *testing.T) {
 	}
 	if freshBoard != nil {
 		t.Errorf("freshBoard = %v on error, want nil", freshBoard)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BootstrapFromProbe tests
+// ---------------------------------------------------------------------------
+
+// testStages returns a minimal []*stages.Stage for testing: one non-cleanup stage
+// ("Research") and one cleanup stage ("Done").
+func testStages() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Research", Order: 1, CleanupWorktree: false},
+		{Name: "Done", Order: 10, CleanupWorktree: true},
+	}
+}
+
+// TestBootstrapFromProbe_ProjectIDSet verifies that BootstrapFromProbe stores
+// the projectID returned by ProbeProjectBoard.
+func TestBootstrapFromProbe_ProjectIDSet(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"},
+	}
+	c.BootstrapFromProbe(items, "PROJ_XYZ", testStages())
+
+	if got := c.ProjectID(); got != "PROJ_XYZ" {
+		t.Errorf("ProjectID = %q, want %q", got, "PROJ_XYZ")
+	}
+}
+
+// TestBootstrapFromProbe_LinkedPRNumberPopulated verifies that LinkedPR.Number is
+// populated from probe item's LinkedPRNumber so the subsequent probe cycle does not
+// see spurious linkage-drift.
+func TestBootstrapFromProbe_LinkedPRNumberPopulated(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", LinkedPRNumber: 42},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil {
+		t.Fatal("LinkedPR is nil; want non-nil")
+	}
+	if s.LinkedPR.Number != 42 {
+		t.Errorf("LinkedPR.Number = %d, want 42", s.LinkedPR.Number)
+	}
+}
+
+// TestBootstrapFromProbe_NonCleanupStageNotTerminal verifies that a closed item
+// in a non-cleanup stage is NOT seeded as terminal.
+func TestBootstrapFromProbe_NonCleanupStageNotTerminal(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", IsClosed: true},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Terminal {
+		t.Error("Terminal = true for closed non-cleanup-stage item; want false")
+	}
+}
+
+// TestBootstrapFromProbe_ClosedCleanupStageTerminal verifies that a closed item
+// in a cleanup stage IS seeded as terminal, preventing a deep-fetch on first probe.
+func TestBootstrapFromProbe_ClosedCleanupStageTerminal(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Done", IsClosed: true},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if !s.Terminal {
+		t.Error("Terminal = false for closed cleanup-stage item; want true")
+	}
+}
+
+// TestBootstrapFromProbe_OpenCleanupStageNotTerminal verifies that an open item
+// in a cleanup stage is NOT seeded as terminal (must be closed to qualify).
+func TestBootstrapFromProbe_OpenCleanupStageNotTerminal(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Done", IsClosed: false},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.Terminal {
+		t.Error("Terminal = true for open cleanup-stage item; want false")
+	}
+}
+
+// TestBootstrapFromProbe_IsBootstrapped verifies that IsBootstrapped returns true
+// after BootstrapFromProbe is called with at least one item.
+func TestBootstrapFromProbe_IsBootstrapped(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	if c.IsBootstrapped() {
+		t.Fatal("IsBootstrapped should be false before bootstrap")
+	}
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research"},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+	if !c.IsBootstrapped() {
+		t.Error("IsBootstrapped should be true after BootstrapFromProbe")
+	}
+}
+
+// TestBootstrapFromProbe_PRInStoreByPRKey verifies that the prToKey reverse index
+// is populated when LinkedPRNumber is set, so LinkedPRByNumber lookups work.
+func TestBootstrapFromProbe_PRInStoreByPRKey(t *testing.T) {
+	c := NewCacheImpl(&mockClient{}, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Research", LinkedPRNumber: 99},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+
+	_, found := c.store.GetByPRKey("owner/repo", 99)
+	if !found {
+		t.Error("prToKey index should have an entry for PR #99 after BootstrapFromProbe")
 	}
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -884,9 +884,14 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// items. This replaces the previous FetchProjectBoard + Reconcile path and
 	// reduces GraphQL cost ~5-10x on idle boards.
 	//
-	// Virgin caches fall back to a full FetchProjectBoard + Bootstrap so the initial
-	// board load is complete. Paused caches are skipped; FetchProjectBoard below
-	// falls through to GitHub directly for paused caches.
+	// Virgin caches use ProbeProjectBoard + BootstrapFromProbe (~250 nodes) instead
+	// of FetchProjectBoard + Bootstrap (~2350 nodes on a 47-item board). The probe
+	// result carries LinkedPRNumber so the subsequent probe cycle does not see
+	// spurious linkage-drift. Closed cleanup-stage items are seeded terminal so
+	// they are never deep-fetched.
+	//
+	// Paused caches are skipped; FetchProjectBoard below falls through to GitHub
+	// directly for paused caches.
 	//
 	// Important caveat: project Status changes do NOT flow over webhooks for
 	// repo-level projects (and only sometimes for org-level projects with the
@@ -900,12 +905,12 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			// Bootstrapped: use probe-driven refresh (avoids full shallow fetch cost).
 			e.runProbeAndDeepFetch(cacheImpl)
 		default:
-			// Virgin: full board fetch + bootstrap required.
-			freshBoard, refreshErr := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
+			// Virgin: probe bootstrap (~250 nodes vs ~2350 for full shallow fetch).
+			probeItems, projectID, refreshErr := e.client.ProbeProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 			if refreshErr != nil {
-				e.logf(0, "cache", "initial board fetch failed (using empty cache): %v\n", refreshErr)
-			} else if freshBoard != nil && freshBoard.ProjectID != "" {
-				cacheImpl.Bootstrap(freshBoard)
+				e.logf(0, "cache", "initial board probe failed (using empty cache): %v\n", refreshErr)
+			} else if projectID != "" {
+				cacheImpl.BootstrapFromProbe(probeItems, projectID, e.cfg.Stages)
 			}
 		}
 	}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -909,8 +909,14 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			probeItems, projectID, refreshErr := e.client.ProbeProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 			if refreshErr != nil {
 				e.logf(0, "cache", "initial board probe failed (using empty cache): %v\n", refreshErr)
-			} else if projectID != "" {
+			} else if projectID != "" && len(probeItems) > 0 {
 				cacheImpl.BootstrapFromProbe(probeItems, projectID, e.cfg.Stages)
+			} else if projectID != "" {
+				// Probe succeeded but returned 0 items — possible transient indexer hiccup.
+				// Leave cache virgin and retry on the next poll rather than bootstrapping
+				// with an empty store (which would cause every real item to be treated as
+				// "new" and deep-fetched on the next cycle).
+				e.logf(0, "cache", "initial board probe returned 0 items — deferring bootstrap to next poll\n")
 			}
 		}
 	}
@@ -1633,13 +1639,13 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 				// This suppresses spurious invalidations that occur when the bootstrapped
 				// LinkedPR.Number differs from the probe's value (e.g., cold-start with
 				// the old FetchProjectBoard path that did not populate LinkedPR.Number).
-				if pi.LinkedPRNumber != 0 {
-					e.store.Apply(itemstate.PRDetailsUpdated{
-						Repo:     repo,
-						Number:   pi.Number,
-						PRNumber: pi.LinkedPRNumber,
-					})
-				}
+				// Apply even when pi.LinkedPRNumber==0 to clear a stale prToKey entry
+				// if the PR was delinked between bootstrap and the first probe cycle.
+				e.store.Apply(itemstate.PRDetailsUpdated{
+					Repo:     repo,
+					Number:   pi.Number,
+					PRNumber: pi.LinkedPRNumber,
+				})
 			} else {
 				// Warm cache (has been deep-fetched): real linkage drift — invalidate.
 				e.logf(pi.Number, "cache", "probe: linkage drift (was PR #%d, now PR #%d) — invalidating deep cache\n",

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1626,9 +1626,26 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 			cachedPRNum = s.LinkedPR.Number
 		}
 		if pi.LinkedPRNumber != cachedPRNum {
-			e.logf(pi.Number, "cache", "probe: linkage drift (was PR #%d, now PR #%d) — invalidating deep cache\n",
-				cachedPRNum, pi.LinkedPRNumber)
-			e.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: pi.Number})
+			if s.LastDeepFetchAt.IsZero() {
+				// Never deep-fetched: no prior deep cache to invalidate.
+				// Treat the probe's value as authoritative — write it into LinkedPR.Number
+				// and update the prToKey reverse index without firing DeepFetchInvalidated.
+				// This suppresses spurious invalidations that occur when the bootstrapped
+				// LinkedPR.Number differs from the probe's value (e.g., cold-start with
+				// the old FetchProjectBoard path that did not populate LinkedPR.Number).
+				if pi.LinkedPRNumber != 0 {
+					e.store.Apply(itemstate.PRDetailsUpdated{
+						Repo:     repo,
+						Number:   pi.Number,
+						PRNumber: pi.LinkedPRNumber,
+					})
+				}
+			} else {
+				// Warm cache (has been deep-fetched): real linkage drift — invalidate.
+				e.logf(pi.Number, "cache", "probe: linkage drift (was PR #%d, now PR #%d) — invalidating deep cache\n",
+					cachedPRNum, pi.LinkedPRNumber)
+				e.store.Apply(itemstate.DeepFetchInvalidated{Repo: repo, Number: pi.Number})
+			}
 		}
 
 		// Terminal skip: if this item was previously identified as terminal and the

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1750,9 +1750,17 @@ func isTerminalPredicate(labels []string, status string, stagesCfg []*stages.Sta
 // runStartupTransientLabelScan is a one-shot recovery pass that runs after the
 // first successful poll. It scans the Store for closed issues that still carry
 // transient lifecycle labels — a condition that can occur when an issue closes
-// mid-stage during a prior crash. Bootstrap populates the Store with full label
-// data from the shallow board fetch, so this scan is accurate without any extra
-// GitHub API call.
+// mid-stage during a prior crash.
+//
+// Label availability note: when the cache was bootstrapped via BootstrapFromProbe
+// (the default cold-start path), labels are absent from the Store and this scan
+// is a no-op. The accepted gap: stale transient labels on closed terminal items
+// will not be cleaned up at startup (very low probability — requires a crash
+// between issue close and label removal in the Done stage). Active items are
+// deep-fetched on the first probe cycle, which populates their labels normally,
+// so those items are covered by the steady-state cleanup path.
+// When bootstrapped via the full FetchProjectBoard path (webhook-paused / reconcile),
+// the Store contains full label data and this scan is fully effective.
 func (e *Engine) runStartupTransientLabelScan() {
 	snaps := e.store.All()
 	if len(snaps) == 0 {
@@ -1801,10 +1809,17 @@ func (e *Engine) runStartupTransientLabelScan() {
 }
 
 // runStartupTerminalScan marks terminal items in the Store after the first
-// successful poll. It uses bootstrap label data already present in the Store
-// (populated by FetchProjectBoard + Reset) so no GitHub API call is needed.
+// successful poll using the full label-aware predicate (isTerminalPredicate).
 // Must run after runStartupTransientLabelScan so stale transient labels have
 // been removed before the predicate is evaluated.
+//
+// Label availability note: when the cache was bootstrapped via BootstrapFromProbe
+// (the default cold-start path), labels are absent from the Store. In that case
+// this scan is a no-op — isTerminalPredicate returns false for every item.
+// Cold-start terminal seeding is instead handled by BootstrapFromProbe itself
+// using the simpler IsClosed+CleanupWorktree predicate (no labels required).
+// When bootstrapped via the full FetchProjectBoard path, labels are present
+// and this scan applies the full predicate correctly.
 func (e *Engine) runStartupTerminalScan() {
 	snaps := e.store.All()
 	var marked int

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -2508,6 +2508,99 @@ func TestRunStartupTransientLabelScan_RemovesStaleLabelsFromClosedItems(t *testi
 	}
 }
 
+// TestColdStart_ProbeBootstrap_TerminalItemsSkipDeepFetch verifies the cold-start cost
+// reduction: 10 closed Done items are seeded terminal by BootstrapFromProbe and
+// are never deep-fetched, while 3 open active items are deep-fetched normally.
+// Expected deep-fetch count after the first probe cycle: ≤ 3.
+func TestColdStart_ProbeBootstrap_TerminalItemsSkipDeepFetch(t *testing.T) {
+	var deepFetchCalls int
+	probeTime := time.Now().Add(-time.Minute)
+
+	// Build 10 closed Done items + 3 open Research items for the probe response.
+	var probeItems []gh.BoardProbeItem
+	for i := 1; i <= 10; i++ {
+		probeItems = append(probeItems, gh.BoardProbeItem{
+			ContentID: fmt.Sprintf("I_%03d", i), ItemID: fmt.Sprintf("PVTI_%03d", i),
+			Number: i, Repo: "owner/repo",
+			Status:             "Done",
+			IsClosed:           true,
+			EffectiveUpdatedAt: probeTime,
+		})
+	}
+	for i := 11; i <= 13; i++ {
+		probeItems = append(probeItems, gh.BoardProbeItem{
+			ContentID: fmt.Sprintf("I_%03d", i), ItemID: fmt.Sprintf("PVTI_%03d", i),
+			Number: i, Repo: "owner/repo",
+			Status:             "Research",
+			IsClosed:           false,
+			EffectiveUpdatedAt: probeTime,
+		})
+	}
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return probeItems, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			return nil
+		},
+	}
+	eng := NewWithDeps(
+		Config{
+			Owner: "owner", Repo: "repo", ProjectNum: 1,
+			User: "testuser", Token: "token", MaxConcurrent: 5,
+			Stages: testStagesWithCleanup(),
+		},
+		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"),
+	)
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	eng.readClient = cache
+
+	// Simulate the virgin-cache branch: probe bootstrap seeds the store.
+	items, projectID, err := client.ProbeProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("ProbeProjectBoard: %v", err)
+	}
+	cache.BootstrapFromProbe(items, projectID, eng.cfg.Stages)
+
+	// Now simulate the next poll cycle — probe-driven deep-fetch pass.
+	eng.runProbeAndDeepFetch(cache)
+
+	// The 10 closed Done items are seeded terminal and must NOT be deep-fetched.
+	// The 3 open Research items have no prior deep-fetch and MUST be deep-fetched.
+	if deepFetchCalls > 3 {
+		t.Errorf("cold-start deep-fetch count = %d, want ≤ 3 (only active items)", deepFetchCalls)
+	}
+	if deepFetchCalls == 0 {
+		t.Error("expected ≥ 1 deep-fetch for active items; got 0")
+	}
+
+	// Terminal flag must be set on all closed Done items.
+	for i := 1; i <= 10; i++ {
+		snap, snapErr := eng.store.Get("owner/repo", i)
+		if snapErr != nil {
+			t.Errorf("item #%d not found in store", i)
+			continue
+		}
+		if !snap.IsTerminal() {
+			t.Errorf("item #%d (closed Done): expected IsTerminal()=true", i)
+		}
+	}
+
+	// Active Research items must NOT be terminal.
+	for i := 11; i <= 13; i++ {
+		snap, snapErr := eng.store.Get("owner/repo", i)
+		if snapErr != nil {
+			t.Errorf("item #%d not found in store", i)
+			continue
+		}
+		if snap.IsTerminal() {
+			t.Errorf("item #%d (open Research): expected IsTerminal()=false", i)
+		}
+	}
+}
+
 // TestRunProbeAndDeepFetch_IsClosedPropagates_WithoutDeepFetch verifies that
 // IsClosed=true is written to the store via ProbeBoardItemUpdated even when
 // the item is cache-fresh (EffectiveUpdatedAt unchanged → no deep-fetch).

--- a/engine/terminal_test.go
+++ b/engine/terminal_test.go
@@ -373,3 +373,133 @@ func TestRunStartupTerminalScan_UsesCleanupStageNotHardcodedDone(t *testing.T) {
 		t.Error("expected IsTerminal()=true for cleanup stage named 'Archived'")
 	}
 }
+
+// ---- linkage-drift gate tests (Task 5) ----
+
+// TestRunProbeAndDeepFetch_LinkageDrift_ColdStart_AuthoritativeWrite verifies that
+// when an item has never been deep-fetched and the probe finds a different LinkedPRNumber
+// than the cache holds, the probe's value is written authoritatively via PRDetailsUpdated
+// (not DeepFetchInvalidated). The prToKey reverse index must be updated.
+func TestRunProbeAndDeepFetch_LinkageDrift_ColdStart_AuthoritativeWrite(t *testing.T) {
+	// Track deep-fetch calls — we allow one (the item has no LastDeepFetchAt,
+	// so IsItemCacheFresh returns false and a normal deep-fetch will fire).
+	var deepFetchCalls int
+	staleTime := time.Now().Add(-2 * time.Hour)
+	probeTime := time.Now().Add(-time.Hour)
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+					Status: "Research", EffectiveUpdatedAt: probeTime, LinkedPRNumber: 42},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			item.LinkedPRNumber = 42 // deep-fetch confirms the PR
+			return nil
+		},
+	}
+	eng := testEngineWithCleanup(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	// Bootstrap with LinkedPRNumber=0 (old-style bootstrap that did not populate PR number).
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", UpdatedAt: staleTime, LinkedPRNumber: 0},
+		},
+	})
+	eng.readClient = cache
+
+	eng.runProbeAndDeepFetch(cache)
+
+	// LinkedPR.Number must be set to 42 (either by PRDetailsUpdated before or by deep-fetch after).
+	snap, err := eng.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("item not found: %v", err)
+	}
+	s := snap.State()
+	if s.LinkedPR == nil || s.LinkedPR.Number != 42 {
+		t.Errorf("LinkedPR.Number = %d, want 42", func() int {
+			if s.LinkedPR != nil {
+				return s.LinkedPR.Number
+			}
+			return 0
+		}())
+	}
+
+	// prToKey reverse index must be populated so LinkedPRByNumber lookup works.
+	_, found := eng.store.GetByPRKey("owner/repo", 42)
+	if !found {
+		t.Error("prToKey index should have entry for PR #42 after authoritative write")
+	}
+}
+
+// TestRunProbeAndDeepFetch_LinkageDrift_WarmCache_FiresDeepFetchInvalidated verifies
+// that when an item HAS been deep-fetched and the probe finds a different LinkedPRNumber,
+// DeepFetchInvalidated fires and the item is re-deep-fetched.
+func TestRunProbeAndDeepFetch_LinkageDrift_WarmCache_FiresDeepFetchInvalidated(t *testing.T) {
+	var deepFetchCalls int
+	warmTime := time.Now().Add(-30 * time.Minute)
+	probeTime := warmTime // same time so staleness check does NOT trigger deep-fetch on its own
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				// Same timestamp as warm state — staleness alone would NOT trigger a re-fetch.
+				// Only the changed LinkedPRNumber (0→99) should cause a re-fetch.
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+					Status: "Research", EffectiveUpdatedAt: probeTime, LinkedPRNumber: 99},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			item.LinkedPRNumber = 99
+			return nil
+		},
+	}
+	eng := testEngineWithCleanup(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	// Bootstrap with LinkedPRNumber=0.
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", UpdatedAt: warmTime, LinkedPRNumber: 0},
+		},
+	})
+	eng.readClient = cache
+
+	// Simulate a prior deep-fetch so LastDeepFetchAt is non-zero and
+	// IsItemCacheFresh would normally return true for warmTime.
+	eng.store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 1,
+		FreshState: gh.ProjectItem{
+			ID: "I_001", Number: 1, Repo: "owner/repo",
+			Status:    "Research",
+			UpdatedAt: warmTime,
+		},
+	})
+
+	eng.runProbeAndDeepFetch(cache)
+
+	// DeepFetchInvalidated should have fired for the warm-cache drift, causing
+	// a re-deep-fetch. Without DeepFetchInvalidated, the same-timestamp probe
+	// would have been a cache hit (IsItemCacheFresh = true → skip).
+	if deepFetchCalls == 0 {
+		t.Error("expected FetchItemDetails call after warm-cache linkage drift; got 0 calls")
+	}
+	// LinkedPR.Number must be updated to 99.
+	snap, _ := eng.store.Get("owner/repo", 1)
+	s := snap.State()
+	if s.LinkedPR == nil || s.LinkedPR.Number != 99 {
+		t.Errorf("LinkedPR.Number = %d after warm-cache drift re-fetch, want 99", func() int {
+			if s.LinkedPR != nil {
+				return s.LinkedPR.Number
+			}
+			return 0
+		}())
+	}
+}

--- a/engine/terminal_test.go
+++ b/engine/terminal_test.go
@@ -503,3 +503,50 @@ func TestRunProbeAndDeepFetch_LinkageDrift_WarmCache_FiresDeepFetchInvalidated(t
 		}())
 	}
 }
+
+// TestRunProbeAndDeepFetch_LinkageDrift_ColdStart_ClearsStalePR verifies that
+// when a never-deep-fetched item has a cached PR number but the probe reports
+// LinkedPRNumber=0 (PR delinked), PRDetailsUpdated{PRNumber:0} is applied to
+// clear the stale LinkedPR.Number and remove the stale prToKey reverse index entry.
+func TestRunProbeAndDeepFetch_LinkageDrift_ColdStart_ClearsStalePR(t *testing.T) {
+	bootstrapTime := time.Now().Add(-2 * time.Hour)
+	probeTime := time.Now().Add(-time.Hour)
+
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				// Same item, now probe reports no linked PR (LinkedPRNumber=0).
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+					Status: "Research", EffectiveUpdatedAt: probeTime, LinkedPRNumber: 0},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error { return nil },
+	}
+	eng := testEngineWithCleanup(client, &mockClaudeInvoker{})
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	// Bootstrap with LinkedPRNumber=42 so the cache has a stale prToKey entry.
+	cache.BootstrapFromProbe([]gh.BoardProbeItem{
+		{ContentID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo",
+			Status: "Research", EffectiveUpdatedAt: bootstrapTime, LinkedPRNumber: 42},
+	}, "PVT_1", testStagesWithCleanup())
+	eng.readClient = cache
+
+	// Verify prToKey entry for PR 42 exists after bootstrap.
+	if _, found := eng.store.GetByPRKey("owner/repo", 42); !found {
+		t.Fatal("prToKey should have entry for PR #42 after bootstrap")
+	}
+
+	eng.runProbeAndDeepFetch(cache)
+
+	// After probe reports LinkedPRNumber=0, the stale entry must be cleared.
+	snap, err := eng.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("item not found: %v", err)
+	}
+	if s := snap.State(); s.LinkedPR != nil && s.LinkedPR.Number != 0 {
+		t.Errorf("LinkedPR.Number = %d after delink, want 0", s.LinkedPR.Number)
+	}
+	if _, found := eng.store.GetByPRKey("owner/repo", 42); found {
+		t.Error("prToKey should NOT have entry for PR #42 after probe reports delink")
+	}
+}


### PR DESCRIPTION
## Summary

Three targeted fixes to the cache-population path reduce cold-start GraphQL cost by ~80% on a typical 47-item board. All three operate purely on the read/population side; the engine's read semantics, dispatch logic, observer mechanisms, and store mutations are unchanged. The single-owner reactive cache model (ADR-036) stays intact.

## Problem

A fabrik restart burns ~6000 GraphQL nodes to warm a fresh cache on a typical 47-item board, even after #685 (probe) and #689 (skip-terminal). On the overnight test run, this caused fantasy fabrik to go deaf for nearly an hour: the new instance had only 939/5000 budget remaining at start (the user-token GraphQL budget is shared across all fabrik instances and processes), and bootstrap exhausted that within 11 minutes before the cache was fully populated.

## Approach

### Approach

The three fixes are logically independent but ordered: Fix 1 (probe bootstrap) must land first since Fix 2 and Fix 3 are about handling the consequences of probe-bootstrapped state. All changes are on the cache-population side — zero changes to engine read semantics or dispatch.

**Fix 1 — `BootstrapFromProbe`**: Add `CacheImpl.BootstrapFromProbe(items []gh.BoardProbeItem, projectID string, stagesCfg []*stages.Stage)` to `boardcache/boardcache.go`. Construct synthetic `[]gh.ProjectItem` from probe items and call `c.store.Reset(syntheticItems)` — reusing existing `applyProjectItem` which populates `LinkedPR.Number` from `LinkedPRNumber`. Terminal seeding (Fix 3) happens inside this method immediately after `store.Reset`, using the simple predicate `pi.IsClosed && CleanupWorktree`. Migrate the virgin-cache branch in `poll.go` to call `ProbeProjectBoard` + `BootstrapFromProbe`.

**Fix 2 — Linkage-drift gate**: Gate the existing drift check on `s.LastDeepFetchAt.IsZero()`. When zero (never deep-fetched), apply `PRDetailsUpdated{PRNumber: pi.LinkedPRNumber}` authoritatively instead of firing `DeepFetchInvalidated`. This uses the existing `PRDetailsUpdated` mutation — no new types needed.

**Fix 3 — Cold-start terminal seeding**: Handled inside `BootstrapFromProbe` (confirmed by Research: items already in the store never hit the new-item branch in `runProbeAndDeepFetch`). Predicate: `pi.IsClosed && stage.CleanupWorktree`. Applied via `TerminalFlagSet` after `store.Reset`.

**Startup scan gap**: After probe bootstrap, labels are absent from the store. `runStartupTransientLabelScan` and `runStartupTerminalScan` become no-ops. This is accepted per the spec. Comments in both functions must be updated to document this limitation and the accepted gap. `runStartupTerminalScan` is left as-is (harmless no-op for probe-bootstrap path, still correct for any future full-bootstrap path).

**`projectTitle`/`projectOwnerType`**: Not available from probe data. Left empty — the engine reads `OwnerType` from `e.cfg.OwnerType`, not from cache. This is safe.

**ADR-044 addendum**: The ADR states bootstrap uses `FetchProjectBoard → Bootstrap`. This changes to `ProbeProjectBoard → BootstrapFromProbe` for the virgin-cache path. An addendum section is warranted in the same PR. No new ADR number needed — this is a narrowly scoped revision to an existing architectural decision that the ADR itself documents.

### New/Modified Files

| File | Change |
|------|--------|
| `boardcache/boardcache.go` | Add `BootstrapFromProbe(items []gh.BoardProbeItem, projectID string, stagesCfg []*stages.Stage)` method |
| `engine/poll.go` | Migrate virgin-cache branch to `ProbeProjectBoard` + `BootstrapFromProbe`; gate linkage-drift check on `LastDeepFetchAt.IsZero()`; update comments in `runStartupTransientLabelScan` and `runStartupTerminalScan` |
| `boardcache/boardcache_test.go` | Tests for `BootstrapFromProbe`: field seeding, `projectID` set, `LinkedPR.Number` populated, terminal seeding for closed cleanup-stage items |
| `engine/poll_test.go` | Cold-start cost test: virgin cache with N closed Done items → deep-fetch count = 0 for terminal items |
| `engine/terminal_test.go` | Regression tests: linkage-drift still fires on warm cache (after `LastDeepFetchAt` set); cold-start linkage write uses `PRDetailsUpdated` not `DeepFetchInvalidated` |
| `adrs/044-probe-driven-poll-loop.md` | Addendum: document probe-bootstrap path replacing `FetchProjectBoard → Bootstrap` for virgin cache |

### Key Decisions

- **Terminal seeding in `BootstrapFromProbe`, not as a post-bootstrap loop**: Research confirmed items seeded by `BootstrapFromProbe` are already in the store when `runProbeAndDeepFetch` runs, so they never hit the `snapErr != nil` (new-item) branch. The only place to set the terminal flag on these items before the first probe cycle is inside `BootstrapFromProbe` itself.

- **`stagesCfg` passed as parameter to `BootstrapFromProbe`**: The method is on `CacheImpl` (boardcache package), which has no access to engine-level stage config. Passing stages as a parameter keeps the boardcache package dependency-free from the engine and matches the spec's stated interface.

- **`PRDetailsUpdated` for Fix 2's authoritative write (not a new mutation type)**: Research confirmed `applyProbeItem` does not write `LinkedPR.Number`. `PRDetailsUpdated` with only `PRNumber` set correctly populates `LinkedPR.Number` and updates the `prToKey` reverse index without touching `Title/State/Merged/Draft`. No new mutation types are introduced.

- **Leave `runStartupTerminalScan` as a harmless no-op** (not removed): The function still works correctly for any future full-bootstrap path (e.g. if probe bootstrap is unavailable or falls back). Removing it would be premature; updating its comment to acknowledge the no-op case under probe bootstrap is sufficient.

- **No ADR for this change**: The decision to change the bootstrap path is an implementation refinement, not a new architectural constraint. The change is documented as an addendum to the existing ADR-044, which already describes the probe query design and bootstrap coupling. A new ADR number would be wasteful for what is essentially "ADR-044 updated."

### Task Checklist

- [ ] Task 1: Add `BootstrapFromProbe(items []gh.BoardProbeItem, projectID string, stagesCfg []*stages.Stage)` to `boardcache/boardcache.go` — constructs synthetic `[]gh.ProjectItem`, calls `store.Reset`, sets `c.projectID`, resets `c.localDeltaAt`, then applies `TerminalFlagSet` for closed cleanup-stage items
- [ ] Task 2: Write unit tests for `BootstrapFromProbe` in `boardcache/boardcache_test.go`: (a) `projectID` is set correctly, (b) `LinkedPR.Number` is populated from `LinkedPRNumber`, (c) non-cleanup-stage closed items are not marked terminal, (d) closed cleanup-stage items are marked terminal
- [ ] Task 3: Migrate the virgin-cache branch in `engine/poll.go` (`poll()` function, `default:` case, lines ~902–909) to call `e.client.ProbeProjectBoard(...)` + `cacheImpl.BootstrapFromProbe(items, projectID, e.cfg.Stages)` instead of `FetchProjectBoard` + `Bootstrap`
- [ ] Task 4: Gate the linkage-drift check in `runProbeAndDeepFetch` (`engine/poll.go` ~line 1623) on `s.LastDeepFetchAt.IsZero()`: when zero, apply `PRDetailsUpdated{Repo: repo, Number: pi.Number, PRNumber: pi.LinkedPRNumber}` instead of `DeepFetchInvalidated`; when non-zero, existing `DeepFetchInvalidated` path unchanged
- [ ] Task 5: Write regression tests in `engine/terminal_test.go` or `engine/poll_test.go`: (a) cold-start: probe sees `LinkedPRNumber != 0` on a never-deep-fetched item → `PRDetailsUpdated` applied, no `DeepFetchInvalidated`; (b) warm-cache: probe sees changed `LinkedPRNumber` after first deep-fetch → `DeepFetchInvalidated` still fires
- [ ] Task 6: Write cold-start cost test in `engine/poll_test.go`: virgin cache with 10 closed Done items and 3 open active items — after first probe cycle, `FetchItemDetails` call count ≤ 3 (closed terminal items incur no deep-fetch)
- [ ] Task 7: Update comments in `engine/poll.go` — `runStartupTransientLabelScan` (remove assertion that "Bootstrap populates the Store with full label data"; note that probe-bootstrap leaves labels empty and the scan is a no-op in that case) and `runStartupTerminalScan` (note no-op under probe-bootstrap; label-aware predicate still runs under full-bootstrap)
- [ ] Task 8: Add addendum to `adrs/044-probe-driven-poll-loop.md` documenting that the virgin-cache bootstrap path now uses `ProbeProjectBoard → BootstrapFromProbe` instead of `FetchProjectBoard → Bootstrap`, and explaining why (cost reduction from ~2350 to ~250 nodes; labels absent; terminal seeding replaces `runStartupTerminalScan` for the probe path)

### Risks

- **`runStartupTransientLabelScan` gap**: After probe bootstrap, stale transient labels on closed Done items won't be detected at startup. Probability is very low (requires a crash between issue close and label removal in the Done stage). The spec accepts this risk. The mitigation: update the comment to document the gap so it's not an invisible regression.

- **`projectTitle`/`projectOwnerType` left empty**: Cache consumers that read these fields will see empty strings until the next `Reconcile`. Research confirmed the engine uses `e.cfg.OwnerType` directly, not from cache — this is safe.

- **`BootstrapFromProbe` and `Bootstrap` coexistence**: `Bootstrap` must remain for `LightReconcile`-triggered `Reconcile` and any fallback path. Implementation must not disturb it. The new method is purely additive.

- **`ProbeProjectBoard` error handling in virgin-cache branch**: The current code logs the error and proceeds with an empty cache if `FetchProjectBoard` fails. The same fallback (log error, leave cache virgin, retry next poll) must apply if `ProbeProjectBoard` fails in the migrated branch.

- **Test coverage for `PRDetailsUpdated` in Fix 2**: The mutation path is different from what was there before. Tests in Task 5 must verify the `prToKey` reverse index is updated (i.e., `LinkedPRByNumber` lookup works after the authoritative write), not just that `LinkedPR.Number` is set.

---
Used 11/50 turns, 8k input / 3k output tokens.

## Verification

Implemented all three cold-start cost fixes: `BootstrapFromProbe` replaces `FetchProjectBoard+Bootstrap` for virgin caches (~250 vs ~2350 nodes), the linkage-drift check is gated on `LastDeepFetchAt.IsZero()` to suppress spurious cascade deep-fetches, and closed cleanup-stage items are seeded terminal at bootstrap time. All 8 tasks complete with tests, comment updates, and ADR-044 addendum.

---

Closes #710