### PR TITLE
Update docs for v0.0.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Sending `SIGHUP` to the Fabrik process drains in-flight Claude runs, then
 re-execs the binary in place — no terminal disruption, no lost state. Use it
 to pick up a new binary after `go install` without restarting the session.
 The terminal alt-screen is properly restored on signal-driven exit, so no
-`reset` is needed after a kill or SIGHUP. Plugin-skills are checked and
+`reset` is needed after a SIGINT, SIGTERM, or SIGHUP. Plugin-skills are checked and
 refreshed non-interactively during restart — the process never hangs waiting
 for a prompt. See
 [USER_GUIDE.md §Recovering from Wedged State](docs/USER_GUIDE.md#recovering-from-wedged-state)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ GitHub Project Board (source of truth)
 6. **Advance** — In yolo mode, the issue auto-advances to the next stage. Otherwise, a human moves it.
 
 > **Big-board efficiency (v0.0.57):** On large project boards, the per-poll GraphQL cost drops ~5–10× via a lightweight `updatedAt`-only probe that gates the full deep-fetch — only items that changed since the last poll trigger a full query. Terminal items (issues in a cleanup/Done column with `stage:<name>:complete` and no active lifecycle labels) are skipped entirely from both the probe and deep-fetch evaluation.
+>
+> **Cold-start optimization (v0.0.58):** On startup, closed Done items are seeded from probe data as terminal without a deep-fetch, reducing cold-start GraphQL cost by ~80–90%. Combined with probe-driven polling, this makes running two Fabrik instances on a single token budget practical.
 
 ### Webhook Mode (Optional)
 
@@ -183,7 +185,11 @@ for setup details and the self-mention caveat.
 
 Sending `SIGHUP` to the Fabrik process drains in-flight Claude runs, then
 re-execs the binary in place — no terminal disruption, no lost state. Use it
-to pick up a new binary after `go install` without restarting the session. See
+to pick up a new binary after `go install` without restarting the session.
+The terminal alt-screen is properly restored on signal-driven exit, so no
+`reset` is needed after a kill or SIGHUP. Plugin-skills are checked and
+refreshed non-interactively during restart — the process never hangs waiting
+for a prompt. See
 [USER_GUIDE.md §Recovering from Wedged State](docs/USER_GUIDE.md#recovering-from-wedged-state)
 for the full escape-hatch procedure.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1491,7 +1491,7 @@ operator to press `u` to upgrade.
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
-| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` upgrades and clears the badge; active stage invocations pick up new files on next run) |
+| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` shows a confirmation prompt — press `y` to upgrade and clear the badge; active stage invocations pick up new files on next run) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |
@@ -2081,12 +2081,14 @@ pkill -HUP fabrik
 6. The new process starts with a clean in-memory cache, Store, observers, and `mayNeedWork` set.
 
 **Terminal restore:** The terminal alt-screen is properly released before the process
-is replaced or exits — no `reset` command is needed after a kill or SIGHUP. This
-applies to all signal-driven exit paths including SIGHUP re-exec and forced kills.
+is replaced or exits — no `reset` command is needed after a SIGINT, SIGTERM, or SIGHUP.
+This applies to all signal-driven exit paths that go through Fabrik's signal handlers,
+including SIGHUP re-exec.
 
 **Plugin-skills upgrade:** SIGHUP restart proceeds non-interactively through the
-plugin-skills upgrade check — skills are inspected and refreshed silently without
-prompting, so the restart never hangs waiting for user confirmation.
+plugin-skills upgrade check — skills are refreshed automatically without prompting
+(a brief status line is written to stderr), so the restart never hangs waiting for
+user confirmation.
 
 **What is cleared:**
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1473,6 +1473,9 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 (footer) displaying REST and GraphQL rate limit stats. When the GraphQL budget is
 exhausted or rate-limit-induced probe failures are detected, a prominent red alert
 banner appears immediately below the header with a countdown to when polling resumes.
+When plugin skills in `.fabrik/plugin/` are outdated relative to the embedded
+defaults, a `[u] skills out of date` badge appears in the header, reminding the
+operator to press `u` to upgrade.
 
 ### Keyboard Shortcuts
 
@@ -1488,7 +1491,7 @@ banner appears immediately below the header with a countdown to when polling res
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
-| `u` | Upgrade plugin skills (shows confirmation prompt when out of date; active stage invocations pick up new files on next run) |
+| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` upgrades and clears the badge; active stage invocations pick up new files on next run) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |
@@ -1654,6 +1657,15 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.
 
+#### Cold-Start Cache Population
+
+On first startup, Fabrik bootstraps the board cache from the same lightweight probe
+data used for polling — closed Done items are seeded as terminal without a full
+deep-fetch, eliminating the cold-start spike where each item would otherwise require
+an individual deep-fetch to determine its state. This reduces cold-start GraphQL cost
+by ~80–90%. The bootstrap runs once before the first poll and is invisible to the
+operator beyond the faster startup time.
+
 #### Rate-Limit Exhaustion Alert Banner
 
 When the GraphQL budget hits zero or drops below 20% and probe failures begin,
@@ -1666,7 +1678,10 @@ header:
 
 The countdown ticks every second and shows the local time when the quota resets.
 Once the GraphQL budget recovers above 50%, the banner disappears automatically and
-polling resumes. You do not need to restart Fabrik — it recovers on its own.
+polling resumes. You do not need to restart Fabrik — it recovers on its own. On
+recovery from near-zero exhaustion, Fabrik fires an immediate probe rather than
+waiting for the next scheduled poll tick, so processing resumes as soon as the
+budget is restored.
 
 ---
 
@@ -2064,6 +2079,14 @@ pkill -HUP fabrik
 4. The lockfile (`.fabrik/fabrik.lock`) is released.
 5. `syscall.Exec` replaces the process image in place — the PID stays the same, the parent shell and TUI remain attached, and a brief TUI redraw may occur.
 6. The new process starts with a clean in-memory cache, Store, observers, and `mayNeedWork` set.
+
+**Terminal restore:** The terminal alt-screen is properly released before the process
+is replaced or exits — no `reset` command is needed after a kill or SIGHUP. This
+applies to all signal-driven exit paths including SIGHUP re-exec and forced kills.
+
+**Plugin-skills upgrade:** SIGHUP restart proceeds non-interactively through the
+plugin-skills upgrade check — skills are inspected and refreshed silently without
+prompting, so the restart never hangs waiting for user confirmation.
 
 **What is cleared:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -259,7 +259,7 @@ description: >-
         <span class="feature-icon">🚀</span>
         <div class="feature-title">Big-Board Efficiency</div>
         <div class="feature-desc">
-          Probe-driven polling cuts per-poll GraphQL cost ~5–10× on large boards; terminal Done items are skipped entirely.
+          Probe-driven polling cuts per-poll GraphQL cost ~5–10× on large boards; cold-start bootstrap seeds Done items from probe data, cutting startup cost ~80–90% — making two Fabrik instances on a single token budget viable.
         </div>
       </a>
     </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1489,7 +1489,7 @@ operator to press `u` to upgrade.
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
-| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` upgrades and clears the badge; active stage invocations pick up new files on next run) |
+| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` shows a confirmation prompt — press `y` to upgrade and clear the badge; active stage invocations pick up new files on next run) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |
@@ -2079,12 +2079,14 @@ pkill -HUP fabrik
 6. The new process starts with a clean in-memory cache, Store, observers, and `mayNeedWork` set.
 
 **Terminal restore:** The terminal alt-screen is properly released before the process
-is replaced or exits — no `reset` command is needed after a kill or SIGHUP. This
-applies to all signal-driven exit paths including SIGHUP re-exec and forced kills.
+is replaced or exits — no `reset` command is needed after a SIGINT, SIGTERM, or SIGHUP.
+This applies to all signal-driven exit paths that go through Fabrik's signal handlers,
+including SIGHUP re-exec.
 
 **Plugin-skills upgrade:** SIGHUP restart proceeds non-interactively through the
-plugin-skills upgrade check — skills are inspected and refreshed silently without
-prompting, so the restart never hangs waiting for user confirmation.
+plugin-skills upgrade check — skills are refreshed automatically without prompting
+(a brief status line is written to stderr), so the restart never hangs waiting for
+user confirmation.
 
 **What is cleared:**
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1471,6 +1471,9 @@ Claude sessions, a scrollable History pane with completed jobs, and a status bar
 (footer) displaying REST and GraphQL rate limit stats. When the GraphQL budget is
 exhausted or rate-limit-induced probe failures are detected, a prominent red alert
 banner appears immediately below the header with a countdown to when polling resumes.
+When plugin skills in `.fabrik/plugin/` are outdated relative to the embedded
+defaults, a `[u] skills out of date` badge appears in the header, reminding the
+operator to press `u` to upgrade.
 
 ### Keyboard Shortcuts
 
@@ -1486,7 +1489,7 @@ banner appears immediately below the header with a countdown to when polling res
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
-| `u` | Upgrade plugin skills (shows confirmation prompt when out of date; active stage invocations pick up new files on next run) |
+| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` upgrades and clears the badge; active stage invocations pick up new files on next run) |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |
@@ -1652,6 +1655,15 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.
 
+#### Cold-Start Cache Population
+
+On first startup, Fabrik bootstraps the board cache from the same lightweight probe
+data used for polling — closed Done items are seeded as terminal without a full
+deep-fetch, eliminating the cold-start spike where each item would otherwise require
+an individual deep-fetch to determine its state. This reduces cold-start GraphQL cost
+by ~80–90%. The bootstrap runs once before the first poll and is invisible to the
+operator beyond the faster startup time.
+
 #### Rate-Limit Exhaustion Alert Banner
 
 When the GraphQL budget hits zero or drops below 20% and probe failures begin,
@@ -1664,7 +1676,10 @@ header:
 
 The countdown ticks every second and shows the local time when the quota resets.
 Once the GraphQL budget recovers above 50%, the banner disappears automatically and
-polling resumes. You do not need to restart Fabrik — it recovers on its own.
+polling resumes. You do not need to restart Fabrik — it recovers on its own. On
+recovery from near-zero exhaustion, Fabrik fires an immediate probe rather than
+waiting for the next scheduled poll tick, so processing resumes as soon as the
+budget is restored.
 
 ---
 
@@ -2062,6 +2077,14 @@ pkill -HUP fabrik
 4. The lockfile (`.fabrik/fabrik.lock`) is released.
 5. `syscall.Exec` replaces the process image in place — the PID stays the same, the parent shell and TUI remain attached, and a brief TUI redraw may occur.
 6. The new process starts with a clean in-memory cache, Store, observers, and `mayNeedWork` set.
+
+**Terminal restore:** The terminal alt-screen is properly released before the process
+is replaced or exits — no `reset` command is needed after a kill or SIGHUP. This
+applies to all signal-driven exit paths including SIGHUP re-exec and forced kills.
+
+**Plugin-skills upgrade:** SIGHUP restart proceeds non-interactively through the
+plugin-skills upgrade check — skills are inspected and refreshed silently without
+prompting, so the restart never hangs waiting for user confirmation.
 
 **What is cleared:**
 


### PR DESCRIPTION
## Summary

Update USER_GUIDE.md, README.md, and docs/index.md to document the v0.0.58 efficiency and operator-visibility additions. This is a documentation-only change — no code changes.

## Problem

v0.0.58 shipped several operator-visible features that are undocumented or incompletely documented:

- **Cold-start cache optimization** (`BootstrapFromProbe`, #710): ~80–90% reduction in cold-start GraphQL cost — closes Done items are seeded as terminal without a deep-fetch; linkage-drift suppression prevents erroneous re-fetches on never-deep-fetched items. This is the most significant efficiency improvement since v0.0.57's probe-driven polling and deserves a mention in README and docs/index.md.
- **Stale-skills badge** in TUI header (#692): A persistent badge now appears in the header when plugin skills are out of date (separate from the `u`-key confirmation prompt). The `u` keybinding description is present but the badge is not mentioned.
- **SIGHUP restart no longer blocks on plugin-skills upgrade prompt** (#692): The SIGHUP restart path previously could hang waiting for a user response to the skill upgrade confirmation prompt. Now it proceeds non-interactively. The SIGHUP/`ctrl+r` section of USER_GUIDE.md should note this.
- **TUI terminal restored on signal-driven exit** (#693): Before this fix, killing Fabrik via SIGHUP or signal left the terminal in raw mode, requiring `reset`. Now the terminal is properly restored. A "no more `reset` after kill/SIGHUP" callout should appear near the SIGHUP section.
- **Force immediate probe on rate-limit recovery** (#706): On rate-limit exhaustion recovery, Fabrik now fires a probe immediately rather than waiting for the next tick. The rate-limit banner section mentions auto-resume but not the immediate-probe behavior.

The `ctrl+r` keybinding, `u` keybinding, and rate-limit exhaustion banner with countdown are already documented in USER_GUIDE.md and do not need to be re-added.

## Approach

### Approach

Documentation-only: five edits to `docs/USER_GUIDE.md`, two edits to `README.md`, and one edit to `docs/index.md`, followed by a mandatory `docs/llms-full.txt` regeneration. No code changes. Each edit targets a specific line range identified by Research, using content derived from verified source (badge text from `tui/header.go`, node counts from `engine/poll.go`, non-interactive flag from `cmd/root.go`, cleanup hook from `cmd/root.go`).

The implementation order: complete all USER_GUIDE.md edits first (they share a file and the llms-full.txt regen depends on a stable final state), then README.md, then docs/index.md, then regen.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | 5 additions: TUI Layout badge sentence, `u` key row expansion, cold-start bootstrap subsection, immediate-probe sentence, SIGHUP non-blocking + terminal restore notes |
| `README.md` | 2 additions: cold-start callout in Big-board efficiency, SIGHUP terminal restore + non-blocking note |
| `docs/index.md` | Expand Big-Board Efficiency feature card description |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **Subsection vs. inline note for cold-start bootstrap in USER_GUIDE.md**: Add as a separate `#### Cold-Start Cache Population` subsection immediately following the two-phase fetch description (before the Rate-Limit Exhaustion Alert Banner). The cold-start content is substantive enough (~3 sentences) to warrant its own heading rather than a parenthetical; it parallels the two-phase fetch description and operators will look for it independently.

- **No ADRs**: This is a documentation change with no architectural decisions. ADR-044 addendum already covers the design rationale and was committed in the v0.0.58 release.

- **Badge text verbatim**: Document the badge as `[u] skills out of date` matching `tui/header.go` exactly, so operators can recognize it in the terminal without ambiguity.

- **Immediate-probe precision**: Document that the immediate probe fires on recovery from *near-zero* exhaustion specifically, not on any rate-limit backoff clearance, matching the `isRateLimitNearZero` guard in the implementation.

- **docs/index.md regen**: Research confirmed `docs/index.md` is not in `generate-llms-full.sh`'s `ORDERED` array. No regen needed for index-only changes; regen is only required after USER_GUIDE.md edits.

### Task Checklist

- [ ] **Task 1 — USER_GUIDE.md, TUI Layout section (line ~1475)**: After the existing Layout paragraph, add a sentence about the stale-skills badge: when plugin skills in `.fabrik/plugin/` are outdated relative to the embedded defaults, a `[u] skills out of date` badge appears in the TUI header, prompting the operator to press `u` to upgrade.

- [ ] **Task 2 — USER_GUIDE.md, keyboard shortcuts table `u` row (line ~1491)**: Expand the `u` row description from "shows confirmation prompt when out of date" to also mention the persistent header badge: "when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` upgrades and clears the badge."

- [ ] **Task 3 — USER_GUIDE.md, Rate Limit Monitoring (after line ~1655)**: Insert a `#### Cold-Start Cache Population` subsection immediately after the two-phase-fetch description (before the `#### Rate-Limit Exhaustion Alert Banner` heading). Content: on first startup Fabrik bootstraps the board cache from the lightweight probe data — closed Done items are seeded as terminal without a full deep-fetch, eliminating the cold-start spike where each item would otherwise require an individual deep-fetch to determine its state. This reduces cold-start GraphQL cost by ~80–90%. The bootstrap runs once before the first poll and is invisible to the operator beyond the faster startup time.

- [ ] **Task 4 — USER_GUIDE.md, Rate-Limit Exhaustion Alert Banner (line ~1669)**: After "You do not need to restart Fabrik — it recovers on its own," add a sentence: on recovery from near-zero exhaustion, Fabrik fires an immediate probe rather than waiting for the next scheduled poll tick, so processing resumes as soon as the budget is restored.

- [ ] **Task 5 — USER_GUIDE.md, Recovering from Wedged State (after line ~2065, in "What happens" list)**: In the numbered list of SIGHUP steps, after step 5 (syscall.Exec), note: the terminal is properly restored on signal-driven exit — no `reset` command needed. Also add a note near the top of the section (or as a callout paragraph after "What happens") that SIGHUP restart proceeds non-interactively through the plugin-skills upgrade check — skills are refreshed silently without prompting, so the restart never hangs.

- [ ] **Task 6 — README.md, Big-board efficiency callout (line ~91)**: Update the blockquote to add v0.0.58 cold-start optimization: in addition to the ~5–10× per-poll cost reduction (v0.0.57), closed Done items are now seeded from probe data at startup without deep-fetching — reducing cold-start GraphQL cost by ~80–90% (v0.0.58). Retain the existing v0.0.57 attribution; add v0.0.58 attribution for the new content.

- [ ] **Task 7 — README.md, In-Place Restart paragraph (lines ~182–188)**: Expand the paragraph to note: (a) the terminal is properly restored on signal-driven exit — the alt-screen is released before re-exec or exit, so no `reset` is needed after a kill or SIGHUP; (b) SIGHUP restart no longer blocks on the plugin-skills upgrade prompt — skills are checked and refreshed non-interactively.

- [ ] **Task 8 — docs/index.md, Big-Board Efficiency feature card (lines ~258–264)**: Expand the feature card description to mention the cold-start optimization alongside the per-poll efficiency claim. Suggested text: "Probe-driven polling cuts per-poll GraphQL cost ~5–10× on large boards; cold-start bootstrap seeds Done items from probe data, cutting startup cost ~80–90% — making two Fabrik instances on a single token budget viable."

- [ ] **Task 9 — Regenerate docs/llms-full.txt**: Run `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt`. This is required because USER_GUIDE.md is in the `ORDERED` array of the script and CI's `docs-drift` workflow will fail if the bundle is stale.

- [ ] **Task 10 — Commit all changes**: Single commit on `fabrik/issue-723` branch with all doc changes + regenerated llms-full.txt. Message: `docs: document v0.0.58 features (cold-start, stale-skills badge, SIGHUP fixes)`.

### Risks

- **Line number drift**: The Research findings cite specific line numbers (e.g., line 1491 for the `u` row). Between Research and Implement the file hasn't changed (Research confirmed `ca73d269` = main). But Implement should verify the target lines before editing.
- **Badge text accuracy**: Verbatim text `[u] skills out of date` is confirmed from `tui/header.go` — no risk if Implement uses the exact string.
- **llms-full.txt regen timing**: Regen must run after all USER_GUIDE.md edits are complete. If Implement edits USER_GUIDE.md in multiple commits, regen must happen in the final commit that touches the file, or as a separate follow-up commit.

---
Used 11/50 turns, 4k input / 3k output tokens.

## Verification

Updated USER_GUIDE.md (5 additions: stale-skills badge in Layout and `u` key row, Cold-Start Cache Population subsection, immediate-probe note on rate-limit recovery, terminal restore and non-blocking plugin-skills notes in the SIGHUP section), README.md (cold-start v0.0.58 callout and In-Place Restart expansion), and docs/index.md (Big-Board Efficiency feature card). Regenerated docs/llms-full.txt and committed everything in a single commit on fabrik/issue-723.

---

Closes #723