### PR TITLE
Implement/Review pipeline occasionally completes without creating a PR

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2740,14 +2740,64 @@ After a stage invocation (not comment processing), `markCommentsSeenByStage()` a
 
 ### 5.1 Draft PR Creation
 
-**When:** After a stage signals FABRIK_STAGE_COMPLETE, if the stage has `create_draft_pr: true`.
+**When:** After a stage signals FABRIK_STAGE_COMPLETE, if the stage has `create_draft_pr: true`. An early-guard path also runs before output is posted when both `create_draft_pr: true` and `post_to_pr: true` are set, so the PR exists before `postOutputToPR` runs.
 
 **Code path:** `processItem()` → `ensureDraftPR()`
 
-**Flow:**
-1. Check for existing PR via `FindPRForIssue()` — if found, ensure body contains `Closes #N` and return
+**Flow (idempotent, up to 3 attempts with exponential backoff):**
+1. Check for an existing open PR via `FetchLinkedPR()` — if found open and not merged, ensure body contains `Closes #N` and return its number. Closed or merged PRs are ignored; a new PR will be created.
 2. Push the issue branch via `PushBranch()`
-3. Create draft PR via `CreateDraftPR()` with title from issue, targeting `baseBranch`, body containing `Closes #N`
+3. Build a seed body from `.fabrik-context/` files (issue summary, plan approach, verification placeholder)
+4. Create draft PR via `CreateDraftPR()` with title from issue, targeting `baseBranch`, body ending with `Closes #N`
+
+Transient errors (network errors, 5xx) are retried with backoff (base delay 500ms, doubled each attempt). Non-transient errors (4xx including 422) return immediately without retry. Returns `(prNumber, nil)` on success, `(0, error)` on failure.
+
+**Success logging:** `[#N pr] created draft PR #<num> (branch: fabrik/issue-N)`
+
+**Failure logging:** `[#N pr] failed to create draft PR for branch fabrik/issue-N: <error>`
+
+### 5.5 PR Creation Failure Path
+
+**Trigger:** Stage with `create_draft_pr: true` emits `FABRIK_STAGE_COMPLETE`, but `ensureDraftPR` returns `(0, error)` after exhausting its in-process retry loop.
+
+**Critical invariant:** `handleStageComplete` is NOT called when PR creation fails. The stage does not advance. `stage:<X>:complete` is not added.
+
+**Retry counting:** Each PR creation failure increments the same per-stage `Attempts` counter used by `StageRetryIncremented`. The `StageRetryCleared` mutation (which resets the counter) fires only on PR creation success, not on failure. This means PR creation failures count against `MaxRetries` just like Claude failures.
+
+**Code path (completion block in `processItem`):**
+
+```
+FABRIK_STAGE_COMPLETE received
+  → if stage.CreateDraftPR and prNumber == 0:
+      prErr = ensureDraftPR(item, baseBranch)
+      if prErr != nil:
+          if MaxRetries > 0:
+              StageRetryIncremented
+              if Attempts >= MaxRetries:
+                  escalatePRCreationFailure()  → fabrik:paused, stage:<X>:failed, comment
+                  releaseLock()
+                  return
+          PRCreationFailedRecorded            → sets in-memory flag for R5
+          releaseLock()
+          return                               → NO handleStageComplete
+      else:
+          updatePRVerification(prNumber, summary)
+  releaseLock()
+  StageRetryCleared, EngineUnpaused
+  handleStageComplete()                        → stage:X:complete, optional advance
+```
+
+**Escalation comment** (posted by `escalatePRCreationFailure`): Names PR creation as the failure cause (not Claude), includes the manual workaround command using the actual base branch: `` `gh pr create --head fabrik/issue-N --base <baseBranch> --body "Closes #N"` ``, and instructs the user to remove `fabrik:paused` to resume.
+
+**`PRCreationFailed` in-memory flag (R5):** `StageState.PRCreationFailed map[string]bool` records that Claude completed a stage but the draft PR could not be created. This flag does not survive engine restarts. It is cleared by `StageRetryCleared` (on PR creation success). On restart, the item re-runs Claude, which is safe and conservative — Claude's commits are idempotent.
+
+**R5 skip-Claude retry path:** On the next poll cycle for an item with `PRCreationFailed[stageName] == true`, the engine checks this flag early in `runStage` (before the Claude invocation). If `ensureDraftPR` now succeeds, the engine calls `handleStageComplete` directly — no Claude re-invocation needed, since the worktree already has the commits from the prior run. If `ensureDraftPR` still fails, the retry counter is incremented and the escalation path applies when `MaxRetries` is reached.
+
+| State | Trigger | Action | Outcome |
+|-------|---------|--------|---------|
+| Locked + In Progress | `FABRIK_STAGE_COMPLETE` + `create_draft_pr` + PR creation fails | `PRCreationFailedRecorded`; lock released; NO `handleStageComplete` | Item waits for next poll |
+| Locked + In Progress | `FABRIK_STAGE_COMPLETE` + `create_draft_pr` + PR creation fails + `Attempts >= MaxRetries` | `escalatePRCreationFailure`: `fabrik:paused`, `stage:<X>:failed`, comment | Issue paused for human intervention |
+| Locked + In Progress | `PRCreationFailed` flag set; `ensureDraftPR` succeeds on retry (R5) | `StageRetryCleared`, `handleStageComplete` — no Claude run | Stage advances normally |
 
 ### 5.2 Mark PR Ready
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -627,14 +627,64 @@ After a stage invocation (not comment processing), `markCommentsSeenByStage()` a
 
 ### 5.1 Draft PR Creation
 
-**When:** After a stage signals FABRIK_STAGE_COMPLETE, if the stage has `create_draft_pr: true`.
+**When:** After a stage signals FABRIK_STAGE_COMPLETE, if the stage has `create_draft_pr: true`. An early-guard path also runs before output is posted when both `create_draft_pr: true` and `post_to_pr: true` are set, so the PR exists before `postOutputToPR` runs.
 
 **Code path:** `processItem()` → `ensureDraftPR()`
 
-**Flow:**
-1. Check for existing PR via `FindPRForIssue()` — if found, ensure body contains `Closes #N` and return
+**Flow (idempotent, up to 3 attempts with exponential backoff):**
+1. Check for an existing open PR via `FetchLinkedPR()` — if found open and not merged, ensure body contains `Closes #N` and return its number. Closed or merged PRs are ignored; a new PR will be created.
 2. Push the issue branch via `PushBranch()`
-3. Create draft PR via `CreateDraftPR()` with title from issue, targeting `baseBranch`, body containing `Closes #N`
+3. Build a seed body from `.fabrik-context/` files (issue summary, plan approach, verification placeholder)
+4. Create draft PR via `CreateDraftPR()` with title from issue, targeting `baseBranch`, body ending with `Closes #N`
+
+Transient errors (network errors, 5xx) are retried with backoff (base delay 500ms, doubled each attempt). Non-transient errors (4xx including 422) return immediately without retry. Returns `(prNumber, nil)` on success, `(0, error)` on failure.
+
+**Success logging:** `[#N pr] created draft PR #<num> (branch: fabrik/issue-N)`
+
+**Failure logging:** `[#N pr] failed to create draft PR for branch fabrik/issue-N: <error>`
+
+### 5.5 PR Creation Failure Path
+
+**Trigger:** Stage with `create_draft_pr: true` emits `FABRIK_STAGE_COMPLETE`, but `ensureDraftPR` returns `(0, error)` after exhausting its in-process retry loop.
+
+**Critical invariant:** `handleStageComplete` is NOT called when PR creation fails. The stage does not advance. `stage:<X>:complete` is not added.
+
+**Retry counting:** Each PR creation failure increments the same per-stage `Attempts` counter used by `StageRetryIncremented`. The `StageRetryCleared` mutation (which resets the counter) fires only on PR creation success, not on failure. This means PR creation failures count against `MaxRetries` just like Claude failures.
+
+**Code path (completion block in `processItem`):**
+
+```
+FABRIK_STAGE_COMPLETE received
+  → if stage.CreateDraftPR and prNumber == 0:
+      prErr = ensureDraftPR(item, baseBranch)
+      if prErr != nil:
+          if MaxRetries > 0:
+              StageRetryIncremented
+              if Attempts >= MaxRetries:
+                  escalatePRCreationFailure()  → fabrik:paused, stage:<X>:failed, comment
+                  releaseLock()
+                  return
+          PRCreationFailedRecorded            → sets in-memory flag for R5
+          releaseLock()
+          return                               → NO handleStageComplete
+      else:
+          updatePRVerification(prNumber, summary)
+  releaseLock()
+  StageRetryCleared, EngineUnpaused
+  handleStageComplete()                        → stage:X:complete, optional advance
+```
+
+**Escalation comment** (posted by `escalatePRCreationFailure`): Names PR creation as the failure cause (not Claude), includes the manual workaround command using the actual base branch: `` `gh pr create --head fabrik/issue-N --base <baseBranch> --body "Closes #N"` ``, and instructs the user to remove `fabrik:paused` to resume.
+
+**`PRCreationFailed` in-memory flag (R5):** `StageState.PRCreationFailed map[string]bool` records that Claude completed a stage but the draft PR could not be created. This flag does not survive engine restarts. It is cleared by `StageRetryCleared` (on PR creation success). On restart, the item re-runs Claude, which is safe and conservative — Claude's commits are idempotent.
+
+**R5 skip-Claude retry path:** On the next poll cycle for an item with `PRCreationFailed[stageName] == true`, the engine checks this flag early in `runStage` (before the Claude invocation). If `ensureDraftPR` now succeeds, the engine calls `handleStageComplete` directly — no Claude re-invocation needed, since the worktree already has the commits from the prior run. If `ensureDraftPR` still fails, the retry counter is incremented and the escalation path applies when `MaxRetries` is reached.
+
+| State | Trigger | Action | Outcome |
+|-------|---------|--------|---------|
+| Locked + In Progress | `FABRIK_STAGE_COMPLETE` + `create_draft_pr` + PR creation fails | `PRCreationFailedRecorded`; lock released; NO `handleStageComplete` | Item waits for next poll |
+| Locked + In Progress | `FABRIK_STAGE_COMPLETE` + `create_draft_pr` + PR creation fails + `Attempts >= MaxRetries` | `escalatePRCreationFailure`: `fabrik:paused`, `stage:<X>:failed`, comment | Issue paused for human intervention |
+| Locked + In Progress | `PRCreationFailed` flag set; `ensureDraftPR` succeeds on retry (R5) | `StageRetryCleared`, `handleStageComplete` — no Claude run | Stage advances normally |
 
 ### 5.2 Mark PR Ready
 

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -399,7 +399,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		})
 		var prNumber int
 		if stage.CreateDraftPR {
-			prNumber = e.ensureDraftPR(item, baseBranch)
+			// Error is intentionally ignored here — comment processing implies the stage
+			// already advanced; a PR creation failure here is non-fatal for this path.
+			prNumber, _ = e.ensureDraftPR(item, baseBranch)
 			e.updatePRVerification(item, prNumber, summary)
 		}
 		if stage.MarkPRReadyOnComplete {

--- a/engine/comments_stagecompletion_test.go
+++ b/engine/comments_stagecompletion_test.go
@@ -106,6 +106,9 @@ func TestProcessComments_SummaryBeforeStrip_VerificationUpdated(t *testing.T) {
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
 			return prNum, nil
 		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: prNum, State: "open"}, nil
+		},
 		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
 			if issueNumber == prNum {
 				return "## Verification\n\n(Populated by Implement on completion)\n\n---\n\nCloses #30", nil

--- a/engine/engine_extra_test.go
+++ b/engine/engine_extra_test.go
@@ -246,20 +246,20 @@ func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 	}
 }
 
-func TestEnsureDraftPR_NoPR_FailedPush_ReturnsZero(t *testing.T) {
+func TestEnsureDraftPR_NoPR_FailedPush_ReturnsError(t *testing.T) {
 	// No existing PR; push will fail because base dir is not a real repo.
-	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 0, nil
-		},
-	}
+	// fetchLinkedPRFn not set → mock returns nil, nil (no PR found).
+	client := &mockGitHubClient{}
 	eng := testEngine(client, &mockClaudeInvoker{})
 	// WorktreeManager points to /tmp/test-repo which doesn't exist
 	item := gh.ProjectItem{Number: 99, Title: "Test"}
-	prNum := eng.ensureDraftPR(item, "main")
+	prNum, err := eng.ensureDraftPR(item, "main")
 
-	// Push fails → returns 0
+	// Push fails → returns (0, err)
 	if prNum != 0 {
 		t.Errorf("expected 0 when push fails, got %d", prNum)
+	}
+	if err == nil {
+		t.Error("expected error when push fails, got nil")
 	}
 }

--- a/engine/item.go
+++ b/engine/item.go
@@ -685,6 +685,9 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				releaseLock()
 				e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 				e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+				if stage.MarkPRReadyOnComplete {
+					e.markPRReady(item, r5PRNum)
+				}
 				e.handleStageComplete(ctx, board, item, stage)
 				return nil
 			}

--- a/engine/item.go
+++ b/engine/item.go
@@ -674,6 +674,39 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// created by symlinkEnvIfEnabled is never captured and never causes stash-pop conflicts.
 	e.ensureEnvExcluded(item.Number, workDir)
 
+	// R5: If Claude already completed (commits exist) but PR creation failed in the
+	// previous invocation, attempt PR creation before re-invoking Claude. This avoids
+	// running Claude redundantly when the worktree already has the necessary commits.
+	if stage.CreateDraftPR {
+		if r5Snap, r5Err := e.store.Get(repoStr, item.Number); r5Err == nil && r5Snap.PRCreationFailed(stage.Name) {
+			r5PRNum, r5PRErr := e.ensureDraftPR(item, baseBranch)
+			if r5PRErr == nil && r5PRNum > 0 {
+				// PR created successfully — advance without re-running Claude.
+				releaseLock()
+				e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+				e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+				e.handleStageComplete(ctx, board, item, stage)
+				return nil
+			}
+			// PR still failing — count against MaxRetries and potentially escalate.
+			if e.cfg.MaxRetries > 0 {
+				e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+				var count int
+				if r5CountSnap, r5CountErr := e.store.Get(repoStr, item.Number); r5CountErr == nil {
+					count = r5CountSnap.Attempts(stage.Name)
+				}
+				if count >= e.cfg.MaxRetries {
+					e.escalatePRCreationFailure(item, stage, baseBranch)
+					releaseLock()
+					return nil
+				}
+			}
+			// Below threshold — release lock and let cooldown expire before next retry.
+			releaseLock()
+			return nil
+		}
+	}
+
 	// If this is a read-only stage, stash any unexpected dirty state (including
 	// untracked files) before invocation so the stage sees a clean worktree, and
 	// restore it afterward.
@@ -836,9 +869,11 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 
 	// When completing a stage that posts output to a PR and creates a draft PR,
 	// ensure the PR exists before posting so postOutputToPR can find it.
+	// Error is intentionally ignored here — failure is caught and escalated in
+	// the completion block below, which also retries with the full retry/backoff logic.
 	var prNumber int
 	if completed && stage.CreateDraftPR && stage.PostToPR {
-		prNumber = e.ensureDraftPR(item, baseBranch)
+		prNumber, _ = e.ensureDraftPR(item, baseBranch)
 	}
 
 	// Post Claude's output
@@ -962,18 +997,40 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	})
 
 	if completed {
-		releaseLock()
-		// Clear retry tracking for this stage — no longer needed after success.
-		e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-		e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 		// Post-stage: create draft PR and/or mark ready now that commits exist.
 		// prNumber may already be set if the early guard above ran (PostToPR + CreateDraftPR path).
 		if stage.CreateDraftPR {
 			if prNumber == 0 {
-				prNumber = e.ensureDraftPR(item, baseBranch)
+				var prErr error
+				prNumber, prErr = e.ensureDraftPR(item, baseBranch)
+				if prErr != nil {
+					// PR creation failed — route through retry/escalation machinery.
+					// StageRetryCleared must NOT fire so retries count against MaxRetries.
+					if e.cfg.MaxRetries > 0 {
+						e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+						var count int
+						if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
+							count = snap.Attempts(stage.Name)
+						}
+						if count >= e.cfg.MaxRetries {
+							e.escalatePRCreationFailure(item, stage, baseBranch)
+							releaseLock()
+							return nil
+						}
+					}
+					// Below MaxRetries threshold — record flag so next poll retries PR creation
+					// before re-invoking Claude, then release lock and let cooldown expire.
+					e.store.Apply(itemstate.PRCreationFailedRecorded{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+					releaseLock()
+					return nil
+				}
 			}
 			e.updatePRVerification(item, prNumber, extractSummary(output))
 		}
+		// PR creation succeeded (or not required) — advance the stage.
+		releaseLock()
+		e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 		if stage.MarkPRReadyOnComplete {
 			e.markPRReady(item, prNumber)
 		}
@@ -1004,6 +1061,53 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	}
 
 	return nil
+}
+
+// escalatePRCreationFailure is called when create_draft_pr: true and ensureDraftPR
+// fails after MaxRetries attempts. It adds fabrik:paused and stage:<name>:failed labels,
+// posts an explanatory comment naming PR creation as the cause (not Claude), and
+// records the escalation.
+func (e *Engine) escalatePRCreationFailure(item gh.ProjectItem, stage *stages.Stage, baseBranch string) {
+	e.logf(item.Number, "escalate", "PR creation for stage %q failed %d time(s) — pausing issue\n", stage.Name, e.cfg.MaxRetries)
+
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+		}
+	}
+
+	e.addFailedLabel(owner, repo, item.Number, stage.Name)
+
+	comment := fmt.Sprintf(
+		"🏭 **Fabrik — PR creation failed**\n\nStage **%s** completed successfully but the draft PR could not be created after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh pr create --head fabrik/issue-%d --base %s --body \"Closes #%d\"\n```\n\nThen remove the `fabrik:paused` label to resume.",
+		stage.Name, e.cfg.MaxRetries, item.Number, baseBranch, item.Number,
+	)
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+		e.logf(item.Number, "warn", "could not post PR escalation comment: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+		}
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
+	}
+
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 }
 
 // escalateFailedStage is called when a stage has failed MaxRetries times. It adds

--- a/engine/item_test.go
+++ b/engine/item_test.go
@@ -2,11 +2,13 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
 
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
 
@@ -532,5 +534,249 @@ func TestExtendTurns_MaxTurnsZero_NoOp(t *testing.T) {
 	// With MaxTurns == 0, budget must remain 0 regardless of extend-turns label.
 	if gotOverride != 0 {
 		t.Errorf("expected MaxTurnsOverride = 0 for unlimited stage, got %d", gotOverride)
+	}
+}
+
+// ── PR creation failure tests (Tasks 7 & 8) ──────────────────────────────────
+
+// implementDraftPRStages returns a single Implement stage with create_draft_pr true.
+func implementDraftPRStages() []*stages.Stage {
+	return []*stages.Stage{
+		{
+			Name:          "Implement",
+			Order:         1,
+			Prompt:        "implement it",
+			CreateDraftPR: true,
+			Completion:    stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+}
+
+// TestRunStage_CreateDraftPR_Fails_StageNotComplete verifies R1: when Claude
+// completes (FABRIK_STAGE_COMPLETE) but ensureDraftPR fails, handleStageComplete
+// is NOT called and the PRCreationFailed flag is set in the store.
+func TestRunStage_CreateDraftPR_Fails_StageNotComplete(t *testing.T) {
+	skipIfNoGit(t)
+
+	origLock := lockVerifyDelay
+	lockVerifyDelay = 0
+	t.Cleanup(func() { lockVerifyDelay = origLock })
+	origPR := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = origPR })
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, errors.New("GitHub API returned 422: validation failed")
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+	eng := testEngineWithRepo(t, client, claude)
+	stgs := implementDraftPRStages()
+	eng.cfg.Stages = stgs
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 70, Title: "T", Status: "Implement", ItemID: "PVTI_70"}
+
+	if err := eng.processItem(t.Context(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// handleStageComplete must NOT have been called — no stage:Implement:complete label.
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:complete" {
+			t.Errorf("expected no stage:Implement:complete label when PR creation fails")
+			break
+		}
+	}
+
+	// PRCreationFailed flag must be set in the store.
+	snap, err := eng.store.Get("owner/repo", 70)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if !snap.PRCreationFailed("Implement") {
+		t.Error("expected PRCreationFailed flag to be set for Implement stage")
+	}
+}
+
+// TestRunStage_CreateDraftPR_FailsAtMaxRetries_Escalates verifies R3: when PR
+// creation fails and the retry count hits MaxRetries, escalatePRCreationFailure
+// adds fabrik:paused and the stage is not marked complete.
+func TestRunStage_CreateDraftPR_FailsAtMaxRetries_Escalates(t *testing.T) {
+	skipIfNoGit(t)
+
+	origLock := lockVerifyDelay
+	lockVerifyDelay = 0
+	t.Cleanup(func() { lockVerifyDelay = origLock })
+	origPR := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = origPR })
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, errors.New("GitHub API returned 422: validation failed")
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+	eng := testEngineWithRepo(t, client, claude)
+	eng.cfg.MaxRetries = 1
+	eng.cfg.Stages = implementDraftPRStages()
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 71, Title: "T", Status: "Implement", ItemID: "PVTI_71"}
+
+	if err := eng.processItem(t.Context(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// fabrik:paused must have been added (escalation path).
+	var pausedAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedAdded = true
+		}
+	}
+	if !pausedAdded {
+		t.Error("expected fabrik:paused label added on PR creation escalation")
+	}
+
+	// stage:Implement:complete must NOT be present.
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:complete" {
+			t.Errorf("expected no stage:Implement:complete label on escalation path")
+			break
+		}
+	}
+}
+
+// TestRunStage_LockReleasedExactlyOnce_OnPRFailure verifies that releaseLock is
+// called exactly once when PR creation fails — no double-release.
+func TestRunStage_LockReleasedExactlyOnce_OnPRFailure(t *testing.T) {
+	skipIfNoGit(t)
+
+	origLock := lockVerifyDelay
+	lockVerifyDelay = 0
+	t.Cleanup(func() { lockVerifyDelay = origLock })
+	origPR := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = origPR })
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, errors.New("GitHub API returned 422: validation failed")
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+	eng := testEngineWithRepo(t, client, claude)
+	eng.cfg.Stages = implementDraftPRStages()
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 72, Title: "T", Status: "Implement", ItemID: "PVTI_72"}
+
+	if err := eng.processItem(t.Context(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// Count removals of the lock label — must be exactly 1.
+	lockLabel := "fabrik:locked:" + eng.cfg.User
+	var lockRemovals int
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == lockLabel {
+			lockRemovals++
+		}
+	}
+	if lockRemovals != 1 {
+		t.Errorf("expected lock label removed exactly once, got %d removals", lockRemovals)
+	}
+}
+
+// TestProcessItem_PRCreationFailed_SkipsClaudeOnRetry verifies R5: when the
+// PRCreationFailed flag is set (from a prior run where Claude succeeded but the
+// PR could not be created), a subsequent processItem call skips Claude and
+// advances the stage directly once ensureDraftPR succeeds.
+func TestProcessItem_PRCreationFailed_SkipsClaudeOnRetry(t *testing.T) {
+	skipIfNoGit(t)
+
+	origLock := lockVerifyDelay
+	lockVerifyDelay = 0
+	t.Cleanup(func() { lockVerifyDelay = origLock })
+	origPR := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = origPR })
+
+	// FetchLinkedPR fails on first processItem, succeeds on second.
+	var fetchCalls int
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			fetchCalls++
+			if fetchCalls == 1 {
+				return nil, errors.New("GitHub API returned 422: validation failed")
+			}
+			return &gh.PRDetails{Number: 77, State: "open"}, nil
+		},
+	}
+
+	var invokeCount int
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			invokeCount++
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+	eng := testEngineWithRepo(t, client, claude)
+	eng.cfg.Stages = implementDraftPRStages()
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 73, Title: "T", Status: "Implement", ItemID: "PVTI_73"}
+
+	// First call: Claude runs, PR creation fails → PRCreationFailed flag set.
+	if err := eng.processItem(t.Context(), board, item); err != nil {
+		t.Fatalf("first processItem: %v", err)
+	}
+	if invokeCount != 1 {
+		t.Fatalf("expected Claude invoked once on first processItem, got %d", invokeCount)
+	}
+	snap, err := eng.store.Get("owner/repo", 73)
+	if err != nil {
+		t.Fatalf("store.Get after first call: %v", err)
+	}
+	if !snap.PRCreationFailed("Implement") {
+		t.Fatal("expected PRCreationFailed flag set after first call")
+	}
+
+	// Second call: R5 fires → ensureDraftPR succeeds → Claude NOT invoked.
+	// Apply PRCreationFailed flag via the store mutation to simulate the R5 state.
+	eng.store.Apply(itemstate.PRCreationFailedRecorded{Repo: "owner/repo", Number: 73, StageName: "Implement"})
+	if err := eng.processItem(t.Context(), board, item); err != nil {
+		t.Fatalf("second processItem: %v", err)
+	}
+
+	// Claude must not have been invoked again.
+	if invokeCount != 1 {
+		t.Errorf("expected Claude invoked only once total (R5 skip), got %d invocations", invokeCount)
+	}
+
+	// Stage must have advanced — stage:Implement:complete label added.
+	var completeAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:complete" {
+			completeAdded = true
+		}
+	}
+	if !completeAdded {
+		t.Error("expected stage:Implement:complete label added when R5 path advances stage")
 	}
 }

--- a/engine/item_test.go
+++ b/engine/item_test.go
@@ -780,3 +780,55 @@ func TestProcessItem_PRCreationFailed_SkipsClaudeOnRetry(t *testing.T) {
 		t.Error("expected stage:Implement:complete label added when R5 path advances stage")
 	}
 }
+
+// TestProcessItem_PRCreationFailed_R5_CallsMarkPRReady verifies that the R5
+// skip-Claude path calls markPRReady when mark_pr_ready_on_complete: true.
+// The Implement stage uses both create_draft_pr and mark_pr_ready_on_complete,
+// so without this the PR would remain a draft after R5 fires.
+func TestProcessItem_PRCreationFailed_R5_CallsMarkPRReady(t *testing.T) {
+	skipIfNoGit(t)
+
+	origLock := lockVerifyDelay
+	lockVerifyDelay = 0
+	t.Cleanup(func() { lockVerifyDelay = origLock })
+	origPR := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = origPR })
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 88, State: "open"}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+	eng := testEngineWithRepo(t, client, claude)
+	eng.cfg.Stages = []*stages.Stage{
+		{
+			Name:                "Implement",
+			Order:               1,
+			Prompt:              "implement it",
+			CreateDraftPR:       true,
+			MarkPRReadyOnComplete: true,
+			Completion:          stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+
+	// Pre-set PRCreationFailed flag so R5 fires immediately on the first call.
+	eng.store.Apply(itemstate.PRCreationFailedRecorded{Repo: "owner/repo", Number: 74, StageName: "Implement"})
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 74, Title: "T", Status: "Implement", ItemID: "PVTI_74"}
+
+	if err := eng.processItem(t.Context(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// MarkPRReady must have been called.
+	if len(client.markPRReadyCalls) == 0 {
+		t.Error("expected MarkPRReady called in R5 path when mark_pr_ready_on_complete: true")
+	}
+}

--- a/engine/label_helpers_test.go
+++ b/engine/label_helpers_test.go
@@ -200,17 +200,20 @@ func TestRemoveLockLabel_ErrNotFound_Ignored(t *testing.T) {
 	eng.removeLockLabel("owner", "repo", 5, "fabrik:locked:testuser")
 }
 
-func TestEnsureDraftPR_FindPRError_ReturnsZero(t *testing.T) {
+func TestEnsureDraftPR_FetchLinkedPRError_ReturnsError(t *testing.T) {
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 0, errors.New("api error")
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, errors.New("api error")
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 1, Title: "Test"}
-	prNum := eng.ensureDraftPR(item, "main")
+	prNum, err := eng.ensureDraftPR(item, "main")
 	if prNum != 0 {
-		t.Errorf("expected 0 on FindPRForIssue error, got %d", prNum)
+		t.Errorf("expected 0 on FetchLinkedPR error, got %d", prNum)
+	}
+	if err == nil {
+		t.Error("expected error on FetchLinkedPR failure, got nil")
 	}
 }
 

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -15,53 +15,87 @@ import (
 // Declared as a var so tests can set it to 0 to avoid sleeping.
 var markPRReadyRetryDelay = 500 * time.Millisecond
 
+// ensureDraftPRRetryDelay is the base delay for ensureDraftPR retry backoff.
+// Declared as a var so tests can set it to 0 to avoid sleeping.
+var ensureDraftPRRetryDelay = 500 * time.Millisecond
+
 // ensureDraftPR pushes the issue branch and creates a draft PR if one doesn't exist yet.
-// Idempotent: checks for an existing PR first; only pushes and creates if none found.
-func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) int {
+// Idempotent: checks for an existing open PR first; only pushes and creates if none found.
+// Returns (prNumber, nil) on success, (0, err) on failure after retries.
+func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) (int, error) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-
-	// Check for an existing PR first — avoids pushing on retries and handles
-	// the case where a push fails but a PR already exists from a prior run.
-	prNumber, err := e.client.FindPRForIssue(owner, repo, item.Number)
-	if err != nil {
-		e.logf(item.Number, "warn", "could not check for existing PR: %v\n", err)
-		return 0
-	}
-	if prNumber > 0 {
-		e.logf(item.Number, "pr", "PR #%d already exists, ensuring issue link\n", prNumber)
-		e.ensurePRLinksIssue(item, prNumber)
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.RecordPRLinkage(owner+"/"+repo, prNumber, item.Number)
-		}
-		return prNumber
-	}
-
-	// No PR exists — push the branch so GitHub can create a PR against it
-	wm := e.worktreesFor(item.Repo)
-	if err := wm.PushBranch(item.Number); err != nil {
-		e.logf(item.Number, "warn", "could not push branch: %v\n", err)
-		return 0
-	}
-
-	// Build seed body from context files; fall back to minimal body on read errors
-	workDir := wm.WorktreeDir(item.Number)
-	seedBody := e.buildSeedBody(item, workDir)
-
 	head := fmt.Sprintf("fabrik/issue-%d", item.Number)
-	// no write-through: excluded — CreateDraftPR affects PR state, not issue/label cache
-	prNum, err := e.client.CreateDraftPR(owner, repo, item.Title, head, baseBranch, seedBody, item.Number)
-	if err != nil {
-		e.logf(item.Number, "warn", "could not create draft PR: %v\n", err)
-		return 0
+	wm := e.worktreesFor(item.Repo)
+
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		// Check for an existing open PR on each attempt — handles the race where
+		// GitHub auto-created a PR between retries, or a prior attempt succeeded
+		// but the response was lost.
+		pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+		if err != nil {
+			if !isTransientError(err) {
+				e.logf(item.Number, "pr", "failed to create draft PR for branch %s: %v\n", head, err)
+				return 0, fmt.Errorf("checking for existing PR: %w", err)
+			}
+			lastErr = err
+			if attempt < maxAttempts-1 {
+				time.Sleep(ensureDraftPRRetryDelay << attempt)
+			}
+			continue
+		}
+		if pr != nil && pr.State == "open" && !pr.Merged {
+			// An open PR already exists — use it.
+			e.logf(item.Number, "pr", "PR #%d already exists (branch: %s), ensuring issue link\n", pr.Number, head)
+			e.ensurePRLinksIssue(item, pr.Number)
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.RecordPRLinkage(owner+"/"+repo, pr.Number, item.Number)
+			}
+			return pr.Number, nil
+		}
+		// No open PR (or closed/merged) — push and create.
+
+		if err := wm.PushBranch(item.Number); err != nil {
+			if !isTransientError(err) {
+				e.logf(item.Number, "pr", "failed to create draft PR for branch %s: %v\n", head, err)
+				return 0, fmt.Errorf("pushing branch: %w", err)
+			}
+			lastErr = err
+			if attempt < maxAttempts-1 {
+				time.Sleep(ensureDraftPRRetryDelay << attempt)
+			}
+			continue
+		}
+
+		// Build seed body from context files; fall back to minimal body on read errors
+		workDir := wm.WorktreeDir(item.Number)
+		seedBody := e.buildSeedBody(item, workDir)
+
+		// no write-through: excluded — CreateDraftPR affects PR state, not issue/label cache
+		prNum, err := e.client.CreateDraftPR(owner, repo, item.Title, head, baseBranch, seedBody, item.Number)
+		if err != nil {
+			if !isTransientError(err) {
+				e.logf(item.Number, "pr", "failed to create draft PR for branch %s: %v\n", head, err)
+				return 0, fmt.Errorf("creating draft PR: %w", err)
+			}
+			lastErr = err
+			if attempt < maxAttempts-1 {
+				time.Sleep(ensureDraftPRRetryDelay << attempt)
+			}
+			continue
+		}
+		e.logf(item.Number, "pr", "created draft PR #%d (branch: %s)\n", prNum, head)
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("pull_request", "opened", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNum))
+		}
+		return prNum, nil
 	}
-	e.logf(item.Number, "pr", "created draft PR #%d\n", prNum)
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
-	}
-	if e.webhookMgr != nil {
-		e.webhookMgr.RegisterEcho("pull_request", "opened", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNum))
-	}
-	return prNum
+	e.logf(item.Number, "pr", "failed to create draft PR for branch %s: %v\n", head, lastErr)
+	return 0, fmt.Errorf("creating draft PR after %d attempts: %w", maxAttempts, lastErr)
 }
 
 // syncPRBase checks whether the open PR for this issue has the expected base branch and

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -47,7 +47,7 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) (int, err
 		}
 		if pr != nil && pr.State == "open" && !pr.Merged {
 			// An open PR already exists — use it.
-			e.logf(item.Number, "pr", "PR #%d already exists (branch: %s), ensuring issue link\n", pr.Number, head)
+			e.logf(item.Number, "pr", "PR #%d already exists (branch: %s, sha: %s), ensuring issue link\n", pr.Number, head, pr.HeadSHA)
 			e.ensurePRLinksIssue(item, pr.Number)
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 				cacheImpl.RecordPRLinkage(owner+"/"+repo, pr.Number, item.Number)
@@ -85,7 +85,14 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) (int, err
 			}
 			continue
 		}
-		e.logf(item.Number, "pr", "created draft PR #%d (branch: %s)\n", prNum, head)
+		if prNum == 0 {
+			// A nil error with PR number 0 indicates an unexpected API/decoding issue.
+			// Treat as non-transient so the caller enters the escalation path.
+			e.logf(item.Number, "pr", "failed to create draft PR for branch %s: API returned 0\n", head)
+			return 0, fmt.Errorf("creating draft PR: API returned PR number 0")
+		}
+		headSHA, _ := gitHeadSHA(workDir)
+		e.logf(item.Number, "pr", "created draft PR #%d (branch: %s, sha: %s)\n", prNum, head, headSHA)
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
 		}

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -1147,3 +1147,42 @@ func TestEnsureDraftPR_AllRetriesExhausted_ReturnsError(t *testing.T) {
 		t.Errorf("expected exactly 3 FetchLinkedPR calls (maxAttempts), got %d", fetchCalls)
 	}
 }
+
+// TestEnsureDraftPR_CreateDraftPR_ReturnsZeroWithNilErr verifies Copilot finding:
+// when CreateDraftPR returns (0, nil), ensureDraftPR treats it as a non-transient
+// error rather than silently returning (0, nil) to the caller.
+func TestEnsureDraftPR_CreateDraftPR_ReturnsZeroWithNilErr(t *testing.T) {
+	skipIfNoGit(t)
+
+	orig := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = orig })
+
+	sourceDir := initRepoWithRemote(t)
+	wm := NewWorktreeManager(sourceDir)
+	if _, err := wm.EnsureWorktree(54, "main", false); err != nil {
+		t.Fatalf("EnsureWorktree: %v", err)
+	}
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil // no existing PR
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			return 0, nil // unexpected: 0 with no error
+		},
+	}
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", MaxConcurrent: 1, Stages: testStages()},
+		client, &mockClaudeInvoker{}, wm,
+	)
+
+	item := gh.ProjectItem{Number: 54, Title: "Feature"}
+	prNum, err := eng.ensureDraftPR(item, "main")
+	if err == nil {
+		t.Fatal("expected error when CreateDraftPR returns (0, nil), got nil")
+	}
+	if prNum != 0 {
+		t.Errorf("expected 0 on zero-PR-number failure, got %d", prNum)
+	}
+}

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -706,6 +708,9 @@ func TestProcessItem_ImplementStage_UpdatesVerificationOnComplete(t *testing.T) 
 		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
 			return prNum, nil
 		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: prNum, State: "open"}, nil
+		},
 		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
 			if issueNumber == prNum {
 				return "## Verification\n\n(Populated by Implement on completion)\n\n---\n\nCloses #50", nil
@@ -992,5 +997,153 @@ func TestMarkPRReady_NonTransientNoRetry(t *testing.T) {
 
 	if len(client.markPRReadyCalls) != 1 {
 		t.Fatalf("expected 1 MarkPRReady call (non-transient, no retry), got %d", len(client.markPRReadyCalls))
+	}
+}
+
+// ── ensureDraftPR — R2/R6 retry and closed-PR coverage ───────────────────────
+
+// TestEnsureDraftPR_ExistingClosedPR_CreatesNew verifies R6: when FetchLinkedPR
+// returns a closed PR, ensureDraftPR ignores it and creates a new draft PR.
+func TestEnsureDraftPR_ExistingClosedPR_CreatesNew(t *testing.T) {
+	skipIfNoGit(t)
+
+	orig := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = orig })
+
+	sourceDir := initRepoWithRemote(t)
+	wm := NewWorktreeManager(sourceDir)
+	if _, err := wm.EnsureWorktree(50, "main", false); err != nil {
+		t.Fatalf("EnsureWorktree: %v", err)
+	}
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "closed"}, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			return 99, nil
+		},
+	}
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", MaxConcurrent: 1, Stages: testStages()},
+		client, &mockClaudeInvoker{}, wm,
+	)
+
+	item := gh.ProjectItem{Number: 50, Title: "Feature"}
+	prNum, err := eng.ensureDraftPR(item, "main")
+	if err != nil {
+		t.Fatalf("ensureDraftPR returned unexpected error: %v", err)
+	}
+	if prNum != 99 {
+		t.Errorf("expected new PR #99, got %d", prNum)
+	}
+	if len(client.createDraftPRCalls) != 1 {
+		t.Errorf("expected 1 CreateDraftPR call, got %d", len(client.createDraftPRCalls))
+	}
+}
+
+// TestEnsureDraftPR_TransientError_Retries verifies R2: a transient FetchLinkedPR
+// error is retried; on the second attempt the call succeeds (returns nil, nil)
+// and ensureDraftPR proceeds to push + create the PR.
+func TestEnsureDraftPR_TransientError_Retries(t *testing.T) {
+	skipIfNoGit(t)
+
+	orig := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = orig })
+
+	sourceDir := initRepoWithRemote(t)
+	wm := NewWorktreeManager(sourceDir)
+	if _, err := wm.EnsureWorktree(51, "main", false); err != nil {
+		t.Fatalf("EnsureWorktree: %v", err)
+	}
+
+	var fetchCalls int
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			fetchCalls++
+			if fetchCalls == 1 {
+				return nil, fmt.Errorf("executing request: %w", &net.OpError{Op: "read", Net: "tcp"})
+			}
+			return nil, nil // no existing PR on second call
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			return 77, nil
+		},
+	}
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", MaxConcurrent: 1, Stages: testStages()},
+		client, &mockClaudeInvoker{}, wm,
+	)
+
+	item := gh.ProjectItem{Number: 51, Title: "Feature"}
+	prNum, err := eng.ensureDraftPR(item, "main")
+	if err != nil {
+		t.Fatalf("ensureDraftPR returned unexpected error: %v", err)
+	}
+	if prNum != 77 {
+		t.Errorf("expected PR #77, got %d", prNum)
+	}
+	if fetchCalls < 2 {
+		t.Errorf("expected at least 2 FetchLinkedPR calls (retry), got %d", fetchCalls)
+	}
+}
+
+// TestEnsureDraftPR_NonTransientError_ImmediateFailure verifies that a non-transient
+// error from FetchLinkedPR (e.g. 422) returns (0, err) after exactly 1 attempt.
+func TestEnsureDraftPR_NonTransientError_ImmediateFailure(t *testing.T) {
+	orig := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = orig })
+
+	var fetchCalls int
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			fetchCalls++
+			return nil, errors.New("GitHub API returned 422: validation failed")
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 52, Title: "Feature"}
+	prNum, err := eng.ensureDraftPR(item, "main")
+	if err == nil {
+		t.Fatal("expected error from non-transient FetchLinkedPR failure, got nil")
+	}
+	if prNum != 0 {
+		t.Errorf("expected 0 on failure, got %d", prNum)
+	}
+	if fetchCalls != 1 {
+		t.Errorf("expected exactly 1 FetchLinkedPR call (no retry on non-transient), got %d", fetchCalls)
+	}
+}
+
+// TestEnsureDraftPR_AllRetriesExhausted_ReturnsError verifies R2: when all 3
+// FetchLinkedPR attempts return transient errors, ensureDraftPR returns (0, err).
+func TestEnsureDraftPR_AllRetriesExhausted_ReturnsError(t *testing.T) {
+	orig := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = orig })
+
+	var fetchCalls int
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			fetchCalls++
+			return nil, fmt.Errorf("executing request: %w", &net.OpError{Op: "read", Net: "tcp"})
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 53, Title: "Feature"}
+	prNum, err := eng.ensureDraftPR(item, "main")
+	if err == nil {
+		t.Fatal("expected error after all retries exhausted, got nil")
+	}
+	if prNum != 0 {
+		t.Errorf("expected 0 on exhausted retries, got %d", prNum)
+	}
+	if fetchCalls != 3 {
+		t.Errorf("expected exactly 3 FetchLinkedPR calls (maxAttempts), got %d", fetchCalls)
 	}
 }

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -14,15 +14,18 @@ import (
 
 func TestEnsureDraftPR_ExistingPR_SkipsCreate(t *testing.T) {
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 42, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, State: "open"}, nil
 		},
 	}
 	eng := testEngine(client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Title: "Test Issue"}
-	prNum := eng.ensureDraftPR(item, "main")
+	prNum, err := eng.ensureDraftPR(item, "main")
 
+	if err != nil {
+		t.Fatalf("ensureDraftPR returned unexpected error: %v", err)
+	}
 	if prNum != 42 {
 		t.Errorf("ensureDraftPR returned %d, want 42", prNum)
 	}
@@ -372,8 +375,8 @@ func TestEnsureDraftPR_NewPR_SeedsBodyFromContextFiles(t *testing.T) {
 
 	var createdBody string
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 0, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
 		},
 		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
 			createdBody = body
@@ -389,7 +392,10 @@ func TestEnsureDraftPR_NewPR_SeedsBodyFromContextFiles(t *testing.T) {
 	)
 
 	item := gh.ProjectItem{Number: 42, Title: "My issue"}
-	result := eng.ensureDraftPR(item, "main")
+	result, err := eng.ensureDraftPR(item, "main")
+	if err != nil {
+		t.Fatalf("ensureDraftPR returned unexpected error: %v", err)
+	}
 	if result != 77 {
 		t.Fatalf("ensureDraftPR returned %d, want 77", result)
 	}
@@ -436,8 +442,8 @@ func TestEnsureDraftPR_NewPR_MissingContextFiles_UsesPlaceholders(t *testing.T) 
 
 	var createdBody string
 	client := &mockGitHubClient{
-		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) {
-			return 0, nil
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
 		},
 		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
 			createdBody = body
@@ -453,7 +459,10 @@ func TestEnsureDraftPR_NewPR_MissingContextFiles_UsesPlaceholders(t *testing.T) 
 	)
 
 	item := gh.ProjectItem{Number: 43, Title: "My issue"}
-	result := eng.ensureDraftPR(item, "main")
+	result, err := eng.ensureDraftPR(item, "main")
+	if err != nil {
+		t.Fatalf("ensureDraftPR returned unexpected error: %v", err)
+	}
 	if result != 78 {
 		t.Fatalf("ensureDraftPR returned %d, want 78", result)
 	}

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -156,6 +156,10 @@ type StageState struct {
 	// PausedByEngine records engine-initiated pauses (vs user-initiated).
 	// Replaces engine.pausedDueToRetries[stageKey].
 	PausedByEngine map[string]bool
+	// PRCreationFailed records that Claude completed but the draft PR could not
+	// be created. In-memory only — does not survive restart. When set, the next
+	// retry first attempts PR creation before re-invoking Claude.
+	PRCreationFailed map[string]bool
 	// ReviewCycles counts how many review iterations each stage has completed.
 	// Replaces engine.reviewCycleCount[stageKey].
 	ReviewCycles map[string]int

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -420,6 +420,18 @@ type RebaseCycleIncremented struct {
 func (RebaseCycleIncremented) isMutation()       {}
 func (m RebaseCycleIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// PRCreationFailedRecorded records that Claude completed a stage but the draft PR
+// could not be created. In-memory only — does not survive restart. Cleared by
+// StageRetryCleared when the PR is eventually created or the stage succeeds.
+type PRCreationFailedRecorded struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (PRCreationFailedRecorded) isMutation()       {}
+func (m PRCreationFailedRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // EnginePaused records that the engine has paused work on a stage due to
 // repeated failures. (The design doc listed this as "EngineEnginePaused" — typo.)
 type EnginePaused struct {

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -30,6 +30,7 @@ type Snapshot struct {
 //   - ItemState.StageState.Attempts
 //   - ItemState.StageState.LastAttemptAt
 //   - ItemState.StageState.PausedByEngine
+//   - ItemState.StageState.PRCreationFailed
 //   - ItemState.StageState.ReviewCycles
 //   - ItemState.StageState.CIFixCycles
 //   - ItemState.StageState.RebaseCycles
@@ -173,6 +174,12 @@ func (s Snapshot) PausedByEngine(stageName string) bool {
 	return s.state.StageState.PausedByEngine[stageName]
 }
 
+// PRCreationFailed reports whether Claude completed a stage but the draft PR
+// could not be created. In-memory only — does not survive restart.
+func (s Snapshot) PRCreationFailed(stageName string) bool {
+	return s.state.StageState.PRCreationFailed[stageName]
+}
+
 // ReviewCycles returns the review re-invocation cycle count for a given stage.
 func (s Snapshot) ReviewCycles(stageName string) int {
 	return s.state.StageState.ReviewCycles[stageName]
@@ -295,6 +302,7 @@ func copyStageState(s StageState) StageState {
 		Attempts:          copyIntMap(s.Attempts),
 		LastAttemptAt:     copyTimeMap(s.LastAttemptAt),
 		PausedByEngine:    copyBoolMap(s.PausedByEngine),
+		PRCreationFailed:  copyBoolMap(s.PRCreationFailed),
 		ReviewCycles:      copyIntMap(s.ReviewCycles),
 		CIFixCycles:       copyIntMap(s.CIFixCycles),
 		RebaseCycles:      copyIntMap(s.RebaseCycles),

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -391,6 +391,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case StageRetryCleared:
 		ensureStageStateMaps(item)
 		item.StageState.Attempts[v.StageName] = 0
+		delete(item.StageState.PRCreationFailed, v.StageName)
 		return StageStateChanged
 
 	case ReviewCycleIncremented:
@@ -406,6 +407,11 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case RebaseCycleIncremented:
 		ensureStageStateMaps(item)
 		item.StageState.RebaseCycles[v.StageName]++
+		return StageStateChanged
+
+	case PRCreationFailedRecorded:
+		ensureStageStateMaps(item)
+		item.StageState.PRCreationFailed[v.StageName] = true
 		return StageStateChanged
 
 	case EnginePaused:
@@ -1169,6 +1175,9 @@ func ensureStageStateMaps(item *ItemState) {
 	}
 	if ss.PausedByEngine == nil {
 		ss.PausedByEngine = make(map[string]bool)
+	}
+	if ss.PRCreationFailed == nil {
+		ss.PRCreationFailed = make(map[string]bool)
 	}
 	if ss.ReviewCycles == nil {
 		ss.ReviewCycles = make(map[string]int)


### PR DESCRIPTION
## Summary

When `create_draft_pr: true` and `ensureDraftPR` returns 0 after a completed Implement invocation, the engine must **fail the stage** rather than silently advancing to the next stage. PR creation failure must surface as `stage:Implement:failed` so users see a clear signal and the issue does not silently progress through Review without a PR.

## Problem

In ~15–20% of observed Implement-stage runs on `verveguy/fantasy`, the engine reaches `stage:Implement:complete` — and sometimes `stage:Review:complete` — **without ever creating a pull request**. The branch is pushed correctly with all Implement commits, but the draft PR that `create_draft_pr: true` (in `implement.yaml`) should have created is silently absent.

The pipeline then malfunctions downstream: Review waits for reviewers who cannot be assigned (no PR exists), the review-wait timeout fires, and the issue is paused with a message directing the user to "the PR" — which does not exist. The user must manually create the PR and remove `fabrik:paused` to resume.

This defeats the `fabrik:yolo` overnight-autonomy contract on roughly 1 in 5 runs.

**Confirmed occurrences (all `verveguy/fantasy`, within ~36 hours):**

| Issue | Implement marker | PR existed? | Workaround | Outcome |
|---|---|---|---|---|
| #112 | `stage:Implement:complete` | No | Opened PR #118 manually | Validate ran, merged |
| #114 | `stage:Implement:failed` (3 retries) | No | Retried with extend-turns; 2nd attempt produced PR #121 | Eventual success |
| #120 | `stage:Implement:complete` | No | Opened PR #125 manually | Validate ran, merged |
| #132 | `stage:Implement:complete` + `stage:Review:complete` | No | Opened PR #137 manually | In progress |

## Approach

### Approach

The bug has three distinct layers:

1. **`ensureDraftPR` silently swallows errors** (returns 0 with no error return) — fix by changing its signature to `(int, error)`, adding a 3-attempt retry loop (R2), replacing `FindPRForIssue` with `FetchLinkedPR` + open-only state check (R6), and adding structured logging (R4).

2. **The `if completed` block never checks whether PR creation succeeded** — fix by moving `releaseLock()`, `StageRetryCleared`, and `EngineUnpaused` to after the PR creation check, and routing PR failures into the existing retry/escalation machinery (R1, R3).

3. **Subsequent retries blindly re-run Claude even though commits already exist** — fix by adding a `PRCreationFailed` in-memory flag to `StageState` and a skip-Claude early-return path in `processItem` (R5).

R7 is already satisfied: `postOutputToPR` at line 295 already logs `"no open PR found, posting on issue instead\n"` as a warn — no code change needed.

**R5 decision**: Implement in this PR. The design is clear (~50 lines) and deferred implementation would leave unnecessary Claude re-invocations on every PR-only retry. Complexity is low.

**Retry scope**: The `ensureDraftPR` retry loop covers the full "fetch → push → create" sequence on each attempt. This is correct because each step can fail independently, and re-checking for an existing PR on each iteration handles the race where GitHub auto-created a PR between attempts. PushBranch is idempotent on retry.

**Lock restructuring**: `releaseLock()` currently fires at line 965, before `ensureDraftPR`. Move it to after the PR creation check to ensure exact-once release. On PR failure path, release lock in both the retry branch and the escalation branch (matching the `else` block pattern at line 1001).

**`escalatePRCreationFailure` as a new function** rather than parameterizing `escalateFailedStage`. The comment must name PR creation as the failure cause (not Claude), include the actual `baseBranch` in the workaround command, and note that Claude completed successfully.

**No ADR warranted**: R5's "skip Claude on PR-only retry" pattern follows the precedent established in ADR 026 (review reinvocation advances stage without Claude). No new architectural decision is being introduced.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/pr.go` | `ensureDraftPR`: change return to `(int, error)`, add retry loop, R6 open-only check, R4 structured logging |
| `engine/item.go` | Restructure `if completed` block (R1), add `escalatePRCreationFailure` (R3), add R5 skip-Claude check before Claude invocation |
| `internal/itemstate/itemstate.go` | Add `PRCreationFailed map[string]bool` to `StageState` |
| `internal/itemstate/mutation.go` | Add `PRCreationFailedRecorded` mutation type |
| `internal/itemstate/store.go` | Add apply case for `PRCreationFailedRecorded`; clear flag in `StageRetryCleared` apply; lazy-init map |
| `internal/itemstate/snapshot.go` | Add `PRCreationFailed(stageName) bool` accessor; add field to `copyStageState`; update docstring |
| `engine/pr_test.go` | Tests for R2, R4, R6 |
| `engine/item_test.go` | Tests for R1, R3, R5 |
| `docs/state-machine.md` | Document PR creation failure sub-path, `PRCreationFailed` flag, skip-Claude retry |

### Key Decisions

- **Return `(int, error)` from `ensureDraftPR`**: The 0-or-nonzero return was the root cause of silent failures. The error return distinguishes "PR not needed" (impossible in this code path), "PR already exists" (return existing number, nil), and "PR creation failed" (return 0, error). All callers are in the `engine` package.

- **Retry the full fetch→push→create loop (not just CreateDraftPR)**: FetchLinkedPR on each iteration catches the race where GitHub auto-created a PR between attempts. PushBranch is idempotent. This matches the safety-first posture of the rest of the engine.

- **`StageRetryCleared` stays conditional on PR success**: On PR failure, retries must count against `MaxRetries`. Moving `StageRetryCleared` to after successful PR creation is the correct ordering. The escalation comment must explain "PR creation failed N times" not "Claude failed N times" — covered by `escalatePRCreationFailure`.

- **`PRCreationFailed` flag is in-memory only**: Matches `PausedByEngine`'s durability model. On restart, a PR-only-failed issue re-invokes Claude — safe and conservative (re-running Claude produces the same commits idempotently). No label, no GitHub state change.

- **R6 scoped to `ensureDraftPR` only**: Other callers of `FindPRForIssue` (`syncPRBase`, `markPRReady`, `postOutputToPR`) have different semantics and are explicitly out of scope. `FindPRForIssue` itself is unchanged.

- **`var ensureDraftPRRetryDelay = 500 * time.Millisecond` in `pr.go`**: Matches the `markPRReadyRetryDelay` convention; test-overridable; no need to make it an Engine field.

- **Workaround command uses actual `baseBranch`**: The `baseBranch` value is known at the `escalatePRCreationFailure` call site; hardcoding "main" in the comment would be wrong for `base:<branch>` label overrides.

### Task Checklist

- [ ] **Task 1: Update `ensureDraftPR` in `engine/pr.go`** (R2, R4, R6)
  - Change return type to `(int, error)`
  - Add `var ensureDraftPRRetryDelay = 500 * time.Millisecond`
  - Replace `FindPRForIssue` call with `FetchLinkedPR` and check `pr.State == "open" && !pr.Merged`; if found-but-closed, proceed to create a new one
  - Wrap the push+create steps in a `for attempt := 0; attempt < 3; attempt++` loop using `isTransientError` for backoff gating
  - On success: log `[#N pr] created draft PR #<num> (branch: <branch>)\n`
  - On failure: log `[#N pr] failed to create draft PR for branch <branch>: <err>\n` and return `(0, wrappedErr)`
  - Return `(existingPR.Number, nil)` for already-open PRs (R6 fast path)

- [ ] **Task 2: Add `PRCreationFailed` state to `internal/itemstate/`** (R5 prerequisite)
  - `itemstate.go`: Add `PRCreationFailed map[string]bool` to `StageState` with comment "in-memory only, does not survive restart"
  - `mutation.go`: Add `PRCreationFailedRecorded{Repo, Number, StageName}` mutation type with `isMutation()` and `itemKey()` methods
  - `store.go`: Add apply case `case PRCreationFailedRecorded:` (lazy-init `PRCreationFailed` map, set `[v.StageName] = true`); in `StageRetryCleared` apply case, also `delete(item.StageState.PRCreationFailed, v.StageName)`
  - `snapshot.go`: Add `PRCreationFailed(stageName) bool` accessor; add `PRCreationFailed: copyBoolMap(s.PRCreationFailed)` to `copyStageState`; add field to docstring in `newSnapshot`

- [ ] **Task 3: Restructure the `if completed` block in `engine/item.go`** (R1)
  - Move `releaseLock()` from line 965 (before PR check) to after the PR creation result is known
  - Move `StageRetryCleared` and `EngineUnpaused` to after successful PR creation
  - Update the early-guard path (line 840) to handle new `(int, error)` return — use `prNumber, _ = e.ensureDraftPR(...)` since that path is pre-output-post and the error will be caught again in the completion block
  - In the `if completed` block, after `ensureDraftPR` returns error: apply `StageRetryIncremented`, read `count`, if `count >= MaxRetries` call `escalatePRCreationFailure` then `releaseLock()`; otherwise apply `PRCreationFailedRecorded` then `releaseLock()` and return (retry path)
  - On PR success: proceed with `StageRetryCleared`, `EngineUnpaused`, `updatePRVerification`, `markPRReady`, `handleStageComplete` in that order; call `releaseLock()` before `handleStageComplete`

- [ ] **Task 4: Add `escalatePRCreationFailure` in `engine/item.go`** (R3)
  - New function `escalatePRCreationFailure(item gh.ProjectItem, stage *stages.Stage, baseBranch string)`
  - Same label/comment/mutation pattern as `escalateFailedStage`
  - Comment text: `"🏭 **Fabrik — PR creation failed**\n\nStage **%s** completed successfully but the draft PR could not be created after %d attempt(s). The issue has been paused.\n\nManual fix: `gh pr create --head fabrik/issue-%d --base %s --body \"Closes #%d\"`\n\nThen remove the `fabrik:paused` label to resume."`
  - Add `fabrik:paused`, `stage:<name>:failed`, post comment, apply `EnginePaused` mutation

- [ ] **Task 5: Add R5 skip-Claude early-return path in `engine/item.go`**
  - Before the Claude invocation block (after worktree setup, before `invokeClaude`), add:
    ```
    if stage.CreateDraftPR {
        if snap, err := e.store.Get(repoStr, item.Number); err == nil && snap.PRCreationFailed(stage.Name) {
            prNum, prErr := e.ensureDraftPR(item, baseBranch)
            if prErr == nil && prNum > 0 {
                // PR succeeded — advance without re-running Claude
                releaseLock()
                e.store.Apply(itemstate.StageRetryCleared{...})
                e.store.Apply(itemstate.EngineUnpaused{...})
                e.handleStageComplete(ctx, board, item, stage)
                return nil
            }
            // PR still failing — fall through to increment retry counter
            e.store.Apply(itemstate.StageRetryIncremented{...})
            if count >= MaxRetries { escalatePRCreationFailure; releaseLock() } else { releaseLock() }
            return nil
        }
    }
    ```

- [ ] **Task 6: Tests for `ensureDraftPR` in `engine/pr_test.go`**
  - `TestEnsureDraftPR_ExistingOpenPR_ReturnsWithoutCreate`: `FetchLinkedPR` returns open PR → returned, no `CreateDraftPR` call
  - `TestEnsureDraftPR_ExistingClosedPR_CreatesNew`: `FetchLinkedPR` returns closed PR → creates new PR (R6)
  - `TestEnsureDraftPR_TransientError_Retries`: first `FetchLinkedPR` call returns transient error, second returns nil → push + create succeed; result is new PR number (R2)
  - `TestEnsureDraftPR_NonTransientError_ImmediateFailure`: `CreateDraftPR` returns non-transient 422 → returns `(0, err)` after 1 attempt (R2)
  - `TestEnsureDraftPR_AllRetriesExhausted_ReturnsError`: all 3 attempts fail transiently → returns `(0, err)` (R2)
  - `TestEnsureDraftPR_SuccessLog_Format`: verify log contains PR number and branch name (R4)

- [ ] **Task 7: Tests for completion-block restructuring in `engine/item_test.go`**
  - `TestRunStage_CreateDraftPR_Fails_StageNotComplete`: `completed=true`, `create_draft_pr=true`, `ensureDraftPR` returns error → `handleStageComplete` NOT called, `StageRetryIncremented` applied, lock released
  - `TestRunStage_CreateDraftPR_FailsAtMaxRetries_Escalates`: at `MaxRetries`, `escalatePRCreationFailure` comment posted, `fabrik:paused` label added
  - `TestRunStage_LockReleasedExactlyOnce_OnPRFailure`: verify `releaseLock` not double-called on PR failure path

- [ ] **Task 8: Test for R5 skip-Claude path in `engine/item_test.go`**
  - `TestProcessItem_PRCreationFailed_SkipsClaudeOnRetry`: `PRCreationFailed` flag set for stage, `ensureDraftPR` now returns valid PR → `handleStageComplete` called, no Claude invocation

- [ ] **Task 9: Update `docs/state-machine.md`**
  - Add sub-section "PR creation failure path" under Implement stage failures, documenting: trigger (completed + create_draft_pr + ensureDraftPR returns error after 3 attempts), retry counting (counts against MaxRetries), escalation comment content, `PRCreationFailed` in-memory flag, R5 skip-Claude retry behavior on subsequent poll cycles
  - Regenerate `docs/llms-full.txt` with `bash scripts/generate-llms-full.sh`

### Risks

- **Lock double-release**: The restructuring moves `releaseLock()` into multiple branches of the `if completed` block. Implementation must ensure exactly one call in every code path. Tests in Task 7 must verify this.

- **`StageRetryIncremented` in PR failure path**: The attempt counter increments on PR failure, not only on Claude failure. With `MaxRetries=3`, three PR creation failures pause the issue. The escalation comment (Task 4) must clearly say "PR creation failed N times" — not "stage failed" — so users understand Claude succeeded.

- **Early-guard path at line 840**: The pre-output `ensureDraftPR` call (only when `PostToPR && CreateDraftPR`) is changed to ignore the error (`prNumber, _ = e.ensureDraftPR(...)`). This is intentional — the error is surfaced in the completion block where the retry/escalation machinery lives. The `postOutputToPR` fallback handles a 0 PR number gracefully.

- **`isTransientError` is defined in `item.go`**: It's in the same `engine` package as `pr.go`, so it's accessible without moving. Verify this doesn't create a cycle.

- **R5 interplay with `releaseLock` in skip-Claude path**: The skip-Claude path (Task 5) calls `releaseLock()` directly before `handleStageComplete`. Since `releaseLock` is a closure defined within `processItem`, Task 5's code must access it via the same closure scope — it's not a method call. The implementation must ensure the skip-Claude code is within the same function scope where `releaseLock` is defined.

---
Used 29/50 turns, 6k input / 17k output tokens.

## Verification

All 9 plan tasks are implemented and passing: `ensureDraftPR` now returns `(int, error)` with a 3-attempt retry loop, open-only PR check (R6), and structured logging (R4); the `if completed` block gates `handleStageComplete` on PR success (R1) and routes failures through the retry/escalation path with `escalatePRCreationFailure` (R3); the `PRCreationFailed` in-memory flag and R5 skip-Claude early-return path prevent redundant Claude re-invocations on PR-only retries; all tests pass with the race detector and `go vet` is clean.

---

Closes #725