### PR TITLE
fabrik: empty issue title in cache after cold-start causes draft PR creation to fail with HTTP 422

### DIFF
--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -61,6 +61,7 @@ func (m *mockClient) FetchItemDetails(item *gh.ProjectItem) error {
 		if item.Repo == "" && m.itemDetailsResult.Repo != "" {
 			item.Repo = m.itemDetailsResult.Repo
 		}
+		item.Title = m.itemDetailsResult.Title
 		item.Body = m.itemDetailsResult.Body
 		item.Comments = cloneComments(m.itemDetailsResult.Comments)
 		item.LinkedPRNumber = m.itemDetailsResult.LinkedPRNumber
@@ -2374,5 +2375,54 @@ func TestBootstrapFromProbe_PRInStoreByPRKey(t *testing.T) {
 	_, found := c.store.GetByPRKey("owner/repo", 99)
 	if !found {
 		t.Error("prToKey index should have an entry for PR #99 after BootstrapFromProbe")
+	}
+}
+
+// TestBootstrapFromProbe_TitlePopulatedAfterDeepFetch verifies the cold-start
+// title propagation path: probe seeds an item with no title, then
+// FetchItemDetails populates title from the network, and FetchProjectBoard
+// returns the item with the correct title.
+func TestBootstrapFromProbe_TitlePopulatedAfterDeepFetch(t *testing.T) {
+	mc := &mockClient{
+		itemDetailsResult: &gh.ProjectItem{
+			Number: 5,
+			Repo:   "owner/repo",
+			Title:  "Issue Title",
+		},
+	}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	items := []gh.BoardProbeItem{
+		{ContentID: "I_5", ItemID: "PVTI_5", Number: 5, Repo: "owner/repo", Status: "Implement"},
+	}
+	c.BootstrapFromProbe(items, "PID", testStages())
+
+	// Confirm that the bootstrapped item has no title (probe never carries title).
+	s := testGetState(t, c, "owner/repo", 5)
+	if s.Title != "" {
+		t.Errorf("before deep-fetch: Title = %q, want empty", s.Title)
+	}
+
+	// Simulate the deep-fetch that runProbeAndDeepFetch triggers on probe drift.
+	deepItem := gh.ProjectItem{ID: "I_5", Number: 5, Repo: "owner/repo"}
+	if err := c.FetchItemDetails(&deepItem); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+
+	// FetchProjectBoard should now return the item with the populated title.
+	board, err := c.FetchProjectBoard("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	var itemFound bool
+	for _, bi := range board.Items {
+		if bi.Number == 5 {
+			itemFound = true
+			if bi.Title != "Issue Title" {
+				t.Errorf("board item Title = %q, want %q", bi.Title, "Issue Title")
+			}
+		}
+	}
+	if !itemFound {
+		t.Error("item #5 not found in board after deep-fetch")
 	}
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1698,7 +1698,6 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 			Status:    pi.Status,
 			Repo:      repo,
 			UpdatedAt: pi.EffectiveUpdatedAt,
-			Title:     s.Title, // FetchItemDetails doesn't fetch title; preserve cached value
 		}
 		if fetchErr := e.readClient.FetchItemDetails(&minimal); fetchErr != nil {
 			e.logf(pi.Number, "warn", "probe: deep-fetch for stale item failed: %v\n", fetchErr)

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -1186,3 +1186,65 @@ func TestEnsureDraftPR_CreateDraftPR_ReturnsZeroWithNilErr(t *testing.T) {
 		t.Errorf("expected 0 on zero-PR-number failure, got %d", prNum)
 	}
 }
+
+// TestEnsureDraftPR_TitleFromDeepFetch verifies that when FetchItemDetails
+// populates item.Title (the deep-fetch path, triggered after a cold-start probe),
+// ensureDraftPR forwards that title to CreateDraftPR rather than passing "".
+// This is the end-to-end regression test for the empty-title 422 bug.
+func TestEnsureDraftPR_TitleFromDeepFetch(t *testing.T) {
+	skipIfNoGit(t)
+
+	orig := ensureDraftPRRetryDelay
+	ensureDraftPRRetryDelay = 0
+	t.Cleanup(func() { ensureDraftPRRetryDelay = orig })
+
+	sourceDir := initRepoWithRemote(t)
+	wm := NewWorktreeManager(sourceDir)
+	if _, err := wm.EnsureWorktree(60, "main", false); err != nil {
+		t.Fatalf("EnsureWorktree: %v", err)
+	}
+
+	var capturedTitle string
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			// Simulate what github.Client.FetchItemDetails now does after the fix:
+			// populate item.Title from the GraphQL response.
+			item.Title = "My Issue"
+			return nil
+		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil // no existing PR
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			capturedTitle = title
+			return 60, nil
+		},
+	}
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", MaxConcurrent: 1, Stages: testStages()},
+		client, &mockClaudeInvoker{}, wm,
+	)
+
+	// Simulate the cold-start path: item starts with empty title (probe never carries it).
+	item := gh.ProjectItem{Number: 60, Title: "", Status: "Implement", ItemID: "PVTI_60"}
+
+	// Simulate what the poll loop does before calling processItem: deep-fetch the item.
+	if err := eng.readClient.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+	if item.Title != "My Issue" {
+		t.Fatalf("FetchItemDetails did not populate title: got %q, want %q", item.Title, "My Issue")
+	}
+
+	// Now ensureDraftPR should receive and forward the populated title.
+	prNum, err := eng.ensureDraftPR(item, "main")
+	if err != nil {
+		t.Fatalf("ensureDraftPR: %v", err)
+	}
+	if prNum != 60 {
+		t.Errorf("expected prNum=60, got %d", prNum)
+	}
+	if capturedTitle != "My Issue" {
+		t.Errorf("CreateDraftPR called with title=%q, want %q", capturedTitle, "My Issue")
+	}
+}

--- a/github/fetch_details_test.go
+++ b/github/fetch_details_test.go
@@ -226,8 +226,9 @@ func TestFetchItemDetails_PopulatesFullMetadata(t *testing.T) {
 		resp := map[string]interface{}{
 			"data": map[string]interface{}{
 				"node": map[string]interface{}{
-					"body": "This is the issue body.",
-					"url":  "https://github.com/owner/repo/issues/42",
+					"title": "My Issue Title",
+					"body":  "This is the issue body.",
+					"url":   "https://github.com/owner/repo/issues/42",
 					"author": map[string]interface{}{
 						"login": "authoruser",
 					},
@@ -275,6 +276,9 @@ func TestFetchItemDetails_PopulatesFullMetadata(t *testing.T) {
 		t.Fatalf("FetchItemDetails: %v", err)
 	}
 
+	if item.Title != "My Issue Title" {
+		t.Errorf("Title = %q, want %q", item.Title, "My Issue Title")
+	}
 	if item.Body != "This is the issue body." {
 		t.Errorf("Body = %q, want %q", item.Body, "This is the issue body.")
 	}
@@ -616,5 +620,50 @@ func TestFetchItemDetails_LinkedPRNumber_ResetOnRepeat(t *testing.T) {
 	}
 	if item.LinkedPRNumber != 0 {
 		t.Errorf("after second call: LinkedPRNumber = %d, want 0 (should be reset)", item.LinkedPRNumber)
+	}
+}
+
+// TestFetchItemDetails_TitlePopulatedForPRItem verifies that the title field is
+// correctly populated when the node is a PullRequest-type item.
+func TestFetchItemDetails_TitlePopulatedForPRItem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"title": "My PR Title",
+					"body":  "PR body text",
+					"url":   "https://github.com/owner/repo/pull/99",
+					"author": map[string]interface{}{
+						"login": "prauthor",
+					},
+					"labels": map[string]interface{}{
+						"nodes":    []interface{}{},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+					"assignees": map[string]interface{}{
+						"nodes": []interface{}{},
+					},
+					"comments": map[string]interface{}{
+						"nodes":    []interface{}{},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	item := &ProjectItem{ID: "PR_99", Number: 99, IsPR: true}
+	if err := c.FetchItemDetails(item); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+
+	if item.Title != "My PR Title" {
+		t.Errorf("Title = %q, want %q", item.Title, "My PR Title")
+	}
+	if item.Body != "PR body text" {
+		t.Errorf("Body = %q, want %q", item.Body, "PR body text")
 	}
 }

--- a/github/project.go
+++ b/github/project.go
@@ -582,6 +582,7 @@ query($id: ID!) {
   node(id: $id) {
     ... on Issue {
       number
+      title
       body
       url
       repository { nameWithOwner }
@@ -681,6 +682,7 @@ query($id: ID!) {
       }
     }
     ... on PullRequest {
+      title
       body
       url
       author { login }
@@ -717,6 +719,7 @@ query($id: ID!) {
 		Data struct {
 			Node *struct {
 				Number     int    `json:"number"`
+				Title      string `json:"title"`
 				Body       string `json:"body"`
 				URL        string `json:"url"`
 				Repository *struct {
@@ -822,6 +825,7 @@ query($id: ID!) {
 	}
 
 	// Populate scalar fields
+	item.Title = node.Title
 	item.Body = node.Body
 	item.URL = node.URL
 	if node.Author != nil {


### PR DESCRIPTION
## Summary

Add `title` to `FetchItemDetails`'s GraphQL query (both `Issue` and `PullRequest` content fragments) and write it into the Store via the existing `ItemDeepFetched` mutation. Remove the `Title: s.Title` workaround at `engine/poll.go:1701` that was preserving the (now-never-populated) cached value. Items currently in cache with `Title == ""` will be backfilled on their next deep-fetch (triggered by next probe drift); no explicit backfill mutation is needed.

## Problem

When an issue is first discovered via the truly-shallow probe path (added in #685, used for both new-item discovery and `BootstrapFromProbe` cold-start), its **title is never populated in the cache**. Downstream code reading the cached title (`s.Title`) gets the empty string.

The visible symptom: `ensureDraftPR` calls the GitHub REST endpoint with an empty title, and GitHub returns **HTTP 422 Validation Failed — `missing_field: title`**. v0.0.59 (#725) now correctly surfaces this as a hard error instead of silently advancing the stage, but the underlying empty-title bug was masked before that and is the real cause.

Reproduces reliably. Observed in production on verveguy/fantasy after a cold-start: **12 occurrences of `[#N process] "" — stage: X`** across multiple issues in the same log. Issue #162 had its Implement stage fail with 422 four times, escalated to pause, and required manual PR creation to recover.

### Root cause

Three pieces of the read pipeline don't carry title:

1. **The probe** (`ProbeProjectBoard` in `github/project.go`, query at line ~421) was deliberately stripped of `labels` and `closedByPullRequestsReferences(first:5)` to cut idle-poll cost. `title` was dropped along with the other fields. Item ID, number, state, updatedAt, repository, and linked PR remain. **No title.**

2. **`BootstrapFromProbe`** (`boardcache/boardcache.go:268`) seeds synthetic `gh.ProjectItem` records from probe results — has no title to seed.

3. **`FetchItemDetails`** explicitly **does not fetch title**, on the assumption that title came from the heavy shallow board fetch. `engine/poll.go:1701` has the giveaway comment:

   ```go
   Title: s.Title, // FetchItemDetails doesn't fetch title; preserve cached value
   ```

   Pre-#685 this was fine — the original `FetchProjectBoard` (heavy shallow) carried title and called `Reset` / `applyShallowItem` to populate the Store. Post-#685, nothing does.

Result: items discovered after cold-start carry `Title == ""` forever. Specify, Research, Plan all run fine because their context-file logic uses the live issue body fetched from GitHub during stage invocation, not the cached title. **Implement** breaks because `ensureDraftPR` derives the PR title from `item.Title` and GitHub requires a non-empty title.

### Why this regressed past v0.0.59

v0.0.59 (#725) only changed PR-creation failure *visibility* — the engine now hard-errors instead of silently marking Implement complete. The underlying empty-title bug existed since v0.0.57 (when `BootstrapFromProbe` shipped) but was masked because the silent-success path let the pipeline limp forward anyway. v0.0.59's correct error surface makes the pre-existing bug suddenly visible.

## Approach

### Approach

This is a targeted bug fix: `FetchItemDetails` omits `title` from its GraphQL query, so items discovered via the probe-bootstrap path carry `Title == ""` forever, causing HTTP 422 on PR creation. The fix is to add `title` to both content fragments (`... on Issue`, `... on PullRequest`) in the `FetchItemDetails` query, add `Title` to the result struct, copy it to `item.Title` in the parser, and remove the now-incorrect `Title: s.Title` workaround in `engine/poll.go`.

The `CacheImpl.FetchItemDetails` write-back path (`boardcache.go:684`) already applies `ItemDeepFetched{FreshState: *item}` after the network call, so the populated title flows into the store automatically without any additional mutations. No changes are needed to `boardcache.go`, `internal/itemstate/`, or `snapshotToProjectItem`.

### New/Modified Files

| File | Change |
|------|--------|
| `github/project.go` | Add `title` to `Issue` and `PullRequest` GraphQL fragments; add `Title string` to result struct; copy to `item.Title` in parser |
| `engine/poll.go` | Remove `Title: s.Title` workaround at line 1701 |
| `github/fetch_details_test.go` | Extend existing metadata test; add PR-node title test |
| `boardcache/boardcache_test.go` | Update `mockClient.FetchItemDetails` to copy `Title`; add cold-start title propagation test |

### Key Decisions

- **Fix in `FetchItemDetails`, not `ProbeProjectBoard`**: Per spec and ADR-044 intent, the probe is deliberately lightweight (polled frequently). Title belongs in the deep-fetch path which runs only on stale items. Probe carries no title; deep-fetch is authoritative for content.

- **No backfill mutation**: Items already in cache with `Title == ""` will be backfilled on their next probe drift → deep-fetch cycle. The store's `applyProjectItem` already handles the title update when `pi.Title != item.Title`. No explicit migration needed.

- **No ADR needed**: This fixes a field omission in an existing query, consistent with what ADR-044 already prescribes. There is no new architectural decision being made.

- **No doc updates needed**: Per the research findings, this introduces no new CLI commands, config options, labels, markers, or user-visible behavior. Neither `docs/state-machine.md` nor `docs/stage-lifecycle.md` need updates.

### Task Checklist

- [ ] **Task 1**: Add `title` to the `... on Issue` fragment in `FetchItemDetails` query in `github/project.go` (after `number`, before `body`)
- [ ] **Task 2**: Add `title` to the `... on PullRequest` fragment in `FetchItemDetails` query in `github/project.go` (after the opening brace, consistent with Issue placement)
- [ ] **Task 3**: Add `Title string \`json:"title"\`` field to the result `Node` struct in `FetchItemDetails` in `github/project.go`
- [ ] **Task 4**: Add `item.Title = node.Title` in the scalar-fields population block in `FetchItemDetails` (alongside the existing `item.Body`, `item.URL`, `item.Author` assignments)
- [ ] **Task 5**: Remove the `Title: s.Title, // FetchItemDetails doesn't fetch title; preserve cached value` line from `engine/poll.go:1701` (the `minimal` struct literal in the stale-item path of `runProbeAndDeepFetch`)
- [ ] **Task 6**: Extend `TestFetchItemDetails_PopulatesFullMetadata` in `github/fetch_details_test.go` to include `"title": "My Issue Title"` in the mock node response and assert `item.Title == "My Issue Title"`
- [ ] **Task 7**: Add `TestFetchItemDetails_TitlePopulatedForPRItem` in `github/fetch_details_test.go`: mock returns a PullRequest-type node with `"title": "My PR Title"`; assert `item.Title == "My PR Title"`
- [ ] **Task 8**: Update `mockClient.FetchItemDetails` in `boardcache/boardcache_test.go` to copy `item.Title = m.itemDetailsResult.Title` (mirror the pattern for `item.Body`, `item.Author`, etc.)
- [ ] **Task 9**: Add `TestBootstrapFromProbe_TitlePopulatedAfterDeepFetch` in `boardcache/boardcache_test.go`: bootstrap with a probe item (no title), set `itemDetailsResult.Title = "Issue Title"`, call `FetchItemDetails` through `CacheImpl`, then call `FetchProjectBoard` and assert the returned item has `Title == "Issue Title"`
- [ ] **Task 10**: Add a test in `engine/` (extend existing `TestRunStage_CreateDraftPR_*` pattern or add new) asserting that `CreateDraftPR` is called with a non-empty title when the item was cold-started via the probe path with `mockClient.FetchItemDetails` returning `Title: "My Issue"`
- [ ] **Task 11**: Run `go test ./...` and `go vet ./...` to verify all tests pass and no regressions

### Risks

- **PullRequest-node title field**: GitHub's GraphQL `PullRequest` type does expose `title` as a standard scalar field, identical to `Issue`. The fix is safe and additive — the Go JSON decoder ignores absent fields, so no breakage if the field is missing in an edge case.
- **`applyProjectItem` condition guard**: The `item.Title != pi.Title` guard already handles the case where store title was `""` and the fetched title is non-empty — the condition fires and writes the title. The fix depends on this existing behavior being correct, which it is.
- **Low risk overall**: Changes are purely additive. No existing behavior is modified beyond removing a workaround that preserved an empty string. Test coverage will confirm both Issue and PullRequest paths.

---
Used 11/50 turns, 5k input / 2k output tokens.

## Verification

Fixed the empty-title 422 bug by adding `title` to both `... on Issue` and `... on PullRequest` fragments in `FetchItemDetails`'s GraphQL query, adding the `Title` field to the result struct, populating `item.Title` from the response, and removing the now-obsolete `Title: s.Title` workaround in `runProbeAndDeepFetch`. Four tests were added: title assertion in the existing metadata test, a new PR-node title test, a cold-start propagation test verifying probe→deep-fetch→FetchProjectBoard title flow, and an end-to-end test confirming `CreateDraftPR` receives the non-empty title that `FetchItemDetails` populates.

---

Closes #729