### PR TITLE
fabrik: Plan stage should be able to signal 'no work needed' and short-circuit the pipeline

### DIFF
--- a/adrs/045-no-work-needed-marker.md
+++ b/adrs/045-no-work-needed-marker.md
@@ -1,0 +1,75 @@
+# ADR 045: FABRIK_NO_WORK_NEEDED Marker
+
+**Date**: 2026-05-13  
+**Status**: Accepted
+
+## Context
+
+When the Plan stage (or any stage) concludes that no implementation work is required — e.g., a docs audit for a pure-internal release, or an issue filed against a problem that no longer exists — the engine previously had no way to short-circuit. It advanced blindly to Implement, which ran Claude, found nothing to do, exited without committing, and then `ensureDraftPR` failed:
+
+```
+HTTP 422: Validation Failed — No commits between main and fabrik/issue-N
+```
+
+After three retries, the engine escalated and paused the issue. The issue was genuinely complete-with-no-action but was treated as failed. This pattern was observed in issues #728 and #732.
+
+The existing `FABRIK_DECOMPOSED` marker moves an issue directly to Done, but for a different reason — the issue was split into sub-issues. `FABRIK_DECOMPOSED` does not add dummy completion labels for the bypassed stages and does not post "skipped" comments. It is also a standalone marker that does not require `FABRIK_STAGE_COMPLETE` to co-occur.
+
+## Decision
+
+Add a new marker `FABRIK_NO_WORK_NEEDED` that any stage can emit to signal "this issue is complete; no code or documentation changes are required."
+
+Key design choices:
+
+1. **Requires `FABRIK_STAGE_COMPLETE` to co-occur.** Unlike `FABRIK_DECOMPOSED`, this marker does not stand alone. Both `FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED` must appear in the same output for the no-work path to fire. This keeps Claude honest: the emitting stage must explicitly declare itself complete before the bypass fires. It also means the timeout/kill recovery path (which scans only for `FABRIK_STAGE_COMPLETE`) does not inadvertently trigger the no-work path.
+
+2. **Adds dummy `stage:<name>:complete` labels for all bypassed non-cleanup stages.** This provides an explicit audit trail that the stages were consciously skipped, not forgotten. It also prevents catch-up advancement logic from re-running those stages on restart.
+
+3. **Posts one-line "skipped" comments per bypassed stage.** Engine-generated metadata comments (no rocket reaction): `_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by <stage>)._`. These are visible in the issue history so the operator understands why nothing ran.
+
+4. **Does not create a PR.** The `ensureDraftPR` and `markPRReady` calls in the normal `completed` branch are skipped — this is why `completed && noWorkNeeded` is checked before the plain `completed` branch in `processItem()`'s dispatch chain.
+
+5. **Moves the issue directly to Done.** Same mechanism as `handleDecomposed`: `UpdateProjectItemStatus` with `e.statusField.Options["Done"]`.
+
+A new `handleNoWorkNeeded(board, item, stage)` function is added to `engine/stages.go` immediately after `handleDecomposed`, following the same file-organization convention.
+
+## Rationale
+
+### Why a new marker instead of reusing `FABRIK_DECOMPOSED`?
+
+`FABRIK_DECOMPOSED` is semantically wrong for this case — the issue was not decomposed into sub-issues. Using it would pollute the "parent decomposed" audit signal and would require callers to know that `FABRIK_DECOMPOSED` has a dual meaning.
+
+More concretely, the behaviors differ:
+
+| | `FABRIK_NO_WORK_NEEDED` | `FABRIK_DECOMPOSED` |
+|---|---|---|
+| Requires `FABRIK_STAGE_COMPLETE` | Yes | No |
+| Adds dummy `stage:<name>:complete` for skipped stages | Yes | No |
+| Posts "skipped" comments per stage | Yes | No |
+| Moves to Done | Yes | Yes |
+| Creates PR | No | No |
+
+### Why require `FABRIK_STAGE_COMPLETE` to co-occur?
+
+`FABRIK_DECOMPOSED` was designed as a standalone marker because decomposition is a categorical outcome — if Plan decomposes, it did not produce a plan and `FABRIK_STAGE_COMPLETE` would be misleading. By contrast, "no work needed" is a valid completion outcome for the emitting stage: Plan ran, assessed the research, and concluded the issue is moot. Requiring `FABRIK_STAGE_COMPLETE` preserves the invariant that `stage:<X>:complete` is only added when the stage genuinely completed its work.
+
+The co-occurrence requirement also prevents a half-finished stage from accidentally triggering the bypass. A stage that emits `FABRIK_NO_WORK_NEEDED` without `FABRIK_STAGE_COMPLETE` routes to the normal cooldown/retry path — the same as if no completion marker were present.
+
+### Why add dummy completion labels for skipped stages?
+
+Without `stage:<Y>:complete` labels on bypassed stages, the catch-up advancement logic would treat those stages as incomplete and potentially try to re-run them. The dummy labels prevent this. They also give human operators a clear view of what happened: the issue's label history shows all stages as complete, with "skipped" comments explaining why.
+
+`FABRIK_DECOMPOSED` does not need this because decomposed issues have sub-issues flowing through the full pipeline — the parent's bypassed stages are understood to be irrelevant.
+
+### Priority in the dispatch chain
+
+`completed && noWorkNeeded` is checked before the plain `completed` branch because the plain `completed` branch calls `ensureDraftPR` and `markPRReady`. Both would fail or behave incorrectly when no commits exist on the branch. The priority ordering ensures these operations are never invoked for the no-work path.
+
+## Consequences
+
+- Any stage can emit `FABRIK_NO_WORK_NEEDED` paired with `FABRIK_STAGE_COMPLETE`. By convention this is expected most from Plan. The skill prompt (`fabrik-plan/SKILL.md`) is the primary enforcement point — it instructs Plan when and how to use the marker.
+- Bypassed stages receive `stage:<name>:complete` labels. The catch-up loop will see these and not attempt to re-run them.
+- No PR is created when the no-work path fires. The Done stage's cleanup (worktree removal, label cleanup, issue close) runs as normal.
+- Existing stuck issues with the "no commits" symptom must be manually closed or recovered — the marker is not backported. Future issues of the same class will be caught by Plan emitting the marker.
+
+**References:** [ADR-017: Decomposed Marker State Machine](017-decomposed-marker-state-machine.md)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2249,7 +2249,7 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `attemptMergeOnValidate` (legacy auto-merge path, yolo+Validate without `wait_for_ci`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `attemptMergeOnValidate` (on successful merge, via `removeRebaseNeededLabel` — no-op when absent); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when `MergePR` succeeds; or when issue is closed (defensive sweep) | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
 | `fabrik:blocked` | `checkDependencies` | When open blocking issues exist (first transition only — idempotent) | `PushUnblockObserver` (primary — fires immediately on blocker close, any column); `checkDependencies` (defense-in-depth — fires via `dep-blocked` cooldown-retry for items in stage columns) | When all blocking issues close | Pre-dispatch gate in `itemNeedsWork` prevents re-dispatch after the label is set (parallel to `fabrik:editing` post-#550 and `fabrik:locked:<other>` always); **exception**: when the `dep-blocked` cooldown has expired (or no store entry exists), `itemNeedsWork` admits the item for one dependency re-check per `10 × PollSeconds` — `checkDependencies` either re-stamps the cooldown (still blocked) or removes the label (resolved). Initial detection (first dispatch, label not yet set) still reaches `checkDependencies` normally. Blocks stage start. Push path removes the label even for items in non-stage columns (Backlog, Done, custom columns) that would otherwise never be re-evaluated by `processItem`. |
 | `stage:<X>:in_progress` | `processItem` | After lock acquired and verified | `releaseLock` | Same as `fabrik:locked:<user>` | Informational — shows which stage is active on GitHub |
-| `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleDecomposed`, cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_DECOMPOSED or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
+| `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleDecomposed`, `handleNoWorkNeeded` (emitting stage + all skipped stages), cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_DECOMPOSED or FABRIK_NO_WORK_NEEDED (emitting stage + all subsequent non-cleanup stages) or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
 | `stage:<X>:failed` | `escalateFailedStage` | After MaxRetries exhausted | `clearFailedStage` | When user removes `fabrik:paused` (manual unpause) | Indicates permanent failure; paired with `fabrik:paused` |
 | `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
 | `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
@@ -2342,13 +2342,17 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 **Trigger:** Claude's output contains one of the Fabrik markers. Checked after each stage invocation.
 
 **Markers and priority order** (enforced by the `if/else if` dispatch chain in `processItem()`):
-1. `FABRIK_STAGE_COMPLETE` — highest priority; checked first via `checkCompletion()`
-2. `FABRIK_DECOMPOSED` — checked second; only honored if `completed` is false and `err == nil`
-3. `FABRIK_BLOCKED_ON_INPUT` — checked third; only honored if `completed` and `decomposed` are both false and `err == nil`
+1. `FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED` (both present) — highest priority among `completed == true` paths; `completed && noWorkNeeded` branch fires before the plain `completed` branch
+2. `FABRIK_STAGE_COMPLETE` (alone) — next; handled by the plain `completed` branch
+3. `FABRIK_DECOMPOSED` — checked next; only honored if `completed` is false and `err == nil`
+4. `FABRIK_BLOCKED_ON_INPUT` — checked last; only honored if `completed` and `decomposed` are both false and `err == nil`
+
+`FABRIK_NO_WORK_NEEDED` is ignored unless `FABRIK_STAGE_COMPLETE` also appears in the same output — the no-work path requires the emitting stage to explicitly declare itself complete. The timeout/kill recovery path that scans buffered output for `FABRIK_STAGE_COMPLETE` does not trigger the no-work path (only `FABRIK_STAGE_COMPLETE` is scanned in that recovery path, not `FABRIK_NO_WORK_NEEDED`).
 
 **Code path:** `processItem()` → outcome dispatch based on which marker is present
 
 **Effect:**
+- **FABRIK_STAGE_COMPLETE** + **FABRIK_NO_WORK_NEEDED:** `handleNoWorkNeeded()` — adds completion label for emitting stage; adds dummy `stage:<name>:complete` labels and one-line "skipped" comments for each subsequent non-cleanup stage; moves issue directly to Done; no PR created (see §6.7)
 - **FABRIK_STAGE_COMPLETE:** `handleStageComplete()` — adds completion label, potentially advances to next stage
 - **FABRIK_DECOMPOSED:** `handleDecomposed()` — adds completion label, moves issue directly to Done
 - **FABRIK_BLOCKED_ON_INPUT:** `blockOnInput()` — adds `fabrik:paused` + `fabrik:awaiting-input`
@@ -2682,7 +2686,7 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 4 | Invoke Claude with comment review prompt | `InvokeForComments()` | Uses `comment_prompt` / `comment_skill` and `comment_max_turns` |
 | 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
 | 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Applied unconditionally when markers are present; stripped from output regardless |
-| 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_SUMMARY_BEGIN/END |
+| 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_NO_WORK_NEEDED, FABRIK_SUMMARY_BEGIN/END |
 | 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
 | 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |
 | 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
@@ -3079,7 +3083,7 @@ The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRe
 
 **Trigger:** Claude outputs `FABRIK_DECOMPOSED` marker (expected only from Plan stage).
 
-**Marker priority:** `FABRIK_STAGE_COMPLETE` > `FABRIK_DECOMPOSED` > `FABRIK_BLOCKED_ON_INPUT`. If `completed` is true, `decomposed` is not checked. Both `decomposed` and `blockedOnInput` require `err == nil`.
+**Marker priority:** (`FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED`) > `FABRIK_STAGE_COMPLETE` > `FABRIK_DECOMPOSED` > `FABRIK_BLOCKED_ON_INPUT`. If `completed` is true (FABRIK_STAGE_COMPLETE present), `decomposed` is not checked. Both `decomposed` and `blockedOnInput` require `err == nil`.
 
 **Code path:** `processItem()` → `handleDecomposed()`
 
@@ -3089,6 +3093,46 @@ The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRe
 3. Move the issue directly to Done, bypassing all remaining pipeline stages
 
 **References:** [ADR-017: Decomposed Marker State Machine](../adrs/017-decomposed-marker-state-machine.md)
+
+### 6.7 No Work Needed Path
+
+**Trigger:** Claude outputs both `FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED` in the same invocation output. Expected most commonly from the Plan stage when Research findings show no code or documentation changes are needed.
+
+**Key invariant:** `FABRIK_NO_WORK_NEEDED` alone has no effect. Both markers must co-occur. This keeps Claude honest — the emitting stage must declare itself complete before the bypass fires.
+
+**Marker priority:** This path fires in the `completed && noWorkNeeded` branch, which precedes the plain `completed` branch in `processItem()`'s dispatch chain. This ensures PR creation (`ensureDraftPR`) and `markPRReady` — both in the plain `completed` branch — are not called.
+
+**Mutual exclusivity:** `FABRIK_NO_WORK_NEEDED` is mutually exclusive with `FABRIK_DECOMPOSED` (structurally: if `completed` is true, the `decomposed` branch is never reached) and with `FABRIK_BLOCKED_ON_INPUT` (structurally: `blockedOnInput` is only reached when `completed` is false).
+
+**Code path:** `processItem()` → `handleNoWorkNeeded()`
+
+**Flow:**
+1. Release lock; clear retry state (`StageRetryCleared`, `EngineUnpaused`)
+2. Add `stage:<current>:complete` label for the emitting stage (with cache write-through)
+3. Find `doneOrder`: iterate `e.cfg.Stages` for the stage with `CleanupWorktree == true`; fall back to `math.MaxInt` if none exists
+4. For each stage with `Order > current.Order && Order < doneOrder`:
+   - Add `stage:<name>:complete` label (with cache write-through)
+   - Post one-line comment: `_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by <stage>)._` (no rocket reaction — engine-generated metadata)
+5. Move the issue to Done via `UpdateProjectItemStatus` (same nil/ok guards as `handleDecomposed`)
+6. **No PR is created** — `ensureDraftPR` and `markPRReady` are not called
+
+**Differences from `FABRIK_DECOMPOSED`:**
+
+| | `FABRIK_NO_WORK_NEEDED` | `FABRIK_DECOMPOSED` |
+|---|---|---|
+| Requires `FABRIK_STAGE_COMPLETE` to co-occur | Yes | No (standalone marker) |
+| Adds dummy `stage:<name>:complete` labels for skipped stages | Yes (audit trail) | No |
+| Posts "skipped" comments per stage | Yes | No |
+| Moves to Done | Yes | Yes |
+| Creates PR | No | No |
+
+**State transitions:**
+
+| Before | Trigger | After | Labels Added | Labels Removed |
+|---|---|---|---|---|
+| Column `<X>`, Locked + In Progress | `FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED` | Done, Pending Cleanup | `stage:<X>:complete`, `stage:<Y>:complete` … (all subsequent non-cleanup stages) | `fabrik:locked:<user>`, `stage:<X>:in_progress` |
+
+**References:** [ADR-045: No Work Needed Marker](../adrs/045-no-work-needed-marker.md)
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -136,7 +136,7 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `attemptMergeOnValidate` (legacy auto-merge path, yolo+Validate without `wait_for_ci`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `attemptMergeOnValidate` (on successful merge, via `removeRebaseNeededLabel` — no-op when absent); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when `MergePR` succeeds; or when issue is closed (defensive sweep) | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
 | `fabrik:blocked` | `checkDependencies` | When open blocking issues exist (first transition only — idempotent) | `PushUnblockObserver` (primary — fires immediately on blocker close, any column); `checkDependencies` (defense-in-depth — fires via `dep-blocked` cooldown-retry for items in stage columns) | When all blocking issues close | Pre-dispatch gate in `itemNeedsWork` prevents re-dispatch after the label is set (parallel to `fabrik:editing` post-#550 and `fabrik:locked:<other>` always); **exception**: when the `dep-blocked` cooldown has expired (or no store entry exists), `itemNeedsWork` admits the item for one dependency re-check per `10 × PollSeconds` — `checkDependencies` either re-stamps the cooldown (still blocked) or removes the label (resolved). Initial detection (first dispatch, label not yet set) still reaches `checkDependencies` normally. Blocks stage start. Push path removes the label even for items in non-stage columns (Backlog, Done, custom columns) that would otherwise never be re-evaluated by `processItem`. |
 | `stage:<X>:in_progress` | `processItem` | After lock acquired and verified | `releaseLock` | Same as `fabrik:locked:<user>` | Informational — shows which stage is active on GitHub |
-| `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleDecomposed`, cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_DECOMPOSED or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
+| `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleDecomposed`, `handleNoWorkNeeded` (emitting stage + all skipped stages), cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_DECOMPOSED or FABRIK_NO_WORK_NEEDED (emitting stage + all subsequent non-cleanup stages) or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
 | `stage:<X>:failed` | `escalateFailedStage` | After MaxRetries exhausted | `clearFailedStage` | When user removes `fabrik:paused` (manual unpause) | Indicates permanent failure; paired with `fabrik:paused` |
 | `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
 | `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
@@ -229,13 +229,17 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 **Trigger:** Claude's output contains one of the Fabrik markers. Checked after each stage invocation.
 
 **Markers and priority order** (enforced by the `if/else if` dispatch chain in `processItem()`):
-1. `FABRIK_STAGE_COMPLETE` — highest priority; checked first via `checkCompletion()`
-2. `FABRIK_DECOMPOSED` — checked second; only honored if `completed` is false and `err == nil`
-3. `FABRIK_BLOCKED_ON_INPUT` — checked third; only honored if `completed` and `decomposed` are both false and `err == nil`
+1. `FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED` (both present) — highest priority among `completed == true` paths; `completed && noWorkNeeded` branch fires before the plain `completed` branch
+2. `FABRIK_STAGE_COMPLETE` (alone) — next; handled by the plain `completed` branch
+3. `FABRIK_DECOMPOSED` — checked next; only honored if `completed` is false and `err == nil`
+4. `FABRIK_BLOCKED_ON_INPUT` — checked last; only honored if `completed` and `decomposed` are both false and `err == nil`
+
+`FABRIK_NO_WORK_NEEDED` is ignored unless `FABRIK_STAGE_COMPLETE` also appears in the same output — the no-work path requires the emitting stage to explicitly declare itself complete. The timeout/kill recovery path that scans buffered output for `FABRIK_STAGE_COMPLETE` does not trigger the no-work path (only `FABRIK_STAGE_COMPLETE` is scanned in that recovery path, not `FABRIK_NO_WORK_NEEDED`).
 
 **Code path:** `processItem()` → outcome dispatch based on which marker is present
 
 **Effect:**
+- **FABRIK_STAGE_COMPLETE** + **FABRIK_NO_WORK_NEEDED:** `handleNoWorkNeeded()` — adds completion label for emitting stage; adds dummy `stage:<name>:complete` labels and one-line "skipped" comments for each subsequent non-cleanup stage; moves issue directly to Done; no PR created (see §6.7)
 - **FABRIK_STAGE_COMPLETE:** `handleStageComplete()` — adds completion label, potentially advances to next stage
 - **FABRIK_DECOMPOSED:** `handleDecomposed()` — adds completion label, moves issue directly to Done
 - **FABRIK_BLOCKED_ON_INPUT:** `blockOnInput()` — adds `fabrik:paused` + `fabrik:awaiting-input`
@@ -569,7 +573,7 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 4 | Invoke Claude with comment review prompt | `InvokeForComments()` | Uses `comment_prompt` / `comment_skill` and `comment_max_turns` |
 | 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
 | 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Applied unconditionally when markers are present; stripped from output regardless |
-| 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_SUMMARY_BEGIN/END |
+| 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_DECOMPOSED, FABRIK_NO_WORK_NEEDED, FABRIK_SUMMARY_BEGIN/END |
 | 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
 | 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |
 | 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
@@ -966,7 +970,7 @@ The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRe
 
 **Trigger:** Claude outputs `FABRIK_DECOMPOSED` marker (expected only from Plan stage).
 
-**Marker priority:** `FABRIK_STAGE_COMPLETE` > `FABRIK_DECOMPOSED` > `FABRIK_BLOCKED_ON_INPUT`. If `completed` is true, `decomposed` is not checked. Both `decomposed` and `blockedOnInput` require `err == nil`.
+**Marker priority:** (`FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED`) > `FABRIK_STAGE_COMPLETE` > `FABRIK_DECOMPOSED` > `FABRIK_BLOCKED_ON_INPUT`. If `completed` is true (FABRIK_STAGE_COMPLETE present), `decomposed` is not checked. Both `decomposed` and `blockedOnInput` require `err == nil`.
 
 **Code path:** `processItem()` → `handleDecomposed()`
 
@@ -976,6 +980,46 @@ The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRe
 3. Move the issue directly to Done, bypassing all remaining pipeline stages
 
 **References:** [ADR-017: Decomposed Marker State Machine](../adrs/017-decomposed-marker-state-machine.md)
+
+### 6.7 No Work Needed Path
+
+**Trigger:** Claude outputs both `FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED` in the same invocation output. Expected most commonly from the Plan stage when Research findings show no code or documentation changes are needed.
+
+**Key invariant:** `FABRIK_NO_WORK_NEEDED` alone has no effect. Both markers must co-occur. This keeps Claude honest — the emitting stage must declare itself complete before the bypass fires.
+
+**Marker priority:** This path fires in the `completed && noWorkNeeded` branch, which precedes the plain `completed` branch in `processItem()`'s dispatch chain. This ensures PR creation (`ensureDraftPR`) and `markPRReady` — both in the plain `completed` branch — are not called.
+
+**Mutual exclusivity:** `FABRIK_NO_WORK_NEEDED` is mutually exclusive with `FABRIK_DECOMPOSED` (structurally: if `completed` is true, the `decomposed` branch is never reached) and with `FABRIK_BLOCKED_ON_INPUT` (structurally: `blockedOnInput` is only reached when `completed` is false).
+
+**Code path:** `processItem()` → `handleNoWorkNeeded()`
+
+**Flow:**
+1. Release lock; clear retry state (`StageRetryCleared`, `EngineUnpaused`)
+2. Add `stage:<current>:complete` label for the emitting stage (with cache write-through)
+3. Find `doneOrder`: iterate `e.cfg.Stages` for the stage with `CleanupWorktree == true`; fall back to `math.MaxInt` if none exists
+4. For each stage with `Order > current.Order && Order < doneOrder`:
+   - Add `stage:<name>:complete` label (with cache write-through)
+   - Post one-line comment: `_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by <stage>)._` (no rocket reaction — engine-generated metadata)
+5. Move the issue to Done via `UpdateProjectItemStatus` (same nil/ok guards as `handleDecomposed`)
+6. **No PR is created** — `ensureDraftPR` and `markPRReady` are not called
+
+**Differences from `FABRIK_DECOMPOSED`:**
+
+| | `FABRIK_NO_WORK_NEEDED` | `FABRIK_DECOMPOSED` |
+|---|---|---|
+| Requires `FABRIK_STAGE_COMPLETE` to co-occur | Yes | No (standalone marker) |
+| Adds dummy `stage:<name>:complete` labels for skipped stages | Yes (audit trail) | No |
+| Posts "skipped" comments per stage | Yes | No |
+| Moves to Done | Yes | Yes |
+| Creates PR | No | No |
+
+**State transitions:**
+
+| Before | Trigger | After | Labels Added | Labels Removed |
+|---|---|---|---|---|
+| Column `<X>`, Locked + In Progress | `FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED` | Done, Pending Cleanup | `stage:<X>:complete`, `stage:<Y>:complete` … (all subsequent non-cleanup stages) | `fabrik:locked:<user>`, `stage:<X>:in_progress` |
+
+**References:** [ADR-045: No Work Needed Marker](../adrs/045-no-work-needed-marker.md)
 
 ---
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -759,7 +759,7 @@ func buildPrompt(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Com
 	b.WriteString("Once you emit this marker, do not generate any further output. Continuing after the marker risks leaving the issue in a stuck state if the session ends with an error.\n\n")
 	b.WriteString("If you have unresolved questions that must be answered before the stage can proceed, output instead:\n")
 	b.WriteString("FABRIK_BLOCKED_ON_INPUT\n")
-	b.WriteString("These three markers are mutually exclusive — output exactly one or neither.\n")
+	b.WriteString("These two markers are mutually exclusive — output exactly one or neither.\n")
 	b.WriteString("\nWhen outputting FABRIK_BLOCKED_ON_INPUT, you MUST also emit a summary block containing the specific question you need answered (this is distinct from the stage-completion summary above, if any — here the block must describe the required input, not summarize completed work):\n\n")
 	b.WriteString("FABRIK_SUMMARY_BEGIN\n")
 	b.WriteString("(1–3 sentences stating exactly what input you need — direct and specific, no preamble; the user reads this on a small screen)\n")

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -25,6 +25,7 @@ import (
 var stageCompleteRE = regexp.MustCompile(`(?m)^FABRIK_STAGE_COMPLETE\r?$`)
 var blockedOnInputRE = regexp.MustCompile(`(?m)^FABRIK_BLOCKED_ON_INPUT\r?$`)
 var decomposedRE = regexp.MustCompile(`(?m)^FABRIK_DECOMPOSED\r?$`)
+var noWorkNeededRE = regexp.MustCompile(`(?m)^FABRIK_NO_WORK_NEEDED\r?$`)
 
 // defaultAllowedTools is the comprehensive set of tools Fabrik permits by default
 // when a stage does not specify allowed_tools. This ensures headless Claude Code
@@ -47,6 +48,15 @@ func CheckBlockedOnInput(output string) bool {
 // the parent should be moved directly to Done, bypassing remaining pipeline stages.
 func CheckDecomposed(output string) bool {
 	return decomposedRE.MatchString(output)
+}
+
+// CheckNoWorkNeeded reports whether output contains the FABRIK_NO_WORK_NEEDED marker.
+// This marker signals that the emitting stage determined no code or documentation
+// changes are required. It must co-occur with FABRIK_STAGE_COMPLETE; when both are
+// present the engine skips all remaining non-cleanup stages (adding dummy completion
+// labels and "skipped" comments) and moves the issue directly to Done without a PR.
+func CheckNoWorkNeeded(output string) bool {
+	return noWorkNeededRE.MatchString(output)
 }
 
 // claudeLogf is the logging function used by runClaude. Set by the Engine

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -759,11 +759,17 @@ func buildPrompt(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Com
 	b.WriteString("Once you emit this marker, do not generate any further output. Continuing after the marker risks leaving the issue in a stuck state if the session ends with an error.\n\n")
 	b.WriteString("If you have unresolved questions that must be answered before the stage can proceed, output instead:\n")
 	b.WriteString("FABRIK_BLOCKED_ON_INPUT\n")
-	b.WriteString("These two markers are mutually exclusive — output exactly one or neither.\n")
+	b.WriteString("These three markers are mutually exclusive — output exactly one or neither.\n")
 	b.WriteString("\nWhen outputting FABRIK_BLOCKED_ON_INPUT, you MUST also emit a summary block containing the specific question you need answered (this is distinct from the stage-completion summary above, if any — here the block must describe the required input, not summarize completed work):\n\n")
 	b.WriteString("FABRIK_SUMMARY_BEGIN\n")
 	b.WriteString("(1–3 sentences stating exactly what input you need — direct and specific, no preamble; the user reads this on a small screen)\n")
 	b.WriteString("FABRIK_SUMMARY_END\n")
+	b.WriteString("\nIf your stage determines that no code or documentation changes are required — the issue\n")
+	b.WriteString("is already resolved or the work is genuinely moot — you may signal this by emitting:\n")
+	b.WriteString("FABRIK_NO_WORK_NEEDED\n")
+	b.WriteString("This marker MUST co-occur with FABRIK_STAGE_COMPLETE on its own line. The engine will\n")
+	b.WriteString("mark all remaining pipeline stages complete (with \"skipped\" comments) and move the issue\n")
+	b.WriteString("directly to Done without creating a PR. It is mutually exclusive with FABRIK_BLOCKED_ON_INPUT.\n")
 
 	return b.String()
 }

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -266,6 +266,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	output = stripLine(output, "FABRIK_STAGE_COMPLETE")
 	output = stripLine(output, "FABRIK_BLOCKED_ON_INPUT")
 	output = stripLine(output, "FABRIK_DECOMPOSED")
+	output = stripLine(output, "FABRIK_NO_WORK_NEEDED")
 	output = stripLine(output, "FABRIK_SUMMARY_BEGIN")
 	output = stripLine(output, "FABRIK_SUMMARY_END")
 	output = strings.TrimSpace(output)

--- a/engine/item.go
+++ b/engine/item.go
@@ -865,6 +865,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		postOutput = stripLine(postOutput, "FABRIK_STAGE_COMPLETE")
 		postOutput = stripLine(postOutput, "FABRIK_BLOCKED_ON_INPUT")
 		postOutput = stripLine(postOutput, "FABRIK_DECOMPOSED")
+		postOutput = stripLine(postOutput, "FABRIK_NO_WORK_NEEDED")
 		postOutput = stripLine(postOutput, "FABRIK_SUMMARY_BEGIN")
 		postOutput = stripLine(postOutput, "FABRIK_SUMMARY_END")
 		postOutput = strings.TrimSpace(postOutput)

--- a/engine/item.go
+++ b/engine/item.go
@@ -984,11 +984,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		// the next poll cycle. No explicit eviction is needed.
 	}
 
-	// Only honor the blocked-on-input and decomposed markers if Claude ran without error.
-	// If there was an error, treat the run as a retry/failure rather than
-	// silently pausing the issue.
+	// Only honor the blocked-on-input, decomposed, and no-work-needed markers if Claude
+	// ran without error. If there was an error, treat the run as a retry/failure rather
+	// than silently pausing the issue.
 	blockedOnInput := err == nil && CheckBlockedOnInput(output)
 	decomposed := err == nil && CheckDecomposed(output)
+	noWorkNeeded := err == nil && CheckNoWorkNeeded(output)
 
 	// Store completion/blocked/usage state for TUI event emission in poll.go.
 	e.store.Apply(itemstate.InvocationRecorded{
@@ -1000,7 +1001,14 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		Duration:  time.Since(workerStartedAt),
 	})
 
-	if completed {
+	if completed && noWorkNeeded {
+		// No-work path: stage declared itself complete AND signaled no code/doc changes
+		// are needed. Skip all remaining pipeline stages, move directly to Done, no PR.
+		releaseLock()
+		e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		e.handleNoWorkNeeded(board, item, stage)
+	} else if completed {
 		// Post-stage: create draft PR and/or mark ready now that commits exist.
 		// prNumber may already be set if the early guard above ran (PostToPR + CreateDraftPR path).
 		if stage.CreateDraftPR {

--- a/engine/no_work_needed_test.go
+++ b/engine/no_work_needed_test.go
@@ -1,0 +1,209 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// TestCheckNoWorkNeeded verifies marker detection for FABRIK_NO_WORK_NEEDED.
+func TestCheckNoWorkNeeded(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"marker on its own line", "Some output\nFABRIK_NO_WORK_NEEDED\n", true},
+		{"marker as last line no newline", "output\nFABRIK_NO_WORK_NEEDED", true},
+		{"CRLF line ending", "output\r\nFABRIK_NO_WORK_NEEDED\r\n", true},
+		{"marker followed by more lines", "FABRIK_NO_WORK_NEEDED\nmore output", true},
+		{"not present", "Some output without marker", false},
+		{"embedded in sentence", "Please output FABRIK_NO_WORK_NEEDED when done", false},
+		{"in backticks", "`FABRIK_NO_WORK_NEEDED`", false},
+		{"partial match", "FABRIK_NO_WORK_NEEDED_EXTRA", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CheckNoWorkNeeded(tc.output)
+			if got != tc.want {
+				t.Errorf("CheckNoWorkNeeded(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+// testStagesWithCleanup returns stages with the Done stage marked as CleanupWorktree,
+// for use in handleNoWorkNeeded tests.
+func testStagesWithCleanup() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Research", Order: 1, Prompt: "research"},
+		{Name: "Plan", Order: 2, Prompt: "plan"},
+		{Name: "Implement", Order: 3, Prompt: "implement"},
+		{Name: "Validate", Order: 4, Prompt: "validate"},
+		{Name: "Done", Order: 5, Prompt: "done", CleanupWorktree: true},
+	}
+}
+
+// TestHandleNoWorkNeeded_MovesToDone verifies that handleNoWorkNeeded adds the
+// emitting stage's completion label and moves the item to Done.
+func TestHandleNoWorkNeeded_MovesToDone(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5"}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	// Should add stage:Plan:complete label.
+	found := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Plan:complete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected stage:Plan:complete label to be added")
+	}
+
+	// Should call UpdateProjectItemStatus with the Done option.
+	if len(client.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 status update, got %d", len(client.updateStatusCalls))
+	}
+	if client.updateStatusCalls[0].optionID != "OPT_Done" {
+		t.Errorf("expected Done option ID, got %q", client.updateStatusCalls[0].optionID)
+	}
+	if client.updateStatusCalls[0].projectID != "PVT_1" {
+		t.Errorf("expected projectID PVT_1, got %q", client.updateStatusCalls[0].projectID)
+	}
+}
+
+// TestHandleNoWorkNeeded_NilStatusField logs warning and does not panic.
+func TestHandleNoWorkNeeded_NilStatusField(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng.statusField = nil
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5"}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	// Should not panic.
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	// Completion label still gets added before the nil check.
+	found := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Plan:complete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected stage:Plan:complete label even when statusField is nil")
+	}
+
+	// No status update should happen.
+	if len(client.updateStatusCalls) != 0 {
+		t.Errorf("expected no status update with nil statusField, got %d", len(client.updateStatusCalls))
+	}
+}
+
+// TestHandleNoWorkNeeded_NoDoneOption logs warning and does not panic.
+func TestHandleNoWorkNeeded_NoDoneOption(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+	delete(eng.statusField.Options, "Done")
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5"}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	// Should not panic.
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	// No status update should happen.
+	if len(client.updateStatusCalls) != 0 {
+		t.Errorf("expected no status update when Done option missing, got %d", len(client.updateStatusCalls))
+	}
+}
+
+// TestHandleNoWorkNeeded_SkipsIntermediateStages verifies that all non-cleanup stages
+// after the emitting stage receive a dummy completion label and a "skipped" comment,
+// while the cleanup (Done) stage does not.
+func TestHandleNoWorkNeeded_SkipsIntermediateStages(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 7, ItemID: "PVTI_7"}
+	// Plan emits FABRIK_NO_WORK_NEEDED; Implement (order 3) and Validate (order 4)
+	// should be skipped; Done (order 5, CleanupWorktree) should NOT be skipped.
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	// Collect all labels added.
+	labelSet := make(map[string]bool)
+	for _, c := range client.addLabelCalls {
+		labelSet[c.labelName] = true
+	}
+
+	// Emitting stage gets its completion label.
+	if !labelSet["stage:Plan:complete"] {
+		t.Error("expected stage:Plan:complete label")
+	}
+	// Implement and Validate get skipped labels.
+	if !labelSet["stage:Implement:complete"] {
+		t.Error("expected stage:Implement:complete skip label")
+	}
+	if !labelSet["stage:Validate:complete"] {
+		t.Error("expected stage:Validate:complete skip label")
+	}
+	// Done must NOT get a skip label (it's the cleanup stage).
+	if labelSet["stage:Done:complete"] {
+		t.Error("expected no stage:Done:complete skip label (cleanup stage must be excluded)")
+	}
+
+	// Two "skipped" comments should be posted (one per skipped stage: Implement, Validate).
+	if len(client.addCommentCalls) != 2 {
+		t.Fatalf("expected 2 skipped comments, got %d", len(client.addCommentCalls))
+	}
+	for _, c := range client.addCommentCalls {
+		if !strings.Contains(c.body, "FABRIK_NO_WORK_NEEDED emitted by Plan") {
+			t.Errorf("expected comment to mention emitting stage, got: %q", c.body)
+		}
+	}
+
+	// One status update to Done.
+	if len(client.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 status update, got %d", len(client.updateStatusCalls))
+	}
+	if client.updateStatusCalls[0].optionID != "OPT_Done" {
+		t.Errorf("expected Done option, got %q", client.updateStatusCalls[0].optionID)
+	}
+}
+
+// TestHandleNoWorkNeeded_DirectlyDoneNotNextStage verifies that the issue advances
+// directly to Done, not to the next sequential stage.
+func TestHandleNoWorkNeeded_DirectlyDoneNotNextStage(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 9, ItemID: "PVTI_9"}
+	// Plan is order 2; advanceToNextStage would go to Implement (OPT_Implement).
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	if len(client.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 status update, got %d", len(client.updateStatusCalls))
+	}
+	// Must be Done, not the next sequential stage.
+	if client.updateStatusCalls[0].optionID != "OPT_Done" {
+		t.Errorf("handleNoWorkNeeded must set status to Done, got %q", client.updateStatusCalls[0].optionID)
+	}
+}

--- a/engine/no_work_needed_test.go
+++ b/engine/no_work_needed_test.go
@@ -34,9 +34,9 @@ func TestCheckNoWorkNeeded(t *testing.T) {
 	}
 }
 
-// testStagesWithCleanup returns stages with the Done stage marked as CleanupWorktree,
-// for use in handleNoWorkNeeded tests.
-func testStagesWithCleanup() []*stages.Stage {
+// testStagesWithValidateAndCleanup returns a stage set including Validate and a
+// CleanupWorktree Done stage, suitable for SkipsIntermediateStages tests.
+func testStagesWithValidateAndCleanup() []*stages.Stage {
 	return []*stages.Stage{
 		{Name: "Research", Order: 1, Prompt: "research"},
 		{Name: "Plan", Order: 2, Prompt: "plan"},
@@ -50,6 +50,7 @@ func testStagesWithCleanup() []*stages.Stage {
 // emitting stage's completion label and moves the item to Done.
 func TestHandleNoWorkNeeded_MovesToDone(t *testing.T) {
 	client := &mockGitHubClient{}
+	// testStagesWithCleanup: Research(1), Plan(2), Implement(3), Done(99, cleanup)
 	eng := testEngineWithStages(client, testStagesWithCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -135,7 +136,8 @@ func TestHandleNoWorkNeeded_NoDoneOption(t *testing.T) {
 // while the cleanup (Done) stage does not.
 func TestHandleNoWorkNeeded_SkipsIntermediateStages(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	// Stages: Research(1), Plan(2), Implement(3), Validate(4), Done(5, cleanup)
+	eng := testEngineWithStages(client, testStagesWithValidateAndCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 7, ItemID: "PVTI_7"}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -472,6 +473,95 @@ func (e *Engine) handleDecomposed(board *gh.ProjectBoard, item gh.ProjectItem, s
 
 	e.logf(item.Number, "advance", "moving decomposed issue to Done\n")
 	// write-through: already covered by cacheImpl.UpdateItemStatus call in the else block below
+	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
+		e.logf(item.Number, "warn", "could not move issue to Done: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Done")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
+		}
+	}
+}
+
+// handleNoWorkNeeded is called when a stage outputs both FABRIK_STAGE_COMPLETE and
+// FABRIK_NO_WORK_NEEDED. It marks the emitting stage complete, adds dummy
+// stage:<name>:complete labels for all subsequent non-cleanup stages (with a one-line
+// "skipped" comment per stage), and moves the issue directly to Done without creating
+// a PR. This is the canonical path when Plan (or any stage) determines that no code
+// or documentation changes are required.
+func (e *Engine) handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
+	e.logf(item.Number, "done", "stage %q signaled no work needed — skipping remaining stages and moving to Done\n", stage.Name)
+
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	// Mark the emitting stage complete so the engine doesn't re-run it on restart.
+	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
+		e.logf(item.Number, "warn", "could not add completion label for stage %q: %v\n", stage.Name, err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
+		}
+	}
+
+	// Find the order boundary for the cleanup (Done) stage.
+	doneOrder := math.MaxInt
+	for _, s := range e.cfg.Stages {
+		if s.CleanupWorktree && s.Order < doneOrder {
+			doneOrder = s.Order
+		}
+	}
+
+	// Add dummy completion labels and "skipped" comments for all subsequent non-cleanup stages.
+	skippedComment := fmt.Sprintf("_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by %s)._", stage.Name)
+	for _, s := range e.cfg.Stages {
+		if s.Order <= stage.Order || s.Order >= doneOrder {
+			continue
+		}
+		skipLabel := fmt.Sprintf("stage:%s:complete", s.Name)
+		if err := e.client.AddLabelToIssue(owner, repo, item.Number, skipLabel); err != nil {
+			e.logf(item.Number, "warn", "could not add skip label for stage %q: %v\n", s.Name, err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), skipLabel)
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+skipLabel)
+			}
+		}
+		// Post the "skipped" comment — no rocket reaction, this is engine-generated metadata.
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, skippedComment); err != nil {
+			e.logf(item.Number, "warn", "could not post skipped comment for stage %q: %v\n", s.Name, err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: skippedComment, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+			}
+		}
+	}
+
+	if e.statusField == nil {
+		e.logf(item.Number, "warn", "status field metadata not available; cannot move to Done\n")
+		return
+	}
+
+	optionID, ok := e.statusField.Options["Done"]
+	if !ok {
+		e.logf(item.Number, "warn", "no status option %q found on project board (available: %v); cannot move to Done\n",
+			"Done", mapKeys(e.statusField.Options))
+		return
+	}
+
+	e.logf(item.Number, "advance", "moving no-work-needed issue to Done\n")
 	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
 		e.logf(item.Number, "warn", "could not move issue to Done: %v\n", err)
 	} else {

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -518,7 +518,9 @@ func (e *Engine) handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 	}
 
 	// Add dummy completion labels and "skipped" comments for all subsequent non-cleanup stages.
-	skippedComment := fmt.Sprintf("_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by %s)._", stage.Name)
+	// The comment body must start with the canonical "🏭 **Fabrik" prefix so findNewComments
+	// dedup prevents Fabrik from processing its own output on the next poll.
+	skippedComment := fmt.Sprintf("🏭 **Fabrik — skipped: no work needed**\n\n_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by %s)._", stage.Name)
 	for _, s := range e.cfg.Stages {
 		if s.Order <= stage.Order || s.Order >= doneOrder {
 			continue

--- a/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
@@ -169,6 +169,56 @@ Then:
 
 `FABRIK_DECOMPOSED` is mutually exclusive with `FABRIK_STAGE_COMPLETE` and `FABRIK_BLOCKED_ON_INPUT`. Output exactly one terminal marker. If you decompose, do not also signal completion.
 
+## No Work Needed
+
+When Research findings conclusively show that no code or documentation changes are required — the issue is already resolved, the filed problem doesn't exist in this codebase, or the change is provably moot (e.g., a docs audit for a pure-internal release with no user-visible changes) — Plan should short-circuit the pipeline rather than writing an implementation plan.
+
+### When to Use
+
+Emit `FABRIK_NO_WORK_NEEDED` when **all** of the following are true:
+
+1. Research found no code, test, or doc changes needed
+2. The issue is genuinely complete with no action required
+3. Creating a PR would fail (nothing to commit) or be misleading
+
+Do **not** use this marker if there is any uncertainty. If you're unsure whether work is needed, write a plan. Wrong emissions are reviewable post-hoc; a missed emission just causes a PR-creation failure downstream (the original problem this marker solves).
+
+### How to Signal No Work Needed
+
+In your plan output, enumerate clearly why no work is needed. Then emit **both** markers, each on its own line:
+
+```
+FABRIK_STAGE_COMPLETE
+FABRIK_NO_WORK_NEEDED
+```
+
+Both markers are required. `FABRIK_NO_WORK_NEEDED` alone has no effect — it requires `FABRIK_STAGE_COMPLETE` to co-occur. Order does not matter; both must appear somewhere in your output.
+
+The engine will:
+1. Mark this stage complete
+2. Add `stage:<name>:complete` labels for all subsequent non-cleanup stages
+3. Post a one-line "Skipped: no work needed" comment per skipped stage
+4. Move the issue directly to Done — **no PR is created**
+
+### What to Include in Output
+
+Before emitting the markers, write a short explanation of why no work is needed. Include:
+- What the Research stage found (or didn't find)
+- Why that means no code/doc change is required
+- Confirmation that the issue is complete as-is
+
+Example:
+
+> Research found that the `validateToken()` function already handles the described edge case as of commit abc123 (merged in #456). No code changes are needed. The issue was filed against behavior that no longer exists.
+
+### Mutual Exclusivity
+
+`FABRIK_NO_WORK_NEEDED` is mutually exclusive with `FABRIK_DECOMPOSED` and `FABRIK_BLOCKED_ON_INPUT`.
+- If the issue needs to be split: use `FABRIK_DECOMPOSED` (without `FABRIK_STAGE_COMPLETE`)
+- If you need user input: use `FABRIK_BLOCKED_ON_INPUT` (without `FABRIK_STAGE_COMPLETE`)
+- If no work is needed: use `FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED`
+- If work is needed: use `FABRIK_STAGE_COMPLETE` alone
+
 ## Interaction Pattern
 
 1. Read the spec and research findings thoroughly
@@ -188,7 +238,9 @@ Plans typically complete in a single pass. If the spec and research are solid, t
 
 **Decomposing an oversized issue**: If the issue is too broad for a single Implement cycle, output `FABRIK_DECOMPOSED` on its own line after creating the sub-issues (see the Decomposition section above). The engine adds `stage:Plan:complete` and moves the parent to Done. Sub-issues flow through the pipeline independently as a formation.
 
-These three markers are mutually exclusive — output exactly one.
+**No work needed**: If Research shows no code or doc changes are required, output both `FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED` (each on its own line). The engine skips all remaining pipeline stages and moves the issue to Done without creating a PR. See the No Work Needed section above.
+
+These four markers (`FABRIK_STAGE_COMPLETE`, `FABRIK_NO_WORK_NEEDED`, `FABRIK_DECOMPOSED`, `FABRIK_BLOCKED_ON_INPUT`) are mutually exclusive as terminal signals — output exactly one terminal outcome per invocation.
 
 **Do NOT update the issue body.** The issue body is the spec, owned by Specify. Your plan is posted as a stage comment by the engine automatically. Do not use `FABRIK_ISSUE_UPDATE` markers — they would overwrite the spec.
 


### PR DESCRIPTION
## Summary

Add a new engine marker `FABRIK_NO_WORK_NEEDED` that any stage (most usefully Plan) can emit to signal "this issue is complete; no code or doc changes are required." The engine detects the marker, marks the current stage complete normally, adds dummy `stage:X:complete` labels with "skipped: no work needed" comments for all subsequent non-cleanup stages, and moves the issue directly to Done — where the existing cleanup (worktree removal, label cleanup, issue close) runs as normal. No PR is created, since no commits exist on the branch.

## Problem

When the Plan stage correctly concludes that no implementation work is required — e.g., a verification-only docs audit on a pure-internal release, or a no-op issue that was filed against an already-resolved problem — the engine has no way to short-circuit. It blindly advances to Implement, which runs Claude, finds nothing to do, exits with no commits on the issue branch, and then `ensureDraftPR` fails with:

```
HTTP 422: Validation Failed — No commits between main and fabrik/issue-N
```

Three retries, escalate, pause. The issue is genuinely complete-with-no-action but the engine treats it as failed.

## Approach

### Approach

This is a well-scoped addition following the existing `FABRIK_DECOMPOSED` pattern precisely. The work proceeds in dependency order: add the marker and its detection helpers first, then the engine handler, then wire it into the dispatch chain, then tests, then skill guidance, then docs.

Two open questions from Research are resolved here:

**Rocket reactions on "skipped" comments**: No. Engine-generated metadata comments (`buildAwaitingInputComment`, `escalateFailedStage`) don't receive rocket reactions. These "skipped" comments are engine-generated metadata, not Claude output, so the same rule applies.

**`buildPrompt()` wording**: Add the following block after the `FABRIK_BLOCKED_ON_INPUT` paragraph (non-skill stages only, same block):
```
If your stage determines that no code or documentation changes are required — the issue
is already resolved or the work is genuinely moot — you may signal this by emitting:
FABRIK_NO_WORK_NEEDED
This marker MUST co-occur with FABRIK_STAGE_COMPLETE on its own line. The engine will
mark all remaining pipeline stages complete (with "skipped" comments) and move the issue
directly to Done without creating a PR. It is mutually exclusive with FABRIK_BLOCKED_ON_INPUT.
```

**ADR number**: 045. The highest current ADR is `044-probe-driven-poll-loop.md`. Implement should verify at creation time in case a concurrent issue creates 045 first — if so, use 046.

**Strip location**: `FABRIK_NO_WORK_NEEDED` must be stripped in both `engine/item.go` (lines 865–869) and `engine/comments.go` (lines 266–270). These are two separate strip blocks and both must be updated.

**`handleNoWorkNeeded` placement**: `engine/stages.go`, immediately after `handleDecomposed`, following the same file-organization convention.

**`doneOrder` fallback**: If no `CleanupWorktree` stage exists, set `doneOrder = math.MaxInt`. All stages after current are then iterated — correct behavior, as they are all "non-cleanup."

### New/Modified Files

| File | Change |
|------|--------|
| `engine/claude.go` | Add `noWorkNeededRE`, `CheckNoWorkNeeded()`, update `buildPrompt()` with marker description |
| `engine/item.go` | Add `noWorkNeeded` variable at ~line 990; add `completed && noWorkNeeded` dispatch branch before `completed`; add `stripLine` for `FABRIK_NO_WORK_NEEDED` at lines 865–869 |
| `engine/comments.go` | Add `stripLine` for `FABRIK_NO_WORK_NEEDED` at lines 266–270 |
| `engine/stages.go` | Add `handleNoWorkNeeded()` after `handleDecomposed` |
| `engine/no_work_needed_test.go` | New file: unit tests for `CheckNoWorkNeeded` + integration tests for `handleNoWorkNeeded` |
| `plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md` | Add "No Work Needed" section; update mutual-exclusivity note from three to four markers |
| `docs/state-machine.md` | Add `FABRIK_NO_WORK_NEEDED` to Section 2.6 marker chain; add state-transition row in Section 3; update strip-line table in stage-lifecycle section |
| `docs/llms-full.txt` | Regenerate after `docs/state-machine.md` update |
| `adrs/045-no-work-needed-marker.md` | New ADR explaining why this marker differs from `FABRIK_DECOMPOSED` |

### Key Decisions

- **`completed && noWorkNeeded` before plain `completed` in dispatch chain.** The `completed` branch calls `ensureDraftPR` and `markPRReady`, which must not run when there are no commits. Placing the combined check first gives it priority without restructuring the chain.

- **Both markers required (`FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED`).** This is enforced structurally: `noWorkNeeded` is only checked in the `completed && noWorkNeeded` branch, and `completed` already requires `FABRIK_STAGE_COMPLETE`. No additional runtime guard needed. This also means the timeout/kill recovery path (which checks `FABRIK_STAGE_COMPLETE` on partial output) doesn't inadvertently trigger the no-work path — correct behavior.

- **`handleNoWorkNeeded` in `engine/stages.go`.** Mirrors `handleDecomposed` placement. The function is ~40 lines and needs the full `Engine` receiver for `client`, `readClient`, `statusField`, `cfg`, `webhookMgr`, and `logf` — all of which are available in that file's existing functions.

- **No rocket reactions on skipped-stage comments.** These are engine-generated metadata, not Claude output. Consistent with `escalateFailedStage`, `buildAwaitingInputComment`, and other engine notification comments.

- **ADR 045 is warranted.** Future contributors need to understand: (a) why `FABRIK_NO_WORK_NEEDED` requires `FABRIK_STAGE_COMPLETE` co-occurrence when `FABRIK_DECOMPOSED` does not; (b) why it adds dummy completion labels when `FABRIK_DECOMPOSED` does not; (c) the mutual-exclusivity semantics. ADR-017 (`017-decomposed-marker-state-machine.md`) is the direct precedent.

### Task Checklist

- [x] Task 1: Add `noWorkNeededRE` regex and `CheckNoWorkNeeded()` function in `engine/claude.go` (after `decomposedRE` and `CheckDecomposed()`, matching the same pattern)
- [x] Task 2: Add `stripLine(postOutput, "FABRIK_NO_WORK_NEEDED")` in `engine/item.go` (lines 865–869 block) and `engine/comments.go` (lines 266–270 block)
- [x] Task 3: Update `buildPrompt()` in `engine/claude.go` to describe `FABRIK_NO_WORK_NEEDED` — insert the wording block after the `FABRIK_BLOCKED_ON_INPUT` paragraph; also update the mutual-exclusivity line from "These two markers are mutually exclusive" to "These three markers are mutually exclusive"
- [x] Task 4: Implement `handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage)` in `engine/stages.go` immediately after `handleDecomposed`; the function must: (a) log entry, (b) add `stage:<current>:complete` label with cache write-through, (c) find `doneOrder` by iterating `e.cfg.Stages` for `CleanupWorktree == true` (fallback `math.MaxInt`), (d) for each stage with `Order > current.Order && Order < doneOrder`: add `stage:<name>:complete` label and post comment `_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by <stage>)._` — both with full cache write-through, (e) move issue to Done via `UpdateProjectItemStatus` with same nil/ok guards as `handleDecomposed`
- [x] Task 5: Wire the dispatch branch in `engine/item.go` — add `noWorkNeeded := err == nil && CheckNoWorkNeeded(output)` alongside `decomposed` at ~line 990; add `completed && noWorkNeeded` branch before the `completed` branch (call `releaseLock()`, `store.Apply(StageRetryCleared)`, `store.Apply(EngineUnpaused)`, `handleNoWorkNeeded(...)`)
- [x] Task 6: Add unit tests in `engine/no_work_needed_test.go` for `CheckNoWorkNeeded` — mirror `TestCheckDecomposed`'s 8 cases (own line, last line no newline, CRLF, followed by more lines, not present, embedded in sentence, in backticks, partial match); add `TestHandleNoWorkNeeded_MovesToDone`, `TestHandleNoWorkNeeded_NilStatusField`, `TestHandleNoWorkNeeded_NoDoneOption`, `TestHandleNoWorkNeeded_SkipsIntermediateStages` (verifies dummy labels + comments for each skipped stage)
- [x] Task 7: Run `go test -race ./...` and `go vet ./...` to verify all tests pass
- [x] Task 8: Update `plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md` — add a "No Work Needed" section parallel to the Decomposition section with: when to emit, what to include in output (enumerate why no work needed), the exact two-marker requirement, and update the mutual-exclusivity note from three to four markers
- [x] Task 9: Update `docs/state-machine.md` Section 2.6 to add `FABRIK_NO_WORK_NEEDED` to the marker chain (position: `completed && noWorkNeeded` — highest priority among the `completed == true` paths, before plain `completed`); add a state-transition row; update the strip-line table (Section on stage lifecycle output handling) to include `FABRIK_NO_WORK_NEEDED`; document the engine's response (loop over stages, add dummy labels, post "skipped" comments, move to Done, no PR)
- [x] Task 10: Regenerate `docs/llms-full.txt` by running `bash scripts/generate-llms-full.sh` and staging the output
- [x] Task 11: Create `adrs/045-no-work-needed-marker.md` (verify at creation time that 044 is still highest; use 046 if 045 was taken by a concurrent issue) — document: context (PR 422 failure when no commits), decision (new marker requiring `FABRIK_STAGE_COMPLETE` co-occurrence), contrast with `FABRIK_DECOMPOSED` (no dummy labels vs. dummy labels, standalone vs. co-occurrence), consequences (audit trail per skipped stage, pipeline short-circuit without PR)
- [x] Task 12: Commit all changes on `fabrik/issue-733` with a descriptive message

### Risks

- **Loop correctness in `handleNoWorkNeeded`**: The loop adds labels and posts comments for every non-cleanup stage after the emitting stage. A missing cache write-through for any loop iteration causes stale state. The `handleDecomposed` template is clean for the single-label case; the loop extends it. Tests in Task 6 (`TestHandleNoWorkNeeded_SkipsIntermediateStages`) must verify all label/comment calls for multi-stage configurations.

- **ADR number collision**: If a parallel issue creates `adrs/045-*.md` between Plan and Implement, the number must be bumped to 046. Implement should check `ls adrs/ | sort | tail -1` before creating the ADR file.

- **`engine/comments.go` strip block**: Two separate strip blocks exist (one in `item.go`, one in `comments.go`). Missing the `comments.go` strip means the marker leaks into comment-review output posted to GitHub. Both must be updated in Task 2.

---
Used 13/50 turns, 7k input / 4k output tokens.

## Verification

Implemented `FABRIK_NO_WORK_NEEDED` end-to-end: added the regex/detection function to `engine/claude.go`, a `handleNoWorkNeeded()` handler in `engine/stages.go` that marks the emitting stage complete, adds dummy `stage:<name>:complete` labels with "skipped" comments for all subsequent non-cleanup stages, and moves the issue directly to Done without creating a PR. Wired the `completed && noWorkNeeded` dispatch branch in `processItem()` ahead of the plain `completed` branch, updated strip blocks in both `item.go` and `comments.go`, and updated `buildPrompt()`. Added 5 unit/integration tests, updated `fabrik-plan/SKILL.md` with a "No Work Needed" section, documented the marker in `docs/state-machine.md` (Section 2.6, Section 6.7, strip table, label table), regenerated `docs/llms-full.txt`, and added ADR 045.

---

Closes #733