### PR TITLE
Update docs for v0.0.61

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -771,12 +771,13 @@ if you're not actively watching the issue.
 ### No-Work Short-Circuit
 
 A stage can signal that all remaining pipeline work can be skipped by outputting both
-`FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED`. This is the short-circuit path for
-issues where Research conclusively shows that no code, test, or documentation changes are
-needed.
+`FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED`, each on its own standalone line. This
+is the short-circuit path for issues where Research conclusively shows that no code, test,
+or documentation changes are needed.
 
-**`FABRIK_NO_WORK_NEEDED` alone has no effect.** Both markers must co-occur in the same
-stage output. The emitting stage must declare itself complete before the bypass fires.
+**`FABRIK_NO_WORK_NEEDED` alone has no effect.** Both markers must appear as standalone
+lines in the same stage output — the engine matches each token exactly (the line must
+contain only the marker and nothing else).
 
 When both markers are present, the engine:
 1. Marks the emitting stage complete

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -768,6 +768,34 @@ if you're not actively watching the issue.
 > flag ([#671](https://github.com/handarbeit/fabrik/issues/671)) will make this separation
 > easier once implemented.
 
+### No-Work Short-Circuit
+
+A stage can signal that all remaining pipeline work can be skipped by outputting both
+`FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED`. This is the short-circuit path for
+issues where Research conclusively shows that no code, test, or documentation changes are
+needed.
+
+**`FABRIK_NO_WORK_NEEDED` alone has no effect.** Both markers must co-occur in the same
+stage output. The emitting stage must declare itself complete before the bypass fires.
+
+When both markers are present, the engine:
+1. Marks the emitting stage complete
+2. Adds `stage:<name>:complete` labels for all subsequent non-cleanup stages (audit trail)
+3. Posts a one-line `_Skipped: no work needed_` comment per skipped stage
+4. Moves the issue directly to Done — **no PR is created**
+
+The primary use case is the **Plan stage**: after Research finds the issue is already
+resolved or that no changes are required, Plan emits both markers instead of writing an
+implementation plan. This avoids the HTTP 422 failure that would occur when Implement tried
+to create a PR from a branch with nothing to commit.
+
+Any stage can emit `FABRIK_NO_WORK_NEEDED`, not just Plan. Skill authors should only use it
+when they are **certain** no downstream work is needed.
+
+**Mutual exclusivity:** `FABRIK_NO_WORK_NEEDED` cannot be combined with `FABRIK_DECOMPOSED`
+or `FABRIK_BLOCKED_ON_INPUT`. If the issue needs to be split, use `FABRIK_DECOMPOSED`. If
+a question needs answering first, use `FABRIK_BLOCKED_ON_INPUT`.
+
 ### Dependency-Based Sequencing (Formations)
 
 Fabrik supports dependency-based sequencing of issues using GitHub's native "Blocked by" relationships. This enables **formations** — coordinated sets of issues that execute in parallel where possible and respect ordering constraints automatically.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -766,6 +766,34 @@ if you're not actively watching the issue.
 > flag ([#671](https://github.com/handarbeit/fabrik/issues/671)) will make this separation
 > easier once implemented.
 
+### No-Work Short-Circuit
+
+A stage can signal that all remaining pipeline work can be skipped by outputting both
+`FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED`. This is the short-circuit path for
+issues where Research conclusively shows that no code, test, or documentation changes are
+needed.
+
+**`FABRIK_NO_WORK_NEEDED` alone has no effect.** Both markers must co-occur in the same
+stage output. The emitting stage must declare itself complete before the bypass fires.
+
+When both markers are present, the engine:
+1. Marks the emitting stage complete
+2. Adds `stage:<name>:complete` labels for all subsequent non-cleanup stages (audit trail)
+3. Posts a one-line `_Skipped: no work needed_` comment per skipped stage
+4. Moves the issue directly to Done — **no PR is created**
+
+The primary use case is the **Plan stage**: after Research finds the issue is already
+resolved or that no changes are required, Plan emits both markers instead of writing an
+implementation plan. This avoids the HTTP 422 failure that would occur when Implement tried
+to create a PR from a branch with nothing to commit.
+
+Any stage can emit `FABRIK_NO_WORK_NEEDED`, not just Plan. Skill authors should only use it
+when they are **certain** no downstream work is needed.
+
+**Mutual exclusivity:** `FABRIK_NO_WORK_NEEDED` cannot be combined with `FABRIK_DECOMPOSED`
+or `FABRIK_BLOCKED_ON_INPUT`. If the issue needs to be split, use `FABRIK_DECOMPOSED`. If
+a question needs answering first, use `FABRIK_BLOCKED_ON_INPUT`.
+
 ### Dependency-Based Sequencing (Formations)
 
 Fabrik supports dependency-based sequencing of issues using GitHub's native "Blocked by" relationships. This enables **formations** — coordinated sets of issues that execute in parallel where possible and respect ordering constraints automatically.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -769,12 +769,13 @@ if you're not actively watching the issue.
 ### No-Work Short-Circuit
 
 A stage can signal that all remaining pipeline work can be skipped by outputting both
-`FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED`. This is the short-circuit path for
-issues where Research conclusively shows that no code, test, or documentation changes are
-needed.
+`FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED`, each on its own standalone line. This
+is the short-circuit path for issues where Research conclusively shows that no code, test,
+or documentation changes are needed.
 
-**`FABRIK_NO_WORK_NEEDED` alone has no effect.** Both markers must co-occur in the same
-stage output. The emitting stage must declare itself complete before the bypass fires.
+**`FABRIK_NO_WORK_NEEDED` alone has no effect.** Both markers must appear as standalone
+lines in the same stage output — the engine matches each token exactly (the line must
+contain only the marker and nothing else).
 
 When both markers are present, the engine:
 1. Marks the emitting stage complete


### PR DESCRIPTION
## Summary

Add a new subsection to USER_GUIDE.md §3 (Workflow Patterns), immediately following "Stages Waiting for Input", documenting the `FABRIK_NO_WORK_NEEDED` marker. The subsection should explain: what it does, the co-occurrence requirement with `FABRIK_STAGE_COMPLETE`, what the engine does when it fires (skips remaining non-cleanup stages, posts "skipped" comments, moves to Done without creating a PR), and when skill authors should use it.

## Problem

`USER_GUIDE.md` does not document the `FABRIK_NO_WORK_NEEDED` marker introduced in v0.0.61 (#733). Users and skill authors who read the guide to understand how Fabrik markers work will find `FABRIK_STAGE_COMPLETE` and `FABRIK_BLOCKED_ON_INPUT` explained, but have no guidance on when or how to use the short-circuit marker. This gap means:

- Skill authors (especially custom Plan skill writers) don't know the marker exists or how to trigger it.
- Operators debugging a "skipped" issue won't find an explanation in the guide.
- The guide's coverage of Fabrik markers is incomplete relative to what the engine actually supports.

## Approach

### Approach

This is a pure documentation change. The research findings identified the exact insertion point (after line 770 in `docs/USER_GUIDE.md`, before `### Dependency-Based Sequencing (Formations)`) and the exact content sources (`docs/state-machine.md` §6.7, `adrs/045-no-work-needed-marker.md`, `plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md`). No design decisions are required — follow the `FABRIK_BLOCKED_ON_INPUT` subsection's structure (trigger, what happens, when to use it) and source all behavioral facts from `state-machine.md`.

The subsection title `### No-Work Short-Circuit` is specified in the issue requirements and matches the existing heading style in §3.

After the `USER_GUIDE.md` edit, `docs/llms-full.txt` must be regenerated via `bash scripts/generate-llms-full.sh` and committed in the same change set to pass the CI `docs-drift` check.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Add `### No-Work Short-Circuit` subsection (~25–30 lines) after line 770, before `### Dependency-Based Sequencing (Formations)` |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **Subsection title `### No-Work Short-Circuit`**: Specified in the issue requirements; matches the heading style of adjacent subsections in §3.
- **Insertion point after "Stages Waiting for Input"**: Fixed by Research — both markers are in the "what a stage can signal" family, so they belong together before the unrelated "Dependency-Based Sequencing" subsection.
- **Content sourced from `state-machine.md` §6.7 and `fabrik-plan/SKILL.md`**: The state-machine doc is the authoritative as-built spec; the SKILL.md has the canonical "when to use" guidance. No new behavioral facts are invented.
- **No ADR warranted**: This change adds a new document subsection with no architectural decisions — the design is already captured in ADR-045.

### Task Checklist

- [ ] Task 1: Read `docs/USER_GUIDE.md` lines 739–780, `docs/state-machine.md` §6.7, and `plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md` lines 173–220 to confirm content and insertion point before editing.
- [ ] Task 2: Insert `### No-Work Short-Circuit` subsection into `docs/USER_GUIDE.md` immediately after line 770 (after the `> **Note:**` blockquote, before `### Dependency-Based Sequencing (Formations)`). The subsection must cover:
  - `FABRIK_NO_WORK_NEEDED` must co-occur with `FABRIK_STAGE_COMPLETE`; alone it has no effect.
  - Engine behavior: marks all subsequent non-cleanup stages `:complete`, posts one "skipped: no work needed" comment per stage, moves issue to Done, does not create a PR.
  - Primary use case: Plan stage after Research finds no code/doc changes needed.
  - Any stage may emit it, but only when the author is certain no downstream work is needed.
  - Mutual exclusivity: cannot be combined with `FABRIK_DECOMPOSED` or `FABRIK_BLOCKED_ON_INPUT`.
- [ ] Task 3: Run `bash scripts/generate-llms-full.sh` and verify it completes without error.
- [ ] Task 4: Commit `docs/USER_GUIDE.md` and `docs/llms-full.txt` together in a single commit on the issue branch with a message such as `docs: document FABRIK_NO_WORK_NEEDED marker in USER_GUIDE §3`.

### Risks

- **CI `docs-drift` failure**: `docs/llms-full.txt` must be regenerated and committed in the same change set as `USER_GUIDE.md`. Tasks 3 and 4 are sequentially dependent — the regen must complete before the commit. Mitigation: tasks are ordered accordingly; do not split them across separate commits.
- **No other risks**: additive documentation change with no code impact.

---
Used 7/50 turns, 3k input / 1k output tokens.

## Verification

Added a `### No-Work Short-Circuit` subsection to `docs/USER_GUIDE.md` §3 Workflow Patterns (after "Stages Waiting for Input"), documenting the `FABRIK_NO_WORK_NEEDED` marker — its co-occurrence requirement with `FABRIK_STAGE_COMPLETE`, engine behavior (skipped labels and comments, Done without PR), primary Plan-stage use case, and mutual exclusivity with `FABRIK_DECOMPOSED` / `FABRIK_BLOCKED_ON_INPUT`. Regenerated `docs/llms-full.txt` in the same commit to pass CI drift check.

---

Closes #736