### PR TITLE
fabrik: 'Closes #N' at PR body bottom can be hidden by indented-vs-unindented code fence mismatch; move to top of body

### DIFF
--- a/engine/markdown.go
+++ b/engine/markdown.go
@@ -50,24 +50,37 @@ func firstParagraph(content string) string {
 }
 
 // balanceFences scans body for fence delimiter lines (any line whose trimmed content starts
-// with ``` or ~~~, including language hints such as ```bash) and toggles a parity bit for
-// each. If the final parity is odd (unclosed fence), a closing ``` line is inserted
+// with ``` or ~~~, including language hints such as ```bash) using an indentation-aware
+// state machine. A closer is valid only when its leading-space count is >= the opener's.
+// An unindented closer (column 0) against an indented opener (column >= 1) is treated as
+// content inside the fence, matching CommonMark §4.5 semantics. If the final state is an
+// unclosed fence, a synthetic ``` closer (indented to match the opener) is inserted
 // immediately before the last "---" line (the separator before Closes #N). If no "---" is
 // present, it inserts before the first "Closes #" line. If neither is present, it appends
 // at the end. This ensures that interpolated content with unclosed fences cannot hide
 // trailing lines from GitHub's parser.
 func balanceFences(body string) string {
 	lines := strings.Split(body, "\n")
-	odd := false
+	var fenceActive bool
+	var fenceIndent int
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			odd = !odd
+			indent := len(line) - len(strings.TrimLeft(line, " "))
+			if !fenceActive {
+				fenceActive = true
+				fenceIndent = indent
+			} else if indent >= fenceIndent {
+				fenceActive = false
+			}
+			// else: closer is less-indented than opener → content inside fence, ignore
 		}
 	}
-	if !odd {
+	if !fenceActive {
 		return body
 	}
+	// Synthetic closer matches the opener's indentation; always uses backticks.
+	syntheticCloser := strings.Repeat(" ", fenceIndent) + "```"
 	// Insert closing fence before the last "---" line (the separator before Closes #N).
 	// Using the last "---" rather than the first prevents inserting before an unclosed fence
 	// opener when earlier "---" dividers appear in manually-edited PR bodies.
@@ -88,11 +101,11 @@ func balanceFences(body string) string {
 	}
 	if insertIdx < 0 {
 		// Fallback: append at end.
-		return body + "\n```"
+		return body + "\n" + syntheticCloser
 	}
 	newLines := make([]string, 0, len(lines)+1)
 	newLines = append(newLines, lines[:insertIdx]...)
-	newLines = append(newLines, "```")
+	newLines = append(newLines, syntheticCloser)
 	newLines = append(newLines, lines[insertIdx:]...)
 	return strings.Join(newLines, "\n")
 }

--- a/engine/markdown.go
+++ b/engine/markdown.go
@@ -145,7 +145,9 @@ func buildPRSeedBody(issueContent, planContent string, issueNumber int) string {
 		approach = "(Populated by Implement)"
 	}
 
-	body := fmt.Sprintf(`## Summary
+	body := fmt.Sprintf(`Closes #%d
+
+## Summary
 
 %s
 
@@ -163,7 +165,7 @@ func buildPRSeedBody(issueContent, planContent string, issueNumber int) string {
 
 ---
 
-Closes #%d`, summary, problem, approach, issueNumber)
+Closes #%d`, issueNumber, summary, problem, approach, issueNumber)
 	return balanceFences(body)
 }
 

--- a/engine/markdown.go
+++ b/engine/markdown.go
@@ -56,9 +56,10 @@ func firstParagraph(content string) string {
 // content inside the fence, matching CommonMark §4.5 semantics. If the final state is an
 // unclosed fence, a synthetic ``` closer (indented to match the opener) is inserted
 // immediately before the last "---" line (the separator before Closes #N). If no "---" is
-// present, it inserts before the first "Closes #" line. If neither is present, it appends
-// at the end. This ensures that interpolated content with unclosed fences cannot hide
-// trailing lines from GitHub's parser.
+// present, it inserts before the last "Closes #" line (using the last occurrence avoids
+// placing the synthetic closer before a top-of-body "Closes #N" header). If neither is
+// present, it appends at the end. This ensures that interpolated content with unclosed
+// fences cannot hide trailing lines from GitHub's parser.
 func balanceFences(body string) string {
 	lines := strings.Split(body, "\n")
 	var fenceActive bool
@@ -91,11 +92,11 @@ func balanceFences(body string) string {
 		}
 	}
 	if insertIdx < 0 {
-		// Fallback: before first "Closes #" line.
+		// Fallback: before last "Closes #" line. Using the last occurrence avoids inserting
+		// before a top-of-body "Closes #N" header (which would create a new fence opener).
 		for i, line := range lines {
 			if strings.HasPrefix(strings.TrimSpace(line), "Closes #") {
 				insertIdx = i
-				break
 			}
 		}
 	}
@@ -113,7 +114,9 @@ func balanceFences(body string) string {
 // buildPRSeedBody constructs the structured PR body template from issue and plan context.
 // issueContent is the contents of .fabrik-context/issue.md.
 // planContent is the contents of .fabrik-context/stage-Plan.md (may be empty if missing).
-// issueNumber is used to add the closing reference at the bottom.
+// issueNumber is used for both the top-of-body "Closes #N" (before ## Summary, ensuring
+// GitHub's link extractor sees it regardless of code fence issues in the body) and the
+// redundant footer "Closes #N" (after ---, for defense-in-depth).
 func buildPRSeedBody(issueContent, planContent string, issueNumber int) string {
 	// Extract Summary from issue; fall back to first paragraph
 	summary := extractMarkdownSection(issueContent, "Summary")

--- a/engine/markdown_test.go
+++ b/engine/markdown_test.go
@@ -130,6 +130,9 @@ PR bodies were bare.
 	if !strings.Contains(body, "Closes #42") {
 		t.Error("body missing Closes #42")
 	}
+	if !strings.HasPrefix(strings.TrimSpace(body), "Closes #42") {
+		t.Errorf("Closes #42 must be at the top")
+	}
 	if !strings.HasSuffix(strings.TrimSpace(body), "Closes #42") {
 		t.Errorf("Closes #42 must be at the end, got: %q", body[len(body)-30:])
 	}
@@ -144,6 +147,9 @@ Brief summary.
 
 	if !strings.Contains(body, "(Populated by Implement)") {
 		t.Error("body should contain Approach placeholder when plan is missing")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(body), "Closes #7") {
+		t.Errorf("Closes #7 must be at the top")
 	}
 	if !strings.HasSuffix(strings.TrimSpace(body), "Closes #7") {
 		t.Errorf("Closes #7 must be at the end")
@@ -179,6 +185,9 @@ func TestBuildPRSeedBody_PlanWithPlanHeading(t *testing.T) {
 func TestBuildPRSeedBody_ClosesAtEnd(t *testing.T) {
 	body := buildPRSeedBody("## Summary\n\nS.\n## Problem\n\nP.\n", "## Approach\n\nA.\n", 99)
 	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "Closes #99") {
+		t.Errorf("Closes #99 must be at top")
+	}
 	if !strings.HasSuffix(trimmed, "Closes #99") {
 		t.Errorf("Closes #99 must be at end, body tail: %q", trimmed[max(0, len(trimmed)-50):])
 	}
@@ -434,6 +443,9 @@ func TestBuildPRSeedBody_UnclosedBacktickInPlan(t *testing.T) {
 	planContent := "## Approach\n\nSee below:\n\n```\nsome example that was never closed\n"
 	body := buildPRSeedBody("## Summary\n\nS.\n", planContent, 10)
 	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "Closes #10") {
+		t.Errorf("Closes #10 must be at top")
+	}
 	if !strings.HasSuffix(trimmed, "Closes #10") {
 		t.Errorf("Closes #10 must be at end, got tail: %q", trimmed[max(0, len(trimmed)-60):])
 	}
@@ -443,6 +455,9 @@ func TestBuildPRSeedBody_UnclosedTildeInPlan(t *testing.T) {
 	planContent := "## Approach\n\nSee below:\n\n~~~\nsome example that was never closed\n"
 	body := buildPRSeedBody("## Summary\n\nS.\n", planContent, 11)
 	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "Closes #11") {
+		t.Errorf("Closes #11 must be at top")
+	}
 	if !strings.HasSuffix(trimmed, "Closes #11") {
 		t.Errorf("Closes #11 must be at end, got tail: %q", trimmed[max(0, len(trimmed)-60):])
 	}
@@ -452,6 +467,9 @@ func TestBuildPRSeedBody_UnclosedHintedFenceInPlan(t *testing.T) {
 	planContent := "## Approach\n\nSee below:\n\n```yaml\nfoo: bar\n"
 	body := buildPRSeedBody("## Summary\n\nS.\n", planContent, 12)
 	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "Closes #12") {
+		t.Errorf("Closes #12 must be at top")
+	}
 	if !strings.HasSuffix(trimmed, "Closes #12") {
 		t.Errorf("Closes #12 must be at end, got tail: %q", trimmed[max(0, len(trimmed)-60):])
 	}
@@ -461,6 +479,9 @@ func TestBuildPRSeedBody_BalancedFencesInPlan(t *testing.T) {
 	planContent := "## Approach\n\nSee below:\n\n```bash\necho hi\n```\n\nDone.\n"
 	body := buildPRSeedBody("## Summary\n\nS.\n", planContent, 13)
 	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(trimmed, "Closes #13") {
+		t.Errorf("Closes #13 must be at top")
+	}
 	if !strings.HasSuffix(trimmed, "Closes #13") {
 		t.Errorf("Closes #13 must be at end, got tail: %q", trimmed[max(0, len(trimmed)-60):])
 	}

--- a/engine/markdown_test.go
+++ b/engine/markdown_test.go
@@ -387,6 +387,31 @@ func TestBalanceFences_NoSeparatorNoClosesLine_AppendsAtEnd(t *testing.T) {
 	}
 }
 
+func TestBalanceFences_IndentedOpenerUnindentedCloser(t *testing.T) {
+	// Mirrors PR #187 body shape: list item with indented fence opener at column 2,
+	// followed by an unindented "closer" at column 0, then --- and Closes #184.
+	// GitHub's CommonMark parser treats the column-0 line as content inside the indented
+	// fence, so Closes #184 is absorbed into the code block unless we fix it.
+	body := "- [ ] **Task 2**: implement stuff. When non-empty:\n  ```\nsome code\n\n```\n\n---\n\nCloses #184"
+	result := balanceFences(body)
+
+	if result == body {
+		t.Error("expected balanceFences to modify the body (insert synthetic closer)")
+	}
+	// Synthetic closer must be indented to match the opener (2 spaces) and appear before ---
+	if !strings.Contains(result, "  ```\n---") {
+		t.Errorf("indented synthetic closer must appear before ---, got: %q", result)
+	}
+	// Closes #184 must be present outside any code fence context (after the last fence delimiter)
+	lastFence := strings.LastIndex(result, "```")
+	if lastFence < 0 {
+		t.Fatal("no fence delimiter found in result")
+	}
+	if !strings.Contains(result[lastFence:], "Closes #184") {
+		t.Errorf("Closes #184 must appear after the last fence delimiter, got tail: %q", result[lastFence:])
+	}
+}
+
 func TestBalanceFences_MultipleSeparators_UsesLastOne(t *testing.T) {
 	// A manually-edited PR body may have an earlier --- that appears before the unclosed
 	// fence opener. The closer must go before the LAST --- (the one preceding Closes #N),

--- a/engine/markdown_test.go
+++ b/engine/markdown_test.go
@@ -419,6 +419,26 @@ func TestBalanceFences_NoSeparatorNoClosesLine_AppendsAtEnd(t *testing.T) {
 	}
 }
 
+func TestBalanceFences_NoSeparatorTopAndFooterClosesN(t *testing.T) {
+	// Regression: when the body has both a top-of-body "Closes #N" (as produced by
+	// buildPRSeedBody) and a footer "Closes #N" but no "---" separator, the synthetic
+	// closer must be inserted before the LAST "Closes #" line (the footer), not the first
+	// (which would place a fence delimiter at the top of the body and be parsed as a new
+	// fence opener by GitHub).
+	body := "Closes #42\n\nSome text\n\n```\nunclosed code\n\nCloses #42"
+	result := balanceFences(body)
+	// Synthetic closer must appear before the footer Closes #42, not the top-of-body one.
+	if strings.HasPrefix(strings.TrimSpace(result), "```") {
+		t.Errorf("synthetic closer must not be inserted before top-of-body Closes #42, got: %q", result)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(result), "Closes #42") {
+		t.Errorf("top-of-body Closes #42 must remain first, got: %q", result)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(result), "Closes #42") {
+		t.Errorf("footer Closes #42 must remain at end, got: %q", result)
+	}
+}
+
 func TestBalanceFences_IndentedOpenerUnindentedCloser(t *testing.T) {
 	// Mirrors PR #187 body shape: list item with indented fence opener at column 2,
 	// followed by an unindented "closer" at column 0, then --- and Closes #184.

--- a/engine/markdown_test.go
+++ b/engine/markdown_test.go
@@ -312,6 +312,29 @@ func TestReplaceVerificationSection_CaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestReplaceVerificationSection_PreservesTopOfBodyClosesN(t *testing.T) {
+	// Regression test: the top-of-body Closes #42 (R1) must not be consumed by
+	// replaceVerificationSection's forward scan, which starts after ## Verification.
+	prBody := "Closes #42\n\n## Summary\n\nSome summary.\n\n## Verification\n\n(Populated by Implement on completion)\n\n---\n\nCloses #42"
+
+	updated, ok := replaceVerificationSection(prBody, "All green.")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(updated), "Closes #42") {
+		t.Errorf("top-of-body Closes #42 must be preserved")
+	}
+	if !strings.HasSuffix(strings.TrimSpace(updated), "Closes #42") {
+		t.Errorf("bottom Closes #42 must be preserved")
+	}
+	if strings.Contains(updated, "(Populated by Implement on completion)") {
+		t.Error("placeholder should have been replaced")
+	}
+	if !strings.Contains(updated, "All green.") {
+		t.Error("new verification content must be present")
+	}
+}
+
 func TestReplaceVerificationSection_UnclosedFenceInSummary(t *testing.T) {
 	prBody := "## Verification\n\n(placeholder)\n\n---\n\nCloses #3"
 	// summary contains an unclosed fence — would hide --- and Closes #3


### PR DESCRIPTION
## Summary

Two complementary fixes to `engine/markdown.go`:

1. **Primary**: Move `Closes #N` to the top of the PR seed body (immediately before `## Summary`). A top-of-body position is structurally impossible to absorb into any later code fence. The bottom `Closes #N` is retained as a redundant footer for defense-in-depth and backward compatibility.

2. **Secondary** (defense in depth): Make `balanceFences` indentation-aware so it treats an indented-opener + unindented-closer pair as unmatched and inserts a synthetic closer before the `---` separator, preventing the PR #187 body shape from silently absorbing trailing content.

## Problem

When the Implement stage produces a PR body containing an indented-opening + unindented-closing code fence pair (typical inside a Markdown list-item with a nested code example), GitHub's closing-keyword parser fails to recognize the trailing `Closes #N` line. The PR ends up linked to no issue, causing the linkage gate to stay open forever.

`balanceFences()` in `engine/markdown.go` counts fences correctly but doesn't understand fence context. The body has an EVEN fence count (one indented opener at column 2, one unindented closer at column 0), so `balanceFences` inserts no closing fence. But GitHub's Markdown parser treats the mismatched-indent pair as un-paired and absorbs everything from the indented opener through end-of-body into a code block. The trailing `Closes #N` becomes "code" and is invisible to the link extractor.

Symptom is repeating — operator has hit this more than once on fantasy. Pre-v0.0.59 it was masked because Implement silently advanced; post-v0.0.59 the engine completes Implement and Review but the linkage gate stays open forever.

## Approach

### Approach

All changes are confined to `engine/markdown.go` and `engine/markdown_test.go` (R6). Two complementary fixes:

1. **Primary (R1)** — `buildPRSeedBody` template: add `Closes #N` as the first non-blank line, before `## Summary`. Retain the existing `Closes #N` after `---`. Top-of-body position is structurally unreachable by any later code fence, making it the most robust anchor for GitHub's link extractor.

2. **Secondary (R3)** — `balanceFences` indentation-aware state machine: replace the parity-toggle with single-fence tracking (indent level of opener). A fence "closes" only if the closer's leading-space count ≥ opener's leading-space count. An unindented closer (column 0) against an indented opener (column ≥ 1) is treated as content inside the fence, not a valid close. The synthetic closer uses the opener's indent prefix plus backticks (retaining the existing behavior of always using backticks regardless of opener character, since `TestBalanceFences_UnclosedTilde` asserts this).

The `replaceVerificationSection` and `ensurePRLinksIssue` callsites in `pr.go` benefit automatically from both fixes — no changes to `pr.go` required.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/markdown.go` | Refactor `balanceFences` (indentation-aware); update `buildPRSeedBody` template |
| `engine/markdown_test.go` | Add R4 regression test; add R2 `replaceVerificationSection` test; update R5 `HasSuffix` tests to also assert `HasPrefix` |

### Key Decisions

- **Always emit backtick as synthetic closer, regardless of opener character**: Preserves `TestBalanceFences_UnclosedTilde` (asserts `\`\`\`\n---` even for `~~~` opener). Consistent with existing behavior; tilde-opened fences in PR bodies are vanishingly rare.

- **Synthetic closer uses opener's indentation**: For PR #187 shape (column-2 opener), inserts `  \`\`\`` before `---`. For existing column-0 cases, inserts `` ``` `` — unchanged behavior.

- **Single-fence state machine (no nesting)**: Markdown fences cannot nest per CommonMark spec §4.5. Tracking one active fence at a time is correct and minimal.

- **No ADR warranted**: This is a bug fix in a leaf module correcting an algorithmic deficiency against the CommonMark spec. It doesn't introduce a novel architectural pattern or constrain future contributors in non-obvious ways.

- **No documentation updates needed**: Research confirmed this is an internal PR-body construction fix with no CLI commands, config options, or user-visible workflow changes.

### Task Checklist

- [ ] **Task 1**: Refactor `balanceFences` in `engine/markdown.go` — replace parity-toggle with indentation-aware state machine; track `fenceActive bool` and `fenceIndent int`; on each fence line: if !active → open and record indent; if active AND line's leading-space count ≥ fenceIndent → close; if active AND leading-space count < fenceIndent → treat as content. Synthetic closer: `strings.Repeat(" ", fenceIndent) + "\`\`\`"`. Update the insertion logic to use this indented closer string.

- [ ] **Task 2**: Add `TestBalanceFences_IndentedOpenerUnindentedCloser` to `engine/markdown_test.go` — body mirrors PR #187: a list item with `  \`\`\`` at column 2, then content lines, then `` ``` `` at column 0, then `---`, then `Closes #184`. Assert: (a) result differs from input (fix was applied); (b) `  \`\`\`` synthetic closer appears before `---`; (c) `Closes #184` is present in output after the last fence delimiter.

- [ ] **Task 3**: Update `buildPRSeedBody` template in `engine/markdown.go` — prepend `Closes #%d\n\n` to the `fmt.Sprintf` body string, so the body starts with `Closes #N\n\n## Summary\n...`. Retain the trailing `Closes #N` after `---` unchanged.

- [ ] **Task 4**: Update the seven `buildPRSeedBody` tests in `engine/markdown_test.go` that currently assert only bottom placement — add a `strings.HasPrefix(strings.TrimSpace(body), "Closes #N")` assertion alongside each existing `HasSuffix` check. Affected tests: `TestBuildPRSeedBody_BothFilesPresent`, `TestBuildPRSeedBody_MissingPlanFile`, `TestBuildPRSeedBody_ClosesAtEnd`, `TestBuildPRSeedBody_UnclosedBacktickInPlan`, `TestBuildPRSeedBody_UnclosedTildeInPlan`, `TestBuildPRSeedBody_UnclosedHintedFenceInPlan`, `TestBuildPRSeedBody_BalancedFencesInPlan`.

- [ ] **Task 5**: Add `TestReplaceVerificationSection_PreservesTopOfBodyClosesN` to `engine/markdown_test.go` — body with `Closes #42` as first line, then `## Summary`, ..., `## Verification`, `(placeholder)`, `---`, `Closes #42`. Call `replaceVerificationSection` and assert: (a) `ok=true`; (b) `strings.HasPrefix(strings.TrimSpace(updated), "Closes #42")`; (c) `strings.HasSuffix(strings.TrimSpace(updated), "Closes #42")`; (d) placeholder removed; (e) new content present.

- [ ] **Task 6**: Build and test — `go build ./...`, `go test -race ./...`, `go vet ./...`. All existing tests must pass; new tests must pass.

### Risks

- **`TestBuildPRSeedBody_BalancedFencesInPlan` fence-count check**: The test counts `strings.Count(body, "\`\`\`") == 2`. After R1, no fences are added to the template — only the `Closes #N` line. Count remains 2. ✓ No code change needed; confirm during Task 6.

- **`replaceVerificationSection` stop condition with top-of-body `Closes #`**: The stop-condition scan starts from `verificationIdx + 1`, which is after `## Verification`. The top-of-body `Closes #N` appears before `## Verification` and is therefore never in the scan range. Confirmed structurally safe; Task 5 is the explicit regression guard.

- **PR bodies already in the wild**: Existing PR bodies without top-of-body `Closes #N` are unaffected by R1 (it only changes seed body generation). The R3 `balanceFences` fix is applied by `ensurePRLinksIssue` to existing bodies on every poll cycle — this is the self-healing path that fixes the PR #187 class of body.

---
Used 7/50 turns, 5k input / 8k output tokens.

## Verification

Implemented both fixes in `engine/markdown.go` and `engine/markdown_test.go`: (1) `balanceFences` now uses an indentation-aware state machine — an unindented closer (column 0) no longer incorrectly closes an indented fence opener (column ≥ 1), matching CommonMark §4.5; (2) `buildPRSeedBody` now emits `Closes #N` as the first line of the PR body (before `## Summary`), retaining the bottom `Closes #N` for defense-in-depth. All existing tests updated to assert both top and bottom placement; regression tests added for the PR #187 body shape and `replaceVerificationSection` preservation. Full test suite (`go test -race ./...`) and `go vet` are clean.

---

Closes #738