### PR TITLE
fix(engine): close GitHub issue on FABRIK_NO_WORK_NEEDED path

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -927,6 +927,31 @@ func (c *CacheImpl) ApplyLabelRemoved(key, label string) {
 	c.mu.Unlock()
 }
 
+// ApplyIssueClosed marks the item identified by key as closed in the store.
+// No-op when the key is not in the cache. Safe for concurrent use.
+func (c *CacheImpl) ApplyIssueClosed(key string) {
+	repo, number, ok := parseItemKey(key)
+	if !ok {
+		c.logFn("[cache] ApplyIssueClosed: key %q invalid — no-op\n", key)
+		return
+	}
+	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
+	if _, err := c.store.Get(repo, number); err != nil {
+		return
+	}
+	_, changes, _ := c.store.Apply(itemstate.IssueClosed{
+		Repo:   repo,
+		Number: number,
+	})
+	if len(changes) == 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	c.localDeltaAt[key] = now
+	c.mu.Unlock()
+}
+
 // ApplyCommentAdded appends comment to the cached comment list for the item
 // identified by key. No-op when the key is not in the cache.
 // Safe for concurrent use.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -1659,6 +1659,40 @@ func TestApplyLabelRemovedNoopWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestApplyIssueClosed(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 1)
+
+	c.ApplyIssueClosed(key)
+
+	s := testGetState(t, c, "owner/repo", 1)
+	if !s.IsClosed {
+		t.Error("want IsClosed=true after ApplyIssueClosed")
+	}
+
+	// localDeltaAt must be bumped.
+	c.mu.RLock()
+	deltaAt := c.localDeltaAt[key]
+	c.mu.RUnlock()
+	if deltaAt.IsZero() {
+		t.Error("want localDeltaAt bumped after ApplyIssueClosed")
+	}
+}
+
+func TestApplyIssueClosedNoopOnUnknownKey(t *testing.T) {
+	c := seedCache(t)
+	key := ItemKey("owner/repo", 99) // never bootstrapped
+
+	c.ApplyIssueClosed(key) // must not panic or create phantom entry
+
+	c.mu.RLock()
+	deltaAt := c.localDeltaAt[key]
+	c.mu.RUnlock()
+	if !deltaAt.IsZero() {
+		t.Error("want localDeltaAt NOT bumped for unknown key")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Subscribe tests
 // ---------------------------------------------------------------------------

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -90,8 +90,8 @@ func (m *testGitHubUpgradeClient) UpdatePRBase(owner, repo string, prNumber int,
 func (m *testGitHubUpgradeClient) CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
 	return 0, nil
 }
-func (m *testGitHubUpgradeClient) MarkPRReady(owner, repo string, prNumber int) error { return nil }
-func (m *testGitHubUpgradeClient) MergePR(owner, repo string, prNumber int) error      { return nil }
+func (m *testGitHubUpgradeClient) MarkPRReady(owner, repo string, prNumber int) error   { return nil }
+func (m *testGitHubUpgradeClient) MergePR(owner, repo string, prNumber int) error       { return nil }
 func (m *testGitHubUpgradeClient) CloseIssue(owner, repo string, issueNumber int) error { return nil }
 func (m *testGitHubUpgradeClient) AddPRReviewCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
 	return nil

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -91,7 +91,8 @@ func (m *testGitHubUpgradeClient) CreateDraftPR(owner, repo, title, head, base, 
 	return 0, nil
 }
 func (m *testGitHubUpgradeClient) MarkPRReady(owner, repo string, prNumber int) error { return nil }
-func (m *testGitHubUpgradeClient) MergePR(owner, repo string, prNumber int) error     { return nil }
+func (m *testGitHubUpgradeClient) MergePR(owner, repo string, prNumber int) error      { return nil }
+func (m *testGitHubUpgradeClient) CloseIssue(owner, repo string, issueNumber int) error { return nil }
 func (m *testGitHubUpgradeClient) AddPRReviewCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
 	return nil
 }

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -39,6 +39,7 @@ type GitHubClient interface {
 	CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error)
 	MarkPRReady(owner, repo string, prNumber int) error
 	MergePR(owner, repo string, prNumber int) error
+	CloseIssue(owner, repo string, issueNumber int) error
 	DeleteReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	FetchLatestRelease(owner, repo string) (*gh.LatestRelease, error)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -35,6 +35,7 @@ type mockGitHubClient struct {
 	getPRBaseFn                   func(owner, repo string, prNumber int) (string, error)
 	updatePRBaseFn                func(owner, repo string, prNumber int, newBase string) error
 	mergePRFn                     func(owner, repo string, prNumber int) error
+	closeIssueFn                  func(owner, repo string, issueNumber int) error
 	rateLimitStatsFn              func() (gh.RateLimitStats, gh.RateLimitStats)
 	getIssueBodyFn                func(owner, repo string, issueNumber int) (string, error)
 	markPRReadyFn                 func(owner, repo string, prNumber int) error
@@ -76,6 +77,7 @@ type mockGitHubClient struct {
 	updateCommentCalls              []updateCommentCall
 	updateStatusCalls               []updateStatusCall
 	mergePRCalls                    []mergePRCall
+	closeIssueCalls                 []closeIssueCall
 	markPRReadyCalls                []markPRReadyCall
 	createDraftPRCalls              []createDraftPRCall
 	resolveReviewThreadCalls        []string
@@ -145,6 +147,11 @@ type updatePRBaseCall struct {
 type mergePRCall struct {
 	owner, repo string
 	prNumber    int
+}
+
+type closeIssueCall struct {
+	owner, repo string
+	issueNumber int
 }
 
 type addLabelCall struct {
@@ -387,6 +394,17 @@ func (m *mockGitHubClient) MergePR(owner, repo string, prNumber int) error {
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(owner, repo, prNumber)
+	}
+	return nil
+}
+
+func (m *mockGitHubClient) CloseIssue(owner, repo string, issueNumber int) error {
+	m.mu.Lock()
+	m.closeIssueCalls = append(m.closeIssueCalls, closeIssueCall{owner, repo, issueNumber})
+	fn := m.closeIssueFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, issueNumber)
 	}
 	return nil
 }

--- a/engine/no_work_needed_test.go
+++ b/engine/no_work_needed_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/stages"
 )
@@ -190,10 +191,21 @@ func TestHandleNoWorkNeeded_SkipsIntermediateStages(t *testing.T) {
 }
 
 // TestHandleNoWorkNeeded_ClosesIssue verifies that handleNoWorkNeeded calls
-// CloseIssue after successfully moving the item to Done.
+// CloseIssue after successfully moving the item to Done, and that the
+// ApplyIssueClosed write-through sets IsClosed in the cache.
 func TestHandleNoWorkNeeded_ClosesIssue(t *testing.T) {
 	client := &mockGitHubClient{}
 	eng := testEngineWithStages(client, testStagesWithCleanup())
+
+	// Wire up a live CacheImpl so the ApplyIssueClosed write-through is exercised.
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.Bootstrap(&gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{ID: "I_5", ItemID: "PVTI_5", Number: 5, Repo: "owner/repo", Status: "Plan"},
+		},
+	})
+	eng.readClient = cache
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5", Repo: "owner/repo"}
@@ -201,7 +213,7 @@ func TestHandleNoWorkNeeded_ClosesIssue(t *testing.T) {
 
 	eng.handleNoWorkNeeded(board, item, stage)
 
-	// CloseIssue must be called exactly once.
+	// CloseIssue must be called exactly once with the correct args.
 	if len(client.closeIssueCalls) != 1 {
 		t.Fatalf("expected 1 CloseIssue call, got %d", len(client.closeIssueCalls))
 	}
@@ -214,6 +226,15 @@ func TestHandleNoWorkNeeded_ClosesIssue(t *testing.T) {
 	}
 	if call.issueNumber != 5 {
 		t.Errorf("CloseIssue issueNumber = %d, want 5", call.issueNumber)
+	}
+
+	// ApplyIssueClosed write-through must have set IsClosed=true in the store.
+	snap, err := eng.store.Get("owner/repo", 5)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if !snap.IsClosed() {
+		t.Error("want IsClosed=true in store after handleNoWorkNeeded")
 	}
 }
 

--- a/engine/no_work_needed_test.go
+++ b/engine/no_work_needed_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -185,6 +186,56 @@ func TestHandleNoWorkNeeded_SkipsIntermediateStages(t *testing.T) {
 	}
 	if client.updateStatusCalls[0].optionID != "OPT_Done" {
 		t.Errorf("expected Done option, got %q", client.updateStatusCalls[0].optionID)
+	}
+}
+
+// TestHandleNoWorkNeeded_ClosesIssue verifies that handleNoWorkNeeded calls
+// CloseIssue after successfully moving the item to Done.
+func TestHandleNoWorkNeeded_ClosesIssue(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5", Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	// CloseIssue must be called exactly once.
+	if len(client.closeIssueCalls) != 1 {
+		t.Fatalf("expected 1 CloseIssue call, got %d", len(client.closeIssueCalls))
+	}
+	call := client.closeIssueCalls[0]
+	if call.owner != "owner" {
+		t.Errorf("CloseIssue owner = %q, want %q", call.owner, "owner")
+	}
+	if call.repo != "repo" {
+		t.Errorf("CloseIssue repo = %q, want %q", call.repo, "repo")
+	}
+	if call.issueNumber != 5 {
+		t.Errorf("CloseIssue issueNumber = %d, want 5", call.issueNumber)
+	}
+}
+
+// TestHandleNoWorkNeeded_CloseIssueNotCalledOnStatusFailure verifies that
+// CloseIssue is NOT called when UpdateProjectItemStatus fails — the issue
+// has not reached Done and should not be closed.
+func TestHandleNoWorkNeeded_CloseIssueNotCalledOnStatusFailure(t *testing.T) {
+	client := &mockGitHubClient{
+		updateProjectItemStatusFn: func(_, _, _, _ string) error {
+			return fmt.Errorf("status update failed")
+		},
+	}
+	eng := testEngineWithStages(client, testStagesWithCleanup())
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5", Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Plan", Order: 2}
+
+	eng.handleNoWorkNeeded(board, item, stage)
+
+	if len(client.closeIssueCalls) != 0 {
+		t.Errorf("expected no CloseIssue calls when status update fails, got %d", len(client.closeIssueCalls))
 	}
 }
 

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -573,6 +573,18 @@ func (e *Engine) handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 		}
+		// Close the GitHub issue so it mirrors the normal pipeline close-on-merge path.
+		// No webhook echo registered: applyIssuesDelta's "closed" case never calls
+		// matchEchoFn, so any registered echo would expire unused. The ApplyIssueClosed
+		// write-through handles cache coherence immediately.
+		if err := e.client.CloseIssue(owner, repo, item.Number); err != nil {
+			e.logf(item.Number, "warn", "could not close issue (no work needed): %v\n", err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyIssueClosed(boardcache.ItemKey(item.Repo, item.Number))
+			}
+			e.logf(item.Number, "done", "closed issue (no work needed)\n")
+		}
 	}
 }
 

--- a/github/issues.go
+++ b/github/issues.go
@@ -2,6 +2,16 @@ package github
 
 import "fmt"
 
+// CloseIssue closes a GitHub issue via the REST API.
+func (c *Client) CloseIssue(owner, repo string, issueNumber int) error {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d", c.baseURL, owner, repo, issueNumber)
+	payload := map[string]interface{}{
+		"state":        "closed",
+		"state_reason": "completed",
+	}
+	return c.restPatch(apiURL, payload)
+}
+
 // IssueData holds the fields from a GitHub issue needed by fabrik watch.
 type IssueData struct {
 	Number   int

--- a/github/issues_test.go
+++ b/github/issues_test.go
@@ -7,6 +7,45 @@ import (
 	"testing"
 )
 
+func TestCloseIssue_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/issues/42" {
+			t.Errorf("path = %s, want /repos/owner/repo/issues/42", r.URL.Path)
+		}
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["state"] != "closed" {
+			t.Errorf("state = %v, want closed", body["state"])
+		}
+		if body["state_reason"] != "completed" {
+			t.Errorf("state_reason = %v, want completed", body["state_reason"])
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if err := c.CloseIssue("owner", "repo", 42); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+}
+
+func TestCloseIssue_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if err := c.CloseIssue("owner", "repo", 999); err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
 func TestFetchIssue_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {


### PR DESCRIPTION
## Summary

When a stage emits `FABRIK_NO_WORK_NEEDED`, `handleNoWorkNeeded` correctly marks all stages complete and moves the project board item to Done — but it never closed the GitHub issue. Without a linked PR to merge (the normal close trigger), the issue remained open indefinitely after the pipeline completed.

This PR adds a `CloseIssue` call at the end of `handleNoWorkNeeded` so the no-work-needed path fully mirrors the normal pipeline's close-on-merge behavior.

## Key Changes

- **`github/issues.go`**: New `CloseIssue` function — `PATCH /repos/{owner}/{repo}/issues/{number}` with `state=closed, state_reason=completed`.
- **`engine/interfaces.go`**: `CloseIssue` added to `GitHubClient` interface.
- **`boardcache/boardcache.go`**: `CacheImpl.ApplyIssueClosed` write-through method (mirrors `ApplyLabelAdded`) — keeps the cache coherent immediately without waiting for the webhook echo.
- **`engine/stages.go`**: `handleNoWorkNeeded` calls `CloseIssue` inside the successful `UpdateProjectItemStatus` else-block. Failure is non-fatal (logs warning, continues). No webhook echo registered for `issues/closed` — `applyIssuesDelta`'s "closed" case never calls `matchEchoFn`, so any registered echo would expire unused.

## How to Test

1. Set up an issue where a stage emits `FABRIK_NO_WORK_NEEDED`.
2. Observe the engine log: `[#N done] closed issue (no work needed)`.
3. Verify the GitHub issue state is `closed` after the engine processes it.

## Tests Added

- `TestCloseIssue_Success` / `TestCloseIssue_Error` — verifies PATCH method, URL, and payload.
- `TestApplyIssueClosed` / `TestApplyIssueClosedNoopOnUnknownKey` — verifies cache write-through sets `IsClosed=true`.
- `TestHandleNoWorkNeeded_ClosesIssue` — asserts `CloseIssue` is called with correct args.
- `TestHandleNoWorkNeeded_CloseIssueNotCalledOnStatusFailure` — asserts no close call when status update fails.

Closes #742