### PR TITLE
feat: detect operator customizations in .fabrik/plugin/ before upgrade

### DIFF
--- a/adrs/046-installed-version-tracking.md
+++ b/adrs/046-installed-version-tracking.md
@@ -1,0 +1,103 @@
+# ADR 046: Installed-Version Fingerprint for Plugin Customization Detection
+
+**Date**: 2026-05-17  
+**Status**: Accepted
+
+## Context
+
+Fabrik embeds its plugin skills in the binary and deploys them to `.fabrik/plugin/`
+via `fabrik init` / `fabrik upgrade`. Operators routinely customize these skills by
+editing `.fabrik/plugin/skills/<name>/SKILL.md` to adapt Claude's behavior to their
+team's process.
+
+Before this change, `fabrik upgrade` compared only embedded vs. on-disk hashes.
+Any divergence — whether from an upstream change *or* a local edit — triggered
+the "files differ, upgrade?" prompt. This meant:
+
+1. **Silent overwrite in non-interactive mode.** Auto-upgrade (no TTY) called
+   `RefreshPlugin()` unconditionally, silently erasing operator customizations.
+
+2. **No distinction between "upstream changed" and "operator changed."** Both
+   cases looked identical. The prompt did not help operators know whether the
+   change was coming from upstream or going away from their customization.
+
+## Decision
+
+Track what the binary last wrote to `.fabrik/plugin/` using a fingerprint file:
+`.fabrik/plugin/.installed-version`. The fingerprint is the SHA256 of the
+sorted concatenation of all embedded file hashes.
+
+### Three-way comparison
+
+| installedVer | diskVer | embeddedVer | State | Action |
+|---|---|---|---|---|
+| absent | any | any | Migration (first run) | Seed installedVer=diskVer; no refresh this cycle |
+| present | == installedVer | == installedVer | Up to date | No-op |
+| present | == installedVer | != installedVer | Upgrade available | Auto-refresh (non-TTY) or y/N prompt (TTY) |
+| present | != installedVer | any | Custom workflow | Block refresh; warn operator |
+
+### Migration baseline
+
+On first encounter (no `.installed-version`), the engine seeds the fingerprint
+from the *current disk state*, not from the embedded version. This preserves
+existing customizations on day one without false-positive "custom workflow"
+detections. Seeding from embedded would immediately flag all existing customized
+installs, which is unacceptable for a migration.
+
+### Upgrade paths for custom workflow
+
+When customizations are detected, the engine refuses to overwrite silently and
+instead offers three paths:
+
+- **`fabrik upgrade --force`**: unconditional overwrite, updates `.installed-version`
+- **`fabrik upgrade --reconcile`**: prints a Claude Code prompt for guided diff and
+  merge of customizations against the new embedded version; exits zero
+- **TUI `[u]` key → `[1] Reconcile` / `[2] Overwrite`**: interactive equivalents
+  of the above flags, with a typed `OVERWRITE` confirmation gate for the destructive path
+
+### Implementation
+
+New functions in `plugin/refresh.go`:
+
+- `ComputeEmbeddedVersion() string` — SHA256 of sorted embedded file hashes
+- `ComputeDiskVersion(pluginDir string) (string, error)` — same algorithm over on-disk files; skips `.installed-version`
+- `WriteVersionHash(pluginDir, hash string) error` — writes hash to `.installed-version`
+- `WriteInstalledVersion(pluginDir string) error` — writes the current embedded hash (post-upgrade)
+- `ReadInstalledVersion(pluginDir string) (string, error)` — reads the file; returns `("", nil)` if absent
+- `CheckPluginState(pluginDir string) (customWorkflow, upgradeNeeded bool, err error)` — implements the four-state table above; runs migration as a side-effect when installed-version is absent
+
+All auto-refresh paths in `cmd/root.go` and `cmd/upgrade.go` are updated to call
+`CheckPluginState` before touching `.fabrik/plugin/`.
+
+## Rationale
+
+### Why SHA256-of-hashes instead of a version number?
+
+A version number requires discipline to bump on every skill edit. A content hash
+is computed automatically — no coordination, no manual steps, no version drift.
+The embedded fingerprint changes whenever any skill file changes, regardless of
+whether the release version was bumped.
+
+### Why seed from disk on migration, not from embedded?
+
+The alternative — seeding from embedded — would set `installedVer = embeddedVer`.
+If any disk file differs from embedded (i.e., the operator already customized),
+`diskVer != installedVer` immediately, flagging every existing installation as
+"custom workflow" on the first binary upgrade. That's a false positive for every
+user who ever edited a skill file. Seeding from disk treats the current state as
+the baseline, which is the right assumption: "whatever is on disk was intentionally
+put there."
+
+### Why require typed `OVERWRITE` for the destructive TUI path?
+
+High-friction confirmation follows the same pattern as `terraform destroy` and
+GitHub's repository deletion UI. A simple `y/N` for a destructive reset of
+operator-edited files is too easy to confirm accidentally. The typed word makes
+the operator's intent explicit and prevents accidental data loss.
+
+### Why print the reconcile prompt to stderr after `p.Run()` returns?
+
+The TUI runs in alt-screen mode. Writing to stderr during alt-screen garbles the
+output because the terminal is in a different mode. Storing the prompt in
+`model.pendingReconcilePrompt` and printing it after `p.Run()` returns ensures
+the output appears cleanly in the normal terminal scrollback after the TUI exits.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -503,6 +503,8 @@ func Execute() error {
 			} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
 				fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed: %v\n", err)
 			}
+		} else {
+			fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
 		}
 	}
 
@@ -522,6 +524,8 @@ func Execute() error {
 			} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
 				fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed after SIGHUP restart: %v\n", err)
 			}
+		} else {
+			fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
 		}
 	}
 
@@ -580,16 +584,18 @@ func Execute() error {
 	var skillsStaleCount int
 	var customWorkflow bool
 	if _, statErr := os.Stat(".fabrik/plugin"); statErr == nil {
-		if diffing, diffErr := diffingPluginFiles(".fabrik/plugin"); diffErr != nil {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed: %v\n", diffErr)
-		} else {
-			skillsStaleCount = len(diffing)
-		}
-		cw, _, cwErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+		cw, upgradeNeeded, cwErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
 		if cwErr != nil {
 			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed: %v\n", cwErr)
 		} else {
 			customWorkflow = cw
+			if upgradeNeeded {
+				if diffing, diffErr := diffingPluginFiles(".fabrik/plugin"); diffErr != nil {
+					fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed: %v\n", diffErr)
+				} else {
+					skillsStaleCount = len(diffing)
+				}
+			}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -487,24 +487,41 @@ func Execute() error {
 	}
 	fmt.Printf("  debug-output: %v\n", cfg.DebugOutput)
 
-	// If the process was re-exec'd after an auto-upgrade, refresh embedded plugin
-	// skills before entering the poll loop. The env var is unset immediately so
-	// the re-exec'd process doesn't loop.
+	// If the process was re-exec'd after an auto-upgrade, conditionally refresh
+	// embedded plugin skills. Three-way comparison: skip refresh when operator
+	// has local customizations (disk ≠ installed-version).
 	if os.Getenv("FABRIK_AUTO_UPGRADED") == "1" {
 		os.Unsetenv("FABRIK_AUTO_UPGRADED")
-		if _, err := fabrikplugin.RefreshPlugin(); err != nil {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed: %v\n", err)
+		customWorkflowOnReexec, upgradeNeededOnReexec, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+		if stateErr != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed: %v\n", stateErr)
+		} else if customWorkflowOnReexec {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+		} else if upgradeNeededOnReexec {
+			if _, err := fabrikplugin.RefreshPlugin(); err != nil {
+				fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed: %v\n", err)
+			} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
+				fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed: %v\n", err)
+			}
 		}
 	}
 
-	// If the process was re-exec'd by a SIGHUP restart, force non-interactive
-	// plugin skills refresh. The env var is unset immediately so Claude child
-	// processes do not inherit it. This mirrors the FABRIK_AUTO_UPGRADED pattern
-	// and must happen before engine.New() to close the inheritance window.
+	// If the process was re-exec'd by a SIGHUP restart, conditionally refresh
+	// plugin skills using the same three-way comparison. The env var is unset
+	// immediately so Claude child processes do not inherit it.
 	if os.Getenv("FABRIK_SIGHUP_RESTART") == "1" {
 		os.Unsetenv("FABRIK_SIGHUP_RESTART")
-		if err := checkPluginSkillsWithReader(".fabrik/plugin", false, nil); err != nil {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed after SIGHUP restart: %v\n", err)
+		customWorkflowOnSighup, upgradeNeededOnSighup, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+		if stateErr != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed after SIGHUP restart: %v\n", stateErr)
+		} else if customWorkflowOnSighup {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+		} else if upgradeNeededOnSighup {
+			if _, err := fabrikplugin.RefreshPlugin(); err != nil {
+				fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed after SIGHUP restart: %v\n", err)
+			} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
+				fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed after SIGHUP restart: %v\n", err)
+			}
 		}
 	}
 
@@ -556,19 +573,23 @@ func Execute() error {
 		return err
 	}
 
-	// Evaluate plugin skill staleness after engine.New() (so env vars are unset
-	// and the inheritance window is closed). For non-TUI, refresh silently. For
-	// TUI, the count is passed to tui.New() to drive the header badge.
+	// Evaluate plugin skill staleness and customization state after engine.New()
+	// (so env vars are unset and the inheritance window is closed).
 	// Guard with os.Stat so projects that haven't run `fabrik init` (no
-	// .fabrik/plugin/ dir) always report stale count 0 — diffingPluginFiles
-	// treats every missing on-disk file as diffing, which would produce a
-	// spuriously large count when the directory doesn't exist yet.
+	// .fabrik/plugin/ dir) always report stale count 0.
 	var skillsStaleCount int
+	var customWorkflow bool
 	if _, statErr := os.Stat(".fabrik/plugin"); statErr == nil {
 		if diffing, diffErr := diffingPluginFiles(".fabrik/plugin"); diffErr != nil {
 			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill check failed: %v\n", diffErr)
 		} else {
 			skillsStaleCount = len(diffing)
+		}
+		cw, _, cwErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+		if cwErr != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed: %v\n", cwErr)
+		} else {
+			customWorkflow = cw
 		}
 	}
 
@@ -577,9 +598,11 @@ func Execute() error {
 	if useTUI {
 		wakeCh := make(chan struct{}, 1)
 		eng.SetWakeCh(wakeCh)
-		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.PluginDir, wakeCh, skillsStaleCount)
+		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.PluginDir, wakeCh, skillsStaleCount, customWorkflow)
 	}
-	if skillsStaleCount > 0 {
+	if customWorkflow {
+		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+	} else if skillsStaleCount > 0 {
 		if refreshErr := checkPluginSkillsWithReader(".fabrik/plugin", false, nil); refreshErr != nil {
 			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill refresh failed: %v\n", refreshErr)
 		}
@@ -695,11 +718,12 @@ func buildProjectInfo(cfg *Config, pc config.ProjectConfig) tui.ProjectInfo {
 // runTUI wires the event channel, starts the bubbletea program, and runs the
 // engine. The engine handles SIGINT itself; bubbletea uses WithoutSignalHandler
 // so it doesn't interfere. When the engine exits, the TUI is quit.
-func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir string, wakeCh chan struct{}, skillsStaleCount int) error {
+// customWorkflow is true when operator customizations are detected in .fabrik/plugin/.
+func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir string, wakeCh chan struct{}, skillsStaleCount int, customWorkflow bool) error {
 	events := make(chan tui.Event, 256)
 	eng.SetEvents(events)
 
-	tuiModel := tui.New(pollSeconds, info, pluginDir, wakeCh, skillsStaleCount)
+	tuiModel := tui.New(pollSeconds, info, pluginDir, wakeCh, skillsStaleCount, customWorkflow)
 	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
 	// Register terminal cleanup so force-quit paths (SIGHUP re-exec, second
 	// SIGTERM/SIGHUP) release alt-screen before replacing or exiting the process.
@@ -723,7 +747,8 @@ func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir
 		p.Quit()
 	}()
 
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		p.ReleaseTerminal()
 		// TUI failed — signal the engine to stop so its goroutine and the
 		// forwarding goroutine both exit cleanly.
@@ -732,6 +757,14 @@ func runTUI(eng *engine.Engine, pollSeconds int, info tui.ProjectInfo, pluginDir
 		return err
 	}
 	p.ReleaseTerminal()
+
+	// Print any pending reconcile prompt the user requested before quitting.
+	if fm, ok := finalModel.(tui.Model); ok {
+		if prompt := fm.PendingReconcilePrompt(); prompt != "" {
+			fmt.Fprintf(os.Stderr, "\nReconciliation prompt (paste into Claude Code):\n\n%s\n", prompt)
+		}
+	}
+
 	// TUI exited (user pressed q or ctrl+c). If the engine is still running
 	// (q doesn't send SIGINT), signal it to stop gracefully.
 	select {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -22,6 +22,9 @@ import (
 // replaced in tests to avoid real network calls.
 var upgradeGitHubClient engine.GitHubClient
 
+// upgradeReconcilePrompt is the text printed by --reconcile or the TUI [1] option.
+const upgradeReconcilePrompt = "In .fabrik/plugin/, compare the on-disk plugin files against the embedded source at plugin/fabrik-workflows/ in the fabrik repo. Help me reconcile my local customizations with the new embedded version. Preserve my customizations where they don't conflict with the new behavior; flag conflicts for review."
+
 // runUpgrade implements the `fabrik upgrade` subcommand.
 // For release builds it first checks for a newer binary, downloads and
 // atomically replaces it if found, then re-execs so the new binary's embedded
@@ -29,17 +32,28 @@ var upgradeGitHubClient engine.GitHubClient
 // plugin skills from the current binary's embedded defaults.
 func runUpgrade(args []string) error {
 	fset := flag.NewFlagSet("upgrade", flag.ContinueOnError)
+	var force, reconcile bool
+	fset.BoolVar(&force, "force", false, "Overwrite local plugin customizations (destructive)")
+	fset.BoolVar(&reconcile, "reconcile", false, "Print a Claude Code reconciliation prompt and exit")
 	fset.Usage = func() {
-		fmt.Fprintf(fset.Output(), "Usage: fabrik upgrade\n\n")
+		fmt.Fprintf(fset.Output(), "Usage: fabrik upgrade [--force] [--reconcile]\n\n")
 		fmt.Fprintf(fset.Output(), "Upgrade the Fabrik binary and refresh embedded plugin skills.\n\n")
 		fmt.Fprintf(fset.Output(), "For release builds: downloads the latest binary from GitHub Releases and\n")
 		fmt.Fprintf(fset.Output(), "re-execs with the updated binary. For dev builds (built from source):\n")
 		fmt.Fprintf(fset.Output(), "rebuilds from origin/main rather than downloading a release binary.\n")
 		fmt.Fprintf(fset.Output(), "In both cases, embedded plugin skills are refreshed on disk.\n")
+		fmt.Fprintf(fset.Output(), "\nFlags:\n")
+		fmt.Fprintf(fset.Output(), "  --force      Overwrite local plugin customizations (destructive)\n")
+		fmt.Fprintf(fset.Output(), "  --reconcile  Print a Claude Code reconciliation prompt and exit\n")
 		fmt.Fprintf(fset.Output(), "\nTo update stage YAML files with missing keys, run: fabrik refresh-stages --apply\n")
 	}
 	if err := fset.Parse(args); err != nil {
 		return err
+	}
+
+	if reconcile {
+		fmt.Println(upgradeReconcilePrompt)
+		return nil
 	}
 
 	if !strings.HasPrefix(Version, "dev") {
@@ -53,9 +67,37 @@ func runUpgrade(args []string) error {
 		})
 	}
 
+	if force {
+		wrote, err := fabrikplugin.RefreshPlugin()
+		if err != nil {
+			return err
+		}
+		if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
+			return fmt.Errorf("writing installed version: %w", err)
+		}
+		fmt.Printf("fabrik upgrade --force: overwrote %d plugin file(s) (customizations discarded)\n", wrote)
+		return nil
+	}
+
+	// Default path: check three-way state before refreshing.
+	customWorkflow, _, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+	if stateErr != nil {
+		return fmt.Errorf("checking plugin state: %w", stateErr)
+	}
+	if customWorkflow {
+		return fmt.Errorf("fabrik: local customizations detected in .fabrik/plugin/ — refusing to overwrite.\n" +
+			"  Options:\n" +
+			"    fabrik upgrade --force       Overwrite customizations (destructive)\n" +
+			"    fabrik upgrade --reconcile   Print a Claude Code reconciliation prompt\n" +
+			"    (or use the TUI 'u' key for an interactive dialog)")
+	}
+
 	wrote, err := fabrikplugin.RefreshPlugin()
 	if err != nil {
 		return err
+	}
+	if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
+		return fmt.Errorf("writing installed version: %w", err)
 	}
 	fmt.Printf("fabrik upgrade: refreshed %d plugin file(s)\n", wrote)
 	return nil
@@ -85,7 +127,23 @@ func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) erro
 		return nil
 	}
 
+	// Three-way check: detect operator customizations before refreshing.
+	// upgradeNeeded=true only when disk==installed and embedded differs (safe to refresh).
+	// Migration path (installedVer absent) returns (false,false): do nothing until next cycle.
+	customWorkflow, upgradeNeeded, stateErr := fabrikplugin.CheckPluginState(pluginDir)
+	if stateErr != nil {
+		return fmt.Errorf("checking plugin state: %w", stateErr)
+	}
+
 	if !isTTY {
+		if customWorkflow {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+			return nil
+		}
+		if !upgradeNeeded {
+			// Migration ran (or no-op): no refresh this cycle. Next run will evaluate correctly.
+			return nil
+		}
 		// Non-interactive (headless daemon, auto-upgrade re-exec, CI): refresh
 		// silently so dev builds and auto-upgraded builds always have matching
 		// plugin skills without manual intervention.
@@ -103,7 +161,20 @@ func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) erro
 				return fmt.Errorf("writing %s: %w", destPath, writeErr)
 			}
 		}
+		if werr := fabrikplugin.WriteInstalledVersion(pluginDir); werr != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed: %v\n", werr)
+		}
 		fmt.Fprintf(os.Stderr, "fabrik: auto-refreshed %d plugin file(s)\n", len(diffing))
+		return nil
+	}
+
+	if customWorkflow {
+		fmt.Printf("Local customizations detected in %s.\n", pluginDir)
+		fmt.Printf("Use 'fabrik upgrade --force' to overwrite, or 'fabrik upgrade --reconcile' for a reconciliation prompt.\n")
+		return nil
+	}
+	if !upgradeNeeded {
+		// Migration ran (or no-op): no prompt this cycle.
 		return nil
 	}
 
@@ -128,6 +199,9 @@ func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) erro
 		if writeErr := os.WriteFile(destPath, data, 0644); writeErr != nil {
 			return fmt.Errorf("writing %s: %w", destPath, writeErr)
 		}
+	}
+	if werr := fabrikplugin.WriteInstalledVersion(pluginDir); werr != nil {
+		fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed: %v\n", werr)
 	}
 	fmt.Printf("fabrik: upgraded %d plugin file(s)\n", len(diffing))
 	return nil

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -141,7 +141,8 @@ func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) erro
 			return nil
 		}
 		if !upgradeNeeded {
-			// Migration ran (or no-op): no refresh this cycle. Next run will evaluate correctly.
+			// Migration ran: .installed-version seeded from current disk; refresh deferred to next startup.
+			fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
 			return nil
 		}
 		// Non-interactive (headless daemon, auto-upgrade re-exec, CI): refresh
@@ -174,7 +175,8 @@ func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) erro
 		return nil
 	}
 	if !upgradeNeeded {
-		// Migration ran (or no-op): no prompt this cycle.
+		// Migration ran: .installed-version seeded from current disk; refresh deferred to next startup.
+		fmt.Printf("fabrik: plugin baseline seeded; skill refresh will apply on next startup.\n")
 		return nil
 	}
 

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -90,17 +90,77 @@ func TestCheckPluginSkillsWithReader_AllMatchNoOp(t *testing.T) {
 	}
 }
 
-func TestCheckPluginSkillsWithReader_DifferNonTTYWarning(t *testing.T) {
-	pluginDir := buildPluginDir(t)
+// writeInstalledForDir writes an .installed-version seeded from the current disk state.
+// Equivalent to the migration path in CheckPluginState.
+func writeInstalledForDir(t *testing.T, pluginDir string) {
+	t.Helper()
+	diskVer, err := fabrikplugin.ComputeDiskVersion(pluginDir)
+	if err != nil {
+		t.Fatalf("ComputeDiskVersion: %v", err)
+	}
+	if err := fabrikplugin.WriteVersionHash(pluginDir, diskVer); err != nil {
+		t.Fatalf("WriteVersionHash: %v", err)
+	}
+}
 
-	// Corrupt one file on disk.
+// TestCheckPluginSkillsWithReader_CustomWorkflow_NonTTYWarning verifies that
+// when disk files differ from the recorded installed-version (operator customization),
+// the non-TTY path emits a warning and does NOT auto-refresh.
+func TestCheckPluginSkillsWithReader_CustomWorkflow_NonTTYWarning(t *testing.T) {
+	pluginDir := buildPluginDir(t)
+	// Seed installed = embedded (disk matches embedded at this point).
+	if err := fabrikplugin.WriteInstalledVersion(pluginDir); err != nil {
+		t.Fatal(err)
+	}
+	// Now modify a disk file — disk diverges from installed (customWorkflow case).
 	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
 	if err != nil || len(entries) == 0 {
 		t.Fatal("no SKILL.md files found in test plugin dir")
 	}
-	if err := os.WriteFile(entries[0], []byte("modified content"), 0644); err != nil {
+	if err := os.WriteFile(entries[0], []byte("operator customization"), 0644); err != nil {
 		t.Fatal(err)
 	}
+
+	r, w, _ := os.Pipe()
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	callErr := checkPluginSkillsWithReader(pluginDir, false, strings.NewReader(""))
+
+	w.Close()
+	os.Stderr = origStderr
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if callErr != nil {
+		t.Fatalf("expected nil error, got %v", callErr)
+	}
+	if !strings.Contains(output, "local customizations") {
+		t.Fatalf("expected customization warning on stderr, got: %q", output)
+	}
+	// File must NOT have been overwritten.
+	data, _ := os.ReadFile(entries[0])
+	if string(data) != "operator customization" {
+		t.Fatal("custom-workflow non-TTY path should NOT overwrite operator customizations")
+	}
+}
+
+// TestCheckPluginSkillsWithReader_AutoRefresh_NonTTY verifies that when disk==installed
+// and embedded has changed (upgradeNeeded), non-TTY silently auto-refreshes.
+func TestCheckPluginSkillsWithReader_AutoRefresh_NonTTY(t *testing.T) {
+	pluginDir := buildPluginDir(t)
+	// Simulate "old" installed state: write old content and seed installed from it.
+	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
+	if err != nil || len(entries) == 0 {
+		t.Fatal("no SKILL.md files found in test plugin dir")
+	}
+	if err := os.WriteFile(entries[0], []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Seed installed = current disk (which has old content). So disk == installed.
+	writeInstalledForDir(t, pluginDir)
+	// Now embedded != disk (because we wrote old content to disk).
 
 	r, w, _ := os.Pipe()
 	origStderr := os.Stderr
@@ -120,27 +180,72 @@ func TestCheckPluginSkillsWithReader_DifferNonTTYWarning(t *testing.T) {
 	if !strings.Contains(output, "auto-refreshed") {
 		t.Fatalf("expected auto-refresh message on stderr, got: %q", output)
 	}
-
-	// File must have been refreshed (non-TTY silently updates).
-	data, _ := os.ReadFile(entries[0])
-	if string(data) == "modified content" {
-		t.Fatal("non-TTY path should auto-refresh differing files")
+	// File must have been refreshed to match embedded.
+	rel, _ := filepath.Rel(pluginDir, entries[0])
+	embeddedData, _ := fabrikplugin.FabrikPlugin.ReadFile(filepath.Join("fabrik-workflows", rel))
+	diskData, _ := os.ReadFile(entries[0])
+	if !bytes.Equal(embeddedData, diskData) {
+		t.Fatal("non-TTY auto-refresh path should overwrite disk with embedded content")
 	}
 }
 
-func TestCheckPluginSkillsWithReader_DifferTTYYes(t *testing.T) {
+// TestCheckPluginSkillsWithReader_CustomWorkflow_TTYRedirects verifies that
+// when operator customizations are detected, the TTY path shows a redirect
+// message (--force / --reconcile) instead of the y/N prompt.
+func TestCheckPluginSkillsWithReader_CustomWorkflow_TTYRedirects(t *testing.T) {
 	pluginDir := buildPluginDir(t)
-
+	if err := fabrikplugin.WriteInstalledVersion(pluginDir); err != nil {
+		t.Fatal(err)
+	}
 	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
 	if err != nil || len(entries) == 0 {
 		t.Fatal("no SKILL.md files found in test plugin dir")
 	}
 	modifiedFile := entries[0]
-	if err := os.WriteFile(modifiedFile, []byte("modified content"), 0644); err != nil {
+	if err := os.WriteFile(modifiedFile, []byte("operator customization"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Use a pipe for stdout capture.
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	callErr := checkPluginSkillsWithReader(pluginDir, true, strings.NewReader("y\n"))
+
+	w.Close()
+	os.Stdout = origStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if callErr != nil {
+		t.Fatalf("expected nil error, got %v", callErr)
+	}
+	if !strings.Contains(output, "--force") {
+		t.Fatalf("expected redirect to --force in output, got: %q", output)
+	}
+	// File must NOT have been overwritten.
+	data, _ := os.ReadFile(modifiedFile)
+	if string(data) != "operator customization" {
+		t.Fatal("TTY custom-workflow path should NOT overwrite operator customizations")
+	}
+}
+
+// TestCheckPluginSkillsWithReader_AutoRefresh_TTYYes verifies the TTY y answer
+// triggers auto-refresh when upgradeNeeded (disk==installed, embedded changed).
+func TestCheckPluginSkillsWithReader_AutoRefresh_TTYYes(t *testing.T) {
+	pluginDir := buildPluginDir(t)
+	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
+	if err != nil || len(entries) == 0 {
+		t.Fatal("no SKILL.md files found in test plugin dir")
+	}
+	modifiedFile := entries[0]
+	if err := os.WriteFile(modifiedFile, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Seed installed = current disk (old content). So disk == installed, embedded != installed.
+	writeInstalledForDir(t, pluginDir)
+
 	r, w, _ := os.Pipe()
 	origStdout := os.Stdout
 	os.Stdout = w
@@ -155,31 +260,31 @@ func TestCheckPluginSkillsWithReader_DifferTTYYes(t *testing.T) {
 	if callErr != nil {
 		t.Fatalf("expected nil error, got %v", callErr)
 	}
-
-	// The modified file must now match the embedded version.
+	// File must now match embedded version.
 	rel, _ := filepath.Rel(pluginDir, modifiedFile)
 	embeddedData, _ := fabrikplugin.FabrikPlugin.ReadFile(filepath.Join("fabrik-workflows", rel))
 	diskData, _ := os.ReadFile(modifiedFile)
 	if !bytes.Equal(embeddedData, diskData) {
-		t.Fatal("expected modified file to be overwritten with embedded content")
+		t.Fatal("expected file to be refreshed with embedded content after y answer")
 	}
 }
 
-func TestCheckPluginSkillsWithReader_DifferTTYNo(t *testing.T) {
+// TestCheckPluginSkillsWithReader_AutoRefresh_TTYNo verifies that answering n
+// keeps files unmodified when upgradeNeeded (disk==installed, embedded changed).
+func TestCheckPluginSkillsWithReader_AutoRefresh_TTYNo(t *testing.T) {
 	for _, answer := range []string{"n\n", "N\n", "\n"} {
 		t.Run(answer, func(t *testing.T) {
 			pluginDir := buildPluginDir(t)
-
 			entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
 			if err != nil || len(entries) == 0 {
 				t.Fatal("no SKILL.md files found in test plugin dir")
 			}
 			modifiedFile := entries[0]
-			if err := os.WriteFile(modifiedFile, []byte("modified content"), 0644); err != nil {
+			if err := os.WriteFile(modifiedFile, []byte("old content"), 0644); err != nil {
 				t.Fatal(err)
 			}
+			writeInstalledForDir(t, pluginDir)
 
-			// Suppress stdout.
 			r, w, _ := os.Pipe()
 			origStdout := os.Stdout
 			os.Stdout = w
@@ -193,9 +298,8 @@ func TestCheckPluginSkillsWithReader_DifferTTYNo(t *testing.T) {
 			if callErr != nil {
 				t.Fatalf("expected nil error for answer %q, got %v", answer, callErr)
 			}
-
 			data, _ := os.ReadFile(modifiedFile)
-			if string(data) != "modified content" {
+			if string(data) != "old content" {
 				t.Fatalf("answer %q: expected file to remain unmodified", answer)
 			}
 		})
@@ -208,5 +312,121 @@ func TestRunUpgrade_HelpFlag(t *testing.T) {
 	err := runUpgrade([]string{"--help"})
 	if err != flag.ErrHelp {
 		t.Errorf("expected flag.ErrHelp, got %v", err)
+	}
+}
+
+// buildFabrikPluginDir writes embedded plugin files to .fabrik/plugin/ in cwd.
+// The caller must have already chdirTest'd to a temp dir.
+func buildFabrikPluginDir(t *testing.T) string {
+	t.Helper()
+	pluginDir := ".fabrik/plugin"
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	err := fs.WalkDir(fabrikplugin.FabrikPlugin, "fabrik-workflows", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, _ := filepath.Rel("fabrik-workflows", p)
+		dest := filepath.Join(pluginDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0755)
+		}
+		data, err := fabrikplugin.FabrikPlugin.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(dest, data, 0644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pluginDir
+}
+
+func TestRunUpgrade_Reconcile(t *testing.T) {
+	dir := t.TempDir()
+	chdirTest(t, dir)
+
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+
+	err := runUpgrade([]string{"--reconcile"})
+
+	w.Close()
+	os.Stdout = origStdout
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !strings.Contains(output, "reconcile") {
+		t.Fatalf("expected reconciliation prompt in output, got: %q", output)
+	}
+}
+
+func TestRunUpgrade_Force(t *testing.T) {
+	dir := t.TempDir()
+	chdirTest(t, dir)
+	pluginDir := buildFabrikPluginDir(t)
+
+	if err := fabrikplugin.WriteInstalledVersion(pluginDir); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
+	if err != nil || len(entries) == 0 {
+		t.Fatal("no SKILL.md files found")
+	}
+	modifiedFile := entries[0]
+	if err := os.WriteFile(modifiedFile, []byte("operator customization"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	callErr := runUpgrade([]string{"--force"})
+	if callErr != nil {
+		t.Fatalf("expected nil error, got %v", callErr)
+	}
+
+	rel, _ := filepath.Rel(pluginDir, modifiedFile)
+	embeddedData, _ := fabrikplugin.FabrikPlugin.ReadFile(filepath.Join("fabrik-workflows", rel))
+	diskData, _ := os.ReadFile(modifiedFile)
+	if !bytes.Equal(embeddedData, diskData) {
+		t.Fatal("--force should overwrite operator customization with embedded content")
+	}
+
+	installedVer, readErr := fabrikplugin.ReadInstalledVersion(pluginDir)
+	if readErr != nil || installedVer == "" {
+		t.Fatalf("expected non-empty installed version after --force, err=%v", readErr)
+	}
+}
+
+func TestRunUpgrade_CustomWorkflowError(t *testing.T) {
+	dir := t.TempDir()
+	chdirTest(t, dir)
+	pluginDir := buildFabrikPluginDir(t)
+
+	if err := fabrikplugin.WriteInstalledVersion(pluginDir); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
+	if err != nil || len(entries) == 0 {
+		t.Fatal("no SKILL.md files found")
+	}
+	if err := os.WriteFile(entries[0], []byte("operator customization"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	callErr := runUpgrade([]string{})
+	if callErr == nil {
+		t.Fatal("expected error for custom-workflow state, got nil")
+	}
+	if !strings.Contains(callErr.Error(), "local customizations") {
+		t.Fatalf("expected 'local customizations' in error, got: %v", callErr)
 	}
 }

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1227,6 +1227,33 @@ The stage YAML references the skill by name:
 skill: fabrik-research    # loads .fabrik/plugin/skills/fabrik-research/SKILL.md
 ```
 
+#### Upgrade protection for customized skills
+
+Fabrik tracks what it last installed using a `.fabrik/plugin/.installed-version`
+fingerprint file (SHA256 of all embedded skill files). This enables a three-way
+comparison on every upgrade:
+
+| State | Condition | Behavior |
+|-------|-----------|----------|
+| Up to date | disk == installed == embedded | No-op |
+| Upgrade available | disk == installed, embedded changed | Auto-refresh (non-TTY) or `y/N` prompt (TTY) |
+| Custom workflow | disk != installed | Block refresh; show `[u] custom workflow` badge |
+| First run (migration) | `.installed-version` absent | Seeds fingerprint from current disk; no refresh this cycle |
+
+When customizations are detected, Fabrik refuses to overwrite them silently.
+Use one of:
+
+```bash
+fabrik upgrade --force      # Overwrite all customizations (destructive)
+fabrik upgrade --reconcile  # Print a Claude Code prompt for guided reconciliation
+```
+
+The `--reconcile` output is a prompt you can paste into Claude Code to diff your
+customizations against the new embedded version and preserve non-conflicting changes.
+
+In the TUI, pressing `u` when the `[u] custom workflow` badge is shown opens the
+same three options interactively.
+
 ### Skill vs Prompt
 
 - **`skill:`** references a plugin skill file (recommended). The skill contains rich
@@ -1504,7 +1531,10 @@ exhausted or rate-limit-induced probe failures are detected, a prominent red ale
 banner appears immediately below the header with a countdown to when polling resumes.
 When plugin skills in `.fabrik/plugin/` are outdated relative to the embedded
 defaults, a `[u] skills out of date` badge appears in the header, reminding the
-operator to press `u` to upgrade.
+operator to press `u` to upgrade. When Fabrik detects that the on-disk skills
+differ from the last installed version (indicating operator customizations), the
+badge changes to `[u] custom workflow` and pressing `u` opens a three-option
+dialog instead of a simple y/N prompt (see [Customizing Skills](#customizing-skills)).
 
 ### Keyboard Shortcuts
 
@@ -1520,7 +1550,7 @@ operator to press `u` to upgrade.
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
-| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` shows a confirmation prompt — press `y` to upgrade and clear the badge; active stage invocations pick up new files on next run) |
+| `u` | Upgrade plugin skills. When the `[u] skills out of date` badge is shown (embedded changed, no local edits), pressing `u` shows a `y/N` confirmation and applies the upgrade. When the `[u] custom workflow` badge is shown (local edits detected), pressing `u` opens a three-option dialog: **[1] Reconcile** — quits the TUI and prints a Claude Code prompt to stderr for merging customizations; **[2] Overwrite** — prompts you to type `OVERWRITE` to confirm destructive reset; **[3] Cancel** — dismisses the dialog. Active stage invocations pick up new files on next run. |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1225,6 +1225,33 @@ The stage YAML references the skill by name:
 skill: fabrik-research    # loads .fabrik/plugin/skills/fabrik-research/SKILL.md
 ```
 
+#### Upgrade protection for customized skills
+
+Fabrik tracks what it last installed using a `.fabrik/plugin/.installed-version`
+fingerprint file (SHA256 of all embedded skill files). This enables a three-way
+comparison on every upgrade:
+
+| State | Condition | Behavior |
+|-------|-----------|----------|
+| Up to date | disk == installed == embedded | No-op |
+| Upgrade available | disk == installed, embedded changed | Auto-refresh (non-TTY) or `y/N` prompt (TTY) |
+| Custom workflow | disk != installed | Block refresh; show `[u] custom workflow` badge |
+| First run (migration) | `.installed-version` absent | Seeds fingerprint from current disk; no refresh this cycle |
+
+When customizations are detected, Fabrik refuses to overwrite them silently.
+Use one of:
+
+```bash
+fabrik upgrade --force      # Overwrite all customizations (destructive)
+fabrik upgrade --reconcile  # Print a Claude Code prompt for guided reconciliation
+```
+
+The `--reconcile` output is a prompt you can paste into Claude Code to diff your
+customizations against the new embedded version and preserve non-conflicting changes.
+
+In the TUI, pressing `u` when the `[u] custom workflow` badge is shown opens the
+same three options interactively.
+
 ### Skill vs Prompt
 
 - **`skill:`** references a plugin skill file (recommended). The skill contains rich
@@ -1502,7 +1529,10 @@ exhausted or rate-limit-induced probe failures are detected, a prominent red ale
 banner appears immediately below the header with a countdown to when polling resumes.
 When plugin skills in `.fabrik/plugin/` are outdated relative to the embedded
 defaults, a `[u] skills out of date` badge appears in the header, reminding the
-operator to press `u` to upgrade.
+operator to press `u` to upgrade. When Fabrik detects that the on-disk skills
+differ from the last installed version (indicating operator customizations), the
+badge changes to `[u] custom workflow` and pressing `u` opens a three-option
+dialog instead of a simple y/N prompt (see [Customizing Skills](#customizing-skills)).
 
 ### Keyboard Shortcuts
 
@@ -1518,7 +1548,7 @@ operator to press `u` to upgrade.
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
-| `u` | Upgrade plugin skills (when plugin skills are out of date, a `[u] skills out of date` badge appears in the header; pressing `u` shows a confirmation prompt — press `y` to upgrade and clear the badge; active stage invocations pick up new files on next run) |
+| `u` | Upgrade plugin skills. When the `[u] skills out of date` badge is shown (embedded changed, no local edits), pressing `u` shows a `y/N` confirmation and applies the upgrade. When the `[u] custom workflow` badge is shown (local edits detected), pressing `u` opens a three-option dialog: **[1] Reconcile** — quits the TUI and prints a Claude Code prompt to stderr for merging customizations; **[2] Overwrite** — prompts you to type `OVERWRITE` to confirm destructive reset; **[3] Cancel** — dismisses the dialog. Active stage invocations pick up new files on next run. |
 | `w` | Wake: reset idle backoff and poll immediately |
 | `ctrl+r` | Force refresh: drain in-flight workers and restart in place (same as SIGHUP — see [Recovering from Wedged State](#recovering-from-wedged-state)) |
 | `?` | Toggle help panel (keybindings and labels reference) |

--- a/plugin/refresh.go
+++ b/plugin/refresh.go
@@ -1,11 +1,162 @@
 package plugin
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 )
+
+const installedVersionFile = ".installed-version"
+
+// computePluginFingerprint computes a deterministic SHA256 fingerprint over a
+// set of (path, content) pairs. paths must be sorted lexicographically.
+func computePluginFingerprint(entries []struct{ path, hex string }) string {
+	h := sha256.New()
+	for _, e := range entries {
+		h.Write([]byte(e.hex))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ComputeEmbeddedVersion returns a deterministic fingerprint of the embedded
+// FabrikPlugin FS. It is a pure function — no disk I/O beyond embed.FS reads.
+func ComputeEmbeddedVersion() string {
+	var entries []struct{ path, hex string }
+	_ = fs.WalkDir(FabrikPlugin, "fabrik-workflows", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, readErr := FabrikPlugin.ReadFile(p)
+		if readErr != nil {
+			return readErr
+		}
+		sum := sha256.Sum256(data)
+		entries = append(entries, struct{ path, hex string }{p, hex.EncodeToString(sum[:])})
+		return nil
+	})
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+	return computePluginFingerprint(entries)
+}
+
+// ComputeDiskVersion computes the same fingerprint over on-disk files in
+// pluginDir, skipping .installed-version. Returns ("", nil) if pluginDir does
+// not exist.
+func ComputeDiskVersion(pluginDir string) (string, error) {
+	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+		return "", nil
+	}
+	var entries []struct{ path, hex string }
+	err := filepath.WalkDir(pluginDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(pluginDir, p)
+		// Exclude the metadata file itself so disk and embedded hashes are comparable.
+		if rel == installedVersionFile || strings.HasSuffix(rel, string(filepath.Separator)+installedVersionFile) {
+			return nil
+		}
+		data, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return fmt.Errorf("reading %s: %w", p, readErr)
+		}
+		sum := sha256.Sum256(data)
+		entries = append(entries, struct{ path, hex string }{rel, hex.EncodeToString(sum[:])})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+	return computePluginFingerprint(entries), nil
+}
+
+// WriteVersionHash writes hash to pluginDir/.installed-version.
+func WriteVersionHash(pluginDir, hash string) error {
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		return fmt.Errorf("creating plugin dir: %w", err)
+	}
+	dest := filepath.Join(pluginDir, installedVersionFile)
+	return os.WriteFile(dest, []byte(hash+"\n"), 0644)
+}
+
+// WriteInstalledVersion writes the embedded plugin fingerprint to
+// pluginDir/.installed-version. Call after RefreshPlugin() to record the last
+// known-good installed state.
+func WriteInstalledVersion(pluginDir string) error {
+	return WriteVersionHash(pluginDir, ComputeEmbeddedVersion())
+}
+
+// ReadInstalledVersion reads the hash from pluginDir/.installed-version.
+// Returns ("", nil) if the file does not exist (first-run / pre-migration case).
+func ReadInstalledVersion(pluginDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(pluginDir, installedVersionFile))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading installed version: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// CheckPluginState performs a three-way comparison (embedded vs installedVer vs
+// disk) and determines whether the operator has local customizations or whether
+// an auto-refresh is needed.
+//
+// Migration side-effect: when .installed-version is absent, this function seeds
+// it from the current disk state (not the embedded state). This preserves
+// existing customizations silently on first run of a binary that includes this
+// feature. Subsequent embedded changes are detected correctly.
+//
+// Return values:
+//
+//	customWorkflow=true  — disk differs from installedVer; skip auto-refresh.
+//	upgradeNeeded=true   — disk matches installedVer but embedded differs; auto-refresh safe.
+//	both false           — no action needed.
+func CheckPluginState(pluginDir string) (customWorkflow, upgradeNeeded bool, err error) {
+	installedVer, err := ReadInstalledVersion(pluginDir)
+	if err != nil {
+		return false, false, err
+	}
+
+	diskVer, err := ComputeDiskVersion(pluginDir)
+	if err != nil {
+		return false, false, err
+	}
+
+	embeddedVer := ComputeEmbeddedVersion()
+
+	if installedVer == "" {
+		// Migration: seed from disk state, no refresh.
+		if diskVer != "" {
+			if wErr := WriteVersionHash(pluginDir, diskVer); wErr != nil {
+				return false, false, fmt.Errorf("writing installed version (migration): %w", wErr)
+			}
+		}
+		return false, false, nil
+	}
+
+	if diskVer != installedVer {
+		// Operator has customized the plugin directory.
+		return true, false, nil
+	}
+
+	if embeddedVer != installedVer {
+		// Embedded changed since last install; disk is clean — safe to auto-refresh.
+		return false, true, nil
+	}
+
+	// No-op: everything matches.
+	return false, false, nil
+}
 
 // RefreshPlugin overwrites .fabrik/plugin/ with the embedded plugin files.
 // Returns the number of files written.

--- a/plugin/refresh_test.go
+++ b/plugin/refresh_test.go
@@ -1,0 +1,234 @@
+package plugin
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestComputeEmbeddedVersion_Deterministic(t *testing.T) {
+	v1 := ComputeEmbeddedVersion()
+	v2 := ComputeEmbeddedVersion()
+	if v1 == "" {
+		t.Fatal("ComputeEmbeddedVersion returned empty string")
+	}
+	if v1 != v2 {
+		t.Errorf("ComputeEmbeddedVersion not deterministic: %q != %q", v1, v2)
+	}
+}
+
+func TestComputeDiskVersion_NonExistentDir(t *testing.T) {
+	dir := t.TempDir()
+	ver, err := ComputeDiskVersion(filepath.Join(dir, "nonexistent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ver != "" {
+		t.Errorf("expected empty string for nonexistent dir, got %q", ver)
+	}
+}
+
+func TestComputeDiskVersion_MatchesEmbedded(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	embeddedVer := ComputeEmbeddedVersion()
+	diskVer, err := ComputeDiskVersion(dir)
+	if err != nil {
+		t.Fatalf("ComputeDiskVersion error: %v", err)
+	}
+	if diskVer != embeddedVer {
+		t.Errorf("disk version %q != embedded version %q", diskVer, embeddedVer)
+	}
+}
+
+func TestComputeDiskVersion_SkipsInstalledVersionFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	vBefore, err := ComputeDiskVersion(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write .installed-version — must not affect the disk hash.
+	if err := WriteVersionHash(dir, "somehash"); err != nil {
+		t.Fatal(err)
+	}
+
+	vAfter, err := ComputeDiskVersion(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vBefore != vAfter {
+		t.Errorf("ComputeDiskVersion changed after writing .installed-version: %q -> %q", vBefore, vAfter)
+	}
+}
+
+func TestWriteReadInstalledVersion_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing file returns ("", nil).
+	v, err := ReadInstalledVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadInstalledVersion (missing) error: %v", err)
+	}
+	if v != "" {
+		t.Errorf("expected empty string for missing file, got %q", v)
+	}
+
+	if err := WriteInstalledVersion(dir); err != nil {
+		t.Fatalf("WriteInstalledVersion error: %v", err)
+	}
+
+	v2, err := ReadInstalledVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadInstalledVersion error: %v", err)
+	}
+	if v2 != ComputeEmbeddedVersion() {
+		t.Errorf("ReadInstalledVersion = %q, want %q", v2, ComputeEmbeddedVersion())
+	}
+}
+
+func TestCheckPluginState_Migration(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	cw, up, err := CheckPluginState(dir)
+	if err != nil {
+		t.Fatalf("CheckPluginState error: %v", err)
+	}
+	if cw || up {
+		t.Errorf("migration: want (false,false), got (%v,%v)", cw, up)
+	}
+	// .installed-version must now exist and equal disk version.
+	installedVer, _ := ReadInstalledVersion(dir)
+	diskVer, _ := ComputeDiskVersion(dir)
+	if installedVer != diskVer {
+		t.Errorf("migration: installedVer %q != diskVer %q", installedVer, diskVer)
+	}
+}
+
+func TestCheckPluginState_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Seed installedVer from embedded (disk == embedded == installed).
+	if err := WriteInstalledVersion(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	cw, up, err := CheckPluginState(dir)
+	if err != nil {
+		t.Fatalf("CheckPluginState error: %v", err)
+	}
+	if cw || up {
+		t.Errorf("no-op: want (false,false), got (%v,%v)", cw, up)
+	}
+}
+
+func TestCheckPluginState_AutoRefresh(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Compute current disk version, then set installed == disk so disk==installed.
+	diskVer, _ := ComputeDiskVersion(dir)
+	if err := WriteVersionHash(dir, diskVer); err != nil {
+		t.Fatal(err)
+	}
+	// Now embedded differs from installedVer (diskVer is the real embedded hash but we
+	// faked installed to be a different value to simulate a stale record).
+	// The above already set installed == disk == embedded, so we can't simulate this
+	// without modifying disk. Instead, write a custom installed hash that differs from embedded.
+	embeddedVer := ComputeEmbeddedVersion()
+	if err := WriteVersionHash(dir, "oldversion"); err != nil {
+		t.Fatal(err)
+	}
+	// Now installed="oldversion", disk==embedded, so disk != installed → customWorkflow!
+	// We need disk == "oldversion" too. Let's use a fresh empty plugin dir so embedded
+	// will differ from an empty disk.
+	dir2 := t.TempDir()
+	// dir2 has no files — diskVer2 will be empty hash of empty set.
+	diskVer2, _ := ComputeDiskVersion(dir2)
+	// seed installed == disk (both are "empty" state).
+	if err := WriteVersionHash(dir2, diskVer2); err != nil {
+		t.Fatal(err)
+	}
+	// embedded != diskVer2, disk == installed → auto-refresh.
+	if embeddedVer == diskVer2 {
+		t.Skip("embedded matches empty disk — cannot test auto-refresh")
+	}
+
+	cw, up, err := CheckPluginState(dir2)
+	if err != nil {
+		t.Fatalf("CheckPluginState error: %v", err)
+	}
+	if cw {
+		t.Errorf("auto-refresh: customWorkflow should be false")
+	}
+	if !up {
+		t.Errorf("auto-refresh: upgradeNeeded should be true")
+	}
+}
+
+func TestCheckPluginState_CustomWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Write installed == current disk.
+	diskVer, _ := ComputeDiskVersion(dir)
+	if err := WriteVersionHash(dir, diskVer); err != nil {
+		t.Fatal(err)
+	}
+	// Now mutate a disk file so diskVer != installedVer.
+	entries, _ := filepath.Glob(filepath.Join(dir, "skills", "*", "SKILL.md"))
+	if len(entries) == 0 {
+		t.Fatal("no SKILL.md files found")
+	}
+	if err := os.WriteFile(entries[0], []byte("operator customization"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cw, up, err := CheckPluginState(dir)
+	if err != nil {
+		t.Fatalf("CheckPluginState error: %v", err)
+	}
+	if !cw {
+		t.Errorf("custom-workflow: customWorkflow should be true")
+	}
+	if up {
+		t.Errorf("custom-workflow: upgradeNeeded should be false")
+	}
+}
+
+// populatePluginDir writes the embedded plugin files to pluginDir.
+func populatePluginDir(pluginDir string) error {
+	return fs.WalkDir(FabrikPlugin, "fabrik-workflows", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, _ := filepath.Rel("fabrik-workflows", p)
+		dest := filepath.Join(pluginDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0755)
+		}
+		data, err := FabrikPlugin.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(dest, data, 0644)
+	})
+}

--- a/plugin/refresh_test.go
+++ b/plugin/refresh_test.go
@@ -136,30 +136,10 @@ func TestCheckPluginState_NoOp(t *testing.T) {
 }
 
 func TestCheckPluginState_AutoRefresh(t *testing.T) {
-	dir := t.TempDir()
-	if err := populatePluginDir(dir); err != nil {
-		t.Fatal(err)
-	}
-	// Compute current disk version, then set installed == disk so disk==installed.
-	diskVer, _ := ComputeDiskVersion(dir)
-	if err := WriteVersionHash(dir, diskVer); err != nil {
-		t.Fatal(err)
-	}
-	// Now embedded differs from installedVer (diskVer is the real embedded hash but we
-	// faked installed to be a different value to simulate a stale record).
-	// The above already set installed == disk == embedded, so we can't simulate this
-	// without modifying disk. Instead, write a custom installed hash that differs from embedded.
-	embeddedVer := ComputeEmbeddedVersion()
-	if err := WriteVersionHash(dir, "oldversion"); err != nil {
-		t.Fatal(err)
-	}
-	// Now installed="oldversion", disk==embedded, so disk != installed → customWorkflow!
-	// We need disk == "oldversion" too. Let's use a fresh empty plugin dir so embedded
-	// will differ from an empty disk.
+	// Use an empty dir so disk == installed (both "empty") while embedded differs.
 	dir2 := t.TempDir()
-	// dir2 has no files — diskVer2 will be empty hash of empty set.
+	embeddedVer := ComputeEmbeddedVersion()
 	diskVer2, _ := ComputeDiskVersion(dir2)
-	// seed installed == disk (both are "empty" state).
 	if err := WriteVersionHash(dir2, diskVer2); err != nil {
 		t.Fatal(err)
 	}

--- a/tui/active_test.go
+++ b/tui/active_test.go
@@ -39,7 +39,7 @@ func TestActiveHeight(t *testing.T) {
 
 func TestUpdate_JobStartedAndCompleted(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	start := time.Now()
 
 	// JobStartedEvent adds to active
@@ -80,7 +80,7 @@ func TestUpdate_JobStartedAndCompleted(t *testing.T) {
 }
 
 func TestUpdate_LogEvent_UpdatesActiveJob(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	key7 := activeJobKey("", 7)
 	m.active.active[key7] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
 	m.active.activeNumToKey[7] = key7
@@ -102,7 +102,7 @@ func TestUpdate_LogEvent_UpdatesActiveJob(t *testing.T) {
 
 func TestUpdate_LogEvent_UnknownIssue(t *testing.T) {
 	// LogEvent for an issue not in active map should not panic
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	next, _ := m.Update(LogEvent{IssueNumber: 999, Tag: "warn", Message: "something\n"})
 	nm := next.(Model)
 	if _, ok := nm.active.active[activeJobKey("", 999)]; ok {
@@ -112,7 +112,7 @@ func TestUpdate_LogEvent_UnknownIssue(t *testing.T) {
 
 // TestUpdate_JK_ActivePane verifies j/k navigation in the active pane.
 func TestUpdate_JK_ActivePane(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.active.active[activeJobKey("", 1)] = &activeJob{StageName: "Research", StartedAt: time.Now()}
 	m.active.active[activeJobKey("", 2)] = &activeJob{StageName: "Plan", StartedAt: time.Now()}
 
@@ -130,7 +130,7 @@ func TestUpdate_JK_ActivePane(t *testing.T) {
 
 // TestUpdate_RKey_ActivePane_SetsStatusMsg verifies r on an active pane item sets statusMsg.
 func TestUpdate_RKey_ActivePane_SetsStatusMsg(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneActive
 	key7 := activeJobKey("", 7)
 	m.active.active[key7] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
@@ -148,7 +148,7 @@ func TestUpdate_RKey_ActivePane_SetsStatusMsg(t *testing.T) {
 }
 
 func TestUpdate_RKey_ActivePane_NoJobs_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneActive
 	// No active jobs: r is a no-op
 
@@ -160,7 +160,7 @@ func TestUpdate_RKey_ActivePane_NoJobs_NoOp(t *testing.T) {
 
 // TestViewActive_IsComment verifies the 💬 emoji appears for comment jobs.
 func TestViewActive_IsComment(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.active.active[activeJobKey("", 5)] = &activeJob{StageName: "Implement", IsComment: true, StartedAt: time.Now()}
@@ -172,7 +172,7 @@ func TestViewActive_IsComment(t *testing.T) {
 
 func TestUpdate_IssueBlockedEvent(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 
 	// IssueBlockedEvent adds to blocked map
 	next, _ := m.Update(IssueBlockedEvent{
@@ -208,7 +208,7 @@ func TestUpdate_IssueBlockedEvent(t *testing.T) {
 
 func TestViewActive_BlockedIssue(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 120
 	m.active.now = time.Now()
 
@@ -238,7 +238,7 @@ func TestViewActive_BlockedIssue(t *testing.T) {
 
 func TestViewActive_BlockedCountIncludedInHeader(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 120
 	m.active.now = time.Now()
 
@@ -289,7 +289,7 @@ func TestTurnBadge(t *testing.T) {
 
 // TestUpdate_TurnProgressEvent_UpdatesJob verifies that TurnProgressEvent updates the active job.
 func TestUpdate_TurnProgressEvent_UpdatesJob(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Research", StartedAt: time.Now()}
 	m.active.activeNumToKey[42] = key42
@@ -311,7 +311,7 @@ func TestUpdate_TurnProgressEvent_UpdatesJob(t *testing.T) {
 
 // TestUpdate_TurnProgressEvent_UnknownIssue verifies that an unknown issue number does not panic.
 func TestUpdate_TurnProgressEvent_UnknownIssue(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	// Should not panic for an issue not in the active map.
 	next, _ := m.Update(TurnProgressEvent{IssueNumber: 999, TurnsUsed: 5, MaxTurns: 30})
 	nm := next.(Model)
@@ -322,7 +322,7 @@ func TestUpdate_TurnProgressEvent_UnknownIssue(t *testing.T) {
 
 // TestUpdate_TurnProgressEvent_ResetOnJobStarted verifies that starting a new job resets turn state.
 func TestUpdate_TurnProgressEvent_ResetOnJobStarted(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	key5 := activeJobKey("", 5)
 	m.active.active[key5] = &activeJob{IssueNumber: 5, StageName: "Research", StartedAt: time.Now(), TurnsUsed: 10, MaxTurns: 30}
 	m.active.activeNumToKey[5] = key5
@@ -347,7 +347,7 @@ func TestUpdate_CtrlR_ActivePane_ReturnsSighupCmd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sendSighupCmd is a no-op on Windows")
 	}
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneActive
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
@@ -362,7 +362,7 @@ func TestUpdate_CtrlR_HistoryPane_ReturnsSighupCmd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("sendSighupCmd is a no-op on Windows")
 	}
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneHistory
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -19,13 +19,23 @@ type pluginUpgradeResultMsg struct {
 	Err   error
 }
 
-// upgradePluginCmd returns a tea.Cmd that calls fabrikplugin.RefreshPlugin() in
-// a background goroutine and delivers the result as a pluginUpgradeResultMsg.
-// It does not block the TUI event loop.
-func upgradePluginCmd() tea.Cmd {
+// upgradePluginCmd returns a tea.Cmd that calls fabrikplugin.RefreshPlugin() and
+// fabrikplugin.WriteInstalledVersion() in a background goroutine and delivers
+// the result as a pluginUpgradeResultMsg. It does not block the TUI event loop.
+// pluginDir defaults to ".fabrik/plugin" when empty, matching RefreshPlugin's convention.
+func upgradePluginCmd(pluginDir string) tea.Cmd {
+	if pluginDir == "" {
+		pluginDir = ".fabrik/plugin"
+	}
 	return func() tea.Msg {
 		n, err := fabrikplugin.RefreshPlugin()
-		return pluginUpgradeResultMsg{Wrote: n, Err: err}
+		if err != nil {
+			return pluginUpgradeResultMsg{Wrote: n, Err: err}
+		}
+		if werr := fabrikplugin.WriteInstalledVersion(pluginDir); werr != nil {
+			return pluginUpgradeResultMsg{Wrote: n, Err: werr}
+		}
+		return pluginUpgradeResultMsg{Wrote: n, Err: nil}
 	}
 }
 

--- a/tui/commands_test.go
+++ b/tui/commands_test.go
@@ -104,7 +104,7 @@ func TestTuiReadSessionID_NotFound(t *testing.T) {
 
 // TestUpdate_LKey_Returns_WatchCmd verifies the l key returns a non-nil tea.ExecProcess cmd.
 func TestUpdate_LKey_Returns_WatchCmd(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneActive
 	m.active.active[activeJobKey("", 7)] = &activeJob{IssueNumber: 7, StageName: "Research", StartedAt: time.Now()}
 	m.active.activeNumToKey[7] = activeJobKey("", 7)
@@ -119,7 +119,7 @@ func TestUpdate_LKey_Returns_WatchCmd(t *testing.T) {
 // PATH sets an error status message and returns a nil cmd (no subprocess launched).
 func TestUpdate_AKey_NoAbtop_SetsStatusMsg(t *testing.T) {
 	t.Setenv("PATH", "")
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
 	if cmd != nil {
 		t.Error("expected nil cmd when abtop is not in PATH")
@@ -144,7 +144,7 @@ func TestUpdate_AKey_AbtopFound_ReturnsExecCmd(t *testing.T) {
 	}
 	t.Setenv("PATH", fmt.Sprintf("%s%c%s", dir, os.PathListSeparator, os.Getenv("PATH")))
 
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
 	if cmd == nil {
 		t.Error("expected non-nil cmd (tea.ExecProcess) when abtop is found in PATH")

--- a/tui/detail_test.go
+++ b/tui/detail_test.go
@@ -10,7 +10,7 @@ import (
 // TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel verifies enter in history pane toggles the detail panel.
 func TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -30,7 +30,7 @@ func TestUpdate_EnterKey_HistoryPane_TogglesDetailPanel(t *testing.T) {
 
 // TestUpdate_EscapeKey_ClosesDetailPanel verifies escape closes the detail panel.
 func TestUpdate_EscapeKey_ClosesDetailPanel(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.detailPanel = true
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -45,7 +45,7 @@ func TestUpdate_EscapeKey_ClosesDetailPanel(t *testing.T) {
 
 // TestUpdate_EnterKey_ActivePane_TogglesDetailPanel verifies enter in active pane toggles the detail panel.
 func TestUpdate_EnterKey_ActivePane_TogglesDetailPanel(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneActive

--- a/tui/events.go
+++ b/tui/events.go
@@ -145,6 +145,14 @@ type SkillsStaleEvent struct {
 
 func (SkillsStaleEvent) tuiEvent() {}
 
+// CustomWorkflowEvent is emitted when the three-way plugin comparison determines
+// that the operator has local customizations in .fabrik/plugin/ that differ from
+// the last recorded installed-version. This state is mutually exclusive with
+// SkillsStaleEvent (customWorkflow takes priority over skillsStaleCount).
+type CustomWorkflowEvent struct{}
+
+func (CustomWorkflowEvent) tuiEvent() {}
+
 // RateLimitAlertEvent is emitted by the engine when the GraphQL rate-limit state
 // transitions: Exhausted=true when a probe failure occurs while quota is low or
 // zero; Exhausted=false when quota recovers above rateLimitHealthyThreshold.

--- a/tui/footer_test.go
+++ b/tui/footer_test.go
@@ -18,7 +18,7 @@ func TestFooterHeight(t *testing.T) {
 }
 
 func TestViewFooter_Content(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board", Version: "2.0.0"}, "", nil, 0)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board", Version: "2.0.0"}, "", nil, 0, false)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -34,7 +34,7 @@ func TestViewFooter_Content(t *testing.T) {
 }
 
 func TestViewFooter_NoVersion(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0, false)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -52,7 +52,7 @@ func TestViewFooter_Truncation(t *testing.T) {
 		CWD:        "~/very/long/path/to/a/deeply/nested/project/directory",
 		BoardTitle: "Some Long Board Name For Truncation Test",
 		Version:    "99.99.99",
-	}, "", nil, 0)
+	}, "", nil, 0, false)
 	m.width = 30
 	footer := m.footer.View(m.width)
 
@@ -70,7 +70,7 @@ func TestViewFooter_Truncation(t *testing.T) {
 // TestViewFooter_RateLimitHidden verifies that the rate limit section is omitted
 // when no stats have been received (Limit==0).
 func TestViewFooter_RateLimitHidden(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0, false)
 	m.width = 120
 	// graphqlStats is zero-value (Limit==0) by default.
 	footer := m.footer.View(m.width)
@@ -89,7 +89,7 @@ func TestViewFooter_RateLimitHidden(t *testing.T) {
 // TestViewFooter_RateLimitShown verifies the rate limit section appears once
 // graphqlStats is populated, and contains the fraction and countdown.
 func TestViewFooter_RateLimitShown(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0)
+	m := New(30, ProjectInfo{CWD: "~/projects/myapp", BoardTitle: "My Board"}, "", nil, 0, false)
 	m.width = 120
 	m.footer.now = time.Now()
 	m.footer.graphqlStats = RateLimitStats{
@@ -129,7 +129,7 @@ func TestViewFooter_RateLimitColors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{CWD: "~", BoardTitle: "My Board"}, "", nil, 0)
+			m := New(30, ProjectInfo{CWD: "~", BoardTitle: "My Board"}, "", nil, 0, false)
 			m.width = 120
 			m.footer.now = now
 			m.footer.graphqlStats = RateLimitStats{
@@ -154,7 +154,7 @@ func TestViewFooter_TruncationWithRateLimit(t *testing.T) {
 		CWD:        "~/very/long/path/to/a/deeply/nested/project/directory",
 		BoardTitle: "Some Long Board Name For Truncation Test",
 		Version:    "99.99.99",
-	}, "", nil, 0)
+	}, "", nil, 0, false)
 	m.width = 40
 	m.footer.now = now
 	m.footer.graphqlStats = RateLimitStats{
@@ -188,7 +188,7 @@ func TestViewFooter_OSC8Hyperlink(t *testing.T) {
 		CWD:        "~",
 		BoardTitle: "My Board",
 		BoardURL:   "https://github.com/orgs/acme/projects/1",
-	}, "", nil, 0)
+	}, "", nil, 0, false)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -209,7 +209,7 @@ func TestViewFooter_PlainTextNoOSC8(t *testing.T) {
 		CWD:        "~",
 		BoardTitle: "My Board",
 		BoardURL:   "https://github.com/orgs/acme/projects/1",
-	}, "", nil, 0)
+	}, "", nil, 0, false)
 	m.width = 120
 	footer := m.footer.View(m.width)
 
@@ -224,7 +224,7 @@ func TestViewFooter_PlainTextNoOSC8(t *testing.T) {
 // TestViewFooter_NoTitleSlot verifies that no separator dot is shown when
 // BoardTitle is empty (footer is just CWD with no board title slot).
 func TestViewFooter_NoTitleSlot(t *testing.T) {
-	m := New(30, ProjectInfo{CWD: "~/project"}, "", nil, 0)
+	m := New(30, ProjectInfo{CWD: "~/project"}, "", nil, 0, false)
 	m.width = 120
 	footer := m.footer.View(m.width)
 	plain := ansi.Strip(footer)

--- a/tui/header.go
+++ b/tui/header.go
@@ -18,7 +18,8 @@ type HeaderComponent struct {
 	fabrikVersion     string
 	statusLine        string
 	statusMsg         string
-	skillsStaleCount  int // number of plugin skill files differing from embedded; 0 = up to date
+	skillsStaleCount  int  // number of plugin skill files differing from embedded; 0 = up to date
+	customWorkflow    bool // operator has local customizations in .fabrik/plugin/
 }
 
 func (h HeaderComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
@@ -45,6 +46,9 @@ func (h HeaderComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 		}
 	case SkillsStaleEvent:
 		h.skillsStaleCount = ev.Count
+	case CustomWorkflowEvent:
+		h.customWorkflow = true
+		h.skillsStaleCount = 0
 	}
 	return h, nil
 }
@@ -75,10 +79,13 @@ func (h HeaderComponent) View(width int) string {
 	}
 
 	// Pre-compute badge so its width is factored into the truncation budget.
-	// Without this the badge can push the rendered line past the terminal width.
+	// customWorkflow takes priority over skillsStaleCount — they are mutually exclusive.
 	badge := ""
 	badgeWidth := 0
-	if h.skillsStaleCount > 0 {
+	if h.customWorkflow {
+		badge = dimStyle.Render("  [u] custom workflow")
+		badgeWidth = lipgloss.Width(badge)
+	} else if h.skillsStaleCount > 0 {
 		badge = dimStyle.Render("  [u] skills out of date")
 		badgeWidth = lipgloss.Width(badge)
 	}
@@ -131,4 +138,10 @@ func (h *HeaderComponent) SetStatusMsg(msg string) {
 // the embedded versions. When n > 0, a persistent badge is shown in the header.
 func (h *HeaderComponent) SetSkillsStaleCount(n int) {
 	h.skillsStaleCount = n
+}
+
+// SetCustomWorkflow sets the custom workflow state. When true, a persistent
+// [u] custom workflow badge is shown (with priority over skillsStaleCount).
+func (h *HeaderComponent) SetCustomWorkflow(v bool) {
+	h.customWorkflow = v
 }

--- a/tui/header_test.go
+++ b/tui/header_test.go
@@ -18,7 +18,7 @@ func TestHeaderHeight(t *testing.T) {
 // TestViewHeader_TimerAlwaysVisible verifies that when the status message is
 // long enough to trigger truncation, the timer string still appears in the output.
 func TestViewHeader_TimerAlwaysVisible(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 60
 	m.header.nextPollAt = time.Now().Add(90 * time.Second)
 
@@ -51,7 +51,7 @@ func TestViewHeader_WidthNeverExceedsTerminal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil, 0)
+			m := New(30, ProjectInfo{}, "", nil, 0, false)
 			m.width = tc.width
 			m.header.nextPollAt = time.Now().Add(90 * time.Second)
 			m.header.statusLine = tc.statusLine
@@ -68,7 +68,7 @@ func TestViewHeader_WidthNeverExceedsTerminal(t *testing.T) {
 
 // TestViewHeader_WithStatusLine verifies statusLine content appears in the header.
 func TestViewHeader_WithStatusLine(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.header.statusLine = "some status"
 	header := m.header.View(m.width)
@@ -79,7 +79,7 @@ func TestViewHeader_WithStatusLine(t *testing.T) {
 
 // TestViewHeader_StatusLineTruncation verifies narrow headers truncate statusLine without panic.
 func TestViewHeader_StatusLineTruncation(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 25
 	m.header.statusLine = "a very very very very very very long status message"
 	header := m.header.View(m.width)
@@ -92,7 +92,7 @@ func TestViewHeader_StatusLineTruncation(t *testing.T) {
 // TestViewHeader_EffectiveInterval verifies that PollCompletedEvent with
 // EffectiveInterval updates the header timer to show the effective interval.
 func TestViewHeader_EffectiveInterval(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 
 	// Send a PollCompletedEvent with 2-minute effective interval.
@@ -117,7 +117,7 @@ func TestViewHeader_EffectiveInterval(t *testing.T) {
 // PollCompletedEvent sets the effective interval, a subsequent PollStartedEvent
 // uses that effective interval (not the configured one).
 func TestViewHeader_PollStartedUsesEffectiveInterval(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 
 	// Set effective interval via PollCompletedEvent.

--- a/tui/help.go
+++ b/tui/help.go
@@ -35,6 +35,12 @@ KEYBOARD SHORTCUTS
   Global
     a          Open abtop AI session monitor
     u          Upgrade plugin skills (when out of date; confirms first)
+               When [custom workflow] badge is shown: opens a 3-option dialog:
+               [1] Reconcile — quits TUI and prints a Claude Code prompt to
+                   stderr that walks through merging local customizations
+               [2] Overwrite — prompts you to type OVERWRITE to confirm
+                   (destructive: discards all local changes in .fabrik/plugin/)
+               [3] Cancel — dismisses the dialog
     w          Wake: reset idle backoff and poll immediately
     ctrl+r     Force refresh (same as SIGHUP)
     ?          Toggle this help panel

--- a/tui/history_test.go
+++ b/tui/history_test.go
@@ -26,7 +26,7 @@ func redirectHistory(t *testing.T) {
 // TestUpdate_JK_HistoryPane verifies j/k navigation in the history pane.
 func TestUpdate_JK_HistoryPane(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -59,7 +59,7 @@ func TestUpdate_JK_HistoryPane(t *testing.T) {
 // TestUpdate_CKey_DeletesHistoryEntry verifies c removes the selected entry.
 func TestUpdate_CKey_DeletesHistoryEntry(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -80,7 +80,7 @@ func TestUpdate_CKey_DeletesHistoryEntry(t *testing.T) {
 
 // TestUpdate_CKey_EmptyHistory_NoOp verifies c is a no-op with no history.
 func TestUpdate_CKey_EmptyHistory_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneHistory
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
 	if cmd != nil {
@@ -92,7 +92,7 @@ func TestUpdate_CKey_EmptyHistory_NoOp(t *testing.T) {
 // viewport area scrolls the YOffset down, and navigating back up scrolls it up.
 func TestUpdate_ScrollToVisible(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -149,7 +149,7 @@ func TestUpdate_ScrollToVisible(t *testing.T) {
 // resets the viewport to the top regardless of the current selection position.
 func TestUpdate_JobCompletedScrollsToTop(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -183,7 +183,7 @@ func TestUpdate_JobCompletedScrollsToTop(t *testing.T) {
 // TestUpdate_CapitalC_ClearAll verifies two C presses clear all history.
 func TestUpdate_CapitalC_ClearAll(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -213,7 +213,7 @@ func TestUpdate_CapitalC_ClearAll(t *testing.T) {
 
 // TestUpdate_QuitDuringConfirmClear_Cancels verifies q cancels confirmClear state.
 func TestUpdate_QuitDuringConfirmClear_Cancels(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.history.SetConfirmClear(true)
 	m.focusPane = paneHistory
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
@@ -228,7 +228,7 @@ func TestUpdate_QuitDuringConfirmClear_Cancels(t *testing.T) {
 
 // TestUpdate_NKey_CancelsConfirmClear verifies n cancels the clear confirmation.
 func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.history.SetConfirmClear(true)
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
 	nm := next.(Model)
@@ -240,7 +240,7 @@ func TestUpdate_NKey_CancelsConfirmClear(t *testing.T) {
 // TestViewHistory_ConfirmClear verifies the confirmation prompt is shown.
 func TestViewHistory_ConfirmClear(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.focusPane = paneHistory
@@ -255,7 +255,7 @@ func TestViewHistory_ConfirmClear(t *testing.T) {
 // TestViewHistory_IsComment verifies the 💬 emoji appears for comment history entries.
 func TestViewHistory_IsComment(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.history.history = []HistoryEntry{{IssueNumber: 5, StageName: "Implement", IsComment: true, Success: true}}
@@ -270,7 +270,7 @@ func TestViewHistory_IsComment(t *testing.T) {
 // TestViewHistory_ConfirmQuit verifies the quit confirmation prompt is shown in viewHistory.
 func TestViewHistory_ConfirmQuit(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	key42 := activeJobKey("", 42)
@@ -393,7 +393,7 @@ func TestLoadHistory_Dedup(t *testing.T) {
 func TestJobCompletedEvent_Dedup(t *testing.T) {
 	redirectHistory(t)
 
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -218,7 +218,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.overwriteTyped = ""
 				m.header.SetStatusMsg("")
 				return m, nil
-			case "backspace", "ctrl+h":
+			case "backspace", "ctrl+h", "delete":
 				if len(m.overwriteTyped) > 0 {
 					runes := []rune(m.overwriteTyped)
 					m.overwriteTyped = string(runes[:len(runes)-1])

--- a/tui/model.go
+++ b/tui/model.go
@@ -94,11 +94,15 @@ type Model struct {
 	height int
 
 	// focus and confirmation state
-	focusPane      pane
-	confirmQuit    bool
-	confirmUpgrade bool
-	detailPanel    bool
-	helpPanel      bool
+	focusPane              pane
+	confirmQuit            bool
+	confirmUpgrade         bool
+	confirmReconcile       bool
+	confirmOverwrite       bool
+	overwriteTyped         string
+	pendingReconcilePrompt string
+	detailPanel            bool
+	helpPanel              bool
 
 	// plugin directory
 	pluginDir string
@@ -120,13 +124,21 @@ type Model struct {
 // when the help panel is open, ensuring history always renders.
 const minHistoryRows = 5
 
+// reconcilePromptText is the operator-facing Claude Code reconciliation prompt
+// printed when the user selects [1] from the custom-workflow dialog.
+const reconcilePromptText = "In .fabrik/plugin/, compare the on-disk plugin files against the embedded source at plugin/fabrik-workflows/ in the fabrik repo. Help me reconcile my local customizations with the new embedded version. Preserve my customizations where they don't conflict with the new behavior; flag conflicts for review."
+
+// overwriteConfirmWord is the exact text the operator must type to confirm destructive overwrite.
+const overwriteConfirmWord = "OVERWRITE"
+
 // New creates an initial TUI model.
 // pollSeconds is the configured polling interval.
 // info provides project metadata displayed in the footer.
 // pluginDir is the Fabrik plugin directory passed to claude --plugin-dir (may be empty).
 // wakeCh is an optional channel the TUI sends on to wake the engine poll loop (may be nil).
 // skillsStaleCount is the number of plugin skill files that differ from embedded; 0 means up to date.
-func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct{}, skillsStaleCount int) Model {
+// customWorkflow is true when the three-way plugin comparison detects operator customizations.
+func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct{}, skillsStaleCount int, customWorkflow bool) Model {
 	interval := time.Duration(pollSeconds) * time.Second
 	now := time.Now()
 	spinnerFrames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -150,6 +162,7 @@ func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct
 			now:              now,
 			fabrikVersion:    info.FabrikVersion,
 			skillsStaleCount: skillsStaleCount,
+			customWorkflow:   customWorkflow,
 		},
 		alert:   AlertBannerComponent{now: now},
 		active:  active,
@@ -195,6 +208,42 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+		// When confirmOverwrite is active, collect OVERWRITE typed characters.
+		if m.confirmOverwrite {
+			switch ev.String() {
+			case "ctrl+c":
+				return m, tea.Quit
+			case "esc":
+				m.confirmOverwrite = false
+				m.overwriteTyped = ""
+				m.header.SetStatusMsg("")
+				return m, nil
+			case "backspace", "ctrl+h":
+				if len(m.overwriteTyped) > 0 {
+					runes := []rune(m.overwriteTyped)
+					m.overwriteTyped = string(runes[:len(runes)-1])
+				}
+				return m, nil
+			default:
+				ch := ev.String()
+				if len([]rune(ch)) == 1 && len([]rune(m.overwriteTyped)) < len(overwriteConfirmWord) {
+					m.overwriteTyped += ch
+				}
+				if m.overwriteTyped == overwriteConfirmWord {
+					m.confirmOverwrite = false
+					m.overwriteTyped = ""
+					return m, upgradePluginCmd(m.pluginDir)
+				}
+				if len([]rune(m.overwriteTyped)) == len(overwriteConfirmWord) && m.overwriteTyped != overwriteConfirmWord {
+					// Full word typed but wrong — clear and cancel.
+					m.confirmOverwrite = false
+					m.overwriteTyped = ""
+					m.header.SetStatusMsg("")
+				}
+				return m, nil
+			}
+		}
+
 		switch ev.String() {
 		case "ctrl+c":
 			return m, tea.Quit
@@ -224,6 +273,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "n", "N":
+			if m.confirmReconcile {
+				m.confirmReconcile = false
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
+			if m.confirmOverwrite {
+				m.confirmOverwrite = false
+				m.overwriteTyped = ""
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
 			if m.confirmUpgrade {
 				m.confirmUpgrade = false
 				m.header.SetStatusMsg("")
@@ -246,6 +306,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "esc":
+			if m.confirmReconcile {
+				m.confirmReconcile = false
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
+			if m.confirmOverwrite {
+				m.confirmOverwrite = false
+				m.overwriteTyped = ""
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
 			if m.confirmUpgrade {
 				m.confirmUpgrade = false
 				m.header.SetStatusMsg("")
@@ -329,7 +400,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, sendSighupCmd()
 
 		case "u":
-			if m.header.skillsStaleCount > 0 {
+			if m.header.customWorkflow {
+				m.confirmReconcile = true
+				m.header.SetStatusMsg("[1] Reconcile via Claude Code  [2] Overwrite (destructive)  [3] Cancel")
+			} else if m.header.skillsStaleCount > 0 {
 				m.confirmUpgrade = true
 				m.header.SetStatusMsg(fmt.Sprintf(
 					"Upgrade %d plugin file(s)? Active invocations pick up changes on next run. [y/N]",
@@ -340,10 +414,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
+		case "1":
+			if m.confirmReconcile {
+				m.confirmReconcile = false
+				m.pendingReconcilePrompt = reconcilePromptText
+				return m, tea.Quit
+			}
+			return m, nil
+
+		case "2":
+			if m.confirmReconcile {
+				m.confirmReconcile = false
+				m.confirmOverwrite = true
+				m.overwriteTyped = ""
+				m.header.SetStatusMsg("This will discard your customizations. Type 'OVERWRITE' to confirm.")
+				return m, nil
+			}
+			return m, nil
+
+		case "3":
+			if m.confirmReconcile {
+				m.confirmReconcile = false
+				m.header.SetStatusMsg("")
+				return m, nil
+			}
+			return m, nil
+
 		case "y", "Y":
 			if m.confirmUpgrade {
 				m.confirmUpgrade = false
-				return m, upgradePluginCmd()
+				return m, upgradePluginCmd(m.pluginDir)
 			}
 			// Not confirming — forward to history viewport for scrolling.
 			var cmd tea.Cmd
@@ -418,9 +518,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Fan out to all components
 		comp, _ := m.header.Update(msg)
 		m.header = comp.(HeaderComponent)
-		// TickEvent clears statusMsg; re-show the upgrade confirmation prompt so
-		// it remains visible until the user responds with y/n/esc.
-		if m.confirmUpgrade {
+		// TickEvent clears statusMsg; re-show active confirmation prompts so
+		// they remain visible until the user responds.
+		if m.confirmReconcile {
+			m.header.SetStatusMsg("[1] Reconcile via Claude Code  [2] Overwrite (destructive)  [3] Cancel")
+		} else if m.confirmOverwrite {
+			m.header.SetStatusMsg("This will discard your customizations. Type 'OVERWRITE' to confirm.")
+		} else if m.confirmUpgrade {
 			m.header.SetStatusMsg(fmt.Sprintf(
 				"Upgrade %d plugin file(s)? Active invocations pick up changes on next run. [y/N]",
 				m.header.skillsStaleCount,
@@ -508,14 +612,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case SkillsStaleEvent:
 		m.header.SetSkillsStaleCount(ev.Count)
+		if ev.Count == 0 {
+			m.header.SetCustomWorkflow(false)
+		}
+		return m, nil
+
+	case CustomWorkflowEvent:
+		m.header.SetCustomWorkflow(true)
+		m.header.SetSkillsStaleCount(0)
 		return m, nil
 
 	case pluginUpgradeResultMsg:
 		m.confirmUpgrade = false
+		m.confirmOverwrite = false
+		m.overwriteTyped = ""
 		if ev.Err != nil {
 			m.header.SetStatusMsg(fmt.Sprintf("plugin upgrade failed: %v", ev.Err))
 		} else {
 			m.header.SetSkillsStaleCount(0)
+			m.header.SetCustomWorkflow(false)
 			m.header.SetStatusMsg(fmt.Sprintf("Plugin skills upgraded: %d file(s)", ev.Wrote))
 		}
 		return m, nil
@@ -635,3 +750,10 @@ func (m Model) View() string {
 
 // viewHeader, viewActive, viewHistory, viewFooter, viewDetail are in their
 // respective component files (header.go, active.go, history.go, footer.go, detail.go).
+
+// PendingReconcilePrompt returns the reconciliation prompt text set when the
+// user selects [1] from the custom-workflow dialog, or an empty string if none.
+// The caller (runTUI) should print this to stderr after p.Run() returns.
+func (m Model) PendingReconcilePrompt() string {
+	return m.pendingReconcilePrompt
+}

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -1182,14 +1182,12 @@ func TestUKey_OverwriteConfirm_WrongWord(t *testing.T) {
 	m.confirmOverwrite = true
 
 	// Type a different 9-char word.
-	wrong := "OVERWRITE" // length 9; let's type OVERWRITX (wrong last char)
 	word := []rune("OVERWRITX")
 	for _, ch := range word {
 		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
 		m = next.(Model)
 	}
 
-	_ = wrong
 	if m.confirmOverwrite {
 		t.Error("expected confirmOverwrite=false after wrong full word")
 	}

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -1047,3 +1047,245 @@ func TestUpdate_PluginUpgradeResultMsg_Error(t *testing.T) {
 		t.Errorf("statusMsg should contain error, got %q", nm.header.statusMsg)
 	}
 }
+
+// TestUpdate_CustomWorkflowEvent verifies that CustomWorkflowEvent sets the
+// customWorkflow badge and clears skillsStaleCount.
+func TestUpdate_CustomWorkflowEvent(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 4, false)
+
+	next, cmd := m.Update(CustomWorkflowEvent{})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from CustomWorkflowEvent")
+	}
+	if !nm.header.customWorkflow {
+		t.Error("expected customWorkflow=true after CustomWorkflowEvent")
+	}
+	if nm.header.skillsStaleCount != 0 {
+		t.Errorf("skillsStaleCount = %d, want 0 after CustomWorkflowEvent", nm.header.skillsStaleCount)
+	}
+}
+
+// TestUpdate_New_WithCustomWorkflow verifies customWorkflow=true is wired from New.
+func TestUpdate_New_WithCustomWorkflow(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	if !m.header.customWorkflow {
+		t.Error("expected customWorkflow=true when New called with true")
+	}
+}
+
+// TestUKey_CustomWorkflow verifies pressing u when customWorkflow=true enters
+// confirmReconcile and shows the 3-option status message.
+func TestUKey_CustomWorkflow(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from u key entering confirmReconcile")
+	}
+	if !nm.confirmReconcile {
+		t.Error("expected confirmReconcile=true after u key with customWorkflow")
+	}
+	if !strings.Contains(nm.header.statusMsg, "[1]") {
+		t.Errorf("statusMsg should show 3-option dialog, got %q", nm.header.statusMsg)
+	}
+	if !strings.Contains(nm.header.statusMsg, "[2]") {
+		t.Errorf("statusMsg should show overwrite option, got %q", nm.header.statusMsg)
+	}
+	if !strings.Contains(nm.header.statusMsg, "[3]") {
+		t.Errorf("statusMsg should show cancel option, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUKey_CustomWorkflow_Key3_Cancels verifies [3] cancels confirmReconcile.
+func TestUKey_CustomWorkflow_Key3_Cancels(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmReconcile = true
+	m.header.SetStatusMsg("[1] Reconcile  [2] Overwrite  [3] Cancel")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("3")})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from [3] cancel")
+	}
+	if nm.confirmReconcile {
+		t.Error("expected confirmReconcile=false after [3]")
+	}
+	if nm.header.statusMsg != "" {
+		t.Errorf("expected empty statusMsg after cancel, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUKey_CustomWorkflow_Key2_EntersConfirmOverwrite verifies [2] transitions
+// to confirmOverwrite state with the OVERWRITE prompt.
+func TestUKey_CustomWorkflow_Key2_EntersConfirmOverwrite(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmReconcile = true
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from [2]")
+	}
+	if nm.confirmReconcile {
+		t.Error("expected confirmReconcile=false after [2]")
+	}
+	if !nm.confirmOverwrite {
+		t.Error("expected confirmOverwrite=true after [2]")
+	}
+	if !strings.Contains(nm.header.statusMsg, "OVERWRITE") {
+		t.Errorf("statusMsg should prompt for OVERWRITE, got %q", nm.header.statusMsg)
+	}
+}
+
+// TestUKey_OverwriteConfirm verifies that typing OVERWRITE one character at a
+// time triggers the upgrade cmd.
+func TestUKey_OverwriteConfirm(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmOverwrite = true
+
+	word := "OVERWRITE"
+	var lastModel Model
+	var lastCmd tea.Cmd
+	for i, ch := range word {
+		var next tea.Model
+		next, lastCmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		m = next.(Model)
+		if i < len(word)-1 {
+			if lastCmd != nil {
+				t.Errorf("expected nil cmd after char %d (%c), got non-nil", i, ch)
+			}
+			if !m.confirmOverwrite {
+				t.Errorf("expected confirmOverwrite still true after char %d (%c)", i, ch)
+			}
+		}
+	}
+	lastModel = m
+
+	// After typing full OVERWRITE: confirmOverwrite cleared, cmd returned.
+	if lastModel.confirmOverwrite {
+		t.Error("expected confirmOverwrite=false after full OVERWRITE typed")
+	}
+	if lastCmd == nil {
+		t.Error("expected non-nil cmd (upgrade) after OVERWRITE typed correctly")
+	}
+}
+
+// TestUKey_OverwriteConfirm_WrongWord verifies a wrong word clears confirmOverwrite.
+func TestUKey_OverwriteConfirm_WrongWord(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmOverwrite = true
+
+	// Type a different 9-char word.
+	wrong := "OVERWRITE" // length 9; let's type OVERWRITX (wrong last char)
+	word := []rune("OVERWRITX")
+	for _, ch := range word {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		m = next.(Model)
+	}
+
+	_ = wrong
+	if m.confirmOverwrite {
+		t.Error("expected confirmOverwrite=false after wrong full word")
+	}
+	if m.overwriteTyped != "" {
+		t.Errorf("expected overwriteTyped cleared, got %q", m.overwriteTyped)
+	}
+}
+
+// TestUKey_OverwriteConfirm_Backspace verifies backspace removes last character.
+func TestUKey_OverwriteConfirm_Backspace(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmOverwrite = true
+
+	// Type "OVE" then backspace.
+	for _, ch := range "OVE" {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{ch}})
+		m = next.(Model)
+	}
+	if m.overwriteTyped != "OVE" {
+		t.Fatalf("expected overwriteTyped=OVE, got %q", m.overwriteTyped)
+	}
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(Model)
+	if m.overwriteTyped != "OV" {
+		t.Errorf("expected overwriteTyped=OV after backspace, got %q", m.overwriteTyped)
+	}
+	if !m.confirmOverwrite {
+		t.Error("expected confirmOverwrite=true after backspace")
+	}
+}
+
+// TestUKey_OverwriteConfirm_Esc verifies esc cancels confirmOverwrite.
+func TestUKey_OverwriteConfirm_Esc(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmOverwrite = true
+	m.overwriteTyped = "OVER"
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	nm := next.(Model)
+
+	if cmd != nil {
+		t.Error("expected nil cmd from esc cancel of overwrite")
+	}
+	if nm.confirmOverwrite {
+		t.Error("expected confirmOverwrite=false after esc")
+	}
+	if nm.overwriteTyped != "" {
+		t.Errorf("expected overwriteTyped cleared, got %q", nm.overwriteTyped)
+	}
+}
+
+// TestUpdate_SkillsStaleEvent_Zero_ClearsCustomWorkflow verifies that
+// SkillsStaleEvent{Count:0} clears the customWorkflow badge.
+func TestUpdate_SkillsStaleEvent_Zero_ClearsCustomWorkflow(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true) // customWorkflow=true
+
+	next, _ := m.Update(SkillsStaleEvent{Count: 0})
+	nm := next.(Model)
+
+	if nm.header.customWorkflow {
+		t.Error("expected customWorkflow=false after SkillsStaleEvent{Count:0}")
+	}
+}
+
+// TestUpdate_TickEvent_ConfirmReconcile_PromptPersists verifies the reconcile
+// dialog prompt is re-shown after a TickEvent clears statusMsg.
+func TestUpdate_TickEvent_ConfirmReconcile_PromptPersists(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true)
+	m.confirmReconcile = true
+	m.header.SetStatusMsg("[1] Reconcile  [2] Overwrite  [3] Cancel")
+
+	next, _ := m.Update(TickEvent{At: time.Now()})
+	nm := next.(Model)
+
+	if !nm.confirmReconcile {
+		t.Error("expected confirmReconcile still true after tick")
+	}
+	if nm.header.statusMsg == "" {
+		t.Error("expected dialog prompt to be re-shown after tick")
+	}
+}
+
+// TestUpdate_PluginUpgradeResultMsg_ClearsCustomWorkflow verifies a successful
+// upgrade also clears the customWorkflow badge.
+func TestUpdate_PluginUpgradeResultMsg_ClearsCustomWorkflow(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, 0, true) // customWorkflow=true
+	m.confirmOverwrite = true
+
+	next, _ := m.Update(pluginUpgradeResultMsg{Wrote: 5, Err: nil})
+	nm := next.(Model)
+
+	if nm.header.customWorkflow {
+		t.Error("expected customWorkflow=false after successful upgrade")
+	}
+	if nm.confirmOverwrite {
+		t.Error("expected confirmOverwrite=false after successful upgrade")
+	}
+}

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	if m.header.pollInterval != 30*time.Second {
 		t.Errorf("pollInterval = %v, want 30s", m.header.pollInterval)
 	}
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 
 func TestNew_StoresProjectInfo(t *testing.T) {
 	info := ProjectInfo{CWD: "~/foo", BoardTitle: "Acme Board", Version: "1.2.3"}
-	m := New(30, info, "", nil, 0)
+	m := New(30, info, "", nil, 0, false)
 	if m.footer.projectInfo != info {
 		t.Errorf("projectInfo = %+v, want %+v", m.footer.projectInfo, info)
 	}
@@ -38,7 +38,7 @@ func TestNew_StoresProjectInfo(t *testing.T) {
 
 // TestInit verifies Init returns a non-nil cmd (the initial tick).
 func TestInit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	cmd := m.Init()
 	if cmd == nil {
 		t.Error("Init() should return a non-nil cmd")
@@ -46,7 +46,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestUpdate_TickEvent(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	initial := m.active.spinnerIdx
@@ -67,7 +67,7 @@ func TestUpdate_TickEvent(t *testing.T) {
 }
 
 func TestUpdate_PollStartedAndCompleted(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	before := time.Now()
 
 	next, _ := m.Update(PollStartedEvent{Owner: "o", Repo: "r", Project: 1})
@@ -85,7 +85,7 @@ func TestUpdate_PollStartedAndCompleted(t *testing.T) {
 }
 
 func TestUpdate_QuitKey(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	if cmd == nil {
 		t.Error("expected quit cmd from 'q' key")
@@ -99,7 +99,7 @@ func TestUpdate_QuitKey(t *testing.T) {
 
 // TestUpdate_TabKey_SwitchesPanes verifies tab toggles focus between panes.
 func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	if m.focusPane != paneActive {
@@ -124,7 +124,7 @@ func TestUpdate_RKey_HistoryPane_WithEntry_MissingWorktree(t *testing.T) {
 	redirectHistory(t)
 	// Chdir to a temp dir so worktree path won't accidentally exist.
 	t.Chdir(t.TempDir())
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneHistory
 	m.history.history = []HistoryEntry{
 		{IssueNumber: 42, StageName: "Research", StageModel: "sonnet", Success: true},
@@ -150,7 +150,7 @@ func TestUpdate_RKey_HistoryPane_WithWorktree(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(dir)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneHistory
 	m.history.history = []HistoryEntry{
 		{IssueNumber: 42, StageName: "Research", StageModel: "sonnet", Success: true},
@@ -164,7 +164,7 @@ func TestUpdate_RKey_HistoryPane_WithWorktree(t *testing.T) {
 }
 
 func TestUpdate_RKey_HistoryPane_NoEntries_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneHistory
 	m.history.history = nil
 
@@ -176,7 +176,7 @@ func TestUpdate_RKey_HistoryPane_NoEntries_NoOp(t *testing.T) {
 
 func TestUpdate_RKey_HistoryPane_ActiveIssue_SetsStatusMsg(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.focusPane = paneHistory
 	// Add issue 42 to both active map and history.
 	key42 := activeJobKey("", 42)
@@ -196,7 +196,7 @@ func TestUpdate_RKey_HistoryPane_ActiveIssue_SetsStatusMsg(t *testing.T) {
 }
 
 func TestUpdate_LogEvent_IssueZero_StatusLine(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	next, _ := m.Update(LogEvent{IssueNumber: 0, Tag: "poll", Message: "polling now\n"})
@@ -207,7 +207,7 @@ func TestUpdate_LogEvent_IssueZero_StatusLine(t *testing.T) {
 }
 
 func TestUpdate_QKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
 
@@ -222,7 +222,7 @@ func TestUpdate_QKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
 }
 
 func TestUpdate_QKey_WhenConfirmQuit_Quits(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.confirmQuit = true
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
@@ -238,7 +238,7 @@ func TestUpdate_QKey_WhenConfirmQuit_Quits(t *testing.T) {
 }
 
 func TestUpdate_NKey_CancelsConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.confirmQuit = true
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
@@ -252,7 +252,7 @@ func TestUpdate_NKey_CancelsConfirmQuit(t *testing.T) {
 }
 
 func TestUpdate_EscKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
 
@@ -267,7 +267,7 @@ func TestUpdate_EscKey_WithActiveJobs_ShowsConfirmQuit(t *testing.T) {
 }
 
 func TestUpdate_EscKey_WhenConfirmQuit_Cancels(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.confirmQuit = true
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
@@ -283,7 +283,7 @@ func TestUpdate_EscKey_WhenConfirmQuit_Cancels(t *testing.T) {
 }
 
 func TestUpdate_CtrlC_BypassesConfirmQuit(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.confirmQuit = true
 	key42 := activeJobKey("", 42)
 	m.active.active[key42] = &activeJob{IssueNumber: 42, StageName: "Implement", StartedAt: time.Now()}
@@ -299,7 +299,7 @@ func TestUpdate_CtrlC_BypassesConfirmQuit(t *testing.T) {
 }
 
 func TestView_BeforeWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	// Before width is set, View should return a loading placeholder without panicking
 	v := m.View()
 	if !strings.Contains(v, "Loading") {
@@ -308,7 +308,7 @@ func TestView_BeforeWindowSize(t *testing.T) {
 }
 
 func TestView_AfterWindowSize(t *testing.T) {
-	m := New(30, ProjectInfo{BoardTitle: "Acme PM", CWD: "~/myproject"}, "", nil, 0)
+	m := New(30, ProjectInfo{BoardTitle: "Acme PM", CWD: "~/myproject"}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	m.header.nextPollAt = time.Now().Add(30 * time.Second)
@@ -344,7 +344,7 @@ func TestLayoutHeightInvariant(t *testing.T) {
 
 	for _, n := range []int{0, 1, 7, 8, 15} {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil, 0)
+			m := New(30, ProjectInfo{}, "", nil, 0, false)
 			// Add n active jobs.
 			now := time.Now()
 			for i := 0; i < n; i++ {
@@ -385,7 +385,7 @@ func TestLayoutHeightInvariant_SmallTerminal(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("h=%d,n=%d", tc.termHeight, tc.nActive), func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil, 0)
+			m := New(30, ProjectInfo{}, "", nil, 0, false)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -426,7 +426,7 @@ func TestLayoutHeightInvariant_NarrowWithHint(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil, 0)
+			m := New(30, ProjectInfo{}, "", nil, 0, false)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -468,7 +468,7 @@ func TestTuiEventMethods(t *testing.T) {
 // RateLimitAlertEvent{Exhausted: true}, the alert banner becomes visible when
 // graphqlStats show low remaining quota.
 func TestUpdate_RateLimitAlertEvent_Exhausted(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	// First deliver stats that put ratio at 10% (below 20% threshold).
 	next, _ := m.Update(PollCompletedEvent{
 		GraphQLStats: RateLimitStats{Limit: 100, Remaining: 10},
@@ -490,7 +490,7 @@ func TestUpdate_RateLimitAlertEvent_Exhausted(t *testing.T) {
 // TestUpdate_RateLimitAlertEvent_Recovered verifies that after receiving a
 // RateLimitAlertEvent{Exhausted: false}, the banner's bannerActive flag is cleared.
 func TestUpdate_RateLimitAlertEvent_Recovered(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	// Manually set banner active with stats still low.
 	m.alert.bannerActive = true
 	m.alert.graphqlStats = RateLimitStats{Limit: 100, Remaining: 10}
@@ -512,7 +512,7 @@ func TestUpdateLayout_AlertBannerHeightBudget(t *testing.T) {
 	const termWidth = 80
 	const termHeight = 24
 
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	// Set stats so banner is visible (Remaining == 0).
 	m.alert.graphqlStats = RateLimitStats{Limit: 100, Remaining: 0}
 	m.alert.now = time.Now()
@@ -538,7 +538,7 @@ func TestUpdateLayout_AlertBannerHeightBudget(t *testing.T) {
 // or esc closes it, and opening help closes the detail panel.
 func TestHelpPanelToggle(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 
@@ -567,7 +567,7 @@ func TestHelpPanelToggle(t *testing.T) {
 	}
 
 	// Pressing ? while detail panel is open closes detail and opens help.
-	m2 := New(30, ProjectInfo{}, "", nil, 0)
+	m2 := New(30, ProjectInfo{}, "", nil, 0, false)
 	m2.width = 80
 	m2.height = 24
 	m2.detailPanel = true
@@ -585,7 +585,7 @@ func TestHelpPanelToggle(t *testing.T) {
 // would normally change model state (tab, enter, r, l) are suppressed.
 func TestHelpPanelSuppressKeys(t *testing.T) {
 	redirectHistory(t)
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 	// Open help panel.
@@ -641,7 +641,7 @@ func TestLayoutHeightInvariant_ConfirmClear(t *testing.T) {
 
 	setup := func(t *testing.T) Model {
 		t.Helper()
-		m := New(30, ProjectInfo{}, "", nil, 0)
+		m := New(30, ProjectInfo{}, "", nil, 0, false)
 		for i := 0; i < 3; i++ {
 			m.history.history = append(m.history.history, HistoryEntry{
 				IssueNumber: i + 1, StageName: "Research", Success: true, Completed: true,
@@ -733,7 +733,7 @@ func TestLayoutHeightInvariant_DetailPanel(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil, 0)
+			m := New(30, ProjectInfo{}, "", nil, 0, false)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				key := fmt.Sprintf("issue-%d", i+1)
@@ -795,7 +795,7 @@ func TestLayoutHeightInvariant_WithHelp(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := New(30, ProjectInfo{}, "", nil, 0)
+			m := New(30, ProjectInfo{}, "", nil, 0, false)
 			now := time.Now()
 			for i := 0; i < tc.nActive; i++ {
 				m.active.active[fmt.Sprintf("issue-%d", i+1)] = &activeJob{StageName: "Research", StartedAt: now}
@@ -829,7 +829,7 @@ func TestLayoutHeightInvariant_WithHelp(t *testing.T) {
 // and sets the status message to "waking up...".
 func TestUpdate_WKey_SendsOnWakeCh(t *testing.T) {
 	wakeCh := make(chan struct{}, 1)
-	m := New(30, ProjectInfo{}, "", wakeCh, 0)
+	m := New(30, ProjectInfo{}, "", wakeCh, 0, false)
 	m.width = 80
 	m.height = 24
 	m.header.nextPollAt = time.Now().Add(5 * time.Minute)
@@ -854,7 +854,7 @@ func TestUpdate_WKey_SendsOnWakeCh(t *testing.T) {
 
 // TestUpdate_WKey_NilWakeCh_NoOp verifies that pressing w with no wakeCh is a no-op.
 func TestUpdate_WKey_NilWakeCh_NoOp(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
 	m.height = 24
 
@@ -869,7 +869,7 @@ func TestUpdate_WKey_NilWakeCh_NoOp(t *testing.T) {
 // TestUpdate_UKey_WhenStale_SetsConfirmUpgrade verifies that pressing u when
 // skillsStaleCount > 0 sets confirmUpgrade and shows a confirmation prompt.
 func TestUpdate_UKey_WhenStale_SetsConfirmUpgrade(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 3)
+	m := New(30, ProjectInfo{}, "", nil, 3, false)
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
 	nm := next.(Model)
@@ -888,7 +888,7 @@ func TestUpdate_UKey_WhenStale_SetsConfirmUpgrade(t *testing.T) {
 // TestUpdate_TickEvent_ConfirmUpgrade_PromptPersists verifies that the upgrade
 // confirmation prompt is re-shown after a TickEvent clears statusMsg.
 func TestUpdate_TickEvent_ConfirmUpgrade_PromptPersists(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 2)
+	m := New(30, ProjectInfo{}, "", nil, 2, false)
 	m.confirmUpgrade = true
 	m.header.SetStatusMsg("Upgrade 2 plugin file(s)? Active invocations pick up changes on next run. [y/N]")
 
@@ -909,7 +909,7 @@ func TestUpdate_TickEvent_ConfirmUpgrade_PromptPersists(t *testing.T) {
 // TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg verifies that pressing u when
 // skillsStaleCount == 0 shows "up to date" message without setting confirmUpgrade.
 func TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
 	nm := next.(Model)
@@ -928,7 +928,7 @@ func TestUpdate_UKey_WhenUpToDate_ShowsStatusMsg(t *testing.T) {
 // TestUpdate_YKey_WhenConfirmUpgrade_DispatchesCmd verifies that pressing y
 // when confirmUpgrade is true clears the flag and returns the upgrade cmd.
 func TestUpdate_YKey_WhenConfirmUpgrade_DispatchesCmd(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 2)
+	m := New(30, ProjectInfo{}, "", nil, 2, false)
 	m.confirmUpgrade = true
 
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
@@ -945,7 +945,7 @@ func TestUpdate_YKey_WhenConfirmUpgrade_DispatchesCmd(t *testing.T) {
 // TestUpdate_NKey_CancelsConfirmUpgrade verifies that pressing n when
 // confirmUpgrade is true clears the flag and status message.
 func TestUpdate_NKey_CancelsConfirmUpgrade(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 2)
+	m := New(30, ProjectInfo{}, "", nil, 2, false)
 	m.confirmUpgrade = true
 	m.header.statusMsg = "Upgrade 2 plugin file(s)? [y/N]"
 
@@ -966,7 +966,7 @@ func TestUpdate_NKey_CancelsConfirmUpgrade(t *testing.T) {
 // TestUpdate_EscKey_CancelsConfirmUpgrade verifies that pressing esc when
 // confirmUpgrade is true clears the flag and status message.
 func TestUpdate_EscKey_CancelsConfirmUpgrade(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 2)
+	m := New(30, ProjectInfo{}, "", nil, 2, false)
 	m.confirmUpgrade = true
 	m.header.statusMsg = "Upgrade 2 plugin file(s)? [y/N]"
 
@@ -987,7 +987,7 @@ func TestUpdate_EscKey_CancelsConfirmUpgrade(t *testing.T) {
 // TestUpdate_New_WithSkillsStaleCount initializes with a stale count and
 // verifies the header badge field is set.
 func TestUpdate_New_WithSkillsStaleCount(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 5)
+	m := New(30, ProjectInfo{}, "", nil, 5, false)
 	if m.header.skillsStaleCount != 5 {
 		t.Errorf("skillsStaleCount = %d, want 5", m.header.skillsStaleCount)
 	}
@@ -995,7 +995,7 @@ func TestUpdate_New_WithSkillsStaleCount(t *testing.T) {
 
 // TestUpdate_SkillsStaleEvent updates the header badge count.
 func TestUpdate_SkillsStaleEvent(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 0)
+	m := New(30, ProjectInfo{}, "", nil, 0, false)
 
 	next, cmd := m.Update(SkillsStaleEvent{Count: 4})
 	nm := next.(Model)
@@ -1011,7 +1011,7 @@ func TestUpdate_SkillsStaleEvent(t *testing.T) {
 // TestUpdate_PluginUpgradeResultMsg_Success verifies a successful upgrade clears
 // the badge and shows a success message.
 func TestUpdate_PluginUpgradeResultMsg_Success(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 3)
+	m := New(30, ProjectInfo{}, "", nil, 3, false)
 	m.confirmUpgrade = true
 
 	next, _ := m.Update(pluginUpgradeResultMsg{Wrote: 3, Err: nil})
@@ -1031,7 +1031,7 @@ func TestUpdate_PluginUpgradeResultMsg_Success(t *testing.T) {
 // TestUpdate_PluginUpgradeResultMsg_Error verifies a failed upgrade retains the
 // badge and shows an error message.
 func TestUpdate_PluginUpgradeResultMsg_Error(t *testing.T) {
-	m := New(30, ProjectInfo{}, "", nil, 2)
+	m := New(30, ProjectInfo{}, "", nil, 2, false)
 	m.confirmUpgrade = true
 
 	next, _ := m.Update(pluginUpgradeResultMsg{Wrote: 0, Err: fmt.Errorf("disk full")})


### PR DESCRIPTION
## Summary

Closes #746

Fabrik previously overwrote `.fabrik/plugin/` skills unconditionally on auto-upgrade, silently discarding operator customizations. This PR adds a three-way comparison (embedded ↔ `.installed-version` fingerprint ↔ disk) to distinguish upstream upgrades from operator edits, then routes each case safely.

- **`plugin/refresh.go`**: `CheckPluginState()` implements the four-state table (up-to-date / upgrade-available / custom-workflow / migration); six new hash primitives (`ComputeEmbeddedVersion`, `ComputeDiskVersion`, `WriteVersionHash`, `WriteInstalledVersion`, `ReadInstalledVersion`)
- **`cmd/upgrade.go`**: `--force` (destructive overwrite) and `--reconcile` (prints Claude Code prompt for guided merge); `checkPluginSkillsWithReader` calls `CheckPluginState` before any refresh
- **`tui/model.go`**: `[u] custom workflow` badge → three-option dialog: [1] Reconcile (quits TUI, prints prompt to stderr), [2] Overwrite (typed `OVERWRITE` confirmation), [3] Cancel
- **`cmd/root.go`**: all auto-refresh paths (auto-upgrade, SIGHUP restart) check `CheckPluginState` before calling `RefreshPlugin`
- **Docs**: `docs/USER_GUIDE.md` upgrade-protection subsection with state table; `adrs/046-installed-version-tracking.md`; `tui/help.go` extended `u` key docs

## Test plan

- [x] `go test -race ./...` passes (all packages)
- [x] `go vet ./...` clean
- [x] `plugin/refresh_test.go`: migration, no-op, auto-refresh, custom-workflow states
- [x] `cmd/upgrade_test.go`: `--force`, `--reconcile`, `CustomWorkflowError`, auto-refresh (TTY/non-TTY), custom-workflow (TTY/non-TTY)
- [x] `tui/model_test.go`: `CustomWorkflowEvent`, confirmReconcile dialog, `OVERWRITE` input (correct/wrong/backspace/esc), badge clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)