### PR TITLE
Update docs for v0.0.64

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,11 @@ re-execs the binary in place — no terminal disruption, no lost state. Use it
 to pick up a new binary after `go install` without restarting the session.
 The terminal alt-screen is properly restored on signal-driven exit, so no
 `reset` is needed after a SIGINT, SIGTERM, or SIGHUP. Plugin-skills are checked and
-refreshed non-interactively during restart — the process never hangs waiting
-for a prompt. See
+refreshed non-interactively during restart when no local customizations are detected —
+the process never hangs waiting for a prompt. When local customizations are present,
+the refresh is skipped to preserve your edits and the `[u] custom workflow` badge
+appears on next TUI startup instead, so operator customizations are never silently
+overwritten. See
 [USER_GUIDE.md §Recovering from Wedged State](docs/USER_GUIDE.md#recovering-from-wedged-state)
 for the full escape-hatch procedure.
 
@@ -310,7 +313,7 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `fabrik watch <issue-number>` | Open a real-time TUI for a single issue — live Claude output, stage history, PR/CI status |
 | `fabrik stream-filter` | Read NDJSON Claude output from stdin and render it as human-readable text |
 | `fabrik resume <issue-number>` | Resume an interrupted Claude session for an issue |
-| `fabrik upgrade` | Self-update the Fabrik binary (release builds) and refresh plugin skills in `.fabrik/plugin/` from embedded defaults |
+| `fabrik upgrade` | Self-update the Fabrik binary (release builds) and refresh plugin skills in `.fabrik/plugin/` from embedded defaults. Plain `fabrik upgrade` errors when local customizations are detected; use `--force` to overwrite unconditionally or `--reconcile` for a guided merge prompt. See the [User Guide](docs/USER_GUIDE.md#upgrade-protection-for-customized-skills) for details. |
 
 ## Built-in Skills
 
@@ -320,6 +323,8 @@ Fabrik ships two user-invocable Claude Code skills (type `/skill-name` in any Cl
 |-------|-------------|
 | `/cut-release` | Pre-flight checks, curated release notes, commit/tag/push, and auto-files a doc-update issue — see [§5 of the User Guide](docs/USER_GUIDE.md#built-in-skill-cut-release) |
 | `/audit-documentation` | Scans recently shipped issues, identifies documentation gaps, closes covered issues, and files new gap issues — see [§5 of the User Guide](docs/USER_GUIDE.md#built-in-skill-audit-documentation) |
+
+Operator customizations to built-in skills are protected — upgrades detect local edits and offer guided reconciliation rather than silently overwriting. See [Upgrade protection for customized skills](docs/USER_GUIDE.md#upgrade-protection-for-customized-skills).
 
 The main Fabrik dashboard (enabled by default; disable with `--notui`) shows a live turn counter (`[N/M turns]`) for each active job in the In Progress pane.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -101,6 +101,12 @@ To refresh plugin skills without touching stages or config (e.g., after upgradin
 ./fabrik upgrade
 ```
 
+> **Note:** Plain `fabrik upgrade` errors when local customizations are detected (i.e.,
+> you have edited files under `.fabrik/plugin/`). Use `--force` to overwrite them
+> unconditionally, or `--reconcile` to get a guided merge prompt. See
+> [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
+> for details.
+
 Edit `.fabrik/config.yaml` with your project settings and commit it to git. Add your
 GitHub token to a gitignored `.env` file:
 
@@ -292,10 +298,13 @@ experience as release binaries.
 > **`fabrik upgrade` in non-interactive mode**: Whether called automatically during
 > auto-upgrade or run standalone, `fabrik upgrade` behaves differently depending on
 > whether a TTY is attached. With no TTY (non-interactive), it auto-refreshes plugin
-> skills silently — no prompt, no confirmation required. With a TTY (interactive), it
-> prompts once before applying any skill updates. This means automated environments
-> (CI, background processes, auto-upgrade re-exec) always get a clean, unattended
-> skill refresh.
+> skills silently — no prompt, no confirmation required — *when no local customizations
+> are detected*. With a TTY (interactive), it prompts once before applying any skill
+> updates. When local customizations are present (disk version differs from the installed
+> fingerprint), non-interactive refresh is skipped to preserve your edits; the
+> `[u] custom workflow` badge appears on next TUI startup instead. See
+> [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
+> for details on `--force` and `--reconcile`.
 
 ```bash
 ./fabrik --auto-upgrade --owner your-org --repo your-repo --project 1 --user you
@@ -2145,9 +2154,11 @@ This applies to all signal-driven exit paths that go through Fabrik's signal han
 including SIGHUP re-exec.
 
 **Plugin-skills upgrade:** SIGHUP restart proceeds non-interactively through the
-plugin-skills upgrade check — skills are refreshed automatically without prompting
-(a brief status line is written to stderr), so the restart never hangs waiting for
-user confirmation.
+plugin-skills upgrade check — when no local customizations are detected, skills are
+refreshed automatically without prompting (a brief status line is written to stderr),
+so the restart never hangs waiting for user confirmation. When local customizations are
+present, the refresh is skipped entirely to preserve your edits; the `[u] custom workflow`
+badge appears on next TUI startup instead of silently overwriting your changes.
 
 **What is cleared:**
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -295,16 +295,24 @@ After rebuilding, Fabrik runs `fabrik upgrade` (non-interactive, silent — see 
 and re-execs the new binary. This keeps dev builds current with the same hands-off
 experience as release binaries.
 
-> **`fabrik upgrade` in non-interactive mode**: Whether called automatically during
-> auto-upgrade or run standalone, `fabrik upgrade` behaves differently depending on
-> whether a TTY is attached. With no TTY (non-interactive), it auto-refreshes plugin
-> skills silently — no prompt, no confirmation required — *when no local customizations
-> are detected*. With a TTY (interactive), it prompts once before applying any skill
-> updates. When local customizations are present (disk version differs from the installed
-> fingerprint), non-interactive refresh is skipped to preserve your edits; the
-> `[u] custom workflow` badge appears on next TUI startup instead. See
-> [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
-> for details on `--force` and `--reconcile`.
+> **Plugin-skills upgrade: automatic vs. standalone behavior**: The plugin-skills check
+> runs in two contexts with different behavior.
+>
+> **Automatic check** (during `--auto-upgrade` re-exec or dev-build restart): TTY-sensitive.
+> With no TTY, skills are refreshed silently when no local customizations are detected;
+> when customizations are present, the refresh is skipped and a warning is printed to stderr.
+> With a TTY, you are prompted once to confirm before any refresh is applied; when
+> customizations are present, `--force`/`--reconcile` options are shown instead of a prompt.
+>
+> **Standalone `fabrik upgrade` subcommand**: Not TTY-sensitive — the command never prompts
+> interactively. When no local customizations are detected, skills are refreshed
+> unconditionally. When customizations are detected, the command exits with an error
+> directing you to `--force` (destructive overwrite) or `--reconcile` (guided merge
+> prompt). See [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
+> for details.
+>
+> In both contexts, when customizations are present and the refresh is skipped, the
+> `[u] custom workflow` badge appears on next TUI startup.
 
 ```bash
 ./fabrik --auto-upgrade --owner your-org --repo your-repo --project 1 --user you

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -293,16 +293,24 @@ After rebuilding, Fabrik runs `fabrik upgrade` (non-interactive, silent — see 
 and re-execs the new binary. This keeps dev builds current with the same hands-off
 experience as release binaries.
 
-> **`fabrik upgrade` in non-interactive mode**: Whether called automatically during
-> auto-upgrade or run standalone, `fabrik upgrade` behaves differently depending on
-> whether a TTY is attached. With no TTY (non-interactive), it auto-refreshes plugin
-> skills silently — no prompt, no confirmation required — *when no local customizations
-> are detected*. With a TTY (interactive), it prompts once before applying any skill
-> updates. When local customizations are present (disk version differs from the installed
-> fingerprint), non-interactive refresh is skipped to preserve your edits; the
-> `[u] custom workflow` badge appears on next TUI startup instead. See
-> [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
-> for details on `--force` and `--reconcile`.
+> **Plugin-skills upgrade: automatic vs. standalone behavior**: The plugin-skills check
+> runs in two contexts with different behavior.
+>
+> **Automatic check** (during `--auto-upgrade` re-exec or dev-build restart): TTY-sensitive.
+> With no TTY, skills are refreshed silently when no local customizations are detected;
+> when customizations are present, the refresh is skipped and a warning is printed to stderr.
+> With a TTY, you are prompted once to confirm before any refresh is applied; when
+> customizations are present, `--force`/`--reconcile` options are shown instead of a prompt.
+>
+> **Standalone `fabrik upgrade` subcommand**: Not TTY-sensitive — the command never prompts
+> interactively. When no local customizations are detected, skills are refreshed
+> unconditionally. When customizations are detected, the command exits with an error
+> directing you to `--force` (destructive overwrite) or `--reconcile` (guided merge
+> prompt). See [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
+> for details.
+>
+> In both contexts, when customizations are present and the refresh is skipped, the
+> `[u] custom workflow` badge appears on next TUI startup.
 
 ```bash
 ./fabrik --auto-upgrade --owner your-org --repo your-repo --project 1 --user you

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -99,6 +99,12 @@ To refresh plugin skills without touching stages or config (e.g., after upgradin
 ./fabrik upgrade
 ```
 
+> **Note:** Plain `fabrik upgrade` errors when local customizations are detected (i.e.,
+> you have edited files under `.fabrik/plugin/`). Use `--force` to overwrite them
+> unconditionally, or `--reconcile` to get a guided merge prompt. See
+> [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
+> for details.
+
 Edit `.fabrik/config.yaml` with your project settings and commit it to git. Add your
 GitHub token to a gitignored `.env` file:
 
@@ -290,10 +296,13 @@ experience as release binaries.
 > **`fabrik upgrade` in non-interactive mode**: Whether called automatically during
 > auto-upgrade or run standalone, `fabrik upgrade` behaves differently depending on
 > whether a TTY is attached. With no TTY (non-interactive), it auto-refreshes plugin
-> skills silently — no prompt, no confirmation required. With a TTY (interactive), it
-> prompts once before applying any skill updates. This means automated environments
-> (CI, background processes, auto-upgrade re-exec) always get a clean, unattended
-> skill refresh.
+> skills silently — no prompt, no confirmation required — *when no local customizations
+> are detected*. With a TTY (interactive), it prompts once before applying any skill
+> updates. When local customizations are present (disk version differs from the installed
+> fingerprint), non-interactive refresh is skipped to preserve your edits; the
+> `[u] custom workflow` badge appears on next TUI startup instead. See
+> [Upgrade protection for customized skills](#upgrade-protection-for-customized-skills)
+> for details on `--force` and `--reconcile`.
 
 ```bash
 ./fabrik --auto-upgrade --owner your-org --repo your-repo --project 1 --user you
@@ -2143,9 +2152,11 @@ This applies to all signal-driven exit paths that go through Fabrik's signal han
 including SIGHUP re-exec.
 
 **Plugin-skills upgrade:** SIGHUP restart proceeds non-interactively through the
-plugin-skills upgrade check — skills are refreshed automatically without prompting
-(a brief status line is written to stderr), so the restart never hangs waiting for
-user confirmation.
+plugin-skills upgrade check — when no local customizations are detected, skills are
+refreshed automatically without prompting (a brief status line is written to stderr),
+so the restart never hangs waiting for user confirmation. When local customizations are
+present, the refresh is skipped entirely to preserve your edits; the `[u] custom workflow`
+badge appears on next TUI startup instead of silently overwriting your changes.
 
 **What is cleared:**
 


### PR DESCRIPTION
Closes #749

## Summary

# Update docs for v0.0.64: customization-aware plugin upgrade

## Problem

v0.0.64 shipped the customization-aware plugin upgrade feature (#746), which fundamentally changes how `fabrik upgrade`, `--auto-upgrade`, and SIGHUP restart behave when operator customizations are detected. Several existing documentation passages describe the old behavior (unconditional silent overwrite in non-interactive mode) and need to be corrected. Additionally, the README's subcommands table and feature list do not yet reflect the new `--force`/`--reconcile` flags or the protection guarantee.

## Approach

### Approach

Apply six targeted text edits — three in `USER_GUIDE.md`, two corrections and one enhancement in `README.md` — then regenerate `docs/llms-full.txt`. All changes correct stale descriptions of non-interactive and SIGHUP upgrade behavior to reflect the customization-aware logic shipped in v0.0.64. The edits are independent of each other; order is chosen to group by file for a clean commit history (USER_GUIDE.md, then README.md, then regen).

No new files are needed. No Go code is touched. No ADR is warranted — this issue corrects documentation to match already-shipped behavior; the design decision (ADR 046) was recorded during the implementation of #746.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Three targeted edits: §3 non-interactive callout (item 1), Init section upgrade blurb (item 3), SIGHUP Plugin-skills paragraph (item 2) |
| `README.md` | Two corrections + one enhancement: Subcommands table (item 4), In-Place Restart section (item 5), Built-in Skills feature item (item 6) |
| `docs/llms-full.txt` | Regenerated via `bash scripts/generate-llms-full.sh` after USER_GUIDE.md edits |

### Key Decisions

- **Include item 6 (nice-to-have)**: The Built-in Skills enhancement is low-risk, improves discoverability, and fits naturally in the same commit as items 4–5. Including it avoids a follow-up PR for a one-sentence addition.
- **Exclude docs/index.md (item 7)**: The spec explicitly marks this out of scope. Skipping it.
- **Single commit per file-group**: USER_GUIDE.md edits in one commit, README.md edits in a second, regen in the same commit as USER_GUIDE.md changes (since CI will catch drift). This keeps the diff reviewable.
- **Link anchor to use**: `#upgrade-protection-for-customized-skills` — confirmed by Research as the heading anchor for the new USER_GUIDE.md subsection added in v0.0.64.

### Task Checklist

- [ ] Task 1: Edit USER_GUIDE.md §3 callout (lines 292–298) — add qualifier that silent auto-refresh only applies when no customizations are detected; remove the "always get a clean, unattended skill refresh" claim; add note about `[u] custom workflow` badge appearing instead
- [ ] Task 2: Edit USER_GUIDE.md Init section upgrade blurb (lines 98–102) — add note after the `./fabrik upgrade` code block that plain upgrade errors when customizations are detected; mention `--force`/`--reconcile` flags and link to `#upgrade-protection-for-customized-skills`
- [ ] Task 3: Edit USER_GUIDE.md SIGHUP Plugin-skills paragraph (lines 2147–2150) — qualify automatic refresh with "when no local customizations are detected"; add sentence that when customizations are present, restart skips the refresh (preserving edits) and the `[u] custom workflow` badge appears on next TUI start
- [ ] Task 4: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt`; commit USER_GUIDE.md + llms-full.txt together
- [ ] Task 5: Edit README.md Subcommands table (line 313) — expand `fabrik upgrade` row description to note that plain upgrade errors when customizations are detected, mention `--force` (destructive overwrite) and `--reconcile` (guided-merge prompt), reference User Guide for details
- [ ] Task 6: Edit README.md In-Place Restart section (lines 190–192) — add that when local customizations are detected, SIGHUP skips plugin refresh (preserving edits) and surfaces the `[u] custom workflow` badge instead, so it never hangs and never silently clobbers operator customizations
- [ ] Task 7: Edit README.md Built-in Skills section (lines 315–323) — add one sentence about operator customization protection: upgrades detect local edits and offer guided reconciliation rather than silently overwriting
- [ ] Task 8: Commit README.md changes (items 5–7 together)

### Risks

- **llms-full.txt regen forgotten**: CI `docs-drift` workflow will catch this and fail the PR. Mitigation: Task 4 explicitly covers this immediately after USER_GUIDE.md edits, before moving to README.md.
- **Line numbers shift during editing**: Research confirmed exact current text for each passage. Implement should match on text content, not line number alone, in case earlier edits in the same session shift line positions.
- **Stale anchor link**: The anchor `#upgrade-protection-for-customized-skills` was confirmed by Research. If the heading was renamed, the link would silently 404. Implement should verify the heading exists in USER_GUIDE.md before adding the link.

---
Used 5/50 turns, 4k input / 2k output tokens.

## Verification

Corrected five stale documentation passages across USER_GUIDE.md and README.md that described the old unconditional silent plugin overwrite behavior, qualifying them to reflect that non-interactive refresh and SIGHUP restart skip when local customizations are detected, with the `[u] custom workflow` badge surfaced instead. Also added `--force`/`--reconcile` flag references and a new customization protection sentence in the Built-in Skills section. Regenerated `docs/llms-full.txt` to keep CI docs-drift green.

---

Closes #749