### PR TITLE
Update docs for v0.0.65

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -785,6 +785,8 @@ if you're not actively watching the issue.
 > flag ([#671](https://github.com/handarbeit/fabrik/issues/671)) will make this separation
 > easier once implemented.
 
+**Operator note:** If `fabrik:paused` is removed manually (without also removing `fabrik:awaiting-input`), the orphaned `fabrik:awaiting-input` label will be cleared automatically the next time the stage emits `FABRIK_STAGE_COMPLETE` — the issue will not remain visibly "awaiting input" after the stage has advanced.
+
 ### No-Work Short-Circuit
 
 A stage can signal that all remaining pipeline work can be skipped by outputting both
@@ -1460,7 +1462,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:locked:<user>` | Issue being processed by this user's instance |
 | `fabrik:editing` | Issue body being updated (comment processing) |
 | `fabrik:paused` | Processing paused (max retries exceeded or manual) |
-| `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user |
+| `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user, or when a subsequent `FABRIK_STAGE_COMPLETE` is emitted (clears any orphaned label that survived a manual `fabrik:paused` removal) |
 | `fabrik:awaiting-review` | Set when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding **and** at least one review has been submitted (then re-invocation fires unconditionally), or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
 | `fabrik:awaiting-ci` | Applied immediately when a `wait_for_ci: true` stage emits `FABRIK_STAGE_COMPLETE`; means "CI gate active" and covers both pending and failed CI states; `stage:X:complete` is applied only when CI passes — not when this label is cleared by timeout (conjunctive gate, ADR 032). Triggers `itemMayNeedWork` cache bypass so CI results are re-evaluated on every poll. Cleared when all checks pass or the CI wait timeout elapses (then issue is paused with `fabrik:awaiting-input`). See [§3 CI Gate](USER_GUIDE.md#ci-gate-and-ci-fix-workflow). |
 | `fabrik:rebase-needed` | Set when GitHub reports the linked PR as `mergeable: false` on a `wait_for_ci: true` stage — typically because another PR merged into the base branch during the CI-await window. The engine dispatches a rebase re-invocation instructing Claude to `git fetch && git rebase origin/<base>`, resolve conflicts conservatively (watching for semantic collisions like duplicated ADR numbers), and force-push. The label clears when GitHub flips `mergeable` back to `true`. Triggers `itemMayNeedWork` cache bypass because base-branch advances don't bump the item's `updatedAt`. |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -783,6 +783,8 @@ if you're not actively watching the issue.
 > flag ([#671](https://github.com/handarbeit/fabrik/issues/671)) will make this separation
 > easier once implemented.
 
+**Operator note:** If `fabrik:paused` is removed manually (without also removing `fabrik:awaiting-input`), the orphaned `fabrik:awaiting-input` label will be cleared automatically the next time the stage emits `FABRIK_STAGE_COMPLETE` — the issue will not remain visibly "awaiting input" after the stage has advanced.
+
 ### No-Work Short-Circuit
 
 A stage can signal that all remaining pipeline work can be skipped by outputting both
@@ -1458,7 +1460,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `fabrik:locked:<user>` | Issue being processed by this user's instance |
 | `fabrik:editing` | Issue body being updated (comment processing) |
 | `fabrik:paused` | Processing paused (max retries exceeded or manual) |
-| `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user |
+| `fabrik:awaiting-input` | Stage paused waiting for user input; auto-clears on a new comment from the configured user, or when a subsequent `FABRIK_STAGE_COMPLETE` is emitted (clears any orphaned label that survived a manual `fabrik:paused` removal) |
 | `fabrik:awaiting-review` | Set when a `wait_for_reviews: true` stage completes with outstanding reviewer requests; cleared when no requested reviewers are outstanding **and** at least one review has been submitted (then re-invocation fires unconditionally), or when the `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (then issue is paused with `fabrik:awaiting-input`) |
 | `fabrik:awaiting-ci` | Applied immediately when a `wait_for_ci: true` stage emits `FABRIK_STAGE_COMPLETE`; means "CI gate active" and covers both pending and failed CI states; `stage:X:complete` is applied only when CI passes — not when this label is cleared by timeout (conjunctive gate, ADR 032). Triggers `itemMayNeedWork` cache bypass so CI results are re-evaluated on every poll. Cleared when all checks pass or the CI wait timeout elapses (then issue is paused with `fabrik:awaiting-input`). See [§3 CI Gate](USER_GUIDE.md#ci-gate-and-ci-fix-workflow). |
 | `fabrik:rebase-needed` | Set when GitHub reports the linked PR as `mergeable: false` on a `wait_for_ci: true` stage — typically because another PR merged into the base branch during the CI-await window. The engine dispatches a rebase re-invocation instructing Claude to `git fetch && git rebase origin/<base>`, resolve conflicts conservatively (watching for semantic collisions like duplicated ADR numbers), and force-push. The label clears when GitHub flips `mergeable` back to `true`. Triggers `itemMayNeedWork` cache bypass because base-branch advances don't bump the item's `updatedAt`. |


### PR DESCRIPTION
Closes #757

## Summary

Update `USER_GUIDE.md` to reflect the v0.0.65 `fabrik:awaiting-input` orphan-label fix, then verify README.md and `docs/index.md` for consistency. Regenerate `docs/llms-full.txt` after any canonical-doc edits.

## Problem

Three behavioral changes shipped in v0.0.65 that are not yet reflected in `USER_GUIDE.md`:

1. **`fabrik:awaiting-input` orphan bug fixed**: When a stage was paused with `FABRIK_BLOCKED_ON_INPUT` and `fabrik:paused` was later removed manually (without removing `fabrik:awaiting-input`), a subsequent fresh stage invocation could complete successfully but leave `fabrik:awaiting-input` set — keeping the issue visibly "awaiting input" even though the stage had advanced. `handleStageComplete` now also clears any orphaned `fabrik:awaiting-input` label on `FABRIK_STAGE_COMPLETE`. The state-machine doc already records this; USER_GUIDE.md's label reference table and the "Stages Waiting for Input" section do not yet mention it.

2. **Log output fix for `--auto-upgrade` and `fabrik upgrade`**: These two code paths previously emitted ambiguous or duplicate plugin-check log descriptions. Now each path emits an accurate, distinct log line. The USER_GUIDE.md descriptions of these two paths' behavior are already accurate; no documentation change is needed beyond confirming consistency.

3. **BootstrapFromProbe migration complete (#710 / #685)**: The legacy `Bootstrap()` cold-start path has been deleted; all cold-start callers now go through the probe-driven path. ADR-044 and `docs/state-machine.md` were already updated in-tree. USER_GUIDE.md has no references to the old `Bootstrap()` function name and its cold-start description already describes the probe-based behavior — no changes needed here.

Additionally, README.md already has the non-interactive plugin-refresh description, SIGHUP upgrade description, and customization-protection note; consistency verification is needed.

## Approach

### Approach

This is a documentation-only change. Research confirmed two precise touch points in `docs/USER_GUIDE.md` that omit the `fabrik:awaiting-input` orphan-cleanup behavior added in v0.0.65. All other sections (Auto-upgrade, cold-start, README.md, docs/index.md) were verified by Research as already consistent — no changes needed there.

The implementation is: make two targeted edits to `USER_GUIDE.md`, then regenerate `docs/llms-full.txt` in the same commit to satisfy CI's `docs-drift` check.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Update label table row (line 1463) + add orphan-cleanup note in §"Stages Waiting for Input" (after line 787) |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **Edit USER_GUIDE.md only; do not touch state-machine.md, stage-lifecycle.md, ADRs, or any Go source** — Research confirmed all other docs are already up to date and the spec explicitly excludes them from scope.
- **Wording follows state-machine.md:133 as the reference** — the phrase "to clear any orphaned label that survived a manual `fabrik:paused` removal" is already the authoritative as-built phrasing; USER_GUIDE.md mirrors it for consistency.
- **Bundle regen in the same commit as USER_GUIDE.md** — the CI `docs-drift` workflow fails if they diverge. The two changes are a single logical unit; splitting them across commits risks a failing intermediate state.
- **No ADR needed** — this is a docs-only change documenting already-shipped behavior. No design decisions that constrain future contributors are introduced.

### Task Checklist

- [ ] Task 1: Update `fabrik:awaiting-input` label table row in `docs/USER_GUIDE.md` (line ~1463) to add the `FABRIK_STAGE_COMPLETE` clearing path. Change the cell from "auto-clears on a new comment from the configured user" to: "Stage paused waiting for user input; auto-clears on a new comment from the configured user, or when a subsequent `FABRIK_STAGE_COMPLETE` is emitted (clears any orphaned label that survived a manual `fabrik:paused` removal)"
- [ ] Task 2: Add an operator note paragraph in `docs/USER_GUIDE.md` §"Stages Waiting for Input" (after the `> **Note:** GitHub does not deliver push notifications…` block at line ~787, before the `### No-Work Short-Circuit` heading). Text: "**Operator note:** If `fabrik:paused` is removed manually (without also removing `fabrik:awaiting-input`), the orphaned `fabrik:awaiting-input` label will be cleared automatically the next time the stage emits `FABRIK_STAGE_COMPLETE` — the issue will not remain visibly 'awaiting input' after the stage has advanced."
- [ ] Task 3: Regenerate `docs/llms-full.txt` by running `bash scripts/generate-llms-full.sh`, then `git add docs/llms-full.txt`
- [ ] Task 4: Commit all changes (USER_GUIDE.md + docs/llms-full.txt) in a single commit with message referencing issue #757

### Risks

- **docs-drift CI failure** if `docs/llms-full.txt` is not regenerated in the same commit as USER_GUIDE.md. Mitigation: Task 3 runs the regen script and stages the file before the commit in Task 4 — they must be a single commit.
- **Line number drift** — the research identified approximate line numbers (756–787, 1463) which may shift if main has moved since Research ran. Implement should locate the exact text by searching for the literal strings rather than relying on line numbers.

---
Used 7/50 turns, 4k input / 2k output tokens.

## Verification

Updated `docs/USER_GUIDE.md` with two targeted edits for the v0.0.65 `fabrik:awaiting-input` orphan-label fix: the label quick-reference table now notes that `FABRIK_STAGE_COMPLETE` also clears the label (not only a new user comment), and the "Stages Waiting for Input" section has an operator note explaining that a manually orphaned `fabrik:awaiting-input` label self-heals on the next stage advance. `docs/llms-full.txt` was regenerated in the same commit to satisfy the CI docs-drift check.

---

Closes #757