### PR TITLE
Compare fabrik to the new https://www.kanbots.dev/

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,3 +29,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - competitive

--- a/docs/competitive/kanbots.md
+++ b/docs/competitive/kanbots.md
@@ -1,0 +1,174 @@
+# KanBots vs Fabrik — Competitive Analysis
+
+> **Internal document — frank framing, not for publication.**
+>
+> Analysis date: 2026-05-22
+> KanBots version: v1.0.1
+> KanBots commit: `1b7b8106e6ef4190bfe64054b27494118951ce1e`
+> Source: [github.com/leodavinci1/kanbots](https://github.com/leodavinci1/kanbots) (MIT, 212 stars); [kanbots.dev](https://www.kanbots.dev/)
+>
+> KanBots architectural claims are sourced from the public website and README at the version above, not from a full source-code audit. KanBots was at v1.0.1 as of the analysis date (one day after v1.0.0 shipped); some features may change quickly.
+
+---
+
+KanBots is a local-first Electron desktop app for kanban-board-driven AI agent orchestration, built by Leonardo Cunha (GitHub: `leodavinci1`). It shipped v1.0.1 on 2026-05-22. It targets the same niche as Fabrik — kanban as the driver for AI agent work — but takes a desktop-app / local-state approach vs. Fabrik's server daemon / GitHub-native approach. KanBots is OSS (MIT) with a $19/seat Pro tier and enterprise custom pricing.
+
+---
+
+## Axis 1: Architecture & Deployment Model
+
+**KanBots:** Local Electron desktop app that runs on macOS, Linux, and Windows. All state is local; the app bundles its own SQLite database. The user launches it on their machine; agents run from that machine's environment.
+
+**Fabrik:** Server daemon CLI written in Go. Typically runs on a server, CI runner, or a shared machine. No GUI. Managed via CLI flags and YAML config files checked into the repo.
+
+**Assessment:** KanBots wins for individual developer UX — install it, open it, go. Fabrik wins for team automation: it runs unattended 24/7 without a laptop staying open, survives reboots, and is trivially daemonized. Fabrik is the better fit when the orchestrator is "infrastructure" rather than a personal tool.
+
+---
+
+## Axis 2: Board / Source of Truth
+
+**KanBots:** Maintains an internal SQLite board at `.kanbots/db.sqlite`. GitHub Issues integration is optional — the user can connect a PAT to sync issues bidirectionally, but the canonical state lives locally. Offline-first by design.
+
+**Fabrik:** GitHub Projects v2 is the board. There is no proprietary local store. The issue itself — its status column, labels, comments, linked PRs — is the state. No sync required; no divergence possible.
+
+**Assessment:** Fabrik's approach means zero migration cost, full board history on github.com, and no "local vs. remote" divergence risk. KanBots' SQLite gives offline-first UX and richer local query capability, but you now have two sources of truth to keep in sync. For teams already on GitHub Projects, Fabrik's model is strictly simpler. KanBots' model is better for solo devs who don't want to rely on GitHub at all.
+
+---
+
+## Axis 3: Workflow / Pipeline Model
+
+**KanBots:** No multi-stage pipeline. One agent dispatch per card. The user can trigger slash commands (`/spec`, `/review`, `/split`) to invoke specific behaviors, and Autopilot personas (see Axis 13) can spawn child tasks. Each card dispatch is a single unbounded agent session.
+
+**Fabrik:** YAML-configured sequential multi-stage pipeline (Research → Plan → Implement → Review → Validate by default). Each stage has its own prompt, skill, model, tool allowlist, `max_turns`, `max_wall_time`, `comment_prompt`, `comment_skill`, lifecycle flags (`post_to_pr`, `create_draft_pr`, `read_only`, `cleanup_worktree`, `wait_for_reviews`, `wait_for_ci`), and effort level. Stages are board columns; board column = pipeline position.
+
+**Assessment:** Fabrik wins decisively for complex codebases and team workflows where auditability, reproducibility, and staged review matter. KanBots wins for quick one-shot tasks where the overhead of a multi-stage pipeline is noise. The pipeline model is Fabrik's primary architectural differentiator — KanBots has no equivalent.
+
+---
+
+## Axis 4: Agent Lifecycle Per Task
+
+**KanBots:** Dispatches one agent session per card. In Autopilot mode, up to 4 agents run in parallel across cards. Context accumulates in the conversation window during a session; there is no structured handoff between logical phases.
+
+**Fabrik:** Advances a single issue through multiple sequential stages. Before each stage, the engine writes structured context files to `.fabrik-context/`: the issue body (`issue.md`), prior-stage outputs (`stage-Research.md`, `stage-Plan.md`, etc.), the linked PR description, and a diff of codebase changes since the last stage ran. Each stage starts with full, structured context from prior stages — not a conversation window that may have summarized or lost earlier details.
+
+**Assessment:** Fabrik's context-file handoff model produces more predictable and auditable outcomes — each stage sees exactly what the engine intends, not whatever survived the conversation window. KanBots' single-session model is simpler and requires less configuration, but loses structured recall across logical phases.
+
+---
+
+## Axis 5: Worktree & Git Management
+
+**KanBots:** Uses per-task worktrees at `.kanbots/worktrees/issue-<n>-<runId>/` on branches named `kanbots/issue-N`. A pre-push hook prevents the agent from autonomously pushing to remote. Conflict handling is not documented.
+
+**Fabrik:** Per-issue worktrees at `.fabrik/worktrees/<owner>-<repo>/issue-N/` on branches named `fabrik/issue-N`. The base repo is always bare-cloned to `.fabrik/repos/<owner>-<repo>.git`. On each stage invocation, the engine fetches and merges `origin/<baseBranch>` unless the worktree is dirty (dirty = preserve partial work). Conflicts are left as conflict markers for Claude to resolve. Preservation semantics are documented in ADR 006 — worktrees with content are never destroyed.
+
+**Assessment:** Both tools use the same basic pattern. Fabrik's preservation semantics are more explicit and battle-tested (ADR 006; the dirty-skip logic is intentional). KanBots' conflict handling is a gap — it's unclear what happens if the agent's branch diverges from main during a long run. The pre-push hook in KanBots is a meaningful safety advantage (see Axis 10).
+
+---
+
+## Axis 6: State Model
+
+**KanBots:** SQLite at `.kanbots/db.sqlite` for the free tier; cloud sync added in the $19/seat Pro tier. State is opaque to anyone without the KanBots app (or direct SQLite access).
+
+**Fabrik:** GitHub labels + comment reactions as sole state (ADR 002). Labels like `stage:Research:complete`, `fabrik:paused`, `fabrik:awaiting-review`, `model:opus`, `fabrik:yolo` encode control flow. Comment reactions (👀/🚀) provide durable idempotency. Everything is inspectable on github.com without tooling; state survives machine loss; no migration scripts required.
+
+**Assessment:** Fabrik wins for teams. GitHub-as-state means anyone on the team can read or override state by adding/removing a label — no special tooling, no KanBots install required. KanBots' SQLite gives richer local query capability and offline-first UX, but the opacity is a real cost for collaborative workflows. Cloud sync (Pro) partially recovers inspectability but introduces a proprietary dependency.
+
+---
+
+## Axis 7: Multi-Provider / Model Support
+
+**KanBots:** Supports Claude Code and OpenAI Codex via an `AgentCliAdapter` abstraction. The adapter pattern suggests more providers could be added. Model selection is per-card.
+
+**Fabrik:** Claude Code only. Within Claude, per-stage model override via `model:` label (e.g., `model:opus`) and effort-level override via `effort:` label (e.g., `effort:max`). Stage YAML can specify `model:` and `effort_level:` defaults.
+
+**Assessment:** KanBots wins on breadth — Codex is a real alternative and the adapter pattern is the right abstraction. Fabrik wins on depth of Claude integration — per-stage model and effort-level control is more granular than KanBots' per-card model selection. Fabrik's single-provider focus is a conscious scope choice, but it is a gap if teams want to use Codex or mix providers across stages.
+
+---
+
+## Axis 8: Human-in-the-Loop / Comment-Driven Revision
+
+**KanBots:** Uses "Decision Points" — the agent presents numbered options and the user selects via a slash command. This is a structured, bounded-choice HITL interaction (based on public website description; exact UX flow is not fully documented in the README).
+
+**Fabrik:** Uses `FABRIK_BLOCKED_ON_INPUT` to pause a stage and wait for a free-form comment. Each stage can define a separate `comment_prompt` and `comment_skill` to process comments during normal operation — not just at explicit pause points. Comment-driven revision can steer any prior stage's output at any time.
+
+**Assessment:** KanBots' Decision Points are more structured — bounded choices reduce ambiguity and are easier to act on quickly. Fabrik's approach is more flexible — comments can be free-form, and any stage can receive iteration at any point. The tradeoff is clarity (KanBots) vs. expressiveness (Fabrik). Both approaches are more capable than most tools in the landscape, which treat each card dispatch as one-shot.
+
+---
+
+## Axis 9: Cost Management & Observability
+
+**KanBots:** Per-run, per-card, and per-project cost rollups; a live cost meter; and configurable budget caps that halt execution when the limit is reached.
+
+**Fabrik:** No built-in cost tracking. There is no mechanism to see what a run cost, set a budget, or be alerted when spending exceeds a threshold.
+
+**Assessment:** KanBots leads clearly. This is a meaningful gap for Fabrik — teams using Fabrik at scale have no visibility into Claude API spend until they check their Anthropic billing dashboard. Budget caps would be especially useful for `fabrik:unrestricted` runs, where tool restrictions are lifted.
+
+---
+
+## Axis 10: Trust & Safety Posture
+
+**KanBots:** Pre-push git hook prevents the agent from autonomously publishing to remote. Budget caps halt runaway spending. Both are automatic guardrails — they apply without user configuration.
+
+**Fabrik:** `--permission-mode dontAsk` is the default (tool allowlist enforced per stage). `--dangerously-skip-permissions` is available via `fabrik:unrestricted` label. No pre-push hook. The tool allowlist is highly configurable and per-stage, but the default posture allows `git push` without a confirmation hook.
+
+**Assessment:** KanBots' pre-push hook is a stronger autonomous-push guardrail out of the box. Fabrik's tool allowlist is more granular — you can restrict which tools each stage can use — but it doesn't prevent a push that's within the allowed tool set. For `fabrik:unrestricted` runs especially, the lack of a push hook is a gap.
+
+---
+
+## Axis 11: Team Collaboration
+
+**KanBots Pro ($19/seat):** Real-time presence, cross-device sync, Slack notifications, SSO.
+
+**Fabrik:** OSS; the GitHub Projects board is the collaboration surface — visible and shared by the entire team without additional cost. No proprietary collaboration layer; no per-seat licensing.
+
+**Assessment:** KanBots wins for teams that want a dedicated collaboration layer with real-time features. Fabrik wins for teams already invested in GitHub Projects — the board is the collaboration surface, no additional tool or seat cost required. The $19/seat Pro tier is a meaningful ongoing cost for larger teams; Fabrik's OSS model has no equivalent.
+
+---
+
+## Axis 12: MCP / External Tool Integration
+
+**KanBots:** Exposes the kanban board as an MCP (Model Context Protocol) server. Editors like Cursor and Claude Desktop can read and write tasks directly through the MCP surface — creating cards, updating status, reading context — without opening the KanBots UI.
+
+**Fabrik:** No MCP surface. Fabrik is not accessible to external tools via MCP; the only interaction surface is GitHub (labels, comments) and the CLI.
+
+**Assessment:** KanBots leads. An MCP server is an increasingly expected integration point for agentic tooling. Fabrik's GitHub-native state model means there's already a conceptual path — `gh` API or GraphQL — but no MCP wrapper. This is an addressable gap.
+
+---
+
+## Axis 13: Autopilot Personas
+
+**KanBots:** Ships five Autopilot personas — PM, Senior Engineer, UX Designer, Growth Lead, Reliability Engineer. In Autopilot mode, a persona can autonomously spawn subtasks from a card, creating a self-evolving roadmap. Up to 4 agents run in parallel in Autopilot.
+
+**Fabrik:** No equivalent. Fabrik's pipeline is scoped to a single issue at a time. Cross-issue subtask spawning requires manual issue creation. Sub-issue decomposition is a planned feature (issue #762 area) but is not the same as autonomous persona-driven roadmap generation.
+
+**Assessment:** KanBots leads significantly on autonomous roadmap generation. This is a genuinely differentiated feature that has no Fabrik analog today. Whether this is a gap worth closing depends on how teams use Fabrik — if the issue backlog is human-curated, autonomous persona spawning is noise; if teams want to point an agent at a goal and have it decompose the work, KanBots is well ahead.
+
+---
+
+## Axis 14: Task Templates & Creation Modes
+
+**KanBots:** Provides five task templates (Bug fix, Feature, Refactor, Review, Spike) and three creation modes: spec-first (write the spec, then dispatch), create-and-dispatch (dispatch immediately), and queue-for-later (add to backlog without dispatching). Templates pre-fill the card with structured fields appropriate to the task type.
+
+**Fabrik:** Issues are plain GitHub issues. There are no templates or structured creation modes built into Fabrik. Teams can use GitHub's built-in issue templates, but there's no Fabrik-specific integration or dispatch-control at creation time.
+
+**Assessment:** KanBots wins on onboarding ergonomics — structured templates reduce the spec quality gap between teams and lower the barrier for new users. Fabrik's flexibility is equivalent (a well-written issue works as well as a template), but requires more user discipline. The queue-for-later creation mode maps naturally to GitHub's draft issue concept, but Fabrik doesn't surface it.
+
+---
+
+## Ideas
+
+**Reject** — Internal SQLite state store. Contradicts ADR 002 (GitHub-as-state-store). SQLite would break inspectability, introduce migration risk, and add a new persistence dependency with no clear benefit for Fabrik's team-automation use case.
+
+**Consider** — MCP server surface. Exposing the Fabrik board state as an MCP server for Cursor/Claude Desktop is architecturally tractable — the GitHub GraphQL API already provides the data, and a lightweight MCP adapter could surface it without changing the state model. Low risk, new interaction mode.
+
+**Consider** — Per-run cost analytics. Track Claude API spend per issue/stage and surface it in the GitHub comment output. No budget-cap functionality needed to start — visibility alone is high value for teams watching API costs. Fabrik already logs per-stage output; adding a cost field is incremental.
+
+**Consider** — Pre-push safety hook. A git hook that prevents `git push` without explicit engine confirmation would be a meaningful hardening option, especially for `fabrik:unrestricted` runs. Low implementation effort; reduces the blast radius of a runaway agent.
+
+**Consider** — Issue templates / creation helpers. Lightweight `fabrik init --template=feature` (or equivalent) would reduce spec quality variance across teams and lower the barrier for first-time users. Could be as simple as populating `.github/ISSUE_TEMPLATE/` during `fabrik init`.
+
+**Watch** — Autopilot personas / subtask spawning. KanBots' self-evolving roadmap feature is genuinely differentiated and has no Fabrik equivalent. Sub-issue decomposition (issue #762 area) is in progress but targets a different use case — human-defined decomposition, not autonomous persona-driven spawning. Monitor KanBots' user adoption here before deciding whether to close the gap.
+
+**Watch** — Multi-provider support via AgentCliAdapter. Fabrik is Claude Code only by design; widening this would require significant engine changes. Watch KanBots' adapter abstraction pattern — if it matures and Codex or another provider proves compelling for teams, the adapter interface is worth studying before designing Fabrik's equivalent.
+
+**Watch** — Decision Points HITL model. KanBots' structured numbered-choice prompt is a more constrained form of `FABRIK_BLOCKED_ON_INPUT`. Bounded choices may reduce ambiguity and response latency in HITL flows. Worth monitoring how teams respond to both approaches — if KanBots' model shows meaningfully better HITL completion rates, it's worth offering as an option in `comment_prompt` configuration.

--- a/docs/competitive/kanbots.md
+++ b/docs/competitive/kanbots.md
@@ -99,9 +99,9 @@ KanBots is a local-first Electron desktop app for kanban-board-driven AI agent o
 
 **KanBots:** Per-run, per-card, and per-project cost rollups; a live cost meter; and configurable budget caps that halt execution when the limit is reached.
 
-**Fabrik:** No built-in cost tracking. There is no mechanism to see what a run cost, set a budget, or be alerted when spending exceeds a threshold.
+**Fabrik:** Parses Claude's `total_cost_usd` field from every invocation and logs per-invocation cost (`claudeLog` output, visible in daemon logs) plus aggregate cost stats in the poll loop (format: `[stats] cost: $X.XXXX | in: N | out: N | cache_read: N | cache_write: N`). What is missing: per-issue and per-stage cost is not surfaced in GitHub comments, there are no per-project or per-user rollups, no budget caps or automatic halts, and no alerting when spending exceeds a threshold.
 
-**Assessment:** KanBots leads clearly. This is a meaningful gap for Fabrik — teams using Fabrik at scale have no visibility into Claude API spend until they check their Anthropic billing dashboard. Budget caps would be especially useful for `fabrik:unrestricted` runs, where tool restrictions are lifted.
+**Assessment:** KanBots leads on cost UX. Fabrik has the raw data (cost is logged to daemon stdout per invocation) but no mechanism to surface it where teams actually look — the GitHub issue — or to act on it automatically. The gap is attribution and action, not instrumentation. Budget caps would be especially useful for `fabrik:unrestricted` runs, where tool restrictions are lifted.
 
 ---
 
@@ -139,7 +139,7 @@ KanBots is a local-first Electron desktop app for kanban-board-driven AI agent o
 
 **KanBots:** Ships five Autopilot personas — PM, Senior Engineer, UX Designer, Growth Lead, Reliability Engineer. In Autopilot mode, a persona can autonomously spawn subtasks from a card, creating a self-evolving roadmap. Up to 4 agents run in parallel in Autopilot.
 
-**Fabrik:** No equivalent. Fabrik's pipeline is scoped to a single issue at a time. Cross-issue subtask spawning requires manual issue creation. Sub-issue decomposition is a planned feature (issue #762 area) but is not the same as autonomous persona-driven roadmap generation.
+**Fabrik:** The Plan stage can autonomously decompose an oversized issue into sub-issues by emitting the `FABRIK_DECOMPOSED` marker — the engine then creates the labeled child issues, adds dependency edges, and moves the parent to Done. This decomposition happens once, at Plan time, scoped to a single parent issue. A cross-repo sub-issue decomposition spec (issue #762 area) is in progress but not yet shipped. There are no multi-persona agents, no ongoing autonomous spawning across stages, and no notion of a self-evolving roadmap.
 
 **Assessment:** KanBots leads significantly on autonomous roadmap generation. This is a genuinely differentiated feature that has no Fabrik analog today. Whether this is a gap worth closing depends on how teams use Fabrik — if the issue backlog is human-curated, autonomous persona spawning is noise; if teams want to point an agent at a goal and have it decompose the work, KanBots is well ahead.
 
@@ -161,13 +161,13 @@ KanBots is a local-first Electron desktop app for kanban-board-driven AI agent o
 
 **Consider** — MCP server surface. Exposing the Fabrik board state as an MCP server for Cursor/Claude Desktop is architecturally tractable — the GitHub GraphQL API already provides the data, and a lightweight MCP adapter could surface it without changing the state model. Low risk, new interaction mode.
 
-**Consider** — Per-run cost analytics. Track Claude API spend per issue/stage and surface it in the GitHub comment output. No budget-cap functionality needed to start — visibility alone is high value for teams watching API costs. Fabrik already logs per-stage output; adding a cost field is incremental.
+**Consider** — Per-issue cost surfacing. Fabrik already tracks `total_cost_usd` per invocation and logs it to daemon stdout — the data exists. The incremental work is surfacing per-issue and per-stage cost in the GitHub comment output so teams see it without reading daemon logs. No budget-cap functionality needed to start; visibility alone is high value.
 
 **Consider** — Pre-push safety hook. A git hook that prevents `git push` without explicit engine confirmation would be a meaningful hardening option, especially for `fabrik:unrestricted` runs. Low implementation effort; reduces the blast radius of a runaway agent.
 
 **Consider** — Issue templates / creation helpers. Lightweight `fabrik init --template=feature` (or equivalent) would reduce spec quality variance across teams and lower the barrier for first-time users. Could be as simple as populating `.github/ISSUE_TEMPLATE/` during `fabrik init`.
 
-**Watch** — Autopilot personas / subtask spawning. KanBots' self-evolving roadmap feature is genuinely differentiated and has no Fabrik equivalent. Sub-issue decomposition (issue #762 area) is in progress but targets a different use case — human-defined decomposition, not autonomous persona-driven spawning. Monitor KanBots' user adoption here before deciding whether to close the gap.
+**Watch** — Autopilot personas / subtask spawning. KanBots' self-evolving roadmap feature is genuinely differentiated. Fabrik has Plan-driven decomposition (`FABRIK_DECOMPOSED`) and a cross-repo sub-issue spec in progress (issue #762 area), but neither is the same as continuous persona-driven spawning — autonomous agents that grow the backlog from a high-level goal with no Plan stage boundary. Monitor KanBots' user adoption here before deciding whether to close the gap.
 
 **Watch** — Multi-provider support via AgentCliAdapter. Fabrik is Claude Code only by design; widening this would require significant engine changes. Watch KanBots' adapter abstraction pattern — if it matures and Codex or another provider proves compelling for teams, the adapter interface is worth studying before designing Fabrik's equivalent.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4704,6 +4704,10 @@ Source: https://fabrik.handarbeit.io/positioning
 - **alessiocol/claude-kanban** — `ACTIVE.md` as shared kanban state across multiple agent sessions; addresses context amnesia between sessions; WIP limits per agent.
 - **The Claude Protocol** (github.com/AvivK5498/The-Claude-Protocol) — 13 Claude Code hooks enforce workflow; integrates with Beads (git-native tickets) as kanban; immutable closed issues; git worktree per task.
 
+### Kanban-first, local agent runners
+
+- **KanBots** (leodavinci1, github.com/leodavinci1/kanbots) — local Electron app; SQLite board with optional GitHub Issues sync; single agent per card; Autopilot personas (PM/Eng/UX/Growth/SRE) spawn subtasks autonomously; Claude Code + Codex via AgentCliAdapter; Decision Points for HITL; pre-push safety hook; per-run cost analytics; MCP server surface. OSS (MIT) + $19/seat Pro. See [competitive analysis](competitive/kanbots.md).
+
 ### Platform-level
 
 - **Linear AI Agents** — first-class agent delegation from issues; Copilot integration opens draft PRs from Linear issues.
@@ -4711,10 +4715,11 @@ Source: https://fabrik.handarbeit.io/positioning
 
 ### Patterns observed
 
-- Most tools build their own proprietary kanban rather than integrating with GitHub Projects.
+- Most tools build their own proprietary kanban rather than integrating with GitHub Projects (Vibe Kanban, Kanban Code, KanBots all maintain local or proprietary boards; GitHub Issues sync is a secondary integration, not the source of truth).
 - Split between *observer* tools (watch Claude, reflect state) vs *driver* tools (kanban is source of truth that triggers agent work).
 - Multi-agent coordination (alessiocol, The Claude Protocol) is a distinct and less crowded sub-pattern.
 - GitHub Agentic Workflows is the primary path toward using native GitHub Projects as the driver.
+- Local-first desktop apps (KanBots) are emerging as an alternative to server daemon CLIs — optimizing for individual developer UX over team automation.
 
 ## Where Fabrik sits uniquely
 
@@ -4739,7 +4744,7 @@ Source: https://fabrik.handarbeit.io/positioning
 ## Candidate positioning lines
 
 - *GitHub Agentic Workflows without GitHub Actions — your existing Project board becomes an SDLC pipeline, with YAML-configurable stages and per-stage Claude Code skills, state encoded entirely in issues, labels, and reactions.*
-- *Closest competitor by philosophy: GitHub Agentic Workflows (platform-native, Projects-compatible). Closest by feature set: The Claude Protocol (hooks + worktrees + tickets). Fabrik's niche is the intersection — platform-native and feature-rich, without requiring GHA or a separate ticket system like Beads.*
+- *Closest competitor by philosophy: GitHub Agentic Workflows (platform-native, Projects-compatible). Closest by feature set: The Claude Protocol (hooks + worktrees + tickets). Closest direct competitor by niche: KanBots (kanban-driven agent orchestration, per-issue worktrees, same target user) — differentiated by local-first vs. server-daemon architecture and proprietary SQLite state vs. GitHub-native state. Fabrik's niche is the intersection — platform-native and feature-rich, without requiring GHA, a separate ticket system like Beads, or a proprietary local state store.*
 
 ---
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -22,6 +22,10 @@ title: Fabrik Positioning
 - **alessiocol/claude-kanban** — `ACTIVE.md` as shared kanban state across multiple agent sessions; addresses context amnesia between sessions; WIP limits per agent.
 - **The Claude Protocol** (github.com/AvivK5498/The-Claude-Protocol) — 13 Claude Code hooks enforce workflow; integrates with Beads (git-native tickets) as kanban; immutable closed issues; git worktree per task.
 
+### Kanban-first, local agent runners
+
+- **KanBots** (leodavinci1, github.com/leodavinci1/kanbots) — local Electron app; SQLite board with optional GitHub Issues sync; single agent per card; Autopilot personas (PM/Eng/UX/Growth/SRE) spawn subtasks autonomously; Claude Code + Codex via AgentCliAdapter; Decision Points for HITL; pre-push safety hook; per-run cost analytics; MCP server surface. OSS (MIT) + $19/seat Pro. See [competitive analysis](competitive/kanbots.md).
+
 ### Platform-level
 
 - **Linear AI Agents** — first-class agent delegation from issues; Copilot integration opens draft PRs from Linear issues.
@@ -29,10 +33,11 @@ title: Fabrik Positioning
 
 ### Patterns observed
 
-- Most tools build their own proprietary kanban rather than integrating with GitHub Projects.
+- Most tools build their own proprietary kanban rather than integrating with GitHub Projects (Vibe Kanban, Kanban Code, KanBots all maintain local or proprietary boards; GitHub Issues sync is a secondary integration, not the source of truth).
 - Split between *observer* tools (watch Claude, reflect state) vs *driver* tools (kanban is source of truth that triggers agent work).
 - Multi-agent coordination (alessiocol, The Claude Protocol) is a distinct and less crowded sub-pattern.
 - GitHub Agentic Workflows is the primary path toward using native GitHub Projects as the driver.
+- Local-first desktop apps (KanBots) are emerging as an alternative to server daemon CLIs — optimizing for individual developer UX over team automation.
 
 ## Where Fabrik sits uniquely
 
@@ -57,4 +62,4 @@ title: Fabrik Positioning
 ## Candidate positioning lines
 
 - *GitHub Agentic Workflows without GitHub Actions — your existing Project board becomes an SDLC pipeline, with YAML-configurable stages and per-stage Claude Code skills, state encoded entirely in issues, labels, and reactions.*
-- *Closest competitor by philosophy: GitHub Agentic Workflows (platform-native, Projects-compatible). Closest by feature set: The Claude Protocol (hooks + worktrees + tickets). Fabrik's niche is the intersection — platform-native and feature-rich, without requiring GHA or a separate ticket system like Beads.*
+- *Closest competitor by philosophy: GitHub Agentic Workflows (platform-native, Projects-compatible). Closest by feature set: The Claude Protocol (hooks + worktrees + tickets). Closest direct competitor by niche: KanBots (kanban-driven agent orchestration, per-issue worktrees, same target user) — differentiated by local-first vs. server-daemon architecture and proprietary SQLite state vs. GitHub-native state. Fabrik's niche is the intersection — platform-native and feature-rich, without requiring GHA, a separate ticket system like Beads, or a proprietary local state store.*


### PR DESCRIPTION
Closes #775

## Summary

Produce a structured competitive comparison document (`docs/competitive/kanbots.md`) analyzing KanBots against Fabrik across the same architectural axes used for the Symphony comparison. Update `docs/positioning.md` to reference KanBots in the landscape section, and regenerate `docs/llms-full.txt`.

## Problem

Fabrik operates in a fast-moving competitive landscape of AI-driven SDLC automation tools. The team previously produced a structured comparison with OpenAI Symphony (issue #469) to understand where Fabrik leads, where it lags, and what ideas are worth borrowing. KanBots (https://www.kanbots.dev/) is a recently launched tool in the same space that explicitly targets kanban-board-driven AI agent orchestration — Fabrik's own niche — and warrants the same treatment before it gains further mindshare.

## Approach

### Approach

This is a pure documentation task — no Go code, no tests, no ADRs warranted. Research has collected all KanBots data needed (public repo `leodavinci1/kanbots`, v1.0.1, commit `1b7b8106e6ef4190bfe64054b27494118951ce1e`, 2026-05-22). The three-file scope is:

1. **`docs/competitive/kanbots.md`** — new file (creating the `docs/competitive/` directory in the process). Must follow the format specified in the issue: intro paragraph → 12 per-axis sections (each covering what KanBots does, what Fabrik does, and a frank assessment) → Ideas section with Adopt/Consider/Reject/Watch tags. Frank internal framing throughout.
2. **`docs/positioning.md`** — add KanBots under a new "Kanban-first, local agent runners" subsection in the Landscape section, with a cross-reference link to `competitive/kanbots.md`. Also update the "Patterns observed" and/or "Candidate positioning lines" sections if warranted.
3. **`docs/llms-full.txt`** — regenerated via `bash scripts/generate-llms-full.sh` after `positioning.md` is updated. Must be included in the same commit as `positioning.md` (CI `docs-drift` workflow enforces this).

All three files should ship in a single commit since CI will fail if `positioning.md` and `llms-full.txt` diverge.

No ADRs are warranted — this issue introduces no architectural decisions, only documentation of existing behavior.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/competitive/kanbots.md` | New file — full competitive comparison document |
| `docs/positioning.md` | Add KanBots subsection in Landscape + cross-reference |
| `docs/llms-full.txt` | Regenerated bundle (script-generated, must match `positioning.md`) |

### Key Decisions

- **Single commit for all three files**: CI `docs-drift` requires `positioning.md` and `llms-full.txt` to match exactly. Splitting them across commits would fail CI.
- **New "Kanban-first, local agent runners" subsection in `positioning.md`**: KanBots is more sophisticated than the existing "Open source Claude Code + kanban" entries (it has a commercial tier, Autopilot, MCP, cost analytics) and is local-first rather than platform-level. A new subsection is the cleanest fit without forcing it into either the "Proprietary/commercial" or "Open source" buckets.
- **Axis additions beyond the required 12**: Research surfaced two features not covered by the 12 required axes — Autopilot personas (self-evolving roadmap via multi-persona agents) and task templates (Bug fix, Feature, Refactor, Review, Spike creation modes). These should be covered as two additional axes (13 and 14) since they're architecturally significant and have no Fabrik equivalent.
- **Source transparency**: The comparison doc must note prominently (in its header or a disclaimer paragraph) that KanBots architectural claims are sourced from public website and README at v1.0.1 / commit `1b7b8106e6ef4190bfe64054b27494118951ce1e` (2026-05-22), not from a source-code deep dive. KanBots is new enough that this matters for reproducibility.

### Content Guide for `docs/competitive/kanbots.md`

The implementer should not need to re-research. Here is the concrete content to produce:

**Header / meta**:
- Analysis date: 2026-05-22
- KanBots version: v1.0.1
- KanBots commit: `1b7b8106e6ef4190bfe64054b27494118951ce1e`
- Source: `github.com/leodavinci1/kanbots` (MIT, 212 stars); `kanbots.dev`

**Intro paragraph**: KanBots is a local-first Electron desktop app for kanban-board-driven AI agent orchestration, built by Leonardo Cunha (GitHub: `leodavinci1`). It shipped v1.0.1 on 2026-05-22. It targets the same niche as Fabrik — kanban as the driver for AI agent work — but takes a desktop-app/local-state approach vs. Fabrik's server daemon / GitHub-native approach. OSS (MIT) with a $19/seat Pro tier and enterprise custom.

**Per-axis sections** (frank internal framing; who leads and why):

1. **Architecture & deployment model**: KanBots = Electron desktop app (macOS/Linux/Windows), all state local. Fabrik = server daemon CLI (Go), runs on a server/CI box. KanBots wins for individual developer UX; Fabrik wins for team automation (runs unattended, no laptop required).

2. **Board / source-of-truth**: KanBots maintains its own SQLite board at `.kanbots/db.sqlite`; GitHub Issues integration is optional (PAT-based sync). Fabrik uses GitHub Projects v2 as the native board — no proprietary store. Fabrik's approach means zero migration cost and full board history on github.com; KanBots' approach gives offline-first UX but creates a divergence risk between local state and GitHub.

3. **Workflow / pipeline model**: KanBots has no multi-stage pipeline — one agent dispatch per card, with slash commands (`/spec`, `/review`, `/split`) and Autopilot personas. Fabrik uses YAML-configured sequential stages (Research→Plan→Implement→Review→Validate) with per-stage prompts, skills, models, tool allowlists, `max_turns`, `max_wall_time`, and lifecycle flags. Fabrik wins decisively for complex codebases; KanBots wins for quick one-shot tasks.

4. **Agent lifecycle per task**: KanBots dispatches a single agent per card (Autopilot: up to 4 parallel). Context accumulates in the conversation window; no structured handoff between "stages." Fabrik advances one issue through multiple sequential stages; each stage receives `.fabrik-context/stage-Name.md` files with prior-stage output. Fabrik's handoff model produces more predictable, auditable outcomes; KanBots' single-session model is simpler.

5. **Worktree & git management**: Both use per-issue worktrees. KanBots: `.kanbots/worktrees/issue-<n>-<runId>/` on branch `kanbots/issue-N`; conflict handling undocumented; pre-push hook prevents autonomous push. Fabrik: `.fabrik/worktrees/<owner>-<repo>/issue-N/` on branch `fabrik/issue-N`; conflicts left for Claude to resolve; dirty worktrees skip update (preserves partial work). Fabrik's preservation semantics are explicit (ADR 006); KanBots' conflict handling is a gap.

6. **State model**: KanBots uses SQLite locally + cloud sync (Pro). Fabrik uses GitHub labels + comment reactions as sole state (ADR 002); everything inspectable on github.com without tooling. KanBots' SQLite gives richer local query capability; Fabrik's approach survives machine loss, is trivially auditable, and requires no local DB.

7. **Multi-provider / model support**: KanBots supports Claude Code + OpenAI Codex via `AgentCliAdapter`; the adapter abstraction means more providers could be added. Fabrik is Claude Code only; per-stage model override (`model:opus` label) and effort levels give fine-grained control within Claude. KanBots wins on breadth; Fabrik wins on depth of Claude integration.

8. **Human-in-the-loop / comment-driven revision**: KanBots uses Decision Points — agent presents numbered options, user selects via slash command. Fabrik uses `FABRIK_BLOCKED_ON_INPUT` (open-ended pause) + per-stage `comment_prompt`/`comment_skill` for comment-driven iteration on any prior output. KanBots' Decision Points are more structured (bounded choice set); Fabrik's approach is more flexible (free-form comment iteration).

9. **Cost management & observability**: KanBots has per-run/card/project cost rollups, a live cost meter, and budget caps (halt when limit reached). Fabrik has no built-in cost tracking whatsoever. KanBots leads clearly; this is a gap for Fabrik.

10. **Trust & safety posture**: KanBots uses a pre-push git hook to prevent autonomous publishing + budget caps to halt runaway spending. Fabrik uses `--permission-mode dontAsk` / `--dangerously-skip-permissions` with a configurable per-stage tool allowlist; no pre-push hook. KanBots' pre-push hook is a stronger autonomous-push guardrail; Fabrik's tool allowlist is more granular.

11. **Team collaboration**: KanBots Pro ($19/seat) adds real-time presence, cross-device sync, Slack notifications, SSO. Fabrik is OSS + the GitHub board is the collaboration surface — shared by the whole team without additional cost, no proprietary layer. KanBots wins for teams that want a dedicated collaboration layer; Fabrik wins for teams already on GitHub Projects.

12. **MCP / external tool integration**: KanBots exposes its board as an MCP server — editors like Cursor and Claude Desktop can read/write tasks directly. Fabrik has no MCP surface. KanBots leads; this is an addressable gap for Fabrik.

13. **Autopilot personas** (additional axis): KanBots ships PM, Senior Engineer, UX Designer, Growth Lead, Reliability Engineer personas — each autonomously spawns subtasks from a card, creating a self-evolving roadmap. No Fabrik equivalent. Fabrik's YAML pipeline is scoped to a single issue; cross-issue subtask spawning requires manual issue creation. KanBots leads significantly on autonomous roadmap generation.

14. **Task templates & creation modes** (additional axis): KanBots provides Bug fix, Feature, Refactor, Review, Spike templates + three creation modes (spec-first, create-and-dispatch, queue-for-later). Fabrik issues are plain GitHub issues; there are no templates or structured creation modes. KanBots wins on onboarding ergonomics; Fabrik's flexibility is equivalent but requires more user discipline.

**Ideas section**:

- **Reject** — Internal SQLite state store: contradicts ADR 002 (GitHub-as-state-store). SQLite would break inspectability, introduce migration risk, and add a new persistence dependency. Not worth the tradeoff for Fabrik's use case.
- **Consider** — MCP server surface: exposing the board as an MCP server for Cursor/Claude Desktop integration is architecturally tractable and would unlock a new interaction mode without changing the board model. Low risk.
- **Consider** — Per-run cost analytics: track Claude API spend per issue/stage and surface it in the GitHub comment. No budget-cap functionality needed to start — just visibility. High value for teams watching API costs.
- **Consider** — Pre-push safety hook: a git hook that prevents `git push` without explicit confirmation could be a useful hardening option for `fabrik:unrestricted` runs. Low effort, meaningful safety improvement.
- **Consider** — Task templates: lightweight issue templates (Feature, Bug fix, Refactor) would reduce the spec quality gap between teams. Could be implemented as `fabrik init --template=feature` or similar.
- **Watch** — Autopilot personas / subtask spawning: KanBots' self-evolving roadmap feature (multi-persona Autopilot) is genuinely differentiated and has no Fabrik equivalent. Sub-issue decomposition is in progress (issue #762 area), but not the same as autonomous roadmap growth. Monitor KanBots' uptake here.
- **Watch** — Multi-provider support: Codex integration via AgentCliAdapter. Fabrik is Claude Code only by design; widening this would require significant engine changes. Watch KanBots' adapter abstraction pattern — if it matures it may be worth adopting the interface.
- **Watch** — Decision Points HITL model: KanBots' structured numbered-choice prompt is a more constrained form of `FABRIK_BLOCKED_ON_INPUT`. Structured choices could reduce ambiguity in comment-driven revision. Worth monitoring how users respond to both approaches.

### Content Guide for `docs/positioning.md`

Add after the "Open source Claude Code + kanban" section and before "Platform-level":

```
### Kanban-first, local agent runners

- **KanBots** (leodavinci1, github.com/leodavinci1/kanbots) — local Electron app; SQLite board with optional GitHub Issues sync; single agent per card; Autopilot personas (PM/Eng/UX/Growth/SRE) spawn subtasks autonomously; Claude Code + Codex via AgentCliAdapter; Decision Points for HITL; pre-push safety hook; per-run cost analytics; MCP server surface. OSS (MIT) + $19/seat Pro. See [competitive analysis](competitive/kanbots.md).
```

Also add KanBots to the "Patterns observed" bullet about most tools building proprietary kanban (KanBots is another example), and update the "Candidate positioning lines" section's closing line to mention KanBots as the closest direct competitor by niche.

### Task Checklist

- [ ] Task 1: Create `docs/competitive/kanbots.md` — write the full comparison document per the content guide above: header with analysis date/version/SHA/source, intro paragraph, 14 per-axis sections (12 required + Autopilot and Task templates), and Ideas section with 8 tagged entries
- [ ] Task 2: Update `docs/positioning.md` — add "Kanban-first, local agent runners" subsection with KanBots entry + cross-reference link; update "Patterns observed" section; update closing "Candidate positioning lines" to note KanBots as closest direct competitor by niche
- [ ] Task 3: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh` and stage the result; commit all three changed files together (CI requires `positioning.md` and `llms-full.txt` to be in sync)

### Risks

- **Axis 8 (HITL) framing**: KanBots' Decision Points are described on the website but the exact UX flow is not fully documented. The implementer should note this as "based on public website description" if it can't be fully sourced from the README.
- **`positioning.md` update scope creep**: The current "Candidate positioning lines" section references competitive tools; an edit there must stay minimal — do not restructure that section, only add the KanBots reference.
- **CI failure if files drift**: All three files must land in one commit. Do not commit `docs/positioning.md` before regenerating `docs/llms-full.txt`.

---
Used 7/50 turns, 5k input / 5k output tokens.

## Verification

Created `docs/competitive/kanbots.md` — a 14-axis competitive analysis of KanBots (v1.0.1, commit `1b7b81`, 2026-05-22) vs Fabrik, with an Ideas section tagging 8 actionable findings (1 Reject, 4 Consider, 3 Watch). Updated `docs/positioning.md` to add a "Kanban-first, local agent runners" subsection with a KanBots entry and cross-reference, expanded the Patterns Observed section, and named KanBots as the closest direct competitor by niche in Candidate Positioning Lines. Regenerated `docs/llms-full.txt` — all three files committed together in one commit (`9d7677e7`) and pushed.

---

Closes #775