### PR TITLE
fix(boardcache): repair CI gate HeadSHA population in poll-only mode

### DIFF
--- a/adrs/047-headrefoid-probe-query.md
+++ b/adrs/047-headrefoid-probe-query.md
@@ -1,0 +1,71 @@
+# ADR 047: Add headRefOid to Probe and Deep-Fetch GraphQL Queries
+
+**Date**: 2026-05-23  
+**Status**: Accepted
+
+## Context
+
+ADR 027 explicitly rejected extending the GraphQL query for `headRefOid` when implementing the CI gate:
+
+> Adding `pullRequest { headRefOid }` to the board GraphQL query would avoid a separate REST call for the head SHA. Rejected because the existing query is already large. The head SHA is only needed on CI-gate paths (stages with `wait_for_ci: true`, which is a subset of all items). A targeted REST call via `FetchLinkedPR` has lower cost for the common case (no CI gate).
+
+ADR 027's preferred approach was to fetch `HeadSHA` via the `FetchLinkedPR` REST fallback in `boardcache/boardcache.go`. In production, this path was found to be broken in three colluding ways (tracked as issue #779):
+
+1. **Bug 1** (`PRDetailsUpdated` drops `HeadSHA`): The `PRDetailsUpdated` mutation struct had no `HeadSHA` field, so the REST fallback result's SHA was silently discarded.
+
+2. **Bug 2** (`FetchLinkedPR` cache write fires only once with stale data): The `PRHeadSHAUpdated` write was gated on `linkedPRNum == 0` (only fires at link-establishment), and used the pre-fetch snapshot's SHA instead of the fresh REST result.
+
+3. **Bug 3** (Cache-hit eligibility accepts empty `HeadSHA`): The cache-hit guard for `FetchLinkedPR` required only `lpr.Title != ""`, serving stale records with `HeadSHA == ""` as valid cache hits on every subsequent poll.
+
+The combined effect: `checkCIGate` received `HeadSHA == ""` from the cache after the first poll, treated it as "no PR to gate," and silently cleared the CI gate — adding `stage:Validate:complete` and removing `fabrik:awaiting-ci` even while CI was actively failing. This made the failure mode unrecoverable without restarting Fabrik.
+
+## Decision
+
+Fix all three bugs and extend the GraphQL queries to make `headRefOid` available from the polling paths independently of the REST fallback.
+
+### Fix A: Add `headRefOid` to the Probe and Deep-Fetch Queries
+
+ADR 027's concern was the cost of the **full board query** (`FetchProjectBoard`), which fetches all items with labels, assignees, and linked PRs. This query is already large.
+
+The probe query (`ProbeProjectBoard`) is architecturally distinct: it fetches only scalar identity fields per item (no labels, no comments, no full PR data) and was specifically designed to be cheap. Adding `headRefOid` to the probe's single `closedByPullRequestsReferences(first: 1)` node is a small incremental cost — one additional string field per item with a linked PR — that is negligible relative to the query's total size.
+
+The deep-fetch query (`FetchItemDetails`) is per-item and already fetches extensive linked-PR data (comments, reviews, review threads). Adding `headRefOid` there adds no meaningful cost.
+
+**Scope of change**: `headRefOid` is added to all three `closedByPullRequestsReferences` query blocks in `github/project.go`:
+- Block 2 (probe): populated into `BoardProbeItem.LinkedPRHeadSHA`; applied to the store as `PRHeadSHAUpdated` in `engine/poll.go:runProbeAndDeepFetch` on every poll cycle.
+- Block 3 (deep fetch): populated into `ProjectItem.LinkedPRHeadSHA`; applied as a second `PRHeadSHAUpdated` after `ItemDeepFetched` in `boardcache/boardcache.go:FetchItemDetails`.
+- Block 1 (shallow board / reconcile): populated into `ProjectItem.LinkedPRHeadSHA`; applied as `PRHeadSHAUpdated` in `boardcache/boardcache.go:Reconcile` (60-min backstop repair path).
+
+The existing guard in `applyProjectItem` that prevents `LinkedPR.HeadSHA` from being overwritten by shallow data (`lpr.HeadSHA != ""` guard at `store.go:839`) is intentionally preserved. All SHA writes go through `PRHeadSHAUpdated`, not through `applyProjectItem`.
+
+### Fix B: FetchLinkedPR Cache Write Uses Fresh SHA, Fires Unconditionally
+
+The `FetchLinkedPR` REST fallback now writes `pr.HeadSHA` (the fresh result) instead of `existingSHA` (the stale pre-fetch snapshot), and removes the `linkedPRNum == 0` guard so `PRHeadSHAUpdated` fires on every fallback, not just at link-establishment. `PRHeadSHAUpdated` is idempotent; writing the authoritative REST SHA on every fallback is safe.
+
+### Fix C: Cache-Hit Guard Requires Non-Empty HeadSHA
+
+The `FetchLinkedPR` cache-hit eligibility check is tightened to require `lpr.HeadSHA != ""` in addition to `lpr.Title != ""`. A record with a populated Title but empty HeadSHA is treated as a cache miss, forcing a REST fallback. This prevents any future code path from accidentally writing an empty-SHA record into the cache and having it served as a valid hit.
+
+### Fix E: CI Gate Treats Empty HeadSHA as Blocked
+
+`checkCIGate` in `engine/ci.go` previously treated `pr.HeadSHA == ""` the same as `pr == nil` (clearing the gate). The conditions are now split: `pr == nil` still clears the gate (no PR to check); `pr.HeadSHA == ""` on a non-nil PR blocks the gate with `(true, false, false)` until the SHA is populated. This is a belt-and-suspenders defense — with Fixes A, B, C in place the cache should never serve an empty-SHA record for a valid PR, but if it does, the gate remains armed rather than silently disarming.
+
+## Why Not Extend the Full Board Query
+
+ADR 027's cost concern applies specifically to `FetchProjectBoard`, which runs every 60 minutes as a reconcile backstop. Adding `headRefOid` to that query (Block 1) is a lower-priority improvement included here purely for defense-in-depth (the reconcile path repairs state every 60 min). The critical path is Block 2 (probe), which runs every poll and is already cheap.
+
+## Relationship to ADR 027
+
+This ADR partially supersedes the "Extending the GraphQL Query for Head SHA" alternative rejected in ADR 027. The distinction:
+
+- ADR 027 rejected adding `headRefOid` to the **full board query** (Block 1 = large query, all items).
+- This ADR adds `headRefOid` to the **probe query** (Block 2 = minimal query, one string field per item) and **deep-fetch query** (Block 3 = per-item query that already fetches extensive PR data).
+
+The REST fallback (`FetchLinkedPR`) remains in place as the authoritative source for `HeadSHA` when a direct `checkCIGate` call triggers a cache miss. The GraphQL paths now serve as the primary population mechanism so the REST fallback is rarely needed in practice.
+
+## Consequences
+
+- `headRefOid` is fetched on every probe cycle for items with a linked PR, regardless of whether those items are on CI-gated stages. This is a small cost increase (one extra string per linked PR per poll) accepted as the price of cache correctness.
+- `BoardProbeItem` and `ProjectItem` gain a `LinkedPRHeadSHA string` field.
+- The store's `HeadSHA` for any item with a linked PR is now refreshed at probe frequency rather than only on REST fallback or webhook events.
+- `FetchLinkedPR` cache hits now require both `Title != ""` and `HeadSHA != ""`, meaning more cache misses for newly-linked PRs (they fall through to REST until both fields are populated). This is by design — the brief extra REST call eliminates the failure mode.

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -744,9 +744,11 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 	}
 
 	// Cache-hit: PR details are in the Store (Title is non-empty once PRDetailsUpdated fires,
-	// HeadSHA is non-empty once PRHeadSHAUpdated fires). Require both to prevent serving a
-	// record where Title is set but HeadSHA is missing — checkCIGate treats empty HeadSHA
-	// as "no PR to gate" and would silently disarm the CI gate.
+	// HeadSHA is non-empty once PRHeadSHAUpdated fires). Require both to prevent serving an
+	// incomplete record — a non-empty Title with empty HeadSHA would force checkCIGate to
+	// block indefinitely (empty HeadSHA → blocked, not cleared) and trigger a REST fallback
+	// on every poll until the SHA is populated. Requiring HeadSHA here ensures the cache only
+	// serves fully-populated records, keeping the REST fallback path rare.
 	if linkedPRNum != 0 && snapErr == nil {
 		if lpr := snap.LinkedPR(); lpr != nil && lpr.Title != "" && lpr.HeadSHA != "" {
 			return &gh.PRDetails{

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -337,6 +337,17 @@ func (c *CacheImpl) Reconcile(board *gh.ProjectBoard) {
 			Item:   *pi,
 		})
 
+		// Propagate HeadSHA from the shallow board query when present. The reconcile
+		// path runs every 60 min and acts as a backstop repair path for stale-SHA state.
+		if pi.LinkedPRHeadSHA != "" && pi.LinkedPRNumberShallow != 0 {
+			c.store.Apply(itemstate.PRHeadSHAUpdated{
+				Repo:        pi.Repo,
+				Number:      pi.Number,
+				LinkedPRNum: pi.LinkedPRNumberShallow,
+				SHA:         pi.LinkedPRHeadSHA,
+			})
+		}
+
 		// Note: linkage drift detection (LinkedPRNumber changes) was previously
 		// performed here using LinkedPRNumberShallow. It has moved to the probe
 		// loop in engine/poll.go (runProbeAndDeepFetch), which compares the probe's
@@ -667,6 +678,17 @@ func (c *CacheImpl) FetchItemDetails(item *gh.ProjectItem) error {
 		Number:     item.Number,
 		FreshState: *item,
 	})
+	// Apply the head SHA separately: applyProjectItem deliberately skips HeadSHA to avoid
+	// clobbering a webhook-populated SHA with an empty value from the shallow path.
+	// The deep fetch always carries an authoritative headRefOid from the GraphQL query.
+	if item.LinkedPRHeadSHA != "" && item.LinkedPRNumber != 0 {
+		c.store.Apply(itemstate.PRHeadSHAUpdated{
+			Repo:        item.Repo,
+			Number:      item.Number,
+			LinkedPRNum: item.LinkedPRNumber,
+			SHA:         item.LinkedPRHeadSHA,
+		})
+	}
 	return nil
 }
 
@@ -721,9 +743,12 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		}
 	}
 
-	// Cache-hit: PR details are in the Store (Title is non-empty once PRDetailsUpdated fires).
+	// Cache-hit: PR details are in the Store (Title is non-empty once PRDetailsUpdated fires,
+	// HeadSHA is non-empty once PRHeadSHAUpdated fires). Require both to prevent serving a
+	// record where Title is set but HeadSHA is missing — checkCIGate treats empty HeadSHA
+	// as "no PR to gate" and would silently disarm the CI gate.
 	if linkedPRNum != 0 && snapErr == nil {
-		if lpr := snap.LinkedPR(); lpr != nil && lpr.Title != "" {
+		if lpr := snap.LinkedPR(); lpr != nil && lpr.Title != "" && lpr.HeadSHA != "" {
 			return &gh.PRDetails{
 				Number:         lpr.Number,
 				Title:          lpr.Title,
@@ -753,20 +778,16 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 			Merged:   pr.Merged,
 			Draft:    pr.Draft,
 		})
-		// If the item had no LinkedPRNumber in Store, also register the PR linkage
-		// without touching deep-fetch state. prToKey is maintained by PRDetailsUpdated above.
-		if linkedPRNum == 0 && snapErr == nil {
-			existingSHA := ""
-			if s := snap.State(); s.LinkedPR != nil {
-				existingSHA = s.LinkedPR.HeadSHA
-			}
-			c.store.Apply(itemstate.PRHeadSHAUpdated{
-				Repo:        fullRepo,
-				Number:      issueNumber,
-				LinkedPRNum: pr.Number,
-				SHA:         existingSHA,
-			})
-		}
+		// Always write the fresh HeadSHA from the REST response. This fires on every
+		// fallback (not just at link-establishment) so any prior empty-SHA state is
+		// repaired immediately. PRHeadSHAUpdated is idempotent; the REST-fresh SHA is
+		// always authoritative. prToKey is maintained by PRDetailsUpdated above.
+		c.store.Apply(itemstate.PRHeadSHAUpdated{
+			Repo:        fullRepo,
+			Number:      issueNumber,
+			LinkedPRNum: pr.Number,
+			SHA:         pr.HeadSHA,
+		})
 	}
 	return pr, nil
 }

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -2464,3 +2464,115 @@ func TestBootstrapFromProbe_TitlePopulatedAfterDeepFetch(t *testing.T) {
 		t.Error("item #5 not found in board after deep-fetch")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// FetchLinkedPR — HeadSHA regression tests (issues #779)
+// ---------------------------------------------------------------------------
+
+// TestFetchLinkedPR_SecondCallUsesStoredSHA is a regression test for Bug 2:
+// the FetchLinkedPR fallback path previously wrote a stale (or zero) SHA into
+// the store and was gated on linkedPRNum==0 so it only fired once at
+// link-establishment. After the fix, the fresh HeadSHA from the REST response
+// is written unconditionally on every fallback. The second call must be served
+// from cache and must return the same non-empty SHA.
+func TestFetchLinkedPR_SecondCallUsesStoredSHA(t *testing.T) {
+	mc := &mockClient{
+		linkedPRResult: &gh.PRDetails{
+			Number:  99,
+			Title:   "My PR",
+			State:   "OPEN",
+			HeadSHA: "abc123def",
+		},
+	}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	// Bootstrap item #1 — no LinkedPR yet.
+	c.BootstrapFromProbe([]gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Validate"},
+	}, "PID", nil)
+
+	// First call falls through to GitHub — item has no LinkedPR in the store.
+	pr1, err := c.FetchLinkedPR("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("first FetchLinkedPR: %v", err)
+	}
+	if pr1 == nil || pr1.HeadSHA != "abc123def" {
+		t.Fatalf("first call: want HeadSHA=abc123def, got %v", pr1)
+	}
+	if mc.fetchLinkedPRCount != 1 {
+		t.Errorf("expected 1 GitHub call, got %d", mc.fetchLinkedPRCount)
+	}
+
+	// Verify the store persisted the HeadSHA from the fallback.
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || s.LinkedPR.HeadSHA != "abc123def" {
+		t.Fatalf("store: want HeadSHA=abc123def, got %v", s.LinkedPR)
+	}
+
+	// Second call must be served from cache (no additional GitHub call).
+	pr2, err := c.FetchLinkedPR("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("second FetchLinkedPR: %v", err)
+	}
+	if mc.fetchLinkedPRCount != 1 {
+		t.Errorf("second call triggered a GitHub fetch; want cache hit (count=1, got %d)", mc.fetchLinkedPRCount)
+	}
+	if pr2 == nil || pr2.HeadSHA != "abc123def" {
+		t.Fatalf("second call: want HeadSHA=abc123def, got %v", pr2)
+	}
+}
+
+// TestFetchLinkedPR_EmptyHeadSHAForcesRefetch is a regression test for Bug 3:
+// the cache-hit eligibility check previously required only lpr.Title != "". A
+// record with a populated Title but empty HeadSHA was served as a cache hit,
+// making checkCIGate silently disarm the CI gate. After the fix, the guard
+// also requires lpr.HeadSHA != "", forcing a GitHub fallback for any stale
+// record that lacks a HeadSHA.
+func TestFetchLinkedPR_EmptyHeadSHAForcesRefetch(t *testing.T) {
+	mc := &mockClient{
+		linkedPRResult: &gh.PRDetails{
+			Number:  99,
+			Title:   "My PR",
+			State:   "OPEN",
+			HeadSHA: "fresh_sha",
+		},
+	}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	c.BootstrapFromProbe([]gh.BoardProbeItem{
+		{ContentID: "I_1", Number: 1, Repo: "owner/repo", Status: "Validate"},
+	}, "PID", nil)
+
+	// Simulate the pre-fix state: PRDetailsUpdated populates Title/Number but not HeadSHA.
+	c.store.Apply(itemstate.PRDetailsUpdated{
+		Repo:     "owner/repo",
+		Number:   1,
+		PRNumber: 99,
+		Title:    "My PR",
+		State:    "OPEN",
+	})
+	// Verify the store has Title but no HeadSHA.
+	s := testGetState(t, c, "owner/repo", 1)
+	if s.LinkedPR == nil || s.LinkedPR.Title == "" {
+		t.Fatal("pre-condition: expected LinkedPR.Title to be set")
+	}
+	if s.LinkedPR.HeadSHA != "" {
+		t.Fatalf("pre-condition: expected LinkedPR.HeadSHA to be empty, got %q", s.LinkedPR.HeadSHA)
+	}
+
+	// Call FetchLinkedPR — must NOT return the stale cache hit; must fall back to GitHub.
+	pr, err := c.FetchLinkedPR("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR: %v", err)
+	}
+	if mc.fetchLinkedPRCount != 1 {
+		t.Errorf("want 1 GitHub fallback call (cache miss due to empty HeadSHA), got %d", mc.fetchLinkedPRCount)
+	}
+	if pr == nil || pr.HeadSHA != "fresh_sha" {
+		t.Fatalf("want HeadSHA=fresh_sha from fallback, got %v", pr)
+	}
+
+	// The fallback must also have written the fresh HeadSHA into the store.
+	s2 := testGetState(t, c, "owner/repo", 1)
+	if s2.LinkedPR == nil || s2.LinkedPR.HeadSHA != "fresh_sha" {
+		t.Fatalf("store after fallback: want HeadSHA=fresh_sha, got %v", s2.LinkedPR)
+	}
+}

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -47,10 +47,18 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 		e.logf(item.Number, "ci-gate", "could not fetch linked PR: %v — blocking until API recovers\n", err)
 		return true, false, false // transient error; retry on next poll
 	}
-	if pr == nil || pr.HeadSHA == "" {
+	if pr == nil {
 		e.logf(item.Number, "ci-gate", "no linked PR found; CI gate clears (no PR to check)\n")
 		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
 		return false, false, false
+	}
+	if pr.HeadSHA == "" {
+		// PR exists but HeadSHA is not yet populated in the cache (transient state
+		// between PRDetailsUpdated and PRHeadSHAUpdated, or a stale cache record that
+		// Fix C in boardcache.FetchLinkedPR should prevent). Block until SHA is
+		// available rather than silently disarming the CI gate.
+		e.logf(item.Number, "ci-gate", "linked PR #%d has no HeadSHA — blocking until SHA is populated\n", pr.Number)
+		return true, false, false
 	}
 
 	// Trust GitHub's branch-protection-aware mergeable_state when positive:

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -731,6 +731,44 @@ func TestCheckCIGate_MergeableStateBlocked_FallsThroughToCheckRuns(t *testing.T)
 	}
 }
 
+// TestCheckCIGate_EmptyHeadSHA_StaysBlocked is a regression test for the
+// original symptom of issue #779: when the boardcache layer returned a non-nil
+// PRDetails with HeadSHA=="" (due to Bugs 1/2/3 in the cache layer), checkCIGate
+// was clearing the CI gate as if no PR existed, silently disarming the safety
+// mechanism. After the fix, a non-nil PR with an empty HeadSHA is treated as
+// "data incomplete — block until SHA is populated" rather than "no PR — gate clears."
+func TestCheckCIGate_EmptyHeadSHA_StaysBlocked(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			// Simulate the stale-cache scenario: PR is known but HeadSHA is empty.
+			return &gh.PRDetails{Number: 5, Title: "My PR", HeadSHA: ""}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	tr := true
+	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	if !blocked {
+		t.Error("expected blocked=true when PR exists but HeadSHA is empty")
+	}
+	if ciFailure || timedOut {
+		t.Errorf("expected ciFailure=false timedOut=false for incomplete HeadSHA, got ciFailure=%v timedOut=%v", ciFailure, timedOut)
+	}
+	// addCompleteLabelAndRemoveCI must NOT have been called.
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Validate:complete" {
+			t.Error("stage:Validate:complete must NOT be added when HeadSHA is empty (CI gate must stay armed)")
+		}
+	}
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:awaiting-ci" {
+			t.Error("fabrik:awaiting-ci must NOT be removed when HeadSHA is empty")
+		}
+	}
+}
+
 // TestRemoveAwaitingCILabel_ErrNotFound verifies that a 404 from
 // RemoveLabelFromIssue is treated as success (label already absent) — exactly
 // one call, no warning logged, and cache write-through applied.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1689,6 +1689,19 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 		// intentionally skips Labels to preserve webhook-driven label state).
 		e.store.Apply(itemstate.ProbeBoardItemUpdated{Repo: repo, Number: pi.Number, Item: pi})
 
+		// Unconditionally write the probe's head SHA whenever present — the probe
+		// response is always authoritative, including for cache-fresh items that
+		// skip the deep-fetch below. This is the primary poll-mode path for keeping
+		// HeadSHA populated without relying solely on the REST FetchLinkedPR fallback.
+		if pi.LinkedPRHeadSHA != "" && pi.LinkedPRNumber != 0 {
+			e.store.Apply(itemstate.PRHeadSHAUpdated{
+				Repo:        repo,
+				Number:      pi.Number,
+				LinkedPRNum: pi.LinkedPRNumber,
+				SHA:         pi.LinkedPRHeadSHA,
+			})
+		}
+
 		// Deep-fetch when cache is stale relative to effectiveUpdatedAt.
 		if cacheImpl.IsItemCacheFresh(repo, pi.Number, pi.EffectiveUpdatedAt) {
 			continue

--- a/github/project.go
+++ b/github/project.go
@@ -58,8 +58,9 @@ type itemNode struct {
 		} `json:"labels"`
 		LinkedPRs *struct {
 			Nodes []struct {
-				UpdatedAt string `json:"updatedAt"`
-				Number    int    `json:"number"`
+				UpdatedAt  string `json:"updatedAt"`
+				Number     int    `json:"number"`
+				HeadRefOid string `json:"headRefOid"`
 			} `json:"nodes"`
 		} `json:"closedByPullRequestsReferences"`
 	} `json:"content"`
@@ -199,6 +200,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
                 nodes {
                   updatedAt
                   number
+                  headRefOid
                 }
               }
             }
@@ -324,6 +326,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 			}
 			if len(node.Content.LinkedPRs.Nodes) > 0 {
 				item.LinkedPRNumberShallow = node.Content.LinkedPRs.Nodes[0].Number
+				item.LinkedPRHeadSHA = node.Content.LinkedPRs.Nodes[0].HeadRefOid
 			}
 		}
 
@@ -365,8 +368,9 @@ type probeItemNode struct {
 		// first: 1 is sufficient — each issue has at most one Fabrik-managed PR.
 		LinkedPRs *struct {
 			Nodes []struct {
-				Number    int    `json:"number"`
-				UpdatedAt string `json:"updatedAt"`
+				Number     int    `json:"number"`
+				UpdatedAt  string `json:"updatedAt"`
+				HeadRefOid string `json:"headRefOid"`
 			} `json:"nodes"`
 		} `json:"closedByPullRequestsReferences"`
 	} `json:"content"`
@@ -452,6 +456,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
                 nodes {
                   number
                   updatedAt
+                  headRefOid
                 }
               }
             }
@@ -557,6 +562,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 		if node.Content.LinkedPRs != nil && len(node.Content.LinkedPRs.Nodes) > 0 {
 			pr := node.Content.LinkedPRs.Nodes[0]
 			item.LinkedPRNumber = pr.Number
+			item.LinkedPRHeadSHA = pr.HeadRefOid
 			if t, err := parseTime(pr.UpdatedAt); err == nil {
 				item.LinkedPRUpdatedAt = t
 				if t.After(item.EffectiveUpdatedAt) {
@@ -620,6 +626,7 @@ query($id: ID!) {
         nodes {
           id
           number
+          headRefOid
           comments(first: 100) {
             nodes {
               id
@@ -757,9 +764,10 @@ query($id: ID!) {
 				} `json:"comments"`
 				LinkedPRs *struct {
 					Nodes []struct {
-						ID       string `json:"id"`
-						Number   int    `json:"number"`
-						Comments struct {
+						ID         string `json:"id"`
+						Number     int    `json:"number"`
+						HeadRefOid string `json:"headRefOid"`
+						Comments   struct {
 							Nodes    []commentNodeData `json:"nodes"`
 							PageInfo struct {
 								HasNextPage bool   `json:"hasNextPage"`
@@ -894,9 +902,10 @@ query($id: ID!) {
 	// Merge comments, review requests, and reviews from linked PRs
 	if node.LinkedPRs != nil {
 		for i, pr := range node.LinkedPRs.Nodes {
-			// Record the first linked PR's number for REST re-request and @mention calls.
+			// Record the first linked PR's number and head SHA for REST re-request and CI gate calls.
 			if i == 0 {
 				item.LinkedPRNumber = pr.Number
+				item.LinkedPRHeadSHA = pr.HeadRefOid
 			}
 			prCommentNodes := pr.Comments.Nodes
 			if pr.Comments.PageInfo.HasNextPage {

--- a/github/types.go
+++ b/github/types.go
@@ -90,6 +90,7 @@ type ProjectItem struct {
 	// (runProbeAndDeepFetch via BoardProbeItem.LinkedPRNumber). Retained for compatibility; no longer
 	// read by Reconcile.
 	LinkedPRNumberShallow  int
+	LinkedPRHeadSHA        string          // HeadSHA from headRefOid in the GraphQL query (empty if not fetched)
 	LinkedPRReviewRequests []ReviewRequest // Outstanding reviewer requests on the linked PR
 	LinkedPRReviews        []PRReview      // Reviews already submitted on the linked PR
 	// LinkedPRReviewThreadComments holds the inline (per-line) comments from
@@ -163,6 +164,7 @@ type BoardProbeItem struct {
 	EffectiveUpdatedAt time.Time
 	LinkedPRNumber     int
 	LinkedPRUpdatedAt  time.Time
+	LinkedPRHeadSHA    string // headRefOid from GraphQL probe query; empty if no linked PR
 	Status             string
 }
 


### PR DESCRIPTION
## Summary

Fixes three colluding bugs that caused `checkCIGate` to silently disarm the CI gate after the first poll cycle in poll-only (no-webhooks) mode. The root cause: the boardcache layer returned `PRDetails.HeadSHA == ""` for valid linked PRs on every poll after the first, causing the gate to treat an existing PR as absent and clear `fabrik:awaiting-ci` + add `stage:Validate:complete` even while CI was actively failing.

## Key Changes

**`github/project.go` + `github/types.go`** — Fix A (R1): Add `headRefOid` to all three `closedByPullRequestsReferences` GraphQL query blocks (probe, shallow board, deep fetch). Surface the field as `LinkedPRHeadSHA string` on `BoardProbeItem` and `ProjectItem`. This makes the standard poll path authoritative for `HeadSHA` independently of the REST fallback.

**`engine/poll.go`** — Apply `PRHeadSHAUpdated` from probe results on every cycle for items with a linked PR, so the store is updated at probe frequency without a deep-fetch.

**`boardcache/boardcache.go`** — Fix B (R2): In `FetchLinkedPR`, remove the `linkedPRNum == 0` guard on `PRHeadSHAUpdated` and use `pr.HeadSHA` (fresh REST result) instead of the stale pre-fetch snapshot. Fix C (R3): Tighten the `FetchLinkedPR` cache-hit eligibility check to require `lpr.HeadSHA != ""` in addition to `lpr.Title != ""`.

**`engine/ci.go`** — Split the combined `pr == nil || pr.HeadSHA == ""` early-exit: `pr == nil` still clears the gate; `pr.HeadSHA == ""` on a non-nil PR now blocks the gate (returns `blocked=true`) rather than silently disarming it. Belt-and-suspenders complement to Fix C.

**`adrs/047-headrefoid-probe-query.md`** — Documents why the probe and deep-fetch queries now include `headRefOid`, referencing and partially superseding the rejected alternative in ADR 027.

## How to Test

1. Run `go test ./boardcache/... ./engine/... ./github/... ./internal/...` — all tests pass.
2. New regression tests:
   - `TestFetchLinkedPR_SecondCallUsesStoredSHA` — second `FetchLinkedPR` call is served from cache with the correct non-empty `HeadSHA`.
   - `TestFetchLinkedPR_EmptyHeadSHAForcesRefetch` — cache refuses to serve a record with `Title != ""` but `HeadSHA == ""`, forcing a REST fallback.
   - `TestCheckCIGate_EmptyHeadSHA_StaysBlocked` — `checkCIGate` returns `blocked=true` (not gate-cleared) when PR is non-nil but `HeadSHA == ""`.
3. The pre-existing `TestBuildCloneURL` failure in `engine/` is unrelated to these changes (it expects "acme/fantasy" but the code returns "arbeithand/fantasy" — present on `main` before this branch).

Closes #779