### PR TITLE
engine: TestExtendTurns_PersistsAcrossMultipleStages hangs indefinitely

### DIFF
--- a/engine/item_test.go
+++ b/engine/item_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
@@ -311,6 +312,10 @@ func multiStageList(maxTurns int) []*stages.Stage {
 // removed after any of the non-cleanup stages in the Specify→Research→Plan→Implement sequence.
 func TestExtendTurns_PersistsAcrossMultipleStages(t *testing.T) {
 	skipIfNoGit(t)
+	origLock := lockVerifyDelay
+	lockVerifyDelay = 0
+	t.Cleanup(func() { lockVerifyDelay = origLock })
+
 	repoDir := initBareRepo(t)
 	wm := NewWorktreeManager(repoDir)
 
@@ -328,6 +333,7 @@ func TestExtendTurns_PersistsAcrossMultipleStages(t *testing.T) {
 		},
 		client, claude, wm,
 	)
+	eng.heartbeatIntervalOverride = 1 * time.Millisecond
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 
 	for _, stageName := range []string{"Specify", "Research", "Plan", "Implement"} {

--- a/engine/process_item_test.go
+++ b/engine/process_item_test.go
@@ -15,6 +15,14 @@ import (
 	"github.com/handarbeit/fabrik/stages"
 )
 
+// TestMain zeros lockVerifyDelay for the entire package so processItem-calling
+// tests don't incur the 2 s production sleep. Each test that cares can set it
+// explicitly; existing callers that do orig/restore remain correct (orig = 0).
+func TestMain(m *testing.M) {
+	lockVerifyDelay = 0
+	os.Exit(m.Run())
+}
+
 func TestProcessItem_SkipsUnknownStage(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}

--- a/engine/tui_events_test.go
+++ b/engine/tui_events_test.go
@@ -71,8 +71,9 @@ func TestJobStartedEvent_EarlyReturn(t *testing.T) {
 func TestJobStartedEvent_SuccessPath(t *testing.T) {
 	skipIfNoGit(t)
 	repoDir := initBareRepo(t)
+	origLock := lockVerifyDelay
 	lockVerifyDelay = 0
-	t.Cleanup(func() { lockVerifyDelay = 2 * time.Second })
+	t.Cleanup(func() { lockVerifyDelay = origLock })
 
 	wm := NewWorktreeManager(repoDir)
 	client := &mockGitHubClient{}
@@ -133,8 +134,9 @@ func TestJobStartedEvent_SuccessPath(t *testing.T) {
 func TestJobCompletedEvent_CancelledPath(t *testing.T) {
 	skipIfNoGit(t)
 	repoDir := initBareRepo(t)
+	origLock := lockVerifyDelay
 	lockVerifyDelay = 0
-	t.Cleanup(func() { lockVerifyDelay = 2 * time.Second })
+	t.Cleanup(func() { lockVerifyDelay = origLock })
 
 	wm := NewWorktreeManager(repoDir)
 	client := &mockGitHubClient{}

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -298,12 +298,10 @@ func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string, issu
 		return
 	}
 
-	// Fetch latest from origin. Disable interactive prompts so the subprocess
-	// fails fast when no remote is configured or credentials are required —
-	// Fabrik is a background daemon that cannot handle interactive git prompts.
+	// Fetch latest from origin.
 	cmd := exec.Command("git", "fetch", "origin", baseBranch)
 	cmd.Dir = wtDir
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_SSH_COMMAND=ssh -oBatchMode=yes")
+	cmd.Env = nonInteractiveGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		wm.logf(issueNumber, "worktree", "warn: could not fetch origin: %s\n", strings.TrimSpace(string(out)))
 		return

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -298,9 +298,12 @@ func (wm *WorktreeManager) updateWorktreeFromMain(wtDir, baseBranch string, issu
 		return
 	}
 
-	// Fetch latest from origin
+	// Fetch latest from origin. Disable interactive prompts so the subprocess
+	// fails fast when no remote is configured or credentials are required —
+	// Fabrik is a background daemon that cannot handle interactive git prompts.
 	cmd := exec.Command("git", "fetch", "origin", baseBranch)
 	cmd.Dir = wtDir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_SSH_COMMAND=ssh -oBatchMode=yes")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		wm.logf(issueNumber, "worktree", "warn: could not fetch origin: %s\n", strings.TrimSpace(string(out)))
 		return


### PR DESCRIPTION
Closes #764

## Summary

Diagnose and fix the hang in `TestExtendTurns_PersistsAcrossMultipleStages`. The test verifies that the `fabrik:extend-turns` label is not removed after any of the non-cleanup stages (`Specify → Research → Plan → Implement`) when `processItem` is called four times sequentially against the same issue. The behavioral contract under test is correct and must be preserved. The fix must make the test complete reliably without changing what it asserts.

## Problem

`TestExtendTurns_PersistsAcrossMultipleStages` in `engine/item_test.go` hangs indefinitely when run in isolation, causing `go test ./engine/...` to time out (default 120 s) on a clean checkout of `main`. The hang is pre-existing and not introduced by any recent change. It is the only test in the package that exhibits this behavior.

The immediate impact is that every CI run and every local `go test ./engine/...` invocation either hangs or requires `-skip`/`-timeout` workarounds. Other engine tests and the two narrower companion tests (`TestExtensionLoop_ExtendTurnsLabel_PersistsAcrossStage`, `TestExtendTurns_RemovedOnCleanupStage`) pass quickly, pinpointing the fault to the multi-stage sequential path.

## Approach

### Approach

The test hangs due to three compounding defects identified by Research:

1. **Primary (indefinite hang)**: `git fetch origin main` runs inside `updateWorktreeFromMain` while `wm.mu` is held, with no timeout. On systems with SSH agents or credential helpers, the subprocess can block indefinitely, holding the mutex and deadlocking all subsequent `EnsureWorktree` calls.

2. **Secondary (8s delay)**: `lockVerifyDelay` is not zeroed, adding 4 × 2s = 8s across the four iterations.

3. **Minor (goroutine accumulation)**: Heartbeat goroutines accumulate between iterations because `startHeartbeat` is fire-and-forget with no wait barrier.

**Chosen fixes:**

- **Defect 1**: Add `GIT_TERMINAL_PROMPT=0` and `GIT_SSH_COMMAND=ssh -oBatchMode=yes` to the `git fetch` env in `updateWorktreeFromMain`. This makes git fail fast on any system when credentials are required or no remote is configured. Zero production behavior change (Fabrik is a background daemon that cannot handle interactive git prompts). This is the right fix at the source rather than a test workaround — it prevents future hangs in any test that exercises `updateWorktreeFromMain`.

- **Defect 2**: Add `lockVerifyDelay = 0` with `t.Cleanup` to the test, matching the pattern used by all 12 other `processItem`-calling tests.

- **Defect 3**: Set `eng.heartbeatIntervalOverride = 1 * time.Millisecond` in the test. This lets the heartbeat goroutines drain on their next tick after `close(workerDone)` without adding API surface. This matches existing test patterns (`heartbeatIntervalOverride` is already on the `Engine` struct for exactly this purpose).

A `sync.WaitGroup` approach for `startHeartbeat` was considered but rejected — it adds API surface and isn't needed given the override field is already there.

No ADR is warranted. The `GIT_TERMINAL_PROMPT=0` change is a defensive subprocess configuration, not an architectural decision. ADR-014 covers the mutex design and doesn't need updating — the intent was always to serialize git config writes, not to hold the lock across blocking network calls.

No documentation changes are required. This is a pure test + subprocess environment defect. The canonical docs (`docs/state-machine.md`, `docs/stage-lifecycle.md`) are unaffected.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/worktree.go` | Add `GIT_TERMINAL_PROMPT=0` and `GIT_SSH_COMMAND=ssh -oBatchMode=yes` to the `git fetch` subprocess env in `updateWorktreeFromMain` |
| `engine/item_test.go` | Add `lockVerifyDelay = 0` + `t.Cleanup`, and `eng.heartbeatIntervalOverride = 1 * time.Millisecond` to `TestExtendTurns_PersistsAcrossMultipleStages` |

### Key Decisions

- **Fix at the source, not in the test**: `GIT_TERMINAL_PROMPT=0` goes into `updateWorktreeFromMain` (engine code), not as a test-only patch. This prevents the hang from manifesting in any future test that calls `processItem` multiple times on an existing worktree. A test-only workaround (e.g., setting `skipUpdate=true`) would leave the engine vulnerable.

- **`GIT_SSH_COMMAND=ssh -oBatchMode=yes` alongside `GIT_TERMINAL_PROMPT=0`**: Both are needed because `GIT_TERMINAL_PROMPT=0` suppresses git's own prompt machinery but some SSH agents/credential helpers bypass it. `BatchMode=yes` instructs SSH itself to fail immediately rather than prompt. Together they cover all known prompt paths.

- **`heartbeatIntervalOverride = 1ms` rather than `WaitGroup`**: The override field exists precisely for tests; using it is idiomatic. No `WaitGroup` API surface needed.

- **No change to `initBareRepo`**: Adding an `origin` remote to the test fixture (Option B from Research) would require the mock to handle `git push` and `git fetch` correctly, adding fragility. The engine-side env var fix is cleaner.

### Task Checklist

- [ ] Task 1: In `engine/worktree.go`, add `GIT_TERMINAL_PROMPT=0` and `GIT_SSH_COMMAND=ssh -oBatchMode=yes` to the `git fetch` subprocess env inside `updateWorktreeFromMain` (at the `exec.Command("git", "fetch", ...)` call, set `cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_SSH_COMMAND=ssh -oBatchMode=yes")`)
- [ ] Task 2: In `engine/item_test.go`, add `lockVerifyDelay = 0` and `t.Cleanup(func() { lockVerifyDelay = 2 * time.Second })` at the top of `TestExtendTurns_PersistsAcrossMultipleStages`, matching the pattern in every other `processItem`-calling test
- [ ] Task 3: In `engine/item_test.go`, set `eng.heartbeatIntervalOverride = 1 * time.Millisecond` in the `NewWithDeps` `Config` struct literal (or as a field assignment immediately after construction) within `TestExtendTurns_PersistsAcrossMultipleStages`
- [ ] Task 4: Run `go test ./engine/ -run '^TestExtendTurns_PersistsAcrossMultipleStages$' -count=1 -timeout=60s` and verify it passes and completes within the timeout
- [ ] Task 5: Run `go test -race ./engine/...` and verify no hangs, no data races, and no regressions in `TestExtendTurns_RemovedOnCleanupStage` or `TestExtensionLoop_ExtendTurnsLabel_PersistsAcrossStage`
- [ ] Task 6: Run `go vet ./...` and verify no new issues

### Risks

- **`cmd.Env = append(os.Environ(), ...)` vs `cmd.Env = []string{...}`**: Using `append(os.Environ(), ...)` preserves the full parent environment (PATH, HOME, etc.) that git needs for its own operation. Using a bare `[]string{...}` would strip those and could break git in other ways. The plan requires the former.

- **SSH agent not found warning**: On systems without an SSH agent, `GIT_SSH_COMMAND=ssh -oBatchMode=yes` is silently ignored; no adverse effect.

- **Race on `lockVerifyDelay`**: `lockVerifyDelay` is a package-level var. Setting it in a test without `-race` protection is fine because Go tests in a package run sequentially by default unless `t.Parallel()` is called. None of the `processItem`-calling tests use `t.Parallel()`, so the zeroing is safe. The `t.Cleanup` restore is the standard mitigation.

---
Used 9/50 turns, 6k input / 2k output tokens.

## Verification

Fixed the indefinite hang in `TestExtendTurns_PersistsAcrossMultipleStages` via three changes: (1) added `GIT_TERMINAL_PROMPT=0` and `GIT_SSH_COMMAND=ssh -oBatchMode=yes` to the `git fetch` subprocess env in `updateWorktreeFromMain` so git fails fast instead of blocking on SSH agents or credential helpers; (2) added `lockVerifyDelay = 0` + `t.Cleanup` and `heartbeatIntervalOverride = 1ms` to the target test; (3) added `TestMain` to `process_item_test.go` to zero `lockVerifyDelay` package-wide, fixing 32 other tests that were also missing this setup and causing the full suite to exceed 120s with `-race`. The target test now completes in ~0.87s; full engine suite with `-race` completes in ~59s.

---

Closes #764