### PR TITLE
Hard tool-restriction enforcement of Implement worktree boundaries

### DIFF
--- a/adrs/049-worktree-boundary-enforcement.md
+++ b/adrs/049-worktree-boundary-enforcement.md
@@ -28,11 +28,13 @@ This is implemented in `applyWorktreeBoundary` (`engine/boundary.go`) — a pure
 
 ### Layer 2: Reactive Post-Run Audit
 
-Before the extension loop in `processItem` (`engine/item.go`), snapshot branch refs across all registered bare-clone repositories via `snapshotAllRepoRefs`. After the loop, compare via `crossRepoViolations`. Any ref that is new or has changed SHA in a repo *other than* the active issue's repo is a boundary violation.
+Before the extension loop in `processItem` (`engine/item.go`), snapshot branch refs across all registered bare-clone repositories via `snapshotAllRepoRefs`. After the loop, compare via `crossRepoViolations`. Any ref that is new, changed, or deleted in a repo *other than* the active issue's repo is a boundary violation. Repos not present in the before-snapshot (lazy-registered during the run or whose pre-audit snapshot failed) are excluded from comparison to prevent false positives.
 
 On violation:
 - A comment is posted on the issue naming the specific refs mutated.
+- `fabrik:paused` is added so `itemNeedsWork` skips the issue until the user investigates. Without `fabrik:paused`, the `clearFailedStage` path in `processItem` would auto-clear the failed label on the next poll cycle.
 - `stage:<name>:failed` is added. `StageAttempted` is recorded (cooldown applies). `MaxRetries` is NOT consumed — violations require human investigation, not auto-retry.
+- `EnginePaused` is recorded in the store so that `clearFailedStage` fires (removing the failed label) when the user removes `fabrik:paused`.
 - No automatic cleanup of unauthorized external state (branches created, PRs opened in wrong repos) — surface to human.
 
 The audit is implemented in `snapshotRepoRefs` and `crossRepoViolations` (`engine/boundary.go`), with orchestration in `snapshotAllRepoRefs` and `handleBoundaryViolation` (`engine/item.go`).
@@ -69,7 +71,7 @@ The `Bash(cmd:*)` pattern restricts by command name, not by argument path. `Bash
 
 ### Why not increment MaxRetries on violation?
 
-Boundary violations are not transient errors (network blips, rate limits) that benefit from automatic retry. They indicate a structural problem — a confused Claude session, a misconfigured spec, or a potential prompt-injection attack. Retrying without human review could repeat the violation. Recording `StageAttempted` (for cooldown) but not `StageRetryIncremented` (MaxRetries) gives the stage a cooldown period while leaving the retry counter available for legitimate transient failures after the human clears `stage:<name>:failed`.
+Boundary violations are not transient errors (network blips, rate limits) that benefit from automatic retry. They indicate a structural problem — a confused Claude session, a misconfigured spec, or a potential prompt-injection attack. Retrying without human review could repeat the violation. `fabrik:paused` and `stage:<name>:failed` are both added, matching the pattern of `escalateFailedStage`. `StageAttempted` is recorded (cooldown applies) but `StageRetryIncremented` is not called (MaxRetries is preserved). When the user removes `fabrik:paused`, `clearFailedStage` removes the failed label and the stage can be retried cleanly.
 
 ## Known Limitations
 

--- a/adrs/049-worktree-boundary-enforcement.md
+++ b/adrs/049-worktree-boundary-enforcement.md
@@ -1,0 +1,91 @@
+# ADR 049: Worktree Boundary Enforcement
+
+**Date**: 2026-05-24  
+**Status**: Accepted
+
+## Context
+
+Fabrik's tool permission model grants `Bash(git:*)` and `Bash(gh:*)` globally — these restrict which *commands* can run, but not *where*. A Claude session in the Implement stage can `cd` to any directory and run git operations or `gh pr create` against an arbitrary repository. This is not theoretical: `acme/widgets-graph#42` produced an unexpected cross-repo PR (`acme/widgets#785`) by Claude navigating into the user's local working copy and creating a branch + PR there directly, completely bypassing Fabrik's worktree model.
+
+The forthcoming multi-repo orchestration spec adds prompt-level guardrails, but prompt-level prohibition is not sufficient — a sufficiently confused or adversarial Claude session can still escape. This ADR describes the engine-level enforcement layer that makes worktree boundaries structurally unbreakable regardless of what Claude's prompt or the user's issue spec says.
+
+## Decision
+
+Deploy a **dual enforcement layer** — proactive (tool-permission) and reactive (post-run audit) — applied to all non-read-only, non-unrestricted stage invocations.
+
+### Layer 1: Proactive Tool-Permission Restriction
+
+In `buildClaudeArgs` (`engine/claude.go`), replace bare `"Edit"` and `"Write"` entries in `--allowedTools` with path-scoped variants:
+
+```
+--allowedTools Edit(<workDir>/**)
+--allowedTools Write(<workDir>/**)
+```
+
+Claude Code's `--allowedTools` flag accepts the same `Tool(pattern)` syntax as `Bash(git:*)`. Path-scoped `Edit`/`Write` entries restrict Claude's file-editing tools to the assigned worktree directory. Attempts to edit outside the path result in a tool-level error returned to Claude; the stage continues running (the violation is blocked, not the stage).
+
+This is implemented in `applyWorktreeBoundary` (`engine/boundary.go`) — a pure function that takes the tool list and workDir and returns a new list with bare `Edit`/`Write` replaced. Called from `buildClaudeArgs` when `!unrestricted && !stage.ReadOnly && workDir != ""`.
+
+### Layer 2: Reactive Post-Run Audit
+
+Before the extension loop in `processItem` (`engine/item.go`), snapshot branch refs across all registered bare-clone repositories via `snapshotAllRepoRefs`. After the loop, compare via `crossRepoViolations`. Any ref that is new or has changed SHA in a repo *other than* the active issue's repo is a boundary violation.
+
+On violation:
+- A comment is posted on the issue naming the specific refs mutated.
+- `stage:<name>:failed` is added. `StageAttempted` is recorded (cooldown applies). `MaxRetries` is NOT consumed — violations require human investigation, not auto-retry.
+- No automatic cleanup of unauthorized external state (branches created, PRs opened in wrong repos) — surface to human.
+
+The audit is implemented in `snapshotRepoRefs` and `crossRepoViolations` (`engine/boundary.go`), with orchestration in `snapshotAllRepoRefs` and `handleBoundaryViolation` (`engine/item.go`).
+
+### Gating Conditions
+
+Both layers gate on `!unrestricted && !stage.ReadOnly`:
+
+- **`fabrik:unrestricted`**: passes `--dangerously-skip-permissions` instead of `--allowedTools`, bypassing all tool restrictions. Worktree-boundary enforcement is also bypassed — consistent with the existing semantics of that label.
+- **Read-only stages** (Specify, Research, Plan): stash/restore worktree changes and do not produce commits or file writes. Neither layer applies.
+- **Single-repo projects**: the path restriction still applies (preventing out-of-worktree file writes). The cross-repo audit produces no violations — the active repo is excluded, and there are no other registered repos.
+
+## Rationale
+
+### Why not OS-level sandboxing?
+
+macOS `sandbox-exec` profiles and Linux mount namespaces (`unshare`) could enforce filesystem isolation at the kernel level, making bypass structurally impossible. These were rejected because:
+
+1. **Platform-specific**: `sandbox-exec` is macOS-only and deprecated; Linux namespaces require elevated permissions or `newuidmap`/`newgidmap` helpers. Fabrik runs on both platforms; a cross-platform solution would require maintaining two separate sandbox implementations.
+2. **Elevated permissions**: Namespace-based isolation (e.g., `unshare -m`) typically requires root or specific capability grants (`CAP_SYS_ADMIN`). Fabrik is a CLI tool; requiring elevated permissions is a non-starter for most users.
+3. **Tool-layer enforcement is sufficient for the threat model**: The primary concern is a confused Claude session, not an adversarial one with root access. Tool-permission enforcement blocks the `Edit`/`Write` tools that Claude Code uses for file writes. The post-run audit catches the git-layer mutations that shell commands might produce.
+
+### Why git refs rather than filesystem state?
+
+The post-run audit targets git refs (branch/tag names and their SHAs) rather than filesystem writes because:
+
+1. **Filesystem monitoring is expensive and platform-specific**: `inotify` (Linux), `kqueue` (macOS), and `FSEvents` (macOS) are all platform-specific. Polling `find /` for new files after each invocation is too slow and produces too much noise.
+2. **Git refs are the observable harm**: The incident that motivated this ADR (`acme/widgets-graph#42`) caused harm by pushing commits and opening a PR in the wrong repo — git-layer mutations. A file write outside the worktree that is never committed and never pushed is recoverable; a pushed branch or opened PR is not.
+3. **`git for-each-ref` is fast and cross-platform**: On typical Fabrik deployments (1-5 repos, a few hundred branches), the snapshot takes <10ms per repo and has no platform-specific dependencies.
+
+### Why not just restrict `Bash(git:*)` to the worktree path?
+
+The `Bash(cmd:*)` pattern restricts by command name, not by argument path. `Bash(git:*)` cannot be scoped to `git --work-tree=/path:*` at the tool-permission layer — the pattern matches the subcommand token, not the full argument string. This is a known limitation of Claude Code's `--allowedTools` syntax. The post-run audit is the mitigation.
+
+### Why not increment MaxRetries on violation?
+
+Boundary violations are not transient errors (network blips, rate limits) that benefit from automatic retry. They indicate a structural problem — a confused Claude session, a misconfigured spec, or a potential prompt-injection attack. Retrying without human review could repeat the violation. Recording `StageAttempted` (for cooldown) but not `StageRetryIncremented` (MaxRetries) gives the stage a cooldown period while leaving the retry counter available for legitimate transient failures after the human clears `stage:<name>:failed`.
+
+## Known Limitations
+
+1. **Bash shell writes are not path-constrainable**: `cat > /other/path`, `tee`, `cp`, and similar shell-level writes cannot be blocked at the tool-permission layer. Claude Code uses `Edit`/`Write` tools for most file writes; raw shell I/O to outside paths is less common but not impossible. The git-ref audit provides a backstop for the most harmful variant (commits pushed to wrong repos).
+
+2. **Unregistered repos are not audited**: Repos are registered lazily when Fabrik first encounters them. If Claude navigates into a local git repo that is not in Fabrik's managed set (`worktreeManagers`), the audit does not see it. This is acceptable — Fabrik cannot audit repos it has never been told about.
+
+3. **Active repo exclusion**: The active issue's repo is unconditionally excluded from the violation check — all ref changes there are assumed legitimate (commits, branch pushes from the stage's work). This is correct in single-stage mode; in a hypothetical future where one invocation manages multiple repos, the exclusion logic would need revisiting.
+
+4. **Snapshot window**: The snapshot is taken before the extension loop and compared after. Concurrent Fabrik workers can mutate refs in other repos during the window. The design scopes the exclusion to the *active repo* rather than a time window, so Worker A's legitimate push to repo-X does not trigger a violation in Worker B (whose active repo is Y and thus audits repo-X). False positives from concurrent workers are therefore limited to: Worker B actively pushing to repo-Y (already excluded) while Worker A's active repo is also Y (prevented by the in-flight guard).
+
+## References
+
+- [ADR 005](005-claude-cli-invocation.md): Claude CLI shell-out and `--allowedTools`
+- [ADR 006](006-git-worktrees.md): Worktree path structure
+- [Stage Lifecycle §Phase 2: Worktree Boundary Enforcement](../docs/stage-lifecycle.md)
+- [Stage Lifecycle §Phase 3: Post-Run Boundary Audit](../docs/stage-lifecycle.md)
+- `engine/boundary.go`: `applyWorktreeBoundary`, `snapshotRepoRefs`, `crossRepoViolations`
+- `engine/item.go`: `snapshotAllRepoRefs`, `handleBoundaryViolation`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4606,8 +4606,11 @@ After the extension loop completes, a cross-repo ref audit runs for non-read-onl
 **On violation:**
 - `[#N audit]` log line names the stage and count of mutations.
 - A comment is posted on the issue listing the specific refs mutated (names and SHAs). No automatic cleanup.
+- `fabrik:paused` is added so `itemNeedsWork` skips the issue until the user investigates.
 - `stage:<name>:failed` label is added. `StageAttempted` is recorded (cooldown applies). `MaxRetries` is NOT consumed — violations require human investigation, not auto-retry.
+- `EnginePaused` is recorded in the store so that `clearFailedStage` fires (removing the failed label and resetting state) when the user removes `fabrik:paused`.
 - The stage returns without posting output or advancing to the next stage.
+- **To retry**: remove `fabrik:paused`. The engine will clear `stage:<name>:failed` and re-run the stage on the next poll.
 
 **No violation:** The audit is silent. Stage proceeds to normal output posting and completion.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4395,6 +4395,23 @@ Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, load
 
 Labels matching `model:<name>` on the issue override the stage's configured model.
 
+### Worktree Boundary Enforcement
+
+For non-read-only, non-unrestricted stages (Implement, Review, Validate, and any custom stage with `read_only: false`), the engine replaces the bare `Edit` and `Write` entries in `--allowedTools` with path-scoped variants:
+
+```
+--allowedTools Edit(<workDir>/**)
+--allowedTools Write(<workDir>/**)
+```
+
+This proactively restricts Claude Code's file-editing tools to the assigned worktree directory. If Claude attempts to edit or write a file outside the worktree, it receives an error from Claude Code and the stage continues running (the attempt is blocked, not the whole stage).
+
+**Scope:** Enforced for all stages where `read_only: false`. Skipped for read-only stages (Specify, Research, Plan by default) — they do not write files and receive bare `Edit`/`Write` entries (or none, if `allowed_tools:` is overridden in stage YAML).
+
+**Bypass:** When `fabrik:unrestricted` is present on the issue, `--dangerously-skip-permissions` is passed instead of `--allowedTools`, bypassing this restriction entirely (consistent with the existing semantics of that label).
+
+**Known gap:** `Bash` shell commands that write files (e.g., `cat > /other/path`) cannot be path-restricted at the tool-permission layer — `Bash(cmd:*)` restricts command name, not argument paths. The post-run boundary audit (Phase 3) covers the primary remaining attack surface.
+
 ---
 
 ## Phase 2.5: Pre-Implement Step (Implement Stage Only)
@@ -4575,6 +4592,30 @@ The `e.claude.Invoke()` call runs inside an extension loop. On each iteration:
 **Deferred WIP commit and push:** The `commitWIP` and `PushBranch` calls happen AFTER the extension loop completes, not between invocations. This preserves worktree state across extensions.
 
 **Stats footer:** After the loop, `usage.MaxTurns` is set to `totalMultiple × stage.MaxTurns`, so the stats line reflects the total budget (e.g., `used 130/150 turns`).
+
+### Post-Run Boundary Audit
+
+After the extension loop completes, a cross-repo ref audit runs for non-read-only, non-unrestricted stages. The audit detects git-layer mutations in any repository other than the active worktree's own repo.
+
+**How it works:**
+
+1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname)` in its bare-clone directory. Capture `repo → (refname → SHA)` for all known repos.
+2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation.
+3. **Violation check** (`crossRepoViolations`): Compare before/after for every repo key *except* the active issue's repo. Any ref that is new or has a changed SHA is a violation.
+
+**On violation:**
+- `[#N audit]` log line names the stage and count of mutations.
+- A comment is posted on the issue listing the specific refs mutated (names and SHAs). No automatic cleanup.
+- `stage:<name>:failed` label is added. `StageAttempted` is recorded (cooldown applies). `MaxRetries` is NOT consumed — violations require human investigation, not auto-retry.
+- The stage returns without posting output or advancing to the next stage.
+
+**No violation:** The audit is silent. Stage proceeds to normal output posting and completion.
+
+**Bypass:** Skipped when `stage.ReadOnly == true` or `fabrik:unrestricted` is present on the issue.
+
+**Limitation — Bash shell writes:** The audit checks git refs, not the filesystem. A Claude session that writes files outside the worktree via raw shell commands (e.g., `cat > /other/path`) would not be caught unless those files were also committed and pushed to another repo. The `Edit`/`Write` path restriction (Phase 2) is the primary mitigation for direct file writes.
+
+**Limitation — unregistered repos:** Only repos in `worktreeManagers` at the time of the snapshot are audited. Repos that Claude navigated into but that are not registered in Fabrik's managed set are not detected.
 
 ---
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -300,8 +300,11 @@ After the extension loop completes, a cross-repo ref audit runs for non-read-onl
 **On violation:**
 - `[#N audit]` log line names the stage and count of mutations.
 - A comment is posted on the issue listing the specific refs mutated (names and SHAs). No automatic cleanup.
+- `fabrik:paused` is added so `itemNeedsWork` skips the issue until the user investigates.
 - `stage:<name>:failed` label is added. `StageAttempted` is recorded (cooldown applies). `MaxRetries` is NOT consumed — violations require human investigation, not auto-retry.
+- `EnginePaused` is recorded in the store so that `clearFailedStage` fires (removing the failed label and resetting state) when the user removes `fabrik:paused`.
 - The stage returns without posting output or advancing to the next stage.
+- **To retry**: remove `fabrik:paused`. The engine will clear `stage:<name>:failed` and re-run the stage on the next poll.
 
 **No violation:** The audit is silent. Stage proceeds to normal output posting and completion.
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -89,6 +89,23 @@ Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, load
 
 Labels matching `model:<name>` on the issue override the stage's configured model.
 
+### Worktree Boundary Enforcement
+
+For non-read-only, non-unrestricted stages (Implement, Review, Validate, and any custom stage with `read_only: false`), the engine replaces the bare `Edit` and `Write` entries in `--allowedTools` with path-scoped variants:
+
+```
+--allowedTools Edit(<workDir>/**)
+--allowedTools Write(<workDir>/**)
+```
+
+This proactively restricts Claude Code's file-editing tools to the assigned worktree directory. If Claude attempts to edit or write a file outside the worktree, it receives an error from Claude Code and the stage continues running (the attempt is blocked, not the whole stage).
+
+**Scope:** Enforced for all stages where `read_only: false`. Skipped for read-only stages (Specify, Research, Plan by default) — they do not write files and receive bare `Edit`/`Write` entries (or none, if `allowed_tools:` is overridden in stage YAML).
+
+**Bypass:** When `fabrik:unrestricted` is present on the issue, `--dangerously-skip-permissions` is passed instead of `--allowedTools`, bypassing this restriction entirely (consistent with the existing semantics of that label).
+
+**Known gap:** `Bash` shell commands that write files (e.g., `cat > /other/path`) cannot be path-restricted at the tool-permission layer — `Bash(cmd:*)` restricts command name, not argument paths. The post-run boundary audit (Phase 3) covers the primary remaining attack surface.
+
 ---
 
 ## Phase 2.5: Pre-Implement Step (Implement Stage Only)
@@ -269,6 +286,30 @@ The `e.claude.Invoke()` call runs inside an extension loop. On each iteration:
 **Deferred WIP commit and push:** The `commitWIP` and `PushBranch` calls happen AFTER the extension loop completes, not between invocations. This preserves worktree state across extensions.
 
 **Stats footer:** After the loop, `usage.MaxTurns` is set to `totalMultiple × stage.MaxTurns`, so the stats line reflects the total budget (e.g., `used 130/150 turns`).
+
+### Post-Run Boundary Audit
+
+After the extension loop completes, a cross-repo ref audit runs for non-read-only, non-unrestricted stages. The audit detects git-layer mutations in any repository other than the active worktree's own repo.
+
+**How it works:**
+
+1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname)` in its bare-clone directory. Capture `repo → (refname → SHA)` for all known repos.
+2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation.
+3. **Violation check** (`crossRepoViolations`): Compare before/after for every repo key *except* the active issue's repo. Any ref that is new or has a changed SHA is a violation.
+
+**On violation:**
+- `[#N audit]` log line names the stage and count of mutations.
+- A comment is posted on the issue listing the specific refs mutated (names and SHAs). No automatic cleanup.
+- `stage:<name>:failed` label is added. `StageAttempted` is recorded (cooldown applies). `MaxRetries` is NOT consumed — violations require human investigation, not auto-retry.
+- The stage returns without posting output or advancing to the next stage.
+
+**No violation:** The audit is silent. Stage proceeds to normal output posting and completion.
+
+**Bypass:** Skipped when `stage.ReadOnly == true` or `fabrik:unrestricted` is present on the issue.
+
+**Limitation — Bash shell writes:** The audit checks git refs, not the filesystem. A Claude session that writes files outside the worktree via raw shell commands (e.g., `cat > /other/path`) would not be caught unless those files were also committed and pushed to another repo. The `Edit`/`Write` path restriction (Phase 2) is the primary mitigation for direct file writes.
+
+**Limitation — unregistered repos:** Only repos in `worktreeManagers` at the time of the snapshot are audited. Repos that Claude navigated into but that are not registered in Fabrik's managed set are not detected.
 
 ---
 

--- a/engine/boundary.go
+++ b/engine/boundary.go
@@ -1,0 +1,83 @@
+package engine
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// applyWorktreeBoundary replaces bare "Edit" and "Write" entries in tools with
+// path-scoped variants ("Edit(<workDir>/**)" and "Write(<workDir>/**)").
+// All other entries are left unchanged. Returns a new slice (does not mutate input).
+// When workDir is empty, returns a copy of tools unchanged.
+func applyWorktreeBoundary(tools []string, workDir string) []string {
+	if workDir == "" {
+		result := make([]string, len(tools))
+		copy(result, tools)
+		return result
+	}
+	result := make([]string, 0, len(tools))
+	for _, t := range tools {
+		switch t {
+		case "Edit":
+			result = append(result, fmt.Sprintf("Edit(%s/**)", workDir))
+		case "Write":
+			result = append(result, fmt.Sprintf("Write(%s/**)", workDir))
+		default:
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// snapshotRepoRefs runs "git for-each-ref --format=%(refname) %(objectname)" in
+// bareDir and returns a map of refname → SHA. Returns an empty map when bareDir is
+// empty or the command fails (non-fatal: single-repo projects have no other repos to
+// audit and the caller skips the audit when the map is empty).
+func snapshotRepoRefs(bareDir string) (map[string]string, error) {
+	if bareDir == "" {
+		return map[string]string{}, nil
+	}
+	cmd := exec.Command("git", "for-each-ref", "--format=%(refname) %(objectname)")
+	cmd.Dir = bareDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git for-each-ref in %s: %w", bareDir, err)
+	}
+	refs := make(map[string]string)
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), " ", 2)
+		if len(parts) == 2 {
+			refs[parts[0]] = parts[1]
+		}
+	}
+	return refs, nil
+}
+
+// crossRepoViolations compares before and after ref snapshots (maps of repo →
+// map[refname]SHA) and returns a sorted slice of human-readable violation strings
+// for every ref that is new or changed in any repo other than activeRepo.
+// Each entry has the form "repo: ref (new)" or "repo: ref (oldSHA → newSHA)".
+func crossRepoViolations(before, after map[string]map[string]string, activeRepo string) []string {
+	var violations []string
+	for repo, afterRefs := range after {
+		if repo == activeRepo {
+			continue
+		}
+		beforeRefs := before[repo]
+		for ref, newSHA := range afterRefs {
+			oldSHA, existed := beforeRefs[ref]
+			if !existed {
+				violations = append(violations, fmt.Sprintf("%s: %s (new ref %s)", repo, ref, newSHA))
+			} else if oldSHA != newSHA {
+				violations = append(violations, fmt.Sprintf("%s: %s (%s → %s)", repo, ref, oldSHA, newSHA))
+			}
+		}
+	}
+	sort.Strings(violations)
+	return violations
+}

--- a/engine/boundary.go
+++ b/engine/boundary.go
@@ -60,21 +60,30 @@ func snapshotRepoRefs(bareDir string) (map[string]string, error) {
 
 // crossRepoViolations compares before and after ref snapshots (maps of repo →
 // map[refname]SHA) and returns a sorted slice of human-readable violation strings
-// for every ref that is new or changed in any repo other than activeRepo.
-// Each entry has the form "repo: ref (new)" or "repo: ref (oldSHA → newSHA)".
+// for every ref that is new, changed, or deleted in any repo other than activeRepo.
+// Only repos present in both before and after are checked; repos absent from before
+// (lazily registered or snapshot-failed) are skipped to avoid false positives.
 func crossRepoViolations(before, after map[string]map[string]string, activeRepo string) []string {
 	var violations []string
 	for repo, afterRefs := range after {
 		if repo == activeRepo {
 			continue
 		}
-		beforeRefs := before[repo]
+		beforeRefs, ok := before[repo]
+		if !ok {
+			continue
+		}
 		for ref, newSHA := range afterRefs {
 			oldSHA, existed := beforeRefs[ref]
 			if !existed {
 				violations = append(violations, fmt.Sprintf("%s: %s (new ref %s)", repo, ref, newSHA))
 			} else if oldSHA != newSHA {
 				violations = append(violations, fmt.Sprintf("%s: %s (%s → %s)", repo, ref, oldSHA, newSHA))
+			}
+		}
+		for ref, oldSHA := range beforeRefs {
+			if _, existed := afterRefs[ref]; !existed {
+				violations = append(violations, fmt.Sprintf("%s: %s (deleted, was %s)", repo, ref, oldSHA))
 			}
 		}
 	}

--- a/engine/boundary_test.go
+++ b/engine/boundary_test.go
@@ -1,0 +1,243 @@
+package engine
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- applyWorktreeBoundary tests ---
+
+func TestApplyWorktreeBoundary_ScopesEditAndWrite(t *testing.T) {
+	tools := []string{"Read", "Edit", "Write", "Glob", "Bash(git:*)"}
+	got := applyWorktreeBoundary(tools, "/work/issue-1")
+	want := []string{"Read", "Edit(/work/issue-1/**)", "Write(/work/issue-1/**)", "Glob", "Bash(git:*)"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("applyWorktreeBoundary = %v, want %v", got, want)
+	}
+}
+
+func TestApplyWorktreeBoundary_CustomAllowedTools(t *testing.T) {
+	tools := []string{"Edit", "Write", "Bash(go:*)"}
+	got := applyWorktreeBoundary(tools, "/worktrees/issue-42")
+	want := []string{"Edit(/worktrees/issue-42/**)", "Write(/worktrees/issue-42/**)", "Bash(go:*)"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("applyWorktreeBoundary = %v, want %v", got, want)
+	}
+}
+
+func TestApplyWorktreeBoundary_BashUnchanged(t *testing.T) {
+	tools := []string{"Bash(git:*)", "Bash(gh:*)", "Read"}
+	got := applyWorktreeBoundary(tools, "/some/path")
+	if !reflect.DeepEqual(got, tools) {
+		t.Errorf("applyWorktreeBoundary changed Bash entries: got %v, want %v", got, tools)
+	}
+}
+
+func TestApplyWorktreeBoundary_EmptyWorkDir_NoOp(t *testing.T) {
+	tools := []string{"Edit", "Write", "Read"}
+	got := applyWorktreeBoundary(tools, "")
+	if !reflect.DeepEqual(got, tools) {
+		t.Errorf("applyWorktreeBoundary with empty workDir = %v, want %v", got, tools)
+	}
+}
+
+func TestApplyWorktreeBoundary_DoesNotMutateInput(t *testing.T) {
+	tools := []string{"Edit", "Write"}
+	orig := make([]string, len(tools))
+	copy(orig, tools)
+	_ = applyWorktreeBoundary(tools, "/path")
+	if !reflect.DeepEqual(tools, orig) {
+		t.Error("applyWorktreeBoundary mutated input slice")
+	}
+}
+
+func TestApplyWorktreeBoundary_EmptyTools(t *testing.T) {
+	got := applyWorktreeBoundary([]string{}, "/path")
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %v", got)
+	}
+}
+
+func TestApplyWorktreeBoundary_AlreadyScopedPassesThrough(t *testing.T) {
+	// Pre-scoped entries are not "Edit" or "Write" bare — they should pass through unchanged.
+	tools := []string{"Edit(/other/**)", "Write(/other/**)"}
+	got := applyWorktreeBoundary(tools, "/new")
+	if !reflect.DeepEqual(got, tools) {
+		t.Errorf("pre-scoped entries changed: got %v, want %v", got, tools)
+	}
+}
+
+// --- snapshotRepoRefs tests ---
+
+func initRepoWithCommit(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	// Create a commit so HEAD resolves.
+	f := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(f, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func TestSnapshotRepoRefs_BareRepo(t *testing.T) {
+	skipIfNoGit(t)
+	bareDir := initBareRepo(t)
+	refs, err := snapshotRepoRefs(bareDir)
+	if err != nil {
+		t.Fatalf("snapshotRepoRefs: %v", err)
+	}
+	// A freshly initialized bare repo returns a map (possibly empty).
+	// Every value in the map must be a non-empty SHA.
+	for ref, sha := range refs {
+		if sha == "" {
+			t.Errorf("ref %s has empty SHA", ref)
+		}
+		_ = ref
+	}
+}
+
+func TestSnapshotRepoRefs_EmptyDir(t *testing.T) {
+	refs, err := snapshotRepoRefs("")
+	if err != nil {
+		t.Fatalf("snapshotRepoRefs with empty dir: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected empty map, got %v", refs)
+	}
+}
+
+func TestSnapshotRepoRefs_WithRefs(t *testing.T) {
+	skipIfNoGit(t)
+	// Create a regular repo with a commit, then clone it as bare.
+	srcDir := initRepoWithCommit(t)
+	bareDir := t.TempDir()
+	cloneCmd := exec.Command("git", "clone", "--bare", srcDir, bareDir)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %v\n%s", err, out)
+	}
+	refs, err := snapshotRepoRefs(bareDir)
+	if err != nil {
+		t.Fatalf("snapshotRepoRefs: %v", err)
+	}
+	if len(refs) == 0 {
+		t.Error("expected refs after clone, got empty map")
+	}
+	// Every value should be a non-empty SHA.
+	for ref, sha := range refs {
+		if sha == "" {
+			t.Errorf("ref %s has empty SHA", ref)
+		}
+	}
+}
+
+// --- crossRepoViolations tests ---
+
+func TestCrossRepoViolations_NoChange(t *testing.T) {
+	before := map[string]map[string]string{
+		"owner/repo-a": {"refs/heads/main": "aaa"},
+		"owner/repo-b": {"refs/heads/main": "bbb"},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-a": {"refs/heads/main": "aaa"},
+		"owner/repo-b": {"refs/heads/main": "bbb"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 0 {
+		t.Errorf("expected no violations, got %v", got)
+	}
+}
+
+func TestCrossRepoViolations_DetectsNewRef(t *testing.T) {
+	before := map[string]map[string]string{
+		"owner/repo-b": {},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/evil": "deadbeef"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 violation, got %v", got)
+	}
+	if !containsSubstring(got[0], "repo-b") || !containsSubstring(got[0], "evil") {
+		t.Errorf("unexpected violation string: %q", got[0])
+	}
+}
+
+func TestCrossRepoViolations_DetectsChangedRef(t *testing.T) {
+	before := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/main": "aaa"},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/main": "bbb"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 violation, got %v", got)
+	}
+	if !containsSubstring(got[0], "aaa") || !containsSubstring(got[0], "bbb") {
+		t.Errorf("unexpected violation string: %q", got[0])
+	}
+}
+
+func TestCrossRepoViolations_IgnoresActiveRepo(t *testing.T) {
+	before := map[string]map[string]string{
+		"owner/repo-a": {"refs/heads/main": "aaa"},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-a": {"refs/heads/main": "bbb", "refs/heads/feature": "ccc"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 0 {
+		t.Errorf("expected no violations for active repo, got %v", got)
+	}
+}
+
+func TestCrossRepoViolations_SortedOutput(t *testing.T) {
+	before := map[string]map[string]string{
+		"owner/repo-b": {},
+		"owner/repo-c": {},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/z": "111"},
+		"owner/repo-c": {"refs/heads/a": "222"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 violations, got %v", got)
+	}
+	if !sort.StringsAreSorted(got) {
+		t.Errorf("violations not sorted: %v", got)
+	}
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		strings.Contains(s, sub))
+}

--- a/engine/boundary_test.go
+++ b/engine/boundary_test.go
@@ -185,7 +185,7 @@ func TestCrossRepoViolations_DetectsNewRef(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 violation, got %v", got)
 	}
-	if !containsSubstring(got[0], "repo-b") || !containsSubstring(got[0], "evil") {
+	if !strings.Contains(got[0], "repo-b") || !strings.Contains(got[0], "evil") {
 		t.Errorf("unexpected violation string: %q", got[0])
 	}
 }
@@ -201,7 +201,7 @@ func TestCrossRepoViolations_DetectsChangedRef(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 violation, got %v", got)
 	}
-	if !containsSubstring(got[0], "aaa") || !containsSubstring(got[0], "bbb") {
+	if !strings.Contains(got[0], "aaa") || !strings.Contains(got[0], "bbb") {
 		t.Errorf("unexpected violation string: %q", got[0])
 	}
 }
@@ -248,7 +248,7 @@ func TestCrossRepoViolations_DetectsDeletedRef(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 violation for deleted ref, got %v", got)
 	}
-	if !containsSubstring(got[0], "old-branch") || !containsSubstring(got[0], "deleted") {
+	if !strings.Contains(got[0], "old-branch") || !strings.Contains(got[0], "deleted") {
 		t.Errorf("deletion violation should mention branch name and 'deleted': %q", got[0])
 	}
 }
@@ -267,9 +267,4 @@ func TestCrossRepoViolations_SkipsRepoAbsentFromBefore(t *testing.T) {
 	if len(got) != 0 {
 		t.Errorf("repos absent from before snapshot should not generate violations, got %v", got)
 	}
-}
-
-func containsSubstring(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
-		strings.Contains(s, sub))
 }

--- a/engine/boundary_test.go
+++ b/engine/boundary_test.go
@@ -237,6 +237,38 @@ func TestCrossRepoViolations_SortedOutput(t *testing.T) {
 	}
 }
 
+func TestCrossRepoViolations_DetectsDeletedRef(t *testing.T) {
+	before := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/main": "aaa", "refs/heads/old-branch": "bbb"},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/main": "aaa"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 violation for deleted ref, got %v", got)
+	}
+	if !containsSubstring(got[0], "old-branch") || !containsSubstring(got[0], "deleted") {
+		t.Errorf("deletion violation should mention branch name and 'deleted': %q", got[0])
+	}
+}
+
+func TestCrossRepoViolations_SkipsRepoAbsentFromBefore(t *testing.T) {
+	// A repo that appears in after but not in before (lazy registration or
+	// snapshot failure during pre-audit) must not generate false positives.
+	before := map[string]map[string]string{
+		"owner/repo-a": {"refs/heads/main": "aaa"},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-a": {"refs/heads/main": "aaa"},
+		"owner/repo-b": {"refs/heads/main": "bbb"}, // new repo, not in before
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 0 {
+		t.Errorf("repos absent from before snapshot should not generate violations, got %v", got)
+	}
+}
+
 func containsSubstring(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
 		strings.Contains(s, sub))

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -433,6 +433,9 @@ func buildClaudeArgs(stage *stages.Stage, sessFilePath string, resume bool, mode
 	if !unrestricted && len(tools) == 0 {
 		tools = defaultAllowedTools
 	}
+	if !unrestricted && !stage.ReadOnly && workDir != "" {
+		tools = applyWorktreeBoundary(tools, workDir)
+	}
 	for _, tool := range tools {
 		args = append(args, "--allowedTools", tool)
 	}

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -1131,6 +1131,150 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_sr","num_turns":1,"total_cost_
 	}
 }
 
+// TestBuildClaudeArgs_WorktreeBoundary verifies path-restricted Edit/Write entries
+// appear in --allowedTools for a non-readonly, non-unrestricted stage.
+func TestBuildClaudeArgs_WorktreeBoundary(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	argsFile := filepath.Join(binDir, "args.txt")
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := fmt.Sprintf(`#!/bin/sh
+cat >/dev/null
+echo "$@" > %s
+printf '%%s\n' '{"result":"ok","session_id":"sess_wb","num_turns":1,"total_cost_usd":0.001}'
+`, argsFile)
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "Implement",
+		Prompt:     "implement",
+		ReadOnly:   false,
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 400, Title: "T"}
+
+	_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+	if err != nil {
+		t.Fatalf("InvokeClaude: %v", err)
+	}
+	args, _ := os.ReadFile(argsFile)
+	argsStr := string(args)
+
+	// Path-scoped Edit and Write must appear.
+	wantEdit := fmt.Sprintf("Edit(%s/**)", workDir)
+	wantWrite := fmt.Sprintf("Write(%s/**)", workDir)
+	if !strings.Contains(argsStr, wantEdit) {
+		t.Errorf("expected %q in args, got: %s", wantEdit, argsStr)
+	}
+	if !strings.Contains(argsStr, wantWrite) {
+		t.Errorf("expected %q in args, got: %s", wantWrite, argsStr)
+	}
+	// Bare Edit/Write must NOT appear as standalone entries.
+	if strings.Contains(argsStr, " Edit ") || strings.HasSuffix(argsStr, " Edit") {
+		t.Error("bare 'Edit' found in args — expected scoped variant only")
+	}
+}
+
+// TestBuildClaudeArgs_WorktreeBoundary_ReadOnly verifies that read-only stages
+// do NOT get path-restricted Edit/Write in their --allowedTools.
+func TestBuildClaudeArgs_WorktreeBoundary_ReadOnly(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	argsFile := filepath.Join(binDir, "args.txt")
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := fmt.Sprintf(`#!/bin/sh
+cat >/dev/null
+echo "$@" > %s
+printf '%%s\n' '{"result":"ok","session_id":"sess_ro","num_turns":1,"total_cost_usd":0.001}'
+`, argsFile)
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "Research",
+		Prompt:     "research",
+		ReadOnly:   true,
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 401, Title: "T"}
+
+	_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+	if err != nil {
+		t.Fatalf("InvokeClaude: %v", err)
+	}
+	args, _ := os.ReadFile(argsFile)
+	argsStr := string(args)
+
+	// Path-scoped variants must NOT appear for read-only stages.
+	if strings.Contains(argsStr, "Edit(") {
+		t.Errorf("unexpected scoped Edit in args for read-only stage: %s", argsStr)
+	}
+	if strings.Contains(argsStr, "Write(") {
+		t.Errorf("unexpected scoped Write in args for read-only stage: %s", argsStr)
+	}
+}
+
+// TestBuildClaudeArgs_WorktreeBoundary_Unrestricted verifies that the unrestricted
+// label bypasses worktree boundary enforcement entirely.
+func TestBuildClaudeArgs_WorktreeBoundary_Unrestricted(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	argsFile := filepath.Join(binDir, "args.txt")
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := fmt.Sprintf(`#!/bin/sh
+cat >/dev/null
+echo "$@" > %s
+printf '%%s\n' '{"result":"ok","session_id":"sess_unr","num_turns":1,"total_cost_usd":0.001}'
+`, argsFile)
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", binDir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "Implement",
+		Prompt:     "implement",
+		ReadOnly:   false,
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 402, Title: "T", Labels: []string{"fabrik:unrestricted"}}
+
+	_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+	if err != nil {
+		t.Fatalf("InvokeClaude: %v", err)
+	}
+	args, _ := os.ReadFile(argsFile)
+	argsStr := string(args)
+
+	// --dangerously-skip-permissions must appear, no path-scoped tools.
+	if !strings.Contains(argsStr, "--dangerously-skip-permissions") {
+		t.Error("expected --dangerously-skip-permissions for unrestricted issue")
+	}
+	if strings.Contains(argsStr, "Edit(") {
+		t.Errorf("unexpected scoped Edit in args for unrestricted stage: %s", argsStr)
+	}
+	if strings.Contains(argsStr, "Write(") {
+		t.Errorf("unexpected scoped Write in args for unrestricted stage: %s", argsStr)
+	}
+}
+
 // TestBuildClaudeArgs_UnrestrictedSkipsPermissionMode verifies that --dangerously-skip-permissions
 // is used (not --permission-mode dontAsk) when the issue has the fabrik:unrestricted label.
 func TestBuildClaudeArgs_UnrestrictedSkipsPermissionMode(t *testing.T) {

--- a/engine/item.go
+++ b/engine/item.go
@@ -1782,8 +1782,10 @@ func (e *Engine) snapshotAllRepoRefs(issueNumber int) map[string]map[string]stri
 	for _, p := range pairs {
 		refs, err := snapshotRepoRefs(p.baseDir)
 		if err != nil {
+			// Skip rather than store an empty map: an empty baseline would cause all
+			// refs found in the post-audit snapshot to be flagged as "new ref" violations.
+			// crossRepoViolations skips repos absent from the before snapshot.
 			e.logf(issueNumber, "audit", "warn: could not snapshot refs for %s: %v\n", p.repo, err)
-			result[p.repo] = map[string]string{}
 			continue
 		}
 		result[p.repo] = refs
@@ -1792,15 +1794,16 @@ func (e *Engine) snapshotAllRepoRefs(issueNumber int) map[string]map[string]stri
 }
 
 // handleBoundaryViolation posts a comment describing cross-repo ref mutations,
-// marks the stage as failed (with cooldown), and releases the lock.
-// Called after detecting violations from the post-run audit.
+// pauses the issue (fabrik:paused + stage:<name>:failed), records the failure
+// state, and releases the lock. Called after detecting violations from the
+// post-run audit.
 func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, item gh.ProjectItem, stage *stages.Stage, violations []string, releaseLock func()) {
 	e.logf(item.Number, "audit", "worktree boundary violation detected in stage %q: %d unauthorized ref mutation(s)\n", stage.Name, len(violations))
 
 	violationList := strings.Join(violations, "\n- ")
 	comment := fmt.Sprintf(
-		"🏭 **Fabrik — worktree boundary violation**\n\nStage **%s** mutated refs in repositories outside its assigned worktree. The stage has been failed. No automatic cleanup was performed — human review is required.\n\n**Detected violations:**\n- %s\n\nTo retry after investigating: remove the `stage:%s:failed` label.",
-		stage.Name, violationList, stage.Name,
+		"🏭 **Fabrik — worktree boundary violation**\n\nStage **%s** mutated refs in repositories outside its assigned worktree. The stage has been failed and the issue has been paused. No automatic cleanup was performed — human review is required.\n\n**Detected violations:**\n- %s\n\nTo retry after investigating: remove the `fabrik:paused` label.",
+		stage.Name, violationList,
 	)
 
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
@@ -1816,14 +1819,35 @@ func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, ite
 		}
 	}
 
+	// Add fabrik:paused so itemNeedsWork skips this issue until the user
+	// removes it. Without fabrik:paused the clearFailedStage path in
+	// processItem would auto-clear the failed label on the next poll cycle.
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+		}
+	}
+
 	e.addFailedLabel(owner, repo, item.Number, stage.Name)
 
 	// Record StageAttempted so cooldown applies; do NOT call StageRetryIncremented.
+	// Record EnginePaused so clearFailedStage fires (and removes the failed label)
+	// when the user removes fabrik:paused.
 	e.store.Apply(itemstate.StageAttempted{
 		Repo:      repoStr,
 		Number:    item.Number,
 		StageName: stage.Name,
 		At:        time.Now(),
+	})
+	e.store.Apply(itemstate.EnginePaused{
+		Repo:      repoStr,
+		Number:    item.Number,
+		StageName: stage.Name,
 	})
 
 	releaseLock()

--- a/engine/item.go
+++ b/engine/item.go
@@ -784,6 +784,15 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	}
 	baseline := snapshotBaseline(stage, item, workDir)
 
+	// Pre-audit snapshot: capture refs in all registered repos before Claude runs.
+	// Only taken for non-read-only, non-unrestricted stages (write-capable stages).
+	// In single-repo projects this produces a one-entry map; crossRepoViolations
+	// filters out the active repo, so no false positives are generated.
+	var preAuditSnapshot map[string]map[string]string
+	if !stage.ReadOnly && !hasUnrestrictedLabel(item) {
+		preAuditSnapshot = e.snapshotAllRepoRefs(item.Number)
+	}
+
 	// Extension loop: re-invoke with --resume when max_turns is hit and progress is detected.
 	// Hard cap is 3× stage.MaxTurns total across all invocations.
 	var output string
@@ -817,6 +826,16 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		currentBudget = stage.MaxTurns
 		e.logf(item.Number, "extend-turns", "extending to %d× budget (%d turns used)\n", totalMultiple, usage.TurnsUsed)
 		resume = true
+	}
+
+	// Post-audit: compare ref snapshot taken before Claude ran against current state.
+	// Any new or changed ref in a non-active repo is a boundary violation.
+	if preAuditSnapshot != nil {
+		postAuditSnapshot := e.snapshotAllRepoRefs(item.Number)
+		if violations := crossRepoViolations(preAuditSnapshot, postAuditSnapshot, repoStr); len(violations) > 0 {
+			e.handleBoundaryViolation(owner, repo, repoStr, item, stage, violations, releaseLock)
+			return nil
+		}
 	}
 	// Report cumulative budget across all extensions in stats footer.
 	usage.MaxTurns = totalMultiple * stage.MaxTurns
@@ -1739,4 +1758,73 @@ func detectProgress(_ context.Context, stage *stages.Stage, item *gh.ProjectItem
 	}
 	logfFn("extend-turns", "progress check: stage %s has no progress signal, has_progress=false\n", stage.Name)
 	return false, nil
+}
+
+// snapshotAllRepoRefs snapshots branch refs in every registered bare-clone repository.
+// It reads the worktreeManagers map under e.mu, then runs git for-each-ref outside the
+// lock. Returns a map of "owner/repo" → (refname → SHA). Errors for individual repos
+// are logged and silently skipped so a transient git failure in one repo does not block
+// the audit for others.
+func (e *Engine) snapshotAllRepoRefs(issueNumber int) map[string]map[string]string {
+	// Collect repo→baseDir pairs under lock.
+	e.mu.Lock()
+	type repoDirPair struct {
+		repo    string
+		baseDir string
+	}
+	pairs := make([]repoDirPair, 0, len(e.worktreeManagers))
+	for repo, wm := range e.worktreeManagers {
+		pairs = append(pairs, repoDirPair{repo: repo, baseDir: wm.baseDir})
+	}
+	e.mu.Unlock()
+
+	result := make(map[string]map[string]string, len(pairs))
+	for _, p := range pairs {
+		refs, err := snapshotRepoRefs(p.baseDir)
+		if err != nil {
+			e.logf(issueNumber, "audit", "warn: could not snapshot refs for %s: %v\n", p.repo, err)
+			result[p.repo] = map[string]string{}
+			continue
+		}
+		result[p.repo] = refs
+	}
+	return result
+}
+
+// handleBoundaryViolation posts a comment describing cross-repo ref mutations,
+// marks the stage as failed (with cooldown), and releases the lock.
+// Called after detecting violations from the post-run audit.
+func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, item gh.ProjectItem, stage *stages.Stage, violations []string, releaseLock func()) {
+	e.logf(item.Number, "audit", "worktree boundary violation detected in stage %q: %d unauthorized ref mutation(s)\n", stage.Name, len(violations))
+
+	violationList := strings.Join(violations, "\n- ")
+	comment := fmt.Sprintf(
+		"🏭 **Fabrik — worktree boundary violation**\n\nStage **%s** mutated refs in repositories outside its assigned worktree. The stage has been failed. No automatic cleanup was performed — human review is required.\n\n**Detected violations:**\n- %s\n\nTo retry after investigating: remove the `stage:%s:failed` label.",
+		stage.Name, violationList, stage.Name,
+	)
+
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+		e.logf(item.Number, "warn", "could not post boundary violation comment: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+		}
+	}
+
+	e.addFailedLabel(owner, repo, item.Number, stage.Name)
+
+	// Record StageAttempted so cooldown applies; do NOT call StageRetryIncremented.
+	e.store.Apply(itemstate.StageAttempted{
+		Repo:      repoStr,
+		Number:    item.Number,
+		StageName: stage.Name,
+		At:        time.Now(),
+	})
+
+	releaseLock()
 }

--- a/engine/item_boundary_test.go
+++ b/engine/item_boundary_test.go
@@ -92,18 +92,24 @@ func TestBoundaryAudit_ViolationDetected(t *testing.T) {
 		t.Errorf("violation comment should mention the mutated branch, got: %q", violationComment)
 	}
 
-	// stage:Implement:failed must be added.
+	// stage:Implement:failed and fabrik:paused must both be added.
 	client.mu.Lock()
-	var failedAdded bool
+	var failedAdded, pausedAdded bool
 	for _, c := range client.addLabelCalls {
-		if c.labelName == "stage:Implement:failed" {
+		switch c.labelName {
+		case "stage:Implement:failed":
 			failedAdded = true
+		case "fabrik:paused":
+			pausedAdded = true
 		}
 	}
 	client.mu.Unlock()
 
 	if !failedAdded {
 		t.Error("expected stage:Implement:failed label to be added after violation")
+	}
+	if !pausedAdded {
+		t.Error("expected fabrik:paused label to be added after violation (prevents auto-retry)")
 	}
 
 	// No stage:Implement:complete label should have been added.

--- a/engine/item_boundary_test.go
+++ b/engine/item_boundary_test.go
@@ -1,0 +1,279 @@
+package engine
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// boundaryStages returns a minimal Implement stage for boundary audit tests.
+func boundaryStages() []*stages.Stage {
+	return []*stages.Stage{
+		{
+			Name:       "Implement",
+			Order:      1,
+			Prompt:     "Implement it",
+			Completion: stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+}
+
+// boundaryEngine creates an engine with a primary WorktreeManager backed by
+// primaryDir. A secondary bare-style repo dir is registered under "other/repo"
+// so the cross-repo audit has two repos to compare.
+func boundaryEngine(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker, primaryDir, secondaryDir string) *Engine {
+	t.Helper()
+	wm := NewWorktreeManager(primaryDir)
+	eng := NewWithDeps(Config{
+		Owner:  "owner",
+		Repo:   "repo",
+		User:   "testuser",
+		Token:  "token",
+		Stages: boundaryStages(),
+	}, client, claude, wm)
+
+	// Register the secondary repo so it participates in the cross-repo audit.
+	secondaryWM := NewWorktreeManager(secondaryDir)
+	eng.mu.Lock()
+	eng.worktreeManagers["other/repo"] = secondaryWM
+	eng.mu.Unlock()
+	return eng
+}
+
+// TestBoundaryAudit_ViolationDetected verifies that when the mock Claude invoker
+// mutates a ref in a secondary repo, the engine detects the violation, posts a
+// comment naming the mutation, and adds stage:Implement:failed.
+func TestBoundaryAudit_ViolationDetected(t *testing.T) {
+	skipIfNoGit(t)
+
+	primaryDir := initBareRepo(t)
+	secondaryDir := initBareRepo(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Simulate cross-repo mutation: create a new branch in the secondary repo.
+			cmd := exec.Command("git", "branch", "evil-branch")
+			cmd.Dir = secondaryDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git branch in secondary repo failed: %s: %v", out, err)
+			}
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := boundaryEngine(t, client, claude, primaryDir, secondaryDir)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, Title: "Test", Status: "Implement", ItemID: "PVTI_1"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem returned unexpected error: %v", err)
+	}
+
+	// A boundary violation comment must have been posted.
+	client.mu.Lock()
+	var violationComment string
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "boundary violation") {
+			violationComment = c.body
+		}
+	}
+	client.mu.Unlock()
+
+	if violationComment == "" {
+		t.Fatal("expected a boundary violation comment to be posted")
+	}
+	if !strings.Contains(violationComment, "evil-branch") {
+		t.Errorf("violation comment should mention the mutated branch, got: %q", violationComment)
+	}
+
+	// stage:Implement:failed must be added.
+	client.mu.Lock()
+	var failedAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:failed" {
+			failedAdded = true
+		}
+	}
+	client.mu.Unlock()
+
+	if !failedAdded {
+		t.Error("expected stage:Implement:failed label to be added after violation")
+	}
+
+	// No stage:Implement:complete label should have been added.
+	client.mu.Lock()
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:complete" {
+			t.Errorf("stage:Implement:complete must NOT be added on a violation, but was")
+		}
+	}
+	client.mu.Unlock()
+}
+
+// TestBoundaryAudit_NoViolation verifies that when Claude only modifies the
+// active repo (the primary worktree), no violation is reported and the stage
+// completes normally.
+func TestBoundaryAudit_NoViolation(t *testing.T) {
+	skipIfNoGit(t)
+
+	primaryDir := initBareRepo(t)
+	secondaryDir := initBareRepo(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Only commit in the primary worktree — no cross-repo mutation.
+			cmd := exec.Command("git", "commit", "--allow-empty", "-m", "normal work")
+			cmd.Dir = workDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git commit in worktree failed: %s: %v", out, err)
+			}
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := boundaryEngine(t, client, claude, primaryDir, secondaryDir)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, Title: "Test", Status: "Implement", ItemID: "PVTI_1"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// No boundary violation comment should be posted.
+	client.mu.Lock()
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "boundary violation") {
+			t.Errorf("unexpected boundary violation comment: %q", c.body)
+		}
+	}
+	client.mu.Unlock()
+
+	// stage:Implement:complete should be added (normal completion path).
+	client.mu.Lock()
+	var completionAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:complete" {
+			completionAdded = true
+		}
+	}
+	client.mu.Unlock()
+
+	if !completionAdded {
+		t.Error("expected stage:Implement:complete to be added on a clean run")
+	}
+}
+
+// TestBoundaryAudit_ReadOnlyStageSkipped verifies that read-only stages bypass
+// the boundary audit entirely — mutations in a secondary repo are not detected.
+func TestBoundaryAudit_ReadOnlyStageSkipped(t *testing.T) {
+	skipIfNoGit(t)
+
+	primaryDir := initBareRepo(t)
+	secondaryDir := initBareRepo(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Create a branch in secondary — would be a violation for a write stage.
+			cmd := exec.Command("git", "branch", "leaked-branch")
+			cmd.Dir = secondaryDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git branch in secondary repo: %s: %v", out, err)
+			}
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	wm := NewWorktreeManager(primaryDir)
+	readOnlyStages := []*stages.Stage{
+		{
+			Name:       "Research",
+			Order:      1,
+			Prompt:     "Research it",
+			ReadOnly:   true,
+			Completion: stages.CompletionCriteria{Type: "claude"},
+		},
+	}
+	eng := NewWithDeps(Config{
+		Owner:  "owner",
+		Repo:   "repo",
+		User:   "testuser",
+		Token:  "token",
+		Stages: readOnlyStages,
+	}, client, claude, wm)
+
+	// Register secondary repo so it would be audited if audit ran.
+	eng.mu.Lock()
+	eng.worktreeManagers["other/repo"] = NewWorktreeManager(secondaryDir)
+	eng.mu.Unlock()
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, Title: "Test", Status: "Research", ItemID: "PVTI_1"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// No violation comment must be posted — audit does not run for read-only stages.
+	client.mu.Lock()
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "boundary violation") {
+			t.Errorf("read-only stage should not trigger boundary audit, got: %q", c.body)
+		}
+	}
+	client.mu.Unlock()
+}
+
+// TestBoundaryAudit_UnrestrictedLabelSkipped verifies that when the
+// fabrik:unrestricted label is on the issue, the boundary audit is bypassed.
+func TestBoundaryAudit_UnrestrictedLabelSkipped(t *testing.T) {
+	skipIfNoGit(t)
+
+	primaryDir := initBareRepo(t)
+	secondaryDir := initBareRepo(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Mutate secondary repo — would trigger violation if audit ran.
+			cmd := exec.Command("git", "branch", "unrestricted-branch")
+			cmd.Dir = secondaryDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git branch in secondary repo: %s: %v", out, err)
+			}
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := boundaryEngine(t, client, claude, primaryDir, secondaryDir)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:  1,
+		Title:   "Test",
+		Status:  "Implement",
+		ItemID:  "PVTI_1",
+		Labels:  []string{"fabrik:unrestricted"},
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// No violation comment — audit is bypassed for fabrik:unrestricted.
+	client.mu.Lock()
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "boundary violation") {
+			t.Errorf("unrestricted label should bypass boundary audit, got: %q", c.body)
+		}
+	}
+	client.mu.Unlock()
+}


### PR DESCRIPTION
Closes #776

## Summary

Add engine-level enforcement so that a Fabrik stage invocation cannot mutate state outside its assigned worktree directory — regardless of what Claude's prompt or the user's issue spec says. Enforcement should apply at the tool-permission layer (preventing violations proactively) or via post-run audit (detecting and aborting violations reactively), or both. The specific mechanism depends on what Claude Code's permission model actually supports; Research will determine feasibility.

## Problem

Fabrik's current tool permission model grants `Bash(git:*)` and `Bash(gh:*)` globally — these restrictions constrain which *commands* can run, but not *where*. A Claude session in the Implement stage can `cd` to any directory on the filesystem and run git operations or `gh pr create` against an arbitrary repository. This is not a theoretical concern: `acme/widgets-graph#42` produced an unexpected cross-repo PR (`acme/widgets#785`) by Claude navigating into the user's local working copy of `develop` and creating a branch + PR there directly, completely bypassing Fabrik's worktree model.

The forthcoming multi-repo orchestration spec adds prompt-level guardrails against this, but prompt-level prohibition is not sufficient — a sufficiently confused Claude session, or an adversarial spec, can still escape. This issue introduces hard, engine-level enforcement that makes worktree boundaries structurally unbreakable.

## Approach

### Approach

Deploy a **dual enforcement layer** to make worktree boundaries structurally unbreakable:

1. **Proactive enforcement** (tool-permission layer): In `buildClaudeArgs`, replace bare `"Edit"` and `"Write"` entries with path-restricted variants (`"Edit(<workDir>/**)"` and `"Write(<workDir>/**)"`) for all non-unrestricted, non-read-only stages. When Claude tries to edit a file outside the worktree, it receives an error and the stage continues (the attempt is blocked, not the stage). This covers all `Edit`/`Write` tool calls without any shell script analysis.

2. **Reactive enforcement** (post-run audit): Before the extension loop, snapshot branch refs in every registered bare-clone repository other than the active issue's repo (via `git for-each-ref`). After the extension loop completes, compare. Any new or mutated ref in a non-active repo is a boundary violation — the stage is failed, a comment is posted, and no auto-cleanup is performed.

Both mechanisms gate on `!unrestricted && !stage.ReadOnly`. The `fabrik:unrestricted` label bypasses both layers. Read-only stages are excluded from both layers (they don't produce commits or file writes). Single-repo projects see path-restricted `Edit`/`Write` with no behavioral change (they stay inside the worktree), and the cross-repo audit produces no violations (nothing to compare against).

**Unverified risk**: Research flagged that `Edit(/path/**)` in `--allowedTools` CLI may not be empirically tested. The first implementation task is to verify this works; if Claude Code does not honor path-restricted entries via `--allowedTools`, the fallback is to use `--disallowedTools Edit --disallowedTools Write` plus `--allowedTools "Edit(<workDir>/**)"` and `--allowedTools "Write(<workDir>/**)"`.

**Audit violation failure semantics**: Treat as a permanent failure, not a transient retry. Record `StageAttempted` (cooldown applies), add `stage:<name>:failed`, do NOT increment retry count (violations require human investigation, not auto-retry). The `stage:<name>:failed` label prevents re-dispatch until a human clears it.

**Audit snapshot timing**: Snapshot once before the entire extension loop, compare once after. The audit covers the full session (all re-invocations within the loop), not each individual invocation.

**Bash write gap**: `Bash(cat > ...)` and similar shell-level writes to outside paths cannot be blocked at the tool-permission layer — `Bash(cmd:*)` restricts the command name, not the argument path. The `Edit`/`Write` path restriction and git-ref audit together cover the primary attack surfaces. This known gap is documented in the ADR.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/boundary.go` | New: `applyWorktreeBoundary()`, `snapshotAllRepoRefs()`, `crossRepoViolations()` |
| `engine/boundary_test.go` | New: unit tests for path-restriction and ref-snapshot functions |
| `engine/claude.go` | Modify `buildClaudeArgs` to call `applyWorktreeBoundary` for write stages |
| `engine/invoke_claude_test.go` | Add tests verifying path-restricted args appear/absent in correct conditions |
| `engine/item.go` | Add pre/post-extension-loop audit; violation failure handling |
| `engine/item_boundary_test.go` | New: integration tests for audit violation detection and failure path |
| `docs/stage-lifecycle.md` | Document proactive + reactive enforcement in Phase 2 and Phase 3 |
| `docs/llms-full.txt` | Regenerate (canonical doc changed) |
| `adrs/049-worktree-boundary-enforcement.md` | New ADR for the dual-mechanism design |

### Key Decisions

- **`applyWorktreeBoundary` as a pure function in a new file**: Isolates the boundary logic for easy unit testing without pulling in engine state. The function takes `[]string` (the tool list) and `string` (workDir) and returns a new `[]string` with bare `Edit`/`Write` replaced by path-scoped variants. Side-effect-free and testable.

- **Audit covers ALL known repos except the active one**: The active repo's refs are expected to change (commits, branch pushes). Only other repos in `worktreeManagers` are audited. Repos Claude navigated into that are NOT registered in `worktreeManagers` are not audited (known limitation, documented in ADR).

- **Audit does NOT run for single-invocation cleanup stages**: `engine/item.go:398-468` shows cleanup stages skip Claude invocation entirely — audit never fires there.

- **Violation fails the stage, not the whole run**: Return early after posting the comment and adding `stage:<name>:failed`. The `releaseLock()` and early return pattern matches other failure paths in `processItem`. Normal `StageAttempted` recording still happens (so cooldown applies and the issue doesn't immediately re-dispatch) but `StageRetryIncremented` is NOT called (MaxRetries is not consumed by violations).

- **No ADR for the "verify first" step**: The empirical verification is a one-commit investigation and does not affect whether an ADR is written; the ADR documents the chosen mechanism once we know it works.

- **ADR 049 is warranted** because the dual-mechanism design (proactive + reactive) with specific bypass semantics constrains future contributors: adding new tools, changing permission modes, or adding multi-repo features all need to know about this enforcement layer. Future contributors would not discover this from code alone.

### Task Checklist

- [ ] Task 1: Empirically verify `Edit(/path/**)` works in `--allowedTools` CLI — write a minimal test with a fake claude binary that captures args, pass a path-restricted tool entry, and verify Claude Code rejects edits outside the path in a real invocation; document finding in the commit message. If it fails, fall back to `--disallowedTools Edit` + `--allowedTools "Edit(<workDir>/**)"` and update tasks 2–4 accordingly.
- [ ] Task 2: Create `engine/boundary.go` with `applyWorktreeBoundary(tools []string, workDir string) []string` — replaces bare `"Edit"` and `"Write"` entries with `"Edit(<workDir>/**)"` and `"Write(<workDir>/**)"` respectively; leaves all other tool entries unchanged; returns a copy (does not mutate input).
- [ ] Task 3: Add `engine/boundary_test.go` with unit tests for `applyWorktreeBoundary`: (a) bare Edit/Write get scoped, (b) custom allowedTools with Edit/Write also get scoped, (c) Bash entries are unchanged, (d) read-only-stage path (verify it is NOT called) is indirectly covered in the claude.go tests, (e) empty workDir is a no-op.
- [ ] Task 4: Modify `buildClaudeArgs` in `engine/claude.go`: after the `tools` variable is determined (default or stage-override), and only when `!unrestricted && !stage.ReadOnly && workDir != ""`, call `tools = applyWorktreeBoundary(tools, workDir)`. No signature change needed.
- [ ] Task 5: Add tests to `engine/invoke_claude_test.go` verifying: (a) path-restricted `Edit(<workDir>/**)` and `Write(<workDir>/**)` appear in args for a non-readonly, non-unrestricted stage; (b) bare `Edit`/`Write` appear for a read-only stage (no path restriction); (c) neither appears when `unrestricted=true` (only `--dangerously-skip-permissions`).
- [ ] Task 6: Add to `engine/boundary.go`: `snapshotRepoRefs(bareDir string) (map[string]string, error)` — runs `git for-each-ref --format=%(refname) %(objectname)` in `bareDir` and returns a map of refname→SHA; `crossRepoViolations(before, after map[string]map[string]string, activeRepo string) []string` — for every repo key other than `activeRepo`, collects refnames that are new or changed between before and after snapshots; returns a sorted slice of `"repo: ref old-sha → new-sha"` strings.
- [ ] Task 7: Add ref-snapshot unit tests to `engine/boundary_test.go`: (a) `snapshotRepoRefs` returns empty map for a bare repo with no refs; (b) `crossRepoViolations` returns empty when no change; (c) `crossRepoViolations` detects a new ref in a non-active repo; (d) `crossRepoViolations` ignores changes in the active repo.
- [ ] Task 8: Add pre/post-extension-loop audit in `engine/item.go` (wrapping the loop at lines 793–820): (a) before the loop, if `!stage.ReadOnly && !hasUnrestrictedLabel(item)`, call `snapshotAllRepoRefs()` across all `worktreeManagers` entries (read map under `e.mu` lock, run git outside lock); (b) after the loop, if snapshot was taken, call `crossRepoViolations`; (c) on violation: `e.logf` the violation, post a comment via `e.client.AddComment`, add `stage:<name>:failed` via `ensureLabel`, remove `stage:<name>:in_progress` via `removeLabel`, record `StageAttempted` (so cooldown applies), release lock, and return `nil`.
- [ ] Task 9: Add `engine/item_boundary_test.go` (or extend an existing boundary test) with: (a) a mock that simulates ref changes in a secondary repo's bare clone after Claude invocation; (b) verify the violation triggers a comment with the expected repos/refs listed; (c) verify `stage:<name>:failed` label is added and `stage:<name>:in_progress` is removed; (d) verify no completion label is added; (e) a no-violation path where refs only change in the active repo (should complete normally).
- [ ] Task 10: Update `docs/stage-lifecycle.md`: in Phase 2 (Pre-Stage Setup), add a **"Worktree Boundary Enforcement"** subsection describing `Edit`/`Write` path restriction; in Phase 3 (Claude Invocation), add a **"Post-Run Boundary Audit"** subsection describing the `git for-each-ref` snapshot/compare, violation handling, and the `fabrik:unrestricted` bypass. Note the known gap (Bash shell writes are not path-constrainable at the tool layer).
- [ ] Task 11: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh` and commit alongside the `docs/stage-lifecycle.md` changes.
- [ ] Task 12: Create `adrs/049-worktree-boundary-enforcement.md` documenting: the dual proactive+reactive design, why OS-level sandboxing was rejected (platform-specific, elevated permissions), why the audit targets git refs rather than file system state, the known Bash-write gap, and the `fabrik:unrestricted` bypass semantics.

### Risks

- **`Edit(/path/**)` may not work via `--allowedTools` CLI**: If path-restricted patterns aren't honored in the CLI flag (only in `settings.json`), the proactive layer falls back to `--disallowedTools Edit --disallowedTools Write` plus `--allowedTools "Edit(<workDir>/**)"`. Task 1 catches this before any other changes land. Minimal disruption if the fallback is needed.

- **Concurrent workers cause false-positive audit findings**: Worker A pushes to repo-X while Worker B (auditing repo-Y) has repo-X in its "other repos" snapshot. Mitigation: the snapshot is taken just before Claude starts and compared immediately after Claude exits — the window is seconds. In practice, concurrent workers for the same issue are prevented by the `processedSet` in-flight guard. Different-issue workers for the same repo are legitimate — the audit excludes the active repo, so repo-X changes from Worker A don't trigger violations in Worker B (Worker B's active repo is Y, and only changes to repos other than Y are flagged).

- **`worktreeManagers` snapshot under lock**: The map is read under `e.mu` to get the set of repos, then `git for-each-ref` runs outside the lock. A new repo registered after the snapshot is missed — this is acceptable; lazy-registered repos weren't known at invocation time anyway.

- **`docs/llms-full.txt` regeneration forgetting**: CI's `docs-drift` workflow will fail the PR if the bundle isn't regenerated. Task 11 makes this explicit, but it's easy to forget if tasks are done piecemeal. Mitigation: keep Task 11 strictly after Task 10 in commit order.

---
Used 17/50 turns, 6k input / 10k output tokens.

## Verification

Implemented dual-layer worktree boundary enforcement: (1) proactive path restriction via `Edit(<workDir>/**)` / `Write(<workDir>/**)` in `--allowedTools` for all non-read-only, non-unrestricted stages, and (2) reactive post-run audit using `git for-each-ref` snapshots to detect cross-repo ref mutations during Claude invocations. Added `engine/boundary.go` with pure helper functions, integration tests in `engine/item_boundary_test.go` covering violation detection and bypass conditions, updated `docs/stage-lifecycle.md` with enforcement documentation, and created `adrs/049-worktree-boundary-enforcement.md` documenting the design rationale.

---

Closes #776