### PR TITLE
fix(engine): record Duration on comment-run InvocationRecorded

### DIFF
--- a/engine/comments.go
+++ b/engine/comments.go
@@ -38,7 +38,6 @@ func (e *Engine) findNewComments(item gh.ProjectItem) []gh.Comment {
 // processComments handles new user comments on an issue.
 // Flow: 👀 reactions → editing label → invoke Claude → perform actions / update issue body → remove editing label → 🚀 reactions
 func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment, onPIDReady ...func(int)) error {
-	commentStartedAt := time.Now()
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
 	// Merge any unresolved PR review thread comments into the working slice.
@@ -231,7 +230,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		Number:    item.Number,
 		Usage:     usage,
 		IsComment: true,
-		Duration:  time.Since(commentStartedAt),
+		Duration:  time.Since(startedAt),
 	})
 	if err != nil {
 		e.removeEditingLabel(owner, repo, item.Number)
@@ -398,7 +397,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			Completed: true,
 			Usage:     usage,
 			IsComment: true,
-			Duration:  time.Since(commentStartedAt),
+			Duration:  time.Since(startedAt),
 		})
 		var prNumber int
 		if stage.CreateDraftPR {

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -38,6 +38,7 @@ func (e *Engine) findNewComments(item gh.ProjectItem) []gh.Comment {
 // processComments handles new user comments on an issue.
 // Flow: 👀 reactions → editing label → invoke Claude → perform actions / update issue body → remove editing label → 🚀 reactions
 func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment, onPIDReady ...func(int)) error {
+	commentStartedAt := time.Now()
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
 	// Merge any unresolved PR review thread comments into the working slice.
@@ -230,6 +231,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		Number:    item.Number,
 		Usage:     usage,
 		IsComment: true,
+		Duration:  time.Since(commentStartedAt),
 	})
 	if err != nil {
 		e.removeEditingLabel(owner, repo, item.Number)
@@ -396,6 +398,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			Completed: true,
 			Usage:     usage,
 			IsComment: true,
+			Duration:  time.Since(commentStartedAt),
 		})
 		var prNumber int
 		if stage.CreateDraftPR {


### PR DESCRIPTION
## Summary

Comment-driven Fabrik invocations were recording zero wall-clock duration, so every 💬 entry in the TUI history pane showed `00:00` instead of the actual time spent.

## Root cause

`engine/comments.go:processComments` applies `itemstate.InvocationRecorded` at two sites — the mid-function "finished" record (line 228) and the late "completed" record (line 393). Neither set the `Duration` field, so it defaulted to `0`. `LastInvocationDuration` then propagated through `InvocationObserver` → `JobCompletedEvent` → `HistoryEntry.Duration` → TUI render as `00:00`.

The stage-run path in `engine/item.go:1015` was already correct, capturing `workerStartedAt` at function entry and passing `Duration: time.Since(workerStartedAt)`.

## Fix

Mirror the stage-run pattern: capture `commentStartedAt := time.Now()` at the top of `processComments` and pass `Duration: time.Since(commentStartedAt)` to both `InvocationRecorded` applications.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./engine/ -run 'TestProcessComments|TestAddComment' -count=1` passes
- [ ] After merge: TUI history shows non-zero elapsed time for 💬 entries