### PR TITLE
fabrik skill: document the 'wire blockedBy before Specify' rule for issue chains

### DIFF
--- a/plugin/fabrik/skills/fabrik/SKILL.md
+++ b/plugin/fabrik/skills/fabrik/SKILL.md
@@ -81,6 +81,35 @@ Fabrik **uses labels as durable state**. The user **also** uses some labels to s
 
 When the user asks "how do I make Fabrik do X," your first move is usually to suggest the right label, not to suggest editing config.
 
+### Filing issue chains with `blocked_by` dependencies
+
+When the user wants to create a group of related issues where B is blocked by A, the ordering of operations matters. **Wire the `blocked_by` dependency before moving the blocked issue into Specify** — or disaster follows.
+
+**Why the order matters**: Once an issue lands in Specify with `fabrik:yolo`, the engine picks it up within seconds (poll cadence is 30 s; webhooks fire immediately). `fabrik:blocked` is engine-managed: Fabrik adds it only when it detects an open `blocked_by` link at poll time. If that link isn't present when Fabrik fetches the issue's deep state, `checkDependencies` sees no open dependencies, adds no block label, and dispatches a Claude worker immediately — even if the user intends to wire the dependency a moment later.
+
+**Safe sequence:**
+
+1. **Create all issues in Backlog** (or no column) — not in Specify. This prevents Fabrik from picking them up before you're ready.
+2. **Wire each `blocked_by` dependency via the GitHub API** — before adding labels or moving columns.
+3. **Add labels** (`fabrik:yolo`, `model:opus`, etc.) to all issues.
+4. **Move all issues to Specify** — only now, once the dependency graph is complete.
+
+**Wiring the dependency:**
+
+```bash
+# Get the node ID of the blocking issue (A):
+gh api repos/{owner}/{repo}/issues/{A} --jq '.node_id'
+
+# Wire B as blocked by A:
+gh api repos/{owner}/{repo}/issues/{B}/dependencies/blocked_by \
+  --method POST \
+  -F blocked_by_id=<node-id-of-A>
+```
+
+**The `-F` vs `-f` gotcha**: Use `-F` (uppercase), not `-f` (lowercase). `-F` sends a typed integer/ID field; `-f` sends a plain string. The GitHub dependencies API rejects string IDs and returns a confusing 422 error.
+
+Once the dependency is wired, Fabrik's engine will apply `fabrik:blocked` to B automatically on the next poll, and B will remain blocked until A's linked PR is merged.
+
 ### Comments are the interactive channel
 
 The user can comment on an in-flight issue to redirect the worker. Fabrik picks up comments on the next poll and re-invokes the stage with the comment as additional context. Comments on PRs work the same way (Review and Validate stages read PR comments).

--- a/plugin/fabrik/skills/fabrik/SKILL.md
+++ b/plugin/fabrik/skills/fabrik/SKILL.md
@@ -97,13 +97,13 @@ When the user wants to create a group of related issues where B is blocked by A,
 **Wiring the dependency:**
 
 ```bash
-# Get the node ID of the blocking issue (A):
-gh api repos/{owner}/{repo}/issues/{A} --jq '.node_id'
+# Get the database ID of the blocking issue (A):
+gh api repos/{owner}/{repo}/issues/{A} --jq '.id'
 
 # Wire B as blocked by A:
 gh api repos/{owner}/{repo}/issues/{B}/dependencies/blocked_by \
   --method POST \
-  -F blocked_by_id=<node-id-of-A>
+  -F blocked_by_id=<id-of-A>
 ```
 
 **The `-F` vs `-f` gotcha**: Use `-F` (uppercase), not `-f` (lowercase). `-F` sends a typed integer/ID field; `-f` sends a plain string. The GitHub dependencies API rejects string IDs and returns a confusing 422 error.


### PR DESCRIPTION
Closes #767

## Summary

Add a subsection to `plugin/fabrik/skills/fabrik/SKILL.md` documenting the safe sequence for filing chained issues with `blocked_by` dependencies. The section explains the ordering constraint, provides a copy-paste `gh api` command with the known gotcha (`-F` vs `-f`), and explains *why* the constraint exists (Fabrik picks up issues within seconds of landing in Specify with yolo).

## Problem

The `fabrik` supervisor skill (`plugin/fabrik/skills/fabrik/SKILL.md`) teaches Claude how to act as a PM/supervisor for a Fabrik-driven project — stages, labels, the comment channel, the 👀→🚀 reaction flow. What it does **not** cover is the correct workflow for filing chained issues with GitHub's native `blocked_by` dependency.

The rule experienced Fabrik users learn (sometimes painfully):

> **Wire the `blocked_by` dependency BEFORE moving the blocked issue into Specify.**

Without this discipline, a Claude session filing a chain (issue B blocked_by A, both with `fabrik:yolo`) can put B into Specify with yolo live before the dependency is wired. Fabrik then picks B up on its next poll and starts working it — even though it should be blocked. By the time the dependency lands, Fabrik may already have produced a Specify draft on B that conflicts with what A's plan will eventually decide.

This is generic Fabrik-supervisor knowledge that belongs in the skill, not project-specific knowledge that belongs in each downstream `.claude/memory/` directory.

## Approach

### Approach

This is a single-file documentation insertion — one new subsection added to `plugin/fabrik/skills/fabrik/SKILL.md`. The insertion point is between line 82 (the label advice paragraph) and line 84 (`### Comments are the interactive channel`). No code changes, no tests, no other files.

The new subsection teaches the safe sequence for filing chained issues with `blocked_by` dependencies, documents the `gh api` command with the `-F` vs `-f` gotcha, and explains *why* the ordering constraint exists (Fabrik polls every 30s; webhooks can trigger immediately).

### New/Modified Files

| File | Change |
|------|--------|
| `plugin/fabrik/skills/fabrik/SKILL.md` | Insert new subsection "### Filing issue chains with `blocked_by` dependencies" between the labels section and the comments section |

### Key Decisions

- **Insertion point**: After the user-set labels table's closing paragraph (line 82) and before `### Comments are the interactive channel` (line 84). Research confirmed this placement — `fabrik:blocked` is already documented in the engine-managed table at line 66, and this section explains the workflow that correctly sets up that state. Grouping it near the labels discussion is the most natural location for supervisory guidance about issue setup.

- **No ADR needed**: This is a pure documentation addition to a skill file with no code, interface, or architectural decisions. No new contributor would need an ADR to understand a procedural rule in a skill.

- **No other doc updates needed**: The `docs/` canonical pages (`state-machine.md`, `stage-lifecycle.md`, `USER_GUIDE.md`) cover engine behavior. This skill file is the PM-buddy guidance layer. The two don't overlap here.

### Task Checklist

- [ ] Task 1: Insert the "Filing issue chains with `blocked_by` dependencies" subsection into `plugin/fabrik/skills/fabrik/SKILL.md` at line 83 (after the labels section closing paragraph, before `### Comments are the interactive channel`). The subsection must include: the safe sequence (4 steps), the `gh api` command with `-F` vs `-f` gotcha, and the "why" with poll cadence context.

### Risks

- None. Single-file documentation edit. No code paths affected, no tests required, no build impact. The skill is baked into the binary at build time — users on older binaries won't see the update until `fabrik upgrade` (expected behavior for all skill changes).

---
Used 6/50 turns, 3k input / 1k output tokens.

## Verification

Added a "Filing issue chains with `blocked_by` dependencies" subsection to `plugin/fabrik/skills/fabrik/SKILL.md` documenting the safe 4-step sequence, the `gh api` command with the `-F` vs `-f` gotcha, and the engine timing rationale (30 s poll cadence; webhooks fire immediately). Committed as `5c1299a7` and pushed to `fabrik/issue-767`.

---

Closes #767