### PR TITLE
chore(plugin/fabrik): bump version 0.1.0 → 0.1.1 to release migrated URLs

### DIFF
--- a/plugin/fabrik/.claude-plugin/plugin.json
+++ b/plugin/fabrik/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fabrik",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ambient awareness of Fabrik (the GitHub-Project-driven SDLC pipeline orchestrator) for the human's interactive Claude Code session. Turns Claude into a product-management buddy and supervisor for projects that use Fabrik to automate issue processing.",
   "author": {
     "name": "Tenacious Ventures",


### PR DESCRIPTION
## Summary

Bump `plugin/fabrik/.claude-plugin/plugin.json` from `0.1.0` to `0.1.1` so Claude Code's `/plugin update` detects a new release and re-fetches the source. Plugin source is already migrated to `fabrik.handarbeit.io` — only the version number needs to change for users' caches to refresh.

## Why this is needed

The plugin was originally published as 0.1.0 while the docs site was at `fabrik.shadoworg.dev`. After the org migration, `plugin/fabrik/skills/*/SKILL.md` was updated to point at `fabrik.handarbeit.io`, but the version stayed at 0.1.0. Claude Code's marketplace update flow compares the cached version against the source manifest version — same number means "already up to date" and no refetch happens. Users keep seeing the old shadoworg URLs in the cached SKILL.md.

Bumping the version is the smallest possible fix.

## Test plan

- [x] `cat plugin/fabrik/.claude-plugin/plugin.json` shows `"version": "0.1.1"`
- [ ] After merge: a fresh `/plugin update fabrik` on any user's machine pulls 0.1.1 and the cached SKILL.md now references `fabrik.handarbeit.io`