### PR TITLE
Update docs for v0.0.66

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ When all blocking issues are closed, Fabrik guarantees re-evaluation of a blocke
 
 **Recipe:** file issues → add blocked-by edges in GitHub → label all `fabrik:yolo` → move to Specify → watch it run.
 
-Plan can also decompose an oversized issue autonomously — creating labeled sub-issues, setting up dependency edges, and signaling `FABRIK_DECOMPOSED`; the sub-issues then flow as a formation automatically.
+Plan can also decompose an oversized issue autonomously. It emits `FABRIK_SPAWN_CHILD_BEGIN/END` blocks in its output declaring each sub-issue to create; when the parent advances to Implement, the engine's `preImplement` step creates each child issue in its target repo, adds it to the board, and links it as a `blockedBy` dependency of the parent. The sub-issues then flow as a formation automatically.
 
 **Validated on the Ambient project:** 9 issues, 4 parallel starts, 7 dependency edges — all pipeline constraints respected automatically, ~88 minutes wall-clock, $31 total cost.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1568,6 +1568,20 @@ Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In th
 
 **Note on personal `~/.claude/settings.json`:** Under `dontAsk` mode, tools the user has explicitly allowed in their own `permissions.allow` remain allowed in addition to Fabrik's list — this does not break the isolation goal, it just means personal extras carry through. If your organization deploys managed settings (MDM/enterprise level), a `deny` rule in managed settings cannot be overridden by `--allowedTools` — that is outside Fabrik's control.
 
+### Worktree Boundary Enforcement
+
+Fabrik enforces two independent layers of worktree isolation on every Claude invocation (implemented in `engine/boundary.go`):
+
+**Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.
+
+**Layer 2 — Cross-repo ref audit**: Before the extension loop begins, Fabrik snapshots the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+
+**What to do when a stage fails with a boundary violation:** Check whether the stage's prompt or skill is attempting to write files outside the issue's worktree — for example, writing to `fabrikDir` (the Fabrik config directory) or a sibling worktree. The comment posted on violation lists the specific bare-repo refs that changed, which identifies which repo was touched.
+
+**`fabrik:unrestricted` bypasses both layers.** When this label is present, `applyWorktreeBoundary` is skipped (tool-path restrictions are not applied) and the cross-repo ref snapshot is not taken (the audit does not run). Use with caution — this removes all path-level isolation guarantees, not just tool-permission restrictions.
+
+For the authoritative engine-level spec, see [Stage Lifecycle — Worktree Boundary Enforcement](stage-lifecycle.md#worktree-boundary-enforcement).
+
 ---
 
 ## 8. TUI Dashboard
@@ -1768,6 +1782,12 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
    deep-fetch. New user comments bump the issue's `updatedAt`; PR review submissions
    bump the linked PR's `updatedAt` — both are captured by the shallow scan, so the
    targeted detail fetch fires naturally when there is actually something new to see.
+
+   Items in board columns that have no corresponding stage config (e.g. Backlog, Triage,
+   or custom parking-lot columns) are skipped from `FetchItemDetails` entirely — their
+   probe state is updated (keeping `Status` current for `itemMayNeedWork`) but no
+   deep-fetch is triggered. This reduces per-poll GraphQL cost on boards with large
+   unconfigured column populations.
 
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,7 +161,7 @@ description: >-
         <span class="feature-icon">🌿</span>
         <div class="feature-title">Isolated Git Worktrees</div>
         <div class="feature-desc">
-          Every issue gets a dedicated branch and worktree with zero cross-contamination.
+          Every issue gets a dedicated branch and worktree with zero cross-contamination. Edit and Write tool calls are path-scoped to the issue's worktree; cross-repo writes are audited and blocked.
         </div>
       </a>
       <a class="feature-card" href="{{ '/state-machine' | relative_url }}#4-comment-processing-lifecycle" aria-label="Comment-Driven Steering — open documentation">
@@ -239,6 +239,13 @@ description: >-
         <div class="feature-title">Formations</div>
         <div class="feature-desc">
           Chain issues with GitHub's blocked-by relationships for automatic parallel execution.
+        </div>
+      </a>
+      <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#sub-issue-decomposition" aria-label="Sub-Issue Decomposition — open documentation">
+        <span class="feature-icon">🌱</span>
+        <div class="feature-title">Sub-Issue Decomposition</div>
+        <div class="feature-desc">
+          Plan declares sub-issues to spawn; the engine creates them, links blockedBy edges, and the children run as a formation.
         </div>
       </a>
       <a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#pending-reviewer-gate" aria-label="Pending Reviewer Gate — open documentation">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1566,6 +1566,20 @@ Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In th
 
 **Note on personal `~/.claude/settings.json`:** Under `dontAsk` mode, tools the user has explicitly allowed in their own `permissions.allow` remain allowed in addition to Fabrik's list — this does not break the isolation goal, it just means personal extras carry through. If your organization deploys managed settings (MDM/enterprise level), a `deny` rule in managed settings cannot be overridden by `--allowedTools` — that is outside Fabrik's control.
 
+### Worktree Boundary Enforcement
+
+Fabrik enforces two independent layers of worktree isolation on every Claude invocation (implemented in `engine/boundary.go`):
+
+**Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.
+
+**Layer 2 — Cross-repo ref audit**: Before the extension loop begins, Fabrik snapshots the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+
+**What to do when a stage fails with a boundary violation:** Check whether the stage's prompt or skill is attempting to write files outside the issue's worktree — for example, writing to `fabrikDir` (the Fabrik config directory) or a sibling worktree. The comment posted on violation lists the specific bare-repo refs that changed, which identifies which repo was touched.
+
+**`fabrik:unrestricted` bypasses both layers.** When this label is present, `applyWorktreeBoundary` is skipped (tool-path restrictions are not applied) and the cross-repo ref snapshot is not taken (the audit does not run). Use with caution — this removes all path-level isolation guarantees, not just tool-permission restrictions.
+
+For the authoritative engine-level spec, see [Stage Lifecycle — Worktree Boundary Enforcement](stage-lifecycle.md#worktree-boundary-enforcement).
+
 ---
 
 ## 8. TUI Dashboard
@@ -1766,6 +1780,12 @@ The GraphQL query uses a two-phase fetch to minimize rate limit consumption:
    deep-fetch. New user comments bump the issue's `updatedAt`; PR review submissions
    bump the linked PR's `updatedAt` — both are captured by the shallow scan, so the
    targeted detail fetch fires naturally when there is actually something new to see.
+
+   Items in board columns that have no corresponding stage config (e.g. Backlog, Triage,
+   or custom parking-lot columns) are skipped from `FetchItemDetails` entirely — their
+   probe state is updated (keeping `Status` current for `itemMayNeedWork`) but no
+   deep-fetch is triggered. This reduces per-poll GraphQL cost on boards with large
+   unconfigured column populations.
 
 Typical cost is ~5–30 points per poll depending on active items, well within the
 5,000 points/hour limit.


### PR DESCRIPTION
Closes #792

## Summary

Update `USER_GUIDE.md`, `README.md`, and `docs/index.md` to reflect v0.0.66 changes. The primary gaps are: (1) worktree boundary enforcement is entirely undocumented; (2) `README.md` references the removed `FABRIK_DECOMPOSED` marker in the Formations section; (3) the probe/rate-limit section doesn't mention that unconfigured columns (Backlog/Triage) are now skipped from deep-fetch. All other areas — sub-issue decomposition, awaiting-input orphan-label cleanup — are already covered and only need verification.

## Problem

v0.0.66 shipped three significant user-facing features (cross-repo sub-issue decomposition, worktree boundary enforcement, and a CI-gate fix) plus several engine optimizations. The existing docs do not cover worktree boundary enforcement at all, and README.md still references the removed `FABRIK_DECOMPOSED` marker. Without accurate documentation, users cannot discover or trust the new behavior.

## Approach

### Approach

This is a pure documentation update — no code changes. The work involves four files across two commits (one for doc content edits, one for the `llms-full.txt` regeneration). All changes are surgical: targeted edits to specific sections rather than rewrites.

One correction overrides the spec: the spec says `fabrik:unrestricted` does NOT bypass boundary enforcement, but the code (`buildClaudeArgs`, `processItem`), ADR 049, and `stage-lifecycle.md` all confirm it bypasses **both** layers. The documentation must be accurate; reproducing the spec's error would actively mislead operators.

### New/Modified Files

| File | Change |
|------|--------|
| `README.md` | Replace the `FABRIK_DECOMPOSED` sentence in the Formations section (line 403) with accurate `FABRIK_SPAWN_CHILD_BEGIN/END` + `preImplement` description |
| `docs/USER_GUIDE.md` | (1) Add `### Worktree Boundary Enforcement` subsection in §7, after the `~/.claude/settings.json` note; (2) Add unconfigured-column skip note to the Targeted detail fetch bullet in the Rate Limit section |
| `docs/index.md` | Add Sub-Issue Decomposition feature card to the features grid; update Isolated Git Worktrees card description to mention boundary enforcement |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` after USER_GUIDE.md changes |

### Key Decisions

- **Placement of boundary enforcement section**: §7 Permissions (after the `~/.claude/settings.json` note, before the `---` divider) rather than a standalone §. Boundary enforcement is a permission-adjacent concern — tool-path scoping and the ref audit both relate to what Claude can and cannot touch — making this the most discoverable location.

- **`fabrik:unrestricted` semantics**: Document that it bypasses **both** enforcement layers (tool-permission scoping AND the cross-repo ref audit), not just tool permissions. The spec's claim that it "only affects tool permissions" is wrong per `engine/claude.go:399` and `engine/item.go:787`. Accurate documentation is essential here; this describes failure-mode behavior operators need to trust.

- **Sub-Issue Decomposition card in index.md**: Added immediately after the Formations card since decomposition is a natural extension of Formations. Links to `{{ '/USER_GUIDE' | relative_url }}#sub-issue-decomposition`. Uses 🧩 as the icon since Plugin & Skills already has it — use 🔀 (already used by PR Lifecycle) is wrong. Better icon: 🌱 (new sub-issues growing from the plan).

- **Isolated Git Worktrees card update**: Keep the existing one-liner but append a brief mention of boundary enforcement, linking to the new USER_GUIDE section. The card's existing anchor (`#git-repositories-and-worktrees`) is fine.

- **No ADR needed**: No new design decisions are made. All decisions documented here are already reflected in ADR 048 (spawn) and ADR 049 (boundary). This issue only adds user-facing documentation for existing behavior.

### Task Checklist

- [ ] Task 1: Fix README.md — Formations section: replace the `FABRIK_DECOMPOSED` sentence (line 403) with a description of `FABRIK_SPAWN_CHILD_BEGIN/END` blocks in Plan output and the engine's `preImplement` spawning step
- [ ] Task 2: USER_GUIDE.md — Add `### Worktree Boundary Enforcement` subsection at end of §7 Permissions (after the `~/.claude/settings.json` paragraph, before the `---` divider): dual-layer enforcement description (tool-path scoping + cross-repo ref audit), violation behavior, and accurate `fabrik:unrestricted` bypass semantics (bypasses both layers)
- [ ] Task 3: USER_GUIDE.md — Rate Limit section (line ~1759): add a note to the "Targeted detail fetch" bullet that items in columns with no matching stage config (e.g. Backlog, Triage, custom parking-lot columns) are skipped from `FetchItemDetails` entirely — only their probe state is updated — reducing cold-start and steady-state GraphQL cost on boards with large unconfigured columns
- [ ] Task 4: docs/index.md — Add Sub-Issue Decomposition feature card after the Formations card; update the Isolated Git Worktrees card description to mention boundary enforcement
- [ ] Task 5: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt` (required because USER_GUIDE.md changed)
- [ ] Task 6: Verify — run `go build ./...` (no code changed, but confirms the repo is still clean) and check `git diff docs/llms-full.txt` is non-empty and `scripts/generate-llms-full.sh` exits 0

### Content Guidance for Implement

**Task 1 — README.md replacement text** (replaces the single sentence at line 403):

> Plan can also decompose an oversized issue autonomously. It emits `FABRIK_SPAWN_CHILD_BEGIN/END` blocks in its output declaring each sub-issue to create; when the parent advances to Implement, the engine's `preImplement` step creates each child issue in its target repo, adds it to the board, and links it as a `blockedBy` dependency of the parent. The sub-issues then flow as a formation automatically.

**Task 2 — USER_GUIDE.md boundary enforcement section** (insert after line 1569, before `---`):

```markdown
### Worktree Boundary Enforcement

Fabrik enforces two independent layers of worktree isolation on every Claude invocation (implemented in `engine/boundary.go`):

**Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.

**Layer 2 — Cross-repo ref audit**: Before the extension loop begins, Fabrik snapshots the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.

**What to do when a stage fails with a boundary violation:** Check whether the stage's prompt or skill is attempting to write files outside the issue's worktree — for example, writing to `fabrikDir` (the Fabrik config directory) or a sibling worktree. The comment posted on violation lists the specific bare-repo refs that changed, which identifies which repo was touched.

**`fabrik:unrestricted` bypasses both layers.** When this label is present, `applyWorktreeBoundary` is skipped (tool-path restrictions are not applied) and the cross-repo ref snapshot is not taken (the audit does not run). Use with caution — this removes all path-level isolation guarantees, not just tool-permission restrictions.

For the authoritative engine-level spec, see [Stage Lifecycle — Worktree Boundary Enforcement](stage-lifecycle.md#worktree-boundary-enforcement).
```

**Task 3 — Rate Limit section addition**: After the "Targeted detail fetch" bullet at line 1759, add a sub-bullet:

> Items in board columns that have no corresponding stage config (e.g. Backlog, Triage, or custom parking-lot columns) are skipped from `FetchItemDetails` entirely — their probe state is updated (keeping `Status` current for `itemMayNeedWork`) but no deep-fetch is triggered. This reduces per-poll GraphQL cost on boards with large unconfigured column populations.

**Task 4 — docs/index.md Sub-Issue Decomposition card** (insert after the Formations card):

```html
<a class="feature-card" href="{{ '/USER_GUIDE' | relative_url }}#sub-issue-decomposition" aria-label="Sub-Issue Decomposition — open documentation">
  <span class="feature-icon">🌱</span>
  <div class="feature-title">Sub-Issue Decomposition</div>
  <div class="feature-desc">
    Plan declares sub-issues to spawn; the engine creates them, links blockedBy edges, and the children run as a formation.
  </div>
</a>
```

Update the Isolated Git Worktrees card description to:

> Every issue gets a dedicated branch and worktree with zero cross-contamination. Edit and Write tool calls are path-scoped to the issue's worktree; cross-repo writes are audited and blocked.

### Risks

- **Spec inaccuracy on `fabrik:unrestricted`**: The issue spec incorrectly states this label does not bypass boundary enforcement. The plan resolves this by documenting the accurate behavior (bypasses both layers). Implement must not defer to the spec here.
- **`llms-full.txt` drift**: If Task 5 is skipped or the script fails, CI's `docs-drift` workflow will fail the PR. Task 6 verifies the regen ran and produced non-empty output.
- **`docs/index.md` is HTML+Liquid**, not plain markdown — Implement must use the exact `<a class="feature-card" ...>` pattern and `{{ '/USER_GUIDE' | relative_url }}` for links rather than plain URLs.

---
Used 12/50 turns, 4k input / 4k output tokens.

## Verification

Updated `README.md`, `docs/USER_GUIDE.md`, `docs/index.md`, and regenerated `docs/llms-full.txt` to reflect v0.0.66 changes. Key fixes: removed the stale `FABRIK_DECOMPOSED` marker reference in README (replaced with `FABRIK_SPAWN_CHILD_BEGIN/END` + `preImplement` description); added a Worktree Boundary Enforcement section to USER_GUIDE §7 documenting both enforcement layers and correcting the spec's inaccurate claim that `fabrik:unrestricted` only bypasses tool permissions (it bypasses both layers); added an unconfigured-column skip note to the Rate Limit section; added a Sub-Issue Decomposition feature card to the marketing site.

---

Closes #792