### PR TITLE
fix(github): correct addBlockedBy GraphQL mutation name and input field

### DIFF
--- a/github/project.go
+++ b/github/project.go
@@ -1482,20 +1482,21 @@ mutation($projectId: ID!, $contentId: ID!) {
 // blocked by blockerNodeID. After this call, blockerNodeID will appear in
 // issueNodeID's blockedBy(first: N) GraphQL field.
 //
-// NOTE: The mutation name "addBlockedByIssue" matches GitHub's GraphQL API
-// as of the empirical verification documented in the sub-issue decomposition
-// spec (handarbeit/fabrik#769). Verify against the GitHub GraphQL explorer if
-// this mutation ever stops working.
+// GitHub's GraphQL mutation is asymmetrically named relative to its read
+// field: the read is `Issue.blockedBy(first: N)`, but the write is
+// `addBlockedBy` (no "Issue" suffix), with input shape
+// `{ issueId: ID!, blockingIssueId: ID! }`. Verified via schema
+// introspection against `api.github.com/graphql` on 2026-05-24.
 func (c *Client) AddBlockedByIssue(issueNodeID, blockerNodeID string) error {
 	query := `
-mutation($issueId: ID!, $blockedById: ID!) {
-  addBlockedByIssue(input: {issueId: $issueId, blockedById: $blockedById}) {
+mutation($issueId: ID!, $blockingIssueId: ID!) {
+  addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
     issue { id }
   }
 }`
 	vars := map[string]interface{}{
-		"issueId":    issueNodeID,
-		"blockedById": blockerNodeID,
+		"issueId":         issueNodeID,
+		"blockingIssueId": blockerNodeID,
 	}
 
 	var result struct{}


### PR DESCRIPTION
## Summary

- GitHub's GraphQL mutation is `addBlockedBy` (not `addBlockedByIssue`), with input field `blockingIssueId` (not `blockedById`).
- Verified by schema introspection against `api.github.com/graphql` on 2026-05-24.
- The spec at `specs/sub-issue-decomposition/spec.md` already uses the correct name — the bug was confined to the implementation in `github/project.go`.

## Reproducer

Fabrik instance at `verveguy/#5` paused issue verveguy/liminis#798 (cross-repo decomposition) with:

> 🏭 **Fabrik — pre-Implement spawn failed**
>
> Failed to link child verveguy/liminis-graph#67 as blocked-by of parent: `GraphQL error: Field 'addBlockedByIssue' doesn't exist on type 'Mutation'`
>
> Created so far: verveguy/liminis-graph#67
>
> Manually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.

This is the orphan-then-pause pattern described in the spec under "Partial spawn failure" (line 126). The child issue was created (REST POST works fine), but the GraphQL linking call hit a nonexistent field and crashed.

## Why the bug was subtle

The asymmetric API naming. The **read** field is `Issue.blockedBy(first: N)`, so the original implementer reasonably assumed the **write** mutation would be `addBlockedByIssue`. GitHub instead exposes:

| Op | Name |
|---|---|
| Read | `Issue.blockedBy(first: N)` |
| Mutation | `addBlockedBy(input: { issueId, blockingIssueId })` |
| Payload | `{ issue, blockingIssue, clientMutationId }` |

The code comment even hedged: *"Verify against the GitHub GraphQL explorer if this mutation ever stops working."* It never worked — the verification appears to have skipped the mutation and only checked the read field.

## Test plan

- [x] `go test ./...` passes (full suite: 12 packages, all green; engine tests took ~55s)
- [ ] Verify end-to-end against verveguy/liminis#798 once this lands and the production fabrik binary is upgraded — fabrik should now successfully spawn + link the cross-repo child without orphaning.

## Related

- handarbeit/fabrik#797 — separate bug in the same pre-Implement spawn path (`worktreeManagers` not warmed from on-disk bare clones at startup). Independent root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)