### PR TITLE
fix(github): correct addBlockedBy GraphQL mutation name and input field

### DIFF
--- a/github/project.go
+++ b/github/project.go
@@ -1482,20 +1482,20 @@ mutation($projectId: ID!, $contentId: ID!) {
 // blocked by blockerNodeID. After this call, blockerNodeID will appear in
 // issueNodeID's blockedBy(first: N) GraphQL field.
 //
-// NOTE: The mutation name "addBlockedByIssue" matches GitHub's GraphQL API
-// as of the empirical verification documented in the sub-issue decomposition
-// spec (handarbeit/fabrik#769). Verify against the GitHub GraphQL explorer if
-// this mutation ever stops working.
+// NOTE: GitHub's API is asymmetrically named: the read field is Issue.blockedBy
+// but the write mutation is addBlockedBy (not addBlockedByIssue). The input
+// field is blockingIssueId (not blockedById). Verified via schema introspection
+// against api.github.com/graphql on 2026-05-24.
 func (c *Client) AddBlockedByIssue(issueNodeID, blockerNodeID string) error {
 	query := `
-mutation($issueId: ID!, $blockedById: ID!) {
-  addBlockedByIssue(input: {issueId: $issueId, blockedById: $blockedById}) {
+mutation($issueId: ID!, $blockingIssueId: ID!) {
+  addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingIssueId}) {
     issue { id }
   }
 }`
 	vars := map[string]interface{}{
-		"issueId":    issueNodeID,
-		"blockedById": blockerNodeID,
+		"issueId":         issueNodeID,
+		"blockingIssueId": blockerNodeID,
 	}
 
 	var result struct{}


### PR DESCRIPTION
Closes #800

## Summary

Fix two wrong identifiers in `github/project.go`'s `AddBlockedByIssue` function and correct the misleading docstring above it.

## Problem

Fabrik's `AddBlockedByIssue` in `github/project.go` calls a GraphQL mutation that **does not exist** in GitHub's API. The cross-repo sub-issue decomposition feature shipped in v0.0.66 (#762 / #780) is therefore broken — any attempt to spawn and link a child issue creates the child (REST succeeds) but fails to link it (GraphQL crashes), leaving an orphan and pausing the parent.

## Approach

### Approach

A surgical in-place correction of `github/project.go`'s `AddBlockedByIssue` function. No new files, no interface changes, no test changes. Three identifiers in the mutation string literal, one Go map key, and the misleading docstring comment are all that change.

### New/Modified Files

| File | Change |
|------|--------|
| `github/project.go` | Fix mutation name, variable name, input field name, map key, and docstring (lines 1481–1503) |

### Key Decisions

- **No test changes**: All tests mock at the `GitHubClient` interface level and never inspect the raw GraphQL string. Tests pass before and after; per spec scope, no test changes are warranted.
- **No ADR**: This is a bug fix correcting a misread API name — no design decision is being made. The existing ADR 048 documents the spawn sequence correctly and remains valid.
- **No documentation impact beyond the docstring itself**: The Go function signature, the `GitHubClient` interface, and all call sites are unchanged. The only written artifact that requires correction is the misleading NOTE in the docstring, which is part of the in-scope fix.

### Task Checklist

- [ ] Task 1: Fix `AddBlockedByIssue` in `github/project.go` — correct the three wrong identifiers in the mutation string (`addBlockedByIssue` → `addBlockedBy`, `$blockedById` → `$blockingIssueId`, `blockedById: $blockedById` → `blockingIssueId: $blockingIssueId`), the one wrong Go map key (`"blockedById"` → `"blockingIssueId"`), and replace the misleading docstring NOTE with a correct note that records the asymmetric naming (`Issue.blockedBy` read vs `addBlockedBy` mutation) and the live-schema verification date (2026-05-24)
- [ ] Task 2: Run `go test ./...` and confirm green

### Risks

- **Typo risk**: The only failure mode is a transcription error. Implement should apply each substitution carefully and re-read the final mutation string to confirm it matches the spec table exactly before committing.

---
Used 6/50 turns, 3k input / 1k output tokens.

## Verification

Fixed three wrong GraphQL identifiers in `github/project.go`'s `AddBlockedByIssue` function: mutation name `addBlockedByIssue` → `addBlockedBy`, variable `$blockedById` → `$blockingIssueId`, input field `blockedById` → `blockingIssueId`, and the corresponding Go map key. Also replaced the misleading docstring NOTE that falsely claimed the wrong names were verified. The pre-existing `TestExecute_ConfigYAMLApplied` SIGINT-handling test failure is unrelated to this change (confirmed by running it against the unmodified branch).

---

Closes #800