### PR TITLE
Scaffold tests/e2e/ — scenario-driven integration test harness

### DIFF
--- a/scripts/e2e/reset.sh
+++ b/scripts/e2e/reset.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# scripts/e2e/reset.sh — clear state from prior e2e runs.
+#
+# Closes every OPEN issue in handarbeit/fabrik-test-alpha and fabrik-test-beta.
+# Useful before a clean test session, or to reclaim a half-stuck test bed.
+#
+# Usage:
+#   scripts/e2e/reset.sh             # closes issues only
+#   scripts/e2e/reset.sh --worktrees # also removes Fabrik's worktrees + bare clones
+#
+# The --worktrees mode is destructive — it deletes ~/dev/fabrik-test/.fabrik/worktrees/
+# and ~/dev/fabrik-test/.fabrik/repos/. Use when the test bed itself is wedged.
+
+set -euo pipefail
+
+TEST_BED="${FABRIK_TEST_DIR:-$HOME/dev/fabrik-test}"
+ALPHA="${FABRIK_TEST_REPO_ALPHA:-handarbeit/fabrik-test-alpha}"
+BETA="${FABRIK_TEST_REPO_BETA:-handarbeit/fabrik-test-beta}"
+
+if [ ! -f "$TEST_BED/.env" ]; then
+  echo "test bed not found at $TEST_BED (expected .env)" >&2
+  exit 1
+fi
+
+TOKEN=$(grep '^FABRIK_TOKEN=' "$TEST_BED/.env" | head -1 | cut -d= -f2-)
+if [ -z "$TOKEN" ]; then
+  echo "FABRIK_TOKEN missing from $TEST_BED/.env" >&2
+  exit 1
+fi
+
+close_open_in() {
+  local repo="$1"
+  local nums
+  nums=$(GH_TOKEN="$TOKEN" gh issue list -R "$repo" --state open --json number --jq '.[].number')
+  if [ -z "$nums" ]; then
+    echo "  $repo: no open issues"
+    return
+  fi
+  echo "  $repo: closing: $(echo $nums | tr '\n' ' ')"
+  for n in $nums; do
+    GH_TOKEN="$TOKEN" gh issue close "$n" -R "$repo" \
+      --reason completed --comment "Closed by scripts/e2e/reset.sh" >/dev/null
+  done
+}
+
+echo "== closing open issues =="
+close_open_in "$ALPHA"
+close_open_in "$BETA"
+
+if [ "${1:-}" = "--worktrees" ]; then
+  echo "== removing Fabrik worktrees + bare clones from $TEST_BED =="
+  # Stop the Fabrik instance first if running — otherwise it'll keep using the
+  # deleted dirs and produce confusing errors.
+  pid=$(ps ax -o pid,command | grep "$TEST_BED/fabrik" | grep -v grep | awk '{print $1}' | head -1)
+  if [ -n "$pid" ]; then
+    echo "  fabrik-test pid $pid is running — stop it before --worktrees" >&2
+    exit 1
+  fi
+  rm -rf "$TEST_BED/.fabrik/worktrees" "$TEST_BED/.fabrik/repos"
+  rm -f  "$TEST_BED/.fabrik/fabrik.lock"
+  echo "  worktrees + bare clones removed; restart fabrik-test to re-init"
+fi
+
+echo "done."

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# scripts/e2e/run.sh — runner for the Fabrik end-to-end integration suite.
+#
+# Usage:
+#   scripts/e2e/run.sh                       # full suite
+#   scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch    # one test
+#   scripts/e2e/run.sh -run 'Smoke|NoWork'                 # subset
+#
+# Anything after the script name is passed to `go test`.
+#
+# Prerequisites (one-time setup):
+#   - ~/dev/fabrik-test/ exists with .env (FABRIK_TOKEN for @arbeithand)
+#   - handarbeit/fabrik-test-alpha + fabrik-test-beta exist and seeded
+#   - handarbeit/projects/2 ("Fabrik Test") exists with stage columns
+#   - Fabrik instance running at ~/dev/fabrik-test/ (typically with --auto-upgrade)
+# See tests/e2e/README.md for setup details.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Default timeout — generous because scenarios can wait on Claude for minutes.
+TIMEOUT="${E2E_TIMEOUT:-90m}"
+
+# Default to verbose because these tests are long-running and the operator
+# wants progress.
+exec go test -tags=e2e -v -timeout "$TIMEOUT" ./tests/e2e/... "$@"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,109 @@
+# Fabrik end-to-end tests
+
+Scenario-driven integration tests for Fabrik. Each test drives a real Fabrik
+instance (`~/dev/fabrik-test/`) against the real test repositories
+(`handarbeit/fabrik-test-alpha`, `handarbeit/fabrik-test-beta`), files an
+issue, and asserts on the resulting pipeline behaviour.
+
+## What this is for
+
+These tests catch regressions that escape `go test ./...` — bugs that only
+manifest in real integration with GitHub, real Claude invocations, real
+worktrees, and the real end-to-end stage pipeline. The category of bug:
+
+- The `addBlockedBy` GraphQL mutation name (shipped broken in v0.0.66; fixed by #800)
+- The pre-Implement spawn step failing on never-touched repos (#797, #803)
+- The `Closes #N` getting absorbed into a nested code fence (#738)
+- The CI gate `HeadSHA` resolution in poll-only mode (#779)
+
+Every such regression that escapes a release earns a new scenario here.
+
+## Where this lives in the release flow
+
+```
+[ go test ./... ]               unit tests; fast; run on every PR
+        |
+        v
+[ tests/e2e/... ]               integration tests; slow; run before release
+        |
+        v
+[ scripts/cut-release.sh ]      cuts a release
+```
+
+Suggested integration with `cut-release.sh` (not yet wired):
+
+```bash
+scripts/cut-release.sh v0.0.67                       # default — does NOT run e2e
+scripts/cut-release.sh v0.0.67 --integration-check   # run e2e before tagging
+scripts/cut-release.sh v0.0.67 --skip-integration    # explicit skip when iterating
+```
+
+We'll flip the default to `--integration-check` once the suite is stable.
+
+## Test bed prerequisites
+
+These tests assume:
+
+1. **`~/dev/fabrik-test/` exists** with `.fabrik/config.yaml`, `.env`
+   (containing `FABRIK_TOKEN` for `@arbeithand`), and a built `fabrik` binary.
+2. **`handarbeit/fabrik-test-alpha`** and **`handarbeit/fabrik-test-beta`**
+   are reachable with the token.
+3. **`handarbeit/projects/2`** ("Fabrik Test") exists with stage columns
+   (Backlog, Specify, Research, Plan, Implement, Review, Validate, Done).
+4. **No other Fabrik instance is using the `@arbeithand` token's GraphQL
+   budget concurrently** (or use `--max-concurrent 1` if you have to share).
+
+See `~/fabrik-oss-launch-notes.md` (under "Files and where they live") for
+the canonical setup.
+
+## Running
+
+```bash
+# Run the whole suite (slow — minutes per scenario)
+go test -tags=e2e -timeout 60m ./tests/e2e/...
+
+# Run one scenario
+go test -tags=e2e -timeout 30m -run TestSmokeSingleRepo ./tests/e2e/
+
+# Verbose log streaming (recommended — these are long-running)
+go test -tags=e2e -v -timeout 60m ./tests/e2e/...
+```
+
+The `e2e` build tag keeps these out of the default `go test ./...` run.
+
+## Adding a scenario
+
+1. Pick a name like `cross_repo_spawn_test.go`. Use `Test<DescriptiveName>` for the
+   function so `-run` filtering is clean.
+2. Use the helpers in `harness.go` to file the trigger issue and watch for
+   expected events.
+3. Always clean up at the end — close opened issues, remove the worktree from
+   the test bed (`t.Cleanup` is your friend).
+4. Document what regression the scenario protects against. Reference the
+   originating issue or PR.
+
+## Design notes
+
+- Tests do **not** start or stop the Fabrik instance. The instance is expected
+  to be already running. (Future enhancement: a `harness.StartFabrik(t)` that
+  spawns/stops it per test session.)
+- Assertions are on **observable outcomes**, not internal state. We check
+  GitHub for label changes, comments, PR creation, etc. — not the engine's
+  internal `worktreeManagers` map.
+- Log-line assertions are deliberately last-resort. Prefer GitHub state. Logs
+  are only useful when the observable outcome is "Fabrik logged something
+  specific" (e.g., the spawn error from #797/#803).
+- Scenarios should be **idempotent** — running twice in a row should produce
+  the same result. If a scenario depends on starting state that prior runs
+  modify, normalize it at the start of the test.
+
+## Known limitations
+
+- **Cost per run is non-trivial.** A full cross-repo scenario costs $1–3 in
+  Claude tokens. The suite is not for casual local iteration.
+- **CI integration is not wired yet.** Initially the suite is operator-only —
+  run before cutting a release. Future work: a GitHub Actions runner that
+  exercises the suite on a schedule.
+- **GitHub rate-limit pressure.** Shared with `~/dev/fabrik/` (the dev
+  instance) under the `@arbeithand` token. Stop the dev instance if running
+  the full suite.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -58,18 +58,58 @@ the canonical setup.
 
 ## Running
 
+The recommended entrypoint is the runner script, which sets sensible defaults:
+
 ```bash
-# Run the whole suite (slow — minutes per scenario)
-go test -tags=e2e -timeout 60m ./tests/e2e/...
+# Full suite (slow — multiple scenarios × minutes each)
+scripts/e2e/run.sh
 
-# Run one scenario
-go test -tags=e2e -timeout 30m -run TestSmokeSingleRepo ./tests/e2e/
+# Single scenario
+scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch
 
-# Verbose log streaming (recommended — these are long-running)
-go test -tags=e2e -v -timeout 60m ./tests/e2e/...
+# Subset by name pattern
+scripts/e2e/run.sh -run 'Smoke|NoWork'
 ```
 
-The `e2e` build tag keeps these out of the default `go test ./...` run.
+Anything after the script name is passed through to `go test`. Override the
+overall test timeout with `E2E_TIMEOUT` (default `90m`).
+
+The `e2e` build tag keeps all of this out of the default `go test ./...` run.
+
+### Reset between runs
+
+```bash
+scripts/e2e/reset.sh             # closes open issues in alpha + beta
+scripts/e2e/reset.sh --worktrees # also wipes Fabrik's worktrees + bare clones (destructive)
+```
+
+Use the plain form between test runs to clean issues. The `--worktrees` form
+is for when the test bed itself is wedged (stop Fabrik first, it will refuse
+otherwise).
+
+## Scenarios
+
+| Test | What it verifies | Approx wall-clock | Cost |
+|---|---|---|---|
+| `TestSmokeSingleRepoDispatch` | Worker dispatches on a trivial issue; Specify completes | 3–5 min | $0.10–0.20 |
+| `TestSmokeSingleRepoFullPipeline` | Full single-repo pipeline (Specify → … → Done with merged PR) | 20–40 min | $0.50–1.50 |
+| `TestNoWorkNeeded` | `FABRIK_NO_WORK_NEEDED` short-circuit closes issue without PR | 10–15 min | $0.30–0.50 |
+| `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` pause + comment-driven resume | 10–15 min | $0.30–0.50 |
+| `TestCrossRepoSpawn` | Cross-repo decomposition (spawn child in beta, gate parent, resume on close) | 45–60 min | $1.00–2.00 |
+
+Approximate suite total: 90 min wall-clock, $2–5 in Claude tokens.
+
+### Regression coverage map
+
+| Scenario | Issues / fixes it protects |
+|---|---|
+| `TestSmokeSingleRepoDispatch` | General pipeline breakage |
+| `TestSmokeSingleRepoFullPipeline` | Full pipeline regression |
+| `TestNoWorkNeeded` | #733 (marker), #742 (close-on-no-work) |
+| `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` marker, ed46b7fc (awaiting-input label clear) |
+| `TestCrossRepoSpawn` | #797 / #803 (on-demand spawn-target init), v0.0.66 spawn machinery, #800 (addBlockedBy mutation name) |
+
+Every escape-from-release regression earns a new scenario in this table.
 
 ## Adding a scenario
 

--- a/tests/e2e/blocked_on_input_test.go
+++ b/tests/e2e/blocked_on_input_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestBlockedOnInput verifies the FABRIK_BLOCKED_ON_INPUT pause-and-resume flow.
+//
+// Files an issue with deliberately ambiguous requirements. Specify should
+// recognise the ambiguity, emit FABRIK_BLOCKED_ON_INPUT, and the engine should
+// apply fabrik:paused + fabrik:awaiting-input. We then post a clarifying
+// comment that resolves the ambiguity; Fabrik should resume the stage on the
+// next poll and complete Specify (verified by stage:Specify:complete + label
+// clearing).
+//
+// Also verifies #ed46b7fc — the awaiting-input label clear on stage complete.
+//
+// Wall-clock: ~10-15 min. Cost: ~$0.30-0.50.
+func TestBlockedOnInput(t *testing.T) {
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	startedAt := time.Now()
+	num := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e blocked-on-input (%s)", startedAt.Format("15:04:05")),
+		`## Goal
+
+Verify FABRIK_BLOCKED_ON_INPUT pause + resume.
+
+## Deliberately ambiguous
+
+Make the README "better".
+
+That is all. Specify should immediately notice this is wildly under-specified and emit FABRIK_BLOCKED_ON_INPUT asking for clarification (instead of proceeding to Research with assumptions). The engine should then pause the issue with `+"`fabrik:paused`"+` and `+"`fabrik:awaiting-input`"+`.
+
+This issue is filed by the e2e harness, which will post a clarifying comment to resume.
+
+Regression coverage:
+- #733 / FABRIK_BLOCKED_ON_INPUT marker
+- ed46b7fc — fabrik:awaiting-input clears on FABRIK_STAGE_COMPLETE`,
+		"fabrik:yolo",
+	)
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d at Status=Specify", env.RepoAlpha, num)
+
+	// Wait for the pause to land.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 15*time.Minute)
+	t.Logf("issue paused awaiting input — emitting clarifying comment")
+
+	// Post a resolving comment.
+	CommentOnIssue(t, env, env.RepoAlpha, num,
+		"Clarification: please just close this issue with FABRIK_NO_WORK_NEEDED. "+
+			"The README already covers what it needs to cover and this issue was "+
+			"posted by the e2e test purely to exercise the BLOCKED_ON_INPUT flow.")
+
+	// On next poll, Fabrik should re-invoke Specify. Specify should now see
+	// the comment + a clear answer + react accordingly.
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 15*time.Minute)
+	t.Logf("fabrik:awaiting-input cleared — resume verified")
+
+	// The issue should ultimately close (via NO_WORK_NEEDED, per our clarifying comment).
+	WaitForIssueClosed(t, env, env.RepoAlpha, num, 20*time.Minute)
+	t.Logf("%s#%d closed — pause/resume/short-circuit verified end-to-end", env.RepoAlpha, num)
+}

--- a/tests/e2e/cross_repo_spawn_test.go
+++ b/tests/e2e/cross_repo_spawn_test.go
@@ -1,0 +1,102 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestCrossRepoSpawn verifies that a multi-repo issue filed against alpha
+// successfully decomposes into a sub-issue in beta, the parent is gated until
+// the child closes, the child flows through its own pipeline, and the parent
+// resumes and completes.
+//
+// This is the codified version of the bootstrap test that surfaced #797/#803
+// today. It is THE regression test for the cross-repo spawn machinery
+// shipped in v0.0.66.
+//
+// Wall-clock: ~45-60 min. Cost: ~$1-2.
+//
+// Requires: #803 fix (on-demand spawn-target repo init) shipped in v0.0.67+.
+// Will fail-via-timeout on earlier versions because the spawn aborts with
+// fabrik:paused and the child is never created.
+func TestCrossRepoSpawn(t *testing.T) {
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	startedAt := time.Now()
+	body := fmt.Sprintf(crossRepoBodyTemplate, env.RepoBeta, env.RepoBeta, env.RepoAlpha)
+	parent := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e cross-repo spawn (%s)", startedAt.Format("15:04:05")),
+		body,
+		"fabrik:yolo",
+	)
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, parent)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed parent: %s#%d", env.RepoAlpha, parent)
+
+	// Plan should produce a spawn block. Once the engine sees it, the parent
+	// gets fabrik:children-spawned and a child appears in beta.
+	WaitForIssueLabel(t, env, env.RepoAlpha, parent, "fabrik:children-spawned", 20*time.Minute)
+	t.Logf("parent has fabrik:children-spawned — spawn step ran")
+
+	child := WaitForChildIssueInRepo(t, env, env.RepoBeta, startedAt, 5*time.Minute)
+	t.Logf("child appeared: %s#%d", env.RepoBeta, child)
+	t.Cleanup(func() { CloseIssue(env, env.RepoBeta, child) })
+
+	// The Issue Dependencies API should show parent blockedBy child.
+	AssertBlockedBy(t, env, env.RepoAlpha, parent, env.RepoBeta, child)
+	t.Logf("blockedBy linkage confirmed via API")
+
+	// Sub-issue may need a manual yolo bump until #806 lands. Do it for the test.
+	labels := IssueLabels(t, env, env.RepoBeta, child)
+	hasYolo := false
+	for _, l := range labels {
+		if l == "fabrik:yolo" {
+			hasYolo = true
+			break
+		}
+	}
+	if !hasYolo {
+		t.Logf("child lacks fabrik:yolo (pre-#806 behaviour) — adding manually so the test can proceed")
+		AddLabel(t, env, env.RepoBeta, child, "fabrik:yolo")
+	}
+	// Move child to Specify if it has no status (also a #806 manual step).
+	childItemID := AddIssueToProject(t, env, env.RepoBeta, child)
+	SetIssueStatus(t, env, childItemID, "Specify")
+
+	// Wait for child to close (its PR merges).
+	WaitForIssueClosed(t, env, env.RepoBeta, child, 45*time.Minute)
+	t.Logf("child closed — parent should resume")
+
+	// Parent unblocks, runs Implement → Review → Validate → closes.
+	WaitForIssueClosed(t, env, env.RepoAlpha, parent, 30*time.Minute)
+	t.Logf("parent closed — cross-repo flow complete")
+}
+
+// crossRepoBodyTemplate is the issue body for TestCrossRepoSpawn. Written
+// without raw-string backticks (Go raw strings can't contain them); markdown
+// code spans use *italics* style instead. The two %s placeholders are
+// (1) beta repo name, (2) alpha repo name.
+const crossRepoBodyTemplate = `## Goal
+
+Verify cross-repo decomposition works end-to-end. Plan should spawn a sub-issue in %s because the work requires changes in both repos in strict order.
+
+## What needs to change
+
+### In %s (the beta repo)
+- Add an exported function HelloE2E() string to pkg/greeting/greeting.go returning the literal string "e2e-cross-repo-spawn".
+- Add a test for it in pkg/greeting/greeting_test.go.
+
+### In %s (this repo)
+- Update main.go to call greeting.HelloE2E() (in addition to whatever it already does) and print the result.
+- Run go mod tidy if needed.
+
+## Constraint
+
+Beta must land first because alpha cannot import a function that does not yet exist. Plan should emit a FABRIK_SPAWN_CHILD_BEGIN block targeting the beta repo to decompose.
+
+This is an e2e regression test for #803 (on-demand spawn-target repo init).
+`

--- a/tests/e2e/doc.go
+++ b/tests/e2e/doc.go
@@ -1,0 +1,10 @@
+// Package e2e contains scenario-driven integration tests for Fabrik.
+//
+// These tests drive a real Fabrik instance against real GitHub repositories.
+// They are slow, costly (Claude tokens), and gated behind the e2e build tag.
+//
+// See README.md in this directory for setup, prerequisites, and conventions.
+//
+//go:build e2e
+
+package e2e

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -360,10 +360,34 @@ func splitRepo(repo string) (owner, name string, ok bool) {
 	return parts[0], parts[1], true
 }
 
-// WaitForLogLine tails the test bed's fabrik.log and returns the first line
-// matching the substring (or all of the substrings). Use sparingly — prefer
-// observable GitHub state over log scraping where possible.
-func WaitForLogLine(t *testing.T, env *Env, substring string, timeout time.Duration) string {
+// LogOffset captures the size of the test bed's fabrik.log at this moment.
+// Pass it to WaitForLogLine to scan starting from this offset — call this
+// BEFORE the triggering action (filing an issue, posting a comment, etc.) so
+// the scan doesn't miss lines emitted between the trigger and the wait.
+//
+// Returns 0 if the log file does not yet exist (Fabrik will create it).
+func LogOffset(t *testing.T, env *Env) int64 {
+	t.Helper()
+	info, err := os.Stat(env.LogPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("stat %s: %v", env.LogPath, err)
+	}
+	return info.Size()
+}
+
+// WaitForLogLine scans the test bed's fabrik.log starting at startOffset
+// (typically the value returned by LogOffset before the trigger action) and
+// returns the first line matching the substring, or fails after timeout.
+//
+// Avoids the seek-to-EOF race that would otherwise miss lines emitted
+// between the trigger and the start of the wait.
+//
+// Prefer observable GitHub state over log scraping where possible — log
+// formats are less stable than label/state transitions.
+func WaitForLogLine(t *testing.T, env *Env, substring string, startOffset int64, timeout time.Duration) string {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -375,9 +399,8 @@ func WaitForLogLine(t *testing.T, env *Env, substring string, timeout time.Durat
 	}
 	defer f.Close()
 
-	// Start from end of file; we only care about lines appearing after this call.
-	if _, err := f.Seek(0, 2); err != nil {
-		t.Fatalf("seek %s: %v", env.LogPath, err)
+	if _, err := f.Seek(startOffset, 0); err != nil {
+		t.Fatalf("seek %s to %d: %v", env.LogPath, startOffset, err)
 	}
 	r := bufio.NewReader(f)
 
@@ -391,7 +414,7 @@ func WaitForLogLine(t *testing.T, env *Env, substring string, timeout time.Durat
 			return line
 		}
 	}
-	t.Fatalf("timed out waiting for log line containing %q", substring)
+	t.Fatalf("timed out waiting for log line containing %q (scanned from offset %d)", substring, startOffset)
 	return ""
 }
 
@@ -413,6 +436,10 @@ func expandHome(p string) string {
 	return p
 }
 
+// readEnvFileValue returns the value of `key` from a .env-style file.
+// Tolerates leading/trailing whitespace, surrounding quotes on the value,
+// and blank/comment lines. Does not (yet) handle escapes or line
+// continuations — keep secrets on single lines.
 func readEnvFileValue(path, key string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -420,12 +447,24 @@ func readEnvFileValue(path, key string) (string, error) {
 	}
 	defer f.Close()
 	s := bufio.NewScanner(f)
-	prefix := key + "="
 	for s.Scan() {
-		line := s.Text()
-		if strings.HasPrefix(line, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
 		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) != key {
+			continue
+		}
+		val := strings.TrimSpace(parts[1])
+		// Strip a single matched pair of surrounding double or single quotes.
+		if len(val) >= 2 {
+			first, last := val[0], val[len(val)-1]
+			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+				val = val[1 : len(val)-1]
+			}
+		}
+		return val, nil
 	}
 	return "", fmt.Errorf("%s not found in %s", key, path)
 }
@@ -448,8 +487,11 @@ func lastNonEmpty(s string) string {
 	return ""
 }
 
+// parseIssueNumberFromURL extracts the trailing integer from an issue URL,
+// tolerating optional trailing slash and trailing whitespace.
+// URL form: https://github.com/owner/repo/issues/NUM[/]
 func parseIssueNumberFromURL(url string) int {
-	// URL form: https://github.com/owner/repo/issues/NUM
+	url = strings.TrimRight(strings.TrimSpace(url), "/")
 	parts := strings.Split(url, "/")
 	if len(parts) < 2 {
 		return 0

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1,0 +1,326 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Defaults wire to the canonical test bed. Override via env vars in CI or
+// when the bed lives elsewhere.
+const (
+	defaultFabrikTestDir = "~/dev/fabrik-test"
+	defaultRepoAlpha     = "handarbeit/fabrik-test-alpha"
+	defaultRepoBeta      = "handarbeit/fabrik-test-beta"
+	defaultProjectNumber = 2
+	defaultProjectOwner  = "handarbeit"
+)
+
+// Env carries the resolved test-bed paths and identifiers. Constructed by
+// LoadEnv from environment variables (with sensible defaults).
+type Env struct {
+	FabrikTestDir string // absolute path to ~/dev/fabrik-test
+	LogPath       string // absolute path to the test instance's fabrik.log
+	RepoAlpha     string // "owner/repo" form
+	RepoBeta      string // "owner/repo" form
+	ProjectOwner  string // org or user owning the test project
+	ProjectNumber int    // GitHub Project v2 number
+	GHToken       string // FABRIK_TOKEN from the test bed's .env (passed to gh as GH_TOKEN)
+}
+
+// LoadEnv resolves the test-bed environment. Fails the test cleanly if the
+// bed is not set up.
+func LoadEnv(t *testing.T) *Env {
+	t.Helper()
+
+	dir := getenvOr("FABRIK_TEST_DIR", expandHome(defaultFabrikTestDir))
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("test bed not present at %s — see tests/e2e/README.md for setup", dir)
+	}
+
+	// Read FABRIK_TOKEN from the test bed's own .env so we don't depend on
+	// the operator having the right token in their current shell.
+	envFile := filepath.Join(dir, ".env")
+	token, err := readEnvFileValue(envFile, "FABRIK_TOKEN")
+	if err != nil {
+		t.Fatalf("could not read FABRIK_TOKEN from %s: %v", envFile, err)
+	}
+
+	return &Env{
+		FabrikTestDir: dir,
+		LogPath:       filepath.Join(dir, ".fabrik", "fabrik.log"),
+		RepoAlpha:     getenvOr("FABRIK_TEST_REPO_ALPHA", defaultRepoAlpha),
+		RepoBeta:      getenvOr("FABRIK_TEST_REPO_BETA", defaultRepoBeta),
+		ProjectOwner:  getenvOr("FABRIK_TEST_PROJECT_OWNER", defaultProjectOwner),
+		ProjectNumber: defaultProjectNumber,
+		GHToken:       token,
+	}
+}
+
+// AssertFabrikRunning verifies the test-bed Fabrik instance is alive.
+// Skips the test if not — we don't auto-start it (yet).
+func AssertFabrikRunning(t *testing.T, env *Env) {
+	t.Helper()
+
+	// Look for a process whose command line includes the fabrik-test directory
+	// and ends in "/fabrik" (the binary, not a subprocess).
+	out, _ := exec.Command("ps", "ax", "-o", "pid,command").CombinedOutput()
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, env.FabrikTestDir+"/fabrik") &&
+			!strings.Contains(line, "grep") &&
+			!strings.Contains(line, "claude") {
+			return
+		}
+	}
+	t.Skipf("Fabrik instance not running at %s — start it (cd %s && ./fabrik -notui &)", env.FabrikTestDir, env.FabrikTestDir)
+}
+
+// FileIssue creates an issue in the named repo with the given title, body, and
+// labels. Returns the issue number. Registers a t.Cleanup to close the issue
+// at test end.
+func FileIssue(t *testing.T, env *Env, repo, title, body string, labels ...string) int {
+	t.Helper()
+
+	args := []string{"issue", "create", "-R", repo, "--title", title, "--body", body}
+	for _, l := range labels {
+		args = append(args, "--label", l)
+	}
+	out, err := ghOutput(env, args...)
+	if err != nil {
+		t.Fatalf("file issue %q in %s: %v\n%s", title, repo, err, out)
+	}
+	// gh prints the URL on the last non-empty line.
+	url := lastNonEmpty(out)
+	num := parseIssueNumberFromURL(url)
+	if num == 0 {
+		t.Fatalf("could not parse issue number from gh output: %q", out)
+	}
+
+	t.Cleanup(func() {
+		// Best-effort close; don't fail teardown.
+		_, _ = ghOutput(env, "issue", "close", fmt.Sprint(num), "-R", repo, "--reason", "completed", "--comment", "Closing: e2e test teardown")
+	})
+
+	return num
+}
+
+// AddIssueToProject adds the issue to the test bed's project, returning the
+// project-item ID for subsequent field edits.
+func AddIssueToProject(t *testing.T, env *Env, repo string, issueNumber int) string {
+	t.Helper()
+	url := fmt.Sprintf("https://github.com/%s/issues/%d", repo, issueNumber)
+	out, err := ghOutput(env, "project", "item-add", fmt.Sprint(env.ProjectNumber),
+		"--owner", env.ProjectOwner, "--url", url, "--format", "json")
+	if err != nil {
+		t.Fatalf("add #%d to project: %v\n%s", issueNumber, err, out)
+	}
+	var parsed struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parse project item-add output: %v\n%s", err, out)
+	}
+	return parsed.ID
+}
+
+// SetIssueStatus moves the project item to the named Status column (e.g. "Specify").
+func SetIssueStatus(t *testing.T, env *Env, itemID, columnName string) {
+	t.Helper()
+	projectID, statusFieldID, optionID := resolveStatusOption(t, env, columnName)
+	_, err := ghOutput(env, "project", "item-edit",
+		"--id", itemID, "--project-id", projectID,
+		"--field-id", statusFieldID, "--single-select-option-id", optionID)
+	if err != nil {
+		t.Fatalf("set issue status to %s: %v", columnName, err)
+	}
+}
+
+// WaitForIssueLabel polls the issue until it has all of the named labels, or
+// timeout expires.
+func WaitForIssueLabel(t *testing.T, env *Env, repo string, issueNumber int, label string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		labels := IssueLabels(t, env, repo, issueNumber)
+		for _, l := range labels {
+			if l == label {
+				return
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for label %q on %s#%d (had: %v)",
+		label, repo, issueNumber, IssueLabels(t, env, repo, issueNumber))
+}
+
+// IssueLabels returns the current labels on the issue.
+func IssueLabels(t *testing.T, env *Env, repo string, issueNumber int) []string {
+	t.Helper()
+	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo,
+		"--json", "labels", "--jq", "[.labels[].name]")
+	if err != nil {
+		t.Fatalf("read labels for %s#%d: %v", repo, issueNumber, err)
+	}
+	var labels []string
+	_ = json.Unmarshal([]byte(strings.TrimSpace(out)), &labels)
+	return labels
+}
+
+// WaitForLogLine tails the test bed's fabrik.log and returns the first line
+// matching the substring (or all of the substrings). Use sparingly — prefer
+// observable GitHub state over log scraping where possible.
+func WaitForLogLine(t *testing.T, env *Env, substring string, timeout time.Duration) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	f, err := os.Open(env.LogPath)
+	if err != nil {
+		t.Fatalf("open %s: %v", env.LogPath, err)
+	}
+	defer f.Close()
+
+	// Start from end of file; we only care about lines appearing after this call.
+	if _, err := f.Seek(0, 2); err != nil {
+		t.Fatalf("seek %s: %v", env.LogPath, err)
+	}
+	r := bufio.NewReader(f)
+
+	for ctx.Err() == nil {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		if strings.Contains(line, substring) {
+			return line
+		}
+	}
+	t.Fatalf("timed out waiting for log line containing %q", substring)
+	return ""
+}
+
+// ── small internals ────────────────────────────────────────────────────────
+
+func getenvOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+func readEnvFileValue(path, key string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	prefix := key + "="
+	for s.Scan() {
+		line := s.Text()
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+		}
+	}
+	return "", fmt.Errorf("%s not found in %s", key, path)
+}
+
+func ghOutput(env *Env, args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	cmd.Env = append(os.Environ(), "GH_TOKEN="+env.GHToken)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func lastNonEmpty(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		l := strings.TrimSpace(lines[i])
+		if l != "" {
+			return l
+		}
+	}
+	return ""
+}
+
+func parseIssueNumberFromURL(url string) int {
+	// URL form: https://github.com/owner/repo/issues/NUM
+	parts := strings.Split(url, "/")
+	if len(parts) < 2 {
+		return 0
+	}
+	var n int
+	if _, err := fmt.Sscanf(parts[len(parts)-1], "%d", &n); err != nil {
+		return 0
+	}
+	return n
+}
+
+func resolveStatusOption(t *testing.T, env *Env, columnName string) (projectID, statusFieldID, optionID string) {
+	t.Helper()
+	type field struct {
+		ID      string `json:"id"`
+		Name    string `json:"name"`
+		Options []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"options"`
+	}
+	type projectView struct {
+		ID string `json:"id"`
+	}
+
+	pv, err := ghOutput(env, "project", "view", fmt.Sprint(env.ProjectNumber),
+		"--owner", env.ProjectOwner, "--format", "json")
+	if err != nil {
+		t.Fatalf("project view: %v", err)
+	}
+	var pj projectView
+	if err := json.Unmarshal([]byte(pv), &pj); err != nil {
+		t.Fatalf("parse project view: %v", err)
+	}
+
+	fl, err := ghOutput(env, "project", "field-list", fmt.Sprint(env.ProjectNumber),
+		"--owner", env.ProjectOwner, "--format", "json")
+	if err != nil {
+		t.Fatalf("project field-list: %v", err)
+	}
+	var wrapped struct {
+		Fields []field `json:"fields"`
+	}
+	if err := json.Unmarshal([]byte(fl), &wrapped); err != nil {
+		t.Fatalf("parse field-list: %v", err)
+	}
+	for _, f := range wrapped.Fields {
+		if f.Name != "Status" {
+			continue
+		}
+		for _, o := range f.Options {
+			if o.Name == columnName {
+				return pj.ID, f.ID, o.ID
+			}
+		}
+	}
+	t.Fatalf("could not resolve Status option %q", columnName)
+	return "", "", ""
+}

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -175,6 +175,174 @@ func IssueLabels(t *testing.T, env *Env, repo string, issueNumber int) []string 
 	return labels
 }
 
+// AddLabel adds a label to the issue. Fails the test if gh refuses (e.g. label not seeded).
+func AddLabel(t *testing.T, env *Env, repo string, issueNumber int, label string) {
+	t.Helper()
+	if _, err := ghOutput(env, "issue", "edit", fmt.Sprint(issueNumber), "-R", repo, "--add-label", label); err != nil {
+		t.Fatalf("add label %q on %s#%d: %v", label, repo, issueNumber, err)
+	}
+}
+
+// RemoveLabel removes a label from the issue.
+func RemoveLabel(t *testing.T, env *Env, repo string, issueNumber int, label string) {
+	t.Helper()
+	if _, err := ghOutput(env, "issue", "edit", fmt.Sprint(issueNumber), "-R", repo, "--remove-label", label); err != nil {
+		t.Fatalf("remove label %q on %s#%d: %v", label, repo, issueNumber, err)
+	}
+}
+
+// CommentOnIssue posts a comment as the test bed's PAT identity. Used to simulate
+// user input (e.g. resuming a FABRIK_BLOCKED_ON_INPUT pause).
+func CommentOnIssue(t *testing.T, env *Env, repo string, issueNumber int, body string) {
+	t.Helper()
+	if _, err := ghOutput(env, "issue", "comment", fmt.Sprint(issueNumber), "-R", repo, "--body", body); err != nil {
+		t.Fatalf("post comment on %s#%d: %v", repo, issueNumber, err)
+	}
+}
+
+// WaitForIssueClosed polls until the issue is CLOSED or timeout expires.
+func WaitForIssueClosed(t *testing.T, env *Env, repo string, issueNumber int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if IssueState(t, env, repo, issueNumber) == "CLOSED" {
+			return
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for %s#%d to close (still %s)", repo, issueNumber, IssueState(t, env, repo, issueNumber))
+}
+
+// WaitForLabelAbsent polls until the named label is no longer on the issue.
+func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, label string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		labels := IssueLabels(t, env, repo, issueNumber)
+		present := false
+		for _, l := range labels {
+			if l == label {
+				present = true
+				break
+			}
+		}
+		if !present {
+			return
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for label %q to disappear from %s#%d", label, repo, issueNumber)
+}
+
+// IssueState returns "OPEN" or "CLOSED".
+func IssueState(t *testing.T, env *Env, repo string, issueNumber int) string {
+	t.Helper()
+	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo, "--json", "state", "--jq", ".state")
+	if err != nil {
+		t.Fatalf("read state for %s#%d: %v", repo, issueNumber, err)
+	}
+	return strings.TrimSpace(out)
+}
+
+// WaitForChildIssueInRepo polls the named child repo for the first issue
+// authored by the bot during this test run. Returns the child issue number.
+// Used to detect cross-repo spawn outcomes.
+//
+// Filter: state=OPEN, labels include "fabrik:sub-issue", createdAt >= since.
+func WaitForChildIssueInRepo(t *testing.T, env *Env, childRepo string, since time.Time, timeout time.Duration) int {
+	t.Helper()
+	sinceStr := since.UTC().Format(time.RFC3339)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := ghOutput(env, "issue", "list", "-R", childRepo,
+			"--label", "fabrik:sub-issue", "--state", "open",
+			"--search", "created:>="+sinceStr,
+			"--json", "number,createdAt", "--jq", "[.[] | .number]")
+		if err == nil {
+			var nums []int
+			if json.Unmarshal([]byte(strings.TrimSpace(out)), &nums) == nil && len(nums) > 0 {
+				return nums[0]
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for a child sub-issue in %s (since %s)", childRepo, sinceStr)
+	return 0
+}
+
+// AssertBlockedBy verifies that `issueRepo#issueNumber` is recorded as
+// blocked-by `blockerRepo#blockerNumber` via the Issue Dependencies API.
+func AssertBlockedBy(t *testing.T, env *Env, issueRepo string, issueNumber int, blockerRepo string, blockerNumber int) {
+	t.Helper()
+	owner, name, ok := splitRepo(issueRepo)
+	if !ok {
+		t.Fatalf("bad repo: %q", issueRepo)
+	}
+	q := fmt.Sprintf(`
+query {
+  repository(owner: "%s", name: "%s") {
+    issue(number: %d) {
+      blockedBy(first: 10) { nodes { number repository { nameWithOwner } } }
+    }
+  }
+}`, owner, name, issueNumber)
+	out, err := ghOutput(env, "api", "graphql", "-f", "query="+q,
+		"--jq", ".data.repository.issue.blockedBy.nodes")
+	if err != nil {
+		t.Fatalf("query blockedBy for %s#%d: %v\n%s", issueRepo, issueNumber, err, out)
+	}
+	type node struct {
+		Number     int `json:"number"`
+		Repository struct {
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"repository"`
+	}
+	var nodes []node
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &nodes); err != nil {
+		t.Fatalf("parse blockedBy response: %v\n%s", err, out)
+	}
+	for _, n := range nodes {
+		if n.Number == blockerNumber && n.Repository.NameWithOwner == blockerRepo {
+			return
+		}
+	}
+	t.Fatalf("%s#%d not blocked by %s#%d (blockedBy was: %+v)", issueRepo, issueNumber, blockerRepo, blockerNumber, nodes)
+}
+
+// CloseIssue best-effort closes the named issue (used in t.Cleanup).
+func CloseIssue(env *Env, repo string, issueNumber int) {
+	_, _ = ghOutput(env, "issue", "close", fmt.Sprint(issueNumber), "-R", repo,
+		"--reason", "completed", "--comment", "Closing: e2e test teardown")
+}
+
+// ResetOpenIssues closes every OPEN issue on the test repos. Useful at session
+// start to wipe state from prior runs.
+func ResetOpenIssues(t *testing.T, env *Env) {
+	t.Helper()
+	for _, repo := range []string{env.RepoAlpha, env.RepoBeta} {
+		out, err := ghOutput(env, "issue", "list", "-R", repo, "--state", "open",
+			"--json", "number", "--jq", "[.[] | .number]")
+		if err != nil {
+			t.Logf("ResetOpenIssues: could not list issues in %s: %v", repo, err)
+			continue
+		}
+		var nums []int
+		_ = json.Unmarshal([]byte(strings.TrimSpace(out)), &nums)
+		for _, n := range nums {
+			CloseIssue(env, repo, n)
+			t.Logf("ResetOpenIssues: closed %s#%d", repo, n)
+		}
+	}
+}
+
+func splitRepo(repo string) (owner, name string, ok bool) {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
 // WaitForLogLine tails the test bed's fabrik.log and returns the first line
 // matching the substring (or all of the substrings). Use sparingly — prefer
 // observable GitHub state over log scraping where possible.

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -68,20 +69,36 @@ func LoadEnv(t *testing.T) *Env {
 
 // AssertFabrikRunning verifies the test-bed Fabrik instance is alive.
 // Skips the test if not — we don't auto-start it (yet).
+//
+// Detection strategy: check the lock file. Fabrik atomically writes its PID
+// to .fabrik/fabrik.lock on startup and unlinks it on shutdown. If the file
+// exists and the named PID is still alive, Fabrik is running.
 func AssertFabrikRunning(t *testing.T, env *Env) {
 	t.Helper()
-
-	// Look for a process whose command line includes the fabrik-test directory
-	// and ends in "/fabrik" (the binary, not a subprocess).
-	out, _ := exec.Command("ps", "ax", "-o", "pid,command").CombinedOutput()
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.Contains(line, env.FabrikTestDir+"/fabrik") &&
-			!strings.Contains(line, "grep") &&
-			!strings.Contains(line, "claude") {
-			return
-		}
+	lockPath := filepath.Join(env.FabrikTestDir, ".fabrik", "fabrik.lock")
+	contents, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Skipf("Fabrik instance not running at %s — no lock file (start it: cd %s && ./fabrik -notui --auto-upgrade &)",
+			env.FabrikTestDir, env.FabrikTestDir)
 	}
-	t.Skipf("Fabrik instance not running at %s — start it (cd %s && ./fabrik -notui &)", env.FabrikTestDir, env.FabrikTestDir)
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(contents)), "%d", &pid); err != nil || pid <= 0 {
+		t.Skipf("Fabrik lock file at %s is malformed (%q)", lockPath, contents)
+	}
+	if err := syscallSignalZero(pid); err != nil {
+		t.Skipf("Fabrik lock file claims pid %d but process is dead (%v) — stale lock at %s; remove and restart",
+			pid, err, lockPath)
+	}
+}
+
+// syscallSignalZero sends signal 0 to a pid — a no-op signal that returns an
+// error if the process doesn't exist. POSIX-portable liveness check.
+func syscallSignalZero(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Signal(syscall.Signal(0))
 }
 
 // FileIssue creates an issue in the named repo with the given title, body, and

--- a/tests/e2e/no_work_needed_test.go
+++ b/tests/e2e/no_work_needed_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestNoWorkNeeded verifies the FABRIK_NO_WORK_NEEDED short-circuit.
+//
+// Files an issue describing work that is already done. Plan should determine
+// nothing actually needs implementing, emit FABRIK_NO_WORK_NEEDED, and the
+// engine should mark all downstream stages complete and CLOSE the issue
+// (per #742) — without ever opening a PR.
+//
+// This is the regression test for #733 (the marker itself) and #742 (the
+// close-on-no-work fix).
+//
+// Wall-clock: ~10-15 min. Cost: ~$0.30-0.50.
+func TestNoWorkNeeded(t *testing.T) {
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	startedAt := time.Now()
+	num := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e no-work-needed (%s)", startedAt.Format("15:04:05")),
+		`## Goal
+
+Verify that the FABRIK_NO_WORK_NEEDED short-circuit closes the issue without creating a PR.
+
+## What this asks for
+
+`+"`README.md` in this repo already exists and contains a description of the test bed. Please verify that the README.md file is present, contains the substring \"`+`fabrik-test-alpha`+`\", and has the Apache 2.0 LICENSE pointer."+`
+
+## Hint to Plan
+
+This issue is purely a verification request. There is no code change to make. The Plan stage should recognise that and emit FABRIK_NO_WORK_NEEDED on a line of its own (instead of decomposing or proceeding to Implement).
+
+This is an e2e regression test for #733 (the marker) and #742 (close-on-no-work).`,
+		"fabrik:yolo",
+	)
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d at Status=Specify", env.RepoAlpha, num)
+
+	// Should close within Plan + a few minutes for downstream stage cascade.
+	WaitForIssueClosed(t, env, env.RepoAlpha, num, 20*time.Minute)
+	t.Logf("%s#%d closed without PR — short-circuit verified", env.RepoAlpha, num)
+
+	// Spot-check: should NOT have any open PR referencing this issue.
+	out, err := ghOutput(env, "pr", "list", "-R", env.RepoAlpha, "--state", "open",
+		"--search", fmt.Sprintf("in:body \"Closes #%d\"", num),
+		"--json", "number", "--jq", "length")
+	if err != nil {
+		t.Logf("could not query PRs (non-fatal): %v", err)
+	} else if out != "" && out != "0\n" {
+		t.Errorf("expected 0 open PRs referencing #%d, got: %s", num, out)
+	}
+}

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -3,43 +3,86 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
 
-// TestSmokeSingleRepo files a trivial issue against fabrik-test-alpha, places
-// it at Status=Specify with yolo, and asserts Fabrik dispatches a worker
-// within a reasonable window. It does NOT wait for the full pipeline to
-// complete — that would take 30+ minutes. The point is to verify the test bed
-// is alive and the dispatch path works.
+// TestSmokeSingleRepoDispatch is the minimal proof-of-life test: file an issue,
+// verify a worker dispatches and Specify completes. Does NOT wait for the full
+// pipeline. Always include this in any release-validation run; it's cheap and
+// catches general pipeline breakage.
 //
-// This is the minimal proof-of-life scenario. Always include it in any
-// release-validation run.
-func TestSmokeSingleRepo(t *testing.T) {
+// Wall-clock: ~3-5 min. Cost: ~$0.10-0.20.
+func TestSmokeSingleRepoDispatch(t *testing.T) {
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 
-	issueNum := FileIssue(t, env, env.RepoAlpha,
-		"e2e smoke: minimal single-repo dispatch",
-		"## Goal\n\nVerify Fabrik dispatches a worker on a trivial issue.\n\n"+
-			"## Trivial change\n\nUpdate `README.md` to add a single line at the end:\n\n"+
-			"`<!-- e2e smoke test ran at "+time.Now().UTC().Format(time.RFC3339)+" -->`\n\n"+
-			"That's the entire scope. Implement, open PR, merge. This is purely a "+
-			"smoke test for the e2e harness — it is not testing any specific feature.",
+	num := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e smoke dispatch (%s)", time.Now().UTC().Format("15:04:05")),
+		`## Goal
+
+Verify Fabrik dispatches a worker on a trivial issue.
+
+## Trivial change
+
+This is a dispatch smoke test. The test framework will close this issue before any actual work happens. Specify should just acknowledge the issue and signal complete; no Research/Plan/Implement is expected.
+
+If you (the Specify agent) are reading this, the simplest spec is: "This is a smoke-test issue. No implementation required. Emit FABRIK_NO_WORK_NEEDED to short-circuit." That keeps cost minimal.`,
 		"fabrik:yolo",
 	)
-
-	itemID := AddIssueToProject(t, env, env.RepoAlpha, issueNum)
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
 	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d at Status=Specify", env.RepoAlpha, num)
 
-	t.Logf("filed %s#%d at Status=Specify", env.RepoAlpha, issueNum)
+	// Within 5 minutes Fabrik should have advanced past Specify.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Specify:complete", 5*time.Minute)
+	t.Logf("Specify complete on %s#%d — dispatch path verified", env.RepoAlpha, num)
 
-	// Within 3 minutes Fabrik should have advanced past Specify into Research.
-	// (Specify on a trivial issue typically takes ~30-90 seconds.)
-	WaitForIssueLabel(t, env, env.RepoAlpha, issueNum, "stage:Specify:complete", 3*time.Minute)
-	t.Logf("Specify complete on %s#%d — dispatch path verified", env.RepoAlpha, issueNum)
+	// Don't wait for full pipeline; the t.Cleanup from FileIssue will close it.
+}
 
-	// We stop here. The full pipeline would take 30+ minutes and cost ~$1-2;
-	// not what a smoke test is for. If you want full-pipeline coverage, use
-	// TestCrossRepoSpawn (when it exists post-#803-fix).
+// TestSmokeSingleRepoFullPipeline runs the full single-repo end-to-end flow:
+// file an issue describing a trivial code change, expect Fabrik to take it
+// from Specify all the way to Done with a merged PR.
+//
+// This is the "is the entire pipeline working end-to-end" check, complementary
+// to TestCrossRepoSpawn (which exercises the cross-repo path). Useful when
+// debugging "Implement onwards is broken" classes of issue.
+//
+// Wall-clock: ~20-40 min. Cost: ~$0.50-1.50.
+func TestSmokeSingleRepoFullPipeline(t *testing.T) {
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	stamp := time.Now().UTC().Format("20060102-150405")
+	marker := fmt.Sprintf("smoke-full-pipeline-%s", stamp)
+	num := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e smoke full-pipeline (%s)", stamp),
+		`## Goal
+
+End-to-end single-repo pipeline smoke. Verify Fabrik can take an issue from Specify all the way to Done with a merged PR.
+
+## Trivial change
+
+Append a single comment line to `+"`README.md`"+` at the very end of the file:
+
+`+"```"+`
+<!-- `+marker+` -->
+`+"```"+`
+
+That's the entire change. One file, one line.
+
+## Scope
+
+Single repo only — no cross-repo work. The Plan stage should NOT decompose.`,
+		"fabrik:yolo",
+	)
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d at Status=Specify, marker=%s", env.RepoAlpha, num, marker)
+
+	// Full pipeline can take up to ~30 min depending on Claude latency.
+	WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
+	t.Logf("%s#%d closed — full single-repo pipeline verified", env.RepoAlpha, num)
 }

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -1,0 +1,45 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSmokeSingleRepo files a trivial issue against fabrik-test-alpha, places
+// it at Status=Specify with yolo, and asserts Fabrik dispatches a worker
+// within a reasonable window. It does NOT wait for the full pipeline to
+// complete — that would take 30+ minutes. The point is to verify the test bed
+// is alive and the dispatch path works.
+//
+// This is the minimal proof-of-life scenario. Always include it in any
+// release-validation run.
+func TestSmokeSingleRepo(t *testing.T) {
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	issueNum := FileIssue(t, env, env.RepoAlpha,
+		"e2e smoke: minimal single-repo dispatch",
+		"## Goal\n\nVerify Fabrik dispatches a worker on a trivial issue.\n\n"+
+			"## Trivial change\n\nUpdate `README.md` to add a single line at the end:\n\n"+
+			"`<!-- e2e smoke test ran at "+time.Now().UTC().Format(time.RFC3339)+" -->`\n\n"+
+			"That's the entire scope. Implement, open PR, merge. This is purely a "+
+			"smoke test for the e2e harness — it is not testing any specific feature.",
+		"fabrik:yolo",
+	)
+
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, issueNum)
+	SetIssueStatus(t, env, itemID, "Specify")
+
+	t.Logf("filed %s#%d at Status=Specify", env.RepoAlpha, issueNum)
+
+	// Within 3 minutes Fabrik should have advanced past Specify into Research.
+	// (Specify on a trivial issue typically takes ~30-90 seconds.)
+	WaitForIssueLabel(t, env, env.RepoAlpha, issueNum, "stage:Specify:complete", 3*time.Minute)
+	t.Logf("Specify complete on %s#%d — dispatch path verified", env.RepoAlpha, issueNum)
+
+	// We stop here. The full pipeline would take 30+ minutes and cost ~$1-2;
+	// not what a smoke test is for. If you want full-pipeline coverage, use
+	// TestCrossRepoSpawn (when it exists post-#803-fix).
+}


### PR DESCRIPTION
## Summary

Minimal starting scaffold for end-to-end integration tests under `tests/e2e/`. Drives the canonical test bed at `~/dev/fabrik-test/` against `handarbeit/fabrik-test-alpha` and `fabrik-test-beta` to catch regressions that escape unit tests — bugs that only manifest in real integration with GitHub, real Claude invocations, real worktrees, and the full pipeline.

Examples of the bug class this catches:
- `addBlockedBy` GraphQL mutation name (shipped broken in v0.0.66; fixed by #800)
- Pre-Implement spawn failing on never-touched target repos (#797 / #803 — caught today in the test bed)
- `Closes #N` absorbed into a nested code fence (#738)
- CI gate `HeadSHA` resolution in poll-only mode (#779)

## What's here

| File | Purpose |
|---|---|
| `tests/e2e/README.md` | Design rationale, prerequisites, how to run |
| `tests/e2e/doc.go` | Package docstring + `e2e` build tag |
| `tests/e2e/harness.go` | `Env`, `FileIssue`, `AddIssueToProject`, `SetIssueStatus`, `WaitForIssueLabel`, `WaitForLogLine`, `AssertFabrikRunning` |
| `tests/e2e/smoke_test.go` | `TestSmokeSingleRepo` — the minimal proof-of-life scenario |

## What's deliberately NOT here yet

- **Full pipeline scenarios** (cross-repo spawn, `NO_WORK_NEEDED`, `BLOCKED_ON_INPUT`, CI fix-cycle, etc.). Each becomes a follow-up PR — one per regression we want durably protected against.
- **`cut-release.sh` wiring**. Deferred until the suite is stable. The README sketches the eventual integration.
- **Fabrik lifecycle helpers** (`StartFabrik` / `StopFabrik`). Tests currently expect the instance to be already running and `t.Skip()` if it isn't.

## How to run

Gated behind the `e2e` build tag so `go test ./...` is unaffected:

```bash
go test -tags=e2e -timeout 60m ./tests/e2e/...
```

Requires the canonical test bed (see README.md for setup): a `~/dev/fabrik-test/` directory with `.env`, a running Fabrik instance against project `handarbeit/projects/2`, and access to the two test repos via the `arbeithand` PAT.

## Status

Draft because the first full multi-repo scenario can't pass until **#803** lands (the on-demand spawn-target repo initialization). That bug was caught today in the test bed during the very first cross-repo bootstrap. Once #803 ships in the next release, follow-up PRs add `TestCrossRepoSpawn` and friends.

## Related

- #803 — bug the test bed surfaced today; blocks first cross-repo scenario
- #797 — bug-report form of #803
- Repos: `handarbeit/fabrik-test-alpha`, `handarbeit/fabrik-test-beta`
- Project board: `handarbeit/projects/2` ("Fabrik Test")
- Test-bed location: `~/dev/fabrik-test/`