### PR TITLE
fix(engine): initialize spawn-target repos on-demand in pre-Implement step

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -465,3 +465,95 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 	close(call.done)
 	return nil
 }
+
+// ensureSpawnTargetReady guarantees that a WorktreeManager exists for
+// targetOwner/targetRepo so the pre-Implement spawn step can create child
+// issues there. On first access it bare-clones the repo to
+// .fabrik/repos/<targetOwner>-<targetRepo>.git via the same singleflight
+// coordination used by ensureRepoReady (cloneInFlight key:
+// "targetOwner/targetRepo").
+//
+// Error reporting and label mutations always target parentItem (the spawning
+// parent issue), not the target repo — the two repos are different in the
+// cross-repo spawn path. Unlike ensureRepoReady's waiters (which silently
+// return ErrSkipItem because the reporting item is the same), waiters here
+// post their own error comment and labels on parentItem so no parent issue
+// silently loses its failure notification when concurrent workers race on the
+// same new target repo.
+func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, targetRepo string, parentItem gh.ProjectItem) error {
+	parentOwner, parentRepo := itemOwnerRepo(parentItem, e.defaultRepo())
+	nameWithOwner := targetOwner + "/" + targetRepo
+
+	// Fast path: already registered.
+	e.mu.Lock()
+	_, registered := e.worktreeManagers[nameWithOwner]
+	e.mu.Unlock()
+	if registered {
+		return nil
+	}
+
+	// Singleflight coordination: elect one goroutine to perform the clone.
+	call := &cloneCall{done: make(chan struct{})}
+	actual, loaded := e.cloneInFlight.LoadOrStore(nameWithOwner, call)
+	if loaded {
+		// Another goroutine is already cloning (or has just cloned) this repo.
+		// Each parent item is independent here, so every waiter that observes a
+		// clone failure must post its own error comment — unlike ensureRepoReady
+		// waiters, which silently skip because the same item owns all call sites.
+		existing := actual.(*cloneCall)
+		<-existing.done
+		if existing.err != nil {
+			e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, existing.err)
+			return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s failed: %w", targetOwner, targetRepo, existing.err)
+		}
+		worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
+		e.registerWorktrees(nameWithOwner, existing.dir, worktreeRoot)
+		return nil
+	}
+
+	// This goroutine is the owner: perform the clone.
+	worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
+	bareDir, err := ensureBareClone(e.fabrikDir, targetOwner, targetRepo, e.cfg.User, e.cfg.GitSSH)
+	call.dir = bareDir
+	call.err = err
+
+	if err != nil {
+		// Signal waiters before cleanup so they can read call.err.
+		close(call.done)
+		// Delete so future retries (after user removes fabrik:paused) can re-attempt.
+		e.cloneInFlight.Delete(nameWithOwner)
+		e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, err)
+		return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s: %w", targetOwner, targetRepo, err)
+	}
+
+	// Success: register WM, then signal waiters.
+	e.registerWorktrees(nameWithOwner, bareDir, worktreeRoot)
+	close(call.done)
+	return nil
+}
+
+// postSpawnCloneError posts an error comment and adds fabrik:paused +
+// fabrik:awaiting-input to parentItem when an on-demand clone of a spawn
+// target repo fails.
+func (e *Engine) postSpawnCloneError(parentOwner, parentRepo string, parentItem gh.ProjectItem, targetOwner, targetRepo string, cloneErr error) {
+	msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to clone spawn target `%s/%s`:\n```\n%v\n```\nFix the clone issue (SSH key, PAT access) and remove `fabrik:paused` to retry.",
+		targetOwner, targetRepo, cloneErr)
+	if dbID, commentErr := e.client.AddComment(parentOwner, parentRepo, parentItem.Number, msg); commentErr != nil {
+		e.logf(parentItem.Number, "warn", "could not post spawn clone-failure comment: %v\n", commentErr)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyCommentAdded(boardcache.ItemKey(parentItem.Repo, parentItem.Number), gh.Comment{
+			DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+		})
+	}
+	if labelErr := e.client.AddLabelToIssue(parentOwner, parentRepo, parentItem.Number, "fabrik:paused"); labelErr != nil {
+		e.logf(parentItem.Number, "warn", "could not add fabrik:paused: %v\n", labelErr)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(parentItem.Repo, parentItem.Number), "fabrik:paused")
+	}
+	if labelErr := e.client.AddLabelToIssue(parentOwner, parentRepo, parentItem.Number, "fabrik:awaiting-input"); labelErr != nil {
+		e.logf(parentItem.Number, "warn", "could not add fabrik:awaiting-input: %v\n", labelErr)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(parentItem.Repo, parentItem.Number), "fabrik:awaiting-input")
+	}
+	e.logf(parentItem.Number, "error", "cannot clone spawn target %s/%s: %v — pausing parent\n", targetOwner, targetRepo, cloneErr)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -482,7 +482,11 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 // same new target repo.
 func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, targetRepo string, parentItem gh.ProjectItem) error {
 	parentOwner, parentRepo := itemOwnerRepo(parentItem, e.defaultRepo())
+	if parentOwner == "" || parentRepo == "" {
+		return fmt.Errorf("ensureSpawnTargetReady: cannot determine parent repo for item %d", parentItem.Number)
+	}
 	nameWithOwner := targetOwner + "/" + targetRepo
+	worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
 
 	// Fast path: already registered.
 	e.mu.Lock()
@@ -501,18 +505,20 @@ func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, target
 		// clone failure must post its own error comment — unlike ensureRepoReady
 		// waiters, which silently skip because the same item owns all call sites.
 		existing := actual.(*cloneCall)
-		<-existing.done
+		select {
+		case <-existing.done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 		if existing.err != nil {
 			e.postSpawnCloneError(parentOwner, parentRepo, parentItem, targetOwner, targetRepo, existing.err)
 			return fmt.Errorf("ensureSpawnTargetReady: clone of %s/%s failed: %w", targetOwner, targetRepo, existing.err)
 		}
-		worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
 		e.registerWorktrees(nameWithOwner, existing.dir, worktreeRoot)
 		return nil
 	}
 
 	// This goroutine is the owner: perform the clone.
-	worktreeRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
 	bareDir, err := ensureBareClone(e.fabrikDir, targetOwner, targetRepo, e.cfg.User, e.cfg.GitSSH)
 	call.dir = bareDir
 	call.err = err

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -154,32 +154,23 @@ func (e *Engine) preImplement(ctx context.Context, board *gh.ProjectBoard, item 
 
 	e.logf(item.Number, "spawn", "pre-Implement: found %d child(ren) to spawn\n", len(blocks))
 
-	// Validate all target repos before any mutation.
+	// Ensure all target repos are initialized (bare-cloned) before any mutation.
+	// On-demand clone via singleflight — no prior processing of an issue from the
+	// target repo is required. Error comment and labels are posted by
+	// ensureSpawnTargetReady on failure.
 	uniqueRepos := make(map[string]struct{})
 	for _, b := range blocks {
 		uniqueRepos[b.Repo] = struct{}{}
 	}
-	var unmanaged []string
-	for repo := range uniqueRepos {
-		e.mu.Lock()
-		_, ok := e.worktreeManagers[repo]
-		e.mu.Unlock()
+	for targetRepo := range uniqueRepos {
+		targetOwner, targetRepoName, ok := parseOwnerRepoStr(targetRepo)
 		if !ok {
-			unmanaged = append(unmanaged, repo)
+			// Malformed repo string — the per-block loop below will catch and report it.
+			continue
 		}
-	}
-	if len(unmanaged) > 0 {
-		msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nThe following repos have not yet been initialized by Fabrik (not in worktreeManagers). Fabrik discovers repos lazily — ensure Fabrik can clone each repo (SSH key, webhook config) and that at least one issue from each repo has been processed through the pipeline, then remove `fabrik:paused` to retry:\n\n%s",
-			"- "+strings.Join(unmanaged, "\n- "))
-		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post spawn error comment: %v\n", commentErr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
+		if err := e.ensureSpawnTargetReady(ctx, targetOwner, targetRepoName, item); err != nil {
+			return false, fmt.Errorf("pre-implement: initializing spawn target %s: %w", targetRepo, err)
 		}
-		e.addPausedLabelToItem(owner, repo, item)
-		return false, fmt.Errorf("pre-implement: unmanaged repos: %s", strings.Join(unmanaged, ", "))
 	}
 
 	// Spawn children in order.

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -3,6 +3,9 @@ package engine
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -323,14 +326,20 @@ FABRIK_SPAWN_CHILD_END
 	}
 }
 
-func TestPreImplement_UnmanagedRepo(t *testing.T) {
+// TestPreImplement_CloneFailure replaces the old TestPreImplement_UnmanagedRepo.
+// With on-demand initialization, an unregistered target repo triggers a clone
+// attempt. This test verifies the failure path when the clone cannot succeed.
+func TestPreImplement_CloneFailure(t *testing.T) {
+	skipIfNoGit(t)
 	client := &mockGitHubClient{}
 	eng := spawnTestEngine(client)
-	// "owner/other" is NOT in worktreeManagers.
+	// Point fabrikDir at a tempdir — ensureBareClone will fail to clone the nonexistent repo.
+	eng.fabrikDir = t.TempDir()
 
+	// "owner/newrepo" is NOT in worktreeManagers, and the clone will fail.
 	item := planItemWithBlocks(`
-FABRIK_SPAWN_CHILD_BEGIN owner/other
-TITLE: Child in unmanaged repo
+FABRIK_SPAWN_CHILD_BEGIN owner/newrepo
+TITLE: Child in uncloneable repo
 Body.
 FABRIK_SPAWN_CHILD_END
 `)
@@ -338,29 +347,106 @@ FABRIK_SPAWN_CHILD_END
 
 	spawned, err := eng.preImplement(context.Background(), board, item)
 	if err == nil {
-		t.Fatal("expected error for unmanaged repo")
+		t.Fatal("expected error when clone fails")
 	}
 	if spawned {
-		t.Error("expected spawned=false on error")
+		t.Error("expected spawned=false on clone failure")
 	}
 	if len(client.createIssueCalls) != 0 {
-		t.Error("CreateIssue should not be called for unmanaged repo")
+		t.Error("CreateIssue should not be called when clone fails")
 	}
 
-	// fabrik:paused should have been added.
-	var pausedAdded bool
+	// fabrik:paused and fabrik:awaiting-input must both be added.
+	var pausedAdded, awaitingInputAdded bool
 	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:paused" {
+		switch c.labelName {
+		case "fabrik:paused":
 			pausedAdded = true
+		case "fabrik:awaiting-input":
+			awaitingInputAdded = true
 		}
 	}
 	if !pausedAdded {
-		t.Error("fabrik:paused label not added on unmanaged repo error")
+		t.Error("fabrik:paused label not added on clone failure")
+	}
+	if !awaitingInputAdded {
+		t.Error("fabrik:awaiting-input label not added on clone failure")
 	}
 
-	// Error comment should have been posted.
+	// Error comment must be posted and must not mention the old "not in worktreeManagers" message.
 	if len(client.addCommentCalls) == 0 {
-		t.Error("expected error comment to be posted")
+		t.Error("expected error comment on clone failure")
+	}
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "not in worktreeManagers") {
+			t.Errorf("error comment must not mention 'not in worktreeManagers': %q", c.body)
+		}
+	}
+}
+
+// TestPreImplement_OnDemandClone_Success verifies that a spawn into a repo not
+// yet in worktreeManagers succeeds when the bare clone directory already exists
+// on disk (so ensureBareClone returns nil without hitting the network).
+func TestPreImplement_OnDemandClone_Success(t *testing.T) {
+	skipIfNoGit(t)
+
+	// Create a tempdir to serve as fabrikDir.
+	fabrikDir := t.TempDir()
+
+	// Pre-create the bare clone directory that ensureBareClone will find.
+	// When the directory exists, ensureBareClone skips the `git clone` step and
+	// returns nil (best-effort fetch errors are silently ignored).
+	targetOwner, targetRepoName := "testowner", "testrepo"
+	bareDir := filepath.Join(fabrikDir, ".fabrik", "repos", targetOwner+"-"+targetRepoName+".git")
+	if err := os.MkdirAll(bareDir, 0755); err != nil {
+		t.Fatalf("creating bare dir: %v", err)
+	}
+	initCmd := exec.Command("git", "init", "--bare", bareDir)
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %s: %v", out, err)
+	}
+
+	childCounter := 0
+	client := &mockGitHubClient{
+		createIssueFn: func(owner, repo, title, body string) (int, string, error) {
+			childCounter++
+			return 200 + childCounter, fmt.Sprintf("I_newchild%d", childCounter), nil
+		},
+		addProjectV2ItemByIdFn: func(projectID, contentNodeID string) (string, error) {
+			return "PVTI_" + contentNodeID, nil
+		},
+	}
+	eng := spawnTestEngine(client)
+	eng.fabrikDir = fabrikDir
+
+	// "testowner/testrepo" is NOT in worktreeManagers initially.
+	item := planItemWithBlocks(fmt.Sprintf(`
+FABRIK_SPAWN_CHILD_BEGIN %s/%s
+TITLE: Child in on-demand-cloned repo
+Body of the child issue.
+FABRIK_SPAWN_CHILD_END
+`, targetOwner, targetRepoName))
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	spawned, err := eng.preImplement(context.Background(), board, item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !spawned {
+		t.Fatal("expected spawned=true after on-demand clone")
+	}
+
+	// WorktreeManager must now be registered for the target repo.
+	eng.mu.Lock()
+	_, registered := eng.worktreeManagers[targetOwner+"/"+targetRepoName]
+	eng.mu.Unlock()
+	if !registered {
+		t.Error("worktreeManagers should contain the on-demand-cloned target repo")
+	}
+
+	// CreateIssue must have been called for the child.
+	if len(client.createIssueCalls) != 1 {
+		t.Errorf("expected 1 CreateIssue call, got %d", len(client.createIssueCalls))
 	}
 }
 


### PR DESCRIPTION
Closes #803

## Summary

Add on-demand repo initialization to the pre-Implement spawn step so that spawning into a never-before-processed target repo works identically to spawning into a known repo. The existing `ensureRepoReady` logic (bare clone via singleflight, error posting, `fabrik:paused` on failure) must be reused or extracted into a form callable for a spawn-target repo separate from the parent item's repo.

## Problem

When the Plan stage emits a `FABRIK_SPAWN_CHILD_BEGIN handarbeit/<repo>` block targeting a repo Fabrik has not yet processed any issue from, the pre-Implement spawn step fails with:

> 🏭 **Fabrik — pre-Implement spawn failed**
>
> The following repos have not yet been initialized by Fabrik (not in worktreeManagers). Fabrik discovers repos lazily — ensure Fabrik can clone each repo (SSH key, webhook config) and that at least one issue from each repo has been processed through the pipeline, then remove `fabrik:paused` to retry:
>
> - handarbeit/fabrik-test-beta

This is **issue #797** in the bug-report form. This issue is the fix-scope companion to it.

## Approach

### Approach

The fix is surgical: replace the bare `worktreeManagers` map check in `engine/spawn.go`'s `preImplement` with a new method `ensureSpawnTargetReady` that does on-demand bare-clone initialization via the existing `cloneInFlight` singleflight map. This brings the code into alignment with what `docs/state-machine.md` §6.6 already specifies.

The new method lives in `engine/engine.go` alongside `ensureRepoReady` — all bare-clone initialization logic stays in one file. The method signature takes explicit `(targetOwner, targetRepo string)` and a `parentItem gh.ProjectItem` for error reporting, because the target repo and the parent item's repo are different in the spawn path.

### Key Decisions

**`ensureSpawnTargetReady` in `engine/engine.go` (not `spawn.go`):** All singleflight clone logic (`cloneInFlight`, `ensureBareClone`, `registerWorktrees`, `ensureRepoReady`) lives in `engine.go`. The new function has more coupling to those internals than to spawn.go, so co-location wins. `spawn.go` becomes a caller only.

**Add `fabrik:awaiting-input` alongside `fabrik:paused` on clone failure:** Clone failure is human-intervention regardless of how it was triggered (SSH key, PAT access). Matching the existing `ensureRepoReady` behavior is correct — it signals the engine that the issue needs human attention before retry, and it's consistent.

**Singleflight waiter behavior for the spawn path:** Unlike `ensureRepoReady`'s waiters (which silently return `ErrSkipItem` because the winner's item is the same or covered by another mechanism), in the spawn path each concurrent parent item is independent. If the clone owner already failed (and deleted the `cloneInFlight` entry), a waiter that observed `existing.err != nil` must also post an error comment on *its own* parentItem and add `fabrik:paused` + `fabrik:awaiting-input` to it. This ensures no parent item silently loses its error notification.

**Rewrite `TestPreImplement_UnmanagedRepo` entirely:** The test verifies error-path behavior that disappears ("not in worktreeManagers"). It will be replaced with `TestPreImplement_CloneFailure` (verifying clone-failure behavior with a tempdir that can't access a nonexistent repo — no-network, same technique as `TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses`) and `TestPreImplement_OnDemandClone_Success` (with `skipIfNoGit`, using a real local git remote).

**No new ADR needed:** The fix uses the existing singleflight coordination pattern documented in ADR-022, extended to a new call site. No new architectural decision is being made.

**No documentation update required:** `docs/state-machine.md` §6.6 already describes the correct behavior. The fix brings code into alignment with the doc.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/engine.go` | Add `ensureSpawnTargetReady(ctx, targetOwner, targetRepo string, parentItem gh.ProjectItem) error` |
| `engine/spawn.go` | Replace `unmanaged` map-check block (lines 158–183) with loop calling `ensureSpawnTargetReady` |
| `engine/spawn_test.go` | Rewrite `TestPreImplement_UnmanagedRepo`; add `TestPreImplement_OnDemandClone_Success` |

### Task Checklist

- [ ] Task 1: Add `ensureSpawnTargetReady` to `engine/engine.go` (after `ensureRepoReady`). Signature: `func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, targetRepo string, parentItem gh.ProjectItem) error`. Implement the singleflight protocol identically to `ensureRepoReady`: fast-path registered check, `LoadOrStore`, waiter branch (wait on `done`, post comment + add labels on error, `registerWorktrees` on success), owner branch (`ensureBareClone`, on failure: `close(done)`, `Delete`, post error comment on parentItem with message "🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to clone spawn target `owner/repo`...", add `fabrik:paused` + `fabrik:awaiting-input` to parentItem, return error; on success: `registerWorktrees`, `close(done)`, return nil). No TUI history entry (spawn targets have no associated item number in the target repo).

- [ ] Task 2: Replace the `unmanaged`-check block in `engine/spawn.go:preImplement` (lines 158–183) with a loop over `uniqueRepos` that calls `ensureSpawnTargetReady(ctx, targetOwner, targetRepo, item)` for each repo. Parse each repo string with `parseOwnerRepoStr`. On any error from `ensureSpawnTargetReady`, return `false, err` immediately (no children created). Remove the `unmanaged` slice and old error-posting code entirely. The pre-mutation guarantee is preserved: all repos are validated before any `CreateIssue` call.

- [ ] Task 3: Rewrite `TestPreImplement_UnmanagedRepo` in `engine/spawn_test.go` as `TestPreImplement_CloneFailure`. Add `skipIfNoGit(t)`. Set `eng.fabrikDir` to `t.TempDir()` (same pattern as `TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses`). Verify: (a) `preImplement` returns an error; (b) `spawned == false`; (c) no `CreateIssue` calls; (d) `fabrik:paused` and `fabrik:awaiting-input` labels added; (e) an error comment was posted; (f) comment body does NOT contain "not in worktreeManagers".

- [ ] Task 4: Add `TestPreImplement_OnDemandClone_Success` to `engine/spawn_test.go`. Requires `skipIfNoGit(t)`. Set up a local bare-git repo in `t.TempDir()` as a stand-in remote. Configure the engine to treat that path as the SSH remote (or patch `cloneGitURL` / `GitSSH`). With the target repo not in `worktreeManagers`, call `preImplement` and verify: (a) it succeeds (`spawned == true`, no error); (b) `worktreeManagers` now contains the target repo entry; (c) `CreateIssue` was called. Coordinate with how `TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses` and nearby tests set up the engine to understand what's needed.

- [ ] Task 5: Run `go build ./...`, `go vet ./...`, and `go test -race ./...`. Fix any failures.

### Risks

- **`TestPreImplement_OnDemandClone_Success` may be hard to set up without real SSH transport:** `ensureBareClone` uses the configured SSH remote URL. The test may need to use a `file://` local path or a patched URL builder. If the engine's URL-building logic doesn't support local paths, this test may need to be skipped as a known limitation and only the failure path tested. Mitigation: study how `ensureBareClone` constructs the remote URL and adjust the test setup accordingly.
- **Waiter error-posting in spawn path vs. normal path differs:** The normal-path waiter silently skips; the spawn-path waiter must post its own error. This is intentional but could surprise a future maintainer. A comment on the `ensureSpawnTargetReady` waiter branch is warranted to explain why (see "default to no comments" rule — this is exactly the "hidden invariant" exception).
- **Parent/target repo confusion:** The function signature must be visually unambiguous. Using `targetOwner`/`targetRepo` (for cloning) vs. `parentItem` (for error reporting) is the mitigation already in the design.

---
Used 10/50 turns, 5k input / 5k output tokens.

## Verification

Added `ensureSpawnTargetReady` to `engine/engine.go` — a singleflight-coordinated on-demand bare-clone function for spawn target repos, with error reporting against the parent item. Replaced the bare `worktreeManagers` map check in `spawn.go:preImplement` with calls to this new function. Rewrote `TestPreImplement_UnmanagedRepo` as `TestPreImplement_CloneFailure` (verifies clone-failure error message/labels; confirms the old "not in worktreeManagers" message no longer appears) and added `TestPreImplement_OnDemandClone_Success` (verifies a never-initialized target repo is successfully initialized on demand). All engine tests pass.

---

Closes #803