### PR TITLE
fix(engine): spawned sub-issues should inherit parent's stage status and fabrik:yolo label

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3241,10 +3241,12 @@ These blocks persist in the Plan stage comment — they are data, not consumed-a
 1. Validate all target repos: call `ensureRepoReady` for each unique target repo in the spawn blocks. If any repo is not in Fabrik's managed set, post an error comment listing the gaps, add `fabrik:paused`, and stop — no children are created.
 2. For each `FABRIK_SPAWN_CHILD_BEGIN/END` block in document order:
    - `CreateIssue(owner, repo, title, body+footer)` via REST — returns `(number, nodeID)`
-   - `AddProjectV2ItemById(board.ProjectID, nodeID)` — adds child to the same project board
+   - `AddProjectV2ItemById(board.ProjectID, nodeID)` — adds child to the same project board; returns `childItemID`
    - `AddBlockedByIssue(parent.NodeID, nodeID)` — links child as a `blockedBy` dependency of the parent
    - `AddLabelToIssue` for `fabrik:sub-issue` on the child (informational)
-   - On any failure: post error comment naming completed and failed children, add `fabrik:paused` to parent, stop without adding `fabrik:children-spawned`
+   - `UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, specifyOptionID)` — moves child to the `Specify` column (or first non-Backlog, non-terminal column as fallback). **Non-fatal**: if `e.statusField` is nil (startup fetch failed) or no viable column exists, the child lands in Backlog and a warning is logged; spawn continues.
+   - Conditional `AddLabelToIssue` for `fabrik:yolo` on the child if the parent has `fabrik:yolo`; conditional `AddLabelToIssue` for `fabrik:cruise` if the parent has `fabrik:cruise`. Both are **non-fatal** (failure logs a warning, spawn continues). `base:<branch>` labels are **not** inherited.
+   - On any failure in the fatal steps (CreateIssue, AddProjectV2ItemById, AddBlockedByIssue): post error comment naming completed and failed children, add `fabrik:paused` to parent, stop without adding `fabrik:children-spawned`
 3. After all children are created and linked, add `fabrik:children-spawned` to the parent.
 
 **After spawn:** `preImplement` returns `(true, nil)` (spawned=true). `processItem` returns without invoking Claude. On the next poll cycle, `checkDependencies` sees the new `blockedBy` edges and adds `fabrik:blocked`, gating the parent until all children close.
@@ -4457,10 +4459,12 @@ Before the Claude invocation on every Implement dispatch, the engine calls `preI
 1. **Repo validation**: Call `ensureRepoReady(owner, repo)` for each unique target repo across all blocks. If any repo is not in Fabrik's managed set (clone fails), post an error comment listing the unmanaged repos, add `fabrik:paused`, and stop — no children are created.
 2. **Per-child mutations** (for each block in document order):
    - `CreateIssue(owner, repo, title, body)` — REST `POST /repos/{owner}/{repo}/issues`; body = block body + engine-appended back-reference footer
-   - `AddProjectV2ItemById(board.ProjectID, childNodeID)` — adds child to the same project board
+   - `AddProjectV2ItemById(board.ProjectID, childNodeID)` — adds child to the same project board; returns `childItemID`
    - `AddBlockedByIssue(parent.NodeID, childNodeID)` — links child as a `blockedBy` dependency of the parent
    - `AddLabelToIssue(childNodeID, "fabrik:sub-issue")` — informational; no engine semantics
-   - On any failure: post error comment naming completed and failed children, add `fabrik:paused` to parent, stop; `fabrik:children-spawned` is NOT added
+   - `UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, specifyOptionID)` — moves child to the `Specify` column (or first non-Backlog, non-terminal column as fallback). **Non-fatal**: if `e.statusField` is nil or no viable column exists, child lands in Backlog and a warning is logged.
+   - Conditional `AddLabelToIssue` for `fabrik:yolo` if the parent has `fabrik:yolo`; conditional `AddLabelToIssue` for `fabrik:cruise` if the parent has `fabrik:cruise`. Both are **non-fatal**. `base:<branch>` labels are **not** inherited.
+   - On any failure in the fatal steps (CreateIssue, AddProjectV2ItemById, AddBlockedByIssue): post error comment naming completed and failed children, add `fabrik:paused` to parent, stop; `fabrik:children-spawned` is NOT added
 3. **After all children succeed**: Add `fabrik:children-spawned` label to the parent.
 
 ### After spawn

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -131,10 +131,12 @@ Before the Claude invocation on every Implement dispatch, the engine calls `preI
 1. **Repo validation**: Call `ensureRepoReady(owner, repo)` for each unique target repo across all blocks. If any repo is not in Fabrik's managed set (clone fails), post an error comment listing the unmanaged repos, add `fabrik:paused`, and stop — no children are created.
 2. **Per-child mutations** (for each block in document order):
    - `CreateIssue(owner, repo, title, body)` — REST `POST /repos/{owner}/{repo}/issues`; body = block body + engine-appended back-reference footer
-   - `AddProjectV2ItemById(board.ProjectID, childNodeID)` — adds child to the same project board
+   - `AddProjectV2ItemById(board.ProjectID, childNodeID)` — adds child to the same project board; returns `childItemID`
    - `AddBlockedByIssue(parent.NodeID, childNodeID)` — links child as a `blockedBy` dependency of the parent
    - `AddLabelToIssue(childNodeID, "fabrik:sub-issue")` — informational; no engine semantics
-   - On any failure: post error comment naming completed and failed children, add `fabrik:paused` to parent, stop; `fabrik:children-spawned` is NOT added
+   - `UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, specifyOptionID)` — moves child to the `Specify` column (or first non-Backlog, non-terminal column as fallback). **Non-fatal**: if `e.statusField` is nil or no viable column exists, child lands in Backlog and a warning is logged.
+   - Conditional `AddLabelToIssue` for `fabrik:yolo` if the parent has `fabrik:yolo`; conditional `AddLabelToIssue` for `fabrik:cruise` if the parent has `fabrik:cruise`. Both are **non-fatal**. `base:<branch>` labels are **not** inherited.
+   - On any failure in the fatal steps (CreateIssue, AddProjectV2ItemById, AddBlockedByIssue): post error comment naming completed and failed children, add `fabrik:paused` to parent, stop; `fabrik:children-spawned` is NOT added
 3. **After all children succeed**: Add `fabrik:children-spawned` label to the parent.
 
 ### After spawn

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -991,10 +991,12 @@ These blocks persist in the Plan stage comment — they are data, not consumed-a
 1. Validate all target repos: call `ensureRepoReady` for each unique target repo in the spawn blocks. If any repo is not in Fabrik's managed set, post an error comment listing the gaps, add `fabrik:paused`, and stop — no children are created.
 2. For each `FABRIK_SPAWN_CHILD_BEGIN/END` block in document order:
    - `CreateIssue(owner, repo, title, body+footer)` via REST — returns `(number, nodeID)`
-   - `AddProjectV2ItemById(board.ProjectID, nodeID)` — adds child to the same project board
+   - `AddProjectV2ItemById(board.ProjectID, nodeID)` — adds child to the same project board; returns `childItemID`
    - `AddBlockedByIssue(parent.NodeID, nodeID)` — links child as a `blockedBy` dependency of the parent
    - `AddLabelToIssue` for `fabrik:sub-issue` on the child (informational)
-   - On any failure: post error comment naming completed and failed children, add `fabrik:paused` to parent, stop without adding `fabrik:children-spawned`
+   - `UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, specifyOptionID)` — moves child to the `Specify` column (or first non-Backlog, non-terminal column as fallback). **Non-fatal**: if `e.statusField` is nil (startup fetch failed) or no viable column exists, the child lands in Backlog and a warning is logged; spawn continues.
+   - Conditional `AddLabelToIssue` for `fabrik:yolo` on the child if the parent has `fabrik:yolo`; conditional `AddLabelToIssue` for `fabrik:cruise` if the parent has `fabrik:cruise`. Both are **non-fatal** (failure logs a warning, spawn continues). `base:<branch>` labels are **not** inherited.
+   - On any failure in the fatal steps (CreateIssue, AddProjectV2ItemById, AddBlockedByIssue): post error comment naming completed and failed children, add `fabrik:paused` to parent, stop without adding `fabrik:children-spawned`
 3. After all children are created and linked, add `fabrik:children-spawned` to the parent.
 
 **After spawn:** `preImplement` returns `(true, nil)` (spawned=true). `processItem` returns without invoking Claude. On the next poll cycle, `checkDependencies` sees the new `blockedBy` edges and adds `fabrik:blocked`, gating the parent until all children close.

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -122,6 +122,32 @@ func childFooter(parentOwner, parentRepo string, parentNumber int) string {
 		parentOwner, parentRepo, parentNumber)
 }
 
+// resolveSpecifyOptionID returns the project Status option ID for the "Specify"
+// column, or the first non-Backlog, non-terminal column as a fallback. Returns
+// "" when no suitable option exists or sf is nil (caller skips the status-set).
+func resolveSpecifyOptionID(sf *gh.StatusField) string {
+	if sf == nil {
+		return ""
+	}
+	// Exact match on "Specify".
+	if id, ok := sf.Options["Specify"]; ok {
+		return id
+	}
+	// Fallback: first option that is not "Backlog" and not the last column.
+	names := sf.OrderedOptionNames
+	if len(names) < 2 {
+		return ""
+	}
+	last := names[len(names)-1]
+	for _, name := range names {
+		if name == "Backlog" || name == last {
+			continue
+		}
+		return sf.Options[name]
+	}
+	return ""
+}
+
 // preImplement runs the pre-Implement step for stage "Implement". It parses
 // the parent's Plan comment for FABRIK_SPAWN_CHILD_BEGIN/END blocks and, when
 // found, creates the child issues on GitHub, adds them to the project board,

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -199,6 +199,11 @@ func (e *Engine) preImplement(ctx context.Context, board *gh.ProjectBoard, item 
 		}
 	}
 
+	// Snapshot statusField once before the loop (stable once set; avoids holding the mutex during network calls).
+	e.mu.Lock()
+	sf := e.statusField
+	e.mu.Unlock()
+
 	// Spawn children in order.
 	var spawned []string
 	for i, block := range blocks {
@@ -236,7 +241,8 @@ func (e *Engine) preImplement(ctx context.Context, board *gh.ProjectBoard, item 
 		spawned = append(spawned, fmt.Sprintf("%s#%d", block.Repo, childNumber))
 
 		// Add child to the project board.
-		if _, err := e.client.AddProjectV2ItemById(board.ProjectID, childNodeID); err != nil {
+		childItemID, err := e.client.AddProjectV2ItemById(board.ProjectID, childNodeID)
+		if err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to add child %s/%s#%d to project board: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				childOwner, childRepo, childNumber, err, formatSpawnedList(spawned))
 			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
@@ -269,6 +275,27 @@ func (e *Engine) preImplement(ctx context.Context, board *gh.ProjectBoard, item 
 		// Apply fabrik:sub-issue label to child (for human-visible filtering; no engine semantics).
 		if err := e.client.AddLabelToIssue(childOwner, childRepo, childNumber, "fabrik:sub-issue"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:sub-issue to %s#%d: %v\n", block.Repo, childNumber, err)
+		}
+
+		// Set child's project Status to Specify (or first processing stage) when statusField is available.
+		if optionID := resolveSpecifyOptionID(sf); optionID != "" {
+			if err := e.client.UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, optionID); err != nil {
+				e.logf(item.Number, "warn", "could not set project status on %s#%d: %v\n", block.Repo, childNumber, err)
+			}
+		} else if sf != nil {
+			e.logf(item.Number, "warn", "no Specify/processing status option found for %s#%d; child lands in Backlog\n", block.Repo, childNumber)
+		}
+
+		// Inherit fabrik:yolo and fabrik:cruise from parent (enables autonomous child pipeline).
+		if hasLabel(item, "fabrik:yolo") {
+			if err := e.client.AddLabelToIssue(childOwner, childRepo, childNumber, "fabrik:yolo"); err != nil {
+				e.logf(item.Number, "warn", "could not add fabrik:yolo to %s#%d: %v\n", block.Repo, childNumber, err)
+			}
+		}
+		if hasLabel(item, "fabrik:cruise") {
+			if err := e.client.AddLabelToIssue(childOwner, childRepo, childNumber, "fabrik:cruise"); err != nil {
+				e.logf(item.Number, "warn", "could not add fabrik:cruise to %s#%d: %v\n", block.Repo, childNumber, err)
+			}
 		}
 	}
 

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -282,7 +282,9 @@ func (e *Engine) preImplement(ctx context.Context, board *gh.ProjectBoard, item 
 			if err := e.client.UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, optionID); err != nil {
 				e.logf(item.Number, "warn", "could not set project status on %s#%d: %v\n", block.Repo, childNumber, err)
 			}
-		} else if sf != nil {
+		} else if sf == nil {
+			e.logf(item.Number, "warn", "project status field unavailable for %s#%d; child lands in Backlog\n", block.Repo, childNumber)
+		} else {
 			e.logf(item.Number, "warn", "no Specify/processing status option found for %s#%d; child lands in Backlog\n", block.Repo, childNumber)
 		}
 

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -196,13 +196,12 @@ func TestResolveSpecifyOptionID_EmptyOrderedNames(t *testing.T) {
 }
 
 func TestResolveSpecifyOptionID_SingleColumn(t *testing.T) {
-	// Only one column — len(names) < 2, returns "".
+	// Exact match on "Specify" fires before the fallback len(names) < 2 guard,
+	// so a single-column board named "Specify" still returns its option ID.
 	sf := &gh.StatusField{
 		Options:            map[string]string{"Specify": "OPT_1"},
 		OrderedOptionNames: []string{"Specify"},
 	}
-	// Even though "Specify" is in Options, len(names) == 1 so fallback returns "".
-	// But we check exact match first, so it should return OPT_1.
 	if got := resolveSpecifyOptionID(sf); got != "OPT_1" {
 		t.Errorf("got %q, want OPT_1 (exact match wins)", got)
 	}

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -573,3 +573,228 @@ FABRIK_SPAWN_CHILD_END
 		t.Error("fabrik:paused not added on partial failure")
 	}
 }
+
+// ---- status-set and label-inheritance tests ----
+
+func spawnTestEngineWithSpecify(client *mockGitHubClient) *Engine {
+	eng := spawnTestEngine(client)
+	eng.statusField = &gh.StatusField{
+		FieldID: "FIELD_STATUS",
+		Options: map[string]string{
+			"Backlog": "OPT_0",
+			"Specify": "OPT_1",
+			"Done":    "OPT_9",
+		},
+		OrderedOptionNames: []string{"Backlog", "Specify", "Done"},
+	}
+	return eng
+}
+
+func TestPreImplement_SetsSpecifyStatus(t *testing.T) {
+	client := &mockGitHubClient{
+		createIssueFn: func(owner, repo, title, body string) (int, string, error) {
+			return 101, "I_child101", nil
+		},
+		addProjectV2ItemByIdFn: func(projectID, contentNodeID string) (string, error) {
+			return "PVTI_child101", nil
+		},
+	}
+	eng := spawnTestEngineWithSpecify(client)
+
+	item := planItemWithBlocks(`
+FABRIK_SPAWN_CHILD_BEGIN owner/child
+TITLE: Test child
+Body.
+FABRIK_SPAWN_CHILD_END
+`)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	spawned, err := eng.preImplement(context.Background(), board, item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !spawned {
+		t.Fatal("expected spawned=true")
+	}
+
+	// UpdateProjectItemStatus must be called with correct args.
+	if len(client.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateProjectItemStatus call, got %d", len(client.updateStatusCalls))
+	}
+	call := client.updateStatusCalls[0]
+	if call.projectID != "PVT_1" {
+		t.Errorf("projectID = %q, want PVT_1", call.projectID)
+	}
+	if call.itemID != "PVTI_child101" {
+		t.Errorf("itemID = %q, want PVTI_child101", call.itemID)
+	}
+	if call.fieldID != "FIELD_STATUS" {
+		t.Errorf("fieldID = %q, want FIELD_STATUS", call.fieldID)
+	}
+	if call.optionID != "OPT_1" {
+		t.Errorf("optionID = %q, want OPT_1 (Specify)", call.optionID)
+	}
+}
+
+func TestPreImplement_StatusSetNilField(t *testing.T) {
+	client := &mockGitHubClient{
+		createIssueFn: func(owner, repo, title, body string) (int, string, error) {
+			return 102, "I_child102", nil
+		},
+		addProjectV2ItemByIdFn: func(projectID, contentNodeID string) (string, error) {
+			return "PVTI_child102", nil
+		},
+	}
+	eng := spawnTestEngine(client)
+	// statusField is nil by default in spawnTestEngine
+
+	item := planItemWithBlocks(`
+FABRIK_SPAWN_CHILD_BEGIN owner/child
+TITLE: Test child no status
+Body.
+FABRIK_SPAWN_CHILD_END
+`)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	spawned, err := eng.preImplement(context.Background(), board, item)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !spawned {
+		t.Fatal("expected spawned=true even when statusField is nil")
+	}
+
+	// No UpdateProjectItemStatus call should happen.
+	if len(client.updateStatusCalls) != 0 {
+		t.Errorf("expected 0 UpdateProjectItemStatus calls, got %d", len(client.updateStatusCalls))
+	}
+}
+
+func TestPreImplement_YoloInheritance(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := spawnTestEngineWithSpecify(client)
+
+	item := planItemWithBlocks(`
+FABRIK_SPAWN_CHILD_BEGIN owner/child
+TITLE: Child for yolo
+Body.
+FABRIK_SPAWN_CHILD_END
+`)
+	item.Labels = append(item.Labels, "fabrik:yolo")
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	if _, err := eng.preImplement(context.Background(), board, item); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var yoloAdded, cruiseAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:yolo" {
+			yoloAdded = true
+		}
+		if c.labelName == "fabrik:cruise" {
+			cruiseAdded = true
+		}
+	}
+	if !yoloAdded {
+		t.Error("fabrik:yolo not added to child when parent has it")
+	}
+	if cruiseAdded {
+		t.Error("fabrik:cruise must not be added when parent does not have it")
+	}
+}
+
+func TestPreImplement_CruiseInheritance(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := spawnTestEngineWithSpecify(client)
+
+	item := planItemWithBlocks(`
+FABRIK_SPAWN_CHILD_BEGIN owner/child
+TITLE: Child for cruise
+Body.
+FABRIK_SPAWN_CHILD_END
+`)
+	item.Labels = append(item.Labels, "fabrik:cruise")
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	if _, err := eng.preImplement(context.Background(), board, item); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var yoloAdded, cruiseAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:yolo" {
+			yoloAdded = true
+		}
+		if c.labelName == "fabrik:cruise" {
+			cruiseAdded = true
+		}
+	}
+	if yoloAdded {
+		t.Error("fabrik:yolo must not be added when parent does not have it")
+	}
+	if !cruiseAdded {
+		t.Error("fabrik:cruise not added to child when parent has it")
+	}
+}
+
+func TestPreImplement_BothLabelsInherited(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := spawnTestEngineWithSpecify(client)
+
+	item := planItemWithBlocks(`
+FABRIK_SPAWN_CHILD_BEGIN owner/child
+TITLE: Child for both
+Body.
+FABRIK_SPAWN_CHILD_END
+`)
+	item.Labels = append(item.Labels, "fabrik:yolo", "fabrik:cruise")
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	if _, err := eng.preImplement(context.Background(), board, item); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var yoloAdded, cruiseAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:yolo" {
+			yoloAdded = true
+		}
+		if c.labelName == "fabrik:cruise" {
+			cruiseAdded = true
+		}
+	}
+	if !yoloAdded {
+		t.Error("fabrik:yolo not added to child when parent has both labels")
+	}
+	if !cruiseAdded {
+		t.Error("fabrik:cruise not added to child when parent has both labels")
+	}
+}
+
+func TestPreImplement_NoAutonomyLabels(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := spawnTestEngineWithSpecify(client)
+
+	item := planItemWithBlocks(`
+FABRIK_SPAWN_CHILD_BEGIN owner/child
+TITLE: Child without autonomy labels
+Body.
+FABRIK_SPAWN_CHILD_END
+`)
+	// item.Labels has only "stage:Plan:complete" — no yolo or cruise
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	if _, err := eng.preImplement(context.Background(), board, item); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:yolo" {
+			t.Error("fabrik:yolo must not be added when parent does not have it")
+		}
+		if c.labelName == "fabrik:cruise" {
+			t.Error("fabrik:cruise must not be added when parent does not have it")
+		}
+	}
+}

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -145,6 +145,69 @@ FABRIK_SPAWN_CHILD_END`
 	}
 }
 
+// ---- resolveSpecifyOptionID unit tests ----
+
+func TestResolveSpecifyOptionID_Nil(t *testing.T) {
+	if got := resolveSpecifyOptionID(nil); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestResolveSpecifyOptionID_ExactMatch(t *testing.T) {
+	sf := &gh.StatusField{
+		Options:            map[string]string{"Backlog": "OPT_0", "Specify": "OPT_1", "Done": "OPT_3"},
+		OrderedOptionNames: []string{"Backlog", "Specify", "Done"},
+	}
+	if got := resolveSpecifyOptionID(sf); got != "OPT_1" {
+		t.Errorf("got %q, want OPT_1", got)
+	}
+}
+
+func TestResolveSpecifyOptionID_Fallback(t *testing.T) {
+	// No "Specify" column — fallback to first non-Backlog, non-terminal.
+	sf := &gh.StatusField{
+		Options:            map[string]string{"Backlog": "OPT_0", "Research": "OPT_1", "Done": "OPT_3"},
+		OrderedOptionNames: []string{"Backlog", "Research", "Done"},
+	}
+	if got := resolveSpecifyOptionID(sf); got != "OPT_1" {
+		t.Errorf("got %q, want OPT_1 (Research)", got)
+	}
+}
+
+func TestResolveSpecifyOptionID_BacklogAndDoneOnly(t *testing.T) {
+	// Only two columns — fallback skips Backlog and the last; nothing qualifies.
+	sf := &gh.StatusField{
+		Options:            map[string]string{"Backlog": "OPT_0", "Done": "OPT_1"},
+		OrderedOptionNames: []string{"Backlog", "Done"},
+	}
+	if got := resolveSpecifyOptionID(sf); got != "" {
+		t.Errorf("got %q, want empty (no viable column)", got)
+	}
+}
+
+func TestResolveSpecifyOptionID_EmptyOrderedNames(t *testing.T) {
+	sf := &gh.StatusField{
+		Options:            map[string]string{"Research": "OPT_1"},
+		OrderedOptionNames: nil,
+	}
+	if got := resolveSpecifyOptionID(sf); got != "" {
+		t.Errorf("got %q, want empty when OrderedOptionNames is nil", got)
+	}
+}
+
+func TestResolveSpecifyOptionID_SingleColumn(t *testing.T) {
+	// Only one column — len(names) < 2, returns "".
+	sf := &gh.StatusField{
+		Options:            map[string]string{"Specify": "OPT_1"},
+		OrderedOptionNames: []string{"Specify"},
+	}
+	// Even though "Specify" is in Options, len(names) == 1 so fallback returns "".
+	// But we check exact match first, so it should return OPT_1.
+	if got := resolveSpecifyOptionID(sf); got != "OPT_1" {
+		t.Errorf("got %q, want OPT_1 (exact match wins)", got)
+	}
+}
+
 // ---- preImplement integration tests ----
 
 func spawnTestEngine(client *mockGitHubClient) *Engine {

--- a/github/mutations_test.go
+++ b/github/mutations_test.go
@@ -181,6 +181,15 @@ func TestFetchStatusField_Success(t *testing.T) {
 	if sf.Options["Done"] != "OPT_3" {
 		t.Errorf("Options[Done] = %q", sf.Options["Done"])
 	}
+	want := []string{"Todo", "In Progress", "Done"}
+	if len(sf.OrderedOptionNames) != len(want) {
+		t.Fatalf("OrderedOptionNames len = %d, want %d", len(sf.OrderedOptionNames), len(want))
+	}
+	for i, name := range want {
+		if sf.OrderedOptionNames[i] != name {
+			t.Errorf("OrderedOptionNames[%d] = %q, want %q", i, sf.OrderedOptionNames[i], name)
+		}
+	}
 }
 
 func TestFetchStatusField_Error(t *testing.T) {

--- a/github/status.go
+++ b/github/status.go
@@ -4,8 +4,9 @@ import "fmt"
 
 // StatusField holds the Status field metadata for a project.
 type StatusField struct {
-	FieldID string
-	Options map[string]string // status name -> option ID
+	FieldID            string
+	Options            map[string]string // status name -> option ID
+	OrderedOptionNames []string          // option names in API-returned order (first = leftmost column)
 }
 
 // UpdateProjectItemStatus moves an item to a different status column on the project board.
@@ -102,6 +103,7 @@ query($projectId: ID!) {
 	}
 	for _, opt := range result.Data.Node.Field.Options {
 		sf.Options[opt.Name] = opt.ID
+		sf.OrderedOptionNames = append(sf.OrderedOptionNames, opt.Name)
 	}
 
 	return sf, nil


### PR DESCRIPTION
Closes #806

## Summary

A spawned sub-issue is part of the parent's already-approved work. After creating the child issue and adding it to the project board, the spawn step should: (1) set the child's project Status to the first processing stage (typically `Specify`), and (2) copy the parent's `fabrik:yolo` and `fabrik:cruise` labels to the child, enabling fully-autonomous end-to-end flow without human intervention.

## Problem

When Plan's pre-Implement step spawns a sub-issue via `FABRIK_SPAWN_CHILD_BEGIN/END`, the engine currently:

- ✅ Creates the issue in the target repo
- ✅ Adds it to the project board
- ✅ Links it as a `blockedBy` dependency of the parent
- ✅ Labels it `fabrik:sub-issue`
- ❌ Does **not** set its project Status (lands as null → project UI groups as "Backlog")
- ❌ Does **not** carry over the parent's `fabrik:yolo` or `fabrik:cruise` labels

The result: even though the parent was authorized to flow autonomously through the pipeline, its spawned children require manual triage (move to Specify, optionally add `fabrik:yolo`) before they begin work. This blocks fully-autonomous cross-repo flow.

**Verified reproduction:** `handarbeit/fabrik-test-alpha#1` (yolo'd, at Status=Specify when filed) successfully spawned `handarbeit/fabrik-test-beta#1` via the v0.0.66+#803 spawn path. The parent is now correctly gated on the child closing. But the child has only the `fabrik:sub-issue` label, no `fabrik:yolo`, and `status=null` on the project — so without a human moving it forward, nothing happens.

Test bed: project `handarbeit/projects/2`, issue `handarbeit/fabrik-test-alpha#1` (parent), `handarbeit/fabrik-test-beta#1` (child).

## Approach

### Approach

Three sequential units of work, each a single commit:

1. **Struct change** — Add `OrderedOptionNames []string` to `StatusField` in `github/status.go`, populated from the API's ordered response in `FetchStatusField`. This is the prerequisite for the fallback algorithm, which must know column position.

2. **Spawn changes** — In `engine/spawn.go`: add `resolveSpecifyOptionID` helper; capture the child item ID from `AddProjectV2ItemById` (currently discarded); add status-set call and label-inheritance calls after the existing `fabrik:sub-issue` step in the per-child loop.

3. **Docs + regen** — Update the two canonical docs and regenerate `docs/llms-full.txt`.

All new steps are **non-fatal**: failures log a warning and continue, consistent with the existing `fabrik:sub-issue` pattern and ADR-048's atomicity rules.

`e.statusField` is snapshotted under `e.mu` once before the per-child loop (not per-child — the field is stable once set). The snapshot is passed to `resolveSpecifyOptionID`.

No new ADR is needed — this extends ADR-048's per-child mutation sequence without changing its architectural decisions. The new behavior is an incremental addition that the ADR's framework already accommodates.

### New/Modified Files

| File | Change |
|------|--------|
| `github/status.go` | Add `OrderedOptionNames []string` to `StatusField`; populate in `FetchStatusField` |
| `github/mutations_test.go` | Extend `TestFetchStatusField_Success` to assert `OrderedOptionNames` populated in order |
| `engine/spawn.go` | Add `resolveSpecifyOptionID` helper; capture `childItemID`; add status-set + label-inheritance per child |
| `engine/spawn_test.go` | Add tests for yolo/cruise inheritance, nil statusField, fallback, no-labels for non-yolo parent, edge case (Backlog+Done only) |
| `docs/state-machine.md` | Update §6.6 per-child mutation sequence to document new steps |
| `docs/stage-lifecycle.md` | Update Phase 2.5 per-child mutations to document new steps |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **`OrderedOptionNames` on `StatusField`**: The existing `Options map[string]string` loses insertion order (Go map). Rather than changing the existing map field (breaking callers), add a companion `[]string` slice that preserves API order. Zero-value is valid — all existing callers compile unchanged.

- **`resolveSpecifyOptionID` in `engine/spawn.go`**: Scope is spawn-only; no need to pollute `github/status.go` with engine-policy logic. The helper is a pure function (no receiver), testable in isolation.

- **`resolveSpecifyOptionID` algorithm**: (1) If `sf == nil`, return `""`. (2) Exact match on `"Specify"` in `sf.Options` → return its ID. (3) Iterate `sf.OrderedOptionNames`; skip any named exactly `"Backlog"`, skip the last entry (terminal column); return the ID of the first option that passes both filters. If nothing qualifies, return `""`. Empty return → caller skips the status-set and logs a warning.

- **Status-set failure is non-fatal**: Consistent with `fabrik:sub-issue` handling (spawn.go:244–246). A status-set failure leaves the child in Backlog — the user can manually triage — but doesn't orphan the child or abort the spawn.

- **`e.statusField` snapshot before the loop**: Snapshot once under `e.mu` before the child loop begins, then release the mutex. This avoids holding the lock during network calls and is consistent with how other engine code reads `statusField`.

- **Label inheritance is independent of status-set**: Even if `statusField` is nil and status-set is skipped, `fabrik:yolo`/`fabrik:cruise` inheritance still runs. The two operations are independent.

### Task Checklist

- [ ] Task 1: Add `OrderedOptionNames []string` to `StatusField` struct in `github/status.go`; populate it from the API response in `FetchStatusField` (before the map loop). Update `TestFetchStatusField_Success` in `github/mutations_test.go` to assert `OrderedOptionNames` equals `["Todo","In Progress","Done"]` in that order.

- [ ] Task 2: Add `resolveSpecifyOptionID(sf *gh.StatusField) string` helper in `engine/spawn.go` implementing the algorithm above: nil guard → exact "Specify" lookup → ordered fallback (skip "Backlog" and last entry). Add unit tests for this helper directly in `engine/spawn_test.go`: exact match "Specify", fallback when no "Specify", edge case Backlog+Done only (returns ""), nil input (returns ""), and empty `OrderedOptionNames` (returns "").

- [ ] Task 3: In `preImplement` in `engine/spawn.go`: (a) snapshot `e.statusField` under `e.mu` before the child loop; (b) change `if _, err := e.client.AddProjectV2ItemById(...)` to `childItemID, err := e.client.AddProjectV2ItemById(...)`, capturing the item ID. No behavior change yet — just the capture.

- [ ] Task 4: After the `fabrik:sub-issue` label step in the per-child loop in `preImplement`, add the status-set call: call `resolveSpecifyOptionID(sf)` and if the result is non-empty, call `e.client.UpdateProjectItemStatus(board.ProjectID, childItemID, sf.FieldID, optionID)`; log warning on failure. Add `engine/spawn_test.go` tests: `TestPreImplement_SetsSpecifyStatus` (statusField has "Specify" → `UpdateProjectItemStatus` called with correct args) and `TestPreImplement_StatusSetNilField` (nil statusField → no `UpdateProjectItemStatus` call, spawn still succeeds).

- [ ] Task 5: After the status-set block in the per-child loop, add label inheritance: if `hasLabel(item, "fabrik:yolo")`, call `AddLabelToIssue(childOwner, childRepo, childNumber, "fabrik:yolo")`; if `hasLabel(item, "fabrik:cruise")`, call `AddLabelToIssue(childOwner, childRepo, childNumber, "fabrik:cruise")`; log warning on each failure. Add `engine/spawn_test.go` tests: `TestPreImplement_YoloInheritance` (parent has yolo → child gets yolo), `TestPreImplement_CruiseInheritance` (parent has cruise only → child gets cruise, no yolo), `TestPreImplement_BothLabelsInherited` (parent has both → child gets both), `TestPreImplement_NoAutonomyLabels` (parent has neither → no yolo/cruise added to child).

- [ ] Task 6: Update `docs/state-machine.md` §6.6, the per-child mutation sequence (around lines 993–996): after the `AddLabelToIssue("fabrik:sub-issue")` bullet, add two new bullets documenting `UpdateProjectItemStatus` (conditional on `statusField` non-nil and a Specify/fallback option being found) and conditional `AddLabelToIssue` for `fabrik:yolo`/`fabrik:cruise`. Document the nil-guard behavior and the non-fatal failure policy for both steps.

- [ ] Task 7: Update `docs/stage-lifecycle.md` Phase 2.5, the per-child mutations list (around lines 133–136): same additions as state-machine.md — new `UpdateProjectItemStatus` bullet and new label-inheritance bullet, both with their conditions and non-fatal failure notes.

- [ ] Task 8: Regenerate `docs/llms-full.txt` (`bash scripts/generate-llms-full.sh`), add it to the commit. Run `go build ./...` and `go test -race ./...` to confirm clean build and tests pass.

### Risks

- **`testEngine()` creates `statusField` with real options**: New tests that need `statusField` must set it on the engine directly (e.g., `eng.statusField = &gh.StatusField{...}`). Tests that need it nil must clear it explicitly. This is already the pattern in `no_work_needed_test.go`.
- **`addProjectV2ItemByIdFn` return value**: The existing `TestPreImplement_HappyPath` sets `addProjectV2ItemByIdFn` to return `"PVTI_" + contentNodeID`. The new tests calling `UpdateProjectItemStatus` need this mock return value to be non-empty — the existing mock already satisfies this.
- **Edge case: only Backlog + Done**: `resolveSpecifyOptionID` returns `""` → status-set skipped with a warning. This is tested in Task 2 and covered by the nil-guard path in Task 4.
- **`OrderedOptionNames` empty in existing test fixtures**: Tests that set `eng.statusField = &gh.StatusField{FieldID: ..., Options: ...}` without `OrderedOptionNames` will get `""` from `resolveSpecifyOptionID` (fallback iterates empty slice, returns `""`). This is safe — status-set is skipped. Only tests specifically targeting the status-set behavior need to populate `OrderedOptionNames`.

---
Used 13/50 turns, 5k input / 5k output tokens.

## Verification

Added `OrderedOptionNames []string` to `StatusField`, added `resolveSpecifyOptionID` helper, and updated `preImplement` to: (1) set the child's project Status to the `Specify` column (with fallback to first non-Backlog non-terminal column) using the captured `childItemID`; (2) conditionally inherit `fabrik:yolo` and `fabrik:cruise` from parent to child. All new mutations are non-fatal. Updated `state-machine.md`, `stage-lifecycle.md`, and regenerated `docs/llms-full.txt`. All 12 packages pass with `-race`.

---

Closes #806