### PR TITLE
fix(engine): worktree boundary audit false-positives on remote-tracking ref changes

### DIFF
--- a/adrs/049-worktree-boundary-enforcement.md
+++ b/adrs/049-worktree-boundary-enforcement.md
@@ -83,6 +83,8 @@ Boundary violations are not transient errors (network blips, rate limits) that b
 
 4. **Snapshot window**: The snapshot is taken before the extension loop and compared after. Concurrent Fabrik workers can mutate refs in other repos during the window. The design scopes the exclusion to the *active repo* rather than a time window, so Worker A's legitimate push to repo-X does not trigger a violation in Worker B (whose active repo is Y and thus audits repo-X). False positives from concurrent workers are therefore limited to: Worker B actively pushing to repo-Y (already excluded) while Worker A's active repo is also Y (prevented by the in-flight guard).
 
+5. **Remote-tracking refs are excluded from the snapshot**: `snapshotRepoRefs` passes `refs/heads/` and `refs/tags/` as positional pattern arguments to `git for-each-ref`, so `refs/remotes/origin/*` refs are never captured. Remote-tracking refs are passively-observed upstream state — they are updated by `git fetch` operations that can be triggered by concurrent Fabrik workers, webhook-driven fetches, or routine internal fetches entirely unrelated to Claude's activity. Including them would cause false-positive boundary violations whenever a sibling bare clone's remote-tracking refs changed during the audit window. The audit therefore covers only locally-authored mutations (branches and tags), which are the refs Claude could genuinely create or modify in another repo. `crossRepoViolations` also includes a defense-in-depth `strings.HasPrefix(ref, "refs/remotes/")` guard that preserves this invariant even if a future caller passes unfiltered maps.
+
 ## References
 
 - [ADR 005](005-claude-cli-invocation.md): Claude CLI shell-out and `--allowedTools`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4623,7 +4623,7 @@ After the extension loop completes, a cross-repo ref audit runs for non-read-onl
 
 **How it works:**
 
-1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname)` in its bare-clone directory. Capture `repo → (refname → SHA)` for all known repos.
+1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/` in its bare-clone directory. Capture `repo → (refname → SHA)` for locally-authored refs only. `refs/remotes/` is intentionally excluded — remote-tracking refs are passively-observed upstream state updated by `git fetch` for reasons unrelated to Claude's activity; including them would cause false-positive violations when a concurrent fetch updates a sibling bare clone.
 2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation.
 3. **Violation check** (`crossRepoViolations`): Compare before/after for every repo key *except* the active issue's repo. Any ref that is new or has a changed SHA is a violation.
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -295,7 +295,7 @@ After the extension loop completes, a cross-repo ref audit runs for non-read-onl
 
 **How it works:**
 
-1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname)` in its bare-clone directory. Capture `repo → (refname → SHA)` for all known repos.
+1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/` in its bare-clone directory. Capture `repo → (refname → SHA)` for locally-authored refs only. `refs/remotes/` is intentionally excluded — remote-tracking refs are passively-observed upstream state updated by `git fetch` for reasons unrelated to Claude's activity; including them would cause false-positive violations when a concurrent fetch updates a sibling bare clone.
 2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation.
 3. **Violation check** (`crossRepoViolations`): Compare before/after for every repo key *except* the active issue's repo. Any ref that is new or has a changed SHA is a violation.
 

--- a/engine/boundary.go
+++ b/engine/boundary.go
@@ -79,10 +79,11 @@ func crossRepoViolations(before, after map[string]map[string]string, activeRepo 
 			continue
 		}
 		for ref, newSHA := range afterRefs {
-			// Defense-in-depth: skip remote-tracking refs even if the caller passes
-			// unfiltered maps. snapshotRepoRefs already excludes refs/remotes/, but
-			// this guard preserves correctness if that invariant is ever broken.
-			if strings.HasPrefix(ref, "refs/remotes/") {
+			// Defense-in-depth: only consider refs/heads/ and refs/tags/ even if the
+			// caller passes unfiltered maps. snapshotRepoRefs already restricts to these
+			// namespaces, but this guard preserves correctness if that invariant is ever
+			// broken and also covers other non-standard namespaces (refs/notes/, etc.).
+			if !strings.HasPrefix(ref, "refs/heads/") && !strings.HasPrefix(ref, "refs/tags/") {
 				continue
 			}
 			oldSHA, existed := beforeRefs[ref]
@@ -93,7 +94,7 @@ func crossRepoViolations(before, after map[string]map[string]string, activeRepo 
 			}
 		}
 		for ref, oldSHA := range beforeRefs {
-			if strings.HasPrefix(ref, "refs/remotes/") {
+			if !strings.HasPrefix(ref, "refs/heads/") && !strings.HasPrefix(ref, "refs/tags/") {
 				continue
 			}
 			if _, existed := afterRefs[ref]; !existed {

--- a/engine/boundary.go
+++ b/engine/boundary.go
@@ -33,15 +33,20 @@ func applyWorktreeBoundary(tools []string, workDir string) []string {
 	return result
 }
 
-// snapshotRepoRefs runs "git for-each-ref --format=%(refname) %(objectname)" in
-// bareDir and returns a map of refname → SHA. Returns an empty map when bareDir is
-// empty or the command fails (non-fatal: single-repo projects have no other repos to
-// audit and the caller skips the audit when the map is empty).
+// snapshotRepoRefs runs "git for-each-ref" in bareDir and returns a map of
+// refname → SHA filtered to refs/heads/ and refs/tags/ only. Returns an empty map
+// when bareDir is empty or the command fails (non-fatal: single-repo projects have no
+// other repos to audit and the caller skips the audit when the map is empty).
+//
+// refs/remotes/ is intentionally excluded: remote-tracking refs are passively-observed
+// upstream state updated by git fetch for reasons unrelated to Claude's activity.
+// Including them would cause false-positive boundary violations whenever a concurrent
+// Fabrik worker or webhook-driven fetch updates a sibling bare clone's remote refs.
 func snapshotRepoRefs(bareDir string) (map[string]string, error) {
 	if bareDir == "" {
 		return map[string]string{}, nil
 	}
-	cmd := exec.Command("git", "for-each-ref", "--format=%(refname) %(objectname)")
+	cmd := exec.Command("git", "for-each-ref", "--format=%(refname) %(objectname)", "refs/heads/", "refs/tags/")
 	cmd.Dir = bareDir
 	out, err := cmd.Output()
 	if err != nil {
@@ -74,6 +79,12 @@ func crossRepoViolations(before, after map[string]map[string]string, activeRepo 
 			continue
 		}
 		for ref, newSHA := range afterRefs {
+			// Defense-in-depth: skip remote-tracking refs even if the caller passes
+			// unfiltered maps. snapshotRepoRefs already excludes refs/remotes/, but
+			// this guard preserves correctness if that invariant is ever broken.
+			if strings.HasPrefix(ref, "refs/remotes/") {
+				continue
+			}
 			oldSHA, existed := beforeRefs[ref]
 			if !existed {
 				violations = append(violations, fmt.Sprintf("%s: %s (new ref %s)", repo, ref, newSHA))
@@ -82,6 +93,9 @@ func crossRepoViolations(before, after map[string]map[string]string, activeRepo 
 			}
 		}
 		for ref, oldSHA := range beforeRefs {
+			if strings.HasPrefix(ref, "refs/remotes/") {
+				continue
+			}
 			if _, existed := afterRefs[ref]; !existed {
 				violations = append(violations, fmt.Sprintf("%s: %s (deleted, was %s)", repo, ref, oldSHA))
 			}

--- a/engine/boundary_test.go
+++ b/engine/boundary_test.go
@@ -268,3 +268,39 @@ func TestCrossRepoViolations_SkipsRepoAbsentFromBefore(t *testing.T) {
 		t.Errorf("repos absent from before snapshot should not generate violations, got %v", got)
 	}
 }
+
+func TestCrossRepoViolations_RemoteTrackingRefNotFlagged(t *testing.T) {
+	// Reproduces the real-world false-positive: a refs/remotes/origin/* ref appearing
+	// in a sibling bare clone (updated by a concurrent git fetch) must not be reported
+	// as a boundary violation. Remote-tracking refs are passively-observed upstream
+	// state, not locally-authored mutations.
+	before := map[string]map[string]string{
+		"owner/repo-b": {},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-b": {"refs/remotes/origin/fabrik/issue-64": "dbe2a1c917e2e9f1b7d784724c60717045e7e4dc"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 0 {
+		t.Errorf("remote-tracking ref change must not be flagged as a violation, got %v", got)
+	}
+}
+
+func TestCrossRepoViolations_LocalBranchInSiblingFlagged(t *testing.T) {
+	// A new refs/heads/ ref in a sibling repo IS a genuine boundary violation and
+	// must be detected. This confirms the refs/remotes/ filter does not suppress
+	// legitimate violations.
+	before := map[string]map[string]string{
+		"owner/repo-b": {},
+	}
+	after := map[string]map[string]string{
+		"owner/repo-b": {"refs/heads/feature": "deadbeef"},
+	}
+	got := crossRepoViolations(before, after, "owner/repo-a")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 violation for new local branch in sibling repo, got %v", got)
+	}
+	if !strings.Contains(got[0], "repo-b") || !strings.Contains(got[0], "feature") {
+		t.Errorf("violation should name sibling repo and branch: %q", got[0])
+	}
+}


### PR DESCRIPTION
Closes #808

## Summary

Filter `snapshotRepoRefs()` to capture only `refs/heads/` and `refs/tags/` — the ref namespaces that represent local state Claude could genuinely mutate in another repository. Remote-tracking refs (`refs/remotes/`) are excluded because they are passively observed upstream state, not local mutations. Add a comment documenting the rationale so future contributors don't re-add `refs/remotes/` thinking it was an oversight. Add a test that specifically verifies remote-tracking ref changes in sibling repos are not flagged as violations.

## Problem

`engine/boundary.go`'s cross-repo violation check fails stages with false positives when a sibling bare clone's `refs/remotes/origin/*` refs change between the before-snapshot and after-snapshot. Those changes do not indicate Claude mutated anything outside the worktree — they indicate some process (another Fabrik worker, a webhook-driven fetch, or a routine internal fetch) observed new remote state.

## Approach

### Approach

The fix is narrow: two changes to `engine/boundary.go`, two new test cases in `engine/boundary_test.go`, and documentation updates to the ADR and stage-lifecycle doc.

**Primary fix** (`snapshotRepoRefs`): Add `refs/heads/` and `refs/tags/` as positional pattern arguments to `git for-each-ref`. This filters the snapshot at collection time so remote-tracking refs never enter the maps passed to `crossRepoViolations`.

**Defense-in-depth guard** (`crossRepoViolations`): Add a `strings.HasPrefix(ref, "refs/remotes/")` skip in the loop that scans `afterRefs` (and the symmetric loop for `beforeRefs`). This makes `crossRepoViolations` safe even if a future caller passes unfiltered maps, and — critically — it allows the spec's required pure unit test to be written without real git. The guard is 4 lines and is consistent with the research's architectural principle (the comment documents why remote refs are excluded, preserving the "by design" intent without baking namespace knowledge into the comparison logic at large).

**Tests** (pure unit tests, no real git): Two new test functions in the `crossRepoViolations` block:
- `TestCrossRepoViolations_RemoteTrackingRefNotFlagged`: constructs before/after maps where a `refs/remotes/origin/fabrik/issue-64` ref is new in a sibling repo, asserts 0 violations. This directly reproduces the bug report.
- `TestCrossRepoViolations_LocalBranchInSiblingFlagged`: same structure but `refs/heads/feature`, asserts 1 violation. This confirms the filter does not suppress legitimate violations.

**Documentation**: Update ADR 049's Known Limitations section with a new entry explaining the `refs/heads/` + `refs/tags/` filter and why `refs/remotes/` is excluded. Update `docs/stage-lifecycle.md` (line 298) to show the filter patterns in the pre-audit snapshot description. Because `stage-lifecycle.md` is a canonical doc page, regenerate `docs/llms-full.txt` in the same commit per CLAUDE.md mandate.

No new ADR is warranted — this is a bug fix to an existing mechanism, and ADR 049 is the right place to record the updated behavior.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/boundary.go` | Add `refs/heads/` + `refs/tags/` args to `git for-each-ref`; add explanatory comment on `snapshotRepoRefs`; add `refs/remotes/` skip guards in `crossRepoViolations` |
| `engine/boundary_test.go` | Add `TestCrossRepoViolations_RemoteTrackingRefNotFlagged` and `TestCrossRepoViolations_LocalBranchInSiblingFlagged` |
| `adrs/049-worktree-boundary-enforcement.md` | Add Known Limitations item 5: snapshot namespace filter rationale |
| `docs/stage-lifecycle.md` | Update pre-audit snapshot step to show `refs/heads/ refs/tags/` patterns |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **Defense-in-depth guard in `crossRepoViolations`**: The spec's test requirement ("a new `refs/remotes/` entry in the after-snapshot produces zero violations") cannot be satisfied without either real git or a namespace filter in `crossRepoViolations`. Real git would require creating a bare clone and simulating a concurrent fetch — complex and slow. A 4-line `strings.HasPrefix` guard in `crossRepoViolations` is simpler, documents the contract explicitly, and makes the test directly readable as a regression test for the reported bug. The research note ("has no knowledge of ref namespaces — that's by design") is preserved: this guard doesn't route based on namespace, it simply enforces a known class of no-ops with a self-documenting comment.

- **All changes in one commit**: The fix, tests, and doc updates are small and interdependent. Splitting them would leave the repo in states where tests reference behavior not yet present. Single commit is simpler and cleaner.

- **No changes to `snapshotAllRepoRefs` in `item.go`**: The filter lives entirely in `snapshotRepoRefs`. `snapshotAllRepoRefs` is unchanged — its signature, callers, and behavior are unaffected.

- **No new ADR**: ADR 049 already exists and is being updated. This fix narrows existing behavior; it's not a new architectural decision.

### Task Checklist

- [ ] Task 1: In `engine/boundary.go`, modify `snapshotRepoRefs` — add `refs/heads/` and `refs/tags/` as positional args to `exec.Command("git", "for-each-ref", ...)` and add a comment explaining that `refs/remotes/` is intentionally excluded because remote-tracking refs are passively-observed upstream state, not locally-authored mutations
- [ ] Task 2: In `engine/boundary.go`, add `refs/remotes/` skip guards to both loops in `crossRepoViolations` — skip any `ref` where `strings.HasPrefix(ref, "refs/remotes/")` is true; add a comment tying the guard to the snapshot filter rationale
- [ ] Task 3: In `engine/boundary_test.go`, add `TestCrossRepoViolations_RemoteTrackingRefNotFlagged` — before: `{"owner/repo-b": {}}`, after: `{"owner/repo-b": {"refs/remotes/origin/fabrik/issue-64": "dbe2a1c"}}`, activeRepo: `"owner/repo-a"`, assert 0 violations
- [ ] Task 4: In `engine/boundary_test.go`, add `TestCrossRepoViolations_LocalBranchInSiblingFlagged` — same structure but `refs/heads/feature`: `"deadbeef"` in after, assert exactly 1 violation containing `"repo-b"` and `"feature"`
- [ ] Task 5: Update `adrs/049-worktree-boundary-enforcement.md` — add Known Limitations item 5 documenting that `snapshotRepoRefs` filters to `refs/heads/` and `refs/tags/`, and explaining why `refs/remotes/` is excluded (passively-observed upstream state, updated by `git fetch` for unrelated reasons, not a locally-authored mutation)
- [ ] Task 6: Update `docs/stage-lifecycle.md` line 298 — change the pre-audit snapshot description from `git for-each-ref --format=%(refname) %(objectname)` to `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/`
- [ ] Task 7: Run `bash scripts/generate-llms-full.sh` and stage `docs/llms-full.txt` (required by CLAUDE.md whenever `docs/stage-lifecycle.md` is changed)
- [ ] Task 8: Run `go test ./engine/... -race` and `go vet ./engine/...` to confirm no regressions and the two new tests pass; run `go build -o fabrik .` to confirm the binary builds

### Risks

- **`strings` import**: `crossRepoViolations` is in `boundary.go`, which already imports `strings` (used in `snapshotRepoRefs` for `strings.SplitN`). No import change needed.
- **Test naming collision**: Check that `TestCrossRepoViolations_LocalBranchInSiblingFlagged` doesn't overlap with the existing `TestCrossRepoViolations_DetectsNewRef` test — they test slightly different things (the new test is paired with the remote-tracking test for symmetry and documents the specific scenario from the bug report). Both can coexist.
- **`docs/llms-full.txt` drift**: If the implementer forgets to run the regen script, CI's `docs-drift` workflow will fail the PR. Task 7 makes this explicit and it should be part of the same commit as Task 6.

---
Used 10/50 turns, 4k input / 13k output tokens.

## Verification

Fixed the false-positive worktree boundary audit by filtering `snapshotRepoRefs` to `refs/heads/` and `refs/tags/` only, excluding `refs/remotes/` (passively-observed upstream state). Added a defense-in-depth guard in `crossRepoViolations` and two new unit tests reproducing the exact bug report scenario. Updated ADR 049 and `docs/stage-lifecycle.md` with the filter rationale; regenerated `docs/llms-full.txt`.

---

Closes #808