### PR TITLE
feat(engine): make Layer 2 cross-repo ref audit opt-in via WorktreeBoundaryAudit flag (default off)

### DIFF
--- a/adrs/049-worktree-boundary-enforcement.md
+++ b/adrs/049-worktree-boundary-enforcement.md
@@ -28,7 +28,7 @@ This is implemented in `applyWorktreeBoundary` (`engine/boundary.go`) — a pure
 
 ### Layer 2: Reactive Post-Run Audit (opt-in — default off)
 
-> **Amendment (PR #810):** The Layer 2 audit is now **opt-in via the `WorktreeBoundaryAudit` config flag** (default `false`). It was made opt-in because routine `git fetch origin` calls in sibling bare clones were triggering false-positive violations; the root-cause fix is tracked in #808. To enable the audit, set `worktree_boundary_audit: true` in `.fabrik/config.yaml`, use `--worktree-boundary-audit` on the CLI, or set `FABRIK_WORKTREE_BOUNDARY_AUDIT=true`. Layer 1 is unaffected — it runs unconditionally regardless of this flag.
+> **Amendment (Issue #810 / PR #812):** The Layer 2 audit is now **opt-in via the `WorktreeBoundaryAudit` config flag** (default `false`). It was made opt-in because routine `git fetch origin` calls in sibling bare clones were triggering false-positive violations; the root-cause fix is tracked in #808. To enable the audit, set `worktree_boundary_audit: true` in `.fabrik/config.yaml`, use `--worktree-boundary-audit` on the CLI, or set `FABRIK_WORKTREE_BOUNDARY_AUDIT=true`. Layer 1 is unaffected — it runs unconditionally regardless of this flag.
 
 Before the extension loop in `processItem` (`engine/item.go`), snapshot branch refs across all registered bare-clone repositories via `snapshotAllRepoRefs`. After the loop, compare via `crossRepoViolations`. Any ref that is new, changed, or deleted in a repo *other than* the active issue's repo is a boundary violation. Repos not present in the before-snapshot (lazy-registered during the run or whose pre-audit snapshot failed) are excluded from comparison to prevent false positives.
 

--- a/adrs/049-worktree-boundary-enforcement.md
+++ b/adrs/049-worktree-boundary-enforcement.md
@@ -26,7 +26,9 @@ Claude Code's `--allowedTools` flag accepts the same `Tool(pattern)` syntax as `
 
 This is implemented in `applyWorktreeBoundary` (`engine/boundary.go`) — a pure function that takes the tool list and workDir and returns a new list with bare `Edit`/`Write` replaced. Called from `buildClaudeArgs` when `!unrestricted && !stage.ReadOnly && workDir != ""`.
 
-### Layer 2: Reactive Post-Run Audit
+### Layer 2: Reactive Post-Run Audit (opt-in — default off)
+
+> **Amendment (PR #810):** The Layer 2 audit is now **opt-in via the `WorktreeBoundaryAudit` config flag** (default `false`). It was made opt-in because routine `git fetch origin` calls in sibling bare clones were triggering false-positive violations; the root-cause fix is tracked in #808. To enable the audit, set `worktree_boundary_audit: true` in `.fabrik/config.yaml`, use `--worktree-boundary-audit` on the CLI, or set `FABRIK_WORKTREE_BOUNDARY_AUDIT=true`. Layer 1 is unaffected — it runs unconditionally regardless of this flag.
 
 Before the extension loop in `processItem` (`engine/item.go`), snapshot branch refs across all registered bare-clone repositories via `snapshotAllRepoRefs`. After the loop, compare via `crossRepoViolations`. Any ref that is new, changed, or deleted in a repo *other than* the active issue's repo is a boundary violation. Repos not present in the before-snapshot (lazy-registered during the run or whose pre-audit snapshot failed) are excluded from comparison to prevent false positives.
 
@@ -41,10 +43,11 @@ The audit is implemented in `snapshotRepoRefs` and `crossRepoViolations` (`engin
 
 ### Gating Conditions
 
-Both layers gate on `!unrestricted && !stage.ReadOnly`:
+Layer 1 gates on `!unrestricted && !stage.ReadOnly`. Layer 2 additionally gates on `e.cfg.WorktreeBoundaryAudit`:
 
-- **`fabrik:unrestricted`**: passes `--dangerously-skip-permissions` instead of `--allowedTools`, bypassing all tool restrictions. Worktree-boundary enforcement is also bypassed — consistent with the existing semantics of that label.
+- **`fabrik:unrestricted`**: passes `--dangerously-skip-permissions` instead of `--allowedTools`, bypassing all tool restrictions. Both worktree-boundary layers are also bypassed — consistent with the existing semantics of that label.
 - **Read-only stages** (Specify, Research, Plan): stash/restore worktree changes and do not produce commits or file writes. Neither layer applies.
+- **`WorktreeBoundaryAudit: false` (default)**: Layer 2 pre-audit snapshot is not taken, and `crossRepoViolations` is never called. Layer 1 is unaffected. See the amendment note above for context.
 - **Single-repo projects**: the path restriction still applies (preventing out-of-worktree file writes). The cross-repo audit produces no violations — the active repo is excluded, and there are no other registered repos.
 
 ## Rationale

--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -158,6 +158,25 @@ func TestExecute_FlagSymlinkEnv(t *testing.T) {
 	executeAndStop(t)
 }
 
+func TestExecute_EnvWorktreeBoundaryAudit(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	resetFlags()
+	t.Setenv("FABRIK_WORKTREE_BOUNDARY_AUDIT", "true")
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+	executeAndStop(t)
+}
+
+func TestExecute_FlagWorktreeBoundaryAudit(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir, "--worktree-boundary-audit"}
+	executeAndStop(t)
+}
+
 func TestExecute_StreamFilterSubcommand(t *testing.T) {
 	resetFlags()
 	r, w, _ := os.Pipe()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -385,7 +385,7 @@ func Execute() error {
 			cfg.SymlinkEnv = true
 		}
 	}
-	if !cfg.WorktreeBoundaryAudit {
+	if !explicitFlags["worktree-boundary-audit"] {
 		if v := os.Getenv("FABRIK_WORKTREE_BOUNDARY_AUDIT"); v != "" {
 			lv := strings.ToLower(v)
 			cfg.WorktreeBoundaryAudit = lv == "true" || lv == "1" || lv == "yes"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,9 +44,10 @@ type Config struct {
 	MaxCiFixCycles    int // 0 means use default (5)
 	MaxRebaseCycles   int // 0 means use default (3)
 	ClaudeWaitDelay   int // seconds; 0 means use default (30)
-	DebugOutput       bool
-	SymlinkEnv        bool
-	PluginDir         string
+	DebugOutput              bool
+	SymlinkEnv               bool
+	WorktreeBoundaryAudit    bool
+	PluginDir                string
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     string // comma-separated; empty means default event set
@@ -129,6 +130,7 @@ func Execute() error {
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
 	flag.BoolVar(&cfg.SymlinkEnv, "symlink-env", false, "Symlink the fabrik-dir .env file into each issue worktree at creation time (also FABRIK_SYMLINK_ENV)")
+	flag.BoolVar(&cfg.WorktreeBoundaryAudit, "worktree-boundary-audit", false, "Enable Layer 2 cross-repo ref-mutation audit (default off pending #808 root-cause fix; also FABRIK_WORKTREE_BOUNDARY_AUDIT)")
 	flag.StringVar(&cfg.PluginDir, "plugin-dir", "", "Path to Fabrik plugin directory (for development; overrides installed plugin)")
 	flag.BoolVar(&cfg.Webhooks, "webhooks", false, "Enable webhook-driven event delivery via gh webhook forward (requires gh ≥ 2.32.0; also FABRIK_WEBHOOKS)")
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
@@ -383,6 +385,14 @@ func Execute() error {
 			cfg.SymlinkEnv = true
 		}
 	}
+	if !cfg.WorktreeBoundaryAudit {
+		if v := os.Getenv("FABRIK_WORKTREE_BOUNDARY_AUDIT"); v != "" {
+			lv := strings.ToLower(v)
+			cfg.WorktreeBoundaryAudit = lv == "true" || lv == "1" || lv == "yes"
+		} else if pc.WorktreeBoundaryAudit {
+			cfg.WorktreeBoundaryAudit = true
+		}
+	}
 	if cfg.PluginDir == "" {
 		if v := os.Getenv("FABRIK_PLUGIN_DIR"); v != "" {
 			cfg.PluginDir = v
@@ -564,6 +574,7 @@ func Execute() error {
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		DebugOutput:              cfg.DebugOutput,
 		SymlinkEnv:               cfg.SymlinkEnv,
+		WorktreeBoundaryAudit:    cfg.WorktreeBoundaryAudit,
 		PluginDir:                cfg.PluginDir,
 		Stages:                   stageCfgs,
 		Webhooks:                 cfg.Webhooks,

--- a/config/config.go
+++ b/config/config.go
@@ -27,9 +27,10 @@ type ProjectConfig struct {
 	GitSSH        bool     `yaml:"git_ssh"`
 	TUI           *bool    `yaml:"tui"`
 	DebugOutput   bool     `yaml:"debug_output"`
-	SymlinkEnv    bool     `yaml:"symlink_env"`
-	Version       string   `yaml:"version"`
-	Webhooks      bool     `yaml:"webhooks"`
+	SymlinkEnv              bool     `yaml:"symlink_env"`
+	WorktreeBoundaryAudit   bool     `yaml:"worktree_boundary_audit"`
+	Version                 string   `yaml:"version"`
+	Webhooks                bool     `yaml:"webhooks"`
 	WebhookPort   *int     `yaml:"webhook_port"`
 	WebhookEvents []string `yaml:"webhook_events"`
 	StatusPoll    *int     `yaml:"status_poll"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -151,6 +151,38 @@ func TestLoadProjectConfig_SymlinkEnvDefaultFalse(t *testing.T) {
 	}
 }
 
+func TestLoadProjectConfig_WorktreeBoundaryAuditDefaultFalse(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("owner: org\n"), 0644)
+	pc, err := LoadProjectConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pc.WorktreeBoundaryAudit {
+		t.Error("worktree_boundary_audit: want false by default")
+	}
+}
+
+func TestLoadProjectConfig_WorktreeBoundaryAuditYAML(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("owner: org\nworktree_boundary_audit: true\n"), 0644)
+	pc, err := LoadProjectConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !pc.WorktreeBoundaryAudit {
+		t.Error("worktree_boundary_audit: want true when set in config.yaml")
+	}
+}
+
 func TestLoadProjectConfig_ValidYAML(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1574,7 +1574,22 @@ Fabrik enforces two independent layers of worktree isolation on every Claude inv
 
 **Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.
 
-**Layer 2 — Cross-repo ref audit**: Before the extension loop begins, Fabrik snapshots the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+**Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik can snapshot the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+
+> **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
+>
+> ```yaml
+> # .fabrik/config.yaml
+> worktree_boundary_audit: true
+> ```
+>
+> ```bash
+> # CLI flag
+> ./fabrik --worktree-boundary-audit ...
+>
+> # Environment variable
+> FABRIK_WORKTREE_BOUNDARY_AUDIT=true ./fabrik ...
+> ```
 
 **What to do when a stage fails with a boundary violation:** Check whether the stage's prompt or skill is attempting to write files outside the issue's worktree — for example, writing to `fabrikDir` (the Fabrik config directory) or a sibling worktree. The comment posted on violation lists the specific bare-repo refs that changed, which identifies which repo was touched.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1574,7 +1574,7 @@ Fabrik enforces two independent layers of worktree isolation on every Claude inv
 
 **Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.
 
-**Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik can snapshot the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+**Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik snapshots the git refs of all registered bare repos. After the loop completes, a second snapshot is taken and compared. If any ref in a repo other than the active issue's own repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
 
 > **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
 >

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1572,7 +1572,22 @@ Fabrik enforces two independent layers of worktree isolation on every Claude inv
 
 **Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.
 
-**Layer 2 — Cross-repo ref audit**: Before the extension loop begins, Fabrik snapshots the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+**Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik can snapshot the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+
+> **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
+>
+> ```yaml
+> # .fabrik/config.yaml
+> worktree_boundary_audit: true
+> ```
+>
+> ```bash
+> # CLI flag
+> ./fabrik --worktree-boundary-audit ...
+>
+> # Environment variable
+> FABRIK_WORKTREE_BOUNDARY_AUDIT=true ./fabrik ...
+> ```
 
 **What to do when a stage fails with a boundary violation:** Check whether the stage's prompt or skill is attempting to write files outside the issue's worktree — for example, writing to `fabrikDir` (the Fabrik config directory) or a sibling worktree. The comment posted on violation lists the specific bare-repo refs that changed, which identifies which repo was touched.
 
@@ -4619,12 +4634,14 @@ The `e.claude.Invoke()` call runs inside an extension loop. On each iteration:
 
 ### Post-Run Boundary Audit
 
-After the extension loop completes, a cross-repo ref audit runs for non-read-only, non-unrestricted stages. The audit detects git-layer mutations in any repository other than the active worktree's own repo.
+After the extension loop completes, a cross-repo ref audit runs for non-read-only, non-unrestricted stages **when `e.cfg.WorktreeBoundaryAudit` is `true`** (default: `false`). The audit detects git-layer mutations in any repository other than the active worktree's own repo.
+
+> **Default off (pending #808):** The audit is disabled by default because routine `git fetch origin` in sibling bare clones produces false-positive violations. Enable it with `worktree_boundary_audit: true` in `.fabrik/config.yaml`, `--worktree-boundary-audit` on the CLI, or `FABRIK_WORKTREE_BOUNDARY_AUDIT=true`.
 
 **How it works:**
 
-1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/` in its bare-clone directory. Capture `repo → (refname → SHA)` for locally-authored refs only. `refs/remotes/` is intentionally excluded — remote-tracking refs are passively-observed upstream state updated by `git fetch` for reasons unrelated to Claude's activity; including them would cause false-positive violations when a concurrent fetch updates a sibling bare clone.
-2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation.
+1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/` in its bare-clone directory. Capture `repo → (refname → SHA)` for locally-authored refs only. `refs/remotes/` is intentionally excluded — remote-tracking refs are passively-observed upstream state updated by `git fetch` for reasons unrelated to Claude's activity; including them would cause false-positive violations when a concurrent fetch updates a sibling bare clone. **Skipped entirely when `WorktreeBoundaryAudit` is `false`.**
+2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation. Skipped when the pre-audit snapshot was not taken (i.e., `WorktreeBoundaryAudit` is `false`).
 3. **Violation check** (`crossRepoViolations`): Compare before/after for every repo key *except* the active issue's repo. Any ref that is new or has a changed SHA is a violation.
 
 **On violation:**
@@ -4638,7 +4655,7 @@ After the extension loop completes, a cross-repo ref audit runs for non-read-onl
 
 **No violation:** The audit is silent. Stage proceeds to normal output posting and completion.
 
-**Bypass:** Skipped when `stage.ReadOnly == true` or `fabrik:unrestricted` is present on the issue.
+**Bypass:** Skipped when `WorktreeBoundaryAudit` is `false` (default), `stage.ReadOnly == true`, or `fabrik:unrestricted` is present on the issue.
 
 **Limitation — Bash shell writes:** The audit checks git refs, not the filesystem. A Claude session that writes files outside the worktree via raw shell commands (e.g., `cat > /other/path`) would not be caught unless those files were also committed and pushed to another repo. The `Edit`/`Write` path restriction (Phase 2) is the primary mitigation for direct file writes.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1572,7 +1572,7 @@ Fabrik enforces two independent layers of worktree isolation on every Claude inv
 
 **Layer 1 — Tool-permission scoping**: At invocation time, bare `Edit` and `Write` entries in the allowed-tools list are replaced with `Edit(<workDir>/**)` and `Write(<workDir>/**)`. If Claude attempts to edit or write a file outside the issue's worktree, the tool call receives a permission error — but the stage continues running; only the specific tool call is rejected.
 
-**Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik can snapshot the git refs of every registered bare repo except the active issue's own repo. After the loop completes, a second snapshot is compared. If any ref in a non-active repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
+**Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik snapshots the git refs of all registered bare repos. After the loop completes, a second snapshot is taken and compared. If any ref in a repo other than the active issue's own repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
 
 > **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
 >

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -291,12 +291,14 @@ The `e.claude.Invoke()` call runs inside an extension loop. On each iteration:
 
 ### Post-Run Boundary Audit
 
-After the extension loop completes, a cross-repo ref audit runs for non-read-only, non-unrestricted stages. The audit detects git-layer mutations in any repository other than the active worktree's own repo.
+After the extension loop completes, a cross-repo ref audit runs for non-read-only, non-unrestricted stages **when `e.cfg.WorktreeBoundaryAudit` is `true`** (default: `false`). The audit detects git-layer mutations in any repository other than the active worktree's own repo.
+
+> **Default off (pending #808):** The audit is disabled by default because routine `git fetch origin` in sibling bare clones produces false-positive violations. Enable it with `worktree_boundary_audit: true` in `.fabrik/config.yaml`, `--worktree-boundary-audit` on the CLI, or `FABRIK_WORKTREE_BOUNDARY_AUDIT=true`.
 
 **How it works:**
 
-1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/` in its bare-clone directory. Capture `repo → (refname → SHA)` for locally-authored refs only. `refs/remotes/` is intentionally excluded — remote-tracking refs are passively-observed upstream state updated by `git fetch` for reasons unrelated to Claude's activity; including them would cause false-positive violations when a concurrent fetch updates a sibling bare clone.
-2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation.
+1. **Pre-audit snapshot** (taken immediately before the extension loop): For each registered `WorktreeManager` in the engine, run `git for-each-ref --format=%(refname) %(objectname) refs/heads/ refs/tags/` in its bare-clone directory. Capture `repo → (refname → SHA)` for locally-authored refs only. `refs/remotes/` is intentionally excluded — remote-tracking refs are passively-observed upstream state updated by `git fetch` for reasons unrelated to Claude's activity; including them would cause false-positive violations when a concurrent fetch updates a sibling bare clone. **Skipped entirely when `WorktreeBoundaryAudit` is `false`.**
+2. **Post-audit snapshot** (taken immediately after the extension loop): Same operation. Skipped when the pre-audit snapshot was not taken (i.e., `WorktreeBoundaryAudit` is `false`).
 3. **Violation check** (`crossRepoViolations`): Compare before/after for every repo key *except* the active issue's repo. Any ref that is new or has a changed SHA is a violation.
 
 **On violation:**
@@ -310,7 +312,7 @@ After the extension loop completes, a cross-repo ref audit runs for non-read-onl
 
 **No violation:** The audit is silent. Stage proceeds to normal output posting and completion.
 
-**Bypass:** Skipped when `stage.ReadOnly == true` or `fabrik:unrestricted` is present on the issue.
+**Bypass:** Skipped when `WorktreeBoundaryAudit` is `false` (default), `stage.ReadOnly == true`, or `fabrik:unrestricted` is present on the issue.
 
 **Limitation — Bash shell writes:** The audit checks git refs, not the filesystem. A Claude session that writes files outside the worktree via raw shell commands (e.g., `cat > /other/path`) would not be caught unless those files were also committed and pushed to another repo. The `Edit`/`Write` path restriction (Phase 2) is the primary mitigation for direct file writes.
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -40,6 +40,7 @@ type Config struct {
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
 	DebugOutput              bool
 	SymlinkEnv               bool
+	WorktreeBoundaryAudit    bool
 	PluginDir                string
 	Stages                   []*stages.Stage
 	Webhooks                 bool

--- a/engine/item.go
+++ b/engine/item.go
@@ -789,7 +789,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// In single-repo projects this produces a one-entry map; crossRepoViolations
 	// filters out the active repo, so no false positives are generated.
 	var preAuditSnapshot map[string]map[string]string
-	if !stage.ReadOnly && !hasUnrestrictedLabel(item) {
+	if !stage.ReadOnly && !hasUnrestrictedLabel(item) && e.cfg.WorktreeBoundaryAudit {
 		preAuditSnapshot = e.snapshotAllRepoRefs(item.Number)
 	}
 

--- a/engine/item_boundary_test.go
+++ b/engine/item_boundary_test.go
@@ -210,11 +210,12 @@ func TestBoundaryAudit_ReadOnlyStageSkipped(t *testing.T) {
 		},
 	}
 	eng := NewWithDeps(Config{
-		Owner:  "owner",
-		Repo:   "repo",
-		User:   "testuser",
-		Token:  "token",
-		Stages: readOnlyStages,
+		Owner:                 "owner",
+		Repo:                  "repo",
+		User:                  "testuser",
+		Token:                 "token",
+		Stages:                readOnlyStages,
+		WorktreeBoundaryAudit: true,
 	}, client, claude, wm)
 
 	// Register secondary repo so it would be audited if audit ran.

--- a/engine/item_boundary_test.go
+++ b/engine/item_boundary_test.go
@@ -29,11 +29,12 @@ func boundaryEngine(t *testing.T, client *mockGitHubClient, claude *mockClaudeIn
 	t.Helper()
 	wm := NewWorktreeManager(primaryDir)
 	eng := NewWithDeps(Config{
-		Owner:  "owner",
-		Repo:   "repo",
-		User:   "testuser",
-		Token:  "token",
-		Stages: boundaryStages(),
+		Owner:                 "owner",
+		Repo:                  "repo",
+		User:                  "testuser",
+		Token:                 "token",
+		Stages:                boundaryStages(),
+		WorktreeBoundaryAudit: true,
 	}, client, claude, wm)
 
 	// Register the secondary repo so it participates in the cross-repo audit.
@@ -282,4 +283,71 @@ func TestBoundaryAudit_UnrestrictedLabelSkipped(t *testing.T) {
 		}
 	}
 	client.mu.Unlock()
+}
+
+// TestBoundaryAudit_FlagDisabled verifies that when WorktreeBoundaryAudit is false
+// (the default), cross-repo ref mutations are not detected and the stage completes
+// normally without posting a boundary violation comment.
+func TestBoundaryAudit_FlagDisabled(t *testing.T) {
+	skipIfNoGit(t)
+
+	primaryDir := initBareRepo(t)
+	secondaryDir := initBareRepo(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Simulate cross-repo mutation — would trigger a violation when audit is on.
+			cmd := exec.Command("git", "branch", "cross-repo-branch")
+			cmd.Dir = secondaryDir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git branch in secondary repo failed: %s: %v", out, err)
+			}
+			return "FABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	// Build engine with WorktreeBoundaryAudit: false (the default — audit is off).
+	wm := NewWorktreeManager(primaryDir)
+	eng := NewWithDeps(Config{
+		Owner:                 "owner",
+		Repo:                  "repo",
+		User:                  "testuser",
+		Token:                 "token",
+		Stages:                boundaryStages(),
+		WorktreeBoundaryAudit: false,
+	}, client, claude, wm)
+	eng.mu.Lock()
+	eng.worktreeManagers["other/repo"] = NewWorktreeManager(secondaryDir)
+	eng.mu.Unlock()
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, Title: "Test", Status: "Implement", ItemID: "PVTI_1"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem returned unexpected error: %v", err)
+	}
+
+	// No boundary violation comment should be posted — audit is disabled.
+	client.mu.Lock()
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "boundary violation") {
+			t.Errorf("audit-disabled engine must not post boundary violation, got: %q", c.body)
+		}
+	}
+	client.mu.Unlock()
+
+	// Stage should complete normally.
+	client.mu.Lock()
+	var completionAdded bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Implement:complete" {
+			completionAdded = true
+		}
+	}
+	client.mu.Unlock()
+
+	if !completionAdded {
+		t.Error("expected stage:Implement:complete to be added when audit is disabled and stage signals completion")
+	}
 }


### PR DESCRIPTION
## What this PR does

Makes the Layer 2 cross-repo ref-mutation audit opt-in via a new `WorktreeBoundaryAudit` config flag (default `false`). This immediately unblocks users on affected Fabrik instances where routine `git fetch origin` calls in sibling bare clones were triggering false-positive boundary violations and entering a stuck loop.

Layer 1 (tool-path scoping via `applyWorktreeBoundary`) is **not** gated — it continues to run unconditionally.

## Key changes

- **`config/config.go`**: Added `WorktreeBoundaryAudit bool` with YAML key `worktree_boundary_audit`.
- **`engine/engine.go`**: Added `WorktreeBoundaryAudit bool` to `Config`.
- **`cmd/root.go`**: Registered `--worktree-boundary-audit` flag; added `FABRIK_WORKTREE_BOUNDARY_AUDIT` env var fallback and `config.yaml` fallback following the existing `SymlinkEnv` pattern.
- **`engine/item.go`**: Added `&& e.cfg.WorktreeBoundaryAudit` to the pre-audit guard. When `false`, `snapshotAllRepoRefs` is never called; the post-audit block's `if preAuditSnapshot != nil` guard naturally skips it.
- **`engine/item_boundary_test.go`**: Set `WorktreeBoundaryAudit: true` in `boundaryEngine()` to preserve existing violation-detection tests; added `TestBoundaryAudit_FlagDisabled` verifying that cross-repo mutations are not detected when the flag is `false`.
- **`config/config_test.go`**: Added `TestLoadProjectConfig_WorktreeBoundaryAuditDefaultFalse` and `TestLoadProjectConfig_WorktreeBoundaryAuditYAML`.
- **`cmd/cmd_envvar_test.go`**: Added `TestExecute_EnvWorktreeBoundaryAudit` and `TestExecute_FlagWorktreeBoundaryAudit`.
- **`adrs/049-worktree-boundary-enforcement.md`**: Amended Layer 2 section to note the audit is opt-in, referencing #808 as the reason.
- **`docs/USER_GUIDE.md`** and **`docs/stage-lifecycle.md`**: Documented the flag and default-off behavior.
- **`docs/llms-full.txt`**: Regenerated per CLAUDE.md requirement.

## How to test

1. Build from this branch: `go build -o fabrik .`
2. Start Fabrik with no config changes on an instance that previously hit the false positive — boundary violations from remote-tracking ref updates should no longer occur.
3. Add `worktree_boundary_audit: true` to `.fabrik/config.yaml` and restart — the audit re-activates and the false positive returns (verifying the toggle works).
4. Run `FABRIK_WORKTREE_BOUNDARY_AUDIT=true ./fabrik ...` — same effect as step 3.
5. `go test -race ./...` — all tests green.

Closes #810