### PR TITLE
fabrik skill: document that blockedBy must be wired via the Issue Dependencies API, not body text

### DIFF
--- a/plugin/fabrik/skills/fabrik/SKILL.md
+++ b/plugin/fabrik/skills/fabrik/SKILL.md
@@ -87,6 +87,8 @@ When the user wants to create a group of related issues where B is blocked by A,
 
 **Why the order matters**: Once an issue lands in Specify with `fabrik:yolo`, the engine picks it up within seconds (poll cadence is 30 s; webhooks fire immediately). `fabrik:blocked` is engine-managed: Fabrik adds it only when it detects an open `blocked_by` link at poll time. If that link isn't present when Fabrik fetches the issue's deep state, `checkDependencies` sees no open dependencies, adds no block label, and dispatches a Claude worker immediately — even if the user intends to wire the dependency a moment later.
 
+> **Warning — prose in the body is invisible to Fabrik.** Writing `**BlockedBy**: #N` or any similar free-text marker in the issue description does nothing. Fabrik's `checkDependencies` reads dependency state exclusively from GitHub's Issue Dependencies API (surfaced via GraphQL `blockedBy` nodes) — it never parses the issue body. The only way to create a dependency that Fabrik will respect is the API call below.
+
 **Safe sequence:**
 
 1. **Create all issues in Backlog** (or no column) — not in Specify. This prevents Fabrik from picking them up before you're ready.
@@ -97,13 +99,19 @@ When the user wants to create a group of related issues where B is blocked by A,
 **Wiring the dependency:**
 
 ```bash
-# Get the database ID of the blocking issue (A):
+# Get the database ID of the blocking issue (A).
+# This returns the global numeric database ID — NOT the per-repo #N issue number.
+# Use this ID (e.g. 1234567890) in the next command, not the human-readable issue number.
 gh api repos/{owner}/{repo}/issues/{A} --jq '.id'
 
-# Wire B as blocked by A:
+# Wire B as blocked by A (replace <blocker_global_id> with the database ID from above):
 gh api repos/{owner}/{repo}/issues/{B}/dependencies/blocked_by \
   --method POST \
-  -F blocked_by_id=<id-of-A>
+  -F issue_id=<blocker_global_id>
+
+# Verify the link was created before proceeding:
+gh api repos/{owner}/{repo}/issues/{B}/dependencies/blocked_by \
+  --jq '.[] | {number, state}'
 ```
 
 **The `-F` vs `-f` gotcha**: Use `-F` (uppercase), not `-f` (lowercase). `-F` sends a typed integer/ID field; `-f` sends a plain string. The GitHub dependencies API rejects string IDs and returns a confusing 422 error.


### PR DESCRIPTION
Closes #802

## Summary

Update the "Filing issue chains with `blocked_by` dependencies" section in `plugin/fabrik/skills/fabrik/SKILL.md` to add: (1) an explicit statement that prose body mentions are invisible to Fabrik and must not be used as dependency signals, (2) clarification that `issue_id` in the API call is the global database ID (not the per-repo issue number), and (3) a verify command the author can run to confirm the link before letting Fabrik proceed. Also verify and correct the API field name if needed.

## Problem

The `fabrik:fabrik` skill's section on `blocked_by` dependencies is missing guidance that has caused silent pipeline failures in practice. When Claude acts as a PM buddy (loaded with the `fabrik:fabrik` skill) and creates chained issues, it writes `**BlockedBy**: #N` as a free-text marker in the issue body and treats this as sufficient to wire the dependency. It isn't — Fabrik's engine queries GitHub's Issue Dependencies API, not the issue body text. Body prose is invisible to `checkDependencies`.

In a real session, three issues with prose-stated dependencies (e.g., #382 blocked-by #372, #390 blocked-by #391) went into Specify with `fabrik:yolo`. All three immediately started advancing — the engine saw no `blocked_by` links, added no `fabrik:blocked` label, and dispatched workers. The user caught it mid-flight.

The skill already has a `blocked_by` section (the safe-sequencing guidance and the API call are present) but it is missing three specific elements that would have prevented this failure.

## Approach

### Approach

This is a narrow, additive edit to a single skill file. The research confirmed all three required changes and resolved the only factual question (field name: `issue_id`, not `blocked_by_id`). The implementation is a targeted augmentation of lines 84–111 in `plugin/fabrik/skills/fabrik/SKILL.md` — no restructuring, no new sections, no other files.

The four concrete edits, in order:
1. Insert a "prose is invisible to Fabrik" callout immediately before the safe sequence (after the opening "Why the order matters" paragraph).
2. Correct the field name in the `gh api` wiring command: `blocked_by_id` → `issue_id`.
3. Annotate the ID-lookup step to label its output as "database ID (not the #N issue number)."
4. Insert a verify command immediately after the wiring command.

### New/Modified Files

| File | Change |
|------|--------|
| `plugin/fabrik/skills/fabrik/SKILL.md` | Augment "Filing issue chains with `blocked_by` dependencies" section (lines ~84–111): add prose-invisible warning, fix field name, label ID type, add verify command |

### Key Decisions

- **Field name `issue_id` (not `blocked_by_id`)**: Research confirmed via GitHub REST API documentation that the correct field is `issue_id`. The current skill text is wrong; correct it.
- **Warning placement before the safe sequence**: Placing it between the "Why the order matters" paragraph and the numbered safe-sequence list gives it the most prominent position — a reader who skims to the sequence still sees it.
- **Verify command position**: Immediately after the wiring command, before the `-F` vs `-f` gotcha paragraph. This mirrors the "do, then confirm" pattern the spec calls for.
- **No ADR warranted**: No design decisions affect engine behavior or constrain future contributors in a non-obvious way. This is a documentation correction.
- **No docs bundle update**: `plugin/fabrik/skills/fabrik/SKILL.md` is not one of the canonical doc pages listed in `CLAUDE.md` (`docs/USER_GUIDE.md`, `docs/state-machine.md`, `docs/stage-lifecycle.md`, `docs/positioning.md`). No `docs/llms-full.txt` regen needed.

### Task Checklist

- [ ] Task 1: Edit `plugin/fabrik/skills/fabrik/SKILL.md` — augment the "Filing issue chains with `blocked_by` dependencies" section with: (a) prose-invisible callout before the safe sequence, (b) field name corrected to `issue_id`, (c) "database ID" label on the lookup step, (d) verify command after the wiring command. Commit as the sole change.

### Risks

- **None material.** Single-file documentation edit with no code or behavior change. The only risk is a typo in the new content — the implementer should re-read the diff before committing.

---
Used 6/50 turns, 3k input / 1k output tokens.

## Verification

Augmented `plugin/fabrik/skills/fabrik/SKILL.md` with all four required fixes to the `blocked_by` wiring section: added a blockquote warning that prose body text is invisible to Fabrik's `checkDependencies`, corrected the API field name from `blocked_by_id` to `issue_id`, annotated the lookup step to clarify it returns the global database ID (not the per-repo #N number), and added a verify command immediately after the wiring step. Single commit `9382f407` pushed to `fabrik/issue-802`.

---

Closes #802