### PR TITLE
Update docs for v0.0.67

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -440,6 +440,13 @@ user: your-github-username
 # go.mod (returns module path, not semver), Cargo.toml, or pyproject.toml.
 # Set explicitly to override auto-inference (e.g., version: "1.2.0").
 # version: ""
+
+# When true, enables the Layer 2 cross-repo ref audit: Fabrik snapshots git refs
+# of all registered bare repos before and after each Claude invocation; if any ref
+# in a repo other than the active issue's own repo changes, the stage is failed and
+# paused for inspection. Off by default; the snapshot filters to refs/heads/* and
+# refs/tags/* only to avoid false positives from routine fetches.
+# worktree_boundary_audit: false
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -904,7 +911,8 @@ After spawning, the parent waits at Implement with `fabrik:blocked` until all ch
 #### What You Observe
 
 - During Plan: no sub-issues exist. Plan can be revised freely.
-- After advancing to Implement: child issues appear on the project board in Research, each labeled `fabrik:sub-issue`.
+- After advancing to Implement: child issues appear on the project board in Specify, each labeled `fabrik:sub-issue`.
+- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages without operator intervention.
 - The parent shows `fabrik:blocked` + `fabrik:children-spawned`; a dependency comment lists all open children.
 - As children complete, the dependency comment updates in-place (no duplicate comments).
 - When all children close: `fabrik:blocked` clears, and the parent's own Implement runs.
@@ -1576,7 +1584,7 @@ Fabrik enforces two independent layers of worktree isolation on every Claude inv
 
 **Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik snapshots the git refs of all registered bare repos. After the loop completes, a second snapshot is taken and compared. If any ref in a repo other than the active issue's own repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
 
-> **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
+> **Note:** The Layer 2 audit is off by default. The snapshot filters to `refs/heads/*` and `refs/tags/*` only, so routine `git fetch` against sibling bare clones does not trigger false-positive violations. To enable it, use one of:
 >
 > ```yaml
 > # .fabrik/config.yaml

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -912,7 +912,7 @@ After spawning, the parent waits at Implement with `fabrik:blocked` until all ch
 
 - During Plan: no sub-issues exist. Plan can be revised freely.
 - After advancing to Implement: child issues appear on the project board in Specify, each labeled `fabrik:sub-issue`.
-- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages without operator intervention.
+- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages, while cruise children stop at Validate for manual merge.
 - The parent shows `fabrik:blocked` + `fabrik:children-spawned`; a dependency comment lists all open children.
 - As children complete, the dependency comment updates in-place (no duplicate comments).
 - When all children close: `fabrik:blocked` clears, and the parent's own Implement runs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,7 +161,7 @@ description: >-
         <span class="feature-icon">🌿</span>
         <div class="feature-title">Isolated Git Worktrees</div>
         <div class="feature-desc">
-          Every issue gets a dedicated branch and worktree with zero cross-contamination. Edit and Write tool calls are path-scoped to the issue's worktree; cross-repo writes are audited and blocked.
+          Every issue gets a dedicated branch and worktree with zero cross-contamination. Edit and Write tool calls are path-scoped to the issue's worktree; cross-repo ref changes are detectable via the opt-in Layer 2 audit (worktree_boundary_audit: true).
         </div>
       </a>
       <a class="feature-card" href="{{ '/state-machine' | relative_url }}#4-comment-processing-lifecycle" aria-label="Comment-Driven Steering — open documentation">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -438,6 +438,13 @@ user: your-github-username
 # go.mod (returns module path, not semver), Cargo.toml, or pyproject.toml.
 # Set explicitly to override auto-inference (e.g., version: "1.2.0").
 # version: ""
+
+# When true, enables the Layer 2 cross-repo ref audit: Fabrik snapshots git refs
+# of all registered bare repos before and after each Claude invocation; if any ref
+# in a repo other than the active issue's own repo changes, the stage is failed and
+# paused for inspection. Off by default; the snapshot filters to refs/heads/* and
+# refs/tags/* only to avoid false positives from routine fetches.
+# worktree_boundary_audit: false
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -902,7 +909,8 @@ After spawning, the parent waits at Implement with `fabrik:blocked` until all ch
 #### What You Observe
 
 - During Plan: no sub-issues exist. Plan can be revised freely.
-- After advancing to Implement: child issues appear on the project board in Research, each labeled `fabrik:sub-issue`.
+- After advancing to Implement: child issues appear on the project board in Specify, each labeled `fabrik:sub-issue`.
+- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages without operator intervention.
 - The parent shows `fabrik:blocked` + `fabrik:children-spawned`; a dependency comment lists all open children.
 - As children complete, the dependency comment updates in-place (no duplicate comments).
 - When all children close: `fabrik:blocked` clears, and the parent's own Implement runs.
@@ -1574,7 +1582,7 @@ Fabrik enforces two independent layers of worktree isolation on every Claude inv
 
 **Layer 2 — Cross-repo ref audit (opt-in, default off)**: Before the extension loop begins, Fabrik snapshots the git refs of all registered bare repos. After the loop completes, a second snapshot is taken and compared. If any ref in a repo other than the active issue's own repo has changed, a boundary violation is raised: `fabrik:paused` and `stage:<name>:failed` are applied, a comment is posted listing the specific refs that were mutated, and no automatic cleanup occurs.
 
-> **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
+> **Note:** The Layer 2 audit is off by default. The snapshot filters to `refs/heads/*` and `refs/tags/*` only, so routine `git fetch` against sibling bare clones does not trigger false-positive violations. To enable it, use one of:
 >
 > ```yaml
 > # .fabrik/config.yaml

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -910,7 +910,7 @@ After spawning, the parent waits at Implement with `fabrik:blocked` until all ch
 
 - During Plan: no sub-issues exist. Plan can be revised freely.
 - After advancing to Implement: child issues appear on the project board in Specify, each labeled `fabrik:sub-issue`.
-- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages without operator intervention.
+- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages, while cruise children stop at Validate for manual merge.
 - The parent shows `fabrik:blocked` + `fabrik:children-spawned`; a dependency comment lists all open children.
 - As children complete, the dependency comment updates in-place (no duplicate comments).
 - When all children close: `fabrik:blocked` clears, and the parent's own Implement runs.


### PR DESCRIPTION
Closes #818

## Summary

Four targeted doc changes across USER_GUIDE.md and docs/index.md to bring documentation in sync with v0.0.67's shipped behavior. README.md requires no changes (its spawn description was already updated in v0.0.66 and remains accurate). After all canonical-doc edits, `docs/llms-full.txt` must be regenerated per CLAUDE.md.

## Problem

v0.0.67 changed two areas of documented user-facing behavior and shipped a permanent architectural decision (opt-in boundary audit) that corrected previously inaccurate docs. Without doc updates, users will encounter:
- Incorrect description of where spawned sub-issues land ("Research" vs. "Specify")
- Missing documentation that sub-issues inherit parent's `yolo`/`cruise` labels (key to cross-repo autonomy)
- Stale "pending fix" note in the boundary audit section (fix shipped in v0.0.67)
- `worktree_boundary_audit` key missing from the `.fabrik/config.yaml` reference block
- Inaccurate marketing copy claiming the cross-repo audit "blocks" writes (it's opt-in/default off)

## Approach

### Approach

All five changes are targeted text edits to documentation files — no code changes, no tests. The work is simple enough to execute in a single commit, which is required by the `docs-drift` CI check (it fails if `docs/llms-full.txt` is committed without matching a fresh regen of USER_GUIDE.md changes). The four doc edits will be made first, then `scripts/generate-llms-full.sh` run, and everything committed together.

### New/Modified Files

| File | Change |
|------|--------|
| `docs/USER_GUIDE.md` | Three edits: (1) "Research"→"Specify" + yolo/cruise bullet in §Sub-issue Decomposition; (2) remove stale pending-fix qualifier, update Layer 2 snapshot description in §Worktree Boundary Enforcement; (3) add `worktree_boundary_audit: false` commented entry in config.yaml reference block |
| `docs/index.md` | Update "Isolated Git Worktrees" feature card copy to reflect opt-in Layer 2 |
| `docs/llms-full.txt` | Regenerated by running `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **Single commit for all changes**: The `docs-drift` CI check requires `docs/llms-full.txt` to be consistent with USER_GUIDE.md in the same commit. Splitting into multiple commits would fail CI mid-way. All five changes land in one commit.
- **Plain prose for docs/index.md**: The `feature-desc` div is inside a Jekyll HTML page with no markdown rendering. Code identifiers like `worktree_boundary_audit: true` will render as literal text, which is acceptable for a feature card. The replacement copy uses plain prose with a code identifier appended.
- **No ADR warranted**: This is a doc-sync task. The architectural decisions (opt-in Layer 2, snapshot filter to `refs/heads/*` and `refs/tags/*`) are already recorded in ADR 049. No new design decision is being made here.

### Task Checklist

- [ ] Task 1: Edit `docs/USER_GUIDE.md` §Sub-issue Decomposition — change "Research" to "Specify" on line ~907, and add a bullet about yolo/cruise label inheritance to the "What You Observe" list
- [ ] Task 2: Edit `docs/USER_GUIDE.md` §Worktree Boundary Enforcement — replace the stale "(pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations)" qualifier on line ~1579 with an accurate description of the shipped fix (snapshot filters to `refs/heads/*` and `refs/tags/*` only)
- [ ] Task 3: Edit `docs/USER_GUIDE.md` config.yaml reference block — add a commented-out `worktree_boundary_audit: false` entry with description immediately before the closing ` ``` ` on line ~443
- [ ] Task 4: Edit `docs/index.md` line ~164 — update "Isolated Git Worktrees" feature card to replace "cross-repo writes are audited and blocked" with copy that reflects Layer 1 always-on path-scoping and the opt-in Layer 2 ref audit via `worktree_boundary_audit: true`
- [ ] Task 5: Run `bash scripts/generate-llms-full.sh` from repo root to regenerate `docs/llms-full.txt`
- [ ] Task 6: Commit all changed files (`docs/USER_GUIDE.md`, `docs/index.md`, `docs/llms-full.txt`) in a single commit

### Exact Edit Details (for Task 1)

**Current text (line 907):**
```
- After advancing to Implement: child issues appear on the project board in Research, each labeled `fabrik:sub-issue`.
```

**Replace with:**
```
- After advancing to Implement: child issues appear on the project board in Specify, each labeled `fabrik:sub-issue`.
- If the parent carries `fabrik:yolo` or `fabrik:cruise`, each child inherits those labels on creation — a yolo'd cross-repo parent spawns children that flow autonomously through all stages without operator intervention.
```

### Exact Edit Details (for Task 2)

**Current text (line 1579):**
```
> **Note:** The Layer 2 audit is off by default (pending root-cause fix in #808 — routine `git fetch origin` in sibling bare clones was triggering false-positive violations). To enable it, use one of:
```

**Replace with:**
```
> **Note:** The Layer 2 audit is off by default. The snapshot filters to `refs/heads/*` and `refs/tags/*` only, so routine `git fetch` against sibling bare clones does not trigger false-positive violations. To enable it, use one of:
```

### Exact Edit Details (for Task 3)

**Current text (lines 437–443 — insert before closing ` ``` `):**
```yaml
# symlink_env: false

# Project version shown in the TUI footer. Auto-inferred from package.json,
# go.mod (returns module path, not semver), Cargo.toml, or pyproject.toml.
# Set explicitly to override auto-inference (e.g., version: "1.2.0").
# version: ""
```

**After `# version: ""` and before the closing ` ``` `, add:**
```yaml

# When true, enables the Layer 2 cross-repo ref audit: Fabrik snapshots git refs
# of all registered bare repos before and after each Claude invocation; if any ref
# in a repo other than the active issue's own repo changes, the stage is failed and
# paused for inspection. Off by default; the snapshot filters to refs/heads/* and
# refs/tags/* only to avoid false positives from routine fetches.
# worktree_boundary_audit: false
```

### Exact Edit Details (for Task 4)

**Current text (line 164):**
```
          Every issue gets a dedicated branch and worktree with zero cross-contamination. Edit and Write tool calls are path-scoped to the issue's worktree; cross-repo writes are audited and blocked.
```

**Replace with:**
```
          Every issue gets a dedicated branch and worktree with zero cross-contamination. Edit and Write tool calls are path-scoped to the issue's worktree; cross-repo ref changes are detectable via the opt-in Layer 2 audit (worktree_boundary_audit: true).
```

### Risks

- **docs-drift CI failure**: Mitigated by committing all files (USER_GUIDE.md, docs/index.md, docs/llms-full.txt) together in a single commit after running the regen script.
- **Line number drift from spec's approximate references**: Research confirmed exact text matches, so the Edit tool's old-string matching approach is robust against drift. No risk.

---
Used 9/50 turns, 4k input / 3k output tokens.

## Verification

Four targeted doc edits to sync USER_GUIDE.md and docs/index.md with v0.0.67 shipped behavior: (1) sub-issue spawn column corrected from "Research" to "Specify" with a new bullet on yolo/cruise label inheritance; (2) stale "#808 pending fix" qualifier replaced with accurate description of the shipped snapshot filter (refs/heads/* and refs/tags/* only); (3) `worktree_boundary_audit: false` commented entry added to the config.yaml reference block; (4) docs/index.md feature card updated to reflect opt-in Layer 2 audit. docs/llms-full.txt regenerated and all changes committed together in a single commit (68fcef46) to satisfy CI's docs-drift check.

---

Closes #818