### PR TITLE
feat: promote spec-kit Specify workflow to Fabrik's embedded default

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ GitHub Project Board (source of truth)
 5. **Complete** — When Claude signals completion, the issue is labeled `stage:<name>:complete`.
 6. **Advance** — In yolo mode, the issue auto-advances to the next stage. Otherwise, a human moves it.
 
+The **Specify** stage uses **Spec Kit format** for specifications. The issue body is rewritten
+with a structured template (`## User Scenarios & Testing`, `## Requirements`,
+`## Success Criteria`) and the finalized spec is committed to `specs/<N>-<slug>/spec.md`
+on the issue branch. Run `fabrik init` to seed the spec template
+(`.specify/templates/spec-template.md`) into your project.
+
 > **Big-board efficiency (v0.0.57):** On large project boards, the per-poll GraphQL cost drops ~5–10× via a lightweight `updatedAt`-only probe that gates the full deep-fetch — only items that changed since the last poll trigger a full query. Terminal items (issues in a cleanup/Done column with `stage:<name>:complete` and no active lifecycle labels) are skipped entirely from both the probe and deep-fetch evaluation.
 >
 > **Cold-start optimization (v0.0.58):** On startup, closed Done items are seeded from probe data as terminal without a deep-fetch, reducing cold-start GraphQL cost by ~80–90%. Combined with probe-driven polling, this makes running two Fabrik instances on a single token budget practical.
@@ -188,7 +194,7 @@ The example stages implement a full SDLC pipeline:
 | Stage | Purpose |
 |-------|---------|
 | **Backlog** | Parking lot (no processing) |
-| **Specify** | Refine rough issues into clear, unambiguous specs (Q&A with user) |
+| **Specify** | Refine rough issues into structured Spec Kit specs (Q&A with user); commits `specs/<N>-<slug>/spec.md` to the branch |
 | **Research** | Explore codebase, identify scope, surface questions |
 | **Plan** | Design approach, break into tasks, document decisions |
 | **Implement** | Write code, tests, commit to issue branch |

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -340,6 +340,11 @@ func runInit(args []string) error {
 		fmt.Printf("  plugin: %d skill files written\n", pluginWrote)
 	}
 
+	// Extract spec-kit template to .specify/templates/spec-template.md
+	if err := writeSpecTemplate(*force); err != nil {
+		return err
+	}
+
 	// Generate .fabrik/config.yaml template
 	if err := writeConfigTemplate(owner, project, ownerType, *userFlag, *force); err != nil {
 		return err
@@ -352,6 +357,33 @@ func runInit(args []string) error {
 
 	fmt.Println("\nFabrik is ready. Stage configs and plugin skills are in .fabrik/")
 	fmt.Println("Edit .fabrik/config.yaml with your project settings, then run fabrik.")
+	return nil
+}
+
+// writeSpecTemplate extracts the embedded Spec Kit spec template to
+// .specify/templates/spec-template.md in the current project directory.
+// Skips the write if the file already exists and force is false.
+func writeSpecTemplate(force bool) error {
+	destPath := filepath.Join(".specify", "templates", "spec-template.md")
+
+	if !force {
+		if _, err := os.Stat(destPath); err == nil {
+			fmt.Printf("  skip   %s (already exists; use --force to overwrite)\n", destPath)
+			return nil
+		}
+	}
+
+	data, err := fabrikplugin.FabrikPlugin.ReadFile("fabrik-workflows/specify-templates/spec-template.md")
+	if err != nil {
+		return fmt.Errorf("reading embedded spec template: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(destPath), err)
+	}
+	if err := os.WriteFile(destPath, data, 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", destPath, err)
+	}
+	fmt.Printf("  spec template: %s\n", destPath)
 	return nil
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -510,3 +510,107 @@ func TestRunInit_IdempotentDestDir(t *testing.T) {
 		t.Fatalf("second runInit: %v", err)
 	}
 }
+
+func TestRunInit_WritesSpecTemplate(t *testing.T) {
+	specTemplatePath := filepath.Join(".specify", "templates", "spec-template.md")
+
+	t.Run("writes template to clean dir", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint
+
+		if err := runInit([]string{}); err != nil {
+			t.Fatalf("runInit: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(dir, specTemplatePath))
+		if err != nil {
+			t.Fatalf("spec-template.md not written: %v", err)
+		}
+		if len(got) == 0 {
+			t.Fatal("spec-template.md is empty")
+		}
+		if !strings.Contains(string(got), "Feature Specification") {
+			t.Error("spec-template.md missing expected content")
+		}
+	})
+
+	t.Run("skips existing file without --force", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint
+
+		// First init — writes the template.
+		if err := runInit([]string{}); err != nil {
+			t.Fatalf("first runInit: %v", err)
+		}
+
+		// Overwrite with sentinel.
+		sentinel := []byte("sentinel content")
+		if err := os.WriteFile(filepath.Join(dir, specTemplatePath), sentinel, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Second init without --force — must skip.
+		if err := runInit([]string{}); err != nil {
+			t.Fatalf("second runInit: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(dir, specTemplatePath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(sentinel) {
+			t.Errorf("existing spec-template.md was overwritten without --force")
+		}
+	})
+
+	t.Run("overwrites existing file with --force", func(t *testing.T) {
+		dir := t.TempDir()
+		orig, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint
+
+		// Write sentinel directly.
+		if err := os.MkdirAll(filepath.Join(dir, ".specify", "templates"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		sentinel := []byte("sentinel content")
+		if err := os.WriteFile(filepath.Join(dir, specTemplatePath), sentinel, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Init with --force — must overwrite.
+		if err := runInit([]string{"--force"}); err != nil {
+			t.Fatalf("force runInit: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(dir, specTemplatePath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) == string(sentinel) {
+			t.Error("--force did not overwrite spec-template.md")
+		}
+		if !strings.Contains(string(got), "Feature Specification") {
+			t.Error("overwritten spec-template.md missing expected content")
+		}
+	})
+}

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -671,11 +671,50 @@ refines it into a clear, unambiguous spec:
 - Surfaces missing requirements, ambiguities, and edge cases as questions
 - Checks consistency with existing project features and documentation
 - Researches prior art and established patterns on the web
-- Rewrites the issue body with a structured spec
+- Rewrites the issue body in **Spec Kit format** — a structured template with
+  mandatory `## User Scenarios & Testing`, `## Requirements`, and
+  `## Success Criteria` sections
+
+When all questions are resolved, Claude commits the finalized spec to
+`specs/<issue_number>-<slug>/spec.md` on the issue branch before completing
+the stage. The slug is a 4-word kebab-case identifier derived from the issue
+title and locked at first commit. The `## Open Questions` section is stripped
+before the file is committed.
+
+The spec template that guides the format lives at
+`.specify/templates/spec-template.md` in your project root. `fabrik init`
+seeds this file automatically. If it is absent, the skill falls back to its
+inline template structure.
 
 The user answers questions via comments. Claude incorporates the answers and updates
 the issue body. Once all questions are resolved, the stage completes and the issue is
 ready for Research.
+
+> **Existing operators upgrading from a version before this feature was
+> introduced**: Your `.fabrik/stages/specify.yaml` may still have
+> `read_only: true` and `allowed_tools` without `Write`, `Bash(git:*)`,
+> `Bash(gh:*)`, or `Bash(find:*)`. The stage drift warning will not fire for
+> these fields because they already exist in your file (just with old values).
+> You must update them manually:
+>
+> ```yaml
+> read_only: false
+> allowed_tools:
+>   - Read
+>   - Write
+>   - Grep
+>   - Glob
+>   - TodoWrite
+>   - WebSearch
+>   - WebFetch
+>   - Bash(git:*)
+>   - Bash(gh:*)
+>   - Bash(find:*)
+> ```
+>
+> Without this change, the new skill will write the spec file but the engine
+> will stash and discard it at stage end — the spec file will silently
+> disappear.
 
 ### Steering with Comments
 
@@ -1274,7 +1313,7 @@ The default skills are:
 
 | Skill | Purpose |
 |-------|---------|
-| `fabrik-specify` | Requirements clarification, consistency checks, prior art research; preserves the Problem section verbatim (never compressed) and places it first in the spec |
+| `fabrik-specify` | Requirements clarification, consistency checks, prior art research; rewrites the issue body in Spec Kit format and commits `specs/<N>-<slug>/spec.md` to the branch before completing |
 | `fabrik-research` | Codebase exploration, technical analysis, constraint discovery; includes a Documentation Impact section for user-facing features |
 | `fabrik-plan` | Implementation design, task checklist, decision documentation; includes explicit doc update tasks in the checklist for user-facing features |
 | `fabrik-implement` | Code writing, testing, committing, pushing; updates `USER_GUIDE.md` and/or `README.md` in the same PR for user-facing features — never defers documentation to a follow-up issue |
@@ -1570,7 +1609,7 @@ Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In th
 | Python | `Bash(python:*)`, `Bash(pip:*)`, `Bash(uv:*)`, `Bash(pytest:*)` |
 | Shell utilities | `Bash(ls:*)`, `Bash(cat:*)`, `Bash(rm:*)`, `Bash(cp:*)`, `Bash(mv:*)`, `Bash(mkdir:*)`, `Bash(find:*)` |
 
-**`allowed_tools` replaces the defaults — it is not additive.** When a stage sets `allowed_tools`, only those tools are permitted; the default list above is not merged in. This is intentional: Research, Plan, and Specify stages set `allowed_tools` to a read-only subset to prevent Claude from writing files during those stages.
+**`allowed_tools` replaces the defaults — it is not additive.** When a stage sets `allowed_tools`, only those tools are permitted; the default list above is not merged in. This is intentional: Research and Plan stages set `allowed_tools` to a read-only subset to prevent Claude from writing files during those stages. The Specify stage is write-enabled so it can commit the spec file to the branch.
 
 **`fabrik:unrestricted` bypasses everything** — passes `--dangerously-skip-permissions` instead, granting Claude full tool access. Use this label only when a stage requires tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -669,11 +669,50 @@ refines it into a clear, unambiguous spec:
 - Surfaces missing requirements, ambiguities, and edge cases as questions
 - Checks consistency with existing project features and documentation
 - Researches prior art and established patterns on the web
-- Rewrites the issue body with a structured spec
+- Rewrites the issue body in **Spec Kit format** — a structured template with
+  mandatory `## User Scenarios & Testing`, `## Requirements`, and
+  `## Success Criteria` sections
+
+When all questions are resolved, Claude commits the finalized spec to
+`specs/<issue_number>-<slug>/spec.md` on the issue branch before completing
+the stage. The slug is a 4-word kebab-case identifier derived from the issue
+title and locked at first commit. The `## Open Questions` section is stripped
+before the file is committed.
+
+The spec template that guides the format lives at
+`.specify/templates/spec-template.md` in your project root. `fabrik init`
+seeds this file automatically. If it is absent, the skill falls back to its
+inline template structure.
 
 The user answers questions via comments. Claude incorporates the answers and updates
 the issue body. Once all questions are resolved, the stage completes and the issue is
 ready for Research.
+
+> **Existing operators upgrading from a version before this feature was
+> introduced**: Your `.fabrik/stages/specify.yaml` may still have
+> `read_only: true` and `allowed_tools` without `Write`, `Bash(git:*)`,
+> `Bash(gh:*)`, or `Bash(find:*)`. The stage drift warning will not fire for
+> these fields because they already exist in your file (just with old values).
+> You must update them manually:
+>
+> ```yaml
+> read_only: false
+> allowed_tools:
+>   - Read
+>   - Write
+>   - Grep
+>   - Glob
+>   - TodoWrite
+>   - WebSearch
+>   - WebFetch
+>   - Bash(git:*)
+>   - Bash(gh:*)
+>   - Bash(find:*)
+> ```
+>
+> Without this change, the new skill will write the spec file but the engine
+> will stash and discard it at stage end — the spec file will silently
+> disappear.
 
 ### Steering with Comments
 
@@ -1272,7 +1311,7 @@ The default skills are:
 
 | Skill | Purpose |
 |-------|---------|
-| `fabrik-specify` | Requirements clarification, consistency checks, prior art research; preserves the Problem section verbatim (never compressed) and places it first in the spec |
+| `fabrik-specify` | Requirements clarification, consistency checks, prior art research; rewrites the issue body in Spec Kit format and commits `specs/<N>-<slug>/spec.md` to the branch before completing |
 | `fabrik-research` | Codebase exploration, technical analysis, constraint discovery; includes a Documentation Impact section for user-facing features |
 | `fabrik-plan` | Implementation design, task checklist, decision documentation; includes explicit doc update tasks in the checklist for user-facing features |
 | `fabrik-implement` | Code writing, testing, committing, pushing; updates `USER_GUIDE.md` and/or `README.md` in the same PR for user-facing features — never defers documentation to a follow-up issue |
@@ -1568,7 +1607,7 @@ Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In th
 | Python | `Bash(python:*)`, `Bash(pip:*)`, `Bash(uv:*)`, `Bash(pytest:*)` |
 | Shell utilities | `Bash(ls:*)`, `Bash(cat:*)`, `Bash(rm:*)`, `Bash(cp:*)`, `Bash(mv:*)`, `Bash(mkdir:*)`, `Bash(find:*)` |
 
-**`allowed_tools` replaces the defaults — it is not additive.** When a stage sets `allowed_tools`, only those tools are permitted; the default list above is not merged in. This is intentional: Research, Plan, and Specify stages set `allowed_tools` to a read-only subset to prevent Claude from writing files during those stages.
+**`allowed_tools` replaces the defaults — it is not additive.** When a stage sets `allowed_tools`, only those tools are permitted; the default list above is not merged in. This is intentional: Research and Plan stages set `allowed_tools` to a read-only subset to prevent Claude from writing files during those stages. The Specify stage is write-enabled so it can commit the spec file to the branch.
 
 **`fabrik:unrestricted` bypasses everything** — passes `--dangerously-skip-permissions` instead, granting Claude full tool access. Use this label only when a stage requires tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains).
 

--- a/plugin/embed.go
+++ b/plugin/embed.go
@@ -15,4 +15,5 @@ import "embed"
 //go:embed fabrik-workflows/.claude-plugin/plugin.json
 //go:embed fabrik-workflows/README.md
 //go:embed fabrik-workflows/skills/*/SKILL.md
+//go:embed fabrik-workflows/specify-templates/spec-template.md
 var FabrikPlugin embed.FS

--- a/plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md
@@ -98,7 +98,7 @@ Why this change is needed. What pain point, gap, or opportunity does it address?
 - [Reference]
 ```
 
-**Important**: The `## Open Questions` section appears in the issue body during clarification rounds and is removed when all questions are resolved. It MUST NOT appear in the committed `specs/<issue_number>-<slug>/spec.md` file — the Specify skill strips it before committing. Your job here is to maintain the issue body only; the spec file is written by the Specify skill at final completion.
+**Important**: The `## Open Questions` section appears in the issue body during clarification rounds and is removed when all questions are resolved. It MUST NOT appear in the committed `specs/<issue_number>-<slug>/spec.md` file — strip it before committing. If your update resolves all questions and you are about to complete the stage, you must also commit the spec file as described in the next section.
 
 ### Update the issue body
 
@@ -117,7 +117,7 @@ Include the ENTIRE body — not just changed sections.
 If all questions are now resolved and you are about to emit `FABRIK_STAGE_COMPLETE`, you MUST first commit the spec file — the same step the main Specify skill runs. This ensures the committed spec is produced regardless of which invocation finalizes the stage:
 
 1. Parse `ISSUE_NUM` from the branch name: `git rev-parse --abbrev-ref HEAD` must match `^fabrik/issue-(\d+)(?:-.*)?$`.
-2. Check for a locked slug: `find specs -maxdepth 1 -name "${ISSUE_NUM}-*" -type d | head -1`. Extract the slug from the basename by stripping the `${ISSUE_NUM}-` prefix. If none found, derive from `gh issue view ${ISSUE_NUM} --json title --jq .title` using the algorithm in the main Specify skill.
+2. Check for a locked slug: `find specs -maxdepth 1 -name "${ISSUE_NUM}-*" -type d | head -1`. Extract the slug from the basename by stripping the `${ISSUE_NUM}-` prefix. If none found, derive from `gh issue view ${ISSUE_NUM} --json title --jq .title` (or fall back to the H1 in `.fabrik-context/issue.md` if `gh` fails). Slug derivation algorithm: strip any conventional-commit prefix (`feat:`, `fix:`, `chore:`, etc. — regex: `^[a-z]+(\([^)]+\))?!?:\s*`), lowercase the remainder, replace every non-alphanumeric character with a hyphen, collapse consecutive hyphens into one, split on hyphens, take the first four words, and rejoin with hyphens. If the result is empty, use `untitled`.
 3. Write the spec to `specs/${ISSUE_NUM}-${SLUG}/spec.md` (Spec Kit format, no `## Open Questions` section).
 4. `git add specs/${ISSUE_NUM}-${SLUG}/spec.md` — then check `git diff --cached --quiet`. If exit 0, skip the commit. If exit non-zero, run `git commit -m "docs(spec): add specification for #${ISSUE_NUM}"`.
 

--- a/plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md
@@ -31,29 +31,74 @@ If an answer raises new ambiguities or reveals additional gaps:
 
 ### Maintain spec structure
 
-The issue body should always follow this structure after your update:
+The issue body must follow **Spec Kit format** after your update. This is the same format the Specify skill writes on its first pass. Use this structure:
 
 ```
-## Summary
-One-paragraph description of what this feature does and why.
+# Feature Specification: [Feature Title]
 
-## Requirements
-Bulleted list of specific, testable requirements.
+**Feature Branch**: `fabrik/issue-<N>`
+**Created**: [YYYY-MM-DD]
+**Status**: Draft
+**Input**: User description: "[original request]"
 
-## Scope
-What's in and what's out.
+## Background
 
-## Open Questions
-- [ ] Question (only if unresolved questions remain)
+Why this change is needed. What pain point, gap, or opportunity does it address?
 
-## Prior Art / Context
-Relevant findings from web research or codebase analysis.
+## User Scenarios & Testing *(mandatory)*
 
-## Risks / Dependencies
-Anything that could complicate or block this work.
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[User journey description]
+
+**Why this priority**: [Rationale]
+
+**Independent Test**: [How to test independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [state], **When** [action], **Then** [outcome]
+
+---
+
+### Edge Cases
+
+- [Edge case]
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: [Specific, testable requirement]
+
+### Key Entities *(if applicable)*
+
+- **[Entity]**: [Description]
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable, technology-agnostic outcome]
+
+## Assumptions
+
+- [Assumption]
+
+## Out of Scope *(optional)*
+
+- [Excluded work]
+
+## Open Questions *(only if unresolved questions remain)*
+
+- [ ] [Question]
+
+## Source References *(optional)*
+
+- [Reference]
 ```
 
-Remove the Open Questions section entirely when all questions are resolved.
+**Important**: The `## Open Questions` section appears in the issue body during clarification rounds and is removed when all questions are resolved. It MUST NOT appear in the committed `specs/<issue_number>-<slug>/spec.md` file — the Specify skill strips it before committing. Your job here is to maintain the issue body only; the spec file is written by the Specify skill at final completion.
 
 ### Update the issue body
 
@@ -67,9 +112,20 @@ FABRIK_ISSUE_UPDATE_END
 
 Include the ENTIRE body — not just changed sections.
 
+## Commit the spec file before completion
+
+If all questions are now resolved and you are about to emit `FABRIK_STAGE_COMPLETE`, you MUST first commit the spec file — the same step the main Specify skill runs. This ensures the committed spec is produced regardless of which invocation finalizes the stage:
+
+1. Parse `ISSUE_NUM` from the branch name: `git rev-parse --abbrev-ref HEAD` must match `^fabrik/issue-(\d+)(?:-.*)?$`.
+2. Check for a locked slug: `find specs -maxdepth 1 -name "${ISSUE_NUM}-*" -type d | head -1`. Extract the slug from the basename by stripping the `${ISSUE_NUM}-` prefix. If none found, derive from `gh issue view ${ISSUE_NUM} --json title --jq .title` using the algorithm in the main Specify skill.
+3. Write the spec to `specs/${ISSUE_NUM}-${SLUG}/spec.md` (Spec Kit format, no `## Open Questions` section).
+4. `git add specs/${ISSUE_NUM}-${SLUG}/spec.md` — then check `git diff --cached --quiet`. If exit 0, skip the commit. If exit non-zero, run `git commit -m "docs(spec): add specification for #${ISSUE_NUM}"`.
+
+If the branch does not match the expected pattern, surface an error and do not emit `FABRIK_STAGE_COMPLETE`.
+
 ## Completion
 
-When all questions are resolved and the spec is clear and complete, signal completion:
+When all questions are resolved, the spec is clear and complete, and the spec file has been committed:
 - Output `FABRIK_STAGE_COMPLETE` on its own line
 - Once you emit this marker, stop immediately. Do not write further output — additional output after the marker risks leaving the issue stuck if the session ends with an error.
 - The user will review and manually advance to Research

--- a/plugin/fabrik-workflows/skills/fabrik-specify/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-specify/SKILL.md
@@ -48,32 +48,76 @@ Explicitly state:
 
 ### Rewrite the issue body
 
-Update the issue body (via FABRIK_ISSUE_UPDATE markers) with a structured spec. **Preserve the user's original motivation and problem statement** — the "why" is as important as the "what." Never reduce a detailed problem description to a terse summary that loses context. Use this structure:
+Update the issue body (via FABRIK_ISSUE_UPDATE markers) with a structured spec in **Spec Kit format**. The authoritative template is `.specify/templates/spec-template.md` in the worktree — read it before writing. If the `specs/` directory already contains prior specs, scan one as an example of the project's house style; otherwise the template alone is sufficient.
+
+**Preserve the user's original motivation and problem statement** — the "why" is as important as the "what." Never reduce a detailed problem description to a terse summary that loses context.
+
+Use this structure:
 
 ```
-## Problem
+# Feature Specification: [Feature Title]
+
+**Feature Branch**: `fabrik/issue-<N>`
+**Created**: [YYYY-MM-DD]
+**Status**: Draft
+**Input**: User description: "[original request]"
+
+## Background
+
 Why this change is needed. What pain point, gap, or opportunity does it address?
 Preserve the original issue's motivation — don't compress it away.
 
-## Summary
-One-paragraph description of what this feature does to solve the problem.
+## User Scenarios & Testing *(mandatory)*
 
-## Requirements
-Bulleted list of specific, testable requirements.
+### User Story 1 - [Brief Title] (Priority: P1)
 
-## Scope
-What's in and what's out.
+[User journey in plain language]
 
-## Open Questions
-- [ ] Question 1
-- [ ] Question 2
+**Why this priority**: [Value and rationale]
 
-## Prior Art / Context
-Relevant findings from web research or codebase analysis.
+**Independent Test**: [How this can be tested independently]
 
-## Risks / Dependencies
-Anything that could complicate or block this work.
+**Acceptance Scenarios**:
+
+1. **Given** [state], **When** [action], **Then** [outcome]
+
+---
+
+### Edge Cases
+
+- [Edge case or boundary condition]
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: [Specific, testable requirement]
+- **FR-002**: [Specific, testable requirement]
+
+### Key Entities *(if the feature involves data)*
+
+- **[Entity]**: [What it represents]
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable, technology-agnostic outcome]
+
+## Assumptions
+
+- [Assumption about scope, environment, or behaviour]
+
+## Out of Scope *(optional)*
+
+- [Explicitly excluded work]
+
+## Source References *(optional)*
+
+- [Relevant file paths or prior issues]
 ```
+
+During iterative clarification rounds, an `## Open Questions` section may appear in the issue body to track unresolved items. This section is for in-progress clarification only — it MUST NOT appear in the committed spec file. Remove all open questions before finalizing the spec and committing.
 
 ## What You Do NOT Do
 
@@ -85,14 +129,81 @@ Anything that could complicate or block this work.
 ## Interaction Pattern
 
 1. Read the issue, project docs, and do web research
-2. Rewrite the issue body with a structured spec and open questions
+2. Rewrite the issue body with a structured spec (Spec Kit format) and any open questions
 3. Wait for the user to answer questions via comments
 4. Incorporate answers, remove resolved questions, surface follow-ups if needed
-5. When all questions are resolved and the spec is clear, signal completion
+5. When all questions are resolved and the spec is clear: emit the `FABRIK_ISSUE_UPDATE_BEGIN/END` block, commit the spec file to `specs/<issue_number>-<slug>/spec.md`, then emit `FABRIK_STAGE_COMPLETE`
+
+## Commit the spec file
+
+When the spec is finalized (all open questions resolved, spec is clear and complete), commit it to the worktree branch **before** emitting `FABRIK_STAGE_COMPLETE`. This step runs after the `FABRIK_ISSUE_UPDATE_BEGIN/END` block has been emitted.
+
+### Step-by-step
+
+**1. Parse the issue number from the branch name:**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch must match `^fabrik/issue-(\d+)(?:-.*)?$`. Extract the number as `ISSUE_NUM`. If the branch does not match this pattern, surface a clear error and do not commit — do not guess.
+
+**2. Check whether a slug is already locked:**
+
+```bash
+find specs -maxdepth 1 -name "${ISSUE_NUM}-*" -type d | head -1
+```
+
+If a directory exists (for example, `specs/42-add-foo-bar`), extract the slug from it: take the directory basename, then strip the leading `${ISSUE_NUM}-` prefix to get `SLUG=add-foo-bar`. Do not re-derive — the slug is locked at first commit.
+
+**3. If no slug is locked, derive one from the GitHub issue title:**
+
+```bash
+gh issue view ${ISSUE_NUM} --json title --jq .title
+```
+
+If `gh` fails (network unavailable, not authenticated), fall back: read the H1 from `.fabrik-context/issue.md`, strip the leading `# Feature Specification: ` prefix, then apply the same algorithm below.
+
+Slug derivation algorithm:
+- Strip conventional-commit prefix: remove leading `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `feat(scope):`, `feat!:`, `feat(scope)!:`, etc. (regex: `^[a-z]+(\([^)]+\))?!?:\s*`)
+- Lowercase the remainder
+- Replace any non-alphanumeric character (spaces, punctuation, dots) with a hyphen
+- Collapse consecutive hyphens into one
+- Split on hyphens, take the first four words, rejoin with hyphens
+- If the result is empty, use the fallback slug `untitled`
+
+Example: `feat(fabrik): Specify stage commits spec.md to worktree branch` → strip prefix → `specify stage commits spec.md to worktree branch` → lowercase + replace non-alphanumeric with hyphens → `specify-stage-commits-spec-md-to-worktree-branch` → first four words → `specify-stage-commits-spec`
+
+**4. Write the spec file:**
+
+Use the `Write` tool to create (or overwrite) `specs/${ISSUE_NUM}-${SLUG}/spec.md` with the finalized spec content in Spec Kit format. The `## Open Questions` section MUST NOT appear in this file — strip it entirely if present.
+
+**5. Commit:**
+
+```bash
+git add specs/${ISSUE_NUM}-${SLUG}/spec.md
+```
+
+Check whether there are staged changes before committing (avoids "nothing to commit" errors on exact re-runs):
+```bash
+git diff --cached --quiet
+```
+If that command exits 0, the spec content is unchanged — skip the commit. If it exits non-zero, staged changes exist — commit:
+```bash
+git commit -m "docs(spec): add specification for #${ISSUE_NUM}"
+```
+
+Use `git commit` (not `--amend`) on re-runs so history is preserved and no force-push is needed.
+
+### Notes
+
+- Two simultaneous Specify runs targeting different issues cannot race on the same path — Fabrik serializes per-issue.
+- If the stage is abandoned mid-Specify before any commit, no spec file exists; branch deletion cleans up.
+- The spec file is for human readers and post-merge tracking. Downstream stages (Research, Plan, Implement, Review, Validate) continue to read `.fabrik-context/issue.md` — do not change that.
 
 ## Engine Context
 
-**Before you run**: The engine has created a worktree and rebased onto main. You're in a read-only stage — the worktree will be stashed/restored around your invocation.
+**Before you run**: The engine has created a worktree and rebased onto main. This is a write-enabled stage — commits made here persist on the branch.
 
 **Completing the stage**: When the spec is clear and all questions are resolved, emit the literal token `FABRIK_STAGE_COMPLETE` as the sole content of its own line — no backticks, no code fence, no markdown formatting, no trailing punctuation. The engine matches `^FABRIK_STAGE_COMPLETE$` exactly; backtick-wrapped or formatted variants are silently rejected and you will be re-invoked in a wasteful loop. Once you emit it, stop immediately. Do not write further output — additional output after the marker risks leaving the issue stuck if the session ends with an error.
 

--- a/plugin/fabrik-workflows/specify-templates/spec-template.md
+++ b/plugin/fabrik-workflows/specify-templates/spec-template.md
@@ -1,0 +1,128 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]

--- a/stages/examples/specify.yaml
+++ b/stages/examples/specify.yaml
@@ -5,13 +5,17 @@ comment_skill: fabrik-specify-comment
 auto_advance: false
 model: sonnet
 max_turns: 50
-read_only: true
+read_only: false
 allowed_tools:
   - Read
+  - Write
   - Grep
   - Glob
   - TodoWrite
   - WebSearch
   - WebFetch
+  - Bash(git:*)
+  - Bash(gh:*)
+  - Bash(find:*)
 completion:
   type: claude

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -3,7 +3,9 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -41,6 +43,93 @@ If you (the Specify agent) are reading this, the simplest spec is: "This is a sm
 	t.Logf("Specify complete on %s#%d — dispatch path verified", env.RepoAlpha, num)
 
 	// Don't wait for full pipeline; the t.Cleanup from FileIssue will close it.
+}
+
+// TestSpecKitSpecWritten verifies that when the Specify stage completes,
+// a spec file exists at specs/<N>-<slug>/spec.md on the issue branch, contains
+// a "# Feature Specification:" H1, and includes all mandatory Spec Kit sections.
+// It also verifies that "## Open Questions" is stripped before the file is committed.
+//
+// Wall-clock: ~5-10 min. Cost: ~$0.15-0.30.
+func TestSpecKitSpecWritten(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	stamp := time.Now().UTC().Format("15:04:05")
+	num := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e spec-kit spec file verify (%s)", stamp),
+		`feat: add a hello world utility function
+
+Write a simple Go helper function that returns "hello world".
+This is a minimal e2e verification issue for the Spec Kit spec-file commit feature.
+
+Scope: Single file change, no cross-repo work needed.`,
+		"fabrik:yolo",
+	)
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d at Status=Specify", env.RepoAlpha, num)
+
+	// Wait up to 10 minutes for Specify to complete.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Specify:complete", 10*time.Minute)
+	t.Logf("Specify complete on %s#%d — verifying spec file on branch", env.RepoAlpha, num)
+
+	branchRef := fmt.Sprintf("fabrik/issue-%d", num)
+
+	// List specs/ directory on the issue branch.
+	specsOut, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/contents/specs", env.RepoAlpha),
+		"-f", fmt.Sprintf("ref=%s", branchRef),
+		"--jq", "[.[] | .name]")
+	if err != nil {
+		t.Fatalf("specs/ directory not found on branch %s: %v\n%s", branchRef, err, specsOut)
+	}
+	var dirs []string
+	if parseErr := json.Unmarshal([]byte(strings.TrimSpace(specsOut)), &dirs); parseErr != nil {
+		t.Fatalf("parse specs dir listing: %v\n%s", parseErr, specsOut)
+	}
+
+	prefix := fmt.Sprintf("%d-", num)
+	var specDir string
+	for _, d := range dirs {
+		if strings.HasPrefix(d, prefix) {
+			specDir = d
+			break
+		}
+	}
+	if specDir == "" {
+		t.Fatalf("no specs/%d-* directory on branch %s (dirs: %v)", num, branchRef, dirs)
+	}
+
+	// Fetch the spec file content, decoding the GitHub base64 encoding.
+	specPath := fmt.Sprintf("specs/%s/spec.md", specDir)
+	specContent, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/contents/%s", env.RepoAlpha, specPath),
+		"-f", fmt.Sprintf("ref=%s", branchRef),
+		"--jq", `.content | gsub("\n"; "") | @base64d`)
+	if err != nil {
+		t.Fatalf("read %s on branch %s: %v\n%s", specPath, branchRef, err, specContent)
+	}
+
+	// Verify mandatory Spec Kit sections are present.
+	for _, section := range []string{
+		"# Feature Specification:",
+		"## User Scenarios & Testing",
+		"## Requirements",
+		"## Success Criteria",
+	} {
+		if !strings.Contains(specContent, section) {
+			t.Errorf("spec file %s missing required section %q", specPath, section)
+		}
+	}
+
+	// Verify Open Questions is not committed to the spec file.
+	if strings.Contains(specContent, "## Open Questions") {
+		t.Errorf("spec file %s must not contain '## Open Questions'", specPath)
+	}
+
+	t.Logf("spec file %s verified on branch %s", specPath, branchRef)
 }
 
 // TestSmokeSingleRepoFullPipeline runs the full single-repo end-to-end flow:


### PR DESCRIPTION
Closes #821

## Summary

# Feature Specification: Promote spec-kit Specify workflow to Fabrik's embedded default

## Problem

# Feature Specification: Promote spec-kit Specify workflow to Fabrik's embedded default

## Approach

### Approach

This is primarily a mechanical replacement + additive change: swap two SKILL.md files, add a new embedded template file, update the embed directive, update the stage YAML permissions, add an init extraction step, and update docs. The nuanced pieces are:

1. **Embed + hash consistency**: `specify-templates/spec-template.md` must be embedded AND deployed to `.fabrik/plugin/specify-templates/` via the existing WalkDir loop (no change to loop required). The `.specify/templates/` write in `runInit()` is an additional step after the WalkDir.
2. **`read_only: false` is the highest-severity change**: If omitted or mistyped, the spec commit silently disappears at stage end with no error.
3. **`allowed_tools` additions**: The spec-kit skill requires `Write`, `Bash(git:*)`, `Bash(gh:*)`, and `Bash(find:*)` in addition to the current set.
4. **No ADR needed**: The "commit spec file to branch" pattern is a behavioral extension that fits the existing worktree and stage lifecycle model. ADR 046 already covers the embedded version fingerprint mechanics. No new architectural decision requires recording.
5. **Test split**: Unit test for `fabrik init` spec-template extraction (FR-005) in `cmd/init_test.go`; e2e test for end-to-end Specify commit (FR-008/SC-005) in `tests/e2e/`.

### New/Modified Files

| File | Change |
|------|--------|
| `plugin/fabrik-workflows/specify-templates/spec-template.md` | **New file** — canonical Spec Kit template (129 lines from `~/dev/fantasy/.specify/templates/spec-template.md`) |
| `plugin/embed.go` | Add `//go:embed fabrik-workflows/specify-templates/spec-template.md` directive |
| `plugin/fabrik-workflows/skills/fabrik-specify/SKILL.md` | Replace 117-line version with 229-line spec-kit version from `~/dev/fabrik-test` |
| `plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md` | Replace 96-line version with 151-line spec-kit version from `~/dev/fabrik-test` |
| `stages/examples/specify.yaml` | Change `read_only: true` → `read_only: false`; add `Write`, `Bash(git:*)`, `Bash(gh:*)`, `Bash(find:*)` to `allowed_tools` |
| `cmd/init.go` | Add `writeSpecTemplate(force bool) error` helper + call it from `runInit()` after the plugin WalkDir |
| `cmd/init_test.go` | Add `TestRunInit_WritesSpecTemplate` covering write/skip/force semantics |
| `docs/USER_GUIDE.md` | Update Specify Stage section (lines 666-678) and skills table `fabrik-specify` entry |
| `README.md` | Add brief Spec Kit format note |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` after USER_GUIDE.md edit |
| `tests/e2e/smoke_test.go` | Add `TestSpecKitSpecWritten` e2e test |

### Key Decisions

- **`specify-templates/spec-template.md` is deployed to `.fabrik/plugin/`**: The existing WalkDir in both `init.go` and `refresh.go` will naturally deploy it to `.fabrik/plugin/specify-templates/spec-template.md`. This keeps `ComputeEmbeddedVersion()` consistent with `ComputeDiskVersion()` on stock installs. The `.specify/templates/` write is an additive step only in `runInit()`.

- **`writeSpecTemplate` as a named helper in `cmd/init.go`**: Following the same pattern as `writeConfigTemplate`, a dedicated `writeSpecTemplate(force bool) error` function keeps the skip/force/mkdir/write logic encapsulated and testable. The embedded content is read via `fabrikplugin.FabrikPlugin.ReadFile("fabrik-workflows/specify-templates/spec-template.md")`.

- **`Bash(find:*)` added to `allowed_tools`**: The slug-locking step uses `find specs -maxdepth 1 -name "${ISSUE_NUM}-*"`. This is not covered by any existing tool in the list. Adding `Bash(find:*)` is required.

- **No `comment_max_turns` change**: The research didn't flag this; leaving at default (`min(max_turns, 15)`).

- **`TestRunInit_WritesPluginFiles` already covers new embedded files**: Since that test walks the embedded FS and checks each file appears in `.fabrik/plugin/`, adding `specify-templates/spec-template.md` to the embed automatically extends coverage with no test modification needed.

### Task Checklist

- [ ] Task 1: Create `plugin/fabrik-workflows/specify-templates/spec-template.md` — copy the 129-line content verbatim from `~/dev/fantasy/.specify/templates/spec-template.md`
- [ ] Task 2: Update `plugin/embed.go` — add `//go:embed fabrik-workflows/specify-templates/spec-template.md` as a third directive line (after the existing two, before `var FabrikPlugin embed.FS`)
- [ ] Task 3: Replace `plugin/fabrik-workflows/skills/fabrik-specify/SKILL.md` — overwrite with the 229-line spec-kit version from `~/dev/fabrik-test/.fabrik/plugin/skills/fabrik-specify/SKILL.md`
- [ ] Task 4: Replace `plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md` — overwrite with the 151-line spec-kit version from `~/dev/fabrik-test/.fabrik/plugin/skills/fabrik-specify-comment/SKILL.md`
- [ ] Task 5: Update `stages/examples/specify.yaml` — change `read_only: true` to `read_only: false`; add `Write`, `Bash(git:*)`, `Bash(gh:*)`, `Bash(find:*)` to the `allowed_tools` list
- [ ] Task 6: Add `writeSpecTemplate(force bool) error` to `cmd/init.go` — reads embedded template via `fabrikplugin.FabrikPlugin.ReadFile("fabrik-workflows/specify-templates/spec-template.md")`, creates `.specify/templates/` directory, writes `.specify/templates/spec-template.md` with skip/force semantics, prints status line; call it from `runInit()` after the plugin WalkDir block
- [ ] Task 7: Add `TestRunInit_WritesSpecTemplate` to `cmd/init_test.go` — three sub-cases: (a) clean dir writes the file, (b) existing file is skipped without `--force`, (c) existing file overwritten with `--force`; use same `t.TempDir()` + `os.Chdir()` pattern
- [ ] Task 8: Run `go build -o /tmp/fabrik-821-build .` and `go test ./...` to verify no compilation errors or test failures; run `go vet ./...` for lint
- [ ] Task 9: Update `docs/USER_GUIDE.md` — (a) replace the Specify Stage section (lines 666-678) with updated text describing spec-kit format, `specs/<N>-<slug>/spec.md` committed to branch, `.specify/templates/spec-template.md` role, and the manual operator migration note for `specify.yaml`; (b) update the `fabrik-specify` skills table entry to mention spec file commit; commit this change
- [ ] Task 10: Update `README.md` — add a brief note about Spec Kit format for specifications in the "How It Works" or equivalent section; commit
- [ ] Task 11: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh` and `git add docs/llms-full.txt`; commit in the same commit as the USER_GUIDE.md change (or as a follow-up commit if separate)
- [ ] Task 12: Add `TestSpecKitSpecWritten` to `tests/e2e/smoke_test.go` — tagged `//go:build e2e`; follows `TestSmokeSingleRepoDispatch` pattern: file issue → add to project → set status to Specify → wait for `stage:Specify:complete` → checkout branch → verify `specs/<N>-*/spec.md` exists and contains `# Feature Specification:` H1 and mandatory sections

### Risks

- **`read_only: false` typo is silent**: A YAML whitespace or key-name error on this field will build and run without error but silently discard the spec commit. The build test in Task 8 catches compile-time issues; verify the actual YAML field name matches what the engine's `stages.go` parses (it's `read_only` per CLAUDE.md). Double-check after editing.
- **`embed.go` directive path mismatch**: The embedded path must exactly match the filesystem path relative to `plugin/`. If the directory name or filename differs from what `fabrikplugin.FabrikPlugin.ReadFile(...)` references in `writeSpecTemplate`, the function will panic at runtime. `go test ./...` in Task 8 will catch this since `TestRunInit_WritesPluginFiles` walks the embed FS.
- **`KnownEmbeddedVersions` not updated**: Replacing two SKILL.md files and adding a new embedded file changes `ComputeEmbeddedVersion()`. The Implement stage must NOT update `plugin/known_embedded_versions.go` — `scripts/cut-release.sh` handles this at release time per ADR 046.
- **Operator `specify.yaml` mismatch post-upgrade**: Documented in USER_GUIDE.md update (Task 9) — existing operators need to manually change `read_only: false` and add the new tools to their `specify.yaml`. This is an upgrade risk the USER_GUIDE must clearly call out.
- **e2e test requires live GitHub**: `TestSpecKitSpecWritten` requires `//go:build e2e` and a running Fabrik + GitHub credentials. This is consistent with existing e2e tests and is not a blocker for the unit tests or build gate.

---
Used 16/50 turns, 8k input / 5k output tokens.

## Verification

All 12 plan tasks complete across 4 commits: (1) replaced both embedded Specify skills with the 229-line and 151-line spec-kit variants that commit `specs/<N>-<slug>/spec.md` before `FABRIK_STAGE_COMPLETE`; (2) added `specify-templates/spec-template.md` to the embedded plugin FS with a new `//go:embed` directive; (3) changed `specify.yaml` to `read_only: false` and added `Write`/`Bash(git:*)`/`Bash(gh:*)`/`Bash(find:*)` to `allowed_tools`; (4) added `writeSpecTemplate()` to `cmd/init.go` with skip/force semantics and unit tests; (5) updated `USER_GUIDE.md`, `README.md`, and regenerated `docs/llms-full.txt`; (6) added `TestSpecKitSpecWritten` e2e test. The only pre-existing failing test (`TestExecute_ConfigYAMLApplied`) is a SIGINT timing flap that fails on `main` without this PR's changes.

---

Closes #821