### PR TITLE
feat: convergence budget + GitHub native auto-merge for yolo issues

### DIFF
--- a/adrs/050-convergence-budget-and-native-automerge.md
+++ b/adrs/050-convergence-budget-and-native-automerge.md
@@ -1,0 +1,83 @@
+# ADR 050: Convergence Budget + GitHub Native Auto-Merge for yolo Issues
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #829 addresses two related production failures observed on high-churn repos:
+
+1. **Post-Validate convergence is not composable.** Three independent retry mechanisms gate the final merge for yolo issues: rebase reinvoke (gated by `MaxRebaseCycles`), CI-fix reinvoke (gated by `MaxCiFixCycles`), and a polling merge attempt (`MergePR` on every catch-up cycle). In production, the CI-fix limit fired in 90 seconds with five spurious cycles while CI was still running cleanly — Fabrik paused with "CI fix cycle limit reached" when the actual problem was convergence latency, not CI failure. The user received a misleading diagnostic and chased the wrong fix.
+
+2. **Fabrik's poll-merge loop has its own race conditions.** `MergePR` samples CI status and mergeable status separately, then attempts a merge — between sample and attempt, state can change. This produced HTTP 405 log spam and stale-state false positives on multi-PR repos where main moves frequently.
+
+GitHub's native `enablePullRequestAutoMerge` GraphQL mutation makes the merge decision atomically server-side: when CI passes AND required reviews exist AND the PR is mergeable per branch protection, GitHub merges in a single transaction. The race window between "check CI" and "attempt merge" is eliminated.
+
+Three architectural questions drove the design:
+
+1. **What replaces the per-gate cycle counts as the backstop for yolo issues?** The per-gate counts are fine for non-yolo (cruise, manual) workflows where the PR may sit indefinitely waiting for human review. For yolo, the intent is "merge as soon as GitHub says OK" — a wall-clock budget more accurately captures the intended contract: the PR should converge in *N* minutes, or something is genuinely wrong that needs human intervention.
+
+2. **Where does the budget start time live?** It must survive engine restarts. Three options: (a) in-memory `itemstate` field — fast but reset on restart; (b) a dedicated GitHub issue label with its own timestamp — clean but adds label proliferation; (c) the creation timestamp of the existing `fabrik:auto-merge-enabled` label via `FetchLabelAppliedAt`. Option (c) was chosen: it reuses the label we already apply for idempotency, mirrors the exact pattern used by the CI wait timeout (`FetchLabelAppliedAt("fabrik:awaiting-ci")`), and adds zero new API surface.
+
+3. **How should `fabrik:cruise > fabrik:yolo` precedence extend to the auto-merge path?** The existing rule — cruise wins when both labels are present — must extend to `enablePullRequestAutoMerge` enablement. Cruise users choose manual merge; we must not override that choice even when `fabrik:yolo` is also applied.
+
+## Decision
+
+### GitHub Native Auto-Merge for yolo Issues
+
+After Validate completes for a yolo (non-cruise) issue, Fabrik calls `enablePullRequestAutoMerge` with the configured strategy (`MERGE`, `SQUASH`, or `REBASE`; default `MERGE`) instead of calling `MergePR` directly. On success, Fabrik applies the `fabrik:auto-merge-enabled` label. GitHub then merges the PR atomically when all branch-protection requirements are satisfied.
+
+The legacy `MergePR` call path is retained for non-yolo issues. No behavior change for cruise or manual-workflow issues.
+
+### Wall-Clock Convergence Budget
+
+The per-gate cycle counts (`MaxRebaseCycles`, `MaxCiFixCycles`) remain as observability counters and as the backstop for non-yolo issues, but are not consulted as gates when `fabrik:auto-merge-enabled` is present. Instead, a single wall-clock budget (`ConvergenceBudget`, default 30 minutes) governs the total convergence time for yolo issues. When the budget exhausts, Fabrik posts a structured `pauseForConvergenceFailed` comment naming the actual current state (commits-behind, CI status, mergeable status, elapsed time, rebase cycle count) and pauses the issue.
+
+`FABRIK_CONVERGENCE_BUDGET=0` disables the bounded budget and falls back to the legacy per-gate cycle limits, preserving backward compatibility.
+
+### `FetchLabelAppliedAt` as Restart-Durable Budget Storage
+
+The budget start time is read from the GitHub issue events API via `FetchLabelAppliedAt("fabrik:auto-merge-enabled")` on every poll for convergence-active items. This is the same mechanism used for the CI wait timeout (`FetchLabelAppliedAt("fabrik:awaiting-ci")`) and survives engine restarts without additional infrastructure. Cost: one paginated REST call per convergence-active item per poll cycle — acceptable for Fabrik's use case (same as the existing CI timeout check).
+
+### `checkAutoMergeConvergence` as a Phase 1 Catch-Up Handler
+
+A new `checkAutoMergeConvergence` function in `engine/merge_gate.go` is inserted at the start of the Phase 1 catch-up loop in `poll.go`. When `fabrik:auto-merge-enabled` is present, this function handles all convergence logic and returns immediately, bypassing `checkMergeabilityGate`, `checkCIGate`, and Phase 2 entirely. This is consistent with how `fabrik:awaiting-ci` gates the CI path.
+
+Decision tree in `checkAutoMergeConvergence`:
+1. PR merged or closed → remove label, advance to Done via existing machinery
+2. GitHub auto-merge disabled by user → remove label, post one-liner, treat as cruise
+3. Budget exhausted → `pauseForConvergenceFailed`
+4. Mergeable = UNKNOWN → wait (GitHub still computing)
+5. Mergeable = CONFLICTING, no worker in-flight → dispatch rebase reinvoke (cycle++ for observability, NOT as a gate)
+6. Otherwise → wait (GitHub is handling it)
+
+### Auto-Merge Re-Enable After Rebase Push
+
+GitHub automatically disables auto-merge when any new commit is pushed to the PR branch. `dispatchRebaseReinvoke` is extended to call `EnablePullRequestAutoMerge` after a successful rebase push when `fabrik:auto-merge-enabled` is present. Failure to re-enable is logged as a warning and does not abort; the next catch-up cycle will detect auto-merge is disabled and re-enter the convergence flow.
+
+### cruise > yolo Precedence
+
+The `attemptMergeOnValidate` function checks `hasCruiseLabel` before calling `enablePullRequestAutoMerge`. If cruise is present (regardless of yolo co-presence), the function returns without enabling auto-merge. This extends the existing precedence rule to the auto-merge path.
+
+## Alternatives Considered
+
+**Continue using `MergePR` with better retry logic**: Adding smarter backoff and state re-sampling to the `MergePR` path would reduce (not eliminate) the race window. It does not address the fundamental problem: the merge decision is made client-side by sampling two independently-changing states. Rejected: the race is structural, not fixable by retry tuning.
+
+**Replace cycle counts with per-gate timeouts**: Instead of a single convergence budget, replace `MaxRebaseCycles` with a rebase timeout and `MaxCiFixCycles` with a CI-fix timeout. This keeps the two gates independent but adds two new timeout configurations and still doesn't address the root cause (multiple gates composing non-deterministically). Rejected: complexity without correctness gain.
+
+**Store budget start time in itemstate**: `LinkedPRState` already has `CIMergePendingSince time.Time` as a precedent. Adding `ConvergenceBudgetStart time.Time` would be fast (no API call) and clean. Rejected: in-memory state resets on restart; the guarantee "budget starts when label is applied" is only enforceable if the timestamp survives restarts.
+
+**Dedicated `fabrik:convergence-started` label for the timestamp**: Using a separate label solely for its creation timestamp would cleanly separate concerns from `fabrik:auto-merge-enabled`. Rejected: adding a second label adds label proliferation and confusion; the creation timestamp of `fabrik:auto-merge-enabled` already captures "when did convergence start" semantically.
+
+**Pause clock during UNKNOWN mergeability window**: After a rebase push, GitHub transiently returns `UNKNOWN` mergeability. Pausing the budget clock during UNKNOWN would give the PR more effective convergence time. Rejected: the UNKNOWN window is typically <60s; the 30-minute budget makes this negligible; adding clock-pause logic adds complexity for minimal gain.
+
+## Consequences
+
+- One additional REST call per convergence-active yolo item per poll cycle (`FetchLabelAppliedAt` for budget start). Identical cost to the existing CI wait timeout.
+- GitHub auto-merge must be enabled at the repository level (Settings → Allow auto-merge). If not, `enablePullRequestAutoMerge` returns an error; Fabrik logs guidance and retries on the next poll.
+- Per-gate cycle counts (`MaxRebaseCycles`, `MaxCiFixCycles`) remain in the codebase as observability counters and as the backstop for non-yolo issues. They are not removed.
+- `FABRIK_CONVERGENCE_BUDGET=0` is the backward-compatibility escape hatch for operators who prefer the legacy cycle-limit behavior.
+- The `GitHubClient` interface gains `EnablePullRequestAutoMerge` and `FetchCommitsBehind` — all implementations (real client, mock, test stubs) must implement both.
+- `fabrik:auto-merge-enabled` must be added to `staticLabelDefs` for auto-creation at startup.
+- The convergence-failed pause comment names the actual blocking state, replacing the previously misleading per-gate messages.

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -147,6 +147,12 @@ func (m *testGitHubUpgradeClient) ProbeProjectBoard(owner, repo string, projectN
 	return nil, "", nil
 }
 func (m *testGitHubUpgradeClient) DeleteForwardingHooks(owner, repo string) error { return nil }
+func (m *testGitHubUpgradeClient) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
+	return nil
+}
+func (m *testGitHubUpgradeClient) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
+	return 0, nil
+}
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -731,6 +731,10 @@ func convergenceBudget(s string) time.Duration {
 		fmt.Fprintf(os.Stderr, "[warn] FABRIK_CONVERGENCE_BUDGET=%q is invalid (Go duration syntax required, e.g. 30m, 1h); using default 30m\n", s)
 		return 30 * time.Minute
 	}
+	if d < 0 {
+		fmt.Fprintf(os.Stderr, "[warn] FABRIK_CONVERGENCE_BUDGET=%q is negative; using default 30m\n", s)
+		return 30 * time.Minute
+	}
 	return d
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,8 +42,10 @@ type Config struct {
 	MaxReviewCycles   int // 0 means use default (5)
 	CIWaitTimeout     int // minutes; 0 means use default (30)
 	MaxCiFixCycles    int // 0 means use default (5)
-	MaxRebaseCycles   int // 0 means use default (3)
-	ClaudeWaitDelay   int // seconds; 0 means use default (30)
+	MaxRebaseCycles      int    // 0 means use default (3)
+	ConvergenceBudget    string // Go duration string; "" means use default (30m); "0" means disabled
+	AutoMergeStrategy    string // MERGE, SQUASH, or REBASE; "" means use default (MERGE)
+	ClaudeWaitDelay      int    // seconds; 0 means use default (30)
 	DebugOutput              bool
 	SymlinkEnv               bool
 	WorktreeBoundaryAudit    bool
@@ -127,6 +129,8 @@ func Execute() error {
 	flag.IntVar(&cfg.CIWaitTimeout, "ci-wait-timeout", 0, "Maximum time in minutes to wait for CI in the merge guard before pausing (0 = use default of 30; also FABRIK_CI_WAIT_TIMEOUT)")
 	flag.IntVar(&cfg.MaxCiFixCycles, "max-ci-fix-cycles", 0, "Maximum number of CI-fix cycles per issue before pausing (0 = use default of 5; also FABRIK_MAX_CI_FIX_CYCLES)")
 	flag.IntVar(&cfg.MaxRebaseCycles, "max-rebase-cycles", 0, "Maximum number of rebase-reinvoke cycles per issue before pausing (0 = use default of 3; also FABRIK_MAX_REBASE_CYCLES)")
+	flag.StringVar(&cfg.ConvergenceBudget, "convergence-budget", "", "Wall-clock budget for post-Validate yolo convergence (Go duration: 30m, 1h; \"0\" disables; also FABRIK_CONVERGENCE_BUDGET)")
+	flag.StringVar(&cfg.AutoMergeStrategy, "auto-merge-strategy", "", "Merge method for GitHub auto-merge: MERGE, SQUASH, or REBASE (also FABRIK_AUTO_MERGE_STRATEGY; default MERGE)")
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
 	flag.BoolVar(&cfg.SymlinkEnv, "symlink-env", false, "Symlink the fabrik-dir .env file into each issue worktree at creation time (also FABRIK_SYMLINK_ENV)")
@@ -325,6 +329,16 @@ func Execute() error {
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_REBASE_CYCLES=%q is invalid (must be a positive integer); using default 3\n", v)
 			}
+		}
+	}
+	if !explicitFlags["convergence-budget"] {
+		if v := os.Getenv("FABRIK_CONVERGENCE_BUDGET"); v != "" {
+			cfg.ConvergenceBudget = v // validated in convergenceBudget() helper
+		}
+	}
+	if !explicitFlags["auto-merge-strategy"] {
+		if v := os.Getenv("FABRIK_AUTO_MERGE_STRATEGY"); v != "" {
+			cfg.AutoMergeStrategy = v // validated in autoMergeStrategy() helper
 		}
 	}
 	if !explicitFlags["claude-wait-delay"] {
@@ -571,6 +585,8 @@ func Execute() error {
 		CIWaitTimeout:            ciWaitTimeout(cfg.CIWaitTimeout),
 		MaxCiFixCycles:           maxCiFixCycles(cfg.MaxCiFixCycles),
 		MaxRebaseCycles:          maxRebaseCycles(cfg.MaxRebaseCycles),
+		ConvergenceBudget:        convergenceBudget(cfg.ConvergenceBudget),
+		AutoMergeStrategy:        autoMergeStrategy(cfg.AutoMergeStrategy),
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		DebugOutput:              cfg.DebugOutput,
 		SymlinkEnv:               cfg.SymlinkEnv,
@@ -700,6 +716,40 @@ func reconcileIntervalDuration(seconds int) time.Duration {
 		return 0
 	}
 	return time.Duration(seconds) * time.Second
+}
+
+// convergenceBudget parses a convergence budget string (Go duration syntax) into
+// a time.Duration. An empty string returns the default of 30 minutes. "0" or "0s"
+// disables the bounded budget (returns 0). Invalid values log a warning and return
+// the default.
+func convergenceBudget(s string) time.Duration {
+	if s == "" {
+		return 30 * time.Minute
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[warn] FABRIK_CONVERGENCE_BUDGET=%q is invalid (Go duration syntax required, e.g. 30m, 1h); using default 30m\n", s)
+		return 30 * time.Minute
+	}
+	return d
+}
+
+// autoMergeStrategy validates and returns the merge strategy string for
+// enablePullRequestAutoMerge. Accepts "MERGE", "SQUASH", or "REBASE" (case
+// insensitive). Returns "MERGE" for empty input or unrecognised values (with a
+// warning).
+func autoMergeStrategy(s string) string {
+	if s == "" {
+		return "MERGE"
+	}
+	upper := strings.ToUpper(s)
+	switch upper {
+	case "MERGE", "SQUASH", "REBASE":
+		return upper
+	default:
+		fmt.Fprintf(os.Stderr, "[warn] FABRIK_AUTO_MERGE_STRATEGY=%q is invalid (must be MERGE, SQUASH, or REBASE); using default MERGE\n", s)
+		return "MERGE"
+	}
 }
 
 // buildProjectInfo assembles the TUI footer metadata from the active config.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -493,6 +493,8 @@ FABRIK_USER=my-personal-username
 | `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
 | `--max-ci-fix-cycles` | Maximum number of CI-fix re-invocation cycles per issue (0 = use default of 5; also `FABRIK_MAX_CI_FIX_CYCLES`) | `0` (5 cycles) |
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
+| `--convergence-budget` | Wall-clock budget for post-Validate yolo PR convergence (Go duration: `30m`, `1h`; `0` disables the budget entirely; also `FABRIK_CONVERGENCE_BUDGET`) | `30m` |
+| `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
 | `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree; also excluded from git stash via the worktree's git exclude file. Also `FABRIK_SYMLINK_ENV` | `false` |
@@ -522,6 +524,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |
 | `FABRIK_MAX_CI_FIX_CYCLES` | *(no config.yaml key)* | Maximum number of CI-fix re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 | `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
+| `FABRIK_CONVERGENCE_BUDGET` | *(no config.yaml key)* | Wall-clock budget for post-Validate yolo PR convergence (Go duration syntax: `30m`, `1h`, `2h30m`; `0` disables; invalid values default to 30 min). When the budget expires and the PR has not merged, Fabrik pauses the issue with `fabrik:awaiting-input`. | `30m` |
+| `FABRIK_AUTO_MERGE_STRATEGY` | *(no config.yaml key)* | Merge method used when calling GitHub's `enablePullRequestAutoMerge` for yolo PRs. Accepted values: `MERGE`, `SQUASH`, `REBASE`. Invalid or unset values default to `MERGE`. | `MERGE` |
 | `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
@@ -721,9 +725,11 @@ You do not need to babysit the pipeline. The intended human role is:
 
 ### Yolo Mode and Auto-Merge
 
-Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and auto-merges the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
+Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and enables GitHub's native auto-merge on the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
 
-For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you.
+When Validate completes on a yolo issue, Fabrik calls GitHub's `enablePullRequestAutoMerge` API (the same merge-when-ready mechanism available in the GitHub UI) rather than attempting to merge immediately. GitHub holds the merge until all branch-protection requirements are satisfied — required CI checks, required reviews, up-to-date branch — then merges atomically. Fabrik monitors convergence in the background and pauses the issue if the PR does not reach a terminal state within the convergence budget (default 30 min; see `FABRIK_CONVERGENCE_BUDGET`). See [Post-Validate Convergence Monitor (yolo)](#post-validate-convergence-monitor-yolo) for full details.
+
+For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, yolo takes precedence.
 
 See [Stage YAML Reference](#stage-yaml-reference) for the `auto_advance` field, which controls auto-advance behavior per stage independent of the global `--yolo` flag.
 
@@ -1174,6 +1180,75 @@ the canonical CI-gate path (see the section above).
 If your repo has a `.github/workflows/fabrik-advance.yml` installed by an earlier
 `fabrik init`, delete it and ensure `wait_for_ci: true` is set in your Validate
 stage YAML. The Validate stage ships with `wait_for_ci: true` by default.
+
+### Post-Validate Convergence Monitor (yolo)
+
+When Validate completes on a yolo issue, Fabrik enables GitHub's native auto-merge on the linked PR and applies the `fabrik:auto-merge-enabled` label. GitHub then handles the merge atomically once all branch-protection requirements are met. Fabrik monitors the PR's convergence in the background until it reaches a terminal state (merged or closed).
+
+**Yolo vs. cruise in high-contention repos**
+
+- `fabrik:yolo` — full automation, including auto-merge. Best for low-contention repos or issues where merge timing doesn't matter. GitHub's native auto-merge queues the PR and merges it as soon as branch-protection requirements are met.
+- `fabrik:cruise` — automation through all stages, human merge decision. Use in repos with strict merge policies, main-branch freezes, or where you want to review the final diff before merge regardless of CI status.
+
+If both labels are present, yolo takes precedence.
+
+**Convergence budget**
+
+Fabrik gives the PR a wall-clock window (default: 30 minutes) to reach a terminal state after auto-merge is enabled. The budget starts when the `fabrik:auto-merge-enabled` label is applied and is durable across engine restarts (the label's creation timestamp is fetched from the GitHub events API).
+
+```bash
+FABRIK_CONVERGENCE_BUDGET=1h    # Wait up to 1 hour (default: 30m)
+FABRIK_CONVERGENCE_BUDGET=0     # Disable the budget — wait indefinitely
+```
+
+**During the convergence window, Fabrik:**
+
+| PR state | Action |
+|----------|--------|
+| Merged or closed | Removes `fabrik:auto-merge-enabled`; advances to Done |
+| Auto-merge was user-disabled | Posts comment; removes `fabrik:auto-merge-enabled`; pauses for input |
+| Mergeability unknown (GitHub computing) | Waits (no action) |
+| Merge conflict detected | Dispatches rebase re-invocation; re-enables auto-merge after successful push |
+| Budget expired | Calls `pauseForConvergenceFailed` (see below) |
+
+**When the budget expires**
+
+Fabrik posts a structured comment with the current PR state, then pauses the issue:
+
+```
+🏭 Fabrik — convergence budget exhausted
+
+The linked PR did not merge within the convergence budget.
+
+| Field | Value |
+|-------|-------|
+| PR | #123 |
+| mergeable_state | blocked |
+| commits behind base | 2 |
+| elapsed | 32m14s / 30m budget |
+| CI | ✅ Build passed · ❌ Tests failed |
+
+To resume, resolve the blocking condition, then remove fabrik:paused and
+fabrik:awaiting-input. Fabrik will re-enable auto-merge and start a new
+convergence window.
+```
+
+**What to do when the issue is paused:**
+
+1. **CI failure**: Fix the failing check. Push to the PR branch. Remove `fabrik:paused` and `fabrik:awaiting-input`. Fabrik re-enables auto-merge on the next poll and starts a fresh 30-minute window.
+2. **Merge conflict**: Resolve the conflict, force-push the branch (Fabrik will have attempted an automated rebase; check if it already succeeded). Remove the pause labels.
+3. **Review required**: Request and obtain reviewer approval. Remove the pause labels once approved.
+
+**Merge strategy**
+
+By default, Fabrik uses a merge commit (`MERGE`). To use squash or rebase instead:
+
+```bash
+FABRIK_AUTO_MERGE_STRATEGY=SQUASH  # Squash commits into one
+FABRIK_AUTO_MERGE_STRATEGY=REBASE  # Rebase commits onto base branch
+```
+
+Accepted values: `MERGE`, `SQUASH`, `REBASE`. The repository must have the corresponding merge method enabled in its settings.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -729,7 +729,7 @@ Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every s
 
 When Validate completes on a yolo issue, Fabrik calls GitHub's `enablePullRequestAutoMerge` API (the same merge-when-ready mechanism available in the GitHub UI) rather than attempting to merge immediately. GitHub holds the merge until all branch-protection requirements are satisfied — required CI checks, required reviews, up-to-date branch — then merges atomically. Fabrik monitors convergence in the background and pauses the issue if the PR does not reach a terminal state within the convergence budget (default 30 min; see `FABRIK_CONVERGENCE_BUDGET`). See [Post-Validate Convergence Monitor (yolo)](#post-validate-convergence-monitor-yolo) for full details.
 
-For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, yolo takes precedence.
+For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence for the merge decision — the PR is not auto-merged — but the issue still advances to Done.
 
 See [Stage YAML Reference](#stage-yaml-reference) for the `auto_advance` field, which controls auto-advance behavior per stage independent of the global `--yolo` flag.
 
@@ -1190,7 +1190,7 @@ When Validate completes on a yolo issue, Fabrik enables GitHub's native auto-mer
 - `fabrik:yolo` — full automation, including auto-merge. Best for low-contention repos or issues where merge timing doesn't matter. GitHub's native auto-merge queues the PR and merges it as soon as branch-protection requirements are met.
 - `fabrik:cruise` — automation through all stages, human merge decision. Use in repos with strict merge policies, main-branch freezes, or where you want to review the final diff before merge regardless of CI status.
 
-If both labels are present, yolo takes precedence.
+If both labels are present, cruise takes precedence for the merge decision — the PR is not auto-merged — but the issue still advances to Done (as yolo would).
 
 **Convergence budget**
 
@@ -1603,7 +1603,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `effort:max` | Override thinking effort to max for this issue |
 | `fabrik:paused` | Manually pause processing (add to pause, remove to resume) |
 | `fabrik:yolo` | Force auto-advance for this issue even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes. If the linked PR was already manually merged when auto-merge runs, Fabrik treats it as a success and advances the issue to Done normally. |
-| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
+| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence for the merge decision (PR is not auto-merged), but the issue still advances to Done. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` for this issue; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set or when the default posture prevents required work. **Caution:** removes all tool restrictions. |
 | `fabrik:extend-turns` | Pre-grant 2× `max_turns` for every stage invocation while the label is present. Auto-extends to 3× when actual progress is detected during an invocation (Implement: new git commit (HEAD SHA changed) OR (baseline was clean AND working tree is now dirty — uncommitted file edits by Claude); Review: new git commit or resolved reviewer thread count; Validate: new comment; other stages: no progress signal). The label **persists across all stages** — apply it once and every stage from the current one through Done will benefit. It is removed automatically when the Done stage cleanup runs. No-op when `max_turns` is 0 (unlimited). The displayed turn counter denominator always reflects the effective budget. |
 | `base:<branch>` | Override the base branch for this issue (e.g. `base:develop`). Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default. Apply before Research; adding mid-pipeline is unsupported and may produce unexpected results. Branch names containing `/` are supported (e.g. `base:release/1.x`). If the named branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment on the issue. |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -727,7 +727,7 @@ Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every s
 
 When Validate completes on a yolo issue, Fabrik calls GitHub's `enablePullRequestAutoMerge` API (the same merge-when-ready mechanism available in the GitHub UI) rather than attempting to merge immediately. GitHub holds the merge until all branch-protection requirements are satisfied — required CI checks, required reviews, up-to-date branch — then merges atomically. Fabrik monitors convergence in the background and pauses the issue if the PR does not reach a terminal state within the convergence budget (default 30 min; see `FABRIK_CONVERGENCE_BUDGET`). See [Post-Validate Convergence Monitor (yolo)](#post-validate-convergence-monitor-yolo) for full details.
 
-For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, yolo takes precedence.
+For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence for the merge decision — the PR is not auto-merged — but the issue still advances to Done.
 
 See [Stage YAML Reference](#stage-yaml-reference) for the `auto_advance` field, which controls auto-advance behavior per stage independent of the global `--yolo` flag.
 
@@ -1188,7 +1188,7 @@ When Validate completes on a yolo issue, Fabrik enables GitHub's native auto-mer
 - `fabrik:yolo` — full automation, including auto-merge. Best for low-contention repos or issues where merge timing doesn't matter. GitHub's native auto-merge queues the PR and merges it as soon as branch-protection requirements are met.
 - `fabrik:cruise` — automation through all stages, human merge decision. Use in repos with strict merge policies, main-branch freezes, or where you want to review the final diff before merge regardless of CI status.
 
-If both labels are present, yolo takes precedence.
+If both labels are present, cruise takes precedence for the merge decision — the PR is not auto-merged — but the issue still advances to Done (as yolo would).
 
 **Convergence budget**
 
@@ -1601,7 +1601,7 @@ For developing the plugin itself, use `--plugin-dir` to point at your working co
 | `effort:max` | Override thinking effort to max for this issue |
 | `fabrik:paused` | Manually pause processing (add to pause, remove to resume) |
 | `fabrik:yolo` | Force auto-advance for this issue even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes. If the linked PR was already manually merged when auto-merge runs, Fabrik treats it as a success and advances the issue to Done normally. |
-| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
+| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence for the merge decision (PR is not auto-merged), but the issue still advances to Done. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` for this issue; bypasses the default tool allowlist entirely. Use only when a stage needs tools outside the default set or when the default posture prevents required work. **Caution:** removes all tool restrictions. |
 | `fabrik:extend-turns` | Pre-grant 2× `max_turns` for every stage invocation while the label is present. Auto-extends to 3× when actual progress is detected during an invocation (Implement: new git commit (HEAD SHA changed) OR (baseline was clean AND working tree is now dirty — uncommitted file edits by Claude); Review: new git commit or resolved reviewer thread count; Validate: new comment; other stages: no progress signal). The label **persists across all stages** — apply it once and every stage from the current one through Done will benefit. It is removed automatically when the Done stage cleanup runs. No-op when `max_turns` is 0 (unlimited). The displayed turn counter denominator always reflects the effective budget. |
 | `base:<branch>` | Override the base branch for this issue (e.g. `base:develop`). Fabrik will fork from, rebase onto, and target PRs at `<branch>` instead of the repository default. Apply before Research; adding mid-pipeline is unsupported and may produce unexpected results. Branch names containing `/` are supported (e.g. `base:release/1.x`). If the named branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment on the issue. |
@@ -2427,7 +2427,7 @@ These labels do not define distinct states but influence transition behavior:
 | Label | Effect |
 |-------|--------|
 | `fabrik:yolo` | Forces auto-advance; triggers GitHub native auto-merge at Validate; overrides `auto_advance: false` |
-| `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
+| `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; cruise wins over yolo for auto-merge (PR is not auto-merged even when yolo is also present), but the stop-at-Validate behaviour is overridden by yolo (issue advances to Done) |
 | `fabrik:auto-merge-enabled` | Engine-internal; marks that GitHub's native auto-merge has been enabled on the linked PR; anchors the convergence budget start time; bypasses legacy merge/CI gates |
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
 | `fabrik:extend-turns` | Pre-grants a 2× turn budget for every stage invocation and comment processing invocation while present; persists across stages; removed only at the Done cleanup stage or manually; no-op when `max_turns == 0` (stage) or always applies for comments since `commentMaxTurns` is never 0 |
@@ -2489,7 +2489,7 @@ Each active stage column has the same set of reachable sub-states:
 | `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleNoWorkNeeded` (emitting stage + all skipped stages), cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_NO_WORK_NEEDED (emitting stage + all subsequent non-cleanup stages) or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
 | `stage:<X>:failed` | `escalateFailedStage` | After MaxRetries exhausted | `clearFailedStage` | When user removes `fabrik:paused` (manual unpause) | Indicates permanent failure; paired with `fabrik:paused` |
 | `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
-| `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
+| `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; cruise wins over yolo for auto-merge (auto-merge suppressed even when yolo present); stop-at-Validate is overridden when yolo is also present (issue advances to Done, but PR is not auto-merged) |
 | `fabrik:unrestricted` | User (manual) | Any time | User (manual) | Any time | Passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` |
 | `fabrik:extend-turns` | User (manual) | Any time | `processItem` cleanup branch or User (manual) | At Done cleanup stage completion; or manual removal | Pre-grants 2× `stage.MaxTurns` budget for every stage invocation while present; no-op for stage path when `max_turns == 0` (unlimited); also pre-grants 2× `commentMaxTurns(stage)` budget for every comment processing invocation (comment budget is never 0); subsequent extensions beyond 2× require progress detection for both paths; persists across all intermediate stages |
 | `model:<name>` | User (manual) | Any time | User (manual) | Any time | Selects Claude model; first label wins if multiple present |
@@ -3085,7 +3085,7 @@ After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iterat
 **Convergence budget:**
 
 - The budget starts when `fabrik:auto-merge-enabled` is applied. The start timestamp is stored durably in GitHub's issue event log (`FetchLabelAppliedAt("fabrik:auto-merge-enabled")`), so it survives engine restarts.
-- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget (falls back to `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates — legacy behavior).
+- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget — Fabrik waits indefinitely for auto-merge to complete (or for the user to disable auto-merge in the GitHub UI). `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates are NOT consulted while `fabrik:auto-merge-enabled` is present.
 - On each Phase 1 iteration: `elapsed = time.Since(budgetStart)`. If `elapsed > budget`, `pauseForConvergenceFailed()` fires.
 
 **`checkAutoMergeConvergence()` decision tree:**
@@ -3093,7 +3093,7 @@ After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iterat
 | Observed state | Action |
 |---|---|
 | PR merged or closed | Remove `fabrik:auto-merge-enabled` + `fabrik:rebase-needed` (if present); existing machinery advances to Done |
-| `AutoMergeEnabled == false` (user disabled) | Remove `fabrik:auto-merge-enabled`; post one-liner comment; treat as cruise from this point |
+| `AutoMergeEnabled == false` (user disabled) | Apply `fabrik:paused` + `fabrik:awaiting-input`; remove `fabrik:auto-merge-enabled`; post comment with resume options (prevents Phase 2 from re-enabling auto-merge on the next poll) |
 | Budget exhausted | Call `pauseForConvergenceFailed()` (see below) |
 | `mergeable_state == "unknown"` | Wait — GitHub still computing after a push; re-evaluate next poll |
 | `mergeable_state == "dirty"` (conflict) | Dispatch rebase reinvoke (one per conflict transition); increment `RebaseCycles` for observability only (not a gate); skip if worker in-flight |
@@ -3113,7 +3113,7 @@ Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`
 
 Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-merge-enabled`. Does NOT add `fabrik:awaiting-ci` (CI may be healthy; the convergence failure is about the merge window, not CI).
 
-**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, yolo issues fall back to using `MaxRebaseCycles` and `MaxCiFixCycles` as gates — legacy behavior.
+**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, the budget check is skipped entirely — Fabrik waits indefinitely for the PR to be merged or closed.
 
 **State transitions for yolo Validate convergence:**
 
@@ -3124,7 +3124,7 @@ Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-me
 | Validate, Convergence | `mergeable_state=dirty` (conflict) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
 | Validate, Convergence + Rebase in-flight | Rebase push succeeds | Validate, Convergence | | |
 | Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
-| Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Complete (cruise behavior) | | `fabrik:auto-merge-enabled` |
+| Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -491,6 +491,8 @@ FABRIK_USER=my-personal-username
 | `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
 | `--max-ci-fix-cycles` | Maximum number of CI-fix re-invocation cycles per issue (0 = use default of 5; also `FABRIK_MAX_CI_FIX_CYCLES`) | `0` (5 cycles) |
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
+| `--convergence-budget` | Wall-clock budget for post-Validate yolo PR convergence (Go duration: `30m`, `1h`; `0` disables the budget entirely; also `FABRIK_CONVERGENCE_BUDGET`) | `30m` |
+| `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |
 | `--symlink-env` | Create a relative symlink at `<worktree>/.env` pointing to the fabrikDir `.env` file at worktree setup time. Enables stage code to read credentials (e.g. `ANTHROPIC_API_KEY`) from `.env` without copying secrets. No-op when source `.env` is absent; never overwrites an existing `.env` in the worktree; also excluded from git stash via the worktree's git exclude file. Also `FABRIK_SYMLINK_ENV` | `false` |
@@ -520,6 +522,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_CI_WAIT_TIMEOUT` | *(no config.yaml key)* | Minutes to wait for CI checks to pass before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 30) | `30` |
 | `FABRIK_MAX_CI_FIX_CYCLES` | *(no config.yaml key)* | Maximum number of CI-fix re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5) | `5` |
 | `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
+| `FABRIK_CONVERGENCE_BUDGET` | *(no config.yaml key)* | Wall-clock budget for post-Validate yolo PR convergence (Go duration syntax: `30m`, `1h`, `2h30m`; `0` disables; invalid values default to 30 min). When the budget expires and the PR has not merged, Fabrik pauses the issue with `fabrik:awaiting-input`. | `30m` |
+| `FABRIK_AUTO_MERGE_STRATEGY` | *(no config.yaml key)* | Merge method used when calling GitHub's `enablePullRequestAutoMerge` for yolo PRs. Accepted values: `MERGE`, `SQUASH`, `REBASE`. Invalid or unset values default to `MERGE`. | `MERGE` |
 | `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
 
 Token precedence: `--token` flag > `FABRIK_TOKEN` > `GITHUB_TOKEN`
@@ -719,9 +723,11 @@ You do not need to babysit the pipeline. The intended human role is:
 
 ### Yolo Mode and Auto-Merge
 
-Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and auto-merges the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
+Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and enables GitHub's native auto-merge on the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
 
-For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you.
+When Validate completes on a yolo issue, Fabrik calls GitHub's `enablePullRequestAutoMerge` API (the same merge-when-ready mechanism available in the GitHub UI) rather than attempting to merge immediately. GitHub holds the merge until all branch-protection requirements are satisfied — required CI checks, required reviews, up-to-date branch — then merges atomically. Fabrik monitors convergence in the background and pauses the issue if the PR does not reach a terminal state within the convergence budget (default 30 min; see `FABRIK_CONVERGENCE_BUDGET`). See [Post-Validate Convergence Monitor (yolo)](#post-validate-convergence-monitor-yolo) for full details.
+
+For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, yolo takes precedence.
 
 See [Stage YAML Reference](#stage-yaml-reference) for the `auto_advance` field, which controls auto-advance behavior per stage independent of the global `--yolo` flag.
 
@@ -1172,6 +1178,75 @@ the canonical CI-gate path (see the section above).
 If your repo has a `.github/workflows/fabrik-advance.yml` installed by an earlier
 `fabrik init`, delete it and ensure `wait_for_ci: true` is set in your Validate
 stage YAML. The Validate stage ships with `wait_for_ci: true` by default.
+
+### Post-Validate Convergence Monitor (yolo)
+
+When Validate completes on a yolo issue, Fabrik enables GitHub's native auto-merge on the linked PR and applies the `fabrik:auto-merge-enabled` label. GitHub then handles the merge atomically once all branch-protection requirements are met. Fabrik monitors the PR's convergence in the background until it reaches a terminal state (merged or closed).
+
+**Yolo vs. cruise in high-contention repos**
+
+- `fabrik:yolo` — full automation, including auto-merge. Best for low-contention repos or issues where merge timing doesn't matter. GitHub's native auto-merge queues the PR and merges it as soon as branch-protection requirements are met.
+- `fabrik:cruise` — automation through all stages, human merge decision. Use in repos with strict merge policies, main-branch freezes, or where you want to review the final diff before merge regardless of CI status.
+
+If both labels are present, yolo takes precedence.
+
+**Convergence budget**
+
+Fabrik gives the PR a wall-clock window (default: 30 minutes) to reach a terminal state after auto-merge is enabled. The budget starts when the `fabrik:auto-merge-enabled` label is applied and is durable across engine restarts (the label's creation timestamp is fetched from the GitHub events API).
+
+```bash
+FABRIK_CONVERGENCE_BUDGET=1h    # Wait up to 1 hour (default: 30m)
+FABRIK_CONVERGENCE_BUDGET=0     # Disable the budget — wait indefinitely
+```
+
+**During the convergence window, Fabrik:**
+
+| PR state | Action |
+|----------|--------|
+| Merged or closed | Removes `fabrik:auto-merge-enabled`; advances to Done |
+| Auto-merge was user-disabled | Posts comment; removes `fabrik:auto-merge-enabled`; pauses for input |
+| Mergeability unknown (GitHub computing) | Waits (no action) |
+| Merge conflict detected | Dispatches rebase re-invocation; re-enables auto-merge after successful push |
+| Budget expired | Calls `pauseForConvergenceFailed` (see below) |
+
+**When the budget expires**
+
+Fabrik posts a structured comment with the current PR state, then pauses the issue:
+
+```
+🏭 Fabrik — convergence budget exhausted
+
+The linked PR did not merge within the convergence budget.
+
+| Field | Value |
+|-------|-------|
+| PR | #123 |
+| mergeable_state | blocked |
+| commits behind base | 2 |
+| elapsed | 32m14s / 30m budget |
+| CI | ✅ Build passed · ❌ Tests failed |
+
+To resume, resolve the blocking condition, then remove fabrik:paused and
+fabrik:awaiting-input. Fabrik will re-enable auto-merge and start a new
+convergence window.
+```
+
+**What to do when the issue is paused:**
+
+1. **CI failure**: Fix the failing check. Push to the PR branch. Remove `fabrik:paused` and `fabrik:awaiting-input`. Fabrik re-enables auto-merge on the next poll and starts a fresh 30-minute window.
+2. **Merge conflict**: Resolve the conflict, force-push the branch (Fabrik will have attempted an automated rebase; check if it already succeeded). Remove the pause labels.
+3. **Review required**: Request and obtain reviewer approval. Remove the pause labels once approved.
+
+**Merge strategy**
+
+By default, Fabrik uses a merge commit (`MERGE`). To use squash or rebase instead:
+
+```bash
+FABRIK_AUTO_MERGE_STRATEGY=SQUASH  # Squash commits into one
+FABRIK_AUTO_MERGE_STRATEGY=REBASE  # Rebase commits onto base branch
+```
+
+Accepted values: `MERGE`, `SQUASH`, `REBASE`. The repository must have the corresponding merge method enabled in its settings.
 
 ---
 
@@ -2351,8 +2426,9 @@ These labels do not define distinct states but influence transition behavior:
 
 | Label | Effect |
 |-------|--------|
-| `fabrik:yolo` | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` |
+| `fabrik:yolo` | Forces auto-advance; triggers GitHub native auto-merge at Validate; overrides `auto_advance: false` |
 | `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
+| `fabrik:auto-merge-enabled` | Engine-internal; marks that GitHub's native auto-merge has been enabled on the linked PR; anchors the convergence budget start time; bypasses legacy merge/CI gates |
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
 | `fabrik:extend-turns` | Pre-grants a 2× turn budget for every stage invocation and comment processing invocation while present; persists across stages; removed only at the Done cleanup stage or manually; no-op when `max_turns == 0` (stage) or always applies for comments since `commentMaxTurns` is never 0 |
 | `model:<name>` | Selects a specific model for this issue (e.g., `model:opus`) |
@@ -2406,7 +2482,8 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:awaiting-input` | `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `pauseForCITimeout`, `pauseForCIFixCycleLimit` | After FABRIK_BLOCKED_ON_INPUT or review/CI timeout/cycle limit | `unblockAwaitingInput`; `handleStageComplete` (on FABRIK_STAGE_COMPLETE, to clear any orphaned label); `handleNoWorkNeeded` (on FABRIK_NO_WORK_NEEDED); `cleanupClosedIssueTransientLabels` (defensive sweep) | When user comment arrives; when a stage completes (removes any orphaned label that survived a manual `fabrik:paused` removal); or when issue is closed (defensive sweep — label has no meaning on a closed issue) | Combined with `fabrik:paused`, identifies the "awaiting user input" pause variant |
 | `fabrik:awaiting-review` | `handleStageComplete` (Path 1 — only when `wait_for_ci: false`), `checkReviewGate` (Path 2) | Path 1: optimistically after stage completion when `wait_for_reviews: true` **and `wait_for_ci: false`** (does not check reviewer state — data is stale; omitted for `wait_for_ci: true` stages because Path 2 handles the gate after CI clears). Path 2: when `LinkedPRReviewRequests` is non-empty OR when `len(outstanding)==0 && !hasReviews` (the bot self-submission case — covers Copilot/Gemini-style reviewers that don't appear in the formal requested-reviewer list but still need to submit a review) | `checkReviewGate` (both natural clear and timeout paths); `cleanupClosedIssueTransientLabels` (defensive sweep) | When all reviewers submit, or when timeout elapses (removed by `checkReviewGate` before `pauseForReviewTimeout` is called); or when issue is closed (defensive sweep) | Phase 1 / Phase 2 reprompt timers in `checkReviewGate` fire on label-applied-at age (not on `updatedAt` movement). A non-responsive bot reviewer produces no comment / no review / no PR activity, so `updatedAt` never moves — without periodic re-evaluation the timers would never get a chance to fire. The catch-up loop's blocked-path records `CooldownAt("review-blocked")` (via `CooldownRecorded{Reason: "review-blocked"}` mutation) so `itemMayNeedWork`'s cooldown retry path re-admits the item every 10 × `PollSeconds` (same pattern as `fabrik:blocked`); a per-poll cache bypass is intentionally avoided because long-lived review-waiting items would otherwise become a permanent GraphQL hot path. Blocks auto-advance until review gate clears |
 | `fabrik:awaiting-ci` | `handleStageComplete` (on FABRIK_STAGE_COMPLETE for `wait_for_ci: true` stages; idempotent); `checkCIGate` (on confirmed CI failure; idempotent) | `handleStageComplete`: immediately on FABRIK_STAGE_COMPLETE — replaces premature `stage:X:complete` and keeps the item in the CI-await window (ADR 032). `checkCIGate`: when CI check runs for the PR head SHA have `conclusion: failure/timed_out/action_required`. | `checkCIGate` (when `mergeable_state ∈ {clean, unstable}`, when CI check classification reports all-green, or when gate times out); `attemptMergeOnValidate` (when `mergeable_state ∈ {clean, unstable}` shortcut fires); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub's `mergeable_state` indicates the PR is mergeable (v0.0.52 shortcut — the `MergeableStateAccepted` allowlist); when all CI checks pass (green) under the per-check classification fallback; when timeout elapses (removed before `pauseForCITimeout` is called); or when issue is closed (defensive sweep) | Signals CI gate is active (pending or failed); triggers `itemMayNeedWork` updatedAt cache bypass; suppresses dispatcher re-invocation (`itemNeedsWork` returns false); blocks auto-advance until CI gate clears. **`stage:X:complete` is absent while this label is present — it is added by `checkCIGate` when CI clears (R5) or when `mergeable_state` shortcut clears the gate (v0.0.52).** |
-| `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `attemptMergeOnValidate` (legacy auto-merge path, yolo+Validate without `wait_for_ci`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `attemptMergeOnValidate` (on successful merge, via `removeRebaseNeededLabel` — no-op when absent); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when `MergePR` succeeds; or when issue is closed (defensive sweep) | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
+| `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `checkAutoMergeConvergence` (convergence flow, yolo+Validate with `fabrik:auto-merge-enabled`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `checkAutoMergeConvergence` (when PR merges or closes); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when PR merges/closes; or when issue is closed (defensive sweep) | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
+| `fabrik:auto-merge-enabled` | `attemptMergeOnValidate` (yolo, non-cruise, Validate completion) | After successful `enablePullRequestAutoMerge` GraphQL call — signals GitHub is handling the merge atomically. Also serves as the idempotency guard (prevents re-calling the mutation) and the budget-start anchor (timestamp read by `FetchLabelAppliedAt` to compute convergence budget elapsed time). | `checkAutoMergeConvergence` (when PR merges, PR closes, user disables auto-merge, or budget exhausts); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub merges the PR; when PR is closed without merging; when user disables auto-merge in GitHub UI; or when convergence budget exhausts (→ `pauseForConvergenceFailed`); or when issue is closed (defensive sweep) | Engine-internal label. Bypasses legacy merge/CI gate dispatch — `checkAutoMergeConvergence` is the sole Phase 1 handler while present. Triggers `itemMayNeedWork` updatedAt cache bypass (convergence state changes independently of issue `updatedAt`). `stage:Validate:complete` remains in place while this label is present; `checkAutoMergeConvergence` removes it when the PR merges and the item advances to Done. NOT applied when `fabrik:cruise` is also present (cruise wins). |
 | `fabrik:blocked` | `checkDependencies` | When open blocking issues exist (first transition only — idempotent) | `PushUnblockObserver` (primary — fires immediately on blocker close, any column); `checkDependencies` (defense-in-depth — fires via `dep-blocked` cooldown-retry for items in stage columns) | When all blocking issues close | Pre-dispatch gate in `itemNeedsWork` prevents re-dispatch after the label is set (parallel to `fabrik:editing` post-#550 and `fabrik:locked:<other>` always); **exception**: when the `dep-blocked` cooldown has expired (or no store entry exists), `itemNeedsWork` admits the item for one dependency re-check per `10 × PollSeconds` — `checkDependencies` either re-stamps the cooldown (still blocked) or removes the label (resolved). Initial detection (first dispatch, label not yet set) still reaches `checkDependencies` normally. Blocks stage start. Push path removes the label even for items in non-stage columns (Backlog, Done, custom columns) that would otherwise never be re-evaluated by `processItem`. |
 | `stage:<X>:in_progress` | `processItem` | After lock acquired and verified | `releaseLock` | Same as `fabrik:locked:<user>` | Informational — shows which stage is active on GitHub |
 | `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleNoWorkNeeded` (emitting stage + all skipped stages), cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_NO_WORK_NEEDED (emitting stage + all subsequent non-cleanup stages) or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
@@ -2981,30 +3058,73 @@ FABRIK_STAGE_COMPLETE received
 
 Fabrik discovers PR comments through the `closedByPullRequestsReferences` GraphQL field, which traverses issue → linked PRs → PR comments. The `Closes #N` keyword in the PR body creates this linkage.
 
-### 5.4 Auto-Merge on Validate
+### 5.4 Auto-Merge on Validate (yolo issues)
 
-**When:** Validate stage completes and yolo is active (either `cfg.Yolo` or `fabrik:yolo` label).
+**When:** Validate stage completes and the issue has `fabrik:yolo` (or global `cfg.Yolo`) and does NOT have `fabrik:cruise`.
 
-**Code path:** `handleStageComplete()` → `attemptMergeOnValidate()` (Path 1); or catch-up loop → `attemptMergeOnValidate()` (Path 2)
+**Code path:** `handleStageComplete()` → `attemptMergeOnValidate()` (Path 1); or catch-up loop Phase 2 → `attemptMergeOnValidate()` (Path 2 — when `fabrik:auto-merge-enabled` is absent)
 
 **Flow:**
-1. Find linked PR via `FindPRForIssue()` / `FetchLinkedPR()` (the latter also returns the head SHA needed for the per-check classification fallback).
-2. Query `FetchPRMergeableState()` (REST single-PR endpoint). If the result is `clean` or `unstable` (per `github.MergeableStateAccepted`), **skip the raw check_runs gate**: clear any stale `fabrik:awaiting-ci` label, clear the `LinkedPRState.CIMergePendingSince` entry in the store, and proceed directly to step 4. Other states fall through to the per-check classification in step 3.
-3. **Per-check classification (fallback)**: fetch check runs via `FetchCheckRuns()`. Apply R1–R6 rules (no checks → R5 clears; failed → R3 applies `fabrik:awaiting-ci` and returns error; pending → R2 returns error and tracks `LinkedPRState.CIMergePendingSince` for the timeout; all green → R4 clears).
-4. Attempt merge via `MergePR()`. `MergePR` first checks the PR's `merged` field — if the PR was already merged (e.g., by a human), it returns nil immediately (no-op success). Otherwise it checks `mergeable` and attempts the merge.
-5. On `ErrNotMergeable`: apply `fabrik:rebase-needed` idempotently. Then:
-   - **Worker guard (`snap.Worker() != nil`):** if a rebase goroutine is already running for this item, return a plain error (skip — prevents cycle-counter drift).
-   - **Cycle limit check:** compare `snap.RebaseCycles(stage.Name)` against `MaxRebaseCycles` (default 3):
-     - If at or above the limit: call `pauseForRebaseCycleLimit()` (`fabrik:paused` + `fabrik:awaiting-input` + explanatory comment); return a plain error.
-     - If below the limit: apply `RebaseCycleIncremented`, call `dispatchRebaseReinvoke()`, return the `errRebaseDispatched` sentinel.
-6. On other API errors: return error (same retry behavior)
-7. On success (including already-merged): call `removeRebaseNeededLabel()` (no-op when absent), log and return nil — advancement proceeds
+1. If `fabrik:auto-merge-enabled` is already present on the issue: return nil (idempotent — auto-merge was already enabled in a previous invocation).
+2. Fetch linked PR via `FetchLinkedPR()`.
+3. Call `EnablePullRequestAutoMerge(owner, repo, pr.Number, AutoMergeStrategy)`. The strategy defaults to `MERGE` and is configurable via `FABRIK_AUTO_MERGE_STRATEGY`. On failure: log a guidance message and return a retriable error (next poll retries).
+4. On success: apply `fabrik:auto-merge-enabled` label. GitHub now owns the merge decision atomically — no Fabrik-side `MergePR` call. Done advancement is deferred to `checkAutoMergeConvergence` in Phase 1 of the catch-up loop.
 
-**Why the `mergeable_state` shortcut (v0.0.52):** the per-check classification at step 3 was over-aggressive — any check_run with `conclusion ∈ {failure, timed_out, action_required}` blocked the merge, including non-required workflow jobs (e.g. `Cleanup artifacts`) that GitHub itself does not treat as merge blockers per branch protection. When `mergeable_state` says the PR is mergeable, Fabrik now trusts that and bypasses the per-check gate. The shortcut sits *after* `stage:Validate:complete` is already on the issue (the catch-up loop's entry condition), so it cannot cause Validate-Claude work to be skipped — it only changes the behavior of the post-completion CI wait.
+**`cruise > yolo` precedence:** If `fabrik:cruise` is present on the issue, `attemptMergeOnValidate` returns immediately without calling `EnablePullRequestAutoMerge`. Cruise items keep the current `stage:Validate:complete` behavior: the branch is maintained (rebase reinvoke, CI-fix reinvoke) but merging is left to the user.
 
-**Unified rebase-reinvoke recovery (Path 1 and Path 2):** Both code paths now use the same `snap.RebaseCycles(stage.Name)` + `RebaseCycleIncremented` mutation, `dispatchRebaseReinvoke()`, and `pauseForRebaseCycleLimit()`. The `MaxRebaseCycles` and `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` controls apply to both paths. Previously, Path 1 immediately paused on `ErrNotMergeable`; it now dispatches the rebase reinvoke autopilot instead, falling back to the pause only when the cycle limit is reached.
+See **section 5.5** for how Fabrik monitors the convergence flow after auto-merge is enabled.
 
-**Important — Path 1 vs Path 2 distinction:** In Path 1 (`handleStageComplete`), the merge runs BEFORE adding `stage:Validate:complete`. On a plain merge failure (non-`ErrNotMergeable`), no completion label is added, so `itemNeedsWork` can retry the full Validate invocation after cooldown. On `ErrNotMergeable`, `handleStageComplete` detects the `errRebaseDispatched` sentinel and **adds `stage:Validate:complete` before returning** — ensuring the catch-up loop's Phase 2 drives the merge retry rather than `itemNeedsWork` triggering a new full Validate invocation. In Path 2 (catch-up loop), `stage:Validate:complete` already exists when `attemptMergeOnValidate()` runs; on `ErrNotMergeable` the rebase is dispatched and the catch-up loop retries on the next poll.
+**Non-yolo issues:** Items without `fabrik:yolo` and without `fabrik:cruise` follow the same behavior as cruise for purposes of merge tracking — `checkMergeabilityGate` and `checkCIGate` continue to operate using `MaxRebaseCycles` / `MaxCiFixCycles` per-gate cycle limits. `EnablePullRequestAutoMerge` is never called for these issues. This is unchanged from pre-5.4 behavior.
+
+---
+
+### 5.5 Post-Validate Convergence Monitor (yolo issues)
+
+After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iteration of the catch-up loop calls `checkAutoMergeConvergence()` instead of the legacy `checkMergeabilityGate` / `checkCIGate` path. All merge decisions for the issue are delegated to GitHub's server-side auto-merge logic.
+
+**Convergence budget:**
+
+- The budget starts when `fabrik:auto-merge-enabled` is applied. The start timestamp is stored durably in GitHub's issue event log (`FetchLabelAppliedAt("fabrik:auto-merge-enabled")`), so it survives engine restarts.
+- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget (falls back to `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates — legacy behavior).
+- On each Phase 1 iteration: `elapsed = time.Since(budgetStart)`. If `elapsed > budget`, `pauseForConvergenceFailed()` fires.
+
+**`checkAutoMergeConvergence()` decision tree:**
+
+| Observed state | Action |
+|---|---|
+| PR merged or closed | Remove `fabrik:auto-merge-enabled` + `fabrik:rebase-needed` (if present); existing machinery advances to Done |
+| `AutoMergeEnabled == false` (user disabled) | Remove `fabrik:auto-merge-enabled`; post one-liner comment; treat as cruise from this point |
+| Budget exhausted | Call `pauseForConvergenceFailed()` (see below) |
+| `mergeable_state == "unknown"` | Wait — GitHub still computing after a push; re-evaluate next poll |
+| `mergeable_state == "dirty"` (conflict) | Dispatch rebase reinvoke (one per conflict transition); increment `RebaseCycles` for observability only (not a gate); skip if worker in-flight |
+| Any other state (`clean`, `blocked`, `behind`, `unstable`, `has_hooks`) | Wait — GitHub is handling it |
+
+**Rebase reinvoke + auto-merge re-enable:**
+GitHub disables auto-merge on every push. After `dispatchRebaseReinvoke()` completes successfully (Claude resolved conflicts, pushed), `EnablePullRequestAutoMerge` is called again to re-arm auto-merge. This is the only scenario where auto-merge is re-enabled without going through `attemptMergeOnValidate`.
+
+**`pauseForConvergenceFailed()` — convergence budget exhausted:**
+Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`, and current rebase cycle count. Posts a structured pause comment containing:
+- Total wall-clock elapsed time and configured budget
+- Number of rebase reinvokes dispatched
+- Commits-behind-base count
+- Current `mergeable_state`
+- Latest CI check run summary (passed / failed / pending)
+- Three named user options: (1) manual rebase + re-yolo, (2) switch to cruise, (3) leave as-is
+
+Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-merge-enabled`. Does NOT add `fabrik:awaiting-ci` (CI may be healthy; the convergence failure is about the merge window, not CI).
+
+**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, yolo issues fall back to using `MaxRebaseCycles` and `MaxCiFixCycles` as gates — legacy behavior.
+
+**State transitions for yolo Validate convergence:**
+
+| State | Trigger | New state | Labels added | Labels removed |
+|---|---|---|---|---|
+| Validate, Complete | Poll tick (Phase 2) | Validate, Convergence | `fabrik:auto-merge-enabled` | |
+| Validate, Convergence | PR merged (GitHub) | Done, Pending Cleanup | | `fabrik:auto-merge-enabled`, `fabrik:rebase-needed` |
+| Validate, Convergence | `mergeable_state=dirty` (conflict) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
+| Validate, Convergence + Rebase in-flight | Rebase push succeeds | Validate, Convergence | | |
+| Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
+| Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Complete (cruise behavior) | | `fabrik:auto-merge-enabled` |
 
 ---
 
@@ -4722,6 +4842,8 @@ When `FABRIK_STAGE_COMPLETE` is detected (regardless of Claude's exit code — a
 4. PR marked ready (if `mark_pr_ready_on_complete: true`)
 5. `stage:<name>:complete` label added
 6. Auto-advance to next stage (if `auto_advance: true` or global `yolo`)
+
+**Validate + yolo**: At Validate completion, if the issue carries `fabrik:yolo` (and not `fabrik:cruise`), Fabrik calls `enablePullRequestAutoMerge` on the linked PR and applies `fabrik:auto-merge-enabled` rather than calling `MergePR` directly. GitHub then merges the PR atomically once branch-protection requirements are satisfied. The post-Validate convergence monitor (`checkAutoMergeConvergence`) tracks the PR in subsequent poll cycles until it reaches a terminal state or the convergence budget expires. See `docs/state-machine.md` §5.4–5.5 for full details.
 
 Note: `fabrik:extend-turns` is **not** removed here. It persists across all intermediate stages and is removed only during the Done stage's cleanup path (see Cleanup Stage below).
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -372,6 +372,8 @@ When `FABRIK_STAGE_COMPLETE` is detected (regardless of Claude's exit code — a
 5. `stage:<name>:complete` label added
 6. Auto-advance to next stage (if `auto_advance: true` or global `yolo`)
 
+**Validate + yolo**: At Validate completion, if the issue carries `fabrik:yolo` (and not `fabrik:cruise`), Fabrik calls `enablePullRequestAutoMerge` on the linked PR and applies `fabrik:auto-merge-enabled` rather than calling `MergePR` directly. GitHub then merges the PR atomically once branch-protection requirements are satisfied. The post-Validate convergence monitor (`checkAutoMergeConvergence`) tracks the PR in subsequent poll cycles until it reaches a terminal state or the convergence budget expires. See `docs/state-machine.md` §5.4–5.5 for full details.
+
 Note: `fabrik:extend-turns` is **not** removed here. It persists across all intermediate stages and is removed only during the Done stage's cleanup path (see Cleanup Stage below).
 
 ### Blocked-on-Input Path

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -78,8 +78,9 @@ These labels do not define distinct states but influence transition behavior:
 
 | Label | Effect |
 |-------|--------|
-| `fabrik:yolo` | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` |
+| `fabrik:yolo` | Forces auto-advance; triggers GitHub native auto-merge at Validate; overrides `auto_advance: false` |
 | `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
+| `fabrik:auto-merge-enabled` | Engine-internal; marks that GitHub's native auto-merge has been enabled on the linked PR; anchors the convergence budget start time; bypasses legacy merge/CI gates |
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
 | `fabrik:extend-turns` | Pre-grants a 2× turn budget for every stage invocation and comment processing invocation while present; persists across stages; removed only at the Done cleanup stage or manually; no-op when `max_turns == 0` (stage) or always applies for comments since `commentMaxTurns` is never 0 |
 | `model:<name>` | Selects a specific model for this issue (e.g., `model:opus`) |
@@ -133,7 +134,8 @@ Each active stage column has the same set of reachable sub-states:
 | `fabrik:awaiting-input` | `blockOnInput`, `pauseForReviewTimeout`, `pauseForReviewCycleLimit`, `pauseForCITimeout`, `pauseForCIFixCycleLimit` | After FABRIK_BLOCKED_ON_INPUT or review/CI timeout/cycle limit | `unblockAwaitingInput`; `handleStageComplete` (on FABRIK_STAGE_COMPLETE, to clear any orphaned label); `handleNoWorkNeeded` (on FABRIK_NO_WORK_NEEDED); `cleanupClosedIssueTransientLabels` (defensive sweep) | When user comment arrives; when a stage completes (removes any orphaned label that survived a manual `fabrik:paused` removal); or when issue is closed (defensive sweep — label has no meaning on a closed issue) | Combined with `fabrik:paused`, identifies the "awaiting user input" pause variant |
 | `fabrik:awaiting-review` | `handleStageComplete` (Path 1 — only when `wait_for_ci: false`), `checkReviewGate` (Path 2) | Path 1: optimistically after stage completion when `wait_for_reviews: true` **and `wait_for_ci: false`** (does not check reviewer state — data is stale; omitted for `wait_for_ci: true` stages because Path 2 handles the gate after CI clears). Path 2: when `LinkedPRReviewRequests` is non-empty OR when `len(outstanding)==0 && !hasReviews` (the bot self-submission case — covers Copilot/Gemini-style reviewers that don't appear in the formal requested-reviewer list but still need to submit a review) | `checkReviewGate` (both natural clear and timeout paths); `cleanupClosedIssueTransientLabels` (defensive sweep) | When all reviewers submit, or when timeout elapses (removed by `checkReviewGate` before `pauseForReviewTimeout` is called); or when issue is closed (defensive sweep) | Phase 1 / Phase 2 reprompt timers in `checkReviewGate` fire on label-applied-at age (not on `updatedAt` movement). A non-responsive bot reviewer produces no comment / no review / no PR activity, so `updatedAt` never moves — without periodic re-evaluation the timers would never get a chance to fire. The catch-up loop's blocked-path records `CooldownAt("review-blocked")` (via `CooldownRecorded{Reason: "review-blocked"}` mutation) so `itemMayNeedWork`'s cooldown retry path re-admits the item every 10 × `PollSeconds` (same pattern as `fabrik:blocked`); a per-poll cache bypass is intentionally avoided because long-lived review-waiting items would otherwise become a permanent GraphQL hot path. Blocks auto-advance until review gate clears |
 | `fabrik:awaiting-ci` | `handleStageComplete` (on FABRIK_STAGE_COMPLETE for `wait_for_ci: true` stages; idempotent); `checkCIGate` (on confirmed CI failure; idempotent) | `handleStageComplete`: immediately on FABRIK_STAGE_COMPLETE — replaces premature `stage:X:complete` and keeps the item in the CI-await window (ADR 032). `checkCIGate`: when CI check runs for the PR head SHA have `conclusion: failure/timed_out/action_required`. | `checkCIGate` (when `mergeable_state ∈ {clean, unstable}`, when CI check classification reports all-green, or when gate times out); `attemptMergeOnValidate` (when `mergeable_state ∈ {clean, unstable}` shortcut fires); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub's `mergeable_state` indicates the PR is mergeable (v0.0.52 shortcut — the `MergeableStateAccepted` allowlist); when all CI checks pass (green) under the per-check classification fallback; when timeout elapses (removed before `pauseForCITimeout` is called); or when issue is closed (defensive sweep) | Signals CI gate is active (pending or failed); triggers `itemMayNeedWork` updatedAt cache bypass; suppresses dispatcher re-invocation (`itemNeedsWork` returns false); blocks auto-advance until CI gate clears. **`stage:X:complete` is absent while this label is present — it is added by `checkCIGate` when CI clears (R5) or when `mergeable_state` shortcut clears the gate (v0.0.52).** |
-| `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `attemptMergeOnValidate` (legacy auto-merge path, yolo+Validate without `wait_for_ci`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `attemptMergeOnValidate` (on successful merge, via `removeRebaseNeededLabel` — no-op when absent); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when `MergePR` succeeds; or when issue is closed (defensive sweep) | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
+| `fabrik:rebase-needed` | `checkMergeabilityGate` (catch-up loop, `wait_for_ci: true` stages); `checkAutoMergeConvergence` (convergence flow, yolo+Validate with `fabrik:auto-merge-enabled`) | When GitHub reports `mergeable == false` on the linked PR — a confirmed base-branch conflict. Applied idempotently in both paths. NOT added when `mergeable == null` (GitHub still computing). | `checkMergeabilityGate` (when mergeable flips back to true); `checkAutoMergeConvergence` (when PR merges or closes); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub reports `mergeable == true` (after Claude's rebase push lands), or when PR merges/closes; or when issue is closed (defensive sweep) | Signals confirmed merge conflict; triggers `itemMayNeedWork` updatedAt cache bypass (base-branch advances don't bump the item's `updatedAt`); blocks CI gate and auto-advance until rebase resolves the conflict |
+| `fabrik:auto-merge-enabled` | `attemptMergeOnValidate` (yolo, non-cruise, Validate completion) | After successful `enablePullRequestAutoMerge` GraphQL call — signals GitHub is handling the merge atomically. Also serves as the idempotency guard (prevents re-calling the mutation) and the budget-start anchor (timestamp read by `FetchLabelAppliedAt` to compute convergence budget elapsed time). | `checkAutoMergeConvergence` (when PR merges, PR closes, user disables auto-merge, or budget exhausts); `cleanupClosedIssueTransientLabels` (defensive sweep) | When GitHub merges the PR; when PR is closed without merging; when user disables auto-merge in GitHub UI; or when convergence budget exhausts (→ `pauseForConvergenceFailed`); or when issue is closed (defensive sweep) | Engine-internal label. Bypasses legacy merge/CI gate dispatch — `checkAutoMergeConvergence` is the sole Phase 1 handler while present. Triggers `itemMayNeedWork` updatedAt cache bypass (convergence state changes independently of issue `updatedAt`). `stage:Validate:complete` remains in place while this label is present; `checkAutoMergeConvergence` removes it when the PR merges and the item advances to Done. NOT applied when `fabrik:cruise` is also present (cruise wins). |
 | `fabrik:blocked` | `checkDependencies` | When open blocking issues exist (first transition only — idempotent) | `PushUnblockObserver` (primary — fires immediately on blocker close, any column); `checkDependencies` (defense-in-depth — fires via `dep-blocked` cooldown-retry for items in stage columns) | When all blocking issues close | Pre-dispatch gate in `itemNeedsWork` prevents re-dispatch after the label is set (parallel to `fabrik:editing` post-#550 and `fabrik:locked:<other>` always); **exception**: when the `dep-blocked` cooldown has expired (or no store entry exists), `itemNeedsWork` admits the item for one dependency re-check per `10 × PollSeconds` — `checkDependencies` either re-stamps the cooldown (still blocked) or removes the label (resolved). Initial detection (first dispatch, label not yet set) still reaches `checkDependencies` normally. Blocks stage start. Push path removes the label even for items in non-stage columns (Backlog, Done, custom columns) that would otherwise never be re-evaluated by `processItem`. |
 | `stage:<X>:in_progress` | `processItem` | After lock acquired and verified | `releaseLock` | Same as `fabrik:locked:<user>` | Informational — shows which stage is active on GitHub |
 | `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleNoWorkNeeded` (emitting stage + all skipped stages), cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_NO_WORK_NEEDED (emitting stage + all subsequent non-cleanup stages) or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
@@ -708,30 +710,73 @@ FABRIK_STAGE_COMPLETE received
 
 Fabrik discovers PR comments through the `closedByPullRequestsReferences` GraphQL field, which traverses issue → linked PRs → PR comments. The `Closes #N` keyword in the PR body creates this linkage.
 
-### 5.4 Auto-Merge on Validate
+### 5.4 Auto-Merge on Validate (yolo issues)
 
-**When:** Validate stage completes and yolo is active (either `cfg.Yolo` or `fabrik:yolo` label).
+**When:** Validate stage completes and the issue has `fabrik:yolo` (or global `cfg.Yolo`) and does NOT have `fabrik:cruise`.
 
-**Code path:** `handleStageComplete()` → `attemptMergeOnValidate()` (Path 1); or catch-up loop → `attemptMergeOnValidate()` (Path 2)
+**Code path:** `handleStageComplete()` → `attemptMergeOnValidate()` (Path 1); or catch-up loop Phase 2 → `attemptMergeOnValidate()` (Path 2 — when `fabrik:auto-merge-enabled` is absent)
 
 **Flow:**
-1. Find linked PR via `FindPRForIssue()` / `FetchLinkedPR()` (the latter also returns the head SHA needed for the per-check classification fallback).
-2. Query `FetchPRMergeableState()` (REST single-PR endpoint). If the result is `clean` or `unstable` (per `github.MergeableStateAccepted`), **skip the raw check_runs gate**: clear any stale `fabrik:awaiting-ci` label, clear the `LinkedPRState.CIMergePendingSince` entry in the store, and proceed directly to step 4. Other states fall through to the per-check classification in step 3.
-3. **Per-check classification (fallback)**: fetch check runs via `FetchCheckRuns()`. Apply R1–R6 rules (no checks → R5 clears; failed → R3 applies `fabrik:awaiting-ci` and returns error; pending → R2 returns error and tracks `LinkedPRState.CIMergePendingSince` for the timeout; all green → R4 clears).
-4. Attempt merge via `MergePR()`. `MergePR` first checks the PR's `merged` field — if the PR was already merged (e.g., by a human), it returns nil immediately (no-op success). Otherwise it checks `mergeable` and attempts the merge.
-5. On `ErrNotMergeable`: apply `fabrik:rebase-needed` idempotently. Then:
-   - **Worker guard (`snap.Worker() != nil`):** if a rebase goroutine is already running for this item, return a plain error (skip — prevents cycle-counter drift).
-   - **Cycle limit check:** compare `snap.RebaseCycles(stage.Name)` against `MaxRebaseCycles` (default 3):
-     - If at or above the limit: call `pauseForRebaseCycleLimit()` (`fabrik:paused` + `fabrik:awaiting-input` + explanatory comment); return a plain error.
-     - If below the limit: apply `RebaseCycleIncremented`, call `dispatchRebaseReinvoke()`, return the `errRebaseDispatched` sentinel.
-6. On other API errors: return error (same retry behavior)
-7. On success (including already-merged): call `removeRebaseNeededLabel()` (no-op when absent), log and return nil — advancement proceeds
+1. If `fabrik:auto-merge-enabled` is already present on the issue: return nil (idempotent — auto-merge was already enabled in a previous invocation).
+2. Fetch linked PR via `FetchLinkedPR()`.
+3. Call `EnablePullRequestAutoMerge(owner, repo, pr.Number, AutoMergeStrategy)`. The strategy defaults to `MERGE` and is configurable via `FABRIK_AUTO_MERGE_STRATEGY`. On failure: log a guidance message and return a retriable error (next poll retries).
+4. On success: apply `fabrik:auto-merge-enabled` label. GitHub now owns the merge decision atomically — no Fabrik-side `MergePR` call. Done advancement is deferred to `checkAutoMergeConvergence` in Phase 1 of the catch-up loop.
 
-**Why the `mergeable_state` shortcut (v0.0.52):** the per-check classification at step 3 was over-aggressive — any check_run with `conclusion ∈ {failure, timed_out, action_required}` blocked the merge, including non-required workflow jobs (e.g. `Cleanup artifacts`) that GitHub itself does not treat as merge blockers per branch protection. When `mergeable_state` says the PR is mergeable, Fabrik now trusts that and bypasses the per-check gate. The shortcut sits *after* `stage:Validate:complete` is already on the issue (the catch-up loop's entry condition), so it cannot cause Validate-Claude work to be skipped — it only changes the behavior of the post-completion CI wait.
+**`cruise > yolo` precedence:** If `fabrik:cruise` is present on the issue, `attemptMergeOnValidate` returns immediately without calling `EnablePullRequestAutoMerge`. Cruise items keep the current `stage:Validate:complete` behavior: the branch is maintained (rebase reinvoke, CI-fix reinvoke) but merging is left to the user.
 
-**Unified rebase-reinvoke recovery (Path 1 and Path 2):** Both code paths now use the same `snap.RebaseCycles(stage.Name)` + `RebaseCycleIncremented` mutation, `dispatchRebaseReinvoke()`, and `pauseForRebaseCycleLimit()`. The `MaxRebaseCycles` and `--max-rebase-cycles` / `FABRIK_MAX_REBASE_CYCLES` controls apply to both paths. Previously, Path 1 immediately paused on `ErrNotMergeable`; it now dispatches the rebase reinvoke autopilot instead, falling back to the pause only when the cycle limit is reached.
+See **section 5.5** for how Fabrik monitors the convergence flow after auto-merge is enabled.
 
-**Important — Path 1 vs Path 2 distinction:** In Path 1 (`handleStageComplete`), the merge runs BEFORE adding `stage:Validate:complete`. On a plain merge failure (non-`ErrNotMergeable`), no completion label is added, so `itemNeedsWork` can retry the full Validate invocation after cooldown. On `ErrNotMergeable`, `handleStageComplete` detects the `errRebaseDispatched` sentinel and **adds `stage:Validate:complete` before returning** — ensuring the catch-up loop's Phase 2 drives the merge retry rather than `itemNeedsWork` triggering a new full Validate invocation. In Path 2 (catch-up loop), `stage:Validate:complete` already exists when `attemptMergeOnValidate()` runs; on `ErrNotMergeable` the rebase is dispatched and the catch-up loop retries on the next poll.
+**Non-yolo issues:** Items without `fabrik:yolo` and without `fabrik:cruise` follow the same behavior as cruise for purposes of merge tracking — `checkMergeabilityGate` and `checkCIGate` continue to operate using `MaxRebaseCycles` / `MaxCiFixCycles` per-gate cycle limits. `EnablePullRequestAutoMerge` is never called for these issues. This is unchanged from pre-5.4 behavior.
+
+---
+
+### 5.5 Post-Validate Convergence Monitor (yolo issues)
+
+After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iteration of the catch-up loop calls `checkAutoMergeConvergence()` instead of the legacy `checkMergeabilityGate` / `checkCIGate` path. All merge decisions for the issue are delegated to GitHub's server-side auto-merge logic.
+
+**Convergence budget:**
+
+- The budget starts when `fabrik:auto-merge-enabled` is applied. The start timestamp is stored durably in GitHub's issue event log (`FetchLabelAppliedAt("fabrik:auto-merge-enabled")`), so it survives engine restarts.
+- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget (falls back to `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates — legacy behavior).
+- On each Phase 1 iteration: `elapsed = time.Since(budgetStart)`. If `elapsed > budget`, `pauseForConvergenceFailed()` fires.
+
+**`checkAutoMergeConvergence()` decision tree:**
+
+| Observed state | Action |
+|---|---|
+| PR merged or closed | Remove `fabrik:auto-merge-enabled` + `fabrik:rebase-needed` (if present); existing machinery advances to Done |
+| `AutoMergeEnabled == false` (user disabled) | Remove `fabrik:auto-merge-enabled`; post one-liner comment; treat as cruise from this point |
+| Budget exhausted | Call `pauseForConvergenceFailed()` (see below) |
+| `mergeable_state == "unknown"` | Wait — GitHub still computing after a push; re-evaluate next poll |
+| `mergeable_state == "dirty"` (conflict) | Dispatch rebase reinvoke (one per conflict transition); increment `RebaseCycles` for observability only (not a gate); skip if worker in-flight |
+| Any other state (`clean`, `blocked`, `behind`, `unstable`, `has_hooks`) | Wait — GitHub is handling it |
+
+**Rebase reinvoke + auto-merge re-enable:**
+GitHub disables auto-merge on every push. After `dispatchRebaseReinvoke()` completes successfully (Claude resolved conflicts, pushed), `EnablePullRequestAutoMerge` is called again to re-arm auto-merge. This is the only scenario where auto-merge is re-enabled without going through `attemptMergeOnValidate`.
+
+**`pauseForConvergenceFailed()` — convergence budget exhausted:**
+Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`, and current rebase cycle count. Posts a structured pause comment containing:
+- Total wall-clock elapsed time and configured budget
+- Number of rebase reinvokes dispatched
+- Commits-behind-base count
+- Current `mergeable_state`
+- Latest CI check run summary (passed / failed / pending)
+- Three named user options: (1) manual rebase + re-yolo, (2) switch to cruise, (3) leave as-is
+
+Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-merge-enabled`. Does NOT add `fabrik:awaiting-ci` (CI may be healthy; the convergence failure is about the merge window, not CI).
+
+**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, yolo issues fall back to using `MaxRebaseCycles` and `MaxCiFixCycles` as gates — legacy behavior.
+
+**State transitions for yolo Validate convergence:**
+
+| State | Trigger | New state | Labels added | Labels removed |
+|---|---|---|---|---|
+| Validate, Complete | Poll tick (Phase 2) | Validate, Convergence | `fabrik:auto-merge-enabled` | |
+| Validate, Convergence | PR merged (GitHub) | Done, Pending Cleanup | | `fabrik:auto-merge-enabled`, `fabrik:rebase-needed` |
+| Validate, Convergence | `mergeable_state=dirty` (conflict) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
+| Validate, Convergence + Rebase in-flight | Rebase push succeeds | Validate, Convergence | | |
+| Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
+| Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Complete (cruise behavior) | | `fabrik:auto-merge-enabled` |
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -79,7 +79,7 @@ These labels do not define distinct states but influence transition behavior:
 | Label | Effect |
 |-------|--------|
 | `fabrik:yolo` | Forces auto-advance; triggers GitHub native auto-merge at Validate; overrides `auto_advance: false` |
-| `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; suppressed by yolo |
+| `fabrik:cruise` | Forces auto-advance without auto-merge; stops at Validate completion; cruise wins over yolo for auto-merge (PR is not auto-merged even when yolo is also present), but the stop-at-Validate behaviour is overridden by yolo (issue advances to Done) |
 | `fabrik:auto-merge-enabled` | Engine-internal; marks that GitHub's native auto-merge has been enabled on the linked PR; anchors the convergence budget start time; bypasses legacy merge/CI gates |
 | `fabrik:unrestricted` | Passes `--dangerously-skip-permissions` to Claude Code |
 | `fabrik:extend-turns` | Pre-grants a 2× turn budget for every stage invocation and comment processing invocation while present; persists across stages; removed only at the Done cleanup stage or manually; no-op when `max_turns == 0` (stage) or always applies for comments since `commentMaxTurns` is never 0 |
@@ -141,7 +141,7 @@ Each active stage column has the same set of reachable sub-states:
 | `stage:<X>:complete` | `handleStageComplete` (for non-`wait_for_ci` stages), `checkCIGate` (for `wait_for_ci: true` stages — added only after CI passes), `handleNoWorkNeeded` (emitting stage + all skipped stages), cleanup stage handler | `handleStageComplete`: after Claude signals FABRIK_STAGE_COMPLETE on stages without `wait_for_ci: true`. `checkCIGate`: when all CI checks pass (R5) — this is the conjunctive gate (ADR 032): `stage:X:complete` is deferred until the CI gate actually clears, not applied on FABRIK_STAGE_COMPLETE. After FABRIK_NO_WORK_NEEDED (emitting stage + all subsequent non-cleanup stages) or worktree cleanup. | Never removed | Permanent | Prevents re-invocation of the stage; triggers catch-up advancement |
 | `stage:<X>:failed` | `escalateFailedStage` | After MaxRetries exhausted | `clearFailedStage` | When user removes `fabrik:paused` (manual unpause) | Indicates permanent failure; paired with `fabrik:paused` |
 | `fabrik:yolo` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance; triggers auto-merge at Validate; overrides `auto_advance: false` per stage |
-| `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; suppressed when yolo is also present |
+| `fabrik:cruise` | User (manual) | Any time | User (manual) | Any time | Forces auto-advance without merge; stops at Validate; cruise wins over yolo for auto-merge (auto-merge suppressed even when yolo present); stop-at-Validate is overridden when yolo is also present (issue advances to Done, but PR is not auto-merged) |
 | `fabrik:unrestricted` | User (manual) | Any time | User (manual) | Any time | Passes `--dangerously-skip-permissions` instead of `--permission-mode dontAsk` |
 | `fabrik:extend-turns` | User (manual) | Any time | `processItem` cleanup branch or User (manual) | At Done cleanup stage completion; or manual removal | Pre-grants 2× `stage.MaxTurns` budget for every stage invocation while present; no-op for stage path when `max_turns == 0` (unlimited); also pre-grants 2× `commentMaxTurns(stage)` budget for every comment processing invocation (comment budget is never 0); subsequent extensions beyond 2× require progress detection for both paths; persists across all intermediate stages |
 | `model:<name>` | User (manual) | Any time | User (manual) | Any time | Selects Claude model; first label wins if multiple present |
@@ -737,7 +737,7 @@ After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iterat
 **Convergence budget:**
 
 - The budget starts when `fabrik:auto-merge-enabled` is applied. The start timestamp is stored durably in GitHub's issue event log (`FetchLabelAppliedAt("fabrik:auto-merge-enabled")`), so it survives engine restarts.
-- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget (falls back to `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates — legacy behavior).
+- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget — Fabrik waits indefinitely for auto-merge to complete (or for the user to disable auto-merge in the GitHub UI). `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates are NOT consulted while `fabrik:auto-merge-enabled` is present.
 - On each Phase 1 iteration: `elapsed = time.Since(budgetStart)`. If `elapsed > budget`, `pauseForConvergenceFailed()` fires.
 
 **`checkAutoMergeConvergence()` decision tree:**
@@ -745,7 +745,7 @@ After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iterat
 | Observed state | Action |
 |---|---|
 | PR merged or closed | Remove `fabrik:auto-merge-enabled` + `fabrik:rebase-needed` (if present); existing machinery advances to Done |
-| `AutoMergeEnabled == false` (user disabled) | Remove `fabrik:auto-merge-enabled`; post one-liner comment; treat as cruise from this point |
+| `AutoMergeEnabled == false` (user disabled) | Apply `fabrik:paused` + `fabrik:awaiting-input`; remove `fabrik:auto-merge-enabled`; post comment with resume options (prevents Phase 2 from re-enabling auto-merge on the next poll) |
 | Budget exhausted | Call `pauseForConvergenceFailed()` (see below) |
 | `mergeable_state == "unknown"` | Wait — GitHub still computing after a push; re-evaluate next poll |
 | `mergeable_state == "dirty"` (conflict) | Dispatch rebase reinvoke (one per conflict transition); increment `RebaseCycles` for observability only (not a gate); skip if worker in-flight |
@@ -765,7 +765,7 @@ Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`
 
 Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-merge-enabled`. Does NOT add `fabrik:awaiting-ci` (CI may be healthy; the convergence failure is about the merge window, not CI).
 
-**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, yolo issues fall back to using `MaxRebaseCycles` and `MaxCiFixCycles` as gates — legacy behavior.
+**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, the budget check is skipped entirely — Fabrik waits indefinitely for the PR to be merged or closed.
 
 **State transitions for yolo Validate convergence:**
 
@@ -776,7 +776,7 @@ Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-me
 | Validate, Convergence | `mergeable_state=dirty` (conflict) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
 | Validate, Convergence + Rebase in-flight | Rebase push succeeds | Validate, Convergence | | |
 | Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
-| Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Complete (cruise behavior) | | `fabrik:auto-merge-enabled` |
+| Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 
 ---
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -37,6 +37,8 @@ type Config struct {
 	CIWaitTimeout            time.Duration // How long to wait for CI in the merge guard before pausing (default 30m)
 	MaxCiFixCycles           int           // Max CI-fix re-invocation cycles per issue before pausing (default 5)
 	MaxRebaseCycles          int           // Max rebase re-invocation cycles per issue before pausing (default 3)
+	ConvergenceBudget        time.Duration // Wall-clock budget for post-Validate yolo convergence (default 30m; 0 = disabled, fall back to cycle limits)
+	AutoMergeStrategy        string        // Merge method for enablePullRequestAutoMerge: MERGE, SQUASH, or REBASE (default MERGE)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
 	DebugOutput              bool
 	SymlinkEnv               bool

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -37,7 +37,7 @@ type Config struct {
 	CIWaitTimeout            time.Duration // How long to wait for CI in the merge guard before pausing (default 30m)
 	MaxCiFixCycles           int           // Max CI-fix re-invocation cycles per issue before pausing (default 5)
 	MaxRebaseCycles          int           // Max rebase re-invocation cycles per issue before pausing (default 3)
-	ConvergenceBudget        time.Duration // Wall-clock budget for post-Validate yolo convergence (default 30m; 0 = disabled, fall back to cycle limits)
+	ConvergenceBudget        time.Duration // Wall-clock budget for post-Validate yolo convergence (default 30m; 0 = disabled, waits indefinitely)
 	AutoMergeStrategy        string        // Merge method for enablePullRequestAutoMerge: MERGE, SQUASH, or REBASE (default MERGE)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
 	DebugOutput              bool

--- a/engine/handle_stage_complete_test.go
+++ b/engine/handle_stage_complete_test.go
@@ -487,11 +487,11 @@ func TestHandleStageComplete_WaitForCI_AppliesRegardlessOfYolo(t *testing.T) {
 	}
 }
 
-// TestHandleStageComplete_BothCruiseAndYolo_YoloWins verifies that when both
-// fabrik:cruise and fabrik:yolo labels are present, yolo takes precedence:
-// EnablePullRequestAutoMerge is called (cruise alone would skip it). Done
-// advancement is deferred to checkAutoMergeConvergence (same as yolo-only).
-func TestHandleStageComplete_BothCruiseAndYolo_YoloWins(t *testing.T) {
+// TestHandleStageComplete_BothCruiseAndYolo_CruiseWins verifies that when both
+// fabrik:cruise and fabrik:yolo labels are present, cruise takes precedence at
+// Validate: EnablePullRequestAutoMerge is NOT called and the item is NOT advanced
+// to Done. This implements FR-003 / FR-015: cruise leaves the PR for human merge.
+func TestHandleStageComplete_BothCruiseAndYolo_CruiseWins(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 99, HeadSHA: "abc123"}, nil
@@ -506,16 +506,16 @@ func TestHandleStageComplete_BothCruiseAndYolo_YoloWins(t *testing.T) {
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
 
-	// yolo wins: auto-merge should be enabled (cruise alone would suppress it).
-	if len(client.enablePullRequestAutoMergeCalls) != 1 {
-		t.Fatalf("expected EnablePullRequestAutoMerge when yolo wins over cruise, got %d", len(client.enablePullRequestAutoMergeCalls))
+	// cruise wins: auto-merge must NOT be enabled.
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Fatalf("expected no EnablePullRequestAutoMerge when cruise wins over yolo, got %d", len(client.enablePullRequestAutoMergeCalls))
 	}
 	if len(client.mergePRCalls) != 0 {
-		t.Errorf("MergePR must not be called in new auto-merge path, got %d", len(client.mergePRCalls))
+		t.Errorf("MergePR must not be called, got %d", len(client.mergePRCalls))
 	}
-	// Done advancement deferred to convergence monitor — no immediate advance.
+	// No advancement — cruise stops at Validate.
 	if len(client.updateStatusCalls) != 0 {
-		t.Errorf("expected no immediate advance (deferred to convergence monitor), got %d status updates", len(client.updateStatusCalls))
+		t.Errorf("expected no advance when cruise wins at Validate, got %d status updates", len(client.updateStatusCalls))
 	}
 }
 

--- a/engine/handle_stage_complete_test.go
+++ b/engine/handle_stage_complete_test.go
@@ -117,63 +117,57 @@ func TestHandleStageComplete_YoloLabel_ValidateMergeableAdvances(t *testing.T) {
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
 
-	// MergePR should have been called once
-	if len(client.mergePRCalls) != 1 {
-		t.Fatalf("expected 1 MergePR call, got %d", len(client.mergePRCalls))
+	// EnablePullRequestAutoMerge (not MergePR) should have been called once.
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected 1 EnablePullRequestAutoMerge call, got %d", len(client.enablePullRequestAutoMergeCalls))
 	}
-	if client.mergePRCalls[0].prNumber != 99 {
-		t.Errorf("MergePR called with prNumber %d, want 99", client.mergePRCalls[0].prNumber)
+	if client.enablePullRequestAutoMergeCalls[0].prNumber != 99 {
+		t.Errorf("EnablePullRequestAutoMerge called with prNumber %d, want 99", client.enablePullRequestAutoMergeCalls[0].prNumber)
 	}
-	// Should advance to Done
-	if len(client.updateStatusCalls) != 1 {
-		t.Fatalf("expected advance after merge, got %d status updates", len(client.updateStatusCalls))
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("MergePR must not be called in the new auto-merge path, got %d call(s)", len(client.mergePRCalls))
+	}
+	// Done advancement is deferred to checkAutoMergeConvergence; no immediate advance.
+	if len(client.updateStatusCalls) != 0 {
+		t.Errorf("expected no immediate advance (deferred to convergence monitor), got %d status updates", len(client.updateStatusCalls))
 	}
 }
 
-func TestHandleStageComplete_YoloLabel_ValidateUnmergeable_RebaseDispatched(t *testing.T) {
+// TestHandleStageComplete_YoloLabel_ValidateAutoMergeNotEnabled_NoAdvance verifies
+// that when EnablePullRequestAutoMerge returns ErrAutoMergeNotEnabled (the repository
+// has not enabled auto-merge in its settings), handleStageComplete logs a warning,
+// does NOT add stage:Validate:complete, and does NOT advance to Done — so the engine
+// can retry on the next poll cycle.
+func TestHandleStageComplete_YoloLabel_ValidateAutoMergeNotEnabled_NoAdvance(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 99, HeadSHA: "abc123"}, nil
 		},
-		mergePRFn: func(owner, repo string, prNumber int) error {
-			return gh.ErrNotMergeable
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			return gh.ErrAutoMergeNotEnabled
 		},
 	}
 	stgs := testStagesWithValidate()
 	eng := testEngineWithStages(client, stgs)
-	eng.cfg.MaxRebaseCycles = 3
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
 	validateStage := &stages.Stage{Name: "Validate"}
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
-	// Wait for the dispatched rebase goroutine (exits early via ErrSkipItem in tests).
-	eng.wg.Wait()
 
-	// stage:Validate:complete must be added so catch-up loop retries the merge.
-	foundComplete := false
+	// No pause, no completion label — engine retries on next poll.
 	for _, c := range client.addLabelCalls {
-		if c.labelName == "stage:Validate:complete" {
-			foundComplete = true
-		}
 		if c.labelName == "fabrik:paused" {
-			t.Error("fabrik:paused must NOT be added when dispatching rebase")
+			t.Error("fabrik:paused must NOT be added when auto-merge is not enabled on the repo")
+		}
+		if c.labelName == "stage:Validate:complete" {
+			t.Error("stage:Validate:complete must NOT be added when auto-merge enablement failed")
 		}
 	}
-	if !foundComplete {
-		t.Error("expected stage:Validate:complete to be added when rebase dispatched (Path 1 ordering)")
-	}
-	// Should NOT advance to the next stage — rebase is in progress.
+	// No advance.
 	if len(client.updateStatusCalls) != 0 {
-		t.Errorf("expected no advance when rebase dispatched, got %d status updates", len(client.updateStatusCalls))
-	}
-	snap, snapErr := eng.store.Get("owner/repo", 1)
-	if snapErr != nil {
-		t.Fatalf("store.Get: %v", snapErr)
-	}
-	if snap.RebaseCycles("Validate") != 1 {
-		t.Errorf("expected RebaseCycles[Validate] == 1, got %d", snap.RebaseCycles("Validate"))
+		t.Errorf("expected no advance when auto-merge enablement failed, got %d status updates", len(client.updateStatusCalls))
 	}
 }
 
@@ -225,9 +219,9 @@ func TestHandleStageComplete_YoloLabel_NonValidate_NoMergeAttempt(t *testing.T) 
 }
 
 func TestHandleStageComplete_AutoAdvanceFalse_OverridesAdvanceButMergeStillFires(t *testing.T) {
-	// auto_advance: false on Validate should suppress advancement but NOT suppress merge.
-	// Global cfg.Yolo=true activates merge; item has no fabrik:yolo label so
-	// auto_advance:false is respected (item-level yolo would override it).
+	// auto_advance: false on Validate should suppress advancement but NOT suppress
+	// auto-merge enablement. Global cfg.Yolo=true activates auto-merge; item has no
+	// fabrik:yolo label so auto_advance:false is respected (item-level yolo would override it).
 	f := false
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
@@ -236,7 +230,7 @@ func TestHandleStageComplete_AutoAdvanceFalse_OverridesAdvanceButMergeStillFires
 	}
 	stgs := testStagesWithValidate()
 	eng := testEngineWithStages(client, stgs)
-	eng.cfg.Yolo = true // global yolo triggers merge
+	eng.cfg.Yolo = true // global yolo triggers auto-merge
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"} // no fabrik:yolo label
@@ -244,25 +238,29 @@ func TestHandleStageComplete_AutoAdvanceFalse_OverridesAdvanceButMergeStillFires
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
 
-	// Merge should still fire (global yolo active)
-	if len(client.mergePRCalls) != 1 {
-		t.Fatalf("expected MergePR to fire even with auto_advance:false, got %d", len(client.mergePRCalls))
+	// EnablePullRequestAutoMerge should fire (global yolo active).
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge to fire even with auto_advance:false, got %d", len(client.enablePullRequestAutoMergeCalls))
 	}
-	// But advancement should be suppressed (auto_advance:false, no item-level yolo to override)
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("MergePR must not be called in new auto-merge path, got %d", len(client.mergePRCalls))
+	}
+	// Advancement suppressed: auto_advance:false AND autoMergeEnabled defers Done.
 	if len(client.updateStatusCalls) != 0 {
 		t.Errorf("expected no advance when auto_advance:false, got %d", len(client.updateStatusCalls))
 	}
 }
 
 func TestHandleStageComplete_MergeAPIError_LogsAndDoesNotAdvance(t *testing.T) {
-	// Non-ErrNotMergeable error from MergePR: log the error and do NOT advance.
-	// This prevents silently moving to Done when the PR merge failed (e.g. transient
-	// 5xx, permissions). The engine will retry Validate on the next cooldown cycle.
+	// Transient API error from EnablePullRequestAutoMerge: log the error and do NOT
+	// advance. This prevents silently moving to Done when auto-merge enablement failed
+	// (e.g. transient 5xx, permissions). The engine will retry Validate on the next
+	// cooldown cycle.
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 88, HeadSHA: "abc123"}, nil
 		},
-		mergePRFn: func(owner, repo string, prNumber int) error {
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
 			return errors.New("network error")
 		},
 	}
@@ -275,20 +273,20 @@ func TestHandleStageComplete_MergeAPIError_LogsAndDoesNotAdvance(t *testing.T) {
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
 
-	// Should NOT post unmergeable comment or fabrik:paused (not ErrNotMergeable)
+	// Should NOT add fabrik:paused (not a terminal failure, just a retriable error).
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:paused" {
-			t.Error("should not add fabrik:paused for non-ErrNotMergeable error")
+			t.Error("should not add fabrik:paused for transient auto-merge API error")
 		}
 	}
-	// Should NOT advance — merge failed, no completion label was added, engine retries
+	// Should NOT advance — enablement failed, no completion label added, engine retries.
 	if len(client.updateStatusCalls) != 0 {
-		t.Errorf("expected no advance when merge API error, got %d status updates", len(client.updateStatusCalls))
+		t.Errorf("expected no advance when auto-merge enablement fails, got %d status updates", len(client.updateStatusCalls))
 	}
-	// Should NOT add completion label — engine must be able to retry Validate
+	// Should NOT add completion label — engine must be able to retry Validate.
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "stage:Validate:complete" {
-			t.Error("should not add stage:Validate:complete when merge failed")
+			t.Error("should not add stage:Validate:complete when auto-merge enablement failed")
 		}
 	}
 }
@@ -491,7 +489,8 @@ func TestHandleStageComplete_WaitForCI_AppliesRegardlessOfYolo(t *testing.T) {
 
 // TestHandleStageComplete_BothCruiseAndYolo_YoloWins verifies that when both
 // fabrik:cruise and fabrik:yolo labels are present, yolo takes precedence:
-// the PR is merged and the stage advances past Validate.
+// EnablePullRequestAutoMerge is called (cruise alone would skip it). Done
+// advancement is deferred to checkAutoMergeConvergence (same as yolo-only).
 func TestHandleStageComplete_BothCruiseAndYolo_YoloWins(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
@@ -507,13 +506,16 @@ func TestHandleStageComplete_BothCruiseAndYolo_YoloWins(t *testing.T) {
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
 
-	// yolo wins: merge should fire
-	if len(client.mergePRCalls) != 1 {
-		t.Fatalf("expected MergePR to fire when both yolo and cruise present, got %d", len(client.mergePRCalls))
+	// yolo wins: auto-merge should be enabled (cruise alone would suppress it).
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge when yolo wins over cruise, got %d", len(client.enablePullRequestAutoMergeCalls))
 	}
-	// yolo wins: advance to Done should happen
-	if len(client.updateStatusCalls) != 1 {
-		t.Fatalf("expected advance when yolo wins over cruise, got %d status updates", len(client.updateStatusCalls))
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("MergePR must not be called in new auto-merge path, got %d", len(client.mergePRCalls))
+	}
+	// Done advancement deferred to convergence monitor — no immediate advance.
+	if len(client.updateStatusCalls) != 0 {
+		t.Errorf("expected no immediate advance (deferred to convergence monitor), got %d status updates", len(client.updateStatusCalls))
 	}
 }
 

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -39,6 +39,8 @@ type GitHubClient interface {
 	CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error)
 	MarkPRReady(owner, repo string, prNumber int) error
 	MergePR(owner, repo string, prNumber int) error
+	EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error
+	FetchCommitsBehind(owner, repo, base, head string) (int, error)
 	CloseIssue(owner, repo string, issueNumber int) error
 	CreateIssue(owner, repo, title, body string) (number int, nodeID string, err error)
 	AddProjectV2ItemById(projectID, contentNodeID string) (string, error)

--- a/engine/item.go
+++ b/engine/item.go
@@ -105,7 +105,10 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 		}
 		// Also admit closed items with fabrik:awaiting-ci so the catch-up loop
 		// can complete the CI gate after a PR merge closes the issue.
-		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") {
+		// Admit fabrik:auto-merge-enabled for the same reason: when GitHub merges
+		// the PR the issue is closed; checkAutoMergeConvergence needs to run to
+		// detect the merged state and advance to Done.
+		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") && !hasLabel(item, "fabrik:auto-merge-enabled") {
 			return false
 		}
 	}
@@ -155,12 +158,14 @@ func (e *Engine) itemNeedsWork(item gh.ProjectItem) bool {
 	// Closed issues are skipped unless the current stage is a cleanup stage
 	// (so cleanup can remove the worktree) OR the current stage is already
 	// marked complete (so the catch-up loop can advance to the next stage) OR
-	// fabrik:awaiting-ci is present (so the catch-up loop can finish the CI gate).
+	// fabrik:awaiting-ci is present (so the catch-up loop can finish the CI gate) OR
+	// fabrik:auto-merge-enabled is present (so checkAutoMergeConvergence can detect
+	// the merged PR and advance to Done after GitHub closes the issue).
 	if item.IsClosed {
 		if stage == nil {
 			return false
 		}
-		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") {
+		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") && !hasLabel(item, "fabrik:auto-merge-enabled") {
 			return false
 		}
 	}

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -256,15 +256,20 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 		return
 	}
 
-	// PR merged or closed: remove label and let existing machinery advance to Done.
+	// PR merged or closed: remove label and advance to the next stage (Done).
+	// There is no passive machinery that would advance the board column after the
+	// label is removed; advanceToNextStage must be called explicitly here.
 	if pr.Merged || pr.State == "closed" {
-		e.logf(item.Number, "auto-merge", "PR #%d merged or closed — removing fabrik:auto-merge-enabled\n", pr.Number)
+		e.logf(item.Number, "auto-merge", "PR #%d merged or closed — advancing to Done\n", pr.Number)
 		if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); rerr != nil {
 			e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", rerr)
 		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
 		}
 		e.removeRebaseNeededLabel(owner, repo, item)
+		if err := e.advanceToNextStage(board, item, stage); err != nil {
+			e.logf(item.Number, "warn", "could not advance to Done after PR merge: %v\n", err)
+		}
 		return
 	}
 

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -243,7 +243,11 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 
-	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
+	// Use e.client (direct GitHub API) rather than e.readClient (boardcache) so
+	// that pr.AutoMergeEnabled reflects the live GitHub state. The boardcache
+	// LinkedPRState does not persist AutoMergeEnabled; a cache hit would return
+	// false and incorrectly trigger the "user disabled auto-merge" path on every poll.
+	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
 		e.logf(item.Number, "auto-merge", "could not fetch linked PR: %v — skipping convergence check\n", err)
 		return

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -209,6 +209,7 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 		}
 
 		e.logf(item.Number, "rebase-reinvoke", "re-invoking stage %q via comment processing with rebase context\n", stage.Name)
+		owner, repo := itemOwnerRepo(item, e.defaultRepo())
 		err := e.processComments(ctx, board, item, &rebaseStage, []gh.Comment{syntheticComment}, onPIDReady)
 
 		if err != nil {
@@ -216,8 +217,224 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 				return
 			}
 			e.logf(item.Number, "warn", "rebase re-invocation failed: %v\n", err)
+			return
+		}
+
+		// GitHub disables auto-merge on every push. Re-enable it if this issue is in
+		// the convergence flow (fabrik:auto-merge-enabled present at dispatch time).
+		if hasLabel(item, "fabrik:auto-merge-enabled") {
+			pr, prErr := e.client.FetchLinkedPR(owner, repo, item.Number)
+			if prErr != nil || pr == nil || pr.Number == 0 {
+				e.logf(item.Number, "warn", "rebase reinvoke: could not fetch linked PR for auto-merge re-enable: %v\n", prErr)
+			} else if rerr := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, e.cfg.AutoMergeStrategy); rerr != nil {
+				e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
+			} else {
+				e.logf(item.Number, "auto-merge", "re-enabled auto-merge on PR #%d after rebase push\n", pr.Number)
+			}
 		}
 	}()
+}
+
+// checkAutoMergeConvergence monitors a yolo issue that has entered the GitHub
+// native auto-merge convergence flow (fabrik:auto-merge-enabled is present).
+// Called from Phase 1 of the catch-up loop; replaces checkMergeabilityGate and
+// checkCIGate for these items. Returns after completing any dispatch or pause.
+func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+
+	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
+	if err != nil {
+		e.logf(item.Number, "auto-merge", "could not fetch linked PR: %v — skipping convergence check\n", err)
+		return
+	}
+	if pr == nil || pr.Number == 0 {
+		return
+	}
+
+	// PR merged or closed: remove label and let existing machinery advance to Done.
+	if pr.Merged || pr.State == "closed" {
+		e.logf(item.Number, "auto-merge", "PR #%d merged or closed — removing fabrik:auto-merge-enabled\n", pr.Number)
+		if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); rerr != nil {
+			e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", rerr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+		}
+		e.removeRebaseNeededLabel(owner, repo, item)
+		return
+	}
+
+	// User manually disabled auto-merge: back off, treat as cruise from this point.
+	if !pr.AutoMergeEnabled {
+		e.logf(item.Number, "auto-merge", "PR #%d auto-merge disabled by user — treating as cruise\n", pr.Number)
+		msg := fmt.Sprintf("🏭 **Fabrik — auto-merge disabled**\n\n" +
+			"Fabrik detected that GitHub auto-merge was disabled on the linked PR. " +
+			"Fabrik will no longer attempt to merge this PR automatically — treating as `fabrik:cruise` from this point. " +
+			"To re-enable, add `fabrik:yolo` and remove `fabrik:auto-merge-enabled` after the branch is ready.")
+		if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
+			e.logf(item.Number, "warn", "could not post auto-merge disabled comment: %v\n", cerr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+		}
+		if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); rerr != nil {
+			e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", rerr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+		}
+		return
+	}
+
+	// Check convergence budget.
+	if e.cfg.ConvergenceBudget > 0 {
+		budgetStart, berr := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:auto-merge-enabled")
+		if berr != nil {
+			e.logf(item.Number, "auto-merge", "could not fetch fabrik:auto-merge-enabled applied-at: %v\n", berr)
+		} else if !budgetStart.IsZero() {
+			elapsed := time.Since(budgetStart)
+			if elapsed > e.cfg.ConvergenceBudget {
+				e.logf(item.Number, "auto-merge", "convergence budget exhausted (%.0fs / %.0fs) — pausing\n",
+					elapsed.Seconds(), e.cfg.ConvergenceBudget.Seconds())
+				e.pauseForConvergenceFailed(ctx, board, item, stage, elapsed)
+				return
+			}
+		}
+	}
+
+	// GitHub transiently returns "unknown" mergeability after a push. Wait.
+	if pr.MergeableState == "unknown" {
+		e.logf(item.Number, "auto-merge", "PR #%d mergeable_state=unknown — waiting for GitHub to compute\n", pr.Number)
+		return
+	}
+
+	// Confirmed conflict (dirty): dispatch one rebase reinvoke if none is in-flight.
+	// Cycle count is incremented for observability but not consulted as a gate.
+	if pr.MergeableState == "dirty" {
+		if snap, serr := e.store.Get(repoStr, item.Number); serr == nil && snap.Worker() != nil {
+			e.logf(item.Number, "auto-merge", "rebase already in-flight — skipping dispatch\n")
+			return
+		}
+		e.logf(item.Number, "auto-merge", "PR #%d merge conflict — dispatching rebase reinvoke\n", pr.Number)
+		e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		e.dispatchRebaseReinvoke(ctx, board, item, stage)
+		return
+	}
+
+	// All other states (clean, blocked, behind, unstable, has_hooks): GitHub is handling it.
+	e.logf(item.Number, "auto-merge", "PR #%d mergeable_state=%q — waiting for GitHub auto-merge\n", pr.Number, pr.MergeableState)
+}
+
+// pauseForConvergenceFailed is called when the convergence budget exhausts before
+// the yolo PR merges. Posts a structured comment naming the actual current state,
+// applies fabrik:paused + fabrik:awaiting-input, and removes fabrik:auto-merge-enabled.
+func (e *Engine) pauseForConvergenceFailed(_ context.Context, _ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, elapsed time.Duration) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+
+	// Fetch fresh state for the comment.
+	pr, _ := e.client.FetchLinkedPR(owner, repo, item.Number)
+	var mergeableState, headSHA, latestCI string
+	var commitsBehind int
+	if pr != nil && pr.Number != 0 {
+		mergeableState = pr.MergeableState
+		headSHA = pr.HeadSHA
+		// Determine base branch for commits-behind count.
+		wm := e.worktreesFor(item.Repo)
+		baseBranch, _ := e.baseBranchForItem(item, wm)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+		commitsBehind, _ = e.client.FetchCommitsBehind(owner, repo, baseBranch, headSHA)
+		if headSHA != "" {
+			runs, _ := e.readClient.FetchCheckRuns(owner, repo, headSHA)
+			latestCI = summarizeCIRuns(runs)
+		}
+	}
+
+	var rebaseCycles int
+	if snap, serr := e.store.Get(repoStr, item.Number); serr == nil {
+		rebaseCycles = snap.RebaseCycles(stage.Name)
+	}
+
+	budgetStr := e.cfg.ConvergenceBudget.String()
+	elapsedStr := elapsed.Round(time.Second).String()
+
+	msg := fmt.Sprintf(
+		"🏭 **Fabrik — convergence budget exhausted**\n\n"+
+			"Fabrik attempted to merge the linked PR via GitHub native auto-merge for **%s** "+
+			"(budget: %s) without converging. Current state:\n\n"+
+			"| | |\n"+
+			"|---|---|\n"+
+			"| Elapsed | %s |\n"+
+			"| Rebase reinvokes dispatched | %d |\n"+
+			"| Commits behind base | %d |\n"+
+			"| PR `mergeable_state` | `%s` |\n"+
+			"| Latest CI (SHA `%s`) | %s |\n\n"+
+			"**Next steps — choose one:**\n"+
+			"1. **Manual rebase + re-yolo**: Resolve conflicts manually, push, then remove `fabrik:paused` and ensure `fabrik:yolo` is present. Fabrik will re-enable auto-merge and restart the convergence budget.\n"+
+			"2. **Switch to cruise**: Remove `fabrik:paused` + `fabrik:yolo`, add `fabrik:cruise`. Fabrik will keep the branch rebased against main but leave merging to you.\n"+
+			"3. **Leave as-is**: Remove `fabrik:paused` when ready. Fabrik will retry auto-merge from the current state.",
+		elapsedStr, budgetStr,
+		elapsedStr, rebaseCycles, commitsBehind,
+		mergeableState, headSHA, latestCI,
+	)
+
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+		e.logf(item.Number, "warn", "could not post convergence-failed pause comment: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to convergence-failed comment: %v\n", reactErr)
+		}
+	}
+
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+	}
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+	}
+	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); err != nil {
+		e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+	}
+}
+
+// summarizeCIRuns produces a brief human-readable summary of check run results.
+func summarizeCIRuns(runs []gh.CheckRun) string {
+	if len(runs) == 0 {
+		return "none"
+	}
+	var failed, pending, passed int
+	for _, r := range runs {
+		switch {
+		case r.Status != "completed":
+			pending++
+		case r.Conclusion == "success" || r.Conclusion == "neutral" || r.Conclusion == "skipped":
+			passed++
+		default:
+			failed++
+		}
+	}
+	if failed > 0 {
+		return fmt.Sprintf("❌ %d failed, %d passed, %d pending", failed, passed, pending)
+	}
+	if pending > 0 {
+		return fmt.Sprintf("⏳ %d pending, %d passed", pending, passed)
+	}
+	return fmt.Sprintf("✅ %d passed", passed)
 }
 
 // pauseForRebaseCycleLimit pauses the issue when rebase re-invocations have

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -226,10 +226,16 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 			pr, prErr := e.client.FetchLinkedPR(owner, repo, item.Number)
 			if prErr != nil || pr == nil || pr.Number == 0 {
 				e.logf(item.Number, "warn", "rebase reinvoke: could not fetch linked PR for auto-merge re-enable: %v\n", prErr)
-			} else if rerr := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, e.cfg.AutoMergeStrategy); rerr != nil {
-				e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
 			} else {
-				e.logf(item.Number, "auto-merge", "re-enabled auto-merge on PR #%d after rebase push\n", pr.Number)
+				strategy := e.cfg.AutoMergeStrategy
+				if strategy == "" {
+					strategy = "MERGE"
+				}
+				if rerr := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, strategy); rerr != nil {
+					e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
+				} else {
+					e.logf(item.Number, "auto-merge", "re-enabled auto-merge on PR #%d after rebase push\n", pr.Number)
+				}
 			}
 		}
 	}()
@@ -273,13 +279,17 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 		return
 	}
 
-	// User manually disabled auto-merge: back off, treat as cruise from this point.
+	// User manually disabled auto-merge: pause the issue to prevent the next poll
+	// from re-enabling auto-merge via Phase 2 (yoloActive=true + no label → attemptMergeOnValidate).
 	if !pr.AutoMergeEnabled {
-		e.logf(item.Number, "auto-merge", "PR #%d auto-merge disabled by user — treating as cruise\n", pr.Number)
+		e.logf(item.Number, "auto-merge", "PR #%d auto-merge disabled by user — pausing\n", pr.Number)
 		msg := fmt.Sprintf("🏭 **Fabrik — auto-merge disabled**\n\n" +
 			"Fabrik detected that GitHub auto-merge was disabled on the linked PR. " +
-			"Fabrik will no longer attempt to merge this PR automatically — treating as `fabrik:cruise` from this point. " +
-			"To re-enable, add `fabrik:yolo` and remove `fabrik:auto-merge-enabled` after the branch is ready.")
+			"This issue has been paused (`fabrik:paused` + `fabrik:awaiting-input`) to prevent Fabrik from re-enabling auto-merge on the next poll cycle.\n\n" +
+			"To resume:\n" +
+			"- **Keep cruise behavior**: Remove `fabrik:paused` and `fabrik:yolo`. Fabrik will keep the branch up-to-date but leave merging to you.\n" +
+			"- **Re-enable auto-merge**: Remove `fabrik:paused`. Fabrik will re-enable auto-merge on the next poll cycle.\n" +
+			"- **Leave as-is**: Take no action. The PR remains open and unmerged until you act.")
 		if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
 			e.logf(item.Number, "warn", "could not post auto-merge disabled comment: %v\n", cerr)
 		} else {
@@ -288,6 +298,16 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
+		}
+		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+		}
+		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 		}
 		if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); rerr != nil {
 			e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", rerr)

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -217,7 +217,7 @@ func (e *stubError) Error() string { return e.msg }
 
 // ── checkAutoMergeConvergence tests ──────────────────────────────────────────
 
-func TestCheckAutoMergeConvergence_PRMerged_RemovesLabel(t *testing.T) {
+func TestCheckAutoMergeConvergence_PRMerged_RemovesLabelAndAdvances(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 10, State: "closed", Merged: true, AutoMergeEnabled: true}, nil
@@ -227,21 +227,28 @@ func TestCheckAutoMergeConvergence_PRMerged_RemovesLabel(t *testing.T) {
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
 
-	found := false
+	foundRemove := false
 	for _, c := range client.removeLabelCalls {
 		if c.labelName == "fabrik:auto-merge-enabled" {
-			found = true
+			foundRemove = true
 		}
 	}
-	if !found {
+	if !foundRemove {
 		t.Error("expected fabrik:auto-merge-enabled to be removed when PR merges")
 	}
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:paused" {
 			t.Error("should not pause when PR merges normally")
 		}
+	}
+	// Verify Done advancement was attempted: advanceToNextStage calls UpdateProjectItemStatus.
+	client.mu.Lock()
+	advanceCalls := len(client.updateStatusCalls)
+	client.mu.Unlock()
+	if advanceCalls == 0 {
+		t.Error("expected UpdateProjectItemStatus to be called to advance to Done when PR merges")
 	}
 }
 

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -1,9 +1,13 @@
 package engine
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
 
@@ -210,3 +214,297 @@ var errStubTransient = &stubError{"simulated transient error"}
 type stubError struct{ msg string }
 
 func (e *stubError) Error() string { return e.msg }
+
+// ── checkAutoMergeConvergence tests ──────────────────────────────────────────
+
+func TestCheckAutoMergeConvergence_PRMerged_RemovesLabel(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "closed", Merged: true, AutoMergeEnabled: true}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+
+	found := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected fabrik:auto-merge-enabled to be removed when PR merges")
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			t.Error("should not pause when PR merges normally")
+		}
+	}
+}
+
+func TestCheckAutoMergeConvergence_UserDisabledAutoMerge_PostsCommentRemovesLabel(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			// AutoMergeEnabled=false simulates user clicking "Disable auto-merge".
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: false}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+
+	foundRemove := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundRemove = true
+		}
+	}
+	if !foundRemove {
+		t.Error("expected fabrik:auto-merge-enabled to be removed when user disables auto-merge")
+	}
+	if len(client.addCommentCalls) == 0 {
+		t.Error("expected a comment to be posted when user disables auto-merge")
+	}
+	for _, c := range client.addCommentCalls {
+		if !strings.Contains(c.body, "🏭 **Fabrik") {
+			t.Errorf("comment body should start with 🏭 **Fabrik, got: %q", c.body)
+		}
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			t.Error("should not pause when user takes over by disabling auto-merge")
+		}
+	}
+}
+
+func TestCheckAutoMergeConvergence_BudgetExhausted_PausesIssue(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "blocked"}, nil
+		},
+		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+			// Report label applied 2 hours ago (exceeds any budget in test).
+			return time.Now().Add(-2 * time.Hour), nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	eng.cfg.ConvergenceBudget = 30 * time.Minute
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+
+	foundPaused := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			foundPaused = true
+		}
+	}
+	if !foundPaused {
+		t.Error("expected fabrik:paused to be applied when convergence budget exhausts")
+	}
+
+	foundRemoveAutoMerge := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundRemoveAutoMerge = true
+		}
+	}
+	if !foundRemoveAutoMerge {
+		t.Error("expected fabrik:auto-merge-enabled to be removed on budget exhaustion")
+	}
+
+	if len(client.addCommentCalls) == 0 {
+		t.Error("expected convergence-failed pause comment to be posted")
+	}
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "convergence budget exhausted") {
+			return // found it
+		}
+	}
+	t.Error("pause comment should mention 'convergence budget exhausted'")
+}
+
+func TestCheckAutoMergeConvergence_BudgetDisabled_NoPause(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "blocked"}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	eng.cfg.ConvergenceBudget = 0 // disabled
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			t.Error("should not pause when convergence budget is disabled")
+		}
+	}
+}
+
+func TestCheckAutoMergeConvergence_UnknownMergeability_Waits(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "unknown"}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+
+	// No labels changed, no comments posted — just waiting.
+	for _, c := range client.addLabelCalls {
+		t.Errorf("unexpected AddLabel call for %q when mergeability is unknown", c.labelName)
+	}
+	for _, c := range client.removeLabelCalls {
+		t.Errorf("unexpected RemoveLabel call for %q when mergeability is unknown", c.labelName)
+	}
+}
+
+func TestCheckAutoMergeConvergence_DirtyConflict_IncrementsCycleCount(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+
+	snap, err := eng.store.Get("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if snap.RebaseCycles("Validate") != 1 {
+		t.Errorf("expected RebaseCycles=1 after dirty dispatch, got %d", snap.RebaseCycles("Validate"))
+	}
+	// Should not pause — only dispatch.
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			t.Error("should not pause on first conflict within budget")
+		}
+	}
+}
+
+// TestCheckAutoMergeConvergence_DirtyConflict_InFlight_SkipsDispatch verifies
+// that a second rebase dispatch is skipped when one is already in-flight
+// (existing worker set in store).
+func TestCheckAutoMergeConvergence_DirtyConflict_InFlight_SkipsDispatch(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	// Simulate in-flight worker.
+	eng.store.Apply(itemstate.LocalLockAcquired{
+		Repo: "owner/repo", Number: 42, User: "testuser", AcquiredAt: time.Now(),
+		Worker: &itemstate.WorkerHandle{StageName: "Validate", StartedAt: time.Now()},
+	})
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+
+	snap, err := eng.store.Get("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	// Cycle count should NOT be incremented when dispatch is skipped.
+	if snap.RebaseCycles("Validate") != 0 {
+		t.Errorf("expected RebaseCycles=0 when dispatch skipped (in-flight), got %d", snap.RebaseCycles("Validate"))
+	}
+}
+
+// TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain verifies SC-008:
+// after a first rebase reinvoke, if main moves again causing another conflict,
+// a second rebase reinvoke is dispatched. Cycle count is not a gate.
+func TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	// Simulate prior rebase cycle having completed (no in-flight worker).
+	eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 42, StageName: "Validate"})
+
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+
+	snap, err := eng.store.Get("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	// Cycle count should now be 2; dispatch was not gated by MaxRebaseCycles.
+	if snap.RebaseCycles("Validate") != 2 {
+		t.Errorf("expected RebaseCycles=2 after second dispatch, got %d", snap.RebaseCycles("Validate"))
+	}
+}
+
+// TestPauseForConvergenceFailed_PostsComment_AppliesLabels verifies that the
+// convergence-failed pause comment contains the expected fields and that
+// fabrik:paused, fabrik:awaiting-input are applied and fabrik:auto-merge-enabled removed.
+func TestPauseForConvergenceFailed_PostsComment_AppliesLabels(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", MergeableState: "dirty", HeadSHA: "abc123"}, nil
+		},
+		fetchCommitsBehindFn: func(owner, repo, base, head string) (int, error) {
+			return 3, nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	eng.cfg.ConvergenceBudget = 30 * time.Minute
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+	elapsed := 45 * time.Minute
+
+	eng.pauseForConvergenceFailed(context.Background(), &gh.ProjectBoard{}, item, stage, elapsed)
+
+	// Verify pause comment posted.
+	if len(client.addCommentCalls) == 0 {
+		t.Fatal("expected a comment to be posted")
+	}
+	body := client.addCommentCalls[0].body
+	if !strings.Contains(body, "convergence budget exhausted") {
+		t.Errorf("comment should mention 'convergence budget exhausted', got: %q", body)
+	}
+	if !strings.Contains(body, "dirty") {
+		t.Errorf("comment should include mergeable_state 'dirty', got: %q", body)
+	}
+
+	// Verify labels.
+	wantAdded := map[string]bool{"fabrik:paused": false, "fabrik:awaiting-input": false}
+	for _, c := range client.addLabelCalls {
+		wantAdded[c.labelName] = true
+	}
+	for label, found := range wantAdded {
+		if !found {
+			t.Errorf("expected label %q to be added", label)
+		}
+	}
+	foundRemove := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundRemove = true
+		}
+	}
+	if !foundRemove {
+		t.Error("expected fabrik:auto-merge-enabled to be removed on convergence failure")
+	}
+}

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -260,7 +260,7 @@ func TestCheckAutoMergeConvergence_UserDisabledAutoMerge_PostsCommentRemovesLabe
 		},
 	}
 	eng := testEngineForMerge(client)
-	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled", "fabrik:yolo"}}
 	stage := &stages.Stage{Name: "Validate"}
 
 	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
@@ -282,9 +282,15 @@ func TestCheckAutoMergeConvergence_UserDisabledAutoMerge_PostsCommentRemovesLabe
 			t.Errorf("comment body should start with 🏭 **Fabrik, got: %q", c.body)
 		}
 	}
+	// fabrik:paused + fabrik:awaiting-input must be applied to prevent Phase 2 from
+	// re-enabling auto-merge on the next poll cycle.
+	wantAdded := map[string]bool{"fabrik:paused": false, "fabrik:awaiting-input": false}
 	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:paused" {
-			t.Error("should not pause when user takes over by disabling auto-merge")
+		wantAdded[c.labelName] = true
+	}
+	for label, found := range wantAdded {
+		if !found {
+			t.Errorf("expected label %q to be added when user disables auto-merge", label)
 		}
 	}
 }

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -608,6 +608,38 @@ type addBlockedByIssueCall struct {
 	issueNodeID, blockerNodeID string
 }
 
+type enablePullRequestAutoMergeCall struct {
+	owner, repo string
+	prNumber    int
+	strategy    string
+}
+
+type fetchCommitsBehindCall struct {
+	owner, repo, base, head string
+}
+
+func (m *mockGitHubClient) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
+	m.mu.Lock()
+	m.enablePullRequestAutoMergeCalls = append(m.enablePullRequestAutoMergeCalls, enablePullRequestAutoMergeCall{owner, repo, prNumber, strategy})
+	fn := m.enablePullRequestAutoMergeFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber, strategy)
+	}
+	return nil
+}
+
+func (m *mockGitHubClient) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
+	m.mu.Lock()
+	m.fetchCommitsBehindCalls = append(m.fetchCommitsBehindCalls, fetchCommitsBehindCall{owner, repo, base, head})
+	fn := m.fetchCommitsBehindFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, base, head)
+	}
+	return 0, nil
+}
+
 func (m *mockGitHubClient) CreateIssue(owner, repo, title, body string) (int, string, error) {
 	m.mu.Lock()
 	m.createIssueCalls = append(m.createIssueCalls, createIssueCall{owner, repo, title, body})

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -52,8 +52,10 @@ type mockGitHubClient struct {
 	fetchPRClosingIssuesFn        func(owner, repo string, prNumber int) ([]int, error)
 	fetchPRsForSHAFn              func(owner, repo, sha string) ([]int, error)
 	createIssueFn                 func(owner, repo, title, body string) (int, string, error)
-	addProjectV2ItemByIdFn        func(projectID, contentNodeID string) (string, error)
-	addBlockedByIssueFn           func(issueNodeID, blockerNodeID string) error
+	addProjectV2ItemByIdFn              func(projectID, contentNodeID string) (string, error)
+	addBlockedByIssueFn                 func(issueNodeID, blockerNodeID string) error
+	enablePullRequestAutoMergeFn        func(owner, repo string, prNumber int, strategy string) error
+	fetchCommitsBehindFn                func(owner, repo, base, head string) (int, error)
 
 	// Track call counts for FetchProjectItemStatus
 	fetchProjectItemStatusCalls []string
@@ -89,9 +91,11 @@ type mockGitHubClient struct {
 	addReviewRequestCalls           []reviewRequestCall
 	seedLabelsCalls                 []seedLabelsCall
 	seedLabelsFn                    func(owner, repo string, stageNames []string, lockedUser string) error
-	createIssueCalls                []createIssueCall
-	addProjectV2ItemCalls           []addProjectV2ItemCall
-	addBlockedByIssueCalls          []addBlockedByIssueCall
+	createIssueCalls                    []createIssueCall
+	addProjectV2ItemCalls               []addProjectV2ItemCall
+	addBlockedByIssueCalls              []addBlockedByIssueCall
+	enablePullRequestAutoMergeCalls     []enablePullRequestAutoMergeCall
+	fetchCommitsBehindCalls             []fetchCommitsBehindCall
 }
 
 type reviewRequestCall struct {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -758,6 +758,7 @@ func (e *Engine) cleanupClosedIssueLocks(board *gh.ProjectBoard) {
 var transientLifecycleLabels = []string{
 	"fabrik:awaiting-review",
 	"fabrik:awaiting-ci",
+	"fabrik:auto-merge-enabled",
 	"fabrik:awaiting-input",
 	"fabrik:rebase-needed",
 	"fabrik:bot-reprompted",
@@ -1107,7 +1108,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		if !cycleSet[iKey] {
 			stage := stages.FindStage(e.cfg.Stages, item.Status)
 			isCleanup := stage != nil && stage.CleanupWorktree
-			hasAwaitingLabel := hasLabel(item, "fabrik:awaiting-ci") || hasLabel(item, "fabrik:rebase-needed") || hasLabel(item, "fabrik:awaiting-review")
+			hasAwaitingLabel := hasLabel(item, "fabrik:awaiting-ci") || hasLabel(item, "fabrik:rebase-needed") || hasLabel(item, "fabrik:awaiting-review") || hasLabel(item, "fabrik:auto-merge-enabled")
 			var hasExpiredCooldown, notInStore bool
 			if !isCleanup && !hasAwaitingLabel {
 				repo := itemOwnerRepoString(item, e.defaultRepo())

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1357,24 +1357,23 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		}
 
 		if stage.Name == "Validate" {
-			// auto-merge is yolo-only — matches handleStageComplete gating.
-			// cruise and auto_advance:true both stop here without merging.
+			// auto-merge is yolo-only — cruise and auto_advance:true stop here.
 			yoloActive := e.cfg.Yolo || hasYoloLabel(item)
 			if !yoloActive {
 				continue
 			}
-			if err := e.attemptMergeOnValidate(ctx, board, item, stage); err != nil {
-				if errors.Is(err, errRebaseDispatched) {
-					e.logf(item.Number, "rebase-reinvoke", "PR merge deferred — rebase dispatched during catch-up\n")
-					// Mark as advanced so CooldownAt["periodic-re-eval"] is NOT stamped —
-					// the column move fires StatusChanged → mayNeedWork observer already
-					// queues re-evaluation for the next poll cycle.
-					advancedItems[issueKey(item, e.defaultRepo())] = true
-				} else {
-					e.logf(item.Number, "warn", "PR not merged during catch-up: %v\n", err)
-				}
+			// Items with fabrik:auto-merge-enabled are already in the GitHub
+			// auto-merge convergence flow; checkAutoMergeConvergence (Phase 1)
+			// monitors them and advances to Done when the PR merges.
+			if hasLabel(item, "fabrik:auto-merge-enabled") {
 				continue
 			}
+			if _, mergeErr := e.attemptMergeOnValidate(ctx, board, item, stage); mergeErr != nil {
+				e.logf(item.Number, "warn", "auto-merge enablement failed during catch-up: %v\n", mergeErr)
+			}
+			// Auto-merge enabled (or failed); Done advancement deferred to
+			// checkAutoMergeConvergence in Phase 1 — do not advance immediately.
+			continue
 		}
 		if newComments := e.findNewComments(item); len(newComments) > 0 {
 			e.logf(item.Number, "advance", "skipping stage %q — %d unprocessed comment(s) pending\n", stage.Name, len(newComments))

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1281,6 +1281,15 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			}
 		}
 
+		// Convergence monitor: items with fabrik:auto-merge-enabled are in the
+		// GitHub native auto-merge flow. checkAutoMergeConvergence handles PR
+		// state changes, budget exhaustion, and rebase dispatch. All other
+		// merge/CI gates are bypassed — GitHub owns the merge decision.
+		if hasLabel(item, "fabrik:auto-merge-enabled") {
+			e.checkAutoMergeConvergence(ctx, board, item, stage)
+			continue
+		}
+
 		// Merge-conflict gate: runs before the CI gate so that a PR made
 		// unmergeable by a base-branch advance is rebased immediately instead
 		// of the engine spinning on CI-await polls while the underlying

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -811,10 +812,11 @@ func TestArchiveDoneCompleteItems_SkipsIncompleteItems(t *testing.T) {
 	}
 }
 
-// TestYoloCatchUpMergesBeforeAdvance verifies that when an item sits in the
+// TestYoloCatchUpEnablesAutoMerge verifies that when an item sits in the
 // Validate column with stage:Validate:complete + fabrik:yolo, the catch-up loop
-// calls MergePR before calling UpdateProjectItemStatus (advancing to Done).
-func TestYoloCatchUpMergesBeforeAdvance(t *testing.T) {
+// calls EnablePullRequestAutoMerge (not MergePR) and does NOT immediately advance
+// to Done (advancement is deferred to checkAutoMergeConvergence).
+func TestYoloCatchUpEnablesAutoMerge(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
 			return &gh.ProjectBoard{
@@ -845,17 +847,6 @@ func TestYoloCatchUpMergesBeforeAdvance(t *testing.T) {
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 99, HeadSHA: "sha1"}, nil
 		},
-	}
-	// Set after construction so the closure can reference client.
-	client.updateProjectItemStatusFn = func(projectID, itemID, statusFieldID, statusOptionID string) error {
-		// Ordering assertion: MergePR must have been called before UpdateProjectItemStatus.
-		client.mu.Lock()
-		mergedBefore := len(client.mergePRCalls) > 0
-		client.mu.Unlock()
-		if !mergedBefore {
-			t.Error("UpdateProjectItemStatus called before MergePR — ordering violated")
-		}
-		return nil
 	}
 	eng := testEngineWithStages(client, testStagesWithValidate())
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
@@ -869,25 +860,31 @@ func TestYoloCatchUpMergesBeforeAdvance(t *testing.T) {
 	}
 
 	client.mu.Lock()
+	autoMergeCalls := len(client.enablePullRequestAutoMergeCalls)
 	merges := len(client.mergePRCalls)
 	advances := len(client.updateStatusCalls)
 	client.mu.Unlock()
 
-	if merges == 0 {
-		t.Fatal("expected MergePR to be called")
+	if autoMergeCalls == 0 {
+		t.Fatal("expected EnablePullRequestAutoMerge to be called")
 	}
-	if advances == 0 {
-		t.Fatal("expected UpdateProjectItemStatus to be called after merge")
+	if merges != 0 {
+		t.Errorf("MergePR must not be called in the new auto-merge path, got %d", merges)
 	}
-	if client.mergePRCalls[0].prNumber != 99 {
-		t.Errorf("MergePR called with prNumber %d, want 99", client.mergePRCalls[0].prNumber)
+	// Done advancement is deferred to checkAutoMergeConvergence, not immediate.
+	if advances != 0 {
+		t.Errorf("expected no immediate advance (deferred to convergence monitor), got %d", advances)
+	}
+	if client.enablePullRequestAutoMergeCalls[0].prNumber != 99 {
+		t.Errorf("EnablePullRequestAutoMerge called with prNumber %d, want 99", client.enablePullRequestAutoMergeCalls[0].prNumber)
 	}
 }
 
-// TestYoloCatchUpSkipsAdvanceOnMergeError verifies that when MergePR returns an
-// error in the catch-up loop, UpdateProjectItemStatus is NOT called (advance is
-// skipped).
-func TestYoloCatchUpSkipsAdvanceOnMergeError(t *testing.T) {
+// TestYoloCatchUpSkipsAdvanceOnAutoMergeError verifies that when
+// EnablePullRequestAutoMerge returns an error in the catch-up loop,
+// UpdateProjectItemStatus is NOT called (advance is skipped) and the engine
+// does not dispatch a rebase or pause the issue — it simply retries next poll.
+func TestYoloCatchUpSkipsAdvanceOnAutoMergeError(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
 			return &gh.ProjectBoard{
@@ -918,12 +915,11 @@ func TestYoloCatchUpSkipsAdvanceOnMergeError(t *testing.T) {
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 99, HeadSHA: "sha1"}, nil
 		},
-		mergePRFn: func(owner, repo string, prNumber int) error {
-			return gh.ErrNotMergeable
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			return errors.New("transient API error")
 		},
 	}
 	eng := testEngineWithStages(client, testStagesWithValidate())
-	eng.cfg.MaxRebaseCycles = 3
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#42"] = true
@@ -933,24 +929,21 @@ func TestYoloCatchUpSkipsAdvanceOnMergeError(t *testing.T) {
 	if _, err := eng.poll(ctx); err != nil {
 		t.Fatalf("poll: %v", err)
 	}
-	// Wait for the dispatched rebase goroutine to exit (exits early via ErrSkipItem in tests).
-	eng.wg.Wait()
 
 	client.mu.Lock()
 	advances := len(client.updateStatusCalls)
 	client.mu.Unlock()
 
 	if advances != 0 {
-		t.Errorf("expected no UpdateProjectItemStatus when merge fails, got %d", advances)
+		t.Errorf("expected no UpdateProjectItemStatus when auto-merge enablement fails, got %d", advances)
 	}
-	// Rebase dispatch should have fired, not immediate pause.
-	snap42, _ := eng.store.Get("owner/repo", 42)
-	if snap42.RebaseCycles("Validate") != 1 {
-		t.Errorf("expected rebaseCycles(Validate) == 1, got %d", snap42.RebaseCycles("Validate"))
-	}
+	// No rebase dispatch — error path in new auto-merge flow just logs and retries.
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:paused" {
-			t.Error("fabrik:paused must NOT be added when dispatching rebase reinvoke")
+			t.Error("fabrik:paused must NOT be added for transient auto-merge enablement error")
+		}
+		if c.labelName == "fabrik:rebase-needed" {
+			t.Error("fabrik:rebase-needed must NOT be added for auto-merge enablement error")
 		}
 	}
 }
@@ -1146,10 +1139,11 @@ func TestCruiseCatchUp_Validate_NoMergeNoAdvance(t *testing.T) {
 	}
 }
 
-// TestCruiseCatchUp_BothCruiseAndYolo_YoloWins verifies that when both fabrik:cruise
-// and fabrik:yolo are present, yolo takes precedence: the PR is merged and the item
-// advances past Validate in the catch-up loop.
-func TestCruiseCatchUp_BothCruiseAndYolo_YoloWins(t *testing.T) {
+// TestCruiseCatchUp_BothCruiseAndYolo_CruiseWins verifies that when both fabrik:cruise
+// and fabrik:yolo are present, cruise takes precedence at Validate: neither
+// EnablePullRequestAutoMerge nor MergePR is called and the item is not advanced
+// (FR-003, FR-015: cruise leaves the PR for human merge).
+func TestCruiseCatchUp_BothCruiseAndYolo_CruiseWins(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
 			return &gh.ProjectBoard{
@@ -1195,13 +1189,17 @@ func TestCruiseCatchUp_BothCruiseAndYolo_YoloWins(t *testing.T) {
 	client.mu.Lock()
 	advances := len(client.updateStatusCalls)
 	merges := len(client.mergePRCalls)
+	autoMergeCalls := len(client.enablePullRequestAutoMergeCalls)
 	client.mu.Unlock()
 
-	if merges != 1 {
-		t.Errorf("expected MergePR to fire when yolo wins over cruise, got %d", merges)
+	if merges != 0 {
+		t.Errorf("expected no MergePR when cruise wins over yolo, got %d", merges)
 	}
-	if advances != 1 {
-		t.Errorf("expected advance when yolo wins over cruise, got %d", advances)
+	if autoMergeCalls != 0 {
+		t.Errorf("expected no EnablePullRequestAutoMerge when cruise wins over yolo, got %d", autoMergeCalls)
+	}
+	if advances != 0 {
+		t.Errorf("expected no advance when cruise wins at Validate, got %d", advances)
 	}
 }
 

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -5,21 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
-	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
-
-// errRebaseDispatched is returned by attemptMergeOnValidate when a rebase
-// reinvoke has been dispatched instead of immediately pausing. handleStageComplete
-// detects this sentinel and adds stage:Validate:complete so the catch-up loop's
-// Phase 2 drives the merge retry rather than itemNeedsWork triggering a full
-// Validate re-invocation.
-var errRebaseDispatched = errors.New("rebase reinvoke dispatched")
 
 // hasYoloLabel reports whether item has the "fabrik:yolo" label.
 func hasYoloLabel(item gh.ProjectItem) bool {
@@ -96,34 +87,22 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	// cruise is suppressed so yolo always takes precedence.
 	cruiseActive := !yoloActive && hasCruiseLabel(item)
 
-	// Attempt PR merge after Validate when yolo is active and wait_for_ci is false.
-	// When wait_for_ci: true the merge happens in the catch-up loop's Phase 2 after
-	// the CI gate clears (see ADR 032). This runs BEFORE adding the completion label
-	// so that on merge failure the engine can retry Validate (itemNeedsWork skips
-	// stages with a complete label).
+	// autoMergeEnabled is true when attemptMergeOnValidate successfully called
+	// EnablePullRequestAutoMerge. Done advancement is deferred to the convergence
+	// monitor (checkAutoMergeConvergence in the catch-up loop) in that case.
+	autoMergeEnabled := false
+
+	// Enable GitHub native auto-merge after Validate when yolo is active and
+	// wait_for_ci is false. When wait_for_ci: true the merge path is handled by
+	// checkCIGate in the catch-up loop (see ADR 032). This runs BEFORE adding the
+	// completion label so that on failure the engine retries Validate (itemNeedsWork
+	// skips stages with a complete label).
 	waitForCI := stage.WaitForCI != nil && *stage.WaitForCI
 	if yoloActive && stage.Name == "Validate" && !waitForCI {
-		if err := e.attemptMergeOnValidate(ctx, board, item, stage); err != nil {
-			if errors.Is(err, errRebaseDispatched) {
-				// Rebase reinvoke dispatched — add completion label so the catch-up
-				// loop retries the merge rather than itemNeedsWork triggering a full
-				// Validate re-invocation.
-				completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
-				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); lerr != nil {
-					e.logf(item.Number, "warn", "could not add completion label: %v\n", lerr)
-				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
-					}
-				}
-				e.logf(item.Number, "rebase-reinvoke", "PR merge deferred — rebase dispatched\n")
-			} else {
-				// Merge failed: post/pause already handled inside attemptMergeOnValidate.
-				e.logf(item.Number, "warn", "PR not merged: %v\n", err)
-			}
+		var mergeErr error
+		autoMergeEnabled, mergeErr = e.attemptMergeOnValidate(ctx, board, item, stage)
+		if mergeErr != nil {
+			e.logf(item.Number, "warn", "PR not merged: %v\n", mergeErr)
 			return
 		}
 	}
@@ -184,6 +163,13 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 		shouldAdvance = false
 	}
 
+	// If GitHub auto-merge was just enabled, defer Done advancement to
+	// checkAutoMergeConvergence in the catch-up loop. Done cleanup must not
+	// run until the PR is actually merged by GitHub.
+	if autoMergeEnabled {
+		shouldAdvance = false
+	}
+
 	if shouldAdvance {
 		if e.checkDependencies(board, item, stage) {
 			return // blocked; checkDependencies handled label + comment
@@ -224,235 +210,56 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	}
 }
 
-// attemptMergeOnValidate finds the linked PR for item, gates on CI status,
-// and merges it. Returns nil on success or when no PR exists.
-// On CI timeout, returns a handled error (pause already applied).
-// On ErrNotMergeable (base-branch conflict): applies fabrik:rebase-needed
-// idempotently, then dispatches dispatchRebaseReinvoke and returns the
-// errRebaseDispatched sentinel (caller must add stage:Validate:complete so
-// the catch-up loop retries the merge). At MaxRebaseCycles, falls back to
-// pauseForRebaseCycleLimit (handled error, pause applied).
-// Returns a retriable error (caller should retry) when CI is pending or a
-// transient API error occurs.
-//
-// CI gate logic (R1–R6):
-//   - No check runs → gate clears (R5: repo has no CI)
-//   - Any pending/queued → block; track ciMergePendingSince; pause after CIWaitTimeout
-//   - Any failed → add fabrik:awaiting-ci; return error
-//   - All green → clear ciMergePendingSince; clear fabrik:awaiting-ci; proceed to merge
-func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) error {
+// attemptMergeOnValidate enables GitHub native auto-merge for the linked PR
+// of a yolo issue at Validate completion. Returns (true, nil) when auto-merge
+// was enabled (or is already enabled as an idempotency guard), (false, nil)
+// when no action is needed (cruise label, no linked PR), and (false, err) on
+// failure. The fabrik:auto-merge-enabled label serves as both the idempotency
+// guard and the budget-start anchor read by checkAutoMergeConvergence.
+func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, item gh.ProjectItem, _ *stages.Stage) (bool, error) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	// Use FetchLinkedPR (REST) to get both the PR number and head SHA in one call.
+	// Idempotency: auto-merge was already enabled on a prior run.
+	if hasLabel(item, "fabrik:auto-merge-enabled") {
+		return true, nil
+	}
+
 	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
 	if err != nil {
-		e.logf(item.Number, "warn", "could not fetch linked PR for merge: %v — will retry\n", err)
-		return fmt.Errorf("fetch linked PR: %w", err)
+		e.logf(item.Number, "warn", "could not fetch linked PR for auto-merge: %v — will retry\n", err)
+		return false, fmt.Errorf("fetch linked PR: %w", err)
 	}
 	if pr == nil {
 		e.logf(item.Number, "warn", "no linked PR found at Validate completion; skipping auto-merge\n")
-		return nil
+		return false, nil
 	}
 
-	// Trust GitHub's branch-protection-aware mergeable_state when it's
-	// positive: "clean" = ready to merge per branch protection; "unstable" =
-	// non-required checks failing but still mergeable. In both cases, skip
-	// the raw check_runs gate below — that gate is over-aggressive, treating
-	// any check_run failure (including non-required workflow jobs like
-	// "Cleanup artifacts") as blocking, which contradicts GitHub's own
-	// merge decision. mergeable_state is only available from the single-PR
-	// endpoint, so this requires an extra REST call.
-	bypassCheckRunsGate := false
-	if pr.HeadSHA != "" {
-		mergeableState, msErr := e.readClient.FetchPRMergeableState(owner, repo, pr.Number)
-		if msErr != nil {
-			e.logf(item.Number, "warn", "could not fetch mergeable_state: %v — falling back to check-runs gate\n", msErr)
-		} else if gh.MergeableStateAccepted(mergeableState) {
-			e.logf(item.Number, "ci-gate", "mergeable_state=%q — skipping check_runs gate, proceeding to merge\n", mergeableState)
-			// Clear stale CI-await state so a stuck fabrik:awaiting-ci from
-			// the prior over-aggressive gate doesn't survive past the merge.
-			e.removeAwaitingCILabel(owner, repo, item)
-			e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
-			bypassCheckRunsGate = true
+	strategy := e.cfg.AutoMergeStrategy
+	if strategy == "" {
+		strategy = "MERGE"
+	}
+	if err := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, strategy); err != nil {
+		if errors.Is(err, gh.ErrAutoMergeNotEnabled) {
+			e.logf(item.Number, "warn", "auto-merge is not enabled for this repository — "+
+				"enable it in Settings → General → Allow auto-merge; Fabrik will retry on the next poll\n")
+		}
+		return false, fmt.Errorf("enabling auto-merge on PR #%d: %w", pr.Number, err)
+	}
+
+	// Apply fabrik:auto-merge-enabled as idempotency guard and budget-start anchor.
+	if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
 		}
 	}
 
-	// CI gate: fetch check runs and evaluate (R1-R6). Skipped when GitHub's
-	// mergeable_state already says the PR is mergeable (above).
-	if !bypassCheckRunsGate && pr.HeadSHA != "" {
-		checkRuns, err := e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
-		if err != nil {
-			e.logf(item.Number, "warn", "could not fetch check runs for merge guard: %v — skipping merge until CI status can be fetched\n", err)
-			return fmt.Errorf("merge guard: fetch check runs: %w", err)
-		} else if len(checkRuns) > 0 {
-			var pending, failed []gh.CheckRun
-			for _, cr := range checkRuns {
-				switch cr.Status {
-				case "queued", "in_progress":
-					pending = append(pending, cr)
-				case "completed":
-					switch cr.Conclusion {
-					case "failure", "timed_out", "action_required":
-						failed = append(failed, cr)
-					}
-				}
-			}
-
-			if len(failed) > 0 {
-				// R3: CI failed — apply label and block merge.
-				names := make([]string, 0, len(failed))
-				for _, cr := range failed {
-					names = append(names, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
-				}
-				e.logf(item.Number, "ci-gate", "merge blocked — CI failed: %s\n", strings.Join(names, ", "))
-				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); lerr != nil {
-					e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci: %v\n", lerr)
-				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-ci")
-					}
-				}
-				// Clean up pending timer since we now have a definitive failure state.
-				e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
-				return fmt.Errorf("merge blocked: CI checks failed")
-			}
-
-			if len(pending) > 0 {
-				// R2: CI still running — check timeout (R6).
-				names := make([]string, 0, len(pending))
-				for _, cr := range pending {
-					names = append(names, cr.Name)
-				}
-				e.logf(item.Number, "ci-gate", "merge blocked — CI still running: %s\n", strings.Join(names, ", "))
-
-				timeout := e.cfg.CIWaitTimeout
-				if timeout <= 0 {
-					timeout = 30 * time.Minute
-				}
-				snap, _ := e.store.Get(owner+"/"+repo, item.Number)
-				var since time.Time
-				if lpr := snap.LinkedPR(); lpr != nil {
-					since = lpr.CIMergePendingSince
-				}
-				if since.IsZero() {
-					now := time.Now()
-					e.store.Apply(itemstate.CIMergePendingStarted{Repo: owner + "/" + repo, Number: item.Number, At: now})
-					since = now
-				}
-
-				if time.Since(since) >= timeout {
-					// R6: timeout elapsed — pause issue.
-					e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
-					msg := fmt.Sprintf("🏭 **Fabrik — CI wait timeout (merge guard)**\n\n"+
-						"Auto-merge blocked: CI checks for PR #%d have been in progress for longer than "+
-						"the configured timeout (%s). Fabrik has paused this issue for human review.\n\n"+
-						"Pending checks: %s\n\nOnce CI resolves, remove `fabrik:paused` to resume.",
-						pr.Number, timeout, strings.Join(names, ", "))
-					if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
-						e.logf(item.Number, "warn", "could not post CI timeout comment: %v\n", cerr)
-					} else {
-						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-							cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-								DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-							})
-						}
-						if e.webhookMgr != nil {
-							e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-						}
-						// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-						if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-							e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-						}
-					}
-					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); lerr != nil {
-						e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", lerr)
-					} else {
-						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-							cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-						}
-						if e.webhookMgr != nil {
-							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-						}
-					}
-					if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); lerr != nil {
-						e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", lerr)
-					} else {
-						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-							cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-						}
-						if e.webhookMgr != nil {
-							e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
-						}
-					}
-					return fmt.Errorf("merge guard: CI wait timeout elapsed after %s", timeout)
-				}
-				return fmt.Errorf("merge blocked: CI checks still running")
-			}
-
-			// R4: All checks green — clear pending timer and awaiting-ci label.
-			e.store.Apply(itemstate.CIMergePendingCleared{Repo: owner + "/" + repo, Number: item.Number})
-			e.removeAwaitingCILabel(owner, repo, item)
-		}
-		// R5: len(checkRuns) == 0 — no CI configured; gate clears.
-	}
-
-	// no write-through: excluded — MergePR affects PR state, not issue/label cache
-	if err := e.client.MergePR(owner, repo, pr.Number); err != nil {
-		if errors.Is(err, gh.ErrNotMergeable) {
-			// Apply fabrik:rebase-needed idempotently.
-			alreadyLabeled := false
-			for _, l := range item.Labels {
-				if l == "fabrik:rebase-needed" {
-					alreadyLabeled = true
-					break
-				}
-			}
-			if !alreadyLabeled {
-				if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); lerr != nil {
-					e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", lerr)
-				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:rebase-needed")
-					}
-				}
-			}
-			// Store Worker field is the semantic source of truth for in-flight state.
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
-				e.logf(item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
-				return fmt.Errorf("PR #%d not mergeable (rebase in-flight)", pr.Number)
-			}
-			var cycleCount int
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
-				cycleCount = snap.RebaseCycles(stage.Name)
-			}
-			maxCycles := e.cfg.MaxRebaseCycles
-			if cycleCount >= maxCycles {
-				e.pauseForRebaseCycleLimit(board, item, stage, cycleCount, maxCycles)
-				return fmt.Errorf("PR #%d not mergeable — rebase cycle limit reached", pr.Number)
-			}
-			e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-			e.dispatchRebaseReinvoke(ctx, board, item, stage)
-			return errRebaseDispatched
-		}
-		// Other API errors (transient 5xx, permissions, etc.): log and return an
-		// error so the caller retries on the next cooldown cycle.
-		e.logf(item.Number, "warn", "auto-merge of PR #%d failed: %v\n", pr.Number, err)
-		return fmt.Errorf("auto-merge failed: %w", err)
-	}
-
-	if e.webhookMgr != nil {
-		e.webhookMgr.RegisterEcho("pull_request", "closed", fmt.Sprintf("%s/%s#pr%d", owner, repo, pr.Number))
-	}
-	e.removeRebaseNeededLabel(owner, repo, item)
-	e.logf(item.Number, "info", "auto-merged PR #%d\n", pr.Number)
-	return nil
+	e.logf(item.Number, "info", "GitHub auto-merge enabled on PR #%d (%s) — awaiting GitHub atomic merge\n", pr.Number, strategy)
+	return true, nil
 }
 
 // handleNoWorkNeeded is called when a stage outputs both FABRIK_STAGE_COMPLETE and

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -158,8 +158,9 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	}
 
 	// cruise stops at Validate: do not advance to Done or trigger any further
-	// stage movement. The PR merge was already skipped (yoloActive is false).
-	if cruiseActive && stage.Name == "Validate" {
+	// stage movement. cruise wins over yolo — when both labels are present,
+	// the PR is left for human merge (FR-003, FR-015).
+	if hasCruiseLabel(item) && stage.Name == "Validate" {
 		shouldAdvance = false
 	}
 
@@ -218,6 +219,12 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 // guard and the budget-start anchor read by checkAutoMergeConvergence.
 func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, item gh.ProjectItem, _ *stages.Stage) (bool, error) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	// cruise > yolo: when cruise is present, auto-merge is suppressed regardless of yolo.
+	// cruise auto-advances through stages but leaves the PR for human merge at Validate.
+	if hasCruiseLabel(item) {
+		return false, nil
+	}
 
 	// Idempotency: auto-merge was already enabled on a prior run.
 	if hasLabel(item, "fabrik:auto-merge-enabled") {

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
-	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
 
@@ -18,210 +16,87 @@ func testEngineForMerge(client *mockGitHubClient) *Engine {
 	return testEngineWithStages(client, stgs)
 }
 
-// TestAttemptMergeOnValidate_NoCheckRuns_MergeProceeds verifies R5: when there are
-// no CI check runs at all the gate clears and MergePR is called.
-func TestAttemptMergeOnValidate_NoCheckRuns_MergeProceeds(t *testing.T) {
+// TestAttemptMergeOnValidate_YoloEnablesAutoMerge verifies that for a yolo item
+// at Validate completion, EnablePullRequestAutoMerge is called (not MergePR),
+// fabrik:auto-merge-enabled is applied, and (true, nil) is returned.
+func TestAttemptMergeOnValidate_YoloEnablesAutoMerge(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
 		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil // R5: no CI
-		},
 	}
 	eng := testEngineForMerge(client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
-	if err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"}); err != nil {
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(client.mergePRCalls) != 1 {
-		t.Fatalf("expected MergePR called once, got %d", len(client.mergePRCalls))
-	}
-	if client.mergePRCalls[0].prNumber != 10 {
-		t.Errorf("MergePR called with pr %d, want 10", client.mergePRCalls[0].prNumber)
-	}
-}
-
-// TestAttemptMergeOnValidate_AllGreen_MergeProceeds verifies R4: all checks green clears
-// the pending timer, removes fabrik:awaiting-ci, and proceeds to merge.
-func TestAttemptMergeOnValidate_AllGreen_MergeProceeds(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 11, HeadSHA: "sha2"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "completed", Conclusion: "success"},
-				{Name: "test", Status: "completed", Conclusion: "success"},
-			}, nil
-		},
-	}
-	eng := testEngineForMerge(client)
-	// Seed a stale pending timer to confirm it gets cleared on green.
-	eng.store.Apply(itemstate.CIMergePendingStarted{Repo: "owner/repo", Number: 1, At: time.Now().Add(-1 * time.Minute)})
-
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-	if err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(client.mergePRCalls) != 1 {
-		t.Fatalf("expected MergePR called once, got %d", len(client.mergePRCalls))
-	}
-	snap, _ := eng.store.Get("owner/repo", 1)
-	if lpr := snap.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
-		t.Error("ciMergePendingSince should be cleared on all-green")
-	}
-}
-
-// TestAttemptMergeOnValidate_CIFailed_BlocksMerge verifies R3: when any check fails,
-// merge is blocked, fabrik:awaiting-ci is added, and error is returned.
-func TestAttemptMergeOnValidate_CIFailed_BlocksMerge(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 12, HeadSHA: "sha3"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "completed", Conclusion: "success"},
-				{Name: "lint", Status: "completed", Conclusion: "failure"},
-			}, nil
-		},
-	}
-	eng := testEngineForMerge(client)
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
-	if err == nil {
-		t.Fatal("expected error when CI failed, got nil")
+	if !enabled {
+		t.Fatal("expected autoMergeEnabled=true, got false")
 	}
 	if len(client.mergePRCalls) != 0 {
-		t.Errorf("expected no MergePR on CI failure, got %d", len(client.mergePRCalls))
+		t.Errorf("MergePR must not be called in yolo auto-merge path, got %d call(s)", len(client.mergePRCalls))
 	}
-	found := false
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge called once, got %d", len(client.enablePullRequestAutoMergeCalls))
+	}
+	if client.enablePullRequestAutoMergeCalls[0].prNumber != 10 {
+		t.Errorf("EnablePullRequestAutoMerge called with PR %d, want 10", client.enablePullRequestAutoMergeCalls[0].prNumber)
+	}
+	foundLabel := false
 	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:awaiting-ci" {
-			found = true
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundLabel = true
 		}
 	}
-	if !found {
-		t.Error("expected fabrik:awaiting-ci to be added on CI failure")
+	if !foundLabel {
+		t.Error("expected fabrik:auto-merge-enabled label to be applied")
 	}
 }
 
-// TestAttemptMergeOnValidate_CIPending_BlocksMergeNoLabel verifies R2 + R10c: when
-// checks are still running, merge is blocked but fabrik:awaiting-ci is NOT applied.
-func TestAttemptMergeOnValidate_CIPending_BlocksMergeNoLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 13, HeadSHA: "sha4"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "in_progress", Conclusion: ""},
-			}, nil
-		},
-	}
+// TestAttemptMergeOnValidate_CruiseSkipsAutoMerge verifies that cruise > yolo:
+// a cruise-labelled item returns (false, nil) without calling EnablePullRequestAutoMerge.
+func TestAttemptMergeOnValidate_CruiseSkipsAutoMerge(t *testing.T) {
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(client)
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
 
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
-	if err == nil {
-		t.Fatal("expected error when CI pending, got nil")
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error for cruise item: %v", err)
 	}
-	if len(client.mergePRCalls) != 0 {
-		t.Errorf("expected no MergePR on pending CI, got %d", len(client.mergePRCalls))
+	if enabled {
+		t.Error("expected autoMergeEnabled=false for cruise item")
 	}
-	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:awaiting-ci" {
-			t.Error("fabrik:awaiting-ci must NOT be added when CI is only pending (R10c)")
-		}
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Errorf("EnablePullRequestAutoMerge must not be called for cruise items, got %d call(s)", len(client.enablePullRequestAutoMergeCalls))
 	}
 }
 
-// TestAttemptMergeOnValidate_CIPending_TracksTimer verifies R2: on first pending observation
-// ciMergePendingSince is populated so the timeout clock starts.
-func TestAttemptMergeOnValidate_CIPending_TracksTimer(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 14, HeadSHA: "sha5"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "ci", Status: "queued", Conclusion: ""},
-			}, nil
-		},
-	}
+// TestAttemptMergeOnValidate_AlreadyLabeled_Idempotent verifies that when
+// fabrik:auto-merge-enabled is already present, the function returns (true, nil)
+// without calling EnablePullRequestAutoMerge a second time.
+func TestAttemptMergeOnValidate_AlreadyLabeled_Idempotent(t *testing.T) {
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(client)
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:auto-merge-enabled"}}
 
-	snapBefore, _ := eng.store.Get("owner/repo", 1)
-	if lpr := snapBefore.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
-		t.Fatal("expected no pending entry before first call")
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error for already-labeled item: %v", err)
 	}
-
-	_ = eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
-
-	snapAfter, _ := eng.store.Get("owner/repo", 1)
-	var afterSince time.Time
-	if lpr := snapAfter.LinkedPR(); lpr != nil {
-		afterSince = lpr.CIMergePendingSince
+	if !enabled {
+		t.Error("expected autoMergeEnabled=true for already-labeled item")
 	}
-	if afterSince.IsZero() {
-		t.Error("expected ciMergePendingSince to be set after first pending observation")
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Errorf("EnablePullRequestAutoMerge must not be called again for idempotency, got %d call(s)", len(client.enablePullRequestAutoMergeCalls))
 	}
 }
 
-// TestAttemptMergeOnValidate_CIPendingTimeout_PausesIssue verifies R6: when CI has
-// been pending longer than CIWaitTimeout the issue is paused with a comment.
-func TestAttemptMergeOnValidate_CIPendingTimeout_PausesIssue(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 15, HeadSHA: "sha6"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "slow-ci", Status: "in_progress", Conclusion: ""},
-			}, nil
-		},
-	}
-	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
-	eng.cfg.CIWaitTimeout = 1 * time.Millisecond // tiny timeout for test
-
-	// Pre-seed as if first observed 1 second ago (well past 1ms timeout).
-	eng.store.Apply(itemstate.CIMergePendingStarted{Repo: "owner/repo", Number: 1, At: time.Now().Add(-1 * time.Second)})
-
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
-	if err == nil {
-		t.Fatal("expected error on CI timeout, got nil")
-	}
-	if len(client.mergePRCalls) != 0 {
-		t.Errorf("expected no MergePR on timeout, got %d", len(client.mergePRCalls))
-	}
-	if len(client.addCommentCalls) == 0 {
-		t.Error("expected timeout comment to be posted")
-	}
-	foundPaused := false
-	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:paused" {
-			foundPaused = true
-		}
-	}
-	if !foundPaused {
-		t.Error("expected fabrik:paused label on CI timeout")
-	}
-	// CIMergePendingSince should be cleared after timeout.
-	snapTimeout, _ := eng.store.Get("owner/repo", 1)
-	if lpr := snapTimeout.LinkedPR(); lpr != nil && !lpr.CIMergePendingSince.IsZero() {
-		t.Error("ciMergePendingSince should be deleted after timeout fires")
-	}
-}
-
-// TestAttemptMergeOnValidate_NoPR_ReturnsNil verifies that when FetchLinkedPR finds
-// no PR, attemptMergeOnValidate returns nil (no error, no merge).
-func TestAttemptMergeOnValidate_NoPR_ReturnsNil(t *testing.T) {
+// TestAttemptMergeOnValidate_NoPR_SkipsAutoMerge verifies that when no linked PR
+// exists, the function returns (false, nil) without error.
+func TestAttemptMergeOnValidate_NoPR_SkipsAutoMerge(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return nil, nil
@@ -230,100 +105,36 @@ func TestAttemptMergeOnValidate_NoPR_ReturnsNil(t *testing.T) {
 	eng := testEngineForMerge(client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
-	if err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"}); err != nil {
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
 		t.Fatalf("expected nil when no PR, got %v", err)
 	}
-	if len(client.mergePRCalls) != 0 {
-		t.Errorf("expected no MergePR when no PR, got %d", len(client.mergePRCalls))
+	if enabled {
+		t.Error("expected autoMergeEnabled=false when no linked PR")
+	}
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Errorf("EnablePullRequestAutoMerge must not be called when no PR, got %d call(s)", len(client.enablePullRequestAutoMergeCalls))
 	}
 }
 
-// TestAttemptMergeOnValidate_ErrNotMergeable_DispatchesRebase verifies that
-// ErrNotMergeable dispatches a rebase reinvoke (not immediate pause) and returns
-// errRebaseDispatched, adding fabrik:rebase-needed but NOT fabrik:paused.
-func TestAttemptMergeOnValidate_ErrNotMergeable_DispatchesRebase(t *testing.T) {
+// TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError verifies that a
+// transient FetchLinkedPR API error returns (false, err) rather than (false, nil),
+// preventing advancement past Validate without enabling auto-merge.
+func TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 20, HeadSHA: "sha7"}, nil
-		},
-		mergePRFn: func(owner, repo string, prNumber int) error {
-			return gh.ErrNotMergeable
+			return nil, errors.New("network error")
 		},
 	}
 	eng := testEngineForMerge(client)
-	eng.cfg.MaxRebaseCycles = 3
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-	stage := &stages.Stage{Name: "Validate"}
 
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, stage)
-	// Wait for the dispatched goroutine to exit (exits early via ErrSkipItem in tests).
-	eng.wg.Wait()
-
-	if !errors.Is(err, errRebaseDispatched) {
-		t.Fatalf("expected errRebaseDispatched, got %v", err)
-	}
-	foundRebaseNeeded := false
-	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:rebase-needed" {
-			foundRebaseNeeded = true
-		}
-		if c.labelName == "fabrik:paused" {
-			t.Error("fabrik:paused must NOT be added when dispatching rebase")
-		}
-	}
-	if !foundRebaseNeeded {
-		t.Error("expected fabrik:rebase-needed to be added on ErrNotMergeable")
-	}
-	snap1, _ := eng.store.Get("owner/repo", 1)
-	if snap1.RebaseCycles("Validate") != 1 {
-		t.Errorf("expected RebaseCycles(Validate) == 1, got %d", snap1.RebaseCycles("Validate"))
-	}
-}
-
-// TestAttemptMergeOnValidate_ErrNotMergeable_CycleLimitPause verifies that
-// when the rebase cycle limit is already reached, ErrNotMergeable falls through
-// to the existing pause path: fabrik:paused + fabrik:awaiting-input.
-func TestAttemptMergeOnValidate_ErrNotMergeable_CycleLimitPause(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 21, HeadSHA: "sha8"}, nil
-		},
-		mergePRFn: func(owner, repo string, prNumber int) error {
-			return gh.ErrNotMergeable
-		},
-	}
-	eng := testEngineForMerge(client)
-	eng.cfg.MaxRebaseCycles = 3
-	// Pre-seed 3 rebase cycles to simulate hitting the limit
-	for i := 0; i < 3; i++ {
-		eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 1, StageName: "Validate"})
-	}
-
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-	stage := &stages.Stage{Name: "Validate"}
-
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, stage)
+	_, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
 	if err == nil {
-		t.Fatal("expected error at cycle limit")
+		t.Fatal("expected error when FetchLinkedPR fails, got nil (would incorrectly allow advancement)")
 	}
-	if errors.Is(err, errRebaseDispatched) {
-		t.Fatal("expected plain error at cycle limit, not errRebaseDispatched")
-	}
-	foundPaused := false
-	foundRebaseNeeded := false
-	for _, c := range client.addLabelCalls {
-		if c.labelName == "fabrik:paused" {
-			foundPaused = true
-		}
-		if c.labelName == "fabrik:rebase-needed" {
-			foundRebaseNeeded = true
-		}
-	}
-	if !foundPaused {
-		t.Error("expected fabrik:paused when rebase cycle limit reached")
-	}
-	if !foundRebaseNeeded {
-		t.Error("expected fabrik:rebase-needed to be added on ErrNotMergeable")
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Errorf("EnablePullRequestAutoMerge must not be called on FetchLinkedPR error, got %d call(s)", len(client.enablePullRequestAutoMergeCalls))
 	}
 }
 
@@ -332,13 +143,13 @@ func TestAttemptMergeOnValidate_ErrNotMergeable_CycleLimitPause(t *testing.T) {
 // stage:Validate:complete, and does NOT call attemptMergeOnValidate.
 // The completion label is deferred to checkCIGate in the catch-up loop (ADR 032).
 func TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns(t *testing.T) {
-	merged := false
+	autoMergeCalled := false
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 99, HeadSHA: "sha8"}, nil
 		},
-		mergePRFn: func(owner, repo string, prNumber int) error {
-			merged = true
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			autoMergeCalled = true
 			return nil
 		},
 	}
@@ -352,8 +163,8 @@ func TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns(t *testing.T) {
 
 	eng.handleStageComplete(context.Background(), board, item, validateStage)
 
-	if merged {
-		t.Error("MergePR must not be called when wait_for_ci is true")
+	if autoMergeCalled {
+		t.Error("EnablePullRequestAutoMerge must not be called when wait_for_ci is true")
 	}
 	// Completion label must NOT be added — deferred to checkCIGate (ADR 032).
 	for _, c := range client.addLabelCalls {
@@ -370,51 +181,6 @@ func TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns(t *testing.T) {
 	}
 	if !foundCI {
 		t.Error("fabrik:awaiting-ci must be added when wait_for_ci: true")
-	}
-}
-
-// TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError verifies that a
-// transient FetchLinkedPR API error returns an error (retriable) rather than nil
-// (which would allow the caller to advance past Validate without merging the PR).
-func TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return nil, errors.New("network error")
-		},
-	}
-	eng := testEngineForMerge(client)
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
-	if err == nil {
-		t.Fatal("expected error when FetchLinkedPR fails, got nil (would incorrectly allow advancement)")
-	}
-	if len(client.mergePRCalls) != 0 {
-		t.Errorf("expected no MergePR on FetchLinkedPR error, got %d", len(client.mergePRCalls))
-	}
-}
-
-// TestAttemptMergeOnValidate_FetchCheckRunsError_ReturnsError verifies that a
-// transient FetchCheckRuns API error returns an error (retriable) rather than
-// proceeding to merge with unknown CI status.
-func TestAttemptMergeOnValidate_FetchCheckRunsError_ReturnsError(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, errors.New("GitHub API 503")
-		},
-	}
-	eng := testEngineForMerge(client)
-	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
-
-	err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
-	if err == nil {
-		t.Fatal("expected error when FetchCheckRuns fails, got nil (would proceed to merge with unknown CI status)")
-	}
-	if len(client.mergePRCalls) != 0 {
-		t.Errorf("expected no MergePR on FetchCheckRuns error, got %d", len(client.mergePRCalls))
 	}
 }
 

--- a/github/labels.go
+++ b/github/labels.go
@@ -38,6 +38,7 @@ var staticLabelDefs = []labelDef{
 	{"fabrik:bot-reprompted", "Bot re-prompt sent; waiting for bot to respond (transient; removed at gate-cycle end)", "e4e669"},
 
 	// --- neutral / transient labels (grey) ---
+	{"fabrik:auto-merge-enabled", "GitHub auto-merge enabled on linked PR; engine awaiting GitHub atomic merge", "cfd3d7"},
 	{"fabrik:editing", "Issue is being edited by the user; processing deferred", "cfd3d7"},
 	{"fabrik:children-spawned", "Pre-Implement spawned sub-issues; idempotency guard — remove to re-trigger spawn", "cfd3d7"},
 	{"fabrik:sub-issue", "Created by Fabrik's pre-Implement spawn step; no engine-gate semantics", "cfd3d7"},

--- a/github/prs.go
+++ b/github/prs.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // reClosingKeyword matches GitHub closing keywords followed by a same-repo issue
@@ -84,6 +85,10 @@ type PRDetails struct {
 	// CI gate as the authoritative signal — non-required check_run
 	// failures (e.g., workflow cleanup jobs) do not block "clean"/"unstable".
 	MergeableState string
+	// AutoMergeEnabled is true when GitHub's native auto-merge is enabled on
+	// the PR (auto_merge field is non-null). False when the user or engine
+	// has disabled it, or when it was never enabled.
+	AutoMergeEnabled bool
 }
 
 // FetchPRMergeable returns GitHub's mergeable flag for a single PR.
@@ -130,12 +135,13 @@ func (c *Client) FetchPRMergeableState(owner, repo string, prNumber int) (string
 func (c *Client) FetchPRDetails(owner, repo string, prNumber int) (*PRDetails, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
 	var raw struct {
-		Number         int    `json:"number"`
-		Title          string `json:"title"`
-		State          string `json:"state"`
-		Merged         bool   `json:"merged"`
-		Draft          bool   `json:"draft"`
-		MergeableState string `json:"mergeable_state"`
+		Number         int         `json:"number"`
+		Title          string      `json:"title"`
+		State          string      `json:"state"`
+		Merged         bool        `json:"merged"`
+		Draft          bool        `json:"draft"`
+		MergeableState string      `json:"mergeable_state"`
+		AutoMerge      interface{} `json:"auto_merge"` // non-null object = enabled, null = disabled
 		Head           struct {
 			SHA string `json:"sha"`
 		} `json:"head"`
@@ -144,13 +150,14 @@ func (c *Client) FetchPRDetails(owner, repo string, prNumber int) (*PRDetails, e
 		return nil, fmt.Errorf("fetching PR #%d: %w", prNumber, err)
 	}
 	return &PRDetails{
-		Number:         raw.Number,
-		Title:          raw.Title,
-		State:          raw.State,
-		Merged:         raw.Merged,
-		Draft:          raw.Draft,
-		HeadSHA:        raw.Head.SHA,
-		MergeableState: raw.MergeableState,
+		Number:           raw.Number,
+		Title:            raw.Title,
+		State:            raw.State,
+		Merged:           raw.Merged,
+		Draft:            raw.Draft,
+		HeadSHA:          raw.Head.SHA,
+		MergeableState:   raw.MergeableState,
+		AutoMergeEnabled: raw.AutoMerge != nil,
 	}, nil
 }
 
@@ -191,12 +198,13 @@ func (c *Client) FetchLinkedPR(owner, repo string, issueNumber int) (*PRDetails,
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls?head=%s:%s&state=all&per_page=1",
 		c.baseURL, owner, repo, url.PathEscape(owner), url.PathEscape(branch))
 	var raw []struct {
-		Number         int    `json:"number"`
-		Title          string `json:"title"`
-		State          string `json:"state"`
-		Merged         bool   `json:"merged"`
-		Draft          bool   `json:"draft"`
-		MergeableState string `json:"mergeable_state"`
+		Number         int         `json:"number"`
+		Title          string      `json:"title"`
+		State          string      `json:"state"`
+		Merged         bool        `json:"merged"`
+		Draft          bool        `json:"draft"`
+		MergeableState string      `json:"mergeable_state"`
+		AutoMerge      interface{} `json:"auto_merge"` // non-null object = enabled, null = disabled
 		Head           struct {
 			SHA string `json:"sha"`
 		} `json:"head"`
@@ -208,13 +216,14 @@ func (c *Client) FetchLinkedPR(owner, repo string, issueNumber int) (*PRDetails,
 		return nil, nil
 	}
 	return &PRDetails{
-		Number:         raw[0].Number,
-		Title:          raw[0].Title,
-		State:          raw[0].State,
-		Merged:         raw[0].Merged,
-		Draft:          raw[0].Draft,
-		HeadSHA:        raw[0].Head.SHA,
-		MergeableState: raw[0].MergeableState,
+		Number:           raw[0].Number,
+		Title:            raw[0].Title,
+		State:            raw[0].State,
+		Merged:           raw[0].Merged,
+		Draft:            raw[0].Draft,
+		HeadSHA:          raw[0].Head.SHA,
+		MergeableState:   raw[0].MergeableState,
+		AutoMergeEnabled: raw[0].AutoMerge != nil,
 	}, nil
 }
 
@@ -373,6 +382,96 @@ func (c *Client) AddReviewRequest(owner, repo string, prNumber int, reviewers []
 		return fmt.Errorf("adding review request on PR #%d: %w", prNumber, err)
 	}
 	return nil
+}
+
+// ErrAutoMergeNotEnabled is returned by EnablePullRequestAutoMerge when the
+// repository has not enabled the auto-merge feature in its settings.
+var ErrAutoMergeNotEnabled = errors.New("repository has not enabled auto-merge")
+
+// EnablePullRequestAutoMerge enables GitHub's native auto-merge on a pull request.
+// strategy must be one of "MERGE", "SQUASH", or "REBASE". GitHub merges the PR
+// atomically when all branch-protection requirements are satisfied.
+//
+// Returns ErrAutoMergeNotEnabled when the repository setting is disabled.
+func (c *Client) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
+	// Fetch the PR node ID (required for the GraphQL mutation).
+	fetchQuery := `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}`
+	fetchVars := map[string]interface{}{
+		"owner":  owner,
+		"repo":   repo,
+		"number": prNumber,
+	}
+	var fetchResult struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ID string `json:"id"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
+		return fmt.Errorf("fetching PR node ID: %w", err)
+	}
+	nodeID := fetchResult.Data.Repository.PullRequest.ID
+	if nodeID == "" {
+		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	}
+
+	mutation := `
+mutation($prId: ID!, $method: PullRequestMergeMethod!) {
+  enablePullRequestAutoMerge(input: { pullRequestId: $prId, mergeMethod: $method }) {
+    pullRequest {
+      id
+    }
+  }
+}`
+	mutVars := map[string]interface{}{
+		"prId":   nodeID,
+		"method": strategy,
+	}
+	var mutResult struct{}
+	if err := c.graphqlRequest(mutation, mutVars, &mutResult); err != nil {
+		// Surface a recognizable sentinel when the repo setting is disabled.
+		if isAutoMergeNotEnabledError(err) {
+			return fmt.Errorf("%w: %v", ErrAutoMergeNotEnabled, err)
+		}
+		return fmt.Errorf("enabling auto-merge on PR #%d: %w", prNumber, err)
+	}
+	return nil
+}
+
+// isAutoMergeNotEnabledError reports whether a GraphQL error indicates the
+// repository has not enabled the auto-merge feature.
+func isAutoMergeNotEnabledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Pull requests cannot be merged using the auto-merge feature") ||
+		strings.Contains(msg, "auto merge is not allowed")
+}
+
+// FetchCommitsBehind returns how many commits base is ahead of head using the
+// GitHub compare API. A positive result means head is that many commits behind
+// base. Returns 0, nil when head is up to date.
+func (c *Client) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/compare/%s...%s", c.baseURL, owner, repo,
+		url.PathEscape(base), url.PathEscape(head))
+	var raw struct {
+		BehindBy int `json:"behind_by"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		return 0, fmt.Errorf("comparing %s...%s: %w", base, head, err)
+	}
+	return raw.BehindBy, nil
 }
 
 // MergePR merges the pull request identified by prNumber. It first checks


### PR DESCRIPTION
## What this PR does

Replaces Fabrik's poll-merge loop for `fabrik:yolo` issues with GitHub's native `enablePullRequestAutoMerge` GraphQL mutation, and replaces the per-gate cycle limits (`MaxRebaseCycles`, `MaxCiFixCycles`) with a single wall-clock convergence budget for post-Validate yolo PRs.

**The core problem being fixed:** On high-churn repos, Fabrik's sampling-then-merging approach races against state changes between sample and merge attempt (HTTP 405 spam), and the CI-fix cycle limit fires with a misleading error message when CI is actually passing and the real issue is convergence latency. GitHub's native auto-merge makes the merge decision atomically server-side, eliminating the race.

## Key changes

**`github/prs.go`** — New `EnablePullRequestAutoMerge` (GraphQL mutation mirroring `MarkPRReady`) and `FetchCommitsBehind` (REST compare endpoint); `PRDetails.AutoMergeEnabled bool` parsed from `auto_merge` field.

**`engine/stages.go`** — `attemptMergeOnValidate` yolo branch rewritten: calls `EnablePullRequestAutoMerge` and applies `fabrik:auto-merge-enabled` instead of calling `MergePR`. Cruise label still gates the call (cruise > yolo precedence preserved).

**`engine/merge_gate.go`** — New `checkAutoMergeConvergence` (Phase 1 catch-up handler for convergence-active items) and `pauseForConvergenceFailed` (structured pause comment with current PR state). `dispatchRebaseReinvoke` extended to re-enable auto-merge after each rebase push (GitHub disables it on force-push).

**`engine/poll.go`** — `fabrik:auto-merge-enabled` added to `hasAwaitingLabel`, `transientLifecycleLabels`, and closed-item admission. Phase 1 calls `checkAutoMergeConvergence` first and short-circuits when label is present; Phase 2 Validate block guards against re-invoking `attemptMergeOnValidate` for items already in the convergence flow.

**`engine/engine.go` + `cmd/root.go`** — `ConvergenceBudget time.Duration` (default 30m, `FABRIK_CONVERGENCE_BUDGET`) and `AutoMergeStrategy string` (default `"MERGE"`, `FABRIK_AUTO_MERGE_STRATEGY`) added to `Config`; env vars parsed with validation.

**Non-yolo issues are completely unchanged.** `MaxRebaseCycles`/`MaxCiFixCycles` remain active for cruise and manual-workflow issues.

**Docs** — `docs/state-machine.md` (new label table entry, sections 5.4–5.5), `docs/USER_GUIDE.md` (new "Post-Validate Convergence Monitor" section, updated CLI flags and env vars tables), `docs/stage-lifecycle.md` (Validate completion note), `docs/llms-full.txt` (regenerated), `adrs/050-convergence-budget-and-native-automerge.md` (new ADR).

## How to test

1. **Yolo auto-merge path**: Create a yolo issue, run it through to Validate. Confirm `enablePullRequestAutoMerge` is called (check logs for `auto-merge` tag), `fabrik:auto-merge-enabled` label is applied, and no direct `MergePR` call is made.

2. **Cruise unchanged**: Apply `fabrik:cruise` (with or without `fabrik:yolo`) to an issue, let it complete Validate. Confirm no `fabrik:auto-merge-enabled` label, no auto-merge enablement, existing rebase/CI behavior intact.

3. **Budget exhaust**: Set `FABRIK_CONVERGENCE_BUDGET=2m` on a yolo issue with a PR that can't merge (e.g., requires a review that hasn't landed). After 2 minutes, the pause comment should name commits-behind, CI status, mergeable status, and elapsed/budget.

4. **Rebase re-enable**: Force a conflict on a yolo PR in the convergence flow. Confirm Fabrik dispatches a rebase reinvoke, and after the push re-enables auto-merge (look for `re-enabled auto-merge on PR #N after rebase push` in logs).

5. **Unit tests**: `go test -timeout 5m ./engine/...` — all engine tests pass including the 9 new `checkAutoMergeConvergence`/`pauseForConvergenceFailed` tests and the updated `attemptMergeOnValidate` tests.

Closes #829