### PR TITLE
fix: fall back to direct merge when yolo PR is already in CLEAN status

### DIFF
--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -232,7 +232,19 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 					strategy = "MERGE"
 				}
 				if rerr := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, strategy); rerr != nil {
-					e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
+					if errors.Is(rerr, gh.ErrAutoMergeAlreadyClean) {
+						// PR is already CLEAN after the rebase push — merge directly.
+						// Without this, checkAutoMergeConvergence sees AutoMergeEnabled=false
+						// and incorrectly pauses the issue as "user disabled auto-merge".
+						e.logf(item.Number, "info", "PR #%d is already in clean status after rebase — falling back to direct merge\n", pr.Number)
+						if mergeErr := e.client.MergePR(owner, repo, pr.Number); mergeErr != nil {
+							e.logf(item.Number, "warn", "direct merge fallback after rebase failed: %v\n", mergeErr)
+						} else {
+							e.logf(item.Number, "info", "PR #%d merged directly after rebase push (already-clean fallback)\n", pr.Number)
+						}
+					} else {
+						e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
+					}
 				} else {
 					e.logf(item.Number, "auto-merge", "re-enabled auto-merge on PR #%d after rebase push\n", pr.Number)
 				}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -249,6 +249,28 @@ func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, i
 		if errors.Is(err, gh.ErrAutoMergeNotEnabled) {
 			e.logf(item.Number, "warn", "auto-merge is not enabled for this repository — "+
 				"enable it in Settings → General → Allow auto-merge; Fabrik will retry on the next poll\n")
+			return false, fmt.Errorf("enabling auto-merge on PR #%d: %w", pr.Number, err)
+		}
+		if errors.Is(err, gh.ErrAutoMergeAlreadyClean) {
+			// PR is already CLEAN (all checks passed) — GitHub won't queue auto-merge.
+			// Fall back to a direct merge call instead.
+			e.logf(item.Number, "info", "PR #%d is already in clean status — falling back to direct merge\n", pr.Number)
+			if mergeErr := e.client.MergePR(owner, repo, pr.Number); mergeErr != nil {
+				return false, fmt.Errorf("direct merge fallback on PR #%d: %w", pr.Number, mergeErr)
+			}
+			// Apply idempotency guard and convergence anchor after successful direct merge.
+			if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
+				e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
+			} else {
+				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+				}
+				if e.webhookMgr != nil {
+					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
+				}
+			}
+			e.logf(item.Number, "info", "PR #%d merged directly (already-clean fallback)\n", pr.Number)
+			return true, nil
 		}
 		return false, fmt.Errorf("enabling auto-merge on PR #%d: %w", pr.Number, err)
 	}

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/handarbeit/fabrik/boardcache"
@@ -135,6 +136,51 @@ func TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError(t *testing.T) {
 	}
 	if len(client.enablePullRequestAutoMergeCalls) != 0 {
 		t.Errorf("EnablePullRequestAutoMerge must not be called on FetchLinkedPR error, got %d call(s)", len(client.enablePullRequestAutoMergeCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenClean verifies that when
+// EnablePullRequestAutoMerge returns ErrAutoMergeAlreadyClean, the function falls
+// back to a direct MergePR call, applies fabrik:auto-merge-enabled, and returns (true, nil).
+func TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenClean(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, HeadSHA: "sha42"}, nil
+		},
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			return fmt.Errorf("%w: GraphQL error: Pull request is in clean status", gh.ErrAutoMergeAlreadyClean)
+		},
+		mergePRFn: func(owner, repo string, prNumber int) error {
+			return nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected autoMergeEnabled=true for already-clean fallback")
+	}
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge called once, got %d", len(client.enablePullRequestAutoMergeCalls))
+	}
+	if len(client.mergePRCalls) != 1 {
+		t.Fatalf("expected MergePR called once as fallback, got %d", len(client.mergePRCalls))
+	}
+	if client.mergePRCalls[0].prNumber != 42 {
+		t.Errorf("MergePR called with PR %d, want 42", client.mergePRCalls[0].prNumber)
+	}
+	foundLabel := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundLabel = true
+		}
+	}
+	if !foundLabel {
+		t.Error("expected fabrik:auto-merge-enabled label to be applied after direct merge fallback")
 	}
 }
 

--- a/github/prs.go
+++ b/github/prs.go
@@ -388,6 +388,13 @@ func (c *Client) AddReviewRequest(owner, repo string, prNumber int, reviewers []
 // repository has not enabled the auto-merge feature in its settings.
 var ErrAutoMergeNotEnabled = errors.New("repository has not enabled auto-merge")
 
+// ErrAutoMergeAlreadyClean is returned by EnablePullRequestAutoMerge when the
+// PR is already in CLEAN status (all checks passed, immediately mergeable).
+// GitHub rejects auto-merge enablement in this state — the caller must merge
+// directly instead. Matched on the string "Pull request is in clean status"
+// from the GitHub GraphQL API (confirmed from production logs).
+var ErrAutoMergeAlreadyClean = errors.New("PR is already in clean status — merge directly")
+
 // EnablePullRequestAutoMerge enables GitHub's native auto-merge on a pull request.
 // strategy must be one of "MERGE", "SQUASH", or "REBASE". GitHub merges the PR
 // atomically when all branch-protection requirements are satisfied.
@@ -443,6 +450,11 @@ mutation($prId: ID!, $method: PullRequestMergeMethod!) {
 		if isAutoMergeNotEnabledError(err) {
 			return fmt.Errorf("%w: %v", ErrAutoMergeNotEnabled, err)
 		}
+		// Surface a recognizable sentinel when the PR is already CLEAN.
+		// GitHub refuses auto-merge on a PR that is immediately mergeable.
+		if isAutoMergeAlreadyCleanError(err) {
+			return fmt.Errorf("%w: %v", ErrAutoMergeAlreadyClean, err)
+		}
 		return fmt.Errorf("enabling auto-merge on PR #%d: %w", prNumber, err)
 	}
 	return nil
@@ -457,6 +469,16 @@ func isAutoMergeNotEnabledError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "Pull requests cannot be merged using the auto-merge feature") ||
 		strings.Contains(msg, "auto merge is not allowed")
+}
+
+// isAutoMergeAlreadyCleanError reports whether a GraphQL error indicates the
+// PR is already in CLEAN status (all checks passed, immediately mergeable).
+// GitHub refuses auto-merge on such PRs — the caller must merge directly.
+func isAutoMergeAlreadyCleanError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Pull request is in clean status")
 }
 
 // FetchCommitsBehind returns how many commits base is ahead of head using the


### PR DESCRIPTION
## Summary

When a yolo PR reaches `MERGEABLE/CLEAN` (all checks passed) before Fabrik's `attemptMergeOnValidate` runs, GitHub's `enablePullRequestAutoMerge` mutation rejects the request with "Pull request is in clean status" — there's nothing to queue. Prior to #829, the direct-merge poll loop handled this case. After #829 removed the direct-merge path, these PRs stuck open indefinitely.

This PR restores the behavior by adding a typed error sentinel and a direct-merge fallback.

## Key changes

- **`github/prs.go`**: New `ErrAutoMergeAlreadyClean` sentinel var and `isAutoMergeAlreadyCleanError` helper. Detected inside `EnablePullRequestAutoMerge` before the catch-all error wrap, matching on `"Pull request is in clean status"`. Mirrors the existing `ErrAutoMergeNotEnabled` pattern exactly.

- **`engine/stages.go`** (`attemptMergeOnValidate`): When `EnablePullRequestAutoMerge` returns `ErrAutoMergeAlreadyClean`, calls `MergePR` directly. After a successful direct merge, applies `fabrik:auto-merge-enabled` (idempotency guard + convergence anchor) so `checkAutoMergeConvergence` picks up the already-merged PR and advances the issue to Done on the next poll.

- **`engine/stages_test.go`**: New `TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenClean` verifying all four R6 criteria.

## How to test

1. Set up a yolo issue against a repo with fast CI (< Validate stage runtime).
2. Observe that Validate completes and the PR merges instead of sitting open.
3. Alternatively: run `go test -race ./engine/ -run TestAttemptMergeOnValidate` — all six tests pass.

Closes #831