### PR TITLE
docs(init): allow_auto_merge must be enabled at the repo level — call it out in USER_GUIDE and consider a fabrik init pre-flight check

### DIFF
--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -32,6 +32,9 @@ func (m *testGitHubUpgradeClient) FetchLatestRelease(owner, repo string) (*gh.La
 	}
 	return nil, nil
 }
+func (m *testGitHubUpgradeClient) FetchAllowAutoMerge(owner, repo string) (bool, error) {
+	return true, nil
+}
 func (m *testGitHubUpgradeClient) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
 	return &gh.ProjectBoard{}, nil
 }

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -727,6 +727,12 @@ You do not need to babysit the pipeline. The intended human role is:
 
 Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and enables GitHub's native auto-merge on the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
 
+> **Prerequisite — Allow auto-merge:** GitHub's native auto-merge must be enabled at the repository level before yolo mode can merge PRs. Enable it under **Settings → General → Pull Requests → "Allow auto-merge"**, or run:
+> ```
+> gh api -X PATCH repos/{owner}/{repo} -f allow_auto_merge=true
+> ```
+> Without this setting, Fabrik will reach Validate complete and attempt auto-merge, but GitHub will reject it. The Fabrik engine emits a `[startup] WARNING` at startup if this setting is disabled on any managed repo.
+
 When Validate completes on a yolo issue, Fabrik calls GitHub's `enablePullRequestAutoMerge` API (the same merge-when-ready mechanism available in the GitHub UI) rather than attempting to merge immediately. GitHub holds the merge until all branch-protection requirements are satisfied — required CI checks, required reviews, up-to-date branch — then merges atomically. Fabrik monitors convergence in the background and pauses the issue if the PR does not reach a terminal state within the convergence budget (default 30 min; see `FABRIK_CONVERGENCE_BUDGET`). See [Post-Validate Convergence Monitor (yolo)](#post-validate-convergence-monitor-yolo) for full details.
 
 For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence for the merge decision — the PR is not auto-merged — but the issue still advances to Done.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -725,6 +725,12 @@ You do not need to babysit the pipeline. The intended human role is:
 
 Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every stage automatically without waiting for human approval, and enables GitHub's native auto-merge on the linked PR once Validate completes. To scope the same behavior to a single issue, apply the `fabrik:yolo` label — Fabrik auto-advances and auto-merges that issue only.
 
+> **Prerequisite — Allow auto-merge:** GitHub's native auto-merge must be enabled at the repository level before yolo mode can merge PRs. Enable it under **Settings → General → Pull Requests → "Allow auto-merge"**, or run:
+> ```
+> gh api -X PATCH repos/{owner}/{repo} -f allow_auto_merge=true
+> ```
+> Without this setting, Fabrik will reach Validate complete and attempt auto-merge, but GitHub will reject it. The Fabrik engine emits a `[startup] WARNING` at startup if this setting is disabled on any managed repo.
+
 When Validate completes on a yolo issue, Fabrik calls GitHub's `enablePullRequestAutoMerge` API (the same merge-when-ready mechanism available in the GitHub UI) rather than attempting to merge immediately. GitHub holds the merge until all branch-protection requirements are satisfied — required CI checks, required reviews, up-to-date branch — then merges atomically. Fabrik monitors convergence in the background and pauses the issue if the PR does not reach a terminal state within the convergence budget (default 30 min; see `FABRIK_CONVERGENCE_BUDGET`). See [Post-Validate Convergence Monitor (yolo)](#post-validate-convergence-monitor-yolo) for full details.
 
 For lighter automation without auto-merge, use `fabrik:cruise`: it auto-advances through all stages but stops at Validate, leaving the merge decision to you. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence for the merge decision — the PR is not auto-merged — but the issue still advances to Done.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -77,7 +77,8 @@ type Engine struct {
 	lastReportedCost     float64          // cost at last [stats] report; skip repeat prints when unchanged
 	mayNeedWork          map[string]bool  // key: issueKey; items that have changed since the last poll cycle
 	mayNeedWorkMu        sync.Mutex       // guards mayNeedWork
-	seededRepos          map[string]bool  // key: "owner/repo"; in-memory guard to avoid re-seeding on every poll
+	seededRepos              map[string]bool  // key: "owner/repo"; in-memory guard to avoid re-seeding on every poll
+	checkedAutoMergeRepos    map[string]bool  // key: "owner/repo"; guard to emit allow_auto_merge warning at most once per run
 	idleCount            int              // consecutive idle polls; triggers self-upgrade at threshold
 	idleStart            time.Time        // when consecutive idle polls began; zero value = not idle
 	lastProjectUpdatedAt time.Time        // last seen project.updatedAt from FetchProjectUpdatedAt gate; zero = not yet checked
@@ -144,9 +145,10 @@ func New(cfg Config) (*Engine, error) {
 		worktreeManagers: make(map[string]*WorktreeManager),
 		fabrikDir:        fabrikDir,
 		store:            sharedStore,
-		mayNeedWork:      make(map[string]bool),
-		seededRepos:      make(map[string]bool),
-		sem:              make(chan struct{}, cfg.MaxConcurrent),
+		mayNeedWork:           make(map[string]bool),
+		seededRepos:           make(map[string]bool),
+		checkedAutoMergeRepos: make(map[string]bool),
+		sem:                   make(chan struct{}, cfg.MaxConcurrent),
 	}
 
 	// Migrate any old-style worktrees (issue-N/) to the new per-repo layout.
@@ -191,14 +193,15 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 	}
 	wms := make(map[string]*WorktreeManager)
 	eng := &Engine{
-		cfg:              cfg,
-		client:           client,
-		claude:           claude,
-		worktreeManagers: wms,
-		store:            itemstate.NewStore(nil),
-		mayNeedWork:      make(map[string]bool),
-		seededRepos:      make(map[string]bool),
-		sem:              make(chan struct{}, maxConcurrent),
+		cfg:                   cfg,
+		client:                client,
+		claude:                claude,
+		worktreeManagers:      wms,
+		store:                 itemstate.NewStore(nil),
+		mayNeedWork:           make(map[string]bool),
+		seededRepos:           make(map[string]bool),
+		checkedAutoMergeRepos: make(map[string]bool),
+		sem:                   make(chan struct{}, maxConcurrent),
 	}
 	if worktrees != nil {
 		worktrees.logfFn = eng.logf

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -48,6 +48,7 @@ type GitHubClient interface {
 	DeleteReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	FetchLatestRelease(owner, repo string) (*gh.LatestRelease, error)
+	FetchAllowAutoMerge(owner, repo string) (bool, error)
 	FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error)
 	SeedLabels(owner, repo string, stageNames []string, lockedUser string) error
 	RateLimitStats() (rest, graphql gh.RateLimitStats)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -56,6 +56,7 @@ type mockGitHubClient struct {
 	addBlockedByIssueFn                 func(issueNodeID, blockerNodeID string) error
 	enablePullRequestAutoMergeFn        func(owner, repo string, prNumber int, strategy string) error
 	fetchCommitsBehindFn                func(owner, repo, base, head string) (int, error)
+	fetchAllowAutoMergeFn               func(owner, repo string) (bool, error)
 
 	// Track call counts for FetchProjectItemStatus
 	fetchProjectItemStatusCalls []string
@@ -459,6 +460,16 @@ func (m *mockGitHubClient) FetchLatestRelease(owner, repo string) (*gh.LatestRel
 		return fn(owner, repo)
 	}
 	return nil, nil
+}
+
+func (m *mockGitHubClient) FetchAllowAutoMerge(owner, repo string) (bool, error) {
+	m.mu.Lock()
+	fn := m.fetchAllowAutoMergeFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo)
+	}
+	return true, nil
 }
 
 func (m *mockGitHubClient) FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -2134,9 +2134,9 @@ func (e *Engine) checkAllowAutoMerge(owner, repo string) {
 		return
 	}
 	if !enabled {
-		fmt.Printf("[startup] WARNING: %s has allow_auto_merge disabled.\n", key)
-		fmt.Printf("[startup] WARNING: yolo issues on this repo will reach Validate complete but their PRs will not merge.\n")
-		fmt.Printf("[startup] WARNING: Fix: gh api -X PATCH repos/%s -f allow_auto_merge=true\n", key)
+		e.logf(0, "startup", "WARNING: %s has allow_auto_merge disabled.\n", key)
+		e.logf(0, "startup", "WARNING: yolo issues on this repo will reach Validate complete but their PRs will not merge.\n")
+		e.logf(0, "startup", "WARNING: Fix: gh api -X PATCH repos/%s -f allow_auto_merge=true\n", key)
 	}
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -301,6 +301,9 @@ func (e *Engine) Run() error {
 	// rewritten to SSH by the user's git config.
 	httpsToSSH := e.checkURLRewrite()
 	e.checkHTTPSCredentials(httpsToSSH)
+	if e.cfg.Repo != "" {
+		e.checkAllowAutoMerge(e.cfg.Owner, e.cfg.Repo)
+	}
 
 	// Seed all known Fabrik labels with descriptions and sensible default colors.
 	// Non-fatal: a seeding failure must not prevent the engine from polling.
@@ -1049,6 +1052,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 				e.mu.Unlock()
 				continue
 			}
+			e.checkAllowAutoMerge(owner, repo)
 			if err := e.client.SeedLabels(owner, repo, sn, e.cfg.User); err != nil {
 				e.logf(0, "warn", "label seeding for %s failed (non-fatal): %v\n", ownerRepo, err)
 			}
@@ -2108,6 +2112,31 @@ func (e *Engine) checkHTTPSCredentials(hasSSHRewrite bool) {
 		fmt.Printf("[startup] warn: no git credential helper configured; HTTPS cloning may prompt for credentials.\n")
 		fmt.Printf("[startup] warn: configure one (e.g. git-credential-osxkeychain) or use --ssh / git_ssh: true in .fabrik/config.yaml.\n")
 		fmt.Printf("[startup] note: existing bare clones retain their original remote URL and are not affected by this setting.\n")
+	}
+}
+
+// checkAllowAutoMerge queries the GitHub API for the allow_auto_merge setting on
+// owner/repo and prints a WARNING if it is disabled. Non-fatal: API errors are
+// logged at warn level and processing continues. The check fires at most once per
+// repo per process run (guarded by checkedAutoMergeRepos).
+func (e *Engine) checkAllowAutoMerge(owner, repo string) {
+	key := owner + "/" + repo
+	e.mu.Lock()
+	already := e.checkedAutoMergeRepos[key]
+	e.checkedAutoMergeRepos[key] = true
+	e.mu.Unlock()
+	if already {
+		return
+	}
+	enabled, err := e.client.FetchAllowAutoMerge(owner, repo)
+	if err != nil {
+		e.logf(0, "warn", "could not check allow_auto_merge for %s: %v\n", key, err)
+		return
+	}
+	if !enabled {
+		fmt.Printf("[startup] WARNING: %s has allow_auto_merge disabled.\n", key)
+		fmt.Printf("[startup] WARNING: yolo issues on this repo will reach Validate complete but their PRs will not merge.\n")
+		fmt.Printf("[startup] WARNING: Fix: gh api -X PATCH repos/%s -f allow_auto_merge=true\n", key)
 	}
 }
 

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2788,5 +2789,109 @@ func TestProbeNewItem_ClosedDone_SkipsDeepFetch(t *testing.T) {
 		if snap.IsTerminal() {
 			t.Errorf("item #%d (open Research): expected IsTerminal()=false", i)
 		}
+	}
+}
+
+// captureStdout redirects os.Stdout to a pipe for the duration of fn,
+// then returns everything written to stdout. The original os.Stdout is
+// restored before returning.
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf strings.Builder
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestCheckAllowAutoMerge_DisabledEmitsWarning(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
+			return false, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	out := captureStdout(func() {
+		eng.checkAllowAutoMerge("owner", "repo")
+	})
+
+	if !strings.Contains(out, "WARNING") {
+		t.Errorf("expected WARNING in output; got: %q", out)
+	}
+	if !strings.Contains(out, "allow_auto_merge") {
+		t.Errorf("expected allow_auto_merge mention in output; got: %q", out)
+	}
+	if !strings.Contains(out, "gh api -X PATCH repos/owner/repo") {
+		t.Errorf("expected fix command in output; got: %q", out)
+	}
+}
+
+func TestCheckAllowAutoMerge_EnabledIsSilent(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
+			return true, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	out := captureStdout(func() {
+		eng.checkAllowAutoMerge("owner", "repo")
+	})
+
+	if out != "" {
+		t.Errorf("expected no output for enabled repo; got: %q", out)
+	}
+}
+
+func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
+			return false, errors.New("network error")
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	// Should not panic; engine should log the error at warn level and continue.
+	out := captureStdout(func() {
+		eng.checkAllowAutoMerge("owner", "repo")
+	})
+
+	// No WARNING block should be emitted for an API error.
+	if strings.Contains(out, "WARNING") {
+		t.Errorf("should not print WARNING on API error; got: %q", out)
+	}
+}
+
+func TestCheckAllowAutoMerge_DedupSuppressesSecondCall(t *testing.T) {
+	var callCount int
+	client := &mockGitHubClient{
+		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
+			callCount++
+			return false, nil
+		},
+	}
+	eng := testEngine(client, &mockClaudeInvoker{})
+
+	// First call should emit warning.
+	out1 := captureStdout(func() {
+		eng.checkAllowAutoMerge("owner", "repo")
+	})
+	if !strings.Contains(out1, "WARNING") {
+		t.Errorf("first call: expected WARNING; got: %q", out1)
+	}
+
+	// Second call for the same repo should be a no-op.
+	out2 := captureStdout(func() {
+		eng.checkAllowAutoMerge("owner", "repo")
+	})
+	if out2 != "" {
+		t.Errorf("second call: expected no output (dedup); got: %q", out2)
+	}
+	if callCount != 1 {
+		t.Errorf("expected API to be called exactly once; got %d", callCount)
 	}
 }

--- a/github/client.go
+++ b/github/client.go
@@ -151,3 +151,16 @@ func (c *Client) FetchLatestRelease(owner, repo string) (*LatestRelease, error) 
 	}
 	return &release, nil
 }
+
+// FetchAllowAutoMerge calls GET /repos/{owner}/{repo} and returns the value of
+// the allow_auto_merge field. Returns an error if the request fails.
+func (c *Client) FetchAllowAutoMerge(owner, repo string) (bool, error) {
+	url := c.baseURL + "/repos/" + owner + "/" + repo
+	var result struct {
+		AllowAutoMerge bool `json:"allow_auto_merge"`
+	}
+	if err := c.restGetJSON(url, &result); err != nil {
+		return false, fmt.Errorf("fetching allow_auto_merge for %s/%s: %w", owner, repo, err)
+	}
+	return result.AllowAutoMerge, nil
+}


### PR DESCRIPTION
Closes #832

## Summary

Two changes: (1) add an explicit callout to `docs/USER_GUIDE.md` telling operators they must enable `allow_auto_merge` on each managed repo before using yolo mode, with the one-line fix command; and (2) add a non-fatal startup pre-flight check in the engine that queries the GitHub REST API for each managed repo and emits a loud `[startup] WARNING:` message if `allow_auto_merge` is disabled.

## Problem

Fabrik's GitHub native auto-merge (shipped in #829 / v0.0.68) requires `allow_auto_merge` to be enabled at the repository level under **Settings → General → Pull Requests → "Allow auto-merge."** When this setting is off, `enablePullRequestAutoMerge` returns:

```
GraphQL error: Auto merge is not allowed for this repository
```

The engine already logs a clear warning at `engine/stages.go:250`:

```go
e.logf(item.Number, "warn", "auto-merge is not enabled for this repository — "+
    "enable it in Settings → General → Allow auto-merge; Fabrik will retry on the next poll\n")
```

…but the operator has to be tailing logs to see it, and by then their PRs are already stuck open. None of the setup-facing surfaces mention this requirement:

- `docs/USER_GUIDE.md` — no mention of `allow_auto_merge`
- `cmd/init.go` — no pre-flight check, no warning printed at init time
- Onboarding flow — silent

Found while running the e2e tests for #829 against fabrik-test-alpha. The repo was set up before #829 shipped, so `allow_auto_merge` defaulted to OFF. Three PRs sat MERGEABLE/CLEAN with the warning fired on every poll — operator-facing impact is "my PRs aren't merging and there's no obvious reason."

## Approach

### Approach

Three coordinated changes:

1. **GitHub client**: Add `FetchAllowAutoMerge(owner, repo string) (bool, error)` to the `GitHubClient` interface and implement it in `github/client.go` using the `restGetJSON` pattern, extracting `allow_auto_merge` from the `GET /repos/{owner}/{repo}` response.

2. **Engine startup check**: Add a `checkAllowAutoMerge(owner, repo string)` method to the engine (parallel to `checkHTTPSCredentials`). Wire it into both call sites: the single-repo startup block in `Run()` (after `checkHTTPSCredentials`) and the multi-repo `seenRepos` loop in `poll()` (adjacent to the `seededRepos` dedup block). Use a new `checkedAutoMergeRepos map[string]bool` field on `Engine` (parallel to `seededRepos`) as the dedup guard.

3. **Docs**: Add a highlighted prerequisite callout to the Yolo Mode and Auto-Merge section of `docs/USER_GUIDE.md`, then regenerate `docs/llms-full.txt`.

The multi-repo check is placed in the `poll()` seenRepos loop rather than `ensureRepoReady` — the spec mentions `ensureRepoReady` but that runs in concurrent worker goroutines; the seenRepos loop is single-goroutine, has identical "first time seen" semantics, and avoids the locking complexity. This matches the actual `seededRepos` pattern the spec references.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/interfaces.go` | Add `FetchAllowAutoMerge(owner, repo string) (bool, error)` to `GitHubClient` interface |
| `github/client.go` | Implement `FetchAllowAutoMerge` on `*Client` — `GET /repos/{owner}/{repo}`, extract `allow_auto_merge` |
| `engine/engine.go` | Add `checkedAutoMergeRepos map[string]bool` field to `Engine` struct; initialize in `New()` |
| `engine/poll.go` | Add `checkAllowAutoMerge(owner, repo string)` method; wire into `Run()` startup and `poll()` seenRepos loop |
| `engine/mocks_test.go` | Add `fetchAllowAutoMergeFn` field and `FetchAllowAutoMerge` method to `mockGitHubClient`; nil-fn default returns `true, nil` |
| `docs/USER_GUIDE.md` | Add highlighted prerequisite callout in §3 Yolo Mode and Auto-Merge |
| `docs/llms-full.txt` | Regenerate via `bash scripts/generate-llms-full.sh` |

### Key Decisions

- **Multi-repo check location is `poll()` seenRepos loop, not `ensureRepoReady`**: `ensureRepoReady` runs in concurrent workers; the seenRepos loop at lines 1030–1058 is single-goroutine and directly adjacent to the `seededRepos` guard — the natural twin. Semantics are identical: "fires exactly once per repo per process run."

- **Extract to a named method `checkAllowAutoMerge`**: Both `Run()` and `poll()` need the same dedup guard, warning format, and error handling. A method keeps both call sites to a single line and avoids duplicating R4's exact format string in two places. Same rationale as `checkHTTPSCredentials` being a method rather than inline code.

- **Mock nil-fn default is `true, nil` (assume enabled)**: Existing tests that construct `mockGitHubClient{}` without setting `fetchAllowAutoMergeFn` would otherwise emit spurious `[startup] WARNING:` output that could break test assertions. Defaulting to "enabled" is the safest and least surprising behavior.

- **No ADR**: This is a non-architectural advisory check following an established engine pattern. No new pattern is introduced that would constrain future contributors in a non-obvious way.

- **USER_GUIDE.md callout format**: Use a blockquote with bold lead (`> **Prerequisite — Allow auto-merge:**`) to make it visually distinct — consistent with the callout style the guide already uses elsewhere — inserted as the second paragraph of the Yolo Mode and Auto-Merge section (after the intro paragraph, before the "When Validate completes…" paragraph).

### Task Checklist

- [ ] Task 1: Add `FetchAllowAutoMerge(owner, repo string) (bool, error)` to the `GitHubClient` interface in `engine/interfaces.go` (after `FetchLatestRelease`)
- [ ] Task 2: Implement `FetchAllowAutoMerge` on `*Client` in `github/client.go` — call `GET /repos/{owner}/{repo}`, unmarshal into a local struct `{ AllowAutoMerge bool \`json:"allow_auto_merge"\` }`, return the field value; wrap errors with `fmt.Errorf("fetching allow_auto_merge for %s/%s: %w", owner, repo, err)`
- [ ] Task 3: Add `checkedAutoMergeRepos map[string]bool` field to `Engine` struct in `engine/engine.go` (adjacent to `seededRepos`); initialize it in `New()` alongside `seededRepos`
- [ ] Task 4: Add `checkAllowAutoMerge(owner, repo string)` method on `*Engine` in `engine/poll.go` — check `checkedAutoMergeRepos` under `e.mu`, mark checked, call `e.client.FetchAllowAutoMerge`, on error log at warn and return, if `allow_auto_merge` is false print the three-line R4 warning using `fmt.Printf`
- [ ] Task 5: Wire `checkAllowAutoMerge` into the single-repo startup path in `engine/poll.go` `Run()` — call `e.checkAllowAutoMerge(e.cfg.Owner, e.cfg.Repo)` directly after `e.checkHTTPSCredentials(httpsToSSH)` (line 303), before `SeedLabels`
- [ ] Task 6: Wire `checkAllowAutoMerge` into the multi-repo `seenRepos` loop in `engine/poll.go` `poll()` — inside the `for ownerRepo := range seenRepos` block (lines 1037–1058), after the `parseOwnerRepo` call, call `e.checkAllowAutoMerge(owner, repo)` before `SeedLabels`
- [ ] Task 7: Add `fetchAllowAutoMergeFn func(owner, repo string) (bool, error)` field to `mockGitHubClient` in `engine/mocks_test.go`; add `FetchAllowAutoMerge` method that acquires the lock, reads the fn, releases lock, calls fn if non-nil, otherwise returns `true, nil`
- [ ] Task 8: Add a test for `checkAllowAutoMerge` in `engine/poll_test.go` (or nearest applicable test file) — cover: (a) disabled `allow_auto_merge` emits the R4 warning; (b) enabled is silent; (c) API error is non-fatal and logged at warn; (d) dedup guard suppresses second call
- [ ] Task 9: Update `docs/USER_GUIDE.md` — insert the highlighted prerequisite callout as the second paragraph of `### Yolo Mode and Auto-Merge` (after the intro paragraph, before "When Validate completes…"), using R1's required content: setting path and fix command
- [ ] Task 10: Regenerate `docs/llms-full.txt` — run `bash scripts/generate-llms-full.sh` and stage the result (`git add docs/llms-full.txt`)
- [ ] Task 11: Build and test — `go build ./...`, `go vet ./...`, `go test -race ./...`

### Risks

- **`checkedAutoMergeRepos` and `seededRepos` dedup in single-repo mode**: In `Run()`, the single-repo path marks `seededRepos` under lock at line 317. The `checkAllowAutoMerge` call (Task 5) runs just before this and marks `checkedAutoMergeRepos` internally — both maps are marked before the first `poll()` fires, so the seenRepos loop won't re-check the repo. Verify that `checkedAutoMergeRepos` is marked even when `allow_auto_merge` is true (warning suppressed) — it must be marked regardless of the result to satisfy R7.

- **Multi-repo malformed owner**: The seenRepos loop already has a guard for malformed repo strings (`parseOwnerRepo` returns `""`). The `checkAllowAutoMerge` call is placed after this guard (Task 6), so malformed repos are skipped automatically.

- **Test `fmt.Printf` capture**: Tests for the warning output need to redirect `os.Stdout` or use a pattern similar to other startup-check tests. Check existing test files for any stdout-capture helpers before writing new ones.

---
Used 13/50 turns, 5k input / 4k output tokens.

## Verification

Implemented all 11 plan tasks: added `FetchAllowAutoMerge` to the GitHub client interface and implemented it via `GET /repos/{owner}/{repo}`; added `checkAllowAutoMerge` engine method with dedup guard wired into both single-repo startup and multi-repo seenRepos loop; added 4 tests; updated `docs/USER_GUIDE.md` with a highlighted prerequisite callout and regenerated `docs/llms-full.txt`. The only test failure (`TestExecute_ConfigYAMLApplied`) is pre-existing and unrelated to these changes.

---

Closes #832