### PR TITLE
engine: generalize attemptMergeOnValidate fallback to cover ALL enable_auto_merge terminal errors (clean status was only the first variant)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3073,8 +3073,10 @@ Fabrik discovers PR comments through the `closedByPullRequestsReferences` GraphQ
 **Flow:**
 1. If `fabrik:auto-merge-enabled` is already present on the issue: return nil (idempotent — auto-merge was already enabled in a previous invocation).
 2. Fetch linked PR via `FetchLinkedPR()`.
-3. Call `EnablePullRequestAutoMerge(owner, repo, pr.Number, AutoMergeStrategy)`. The strategy defaults to `MERGE` and is configurable via `FABRIK_AUTO_MERGE_STRATEGY`. On failure: log a guidance message and return a retriable error (next poll retries).
-4. On success: apply `fabrik:auto-merge-enabled` label. GitHub now owns the merge decision atomically — no Fabrik-side `MergePR` call. Done advancement is deferred to `checkAutoMergeConvergence` in Phase 1 of the catch-up loop.
+3. Call `EnablePullRequestAutoMerge(owner, repo, pr.Number, AutoMergeStrategy)`. The strategy defaults to `MERGE` and is configurable via `FABRIK_AUTO_MERGE_STRATEGY`. On failure, two branches apply:
+   - **`ErrAutoMergeNotEnabled`** (repo-level setting disabled): log a guidance message pointing to Settings → General → Allow auto-merge; return a retriable error (next poll retries). No direct-merge attempt.
+   - **Any other error** (PR in a terminal GitHub state — e.g. CLEAN, UNSTABLE, or future variants where GitHub refuses to queue auto-merge): log the specific error, then attempt a direct `MergePR` call as a fallback. If `MergePR` succeeds: apply `fabrik:auto-merge-enabled` and return `(true, nil)`. If `MergePR` also fails (e.g. `ErrNotMergeable` for a DIRTY PR): return `(false, err)` so existing rebase/CI-fix gates can act on it.
+4. On `EnablePullRequestAutoMerge` success: apply `fabrik:auto-merge-enabled` label. GitHub now owns the merge decision atomically — no Fabrik-side `MergePR` call. Done advancement is deferred to `checkAutoMergeConvergence` in Phase 1 of the catch-up loop.
 
 **`cruise > yolo` precedence:** If `fabrik:cruise` is present on the issue, `attemptMergeOnValidate` returns immediately without calling `EnablePullRequestAutoMerge`. Cruise items keep the current `stage:Validate:complete` behavior: the branch is maintained (rebase reinvoke, CI-fix reinvoke) but merging is left to the user.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -719,8 +719,10 @@ Fabrik discovers PR comments through the `closedByPullRequestsReferences` GraphQ
 **Flow:**
 1. If `fabrik:auto-merge-enabled` is already present on the issue: return nil (idempotent — auto-merge was already enabled in a previous invocation).
 2. Fetch linked PR via `FetchLinkedPR()`.
-3. Call `EnablePullRequestAutoMerge(owner, repo, pr.Number, AutoMergeStrategy)`. The strategy defaults to `MERGE` and is configurable via `FABRIK_AUTO_MERGE_STRATEGY`. On failure: log a guidance message and return a retriable error (next poll retries).
-4. On success: apply `fabrik:auto-merge-enabled` label. GitHub now owns the merge decision atomically — no Fabrik-side `MergePR` call. Done advancement is deferred to `checkAutoMergeConvergence` in Phase 1 of the catch-up loop.
+3. Call `EnablePullRequestAutoMerge(owner, repo, pr.Number, AutoMergeStrategy)`. The strategy defaults to `MERGE` and is configurable via `FABRIK_AUTO_MERGE_STRATEGY`. On failure, two branches apply:
+   - **`ErrAutoMergeNotEnabled`** (repo-level setting disabled): log a guidance message pointing to Settings → General → Allow auto-merge; return a retriable error (next poll retries). No direct-merge attempt.
+   - **Any other error** (PR in a terminal GitHub state — e.g. CLEAN, UNSTABLE, or future variants where GitHub refuses to queue auto-merge): log the specific error, then attempt a direct `MergePR` call as a fallback. If `MergePR` succeeds: apply `fabrik:auto-merge-enabled` and return `(true, nil)`. If `MergePR` also fails (e.g. `ErrNotMergeable` for a DIRTY PR): return `(false, err)` so existing rebase/CI-fix gates can act on it.
+4. On `EnablePullRequestAutoMerge` success: apply `fabrik:auto-merge-enabled` label. GitHub now owns the merge decision atomically — no Fabrik-side `MergePR` call. Done advancement is deferred to `checkAutoMergeConvergence` in Phase 1 of the catch-up loop.
 
 **`cruise > yolo` precedence:** If `fabrik:cruise` is present on the issue, `attemptMergeOnValidate` returns immediately without calling `EnablePullRequestAutoMerge`. Cruise items keep the current `stage:Validate:complete` behavior: the branch is maintained (rebase reinvoke, CI-fix reinvoke) but merging is left to the user.
 

--- a/engine/handle_stage_complete_test.go
+++ b/engine/handle_stage_complete_test.go
@@ -252,15 +252,19 @@ func TestHandleStageComplete_AutoAdvanceFalse_OverridesAdvanceButMergeStillFires
 }
 
 func TestHandleStageComplete_MergeAPIError_LogsAndDoesNotAdvance(t *testing.T) {
-	// Transient API error from EnablePullRequestAutoMerge: log the error and do NOT
-	// advance. This prevents silently moving to Done when auto-merge enablement failed
-	// (e.g. transient 5xx, permissions). The engine will retry Validate on the next
-	// cooldown cycle.
+	// Transient API error from both EnablePullRequestAutoMerge and the MergePR fallback:
+	// log the error and do NOT advance. Under the generalised fallback, any
+	// non-ErrAutoMergeNotEnabled error triggers a direct MergePR attempt. When that
+	// also fails (e.g. PR not yet mergeable), the engine must not advance — it will
+	// retry Validate on the next cooldown cycle.
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 88, HeadSHA: "abc123"}, nil
 		},
 		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			return errors.New("network error")
+		},
+		mergePRFn: func(owner, repo string, prNumber int) error {
 			return errors.New("network error")
 		},
 	}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -251,28 +251,27 @@ func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, i
 				"enable it in Settings → General → Allow auto-merge; Fabrik will retry on the next poll\n")
 			return false, fmt.Errorf("enabling auto-merge on PR #%d: %w", pr.Number, err)
 		}
-		if errors.Is(err, gh.ErrAutoMergeAlreadyClean) {
-			// PR is already CLEAN (all checks passed) — GitHub won't queue auto-merge.
-			// Fall back to a direct merge call instead.
-			e.logf(item.Number, "info", "PR #%d is already in clean status — falling back to direct merge\n", pr.Number)
-			if mergeErr := e.client.MergePR(owner, repo, pr.Number); mergeErr != nil {
-				return false, fmt.Errorf("direct merge fallback on PR #%d: %w", pr.Number, mergeErr)
-			}
-			// Apply idempotency guard and convergence anchor after successful direct merge.
-			if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
-				e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
-			} else {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
-				}
-				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
-				}
-			}
-			e.logf(item.Number, "info", "PR #%d merged directly (already-clean fallback)\n", pr.Number)
-			return true, nil
+		// Any error other than ErrAutoMergeNotEnabled means the PR is in a terminal
+		// GitHub state (CLEAN, UNSTABLE, or any future variant) where auto-merge cannot
+		// be queued. Fall back to a direct merge call. If that also fails (e.g. DIRTY),
+		// surface the MergePR error so existing rebase/CI-fix gates can act on it.
+		e.logf(item.Number, "info", "PR #%d: enable auto-merge failed (%v) — falling back to direct merge\n", pr.Number, err)
+		if mergeErr := e.client.MergePR(owner, repo, pr.Number); mergeErr != nil {
+			return false, fmt.Errorf("direct merge fallback on PR #%d: %w", pr.Number, mergeErr)
 		}
-		return false, fmt.Errorf("enabling auto-merge on PR #%d: %w", pr.Number, err)
+		// Apply idempotency guard and convergence anchor after successful direct merge.
+		if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
+			}
+		}
+		e.logf(item.Number, "info", "PR #%d merged directly (auto-merge unavailable fallback)\n", pr.Number)
+		return true, nil
 	}
 
 	// Apply fabrik:auto-merge-enabled as idempotency guard and budget-start anchor.

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -184,6 +184,88 @@ func TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenClean(t *testing.T) {
 	}
 }
 
+// TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenUnstable verifies that when
+// EnablePullRequestAutoMerge returns a non-sentinel error (e.g. UNSTABLE status),
+// the function falls back to a direct MergePR call, applies fabrik:auto-merge-enabled,
+// and returns (true, nil). This is AC#2.
+func TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenUnstable(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, HeadSHA: "sha42"}, nil
+		},
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			return errors.New("GraphQL error: Pull request is in unstable status")
+		},
+		mergePRFn: func(owner, repo string, prNumber int) error {
+			return nil
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected autoMergeEnabled=true for unstable-status fallback")
+	}
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge called once, got %d", len(client.enablePullRequestAutoMergeCalls))
+	}
+	if len(client.mergePRCalls) != 1 {
+		t.Fatalf("expected MergePR called once as fallback, got %d", len(client.mergePRCalls))
+	}
+	if client.mergePRCalls[0].prNumber != 42 {
+		t.Errorf("MergePR called with PR %d, want 42", client.mergePRCalls[0].prNumber)
+	}
+	foundLabel := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundLabel = true
+		}
+	}
+	if !foundLabel {
+		t.Error("expected fabrik:auto-merge-enabled label to be applied after direct merge fallback")
+	}
+}
+
+// TestAttemptMergeOnValidate_DirectMergeAlsoFails verifies that when
+// EnablePullRequestAutoMerge returns an arbitrary error AND MergePR also fails
+// (e.g. ErrNotMergeable from a DIRTY PR), the function returns (false, err) and
+// does NOT apply the fabrik:auto-merge-enabled label. This is AC#3.
+func TestAttemptMergeOnValidate_DirectMergeAlsoFails(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, HeadSHA: "sha42"}, nil
+		},
+		enablePullRequestAutoMergeFn: func(owner, repo string, prNumber int, strategy string) error {
+			return errors.New("GraphQL error: Pull request is in unstable status")
+		},
+		mergePRFn: func(owner, repo string, prNumber int) error {
+			return gh.ErrNotMergeable
+		},
+	}
+	eng := testEngineForMerge(client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err == nil {
+		t.Fatal("expected error when MergePR also fails, got nil")
+	}
+	if enabled {
+		t.Fatal("expected autoMergeEnabled=false when both auto-merge and direct merge fail")
+	}
+	if len(client.mergePRCalls) != 1 {
+		t.Fatalf("expected MergePR called once as fallback, got %d", len(client.mergePRCalls))
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			t.Error("fabrik:auto-merge-enabled label must NOT be applied when direct merge fails")
+		}
+	}
+}
+
 // TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns verifies Approach A': when
 // wait_for_ci is true, handleStageComplete adds fabrik:awaiting-ci, does NOT add
 // stage:Validate:complete, and does NOT call attemptMergeOnValidate.


### PR DESCRIPTION
Closes #835

## Summary

Generalize `attemptMergeOnValidate` in `engine/stages.go` to treat **any** error from `EnablePullRequestAutoMerge` that is not `ErrAutoMergeNotEnabled` (the repo-level disable, which requires operator action) as a signal to fall back to a direct `MergePR` call. This replaces the brittle type-match on `ErrAutoMergeAlreadyClean` with a broader "any terminal state → merge directly; if that also fails, surface the real error" pattern, covering both the known `CLEAN` and `UNSTABLE` cases and any future GitHub-side terminal states.

## Problem

#831 fixed the specific `"Pull request is in clean status"` error from GitHub's `enablePullRequestAutoMerge` mutation by falling back to direct merge. But that's only one of several terminal states GitHub can return — and within the same test session that surfaced #831, we already observed a second variant on a different PR:

```
[#832 warn] auto-merge enablement failed during catch-up: enabling auto-merge on PR #834:
  GraphQL error: Pull request Pull request is in unstable status
```

Any uncovered variant produces the same stuck-PR pattern that #831 fixed for the `CLEAN` case.

Worse, Fabrik's cache-driven dispatch means once an item's catch-up retry fails terminally and nothing else changes on GitHub, the cache stays warm and the item is never re-evaluated — even though every poll has the data and capability to retry. The convergence-budget safety net from #829 is gated on `fabrik:auto-merge-enabled` being present, which is never applied if the initial enable call errors out. So the safety net has a hole exactly where it's most needed.

### Observed terminal-error variants

| State | GitHub error | Currently handled? |
|---|---|---|
| `CLEAN` | `Pull request is in clean status` | YES (#831 fix in PR #833) |
| `UNSTABLE` | `Pull request is in unstable status` | NO — observed on PR #834 |
| `DIRTY` | (likely refuses; conflict means auto-merge can't help) | NO — handled separately by rebase reinvoke gate |
| `BLOCKED` | (likely; required reviews missing) | Unknown |
| `BEHIND` | (probably succeeds — canonical auto-merge use case) | Probably OK |
| `UNKNOWN` | (probably transient) | Probably OK |
| Repo-level disable | `Auto merge is not allowed for this repository` | YES (#832) |

The pattern: GitHub refuses `enable_auto_merge` whenever the PR is in a state where auto-merge has nothing useful to do — either it's already mergeable (CLEAN) or it's in a state where waiting wouldn't help (UNSTABLE; possibly DIRTY).

## Approach

### Approach

The change is surgical: replace the narrow `errors.Is(err, gh.ErrAutoMergeAlreadyClean)` branch inside `attemptMergeOnValidate` with a generic catch-all for any error that is not `ErrAutoMergeNotEnabled`. The CLEAN case becomes subsumed by the generic fallback — no behavioral change for that case, but UNSTABLE and all future terminal GitHub states are now covered automatically.

No new types, sentinels, or abstractions are introduced. `ErrAutoMergeAlreadyClean` stays in `github/prs.go` because `merge_gate.go:235` still consumes it via `errors.Is` (out of scope for this issue). The only change to `engine/stages.go` is the error-handling block after `EnablePullRequestAutoMerge` returns an error (lines 254–275).

The log message for the fallback path is updated to include the specific error so operators can distinguish CLEAN from UNSTABLE from any future variant.

No ADR is needed. This is a bug fix that strengthens the implementation of ADR 050's design decision without deviating from it.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/stages.go` | Replace narrow `ErrAutoMergeAlreadyClean` branch (lines 254–275) with generic fallback for any non-`ErrAutoMergeNotEnabled` error |
| `engine/stages_test.go` | Add two new unit tests (AC#2 and AC#3); existing AC#1 and AC#4 tests verified unchanged |
| `docs/state-machine.md` | Update section 5.4 step 3 to describe the new branching logic |
| `docs/llms-full.txt` | Regenerated from updated docs |

### Key Decisions

- **Generic fallback, not a list of known states**: The spec explicitly calls for "any error that is not `ErrAutoMergeNotEnabled`" rather than matching individual state strings. This is future-proof — any new GitHub terminal state is handled without a code change.

- **Retain `ErrAutoMergeAlreadyClean` in `github/prs.go`**: `merge_gate.go:235` uses `errors.Is(rerr, gh.ErrAutoMergeAlreadyClean)` in the rebase reinvoke re-enable path (out of scope). Removing the sentinel would silently break that path.

- **Log the original `EnablePullRequestAutoMerge` error in the fallback log line**: Requirement #5 is explicit. Using `%v` with the original error lets operators see the GitHub state string (e.g., `"Pull request is in unstable status"`) in the log without needing separate sentinel parsing.

- **No E2E tests created**: `tests/e2e/auto_merge_test.go` and `tests/e2e/convergence_race_test.go` don't exist in the worktree. AC#5 and AC#6 reference external integration tests presumed to run against `fabrik-test-alpha`; they are outside this implementation's scope as confirmed by the spec's "In scope" section.

### Task Checklist

- [ ] Task 1: Modify `engine/stages.go` lines 254–275 — replace the `errors.Is(err, gh.ErrAutoMergeAlreadyClean)` branch and the trailing `return false` with a single generic fallback block: log the specific error, call `MergePR`, on success apply label and return `(true, nil)`, on failure return `(false, mergeErr)`
- [ ] Task 2: Add `TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenUnstable` in `engine/stages_test.go` — `EnablePullRequestAutoMerge` returns `errors.New("Pull request is in unstable status")`, `MergePR` returns nil → verify `(true, nil)` with `fabrik:auto-merge-enabled` applied and `MergePR` called once (AC#2)
- [ ] Task 3: Add `TestAttemptMergeOnValidate_DirectMergeAlsoFails` in `engine/stages_test.go` — `EnablePullRequestAutoMerge` returns an arbitrary error, `MergePR` returns `gh.ErrNotMergeable` → verify `(false, err)` is returned and `fabrik:auto-merge-enabled` label is NOT applied (AC#3)
- [ ] Task 4: Run `go test -race ./engine/...` to confirm all four affected tests pass: new AC#2 and AC#3, plus existing `TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenClean` (AC#1 regression) and `TestAttemptMergeOnValidate_RepoAutoMergeDisabled` (AC#4 regression)
- [ ] Task 5: Run `go vet ./...` to confirm no issues introduced
- [ ] Task 6: Update `docs/state-machine.md` section 5.4 step 3 — replace the single "On failure: log a guidance message and return a retriable error" sentence with the two-branch description: `ErrAutoMergeNotEnabled` → log repo-level warning, return `(false, err)` (unchanged); any other error → log specific error, attempt `MergePR` fallback; fallback success → apply label, return `(true, nil)`; fallback failure → return `(false, err)` for rebase/CI-fix gates
- [ ] Task 7: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh` and stage the result

### Risks

- **E2E tests (AC#5–6) are out of scope**: The referenced test files do not exist in the worktree. These are external integration tests presumably run against `fabrik-test-alpha`. The plan covers only the unit-test criteria (AC#1–4) matching the spec's "In scope" section.
- **`merge_gate.go` narrow check remains** (documented out of scope): The UNSTABLE case in the rebase reinvoke re-enable path is still unhandled. This is a follow-up, and this change does not regress it.

---
Used 8/50 turns, 5k input / 4k output tokens.

## Verification

Generalized `attemptMergeOnValidate` in `engine/stages.go` to fall back to direct `MergePR` for any error from `EnablePullRequestAutoMerge` that is not `ErrAutoMergeNotEnabled` — covering CLEAN, UNSTABLE, and any future terminal GitHub states. Added unit tests for the UNSTABLE case (AC#2) and the "direct-merge also fails" case (AC#3), and updated `docs/state-machine.md` section 5.4 to document the new two-branch error handling. All tests pass and `go vet` is clean.

---

Closes #835