### PR TITLE
test(e2e): add regression tests for #829 auto-merge + harden poll waits

### DIFF
--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -1,0 +1,96 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestYoloAutoMergeLabel is the regression test for #829 — replacing Fabrik's
+// poll-merge loop with GitHub's native auto-merge for yolo issues.
+//
+// The headline observable behaviour change: after Validate completes for a
+// fabrik:yolo issue, the engine calls enablePullRequestAutoMerge once and
+// tags the issue with fabrik:auto-merge-enabled. GitHub then merges the PR
+// atomically when CI passes and the PR is mergeable, eliminating the
+// HTTP 405 spam and race window that the poll-merge loop produced.
+//
+// What this test verifies (FR-004, FR-005, SC-001 from the #829 spec):
+//   - fabrik:auto-merge-enabled is applied at some point during the issue's
+//     lifetime (observed via the issue timeline, so we don't miss a fast
+//     add-then-remove cycle on a trivial PR).
+//   - The issue ultimately closes — i.e. GitHub auto-merge actually merged
+//     the PR end-to-end.
+//   - fabrik:auto-merge-enabled is NOT present on the closed issue (FR-005:
+//     removed once the PR merges).
+//
+// Out of scope here (better suited to unit/integration tests because
+// provoking them deterministically in e2e is hard):
+//   - convergence budget exhaustion (Story 3 / SC-003)
+//   - mid-flight conflict triggering a bounded rebase (Story 2 / SC-002)
+//   - cruise preservation (Story 4 / SC-004 — covered by unit tests of the
+//     yolo/cruise gating logic)
+//
+// Wall-clock: ~20-40 min. Cost: ~$0.50-1.50.
+func TestYoloAutoMergeLabel(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	stamp := time.Now().UTC().Format("20060102-150405")
+	marker := fmt.Sprintf("auto-merge-yolo-%s", stamp)
+	body := fmt.Sprintf(autoMergeBodyTemplate, "`", "`", "```", marker, "```")
+
+	num := FileIssue(t, env, env.RepoAlpha,
+		fmt.Sprintf("e2e yolo auto-merge (%s)", stamp),
+		body, "fabrik:yolo")
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d at Status=Specify, marker=%s", env.RepoAlpha, num, marker)
+
+	// Wait for the full pipeline to land the merge. On trivial PRs with no
+	// branch protection or required reviews, GitHub may merge within seconds
+	// of auto-merge being enabled — so we don't poll for the transient
+	// fabrik:auto-merge-enabled label here. We let the issue close and then
+	// audit the timeline.
+	WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
+	t.Logf("%s#%d closed — checking the auto-merge path was taken", env.RepoAlpha, num)
+
+	// Race-free verification that auto-merge enablement happened: scan the
+	// issue's timeline for a labeled-with-fabrik:auto-merge-enabled event.
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
+	t.Logf("fabrik:auto-merge-enabled was applied at some point — GitHub native auto-merge path verified")
+
+	// FR-005: the label must be removed when the PR merges. Fabrik needs
+	// 1-2 poll cycles (~30-60s) after the merge to observe it and remove the
+	// label — checking immediately races the cleanup poll.
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled", 5*time.Minute)
+	t.Logf("fabrik:auto-merge-enabled was cleaned up after merge — FR-005 verified")
+}
+
+// autoMergeBodyTemplate is the issue body for TestYoloAutoMergeLabel. The five
+// %s placeholders are: backtick, backtick, codefence, marker, codefence
+// (Go raw strings can't contain backticks).
+const autoMergeBodyTemplate = `## Goal
+
+End-to-end verification of the GitHub native auto-merge path for yolo issues (#829).
+
+## Trivial change
+
+Append a single HTML comment line to %sREADME.md%s at the very end of the file:
+
+%s
+<!-- %s -->
+%s
+
+That is the entire change. One file, one line. Plan should NOT decompose.
+
+## Scope
+
+Single repo only. This issue exists purely to drive a yolo PR through the new
+post-Validate convergence flow and verify Fabrik enables GitHub auto-merge
+(applying the fabrik:auto-merge-enabled label) rather than running the legacy
+poll-merge loop.
+`

--- a/tests/e2e/convergence_race_test.go
+++ b/tests/e2e/convergence_race_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConvergenceRace is the deterministic provocation test for the
+// post-Validate auto-merge race covered by handarbeit/fabrik#829 (Story 2 /
+// SC-002).
+//
+// The test bed's CI workflow has a required "slow-gate" job that sleeps for
+// ~6 minutes when the PR body contains the literal string "slow-ci-required".
+// We file two yolo issues that BOTH target the same anchor in the same file
+// (the first line of README.md) and BOTH carry the marker. The arrangement
+// makes the race deterministic:
+//
+//  1. Both issues flow through Specify → Research → Plan → Implement.
+//  2. Both PRs open against main from the same base SHA.
+//  3. Validate completes on both; engine enables GitHub native auto-merge on
+//     both PRs (fabrik:auto-merge-enabled is applied).
+//  4. Both PRs wait on the 6-minute slow-gate check.
+//  5. Whichever finishes first merges atomically via GitHub auto-merge. Main
+//     now has a new HTML comment line immediately after the first line.
+//  6. The OTHER PR is now "behind main" AND has a true textual conflict at
+//     the same anchor — mergeable=CONFLICTING. Fabrik must observe this and
+//     dispatch a single rebase reinvoke (NOT a CI-fix reinvoke, NOT a stream
+//     of spurious cycles bounded by MaxRebaseCycles/MaxCiFixCycles).
+//  7. Claude resolves the conflict (keeps both markers), pushes; auto-merge
+//     re-enables; the slow-gate runs again; the second PR merges; the issue
+//     closes.
+//
+// Pass criteria:
+//   - Both issues close within the wall-clock budget.
+//   - Both had fabrik:auto-merge-enabled applied (FR-004).
+//   - Neither ends in fabrik:paused (FR-013 was NOT triggered — convergence
+//     succeeded within budget).
+//
+// This is the regression test for the production failure on
+// verveguy/liminis-graph#82 (spurious "CI fix cycle limit reached" on a
+// post-Validate yolo PR whose only real problem was that main moved during
+// its CI run). Before #829, this test would fail with the second PR stuck
+// in fabrik:paused.
+//
+// Wall-clock: ~75-90 min. Cost: ~$2-4.
+func TestConvergenceRace(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	stamp := time.Now().UTC().Format("20060102-150405")
+
+	// Two issues, deliberately conflicting. Filed concurrently so the
+	// dispatcher picks them up on the same poll where possible.
+	type issuePair struct {
+		title string
+		body  string
+	}
+	pairs := []issuePair{
+		{
+			title: fmt.Sprintf("e2e convergence-race A (%s)", stamp),
+			body:  fmt.Sprintf(convergenceBodyTemplate, "A", stamp),
+		},
+		{
+			title: fmt.Sprintf("e2e convergence-race B (%s)", stamp),
+			body:  fmt.Sprintf(convergenceBodyTemplate, "B", stamp),
+		},
+	}
+
+	nums := make([]int, len(pairs))
+	var fileWg sync.WaitGroup
+	for i := range pairs {
+		fileWg.Add(1)
+		go func(i int) {
+			defer fileWg.Done()
+			num := FileIssue(t, env, env.RepoAlpha, pairs[i].title, pairs[i].body, "fabrik:yolo")
+			itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+			SetIssueStatus(t, env, itemID, "Specify")
+			nums[i] = num
+		}(i)
+	}
+	fileWg.Wait()
+	t.Logf("filed contention pair: %s#%d and %s#%d", env.RepoAlpha, nums[0], env.RepoAlpha, nums[1])
+
+	// Both must reach closed (merged). Wait in parallel — one will close
+	// well before the other; the second is the interesting one because it
+	// had to rebase through a conflict.
+	var closeWg sync.WaitGroup
+	for _, num := range nums {
+		closeWg.Add(1)
+		go func(num int) {
+			defer closeWg.Done()
+			WaitForIssueClosed(t, env, env.RepoAlpha, num, 90*time.Minute)
+			t.Logf("%s#%d closed", env.RepoAlpha, num)
+		}(num)
+	}
+	closeWg.Wait()
+
+	// Both PRs must have gone through the GitHub native auto-merge path.
+	for _, num := range nums {
+		AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
+	}
+	t.Logf("both issues had fabrik:auto-merge-enabled applied — FR-004 verified for both")
+
+	// Neither issue should have ended in fabrik:paused — that would mean
+	// either the convergence budget exhausted (FR-013) OR a legacy cycle
+	// limit fired (the bug #829 fixes). Either way, the test fails.
+	for _, num := range nums {
+		for _, l := range IssueLabels(t, env, env.RepoAlpha, num) {
+			if l == "fabrik:paused" {
+				t.Fatalf("%s#%d ended in fabrik:paused — convergence failed (regression of #829)",
+					env.RepoAlpha, num)
+			}
+		}
+	}
+	t.Logf("neither issue ended paused — bounded convergence verified (SC-002)")
+}
+
+// convergenceBodyTemplate is the issue body for TestConvergenceRace. Two
+// %s placeholders: a single-letter discriminator (A or B), and a timestamp
+// shared between the pair so the resulting README lines are unique per run
+// but collide on the same anchor between the two issues.
+//
+// CRITICAL: both issues MUST instruct Claude to insert the marker at the
+// SAME anchor (the line immediately following "# fabrik-test-alpha"). That
+// is what makes the textual conflict deterministic. If Claude is allowed
+// freedom in where to put the line, the conflict may not materialise.
+//
+// The PR body MUST also contain the literal string "slow-ci-required". The
+// test repo's CI workflow keys on that string to enable the 6-minute
+// slow-gate that widens the merge-race window enough for #829's bug to
+// manifest reliably.
+const convergenceBodyTemplate = `## Goal
+
+Deterministic provocation of the post-Validate auto-merge race covered by
+handarbeit/fabrik#829. This issue is one of a deliberately-conflicting
+pair filed by the e2e harness.
+
+## The change
+
+Insert exactly one new line into README.md immediately AFTER the line that
+says "# fabrik-test-alpha". The new line must be EXACTLY:
+
+    <!-- convergence-race-%s-%s -->
+
+(That is: an HTML comment with the discriminator and a shared timestamp.)
+
+Do NOT insert the line anywhere else. Do NOT modify any other file. The
+position is load-bearing: this issue's pair partner inserts a different
+discriminator at the same position, and the e2e test depends on the two
+inserts producing a true textual conflict during rebase.
+
+If, during rebase, you encounter the other pair member's marker already
+present, RESOLVE the conflict by keeping BOTH lines, in either order.
+
+## CI behaviour required
+
+The PR body MUST carry the literal marker below so the test repo's CI
+slow-gate fires:
+
+slow-ci-required
+
+This is what gives the auto-merge race a deterministic 6-minute window
+during which main can move under us.
+
+## Scope
+
+Single repo. No decomposition. No additional files. Plan should be a
+one-line edit and Implement should be a one-line commit.
+`

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -167,7 +167,12 @@ func WaitForIssueLabel(t *testing.T, env *Env, repo string, issueNumber int, lab
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		labels := IssueLabels(t, env, repo, issueNumber)
+		labels, err := tryIssueLabels(env, repo, issueNumber)
+		if err != nil {
+			t.Logf("WaitForIssueLabel: transient gh error on %s#%d: %v (will retry)", repo, issueNumber, err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
 		for _, l := range labels {
 			if l == label {
 				return
@@ -175,8 +180,8 @@ func WaitForIssueLabel(t *testing.T, env *Env, repo string, issueNumber int, lab
 		}
 		time.Sleep(15 * time.Second)
 	}
-	t.Fatalf("timed out waiting for label %q on %s#%d (had: %v)",
-		label, repo, issueNumber, IssueLabels(t, env, repo, issueNumber))
+	last, _ := tryIssueLabels(env, repo, issueNumber)
+	t.Fatalf("timed out waiting for label %q on %s#%d (had: %v)", label, repo, issueNumber, last)
 }
 
 // IssueLabels returns the current labels on the issue.
@@ -218,24 +223,37 @@ func CommentOnIssue(t *testing.T, env *Env, repo string, issueNumber int, body s
 }
 
 // WaitForIssueClosed polls until the issue is CLOSED or timeout expires.
+// Transient gh errors (rate-limit blips, network hiccups) are logged and the
+// poll continues — only the timeout itself fails the test, since over a 45-min
+// wait one stray exit-1 from `gh` would otherwise kill an otherwise-healthy run.
 func WaitForIssueClosed(t *testing.T, env *Env, repo string, issueNumber int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if IssueState(t, env, repo, issueNumber) == "CLOSED" {
+		state, err := tryIssueState(env, repo, issueNumber)
+		if err != nil {
+			t.Logf("WaitForIssueClosed: transient gh error on %s#%d: %v (will retry)", repo, issueNumber, err)
+		} else if state == "CLOSED" {
 			return
 		}
 		time.Sleep(15 * time.Second)
 	}
-	t.Fatalf("timed out waiting for %s#%d to close (still %s)", repo, issueNumber, IssueState(t, env, repo, issueNumber))
+	state, _ := tryIssueState(env, repo, issueNumber)
+	t.Fatalf("timed out waiting for %s#%d to close (last observed: %q)", repo, issueNumber, state)
 }
 
 // WaitForLabelAbsent polls until the named label is no longer on the issue.
+// Tolerant of transient gh errors — see WaitForIssueClosed for rationale.
 func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, label string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		labels := IssueLabels(t, env, repo, issueNumber)
+		labels, err := tryIssueLabels(env, repo, issueNumber)
+		if err != nil {
+			t.Logf("WaitForLabelAbsent: transient gh error on %s#%d: %v (will retry)", repo, issueNumber, err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
 		present := false
 		for _, l := range labels {
 			if l == label {
@@ -249,6 +267,78 @@ func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, la
 		time.Sleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for label %q to disappear from %s#%d", label, repo, issueNumber)
+}
+
+// tryIssueState is the non-fatal counterpart to IssueState — returns (state, err)
+// instead of t.Fatalf'ing. Used by long-running pollers so a single transient
+// gh failure doesn't kill an otherwise-healthy multi-minute wait.
+func tryIssueState(env *Env, repo string, issueNumber int) (string, error) {
+	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo, "--json", "state", "--jq", ".state")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// tryIssueLabels is the non-fatal counterpart to IssueLabels.
+func tryIssueLabels(env *Env, repo string, issueNumber int) ([]string, error) {
+	out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo,
+		"--json", "labels", "--jq", "[.labels[].name]")
+	if err != nil {
+		return nil, err
+	}
+	var labels []string
+	if uerr := json.Unmarshal([]byte(strings.TrimSpace(out)), &labels); uerr != nil {
+		return nil, fmt.Errorf("parse labels: %w", uerr)
+	}
+	return labels, nil
+}
+
+// AssertLabelWasApplied queries the issue's timeline events and asserts the
+// named label was applied at some point during the issue's lifetime. Survives
+// the case where Fabrik adds-and-removes a label faster than a polling
+// interval can observe (e.g. fabrik:auto-merge-enabled on a PR that merges
+// instantly because CI is trivial and there's no branch protection).
+func AssertLabelWasApplied(t *testing.T, env *Env, repo string, issueNumber int, label string) {
+	t.Helper()
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		t.Fatalf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api", "--paginate",
+		fmt.Sprintf("repos/%s/%s/issues/%d/timeline", owner, name, issueNumber),
+		"--jq", `[.[] | select(.event == "labeled") | .label.name]`)
+	if err != nil {
+		t.Fatalf("query timeline for %s#%d: %v\n%s", repo, issueNumber, err, out)
+	}
+	// --paginate concatenates one JSON array per page. Split, parse each, union.
+	seen := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var names []string
+		if err := json.Unmarshal([]byte(line), &names); err != nil {
+			continue
+		}
+		for _, n := range names {
+			seen[n] = true
+		}
+	}
+	if seen[label] {
+		return
+	}
+	t.Fatalf("label %q was never applied to %s#%d (labels ever applied: %v)",
+		label, repo, issueNumber, mapKeys(seen))
+}
+
+func mapKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // IssueState returns "OPEN" or "CLOSED".


### PR DESCRIPTION
## Summary

Adds two new e2e tests (gated behind the `e2e` build tag) that codify the post-Validate auto-merge behaviour shipped in #829, plus hardens the e2e harness poll-loops to tolerate transient gh errors.

These tests caught three real bugs in #829's implementation (#831, #832, #835) during their first runs against the test bed — all now shipped.

## Tests added

- **`TestYoloAutoMergeLabel`** — proves `fabrik:auto-merge-enabled` is applied during convergence (FR-004), the issue merges via GitHub native auto-merge (SC-001), and the label is cleaned up post-merge (FR-005). Uses the issue timeline to detect label-was-applied so we don't race a fast add-then-remove cycle. ~16-20 min wall-clock, ~$0.50-1.50.

- **`TestConvergenceRace`** — deterministic provocation of the post-Validate auto-merge race (Story 2 / SC-002). Files two yolo issues whose Plans target the same anchor in README.md, both carrying a `slow-ci-required` marker so the test-alpha CI workflow's slow-gate job delays merge enough for the race to manifest. One PR merges atomically; the other becomes `CONFLICTING` and is bounded-rebase'd to convergence. Both close, neither pauses — pins the regression that broke `verveguy/liminis-graph#82` in production. ~45-75 min wall-clock, ~$2-4.

## Harness hardening

- `WaitForIssueClosed`, `WaitForIssueLabel`, `WaitForLabelAbsent` now tolerate transient gh errors. Over a 45-min poll loop a single rate-limit blip or network hiccup would previously have killed an otherwise-healthy run; now the error is logged and the poll continues. Only the timeout itself fails the test.
- Adds `AssertLabelWasApplied` (paginated timeline query) for race-free "label was ever applied" assertions.

## Test plan

- [x] Both tests run green against `dev(ecfe11c)` (the binary that would ship as v0.0.69)
- [x] `go vet -tags=e2e ./tests/e2e/` clean
- [x] Each test caught a real bug during its first execution before being green (#831, #832, #835)

## Notes

- Tests require the canonical test bed (`~/dev/fabrik-test/`) and the slow-gate CI job on fabrik-test-alpha (already provisioned).
- Not added to default `go test ./...` runs — `-tags=e2e` opt-in only, since they take ~90 min in parallel and cost real Claude tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)