### PR TITLE
Update docs for v0.0.68

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ GITHUB_TOKEN=ghp_...    # Fallback
 
 > **Prerequisite for yolo auto-merge:** GitHub's `allow_auto_merge` setting must be enabled on the repository before Fabrik can enable native auto-merge on yolo PRs. Enable it under **Settings → General → Pull Requests → "Allow auto-merge"**, or run:
 > ```
-> gh api -X PATCH repos/{owner}/{repo} -f allow_auto_merge=true
+> gh api -X PATCH repos/{owner}/{repo} -F allow_auto_merge=true
 > ```
 > Fabrik emits a `[startup] WARNING` if this setting is disabled on any managed repo.
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,9 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `--user` | Your GitHub username | required |
 | `--token` | GitHub token | `$GITHUB_TOKEN` |
 | `--stages` | Stage configs directory | `./.fabrik/stages` |
-| `--yolo` | Auto-advance through stages | `false` |
+| `--yolo` | Auto-advance issues through stages without human approval; also auto-merges the linked PR when Validate completes | `false` |
+| `--convergence-budget` | Wall-clock budget for post-Validate yolo PR convergence (Go duration: `30m`, `1h`; `0` disables the budget entirely; also `FABRIK_CONVERGENCE_BUDGET`) | `30m` |
+| `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
 | `--auto-upgrade` | Self-upgrade from handarbeit/fabrik GitHub Releases at startup and when idle (after 2 idle polls) | `false` |
 | `--poll` | Poll interval in seconds | `30` |
 | `--notui` | Disable the interactive TUI dashboard | TUI on by default |
@@ -287,6 +289,12 @@ GITHUB_TOKEN=ghp_...    # Fallback
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides installed plugin) | `""` |
 | `--webhooks` | Enable real-time webhook event delivery via `gh webhook forward` (requires `cli/gh-webhook` extension; also `FABRIK_WEBHOOKS`) | `false` |
 | `--reconcile-interval` | Seconds between periodic light-reconcile health checks when webhooks are enabled (0 = default 180; also `FABRIK_RECONCILE_INTERVAL`) | `0` (180 s) |
+
+> **Prerequisite for yolo auto-merge:** GitHub's `allow_auto_merge` setting must be enabled on the repository before Fabrik can enable native auto-merge on yolo PRs. Enable it under **Settings → General → Pull Requests → "Allow auto-merge"**, or run:
+> ```
+> gh api -X PATCH repos/{owner}/{repo} -f allow_auto_merge=true
+> ```
+> Fabrik emits a `[startup] WARNING` if this setting is disabled on any managed repo.
 
 > **Releases:** New releases are announced in the [handarbeit/fabrik Discussions "Announcements" category](https://github.com/handarbeit/fabrik/discussions/categories/announcements) after each successful release.
 
@@ -345,6 +353,7 @@ Fabrik uses labels to track state:
 | `model:<name>` | Use this model for the issue (e.g. `model:opus` overrides the stage YAML default) |
 | `effort:<level>` | Override thinking effort for this issue only — valid values: `low`, `medium`, `high`, `max`; precedence: `max > high > medium > low`. Complements `model:` label. |
 | `fabrik:yolo` | Force auto-advance even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes |
+| `fabrik:auto-merge-enabled` | Applied when Fabrik enables GitHub's native auto-merge on a yolo PR after Validate completes; serves as the idempotency guard and convergence-budget start anchor; removed when the PR merges or is closed |
 | `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` to Claude Code for this issue only, bypassing the default `--permission-mode dontAsk` posture and the entire tool allowlist. Use only when a stage needs tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains). **Caution:** removes all tool restrictions. |
 | `fabrik:extend-turns` | Pre-grant 2× `max_turns` budget for the next invocation; auto-extends to 3× when stage progress is detected; auto-removed on successful stage completion. |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -729,7 +729,7 @@ Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every s
 
 > **Prerequisite — Allow auto-merge:** GitHub's native auto-merge must be enabled at the repository level before yolo mode can merge PRs. Enable it under **Settings → General → Pull Requests → "Allow auto-merge"**, or run:
 > ```
-> gh api -X PATCH repos/{owner}/{repo} -f allow_auto_merge=true
+> gh api -X PATCH repos/{owner}/{repo} -F allow_auto_merge=true
 > ```
 > Without this setting, Fabrik will reach Validate complete and attempt auto-merge, but GitHub will reject it. The Fabrik engine emits a `[startup] WARNING` at startup if this setting is disabled on any managed repo.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -727,7 +727,7 @@ Pass `--yolo` to enable global auto-advance: Fabrik moves issues through every s
 
 > **Prerequisite — Allow auto-merge:** GitHub's native auto-merge must be enabled at the repository level before yolo mode can merge PRs. Enable it under **Settings → General → Pull Requests → "Allow auto-merge"**, or run:
 > ```
-> gh api -X PATCH repos/{owner}/{repo} -f allow_auto_merge=true
+> gh api -X PATCH repos/{owner}/{repo} -F allow_auto_merge=true
 > ```
 > Without this setting, Fabrik will reach Validate complete and attempt auto-merge, but GitHub will reject it. The Fabrik engine emits a `[startup] WARNING` at startup if this setting is disabled on any managed repo.
 


### PR DESCRIPTION
Closes #839

## Summary

Audit README.md, USER_GUIDE.md, and docs/index.md against the v0.0.68 release notes. The USER_GUIDE and state-machine docs are largely current (updated in feature commits); the work is primarily to bring README.md's Flags and Labels tables up to date, add a brief `allow_auto_merge` prerequisite callout to README, and verify USER_GUIDE completeness. Regenerate `docs/llms-full.txt` if any canonical docs change.

## Problem

v0.0.68 shipped three significant user-facing changes — GitHub native auto-merge for yolo issues, the `allow_auto_merge` startup pre-flight check, and a fix to the auto-merge fallback that covers all terminal GitHub PR states. Most of these changes were documented inline as part of their feature PRs (USER_GUIDE.md and state-machine.md were updated at the time), but the README's Flags and Labels tables were not updated, leaving the top-level reference document out of sync with shipped behavior.

## Approach

### Approach

All four required edits are confined to `README.md`. Research confirmed that `USER_GUIDE.md`, `docs/index.md`, and `docs/llms-full.txt` are already current (updated in v0.0.68 feature commits) and require no changes unless an inaccuracy is found during the mandatory audit.

The README edits are:
1. Update the `--yolo` flag description in the Flags table (line 275)
2. Insert `--convergence-budget` and `--auto-merge-strategy` rows immediately after `--yolo` in the Flags table
3. Add an `allow_auto_merge` prerequisite blockquote note after the Flags table ends (between the table closing and the existing `> **Releases:**` note at line 291) — blockquote position keeps the table intact while satisfying the "near `--yolo`" proximity requirement
4. Insert `fabrik:auto-merge-enabled` label row in the Labels table after `fabrik:yolo` (line 347), grouping it with the yolo-related labels

No ADR is needed — ADR 050 already documents these design decisions.

### New/Modified Files

| File | Change |
|------|--------|
| `README.md` | Update `--yolo` description (line 275); add 2 flag rows after `--yolo`; add `allow_auto_merge` blockquote note after flags table; add 1 label row after `fabrik:yolo` |

### Key Decisions

- **`allow_auto_merge` note as a blockquote after the flags table, not inline in the `--yolo` row**: Markdown tables cannot embed multi-line callouts. A brief inline mention in the `--yolo` description would be too terse to be actionable; a blockquote immediately below the table is the established README pattern (see lines 136–142 for `--review-wait-timeout`) and keeps the note visible and scannable without breaking table formatting. The note should mirror the USER_GUIDE prerequisite callout (lines 730–734) but in condensed form.

- **`fabrik:auto-merge-enabled` label insertion after `fabrik:yolo` (line 347)**: The label is semantically owned by yolo auto-merge behavior, so it belongs immediately adjacent to `fabrik:yolo` in the Labels table rather than in the "awaiting-*" group (which covers CI/review gates, not merge mechanics).

- **`--yolo` description update**: Use the USER_GUIDE line 484 as the authoritative wording — "Auto-advance issues through stages without human approval; also auto-merges the linked PR when Validate completes" — adapted to README's terse one-liner style (no `allow_auto_merge` caveat in the cell itself; that lives in the blockquote note below).

- **`--convergence-budget` and `--auto-merge-strategy` descriptions**: Mirror USER_GUIDE lines 496–497 verbatim; they are already terse enough for README's table style.

- **No `docs/llms-full.txt` regeneration unless USER_GUIDE changes**: README.md is not a canonical doc per CLAUDE.md. If the USER_GUIDE or index.md audit in Tasks 5–6 turns up an inaccuracy requiring edits, regeneration is mandatory in that same commit.

### Task Checklist

- [ ] Task 1: In `README.md` Flags table (line 275), update `--yolo` description from `"Auto-advance through stages"` to `"Auto-advance issues through stages without human approval; also auto-merges the linked PR when Validate completes"`
- [ ] Task 2: Insert `--convergence-budget` and `--auto-merge-strategy` flag rows immediately after `--yolo` in `README.md` Flags table, using descriptions from USER_GUIDE lines 496–497; insert before `--auto-upgrade`
- [ ] Task 3: Add `allow_auto_merge` prerequisite blockquote note to `README.md` immediately after the Flags table closing row (after `--reconcile-interval`, before the `> **Releases:**` blockquote); content: GitHub's `allow_auto_merge` must be enabled on the repo for yolo auto-merge; engine warns at startup if disabled; include the `gh api -X PATCH` one-liner (mirrors USER_GUIDE lines 730–734 in condensed form)
- [ ] Task 4: Insert `fabrik:auto-merge-enabled` label row in `README.md` Labels table immediately after `fabrik:yolo` (line 347); description: "Applied when Fabrik enables GitHub's native auto-merge on a yolo PR after Validate completes; idempotency guard and convergence-budget start anchor; removed when the PR merges or is closed" (mirrors state-machine.md line 83)
- [ ] Task 5: Audit `docs/USER_GUIDE.md` Yolo Mode section (lines ~726–740), Post-Validate Convergence Monitor section (lines ~1190–1254), and Flags/Env tables (lines ~480–530) for consistency with shipped v0.0.68 behavior; fix any inaccuracies found; add nothing new unless a clear gap exists
- [ ] Task 6: Audit `docs/index.md` for v0.0.68 accuracy — confirm Yolo Mode & Auto-Merge feature card (line ~251) and Webhook Mode feature card (line ~363) are present and accurate; fix only if an inaccuracy is found
- [ ] Task 7: If any edits were made to `docs/USER_GUIDE.md` in Task 5 (or any other canonical doc), run `bash scripts/generate-llms-full.sh` and include `docs/llms-full.txt` in the same commit; skip if only README.md was changed

### Risks

- **`docs/llms-full.txt` CI drift**: If Task 5 or 6 uncovers an inaccuracy and USER_GUIDE.md is edited, the bundle must be regenerated in the same commit or CI will fail with a drift error. The research audit found no inaccuracies, so this risk is low but must not be forgotten.
- **Table row ordering**: Inserting `--convergence-budget` and `--auto-merge-strategy` after `--yolo` means they appear before `--auto-upgrade`. Verify the existing `--auto-upgrade` row is at line 276 after the insertion so there are no off-by-one errors.

---
Used 8/50 turns, 4k input / 4k output tokens.

## Verification

Updated README.md with four v0.0.68 changes: updated `--yolo` flag description to mention native auto-merge, added `--convergence-budget` and `--auto-merge-strategy` flag rows, added an `allow_auto_merge` prerequisite blockquote note after the Flags table, and added the `fabrik:auto-merge-enabled` label row after `fabrik:yolo` in the Labels table. USER_GUIDE.md and docs/index.md audited and confirmed current — no changes needed, so `docs/llms-full.txt` regeneration was not required.

---

Closes #839