### PR TITLE
Engine-mechanized `Closes #N` linkage on every Fabrik PR

### DIFF
--- a/adrs/051-engine-mechanized-pr-creation.md
+++ b/adrs/051-engine-mechanized-pr-creation.md
@@ -1,0 +1,75 @@
+# ADR 051: Engine-Mechanized PR Creation via `FABRIK_PR_CREATE` Marker
+
+**Date**: 2026-05-28  
+**Status**: Accepted  
+**Extends**: [ADR 048](048-spawn-child-engine-side.md)
+
+## Context
+
+The Implement skill was responsible for creating the draft PR via `gh pr create` and for including `Closes #N` in the PR body so GitHub's `closingIssuesReferences` / `closedByPullRequestsReferences` fields would link the PR to its parent issue.
+
+In production, a Fabrik-driven Implement stage produced a PR body that referenced an internal FR identifier (`Fixes FR-007`) but omitted the canonical `Closes #N` closing reference. The consequences cascaded:
+
+- **Review gate** (`checkReviewGate`): reads `item.LinkedPRReviews`, populated only when the GraphQL deep-fetch finds a linked PR via `closedByPullRequestsReferences`. With no link, `hasReviews` stayed false and `fabrik:awaiting-review` was reapplied on every poll — indefinitely — despite six reviews having been submitted. The user saw no diagnostic signal.
+- **CI gate and auto-merge**: similarly depend on `LinkedPR` state populated through the same GraphQL linkage.
+
+The root cause: the engine seeded the draft PR body with `Closes #N` as the first line, but the Implement skill later replaced the body via `gh pr edit`, overwriting the closing keyword. The skill prompt asked Claude to maintain the closing keyword — a constraint Claude can silently violate when producing long output.
+
+## Decision
+
+Move PR creation authority from the Implement skill to the engine, using the same `FABRIK_*_BEGIN/END` structured-marker convention established by ADR 048 for sub-issue spawning.
+
+**Implement skill** emits a `FABRIK_PR_CREATE_BEGIN/END` block in its output:
+
+```
+FABRIK_PR_CREATE_BEGIN
+TITLE: <single-line PR title>
+
+<PR body content — no closing keyword>
+FABRIK_PR_CREATE_END
+```
+
+The skill is explicitly prohibited from calling `gh pr create` and from writing any closing keyword (`Closes`, `Fixes`, `Resolves` + `#N`).
+
+**Engine** (`engine/prcreate.go`) processes the marker block during `processItem()`:
+
+1. Parses title and body from the block.
+2. Composes the final PR body as `"Closes #N\n\n" + block.Body` — the closing keyword is the engine's responsibility and is always the first line.
+3. Calls `CreateDraftPR()` with the composed body.
+4. Records the PR number in the Store and posts an acknowledgement comment.
+5. Falls back to `ensureDraftPR` (legacy path) when no marker is found.
+
+**Post-Implement linkage backstop** (`verifyAndHealLinkage`): after any Implement completion, the engine verifies `closedByPullRequestsReferences` via `FetchItemDetails`. If linkage is missing, it attempts one auto-heal: prepend `Closes #N\n\n` to the existing PR body and re-verify. An in-memory `LinkageHealAttempted` flag (keyed by PR head SHA) prevents repeated heal attempts. If heal fails or cannot be attempted, the issue is paused with `fabrik:paused` and a copy-paste `gh pr edit` recovery command.
+
+**Gate-side broken-linkage detection** (`checkReviewGate`): if `item.LinkedPRNumber == 0` despite a PR existing on the `fabrik/issue-N` branch (discovered via `FetchLinkedPR` REST fallback), the gate pauses the issue rather than silently reapplying `fabrik:awaiting-review`. `fabrik:awaiting-review` is NOT applied in the broken-linkage case.
+
+## Rationale
+
+### Engine-owns-mutations (ADR 048 extended)
+
+The core principle from ADR 048 applies: GitHub mutations that Fabrik's engine depends on for correctness MUST go through `GitHubClient` in engine code, not through Claude subprocess `gh` calls. PR creation with the closing keyword is a mutation the engine's every downstream gate depends on — it belongs in engine code.
+
+### First-line placement
+
+`Closes #N` is the first line of the PR body (not a footer) for two reasons:
+1. **Visibility**: humans reading the PR see the parent issue link immediately.
+2. **Reliability**: GitHub's closing-keyword detection is not positionally sensitive, but placing the keyword first makes it harder for subsequent `gh pr edit` calls (which could truncate or replace later sections) to inadvertently remove it.
+
+### Belt-and-braces design
+
+The marker path (primary), the post-Implement linkage backstop (secondary), and the gate-side detection (tertiary) are shipped together. In the transition period, some Implement sessions may still use the old skill version. The backstop catches those cases. Once all skill versions are updated, the backstop becomes a cold safety net — but it stays because future body edits can always re-introduce the problem.
+
+## Alternatives Considered
+
+**Post-process body injection (engine rewrites the body after `gh pr create`):** The skill still calls `gh pr create`; the engine then edits the body to prepend `Closes #N`. Rejected: requires the engine to know that a `gh pr create` just happened (no durable signal), and still leaves a race window where the uncorrected PR is visible.
+
+**Skill-side guard (stronger prompt instructions):** The skill prompt is made more explicit. Rejected: the observed failure was a prompt-following failure; stronger prompts make the failure less likely but not impossible. The whole point of mechanization is to eliminate the "skill can silently drop it" failure class, not to reduce its probability.
+
+**Append to footer (keep existing `ensurePRLinksIssue` behavior):** The existing `ensurePRLinksIssue` appends `Closes #N` to the body footer. Rejected as the sole mechanism: footer placement is less visible, and the function uses a `strings.Contains` check (not GraphQL verification) — it cannot detect when a subsequent body overwrite removes the keyword. The new post-Implement check uses the authoritative GraphQL `closingIssuesReferences` field.
+
+## Consequences
+
+- **Skill prompt changed**: The Implement skill no longer calls `gh pr create`. It emits `FABRIK_PR_CREATE_BEGIN/END`. This is a breaking change for skill versions that still use `gh pr create` — the backstop catches those cases during the transition period.
+- **One extra GraphQL call per Implement completion**: `verifyAndHealLinkage` calls `FetchItemDetails` (and possibly a second time after healing). This is ~1–2 API calls per Implement stage — acceptable given infrequency.
+- **`postHealComment` removed**: The heal confirmation comment is inlined into `verifyAndHealLinkage` to satisfy the `TestAddCommentCompliance` invariant (all `AddComment` body arguments must start with `"🏭 **Fabrik"`).
+- **`PRCreationFailed` retry path unchanged**: The marker-based creation failure path reuses the same `PRCreationFailed` in-memory flag and R5 retry logic as the legacy `ensureDraftPR` path.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -752,7 +752,23 @@ The Implement stage creates a **draft PR** linked to the issue when `create_draf
 | `## Approach` | Extracted from the Plan stage output (`.fabrik-context/stage-Plan.md`); falls back to a placeholder if absent |
 | `## Verification` | Placeholder text, auto-replaced by an extracted stage summary when available |
 
-The `Closes #N` footer in the PR body links the PR to the issue so Fabrik can discover PR comments via GraphQL.
+**`Closes #N` — engine-generated, always first:** Fabrik generates the `Closes #N` closing keyword as the **first line** of every PR body it creates. The Implement skill emits a `FABRIK_PR_CREATE_BEGIN/END` marker block (not a direct `gh pr create` call), and the engine prepends `Closes #N\n\n` before calling `gh pr create`. This guarantees the keyword is always present and always at the top — the first thing a reviewer sees. The skill is explicitly prohibited from writing this line, so it cannot silently drop it.
+
+Example PR body shape:
+```
+Closes #841
+
+## Summary
+...
+
+## Approach
+...
+
+## Verification
+...
+```
+
+The `Closes #N` first line links the PR to the issue so Fabrik can discover PR comments via GraphQL. Every downstream gate (review gate, CI gate, auto-merge) depends on this linkage. If the closing keyword is ever missing from an existing PR body, Fabrik detects it post-Implement and auto-heals by prepending `Closes #N` to the body.
 
 **Verification auto-update**: For draft PRs created with `create_draft_pr: true`, Fabrik updates the `## Verification` section only when it can extract a summary block delimited by `FABRIK_SUMMARY_BEGIN` and `FABRIK_SUMMARY_END` from stage output. This keeps the PR description current when a stage provides a structured summary for PR-body updates.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -750,7 +750,23 @@ The Implement stage creates a **draft PR** linked to the issue when `create_draf
 | `## Approach` | Extracted from the Plan stage output (`.fabrik-context/stage-Plan.md`); falls back to a placeholder if absent |
 | `## Verification` | Placeholder text, auto-replaced by an extracted stage summary when available |
 
-The `Closes #N` footer in the PR body links the PR to the issue so Fabrik can discover PR comments via GraphQL.
+**`Closes #N` — engine-generated, always first:** Fabrik generates the `Closes #N` closing keyword as the **first line** of every PR body it creates. The Implement skill emits a `FABRIK_PR_CREATE_BEGIN/END` marker block (not a direct `gh pr create` call), and the engine prepends `Closes #N\n\n` before calling `gh pr create`. This guarantees the keyword is always present and always at the top — the first thing a reviewer sees. The skill is explicitly prohibited from writing this line, so it cannot silently drop it.
+
+Example PR body shape:
+```
+Closes #841
+
+## Summary
+...
+
+## Approach
+...
+
+## Verification
+...
+```
+
+The `Closes #N` first line links the PR to the issue so Fabrik can discover PR comments via GraphQL. Every downstream gate (review gate, CI gate, auto-merge) depends on this linkage. If the closing keyword is ever missing from an existing PR body, Fabrik detects it post-Implement and auto-heals by prepending `Closes #N` to the body.
 
 **Verification auto-update**: For draft PRs created with `create_draft_pr: true`, Fabrik updates the `## Verification` section only when it can extract a summary block delimited by `FABRIK_SUMMARY_BEGIN` and `FABRIK_SUMMARY_END` from stage output. This keeps the PR description current when a stage provides a structured summary for PR-body updates.
 
@@ -2602,6 +2618,8 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **`FABRIK_SPAWN_CHILD_BEGIN/END` blocks** are not processed inline — they are structured data emitted by the Plan stage and preserved in the Plan stage comment. The engine's `preImplement` step reads them at Implement dispatch time to create child issues. See §6.6.
 
+**`FABRIK_PR_CREATE_BEGIN/END` blocks** are processed inline — the engine parses the block during `processItem()`, creates the draft PR with `Closes #N` prepended as the first line, and records the PR number before posting output. See §5.6.
+
 **Invocation-level kill paths:** The `max_wall_time` and inactivity timeout mechanisms (see §7.6) can terminate the Claude process before it writes a clean `{"type":"result"}` line. After such a kill, `runClaude()` retroactively scans the already-buffered output for `FABRIK_STAGE_COMPLETE` in intermediate `{"type":"assistant"}` NDJSON lines via `extractTextFromAssistantTurns()`. If found, `completed=true` is returned and the invocation is treated identically to a live `FABRIK_STAGE_COMPLETE`. If not found, `completed=false` is returned and the invocation routes to the cooldown/retry path. These kills are distinguished from engine-shutdown cancellation by the `wasTimedOut` flag, so they do not trigger the hard-error path.
 
 ### 2.7 Manual Label Change
@@ -3134,6 +3152,89 @@ Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-me
 | Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 | Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 
+### 5.6 Engine-Mechanized PR Creation (`FABRIK_PR_CREATE` Marker)
+
+**Motivation:** If the Implement skill creates the draft PR directly via `gh pr create`, it can silently omit the `Closes #N` closing keyword. Without that keyword, GitHub's `closingIssuesReferences` / `closedByPullRequestsReferences` fields return empty, breaking every downstream gate (review gate, CI gate, auto-merge). To eliminate this failure class, PR creation is mechanized: the skill emits a structured marker block, the engine creates the PR with `Closes #N` guaranteed as the first line.
+
+**Marker format:**
+
+```
+FABRIK_PR_CREATE_BEGIN [owner/repo]
+TITLE: <single-line PR title>
+
+<PR body content — no closing keyword>
+FABRIK_PR_CREATE_END
+```
+
+- `BEGIN` and `END` must each be on their own line.
+- Optional `owner/repo` on the `BEGIN` line (cross-repo target; v1: only same-repo supported).
+- First non-empty line inside the block must be `TITLE: <title>`.
+- Body is everything after the title line. Must be non-empty.
+- The skill MUST NOT write any closing keyword (`Closes`, `Fixes`, `Resolves` + `#N`); the engine prepends one.
+
+**Code path:** `processItem()` → `ParsePRCreateBlock()` → `processPRCreateMarker()`
+
+**Processing** (runs when `stage.CreateDraftPR` and a `FABRIK_PR_CREATE_BEGIN/END` block is found in output, before output is posted):
+
+1. **Cross-repo guard:** If the `BEGIN` line specifies a different `owner/repo`, the engine pauses the issue with `fabrik:paused` and a "cross-repo PR creation not supported in v1" comment. Does not create a PR.
+2. **Idempotency:** Call `FetchLinkedPR()` — if an open PR already exists on `fabrik/issue-N`, use it (record in Store, skip create).
+3. **Push branch:** Call `PushBranch()` (non-fatal warning if push fails — mirrors `ensureDraftPR`).
+4. **Compose body:** `finalBody = "Closes #N\n\n" + block.Body`. This is the mechanized guarantee.
+5. **Create PR:** Call `CreateDraftPR()` with the composed body and verbatim title. Up to 3 attempts with exponential backoff for transient errors.
+6. **On success:** Cache write-through (`RecordPRLinkage`), `RegisterEcho("pull_request", "opened")`, post acknowledgement comment `"🏭 **Fabrik** — opened PR #M"` on the issue.
+7. **On failure:** Apply `fabrik:paused`, post error comment, return error. `handleStageComplete` is NOT called — the stage does not advance.
+
+After the marker block is processed, the `FABRIK_PR_CREATE_BEGIN/END` content is stripped from the output string before posting the stage comment.
+
+**Malformed marker** (missing TITLE, empty body, missing END, invalid `owner/repo` format): `ParsePRCreateBlock` returns an error. The engine pauses the issue with `fabrik:paused` and a comment naming the malformation. Does not create a PR.
+
+**Fallback to `ensureDraftPR`:** If no `FABRIK_PR_CREATE` marker is found and `stage.CreateDraftPR` is true, the engine falls back to the legacy `ensureDraftPR` path (§5.1). The post-Implement linkage backstop (§5.7) runs in either case.
+
+**`PRCreationFailed` in-memory flag and retry path:** When the marker path fails to create a PR, the same `PRCreationFailed` and R5 retry path as §5.5 applies.
+
+| State | Trigger | Action | Outcome |
+|-------|---------|--------|---------|
+| Locked + In Progress | `FABRIK_PR_CREATE` block found + valid | `processPRCreateMarker` → `CreateDraftPR` + acknowledgement comment | PR created with `Closes #N` as first line |
+| Locked + In Progress | `FABRIK_PR_CREATE` block malformed | `fabrik:paused` + comment naming malformation | Issue paused; no PR created |
+| Locked + In Progress | `FABRIK_PR_CREATE` block → cross-repo target | `fabrik:paused` + "cross-repo not supported" comment | Issue paused; no PR created |
+| Locked + In Progress | `FABRIK_PR_CREATE` block → `CreateDraftPR` fails | `fabrik:paused` + error comment | Issue paused; no PR created |
+
+### 5.7 Post-Implement Linkage Backstop
+
+**Motivation:** Belt-and-braces for the case where a PR exists but lacks the `Closes #N` keyword — either because a legacy skill called `gh pr create` directly, because a `gh pr edit` overwrote the body, or because the engine-mechanized path (§5.6) failed and a fallback PR was opened manually.
+
+**Trigger:** After the Implement stage signals `FABRIK_STAGE_COMPLETE` (via either the marker path or the `ensureDraftPR` fallback), before `handleStageComplete()` is called. Only runs when `stage.CreateDraftPR` is true.
+
+**Code path:** `processItem()` → `verifyAndHealLinkage()`
+
+**Flow:**
+
+1. If `prNumber == 0` (no PR exists): skip, return true (no linkage to verify).
+2. Call `FetchItemDetails(&item)` (GraphQL `closedByPullRequestsReferences`) to get fresh `item.LinkedPRNumber`.
+3. If `item.LinkedPRNumber != 0`: linkage confirmed — return true.
+4. If `item.LinkedPRNumber == 0`: call `FetchLinkedPR()` to find the PR by branch name (`fabrik/issue-N`).
+   - If no PR found: user has diverged from the `fabrik/issue-N` naming convention; log warning and return true (skip heal — do not pause).
+5. **Body-length guard (FR-015):** If `len(currentBody) + len("Closes #N\n\n") > 65,300`, pause with `fabrik:paused` + "body too long for auto-heal" comment. Return false.
+6. **Idempotency guard:** Check `Snapshot.LinkageHealAttempted(stage.Name, prSHA)`. If true (heal already attempted once for this PR head SHA): pause with `fabrik:paused` + copy-paste `gh pr edit` recovery command. Return false.
+7. Record `LinkageHealAttempted{Repo, Number, StageName, PRSHA}` mutation in Store (in-memory only).
+8. **Heal:** call `balanceFences(currentBody)`, prepend `"Closes #N\n\n"`, call `UpdateIssueBody()`.
+9. **Re-verify:** call `FetchItemDetails` again.
+   - If `item.LinkedPRNumber != 0`: post `"🏭 **Fabrik** — PR body auto-corrected: Closes #N prepended"` comment, return true.
+   - If still 0: call `pauseForBrokenLinkage()` — `fabrik:paused` + copy-paste recovery command. Return false.
+10. If heal returns false: `handleStageComplete` is NOT called — `stage:Implement:complete` is NOT applied.
+
+**`LinkageHealAttempted` in-memory flag:** `StageState.LinkageHealAttempted map[string]string` maps stage name to PR head SHA. In-memory only — does not survive engine restart. On restart, one more heal attempt is permitted (conservative / safe). Keyed by SHA so a force-push clears the guard naturally.
+
+**`pauseForBrokenLinkage` comment:** Names PR number, issue number, failure reason, and provides a copy-paste `gh pr edit ... --body-file ...` command the user can run to manually add the closing keyword. After running the command, the user removes `fabrik:paused` to resume.
+
+| State | Trigger | Action | Outcome |
+|-------|---------|--------|---------|
+| Locked + FABRIK_STAGE_COMPLETE | `FetchItemDetails` confirms linkage | Return true | `handleStageComplete` proceeds normally |
+| Locked + FABRIK_STAGE_COMPLETE | No linkage; PR found on branch; body short; no prior heal | Auto-heal: prepend `Closes #N`, re-verify | If verified: comment + advance; if still missing: pause |
+| Locked + FABRIK_STAGE_COMPLETE | No linkage; body too long (> 65,300 chars) | `fabrik:paused` + "body too long" comment | Issue paused for manual recovery |
+| Locked + FABRIK_STAGE_COMPLETE | No linkage; heal already attempted for this SHA | `fabrik:paused` + copy-paste recovery comment | Issue paused for manual recovery |
+| Locked + FABRIK_STAGE_COMPLETE | No PR found by branch name | Log warning; return true (user-diverged) | Stage advances normally |
+
 ---
 
 ## 6. Review Gate and Review Reinvoke
@@ -3155,6 +3256,7 @@ The review gate has two paths that handle different timing scenarios:
 - Calls `checkReviewGate()` for the real gate evaluation
 - **Gate clears only when `len(LinkedPRReviewRequests) == 0` AND at least one non-DISMISSED review exists in `LinkedPRReviews`.** This means: no requested reviewers are outstanding AND at least one review with `State != "DISMISSED"` has been submitted. Waiting on `LinkedPRReviews` (not just `LinkedPRReviewRequests`) is what catches bot reviewers like Copilot and Gemini that self-trigger via webhooks without ever appearing in the formal requested-reviewer list. DISMISSED reviews are excluded from this check because a dismissed review indicates the reviewer's prior response was revoked — the gate must re-block until a new non-dismissed review arrives or the reviewer re-submits. This filter is necessary because the `dismissed` webhook action is now processed (not silently dropped), and there is a race window between a `pull_request_review.dismissed` event and the subsequent `pull_request.review_requested` event that re-adds the reviewer to outstanding.
 - `ReviewRequest.IsBot` is populated from `requestedReviewer.__typename == "Bot"` in the GraphQL query, with a login-pattern fallback (`*[bot]`, `*-bot`, `copilot-*`, `dependabot`, `gemini-code-assist`). This drives the bot-aware escalation ladder.
+- **Broken-linkage guard (FR-013/FR-014):** Before evaluating reviewers, `checkReviewGate()` checks whether `item.LinkedPRNumber == 0`. If so, it calls `FetchLinkedPR()` to look for a PR on the `fabrik/issue-N` branch. If a PR is found open and unmerged: the issue is paused with `fabrik:paused` and a comment — `"🏭 **Fabrik** — PR #M exists on branch fabrik/issue-N but is not linked to this issue via a closing keyword. Add Closes #N to the PR body and remove fabrik:paused to resume."` — and `(false, false)` is returned. `fabrik:awaiting-review` is NOT applied (FR-014). If no PR is found on the branch: gate falls through to the normal reviewer evaluation path.
 - Four outcomes from `checkReviewGate()`:
   - `(blocked=true, timedOut=false)` — still waiting; `fabrik:awaiting-review` maintained. Either outstanding requested reviewers remain, or no reviews submitted yet (bots may still be processing). Also returned after Phase 1 (bot re-prompt fired, waiting for Phase 2 window).
   - `(blocked=false, timedOut=false)` — gate cleared naturally; `fabrik:awaiting-review` removed; `fabrik:bot-reprompted` label cleaned if present; advance or reinvoke.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -248,6 +248,8 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **`FABRIK_SPAWN_CHILD_BEGIN/END` blocks** are not processed inline — they are structured data emitted by the Plan stage and preserved in the Plan stage comment. The engine's `preImplement` step reads them at Implement dispatch time to create child issues. See §6.6.
 
+**`FABRIK_PR_CREATE_BEGIN/END` blocks** are processed inline — the engine parses the block during `processItem()`, creates the draft PR with `Closes #N` prepended as the first line, and records the PR number before posting output. See §5.6.
+
 **Invocation-level kill paths:** The `max_wall_time` and inactivity timeout mechanisms (see §7.6) can terminate the Claude process before it writes a clean `{"type":"result"}` line. After such a kill, `runClaude()` retroactively scans the already-buffered output for `FABRIK_STAGE_COMPLETE` in intermediate `{"type":"assistant"}` NDJSON lines via `extractTextFromAssistantTurns()`. If found, `completed=true` is returned and the invocation is treated identically to a live `FABRIK_STAGE_COMPLETE`. If not found, `completed=false` is returned and the invocation routes to the cooldown/retry path. These kills are distinguished from engine-shutdown cancellation by the `wasTimedOut` flag, so they do not trigger the hard-error path.
 
 ### 2.7 Manual Label Change
@@ -780,6 +782,89 @@ Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-me
 | Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 | Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 
+### 5.6 Engine-Mechanized PR Creation (`FABRIK_PR_CREATE` Marker)
+
+**Motivation:** If the Implement skill creates the draft PR directly via `gh pr create`, it can silently omit the `Closes #N` closing keyword. Without that keyword, GitHub's `closingIssuesReferences` / `closedByPullRequestsReferences` fields return empty, breaking every downstream gate (review gate, CI gate, auto-merge). To eliminate this failure class, PR creation is mechanized: the skill emits a structured marker block, the engine creates the PR with `Closes #N` guaranteed as the first line.
+
+**Marker format:**
+
+```
+FABRIK_PR_CREATE_BEGIN [owner/repo]
+TITLE: <single-line PR title>
+
+<PR body content — no closing keyword>
+FABRIK_PR_CREATE_END
+```
+
+- `BEGIN` and `END` must each be on their own line.
+- Optional `owner/repo` on the `BEGIN` line (cross-repo target; v1: only same-repo supported).
+- First non-empty line inside the block must be `TITLE: <title>`.
+- Body is everything after the title line. Must be non-empty.
+- The skill MUST NOT write any closing keyword (`Closes`, `Fixes`, `Resolves` + `#N`); the engine prepends one.
+
+**Code path:** `processItem()` → `ParsePRCreateBlock()` → `processPRCreateMarker()`
+
+**Processing** (runs when `stage.CreateDraftPR` and a `FABRIK_PR_CREATE_BEGIN/END` block is found in output, before output is posted):
+
+1. **Cross-repo guard:** If the `BEGIN` line specifies a different `owner/repo`, the engine pauses the issue with `fabrik:paused` and a "cross-repo PR creation not supported in v1" comment. Does not create a PR.
+2. **Idempotency:** Call `FetchLinkedPR()` — if an open PR already exists on `fabrik/issue-N`, use it (record in Store, skip create).
+3. **Push branch:** Call `PushBranch()` (non-fatal warning if push fails — mirrors `ensureDraftPR`).
+4. **Compose body:** `finalBody = "Closes #N\n\n" + block.Body`. This is the mechanized guarantee.
+5. **Create PR:** Call `CreateDraftPR()` with the composed body and verbatim title. Up to 3 attempts with exponential backoff for transient errors.
+6. **On success:** Cache write-through (`RecordPRLinkage`), `RegisterEcho("pull_request", "opened")`, post acknowledgement comment `"🏭 **Fabrik** — opened PR #M"` on the issue.
+7. **On failure:** Apply `fabrik:paused`, post error comment, return error. `handleStageComplete` is NOT called — the stage does not advance.
+
+After the marker block is processed, the `FABRIK_PR_CREATE_BEGIN/END` content is stripped from the output string before posting the stage comment.
+
+**Malformed marker** (missing TITLE, empty body, missing END, invalid `owner/repo` format): `ParsePRCreateBlock` returns an error. The engine pauses the issue with `fabrik:paused` and a comment naming the malformation. Does not create a PR.
+
+**Fallback to `ensureDraftPR`:** If no `FABRIK_PR_CREATE` marker is found and `stage.CreateDraftPR` is true, the engine falls back to the legacy `ensureDraftPR` path (§5.1). The post-Implement linkage backstop (§5.7) runs in either case.
+
+**`PRCreationFailed` in-memory flag and retry path:** When the marker path fails to create a PR, the same `PRCreationFailed` and R5 retry path as §5.5 applies.
+
+| State | Trigger | Action | Outcome |
+|-------|---------|--------|---------|
+| Locked + In Progress | `FABRIK_PR_CREATE` block found + valid | `processPRCreateMarker` → `CreateDraftPR` + acknowledgement comment | PR created with `Closes #N` as first line |
+| Locked + In Progress | `FABRIK_PR_CREATE` block malformed | `fabrik:paused` + comment naming malformation | Issue paused; no PR created |
+| Locked + In Progress | `FABRIK_PR_CREATE` block → cross-repo target | `fabrik:paused` + "cross-repo not supported" comment | Issue paused; no PR created |
+| Locked + In Progress | `FABRIK_PR_CREATE` block → `CreateDraftPR` fails | `fabrik:paused` + error comment | Issue paused; no PR created |
+
+### 5.7 Post-Implement Linkage Backstop
+
+**Motivation:** Belt-and-braces for the case where a PR exists but lacks the `Closes #N` keyword — either because a legacy skill called `gh pr create` directly, because a `gh pr edit` overwrote the body, or because the engine-mechanized path (§5.6) failed and a fallback PR was opened manually.
+
+**Trigger:** After the Implement stage signals `FABRIK_STAGE_COMPLETE` (via either the marker path or the `ensureDraftPR` fallback), before `handleStageComplete()` is called. Only runs when `stage.CreateDraftPR` is true.
+
+**Code path:** `processItem()` → `verifyAndHealLinkage()`
+
+**Flow:**
+
+1. If `prNumber == 0` (no PR exists): skip, return true (no linkage to verify).
+2. Call `FetchItemDetails(&item)` (GraphQL `closedByPullRequestsReferences`) to get fresh `item.LinkedPRNumber`.
+3. If `item.LinkedPRNumber != 0`: linkage confirmed — return true.
+4. If `item.LinkedPRNumber == 0`: call `FetchLinkedPR()` to find the PR by branch name (`fabrik/issue-N`).
+   - If no PR found: user has diverged from the `fabrik/issue-N` naming convention; log warning and return true (skip heal — do not pause).
+5. **Body-length guard (FR-015):** If `len(currentBody) + len("Closes #N\n\n") > 65,300`, pause with `fabrik:paused` + "body too long for auto-heal" comment. Return false.
+6. **Idempotency guard:** Check `Snapshot.LinkageHealAttempted(stage.Name, prSHA)`. If true (heal already attempted once for this PR head SHA): pause with `fabrik:paused` + copy-paste `gh pr edit` recovery command. Return false.
+7. Record `LinkageHealAttempted{Repo, Number, StageName, PRSHA}` mutation in Store (in-memory only).
+8. **Heal:** call `balanceFences(currentBody)`, prepend `"Closes #N\n\n"`, call `UpdateIssueBody()`.
+9. **Re-verify:** call `FetchItemDetails` again.
+   - If `item.LinkedPRNumber != 0`: post `"🏭 **Fabrik** — PR body auto-corrected: Closes #N prepended"` comment, return true.
+   - If still 0: call `pauseForBrokenLinkage()` — `fabrik:paused` + copy-paste recovery command. Return false.
+10. If heal returns false: `handleStageComplete` is NOT called — `stage:Implement:complete` is NOT applied.
+
+**`LinkageHealAttempted` in-memory flag:** `StageState.LinkageHealAttempted map[string]string` maps stage name to PR head SHA. In-memory only — does not survive engine restart. On restart, one more heal attempt is permitted (conservative / safe). Keyed by SHA so a force-push clears the guard naturally.
+
+**`pauseForBrokenLinkage` comment:** Names PR number, issue number, failure reason, and provides a copy-paste `gh pr edit ... --body-file ...` command the user can run to manually add the closing keyword. After running the command, the user removes `fabrik:paused` to resume.
+
+| State | Trigger | Action | Outcome |
+|-------|---------|--------|---------|
+| Locked + FABRIK_STAGE_COMPLETE | `FetchItemDetails` confirms linkage | Return true | `handleStageComplete` proceeds normally |
+| Locked + FABRIK_STAGE_COMPLETE | No linkage; PR found on branch; body short; no prior heal | Auto-heal: prepend `Closes #N`, re-verify | If verified: comment + advance; if still missing: pause |
+| Locked + FABRIK_STAGE_COMPLETE | No linkage; body too long (> 65,300 chars) | `fabrik:paused` + "body too long" comment | Issue paused for manual recovery |
+| Locked + FABRIK_STAGE_COMPLETE | No linkage; heal already attempted for this SHA | `fabrik:paused` + copy-paste recovery comment | Issue paused for manual recovery |
+| Locked + FABRIK_STAGE_COMPLETE | No PR found by branch name | Log warning; return true (user-diverged) | Stage advances normally |
+
 ---
 
 ## 6. Review Gate and Review Reinvoke
@@ -801,6 +886,7 @@ The review gate has two paths that handle different timing scenarios:
 - Calls `checkReviewGate()` for the real gate evaluation
 - **Gate clears only when `len(LinkedPRReviewRequests) == 0` AND at least one non-DISMISSED review exists in `LinkedPRReviews`.** This means: no requested reviewers are outstanding AND at least one review with `State != "DISMISSED"` has been submitted. Waiting on `LinkedPRReviews` (not just `LinkedPRReviewRequests`) is what catches bot reviewers like Copilot and Gemini that self-trigger via webhooks without ever appearing in the formal requested-reviewer list. DISMISSED reviews are excluded from this check because a dismissed review indicates the reviewer's prior response was revoked — the gate must re-block until a new non-dismissed review arrives or the reviewer re-submits. This filter is necessary because the `dismissed` webhook action is now processed (not silently dropped), and there is a race window between a `pull_request_review.dismissed` event and the subsequent `pull_request.review_requested` event that re-adds the reviewer to outstanding.
 - `ReviewRequest.IsBot` is populated from `requestedReviewer.__typename == "Bot"` in the GraphQL query, with a login-pattern fallback (`*[bot]`, `*-bot`, `copilot-*`, `dependabot`, `gemini-code-assist`). This drives the bot-aware escalation ladder.
+- **Broken-linkage guard (FR-013/FR-014):** Before evaluating reviewers, `checkReviewGate()` checks whether `item.LinkedPRNumber == 0`. If so, it calls `FetchLinkedPR()` to look for a PR on the `fabrik/issue-N` branch. If a PR is found open and unmerged: the issue is paused with `fabrik:paused` and a comment — `"🏭 **Fabrik** — PR #M exists on branch fabrik/issue-N but is not linked to this issue via a closing keyword. Add Closes #N to the PR body and remove fabrik:paused to resume."` — and `(false, false)` is returned. `fabrik:awaiting-review` is NOT applied (FR-014). If no PR is found on the branch: gate falls through to the normal reviewer evaluation path.
 - Four outcomes from `checkReviewGate()`:
   - `(blocked=true, timedOut=false)` — still waiting; `fabrik:awaiting-review` maintained. Either outstanding requested reviewers remain, or no reviews submitted yet (bots may still be processing). Also returned after Phase 1 (bot re-prompt fired, waiting for Phase 2 window).
   - `(blocked=false, timedOut=false)` — gate cleared naturally; `fabrik:awaiting-review` removed; `fabrik:bot-reprompted` label cleaned if present; advance or reinvoke.

--- a/engine/item.go
+++ b/engine/item.go
@@ -896,6 +896,37 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		}
 	}
 
+	// Process FABRIK_PR_CREATE marker — the Implement skill emits this block to signal
+	// that the engine should create the draft PR (with "Closes #N" prepended mechanically).
+	// Fires unconditionally (not gated on completed) when CreateDraftPR is enabled.
+	var prNumber int
+	if stage.CreateDraftPR && output != "" {
+		prBlock, prBlockErr := ParsePRCreateBlock(output)
+		if prBlockErr != nil {
+			msg := fmt.Sprintf("🏭 **Fabrik — malformed FABRIK_PR_CREATE marker**\n\n%v\n\nRemove `fabrik:paused` after fixing the skill output to retry.", prBlockErr)
+			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
+				e.logf(item.Number, "warn", "could not post FABRIK_PR_CREATE error comment: %v\n", commentErr)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			e.addPausedLabelToItem(owner, repo, item)
+			releaseLock()
+			return nil
+		} else if prBlock != nil {
+			createdPRNum, createErr := e.processPRCreateMarker(ctx, item, prBlock, owner, repo, baseBranch, repoStr)
+			if createErr != nil {
+				// processPRCreateMarker already paused the issue and posted a comment.
+				releaseLock()
+				return nil
+			}
+			prNumber = createdPRNum
+			// Strip the marker block from output so it is not posted as a comment.
+			output = stripMarkers(output, "FABRIK_PR_CREATE_BEGIN", "FABRIK_PR_CREATE_END")
+		}
+	}
+
 	// Strip all Fabrik markers from output before posting as a comment.
 	// This must happen after extractUpdatedBody (above) but the raw output is
 	// still needed for CheckBlockedOnInput (below), so we strip into a separate
@@ -914,8 +945,8 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// ensure the PR exists before posting so postOutputToPR can find it.
 	// Error is intentionally ignored here — failure is caught and escalated in
 	// the completion block below, which also retries with the full retry/backoff logic.
-	var prNumber int
-	if completed && stage.CreateDraftPR && stage.PostToPR {
+	// prNumber may already be set if the FABRIK_PR_CREATE marker path ran above.
+	if prNumber == 0 && completed && stage.CreateDraftPR && stage.PostToPR {
 		prNumber, _ = e.ensureDraftPR(item, baseBranch)
 	}
 
@@ -1076,6 +1107,13 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				}
 			}
 			e.updatePRVerification(item, prNumber, extractSummary(output))
+			// Verify that the PR's closingIssuesReferences includes this issue.
+			// If missing, attempt one auto-heal before advancing to handleStageComplete.
+			// Returns false only when linkage cannot be established — issue is already paused.
+			if !e.verifyAndHealLinkage(ctx, item, prNumber, stage, owner, repo, repoStr) {
+				releaseLock()
+				return nil
+			}
 		}
 		// PR creation succeeded (or not required) — advance the stage.
 		releaseLock()

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -711,6 +711,10 @@ func TestProcessItem_ImplementStage_UpdatesVerificationOnComplete(t *testing.T) 
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: prNum, State: "open"}, nil
 		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRNumber = prNum
+			return nil
+		},
 		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
 			if issueNumber == prNum {
 				return "## Verification\n\n(Populated by Implement on completion)\n\n---\n\nCloses #50", nil

--- a/engine/prcreate.go
+++ b/engine/prcreate.go
@@ -156,21 +156,9 @@ func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem,
 		return existingPR.Number, nil
 	}
 
-	// Push the branch before creating the PR.
+	// Push the branch before creating the PR (non-fatal: mirrors ensureDraftPR behavior).
 	if err := wm.PushBranch(item.Number); err != nil {
-		msg := fmt.Sprintf(
-			"🏭 **Fabrik — PR creation failed**\n\nFailed to push branch for issue #%d: `%v`\n\nRemove `fabrik:paused` to retry.",
-			item.Number, err,
-		)
-		e.addPausedLabelToItem(owner, repo, item)
-		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post push error comment: %v\n", commentErr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		return 0, fmt.Errorf("pushing branch for FABRIK_PR_CREATE: %w", err)
+		e.logf(item.Number, "warn", "could not push branch: pushing branch fabrik/issue-%d: %v\n", item.Number, err)
 	}
 
 	// Compose body: engine prepends "Closes #N\n\n" — this is the mechanized guarantee.
@@ -225,7 +213,7 @@ func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem,
 	}
 
 	// Acknowledgement comment on the issue.
-	ackMsg := fmt.Sprintf("🏭 Fabrik — opened PR #%d", prNum)
+	ackMsg := fmt.Sprintf("🏭 **Fabrik** — opened PR #%d", prNum)
 	if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, ackMsg); commentErr != nil {
 		e.logf(item.Number, "warn", "could not post PR-opened acknowledgement: %v\n", commentErr)
 	} else {
@@ -327,15 +315,32 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 	if err := e.client.FetchItemDetails(&item); err != nil {
 		e.logf(item.Number, "warn", "verifyAndHealLinkage: re-verification FetchItemDetails failed: %v\n", err)
 		// Can't confirm — treat as success (heal likely took effect; GitHub may lag).
-		healMsg := fmt.Sprintf("🏭 Fabrik — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference). Re-verification fetch failed; please confirm linkage.", closingLine)
-		e.postHealComment(owner, repo, item, healMsg)
+		healMsg := fmt.Sprintf("🏭 **Fabrik** — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference). Re-verification fetch failed; please confirm linkage.", closingLine)
+		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, healMsg); commentErr != nil {
+			e.logf(item.Number, "warn", "could not post heal confirmation comment: %v\n", commentErr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: healMsg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
 		return true
 	}
 
 	if item.LinkedPRNumber != 0 {
 		e.logf(item.Number, "pr", "verifyAndHealLinkage: linkage confirmed for PR #%d\n", pr.Number)
-		healMsg := fmt.Sprintf("🏭 Fabrik — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference).", closingLine)
-		e.postHealComment(owner, repo, item, healMsg)
+		healMsg := fmt.Sprintf("🏭 **Fabrik** — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference).", closingLine)
+		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, healMsg); commentErr != nil {
+			e.logf(item.Number, "warn", "could not post heal confirmation comment: %v\n", commentErr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: healMsg, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+			}
+		}
 		return true
 	}
 
@@ -371,18 +376,3 @@ func (e *Engine) pauseForBrokenLinkage(owner, repo string, item gh.ProjectItem, 
 	}
 }
 
-// postHealComment posts the heal confirmation comment on the issue.
-func (e *Engine) postHealComment(owner, repo string, item gh.ProjectItem, msg string) {
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post heal confirmation comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-	}
-}

--- a/engine/prcreate.go
+++ b/engine/prcreate.go
@@ -1,0 +1,388 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/handarbeit/fabrik/boardcache"
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// PRCreateBlock holds the parsed content of a FABRIK_PR_CREATE_BEGIN/END marker block.
+type PRCreateBlock struct {
+	// TargetRepo is "owner/repo" from the BEGIN line, or "" for same-repo.
+	TargetRepo string
+	Title      string
+	Body       string
+}
+
+// ParsePRCreateBlock scans s for a FABRIK_PR_CREATE_BEGIN/END marker block.
+//
+// Returns:
+//   - (nil, nil)   — no marker found
+//   - (nil, err)   — marker frame present but block is malformed
+//   - (block, nil) — valid block
+//
+// Marker format:
+//
+//	FABRIK_PR_CREATE_BEGIN [owner/repo]
+//	TITLE: <single-line title>
+//
+//	<PR body content — no closing keyword>
+//	FABRIK_PR_CREATE_END
+func ParsePRCreateBlock(s string) (*PRCreateBlock, error) {
+	const beginPrefix = "FABRIK_PR_CREATE_BEGIN"
+	const endMarker = "FABRIK_PR_CREATE_END"
+
+	beginIdx := strings.Index(s, beginPrefix)
+	if beginIdx == -1 {
+		return nil, nil // not found
+	}
+
+	// Extract the rest of the BEGIN line for the optional owner/repo arg.
+	lineEnd := strings.IndexByte(s[beginIdx:], '\n')
+	var beginLine, afterBegin string
+	if lineEnd == -1 {
+		beginLine = s[beginIdx:]
+		afterBegin = ""
+	} else {
+		beginLine = s[beginIdx : beginIdx+lineEnd]
+		afterBegin = s[beginIdx+lineEnd+1:]
+	}
+	beginLine = strings.TrimRight(beginLine, "\r")
+
+	// Optional owner/repo on the BEGIN line.
+	targetRepo := ""
+	if parts := strings.Fields(strings.TrimPrefix(beginLine, beginPrefix)); len(parts) > 0 {
+		targetRepo = parts[0]
+		// Validate that it looks like owner/repo (contains exactly one slash with content on each side).
+		if !strings.Contains(targetRepo, "/") || strings.HasPrefix(targetRepo, "/") || strings.HasSuffix(targetRepo, "/") {
+			return nil, fmt.Errorf("FABRIK_PR_CREATE_BEGIN: invalid repo %q — expected owner/repo format", targetRepo)
+		}
+	}
+
+	// Find the matching END marker.
+	endIdx := strings.Index(afterBegin, endMarker)
+	if endIdx == -1 {
+		return nil, fmt.Errorf("FABRIK_PR_CREATE_BEGIN found but no matching FABRIK_PR_CREATE_END")
+	}
+
+	blockContent := afterBegin[:endIdx]
+
+	title, body := parsePRCreateTitleAndBody(blockContent)
+	if title == "" {
+		return nil, fmt.Errorf("FABRIK_PR_CREATE block is malformed: missing TITLE line")
+	}
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("FABRIK_PR_CREATE block is malformed: PR body is empty")
+	}
+
+	return &PRCreateBlock{
+		TargetRepo: targetRepo,
+		Title:      title,
+		Body:       strings.TrimSpace(body),
+	}, nil
+}
+
+// parsePRCreateTitleAndBody extracts the TITLE: line and remaining body from inside
+// a FABRIK_PR_CREATE_BEGIN/END block. Returns ("", "") when no TITLE: line is found.
+func parsePRCreateTitleAndBody(content string) (title, body string) {
+	lines := strings.Split(content, "\n")
+	titleIdx := -1
+	for i, l := range lines {
+		l = strings.TrimRight(l, "\r")
+		trimmed := strings.TrimSpace(l)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "TITLE:") {
+			title = strings.TrimSpace(strings.TrimPrefix(trimmed, "TITLE:"))
+			titleIdx = i
+			break
+		}
+		// First non-empty line isn't TITLE: — malformed.
+		return "", ""
+	}
+	if title == "" || titleIdx == -1 {
+		return "", ""
+	}
+	bodyLines := lines[titleIdx+1:]
+	body = strings.Join(bodyLines, "\n")
+	return title, body
+}
+
+// processPRCreateMarker handles a parsed FABRIK_PR_CREATE block: validates the
+// target repo, ensures idempotency, pushes the branch, creates the PR with the
+// engine-generated "Closes #N" first line, and posts an acknowledgement comment.
+//
+// On success, returns (prNumber, nil). On failure, pauses the issue and returns (0, err).
+func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem, block *PRCreateBlock, owner, repo, baseBranch, repoStr string) (int, error) {
+	// Cross-repo guard: v1 does not support creating PRs in a different repo.
+	if block.TargetRepo != "" && block.TargetRepo != owner+"/"+repo {
+		msg := fmt.Sprintf(
+			"🏭 **Fabrik — PR creation failed**\n\n"+
+				"The `FABRIK_PR_CREATE_BEGIN` marker specified a cross-repo target (`%s`), "+
+				"but cross-repo PR creation is not supported in this version of Fabrik.\n\n"+
+				"The Implement skill must not specify a `FABRIK_PR_CREATE_BEGIN owner/repo` line "+
+				"pointing to a different repo. Remove the target repo from the BEGIN line to create "+
+				"the PR in the same repo as the issue (`%s/%s`).\n\n"+
+				"Remove `fabrik:paused` after correcting the skill output to retry.",
+			block.TargetRepo, owner, repo,
+		)
+		e.addPausedLabelToItem(owner, repo, item)
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+			e.logf(item.Number, "warn", "could not post cross-repo PR error comment: %v\n", err)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		return 0, fmt.Errorf("cross-repo PR creation not supported (target: %s)", block.TargetRepo)
+	}
+
+	wm := e.worktreesFor(item.Repo)
+
+	// Idempotency: if a PR already exists on this branch, use it rather than creating another.
+	existingPR, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	if err == nil && existingPR != nil && existingPR.State == "open" && !existingPR.Merged {
+		e.logf(item.Number, "pr", "FABRIK_PR_CREATE: PR #%d already exists — using existing PR\n", existingPR.Number)
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.RecordPRLinkage(owner+"/"+repo, existingPR.Number, item.Number)
+		}
+		return existingPR.Number, nil
+	}
+
+	// Push the branch before creating the PR.
+	if err := wm.PushBranch(item.Number); err != nil {
+		msg := fmt.Sprintf(
+			"🏭 **Fabrik — PR creation failed**\n\nFailed to push branch for issue #%d: `%v`\n\nRemove `fabrik:paused` to retry.",
+			item.Number, err,
+		)
+		e.addPausedLabelToItem(owner, repo, item)
+		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
+			e.logf(item.Number, "warn", "could not post push error comment: %v\n", commentErr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		return 0, fmt.Errorf("pushing branch for FABRIK_PR_CREATE: %w", err)
+	}
+
+	// Compose body: engine prepends "Closes #N\n\n" — this is the mechanized guarantee.
+	closingLine := fmt.Sprintf("Closes #%d", item.Number)
+	finalBody := closingLine + "\n\n" + block.Body
+
+	head := fmt.Sprintf("fabrik/issue-%d", item.Number)
+	const maxAttempts = 3
+	var lastErr error
+	var prNum int
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		prNum, lastErr = e.client.CreateDraftPR(owner, repo, block.Title, head, baseBranch, finalBody, item.Number)
+		if lastErr == nil {
+			break
+		}
+		if !isTransientError(lastErr) {
+			break
+		}
+		if attempt < maxAttempts-1 {
+			time.Sleep(ensureDraftPRRetryDelay << attempt)
+		}
+	}
+	if lastErr != nil || prNum == 0 {
+		if lastErr == nil {
+			lastErr = fmt.Errorf("API returned PR number 0")
+		}
+		msg := fmt.Sprintf(
+			"🏭 **Fabrik — PR creation failed**\n\n"+
+				"The engine failed to create a draft PR for issue #%d after %d attempt(s): `%v`\n\n"+
+				"Remove `fabrik:paused` to retry.",
+			item.Number, maxAttempts, lastErr,
+		)
+		e.addPausedLabelToItem(owner, repo, item)
+		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
+			e.logf(item.Number, "warn", "could not post PR creation error comment: %v\n", commentErr)
+		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		return 0, fmt.Errorf("creating PR via FABRIK_PR_CREATE: %w", lastErr)
+	}
+
+	e.logf(item.Number, "pr", "FABRIK_PR_CREATE: created draft PR #%d (title: %q)\n", prNum, block.Title)
+
+	// Cache write-through.
+	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
+	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("pull_request", "opened", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNum))
+	}
+
+	// Acknowledgement comment on the issue.
+	ackMsg := fmt.Sprintf("🏭 Fabrik — opened PR #%d", prNum)
+	if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, ackMsg); commentErr != nil {
+		e.logf(item.Number, "warn", "could not post PR-opened acknowledgement: %v\n", commentErr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: ackMsg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+		}
+	}
+
+	return prNum, nil
+}
+
+// verifyAndHealLinkage verifies that the linked PR's closingIssuesReferences includes the
+// parent issue after Implement completes, and attempts one auto-heal if missing.
+//
+// Returns true when linkage is confirmed (either already present or healed).
+// Returns false when linkage cannot be established — the issue is paused before returning.
+func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, prNumber int, stage *stages.Stage, owner, repo, repoStr string) bool {
+	if prNumber == 0 {
+		return true // no PR to verify
+	}
+
+	// Re-fetch item to get fresh closedByPullRequestsReferences data.
+	if err := e.client.FetchItemDetails(&item); err != nil {
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: FetchItemDetails failed: %v\n", err)
+		// Non-fatal: skip verification to avoid false positives on transient errors.
+		return true
+	}
+
+	if item.LinkedPRNumber != 0 {
+		// Linkage is present — nothing to do.
+		return true
+	}
+
+	// LinkedPRNumber == 0 despite a known prNumber. Try to find the PR by branch name.
+	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
+	if err != nil || pr == nil || pr.Number == 0 {
+		// No PR found via branch lookup either — user has diverged from the naming convention.
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: no PR found for branch fabrik/issue-%d — skipping heal (user-diverged branch)\n", item.Number)
+		return true
+	}
+
+	// PR exists but is not linked. Attempt auto-heal.
+	prSHA := pr.HeadSHA
+	closingLine := fmt.Sprintf("Closes #%d", item.Number)
+
+	// Fetch current PR body.
+	currentBody, fetchErr := e.client.GetIssueBody(owner, repo, pr.Number)
+	if fetchErr != nil {
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: could not fetch PR #%d body: %v\n", pr.Number, fetchErr)
+		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "could not fetch PR body for auto-heal")
+		return false
+	}
+
+	// Body-length safety (FR-015): ensure prepend doesn't overflow GitHub's limit.
+	const maxBodyLen = 65300
+	if len(currentBody)+len(closingLine)+2 > maxBodyLen {
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: PR #%d body is too long (%d chars) to prepend closing keyword\n", pr.Number, len(currentBody))
+		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "PR body too long for auto-heal")
+		return false
+	}
+
+	// Idempotency guard: only attempt one heal per PR head SHA.
+	snap, _ := e.store.Get(repoStr, item.Number)
+	if snap.LinkageHealAttempted(stage.Name, prSHA) {
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: heal already attempted for PR #%d (SHA %s) — pausing\n", pr.Number, prSHA)
+		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "auto-heal was already attempted once but linkage is still missing")
+		return false
+	}
+
+	// Record that we're attempting the heal.
+	e.store.Apply(itemstate.LinkageHealAttempted{
+		Repo:      repoStr,
+		Number:    item.Number,
+		StageName: stage.Name,
+		PRSHA:     prSHA,
+	})
+
+	// Balance any unclosed code fences, then prepend the closing line.
+	balanced := balanceFences(currentBody)
+	healedBody := closingLine + "\n\n" + balanced
+
+	// no write-through: excluded — issue body is not read from cache for dispatch decisions
+	if err := e.client.UpdateIssueBody(owner, repo, pr.Number, healedBody); err != nil {
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: could not update PR #%d body: %v\n", pr.Number, err)
+		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, fmt.Sprintf("UpdateIssueBody failed: %v", err))
+		return false
+	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, pr.Number))
+	}
+	e.logf(item.Number, "pr", "verifyAndHealLinkage: prepended '%s' to PR #%d body\n", closingLine, pr.Number)
+
+	// Re-verify using FetchItemDetails.
+	if err := e.client.FetchItemDetails(&item); err != nil {
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: re-verification FetchItemDetails failed: %v\n", err)
+		// Can't confirm — treat as success (heal likely took effect; GitHub may lag).
+		healMsg := fmt.Sprintf("🏭 Fabrik — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference). Re-verification fetch failed; please confirm linkage.", closingLine)
+		e.postHealComment(owner, repo, item, healMsg)
+		return true
+	}
+
+	if item.LinkedPRNumber != 0 {
+		e.logf(item.Number, "pr", "verifyAndHealLinkage: linkage confirmed for PR #%d\n", pr.Number)
+		healMsg := fmt.Sprintf("🏭 Fabrik — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference).", closingLine)
+		e.postHealComment(owner, repo, item, healMsg)
+		return true
+	}
+
+	// Still not linked after heal — pause with recovery commands.
+	e.logf(item.Number, "warn", "verifyAndHealLinkage: linkage still missing after heal — pausing\n")
+	e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "auto-heal completed but GitHub still reports no closing-issue linkage")
+	return false
+}
+
+// pauseForBrokenLinkage pauses the issue with fabrik:paused and posts a comment
+// naming the failure mode and providing a copy-paste recovery command.
+func (e *Engine) pauseForBrokenLinkage(owner, repo string, item gh.ProjectItem, prNumber int, closingLine, reason string) {
+	msg := fmt.Sprintf(
+		"🏭 **Fabrik — broken PR↔issue linkage**\n\n"+
+			"PR #%d exists but is not linked to issue #%d via a closing keyword (`closingIssuesReferences` is empty). "+
+			"Cause: %s.\n\n"+
+			"To recover, add the closing keyword to the PR body and remove `fabrik:paused`:\n\n"+
+			"```bash\n"+
+			"gh pr view %d --json body --jq '.body' > /tmp/pr_body.txt && "+
+			"printf '%%s\\n\\n' '%s' | cat - /tmp/pr_body.txt | "+
+			"gh pr edit %d --body-file -\n"+
+			"```\n\n"+
+			"Then remove `fabrik:paused` to resume.",
+		prNumber, item.Number, reason, prNumber, closingLine, prNumber,
+	)
+	e.addPausedLabelToItem(owner, repo, item)
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+		e.logf(item.Number, "warn", "could not post broken-linkage comment: %v\n", err)
+	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+			DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+		})
+	}
+}
+
+// postHealComment posts the heal confirmation comment on the issue.
+func (e *Engine) postHealComment(owner, repo string, item gh.ProjectItem, msg string) {
+	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
+		e.logf(item.Number, "warn", "could not post heal confirmation comment: %v\n", err)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+			})
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+		}
+	}
+}

--- a/engine/prcreate.go
+++ b/engine/prcreate.go
@@ -59,8 +59,9 @@ func ParsePRCreateBlock(s string) (*PRCreateBlock, error) {
 	targetRepo := ""
 	if parts := strings.Fields(strings.TrimPrefix(beginLine, beginPrefix)); len(parts) > 0 {
 		targetRepo = parts[0]
-		// Validate that it looks like owner/repo (contains exactly one slash with content on each side).
-		if !strings.Contains(targetRepo, "/") || strings.HasPrefix(targetRepo, "/") || strings.HasSuffix(targetRepo, "/") {
+		// Validate exactly "owner/repo": two non-empty parts separated by a single slash.
+		repoParts := strings.Split(targetRepo, "/")
+		if len(repoParts) != 2 || repoParts[0] == "" || repoParts[1] == "" {
 			return nil, fmt.Errorf("FABRIK_PR_CREATE_BEGIN: invalid repo %q — expected owner/repo format", targetRepo)
 		}
 	}
@@ -254,9 +255,9 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 
 	// LinkedPRNumber == 0 despite a known prNumber. Try to find the PR by branch name.
 	pr, err := e.client.FetchLinkedPR(owner, repo, item.Number)
-	if err != nil || pr == nil || pr.Number == 0 {
-		// No PR found via branch lookup either — user has diverged from the naming convention.
-		e.logf(item.Number, "warn", "verifyAndHealLinkage: no PR found for branch fabrik/issue-%d — skipping heal (user-diverged branch)\n", item.Number)
+	if err != nil || pr == nil || pr.Number == 0 || pr.State != "open" || pr.Merged {
+		// No active PR found via branch lookup — user has diverged, or PR is closed/merged.
+		e.logf(item.Number, "warn", "verifyAndHealLinkage: no active PR found for branch fabrik/issue-%d — skipping heal\n", item.Number)
 		return true
 	}
 

--- a/engine/prcreate_test.go
+++ b/engine/prcreate_test.go
@@ -1,0 +1,457 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// ---- ParsePRCreateBlock unit tests ----
+
+func TestParsePRCreateBlock_NotFound(t *testing.T) {
+	block, err := ParsePRCreateBlock("no marker here")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if block != nil {
+		t.Fatalf("expected nil block, got %+v", block)
+	}
+}
+
+func TestParsePRCreateBlock_ValidNoTargetRepo(t *testing.T) {
+	input := `
+Some output before the marker.
+
+FABRIK_PR_CREATE_BEGIN
+TITLE: Add authentication module
+
+This PR implements the authentication feature.
+
+Key changes:
+- JWT validation
+- Session handling
+FABRIK_PR_CREATE_END
+
+Some output after.
+`
+	block, err := ParsePRCreateBlock(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if block == nil {
+		t.Fatal("expected non-nil block")
+	}
+	if block.TargetRepo != "" {
+		t.Errorf("TargetRepo: got %q, want empty", block.TargetRepo)
+	}
+	if block.Title != "Add authentication module" {
+		t.Errorf("Title: got %q, want %q", block.Title, "Add authentication module")
+	}
+	if !strings.Contains(block.Body, "JWT validation") {
+		t.Errorf("Body should contain 'JWT validation', got: %q", block.Body)
+	}
+}
+
+func TestParsePRCreateBlock_ValidWithTargetRepo(t *testing.T) {
+	input := `FABRIK_PR_CREATE_BEGIN owner/other-repo
+TITLE: Cross-repo PR
+
+This is a cross-repo PR body.
+FABRIK_PR_CREATE_END`
+	block, err := ParsePRCreateBlock(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if block == nil {
+		t.Fatal("expected non-nil block")
+	}
+	if block.TargetRepo != "owner/other-repo" {
+		t.Errorf("TargetRepo: got %q, want %q", block.TargetRepo, "owner/other-repo")
+	}
+	if block.Title != "Cross-repo PR" {
+		t.Errorf("Title: got %q", block.Title)
+	}
+}
+
+func TestParsePRCreateBlock_MissingTitle(t *testing.T) {
+	input := `FABRIK_PR_CREATE_BEGIN
+Some body content without a TITLE: line.
+FABRIK_PR_CREATE_END`
+	block, err := ParsePRCreateBlock(input)
+	if err == nil {
+		t.Fatal("expected error for missing TITLE, got nil")
+	}
+	if block != nil {
+		t.Fatalf("expected nil block, got %+v", block)
+	}
+	if !strings.Contains(err.Error(), "TITLE") {
+		t.Errorf("error should mention TITLE, got: %v", err)
+	}
+}
+
+func TestParsePRCreateBlock_EmptyBody(t *testing.T) {
+	input := `FABRIK_PR_CREATE_BEGIN
+TITLE: PR with empty body
+FABRIK_PR_CREATE_END`
+	block, err := ParsePRCreateBlock(input)
+	if err == nil {
+		t.Fatal("expected error for empty body, got nil")
+	}
+	if block != nil {
+		t.Fatalf("expected nil block, got %+v", block)
+	}
+}
+
+func TestParsePRCreateBlock_MissingEnd(t *testing.T) {
+	input := `FABRIK_PR_CREATE_BEGIN
+TITLE: Missing end marker
+
+PR body content.`
+	block, err := ParsePRCreateBlock(input)
+	if err == nil {
+		t.Fatal("expected error for missing END, got nil")
+	}
+	if block != nil {
+		t.Fatalf("expected nil block, got %+v", block)
+	}
+}
+
+func TestParsePRCreateBlock_InvalidRepoFormat(t *testing.T) {
+	input := `FABRIK_PR_CREATE_BEGIN noslash
+TITLE: Bad repo
+
+Body.
+FABRIK_PR_CREATE_END`
+	_, err := ParsePRCreateBlock(input)
+	if err == nil {
+		t.Fatal("expected error for invalid repo format, got nil")
+	}
+}
+
+// ---- processPRCreateMarker tests ----
+
+func TestProcessPRCreateMarker_Success(t *testing.T) {
+	ensureDraftPRRetryDelay = 0
+	var capturedBody string
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil // no existing PR
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			capturedBody = body
+			return 42, nil
+		},
+	}
+	eng := testEngine(client, nil)
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	block := &PRCreateBlock{
+		Title: "My PR Title",
+		Body:  "This implements the feature.",
+	}
+
+	prNum, err := eng.processPRCreateMarker(context.Background(), item, block, "owner", "repo", "main", "owner/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prNum != 42 {
+		t.Errorf("prNum: got %d, want 42", prNum)
+	}
+	// Verify "Closes #1" is the FIRST line of the PR body.
+	if !strings.HasPrefix(capturedBody, "Closes #1\n\n") {
+		t.Errorf("PR body should start with 'Closes #1\\n\\n', got: %q", capturedBody)
+	}
+	// Verify the skill body is included.
+	if !strings.Contains(capturedBody, "This implements the feature.") {
+		t.Errorf("PR body should contain skill body content")
+	}
+}
+
+func TestProcessPRCreateMarker_IdempotencyExistingPR(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 99, State: "open"}, nil
+		},
+	}
+	eng := testEngine(client, nil)
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	block := &PRCreateBlock{Title: "T", Body: "B"}
+
+	prNum, err := eng.processPRCreateMarker(context.Background(), item, block, "owner", "repo", "main", "owner/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prNum != 99 {
+		t.Errorf("should reuse existing PR #99, got %d", prNum)
+	}
+	// Verify no new PR was created.
+	client.mu.Lock()
+	created := len(client.createDraftPRCalls)
+	client.mu.Unlock()
+	if created != 0 {
+		t.Errorf("should not create a new PR when one exists, createDraftPRCalls = %d", created)
+	}
+}
+
+func TestProcessPRCreateMarker_CrossRepoNotSupported(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(client, nil)
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	block := &PRCreateBlock{
+		TargetRepo: "other-org/other-repo",
+		Title:      "T",
+		Body:       "B",
+	}
+
+	prNum, err := eng.processPRCreateMarker(context.Background(), item, block, "owner", "repo", "main", "owner/repo")
+	if err == nil {
+		t.Fatal("expected error for cross-repo, got nil")
+	}
+	if prNum != 0 {
+		t.Errorf("expected prNum 0 on error, got %d", prNum)
+	}
+	// Issue should be paused.
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Error("issue should be paused for cross-repo PR creation attempt")
+	}
+}
+
+func TestProcessPRCreateMarker_CreateFailurePauses(t *testing.T) {
+	ensureDraftPRRetryDelay = 0
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			return 0, fmt.Errorf("API rate limit exceeded")
+		},
+	}
+	eng := testEngine(client, nil)
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	block := &PRCreateBlock{Title: "T", Body: "Body content here."}
+
+	prNum, err := eng.processPRCreateMarker(context.Background(), item, block, "owner", "repo", "main", "owner/repo")
+	if err == nil {
+		t.Fatal("expected error on create failure, got nil")
+	}
+	if prNum != 0 {
+		t.Errorf("expected prNum 0 on error, got %d", prNum)
+	}
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Error("issue should be paused on PR creation failure")
+	}
+}
+
+// ---- verifyAndHealLinkage tests ----
+
+func TestVerifyAndHealLinkage_NoPR(t *testing.T) {
+	eng := testEngine(&mockGitHubClient{}, nil)
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Implement"}
+	ok := eng.verifyAndHealLinkage(context.Background(), item, 0, stage, "owner", "repo", "owner/repo")
+	if !ok {
+		t.Error("should return true when prNumber == 0")
+	}
+}
+
+func TestVerifyAndHealLinkage_AlreadyLinked(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRNumber = 42
+			return nil
+		},
+	}
+	eng := testEngine(client, nil)
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Implement"}
+	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
+	if !ok {
+		t.Error("should return true when linkage already confirmed")
+	}
+}
+
+func TestVerifyAndHealLinkage_BranchMismatch_NoLinkedPR(t *testing.T) {
+	// FetchItemDetails returns LinkedPRNumber=0 but FetchLinkedPR finds nothing.
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRNumber = 0
+			return nil
+		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil // no PR on branch
+		},
+	}
+	eng := testEngine(client, nil)
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Implement"}
+	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
+	if !ok {
+		t.Error("should return true when no PR found via branch (user-diverged)")
+	}
+	// Issue should NOT be paused.
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			t.Error("should not pause when no PR found via branch lookup")
+		}
+	}
+}
+
+func TestVerifyAndHealLinkage_HealSuccess(t *testing.T) {
+	callCount := 0
+	var capturedHealBody string
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			callCount++
+			if callCount == 1 {
+				item.LinkedPRNumber = 0 // linkage missing on first check
+			} else {
+				item.LinkedPRNumber = 42 // linkage present after heal
+			}
+			return nil
+		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, State: "open", HeadSHA: "abc123"}, nil
+		},
+		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
+			return "## Summary\n\nThis PR does something.", nil
+		},
+		updateIssueBodyFn: func(owner, repo string, issueNumber int, body string) error {
+			capturedHealBody = body
+			return nil
+		},
+	}
+	eng := testEngine(client, nil)
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Implement"}
+
+	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
+	if !ok {
+		t.Error("heal should succeed, expected true")
+	}
+	if !strings.HasPrefix(capturedHealBody, "Closes #1\n\n") {
+		t.Errorf("healed body should start with 'Closes #1\\n\\n', got: %q", capturedHealBody)
+	}
+	if !strings.Contains(capturedHealBody, "## Summary") {
+		t.Error("healed body should contain original body content")
+	}
+	// Issue should NOT be paused on successful heal.
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			t.Error("should not pause on successful heal")
+		}
+	}
+}
+
+func TestVerifyAndHealLinkage_HealAlreadyAttempted(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRNumber = 0
+			return nil
+		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, State: "open", HeadSHA: "abc123"}, nil
+		},
+		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
+			return "PR body.", nil
+		},
+	}
+	eng := testEngine(client, nil)
+
+	// Record that we've already attempted healing for this SHA.
+	eng.store.Apply(itemstate.LinkageHealAttempted{
+		Repo:      "owner/repo",
+		Number:    1,
+		StageName: "Implement",
+		PRSHA:     "abc123",
+	})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Implement"}
+
+	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
+	if ok {
+		t.Error("should return false when heal was already attempted")
+	}
+	// Issue should be paused.
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Error("issue should be paused when heal was already attempted")
+	}
+}
+
+func TestVerifyAndHealLinkage_BodyTooLong(t *testing.T) {
+	// Generate a body that exceeds the 65300 char limit when closing line is prepended.
+	longBody := strings.Repeat("x", 65300)
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			item.LinkedPRNumber = 0
+			return nil
+		},
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, State: "open", HeadSHA: "sha1"}, nil
+		},
+		getIssueBodyFn: func(owner, repo string, issueNumber int) (string, error) {
+			return longBody, nil
+		},
+	}
+	eng := testEngine(client, nil)
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Implement"}
+
+	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
+	if ok {
+		t.Error("should return false when body is too long for auto-heal")
+	}
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Error("issue should be paused when body is too long")
+	}
+}

--- a/engine/prcreate_test.go
+++ b/engine/prcreate_test.go
@@ -133,6 +133,19 @@ FABRIK_PR_CREATE_END`
 	}
 }
 
+func TestParsePRCreateBlock_InvalidRepoFormatExtraSegment(t *testing.T) {
+	// "owner/repo/extra" has two slashes — old validation passed it, new validation rejects it.
+	input := `FABRIK_PR_CREATE_BEGIN owner/repo/extra
+TITLE: Bad repo
+
+Body.
+FABRIK_PR_CREATE_END`
+	_, err := ParsePRCreateBlock(input)
+	if err == nil {
+		t.Fatal("expected error for owner/repo/extra format, got nil")
+	}
+}
+
 // ---- processPRCreateMarker tests ----
 
 func TestProcessPRCreateMarker_Success(t *testing.T) {

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -79,6 +79,42 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
+	// Broken-linkage guard (FR-013): if the item has no linked PR via
+	// closingIssuesReferences (LinkedPRNumber == 0) but a PR exists on the
+	// fabrik/issue-N branch, the gate would silently loop forever applying
+	// fabrik:awaiting-review. Detect this, pause with a clear message, and
+	// do NOT apply fabrik:awaiting-review.
+	if item.LinkedPRNumber == 0 {
+		pr, prErr := e.readClient.FetchLinkedPR(owner, repo, item.Number)
+		if prErr == nil && pr != nil && pr.Number > 0 && pr.State == "open" && !pr.Merged {
+			e.logf(item.Number, "review-gate", "broken linkage: PR #%d exists on branch fabrik/issue-%d but is not linked via closing keyword\n", pr.Number, item.Number)
+			msg := fmt.Sprintf(
+				"🏭 **Fabrik — broken PR↔issue linkage**\n\n"+
+					"PR #%d exists on branch `fabrik/issue-%d` but is not linked to this issue via a closing keyword "+
+					"(`closingIssuesReferences` is empty). The review gate cannot proceed without this linkage.\n\n"+
+					"Add `Closes #%d` as the first line of the PR body and remove `fabrik:paused` to resume:\n\n"+
+					"```bash\n"+
+					"gh pr view %d --json body --jq '.body' > /tmp/pr_body.txt && "+
+					"printf 'Closes #%d\\n\\n' | cat - /tmp/pr_body.txt | "+
+					"gh pr edit %d --body-file -\n"+
+					"```",
+				pr.Number, item.Number, item.Number,
+				pr.Number, item.Number, pr.Number,
+			)
+			e.addPausedLabelToItem(owner, repo, item)
+			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
+				e.logf(item.Number, "warn", "could not post broken-linkage comment: %v\n", commentErr)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
+				})
+			}
+			// Return (false, false): the gate did not time out — it paused for a different reason.
+			// The catch-up loop will not reapply fabrik:awaiting-review.
+			return false, false
+		}
+	}
+
 	// Outstanding requested reviewers (humans or bots using the formal
 	// request mechanism). A dismissed review puts the reviewer back here;
 	// if they're not here, they've finished.

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1031,3 +1031,94 @@ func TestCheckReviewGate_BotPhase1_NonCopilot_MentionsLogin(t *testing.T) {
 		t.Errorf("expected @dependabot[bot] in reprompt comment body, got: %q", body)
 	}
 }
+
+// Broken-linkage guard: PR exists on branch but LinkedPRNumber == 0 → pause instead of loop.
+func TestCheckReviewGate_BrokenLinkage_PRFound_Pauses(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 77, State: "open"}, nil
+		},
+	}
+	eng := reviewTestEngine(client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		LinkedPRNumber: 0, // no linkage via closingIssuesReferences
+	}
+	stage := &stages.Stage{Name: "Implement", WaitForReviews: boolPtr(true)}
+
+	blocked, timedOut := eng.checkReviewGate(board, item, stage)
+
+	// Gate returns (false, false) — not blocked-for-reviews, not timed out.
+	if blocked {
+		t.Error("gate should not report blocked when broken linkage detected")
+	}
+	if timedOut {
+		t.Error("gate should not report timedOut for broken linkage")
+	}
+
+	// Issue MUST be paused.
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Error("issue should have fabrik:paused label applied")
+	}
+
+	// fabrik:awaiting-review must NOT be applied.
+	for _, l := range labels {
+		if l.labelName == "fabrik:awaiting-review" {
+			t.Error("fabrik:awaiting-review must not be applied for broken linkage")
+		}
+	}
+
+	// Comment should mention the closing keyword and PR number.
+	if len(client.addCommentCalls) == 0 {
+		t.Fatal("expected a broken-linkage comment to be posted")
+	}
+	body := client.addCommentCalls[0].body
+	if !strings.Contains(body, "Closes #10") {
+		t.Errorf("comment should contain recovery closing keyword, got: %q", body)
+	}
+}
+
+// Broken-linkage guard: LinkedPRNumber == 0 and no PR found on branch → falls through to normal logic.
+func TestCheckReviewGate_BrokenLinkage_NoPRFound_FallsThrough(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil // no PR on branch
+		},
+	}
+	eng := reviewTestEngine(client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		LinkedPRNumber: 0,
+	}
+	stage := &stages.Stage{Name: "Implement", WaitForReviews: boolPtr(true)}
+
+	blocked, _ := eng.checkReviewGate(board, item, stage)
+
+	// No PR found → falls through to normal reviewer logic. With no reviews, gate blocks.
+	if !blocked {
+		t.Error("gate should still block when no PR is found (normal logic applies)")
+	}
+
+	// Issue must NOT be paused for broken linkage.
+	client.mu.Lock()
+	labels := client.addLabelCalls
+	client.mu.Unlock()
+	for _, l := range labels {
+		if l.labelName == "fabrik:paused" {
+			t.Error("should not pause when no PR exists on branch")
+		}
+	}
+}

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -171,6 +171,10 @@ type StageState struct {
 	RebaseCycles map[string]int
 	// ProcessedComments maps comment ID to the time Fabrik finished processing it.
 	ProcessedComments map[string]time.Time
+	// LinkageHealAttempted maps stage name to the PR head SHA for which a linkage
+	// auto-heal was attempted. In-memory only — does not survive restart. Keyed by
+	// stage name so force-push (new SHA) clears the guard naturally.
+	LinkageHealAttempted map[string]string
 }
 
 // LockState describes who holds the fabrik:locked:<user> label on this issue.

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -632,6 +632,20 @@ type EngineCyclesCleared struct {
 func (EngineCyclesCleared) isMutation()       {}
 func (m EngineCyclesCleared) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// LinkageHealAttempted records that the engine attempted to auto-heal missing
+// PR↔issue linkage for the given stage. Keyed by stage name → PR head SHA.
+// In-memory only — does not survive restart. A force-push (new SHA) clears the
+// guard naturally by virtue of the SHA not matching the stored value.
+type LinkageHealAttempted struct {
+	Repo      string
+	Number    int
+	StageName string
+	PRSHA     string
+}
+
+func (LinkageHealAttempted) isMutation()       {}
+func (m LinkageHealAttempted) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // itemKeyFor constructs the canonical "owner/repo#N" item key used throughout the Store.
 // Returns "" when repo is empty (indicating an invalid or unroutable mutation).
 func itemKeyFor(repo string, number int) string {

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -35,6 +35,7 @@ type Snapshot struct {
 //   - ItemState.StageState.CIFixCycles
 //   - ItemState.StageState.RebaseCycles
 //   - ItemState.StageState.ProcessedComments
+//   - ItemState.StageState.LinkageHealAttempted
 //   - LinkedPRState.Reviews
 //   - LinkedPRState.ReviewRequests
 //   - LinkedPRState.ThreadComments
@@ -201,6 +202,13 @@ func (s Snapshot) CommentProcessed(commentID string) time.Time {
 	return s.state.StageState.ProcessedComments[commentID]
 }
 
+// LinkageHealAttempted returns true when a linkage auto-heal has already been
+// attempted for the given stage and PR head SHA. Returns false if either is unknown.
+func (s Snapshot) LinkageHealAttempted(stageName, prSHA string) bool {
+	recorded := s.state.StageState.LinkageHealAttempted[stageName]
+	return recorded != "" && recorded == prSHA
+}
+
 // ---- deep-copy helpers ----
 
 func copyStrings(src []string) []string {
@@ -299,13 +307,25 @@ func copyIntMap(src map[string]int) map[string]int {
 
 func copyStageState(s StageState) StageState {
 	return StageState{
-		Attempts:          copyIntMap(s.Attempts),
-		LastAttemptAt:     copyTimeMap(s.LastAttemptAt),
-		PausedByEngine:    copyBoolMap(s.PausedByEngine),
-		PRCreationFailed:  copyBoolMap(s.PRCreationFailed),
-		ReviewCycles:      copyIntMap(s.ReviewCycles),
-		CIFixCycles:       copyIntMap(s.CIFixCycles),
-		RebaseCycles:      copyIntMap(s.RebaseCycles),
-		ProcessedComments: copyTimeMap(s.ProcessedComments),
+		Attempts:             copyIntMap(s.Attempts),
+		LastAttemptAt:        copyTimeMap(s.LastAttemptAt),
+		PausedByEngine:       copyBoolMap(s.PausedByEngine),
+		PRCreationFailed:     copyBoolMap(s.PRCreationFailed),
+		ReviewCycles:         copyIntMap(s.ReviewCycles),
+		CIFixCycles:          copyIntMap(s.CIFixCycles),
+		RebaseCycles:         copyIntMap(s.RebaseCycles),
+		ProcessedComments:    copyTimeMap(s.ProcessedComments),
+		LinkageHealAttempted: copyStringMap(s.LinkageHealAttempted),
 	}
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -431,6 +431,11 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		delete(item.StageState.RebaseCycles, v.StageName)
 		return StageStateChanged
 
+	case LinkageHealAttempted:
+		ensureStageStateMaps(item)
+		item.StageState.LinkageHealAttempted[v.StageName] = v.PRSHA
+		return StageStateChanged
+
 	case StageLastAttemptCleared:
 		ensureStageStateMaps(item)
 		delete(item.StageState.LastAttemptAt, v.StageName)
@@ -1190,6 +1195,9 @@ func ensureStageStateMaps(item *ItemState) {
 	}
 	if ss.ProcessedComments == nil {
 		ss.ProcessedComments = make(map[string]time.Time)
+	}
+	if ss.LinkageHealAttempted == nil {
+		ss.LinkageHealAttempted = make(map[string]string)
 	}
 }
 

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -104,15 +104,27 @@ gh api -X PATCH /repos/{owner}/{repo}/issues/comments/$COMMENT_ID \
 
 If no Plan stage comment exists (Plan was never run or comment was deleted), skip task tracking gracefully — don't fail.
 
-### Write a reviewer-oriented PR description
+### Signal PR creation via the FABRIK_PR_CREATE marker
 
-When creating the draft PR, write a PR description for a human reviewer — not a copy of the plan. The description should cover:
-1. **What the PR does** — a concise summary of the feature or fix
-2. **Key changes** — the most significant code changes (files, interfaces, behaviors)
-3. **How to test** — steps a reviewer can take to verify the change works
-4. **Closing reference**: `Closes #N`
+**Do NOT call `gh pr create` directly.** The engine creates the PR. To signal PR creation, emit a `FABRIK_PR_CREATE_BEGIN/END` marker block in your output:
 
-This is not a task checklist. It is not the plan. It is a summary for someone reviewing the diff who may not have read the issue.
+```
+FABRIK_PR_CREATE_BEGIN
+TITLE: <single-line PR title>
+
+<PR body content for a human reviewer>
+FABRIK_PR_CREATE_END
+```
+
+The engine reads this block, prepends `Closes #N` as the first line of the PR body, and calls `gh pr create` itself. You never write the closing keyword — the engine owns it.
+
+**Rules for the block**:
+- `FABRIK_PR_CREATE_BEGIN` and `FABRIK_PR_CREATE_END` must each be on their own line.
+- The first non-empty line after `BEGIN` must be `TITLE: <title>`.
+- The body (after the title line) should be a reviewer-oriented description — not a copy of the plan. Cover: what the PR does, key changes, and how to test.
+- **Do NOT write `Closes #N`, `Fixes #N`, `Resolves #N`, or any form of closing keyword referencing the issue number in the body.** The engine generates this line. If you write one, it will be duplicated.
+- You MAY reference internal identifiers in prose (e.g., `Implements FR-007`, `Addresses the auth flow described in the spec`) — just not the literal `Closes`/`Fixes`/`Resolves` + `#issue-number` form.
+- Emit exactly one `FABRIK_PR_CREATE` block per run. Multiple blocks are an error.
 
 ### Write tests
 
@@ -154,6 +166,8 @@ Before signaling completion:
 - **Do not add features not in the plan** — no scope creep
 - **Do not leave the branch in a broken state** — every push should compile and pass tests
 - **Do not defer documentation** — if the change is user-facing, update the docs in the same PR. A doc update that gets "tracked as a follow-up" is a doc update that never happens.
+- **Never call `gh pr create` directly.** Use the `FABRIK_PR_CREATE_BEGIN/END` marker instead. The engine creates the PR and guarantees the `Closes #N` closing line. A direct `gh pr create` bypasses this guarantee and will break downstream gates.
+- **Never write `Closes #N`, `Fixes #N`, `Resolves #N`, or any closing keyword referencing the issue number in a PR body.** The engine generates this line as the first line of the PR body. Writing one yourself either duplicates it (harmless but messy) or, if you called `gh pr create` directly and omitted it, breaks every downstream gate. The engine owns this line — you don't.
 - **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
 
   Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.
@@ -166,7 +180,7 @@ Your assigned worktree is your entire operating boundary. You MUST NOT cross it.
 
 **Prohibited actions**:
 - Writing, editing, or deleting files outside the worktree working directory — regardless of absolute path
-- Running `gh pr create`, `git push`, or branch creation commands targeting any repo other than the worktree's own repo
+- Running `gh pr create` (use the `FABRIK_PR_CREATE_BEGIN/END` marker instead — see above), `git push`, or branch creation commands targeting any repo other than the worktree's own repo
 - `cd`-ing into, or referencing via absolute path, any working copy in the user's local environment outside `.fabrik/worktrees/`
 
 **When the spec references out-of-scope work**: If your Plan or spec describes changes in another repo (files, APIs, or logic that lives outside the worktree's repo), do NOT reach outside. Instead:
@@ -190,7 +204,7 @@ Out-of-scope work in the same Fabrik run belongs to a sibling issue's worktree, 
 
 **If you hit max turns**: The engine will create a partial-progress commit (`chore: partial <StageName> stage progress (incomplete)`) of any uncommitted changes and push them. Your progress is preserved for the next attempt.
 
-**Draft PR**: If the stage config has `create_draft_pr: true`, the engine creates a draft PR after you signal completion. Make sure your branch is pushed before completing.
+**Draft PR**: When `create_draft_pr: true` (Implement's default), the engine creates the draft PR by processing the `FABRIK_PR_CREATE_BEGIN/END` marker you emit. The engine prepends `Closes #N` as the first line of the PR body, then calls `gh pr create`. Push your branch before emitting `FABRIK_STAGE_COMPLETE`.
 
 **Comment processing**: If the user comments during implementation, you'll be invoked to process their comment. Read what they're asking, make the change, and continue with the task list.
 


### PR DESCRIPTION
Closes #841

## Summary

# Feature Specification: Engine-mechanized `Closes #N` linkage on every Fabrik PR

## Problem

# Feature Specification: Engine-mechanized `Closes #N` linkage on every Fabrik PR

## Approach

### Approach

Three layered protections, implemented in order from innermost to outermost:

1. **Primary path (marker-based PR creation)**: The engine parses `FABRIK_PR_CREATE_BEGIN/END` from Implement's output and calls `CreateDraftPR` with `Closes #N

` prepended. The Implement skill emits the marker instead of calling `gh pr create` directly.

2. **Backstop (post-Implement linkage verification)**: After any Implement completion, the engine calls `FetchItemDetails` (GraphQL `closingIssuesReferences`) to verify linkage. If missing: one auto-heal attempt (prepend `Closes #N`, re-verify), then pause with recovery commands.

3. **Gate-side broken-linkage detection**: `checkReviewGate` detects `LinkedPRNumber == 0` despite a PR on the `fabrik/issue-N` branch and pauses instead of silently looping `fabrik:awaiting-review`.

All new engine logic lives in a new `engine/prcreate.go` file (mirrors `engine/spawn.go`'s pattern for `FABRIK_SPAWN_CHILD`). `engine/item.go` gets two wiring blocks: marker scanning and linkage verification. `engine/reviews.go` gets a broken-linkage guard at the top of `checkReviewGate`.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/prcreate.go` | New file: `PRCreateBlock`, `ParsePRCreateBlock`, `processPRCreateMarker`, `verifyAndHealLinkage` |
| `engine/prcreate_test.go` | New file: unit tests for all above functions |
| `engine/item.go` | Wire marker scanning after `extractUpdatedBody`; strip `FABRIK_PR_CREATE_BEGIN/END` from `output`; call `verifyAndHealLinkage` in completion block before `releaseLock` |
| `engine/reviews.go` | Add broken-linkage guard at top of `checkReviewGate` |
| `engine/reviews_test.go` | Add tests for broken-linkage guard path |
| `internal/itemstate/itemstate.go` | Add `LinkageHealAttempted map[string]string` to `StageState` |
| `internal/itemstate/mutation.go` | Add `LinkageHealAttempted` mutation type |
| `internal/itemstate/snapshot.go` | Add `LinkageHealAttempted(stageName, prSHA string) bool` snapshot method |
| `internal/itemstate/store.go` | Handle `LinkageHealAttempted` mutation in `Apply` |
| `plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md` | Rewrite PR creation section with `FABRIK_PR_CREATE` marker instructions; prohibit `gh pr create` and closing keywords |
| `docs/state-machine.md` | Document `FABRIK_PR_CREATE` marker, linkage backstop, gate-side detection |
| `docs/USER_GUIDE.md` | Document engine-owned closing line, new PR body shape |
| `docs/llms-full.txt` | Regenerate after doc edits |

### Key Decisions

- **`engine/prcreate.go` as new file**: All marker/verification logic is isolated from `engine/item.go` and `engine/pr.go`, keeping those files readable. Same pattern as `engine/spawn.go`. `ParsePRCreateBlock` returns `(*PRCreateBlock, error)` where `nil, nil` = not found, `nil, err` = malformed, `block, nil` = valid.

- **Marker scanning fires unconditionally (not gated on `completed`)**: When `stage.CreateDraftPR` is true and the marker is found in the accumulated output, the engine processes it regardless of whether the stage completed. The idempotency guard (`FetchLinkedPR` before `CreateDraftPR`) prevents duplicate PRs when the marker appears in multiple retries.

- **`ensurePRLinksIssue` retained**: The existing footer-append function in `ensureDraftPR` stays as belt-and-braces for legacy path. The new GraphQL-based `verifyAndHealLinkage` is the authoritative backstop. Keeping both avoids regression risk.

- **`LinkageHealAttempted` in-memory only**: Like `PRCreationFailed`, stored in `StageState` as `map[string]string` (stage → PR SHA). In-memory only — survives within a session but not across restarts. On restart, one more heal is permitted (conservative/safe). Keyed by PR SHA so force-push clears the guard naturally.

- **`verifyAndHealLinkage` scoped to `create_draft_pr: true` stages**: Only Implement creates PRs, so the verification only fires on those stages. Placement: after `updatePRVerification` and before `releaseLock()` in the `completed` block.

- **Cross-repo in marker (v1)**: When `FABRIK_PR_CREATE_BEGIN owner/repo` specifies a different repo, pause immediately with a clear "cross-repo PR creation not supported in v1" comment. No network calls attempted.

- **ADR 051 warranted**: Extends ADR 048's engine-owns-mutations principle to PR creation. New contributors need to understand why `FABRIK_PR_CREATE` is a marker (not a skill-side `gh` call) — a non-obvious architectural choice with a specific failure-mode motivation.

### Task Checklist

- [x] Task 1: Add `LinkageHealAttempted` to `internal/itemstate` — new `map[string]string` field in `StageState`, `LinkageHealAttempted` mutation type in `mutation.go`, `Snapshot.LinkageHealAttempted(stageName, prSHA string) bool` method, `Apply` handler in `store.go`; update `copyStageState` in `snapshot.go` to deep-copy the new map

- [x] Task 2: Create `engine/prcreate.go` — define `PRCreateBlock{TargetRepo, Title, Body string}` and `ParsePRCreateBlock(s string) (*PRCreateBlock, error)` which returns `nil, nil` when no marker is found, `nil, err` when the BEGIN/END frame is present but malformed (missing TITLE, empty body), and `*block, nil` when valid; reuse `parseTitleAndBody` from `spawn.go` by promoting it to an exported `ParseTitleAndBody` helper or duplicating the compact logic directly in `prcreate.go` (separate implementations are cleaner given diverging semantics — use a local unexported helper)

- [x] Task 3: Add `processPRCreateMarker(item, block, owner, repo, baseBranch, repoStr string) (prNumber int, err error)` to `engine/prcreate.go` — (a) cross-repo guard: if `block.TargetRepo != "" && block.TargetRepo != owner+"/"+repo`, pause with clear v1-unsupported comment and return `0, err`; (b) idempotency: call `FetchLinkedPR` — if PR already exists, record linkage and return existing PR number; (c) push branch via `wm.PushBranch`; (d) compose body as `"Closes #N

" + block.Body` (or `"Closes owner/repo#N

"` for cross-repo: not applicable in v1); (e) call `CreateDraftPR`, with up to 3 retries for transient errors; (f) on success: cache write-through, `webhookMgr.RegisterEcho`, post acknowledgement comment `"🏭 Fabrik — opened PR #M"`; (g) on persistent failure: pause with `fabrik:paused` + comment, return `0, err`

- [x] Task 4: Add `verifyAndHealLinkage(ctx, item, prNumber, stage, owner, repo, repoStr string) (ok bool)` to `engine/prcreate.go` — (a) if `prNumber == 0`: skip, return true; (b) call `e.client.FetchItemDetails(&item)` to refresh `item.LinkedPRNumber`; (c) if linked: return true; (d) try `FetchLinkedPR` to find PR by branch name; if no PR found by branch, log warning and return true (user-diverged branch — don't pause); (e) check body length guard (FR-015): if `len(body) + len(closingLine) + 2 > 65300`, pause with "body too long" comment, return false; (f) check `snap.LinkageHealAttempted(stage.Name, prSHA)` — if true, escalate to pause with copy-paste `gh pr edit --body` command, return false; (g) record `LinkageHealAttempted` in store; (h) prepend `"Closes #N

"` to `balanceFences(body)`, call `UpdateIssueBody`; (i) re-call `FetchItemDetails` to re-verify; (j) if healed: post `"🏭 Fabrik — PR body auto-corrected: Closes #N prepended"` comment, return true; (k) if still missing: pause with copy-paste recovery comment, return false

- [x] Task 5: Wire marker scanning into `engine/item.go` — after the `extractUpdatedBody` block (line ~896) and before `postOutput := output`: scan `output` with `ParsePRCreateBlock`; on parse error (`nil, err`): call `addPausedLabelToItem`, post comment, `releaseLock()`, return nil; on valid block: call `processPRCreateMarker`, on error: `releaseLock()`, return nil; on success: update local `prNumber`; strip block from output: `output = stripMarkers(output, "FABRIK_PR_CREATE_BEGIN", "FABRIK_PR_CREATE_END")`

- [x] Task 6: Wire `verifyAndHealLinkage` into `engine/item.go` completion block — after `e.updatePRVerification` call (line ~1079) and before `releaseLock()`: when `stage.CreateDraftPR`, call `e.verifyAndHealLinkage(ctx, item, prNumber, stage, owner, repo, repoStr)`; if `!ok`: `releaseLock()`, return nil (do NOT call `handleStageComplete`)

- [x] Task 7: Add broken-linkage guard to `engine/reviews.go:checkReviewGate` — before the existing reviewer-list logic: if `item.LinkedPRNumber == 0`, call `e.readClient.FetchLinkedPR(owner, repo, item.Number)` (REST branch lookup); if PR found (non-nil, State=="open"): pause with `fabrik:paused` + comment `"🏭 Fabrik — PR #M exists on branch fabrik/issue-N but is not linked..."` (per spec); do NOT apply `fabrik:awaiting-review`; return `(false, false)` so the outer catch-up loop knows the gate was resolved (via pause); add `engine/reviews_test.go` tests covering broken-linkage detection (PR found → pause, no PR found → fall through to existing logic)

- [x] Task 8: Write `engine/prcreate_test.go` — `TestParsePRCreateBlock` (valid, no marker, malformed-missing-TITLE, malformed-empty-body, cross-repo-target-on-BEGIN-line); `TestProcessPRCreateMarker` (success creates PR with `Closes #N` first line, idempotency when PR already exists, cross-repo pause, create-failure pause); `TestVerifyAndHealLinkage` (already linked returns true, heal success with correct body prepend, heal-already-attempted escalates to pause, body-length guard pauses, branch-mismatch skips heal)

- [x] Task 9: Update `plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md` — replace "Write a reviewer-oriented PR description" section's `gh pr create` instructions with `FABRIK_PR_CREATE_BEGIN/END` marker format; add explicit prohibition on calling `gh pr create` directly; add explicit prohibition on writing `Closes #N` / `Fixes #N` / `Resolves #N` in the PR body (per FR-006/FR-007); update the Engine Context note about `create_draft_pr: true`

- [x] Task 10: Update `docs/state-machine.md` — add section documenting `FABRIK_PR_CREATE` marker format (mirroring `FABRIK_SPAWN_CHILD` coverage), engine-mechanized PR creation flow, post-Implement linkage backstop (FR-008–012), and gate-side broken-linkage detection (FR-013/014)

- [x] Task 11: Update `docs/USER_GUIDE.md` — document that `Closes #N` is now the FIRST line of every Fabrik-opened PR body, generated by the engine; add example of resulting PR body shape; note that the Implement skill must not write the closing keyword

- [x] Task 12: Regenerate `docs/llms-full.txt` via `bash scripts/generate-llms-full.sh && git add docs/llms-full.txt` (must follow in the same commit as doc edits)

- [x] Task 13: Create ADR 051 — title "FABRIK_PR_CREATE: engine-mechanized PR creation via marker" documenting: the problem (Implement skill silently drops `Closes #N`), the decision (marker-based engine-side PR creation, prepend rather than append, engine-owns-mutations extension of ADR 048), alternatives considered (post-process body injection, per-session body guard), and consequences (skill prompt updated, `gh pr create` prohibited in Implement, post-Implement linkage verification added as backstop)

### Risks

- **`FetchItemDetails` added latency**: One extra GraphQL API call per Implement completion. Acceptable given infrequency; the call refreshes PR review data as a side effect (cheap reuse).

- **Transition period coverage**: Existing Implement sessions that were already mid-run before this ships will use the old skill prompt. The post-Implement linkage check (`verifyAndHealLinkage`) catches those via auto-heal. Both paths ship together so no window exists where the marker is expected but the backstop is absent.

- **`stripMarkers` for `FABRIK_PR_CREATE_BEGIN/END` must fire on `output` (raw), not `postOutput`**: The BEGIN line may contain `owner/repo`, making it a non-exact `stripLine` target. Use `stripMarkers` on `output` (same pattern as `FABRIK_ISSUE_UPDATE_BEGIN/END`) so the entire block is removed from postOutput automatically when `postOutput = output` is assigned.

- **`verifyAndHealLinkage` runs after `updatePRVerification`**: The `updatePRVerification` call modifies the PR body (adds/updates the `## Verification` section). The linkage check fires after that edit. The new `FetchItemDetails` call in `verifyAndHealLinkage` fetches the freshest body — no stale-body risk.

- **`parseTitleAndBody` in `spawn.go` is unexported**: The new `prcreate.go` uses a local unexported helper with the same logic rather than promoting the `spawn.go` function. This avoids changing the `spawn.go` API surface. The helpers are small enough that duplication is less risk than promotion.

---
Used 26/50 turns, 14k input / 18k output tokens.

## Verification

All 13 tasks completed: new `engine/prcreate.go` implements marker-based PR creation (`FABRIK_PR_CREATE_BEGIN/END`), post-Implement linkage verification with auto-heal, and gate-side broken-linkage detection in `checkReviewGate`. The Implement skill prompt was rewritten to prohibit direct `gh pr create` and closing keywords, and `docs/state-machine.md`, `docs/USER_GUIDE.md`, and ADR 051 document the full design.

---

Closes #841