### PR TITLE
feat(tui): add persistent pre-flight warnings panel backed by warnings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 .fabrik/debug/
 .fabrik/history.json
 */.fabrik/history.json
+.fabrik/warnings.json
+*/.fabrik/warnings.json
 .fabrik/repo.git/
 .fabrik/issue.md
 .fabrik/stage-*.md

--- a/adrs/052-warnings-file-backed-panel-state.md
+++ b/adrs/052-warnings-file-backed-panel-state.md
@@ -1,0 +1,51 @@
+# ADR 052: Warnings Panel Backed by mtime-Polled File
+
+**Date**: 2026-05-28  
+**Status**: Accepted  
+**Issue**: #843 — Persistent pre-flight warnings panel in TUI
+
+## Context
+
+The TUI needs to surface pre-flight warnings (e.g. `allow_auto_merge` disabled, stage-config drift) persistently across auto-upgrade restarts. Two architectural options were considered for how the Warnings panel receives state updates:
+
+**Option A — Engine event channel**: The engine emits events (via the existing typed-event pattern) every time a detector fires. The TUI subscribes and updates its in-memory state. State is lost when the process restarts (including auto-upgrade).
+
+**Option B — File-backed state with mtime polling**: Warnings are written to `.fabrik/warnings.json` by detectors. The TUI polls the file's mtime every second (existing `TickEvent` cadence) and reloads when changed.
+
+The headline requirement is that warnings survive auto-upgrade restarts — the operator may be away for days while Fabrik self-restarts multiple times. Option A cannot satisfy this without additional IPC or a separate persistence layer. The operator's explicit constraint is: "auto-upgrade is fine to skip [prompts] SO LONG AS the warnings appear at the bottom of the panel and are actionable by the user next time they look at the TUI."
+
+## Decision
+
+Use **Option B**: file-backed state with mtime polling.
+
+`warnings/warnings.go` is a new top-level package (importable by both `engine/` and `stages/` without cycle risk) that provides:
+- `Record(entry Entry) error` — upsert; preserves `first_seen` and `dismissed` on re-record
+- `Clear(key string) error` — removes entry regardless of dismissed state
+- `Dismiss(key string) error` / `Undismiss(key string) error` — toggle
+- `Load() ([]Entry, error)` — read-only; missing file → nil, nil; corrupt → nil, err
+
+Storage is `.fabrik/warnings.json` (CWD-relative, consistent with `.fabrik/history.json` per ADR 023). Writes are atomic (temp-file-then-rename) and protected by a package-level `sync.Mutex` for concurrent-goroutine safety.
+
+The `WarningsPaneComponent` in `tui/warnings.go` calls `os.Stat(warnings.Path())` on each `TickEvent` and reloads if `ModTime()` changed. Initial load happens at component creation, so entries visible at startup are immediate.
+
+## Consequences
+
+**Positive**:
+- Warnings survive auto-upgrade restarts with `first_seen` preserved and `dismissed` sticky — the P1 headline requirement is fully satisfied.
+- No IPC, no shared memory, no new Bubbletea event types required. The file is the message.
+- Consistent with the existing `history.json` precedent (ADR 023).
+- External processes (operator, tests, future tools) can read/write the file without engine coordination.
+- `--no-tui` mode gets warnings persistence for free (detectors write the file unconditionally).
+
+**Negative / trade-offs**:
+- The TUI lags up to 1 second behind file changes (bounded by `TickEvent` cadence). For warnings that change at startup frequency, this is imperceptible.
+- A new contributor would expect a Bubbletea model to receive engine events for state updates, not poll a file. This ADR documents why the file-based approach is correct here.
+- The file write on every `Record`/`Clear` adds latency to detector paths. For startup-time detectors (the only current callers), this is acceptable — the file is small and the write is a single atomic rename.
+
+## Alternative Considered
+
+**Shared in-memory state via channel**: The engine could send `WarningEvent` messages to the TUI's program via `tui.Program.Send()`. This eliminates polling but:
+1. Does not persist across restarts.
+2. Requires the TUI to be running when the event fires (auto-upgrade restarts happen headlessly).
+3. Adds coupling between engine and TUI packages.
+The file-backed approach is strictly superior for the auto-upgrade use case.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -369,6 +369,7 @@ func writeGitExclude() {
 		".fabrik/worktrees/",
 		".fabrik/debug/",
 		".fabrik/history.json",
+		".fabrik/warnings.json",
 	}
 
 	existing, _ := os.ReadFile(excludePath)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1715,10 +1715,11 @@ The interactive terminal dashboard is enabled by default when running in a real 
 ### Layout
 
 The TUI shows a compact header with poll status, an In Progress pane showing active
-Claude sessions, a scrollable History pane with completed jobs, and a status bar
-(footer) displaying REST and GraphQL rate limit stats. When the GraphQL budget is
-exhausted or rate-limit-induced probe failures are detected, a prominent red alert
-banner appears immediately below the header with a countdown to when polling resumes.
+Claude sessions, a scrollable History pane with completed jobs, a Warnings panel
+surfacing actionable pre-flight issues (below History), and a status bar (footer)
+displaying REST and GraphQL rate limit stats. When the GraphQL budget is exhausted
+or rate-limit-induced probe failures are detected, a prominent red alert banner
+appears immediately below the header with a countdown to when polling resumes.
 When plugin skills in `.fabrik/plugin/` are outdated relative to the embedded
 defaults, a `[u] skills out of date` badge appears in the header, reminding the
 operator to press `u` to upgrade. When Fabrik detects that the on-disk skills
@@ -1730,15 +1731,18 @@ dialog instead of a simple y/N prompt (see [Customizing Skills](#customizing-ski
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Switch focus between In Progress and History panes |
+| `Tab` | Cycle focus: In Progress → History → Warnings → (repeat) |
 | `Up/Down` or `j/k` | Navigate items within the focused pane |
 | `l` | Open `fabrik watch` for selected issue (live Claude output, stage tabs, PR/CI status) |
-| `enter` | Toggle inline detail panel for the selected item |
+| `enter` | Toggle inline detail panel (History pane); toggle expanded detail (Warnings pane) |
 | `r` | Resume Claude session for selected history item (history pane only, item must not be active) |
 | `Escape` | Close open dialogs; with no dialog open, triggers quit confirmation |
 | `n` / `N` | Cancel quit or clear-all confirmation dialogs |
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
+| `F` | **Fix** selected warning (Warnings pane only) — tears down TUI, runs the fix command in the foreground, re-renders on exit |
+| `D` | **Dismiss / undismiss** selected warning (Warnings pane only) — sticky across restarts; dismissed entries are hidden by default |
+| `S` | **Show / hide dismissed** warnings (Warnings pane only) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
 | `u` | Upgrade plugin skills. When the `[u] skills out of date` badge is shown (embedded changed, no local edits), pressing `u` shows a `y/N` confirmation and applies the upgrade. When the `[u] custom workflow` badge is shown (local edits detected), pressing `u` opens a three-option dialog: **[1] Reconcile** — quits the TUI and prints a Claude Code prompt to stderr for merging customizations; **[2] Overwrite** — prompts you to type `OVERWRITE` to confirm destructive reset; **[3] Cancel** — dismisses the dialog. Active stage invocations pick up new files on next run. |
 | `w` | Wake: reset idle backoff and poll immediately |
@@ -1787,6 +1791,16 @@ cost, and issue title. Status icons:
 | `?` | Stage blocked / awaiting user input |
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
+
+**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no non-dismissed entries, the panel collapses to a single `Warnings: none` line so History retains maximum vertical space.
+
+Tab into the Warnings panel to take action:
+- **F** — run the fix command in the foreground (tears down the TUI, executes, re-renders)
+- **D** — dismiss the selected entry (sticky: survives restarts; dismissed entries are hidden by default)
+- **S** — show/hide dismissed entries
+- **Enter** — expand/collapse the full detail text for the selected entry
+
+Warning entries persist to `.fabrik/warnings.json` and survive auto-upgrade restarts. Dismissed entries are preserved in the file until the underlying condition clears, at which point they are removed entirely.
 
 ### History Persistence
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1713,10 +1713,11 @@ The interactive terminal dashboard is enabled by default when running in a real 
 ### Layout
 
 The TUI shows a compact header with poll status, an In Progress pane showing active
-Claude sessions, a scrollable History pane with completed jobs, and a status bar
-(footer) displaying REST and GraphQL rate limit stats. When the GraphQL budget is
-exhausted or rate-limit-induced probe failures are detected, a prominent red alert
-banner appears immediately below the header with a countdown to when polling resumes.
+Claude sessions, a scrollable History pane with completed jobs, a Warnings panel
+surfacing actionable pre-flight issues (below History), and a status bar (footer)
+displaying REST and GraphQL rate limit stats. When the GraphQL budget is exhausted
+or rate-limit-induced probe failures are detected, a prominent red alert banner
+appears immediately below the header with a countdown to when polling resumes.
 When plugin skills in `.fabrik/plugin/` are outdated relative to the embedded
 defaults, a `[u] skills out of date` badge appears in the header, reminding the
 operator to press `u` to upgrade. When Fabrik detects that the on-disk skills
@@ -1728,15 +1729,18 @@ dialog instead of a simple y/N prompt (see [Customizing Skills](#customizing-ski
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Switch focus between In Progress and History panes |
+| `Tab` | Cycle focus: In Progress → History → Warnings → (repeat) |
 | `Up/Down` or `j/k` | Navigate items within the focused pane |
 | `l` | Open `fabrik watch` for selected issue (live Claude output, stage tabs, PR/CI status) |
-| `enter` | Toggle inline detail panel for the selected item |
+| `enter` | Toggle inline detail panel (History pane); toggle expanded detail (Warnings pane) |
 | `r` | Resume Claude session for selected history item (history pane only, item must not be active) |
 | `Escape` | Close open dialogs; with no dialog open, triggers quit confirmation |
 | `n` / `N` | Cancel quit or clear-all confirmation dialogs |
 | `c` | Delete selected history entry |
 | `C` | Clear all history (with confirmation) |
+| `F` | **Fix** selected warning (Warnings pane only) — tears down TUI, runs the fix command in the foreground, re-renders on exit |
+| `D` | **Dismiss / undismiss** selected warning (Warnings pane only) — sticky across restarts; dismissed entries are hidden by default |
+| `S` | **Show / hide dismissed** warnings (Warnings pane only) |
 | `a` | Open abtop AI session monitor (shows token usage, context window, rate limits for all Claude sessions) |
 | `u` | Upgrade plugin skills. When the `[u] skills out of date` badge is shown (embedded changed, no local edits), pressing `u` shows a `y/N` confirmation and applies the upgrade. When the `[u] custom workflow` badge is shown (local edits detected), pressing `u` opens a three-option dialog: **[1] Reconcile** — quits the TUI and prints a Claude Code prompt to stderr for merging customizations; **[2] Overwrite** — prompts you to type `OVERWRITE` to confirm destructive reset; **[3] Cancel** — dismisses the dialog. Active stage invocations pick up new files on next run. |
 | `w` | Wake: reset idle backoff and poll immediately |
@@ -1785,6 +1789,16 @@ cost, and issue title. Status icons:
 | `?` | Stage blocked / awaiting user input |
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
+
+**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no non-dismissed entries, the panel collapses to a single `Warnings: none` line so History retains maximum vertical space.
+
+Tab into the Warnings panel to take action:
+- **F** — run the fix command in the foreground (tears down the TUI, executes, re-renders)
+- **D** — dismiss the selected entry (sticky: survives restarts; dismissed entries are hidden by default)
+- **S** — show/hide dismissed entries
+- **Enter** — expand/collapse the full detail text for the selected entry
+
+Warning entries persist to `.fabrik/warnings.json` and survive auto-upgrade restarts. Dismissed entries are preserved in the file until the underlying condition clears, at which point they are removed entirely.
 
 ### History Persistence
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -19,6 +19,7 @@ import (
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 	"github.com/handarbeit/fabrik/tui"
+	"github.com/handarbeit/fabrik/warnings"
 )
 
 const idleUpgradeThreshold = 2 // consecutive idle polls before checking for upgrades
@@ -2137,6 +2138,16 @@ func (e *Engine) checkAllowAutoMerge(owner, repo string) {
 		e.logf(0, "startup", "WARNING: %s has allow_auto_merge disabled.\n", key)
 		e.logf(0, "startup", "WARNING: yolo issues on this repo will reach Validate complete but their PRs will not merge.\n")
 		e.logf(0, "startup", "WARNING: Fix: gh api -X PATCH repos/%s -f allow_auto_merge=true\n", key)
+		_ = warnings.Record(warnings.Entry{
+			Key:       "allow_auto_merge:" + key,
+			Type:      "allow_auto_merge",
+			Title:     "allow_auto_merge disabled on " + key,
+			Detail:    fmt.Sprintf("yolo issues on this repo will reach Validate complete but their PRs will not merge.\n\nFix: gh api -X PATCH repos/%s -f allow_auto_merge=true", key),
+			FixAction: "shell_command",
+			FixParams: map[string]string{"cmd": fmt.Sprintf("gh api -X PATCH repos/%s -f allow_auto_merge=true", key)},
+		})
+	} else {
+		_ = warnings.Clear("allow_auto_merge:" + key)
 	}
 }
 

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 	"github.com/handarbeit/fabrik/tui"
+	"github.com/handarbeit/fabrik/warnings"
 )
 
 func TestPoll_FetchesBoardAndProcessesItems(t *testing.T) {
@@ -2808,6 +2809,8 @@ func captureStdout(fn func()) string {
 }
 
 func TestCheckAllowAutoMerge_DisabledEmitsWarning(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	client := &mockGitHubClient{
 		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
 			return false, nil
@@ -2831,6 +2834,8 @@ func TestCheckAllowAutoMerge_DisabledEmitsWarning(t *testing.T) {
 }
 
 func TestCheckAllowAutoMerge_EnabledIsSilent(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	client := &mockGitHubClient{
 		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
 			return true, nil
@@ -2848,6 +2853,8 @@ func TestCheckAllowAutoMerge_EnabledIsSilent(t *testing.T) {
 }
 
 func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	client := &mockGitHubClient{
 		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
 			return false, errors.New("network error")
@@ -2867,6 +2874,8 @@ func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
 }
 
 func TestCheckAllowAutoMerge_DedupSuppressesSecondCall(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	var callCount int
 	client := &mockGitHubClient{
 		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {

--- a/stages/drift.go
+++ b/stages/drift.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/handarbeit/fabrik/warnings"
 	"gopkg.in/yaml.v3"
 )
 
@@ -82,12 +83,24 @@ func warnDriftFrom(userStages []*Stage, version string, w io.Writer, defaults fs
 		}
 
 		missing, err := MissingTopLevelKeys(userStage.FilePath, defaultKeys)
-		if err != nil || len(missing) == 0 {
+		if err != nil {
+			return nil
+		}
+		if len(missing) == 0 {
+			_ = warnings.Clear("stage_drift:" + name)
 			return nil
 		}
 
 		fmt.Fprintf(w, "[startup] warning: %s is missing fields present in %s defaults: %s. Run `fabrik refresh-stages --apply` to add the missing keys.\n",
 			userStage.FilePath, version, strings.Join(missing, ", "))
+		_ = warnings.Record(warnings.Entry{
+			Key:       "stage_drift:" + name,
+			Type:      "stage_drift",
+			Title:     fmt.Sprintf("%s has %d missing field(s)", userStage.FilePath, len(missing)),
+			Detail:    fmt.Sprintf("%s is missing fields present in %s defaults: %s\n\nFix: fabrik refresh-stages --apply", userStage.FilePath, version, strings.Join(missing, ", ")),
+			FixAction: "fabrik_command",
+			FixParams: map[string]string{"args": "refresh-stages --apply"},
+		})
 		return nil
 	})
 }

--- a/stages/drift_test.go
+++ b/stages/drift_test.go
@@ -6,7 +6,16 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/handarbeit/fabrik/warnings"
 )
+
+// setWarningsOverride redirects warnings I/O to a temp file for test isolation.
+func setWarningsOverride(t *testing.T) {
+	t.Helper()
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
+}
 
 // syntheticFS builds an in-memory fs.FS with a single default stage YAML under
 // examples/<name>.yaml for use in drift tests.
@@ -48,6 +57,7 @@ func extractName(t *testing.T, yaml string) string {
 }
 
 func TestWarnStageDrift_MissingKey(t *testing.T) {
+	setWarningsOverride(t)
 	dir := t.TempDir()
 	// User stage is missing "wait_for_ci" which the embedded default has.
 	userStage := makeUserStage(t, dir, "validate.yaml", "name: Validate\nprompt: do stuff\n")
@@ -73,6 +83,7 @@ func TestWarnStageDrift_MissingKey(t *testing.T) {
 }
 
 func TestWarnStageDrift_AllKeysPresent(t *testing.T) {
+	setWarningsOverride(t)
 	dir := t.TempDir()
 	// User stage has all keys that the embedded default has.
 	userStage := makeUserStage(t, dir, "validate.yaml", "name: Validate\nprompt: do stuff\nwait_for_ci: true\n")
@@ -88,6 +99,7 @@ func TestWarnStageDrift_AllKeysPresent(t *testing.T) {
 }
 
 func TestWarnStageDrift_KeyPresentWithNonDefaultValue(t *testing.T) {
+	setWarningsOverride(t)
 	dir := t.TempDir()
 	// User stage has wait_for_ci explicitly set to false — key is present, no warning.
 	userStage := makeUserStage(t, dir, "validate.yaml", "name: Validate\nprompt: do stuff\nwait_for_ci: false\n")
@@ -103,6 +115,7 @@ func TestWarnStageDrift_KeyPresentWithNonDefaultValue(t *testing.T) {
 }
 
 func TestWarnStageDrift_CustomStageSkipped(t *testing.T) {
+	setWarningsOverride(t)
 	dir := t.TempDir()
 	// "Custom" does not appear in the synthetic defaults — should be silently skipped.
 	userStage := makeUserStage(t, dir, "custom.yaml", "name: Custom\nprompt: do custom stuff\n")
@@ -118,6 +131,7 @@ func TestWarnStageDrift_CustomStageSkipped(t *testing.T) {
 }
 
 func TestWarnStageDrift_EmptyUserStages(t *testing.T) {
+	setWarningsOverride(t)
 	defaults := syntheticFS(t, "Validate", "prompt", "wait_for_ci")
 
 	var out strings.Builder
@@ -129,6 +143,7 @@ func TestWarnStageDrift_EmptyUserStages(t *testing.T) {
 }
 
 func TestWarnStageDrift_MultipleMissingKeysSorted(t *testing.T) {
+	setWarningsOverride(t)
 	dir := t.TempDir()
 	// User stage is missing both wait_for_ci and wait_for_reviews.
 	userStage := makeUserStage(t, dir, "validate.yaml", "name: Validate\nprompt: do stuff\n")

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -11,6 +11,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	fabrikplugin "github.com/handarbeit/fabrik/plugin"
+	"github.com/handarbeit/fabrik/warnings"
 )
 
 // pluginUpgradeResultMsg is returned by upgradePluginCmd when RefreshPlugin completes.
@@ -170,6 +171,53 @@ func openAbtopInlineCmd() tea.Cmd {
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return abtopFinishedMsg{Err: err}
 	})
+}
+
+// warningsFixFinishedMsg is returned by tea.ExecProcess when a Warnings-panel fix command exits.
+type warningsFixFinishedMsg struct {
+	Key     string
+	ExitErr error
+}
+
+// runWarningsFixCmd builds a tea.Cmd that tears down the TUI, runs the fix
+// command for the given warnings entry, and delivers warningsFixFinishedMsg
+// when the subprocess exits.
+func runWarningsFixCmd(entry warnings.Entry) tea.Cmd {
+	key := entry.Key
+	switch entry.FixAction {
+	case "shell_command":
+		cmd := exec.Command("sh", "-c", entry.FixParams["cmd"])
+		return tea.ExecProcess(cmd, func(err error) tea.Msg {
+			return warningsFixFinishedMsg{Key: key, ExitErr: err}
+		})
+	case "fabrik_command":
+		fabrikBin, err := os.Executable()
+		if err != nil {
+			fabrikBin = "fabrik"
+		}
+		args := strings.Fields(entry.FixParams["args"])
+		cmd := exec.Command(fabrikBin, args...)
+		return tea.ExecProcess(cmd, func(err error) tea.Msg {
+			return warningsFixFinishedMsg{Key: key, ExitErr: err}
+		})
+	case "claude_code_session":
+		if _, err := exec.LookPath("claude"); err != nil {
+			return func() tea.Msg {
+				return warningsFixFinishedMsg{Key: key, ExitErr: fmt.Errorf("claude not found in PATH: install Claude Code to use this fix")}
+			}
+		}
+		cmd := exec.Command("claude", "--system-prompt", entry.FixParams["system_prompt"])
+		if cwd := entry.FixParams["cwd"]; cwd != "" {
+			cmd.Dir = cwd
+		}
+		return tea.ExecProcess(cmd, func(err error) tea.Msg {
+			return warningsFixFinishedMsg{Key: key, ExitErr: err}
+		})
+	default:
+		return func() tea.Msg {
+			return warningsFixFinishedMsg{Key: key, ExitErr: fmt.Errorf("unknown fix_action: %q", entry.FixAction)}
+		}
+	}
 }
 
 // worktreePathForIssue returns the absolute path to the issue's git worktree.

--- a/tui/help.go
+++ b/tui/help.go
@@ -16,9 +16,9 @@ var helpContent = strings.TrimSpace(`
 KEYBOARD SHORTCUTS
 
   Navigation
-    tab        Switch focus: In Progress <-> History
+    tab        Switch focus: In Progress → History → Warnings → (repeat)
     ↑/↓  k/j  Navigate items in the focused pane
-    enter      Toggle inline detail panel
+    enter      Toggle inline detail panel (History); toggle detail (Warnings)
     esc        Close open panels; with none open, triggers quit confirmation
     n / N      Cancel quit or clear-all confirmation
 
@@ -31,6 +31,12 @@ KEYBOARD SHORTCUTS
     r          Resume Claude session for selected history entry
     c          Delete selected history entry
     C          Clear all history (with confirmation)
+
+  Warnings pane
+    F          Fix selected warning (runs fix command in foreground)
+    D          Dismiss / undismiss selected warning (sticky across restarts)
+    S          Show / hide dismissed warnings
+    enter      Toggle expanded detail for selected warning
 
   Global
     a          Open abtop AI session monitor

--- a/tui/model.go
+++ b/tui/model.go
@@ -735,9 +735,10 @@ func (m *Model) updateLayout(scrollToTop bool) {
 		helpH = m.help.Height()
 	}
 
-	warningsH := m.warnings.Height()
+	available := max(totalAvail-helpH, 0)
+	warningsH := min(m.warnings.Height(), available)
 	m.warnings.SetLayout(m.width, warningsH)
-	availableHistoryH := max(totalAvail-helpH-warningsH, 0)
+	availableHistoryH := max(available-warningsH, 0)
 	m.history.SetLayout(m.width, availableHistoryH, m.confirmQuit, m.active.ActiveCount())
 	if scrollToTop {
 		m.history.ScrollToTop()

--- a/tui/model.go
+++ b/tui/model.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/handarbeit/fabrik/warnings"
 )
 
 // HistoryEntry records a completed job for the history pane.
@@ -348,9 +349,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "tab":
-			if m.focusPane == paneActive {
+			switch m.focusPane {
+			case paneActive:
 				m.focusPane = paneHistory
-			} else {
+			case paneHistory:
+				m.focusPane = paneWarnings
+			default:
 				m.focusPane = paneActive
 			}
 			m.syncFocus()
@@ -358,8 +362,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 
 		case "enter":
+			if m.focusPane == paneWarnings {
+				comp, cmd := m.warnings.Update(msg)
+				m.warnings = comp.(WarningsPaneComponent)
+				m.updateLayout(false)
+				return m, cmd
+			}
 			m.detailPanel = !m.detailPanel
 			m.updateLayout(false)
+			return m, nil
+
+		case "f", "F":
+			if m.focusPane == paneWarnings {
+				if entry := m.warnings.SelectedEntry(); entry != nil {
+					return m, runWarningsFixCmd(*entry)
+				}
+			}
+			return m, nil
+
+		case "d", "D":
+			if m.focusPane == paneWarnings {
+				comp, cmd := m.warnings.Update(msg)
+				m.warnings = comp.(WarningsPaneComponent)
+				m.updateLayout(false)
+				return m, cmd
+			}
+			return m, nil
+
+		case "s", "S":
+			if m.focusPane == paneWarnings {
+				comp, cmd := m.warnings.Update(msg)
+				m.warnings = comp.(WarningsPaneComponent)
+				m.updateLayout(false)
+				return m, cmd
+			}
 			return m, nil
 
 		case "r":
@@ -475,6 +511,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.active = comp.(ActivePaneComponent)
 				return m, cmd
 			}
+			if m.focusPane == paneWarnings {
+				comp, cmd := m.warnings.Update(msg)
+				m.warnings = comp.(WarningsPaneComponent)
+				m.updateLayout(false)
+				return m, cmd
+			}
 			comp, cmd := m.history.Update(msg)
 			m.history = comp.(HistoryPaneComponent)
 			m.updateLayout(false)
@@ -539,6 +581,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.alert = comp.(AlertBannerComponent)
 		comp, _ = m.footer.Update(msg)
 		m.footer = comp.(FooterComponent)
+		wcomp, _ := m.warnings.Update(msg)
+		m.warnings = wcomp.(WarningsPaneComponent)
+		m.updateLayout(false)
 		return m, tickCmd()
 
 	case ProjectMetaEvent:
@@ -638,6 +683,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case warningsFixFinishedMsg:
+		if ev.ExitErr != nil {
+			// Append error excerpt to entry detail so operator can see what failed.
+			if entries, err := warnings.Load(); err == nil {
+				for _, e := range entries {
+					if e.Key == ev.Key {
+						e.Detail += "\n\n[Fix failed]: " + ev.ExitErr.Error()
+						_ = warnings.Record(e)
+						break
+					}
+				}
+			}
+			m.header.SetStatusMsg("fix failed: " + ev.ExitErr.Error())
+		} else {
+			_ = warnings.Clear(ev.Key)
+			m.header.SetStatusMsg("fix applied")
+		}
+		m.updateLayout(false)
+		return m, nil
+
 	}
 
 	return m, nil
@@ -647,6 +712,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) syncFocus() {
 	m.active.SetFocused(m.focusPane == paneActive)
 	m.history.SetFocused(m.focusPane == paneHistory)
+	m.warnings.SetFocused(m.focusPane == paneWarnings)
 }
 
 // updateLayout recomputes the history and help viewport dimensions and content.
@@ -669,7 +735,9 @@ func (m *Model) updateLayout(scrollToTop bool) {
 		helpH = m.help.Height()
 	}
 
-	availableHistoryH := max(totalAvail-helpH, 0)
+	warningsH := m.warnings.Height()
+	m.warnings.SetLayout(m.width, warningsH)
+	availableHistoryH := max(totalAvail-helpH-warningsH, 0)
 	m.history.SetLayout(m.width, availableHistoryH, m.confirmQuit, m.active.ActiveCount())
 	if scrollToTop {
 		m.history.ScrollToTop()
@@ -745,6 +813,9 @@ func (m Model) View() string {
 
 	if histView := m.history.View(m.width); histView != "" {
 		sections = append(sections, histView)
+	}
+	if warningsView := m.warnings.View(m.width); warningsView != "" {
+		sections = append(sections, warningsView)
 	}
 	sections = append(sections, m.footer.View(m.width))
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -75,6 +75,7 @@ type pane int
 const (
 	paneActive pane = iota
 	paneHistory
+	paneWarnings
 )
 
 // ProjectInfo holds display metadata about the monitored project shown in the footer.
@@ -111,13 +112,14 @@ type Model struct {
 	wakeCh chan<- struct{}
 
 	// components
-	header  HeaderComponent
-	alert   AlertBannerComponent
-	active  ActivePaneComponent
-	history HistoryPaneComponent
-	detail  DetailPanelComponent
-	help    HelpPanelComponent
-	footer  FooterComponent
+	header   HeaderComponent
+	alert    AlertBannerComponent
+	active   ActivePaneComponent
+	history  HistoryPaneComponent
+	warnings WarningsPaneComponent
+	detail   DetailPanelComponent
+	help     HelpPanelComponent
+	footer   FooterComponent
 }
 
 // minHistoryRows is the minimum number of rows reserved for the history pane
@@ -165,8 +167,9 @@ func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct
 			customWorkflow:   customWorkflow,
 		},
 		alert:   AlertBannerComponent{now: now},
-		active:  active,
-		history: NewHistoryPaneComponent(info.Repo),
+		active:   active,
+		history:  NewHistoryPaneComponent(info.Repo),
+		warnings: NewWarningsPaneComponent(),
 		footer: FooterComponent{
 			projectInfo: info,
 			now:         now,

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -97,7 +97,7 @@ func TestUpdate_QuitKey(t *testing.T) {
 	}
 }
 
-// TestUpdate_TabKey_SwitchesPanes verifies tab toggles focus between panes.
+// TestUpdate_TabKey_SwitchesPanes verifies tab cycles through all three panes.
 func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
 	m := New(30, ProjectInfo{}, "", nil, 0, false)
 	m.width = 80
@@ -108,15 +108,20 @@ func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	nm := next.(Model)
 	if nm.focusPane != paneHistory {
-		t.Error("expected pane to switch to history after tab")
+		t.Error("expected pane to switch to history after first tab")
 	}
 	if cmd != nil {
 		t.Error("expected nil cmd from tab")
 	}
 	next2, _ := nm.Update(tea.KeyMsg{Type: tea.KeyTab})
 	nm2 := next2.(Model)
-	if nm2.focusPane != paneActive {
-		t.Error("expected pane to switch back to active after second tab")
+	if nm2.focusPane != paneWarnings {
+		t.Error("expected pane to switch to warnings after second tab")
+	}
+	next3, _ := nm2.Update(tea.KeyMsg{Type: tea.KeyTab})
+	nm3 := next3.(Model)
+	if nm3.focusPane != paneActive {
+		t.Error("expected pane to switch back to active after third tab")
 	}
 }
 

--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -1,0 +1,292 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/handarbeit/fabrik/warnings"
+)
+
+const maxWarningRows = 3
+const maxDetailLines = 10
+
+// WarningsPaneComponent renders the persistent pre-flight warnings panel.
+type WarningsPaneComponent struct {
+	entries        []warnings.Entry
+	curIdx         int
+	showDismissed  bool
+	expandedDetail bool
+	focused        bool
+	lastMtime      time.Time
+	width          int
+}
+
+// NewWarningsPaneComponent creates a WarningsPaneComponent loaded from disk.
+func NewWarningsPaneComponent() WarningsPaneComponent {
+	c := WarningsPaneComponent{}
+	entries, err := warnings.Load()
+	if err != nil {
+		// Corrupt file — treat as empty, errors are logged by Load's caller.
+		entries = nil
+	}
+	c.entries = entries
+	if info, err := os.Stat(warnings.Path()); err == nil {
+		c.lastMtime = info.ModTime()
+	}
+	return c
+}
+
+// Update handles messages for the warnings pane.
+func (c WarningsPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case TickEvent:
+		info, err := os.Stat(warnings.Path())
+		if err != nil {
+			// File disappeared — treat as empty.
+			if len(c.entries) > 0 {
+				c.entries = nil
+				c.curIdx = 0
+			}
+			break
+		}
+		if info.ModTime().After(c.lastMtime) {
+			c.lastMtime = info.ModTime()
+			entries, loadErr := warnings.Load()
+			if loadErr == nil {
+				c.entries = entries
+			}
+			// Clamp curIdx after reload.
+			visible := c.visibleEntries()
+			if c.curIdx >= len(visible) && c.curIdx > 0 {
+				c.curIdx = max(len(visible)-1, 0)
+			}
+		}
+
+	case tea.KeyMsg:
+		if !c.focused {
+			break
+		}
+		visible := c.visibleEntries()
+		switch ev.String() {
+		case "up", "k":
+			if c.curIdx > 0 {
+				c.curIdx--
+				c.expandedDetail = false
+			}
+		case "down", "j":
+			if c.curIdx < len(visible)-1 {
+				c.curIdx++
+				c.expandedDetail = false
+			}
+		case "d", "D":
+			if entry := c.currentVisible(); entry != nil {
+				if entry.Dismissed {
+					_ = warnings.Undismiss(entry.Key)
+				} else {
+					_ = warnings.Dismiss(entry.Key)
+				}
+				// Reload to reflect the change.
+				if entries, err := warnings.Load(); err == nil {
+					c.entries = entries
+				}
+				visible = c.visibleEntries()
+				if c.curIdx >= len(visible) && c.curIdx > 0 {
+					c.curIdx = max(len(visible)-1, 0)
+				}
+			}
+		case "s", "S":
+			c.showDismissed = !c.showDismissed
+			visible = c.visibleEntries()
+			if c.curIdx >= len(visible) && c.curIdx > 0 {
+				c.curIdx = max(len(visible)-1, 0)
+			}
+		case "enter":
+			if len(visible) > 0 {
+				c.expandedDetail = !c.expandedDetail
+			}
+		}
+	}
+	return c, nil
+}
+
+// visibleEntries returns entries to show based on showDismissed flag.
+func (c WarningsPaneComponent) visibleEntries() []warnings.Entry {
+	if c.showDismissed {
+		return c.entries
+	}
+	out := make([]warnings.Entry, 0, len(c.entries))
+	for _, e := range c.entries {
+		if !e.Dismissed {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// currentVisible returns the currently selected visible entry, or nil.
+func (c WarningsPaneComponent) currentVisible() *warnings.Entry {
+	visible := c.visibleEntries()
+	if len(visible) == 0 || c.curIdx >= len(visible) {
+		return nil
+	}
+	return &visible[c.curIdx]
+}
+
+// SelectedEntry returns the currently selected entry, or nil if none.
+func (c WarningsPaneComponent) SelectedEntry() *warnings.Entry {
+	return c.currentVisible()
+}
+
+// SetFocused updates the focused state.
+func (c *WarningsPaneComponent) SetFocused(f bool) {
+	c.focused = f
+}
+
+// SetLayout updates the available width.
+func (c *WarningsPaneComponent) SetLayout(width, availableH int) {
+	c.width = width
+}
+
+// Height returns the rendered height of the warnings panel.
+func (c WarningsPaneComponent) Height() int {
+	visible := c.visibleEntries()
+	if len(visible) == 0 {
+		return 1
+	}
+	rows := min(len(visible), maxWarningRows)
+	h := 2 + 1 + rows // border (2) + title line (1) + entry rows
+	if c.expandedDetail {
+		entry := c.currentVisible()
+		if entry != nil {
+			detailLines := strings.Count(entry.Detail, "\n") + 1
+			if detailLines > maxDetailLines {
+				detailLines = maxDetailLines
+			}
+			h += detailLines + 1 // +1 for separator line
+		}
+	}
+	return h
+}
+
+// View renders the warnings panel.
+func (c WarningsPaneComponent) View(width int) string {
+	if width == 0 {
+		width = c.width
+	}
+	if width == 0 {
+		width = 80
+	}
+	visible := c.visibleEntries()
+
+	if len(visible) == 0 {
+		// Count dismissed entries for the footer hint.
+		dismissedCount := 0
+		for _, e := range c.entries {
+			if e.Dismissed {
+				dismissedCount++
+			}
+		}
+		msg := "  Warnings: none"
+		if dismissedCount > 0 {
+			msg = fmt.Sprintf("  Warnings: none (%d dismissed, press tab + S to show)", dismissedCount)
+		}
+		return dimStyle.Render(msg)
+	}
+
+	innerWidth := max(width-6, 20)
+	focusIndicator := " "
+	if c.focused {
+		focusIndicator = "▸"
+	}
+
+	// Header colour based on non-dismissed count.
+	nonDismissedCount := 0
+	for _, e := range c.entries {
+		if !e.Dismissed {
+			nonDismissedCount++
+		}
+	}
+	var headerStyle lipgloss.Style
+	switch {
+	case nonDismissedCount >= 3:
+		headerStyle = failStyle
+	case nonDismissedCount >= 1:
+		headerStyle = activeStyle
+	default:
+		headerStyle = dimStyle
+	}
+
+	titleText := fmt.Sprintf("%s Warnings (%d)", focusIndicator, nonDismissedCount)
+	dismissedHint := ""
+	dismissedCount := 0
+	for _, e := range c.entries {
+		if e.Dismissed {
+			dismissedCount++
+		}
+	}
+	if dismissedCount > 0 && !c.showDismissed {
+		dismissedHint = dimStyle.Render(fmt.Sprintf("  %d dismissed [S to show]", dismissedCount))
+	} else if c.showDismissed && dismissedCount > 0 {
+		dismissedHint = dimStyle.Render("  [S to hide dismissed]")
+	}
+	var focusHint string
+	if c.focused {
+		focusHint = dimStyle.Render("  [F]ix  [D]ismiss  [enter] detail")
+	}
+	title := headerStyle.Render(titleText) + dismissedHint + focusHint
+
+	var lines []string
+	lines = append(lines, title)
+
+	displayRows := min(len(visible), maxWarningRows)
+	for i := 0; i < displayRows; i++ {
+		e := visible[i]
+		prefix := "  "
+		if c.focused && i == c.curIdx {
+			prefix = "▸ "
+		}
+		titleText := e.Title
+		// Truncate title before applying styles so ANSI codes don't bloat visible length.
+		maxTitleRunes := innerWidth - len([]rune(prefix)) - 3
+		if maxTitleRunes < 5 {
+			maxTitleRunes = 5
+		}
+		if runes := []rune(titleText); len(runes) > maxTitleRunes {
+			titleText = string(runes[:maxTitleRunes]) + "…"
+		}
+		var label string
+		if e.Dismissed {
+			label = dimStyle.Render(prefix + "✓ " + titleText + " (dismissed)")
+		} else {
+			line := prefix + titleText
+			if c.focused && i == c.curIdx {
+				label = selectedStyle.Render(line)
+			} else {
+				label = line
+			}
+		}
+		lines = append(lines, label)
+	}
+
+	// Expanded detail for the selected entry.
+	if c.expandedDetail {
+		entry := c.currentVisible()
+		if entry != nil {
+			lines = append(lines, dimStyle.Render(strings.Repeat("─", innerWidth)))
+			detailLines := strings.Split(entry.Detail, "\n")
+			if len(detailLines) > maxDetailLines {
+				detailLines = detailLines[:maxDetailLines]
+			}
+			for _, dl := range detailLines {
+				lines = append(lines, dimStyle.Render("  "+dl))
+			}
+		}
+	}
+
+	content := strings.Join(lines, "\n")
+	return borderStyle.Width(width - 4).Render(content)
+}

--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -23,11 +23,15 @@ type WarningsPaneComponent struct {
 	focused        bool
 	lastMtime      time.Time
 	width          int
+	// availableH is the vertical space allocated by updateLayout.
+	// -1 means SetLayout has not been called yet.
+	// 0 means no space available (View returns "", Height returns 0).
+	availableH int
 }
 
 // NewWarningsPaneComponent creates a WarningsPaneComponent loaded from disk.
 func NewWarningsPaneComponent() WarningsPaneComponent {
-	c := WarningsPaneComponent{}
+	c := WarningsPaneComponent{availableH: -1}
 	entries, err := warnings.Load()
 	if err != nil {
 		// Corrupt file — treat as empty, errors are logged by Load's caller.
@@ -146,13 +150,17 @@ func (c *WarningsPaneComponent) SetFocused(f bool) {
 	c.focused = f
 }
 
-// SetLayout updates the available width.
+// SetLayout updates the available width and height.
 func (c *WarningsPaneComponent) SetLayout(width, availableH int) {
 	c.width = width
+	c.availableH = availableH
 }
 
 // Height returns the rendered height of the warnings panel.
 func (c WarningsPaneComponent) Height() int {
+	if c.availableH == 0 {
+		return 0
+	}
 	visible := c.visibleEntries()
 	if len(visible) == 0 {
 		return 1
@@ -174,6 +182,9 @@ func (c WarningsPaneComponent) Height() int {
 
 // View renders the warnings panel.
 func (c WarningsPaneComponent) View(width int) string {
+	if c.availableH == 0 {
+		return ""
+	}
 	if width == 0 {
 		width = c.width
 	}

--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -50,11 +50,13 @@ func (c WarningsPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 	case TickEvent:
 		info, err := os.Stat(warnings.Path())
 		if err != nil {
-			// File disappeared — treat as empty.
+			// File disappeared — treat as empty and reset mtime so a
+			// recreated file with any timestamp is detected on next tick.
 			if len(c.entries) > 0 {
 				c.entries = nil
 				c.curIdx = 0
 			}
+			c.lastMtime = time.Time{}
 			break
 		}
 		if info.ModTime().After(c.lastMtime) {
@@ -299,5 +301,12 @@ func (c WarningsPaneComponent) View(width int) string {
 	}
 
 	content := strings.Join(lines, "\n")
-	return borderStyle.Width(width - 4).Render(content)
+	rendered := borderStyle.Width(width - 4).Render(content)
+	if c.availableH > 0 {
+		rLines := strings.Split(rendered, "\n")
+		if len(rLines) > c.availableH {
+			return strings.Join(rLines[:c.availableH], "\n")
+		}
+	}
+	return rendered
 }

--- a/warnings/warnings.go
+++ b/warnings/warnings.go
@@ -1,0 +1,185 @@
+package warnings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// WarningsPathOverride can be set by tests to redirect I/O to a temp file.
+var WarningsPathOverride string
+
+var mu sync.Mutex
+
+// Entry is a single actionable warning surfaced in the TUI Warnings panel.
+type Entry struct {
+	Key       string            `json:"key"`
+	Type      string            `json:"type"`
+	Title     string            `json:"title"`
+	Detail    string            `json:"detail"`
+	FixAction string            `json:"fix_action"`
+	FixParams map[string]string `json:"fix_params,omitempty"`
+	FirstSeen time.Time         `json:"first_seen"`
+	LastSeen  time.Time         `json:"last_seen"`
+	Dismissed bool              `json:"dismissed"`
+}
+
+type warningsFile struct {
+	Version int     `json:"version"`
+	Entries []Entry `json:"entries"`
+}
+
+const currentVersion = 1
+
+func warningsPath() string {
+	if WarningsPathOverride != "" {
+		return WarningsPathOverride
+	}
+	return filepath.Join(".fabrik", "warnings.json")
+}
+
+// load reads and parses the warnings file. Missing file returns empty file, nil.
+// Corrupt or version-mismatch returns empty file, err.
+func load() (warningsFile, error) {
+	data, err := os.ReadFile(warningsPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return warningsFile{Version: currentVersion}, nil
+		}
+		return warningsFile{}, fmt.Errorf("reading warnings file: %w", err)
+	}
+	var wf warningsFile
+	if err := json.Unmarshal(data, &wf); err != nil {
+		return warningsFile{}, fmt.Errorf("parsing warnings file: %w", err)
+	}
+	if wf.Version != currentVersion {
+		return warningsFile{}, fmt.Errorf("warnings file version %d not supported (expected %d)", wf.Version, currentVersion)
+	}
+	return wf, nil
+}
+
+// save writes the warningsFile atomically via temp-file-then-rename.
+func save(wf warningsFile) error {
+	wf.Version = currentVersion
+	data, err := json.MarshalIndent(wf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling warnings: %w", err)
+	}
+	p := warningsPath()
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		return fmt.Errorf("creating warnings dir: %w", err)
+	}
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("writing warnings tmp: %w", err)
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		return fmt.Errorf("renaming warnings tmp: %w", err)
+	}
+	return nil
+}
+
+// Load reads the current warnings entries. Missing file returns nil, nil.
+// Corrupt or version-mismatch file returns nil, err.
+func Load() ([]Entry, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	wf, err := load()
+	if err != nil {
+		return nil, err
+	}
+	if len(wf.Entries) == 0 {
+		return nil, nil
+	}
+	out := make([]Entry, len(wf.Entries))
+	copy(out, wf.Entries)
+	return out, nil
+}
+
+// Record upserts an entry. For new keys: sets first_seen=now, last_seen=now,
+// dismissed=false. For existing keys: preserves first_seen and dismissed;
+// updates detail and last_seen.
+func Record(entry Entry) error {
+	mu.Lock()
+	defer mu.Unlock()
+	wf, err := load()
+	if err != nil {
+		// On parse error treat as empty so we can still write the new entry.
+		wf = warningsFile{Version: currentVersion}
+	}
+	now := time.Now().UTC()
+	found := false
+	for i, e := range wf.Entries {
+		if e.Key == entry.Key {
+			wf.Entries[i].Title = entry.Title
+			wf.Entries[i].Detail = entry.Detail
+			wf.Entries[i].LastSeen = now
+			// Preserve first_seen and dismissed.
+			found = true
+			break
+		}
+	}
+	if !found {
+		entry.FirstSeen = now
+		entry.LastSeen = now
+		entry.Dismissed = false
+		wf.Entries = append(wf.Entries, entry)
+	}
+	return save(wf)
+}
+
+// Clear removes an entry by key regardless of its dismissed state.
+func Clear(key string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	wf, err := load()
+	if err != nil {
+		return err
+	}
+	filtered := wf.Entries[:0]
+	for _, e := range wf.Entries {
+		if e.Key != key {
+			filtered = append(filtered, e)
+		}
+	}
+	wf.Entries = filtered
+	return save(wf)
+}
+
+// Dismiss sets dismissed=true for the entry with the given key.
+func Dismiss(key string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	wf, err := load()
+	if err != nil {
+		return err
+	}
+	for i, e := range wf.Entries {
+		if e.Key == key {
+			wf.Entries[i].Dismissed = true
+			return save(wf)
+		}
+	}
+	return nil
+}
+
+// Undismiss sets dismissed=false for the entry with the given key.
+func Undismiss(key string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	wf, err := load()
+	if err != nil {
+		return err
+	}
+	for i, e := range wf.Entries {
+		if e.Key == key {
+			wf.Entries[i].Dismissed = false
+			return save(wf)
+		}
+	}
+	return nil
+}

--- a/warnings/warnings.go
+++ b/warnings/warnings.go
@@ -42,6 +42,11 @@ func warningsPath() string {
 	return filepath.Join(".fabrik", "warnings.json")
 }
 
+// Path returns the resolved warnings file path. Used by the TUI for mtime polling.
+func Path() string {
+	return warningsPath()
+}
+
 // load reads and parses the warnings file. Missing file returns empty file, nil.
 // Corrupt or version-mismatch returns empty file, err.
 func load() (warningsFile, error) {

--- a/warnings/warnings.go
+++ b/warnings/warnings.go
@@ -120,10 +120,10 @@ func Record(entry Entry) error {
 	found := false
 	for i, e := range wf.Entries {
 		if e.Key == entry.Key {
-			wf.Entries[i].Title = entry.Title
-			wf.Entries[i].Detail = entry.Detail
-			wf.Entries[i].LastSeen = now
-			// Preserve first_seen and dismissed.
+			entry.FirstSeen = e.FirstSeen
+			entry.Dismissed = e.Dismissed
+			entry.LastSeen = now
+			wf.Entries[i] = entry
 			found = true
 			break
 		}

--- a/warnings/warnings_test.go
+++ b/warnings/warnings_test.go
@@ -1,0 +1,233 @@
+package warnings
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func setOverride(t *testing.T) {
+	t.Helper()
+	WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { WarningsPathOverride = "" })
+}
+
+func TestRecord_NewEntry(t *testing.T) {
+	setOverride(t)
+	before := time.Now().UTC().Add(-time.Second)
+	entry := Entry{
+		Key:       "allow_auto_merge:owner/repo",
+		Type:      "allow_auto_merge",
+		Title:     "allow_auto_merge disabled on owner/repo",
+		Detail:    "fix: gh api ...",
+		FixAction: "shell_command",
+		FixParams: map[string]string{"cmd": "gh api -X PATCH repos/owner/repo -f allow_auto_merge=true"},
+	}
+	if err := Record(entry); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Key != entry.Key {
+		t.Errorf("key = %q, want %q", e.Key, entry.Key)
+	}
+	if e.Dismissed {
+		t.Errorf("dismissed should be false for new entry")
+	}
+	if e.FirstSeen.Before(before) {
+		t.Errorf("first_seen too early")
+	}
+	if e.LastSeen.Before(before) {
+		t.Errorf("last_seen too early")
+	}
+}
+
+func TestRecord_Upsert_PreservesFirstSeenAndDismissed(t *testing.T) {
+	setOverride(t)
+	entry := Entry{
+		Key:    "allow_auto_merge:owner/repo",
+		Type:   "allow_auto_merge",
+		Title:  "title v1",
+		Detail: "detail v1",
+	}
+	if err := Record(entry); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	// Dismiss it.
+	if err := Dismiss(entry.Key); err != nil {
+		t.Fatalf("Dismiss: %v", err)
+	}
+	entries, _ := Load()
+	firstSeen := entries[0].FirstSeen
+
+	// Wait a moment then re-record with updated detail.
+	time.Sleep(10 * time.Millisecond)
+	entry.Title = "title v2"
+	entry.Detail = "detail v2"
+	if err := Record(entry); err != nil {
+		t.Fatalf("Record upsert: %v", err)
+	}
+
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if !e.FirstSeen.Equal(firstSeen) {
+		t.Errorf("first_seen changed: got %v, want %v", e.FirstSeen, firstSeen)
+	}
+	if !e.Dismissed {
+		t.Errorf("dismissed should be preserved (true)")
+	}
+	if e.Title != "title v2" {
+		t.Errorf("title not updated: got %q", e.Title)
+	}
+	if e.Detail != "detail v2" {
+		t.Errorf("detail not updated: got %q", e.Detail)
+	}
+	if !e.LastSeen.After(firstSeen) {
+		t.Errorf("last_seen not updated")
+	}
+}
+
+func TestClear_RemovesEntry(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "k1", Type: "allow_auto_merge", Title: "K1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Record(Entry{Key: "k2", Type: "stage_drift", Title: "K2"}); err != nil {
+		t.Fatal(err)
+	}
+	// Dismiss k1 — Clear should still remove it.
+	if err := Dismiss("k1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Clear("k1"); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	entries, _ := Load()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry after clear, got %d", len(entries))
+	}
+	if entries[0].Key != "k2" {
+		t.Errorf("expected k2 remaining, got %q", entries[0].Key)
+	}
+}
+
+func TestDismiss_SetsDismissed(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "k1", Type: "allow_auto_merge", Title: "K1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Dismiss("k1"); err != nil {
+		t.Fatalf("Dismiss: %v", err)
+	}
+	entries, _ := Load()
+	if len(entries) != 1 || !entries[0].Dismissed {
+		t.Errorf("expected dismissed=true, got entries=%v", entries)
+	}
+}
+
+func TestUndismiss_ClearsDismissed(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "k1", Type: "allow_auto_merge", Title: "K1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Dismiss("k1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Undismiss("k1"); err != nil {
+		t.Fatalf("Undismiss: %v", err)
+	}
+	entries, _ := Load()
+	if len(entries) != 1 || entries[0].Dismissed {
+		t.Errorf("expected dismissed=false after undismiss, got %v", entries)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	setOverride(t)
+	// File doesn't exist yet.
+	entries, err := Load()
+	if err != nil {
+		t.Errorf("expected nil error for missing file, got %v", err)
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries for missing file, got %v", entries)
+	}
+}
+
+func TestLoad_CorruptFile(t *testing.T) {
+	setOverride(t)
+	path := WarningsPathOverride
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not valid json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := Load()
+	if err == nil {
+		t.Errorf("expected error for corrupt file, got nil")
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries for corrupt file")
+	}
+}
+
+func TestLoad_VersionMismatch(t *testing.T) {
+	setOverride(t)
+	path := WarningsPathOverride
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	wf := warningsFile{Version: 99, Entries: nil}
+	data, _ := json.Marshal(wf)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := Load()
+	if err == nil {
+		t.Errorf("expected error for version mismatch, got nil")
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries for version mismatch")
+	}
+}
+
+func TestConcurrentRecord(t *testing.T) {
+	setOverride(t)
+	var wg sync.WaitGroup
+	keys := []string{"key-a", "key-b", "key-c", "key-d"}
+	for _, k := range keys {
+		k := k
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				_ = Record(Entry{Key: k, Type: "allow_auto_merge", Title: k})
+			}
+		}()
+	}
+	wg.Wait()
+
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load after concurrent writes: %v", err)
+	}
+	if len(entries) != len(keys) {
+		t.Errorf("expected %d entries, got %d: %v", len(keys), len(entries), entries)
+	}
+}


### PR DESCRIPTION
Closes #843

## Summary

Implements a file-backed persistent warnings panel at the bottom of the TUI that surfaces pre-flight warnings (allow_auto_merge disabled, stage-config drift) and survives auto-upgrade restarts. Warnings are written to `.fabrik/warnings.json` and the TUI polls mtime at 1-second cadence.

## Key Changes

**New `warnings/` package** (`warnings/warnings.go`, `warnings/warnings_test.go`):
- `Entry` type with Key, Type, Title, Detail, FixAction, FixParams, FirstSeen, LastSeen, Dismissed fields
- `Record(entry)` — upsert that preserves `first_seen` and `dismissed` on re-record
- `Clear(key)` — removes regardless of dismissed state
- `Load()`, `Dismiss(key)`, `Undismiss(key)`
- Atomic write via temp-file-then-rename, protected by package-level `sync.Mutex`
- `WarningsPathOverride` for test isolation

**Detector integration**:
- `stages/drift.go`: `warnDriftFrom` now calls `warnings.Record` for drifted stages and `warnings.Clear` for clean ones. The compound `err != nil || len(missing) == 0` guard is split so `Clear` only fires on actual no-drift, not read errors.
- `engine/poll.go`: `checkAllowAutoMerge` calls `warnings.Record` when disabled, `warnings.Clear` when enabled.

**New `tui/warnings.go` — `WarningsPaneComponent`**:
- Tab-navigable (Active → History → Warnings → Active, three-way cycle, FR-006)
- ↑/↓/k/j navigation, Enter expands detail inline, D dismisses/undismisses, S toggles show-dismissed
- Header colour: dim=0 entries, yellow=1–2, red=3+ (FR-010)
- Collapses to 1 dim line "Warnings: none" when no active entries, freeing vertical space for History (FR-005)
- `availableH` guard: returns empty string and height 0 when layout allocates no space (prevents overflow on small terminals)

**TUI model wiring** (`tui/model.go`, `tui/commands.go`):
- `warningsFixFinishedMsg` + `runWarningsFixCmd` dispatches all three fix flavors via `tea.ExecProcess` (ADR-015): `shell_command`, `fabrik_command`, `claude_code_session` with `exec.LookPath("claude")` preflight
- On fix exit-0: `warnings.Clear(key)` + status message; on non-zero: error appended to entry detail (FR-009, D1)
- `updateLayout` clips `warningsH` to available space before allocating remainder to History

**Docs and housekeeping**:
- `tui/help.go` and `docs/USER_GUIDE.md` updated with Warnings panel keyboard shortcuts
- `docs/llms-full.txt` regenerated
- `.fabrik/warnings.json` added to `.gitignore` and `writeGitExclude`
- `adrs/052-warnings-file-backed-panel-state.md` documents the file-backed-vs-event-channel decision
- All drift and allow_auto_merge tests updated with `WarningsPathOverride` for isolation

## How to Test

1. **File persistence**: Run Fabrik with `allow_auto_merge=false` on a managed repo; confirm `.fabrik/warnings.json` is written with the entry. Stop and restart with the same condition; confirm `first_seen` is preserved and `last_seen` is updated.

2. **TUI rendering**: Open the TUI with entries present; confirm Warnings panel appears below History with yellow/red header. Press Tab twice to focus Warnings; use ↑/↓ to navigate, Enter to expand detail, D to dismiss. Confirm dismissed entry hides and footer shows "N dismissed [S to show]".

3. **Fix flow**: With an `allow_auto_merge` entry focused, press F; confirm TUI tears down, `gh api` runs, TUI resumes. On success the entry is gone.

4. **Small terminal**: Resize to <10 lines; confirm TUI doesn't overflow (Warnings collapses gracefully).

5. **go test -race ./...**: All packages pass. (`TestExecute_ConfigYAMLApplied` in `cmd/` is a pre-existing SIGINT-timing flake that fails identically on `main`.)