### PR TITLE
fix(watch): multi-repo worktree path, closed-issue resume, and two-zone status bar

### DIFF
--- a/watch/model.go
+++ b/watch/model.go
@@ -269,10 +269,16 @@ func sessionDir(owner, repo string, issueNumber int) string {
 	return filepath.Join(cwd, ".fabrik", "sessions", owner+"-"+repo, issuePart)
 }
 
-// worktreeDir returns .fabrik/worktrees/issue-N relative to CWD.
-func worktreeDir(issueNumber int) string {
+// worktreeDir returns .fabrik/worktrees/[<owner>-<repo>/]issue-N relative to CWD.
+// When owner and repo are both non-empty it produces the multi-repo-qualified path;
+// when either is empty it falls back to the legacy bare path.
+func worktreeDir(owner, repo string, issueNumber int) string {
 	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, ".fabrik", "worktrees", fmt.Sprintf("issue-%d", issueNumber))
+	issuePart := fmt.Sprintf("issue-%d", issueNumber)
+	if owner == "" || repo == "" {
+		return filepath.Join(cwd, ".fabrik", "worktrees", issuePart)
+	}
+	return filepath.Join(cwd, ".fabrik", "worktrees", owner+"-"+repo, issuePart)
 }
 
 // currentStageFromLog returns the stage name derived from the newest .log filename
@@ -564,8 +570,8 @@ func issueHistory(issueNumber int) []tui.HistoryEntry {
 func (m WatchModel) viewportHeight() int {
 	// Overhead when labels row and tab bar are both shown (common runtime case):
 	//   header + \n: 2, labels + \n: 2, prLine + \n: 2, tabBar + \n: 2,
-	//   \n after viewport: 1, statusBar: 1 → 10 total.
-	reserved := 10
+	//   hintStrip + \n: 2, \n after viewport: 1, bottomInfoLine: 1 → 12 total.
+	reserved := 12
 	if m.height > reserved+5 {
 		return m.height - reserved
 	}
@@ -612,12 +618,16 @@ func (m WatchModel) View() string {
 		b.WriteString("\n")
 	}
 
+	// ── Keyboard hint strip ──
+	b.WriteString(topKeyHints())
+	b.WriteString("\n")
+
 	// ── Viewport ──
 	b.WriteString(m.vp.View())
 	b.WriteString("\n")
 
-	// ── Status bar ──
-	b.WriteString(m.statusBar())
+	// ── Bottom info line (session UUID + poll info) ──
+	b.WriteString(m.bottomStatusLine(m.width))
 
 	return b.String()
 }
@@ -708,39 +718,92 @@ func (m WatchModel) checkRunSummary() string {
 	return strings.Join(parts, " ")
 }
 
-// statusBar renders the bottom status bar.
-func (m WatchModel) statusBar() string {
-	keys := dimStyle.Render("q quit  ↑↓ scroll  ←→ tabs  G bottom  g top  i resume claude")
+// topKeyHints returns the static keyboard-hint strip rendered in dim style.
+func topKeyHints() string {
+	return dimStyle.Render("q quit  ↑↓ scroll  ←→ tabs  G bottom  g top  i resume claude")
+}
 
-	// Session ID for current stage.
-	sessionID := readSessionID(m.opts.Owner, m.opts.Repo, m.issueNumber, currentStageFromLog(m.logDir))
-	if sessionID != "" {
-		keys += dimStyle.Render("  |  session: " + sessionID)
-	}
-
-	// Transient status message takes precedence over poll info.
+// bottomStatusLine renders the dedicated bottom info line: session UUID + poll info.
+// Width-aware: the poll suffix is dropped when it would not fit.
+// If a transient status message is set it is shown instead.
+func (m WatchModel) bottomStatusLine(width int) string {
 	if m.statusMsg != "" {
-		return keys + "  " + failStyle.Render(m.statusMsg)
+		return failStyle.Render(m.statusMsg)
 	}
 
-	var pollInfo string
-	if !m.lastPollAt.IsZero() {
-		ago := time.Since(m.lastPollAt).Round(time.Second)
-		pollInfo = dimStyle.Render(fmt.Sprintf("  polled %s ago", ago))
+	sessionID := readSessionID(m.opts.Owner, m.opts.Repo, m.issueNumber, currentStageFromLog(m.logDir))
+	prefix := "no session yet"
+	if sessionID != "" {
+		prefix = "session: " + sessionID
 	}
+
+	// Build poll suffix before styling so widths can be measured accurately.
+	var pollSuffix string
+	isPollErr := false
 	if m.pollErr != "" {
-		pollInfo = failStyle.Render("  " + m.pollErr)
+		pollSuffix = "  " + m.pollErr
+		isPollErr = true
+	} else if !m.lastPollAt.IsZero() {
+		ago := time.Since(m.lastPollAt).Round(time.Second)
+		pollSuffix = fmt.Sprintf("  polled %s ago", ago)
 	}
-	return keys + pollInfo
+
+	// Drop the poll suffix when it would overflow the terminal width.
+	if width > 0 && ansi.StringWidth(prefix)+ansi.StringWidth(pollSuffix) > width {
+		pollSuffix = ""
+	}
+
+	// Apply styles after width comparison to avoid ANSI-escape inflation.
+	result := dimStyle.Render(prefix)
+	if pollSuffix != "" {
+		if isPollErr {
+			result += failStyle.Render(pollSuffix)
+		} else {
+			result += dimStyle.Render(pollSuffix)
+		}
+	}
+	return result
 }
 
 // openClaudeInlineCmd returns a tea.Cmd that suspends the TUI and launches
-// claude --resume <session-id> inline in the current terminal via tea.ExecProcess.
-// When Claude exits, the TUI resumes and ClaudeFinishedMsg is sent.
+// claude (optionally --resume <session-id>) inline in the current terminal via
+// tea.ExecProcess. When Claude exits, the TUI resumes and ClaudeFinishedMsg is sent.
+//
+// Worktree resolution order:
+//  1. Multi-repo path: .fabrik/worktrees/<owner>-<repo>/issue-N/
+//  2. Legacy bare path: .fabrik/worktrees/issue-N/  (when owner/repo are set but multi-repo path is absent)
+//  3. Fallback to cwd when worktree is gone but a session file exists (closed-issue resume).
+//
+// If neither a worktree nor a session file exists, a StatusMsgMsg is emitted and
+// tea.ExecProcess is NOT called.
 func (m WatchModel) openClaudeInlineCmd() tea.Cmd {
 	stageName := currentStageFromLog(m.logDir)
 	sessionID := readSessionID(m.opts.Owner, m.opts.Repo, m.issueNumber, stageName)
-	wt := worktreeDir(m.issueNumber)
+
+	// Resolve worktree directory: try multi-repo path first, then legacy bare path.
+	wt := ""
+	multiPath := worktreeDir(m.opts.Owner, m.opts.Repo, m.issueNumber)
+	if _, err := os.Stat(multiPath); err == nil {
+		wt = multiPath
+	} else if m.opts.Owner != "" && m.opts.Repo != "" {
+		barePath := worktreeDir("", "", m.issueNumber)
+		if _, err := os.Stat(barePath); err == nil {
+			wt = barePath
+		}
+	}
+
+	if wt == "" && sessionID == "" {
+		return func() tea.Msg {
+			return StatusMsgMsg{Text: "no session for this stage — nothing to resume"}
+		}
+	}
+
+	// When the worktree has been cleaned up (closed issue) but the session file
+	// persists, fall back to cwd so Claude can still resume the conversation.
+	workDir := wt
+	if workDir == "" {
+		workDir, _ = os.Getwd()
+	}
 
 	var args []string
 	if sessionID != "" {
@@ -751,7 +814,7 @@ func (m WatchModel) openClaudeInlineCmd() tea.Cmd {
 	}
 
 	cmd := exec.Command("claude", args...)
-	cmd.Dir = wt
+	cmd.Dir = workDir
 
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return ClaudeFinishedMsg{Err: err}

--- a/watch/model_test.go
+++ b/watch/model_test.go
@@ -1,9 +1,12 @@
 package watch
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -224,6 +227,134 @@ func TestActiveStageFromLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWorktreeDir verifies that worktreeDir builds the correct path for multi-repo
+// and legacy single-repo layouts.
+func TestWorktreeDir(t *testing.T) {
+	cwd, _ := os.Getwd()
+	tests := []struct {
+		name        string
+		owner, repo string
+		issueNumber int
+		wantSuffix  string
+	}{
+		{
+			"multi-repo",
+			"myowner", "myrepo", 42,
+			filepath.Join(cwd, ".fabrik", "worktrees", "myowner-myrepo", "issue-42"),
+		},
+		{
+			"empty owner falls back to bare",
+			"", "myrepo", 42,
+			filepath.Join(cwd, ".fabrik", "worktrees", "issue-42"),
+		},
+		{
+			"empty repo falls back to bare",
+			"myowner", "", 42,
+			filepath.Join(cwd, ".fabrik", "worktrees", "issue-42"),
+		},
+		{
+			"both empty falls back to bare",
+			"", "", 99,
+			filepath.Join(cwd, ".fabrik", "worktrees", "issue-99"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := worktreeDir(tt.owner, tt.repo, tt.issueNumber)
+			if got != tt.wantSuffix {
+				t.Errorf("worktreeDir(%q, %q, %d) = %q, want %q",
+					tt.owner, tt.repo, tt.issueNumber, got, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+// TestTopKeyHints verifies that topKeyHints returns all expected key labels
+// and does not end with a newline.
+func TestTopKeyHints(t *testing.T) {
+	got := topKeyHints()
+
+	for _, want := range []string{"q quit", "↑↓ scroll", "←→ tabs", "G bottom", "g top", "i resume claude"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("topKeyHints() missing %q; got %q", want, got)
+		}
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Errorf("topKeyHints() must not end with a newline; got %q", got)
+	}
+}
+
+// TestBottomStatusLine covers the four key behaviors of the bottom info line.
+func TestBottomStatusLine(t *testing.T) {
+	// (a) statusMsg set → transient message replaces session/poll content.
+	t.Run("statusMsg", func(t *testing.T) {
+		m := newTestModel()
+		m.statusMsg = "stage is active"
+		got := m.bottomStatusLine(200)
+		if !strings.Contains(got, "stage is active") {
+			t.Errorf("expected statusMsg text, got %q", got)
+		}
+		if strings.Contains(got, "session") {
+			t.Errorf("statusMsg should replace session info, got %q", got)
+		}
+	})
+
+	// (d) no session file → "no session yet".
+	t.Run("no session", func(t *testing.T) {
+		m := newTestModel()
+		// logDir is empty → currentStageFromLog("") returns "" → readSessionID returns "".
+		got := m.bottomStatusLine(200)
+		if !strings.Contains(got, "no session yet") {
+			t.Errorf("expected 'no session yet', got %q", got)
+		}
+	})
+
+	// (b) session present + wide terminal → UUID and poll suffix both visible.
+	// (c) session present + narrow terminal → UUID present, poll suffix dropped.
+	t.Run("session present width handling", func(t *testing.T) {
+		// Create a fake log file so currentStageFromLog returns a stage name.
+		logDir := t.TempDir()
+		writeLog(t, logDir, "Validate-20260101-120000-000000000.log")
+
+		// Write the session file at the cwd-relative path that readSessionID expects.
+		uuid := "dd9fe2fd-132f-44ed-9c3a-6b7c2b46cc30"
+		cwd, _ := os.Getwd()
+		sessDir := filepath.Join(cwd, ".fabrik", "sessions", "issue-88888")
+		if err := os.MkdirAll(sessDir, 0o755); err != nil {
+			t.Fatalf("mkdir session dir: %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(sessDir) })
+		sessionFile := filepath.Join(sessDir, "Validate.session")
+		if err := os.WriteFile(sessionFile, []byte(uuid+"\n"), 0o644); err != nil {
+			t.Fatalf("write session file: %v", err)
+		}
+
+		m := newTestModel()
+		m.issueNumber = 88888
+		m.logDir = logDir
+		m.lastPollAt = time.Now()
+
+		// (b) wide terminal — full UUID and poll suffix should both appear.
+		gotWide := m.bottomStatusLine(200)
+		if !strings.Contains(gotWide, uuid) {
+			t.Errorf("wide: expected UUID in output, got %q", gotWide)
+		}
+		if !strings.Contains(gotWide, "polled") {
+			t.Errorf("wide: expected poll suffix, got %q", gotWide)
+		}
+
+		// (c) narrow terminal (50 cols): "session: "+UUID = 45 visible chars;
+		// any poll suffix pushes past 50, so it must be dropped.
+		gotNarrow := m.bottomStatusLine(50)
+		if !strings.Contains(gotNarrow, uuid) {
+			t.Errorf("narrow: expected UUID preserved, got %q", gotNarrow)
+		}
+		if strings.Contains(gotNarrow, "polled") {
+			t.Errorf("narrow: expected poll suffix to be dropped, got %q", gotNarrow)
+		}
+	})
 }
 
 // TestUpdate_NewLogFileMsg_LabelOverride is the primary regression test: when an

--- a/watch/model_test.go
+++ b/watch/model_test.go
@@ -314,18 +314,34 @@ func TestBottomStatusLine(t *testing.T) {
 	// (b) session present + wide terminal → UUID and poll suffix both visible.
 	// (c) session present + narrow terminal → UUID present, poll suffix dropped.
 	t.Run("session present width handling", func(t *testing.T) {
+		// Use a temporary directory as CWD so session files don't pollute the repo.
+		tmpDir := t.TempDir()
+		oldCwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("chdir tmpDir: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := os.Chdir(oldCwd); err != nil {
+				t.Errorf("restore cwd: %v", err)
+			}
+		})
+
 		// Create a fake log file so currentStageFromLog returns a stage name.
-		logDir := t.TempDir()
+		logDir := filepath.Join(tmpDir, "logs")
+		if err := os.MkdirAll(logDir, 0o755); err != nil {
+			t.Fatalf("mkdir log dir: %v", err)
+		}
 		writeLog(t, logDir, "Validate-20260101-120000-000000000.log")
 
 		// Write the session file at the cwd-relative path that readSessionID expects.
 		uuid := "dd9fe2fd-132f-44ed-9c3a-6b7c2b46cc30"
-		cwd, _ := os.Getwd()
-		sessDir := filepath.Join(cwd, ".fabrik", "sessions", "issue-88888")
+		sessDir := filepath.Join(tmpDir, ".fabrik", "sessions", "issue-88888")
 		if err := os.MkdirAll(sessDir, 0o755); err != nil {
 			t.Fatalf("mkdir session dir: %v", err)
 		}
-		t.Cleanup(func() { os.RemoveAll(sessDir) })
 		sessionFile := filepath.Join(sessDir, "Validate.session")
 		if err := os.WriteFile(sessionFile, []byte(uuid+"\n"), 0o644); err != nil {
 			t.Fatalf("write session file: %v", err)


### PR DESCRIPTION
Closes #848

## What this PR does

Fixes three independent bugs in `fabrik watch`:

**A — `[i]` silently failing on multi-repo layouts**  
`worktreeDir` previously ignored `<owner>-<repo>`, so pressing `[i]` always set `cmd.Dir` to a path that didn't exist and `tea.ExecProcess` silently failed. The function now accepts `owner` and `repo` parameters and produces the correct `.fabrik/worktrees/<owner>-<repo>/issue-N/` path, matching the convention already used by `issueLogDir` and `sessionDir` in the same file.

**B — Closed-issue sessions were completely un-resumable**  
When a worktree is cleaned up (post-Done or `cleanup_worktree: true`) but the session file at `.fabrik/sessions/<owner>-<repo>/issue-N/<stage>.session` still exists, `[i]` previously failed because it required the worktree to exist. `openClaudeInlineCmd` now:
1. Probes the multi-repo path, then the legacy bare path (for pre-multi-repo worktrees).
2. Falls back to `cwd` when the worktree is gone but a session file exists — Claude handles the resume fine without the original working directory.
3. Emits a `StatusMsgMsg` and skips `tea.ExecProcess` entirely when neither a worktree nor a session file exists, giving a clear message instead of a silent no-op.

**C — Status bar truncating the session UUID**  
The single-line status bar packed keyboard hints + `session: <36-char-UUID>` + poll info onto one line. On terminals ≤120 cols the UUID was clipped. The status bar is now split into two zones:
- **Top hint strip** (`topKeyHints()`): static keyboard bindings, rendered between the tab bar and the viewport.
- **Bottom info line** (`bottomStatusLine(width int)`): session UUID + poll info, width-aware — the poll suffix is dropped when the UUID alone wouldn't fit. Shows "no session yet" gracefully when no session file exists.

`viewportHeight()`'s `reserved` constant is updated from 10 to 12 to account for the extra line.

## Key files changed

- `watch/model.go`: `worktreeDir`, `openClaudeInlineCmd`, `statusBar` → `topKeyHints` + `bottomStatusLine`, `View`, `viewportHeight`
- `watch/model_test.go`: `TestWorktreeDir`, `TestTopKeyHints`, `TestBottomStatusLine`

## How to test

1. **Multi-repo layout** (`[i]` fix): Run `fabrik watch <N>` for a multi-repo issue, press `[i]` — Claude should launch with `--resume <session-id>` and `cmd.Dir` set to the correct path.
2. **Closed-issue resume**: After a worktree is cleaned up but the session file persists, press `[i]` — Claude launches with `--resume <id>` and `cmd.Dir = cwd`.
3. **No session**: Press `[i]` when no stage has run — status bar shows "no session for this stage — nothing to resume".
4. **Layout**: Terminal ≥80 cols shows hint strip below tabs and UUID on a dedicated bottom line. Resize to 60 cols — full UUID remains visible; poll suffix is dropped.
5. Run `go test -race ./watch/...` — all tests pass.