### PR TITLE
fix(poll): stop cancelling in-flight workers on every poll re-encounter (URGENT)

### DIFF
--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1493,15 +1493,16 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		// Skip issues already being processed by a previous poll cycle's worker.
 		// Use the Store-backed Worker field (set by WorkerEntered before goroutine launch)
 		// so this check is consistent with the observer pipeline.
-		// When a new poll detects a comment or reinvoke for an in-flight issue,
-		// annotate the in-flight context with "supplant_by_new_invocation" so the
-		// kill log emits the correct reason code when it is eventually cancelled.
+		//
+		// Do NOT cancel the in-flight context here. Every stage adds
+		// stage:X:in_progress when it starts, which fires a webhook, marks the cache
+		// stale, and triggers a new poll while the worker is still running. Cancelling
+		// on every re-encounter creates a tight dispatch → label → webhook → poll →
+		// cancel → respawn feedback loop that prevents any stage from completing a
+		// turn. Genuine "supplant on new event" semantics need to distinguish
+		// self-generated label changes from external ones — left as future work.
 		if snap, err := e.store.Get(itemRepo, item.Number); err == nil && snap.Worker() != nil {
 			debugLog("dispatch-skip-inflight", map[string]interface{}{"number": item.Number})
-			if entry, ok := e.issueCtxs.Load(iKey); ok {
-				entry.(issueCtxEntry).holder.val.Store("supplant_by_new_invocation")
-				entry.(issueCtxEntry).cancel()
-			}
 			continue
 		}
 		debugLog("dispatch-WILL-DISPATCH", map[string]interface{}{

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -2904,3 +2904,79 @@ func TestCheckAllowAutoMerge_DedupSuppressesSecondCall(t *testing.T) {
 		t.Errorf("expected API to be called exactly once; got %d", callCount)
 	}
 }
+
+// TestPoll_InFlightWorker_NotSupplanted is a regression test for the
+// dispatch → label → webhook → poll → cancel feedback loop introduced by the
+// kill-reason propagation work and observed on 2026-06-15: every stage that
+// adds stage:X:in_progress fires a webhook, marks the cache stale, and triggers
+// a re-poll while the worker is still running. If the dispatch loop cancels the
+// in-flight context on every re-encounter, no stage can complete a turn.
+//
+// This test asserts: when poll() encounters an item whose Store has a
+// registered Worker AND whose issueCtxs entry is live, the entry's context is
+// NOT cancelled by the poll cycle.
+func TestPoll_InFlightWorker_NotSupplanted(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{
+				ProjectID: "PVT_1",
+				Items: []gh.ProjectItem{
+					{
+						Number:    42,
+						ItemID:    "PVTI_42",
+						Status:    "Validate",
+						Repo:      "owner/repo",
+						UpdatedAt: time.Now(),
+						Labels:    []string{"stage:Validate:in_progress", "fabrik:yolo"},
+					},
+				},
+			}, nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error { return nil },
+	}
+
+	eng := NewWithDeps(Config{
+		Owner:         "owner",
+		Repo:          "repo",
+		ProjectNum:    1,
+		User:          "testuser",
+		Token:         "token",
+		MaxConcurrent: 5,
+		PollSeconds:   1,
+		Stages:        testStagesWithValidate(),
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+
+	// Simulate an in-flight worker: WorkerEntered in the Store + a live
+	// issueCtxs entry with a cancellable context. This is the exact state poll()
+	// will see during a stage's mid-flight on the next poll cycle.
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo:      "owner/repo",
+		Number:    42,
+		StageName: "Validate",
+		StartedAt: time.Now(),
+	})
+	holder := &killReasonHolder{}
+	iCtx, iCancel := context.WithCancel(context.Background())
+	defer iCancel()
+	eng.issueCtxs.Store("owner/repo#42", issueCtxEntry{cancel: iCancel, holder: holder})
+
+	// Run one poll.
+	if _, err := eng.poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	// The in-flight context must NOT have been cancelled by the dispatch loop.
+	select {
+	case <-iCtx.Done():
+		t.Fatal("poll cancelled the in-flight context — supplant feedback loop regression")
+	default:
+		// expected: context still live
+	}
+
+	// The kill-reason holder must also NOT have been annotated with
+	// supplant_by_new_invocation; this prevents an unrelated later cancel
+	// (e.g. daemon shutdown) from being mislabeled.
+	if v, ok := holder.val.Load().(string); ok && v == "supplant_by_new_invocation" {
+		t.Errorf("holder reason annotated to %q by poll — should be untouched while in-flight worker still running", v)
+	}
+}


### PR DESCRIPTION
## Summary

- **Urgent regression from PR #854.** The kill-reason propagation work added an unconditional cancel of the in-flight per-issue context whenever a poll cycle observed an item already had a Worker in the Store. This created a tight feedback loop where every stage's own \`stage:X:in_progress\` label write fired a webhook → marked the cache stale → triggered a re-poll → cancelled the in-flight worker → respawned a fresh dispatch → repeat.
- **Observed cost on \`handarbeit/fabrik\` 2026-06-15**: 2898 supplant events between 15:34 UTC and 02:29 UTC (~263–320/hr). Every Fabrik-driven yolo issue stuck at ~5–8 seconds of stage runtime before being killed. #855 stuck at Validate, #858 stuck at Plan, both made zero progress over 11 hours despite sustained engine activity. GraphQL rate budget exhausted; ~\$0.05 burned per cancel cycle.
- **Fix**: remove the unconditional \`.cancel()\` call in \`engine/poll.go:1502-1504\`. Comment was correct ("skip issues already being processed"); implementation was not. Restores the pre-#854 skip-if-in-flight behavior. Genuine "supplant on new event" semantics need to distinguish self-generated label changes from external ones — left as future work.

## Test plan

- [x] \`go test -race ./...\` — all packages green
- [x] \`go vet ./...\` — clean
- [x] New regression test \`TestPoll_InFlightWorker_NotSupplanted\` — passes; would fail before fix
- [ ] Manual: restart Fabrik on handarbeit/fabrik board; observe \`grep supplant_by_new_invocation .fabrik/fabrik.log\` returns no new entries for actively-progressing issues

## Note on shipping

This should ship as a hotfix release as soon as it merges. Without it, every running Fabrik instance is in the feedback loop and cannot make progress on any yolo-driven work. Auto-upgrade will pull it on next poll-cycle's upgrade check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)