### PR TITLE
chore(tests): sweep test-harness hygiene — /tmp paths, network failures, env-var pollution

### DIFF
--- a/.claude/rules/golang.md
+++ b/.claude/rules/golang.md
@@ -13,6 +13,8 @@
 ## Testing
 - Use stdlib `testing` only — no testify or external test frameworks.
 - Use `t.TempDir()` for temp files, `httptest.NewServer` for HTTP mocks.
+- Use `t.Setenv()` for environment variables in tests — auto-restores on exit, survives panics.
+- Do not depend on external network for failure injection — use ENAMETOOLONG (`strings.Repeat("a", 10000)` as baseDir) or local path tricks instead.
 - Real `git` binary is acceptable in tests (use `skipIfNoGit` guard).
 - Mock Claude via the `ClaudeInvoker` interface, not a fake binary.
 - Always run `go test -race ./...` to catch data races.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,17 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: Test hygiene lint
+        run: |
+          if grep -rn '"/tmp/' --include="*_test.go" .; then
+            echo "ERROR: hardcoded /tmp/ paths found in test files. Use t.TempDir() instead."
+            exit 1
+          fi
+          if grep -rn 'nonexistent-xyz' --include="*_test.go" .; then
+            echo "ERROR: network-dependent failure injection found. Use ENAMETOOLONG instead."
+            exit 1
+          fi
+
       - name: go test
         # TestExecute_ConfigYAMLApplied is a timing-sensitive SIGINT integration
         # test that fails intermittently on CI; it is tracked separately.

--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -123,7 +123,7 @@ func TestExecute_EnvPluginDir(t *testing.T) {
 	dir, stagesDir := setupValidStages(t)
 	chdirTest(t, dir)
 	resetFlags()
-	t.Setenv("FABRIK_PLUGIN_DIR", "/tmp/plugin")
+	t.Setenv("FABRIK_PLUGIN_DIR", t.TempDir())
 	t.Setenv("GITHUB_TOKEN", "tok")
 	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
 	executeAndStop(t)

--- a/cmd/resume_test.go
+++ b/cmd/resume_test.go
@@ -123,9 +123,7 @@ func TestRunResume_ClaudeNotInPath(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(orig) })
 
 	// Hide claude from PATH
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmp) // tmp has no claude binary
-	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+	t.Setenv("PATH", tmp) // tmp has no claude binary
 
 	err := runResume([]string{"10", "--stage", "Research", "--stages", stagesDir})
 	if err == nil {
@@ -158,9 +156,7 @@ func TestRunResume_SuccessfulExecConstruction(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chdir(orig) })
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmp)
-	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+	t.Setenv("PATH", tmp)
 
 	captured := withExecCapture(t)
 
@@ -221,9 +217,7 @@ func TestRunResume_SuccessfulExecWithSession(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Chdir(orig) })
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmp)
-	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+	t.Setenv("PATH", tmp)
 
 	captured := withExecCapture(t)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -50,9 +50,7 @@ func TestExecute_MissingToken(t *testing.T) {
 	resetFlags()
 	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u"}
 	// Clear GITHUB_TOKEN env var
-	prev := os.Getenv("GITHUB_TOKEN")
-	os.Unsetenv("GITHUB_TOKEN")
-	defer os.Setenv("GITHUB_TOKEN", prev)
+	t.Setenv("GITHUB_TOKEN", "")
 
 	err := Execute()
 	if err == nil {
@@ -75,8 +73,7 @@ func TestExecute_TokenFromEnv(t *testing.T) {
 	stagesDir := t.TempDir()
 	// No stage files — should fail with "no stage configurations"
 	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
-	os.Setenv("GITHUB_TOKEN", "env-token")
-	defer os.Unsetenv("GITHUB_TOKEN")
+	t.Setenv("GITHUB_TOKEN", "env-token")
 
 	err := Execute()
 	if err == nil {

--- a/engine/advance_stage_test.go
+++ b/engine/advance_stage_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAdvanceToNextStage_Success(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{
 		FieldID: "FIELD_1",
 		Options: map[string]string{
@@ -37,7 +37,7 @@ func TestAdvanceToNextStage_Success(t *testing.T) {
 
 func TestAdvanceToNextStage_LastStage(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{
 		FieldID: "FIELD_1",
 		Options: map[string]string{},
@@ -57,7 +57,7 @@ func TestAdvanceToNextStage_LastStage(t *testing.T) {
 }
 
 func TestAdvanceToNextStage_NoStatusField(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	// statusField is nil
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -71,7 +71,7 @@ func TestAdvanceToNextStage_NoStatusField(t *testing.T) {
 }
 
 func TestAdvanceToNextStage_MissingOption(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{
 		FieldID: "FIELD_1",
 		Options: map[string]string{

--- a/engine/blocked_on_input_test.go
+++ b/engine/blocked_on_input_test.go
@@ -64,7 +64,7 @@ func TestIsAwaitingInput(t *testing.T) {
 // --- (c) itemMayNeedWork with awaiting-input ---
 
 func TestItemMayNeedWork_AwaitingInput_PassesThrough(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number:    1,
@@ -79,7 +79,7 @@ func TestItemMayNeedWork_AwaitingInput_PassesThrough(t *testing.T) {
 }
 
 func TestItemMayNeedWork_AwaitingInput_LockedByOther(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 1,
@@ -94,7 +94,7 @@ func TestItemMayNeedWork_AwaitingInput_LockedByOther(t *testing.T) {
 }
 
 func TestItemNeedsWork_AwaitingInput_LockedByOther(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 1,
@@ -112,7 +112,7 @@ func TestItemNeedsWork_AwaitingInput_LockedByOther(t *testing.T) {
 }
 
 func TestItemMayNeedWork_PausedOnly_Blocked(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number:    1,
@@ -130,7 +130,7 @@ func TestItemMayNeedWork_PausedOnly_Blocked(t *testing.T) {
 // --- (d) itemNeedsWork with awaiting-input ---
 
 func TestItemNeedsWork_AwaitingInput_WithNewComments(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 1,
@@ -147,7 +147,7 @@ func TestItemNeedsWork_AwaitingInput_WithNewComments(t *testing.T) {
 }
 
 func TestItemNeedsWork_AwaitingInput_NoComments(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number:   1,
@@ -236,7 +236,7 @@ func TestProcessItem_AwaitingInput_UnblocksOnComment(t *testing.T) {
 func TestProcessItem_AwaitingInput_NoComment_Skips(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -23,7 +23,7 @@ func TestCheckCIGate_WaitForCIFalse_ClearsImmediately(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate"} // WaitForCI is nil
 
@@ -42,7 +42,7 @@ func TestCheckCIGate_NoPR_ClearsGate(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -62,7 +62,7 @@ func TestCheckCIGate_NoCheckRuns_ClearsGate(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -82,7 +82,7 @@ func TestCheckCIGate_PostPushDelay_BlocksGate(t *testing.T) {
 			return nil, nil // no checks yet for the new SHA
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	// Pre-seed: this issue has previously had check runs registered.
 	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 1})
 
@@ -116,7 +116,7 @@ func TestCheckCIGate_AllGreen_ClearsGate(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -138,7 +138,7 @@ func TestCheckCIGate_Pending_BlocksNoLabel(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -184,7 +184,7 @@ func TestCheckCIGate_Pending_TimedOut(t *testing.T) {
 			return time.Now().Add(-2 * time.Hour), nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.CIWaitTimeout = 30 * time.Minute
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
@@ -220,7 +220,7 @@ func TestCheckCIGate_Failed_BlocksAndAddsLabel(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -259,7 +259,7 @@ func TestCheckCIGate_Failed_AlreadyLabeledWithTimeout_TimesOut(t *testing.T) {
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.CIWaitTimeout = 1 * time.Millisecond // tiny timeout
 
 	tr := true
@@ -301,7 +301,7 @@ func TestCheckCIGate_Failed_AlreadyLabeledNotYetTimedOut_Blocked(t *testing.T) {
 			return appliedAt, nil
 		},
 	}
-	eng := testEngineForMerge(client) // CIWaitTimeout = 0 → defaults to 30 min
+	eng := testEngineForMerge(t, client) // CIWaitTimeout = 0 → defaults to 30 min
 
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
@@ -331,7 +331,7 @@ func TestCheckCIGate_AllGreen_AddsCompleteLabel(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -372,7 +372,7 @@ func TestCheckCIGate_NoCheckRuns_AddsCompleteLabel(t *testing.T) {
 			return nil, nil // no check runs (R5)
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -402,7 +402,7 @@ func TestCheckCIGate_NoPR_AddsCompleteLabel(t *testing.T) {
 			return nil, nil // no linked PR
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -444,7 +444,7 @@ func TestCheckCIGate_Failed_DoesNotAddCompleteLabel(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -474,7 +474,7 @@ func TestCheckCIGate_NonValidateStage_AddsCorrectCompleteLabel(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	// Use a non-Validate stage name
@@ -520,7 +520,7 @@ func TestAddCompleteLabelAndRemoveCI_AddLabelFails_PreservesAwaitingCI(t *testin
 			return nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -548,7 +548,7 @@ func TestBuildCIFixComment_IncludesFailedChecks(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	tr := true
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -574,7 +574,7 @@ func TestCheckCIGate_FetchLinkedPRError_BlocksGate(t *testing.T) {
 			return nil, fmt.Errorf("transient network error")
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -599,7 +599,7 @@ func TestCheckCIGate_MergedPR_ClearsGate(t *testing.T) {
 			return &gh.PRDetails{Number: 5, HeadSHA: "sha-merged", Merged: true, State: "closed"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -638,7 +638,7 @@ func TestCheckCIGate_ClosedNotMergedPR_Pauses(t *testing.T) {
 			return &gh.PRDetails{Number: 5, HeadSHA: "sha-closed", Merged: false, State: "closed"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -696,7 +696,7 @@ func TestCheckCIGate_OpenBlockedNoChecks_DwellNotElapsed_StaysBlocked(t *testing
 			return time.Now().Add(-1 * time.Minute), nil // well within the 30-min default timeout
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -734,7 +734,7 @@ func TestCheckCIGate_OpenBlockedNoChecks_DwellElapsed_Pauses(t *testing.T) {
 			return time.Now().Add(-2 * time.Hour), nil // well past the 30-min default timeout
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.CIWaitTimeout = 30 * time.Minute
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
@@ -796,7 +796,7 @@ func TestCheckCIGate_OpenBlockedNoChecks_HadChecks_Waits(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	// Pre-seed: this issue has previously had check runs registered.
 	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 1})
 	tr := true
@@ -829,7 +829,7 @@ func TestCheckCIGate_FetchCheckRunsError_BlocksGate(t *testing.T) {
 			return nil, fmt.Errorf("GitHub API 503")
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -845,7 +845,7 @@ func TestCheckCIGate_FetchCheckRunsError_BlocksGate(t *testing.T) {
 
 func TestBuildCIFixComment_SyntheticHasDatabaseIDZero(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42}
 	stage := &stages.Stage{Name: "Validate"}
 
@@ -881,7 +881,7 @@ func TestCheckCIGate_MergeableStateClean_ClearsGate(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -918,7 +918,7 @@ func TestCheckCIGate_MergeableStateUnstable_ClearsGate(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -947,7 +947,7 @@ func TestCheckCIGate_MergeableStateBlocked_FallsThroughToCheckRuns(t *testing.T)
 			return []gh.CheckRun{{Name: "ci", Status: "in_progress"}}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -974,7 +974,7 @@ func TestCheckCIGate_EmptyHeadSHA_StaysBlocked(t *testing.T) {
 			return &gh.PRDetails{Number: 5, Title: "My PR", HeadSHA: ""}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -1013,7 +1013,7 @@ func TestRemoveAwaitingCILabel_ErrNotFound(t *testing.T) {
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:awaiting-ci")
 
 	eventsCh := make(chan tui.Event, 16)
@@ -1068,7 +1068,7 @@ func TestCheckCIGate_BehindNoChecks_Blocks(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -1104,7 +1104,7 @@ func TestCheckCIGate_DirtyNoChecks_Blocks(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -1143,7 +1143,7 @@ func TestCheckCIGate_BehindNoChecks_TimeoutElapsed_TimesOut(t *testing.T) {
 			return time.Now().Add(-2 * time.Hour), nil // well past the 30-min default timeout
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.CIWaitTimeout = 30 * time.Minute
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -222,7 +222,7 @@ func min(a, b int) int {
 // skips a comment that has a 🚀 reaction even if the body lacks the Fabrik header.
 // This is the defense-in-depth dedup signal for engine-authored comments.
 func TestFindNewComments_SkipsRocketReactedComment(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 20,
 		Comments: []gh.Comment{

--- a/engine/context_extra_test.go
+++ b/engine/context_extra_test.go
@@ -16,7 +16,7 @@ import (
 // with owner, repo, project number, and owner type from engine config.
 func TestWriteContextFiles_WritesProjectMD(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.Owner = "myorg"
 	eng.cfg.Repo = "myrepo"
 	eng.cfg.ProjectNum = 42
@@ -56,7 +56,7 @@ func TestWriteContextFiles_PostToPR_WritesPRDescription(t *testing.T) {
 			return "This PR implements the feature.\n\nCloses #1", nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	workDir := t.TempDir()
 	reviewStage := &stages.Stage{Name: "Review", Order: 4, PostToPR: true}
@@ -82,7 +82,7 @@ func TestWriteContextFiles_PostToPR_NoPR_SkipsPRDescription(t *testing.T) {
 			return 0, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	workDir := t.TempDir()
 	reviewStage := &stages.Stage{Name: "Review", Order: 4, PostToPR: true}
@@ -101,7 +101,7 @@ func TestWriteContextFiles_PostToPR_NoPR_SkipsPRDescription(t *testing.T) {
 // rocket reaction (excluding bot comments and already-seen comments).
 func TestMarkCommentsSeenByStage_AddsRocketToUnseenUserComments(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 30,
@@ -139,7 +139,7 @@ func TestMarkCommentsSeenByStage_AddsRocketToUnseenUserComments(t *testing.T) {
 // TestItemMayNeedWork_CooldownRetry verifies that an unchanged item is retried
 // after the cooldown period expires.
 func TestItemMayNeedWork_CooldownRetry(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 40,

--- a/engine/context_test.go
+++ b/engine/context_test.go
@@ -88,7 +88,7 @@ func TestFindStageComment_MatchesAmongMixed(t *testing.T) {
 func TestWriteContextFiles_IssueAlwaysWritten(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = []*stages.Stage{
 		{Name: "Research", Order: 1},
 		{Name: "Plan", Order: 2},
@@ -115,7 +115,7 @@ func TestWriteContextFiles_IssueAlwaysWritten(t *testing.T) {
 func TestWriteContextFiles_PriorStagesOnly(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = []*stages.Stage{
 		{Name: "Research", Order: 1},
 		{Name: "Plan", Order: 2},
@@ -150,7 +150,7 @@ func TestWriteContextFiles_PriorStagesOnly(t *testing.T) {
 func TestWriteContextFiles_CommentProcessingIncludesCurrent(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = []*stages.Stage{
 		{Name: "Research", Order: 1},
 		{Name: "Plan", Order: 2},
@@ -180,7 +180,7 @@ func TestWriteContextFiles_CommentProcessingIncludesCurrent(t *testing.T) {
 func TestWriteContextFiles_SkipsStagesWithNoComment(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = []*stages.Stage{
 		{Name: "Research", Order: 1},
 		{Name: "Plan", Order: 2},
@@ -281,7 +281,7 @@ func initTestRepo(t *testing.T) string {
 func TestWriteCodebaseChanges_NopriorSHA(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	workDir := t.TempDir()
 	fabrikDir := filepath.Join(workDir, ".fabrik-context")
@@ -308,7 +308,7 @@ func TestWriteCodebaseChanges_SHAsMatch(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.worktreeManagers["owner/repo"] = NewWorktreeManager(repoDir)
 
 	// Get the current HEAD SHA (there's only one commit, so origin doesn't exist;
@@ -383,7 +383,7 @@ func TestWriteCodebaseChanges_DiffWritten(t *testing.T) {
 
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.worktreeManagers["owner/repo"] = NewWorktreeManager(repoDir)
 
 	fabrikDir := filepath.Join(repoDir, ".fabrik-context")
@@ -424,7 +424,7 @@ func TestWriteCodebaseChanges_DiffWritten(t *testing.T) {
 func TestWriteContextFiles_CreatesGitignore(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = []*stages.Stage{
 		{Name: "Research", Order: 1},
 	}

--- a/engine/dependencies_test.go
+++ b/engine/dependencies_test.go
@@ -25,13 +25,14 @@ func depTestStages() []*stages.Stage {
 	}
 }
 
-func depTestEngine(client *mockGitHubClient) *Engine {
-	return testEngineWithStages(client, depTestStages())
+func depTestEngine(t *testing.T, client *mockGitHubClient) *Engine {
+	t.Helper()
+	return testEngineWithStages(t, client, depTestStages())
 }
 
 func TestCheckDependencies_NoDeps_ReturnsFalse(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 10, Repo: "owner/repo"}
 	stage := &stages.Stage{Name: "Research"}
@@ -51,7 +52,7 @@ func TestCheckDependencies_NoDeps_ReturnsFalse(t *testing.T) {
 
 func TestCheckDependencies_AllDepsClosed_ReturnsFalse(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -84,7 +85,7 @@ func TestCheckDependencies_AllDepsClosed_ReturnsFalse(t *testing.T) {
 // blocker actually closed.
 func TestCheckDependencies_StorePreemptsStaleDepState(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 
 	// Seed the Store with the blocker as closed — this is what a fresh Reconcile
 	// would have written before checkDependencies runs.
@@ -120,7 +121,7 @@ func TestCheckDependencies_StorePreemptsStaleDepState(t *testing.T) {
 
 func TestCheckDependencies_AllDepsClosed_RemovesBlockedLabel(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -147,7 +148,7 @@ func TestCheckDependencies_AllDepsClosed_RemovesBlockedLabel(t *testing.T) {
 
 func TestCheckDependencies_OpenDeps_ReturnsTrue_FirstTime(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -182,7 +183,7 @@ func TestCheckDependencies_OpenDeps_ReturnsTrue_FirstTime(t *testing.T) {
 
 func TestCheckDependencies_OpenDeps_AlreadyBlocked_NoComment(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -210,7 +211,7 @@ func TestCheckDependencies_OpenDeps_AlreadyBlocked_NoComment(t *testing.T) {
 
 func TestCheckDependencies_FirstStage_BlockedWithOpenDeps(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -241,7 +242,7 @@ func TestCheckDependencies_FirstStage_BlockedWithOpenDeps(t *testing.T) {
 
 func TestCheckDependencies_CrossRepoDep_FormattedCorrectly(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -286,7 +287,7 @@ func TestProcessItem_SkipsBlockedNonFirstStage(t *testing.T) {
 		},
 		client,
 		claude,
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -331,7 +332,7 @@ func TestProcessItem_SkipsBlockedFirstStage(t *testing.T) {
 		},
 		client,
 		claude,
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -377,7 +378,7 @@ func TestRemoveBlockedIfResolved_Success(t *testing.T) {
 			return nil
 		},
 	}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	eng.removeBlockedIfResolved("owner", "repo", 10)
 	if calls != 1 {
 		t.Errorf("expected 1 RemoveLabelFromIssue call, got %d", calls)
@@ -401,7 +402,7 @@ func TestRemoveBlockedIfResolved_ErrNotFound(t *testing.T) {
 			return nil
 		},
 	}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	eng.removeBlockedIfResolved("owner", "repo", 10)
 	if calls != 1 {
 		t.Errorf("expected exactly 1 call for ErrNotFound, got %d", calls)
@@ -427,7 +428,7 @@ func TestRemoveBlockedIfResolved_TransientRetrySucceeds(t *testing.T) {
 			return nil
 		},
 	}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	eng.removeBlockedIfResolved("owner", "repo", 10)
 	if calls != 3 {
 		t.Errorf("expected 3 calls (2 transient then success), got %d", calls)
@@ -451,7 +452,7 @@ func TestRemoveBlockedIfResolved_NonTransientNoRetry(t *testing.T) {
 			return nil
 		},
 	}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	eng.removeBlockedIfResolved("owner", "repo", 10)
 	if calls != 1 {
 		t.Errorf("expected exactly 1 call for non-transient error, got %d", calls)
@@ -475,7 +476,7 @@ func TestRemoveBlockedIfResolved_TransientExhausted(t *testing.T) {
 			return nil
 		},
 	}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	eng.removeBlockedIfResolved("owner", "repo", 10)
 	if calls != 3 {
 		t.Errorf("expected 3 calls (all transient, exhausted), got %d", calls)
@@ -644,7 +645,7 @@ func TestPushUnblockObserver_NoBlockedLabel_NotRemoved(t *testing.T) {
 // when invoked for items in stage columns.
 func TestCheckDependencies_PullPath_Regression(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := depTestEngine(client)
+	eng := depTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -681,7 +682,7 @@ func TestCheckDependencies_RemoveBlocked_ErrNotFound(t *testing.T) {
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:blocked")
 
 	eventsCh := make(chan tui.Event, 16)

--- a/engine/engine_extra_test.go
+++ b/engine/engine_extra_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSetEvents_ConfiguresChannel(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	ch := make(chan tui.Event, 4)
 	eng.SetEvents(ch)
 
@@ -23,13 +23,13 @@ func TestSetEvents_ConfiguresChannel(t *testing.T) {
 }
 
 func TestEmit_NilChannel_NoOp(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	// No channel set — emit should not panic
 	eng.emit(tui.LogEvent{IssueNumber: 1, Tag: "test", Message: "hello"})
 }
 
 func TestEmit_WithChannel_SendsEvent(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	ch := make(chan tui.Event, 4)
 	eng.events = ch
 
@@ -51,7 +51,7 @@ func TestEmit_WithChannel_SendsEvent(t *testing.T) {
 
 func TestCleanupLockedIssues_RemovesLabels(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Seed locks in the store via LocalLockAcquired mutations.
 	now := time.Now()
@@ -81,7 +81,7 @@ func TestCleanupLockedIssues_RemovesLabels(t *testing.T) {
 
 func TestCleanupLockedIssues_Empty_NoOp(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// No locked issues
 	eng.cleanupLockedIssues()
 	if len(client.removeLabelCalls) != 0 {
@@ -130,23 +130,23 @@ func TestChangeType(t *testing.T) {
 }
 
 func TestRegisterWorktrees_Idempotent(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	// Use a new repo key (not "owner/repo" which testEngine already registers).
-	wm1 := eng.registerWorktrees("other/repo", "/tmp/base", "/tmp/worktrees")
+	wm1 := eng.registerWorktrees("other/repo", t.TempDir(), t.TempDir())
 	if wm1 == nil {
 		t.Fatal("registerWorktrees returned nil on first registration")
 	}
 	// Second call with same key should return the existing WM.
-	wm2 := eng.registerWorktrees("other/repo", "/tmp/base", "/tmp/worktrees")
+	wm2 := eng.registerWorktrees("other/repo", t.TempDir(), t.TempDir())
 	if wm1 != wm2 {
 		t.Error("registerWorktrees should return the same WM on repeated calls")
 	}
 }
 
 func TestEnsureRepoReady_AlreadyRegistered_ReturnsNil(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	// Pre-register a new repo so ensureRepoReady returns immediately for it.
-	eng.registerWorktrees("newowner/newrepo", "/tmp/base", "/tmp/worktrees")
+	eng.registerWorktrees("newowner/newrepo", t.TempDir(), t.TempDir())
 	item := gh.ProjectItem{Number: 1, Repo: "newowner/newrepo"}
 	if err := eng.ensureRepoReady(context.Background(), item); err != nil {
 		t.Errorf("expected nil when repo already registered, got %v", err)
@@ -169,7 +169,7 @@ func TestEnsureRepoReady_EmptyOwner_ReturnsNil(t *testing.T) {
 func TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses(t *testing.T) {
 	skipIfNoGit(t)
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Set fabrikDir to a tempdir so ensureBareClone tries (and fails) to clone.
 	eng.fabrikDir = t.TempDir()
 
@@ -206,7 +206,7 @@ func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 
 	const numWorkers = 8
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.fabrikDir = t.TempDir() // causes ensureBareClone to fail (no network)
 
 	item := gh.ProjectItem{Number: 42, Repo: "nonexistent-xyz/nonexistent-repo-concurrent-test"}
@@ -250,7 +250,7 @@ func TestEnsureDraftPR_NoPR_FailedPush_ReturnsError(t *testing.T) {
 	// No existing PR; push will fail because base dir is not a real repo.
 	// fetchLinkedPRFn not set → mock returns nil, nil (no PR found).
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// WorktreeManager points to /tmp/test-repo which doesn't exist
 	item := gh.ProjectItem{Number: 99, Title: "Test"}
 	prNum, err := eng.ensureDraftPR(item, "main")

--- a/engine/engine_extra_test.go
+++ b/engine/engine_extra_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -158,7 +159,7 @@ func TestEnsureRepoReady_EmptyOwner_ReturnsNil(t *testing.T) {
 	client := &mockGitHubClient{}
 	eng := NewWithDeps(
 		Config{Owner: "", Repo: "", User: "u", Token: "t", Stages: testStages()},
-		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp"),
+		client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()),
 	)
 	item := gh.ProjectItem{Number: 1}
 	if err := eng.ensureRepoReady(context.Background(), item); err != nil {
@@ -170,11 +171,11 @@ func TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses(t *testing.T) {
 	skipIfNoGit(t)
 	client := &mockGitHubClient{}
 	eng := testEngine(t, client, &mockClaudeInvoker{})
-	// Set fabrikDir to a tempdir so ensureBareClone tries (and fails) to clone.
-	eng.fabrikDir = t.TempDir()
+	// ENAMETOOLONG: fails os.MkdirAll before any network call — deterministic, no git subprocess.
+	eng.fabrikDir = strings.Repeat("a", 10000)
 
-	// Item with a new (unregistered) repo — ensureBareClone will fail (no network to nonexistent).
-	item := gh.ProjectItem{Number: 77, Repo: "nonexistent-xyz/nonexistent-repo-abc123"}
+	// Item with a new (unregistered) repo — ensureBareClone will fail at os.MkdirAll.
+	item := gh.ProjectItem{Number: 77, Repo: "fail-test/unregistered"}
 	err := eng.ensureRepoReady(context.Background(), item)
 	if err != ErrSkipItem {
 		t.Errorf("expected ErrSkipItem on clone failure, got %v", err)
@@ -207,9 +208,10 @@ func TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt(t *testing.T) {
 	const numWorkers = 8
 	client := &mockGitHubClient{}
 	eng := testEngine(t, client, &mockClaudeInvoker{})
-	eng.fabrikDir = t.TempDir() // causes ensureBareClone to fail (no network)
+	// ENAMETOOLONG: fails os.MkdirAll before any network call — deterministic, no git subprocess.
+	eng.fabrikDir = strings.Repeat("a", 10000)
 
-	item := gh.ProjectItem{Number: 42, Repo: "nonexistent-xyz/nonexistent-repo-concurrent-test"}
+	item := gh.ProjectItem{Number: 42, Repo: "fail-test/concurrent"}
 
 	// Use a barrier so all goroutines start at the same moment.
 	var barrier sync.WaitGroup

--- a/engine/engine_helpers_test.go
+++ b/engine/engine_helpers_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"testing"
+
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/stages"
@@ -28,7 +30,8 @@ func testStages() []*stages.Stage {
 		},
 	}
 }
-func testEngine(client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
+func testEngine(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
+	t.Helper()
 	return NewWithDeps(
 		Config{
 			Owner:         "owner",
@@ -41,15 +44,16 @@ func testEngine(client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
 		},
 		client,
 		claude,
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 }
 
 // testEngineWithCache creates an Engine with a live CacheImpl wired as readClient.
 // Returns the engine and the cache so tests can query cached state directly.
 // The cache is bootstrapped with a single item: owner/repo issue #1 in "Research".
-func testEngineWithCache(client *mockGitHubClient, claude *mockClaudeInvoker) (*Engine, *boardcache.CacheImpl) {
-	eng := testEngine(client, claude)
+func testEngineWithCache(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker) (*Engine, *boardcache.CacheImpl) {
+	t.Helper()
+	eng := testEngine(t, client, claude)
 
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	cache.BootstrapFromProbe([]gh.BoardProbeItem{

--- a/engine/engine_migration_test.go
+++ b/engine/engine_migration_test.go
@@ -18,7 +18,7 @@ import (
 // TestMigration_LockAcquireReleaseRoundtrip verifies the lock acquire → read → release
 // cycle via the store: acquire sets HeldByThis=true, release clears it (Lock==nil).
 func TestMigration_LockAcquireReleaseRoundtrip(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	// Before acquire: item may not exist yet; if it does, no lock.
 	if snap0, err := eng.store.Get("owner/repo", 42); err == nil {
@@ -65,7 +65,7 @@ func TestMigration_LockAcquireReleaseRoundtrip(t *testing.T) {
 // nil → set by self (HeldByThis=true) → released (Lock==nil).
 // (Other-user locks arrive via webhook IssueLabeled and are not emitted by LocalLockAcquired.)
 func TestMigration_LockDerivedField(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	// nil state.
 	snap, _ := eng.store.Get("owner/repo", 5)
@@ -91,7 +91,7 @@ func TestMigration_LockDerivedField(t *testing.T) {
 // TestMigration_TokenUsageUpdate verifies that InvocationRecorded stores
 // LastTokenUsage, LastInvocationCompleted, and LastInvocationBlocked atomically.
 func TestMigration_TokenUsageUpdate(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	usage := itemstate.TokenUsage{InputTokens: 100, OutputTokens: 200, CacheReadTokens: 50}
 	eng.store.Apply(itemstate.InvocationRecorded{
@@ -117,7 +117,7 @@ func TestMigration_TokenUsageUpdate(t *testing.T) {
 
 // TestMigration_CompletionFlags verifies completed=true, blocked=false → correct snapshot.
 func TestMigration_CompletionFlags(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	eng.store.Apply(itemstate.InvocationRecorded{
 		Repo:      "owner/repo",
@@ -155,7 +155,7 @@ func TestMigration_CompletionFlags(t *testing.T) {
 // TestMigration_DeepFetchCooldown verifies the 10×PollSeconds cooldown semantics:
 // recent failure → itemMayNeedWork returns false; expired failure → returns true.
 func TestMigration_DeepFetchCooldown(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1 // 10-second cooldown
 
 	item := gh.ProjectItem{Number: 51, Status: "Research", ItemID: "PVTI_51"}
@@ -175,7 +175,7 @@ func TestMigration_DeepFetchCooldown(t *testing.T) {
 
 // TestMigration_DeepFetchSuccessClears verifies that ItemDeepFetched zeros LastDeepFetchFailureAt.
 func TestMigration_DeepFetchSuccessClears(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 20, At: time.Now().Add(-time.Minute)})
 
@@ -199,7 +199,7 @@ func TestMigration_DeepFetchSuccessClears(t *testing.T) {
 // TestMigration_PRChecksObservedMonotonic verifies HasHadChecks transitions false→true
 // when PRChecksObserved is applied and remains true on subsequent applications.
 func TestMigration_PRChecksObservedMonotonic(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	// Initially false.
 	snap0, _ := eng.store.Get("owner/repo", 30)
@@ -226,7 +226,7 @@ func TestMigration_PRChecksObservedMonotonic(t *testing.T) {
 
 // TestMigration_CIMergePendingSetAndClear verifies CIMergePendingSince set/clear transitions.
 func TestMigration_CIMergePendingSetAndClear(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	// Initially zero.
 	snap0, _ := eng.store.Get("owner/repo", 40)
@@ -260,7 +260,7 @@ func TestMigration_CIMergePendingSetAndClear(t *testing.T) {
 // TestMigration_SnapshotImmutability verifies that a snapshot taken before an Apply
 // is not affected by the subsequent mutation.
 func TestMigration_SnapshotImmutability(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 50})
 	snapBefore, _ := eng.store.Get("owner/repo", 50)
@@ -277,7 +277,7 @@ func TestMigration_SnapshotImmutability(t *testing.T) {
 // TestMigration_ConcurrentCompletions verifies that concurrent InvocationRecorded
 // applications for different issues are race-detector clean.
 func TestMigration_ConcurrentCompletions(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	const n = 50
 	var wg sync.WaitGroup

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestItemNeedsWork_SkipsPaused(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 1,
@@ -31,7 +31,7 @@ func TestItemNeedsWork_SkipsPaused(t *testing.T) {
 }
 
 func TestItemNeedsWork_SkipsPausedWithNewComments(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 1,
@@ -49,7 +49,7 @@ func TestItemNeedsWork_SkipsPausedWithNewComments(t *testing.T) {
 }
 
 func TestFindNewComments(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{
 		Number: 1,
@@ -146,7 +146,7 @@ func TestRun_ShutdownOnSignal(t *testing.T) {
 			return &gh.ProjectBoard{}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 300 // long poll so we don't hit a second tick
 
 	// Provide a temp fabrikDir so Run() can create the lock file.
@@ -468,7 +468,7 @@ func TestIdleCountNotIncrementedWhileWorkersInFlight(t *testing.T) {
 }
 
 func TestExtractModelOverride(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	tests := []struct {
 		name   string
 		labels []string
@@ -494,7 +494,7 @@ func TestExtractModelOverride(t *testing.T) {
 func TestExtractModelOverrideWarnsOnMultiple(t *testing.T) {
 	// Verify no panic and correct return value when multiple model labels are present.
 	// The warning goes to eng.logf (stdout in test mode) and is tested behaviorally above.
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	result := eng.extractModelOverride(0, []string{"model:opus", "model:sonnet", "model:haiku"})
 	if result != "opus" {
 		t.Errorf("expected %q, got %q", "opus", result)
@@ -502,7 +502,7 @@ func TestExtractModelOverrideWarnsOnMultiple(t *testing.T) {
 }
 
 func TestExtractEffortOverride(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	tests := []struct {
 		name   string
 		labels []string
@@ -531,7 +531,7 @@ func TestExtractEffortOverride(t *testing.T) {
 func TestExtractEffortOverrideMultipleLabelsPrecedence(t *testing.T) {
 	// When multiple effort: labels are present, the highest-ranked wins (max > high > medium > low).
 	// This differs from model: override which uses first-found.
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	tests := []struct {
 		name   string
@@ -623,7 +623,7 @@ func TestBaseBranchForItem(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &mockGitHubClient{}
-			eng := testEngine(client, &mockClaudeInvoker{})
+			eng := testEngine(t, client, &mockClaudeInvoker{})
 			wm := NewWorktreeManager(repoDir)
 			item := gh.ProjectItem{Number: 42, Labels: tc.labels}
 
@@ -680,7 +680,7 @@ func TestItemNeedsWork_CleanupStage_NeedsWork(t *testing.T) {
 }
 
 func TestItemNeedsWork_CleanupStage_AlreadyComplete(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	item := gh.ProjectItem{
@@ -694,7 +694,7 @@ func TestItemNeedsWork_CleanupStage_AlreadyComplete(t *testing.T) {
 }
 
 func TestItemNeedsWork_CleanupStage_PausedItem(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	item := gh.ProjectItem{

--- a/engine/grandchild_test.go
+++ b/engine/grandchild_test.go
@@ -35,9 +35,7 @@ func TestInvokeClaude_GrandchildHoldsPipe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	// Short WaitDelay so the test completes quickly (1s vs the production default of 30s).
 	origDelay := claudeWaitDelay
@@ -91,9 +89,7 @@ func TestInvokeClaude_MaxWallTimeKillsWithComplete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	origDelay := claudeWaitDelay
 	claudeWaitDelay = 1 * time.Second
@@ -143,9 +139,7 @@ func TestInvokeClaude_MaxWallTimeKillsWithoutComplete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	origDelay := claudeWaitDelay
 	claudeWaitDelay = 1 * time.Second
@@ -197,9 +191,7 @@ func TestKillProcGroupGraceful_StructuredLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	origDelay := claudeWaitDelay
 	claudeWaitDelay = 500 * time.Millisecond
@@ -291,9 +283,7 @@ func TestKillProcGroupGraceful_SIGINTGraceWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	origDelay := claudeWaitDelay
 	claudeWaitDelay = 500 * time.Millisecond
@@ -341,9 +331,7 @@ func TestInvokeClaude_InactivityTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	origDelay := claudeWaitDelay
 	claudeWaitDelay = 1 * time.Second

--- a/engine/handle_stage_complete_test.go
+++ b/engine/handle_stage_complete_test.go
@@ -23,7 +23,8 @@ func testStagesWithValidate() []*stages.Stage {
 
 // testEngineWithStages creates an engine with the given stages and a status field
 // configured for all of them.
-func testEngineWithStages(client *mockGitHubClient, stgs []*stages.Stage) *Engine {
+func testEngineWithStages(t *testing.T, client *mockGitHubClient, stgs []*stages.Stage) *Engine {
+	t.Helper()
 	eng := NewWithDeps(
 		Config{
 			Owner:         "owner",
@@ -36,7 +37,7 @@ func testEngineWithStages(client *mockGitHubClient, stgs []*stages.Stage) *Engin
 		},
 		client,
 		&mockClaudeInvoker{},
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 	opts := make(map[string]string)
 	for _, s := range stgs {
@@ -48,7 +49,7 @@ func testEngineWithStages(client *mockGitHubClient, stgs []*stages.Stage) *Engin
 
 func TestHandleStageComplete_NoYolo_NoAdvance(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 	// Yolo is false (default), no label
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -65,7 +66,7 @@ func TestHandleStageComplete_NoYolo_NoAdvance(t *testing.T) {
 func TestHandleStageComplete_CfgYolo_Advances(t *testing.T) {
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.Yolo = true
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -85,7 +86,7 @@ func TestHandleStageComplete_CfgYolo_Advances(t *testing.T) {
 func TestHandleStageComplete_YoloLabel_Advances(t *testing.T) {
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	// cfg.Yolo stays false; label provides yolo
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -109,7 +110,7 @@ func TestHandleStageComplete_YoloLabel_ValidateMergeableAdvances(t *testing.T) {
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
@@ -148,7 +149,7 @@ func TestHandleStageComplete_YoloLabel_ValidateAutoMergeNotEnabled_NoAdvance(t *
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
@@ -179,7 +180,7 @@ func TestHandleStageComplete_YoloLabel_ValidateNoPR_AdvancesAnyway(t *testing.T)
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
@@ -200,7 +201,7 @@ func TestHandleStageComplete_YoloLabel_ValidateNoPR_AdvancesAnyway(t *testing.T)
 func TestHandleStageComplete_YoloLabel_NonValidate_NoMergeAttempt(t *testing.T) {
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
@@ -229,7 +230,7 @@ func TestHandleStageComplete_AutoAdvanceFalse_OverridesAdvanceButMergeStillFires
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.Yolo = true // global yolo triggers auto-merge
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -269,7 +270,7 @@ func TestHandleStageComplete_MergeAPIError_LogsAndDoesNotAdvance(t *testing.T) {
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo"}}
@@ -300,7 +301,7 @@ func TestHandleStageComplete_MergeAPIError_LogsAndDoesNotAdvance(t *testing.T) {
 func TestHandleStageComplete_CruiseLabel_NonValidate_Advances(t *testing.T) {
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
@@ -321,7 +322,7 @@ func TestHandleStageComplete_CruiseLabel_NonValidate_Advances(t *testing.T) {
 func TestHandleStageComplete_CruiseLabel_Validate_NoMergeNoAdvance(t *testing.T) {
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
@@ -345,7 +346,7 @@ func TestHandleStageComplete_CruiseLabel_OverridesAutoAdvanceFalse(t *testing.T)
 	f := false
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
@@ -367,7 +368,7 @@ func TestHandleStageComplete_WaitForCI_AddsAwaitingCINotComplete(t *testing.T) {
 	tr := true
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.Yolo = true // ensure yolo doesn't bypass the new gate
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -404,7 +405,7 @@ func TestHandleStageComplete_WaitForCI_Idempotent(t *testing.T) {
 	tr := true
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	// Item already has the awaiting-ci label
@@ -432,7 +433,7 @@ func TestHandleStageComplete_WaitForCI_DoesNotSeedAwaitingReview(t *testing.T) {
 	tr := true
 	client := &mockGitHubClient{}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
@@ -462,7 +463,7 @@ func TestHandleStageComplete_WaitForCI_AppliesRegardlessOfYolo(t *testing.T) {
 		t.Run(fmt.Sprintf("yolo=%v", yolo), func(t *testing.T) {
 			client := &mockGitHubClient{}
 			stgs := testStagesWithValidate()
-			eng := testEngineWithStages(client, stgs)
+			eng := testEngineWithStages(t, client, stgs)
 			eng.cfg.Yolo = yolo
 
 			board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -502,7 +503,7 @@ func TestHandleStageComplete_BothCruiseAndYolo_CruiseWins(t *testing.T) {
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:yolo", "fabrik:cruise"}}
@@ -528,7 +529,7 @@ func TestHandleStageComplete_BothCruiseAndYolo_CruiseWins(t *testing.T) {
 // manually removed fabrik:paused after FABRIK_BLOCKED_ON_INPUT was emitted.
 func TestHandleStageComplete_ClearsAwaitingInput(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:awaiting-input"}}
@@ -555,7 +556,7 @@ func TestHandleStageComplete_ClearsAwaitingInput(t *testing.T) {
 // for that label name.
 func TestHandleStageComplete_NoAwaitingInput_NoSpuriousRemove(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -28,9 +28,7 @@ printf '%s\n' '{"result":"stage output\nFABRIK_STAGE_COMPLETE\n","session_id":"s
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -91,9 +89,7 @@ printf '%s\n' '{"result":"real invoker output","session_id":"sess_ri","num_turns
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	invoker := &RealClaudeInvoker{}
 	stage := &stages.Stage{
@@ -126,9 +122,7 @@ printf '%s\n' '{"result":"Claude output for test\nFABRIK_STAGE_COMPLETE\n","sess
 	}
 
 	// Prepend fake binary dir to PATH
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -179,9 +173,7 @@ printf '%%s\n' '{"result":"resume output","session_id":"sess_resume","num_turns"
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -226,9 +218,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_mt","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -275,9 +265,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_mo","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -312,9 +300,7 @@ exit 1
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -348,9 +334,7 @@ exit 1
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -384,9 +368,7 @@ exit 1
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -421,9 +403,7 @@ printf '%%s\n' '{"result":"comment output","session_id":"sess_c","num_turns":1,"
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -459,9 +439,7 @@ printf '%s\n' '{"result":"fallback output\nFABRIK_STAGE_COMPLETE\n","session_id"
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -505,9 +483,7 @@ func TestRunClaude_StdoutTeeToLogFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -589,9 +565,7 @@ func TestRunClaude_IssueUpdateInIntermediateTurn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -911,9 +885,7 @@ printf '%%s\n' '{"result":"env test\nFABRIK_STAGE_COMPLETE\n","session_id":"sess
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 
@@ -1010,9 +982,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_pm","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -1055,9 +1025,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_dt","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -1098,9 +1066,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_sr","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -1147,9 +1113,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_wb","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -1198,9 +1162,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_ro","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -1243,9 +1205,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_unr","num_turns":1,"total_cost
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{
@@ -1291,9 +1251,7 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_ur","num_turns":1,"total_cost_
 		t.Fatal(err)
 	}
 
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", binDir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
 	workDir := t.TempDir()
 	stage := &stages.Stage{

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestEmitStructural_WithChannel sends a structural event and verifies it's received.
 func TestEmitStructural_WithChannel(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	ch := make(chan tui.Event, 4)
 	eng.events = ch
 
@@ -37,7 +37,7 @@ func TestEmitStructural_WithChannel(t *testing.T) {
 // TestItemMayNeedWork_StaleButCooldownExpired verifies that a stale item is
 // retried after the cooldown period expires.
 func TestItemMayNeedWork_StaleButCooldownExpired(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1 // short cooldown
 
 	ts := time.Now().Add(-time.Minute)
@@ -70,7 +70,7 @@ func TestPollPreFilter_StaleItemWithinCooldown_Skipped(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 60
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 43, Reason: "periodic-re-eval", Until: time.Now().Add(10 * time.Minute)})
 	// item not in cycleSet (eng.mayNeedWork is empty), active CooldownAt → must be skipped
@@ -85,7 +85,7 @@ func TestPollPreFilter_StaleItemWithinCooldown_Skipped(t *testing.T) {
 // TestItemMayNeedWork_LockedByOtherUser verifies that itemMayNeedWork no longer
 // filters locked items — that check moved to itemNeedsWork after deep fetch.
 func TestItemMayNeedWork_LockedByOtherUser(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 44,
 		Status: "Research",
@@ -100,7 +100,7 @@ func TestItemMayNeedWork_LockedByOtherUser(t *testing.T) {
 // TestItemNeedsWork_LockedByOtherUser verifies that items locked by another user
 // are filtered out in itemNeedsWork (which runs after deep fetch).
 func TestItemNeedsWork_LockedByOtherUser(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 44,
 		Status: "Research",
@@ -114,7 +114,7 @@ func TestItemNeedsWork_LockedByOtherUser(t *testing.T) {
 // TestItemNeedsWork_Editing_ReturnsFalse verifies that items with fabrik:editing
 // are filtered out in itemNeedsWork (pre-dispatch gate).
 func TestItemNeedsWork_Editing_ReturnsFalse(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 44,
 		Status: "Research",
@@ -128,7 +128,7 @@ func TestItemNeedsWork_Editing_ReturnsFalse(t *testing.T) {
 // TestItemNeedsWork_Editing_Cleared_ReturnsTrue confirms the gate clears when
 // fabrik:editing is absent.
 func TestItemNeedsWork_Editing_Cleared_ReturnsTrue(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 44,
 		Status: "Research",
@@ -142,7 +142,7 @@ func TestItemNeedsWork_Editing_Cleared_ReturnsTrue(t *testing.T) {
 // TestItemNeedsWork_Blocked_ActiveCooldown_ReturnsFalse verifies that items with
 // fabrik:blocked and an active dep-blocked cooldown are suppressed — #576 gate holds.
 func TestItemNeedsWork_Blocked_ActiveCooldown_ReturnsFalse(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 45, Reason: "dep-blocked", Until: time.Now().Add(10 * time.Minute)})
 	item := gh.ProjectItem{
 		Number: 45,
@@ -158,7 +158,7 @@ func TestItemNeedsWork_Blocked_ActiveCooldown_ReturnsFalse(t *testing.T) {
 // item is admitted when the dep-blocked cooldown has expired, restoring the pull-based
 // safety net so processItem → checkDependencies can re-evaluate the dependency.
 func TestItemNeedsWork_Blocked_ExpiredCooldown_ReturnsTrue(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 45, Reason: "dep-blocked", Until: time.Now().Add(-time.Minute)})
 	item := gh.ProjectItem{
 		Number: 45,
@@ -174,7 +174,7 @@ func TestItemNeedsWork_Blocked_ExpiredCooldown_ReturnsTrue(t *testing.T) {
 // item with no store entry (cold-start or restart) is admitted — no cooldown means
 // no gate, so processItem → checkDependencies can run on the first poll.
 func TestItemNeedsWork_Blocked_NoStoreEntry_ReturnsTrue(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 45,
 		Status: "Research",
@@ -188,7 +188,7 @@ func TestItemNeedsWork_Blocked_NoStoreEntry_ReturnsTrue(t *testing.T) {
 // TestItemNeedsWork_Blocked_Cleared_ReturnsTrue confirms the gate clears when
 // fabrik:blocked is absent.
 func TestItemNeedsWork_Blocked_Cleared_ReturnsTrue(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 45,
 		Status: "Research",
@@ -202,7 +202,7 @@ func TestItemNeedsWork_Blocked_Cleared_ReturnsTrue(t *testing.T) {
 // TestBlockOnInput_Success covers both AddLabel calls and the notification comment.
 func TestBlockOnInput_Success(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	stage := &stages.Stage{Name: "Research", Order: 1}
 	item := gh.ProjectItem{Number: 5}
 	eng.blockOnInput(item, stage, "")
@@ -287,7 +287,7 @@ func TestBlockOnInput_LabelErrors_LogsWarning(t *testing.T) {
 			return errors.New("label error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	stage := &stages.Stage{Name: "Research", Order: 1}
 	item := gh.ProjectItem{Number: 6}
 	// Should not panic when labels fail
@@ -351,7 +351,7 @@ func TestCommitWIP_ExcludesContextFiles(t *testing.T) {
 		t.Fatalf("modify context file: %v", err)
 	}
 
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.commitWIP(workDir, 42, "Research")
 
 	// Verify the partial-progress commit was created.
@@ -399,7 +399,7 @@ func TestCommitWIP_ExcludesContextFiles(t *testing.T) {
 // itemMayNeedWork no longer filters items with open blockers — that check moved
 // to itemNeedsWork after deep fetch.
 func TestItemMayNeedWork_DependencyGate_OpenBlocker_PastFirstStage(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	// testEngine uses testStages(): Research(1), Plan(2), Implement(3)
 	// "Research" is the first stage; "Plan" is past the first.
 	item := gh.ProjectItem{
@@ -423,7 +423,7 @@ func TestItemMayNeedWork_DependencyGate_OpenBlocker_PastFirstStage(t *testing.T)
 // cache-bypass logic in itemMayNeedWork never re-evaluated them after
 // blockers closed (since blocker closure doesn't bump the item's updatedAt).
 func TestItemNeedsWork_DependencyGate_PassesThrough(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 5,
 		Status: "Plan",
@@ -442,7 +442,7 @@ func TestItemNeedsWork_DependencyGate_PassesThrough(t *testing.T) {
 // itemMayNeedWork does not filter first-stage items with open blockers.
 // The dep gate runs in processItem (via checkDependencies), not in itemMayNeedWork.
 func TestItemMayNeedWork_DependencyGate_FirstStage_NotFiltered(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	// "Research" is the first stage in testStages()
 	item := gh.ProjectItem{
 		Number: 5,
@@ -461,7 +461,7 @@ func TestItemMayNeedWork_DependencyGate_FirstStage_NotFiltered(t *testing.T) {
 // an item past the first stage with all blockers closed is not filtered.
 // (Dependency gate check is in itemNeedsWork; all-closed items pass through.)
 func TestItemMayNeedWork_DependencyGate_AllClosed_NotFiltered(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 5,
 		Status: "Plan",
@@ -478,7 +478,7 @@ func TestItemMayNeedWork_DependencyGate_AllClosed_NotFiltered(t *testing.T) {
 // TestItemMayNeedWork_ClosedIssue verifies that a closed issue in a non-cleanup
 // stage is skipped, regardless of yolo or labels.
 func TestItemMayNeedWork_ClosedIssue(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number:   99,
 		Status:   "Research",
@@ -492,7 +492,7 @@ func TestItemMayNeedWork_ClosedIssue(t *testing.T) {
 // TestItemNeedsWork_ClosedIssue verifies that itemNeedsWork returns false for
 // a closed issue in a non-cleanup stage.
 func TestItemNeedsWork_ClosedIssue(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number:   99,
 		Status:   "Research",
@@ -646,7 +646,7 @@ func TestPoll_DeepFetchFailureExcludesFromLastUpdatedAt(t *testing.T) {
 			return errors.New("simulated rate limit error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 999 // very long cooldown so we don't accidentally bypass
 	// Seed item into cycleSet so the pre-filter admits it for deep-fetch.
 	eng.mayNeedWorkMu.Lock()
@@ -680,7 +680,7 @@ func TestPoll_DeepFetchSuccessClearsFailureTime(t *testing.T) {
 		},
 		// fetchItemDetailsFn nil = success (mock returns nil by default)
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Pre-seed a failure time via the store.
 	eng.store.Apply(itemstate.DeepFetchFailed{Repo: "owner/repo", Number: 11, At: now.Add(-time.Minute)})
 	// Seed item into cycleSet so the pre-filter admits it for deep-fetch.
@@ -715,7 +715,7 @@ func TestPollPreFilter_AwaitingInput_WithoutChange_Skipped(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Seed the store so the pre-filter sees this as a known (previously-processed) item.
 	// InvocationRecorded fires InvocationChanged (not wakeChFlags) so no observer side-effect.
 	eng.store.Apply(itemstate.InvocationRecorded{Repo: "owner/repo", Number: 50, Completed: true})
@@ -732,7 +732,7 @@ func TestPollPreFilter_AwaitingInput_WithoutChange_Skipped(t *testing.T) {
 // recorded in deepFetchFailureTime, itemMayNeedWork returns false within the
 // cooldown window and true after the cooldown has expired.
 func TestItemMayNeedWork_DeepFetchFailureCooldown(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1 // 10-second cooldown
 
 	item := gh.ProjectItem{
@@ -761,7 +761,7 @@ func TestItemMayNeedWork_DeepFetchFailureCooldown(t *testing.T) {
 // fabrik:awaiting-ci bypass the updatedAt cache so the catch-up loop can
 // re-evaluate CI status on every poll even when the issue hasn't changed.
 func TestItemMayNeedWork_AwaitingCI_BypassesUpdatedAtCache(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 60 // long cooldown that would normally suppress
 
 	ts := time.Now().Add(-time.Minute)
@@ -798,7 +798,7 @@ func TestPollPreFilter_AwaitingReview_WithinCooldown_Bypassed(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 60
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 67, Reason: "review-blocked", Until: time.Now().Add(10 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
@@ -823,7 +823,7 @@ func TestPollPreFilter_AwaitingReview_ExpiredCooldown_Admitted(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 67, Reason: "review-blocked", Until: time.Now().Add(-15 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
 		t.Fatalf("poll: %v", err)
@@ -850,7 +850,7 @@ func TestPollPreFilter_AwaitingReview_NoCooldown_Bypassed(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 60
 	// Seed the store so the pre-filter sees this as a known (previously-processed) item.
 	eng.store.Apply(itemstate.InvocationRecorded{Repo: "owner/repo", Number: 68, Completed: true})
@@ -878,7 +878,7 @@ func TestPollPreFilter_Blocked_WithinCooldown_Skipped(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 60
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 63, Reason: "dep-blocked", Until: time.Now().Add(10 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
@@ -903,7 +903,7 @@ func TestPollPreFilter_NoSpecialLabel_WithinCooldown_Skipped(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 60
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 62, Reason: "periodic-re-eval", Until: time.Now().Add(10 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
@@ -931,7 +931,7 @@ func TestPollPreFilter_CompleteStage_ExpiredCooldown_DeepFetched(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 70, Reason: "periodic-re-eval", Until: time.Now().Add(-2 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
@@ -957,7 +957,7 @@ func TestPollPreFilter_IncompleteStage_ExpiredCooldown_Admitted(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 71, Reason: "periodic-re-eval", Until: time.Now().Add(-2 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
@@ -985,7 +985,7 @@ func TestPollPreFilter_AwaitingReview_WithCompleteLabel_ExpiredCooldown_Admitted
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { deepFetched = true; return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1
 	eng.store.Apply(itemstate.CooldownRecorded{Repo: "owner/repo", Number: 69, Reason: "review-blocked", Until: time.Now().Add(-2 * time.Minute)})
 	if _, err := eng.poll(t.Context()); err != nil {
@@ -1004,7 +1004,7 @@ func TestPollPreFilter_AwaitingReview_WithCompleteLabel_ExpiredCooldown_Admitted
 func TestItemNeedsWork_AwaitingCI_NoDispatch(t *testing.T) {
 	tr := true
 	stgs := []*stages.Stage{{Name: "Validate", Order: 3, WaitForCI: &tr}}
-	eng := testEngineWithStages(&mockGitHubClient{}, stgs)
+	eng := testEngineWithStages(t, &mockGitHubClient{}, stgs)
 	item := gh.ProjectItem{
 		Number: 64,
 		Status: "Validate",
@@ -1020,7 +1020,7 @@ func TestItemNeedsWork_AwaitingCI_NoDispatch(t *testing.T) {
 // A stale label from a prior CI-gated invocation must not permanently block
 // a stage that was moved to a different (non-CI-gated) column.
 func TestItemNeedsWork_AwaitingCI_NonCIGatedStage_Dispatches(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 	item := gh.ProjectItem{
 		Number: 67,
 		Status: "Research", // no wait_for_ci
@@ -1037,7 +1037,7 @@ func TestItemNeedsWork_AwaitingCI_NonCIGatedStage_Dispatches(t *testing.T) {
 func TestItemMayNeedWork_ClosedIssue_AwaitingCI_Passes(t *testing.T) {
 	tr := true
 	stgs := []*stages.Stage{{Name: "Validate", Order: 3, WaitForCI: &tr}}
-	eng := testEngineWithStages(&mockGitHubClient{}, stgs)
+	eng := testEngineWithStages(t, &mockGitHubClient{}, stgs)
 	item := gh.ProjectItem{
 		Number:   65,
 		Status:   "Validate",
@@ -1056,7 +1056,7 @@ func TestItemMayNeedWork_ClosedIssue_AwaitingCI_Passes(t *testing.T) {
 func TestItemNeedsWork_ClosedIssue_AwaitingCI_Passes(t *testing.T) {
 	tr := true
 	stgs := []*stages.Stage{{Name: "Validate", Order: 3, WaitForCI: &tr}}
-	eng := testEngineWithStages(&mockGitHubClient{}, stgs)
+	eng := testEngineWithStages(t, &mockGitHubClient{}, stgs)
 	item := gh.ProjectItem{
 		Number:   66,
 		Status:   "Validate",
@@ -1091,7 +1091,7 @@ func TestPoll_DeferredRefresh_DoesNotRefreshIncompleteItem(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1 // cooldown = 10s
 
 	initial := time.Now().Add(-2 * time.Minute) // expired timestamp
@@ -1141,7 +1141,7 @@ func TestPoll_DeferredRefresh_RefreshesTerminalItem(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 1 // cooldown = 10s
 
 	// Seed expired CooldownAt so the pre-filter admits the item for deep-fetch

--- a/engine/label_helpers_test.go
+++ b/engine/label_helpers_test.go
@@ -28,7 +28,7 @@ func TestRemoveEditingLabel_NonTransientNoRetry(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.removeEditingLabel("owner", "repo", 5)
 	if calls != 1 {
 		t.Errorf("expected exactly 1 call for non-transient error, got %d", calls)
@@ -54,7 +54,7 @@ func TestRemoveEditingLabel_TransientRetrySucceeds(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.removeEditingLabel("owner", "repo", 5)
 	if calls != 3 {
 		t.Errorf("expected 3 calls (2 transient then success), got %d", calls)
@@ -77,7 +77,7 @@ func TestRemoveEditingLabel_TransientExhausted(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.removeEditingLabel("owner", "repo", 5)
 	if calls != 3 {
 		t.Errorf("expected 3 calls on transient exhaustion, got %d", calls)
@@ -100,7 +100,7 @@ func TestRemoveEditingLabel_ErrNotFoundSilent(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.removeEditingLabel("owner", "repo", 5)
 	if calls != 1 {
 		t.Errorf("expected exactly 1 call for ErrNotFound, got %d", calls)
@@ -184,7 +184,7 @@ func TestRemoveLockLabel_NonNotFoundError_LogsWarning(t *testing.T) {
 			return errors.New("network error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// non-ErrNotFound error should log a warning without panicking
 	eng.removeLockLabel("owner", "repo", 5, "fabrik:locked:testuser")
 }
@@ -195,7 +195,7 @@ func TestRemoveLockLabel_ErrNotFound_Ignored(t *testing.T) {
 			return gh.ErrNotFound
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// ErrNotFound should be silently ignored
 	eng.removeLockLabel("owner", "repo", 5, "fabrik:locked:testuser")
 }
@@ -206,7 +206,7 @@ func TestEnsureDraftPR_FetchLinkedPRError_ReturnsError(t *testing.T) {
 			return nil, errors.New("api error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 1, Title: "Test"}
 	prNum, err := eng.ensureDraftPR(item, "main")
 	if prNum != 0 {
@@ -223,7 +223,7 @@ func TestEnsurePRLinksIssue_GetIssueBodyError_Logs(t *testing.T) {
 			return "", errors.New("not found")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Should not panic when GetIssueBody fails
 	eng.ensurePRLinksIssue(gh.ProjectItem{Number: 5}, 10)
 }
@@ -250,7 +250,7 @@ func TestMarkPRReady_MarkReadyError_LogsWarning(t *testing.T) {
 
 func TestAddFailedLabel_Success(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.addFailedLabel("owner", "repo", 9, "Research")
 
 	if len(client.addLabelCalls) != 1 {
@@ -267,7 +267,7 @@ func TestAddFailedLabel_ErrorLogsWarning(t *testing.T) {
 			return errors.New("api error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Should not panic
 	eng.addFailedLabel("owner", "repo", 10, "Plan")
 }
@@ -278,7 +278,7 @@ func TestRemoveFailedLabel_ErrorLogsWarning(t *testing.T) {
 			return errors.New("api error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Should not panic
 	eng.removeFailedLabel("owner", "repo", 10, "Plan")
 }
@@ -289,7 +289,7 @@ func TestRemoveInProgressLabel_ErrorLogsWarning(t *testing.T) {
 			return errors.New("api error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Should not panic
 	eng.removeInProgressLabel("owner", "repo", 10, "Plan")
 }

--- a/engine/layer1_test.go
+++ b/engine/layer1_test.go
@@ -51,7 +51,7 @@ func TestLayer1StatusRefreshRegression(t *testing.T) {
 			return newItemID, newStatus, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Wire mayNeedWork observer so we can assert StatusChanged fires.
 	mwnObs := newMayNeedWorkObserver(&eng.mayNeedWorkMu, &eng.mayNeedWork)
@@ -126,7 +126,7 @@ func TestLayer1StatusRefreshFastPath(t *testing.T) {
 			return newStatus, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Bootstrap with an item that already has an itemID (normal post-Bootstrap state).
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
@@ -164,7 +164,7 @@ func TestLayer1StatusRefreshSkipWhenNotOnBoard(t *testing.T) {
 			return "", "", nil // issue not on the project
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := layer1Cache(eng, client, "PVT_test", true)
 
 	key := boardcache.ItemKey("owner/repo", 1)
@@ -191,7 +191,7 @@ func TestLayer1StatusRefreshSkipWhenNotOnBoard(t *testing.T) {
 // entirely. This guards against useless API calls during the startup window.
 func TestLayer1StatusRefreshEmptyProjectID(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Bootstrap with empty projectID — simulates pre-Bootstrap or mid-startup state.
 	cache := layer1Cache(eng, client, "" /* empty projectID */, true)

--- a/engine/lock_then_verify_test.go
+++ b/engine/lock_then_verify_test.go
@@ -115,7 +115,7 @@ func TestLockThenVerify_CompetingLockLowerUser_YieldsAndReturnsNil(t *testing.T)
 			return []string{"fabrik:locked:testuser", "fabrik:locked:aardvark"}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	orig := lockVerifyDelay
 	lockVerifyDelay = 0
@@ -123,7 +123,7 @@ func TestLockThenVerify_CompetingLockLowerUser_YieldsAndReturnsNil(t *testing.T)
 
 	// Pre-register the worktree manager so ensureRepoReady returns nil.
 	eng.mu.Lock()
-	eng.worktreeManagers["owner/repo"] = NewWorktreeManager("/tmp/fake-repo")
+	eng.worktreeManagers["owner/repo"] = NewWorktreeManager(t.TempDir())
 	eng.mu.Unlock()
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -19,7 +19,7 @@ func TestCheckMergeabilityGate_WaitForCIFalse_ClearsImmediately(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate"} // WaitForCI is nil
 
@@ -38,7 +38,7 @@ func TestCheckMergeabilityGate_NoPR_ClearsGate(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -59,7 +59,7 @@ func TestCheckMergeabilityGate_Mergeable_ClearsGate_RemovesStaleLabel(t *testing
 			return &tr, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:rebase-needed"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
@@ -88,7 +88,7 @@ func TestCheckMergeabilityGate_NilMergeable_BlockedNoConflict(t *testing.T) {
 			return nil, nil // GitHub hasn't computed yet
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
@@ -114,7 +114,7 @@ func TestCheckMergeabilityGate_FalseMergeable_AppliesLabelAndSignalsConflict(t *
 			return &fa, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
@@ -144,7 +144,7 @@ func TestCheckMergeabilityGate_FalseMergeable_LabelIdempotent(t *testing.T) {
 			return &fa, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	// Label already present — should not be re-added.
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:rebase-needed"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -167,7 +167,7 @@ func TestCheckMergeabilityGate_FetchPRError_BlocksForRetry(t *testing.T) {
 			return nil, errStubTransient
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
@@ -192,7 +192,7 @@ func TestCheckMergeabilityGate_FetchMergeableError_BlocksForRetry(t *testing.T) 
 			return nil, errStubTransient
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
@@ -223,7 +223,7 @@ func TestCheckAutoMergeConvergence_PRMerged_RemovesLabelAndAdvances(t *testing.T
 			return &gh.PRDetails{Number: 10, State: "closed", Merged: true, AutoMergeEnabled: true}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
 
@@ -259,7 +259,7 @@ func TestCheckAutoMergeConvergence_UserDisabledAutoMerge_PostsCommentRemovesLabe
 			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: false}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled", "fabrik:yolo"}}
 	stage := &stages.Stage{Name: "Validate"}
 
@@ -305,7 +305,7 @@ func TestCheckAutoMergeConvergence_BudgetExhausted_PausesIssue(t *testing.T) {
 			return time.Now().Add(-2 * time.Hour), nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.ConvergenceBudget = 30 * time.Minute
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
@@ -349,7 +349,7 @@ func TestCheckAutoMergeConvergence_BudgetDisabled_NoPause(t *testing.T) {
 			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "blocked"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.ConvergenceBudget = 0 // disabled
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
@@ -369,7 +369,7 @@ func TestCheckAutoMergeConvergence_UnknownMergeability_Waits(t *testing.T) {
 			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "unknown"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
 
@@ -390,7 +390,7 @@ func TestCheckAutoMergeConvergence_DirtyConflict_IncrementsCycleCount(t *testing
 			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
 
@@ -420,7 +420,7 @@ func TestCheckAutoMergeConvergence_DirtyConflict_InFlight_SkipsDispatch(t *testi
 			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	// Simulate in-flight worker.
 	eng.store.Apply(itemstate.LocalLockAcquired{
 		Repo: "owner/repo", Number: 42, User: "testuser", AcquiredAt: time.Now(),
@@ -450,7 +450,7 @@ func TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain(t *testing.T) 
 			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	// Simulate prior rebase cycle having completed (no in-flight worker).
 	eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 42, StageName: "Validate"})
 
@@ -481,7 +481,7 @@ func TestPauseForConvergenceFailed_PostsComment_AppliesLabels(t *testing.T) {
 			return 3, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.ConvergenceBudget = 30 * time.Minute
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
@@ -539,7 +539,7 @@ func TestCheckAutoMergeConvergence_UnregisteredRepo_NoPanic(t *testing.T) {
 			return time.Now().Add(-2 * time.Hour), nil // budget exhausted
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	eng.cfg.ConvergenceBudget = 30 * time.Minute
 	eng.fabrikDir = t.TempDir() // forces ensureBareClone to fail (no network for fake repo)
 

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -541,14 +541,15 @@ func TestCheckAutoMergeConvergence_UnregisteredRepo_NoPanic(t *testing.T) {
 	}
 	eng := testEngineForMerge(t, client)
 	eng.cfg.ConvergenceBudget = 30 * time.Minute
-	eng.fabrikDir = t.TempDir() // forces ensureBareClone to fail (no network for fake repo)
+	// ENAMETOOLONG: fails os.MkdirAll before any network call — deterministic, no git subprocess.
+	eng.fabrikDir = strings.Repeat("a", 10000)
 
 	// item.Repo points at a repo with no registered WorktreeManager. The pre-fix
 	// behavior would be: convergence budget exhausted → pauseForConvergenceFailed
-	// → worktreesFor("nonexistent-xyz/nonexistent-repo") → panic.
+	// → worktreesFor("fail-test/unregistered") → panic.
 	item := gh.ProjectItem{
 		Number: 42,
-		Repo:   "nonexistent-xyz/nonexistent-repo-convergence",
+		Repo:   "fail-test/unregistered",
 		Labels: []string{"fabrik:auto-merge-enabled"},
 	}
 	stage := &stages.Stage{Name: "Validate"}

--- a/engine/no_work_needed_test.go
+++ b/engine/no_work_needed_test.go
@@ -53,7 +53,7 @@ func testStagesWithValidateAndCleanup() []*stages.Stage {
 func TestHandleNoWorkNeeded_MovesToDone(t *testing.T) {
 	client := &mockGitHubClient{}
 	// testStagesWithCleanup: Research(1), Plan(2), Implement(3), Done(99, cleanup)
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5"}
@@ -87,7 +87,7 @@ func TestHandleNoWorkNeeded_MovesToDone(t *testing.T) {
 // TestHandleNoWorkNeeded_NilStatusField logs warning and does not panic.
 func TestHandleNoWorkNeeded_NilStatusField(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 	eng.statusField = nil
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -117,7 +117,7 @@ func TestHandleNoWorkNeeded_NilStatusField(t *testing.T) {
 // TestHandleNoWorkNeeded_NoDoneOption logs warning and does not panic.
 func TestHandleNoWorkNeeded_NoDoneOption(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 	delete(eng.statusField.Options, "Done")
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -139,7 +139,7 @@ func TestHandleNoWorkNeeded_NoDoneOption(t *testing.T) {
 func TestHandleNoWorkNeeded_SkipsIntermediateStages(t *testing.T) {
 	client := &mockGitHubClient{}
 	// Stages: Research(1), Plan(2), Implement(3), Validate(4), Done(5, cleanup)
-	eng := testEngineWithStages(client, testStagesWithValidateAndCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 7, ItemID: "PVTI_7"}
@@ -195,7 +195,7 @@ func TestHandleNoWorkNeeded_SkipsIntermediateStages(t *testing.T) {
 // ApplyIssueClosed write-through sets IsClosed in the cache.
 func TestHandleNoWorkNeeded_ClosesIssue(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 
 	// Wire up a live CacheImpl so the ApplyIssueClosed write-through is exercised.
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
@@ -247,7 +247,7 @@ func TestHandleNoWorkNeeded_CloseIssueNotCalledOnStatusFailure(t *testing.T) {
 			return fmt.Errorf("status update failed")
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5", Repo: "owner/repo"}
@@ -264,7 +264,7 @@ func TestHandleNoWorkNeeded_CloseIssueNotCalledOnStatusFailure(t *testing.T) {
 // removed when handleNoWorkNeeded runs, covering the orphaned-label scenario.
 func TestHandleNoWorkNeeded_ClearsAwaitingInput(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 5, ItemID: "PVTI_5", Labels: []string{"fabrik:awaiting-input"}}
@@ -290,7 +290,7 @@ func TestHandleNoWorkNeeded_ClearsAwaitingInput(t *testing.T) {
 // directly to Done, not to the next sequential stage.
 func TestHandleNoWorkNeeded_DirectlyDoneNotNextStage(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineWithStages(client, testStagesWithCleanup())
+	eng := testEngineWithStages(t, client, testStagesWithCleanup())
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{Number: 9, ItemID: "PVTI_9"}

--- a/engine/poll_multirepo_test.go
+++ b/engine/poll_multirepo_test.go
@@ -42,7 +42,7 @@ func TestPoll_MultiRepoFilter_SkipsOtherRepos(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	if _, err := eng.poll(context.Background()); err != nil {
 		t.Fatalf("poll: %v", err)
@@ -87,7 +87,7 @@ func TestPoll_MultiRepoFilter_YoloCatchup_SkipsOtherRepos(t *testing.T) {
 		advancedItems = append(advancedItems, itemID)
 		return nil
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{
 		FieldID: "F1",
 		Options: map[string]string{"Research": "OPT_1", "Plan": "OPT_2"},

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -38,7 +38,7 @@ func TestPoll_FetchesBoardAndProcessesItems(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	_, err := eng.poll(context.Background())
 	if err != nil {
@@ -56,7 +56,7 @@ func TestPoll_Error(t *testing.T) {
 			return nil, fmt.Errorf("network error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	_, err := eng.poll(context.Background())
 	if err == nil {
@@ -73,7 +73,7 @@ func TestPoll_StatusFieldFetchError(t *testing.T) {
 			return nil, fmt.Errorf("status field error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Should not error — status field failure is a warning
 	_, err := eng.poll(context.Background())
@@ -95,7 +95,7 @@ func TestPoll_StatusFieldAlreadySet(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{FieldID: "already-set"}
 
 	_, _ = eng.poll(context.Background())
@@ -111,7 +111,7 @@ func TestPoll_EmptyProjectID(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	_, _ = eng.poll(context.Background())
 }
@@ -128,7 +128,7 @@ func TestPoll_RateLimitLogging(t *testing.T) {
 			return rest, gql
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// poll() must succeed and not panic when rate limit stats are non-zero.
 	if _, err := eng.poll(context.Background()); err != nil {
@@ -147,7 +147,7 @@ func TestPoll_RateLimitLogging_ZeroReset(t *testing.T) {
 			return rest, gh.RateLimitStats{}
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	if _, err := eng.poll(context.Background()); err != nil {
 		t.Fatalf("poll: %v", err)
@@ -280,7 +280,7 @@ func TestItemNeedsWork_CleanupStage_NoWorktree(t *testing.T) {
 // closed issue with fabrik:locked:<user> gets the lock label removed.
 func TestCleanupClosedIssueLocks_RemovesLockFromClosedIssue(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -310,7 +310,7 @@ func TestCleanupClosedIssueLocks_RemovesLockFromClosedIssue(t *testing.T) {
 // with a lock label are left untouched.
 func TestCleanupClosedIssueLocks_IgnoresOpenIssues(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -333,7 +333,7 @@ func TestCleanupClosedIssueLocks_IgnoresOpenIssues(t *testing.T) {
 // belonging to other users are not removed.
 func TestCleanupClosedIssueLocks_IgnoresOtherUsersLocks(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -356,7 +356,7 @@ func TestCleanupClosedIssueLocks_IgnoresOtherUsersLocks(t *testing.T) {
 // any lock label produces no API call.
 func TestCleanupClosedIssueLocks_NoLock(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -402,7 +402,7 @@ func TestYoloCatchup_AdvancesClosedIssue(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.Yolo = true
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
 	eng.mayNeedWorkMu.Lock()
@@ -451,7 +451,7 @@ func TestYoloCatchup_SkipsNotDeepFetched(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.Yolo = true
 	// Seed the store so the pre-filter sees this as a known (previously-processed) item.
 	eng.store.Apply(itemstate.InvocationRecorded{Repo: "owner/repo", Number: 55, Completed: true})
@@ -487,7 +487,7 @@ func TestPoll_RateLimitWarning(t *testing.T) {
 			return gh.RateLimitStats{}, gql
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Use events channel to capture log output without hitting stdout.
 	events := make(chan tui.Event, 64)
@@ -517,7 +517,7 @@ func TestPoll_RateLimitWarning(t *testing.T) {
 // CleanupWorktree stage with the stage:<Name>:complete label are archived.
 func TestArchiveDoneCompleteItems_ArchivesCompleteItems(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	board := &gh.ProjectBoard{
@@ -583,7 +583,7 @@ func TestCatchupLoop_SkipsReviewGate_WhenAwaitingCIWithoutComplete(t *testing.T)
 			return nil, nil
 		},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	if _, err := eng.poll(context.Background()); err != nil {
 		t.Fatalf("poll: %v", err)
@@ -627,7 +627,7 @@ func TestCatchupLoop_RunsReviewGate_WhenHasComplete(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	if _, err := eng.poll(context.Background()); err != nil {
 		t.Fatalf("poll: %v", err)
@@ -655,7 +655,7 @@ func TestCleanupClosedIssueTransientLabels_RemovesAllTransientLabels(t *testing.
 		label := label
 		t.Run(label, func(t *testing.T) {
 			client := &mockGitHubClient{}
-			eng := testEngine(client, &mockClaudeInvoker{})
+			eng := testEngine(t, client, &mockClaudeInvoker{})
 
 			board := &gh.ProjectBoard{
 				Items: []gh.ProjectItem{
@@ -686,7 +686,7 @@ func TestCleanupClosedIssueTransientLabels_RemovesAllTransientLabels(t *testing.
 // issues with transient labels are left untouched.
 func TestCleanupClosedIssueTransientLabels_SkipsOpenIssues(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -709,7 +709,7 @@ func TestCleanupClosedIssueTransientLabels_SkipsOpenIssues(t *testing.T) {
 // issues without any transient labels produce no API call.
 func TestCleanupClosedIssueTransientLabels_SkipsCleanIssues(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -737,7 +737,7 @@ func TestCleanupClosedIssueTransientLabels_ErrNotFoundIsIdempotent(t *testing.T)
 			return gh.ErrNotFound
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -768,7 +768,7 @@ func TestCleanupClosedIssueTransientLabels_APIErrorContinues(t *testing.T) {
 			return fmt.Errorf("simulated API error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	board := &gh.ProjectBoard{
 		Items: []gh.ProjectItem{
@@ -792,7 +792,7 @@ func TestCleanupClosedIssueTransientLabels_APIErrorContinues(t *testing.T) {
 // without the stage:Done:complete label are not archived.
 func TestArchiveDoneCompleteItems_SkipsIncompleteItems(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	board := &gh.ProjectBoard{
@@ -850,7 +850,7 @@ func TestYoloCatchUpEnablesAutoMerge(t *testing.T) {
 			return &gh.PRDetails{Number: 99, HeadSHA: "sha1"}, nil
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#42"] = true
@@ -921,7 +921,7 @@ func TestYoloCatchUpSkipsAdvanceOnAutoMergeError(t *testing.T) {
 			return errors.New("transient API error")
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#42"] = true
@@ -990,7 +990,7 @@ func TestYoloCatchUpSkipsAdvanceOnUnprocessedComment(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 
 	ctx := context.Background()
 	if _, err := eng.poll(ctx); err != nil {
@@ -1010,7 +1010,7 @@ func TestYoloCatchUpSkipsAdvanceOnUnprocessedComment(t *testing.T) {
 // non-cleanup stages are not archived even if they have complete labels.
 func TestArchiveDoneCompleteItems_SkipsNonCleanupStages(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	board := &gh.ProjectBoard{
@@ -1063,7 +1063,7 @@ func TestCruiseCatchUp_NonValidate_Advances(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#10"] = true
@@ -1121,7 +1121,7 @@ func TestCruiseCatchUp_Validate_NoMergeNoAdvance(t *testing.T) {
 			return 55, nil
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 
 	ctx := context.Background()
 	if _, err := eng.poll(ctx); err != nil {
@@ -1177,7 +1177,7 @@ func TestCruiseCatchUp_BothCruiseAndYolo_CruiseWins(t *testing.T) {
 			return &gh.PRDetails{Number: 66, HeadSHA: "sha1"}, nil
 		},
 	}
-	eng := testEngineWithStages(client, testStagesWithValidate())
+	eng := testEngineWithStages(t, client, testStagesWithValidate())
 	// Seed item into cycleSet so the pre-filter admits it (simulates observer firing).
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#12"] = true
@@ -1480,7 +1480,7 @@ func TestPollPreFilter_WaitForCI_CompleteLabelOnly_Skipped(t *testing.T) {
 		Token:         "token",
 		MaxConcurrent: 5,
 		Stages:        stgs,
-	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()))
 	// Seed the store so the pre-filter sees this as a known (previously-processed) item.
 	eng.store.Apply(itemstate.InvocationRecorded{Repo: "owner/repo", Number: 99, Completed: true})
 
@@ -1531,7 +1531,7 @@ func TestPollPreFilter_NoWaitForCI_CompleteLabel_Skipped(t *testing.T) {
 		Token:         "token",
 		MaxConcurrent: 5,
 		Stages:        stgs,
-	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()))
 	// Seed the store so the pre-filter sees this as a known (previously-processed) item.
 	eng.store.Apply(itemstate.InvocationRecorded{Repo: "owner/repo", Number: 99, Completed: true})
 
@@ -1586,7 +1586,7 @@ func TestPoll_CruiseValidateComplete_NoRepeatDeepFetch(t *testing.T) {
 		MaxConcurrent: 5,
 		PollSeconds:   1, // 10s cooldown
 		Stages:        stgs,
-	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()))
 
 	// Simulate the perpetual-loop trigger: CooldownAt["periodic-re-eval"] expired.
 	eng.store.Apply(itemstate.CooldownRecorded{
@@ -1638,7 +1638,7 @@ func TestLayer1StatusRefresh_UpdatesCacheOnIssueCommentEvent(t *testing.T) {
 		},
 	}
 	cache := seedTestCache(t, client)
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	payload, _ := json.Marshal(map[string]any{
 		"issue":      map[string]any{"number": 1},
@@ -1680,7 +1680,7 @@ func TestLayer1StatusRefresh_SkipsWhenCachePaused(t *testing.T) {
 	}
 	cache := seedTestCache(t, client)
 	cache.Pause()
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	payload, _ := json.Marshal(map[string]any{
 		"issue":      map[string]any{"number": 1},
@@ -1702,7 +1702,7 @@ func TestLayer1StatusRefresh_SkipsNonIssueEvents(t *testing.T) {
 		},
 	}
 	cache := seedTestCache(t, client)
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	payload, _ := json.Marshal(map[string]any{
 		"pull_request": map[string]any{"number": 1},
@@ -1729,7 +1729,7 @@ func TestPollGateMiss(t *testing.T) {
 			return t1, nil // same timestamp on every call
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{ProjectID: "PVT_1", Items: nil})
 	eng.readClient = cache
@@ -1769,7 +1769,7 @@ func TestPollGateFire(t *testing.T) {
 			return ts, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{ProjectID: "PVT_1", Items: nil})
 	eng.readClient = cache
@@ -1806,7 +1806,7 @@ func TestPollGateFire_AppliesStatusDrift(t *testing.T) {
 			return map[string]string{"PVTI_001": "Implement"}, nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	ctx := context.Background()
 	if _, err := eng.poll(ctx); err != nil {
@@ -1939,7 +1939,7 @@ func TestPoll_LogBoardFromGitHub(t *testing.T) {
 			return &gh.ProjectBoard{ProjectID: "PVT_1", Items: nil}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	logs := collectPollLogs(t, eng)
 
@@ -1962,7 +1962,7 @@ func TestPoll_LogBoardFromGitHub(t *testing.T) {
 // when readClient is a bootstrapped, unpaused CacheImpl.
 func TestPoll_LogBoardFromCache(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng, _ := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	logs := collectPollLogs(t, eng)
 
@@ -1995,7 +1995,7 @@ func TestPoll_LogBoardBootstrapThenCache(t *testing.T) {
 			return board, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	eng.readClient = cache
 
@@ -2045,7 +2045,7 @@ func TestPoll_LogItemFromGitHub(t *testing.T) {
 			return board, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.readClient = boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 
 	// Register mayNeedWorkObserver before poll(): the per-poll Bootstrap fires
@@ -2080,7 +2080,7 @@ func TestPoll_LogItemFromCache(t *testing.T) {
 		Items:     []gh.ProjectItem{{Number: 1, ItemID: "PVTI_001", Status: "Research", Repo: "owner/repo"}},
 	}
 	client := &mockGitHubClient{}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 
 	// Register the mayNeedWorkObserver before Bootstrap so the StatusChanged
@@ -2147,7 +2147,7 @@ func TestInFlightItem_NotDeepFetchedByWorkerLifecycleChanged(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Register the mayNeedWork observer to demonstrate it does NOT fire for
 	// WorkerLifecycleChanged (Fix B: cycleSetFlags excludes WorkerLifecycleChanged).
@@ -2354,7 +2354,7 @@ func TestRunProbeAndDeepFetch_StaleItem_TriggersDeepFetch(t *testing.T) {
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	eng.runProbeAndDeepFetch(cache)
 	if deepFetchCalls == 0 {
 		t.Error("expected FetchItemDetails called for stale item (zero LastSeenSourceUpdatedAt); got 0 calls")
@@ -2378,7 +2378,7 @@ func TestRunProbeAndDeepFetch_FreshItem_SkipsDeepFetch(t *testing.T) {
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	// Simulate a prior deep-fetch that set LastSeenSourceUpdatedAt = T1.
 	eng.store.Apply(itemstate.ItemDeepFetched{
 		Repo:   "owner/repo",
@@ -2412,7 +2412,7 @@ func TestRunProbeAndDeepFetch_LinkageDrift_InvalidatesAndDeepFetches(t *testing.
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	// Simulate fresh state at T1 with no linked PR (cached LinkedPRNumber = 0).
 	eng.store.Apply(itemstate.ItemDeepFetched{
 		Repo:   "owner/repo",
@@ -2439,7 +2439,7 @@ func TestRunProbeAndDeepFetch_ItemGone_RemovedFromStore(t *testing.T) {
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { return nil },
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{
 		ProjectID: "PVT_1",
@@ -2472,7 +2472,7 @@ func TestRunStartupTransientLabelScan_RemovesStaleLabelsFromClosedItems(t *testi
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Seed three items into the store:
 	//   #1 — closed, carries a transient label → should be cleaned
@@ -2552,7 +2552,7 @@ func TestColdStart_ProbeBootstrap_TerminalItemsSkipDeepFetch(t *testing.T) {
 			User: "testuser", Token: "token", MaxConcurrent: 5,
 			Stages: testStagesWithCleanup(),
 		},
-		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"),
+		client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()),
 	)
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	eng.readClient = cache
@@ -2637,7 +2637,7 @@ func TestWebhookModeStartup_ClosedDoneItemsNotDeepFetched(t *testing.T) {
 			User: "testuser", Token: "token", MaxConcurrent: 5,
 			Stages: testStagesWithCleanup(),
 		},
-		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"),
+		client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()),
 	)
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 
@@ -2686,7 +2686,7 @@ func TestRunProbeAndDeepFetch_IsClosedPropagates_WithoutDeepFetch(t *testing.T) 
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	// Fresh at T1 — deep-fetch should not be triggered.
 	eng.store.Apply(itemstate.ItemDeepFetched{
 		Repo:   "owner/repo",
@@ -2757,7 +2757,7 @@ func TestProbeNewItem_ClosedDone_SkipsDeepFetch(t *testing.T) {
 			User: "testuser", Token: "token", MaxConcurrent: 5,
 			Stages: testStagesWithCleanup(),
 		},
-		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"),
+		client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()),
 	)
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	eng.readClient = cache
@@ -2818,7 +2818,7 @@ func TestCheckAllowAutoMerge_DisabledEmitsWarning(t *testing.T) {
 			return false, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	out := captureStdout(func() {
 		eng.checkAllowAutoMerge("owner", "repo")
@@ -2843,7 +2843,7 @@ func TestCheckAllowAutoMerge_EnabledIsSilent(t *testing.T) {
 			return true, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	out := captureStdout(func() {
 		eng.checkAllowAutoMerge("owner", "repo")
@@ -2862,7 +2862,7 @@ func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
 			return false, errors.New("network error")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Should not panic; engine should log the error at warn level and continue.
 	out := captureStdout(func() {
@@ -2885,7 +2885,7 @@ func TestCheckAllowAutoMerge_DedupSuppressesSecondCall(t *testing.T) {
 			return false, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	// First call should emit warning.
 	out1 := captureStdout(func() {
@@ -2946,7 +2946,7 @@ func TestPoll_InFlightWorker_NotSupplanted(t *testing.T) {
 		MaxConcurrent: 5,
 		PollSeconds:   1,
 		Stages:        testStagesWithValidate(),
-	}, client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"))
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()))
 
 	// Simulate an in-flight worker: WorkerEntered in the Store + a live
 	// issueCtxs entry with a cancellable context. This is the exact state poll()

--- a/engine/pr_test.go
+++ b/engine/pr_test.go
@@ -20,7 +20,7 @@ func TestEnsureDraftPR_ExistingPR_SkipsCreate(t *testing.T) {
 			return &gh.PRDetails{Number: 42, State: "open"}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Title: "Test Issue"}
 	prNum, err := eng.ensureDraftPR(item, "main")
@@ -43,7 +43,7 @@ func TestEnsurePRLinksIssue_AlreadyLinked_NoUpdate(t *testing.T) {
 			return "This PR closes Closes #5", nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	eng.ensurePRLinksIssue(gh.ProjectItem{Number: 5}, 10)
 
@@ -66,7 +66,7 @@ func TestEnsurePRLinksIssue_Missing_AddsKeyword(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	eng.ensurePRLinksIssue(gh.ProjectItem{Number: 7}, 10)
 
@@ -90,7 +90,7 @@ func TestEnsurePRLinksIssue_FencedClosesN_SelfHeals(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	eng.ensurePRLinksIssue(gh.ProjectItem{Number: 7}, 10)
 
@@ -163,7 +163,7 @@ func TestPostOutputToPR_WithPR_PostsToPRAndIssue(t *testing.T) {
 			return 0, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 3, Title: "Issue"}
 
 	eng.postOutputToPR(item, "Implement", "detailed output", "", "main-branch", "abc123", "", "2024-01-01")
@@ -200,7 +200,7 @@ func TestPostOutputToPR_FindPRError_FallsBackToIssue(t *testing.T) {
 			return 0, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 5, Title: "Issue"}
 
 	eng.postOutputToPR(item, "Review", "output", "", "", "", "", "")
@@ -220,7 +220,7 @@ func TestPostOutputToPR_AddCommentErrors_LogsWarnings(t *testing.T) {
 			return 0, errors.New("post error") // all AddComment calls fail
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 6, Title: "Issue"}
 
 	// Should not panic when AddComment fails
@@ -238,7 +238,7 @@ func TestPostOutputToPR_NoPR_FallsBackToIssue(t *testing.T) {
 			return 0, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 4, Title: "Issue"}
 
 	eng.postOutputToPR(item, "Review", "output", "", "", "", "", "")
@@ -267,7 +267,7 @@ func TestUpdatePRVerification_ReplacesSectionAndCallsUpdateIssueBody(t *testing.
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{Number: 10, Title: "My issue"}
 	eng.updatePRVerification(item, 99, "All tests pass.")
@@ -294,7 +294,7 @@ func TestUpdatePRVerification_EmptySummaryIsNoop(t *testing.T) {
 			return "## Verification\n\nplaceholder.\n\n---\n\nCloses #1", nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.updatePRVerification(gh.ProjectItem{Number: 1}, 55, "")
 
 	if called {
@@ -313,7 +313,7 @@ func TestUpdatePRVerification_SectionNotFound_WarnsAndSkips(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.updatePRVerification(gh.ProjectItem{Number: 2}, 88, "my summary")
 
 	if updateCalled {
@@ -614,7 +614,7 @@ func TestSyncPRBase_NoPR_NoUpdateAttempted(t *testing.T) {
 			return 0, nil // no PR
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 1}
 
 	eng.syncPRBase(item, "main") // must not panic or call UpdatePRBase
@@ -636,7 +636,7 @@ func TestSyncPRBase_MatchingBase_NoUpdateAttempted(t *testing.T) {
 			return "main", nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 1}
 
 	eng.syncPRBase(item, "main") // base matches — no update
@@ -655,7 +655,7 @@ func TestSyncPRBase_MismatchedBase_UpdatesExactlyOnce(t *testing.T) {
 			return "main", nil // current base
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 1}
 
 	eng.syncPRBase(item, "feature/foo") // desired base differs
@@ -684,7 +684,7 @@ func TestSyncPRBase_UpdateError_StageContinues(t *testing.T) {
 			return errors.New("github: unprocessable entity")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	item := gh.ProjectItem{Number: 1}
 
 	// syncPRBase must not propagate the error — caller sees no return value
@@ -1108,7 +1108,7 @@ func TestEnsureDraftPR_NonTransientError_ImmediateFailure(t *testing.T) {
 			return nil, errors.New("GitHub API returned 422: validation failed")
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{Number: 52, Title: "Feature"}
 	prNum, err := eng.ensureDraftPR(item, "main")
@@ -1137,7 +1137,7 @@ func TestEnsureDraftPR_AllRetriesExhausted_ReturnsError(t *testing.T) {
 			return nil, fmt.Errorf("executing request: %w", &net.OpError{Op: "read", Net: "tcp"})
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{Number: 53, Title: "Feature"}
 	prNum, err := eng.ensureDraftPR(item, "main")

--- a/engine/prcreate_test.go
+++ b/engine/prcreate_test.go
@@ -160,7 +160,7 @@ func TestProcessPRCreateMarker_Success(t *testing.T) {
 			return 42, nil
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	block := &PRCreateBlock{
@@ -191,7 +191,7 @@ func TestProcessPRCreateMarker_IdempotencyExistingPR(t *testing.T) {
 			return &gh.PRDetails{Number: 99, State: "open"}, nil
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	block := &PRCreateBlock{Title: "T", Body: "B"}
@@ -214,7 +214,7 @@ func TestProcessPRCreateMarker_IdempotencyExistingPR(t *testing.T) {
 
 func TestProcessPRCreateMarker_CrossRepoNotSupported(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	block := &PRCreateBlock{
@@ -255,7 +255,7 @@ func TestProcessPRCreateMarker_CreateFailurePauses(t *testing.T) {
 			return 0, fmt.Errorf("API rate limit exceeded")
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	block := &PRCreateBlock{Title: "T", Body: "Body content here."}
@@ -284,7 +284,7 @@ func TestProcessPRCreateMarker_CreateFailurePauses(t *testing.T) {
 // ---- verifyAndHealLinkage tests ----
 
 func TestVerifyAndHealLinkage_NoPR(t *testing.T) {
-	eng := testEngine(&mockGitHubClient{}, nil)
+	eng := testEngine(t, &mockGitHubClient{}, nil)
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	stage := &stages.Stage{Name: "Implement"}
 	ok := eng.verifyAndHealLinkage(context.Background(), item, 0, stage, "owner", "repo", "owner/repo")
@@ -300,7 +300,7 @@ func TestVerifyAndHealLinkage_AlreadyLinked(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	stage := &stages.Stage{Name: "Implement"}
 	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
@@ -320,7 +320,7 @@ func TestVerifyAndHealLinkage_BranchMismatch_NoLinkedPR(t *testing.T) {
 			return nil, nil // no PR on branch
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	stage := &stages.Stage{Name: "Implement"}
 	ok := eng.verifyAndHealLinkage(context.Background(), item, 42, stage, "owner", "repo", "owner/repo")
@@ -362,7 +362,7 @@ func TestVerifyAndHealLinkage_HealSuccess(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	stage := &stages.Stage{Name: "Implement"}
 
@@ -400,7 +400,7 @@ func TestVerifyAndHealLinkage_HealAlreadyAttempted(t *testing.T) {
 			return "PR body.", nil
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 
 	// Record that we've already attempted healing for this SHA.
 	eng.store.Apply(itemstate.LinkageHealAttempted{
@@ -447,7 +447,7 @@ func TestVerifyAndHealLinkage_BodyTooLong(t *testing.T) {
 			return longBody, nil
 		},
 	}
-	eng := testEngine(client, nil)
+	eng := testEngine(t, client, nil)
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	stage := &stages.Stage{Name: "Implement"}
 

--- a/engine/process_item_test.go
+++ b/engine/process_item_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 func TestProcessItem_SkipsUnknownStage(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
@@ -61,7 +61,7 @@ func TestProcessItem_SkipsUnknownStage(t *testing.T) {
 func TestProcessItem_SkipsLockedByOther(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
@@ -83,7 +83,7 @@ func TestProcessItem_SkipsLockedByOther(t *testing.T) {
 func TestProcessItem_SkipsEditing(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
@@ -105,7 +105,7 @@ func TestProcessItem_SkipsEditing(t *testing.T) {
 func TestProcessItem_SkipsPaused(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
@@ -131,7 +131,7 @@ func TestProcessItem_AllowsOwnLock(t *testing.T) {
 			return "output", false, TokenUsage{}, nil
 		},
 	}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	// Need a real worktree manager for processItem — register a mock WM for the test repo
 	eng.worktreeManagers["owner/repo"] = &WorktreeManager{baseDir: t.TempDir(), rootDir: t.TempDir()}
 
@@ -157,7 +157,7 @@ func TestProcessItem_AllowsOwnLock(t *testing.T) {
 func TestProcessItem_SkipsCompleted(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
@@ -179,7 +179,7 @@ func TestProcessItem_SkipsCompleted(t *testing.T) {
 func TestProcessItem_SkipsAlreadyProcessedNoNewComments(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.PollSeconds = 100 // cooldown = 1000s — ensures recently-processed item stays in cooldown
 
 	// Mark as already processed (sets LastAttemptAt so dispatch cooldown applies)
@@ -937,7 +937,7 @@ func TestProcessItem_ClearsAttemptsOnCompletion(t *testing.T) {
 func TestProcessItem_CleanupStage_SkipsAlreadyComplete(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -1105,7 +1105,7 @@ func TestProcessItem_CleanupStage_PRItem(t *testing.T) {
 	// PR items on the board don't have worktrees — cleanup should just apply the label.
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 	eng.cfg.Stages = testStagesWithCleanup()
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}

--- a/engine/review_phase_test.go
+++ b/engine/review_phase_test.go
@@ -48,7 +48,7 @@ func TestCatchUpLoop_NonYolo_ReviewReinvoke_Fires(t *testing.T) {
 		{Name: "Implement", Order: 1, Prompt: "implement"},
 		{Name: "Review", Order: 2, Prompt: "review"},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MaxReviewCycles = 5
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#55"] = true
@@ -106,7 +106,7 @@ func TestCatchUpLoop_NonYolo_NoThreads_NoAdvance(t *testing.T) {
 		{Name: "Implement", Order: 1, Prompt: "implement"},
 		{Name: "Review", Order: 2, Prompt: "review"},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#56"] = true
 	eng.mayNeedWorkMu.Unlock()
@@ -250,7 +250,7 @@ func TestCatchUpLoop_YoloIssue_ReviewReinvoke_StillFires(t *testing.T) {
 		{Name: "Implement", Order: 1, Prompt: "implement"},
 		{Name: "Review", Order: 2, Prompt: "review"},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MaxReviewCycles = 5
 	eng.mayNeedWorkMu.Lock()
 	eng.mayNeedWork["owner/repo#57"] = true

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -20,8 +20,9 @@ func reviewTestStages() []*stages.Stage {
 	}
 }
 
-func reviewTestEngine(client *mockGitHubClient) *Engine {
-	return testEngineWithStages(client, reviewTestStages())
+func reviewTestEngine(t *testing.T, client *mockGitHubClient) *Engine {
+	t.Helper()
+	return testEngineWithStages(t, client, reviewTestStages())
 }
 
 // (a) No requested reviewers AND no reviews submitted → gate STAYS BLOCKED,
@@ -31,7 +32,7 @@ func reviewTestEngine(client *mockGitHubClient) *Engine {
 // so we wait.
 func TestCheckReviewGate_NoReviewersNoReviews_Blocks(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number:                 10,
@@ -59,7 +60,7 @@ func TestCheckReviewGate_NoReviewersNoReviews_Blocks(t *testing.T) {
 // without ever appearing in reviewRequests.
 func TestCheckReviewGate_NoReviewersWithReview_Clears(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number:                 10,
@@ -87,7 +88,7 @@ func TestCheckReviewGate_NoReviewersWithReview_Clears(t *testing.T) {
 // (a2) Gate disabled (nil WaitForReviews) → always returns false.
 func TestCheckReviewGate_GateDisabled_ReturnsFalse(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -112,7 +113,7 @@ func TestCheckReviewGate_GateDisabled_ReturnsFalse(t *testing.T) {
 // (b) Reviewer requested but no review submitted → block and apply label.
 func TestCheckReviewGate_ReviewerRequested_NoReview_Blocks(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -146,7 +147,7 @@ func TestCheckReviewGate_ReviewerRequested_NoReview_Blocks(t *testing.T) {
 // (b2) Already has awaiting-review label → still blocked but no duplicate label add.
 func TestCheckReviewGate_AlreadyWaiting_NoLabelAdd(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	// FetchLabelAppliedAt returns recent time (no timeout)
 	recentTime := time.Now().Add(-1 * time.Minute)
 	client.fetchLabelAppliedAtFn = func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
@@ -180,7 +181,7 @@ func TestCheckReviewGate_AlreadyWaiting_NoLabelAdd(t *testing.T) {
 // (c) All requested reviewers have submitted → advance (no reviewers in reviewRequests).
 func TestCheckReviewGate_AllReviewersSubmitted_ReturnsFalse(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	// copilot no longer in reviewRequests (they submitted) and awaiting-review label present
 	item := gh.ProjectItem{
@@ -215,7 +216,7 @@ func TestCheckReviewGate_AllReviewersSubmitted_ReturnsFalse(t *testing.T) {
 // (d) Timeout elapsed → advance with warning, label removed.
 func TestCheckReviewGate_TimeoutElapsed_ReturnsFalse(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	// Override timeout to 5 minutes; label was applied 10 minutes ago → timed out
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 	appliedAt := time.Now().Add(-10 * time.Minute)
@@ -258,7 +259,7 @@ func TestCheckReviewGate_TimeoutElapsed_ReturnsFalse(t *testing.T) {
 // (e) Dismissed reviewer re-blocks gate: reviewer re-appears in reviewRequests.
 func TestCheckReviewGate_DismissedReviewer_Reblocks(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	// Label was applied recently — not timed out
 	recentTime := time.Now().Add(-1 * time.Minute)
 	client.fetchLabelAppliedAtFn = func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
@@ -298,7 +299,7 @@ func TestCheckReviewGate_DismissedReviewer_Reblocks(t *testing.T) {
 
 func TestCheckReviewGate_DismissedReviewDoesNotClear(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	recentTime := time.Now().Add(-1 * time.Minute)
 	client.fetchLabelAppliedAtFn = func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 		return recentTime, nil
@@ -328,7 +329,7 @@ func TestCheckReviewGate_DismissedReviewDoesNotClear(t *testing.T) {
 // (f) buildReviewThreadComments returns inline thread comments with real DatabaseIDs.
 func TestBuildReviewThreadComments(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	item := gh.ProjectItem{
 		Number: 10,
 		Repo:   "owner/repo",
@@ -354,7 +355,7 @@ func TestBuildReviewThreadComments(t *testing.T) {
 // (f2) buildReviewThreadComments skips comments already present in ProcessedComments.
 func TestBuildReviewThreadComments_ProcessedCommentsSkip(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	item := gh.ProjectItem{
 		Number: 10,
 		Repo:   "owner/repo",
@@ -414,7 +415,7 @@ func TestCatchUpLoop_InFlightGuard(t *testing.T) {
 		{Name: "Implement", Order: 1, Prompt: "implement"},
 		{Name: "Review", Order: 2, Prompt: "review"},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MaxReviewCycles = 5
 
 	// Pre-populate the store Worker to simulate a goroutine already running.
@@ -445,7 +446,7 @@ func TestCatchUpLoop_InFlightGuard(t *testing.T) {
 // (g) pauseForReviewTimeout applies labels and posts a comment.
 func TestPauseForReviewTimeout(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -477,7 +478,7 @@ func TestPauseForReviewTimeout(t *testing.T) {
 // (h) pauseForReviewCycleLimit applies labels, posts a comment with cycle count.
 func TestPauseForReviewCycleLimit(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -513,7 +514,7 @@ func TestReviewCycleCount_PerStageNotPerIssue(t *testing.T) {
 		{Name: "Review", Order: 1, Prompt: "review"},
 		{Name: "Validate", Order: 2, Prompt: "validate"},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	// Simulate Review consuming 3 cycles out of 5.
 	for i := 0; i < 3; i++ {
@@ -550,7 +551,7 @@ func TestClearFailedStage_ReviewCycleCount_ResetsOnlyCurrentStage(t *testing.T) 
 		{Name: "Review", Order: 1, Prompt: "review", WaitForReviews: boolPtr(true)},
 		{Name: "Validate", Order: 2, Prompt: "validate", WaitForReviews: boolPtr(true)},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 	item := gh.ProjectItem{
 		Number: 10,
 		Repo:   "owner/repo",
@@ -590,7 +591,7 @@ func TestClearFailedStage_ReviewCycleCount_ResetsOnlyCurrentStage(t *testing.T) 
 // Gate returns (true, false) — still blocked.
 func TestCheckReviewGate_BotPhase1_Reprompts(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	// awaiting-review label was applied 10 minutes ago — 1× timeout elapsed.
@@ -663,7 +664,7 @@ func TestCheckReviewGate_BotPhase1_Reprompts(t *testing.T) {
 // When the reprompted label is present but not yet timed out, the gate stays blocked silently.
 func TestCheckReviewGate_BotPhase1_Idempotent_StillBlocked(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	awaitingApplied := time.Now().Add(-10 * time.Minute)
@@ -712,7 +713,7 @@ func TestCheckReviewGate_BotPhase1_Idempotent_StillBlocked(t *testing.T) {
 // pauseForReviewTimeout then detects Phase 2 context and posts a contextual message.
 func TestCheckReviewGate_BotPhase2_PausesForHuman(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	awaitingApplied := time.Now().Add(-15 * time.Minute)
@@ -762,7 +763,7 @@ func TestCheckReviewGate_BotPhase2_PausesForHuman(t *testing.T) {
 	}
 
 	// Verify pauseForReviewTimeout posts a Phase 2 contextual message.
-	eng2 := reviewTestEngine(client)
+	eng2 := reviewTestEngine(t, client)
 	eng2.pauseForReviewTimeout(board, item, stage) // item still has pre-cleanup labels
 
 	var foundPhase2Comment bool
@@ -779,7 +780,7 @@ func TestCheckReviewGate_BotPhase2_PausesForHuman(t *testing.T) {
 // Pure-bot stuck then bot responds before Phase 2 — gate clears naturally.
 func TestCheckReviewGate_BotRespondsBeforePhase2_Clears(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -813,7 +814,7 @@ func TestCheckReviewGate_BotRespondsBeforePhase2_Clears(t *testing.T) {
 // Mixed bot+human outstanding at 1× timeout — existing pause path fires, no re-prompt.
 func TestCheckReviewGate_MixedBotHuman_PausesWithoutReprompt(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	awaitingApplied := time.Now().Add(-10 * time.Minute) // 1× elapsed
@@ -864,7 +865,7 @@ func TestCheckReviewGate_MixedBotHuman_PausesWithoutReprompt(t *testing.T) {
 // Pure-human outstanding at 1× timeout — existing pause path fires.
 func TestCheckReviewGate_PureHuman_PausesWithoutReprompt(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	awaitingApplied := time.Now().Add(-10 * time.Minute)
@@ -904,7 +905,7 @@ func TestCheckReviewGate_PureHuman_PausesWithoutReprompt(t *testing.T) {
 // pauseForReviewTimeout enhanced comment lists reviewers with bot/human tags.
 func TestPauseForReviewTimeout_ListsReviewerTypes(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number: 10,
@@ -931,7 +932,7 @@ func TestPauseForReviewTimeout_ListsReviewerTypes(t *testing.T) {
 // removeAwaitingReviewLabel also removes the fabrik:bot-reprompted label.
 func TestRemoveAwaitingReviewLabel_CleansRepromptedLabels(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	item := gh.ProjectItem{
 		Number: 10,
 		Repo:   "owner/repo",
@@ -997,7 +998,7 @@ func TestBotMentionHandle(t *testing.T) {
 // Phase 1: non-Copilot bot reviewer — reprompt comment must mention @<login> directly.
 func TestCheckReviewGate_BotPhase1_NonCopilot_MentionsLogin(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	eng.cfg.ReviewWaitTimeout = 5 * time.Minute
 
 	awaitingApplied := time.Now().Add(-10 * time.Minute)
@@ -1039,7 +1040,7 @@ func TestCheckReviewGate_BrokenLinkage_PRFound_Pauses(t *testing.T) {
 			return &gh.PRDetails{Number: 77, State: "open"}, nil
 		},
 	}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number:         10,
@@ -1096,7 +1097,7 @@ func TestCheckReviewGate_BrokenLinkage_NoPRFound_FallsThrough(t *testing.T) {
 			return nil, nil // no PR on branch
 		},
 	}
-	eng := reviewTestEngine(client)
+	eng := reviewTestEngine(t, client)
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
 	item := gh.ProjectItem{
 		Number:         10,

--- a/engine/sighup_test.go
+++ b/engine/sighup_test.go
@@ -19,7 +19,7 @@ func TestRun_SighupRestart(t *testing.T) {
 			return &gh.ProjectBoard{}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.PollSeconds = 300 // long poll so we don't hit a second tick
 
 	// Set up a temp fabrikDir so Run() can create the lock file.

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -209,11 +209,12 @@ func TestResolveSpecifyOptionID_SingleColumn(t *testing.T) {
 
 // ---- preImplement integration tests ----
 
-func spawnTestEngine(client *mockGitHubClient) *Engine {
-	eng := testEngine(client, &mockClaudeInvoker{})
+func spawnTestEngine(t *testing.T, client *mockGitHubClient) *Engine {
+	t.Helper()
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Register "owner/repo" and "owner/child" as managed repos.
-	eng.worktreeManagers["owner/repo"] = NewWorktreeManager("/tmp/fake-parent")
-	eng.worktreeManagers["owner/child"] = NewWorktreeManager("/tmp/fake-child")
+	eng.worktreeManagers["owner/repo"] = NewWorktreeManager(t.TempDir())
+	eng.worktreeManagers["owner/child"] = NewWorktreeManager(t.TempDir())
 	return eng
 }
 
@@ -237,7 +238,7 @@ func planItemWithBlocks(blocksRaw string) gh.ProjectItem {
 
 func TestPreImplement_NoOp_ChildrenAlreadySpawned(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -262,7 +263,7 @@ FABRIK_SPAWN_CHILD_END
 
 func TestPreImplement_NoOp_NoPlanComment(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 
 	item := gh.ProjectItem{
 		ID:     "I_parent",
@@ -284,7 +285,7 @@ func TestPreImplement_NoOp_NoPlanComment(t *testing.T) {
 
 func TestPreImplement_NoOp_NoBlocks(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 
 	item := planItemWithBlocks("No spawn blocks in here.")
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -309,7 +310,7 @@ func TestPreImplement_HappyPath(t *testing.T) {
 			return "PVTI_" + contentNodeID, nil
 		},
 	}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -394,7 +395,7 @@ FABRIK_SPAWN_CHILD_END
 func TestPreImplement_CloneFailure(t *testing.T) {
 	skipIfNoGit(t)
 	client := &mockGitHubClient{}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 	// Point fabrikDir at a tempdir — ensureBareClone will fail to clone the nonexistent repo.
 	eng.fabrikDir = t.TempDir()
 
@@ -478,7 +479,7 @@ func TestPreImplement_OnDemandClone_Success(t *testing.T) {
 			return "PVTI_" + contentNodeID, nil
 		},
 	}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 	eng.fabrikDir = fabrikDir
 
 	// "testowner/testrepo" is NOT in worktreeManagers initially.
@@ -523,7 +524,7 @@ func TestPreImplement_PartialFailure(t *testing.T) {
 			return 100 + callCount, fmt.Sprintf("I_child%d", callCount), nil
 		},
 	}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -575,8 +576,9 @@ FABRIK_SPAWN_CHILD_END
 
 // ---- status-set and label-inheritance tests ----
 
-func spawnTestEngineWithSpecify(client *mockGitHubClient) *Engine {
-	eng := spawnTestEngine(client)
+func spawnTestEngineWithSpecify(t *testing.T, client *mockGitHubClient) *Engine {
+	t.Helper()
+	eng := spawnTestEngine(t, client)
 	eng.statusField = &gh.StatusField{
 		FieldID: "FIELD_STATUS",
 		Options: map[string]string{
@@ -598,7 +600,7 @@ func TestPreImplement_SetsSpecifyStatus(t *testing.T) {
 			return "PVTI_child101", nil
 		},
 	}
-	eng := spawnTestEngineWithSpecify(client)
+	eng := spawnTestEngineWithSpecify(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -644,7 +646,7 @@ func TestPreImplement_StatusSetNilField(t *testing.T) {
 			return "PVTI_child102", nil
 		},
 	}
-	eng := spawnTestEngine(client)
+	eng := spawnTestEngine(t, client)
 	// statusField is nil by default in spawnTestEngine
 
 	item := planItemWithBlocks(`
@@ -671,7 +673,7 @@ FABRIK_SPAWN_CHILD_END
 
 func TestPreImplement_YoloInheritance(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngineWithSpecify(client)
+	eng := spawnTestEngineWithSpecify(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -705,7 +707,7 @@ FABRIK_SPAWN_CHILD_END
 
 func TestPreImplement_CruiseInheritance(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngineWithSpecify(client)
+	eng := spawnTestEngineWithSpecify(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -739,7 +741,7 @@ FABRIK_SPAWN_CHILD_END
 
 func TestPreImplement_BothLabelsInherited(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngineWithSpecify(client)
+	eng := spawnTestEngineWithSpecify(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child
@@ -773,7 +775,7 @@ FABRIK_SPAWN_CHILD_END
 
 func TestPreImplement_NoAutonomyLabels(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := spawnTestEngineWithSpecify(client)
+	eng := spawnTestEngineWithSpecify(t, client)
 
 	item := planItemWithBlocks(`
 FABRIK_SPAWN_CHILD_BEGIN owner/child

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 // testEngineForMerge returns a minimal engine wired for attemptMergeOnValidate tests.
-func testEngineForMerge(client *mockGitHubClient) *Engine {
+func testEngineForMerge(t *testing.T, client *mockGitHubClient) *Engine {
+	t.Helper()
 	stgs := testStagesWithValidate()
-	return testEngineWithStages(client, stgs)
+	return testEngineWithStages(t, client, stgs)
 }
 
 // TestAttemptMergeOnValidate_YoloEnablesAutoMerge verifies that for a yolo item
@@ -26,7 +27,7 @@ func TestAttemptMergeOnValidate_YoloEnablesAutoMerge(t *testing.T) {
 			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -60,7 +61,7 @@ func TestAttemptMergeOnValidate_YoloEnablesAutoMerge(t *testing.T) {
 // a cruise-labelled item returns (false, nil) without calling EnablePullRequestAutoMerge.
 func TestAttemptMergeOnValidate_CruiseSkipsAutoMerge(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -80,7 +81,7 @@ func TestAttemptMergeOnValidate_CruiseSkipsAutoMerge(t *testing.T) {
 // without calling EnablePullRequestAutoMerge a second time.
 func TestAttemptMergeOnValidate_AlreadyLabeled_Idempotent(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:auto-merge-enabled"}}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -103,7 +104,7 @@ func TestAttemptMergeOnValidate_NoPR_SkipsAutoMerge(t *testing.T) {
 			return nil, nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -127,7 +128,7 @@ func TestAttemptMergeOnValidate_FetchLinkedPRError_ReturnsError(t *testing.T) {
 			return nil, errors.New("network error")
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
 	_, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -154,7 +155,7 @@ func TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenClean(t *testing.T) {
 			return nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -200,7 +201,7 @@ func TestAttemptMergeOnValidate_FallsBackToDirectMergeWhenUnstable(t *testing.T)
 			return nil
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -246,7 +247,7 @@ func TestAttemptMergeOnValidate_DirectMergeAlsoFails(t *testing.T) {
 			return gh.ErrNotMergeable
 		},
 	}
-	eng := testEngineForMerge(client)
+	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
 
 	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
@@ -282,7 +283,7 @@ func TestHandleStageComplete_WaitForCI_SkipsMergeAndReturns(t *testing.T) {
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	tr := true
 	validateStage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
@@ -333,7 +334,7 @@ func TestAdvanceToNextStage_WritesThrough_Cache(t *testing.T) {
 		},
 	}
 	stgs := testStagesWithValidate()
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	// Replace readClient with a CacheImpl bootstrapped with the test item in Research.
 	cache := boardcache.NewCacheImpl(boardcache.NewGitHubAdapter(client), eng.store, func(format string, args ...any) {})

--- a/engine/startup_test.go
+++ b/engine/startup_test.go
@@ -35,7 +35,7 @@ func TestCheckStageColumnAlignment_AllMatch(t *testing.T) {
 		fetchProjectBoardFn: boardWithColumns("proj-1"),
 		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan", "Implement"),
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
@@ -48,7 +48,7 @@ func TestCheckStageColumnAlignment_MissingStage(t *testing.T) {
 		fetchProjectBoardFn: boardWithColumns("proj-1"),
 		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan"),
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	err := e.checkStageColumnAlignment(context.Background())
 	if err == nil {
 		t.Fatal("expected error for missing stage, got nil")
@@ -65,7 +65,7 @@ func TestCheckStageColumnAlignment_ExtraColumns(t *testing.T) {
 		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan", "Implement", "Triage", "Backlog"),
 	}
 	var logged []string
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	// Capture logf output by overriding the events channel (nil = direct print).
 	// We can't easily intercept logf in plain-text mode, so just verify no error.
 	err := e.checkStageColumnAlignment(context.Background())
@@ -81,7 +81,7 @@ func TestCheckStageColumnAlignment_FetchBoardError(t *testing.T) {
 			return nil, fmt.Errorf("network timeout")
 		},
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {
 		t.Fatalf("FetchProjectBoard error should be non-fatal, got: %v", err)
@@ -95,7 +95,7 @@ func TestCheckStageColumnAlignment_FetchStatusFieldError(t *testing.T) {
 			return nil, fmt.Errorf("project %q has no Status field", projectID)
 		},
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {
 		t.Fatalf("FetchStatusField error should be non-fatal, got: %v", err)
@@ -120,7 +120,7 @@ func TestCheckStageColumnAlignment_CleanupStageExcluded(t *testing.T) {
 		},
 		client,
 		&mockClaudeInvoker{},
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {
@@ -133,7 +133,7 @@ func TestCheckStageColumnAlignment_PopulatesStatusField(t *testing.T) {
 		fetchProjectBoardFn: boardWithColumns("proj-1"),
 		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan", "Implement"),
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	if e.statusField != nil {
 		t.Fatal("statusField should be nil before check")
@@ -158,7 +158,7 @@ func TestCheckStageColumnAlignment_CaseSensitive(t *testing.T) {
 		fetchProjectBoardFn: boardWithColumns("proj-1"),
 		fetchStatusFieldFn:  statusFieldWithOptions("research", "plan", "implement"),
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	err := e.checkStageColumnAlignment(context.Background())
 	if err == nil {
 		t.Fatal("case-sensitive mismatch should be fatal, got nil")
@@ -172,7 +172,7 @@ func TestCheckStageColumnAlignment_EmptyProjectID(t *testing.T) {
 			return &gh.ProjectBoard{ProjectID: ""}, nil
 		},
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {
 		t.Fatalf("empty ProjectID should be non-fatal, got: %v", err)
@@ -214,7 +214,7 @@ func TestCheckStageColumnAlignment_OnlyCleanupStages(t *testing.T) {
 		},
 		client,
 		&mockClaudeInvoker{},
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {

--- a/engine/store_unification_test.go
+++ b/engine/store_unification_test.go
@@ -91,7 +91,7 @@ func TestStoreUnification_CrossMutationVisibility(t *testing.T) {
 
 func TestStoreUnification_WorkerLivenessLabelRead(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	// Simulate a webhook delivering "fabrik:locked:testuser" to the cache's delta path.
 	// cacheImpl.ApplyLabelAdded applies LocalLabelAdded on c.store, which after unification

--- a/engine/terminal_test.go
+++ b/engine/terminal_test.go
@@ -76,7 +76,8 @@ func TestIsTerminalPredicate_AllTransientLabels(t *testing.T) {
 
 // ---- runStartupTerminalScan tests (Task 12) ----
 
-func testEngineWithCleanup(client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
+func testEngineWithCleanup(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {
+	t.Helper()
 	return NewWithDeps(
 		Config{
 			Owner:         "owner",
@@ -89,12 +90,12 @@ func testEngineWithCleanup(client *mockGitHubClient, claude *mockClaudeInvoker) 
 		},
 		client,
 		claude,
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 }
 
 func TestRunStartupTerminalScan_MarksTerminalItems(t *testing.T) {
-	eng := testEngineWithCleanup(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngineWithCleanup(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	// Item 1: terminal — Done + stage:Done:complete + no transient labels.
 	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
@@ -142,7 +143,7 @@ func TestRunStartupTerminalScan_MarksTerminalItems(t *testing.T) {
 }
 
 func TestRunStartupTerminalScan_IdempotentOnAlreadyTerminal(t *testing.T) {
-	eng := testEngineWithCleanup(&mockGitHubClient{}, &mockClaudeInvoker{})
+	eng := testEngineWithCleanup(t, &mockGitHubClient{}, &mockClaudeInvoker{})
 
 	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
 		Repo:     "owner/repo",
@@ -166,8 +167,9 @@ func TestRunStartupTerminalScan_IdempotentOnAlreadyTerminal(t *testing.T) {
 
 // testEngineWithCleanupCache creates an Engine with testStagesWithCleanup and a
 // live CacheImpl seeded with one item already in "Done" with stage:Done:complete.
-func testEngineWithCleanupCache(client *mockGitHubClient, claude *mockClaudeInvoker) (*Engine, *boardcache.CacheImpl) {
-	eng := testEngineWithCleanup(client, claude)
+func testEngineWithCleanupCache(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker) (*Engine, *boardcache.CacheImpl) {
+	t.Helper()
+	eng := testEngineWithCleanup(t, client, claude)
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{
 		ProjectID: "PVT_1",
@@ -204,7 +206,7 @@ func TestRunProbeAndDeepFetch_TerminalItem_SkipsDeepFetch(t *testing.T) {
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCleanupCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCleanupCache(t, client, &mockClaudeInvoker{})
 
 	// Mark item 1 as terminal (simulate prior deep-fetch that found it terminal).
 	eng.store.Apply(itemstate.TerminalFlagSet{Repo: "owner/repo", Number: 1, Terminal: true})
@@ -239,7 +241,7 @@ func TestRunProbeAndDeepFetch_TerminalItem_StatusDrift_ClearsFlagAndDeepFetches(
 			return nil
 		},
 	}
-	eng, cache := testEngineWithCleanupCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCleanupCache(t, client, &mockClaudeInvoker{})
 
 	// Pre-set terminal flag.
 	eng.store.Apply(itemstate.TerminalFlagSet{Repo: "owner/repo", Number: 1, Terminal: true})
@@ -311,7 +313,7 @@ func TestRunProbeAndDeepFetch_TerminalItem_MovedBetweenCleanupStages(t *testing.
 			User: "testuser", Token: "token", MaxConcurrent: 5,
 			Stages: twoCleanupStages,
 		},
-		client, &mockClaudeInvoker{}, NewWorktreeManager("/tmp/test-repo"),
+		client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()),
 	)
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{
@@ -359,7 +361,7 @@ func TestRunStartupTerminalScan_UsesCleanupStageNotHardcodedDone(t *testing.T) {
 		},
 		&mockGitHubClient{},
 		&mockClaudeInvoker{},
-		NewWorktreeManager("/tmp/test-repo"),
+		NewWorktreeManager(t.TempDir()),
 	)
 
 	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
@@ -404,7 +406,7 @@ func TestRunProbeAndDeepFetch_LinkageDrift_ColdStart_AuthoritativeWrite(t *testi
 			return nil
 		},
 	}
-	eng := testEngineWithCleanup(client, &mockClaudeInvoker{})
+	eng := testEngineWithCleanup(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	// Bootstrap with LinkedPRNumber=0 (old-style bootstrap that did not populate PR number).
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{
@@ -463,7 +465,7 @@ func TestRunProbeAndDeepFetch_LinkageDrift_WarmCache_FiresDeepFetchInvalidated(t
 			return nil
 		},
 	}
-	eng := testEngineWithCleanup(client, &mockClaudeInvoker{})
+	eng := testEngineWithCleanup(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	// Bootstrap with LinkedPRNumber=0.
 	testBootstrapFromBoard(cache, &gh.ProjectBoard{
@@ -526,7 +528,7 @@ func TestRunProbeAndDeepFetch_LinkageDrift_ColdStart_ClearsStalePR(t *testing.T)
 		},
 		fetchItemDetailsFn: func(item *gh.ProjectItem) error { return nil },
 	}
-	eng := testEngineWithCleanup(client, &mockClaudeInvoker{})
+	eng := testEngineWithCleanup(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	// Bootstrap with LinkedPRNumber=42 so the cache has a stale prToKey entry.
 	cache.BootstrapFromProbe([]gh.BoardProbeItem{
@@ -719,7 +721,7 @@ func TestRunProbeAndDeepFetch_UnconfiguredColumn_ColdCache_SkipsDeepFetch(t *tes
 		},
 	}
 
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
 	eng.readClient = cache
 
@@ -757,7 +759,7 @@ func TestRunProbeAndDeepFetch_UnconfiguredColumn_WarmCache_SkipsDeepFetch(t *tes
 		},
 	}
 
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Seed the Backlog item into the store directly (simulating a prior bootstrap).
 	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
 		ID: "I_002", ItemID: "PVTI_002", Number: 2, Repo: "owner/repo", Status: "Backlog",
@@ -799,7 +801,7 @@ func TestRunProbeAndDeepFetch_UnconfiguredColumn_StatusDrift_UpdatesStore(t *tes
 		},
 	}
 
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	// Seed the item into the store as if it was previously in a configured stage.
 	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
 		ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research",

--- a/engine/tui_events_test.go
+++ b/engine/tui_events_test.go
@@ -40,7 +40,7 @@ func collectEvents(ch chan tui.Event, idle time.Duration) []tui.Event {
 func TestJobStartedEvent_EarlyReturn(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{}
-	eng := testEngine(client, claude)
+	eng := testEngine(t, client, claude)
 
 	ch := make(chan tui.Event, 64)
 	eng.events = ch

--- a/engine/upgrade_test.go
+++ b/engine/upgrade_test.go
@@ -79,7 +79,7 @@ func TestCheckReleaseUpgrade_UpToDate(t *testing.T) {
 			return &gh.LatestRelease{TagName: "v0.0.1"}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.AutoUpgrade = true
 	eng.cfg.Version = "v0.0.1"
 
@@ -102,7 +102,7 @@ func TestCheckReleaseUpgrade_NoMatchingAsset(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.AutoUpgrade = true
 	eng.cfg.Version = "v0.0.1"
 
@@ -137,7 +137,7 @@ func TestCheckReleaseUpgrade_DownloadAttempted(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	eng.cfg.AutoUpgrade = true
 	eng.cfg.Version = "v0.0.1"
 
@@ -440,7 +440,7 @@ func TestStartupUpgradeCheck_FiresWhenEnabled(t *testing.T) {
 			return &gh.ProjectBoard{}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	startupTestSetup(t, eng)
 	eng.cfg.AutoUpgrade = true
 	eng.cfg.PollSeconds = 300
@@ -485,7 +485,7 @@ func TestStartupUpgradeCheck_SkipsWhenDisabled(t *testing.T) {
 			return &gh.ProjectBoard{}, nil
 		},
 	}
-	eng := testEngine(client, &mockClaudeInvoker{})
+	eng := testEngine(t, client, &mockClaudeInvoker{})
 	startupTestSetup(t, eng)
 	eng.cfg.AutoUpgrade = false
 	eng.cfg.PollSeconds = 300

--- a/engine/worker_liveness_test.go
+++ b/engine/worker_liveness_test.go
@@ -92,7 +92,7 @@ func TestCrashRecoveryRegression501(t *testing.T) {
 	}
 
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Start a real subprocess and kill it so we have a confirmed-dead PID.
 	cmd := exec.Command("sleep", "1000")
@@ -137,7 +137,7 @@ func TestCrashRecoveryRegression501(t *testing.T) {
 // advance the LastSignAt timestamp in the store.
 func TestWorkerHeartbeatUpdatesLastSignAt(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 2, nil)
 	t0 := time.Now().Add(-1 * time.Minute)
@@ -168,7 +168,7 @@ func TestWorkerHeartbeatUpdatesLastSignAt(t *testing.T) {
 // cleanly when the done channel is closed, producing no goroutine leak.
 func TestHeartbeatGoroutineCleanup(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 	e.heartbeatIntervalOverride = 5 * time.Millisecond
 
 	bootstrapItem(t, e, 3, nil)
@@ -220,7 +220,7 @@ func TestDetectorFalsePositivePrevention(t *testing.T) {
 	}
 
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 4, []string{"fabrik:locked:testuser", "stage:Research:in_progress"})
 	// Use current process PID — always alive.
@@ -245,7 +245,7 @@ func TestDetectorFalsePositivePrevention(t *testing.T) {
 // applying it twice leaves Worker nil without panicking or corrupting state.
 func TestDetectorRace_WorkerExitIdempotent(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 5, nil)
 	setWorker(e, 5, 12345, "Implement", time.Now())
@@ -263,7 +263,7 @@ func TestDetectorRace_WorkerExitIdempotent(t *testing.T) {
 // apply Worker mutations for different issues. The race detector must see no races.
 func TestConcurrentWorkerSpawnExit(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	const n = 20
 	for i := 1; i <= n; i++ {
@@ -315,7 +315,7 @@ func TestConcurrentWorkerSpawnExit(t *testing.T) {
 // nil in the store (the restart-after-crash case).
 func TestStartupCleanupRemovesStaleLabels(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	// Bootstrap item with stale lock label and in_progress label; no Worker applied.
 	bootstrapItem(t, e, 6, []string{
@@ -345,7 +345,7 @@ func TestStartupCleanupRemovesStaleLabels(t *testing.T) {
 // cleaned up by runStartupCleanup.
 func TestStartupCleanupSkipsActiveWorkers(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 7, []string{
 		"fabrik:locked:testuser",
@@ -372,7 +372,7 @@ func TestStartupCleanupSkipsActiveWorkers(t *testing.T) {
 // when Worker is nil — it must not create a new WorkerHandle.
 func TestWorkerHeartbeatNoOpWhenWorkerNil(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 8, nil)
 	// No Worker applied — store has Worker == nil.
@@ -392,7 +392,7 @@ func TestWorkerHeartbeatNoOpWhenWorkerNil(t *testing.T) {
 // when Worker is nil — it must not create a new WorkerHandle.
 func TestWorkerPIDSetNoOpWhenWorkerNil(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 9, nil)
 
@@ -411,7 +411,7 @@ func TestWorkerPIDSetNoOpWhenWorkerNil(t *testing.T) {
 // PID is 0 (not yet set by OnPIDReady), even if the heartbeat is stale.
 func TestDetectorSkipsPIDZeroWorker(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 10, []string{"fabrik:locked:testuser"})
 	staleTime := time.Now().Add(-10 * time.Minute)
@@ -435,7 +435,7 @@ func TestDetectorSkipsPIDZeroWorker(t *testing.T) {
 // WorkerExited. This is the inFlight replacement semantic test (test #10 from spec).
 func TestWorkerStoreReflectsDispatchPaths(t *testing.T) {
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 11, nil)
 
@@ -488,7 +488,7 @@ func TestRunStartupCleanup_StaleEditingLabel(t *testing.T) {
 	editingLabelRetryDelay = 0
 	t.Cleanup(func() { editingLabelRetryDelay = orig })
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 20, []string{"fabrik:editing"})
 
@@ -512,7 +512,7 @@ func TestRunStartupCleanup_ActiveWorkerSkipsEditing(t *testing.T) {
 	editingLabelRetryDelay = 0
 	t.Cleanup(func() { editingLabelRetryDelay = orig })
 	client := &mockGitHubClient{}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 21, []string{"fabrik:editing"})
 	setWorker(e, 21, os.Getpid(), "Implement", time.Now())
@@ -539,7 +539,7 @@ func TestRunStartupCleanup_EditingLabelErrNotFound_Silent(t *testing.T) {
 			return nil
 		},
 	}
-	e := testEngine(client, &mockClaudeInvoker{})
+	e := testEngine(t, client, &mockClaudeInvoker{})
 
 	bootstrapItem(t, e, 22, []string{"fabrik:editing"})
 

--- a/engine/worktree_extra_test.go
+++ b/engine/worktree_extra_test.go
@@ -154,33 +154,6 @@ func TestEnsureBareClone_ExistingDir_FetchesOnly(t *testing.T) {
 	}
 }
 
-func TestEnsureBareClone_NewDir_ClonesFromLocal(t *testing.T) {
-	skipIfNoGit(t)
-
-	// Create a local "source" git repo to clone from via file:// URL
-	srcDir := initBareRepo(t)
-
-	tmpDir := t.TempDir()
-
-	// Override cloneURL construction by temporarily monkey-patching isn't possible in Go,
-	// but we can test the error path: clone of a non-existent github URL fails.
-	// Instead we test that the function creates the .fabrik directory and returns an error
-	// when git clone fails (no real network in CI).
-	_, err := ensureBareClone(tmpDir, "nonexistent-owner-xyz", "nonexistent-repo-xyz-abc", "", false)
-	// We expect an error because the github URL doesn't exist. The key check is that
-	// the function attempts the clone and returns a wrapped error.
-	if err == nil {
-		t.Log("clone unexpectedly succeeded (real network access?)")
-	}
-	// The .fabrik parent dir should have been created even on failure
-	fabrikDir := filepath.Join(tmpDir, ".fabrik")
-	if _, statErr := os.Stat(fabrikDir); os.IsNotExist(statErr) {
-		t.Error(".fabrik directory should be created before clone attempt")
-	}
-
-	// Suppress unused variable warning from srcDir
-	_ = srcDir
-}
 
 func TestSetCommitterIdentity_SetsWhenUnset(t *testing.T) {
 	skipIfNoGit(t)

--- a/engine/worktree_integration_test.go
+++ b/engine/worktree_integration_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureBareClone_NewDir_ClonesFromLocal verifies that ensureBareClone creates
+// the .fabrik directory before attempting a clone, even when the clone fails.
+//
+// This test requires network access: it calls ensureBareClone with a non-existent
+// GitHub owner/repo, which triggers a real git clone attempt that fails with a
+// network error. The ENAMETOOLONG trick (setting a 10000-char baseDir) cannot be
+// used here because it causes os.MkdirAll to fail, which would prevent the
+// .fabrik directory from being created — invalidating the key assertion below.
+// Integration build tag excludes this from the default `go test ./...` run.
+func TestEnsureBareClone_NewDir_ClonesFromLocal(t *testing.T) {
+	skipIfNoGit(t)
+
+	// Create a local "source" git repo to clone from via file:// URL
+	srcDir := initBareRepo(t)
+
+	tmpDir := t.TempDir()
+
+	// Override cloneURL construction by temporarily monkey-patching isn't possible in Go,
+	// but we can test the error path: clone of a non-existent github URL fails.
+	// Instead we test that the function creates the .fabrik directory and returns an error
+	// when git clone fails (no real network in CI).
+	_, err := ensureBareClone(tmpDir, "nonexistent-owner-xyz", "nonexistent-repo-xyz-abc", "", false)
+	// We expect an error because the github URL doesn't exist. The key check is that
+	// the function attempts the clone and returns a wrapped error.
+	if err == nil {
+		t.Log("clone unexpectedly succeeded (real network access?)")
+	}
+	// The .fabrik parent dir should have been created even on failure
+	fabrikDir := filepath.Join(tmpDir, ".fabrik")
+	if _, statErr := os.Stat(fabrikDir); os.IsNotExist(statErr) {
+		t.Error(".fabrik directory should be created before clone attempt")
+	}
+
+	// Suppress unused variable warning from srcDir
+	_ = srcDir
+}

--- a/engine/worktree_integration_test.go
+++ b/engine/worktree_integration_test.go
@@ -20,9 +20,6 @@ import (
 func TestEnsureBareClone_NewDir_ClonesFromLocal(t *testing.T) {
 	skipIfNoGit(t)
 
-	// Create a local "source" git repo to clone from via file:// URL
-	srcDir := initBareRepo(t)
-
 	tmpDir := t.TempDir()
 
 	// Override cloneURL construction by temporarily monkey-patching isn't possible in Go,
@@ -40,7 +37,4 @@ func TestEnsureBareClone_NewDir_ClonesFromLocal(t *testing.T) {
 	if _, statErr := os.Stat(fabrikDir); os.IsNotExist(statErr) {
 		t.Error(".fabrik directory should be created before clone attempt")
 	}
-
-	// Suppress unused variable warning from srcDir
-	_ = srcDir
 }

--- a/engine/write_through_test.go
+++ b/engine/write_through_test.go
@@ -13,7 +13,7 @@ import (
 // reflected in the in-memory cache without waiting for webhook echo or Reconcile.
 func TestLabelWriteThrough(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	// addFailedLabel → cache should immediately contain "stage:Research:failed"
 	eng.addFailedLabel("owner", "repo", 1, "Research")
@@ -42,7 +42,7 @@ func TestLabelWriteThrough(t *testing.T) {
 // for lock-style labels.
 func TestLockLabelWriteThrough(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
 	stage := testStages()[0]
@@ -97,7 +97,7 @@ func TestCommentWriteThrough(t *testing.T) {
 			return 9001, nil
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	// Warm up the deep-fetch cache so FetchItemDetails returns from cache (not fallback).
 	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
@@ -136,7 +136,7 @@ func TestWriteThroughOnFailure(t *testing.T) {
 			return apiErr
 		},
 	}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 
 	// addFailedLabel will call AddLabelToIssue which returns an error.
 	eng.addFailedLabel("owner", "repo", 1, "Implement")
@@ -158,7 +158,7 @@ func TestWriteThroughOnFailure(t *testing.T) {
 // old Status and the catch-up loop would fire again every 15 seconds.
 func TestAdvanceLoopRegression(t *testing.T) {
 	client := &mockGitHubClient{}
-	eng, cache := testEngineWithCache(client, &mockClaudeInvoker{})
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
 	eng.statusField = &gh.StatusField{
 		FieldID: "FIELD_1",
 		Options: map[string]string{

--- a/watch/model_test.go
+++ b/watch/model_test.go
@@ -148,7 +148,7 @@ func TestUpdate_TurnCountMsg_UpdatesTurnsUsed(t *testing.T) {
 func TestUpdate_NewLogFileMsg_ResetsTurnsUsed(t *testing.T) {
 	m := newTestModel()
 	m.turnsUsed = 23
-	model, _ := m.Update(NewLogFileMsg{Path: filepath.Join(t.TempDir(), "fake-Research-20260101-100000-000000000.log")})
+	model, _ := m.Update(NewLogFileMsg{Path: "fake-Research-20260101-100000-000000000.log"})
 	wm := model.(WatchModel)
 	if wm.turnsUsed != 0 {
 		t.Errorf("turnsUsed = %d after NewLogFileMsg, want 0", wm.turnsUsed)

--- a/watch/model_test.go
+++ b/watch/model_test.go
@@ -148,7 +148,7 @@ func TestUpdate_TurnCountMsg_UpdatesTurnsUsed(t *testing.T) {
 func TestUpdate_NewLogFileMsg_ResetsTurnsUsed(t *testing.T) {
 	m := newTestModel()
 	m.turnsUsed = 23
-	model, _ := m.Update(NewLogFileMsg{Path: "/tmp/fake-Research-20260101-100000-000000000.log"})
+	model, _ := m.Update(NewLogFileMsg{Path: filepath.Join(t.TempDir(), "fake-Research-20260101-100000-000000000.log")})
 	wm := model.(WatchModel)
 	if wm.turnsUsed != 0 {
 		t.Errorf("turnsUsed = %d after NewLogFileMsg, want 0", wm.turnsUsed)


### PR DESCRIPTION
Closes #862

## Summary

This PR completes a systematic sweep of three test-hygiene anti-patterns across the Fabrik test suite, installing a permanent CI lint guard to prevent regression.

**What changed:**

- **`/tmp/` paths eliminated (FR-1, FR-5):** `testEngine()` and `testEngineWithCache()` now accept `t *testing.T` and use `t.TempDir()` for the worktree base path. All 221+ call sites updated, along with four secondary helpers (`testEngineWithCleanup`, `spawnTestEngine`, `testEngineForMerge`) and all remaining inline `NewWorktreeManager("/tmp/...")` calls. `grep -rn '"/tmp/' --include="*_test.go"` now returns 0.

- **Network-dependent failure injection replaced (FR-2):** `TestEnsureRepoReady_CloneFailure_PostsCommentAndPauses`, `TestEnsureRepoReady_ConcurrentSameRepo_OnlyOneCloneAttempt`, and `TestCheckAutoMergeConvergence_UnregisteredRepo_NoPanic` now set `eng.fabrikDir = strings.Repeat("a", 10000)` so `os.MkdirAll` fails with `ENAMETOOLONG` before any git subprocess is spawned — deterministic, sub-millisecond. `TestEnsureBareClone_NewDir_ClonesFromLocal` (which asserts `.fabrik/` is created *before* the clone fails) is extracted to `engine/worktree_integration_test.go` with `//go:build integration` per EC-3.

- **`os.Setenv` → `t.Setenv` (FR-3):** Converted 40 sites in `engine/invoke_claude_test.go`, 12 in `engine/grandchild_test.go`, 6 in `cmd/resume_test.go`, and 2 in `cmd/root_test.go`. The `origPath := os.Getenv("PATH"); defer os.Setenv("PATH", origPath)` boilerplate is eliminated.

- **CI lint guard (FR-4):** New `Test hygiene lint` step in `.github/workflows/ci.yml` (before `go test`) fails if any `"/tmp/` literal or `nonexistent-xyz` string appears in test files.

- **Conventions updated (FR-6):** `.claude/rules/golang.md` Testing section gains rules for `t.Setenv()` and the no-external-network pattern.

## Verification

Completed the full test-harness hygiene sweep: eliminated all `/tmp/` hardcoded paths by refactoring `testEngine()` to accept `t *testing.T` (221+ call sites updated), replaced `nonexistent-xyz` network failure injection with deterministic ENAMETOOLONG, converted `os.Setenv` to `t.Setenv` in 60 sites, extracted the one integration test that genuinely needs network to a `//go:build integration` file, and added a CI lint guard to prevent regression. All success criteria pass: 0 `/tmp/` literals, engine tests at 43s (≤ 45s target), full suite green.

## How to test

```bash
# Verify no /tmp/ literals remain
grep -rn '"/tmp/' --include="*_test.go" .
# Should output nothing (exit 1)

# Run full suite (integration tests excluded by default)
go test -race -timeout 5m ./...

# Run integration tests explicitly
go test -tags integration ./engine/
```