### PR TITLE
feat(janitor): periodic worktree janitor — reap orphaned worktrees on startup and hourly

### DIFF
--- a/adrs/006-git-worktrees.md
+++ b/adrs/006-git-worktrees.md
@@ -93,5 +93,7 @@ If stale or invalid, it's removed and recreated.
   This is a one-time cost.
 - **Disk space**: Each worktree is a full checkout. For large repos this
   adds up, though the object store is shared with the bare clone.
-- **Cleanup**: Worktrees accumulate. Currently no automatic cleanup when
-  issues reach Done (planned feature).
+- **Cleanup**: Worktrees accumulate beyond the Done stage for issues that
+  are removed from the board, archived, or otherwise exit the pipeline without
+  the Done stage running. The periodic worktree janitor (ADR 055) addresses
+  this by scanning for and reaping orphaned worktrees on a configurable cadence.

--- a/adrs/055-worktree-janitor.md
+++ b/adrs/055-worktree-janitor.md
@@ -1,0 +1,131 @@
+# ADR 055: Periodic Worktree Janitor
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 006 noted that worktrees accumulate when issues exit the pipeline without
+the Done stage running. Common stranding paths include:
+
+- Issues manually archived or deleted from the project board.
+- Issues moved off-board via the auto-archive pass.
+- A restart window between Validate completing and Done being dispatched.
+- Stage YAML changes that rename or remove the Done stage after existing issues
+  already passed through it.
+
+The poll loop only dispatches work for items currently on the board. Stranded
+worktrees are never visited again and accumulate indefinitely.
+
+## Decision
+
+Introduce a periodic **worktree janitor** (`engine/janitor.go`) that:
+
+1. Runs **once after startup** (after the first successful poll so board state
+   is hydrated in the in-memory store).
+2. Runs **hourly** thereafter on a `time.Ticker` goroutine, same pattern as
+   `startWorkerDetector`.
+3. Scans every `<fabrikDir>/.fabrik/worktrees/<owner>-<repo>/issue-N/`
+   subdirectory and reaps each worktree that satisfies all four conditions of
+   the reaping gate (see below).
+
+## Reaping Gate
+
+A worktree is **only reaped** when all four conditions hold simultaneously:
+
+| # | Condition | Source |
+|---|-----------|--------|
+| 1 | Issue is **closed** | `itemstate.Store` (store hit), or `GitHubClient.FetchIssue` REST call (off-board fallback) |
+| 2 | Issue is **off-board or at a cleanup-complete stage** | `itemstate.Store` snapshot: `snap.Status` empty (not on board) OR the active stage has `CleanupWorktree: true` |
+| 3 | Worktree is **clean** | `isWorkingTreeDirty()` → `git status --porcelain` |
+| 4 | **No in-flight worker** | `itemstate.Snapshot.Worker()` nil |
+
+Conditions are checked in order (1→4) and the first failing condition skips
+the worktree. The gate is deliberately conservative: any ambiguity (e.g. REST
+error, unreadable git state) causes the janitor to leave the worktree alone
+and log a warning.
+
+## Rationale
+
+### Conservative gate — why all four conditions?
+
+- **Closed check**: avoids reaping worktrees for issues that are still open
+  (e.g. temporarily moved off-board for triage).
+- **Off-board or cleanup-complete**: avoids reaping when an issue is on an
+  active stage (engine may dispatch work imminently).
+- **Clean worktree**: preserves uncommitted work from a Claude session that
+  ended before committing. This is the most important safety condition — dirty
+  worktrees always indicate in-progress or abandoned work worth preserving.
+- **No in-flight worker**: races between the janitor scan and the engine
+  dispatcher are possible; the store's worker marker is the single source of
+  truth for in-flight state.
+
+### Fallback hierarchy for unregistered repos
+
+When a worktree directory exists for a `<owner>-<repo>` pair that has no
+registered `WorktreeManager` (e.g. the bare repo was never set up, or the
+config drifted), the janitor:
+
+1. Reads `git remote get-url origin` from the first issue subdirectory to
+   recover the canonical `owner/repo` string.
+2. Constructs a temporary `WorktreeManager` using `NewWorktreeManagerForRepo`
+   pointing at `<fabrikDir>/.fabrik/repos/<owner>-<repo>.git`.
+3. If the bare repo directory does not exist, falls back to `os.RemoveAll`
+   with a warning log (the worktree is already disconnected from git).
+
+This mirrors the approach used in `migrateWorktrees`.
+
+### Closed-state lookup strategy
+
+- **Primary**: check `itemstate.Store` — the in-memory board cache populated
+  by each poll cycle. Zero latency, no API calls.
+- **Fallback**: if the issue is absent from the store (off-board), call
+  `GitHubClient.FetchIssue` (REST `GET /repos/{owner}/{repo}/issues/{number}`).
+  Results are cached in a per-scan `closedCache` map to avoid redundant calls
+  for multi-worktree scenarios.
+
+## Configuration
+
+Cadence is controlled by `JanitorIntervalHours` (engine `Config` field):
+
+| Source | Precedence |
+|--------|-----------|
+| `--janitor-interval` CLI flag | Highest |
+| `FABRIK_JANITOR_INTERVAL` env var | Second |
+| `janitor_interval_hours` in `config.yaml` | Third |
+| Default (`1` hour) | Lowest |
+
+Setting the value to `0` disables the janitor entirely (no startup scan, no
+ticker goroutine). Changing the value at runtime has no effect; restart Fabrik
+to apply a new cadence (EC-6 caveat).
+
+## Alternatives Considered
+
+### Reap on every poll
+
+Rejected: makes the poll loop more complex and adds per-poll git calls for
+every worktree, even when they are being actively used. A separate goroutine
+keeps concerns separated and allows independent scheduling.
+
+### Reap immediately when issue leaves board
+
+Rejected: the board cache may not have flushed yet; races with in-flight workers
+are hard to gate on. The conservative four-condition gate run on a goroutine
+with store reads is safer.
+
+### No janitor — require manual cleanup
+
+Rejected: stranded worktrees accumulate silently and disk usage grows without
+bound. Operator burden for long-running Fabrik deployments is unacceptable.
+
+## Trade-offs
+
+- **REST call per off-board issue**: FetchIssue adds one API call per stranded
+  worktree that isn't in the store. In practice, this is rare and the per-scan
+  cache prevents duplicates.
+- **Startup delay**: the post-first-poll janitor run adds latency before the
+  engine enters steady-state. For large deployments with many stranded worktrees
+  this could take seconds, but it runs concurrently with poll processing.
+- **EC-6 restart caveat**: cadence changes require a restart. Operators must be
+  informed (USER_GUIDE.md note added).

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -156,6 +156,9 @@ func (m *testGitHubUpgradeClient) EnablePullRequestAutoMerge(owner, repo string,
 func (m *testGitHubUpgradeClient) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
 	return 0, nil
 }
+func (m *testGitHubUpgradeClient) FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error) {
+	return nil, nil
+}
 
 // ── upgrade ───────────────────────────────────────────────────────────────────
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,8 +55,9 @@ type Config struct {
 	Webhooks          bool
 	WebhookPort       int
 	WebhookEvents     string // comma-separated; empty means default event set
-	StatusPollSeconds int    // Layer 2 status-only sweep cadence in seconds; 0 = use default (15)
-	ReconcileInterval int    // seconds; 0 means use default (180 = 3 min); also FABRIK_RECONCILE_INTERVAL
+	StatusPollSeconds    int // Layer 2 status-only sweep cadence in seconds; 0 = use default (15)
+	ReconcileInterval    int // seconds; 0 means use default (180 = 3 min); also FABRIK_RECONCILE_INTERVAL
+	JanitorIntervalHours int // hours; 1 = default; 0 disables the janitor
 }
 
 func Execute() error {
@@ -143,6 +144,7 @@ func Execute() error {
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
 	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile webhook-stream-health checks when --webhooks is enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL). Inactive without --webhooks — the per-poll Reconcile is the only freshener in that mode.")
+	flag.IntVar(&cfg.JanitorIntervalHours, "janitor-interval", 1, "Worktree janitor scan interval in hours; 0 disables the janitor (also FABRIK_JANITOR_INTERVAL)")
 	flag.StringVar(&cfg.KillGraceSigInt, "kill-grace-sigint", "", "Grace window after SIGINT before SIGTERM in the kill escalation sequence (Go duration: 10s, 0s to skip SIGINT entirely; also FABRIK_KILL_GRACE_SIGINT; default 10s)")
 	flag.StringVar(&cfg.KillGraceSigTerm, "kill-grace-sigterm", "", "Grace window after SIGTERM before SIGKILL in the kill escalation sequence (Go duration: 10s; also FABRIK_KILL_GRACE_SIGTERM; default 10s)")
 
@@ -365,6 +367,21 @@ func Execute() error {
 				cfg.ReconcileInterval = n // 0 → use engine default (lightReconcileInterval = 3 min)
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_RECONCILE_INTERVAL=%q is invalid (must be a non-negative integer of seconds; 0 = use default 180); using default 180\n", v)
+			}
+		}
+	}
+	if !explicitFlags["janitor-interval"] {
+		if v := os.Getenv("FABRIK_JANITOR_INTERVAL"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				cfg.JanitorIntervalHours = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_JANITOR_INTERVAL=%q is invalid (must be a non-negative integer of hours; 0 = disable); using default 1\n", v)
+			}
+		} else if pc.JanitorIntervalHours != nil {
+			if *pc.JanitorIntervalHours < 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml janitor_interval_hours=%d is invalid (must be a non-negative integer; 0 = disable); using default 1\n", *pc.JanitorIntervalHours)
+			} else {
+				cfg.JanitorIntervalHours = *pc.JanitorIntervalHours
 			}
 		}
 	}
@@ -614,6 +631,7 @@ func Execute() error {
 		WebhookEvents:            webhookEvents,
 		ProjectStatusPollSeconds: statusPollSeconds(cfg.StatusPollSeconds),
 		ReconcileInterval:        reconcileIntervalDuration(cfg.ReconcileInterval),
+		JanitorIntervalHours:     cfg.JanitorIntervalHours,
 		ReadyCh:                  testReadyCh,
 	})
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -31,9 +31,10 @@ type ProjectConfig struct {
 	WorktreeBoundaryAudit   bool     `yaml:"worktree_boundary_audit"`
 	Version                 string   `yaml:"version"`
 	Webhooks                bool     `yaml:"webhooks"`
-	WebhookPort   *int     `yaml:"webhook_port"`
-	WebhookEvents []string `yaml:"webhook_events"`
-	StatusPoll    *int     `yaml:"status_poll"`
+	WebhookPort             *int     `yaml:"webhook_port"`
+	WebhookEvents           []string `yaml:"webhook_events"`
+	StatusPoll              *int     `yaml:"status_poll"`
+	JanitorIntervalHours    *int     `yaml:"janitor_interval_hours"`
 }
 
 // LoadProjectConfig reads .fabrik/config.yaml from CWD.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -367,6 +367,38 @@ Custom stages (names not present in any embedded default) are silently skipped �
 >
 > See [§11 Troubleshooting → Multiple Fabrik Instances](#11-troubleshooting) if you encounter a stale lock or need to run multiple instances against different projects.
 
+### Worktree Janitor
+
+Fabrik's normal worktree cleanup runs only when the Done stage (`cleanup_worktree: true`) is dispatched for an issue. Several situations strand worktrees outside that path:
+
+- Issues removed from the project board (manually archived, deleted, or cleared by the auto-archive pass) are no longer iterated by the poll loop.
+- A narrow restart window between Validate completing and Done being dispatched.
+- Stage YAML drift — if the Done stage is renamed or removed, its worktrees are never cleaned up.
+
+The **worktree janitor** scans `.fabrik/worktrees/<owner>-<repo>/issue-N/` directories and reaps orphaned worktrees automatically. It runs:
+
+1. **Once at startup**, after the first successful poll (so board state is hydrated).
+2. **Hourly** thereafter (configurable; 0 disables).
+
+A worktree is only reaped when **all four** conditions hold: the issue is closed; the issue is not on the board at an active stage (or it's at a cleanup stage that already completed); the worktree is clean (no uncommitted changes); and no worker is currently dispatched for the issue. This conservative gate prevents false positives.
+
+At the end of each scan Fabrik logs:
+
+```
+[janitor] cycle complete: scanned N worktrees, reaped K, skipped M (reasons: ...)
+```
+
+**Configuration:**
+
+```yaml
+# .fabrik/config.yaml
+janitor_interval_hours: 1   # default — set to 0 to disable the janitor entirely
+```
+
+Also controllable via `--janitor-interval` flag or `FABRIK_JANITOR_INTERVAL` environment variable.
+
+> **Note (EC-6):** Changing `janitor_interval_hours` at runtime has no effect. Restart Fabrik for a new cadence to take effect.
+
 ---
 
 ## 2. Configuration Reference
@@ -447,6 +479,11 @@ user: your-github-username
 # paused for inspection. Off by default; the snapshot filters to refs/heads/* and
 # refs/tags/* only to avoid false positives from routine fetches.
 # worktree_boundary_audit: false
+
+# Worktree janitor scan interval in hours (default 1). The janitor runs once after
+# startup and then on this cadence, reaping clean worktrees for closed, off-board
+# issues. Set to 0 to disable the janitor entirely.
+# janitor_interval_hours: 1
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -365,6 +365,38 @@ Custom stages (names not present in any embedded default) are silently skipped �
 >
 > See [§11 Troubleshooting → Multiple Fabrik Instances](#11-troubleshooting) if you encounter a stale lock or need to run multiple instances against different projects.
 
+### Worktree Janitor
+
+Fabrik's normal worktree cleanup runs only when the Done stage (`cleanup_worktree: true`) is dispatched for an issue. Several situations strand worktrees outside that path:
+
+- Issues removed from the project board (manually archived, deleted, or cleared by the auto-archive pass) are no longer iterated by the poll loop.
+- A narrow restart window between Validate completing and Done being dispatched.
+- Stage YAML drift — if the Done stage is renamed or removed, its worktrees are never cleaned up.
+
+The **worktree janitor** scans `.fabrik/worktrees/<owner>-<repo>/issue-N/` directories and reaps orphaned worktrees automatically. It runs:
+
+1. **Once at startup**, after the first successful poll (so board state is hydrated).
+2. **Hourly** thereafter (configurable; 0 disables).
+
+A worktree is only reaped when **all four** conditions hold: the issue is closed; the issue is not on the board at an active stage (or it's at a cleanup stage that already completed); the worktree is clean (no uncommitted changes); and no worker is currently dispatched for the issue. This conservative gate prevents false positives.
+
+At the end of each scan Fabrik logs:
+
+```
+[janitor] cycle complete: scanned N worktrees, reaped K, skipped M (reasons: ...)
+```
+
+**Configuration:**
+
+```yaml
+# .fabrik/config.yaml
+janitor_interval_hours: 1   # default — set to 0 to disable the janitor entirely
+```
+
+Also controllable via `--janitor-interval` flag or `FABRIK_JANITOR_INTERVAL` environment variable.
+
+> **Note (EC-6):** Changing `janitor_interval_hours` at runtime has no effect. Restart Fabrik for a new cadence to take effect.
+
 ---
 
 ## 2. Configuration Reference
@@ -445,6 +477,11 @@ user: your-github-username
 # paused for inspection. Off by default; the snapshot filters to refs/heads/* and
 # refs/tags/* only to avoid false positives from routine fetches.
 # worktree_boundary_audit: false
+
+# Worktree janitor scan interval in hours (default 1). The janitor runs once after
+# startup and then on this cadence, reaping clean worktrees for closed, off-board
+# issues. Set to 0 to disable the janitor entirely.
+# janitor_interval_hours: 1
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -4248,6 +4285,90 @@ stateDiagram-v2
         or adds yolo/cruise label
     end note
 ```
+
+---
+
+## 11. Worktree Janitor
+
+### 11.1 Purpose
+
+The worktree janitor reaps orphaned git worktrees left behind when issues exit the
+managed lifecycle without triggering the normal `cleanup_worktree: true` Done-stage path.
+Three scenarios produce stranded worktrees:
+
+1. **Off-board items** — issues removed from the project board (archived, deleted, or
+   removed by `archiveDoneCompleteItems`) are no longer iterated by the poll loop; their
+   worktrees persist indefinitely.
+2. **Narrow restart window** — Fabrik dies after `attemptMergeOnValidate` advances the
+   board to Done but before the next poll dispatches the Done stage.
+3. **Stage YAML drift** — an operator who renames or removes the Done stage from their
+   config orphans worktrees that will never again be visited by the dispatch loop.
+
+### 11.2 Schedule
+
+- **Startup scan**: runs once after the first successful poll cycle (so the Store is
+  hydrated) immediately after `runStartupTerminalScan`. Gated on `JanitorIntervalHours != 0`.
+- **Hourly recurring scan**: a ticker goroutine started from `Engine.Run()` fires at
+  `JanitorIntervalHours`-hour intervals (default 1 hour). First tick is one interval after
+  startup; the startup scan covers the "now" tick.
+- **EC-3 (cycle overrun)**: the goroutine blocks inside `runWorktreeJanitor` during a
+  long cycle; the ticker fires are dropped naturally. No special handling required.
+
+### 11.3 Reaping Gate (FR-4)
+
+A worktree is reaped only when **all four** conditions hold:
+
+| Condition | Rationale |
+|-----------|-----------|
+| **(a) Issue is closed** | Open issues are never safe to reap — the issue may still be in progress, even if no worker is currently dispatched. |
+| **(b) Off-board OR cleanup-complete** | If the issue is still on the board at an active (non-cleanup) stage, the dispatch loop may still visit it. A worktree at a `cleanup_worktree: true` stage with `stage:<Name>:complete` is safe to reap: `CleanupWorktree` runs *before* the label is applied, so the directory can only persist if `CleanupWorktree` errored. |
+| **(c) Clean worktree** | `git status --porcelain` returns no non-engine-managed paths. Engine-managed files (`.fabrik-context/`, `.fabrik/issue.md`) are excluded by `isEngineManagedPath`. A dirty worktree may contain uncommitted work from an interrupted Claude session. |
+| **(d) No in-flight worker** | `snap.Worker() == nil` from the Store. Concurrent reads are safe — Store uses `RWMutex`. |
+
+All four conditions are evaluated in order (cheapest first). A worktree that fails any
+condition is left in place and counted toward the `skipped` total.
+
+**Closed-status resolution (FR-5):**
+1. Primary: `Store.Get(repo, number)` → `snap.IsClosed()` (free; no API call).
+2. Fallback (item not in Store): `GitHubClient.FetchIssue(owner, repo, number)` — one REST call per stranded worktree per cycle; result cached in-memory for the cycle duration.
+3. Error: skip with warning; treat as not-closed to avoid false positives.
+
+**Cleanup path (FR-6):**  
+`WorktreeManager.CleanupWorktree(number, false)` — the same path used by the Done stage.
+If the bare repo is absent (manually deleted), falls back to `os.RemoveAll` with a warning.
+
+### 11.4 Owner/Repo Resolution
+
+The on-disk directory is named `owner-repo` (dash-separated), which is ambiguous for
+hyphenated owner or repo names.
+
+- **Registered repos**: looked up from the reverse map built from `e.worktreeManagers`
+  (copied under `e.mu` at the start of each cycle; lock held only for the copy).
+- **Unregistered repos** (EC-2 — repo no longer on the board): `git remote get-url origin`
+  is run from the first issue subdirectory found. If the git command fails (corrupt or
+  missing `.git`), the entire `owner-repo` directory is skipped with a warning.
+
+### 11.5 Configuration
+
+```yaml
+# .fabrik/config.yaml
+janitor_interval_hours: 1   # default; set to 0 to disable the janitor entirely
+```
+
+Also settable via flag (`--janitor-interval`) or environment variable
+(`FABRIK_JANITOR_INTERVAL`). **EC-6**: changing this value at runtime has no effect; Fabrik
+must be restarted for a new cadence to take effect.
+
+### 11.6 Summary Log (FR-7)
+
+At the end of each cycle the janitor emits an INFO-level log line:
+
+```
+[janitor] cycle complete: scanned N worktrees, reaped K, skipped M (reasons: ...)
+```
+
+The `reasons` field tallies distinct skip reasons (e.g. `issue open ×3`, `dirty worktree`,
+`in-flight worker`). Each reaped worktree is also logged individually at reap time.
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1866,6 +1866,90 @@ stateDiagram-v2
 
 ---
 
+## 11. Worktree Janitor
+
+### 11.1 Purpose
+
+The worktree janitor reaps orphaned git worktrees left behind when issues exit the
+managed lifecycle without triggering the normal `cleanup_worktree: true` Done-stage path.
+Three scenarios produce stranded worktrees:
+
+1. **Off-board items** — issues removed from the project board (archived, deleted, or
+   removed by `archiveDoneCompleteItems`) are no longer iterated by the poll loop; their
+   worktrees persist indefinitely.
+2. **Narrow restart window** — Fabrik dies after `attemptMergeOnValidate` advances the
+   board to Done but before the next poll dispatches the Done stage.
+3. **Stage YAML drift** — an operator who renames or removes the Done stage from their
+   config orphans worktrees that will never again be visited by the dispatch loop.
+
+### 11.2 Schedule
+
+- **Startup scan**: runs once after the first successful poll cycle (so the Store is
+  hydrated) immediately after `runStartupTerminalScan`. Gated on `JanitorIntervalHours != 0`.
+- **Hourly recurring scan**: a ticker goroutine started from `Engine.Run()` fires at
+  `JanitorIntervalHours`-hour intervals (default 1 hour). First tick is one interval after
+  startup; the startup scan covers the "now" tick.
+- **EC-3 (cycle overrun)**: the goroutine blocks inside `runWorktreeJanitor` during a
+  long cycle; the ticker fires are dropped naturally. No special handling required.
+
+### 11.3 Reaping Gate (FR-4)
+
+A worktree is reaped only when **all four** conditions hold:
+
+| Condition | Rationale |
+|-----------|-----------|
+| **(a) Issue is closed** | Open issues are never safe to reap — the issue may still be in progress, even if no worker is currently dispatched. |
+| **(b) Off-board OR cleanup-complete** | If the issue is still on the board at an active (non-cleanup) stage, the dispatch loop may still visit it. A worktree at a `cleanup_worktree: true` stage with `stage:<Name>:complete` is safe to reap: `CleanupWorktree` runs *before* the label is applied, so the directory can only persist if `CleanupWorktree` errored. |
+| **(c) Clean worktree** | `git status --porcelain` returns no non-engine-managed paths. Engine-managed files (`.fabrik-context/`, `.fabrik/issue.md`) are excluded by `isEngineManagedPath`. A dirty worktree may contain uncommitted work from an interrupted Claude session. |
+| **(d) No in-flight worker** | `snap.Worker() == nil` from the Store. Concurrent reads are safe — Store uses `RWMutex`. |
+
+All four conditions are evaluated in order (cheapest first). A worktree that fails any
+condition is left in place and counted toward the `skipped` total.
+
+**Closed-status resolution (FR-5):**
+1. Primary: `Store.Get(repo, number)` → `snap.IsClosed()` (free; no API call).
+2. Fallback (item not in Store): `GitHubClient.FetchIssue(owner, repo, number)` — one REST call per stranded worktree per cycle; result cached in-memory for the cycle duration.
+3. Error: skip with warning; treat as not-closed to avoid false positives.
+
+**Cleanup path (FR-6):**  
+`WorktreeManager.CleanupWorktree(number, false)` — the same path used by the Done stage.
+If the bare repo is absent (manually deleted), falls back to `os.RemoveAll` with a warning.
+
+### 11.4 Owner/Repo Resolution
+
+The on-disk directory is named `owner-repo` (dash-separated), which is ambiguous for
+hyphenated owner or repo names.
+
+- **Registered repos**: looked up from the reverse map built from `e.worktreeManagers`
+  (copied under `e.mu` at the start of each cycle; lock held only for the copy).
+- **Unregistered repos** (EC-2 — repo no longer on the board): `git remote get-url origin`
+  is run from the first issue subdirectory found. If the git command fails (corrupt or
+  missing `.git`), the entire `owner-repo` directory is skipped with a warning.
+
+### 11.5 Configuration
+
+```yaml
+# .fabrik/config.yaml
+janitor_interval_hours: 1   # default; set to 0 to disable the janitor entirely
+```
+
+Also settable via flag (`--janitor-interval`) or environment variable
+(`FABRIK_JANITOR_INTERVAL`). **EC-6**: changing this value at runtime has no effect; Fabrik
+must be restarted for a new cadence to take effect.
+
+### 11.6 Summary Log (FR-7)
+
+At the end of each cycle the janitor emits an INFO-level log line:
+
+```
+[janitor] cycle complete: scanned N worktrees, reaped K, skipped M (reasons: ...)
+```
+
+The `reasons` field tallies distinct skip reasons (e.g. `issue open ×3`, `dirty worktree`,
+`in-flight worker`). Each reaped worktree is also logged individually at reap time.
+
+---
+
 ## Appendix A: Two Paths to Stage Advancement
 
 Stage advancement can occur through two code paths:

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -51,6 +51,7 @@ type Config struct {
 	WebhookPort              int
 	WebhookEvents            []string
 	ProjectStatusPollSeconds int // Layer 2 status-only sweep cadence in seconds; default 15 s (gate runs every poll cycle; field retained for config compatibility)
+	JanitorIntervalHours     int // Periodic worktree janitor cadence in hours; 0 disables the janitor (default 1)
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -48,6 +48,7 @@ type GitHubClient interface {
 	DeleteReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	FetchLatestRelease(owner, repo string) (*gh.LatestRelease, error)
+	FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error)
 	FetchAllowAutoMerge(owner, repo string) (bool, error)
 	FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error)
 	SeedLabels(owner, repo string, stageNames []string, lockedUser string) error

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -1,0 +1,302 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// janitorWMEntry maps a "owner-repo" directory name to its resolved state.
+type janitorWMEntry struct {
+	ownerRepo string
+	wm        *WorktreeManager
+}
+
+// runWorktreeJanitor scans .fabrik/worktrees/<owner-repo>/issue-N/ directories
+// and reaps worktrees whose issues are provably terminal and whose directories
+// are clean. Conservative: when in doubt, leaves the worktree and logs the reason.
+//
+// Reaping criteria (all must hold):
+//   (a) issue is closed
+//   (b) issue is NOT on the configured project board — OR is on the board at a
+//       cleanup_worktree:true stage AND carries stage:<Name>:complete AND has no
+//       in-flight worker per the store
+//   (c) worktree is clean (git status --porcelain returns no non-engine-managed paths)
+//   (d) no in-flight dispatch is registered for (repo, number) in the store
+func (e *Engine) runWorktreeJanitor(ctx context.Context) {
+	worktreesRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
+
+	// Build reverse map: "owner-repo" dir name → ownerRepo string + WorktreeManager.
+	// Held only long enough to copy; the rest of the cycle is lock-free.
+	e.mu.Lock()
+	wmByDirName := make(map[string]janitorWMEntry, len(e.worktreeManagers))
+	for ownerRepo, wm := range e.worktreeManagers {
+		owner, repo := parseOwnerRepo(ownerRepo)
+		dirName := owner + "-" + repo
+		wmByDirName[dirName] = janitorWMEntry{ownerRepo: ownerRepo, wm: wm}
+	}
+	e.mu.Unlock()
+
+	closedCache := make(map[string]bool) // "owner/repo#N" → isClosed; reset each cycle
+	var scanned, reaped int
+	var skipReasons []string
+
+	ownerRepoDirs, err := os.ReadDir(worktreesRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			e.logf(0, "janitor", "cycle complete: scanned 0 worktrees, reaped 0, skipped 0\n")
+			return
+		}
+		e.logf(0, "janitor", "warn: cannot read worktrees root %s: %v\n", worktreesRoot, err)
+		return
+	}
+
+	for _, orDir := range ownerRepoDirs {
+		if !orDir.IsDir() {
+			continue
+		}
+		dirName := orDir.Name()
+
+		ownerRepo, wm := e.janitorResolveOwnerRepo(dirName, wmByDirName, worktreesRoot)
+		if ownerRepo == "" {
+			e.logf(0, "janitor", "warn: cannot resolve owner/repo for dir %s — skipping\n", dirName)
+			continue
+		}
+		owner, repo := parseOwnerRepo(ownerRepo)
+
+		issueDirs, err := os.ReadDir(filepath.Join(worktreesRoot, dirName))
+		if err != nil {
+			e.logf(0, "janitor", "warn: cannot read dir %s: %v — skipping\n", dirName, err)
+			continue
+		}
+
+		for _, issueDir := range issueDirs {
+			if !issueDir.IsDir() {
+				continue
+			}
+			issueNumber := janitorParseIssueN(issueDir.Name())
+			if issueNumber == 0 {
+				continue
+			}
+			scanned++
+			wtPath := filepath.Join(worktreesRoot, dirName, issueDir.Name())
+
+			// FR-4(d): no in-flight worker — cheapest check, no I/O
+			snap, snapErr := e.store.Get(ownerRepo, issueNumber)
+			if snapErr == nil && snap.Worker() != nil {
+				skipReasons = append(skipReasons, "in-flight worker")
+				e.logf(0, "janitor", "skip #%d in %s: in-flight worker\n", issueNumber, ownerRepo)
+				continue
+			}
+
+			// FR-4(a): issue is closed
+			if !e.janitorIsClosed(ctx, owner, repo, issueNumber, snap, snapErr, closedCache) {
+				skipReasons = append(skipReasons, "issue open")
+				continue
+			}
+
+			// FR-4(b): off-board OR cleanup-complete
+			if !e.janitorIsOffBoardOrCleanupComplete(snap, snapErr) {
+				skipReasons = append(skipReasons, "on active board")
+				continue
+			}
+
+			// FR-4(c): clean worktree
+			dirty, err := isWorkingTreeDirty(wtPath)
+			if err != nil {
+				reason := fmt.Sprintf("cannot check dirty state: %v", err)
+				skipReasons = append(skipReasons, reason)
+				e.logf(0, "janitor", "skip #%d in %s: %s\n", issueNumber, ownerRepo, reason)
+				continue
+			}
+			if dirty {
+				skipReasons = append(skipReasons, "dirty worktree")
+				e.logf(0, "janitor", "skip #%d in %s: dirty worktree\n", issueNumber, ownerRepo)
+				continue
+			}
+
+			// All conditions met — reap via CleanupWorktree or os.RemoveAll fallback.
+			cleanupWM := wm
+			if cleanupWM == nil {
+				// Unregistered repo: construct a temporary WM.
+				bareDir := filepath.Join(e.fabrikDir, ".fabrik", "repos", dirName+".git")
+				if fi, statErr := os.Stat(bareDir); statErr == nil && fi.IsDir() {
+					cleanupWM = NewWorktreeManagerForRepo(bareDir, worktreesRoot, dirName)
+					cleanupWM.logfFn = e.logf
+				}
+			}
+
+			if cleanupWM != nil {
+				if err := cleanupWM.CleanupWorktree(issueNumber, false); err != nil {
+					reason := fmt.Sprintf("cleanup error: %v", err)
+					skipReasons = append(skipReasons, reason)
+					e.logf(0, "janitor", "warn: could not clean up worktree for #%d in %s: %v\n", issueNumber, ownerRepo, err)
+					continue
+				}
+			} else {
+				// Bare repo absent — fall back to direct removal.
+				e.logf(0, "janitor", "warn: bare repo not found for %s — using os.RemoveAll for #%d\n", dirName, issueNumber)
+				if err := os.RemoveAll(wtPath); err != nil {
+					reason := fmt.Sprintf("removeall error: %v", err)
+					skipReasons = append(skipReasons, reason)
+					e.logf(0, "janitor", "warn: os.RemoveAll %s: %v\n", wtPath, err)
+					continue
+				}
+			}
+			reaped++
+			e.logf(0, "janitor", "reaped worktree for #%d in %s\n", issueNumber, ownerRepo)
+		}
+	}
+
+	skipped := scanned - reaped
+	reasonStr := ""
+	if len(skipReasons) > 0 {
+		counts := make(map[string]int)
+		for _, r := range skipReasons {
+			counts[r]++
+		}
+		var parts []string
+		for r, n := range counts {
+			if n == 1 {
+				parts = append(parts, r)
+			} else {
+				parts = append(parts, fmt.Sprintf("%s ×%d", r, n))
+			}
+		}
+		reasonStr = " (reasons: " + strings.Join(parts, ", ") + ")"
+	}
+	e.logf(0, "janitor", "cycle complete: scanned %d worktrees, reaped %d, skipped %d%s\n",
+		scanned, reaped, skipped, reasonStr)
+}
+
+// janitorParseIssueN parses "issue-N" → N; returns 0 for non-matching inputs.
+func janitorParseIssueN(name string) int {
+	if !strings.HasPrefix(name, "issue-") {
+		return 0
+	}
+	n, err := strconv.Atoi(name[len("issue-"):])
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+// janitorResolveOwnerRepo maps a "owner-repo" directory name to "owner/repo".
+// For registered repos it uses the reverse map directly. For unregistered repos
+// it runs `git remote get-url origin` from the first issue subdirectory found.
+// Returns ("", nil) when the repo cannot be identified.
+func (e *Engine) janitorResolveOwnerRepo(dirName string, wmByDirName map[string]janitorWMEntry, worktreesRoot string) (ownerRepo string, wm *WorktreeManager) {
+	if entry, ok := wmByDirName[dirName]; ok {
+		return entry.ownerRepo, entry.wm
+	}
+
+	// Unregistered: try to read git remote from first issue subdirectory.
+	issueDirs, err := os.ReadDir(filepath.Join(worktreesRoot, dirName))
+	if err != nil || len(issueDirs) == 0 {
+		return "", nil
+	}
+	for _, d := range issueDirs {
+		if !d.IsDir() || !strings.HasPrefix(d.Name(), "issue-") {
+			continue
+		}
+		wtPath := filepath.Join(worktreesRoot, dirName, d.Name())
+		cmd := exec.Command("git", "remote", "get-url", "origin")
+		cmd.Dir = wtPath
+		out, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		remoteURL := strings.TrimSpace(string(out))
+		resolvedDirName := ownerRepoDirFromURL(remoteURL)
+		if resolvedDirName == "" {
+			continue
+		}
+		// Reconstruct "owner/repo" from the dirName (or the resolved one).
+		// ownerRepoDirFromURL gives "owner-repo"; we need "owner/repo".
+		// Parse from the URL directly.
+		u := strings.TrimSuffix(remoteURL, ".git")
+		if colonIdx := strings.LastIndex(u, ":"); colonIdx >= 0 {
+			if slashIdx := strings.Index(u, "/"); slashIdx < 0 || slashIdx > colonIdx {
+				u = u[colonIdx+1:]
+			}
+		}
+		parts := strings.Split(u, "/")
+		if len(parts) < 2 {
+			continue
+		}
+		owner := parts[len(parts)-2]
+		repo := parts[len(parts)-1]
+		if owner == "" || repo == "" {
+			continue
+		}
+		return owner + "/" + repo, nil
+	}
+	return "", nil
+}
+
+// janitorIsClosed reports whether the issue is closed.
+// Uses snap when available; falls back to a REST lookup when not in the store.
+// Results are cached in closedCache (keyed by "owner/repo#N") for the cycle.
+func (e *Engine) janitorIsClosed(ctx context.Context, owner, repo string, issueNumber int, snap itemstate.Snapshot, snapErr error, closedCache map[string]bool) bool {
+	key := fmt.Sprintf("%s/%s#%d", owner, repo, issueNumber)
+	if cached, ok := closedCache[key]; ok {
+		return cached
+	}
+	if snapErr == nil {
+		result := snap.IsClosed()
+		closedCache[key] = result
+		return result
+	}
+	// REST fallback for items not in the store (off-board / never seen).
+	issue, err := e.client.FetchIssue(owner, repo, issueNumber)
+	if err != nil {
+		e.logf(0, "janitor", "warn: cannot determine closed state for #%d in %s/%s: %v — skipping\n", issueNumber, owner, repo, err)
+		closedCache[key] = false
+		return false
+	}
+	result := issue.State == "closed"
+	closedCache[key] = result
+	return result
+}
+
+// janitorIsOffBoardOrCleanupComplete reports whether the worktree is eligible
+// for reaping based on its board state:
+//   - Item not in store (off-board) → true
+//   - Item at a cleanup_worktree:true stage with stage:<Name>:complete label → true
+//   - Otherwise → false (on an active board stage or cleanup incomplete)
+func (e *Engine) janitorIsOffBoardOrCleanupComplete(snap itemstate.Snapshot, snapErr error) bool {
+	if errors.Is(snapErr, itemstate.ErrNotFound) || snapErr != nil {
+		return true
+	}
+	status := snap.Status()
+	if status == "" {
+		return true
+	}
+	// Find the stage matching the current board column.
+	var matchedStage *stages.Stage
+	for _, s := range e.cfg.Stages {
+		if s.Name == status {
+			matchedStage = s
+			break
+		}
+	}
+	if matchedStage == nil || !matchedStage.CleanupWorktree {
+		return false
+	}
+	// Cleanup stage found; check that it carries the completion label.
+	completeLabel := "stage:" + status + ":complete"
+	for _, label := range snap.Labels() {
+		if label == completeLabel {
+			return true
+		}
+	}
+	return false
+}

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -65,7 +65,7 @@ func (e *Engine) runWorktreeJanitor(ctx context.Context) {
 		}
 		dirName := orDir.Name()
 
-		ownerRepo, wm := e.janitorResolveOwnerRepo(dirName, wmByDirName, worktreesRoot)
+		ownerRepo, wm := e.janitorResolveOwnerRepo(ctx, dirName, wmByDirName, worktreesRoot)
 		if ownerRepo == "" {
 			e.logf(0, "janitor", "warn: cannot resolve owner/repo for dir %s — skipping\n", dirName)
 			continue
@@ -193,7 +193,7 @@ func janitorParseIssueN(name string) int {
 // For registered repos it uses the reverse map directly. For unregistered repos
 // it runs `git remote get-url origin` from the first issue subdirectory found.
 // Returns ("", nil) when the repo cannot be identified.
-func (e *Engine) janitorResolveOwnerRepo(dirName string, wmByDirName map[string]janitorWMEntry, worktreesRoot string) (ownerRepo string, wm *WorktreeManager) {
+func (e *Engine) janitorResolveOwnerRepo(ctx context.Context, dirName string, wmByDirName map[string]janitorWMEntry, worktreesRoot string) (ownerRepo string, wm *WorktreeManager) {
 	if entry, ok := wmByDirName[dirName]; ok {
 		return entry.ownerRepo, entry.wm
 	}
@@ -208,7 +208,7 @@ func (e *Engine) janitorResolveOwnerRepo(dirName string, wmByDirName map[string]
 			continue
 		}
 		wtPath := filepath.Join(worktreesRoot, dirName, d.Name())
-		cmd := exec.Command("git", "remote", "get-url", "origin")
+		cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
 		cmd.Dir = wtPath
 		out, err := cmd.Output()
 		if err != nil {
@@ -259,6 +259,11 @@ func (e *Engine) janitorIsClosed(ctx context.Context, owner, repo string, issueN
 	issue, err := e.client.FetchIssue(owner, repo, issueNumber)
 	if err != nil {
 		e.logf(0, "janitor", "warn: cannot determine closed state for #%d in %s/%s: %v — skipping\n", issueNumber, owner, repo, err)
+		closedCache[key] = false
+		return false
+	}
+	if issue == nil {
+		e.logf(0, "janitor", "warn: cannot determine closed state for #%d in %s/%s: received nil issue — skipping\n", issueNumber, owner, repo)
 		closedCache[key] = false
 		return false
 	}

--- a/engine/janitor_test.go
+++ b/engine/janitor_test.go
@@ -1,0 +1,241 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// janitorTestSetup creates a minimal environment for janitor tests.
+// Returns the engine (with fabrikDir set), a WorktreeManager backed by a real
+// git repo, and the worktrees root directory.
+func janitorTestSetup(t *testing.T) (eng *Engine, wm *WorktreeManager, worktreesRoot string) {
+	t.Helper()
+	skipIfNoGit(t)
+
+	fabrikDir := t.TempDir()
+	repoDir := initBareRepo(t) // real git repo; used as wm.baseDir
+
+	worktreesRoot = filepath.Join(fabrikDir, ".fabrik", "worktrees")
+	if err := os.MkdirAll(worktreesRoot, 0755); err != nil {
+		t.Fatalf("mkdir worktreesRoot: %v", err)
+	}
+
+	client := &mockGitHubClient{}
+	stagesWithDone := []*stages.Stage{
+		{Name: "Research", Order: 1},
+		{Name: "Plan", Order: 2},
+		{Name: "Implement", Order: 3},
+		{Name: "Done", Order: 99, CleanupWorktree: true},
+	}
+
+	eng = NewWithDeps(Config{
+		Owner:                "owner",
+		Repo:                 "repo",
+		ProjectNum:           1,
+		User:                 "testuser",
+		Token:                "token",
+		MaxConcurrent:        1,
+		Stages:               stagesWithDone,
+		JanitorIntervalHours: 1,
+	}, client, &mockClaudeInvoker{}, nil)
+	eng.fabrikDir = fabrikDir
+
+	const dirName = "testowner-testrepo"
+	wm = NewWorktreeManagerForRepo(repoDir, worktreesRoot, dirName)
+	wm.logfFn = eng.logf
+	eng.mu.Lock()
+	eng.worktreeManagers["testowner/testrepo"] = wm
+	eng.mu.Unlock()
+
+	return eng, wm, worktreesRoot
+}
+
+// seedClosed puts a closed issue into the store.
+func seedClosed(eng *Engine, repo string, number int) {
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo: repo, Number: number, Title: "test",
+	}})
+	eng.store.Apply(itemstate.IssueClosed{Repo: repo, Number: number})
+}
+
+// seedClosedOnStage puts a closed issue on a board stage.
+func seedClosedOnStage(eng *Engine, repo string, number int, stageName string) {
+	seedClosed(eng, repo, number)
+	eng.store.Apply(itemstate.LocalStatusUpdated{Repo: repo, Number: number, NewStatus: stageName})
+}
+
+// seedOpenOnStage puts an open issue on a board stage.
+func seedOpenOnStage(eng *Engine, repo string, number int, stageName string) {
+	eng.store.Apply(itemstate.IssueOpened{Item: gh.ProjectItem{
+		Repo: repo, Number: number, Title: "test",
+	}})
+	eng.store.Apply(itemstate.LocalStatusUpdated{Repo: repo, Number: number, NewStatus: stageName})
+}
+
+// createCleanWorktree creates a real git worktree for issueNumber and returns its path.
+func createCleanWorktree(t *testing.T, wm *WorktreeManager, issueNumber int) string {
+	t.Helper()
+	wtDir, err := wm.EnsureWorktree(issueNumber, "main", false)
+	if err != nil {
+		t.Fatalf("EnsureWorktree(%d): %v", issueNumber, err)
+	}
+	return wtDir
+}
+
+// TestJanitorSC1_ClosedOffBoard_Reaped verifies that a closed, off-board issue
+// with a clean worktree is reaped on a janitor cycle.
+func TestJanitorSC1_ClosedOffBoard_Reaped(t *testing.T) {
+	eng, wm, _ := janitorTestSetup(t)
+	const issueNumber = 1
+
+	// Issue is not in the store (off-board); mock FetchIssue to return "closed".
+	eng.client.(*mockGitHubClient).fetchIssueFn = func(owner, repo string, num int) (*gh.IssueData, error) {
+		return &gh.IssueData{Number: num, State: "closed"}, nil
+	}
+
+	wtDir := createCleanWorktree(t, wm, issueNumber)
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Fatalf("worktree should exist before janitor: %v", err)
+	}
+
+	eng.runWorktreeJanitor(context.Background())
+
+	if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+		t.Errorf("SC-1: expected worktree for issue #%d to be reaped, but it still exists (err=%v)", issueNumber, err)
+	}
+}
+
+// TestJanitorSC2_ClosedOnNonCleanupStage_Skipped verifies that a closed issue
+// still on the board at a non-cleanup stage is NOT reaped.
+func TestJanitorSC2_ClosedOnNonCleanupStage_Skipped(t *testing.T) {
+	eng, wm, _ := janitorTestSetup(t)
+	const issueNumber = 2
+
+	seedClosedOnStage(eng, "testowner/testrepo", issueNumber, "Implement")
+
+	wtDir := createCleanWorktree(t, wm, issueNumber)
+
+	eng.runWorktreeJanitor(context.Background())
+
+	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
+		t.Errorf("SC-2: worktree for #%d should NOT be reaped (closed but on non-cleanup stage Implement)", issueNumber)
+	}
+}
+
+// TestJanitorSC3_OpenIssue_Skipped verifies that an open issue's worktree is
+// never reaped, regardless of board state.
+func TestJanitorSC3_OpenIssue_Skipped(t *testing.T) {
+	eng, wm, _ := janitorTestSetup(t)
+	const issueNumber = 3
+
+	seedOpenOnStage(eng, "testowner/testrepo", issueNumber, "Research")
+
+	wtDir := createCleanWorktree(t, wm, issueNumber)
+
+	eng.runWorktreeJanitor(context.Background())
+
+	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
+		t.Errorf("SC-3: worktree for open issue #%d should NOT be reaped", issueNumber)
+	}
+}
+
+// TestJanitorSC4_DirtyWorktree_Skipped verifies that a dirty worktree is never
+// reaped, even when all other reap conditions hold.
+func TestJanitorSC4_DirtyWorktree_Skipped(t *testing.T) {
+	eng, wm, _ := janitorTestSetup(t)
+	const issueNumber = 4
+
+	// Issue is off-board and closed via REST.
+	eng.client.(*mockGitHubClient).fetchIssueFn = func(owner, repo string, num int) (*gh.IssueData, error) {
+		return &gh.IssueData{Number: num, State: "closed"}, nil
+	}
+
+	wtDir := createCleanWorktree(t, wm, issueNumber)
+
+	// Add an uncommitted file to make the worktree dirty.
+	dirtyFile := filepath.Join(wtDir, "dirty.txt")
+	if err := os.WriteFile(dirtyFile, []byte("dirty"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	eng.runWorktreeJanitor(context.Background())
+
+	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
+		t.Errorf("SC-4: dirty worktree for #%d should NOT be reaped", issueNumber)
+	}
+}
+
+// TestJanitorSC5_InFlightWorker_Skipped verifies that a worktree with an
+// in-flight worker is never reaped.
+func TestJanitorSC5_InFlightWorker_Skipped(t *testing.T) {
+	eng, wm, _ := janitorTestSetup(t)
+	const issueNumber = 5
+	const repo = "testowner/testrepo"
+
+	// Issue is closed and off-board in terms of status, but has an in-flight worker.
+	seedClosed(eng, repo, issueNumber)
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo:      repo,
+		Number:    issueNumber,
+		StageName: "Implement",
+		StartedAt: time.Now(),
+	})
+
+	wtDir := createCleanWorktree(t, wm, issueNumber)
+
+	eng.runWorktreeJanitor(context.Background())
+
+	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
+		t.Errorf("SC-5: worktree for issue #%d with in-flight worker should NOT be reaped", issueNumber)
+	}
+}
+
+// TestJanitorSC6_Integration verifies that three stranded worktrees are reaped
+// while one with an in-flight worker is left alone.
+func TestJanitorSC6_Integration(t *testing.T) {
+	eng, wm, _ := janitorTestSetup(t)
+	const repo = "testowner/testrepo"
+
+	// Issues 10, 11, 12 are stranded: closed, off-board, clean.
+	// Issue 13 has an in-flight worker and should be skipped.
+	eng.client.(*mockGitHubClient).fetchIssueFn = func(owner, r string, num int) (*gh.IssueData, error) {
+		return &gh.IssueData{Number: num, State: "closed"}, nil
+	}
+
+	strandedIssues := []int{10, 11, 12}
+	for _, n := range strandedIssues {
+		createCleanWorktree(t, wm, n)
+	}
+
+	// Issue 13: closed in store, but has an in-flight worker.
+	seedClosed(eng, repo, 13)
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo:      repo,
+		Number:    13,
+		StageName: "Done",
+		StartedAt: time.Now(),
+	})
+	wtDir13 := createCleanWorktree(t, wm, 13)
+
+	eng.runWorktreeJanitor(context.Background())
+
+	// Three stranded worktrees should be gone.
+	for _, n := range strandedIssues {
+		wtDir := wm.WorktreeDir(n)
+		if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+			t.Errorf("SC-6: expected worktree for issue #%d to be reaped, but it still exists", n)
+		}
+	}
+
+	// In-flight worker's worktree should remain.
+	if _, err := os.Stat(wtDir13); os.IsNotExist(err) {
+		t.Errorf("SC-6: worktree for issue #13 (in-flight worker) should NOT be reaped")
+	}
+}

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -57,6 +58,7 @@ type mockGitHubClient struct {
 	enablePullRequestAutoMergeFn        func(owner, repo string, prNumber int, strategy string) error
 	fetchCommitsBehindFn                func(owner, repo, base, head string) (int, error)
 	fetchAllowAutoMergeFn               func(owner, repo string) (bool, error)
+	fetchIssueFn                        func(owner, repo string, issueNumber int) (*gh.IssueData, error)
 
 	// Track call counts for FetchProjectItemStatus
 	fetchProjectItemStatusCalls []string
@@ -470,6 +472,16 @@ func (m *mockGitHubClient) FetchAllowAutoMerge(owner, repo string) (bool, error)
 		return fn(owner, repo)
 	}
 	return true, nil
+}
+
+func (m *mockGitHubClient) FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error) {
+	m.mu.Lock()
+	fn := m.fetchIssueFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, issueNumber)
+	}
+	return nil, errors.New("issue not found")
 }
 
 func (m *mockGitHubClient) FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -629,7 +629,7 @@ func (e *Engine) Run() error {
 		e.runStartupCleanup()
 		e.runStartupTransientLabelScan()
 		e.runStartupTerminalScan()
-		if e.cfg.JanitorIntervalHours != 0 {
+		if e.cfg.JanitorIntervalHours > 0 {
 			e.runWorktreeJanitor(ctx)
 		}
 	}
@@ -640,7 +640,7 @@ func (e *Engine) Run() error {
 
 	// Start periodic worktree janitor. Scans .fabrik/worktrees/ and reaps
 	// orphaned worktrees for closed, off-board issues. Disabled when JanitorIntervalHours == 0.
-	if e.cfg.JanitorIntervalHours != 0 {
+	if e.cfg.JanitorIntervalHours > 0 {
 		go func() {
 			ticker := time.NewTicker(time.Duration(e.cfg.JanitorIntervalHours) * time.Hour)
 			defer ticker.Stop()

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -629,11 +629,31 @@ func (e *Engine) Run() error {
 		e.runStartupCleanup()
 		e.runStartupTransientLabelScan()
 		e.runStartupTerminalScan()
+		if e.cfg.JanitorIntervalHours != 0 {
+			e.runWorktreeJanitor(ctx)
+		}
 	}
 
 	// Start background stale-worker detector. Scans for workers whose heartbeat
 	// has gone stale and cleans up if the process is confirmed dead via signal 0.
 	e.startWorkerDetector(ctx)
+
+	// Start periodic worktree janitor. Scans .fabrik/worktrees/ and reaps
+	// orphaned worktrees for closed, off-board issues. Disabled when JanitorIntervalHours == 0.
+	if e.cfg.JanitorIntervalHours != 0 {
+		go func() {
+			ticker := time.NewTicker(time.Duration(e.cfg.JanitorIntervalHours) * time.Hour)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					e.runWorktreeJanitor(ctx)
+				}
+			}
+		}()
+	}
 
 	for {
 		if e.wakeCh != nil {

--- a/engine/revalidate_test.go
+++ b/engine/revalidate_test.go
@@ -47,7 +47,7 @@ func TestRevalidate_ClearsLabelsOnValidateStage(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	if _, err := eng.poll(context.Background()); err != nil {
 		t.Fatalf("poll: %v", err)
@@ -179,7 +179,7 @@ func TestRevalidate_InFlightWorkerDefersProcessing(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	// Simulate an in-flight Validate worker.
 	eng.store.Apply(itemstate.LocalLockAcquired{
@@ -253,7 +253,7 @@ func TestRevalidate_ItemNeedsWorkAfterLabelClear(t *testing.T) {
 			}, nil
 		},
 	}
-	eng := testEngineWithStages(client, stgs)
+	eng := testEngineWithStages(t, client, stgs)
 
 	// First poll: revalidate scan fires and removes all blocking labels.
 	if _, err := eng.poll(context.Background()); err != nil {


### PR DESCRIPTION
Closes #859

## Summary

Adds `runWorktreeJanitor`, a background engine method that scans `.fabrik/worktrees/<owner>-<repo>/issue-N/` directories and reaps clean worktrees for provably-closed, off-board issues. The janitor runs once after startup (post-first-poll, so board state is hydrated) and hourly thereafter via a `time.Ticker` goroutine gated on `JanitorIntervalHours != 0`.

**Reaping gate (all four conditions must hold):**
1. Issue is closed (board cache primary, REST fallback with per-cycle cache)
2. Issue is off-board OR at a `cleanup_worktree: true` stage with the complete label (meaning a prior `CleanupWorktree` call errored)
3. Worktree is clean (`git status --porcelain`, skipping engine-managed paths)
4. No in-flight worker registered in the itemstate Store

## Key Changes

- **`engine/janitor.go`** — new file with `runWorktreeJanitor(ctx)`, `isClosed`, `isOffBoardOrCleanupComplete`, `resolveOwnerRepo`, and `getWM` helpers; FR-7 summary log
- **`engine/interfaces.go`** — added `FetchIssue` to `GitHubClient` interface (REST fallback for FR-5)
- **`engine/poll.go`** — startup + hourly wiring; both gated on `JanitorIntervalHours != 0`
- **`config/config.go`** / **`engine/engine.go`** / **`cmd/root.go`** — `JanitorIntervalHours` config field, `--janitor-interval` flag, `FABRIK_JANITOR_INTERVAL` env var
- **`engine/janitor_test.go`** — SC-1 through SC-6 (closed off-board → reaped; closed on active stage → skipped; open → skipped; dirty → skipped; in-flight worker → skipped; three stranded + one in-flight integration scenario)
- **`docs/state-machine.md`** — §11 Worktree Janitor subsection
- **`docs/USER_GUIDE.md`** — operator-facing Worktree Janitor section; `janitor_interval_hours` in config reference
- **`adrs/055-worktree-janitor.md`** — new ADR; **`adrs/006-git-worktrees.md`** — addendum closing the "planned feature" note
- **`docs/llms-full.txt`** — regenerated

## Disable

Set `janitor_interval_hours: 0` in `.fabrik/config.yaml` (or `--janitor-interval 0`). Cadence changes require a Fabrik restart (live reload not supported).

## Test Plan

- `go test -race ./engine/... -run TestJanitor` — all SC-1 through SC-6 pass
- `go test -race ./...` — all packages pass (one pre-existing cmd test `TestExecute_ConfigYAMLApplied` times out on SIGINT shutdown; confirmed failing on both `main` and `origin/fabrik/issue-859` before any janitor changes)
- `go vet ./...` — clean