### PR TITLE
feat(skills): add dep-install step to Review and Validate skills

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4890,6 +4890,10 @@ Each issue gets `.fabrik/worktrees/issue-<N>` on branch `fabrik/issue-<N>`:
 - **Retry** (`attempted=true`): Returned as-is — no rebase, preserves Claude's context
 - **Rebase conflicts**: Silently aborted (`git rebase --abort`) — Claude works from current base
 
+#### Dependency Install Responsibility Split
+
+The engine's `updateWorktreeFromMain` rebases the worktree onto main but does not run any dependency install. The Review and Validate skills are responsible for prompting Claude to run the project's install step after the rebase step completes. The project's `CLAUDE.md` is the authoritative source for the install command. This split keeps Fabrik package-manager-agnostic. See `plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md` and `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md` for the skill-side instruction.
+
 ### Read-Only Stage Stashing
 
 For `read_only: true` stages (Specify, Research, Plan): dirty state is auto-stashed before Claude runs and restored after. Claude sees a clean worktree.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4892,7 +4892,7 @@ Each issue gets `.fabrik/worktrees/issue-<N>` on branch `fabrik/issue-<N>`:
 
 #### Dependency Install Responsibility Split
 
-The engine's `updateWorktreeFromMain` rebases the worktree onto main but does not run any dependency install. The Review and Validate skills are responsible for prompting Claude to run the project's install step after the rebase step completes. The project's `CLAUDE.md` is the authoritative source for the install command. This split keeps Fabrik package-manager-agnostic. See `plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md` and `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md` for the skill-side instruction.
+The engine's `updateWorktreeFromMain` rebases the worktree onto main but does not run any dependency install. The Review and Validate skills are responsible for prompting Claude to run the project's install step after the rebase step completes. The project's `CLAUDE.md` is the authoritative source for the install command. This split keeps Fabrik package-manager-agnostic. See `.fabrik/plugin/skills/fabrik-validate/SKILL.md` and `.fabrik/plugin/skills/fabrik-review/SKILL.md` for the skill-side instruction.
 
 ### Read-Only Stage Stashing
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -60,7 +60,7 @@ Each issue gets `.fabrik/worktrees/issue-<N>` on branch `fabrik/issue-<N>`:
 
 #### Dependency Install Responsibility Split
 
-The engine's `updateWorktreeFromMain` rebases the worktree onto main but does not run any dependency install. The Review and Validate skills are responsible for prompting Claude to run the project's install step after the rebase step completes. The project's `CLAUDE.md` is the authoritative source for the install command. This split keeps Fabrik package-manager-agnostic. See `plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md` and `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md` for the skill-side instruction.
+The engine's `updateWorktreeFromMain` rebases the worktree onto main but does not run any dependency install. The Review and Validate skills are responsible for prompting Claude to run the project's install step after the rebase step completes. The project's `CLAUDE.md` is the authoritative source for the install command. This split keeps Fabrik package-manager-agnostic. See `.fabrik/plugin/skills/fabrik-validate/SKILL.md` and `.fabrik/plugin/skills/fabrik-review/SKILL.md` for the skill-side instruction.
 
 ### Read-Only Stage Stashing
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -58,6 +58,10 @@ Each issue gets `.fabrik/worktrees/issue-<N>` on branch `fabrik/issue-<N>`:
 - **Retry** (`attempted=true`): Returned as-is — no rebase, preserves Claude's context
 - **Rebase conflicts**: Silently aborted (`git rebase --abort`) — Claude works from current base
 
+#### Dependency Install Responsibility Split
+
+The engine's `updateWorktreeFromMain` rebases the worktree onto main but does not run any dependency install. The Review and Validate skills are responsible for prompting Claude to run the project's install step after the rebase step completes. The project's `CLAUDE.md` is the authoritative source for the install command. This split keeps Fabrik package-manager-agnostic. See `plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md` and `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md` for the skill-side instruction.
+
 ### Read-Only Stage Stashing
 
 For `read_only: true` stages (Specify, Research, Plan): dirty state is auto-stashed before Claude runs and restored after. Claude sees a clean worktree.

--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -52,6 +52,15 @@ When resolving merge conflicts during rebase, you MUST be conservative:
 
 Common mistake: a feature branch that doesn't have a function added on main will "resolve" the conflict by keeping its version (without the function). This silently deletes working code. Always check `git diff origin/main..HEAD` after rebase to verify you haven't lost anything from main.
 
+### Install dependencies per CLAUDE.md
+
+Main may have introduced dependency changes (version bumps, new packages) since this branch last ran tests. Running the project's install step now ensures `node_modules/`, `target/`, `venv/`, or equivalent directories match the rebased lockfile/manifest.
+
+1. Read `CLAUDE.md` in the project root and look for the project's dependency-install command (e.g. a `## Build`, `## Dependencies`, or `## Development Setup` section).
+2. If a command is specified, run it.
+3. If `CLAUDE.md` is absent, unreadable, or does not specify a dependency-install command, log `no dependency-install command found in CLAUDE.md; skipping install step` and proceed. Do NOT guess or try multiple commands.
+4. **If the install command fails**, stop immediately — do NOT proceed to testing against stale dependencies. Emit `FABRIK_BLOCKED_ON_INPUT` and report the exact failure output so the operator can investigate.
+
 ### Check for external review feedback
 
 If a PR exists, check for comments from review bots and humans:

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -40,6 +40,15 @@ If the rebase produces conflicts, resolve them conservatively:
 - **Check for missing files.** Run `git diff origin/main..HEAD --name-only` and verify no files from main were accidentally deleted. New files added to main (source, tests, subcommands) should all be present.
 - **If unsure about a conflict, abort the rebase** (`git rebase --abort`) and do NOT signal completion. Describe the conflict and let the human resolve it.
 
+### Install dependencies per CLAUDE.md
+
+Main may have introduced dependency changes (version bumps, new packages) since this branch last ran tests. Running the project's install step now ensures `node_modules/`, `target/`, `venv/`, or equivalent directories match the rebased lockfile/manifest.
+
+1. Read `CLAUDE.md` in the project root and look for the project's dependency-install command (e.g. a `## Build`, `## Dependencies`, or `## Development Setup` section).
+2. If a command is specified, run it.
+3. If `CLAUDE.md` is absent, unreadable, or does not specify a dependency-install command, log `no dependency-install command found in CLAUDE.md; skipping install step` and proceed. Do NOT guess or try multiple commands.
+4. **If the install command fails**, stop immediately — do NOT proceed to testing against stale dependencies. Emit `FABRIK_BLOCKED_ON_INPUT` and report the exact failure output so the operator can investigate.
+
 ## What You Validate
 
 ### Requirements verification


### PR DESCRIPTION
Closes #875

## What this PR does

Adds an explicit "Install dependencies per CLAUDE.md" step to both `fabrik-validate/SKILL.md` and `fabrik-review/SKILL.md`, positioned between the merge-conflict-resolution section and the first test run. The step instructs Claude to read the project's `CLAUDE.md` for a dependency-install command, run it if found, and skip silently with a log message if absent. On install failure, Claude emits `FABRIK_BLOCKED_ON_INPUT` rather than proceeding to test-run against stale deps.

Also adds a "Dependency Install Responsibility Split" note to `docs/stage-lifecycle.md` (and regenerates `docs/llms-full.txt`) documenting that the engine handles rebase while the skill text handles install prompting and `CLAUDE.md` specifies the command.

## Key changes

- `plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md` — new `### Install dependencies per CLAUDE.md` section inserted between conflict resolution and `## What You Validate`
- `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md` — identical section inserted between conflict resolution and `### Check for external review feedback`
- `docs/stage-lifecycle.md` — `#### Dependency Install Responsibility Split` subsection under Worktree Setup (Phase 2)
- `docs/llms-full.txt` — regenerated (CI `docs-drift` requirement)

## How to test

On a project whose `CLAUDE.md` specifies a dependency-install command: after rebase, Claude will read `CLAUDE.md` and run the command before running tests. On a project without a `CLAUDE.md` dep-install entry: Claude logs `no dependency-install command found in CLAUDE.md; skipping install step` and continues to test-run normally.