### PR TITLE
test(engine): use t.TempDir() in revalidate_test (fix CI hygiene lint)

### DIFF
--- a/engine/revalidate_test.go
+++ b/engine/revalidate_test.go
@@ -103,7 +103,7 @@ func TestRevalidate_NonValidateStageWarnsAndRemovesLabel(t *testing.T) {
 		},
 		client,
 		claude,
-		NewWorktreeManager("/tmp/test-revalidate-sc2"),
+		NewWorktreeManager(t.TempDir()),
 	)
 	opts := make(map[string]string)
 	for _, s := range stgs {


### PR DESCRIPTION
## What

`engine/revalidate_test.go:106` hardcoded `/tmp/test-revalidate-sc2`, tripping the **Test hygiene lint** step in `ci.yml` (`grep -rn '"/tmp/' --include="*_test.go"`). That failed the **Test and vet** job on **every** PR (it's a non-required check, so merges weren't blocked, but it showed red across the board).

The violation slipped in with the revalidate feature (#856) around the same time the hygiene sweep (#862) landed, so the sweep missed it.

## Fix

One line: `NewWorktreeManager("/tmp/test-revalidate-sc2")` → `NewWorktreeManager(t.TempDir())`, matching the idiom used everywhere else in the package.

Verified locally: lint grep clean, `go vet ./engine/` clean, `go test -race ./engine/ -run Revalidate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)