### PR TITLE
fix(validate): guard FABRIK_STAGE_COMPLETE against aborted-rebase / non-mergeable PR

### DIFF
--- a/engine/validate_mergeability_test.go
+++ b/engine/validate_mergeability_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -50,7 +49,7 @@ func TestValidate_BlockedOnInput_NonMergeableScenario(t *testing.T) {
 		ItemID: "PVTI_42",
 	}
 
-	err := eng.processItem(context.Background(), board, item)
+	err := eng.processItem(t.Context(), board, item)
 	if err != nil {
 		t.Fatalf("processItem: %v", err)
 	}

--- a/engine/validate_mergeability_test.go
+++ b/engine/validate_mergeability_test.go
@@ -1,0 +1,92 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// TestValidate_BlockedOnInput_NonMergeableScenario verifies that when the Validate
+// stage emits FABRIK_BLOCKED_ON_INPUT (e.g. because the PR is non-mergeable),
+// the engine applies fabrik:paused + fabrik:awaiting-input and does NOT apply
+// stage:Validate:complete. This is the engine-side half of the guard introduced
+// to stop false FABRIK_STAGE_COMPLETE signals from Validate on aborted-rebase /
+// non-mergeable PR scenarios (issue #828).
+func TestValidate_BlockedOnInput_NonMergeableScenario(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "PR mergeable: CONFLICTING — rebase required before signaling complete.\nFABRIK_BLOCKED_ON_INPUT\n", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			MaxRetries: 3,
+			Stages:     testStagesWithValidate(),
+		},
+		client,
+		claude,
+		wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number: 42,
+		Title:  "Non-mergeable PR issue",
+		Status: "Validate",
+		ItemID: "PVTI_42",
+	}
+
+	err := eng.processItem(context.Background(), board, item)
+	if err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// fabrik:paused and fabrik:awaiting-input must be added
+	var addedPaused, addedAwaiting bool
+	for _, call := range client.addLabelCalls {
+		if call.labelName == "fabrik:paused" {
+			addedPaused = true
+		}
+		if call.labelName == "fabrik:awaiting-input" {
+			addedAwaiting = true
+		}
+	}
+	if !addedPaused {
+		t.Error("expected fabrik:paused to be added when Validate emits FABRIK_BLOCKED_ON_INPUT")
+	}
+	if !addedAwaiting {
+		t.Error("expected fabrik:awaiting-input to be added when Validate emits FABRIK_BLOCKED_ON_INPUT")
+	}
+
+	// stage:Validate:complete must NOT be added
+	for _, call := range client.addLabelCalls {
+		if call.labelName == "stage:Validate:complete" {
+			t.Errorf("stage:Validate:complete must not be added when FABRIK_BLOCKED_ON_INPUT is emitted, got it in addLabelCalls")
+		}
+	}
+
+	// A notification comment must be posted (awaiting-input notification)
+	var foundNotification bool
+	for _, c := range client.addCommentCalls {
+		if strings.Contains(c.body, "testuser") && strings.Contains(c.body, "awaiting") {
+			foundNotification = true
+		}
+	}
+	if !foundNotification {
+		t.Errorf("expected awaiting-input notification comment containing @testuser and 'awaiting', got: %v", client.addCommentCalls)
+	}
+}

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -23,7 +23,7 @@ Also run `git status` and `git log --oneline -5` to understand the current state
 Read the user's comment carefully to understand what they're requesting:
 
 **Re-run checks**: The user wants validation checks re-executed (e.g., after a recent fix).
-- **Run `git fetch origin main` first** — before any comparison of branch CI failures to base-branch state. The engine's CI snapshot may predate recent commits to main; stale `origin/main` refs produce false "pre-existing" classifications.
+- **Fetch the target base branch first** — run `git fetch origin "$(gh pr view --json baseRefName --jq .baseRefName)"` before any comparison of branch CI failures to base-branch state. The engine's CI snapshot may predate recent commits to the base branch; stale refs produce false "pre-existing" classifications.
 - Run the relevant checks (tests, linting, build)
 - Update the validation report with the new results
 

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -23,6 +23,7 @@ Also run `git status` and `git log --oneline -5` to understand the current state
 Read the user's comment carefully to understand what they're requesting:
 
 **Re-run checks**: The user wants validation checks re-executed (e.g., after a recent fix).
+- **Run `git fetch origin main` first** — before any comparison of branch CI failures to base-branch state. The engine's CI snapshot may predate recent commits to main; stale `origin/main` refs produce false "pre-existing" classifications.
 - Run the relevant checks (tests, linting, build)
 - Update the validation report with the new results
 

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -177,19 +177,22 @@ Before you emit `FABRIK_STAGE_COMPLETE`, you MUST complete this checklist. Do no
 
 ### Step 1 — Final rebase verification
 
+Get the PR's actual target base branch, then rebase against it:
+
 ```bash
-git fetch origin main
-git rebase origin/main
+base_branch=$(gh pr view --json baseRefName --jq .baseRefName)
+git fetch origin "$base_branch"
+git rebase "origin/$base_branch"
 ```
 
 If the rebase succeeds cleanly, continue to Step 2.
 
 If the rebase produces conflicts:
 - Resolve them (see "Merge conflict resolution" above for guidance)
-- Run `go build ./...` and `go test ./...` to verify the resolution is correct
+- Run the project's build and test commands (as specified in `CLAUDE.md`) to verify the resolution is correct
 - If you cannot confidently resolve the conflicts, run `git rebase --abort` and emit `FABRIK_BLOCKED_ON_INPUT` with a list of the conflicting files
 
-**Why a final rebase re-run, not reflog inspection**: If you attempted and aborted a rebase earlier in this invocation, the prior abort left the branch behind `origin/main`. Re-running the rebase catches that state directly — either it succeeds (clearing the conflict) or it fails again (caught here, emit blocked). This is more reliable than parsing reflog history for abort markers.
+**Why a final rebase re-run, not reflog inspection**: If you attempted and aborted a rebase earlier in this invocation, the prior abort left the branch behind `origin/<base_branch>`. Re-running the rebase catches that state directly — either it succeeds (clearing the conflict) or it fails again (caught here, emit blocked). This is more reliable than parsing reflog history for abort markers.
 
 ### Step 2 — PR mergeability check
 
@@ -260,7 +263,7 @@ If you find major issues (wrong architecture, missing feature, design flaw):
 - The base branch CI status for comparison
 
 When you receive this comment:
-0. **Run `git fetch origin main`** — refresh local refs before comparing branch state to the base branch. The engine's CI snapshot may predate recent commits to main; comparing against a stale `origin/main` tip produces false "pre-existing" classifications.
+0. **Fetch the target base branch** — run `git fetch origin "$(gh pr view --json baseRefName --jq .baseRefName)"` to refresh local refs before comparing branch state to the base. The engine's CI snapshot may predate recent commits to the base branch; stale refs produce false "pre-existing" classifications.
 1. Run `gh run list --branch fabrik/issue-<N> --limit 5` then `gh run view <run-id> --log-failed` to inspect logs
 2. Fix only **NEW REGRESSION** failures — do not attempt to fix pre-existing base-branch failures
 3. Commit and push your fixes

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -166,8 +166,64 @@ The marker must be the *only* content on its line. Treat it as a control signal,
 - Tests fail
 - Regressions detected
 - Merge conflicts unresolved
+- You aborted a rebase during this invocation without subsequently completing a clean rebase
+- The PR's `mergeable=CONFLICTING` or `mergeStateStatus=DIRTY` (verified in the Pre-Completion Gate)
 
 If blocked, describe exactly what's wrong. Be specific enough that someone can act on it without re-investigating.
+
+## Pre-Completion Gate — MANDATORY before emitting FABRIK_STAGE_COMPLETE
+
+Before you emit `FABRIK_STAGE_COMPLETE`, you MUST complete this checklist. Do not skip it even if validation passed and tests are green.
+
+### Step 1 — Final rebase verification
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+If the rebase succeeds cleanly, continue to Step 2.
+
+If the rebase produces conflicts:
+- Resolve them (see "Merge conflict resolution" above for guidance)
+- Run `go build ./...` and `go test ./...` to verify the resolution is correct
+- If you cannot confidently resolve the conflicts, run `git rebase --abort` and emit `FABRIK_BLOCKED_ON_INPUT` with a list of the conflicting files
+
+**Why a final rebase re-run, not reflog inspection**: If you attempted and aborted a rebase earlier in this invocation, the prior abort left the branch behind `origin/main`. Re-running the rebase catches that state directly — either it succeeds (clearing the conflict) or it fails again (caught here, emit blocked). This is more reliable than parsing reflog history for abort markers.
+
+### Step 2 — PR mergeability check
+
+```bash
+gh pr view --json mergeable,mergeStateStatus
+```
+
+Inspect both fields:
+- `mergeable`: `"MERGEABLE"`, `"CONFLICTING"`, or `"UNKNOWN"`
+- `mergeStateStatus`: `"CLEAN"`, `"DIRTY"`, `"BLOCKED"`, `"BEHIND"`, `"UNKNOWN"`, `"DRAFT"`, or `"HAS_HOOKS"`
+
+**Block (emit `FABRIK_BLOCKED_ON_INPUT`) if**:
+- `mergeable` is `"CONFLICTING"`, OR
+- `mergeStateStatus` is `"DIRTY"`
+
+Both signals mean the PR has merge conflicts that must be resolved before merge.
+
+`"UNKNOWN"` on either field means GitHub hasn't finished computing merge state. Wait 10 seconds and re-query once. If still `"UNKNOWN"`, treat it as `"MERGEABLE"`/`"CLEAN"` and proceed — GitHub sometimes takes extra time on large repos.
+
+**Proceed (emit `FABRIK_STAGE_COMPLETE`) if** `mergeable` is `"MERGEABLE"` (or `"UNKNOWN"` after the wait) and `mergeStateStatus` is anything except `"DIRTY"`.
+
+### Step 3 — Include merge state in the summary
+
+When writing the `FABRIK_SUMMARY_BEGIN`/`FABRIK_SUMMARY_END` block, always include the PR merge state:
+
+```
+FABRIK_SUMMARY_BEGIN
+Validation passed. PR mergeable: MERGEABLE, mergeStateStatus: CLEAN. All N requirements verified, tests pass (M packages), no regressions.
+FABRIK_SUMMARY_END
+```
+
+If no linked PR exists, say so: `"No linked PR found."`.
+
+This gives operators reading the issue comment a fast signal about merge readiness without opening the PR.
 
 ## Fixing Issues
 
@@ -204,6 +260,7 @@ If you find major issues (wrong architecture, missing feature, design flaw):
 - The base branch CI status for comparison
 
 When you receive this comment:
+0. **Run `git fetch origin main`** — refresh local refs before comparing branch state to the base branch. The engine's CI snapshot may predate recent commits to main; comparing against a stale `origin/main` tip produces false "pre-existing" classifications.
 1. Run `gh run list --branch fabrik/issue-<N> --limit 5` then `gh run view <run-id> --log-failed` to inspect logs
 2. Fix only **NEW REGRESSION** failures — do not attempt to fix pre-existing base-branch failures
 3. Commit and push your fixes


### PR DESCRIPTION
Closes #828

## What This PR Does

Validates a long-standing false-signal bug: the Validate stage could emit `FABRIK_STAGE_COMPLETE` even after aborting a rebase or without confirming the linked PR was actually mergeable. This caused a cascade of downstream auto-merge failures, stale CI comparisons, and rebase reinvocations that obscured the real diagnosis.

## Changes

**`plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md`**

- Adds a mandatory **Pre-Completion Gate** section that must run before emitting `FABRIK_STAGE_COMPLETE`:
  1. Final `git fetch origin main && git rebase origin/main` — re-attempts any previously aborted rebase, catching conflicts that were silently abandoned
  2. `gh pr view --json mergeable,mergeStateStatus` — blocks with `FABRIK_BLOCKED_ON_INPUT` if `mergeable=CONFLICTING` or `mergeStateStatus=DIRTY`
- Requires `mergeable` and `mergeStateStatus` values in the `FABRIK_SUMMARY_BEGIN`/`END` block so operators see merge state without opening the PR
- Adds `git fetch origin main` as step 0 of the CI-fix re-invocation flow, preventing stale `origin/main` refs from producing false "pre-existing" CI failure classifications
- Expands the "Do NOT signal completion when" list to explicitly include aborted-rebase and non-mergeable PR as blocking conditions

**`plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md`**

- Adds `git fetch origin main` before re-run CI comparisons to ensure base-branch state is current

**`engine/validate_mergeability_test.go`** (new)

- Regression test: Validate stage + mock Claude emitting `FABRIK_BLOCKED_ON_INPUT` → engine applies `fabrik:paused` + `fabrik:awaiting-input`, does NOT apply `stage:Validate:complete`
- Follows the `TestProcessItem_BlockedOnInput_AddsLabels` pattern with `mockClaudeInvoker` + `processItem`

## How to Test

1. The new regression test covers the engine routing: `go test -race ./engine/ -run TestValidate_BlockedOnInput_NonMergeableScenario`
2. Full suite: `go test -race -timeout 5m ./...` — note: `TestExecute_ConfigYAMLApplied` in `cmd/` is a pre-existing flaky SIGINT timing test, not introduced by this PR

## Why This Approach

The plan chose **final rebase re-run instead of reflog inspection** because:
- Reflog parsing requires bounding the search to "this invocation only" — complex to express precisely in skill instructions and error-prone (previous-session aborts could produce false positives)
- Re-running `git rebase origin/main` either succeeds (clearing prior abort) or fails again (caught by the gate) — no ambiguity

This is the first link in the convergence/gate/recovery chain (issue #828 → #888 → #887 → #889 → #890, per ADR-056). Fixing the false signal here stops the cascade before the structural engine work in later issues.