### PR TITLE
feat(engine): single PR merge state settling primitive — kills mergeable/mergeable_state split-brain

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -17,6 +17,7 @@ type ReadClient interface {
 	FetchItemDetails(item *gh.ProjectItem) error
 	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)
 	FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)
+	FetchPRMergeableFields(owner, repo string, prNumber int) (mergeable *bool, mergeableState string, err error)
 	FetchPRMergeable(owner, repo string, prNumber int) (*bool, error)
 	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
 	FetchLabels(owner, repo string, issueNumber int) ([]string, error)
@@ -53,6 +54,10 @@ func (a *GitHubAdapter) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, 
 
 func (a *GitHubAdapter) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 	return a.client.FetchLinkedPR(owner, repo, issueNumber)
+}
+
+func (a *GitHubAdapter) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	return a.client.FetchPRMergeableFields(owner, repo, prNumber)
 }
 
 func (a *GitHubAdapter) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
@@ -771,6 +776,11 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 		})
 	}
 	return pr, nil
+}
+
+// FetchPRMergeableFields always delegates to GitHub — mergeability changes without webhooks.
+func (c *CacheImpl) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	return c.fallback.FetchPRMergeableFields(owner, repo, prNumber)
 }
 
 // FetchPRMergeable always delegates to GitHub — mergeability changes without webhooks.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -93,6 +93,10 @@ func (m *mockClient) FetchPRMergeableState(owner, repo string, prNumber int) (st
 	return "", nil
 }
 
+func (m *mockClient) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	return nil, "", nil
+}
+
 func (m *mockClient) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
 	m.fetchLabelsCount++
 	return m.labelsResult, nil

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -84,6 +84,9 @@ func (m *testGitHubUpgradeClient) FetchPRMergeable(owner, repo string, prNumber 
 func (m *testGitHubUpgradeClient) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
 	return "", nil
 }
+func (m *testGitHubUpgradeClient) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	return nil, "", nil
+}
 func (m *testGitHubUpgradeClient) GetPRBase(owner, repo string, prNumber int) (string, error) {
 	return "", nil
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2711,12 +2711,12 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 **Code path:** `processItem()` → outcome dispatch based on which marker is present
 
 **Effect:**
-- **FABRIK_STAGE_COMPLETE** + **FABRIK_NO_WORK_NEEDED:** `handleNoWorkNeeded()` — adds completion label for emitting stage; adds dummy `stage:<name>:complete` labels and one-line "skipped" comments for each subsequent non-cleanup stage; moves issue directly to Done; no PR created (see §6.7)
+- **FABRIK_STAGE_COMPLETE** + **FABRIK_NO_WORK_NEEDED:** `handleNoWorkNeeded()` — adds completion label for emitting stage; adds dummy `stage:<name>:complete` labels and one-line "skipped" comments for each subsequent non-cleanup stage; moves issue directly to Done; no PR created (see §6.8)
 - **FABRIK_STAGE_COMPLETE:** `handleStageComplete()` — adds completion label, potentially advances to next stage
 - **FABRIK_BLOCKED_ON_INPUT:** `blockOnInput()` — adds `fabrik:paused` + `fabrik:awaiting-input`
 - **None of the above:** cooldown retry path; eventually `escalateFailedStage()` if MaxRetries exceeded
 
-**`FABRIK_SPAWN_CHILD_BEGIN/END` blocks** are not processed inline — they are structured data emitted by the Plan stage and preserved in the Plan stage comment. The engine's `preImplement` step reads them at Implement dispatch time to create child issues. See §6.6.
+**`FABRIK_SPAWN_CHILD_BEGIN/END` blocks** are not processed inline — they are structured data emitted by the Plan stage and preserved in the Plan stage comment. The engine's `preImplement` step reads them at Implement dispatch time to create child issues. See §6.7.
 
 **`FABRIK_PR_CREATE_BEGIN/END` blocks** are processed inline — the engine parses the block during `processItem()`, creates the draft PR with `Closes #N` prepended as the first line, and records the PR number before posting output. See §5.6.
 
@@ -2760,19 +2760,19 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 ### 2.10 CI Check Completed
 
-**Trigger:** CI check runs on the PR head SHA transition from pending to a terminal state (success, failure, etc.). Fabrik detects this by polling `FetchCheckRuns` (REST) on each catch-up loop iteration — there are no webhooks.
+**Trigger:** CI check runs on the PR head SHA transition from pending to a terminal state (success, failure, etc.). Fabrik detects this by polling on each catch-up loop iteration — there are no webhooks.
 
-**Code path:** `poll()` catch-up loop Phase 1 → `checkCIGate()` → `FetchLinkedPR()` (REST, for head SHA and PR state):
-- **R1:** `pr.Merged == true` → `addCompleteLabelAndRemoveCI` → gate clears, advance to Done. No check run fetch needed.
-- **R2:** `pr.State == "closed"` and `pr.Merged == false` → `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
-- Otherwise (PR open): → `FetchPRMergeableState()` (REST, single-PR endpoint) → if `mergeable_state ∈ {clean, unstable}`: gate clears immediately (`addCompleteLabelAndRemoveCI`); otherwise → `FetchCheckRuns()` (REST) → evaluates check run statuses
-  - **R3 (in `len(checkRuns) == 0` arm):** when `mergeable_state == "blocked"` and `hadChecks == false`: check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`
-  - **New guard (in `len(checkRuns) == 0` arm, after R3):** when `mergeableState ∉ {"", "unknown"}` (e.g. `behind`, `dirty`, `draft`, `has_hooks`) and `hadChecks == false`: checks `FetchLabelAppliedAt` inline — if `fabrik:awaiting-ci` has been present ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)` — `mergeable_state` is actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API); re-evaluate on next poll. Only `mergeableState == ""` or `"unknown"` fall through to the post-push dwell guard below.
-  - **Post-push dwell guard (in `len(checkRuns) == 0` arm, after New guard):** when `mergeableState == ""` or `"unknown"` AND `hadChecks == false` AND `lpr.LastHeadSHAUpdate` is non-zero AND `time.Since(lpr.LastHeadSHAUpdate) < PostPushDwell` (default 90 s): return `(true, false, false)` — GitHub has not yet computed mergeability or started CI for the newly-pushed SHA; re-evaluate after the dwell window elapses. Zero `LastHeadSHAUpdate` (cold start / post-restart — `PRHeadSHAUpdated` not yet fired) falls through to the R5 gate-clear, preserving pre-feature behavior (EC-1). `LastHeadSHAUpdate` is stamped in the Store's `PRHeadSHAUpdated` handler only when the SHA actually changes (idempotent against same-SHA re-deliveries). Configured via `PostPushDwell` in `engine.Config`; set from `--post-push-dwell` flag (seconds) or `FABRIK_POST_PUSH_DWELL` env var; default 90 s.
-  - **R5 (fallthrough — `len(checkRuns) == 0` arm):** `hadChecks == false` + `mergeableState ∈ {"", "unknown"}` + dwell elapsed (or `LastHeadSHAUpdate` zero) → `addCompleteLabelAndRemoveCI` → gate clears as "no CI configured"; `stage:<X>:complete` added
-  - Otherwise: classifies check runs → optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
+**Code path:** `poll()` catch-up loop Phase 1 → `settlePRMergeState()` (one combined REST pass for `mergeable`, `mergeable_state`, and check runs) → `checkCIGate()` interprets the `PRSettleResult`:
+- **`PRMergeTerminal` (`pr.Merged == true`):** `addCompleteLabelAndRemoveCI` → gate clears, advance to Done.
+- **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
+- **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately (`addCompleteLabelAndRemoveCI`); per-check classification is skipped.
+- **`PRMergeUnsettled` with `CheckRuns` populated:** evaluates check run statuses; optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
+  - **R3 (empty `CheckRuns` arm, `MergeableState == "blocked"`):** `hadChecks == false`; check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`
+  - **New guard (empty `CheckRuns` arm, `MergeableState ∉ {"", "unknown"}`):** `hadChecks == false`; checks `FetchLabelAppliedAt` inline — if `fabrik:awaiting-ci` has been present ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)` — `mergeable_state` actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API); re-evaluate on next poll.
+  - **Post-push dwell guard (empty `CheckRuns` arm, `MergeableState ∈ {"", "unknown"}`):** when `hadChecks == false` AND `lpr.LastHeadSHAUpdate` is non-zero AND `time.Since(lpr.LastHeadSHAUpdate) < PostPushDwell` (default 90 s): return `(true, false, false)` — GitHub has not yet computed mergeability or started CI for the newly-pushed SHA; re-evaluate after the dwell window elapses. Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through to R5 immediately (EC-1 preserved). `LastHeadSHAUpdate` is stamped in the Store's `PRHeadSHAUpdated` handler only when the SHA actually changes. Configured via `PostPushDwell` in `engine.Config`; set from `--post-push-dwell` flag (seconds) or `FABRIK_POST_PUSH_DWELL` env var; default 90 s.
+  - **R5 (fallthrough):** `hadChecks == false` + `MergeableState ∈ {"", "unknown"}` + dwell elapsed (or `LastHeadSHAUpdate` zero) → `addCompleteLabelAndRemoveCI` → gate clears as "no CI configured"; `stage:<X>:complete` added
 
-**`mergeable_state` shortcut (v0.0.52):** Before classifying raw check_runs, `checkCIGate` queries GitHub's branch-protection-aware `mergeable_state` on the linked PR. When the value is `clean` (ready to merge per branch protection) or `unstable` (non-required checks failing but still mergeable per `github.MergeableStateAccepted`), the gate clears immediately and the per-check classification is skipped. Other states (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`, empty) fall through to `FetchCheckRuns()`. When check runs are present, the per-check classification applies. When `check_runs == []` and `hadChecks == false`, a new guard returns `(true, false, false)` for any `mergeableState ∉ {"", "unknown"}` — branch protection is actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API). Only `mergeableState == ""` (API error, where the value defaults to the zero string) or `mergeableState == "unknown"` (GitHub has not yet computed mergeability) fall through to the post-push dwell guard: if `LastHeadSHAUpdate` is non-zero and within `PostPushDwell` (default 90 s), the gate is held (`(true, false, false)`) until the dwell window elapses; only then does R5 clear the gate as "no CI configured". This prevents premature gate-clear in the brief post-push window when GitHub has not yet computed mergeability or started CI for the new SHA — the root cause of the 2026-06-16 fantasy incident. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs like `Cleanup artifacts`) do not block merges per branch protection, so Fabrik's gate must not block on them either. The `mergeable_state` field is null on the list endpoint used by `FetchLinkedPR`, so a separate single-PR REST call is required (`FetchPRMergeableState`).
+**Settling primitive consolidation (v0.0.53):** `settlePRMergeState()` reads `mergeable`, `mergeable_state`, and check runs in one pass before both the merge-conflict gate and the CI gate. This eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state. See §6.4 for the full specification. `MergeableState` is intentionally omitted from `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases so that `checkCIGate`'s R3 path (`MergeableState == "blocked"` + empty CheckRuns) cannot misfire on those cases. The `mergeable_state` field is null on the list endpoint used by `FetchLinkedPR`, so `FetchPRMergeableFields()` (a separate single-PR REST call) provides both `mergeable` and `mergeable_state` in one request.
 
 **`(false, false, false)` return semantics:** `checkCIGate` returns `(false, false, false)` for all of the following terminal conditions, which it handles internally (the poll.go call site never sees `ciTimedOut=true` for these): R1 merged PR, R2 closed-not-merged PR, R3 required-never-running check, no linked PR, all-green checks. The caller only needs to call `pauseForCITimeout` when `timedOut=true` (the generic check-runs timeout path).
 
@@ -2792,7 +2792,7 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **Trigger:** The PR's base branch moves forward (a different PR merges) while this branch is sitting in the post-`stage:Validate:complete` catch-up window. GitHub recomputes `mergeable` on the linked PR; if the new base conflicts with this branch, `mergeable` transitions from `true` (or `null`) to `false`.
 
-**Code path:** `poll()` catch-up loop Phase 1 → `checkMergeabilityGate()` → `FetchLinkedPR()` (REST, for PR number) → `FetchPRMergeable()` (REST, for the single-PR `mergeable` field) → evaluates the flag → optionally dispatches `dispatchRebaseReinvoke()` → async goroutine → `processComments()` with a synthetic rebase-required comment
+**Code path:** `poll()` catch-up loop Phase 1 → `settlePRMergeState()` (combined REST pass: `FetchLinkedPR` + `FetchPRMergeableFields` for `mergeable` and `mergeable_state`) → `checkMergeabilityGate()` interprets `PRSettleResult` → evaluates the flag → optionally dispatches `dispatchRebaseReinvoke()` → async goroutine → `processComments()` with a synthetic rebase-required comment
 
 **Distinct from CI Check Completed because:**
 - Triggered by base-branch movement, not check run status changes
@@ -3474,21 +3474,23 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
      - Calls `processComments()` with the synthetic review comments asynchronously
      - On exit: releases semaphore, applies `WorkerExited`
    - Either way: `continue` — Phase 2 is skipped this cycle; item re-evaluated on next poll
-6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`, the same opt-in as the CI gate): `checkMergeabilityGate()` fetches GitHub's `mergeable` flag for the linked PR
-   - `mergeable == true` (or no PR): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
-   - `mergeable == null` (GitHub still computing) **or** transient API error on either REST call: block this item for the rest of Phase 1 (skip to next item) — re-evaluated on the next poll (**no label churn** — mirrors the CI gate's R10c rule and matches how the CI gate handles its own transient errors)
-   - `mergeable == false` (confirmed conflict): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
+5.5. **Settle call** (runs immediately before the merge-conflict gate and CI gate; only for stages with `wait_for_ci: true`): `settlePRMergeState()` fetches `mergeable`, `mergeable_state`, and check runs in a single pass, returning a typed `PRSettleResult`. Both gates below receive this result and do not make their own REST calls for these fields — eliminating the split-brain where two separate REST calls within one poll cycle could observe different GitHub state. See §6.4 for the full settling primitive specification.
+6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`): `checkMergeabilityGate()` interprets the `PRSettleResult` from the settle call
+   - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
+   - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
+   - `PRMergeUnsettled` or `PRMergeBlocked`: block this item for the rest of Phase 1 (**no label churn** — mirrors the CI gate's R10c rule)
+   - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
      - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
      - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
-7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` evaluates CI for stages with `wait_for_ci: true`
-   - **R1:** `pr.Merged == true` → gate clears immediately (`addCompleteLabelAndRemoveCI`); no check-run fetch needed; advance to Done
-   - **R2:** `pr.State == "closed"` and `pr.Merged == false` → `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`, posts explanatory comment; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
-   - **`mergeable_state` shortcut (v0.0.52):** before fetching check runs, `checkCIGate` queries `FetchPRMergeableState()` on the linked PR. If the value is `clean` or `unstable` (per `github.MergeableStateAccepted`), the gate clears immediately: `addCompleteLabelAndRemoveCI()` adds `stage:<X>:complete` and removes `fabrik:awaiting-ci`; the per-check classification is skipped. Other states (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`, empty) fall through to `FetchCheckRuns()`. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
-   - **R3 (in no-check-runs arm):** when `mergeable_state == "blocked"` and `hadChecks == false`: check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard — first-push window, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct "required check never runs on PR" comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`, returns `(false, false, false)`
-   - **New guard (in no-check-runs arm, after R3):** when `mergeableState ∉ {"", "unknown"}` (e.g. `behind`, `dirty`, `draft`, `has_hooks`) and `hadChecks == false`: checks `FetchLabelAppliedAt` inline — if `fabrik:awaiting-ci` ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)` — `mergeable_state` is actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API); re-evaluate on next poll. Only `mergeableState == ""` (API error fallback) or `mergeableState == "unknown"` (GitHub not yet computed) fall through to the "no CI configured" gate-clear.
-   - Per-check classification (fallback): fetches `FetchCheckRuns()` and applies R1–R6
-   - Pending/API error: skip (blocked, not failed); item re-evaluated on next poll
-   - Timed out: `pauseForCITimeout()` pauses issue
+7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` interprets the `PRSettleResult` from the settle call for stages with `wait_for_ci: true`
+   - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); advance to Done
+   - **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
+   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+   - **`PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies R1–R6; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
+   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
+   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
+   - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
+   - Timed out (generic path): `pauseForCITimeout()` pauses issue
    - CI failed: **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.CIFixCycles(stage.Name)` vs `MaxCiFixCycles`):
      - If exceeded: `pauseForCIFixCycleLimit()` pauses issue
      - If not exceeded: dispatch `dispatchCIFixReinvoke()`; `continue`
@@ -3519,9 +3521,49 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 | PR summary posting | None | Posts `"<StageName> (review feedback addressed)"` on the linked PR with per-thread footer (one `path:line — resolved` bullet per unique `ReviewThreadID`); skipped when `output == ""` or no linked PR |
 | Worker guard | Uses dispatch loop's `snap.Worker() != nil` | Has its own `snap.Worker() != nil` check in catch-up loop |
 
-### 6.4 CI Gate and CI-Fix Reinvoke
+### 6.4 PR Merge State Settling Primitive
 
-#### 6.4.1 Two-Phase CI Gate
+`settlePRMergeState()` is called **once per catch-up loop Phase 1 iteration — before both the merge-conflict gate and the CI gate** — to read `mergeable`, `mergeable_state`, and check runs in a single pass. Both gates receive this `PRSettleResult` and do not make their own REST calls for these fields; this eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
+
+**Return type:** `PRSettleResult` carries:
+- `Status PRMergeStatus` — one of six typed constants (see below)
+- `PR *gh.PRDetails` — the fetched PR (nil when status is `PRMergeNoPR`)
+- `MergeableState string` — raw `mergeable_state` from GitHub (empty when intentionally omitted — see invariant below)
+- `CheckRuns []gh.CheckRun` — check runs for the PR head SHA (nil when not fetched)
+- `Reason string` — human-readable explanation for the status
+
+**Six status constants:**
+
+| Constant | Meaning |
+|---|---|
+| `PRMergeNoPR` | No linked PR on this item; both gates are no-ops |
+| `PRMergeUnsettled` | GitHub has not yet computed a definitive merge state; gates block without label churn |
+| `PRMergeReady` | `mergeable_state ∈ {clean, unstable}` — PR is ready to merge per branch protection |
+| `PRMergeConflicting` | `mergeable == false` — confirmed base-branch conflict |
+| `PRMergeBlocked` | PR is closed (not merged); `checkCIGate` dispatches `pauseForPRClosedNotMerged()` |
+| `PRMergeTerminal` | PR is merged; both gates clear immediately |
+
+**Settling rules (applied in order):**
+
+1. `FetchLinkedPR()` — if no linked PR: return `PRMergeNoPR`.
+2. PR merged (`pr.Merged == true`): return `PRMergeTerminal`.
+3. PR closed, not merged (`pr.State == "closed"`): return `PRMergeBlocked`.
+4. HeadSHA empty: return `PRMergeUnsettled` (`MergeableState` omitted — see invariant).
+5. `FetchPRMergeableFields()` — fetches `mergeable` (bool ptr) and `mergeable_state` (string) in one REST call (single-PR endpoint; the list endpoint used by `FetchLinkedPR` does not return `mergeable`).
+6. `mergeable_state ∈ {clean, unstable}` (per `MergeableStateAccepted` allowlist): return `PRMergeReady` with `CheckRuns` populated from `FetchCheckRuns()`.
+7. `hadChecks` (store: `LinkedPRState.HasHadChecks`) is true: return `PRMergeUnsettled` with `CheckRuns` populated — `MergeableState` **intentionally omitted** (see invariant).
+8. Post-push dwell active (`LastHeadSHAUpdate` non-zero and `time.Since(LastHeadSHAUpdate) < PostPushDwell`, default 90 s): return `PRMergeUnsettled` — `MergeableState` **intentionally omitted** (see invariant). Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through.
+9. `mergeable == false`: return `PRMergeConflicting`.
+10. `mergeable == nil` or API error: return `PRMergeUnsettled` with `MergeableState` populated.
+11. Fallback with check runs: return `PRMergeUnsettled` with `MergeableState` and `CheckRuns` populated.
+
+**`MergeableState` omission invariant:** `checkCIGate` uses `settle.MergeableState` to detect R3 (OPEN+BLOCKED+no-check-runs+`fabrik:awaiting-ci` elapsed → `pauseForRequiredNeverRunningCheck`). The primitive omits `MergeableState` from the `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases. This prevents R3 from misfiring on cases where `hadChecks == true` (checks have been observed) or where GitHub simply hasn't computed mergeability yet (post-push window). Only a non-empty `MergeableState` in the settle result is genuinely relevant for R3/branch-protection timeout checking.
+
+**`FetchCheckRuns` consolidation:** `buildCIFixComment()` (called inside `dispatchCIFixReinvoke()`) uses `settle.CheckRuns` for the PR-head check runs, eliminating the separate `FetchCheckRuns()` call that previously lived in the CI-fix path. The base-branch `FetchCheckRuns(baseSHA)` inside `buildCIFixComment()` is a **non-gate diagnostic read** — it fetches check runs for the base branch's HEAD SHA for regression-vs-pre-existing classification only, and is structurally independent (different SHA; result is not used by either gate).
+
+### 6.5 CI Gate and CI-Fix Reinvoke
+
+#### 6.5.1 Two-Phase CI Gate
 
 The CI gate has two paths that handle different timing scenarios:
 
@@ -3537,7 +3579,7 @@ The CI gate has two paths that handle different timing scenarios:
 
 **Path 2: Catch-up loop Phase 1 (`checkCIGate()`)**
 - Runs for items with `fabrik:awaiting-ci` on stages with `wait_for_ci: true` (admitted by broadened catch-up loop entry guard: `!hasComplete && !(hasAwaitingCI && isWaitForCI)` — see ADR 032)
-- Has FRESH data from `FetchItemDetails()` and makes targeted REST calls for head SHA and check runs
+- Has FRESH data from `FetchItemDetails()` and receives a `PRSettleResult` from `settlePRMergeState()` (called once per Phase 1 iteration, before both gates) — no separate REST calls for `mergeable`, `mergeable_state`, or PR-head check runs
 - Uses `FetchLabelAppliedAt` on `fabrik:awaiting-ci` for timeout tracking (durable across restarts)
 - Three outcomes:
   - `(ciBlocked=true, ciFailure=false, ciTimedOut=false)` — checks still pending; skip to next item (`fabrik:awaiting-ci` already present — no additional label needed)
@@ -3549,7 +3591,7 @@ The CI gate has two paths that handle different timing scenarios:
 - **Path 1** (merge guard): `itemstate.Store` → `LinkedPRState.CIMergePendingSince`. Acceptable because merge-guard state is transient — engine restarts simply re-evaluate CI on the next poll (store is in-memory only; not persisted across restarts).
 - **Path 2** (catch-up loop): `FetchLabelAppliedAt` REST call on `fabrik:awaiting-ci`. Durable across restarts because the label itself persists. The label is present from the moment Claude emits FABRIK_STAGE_COMPLETE on a `wait_for_ci: true` stage, so timeout tracking is accurate from the start of the CI-await window.
 
-#### 6.4.2 CI Fix Reinvoke Mechanics
+#### 6.5.2 CI Fix Reinvoke Mechanics
 
 The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. When CI has failed:
 
@@ -3559,7 +3601,7 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
    - If not exceeded: increment count, dispatch reinvoke via `dispatchCIFixReinvoke()`:
      - Applies `WorkerEntered` (prevents double-dispatch)
      - Acquires semaphore slot (respects `MaxConcurrent`)
-     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch)
+     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — uses `settle.CheckRuns` for the PR-head check runs (no separate `FetchCheckRuns` call); classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch) by calling `FetchCheckRuns(baseSHA)` for the base-branch HEAD SHA (a **non-gate diagnostic read** — different SHA, independent of the settle result)
      - Calls `processComments()` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if unset)
      - On exit: releases semaphore, applies `WorkerExited`
 
@@ -3567,12 +3609,12 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
 
 **CI-fix cycle counter reset:** `StageState.CIFixCycles[stageName]` is reset to 0 by `clearFailedStage()` (via `EngineCyclesCleared` mutation) when the user removes `fabrik:paused` from a paused-failed item, allowing fresh CI-fix attempts after human intervention. `StageState.RebaseCycles[stageName]` is reset in the same call for the same reason.
 
-#### 6.4.3 CI Fix Reinvoke vs Review Reinvoke
+#### 6.5.3 CI Fix Reinvoke vs Review Reinvoke
 
 | Aspect | Review Reinvoke | CI Fix Reinvoke |
 |--------|-----------------|-----------------|
 | Trigger | Unresolved PR review thread comments | CI check runs with failure/timed_out/action_required conclusion |
-| Source data | `item.LinkedPRReviewThreadComments` | `FetchCheckRuns()` REST call on PR head SHA |
+| Source data | `item.LinkedPRReviewThreadComments` | `settle.CheckRuns` from `settlePRMergeState()` (no separate REST call for PR-head checks) |
 | Label on waiting | `fabrik:awaiting-review` (always applied) | `fabrik:awaiting-ci` (applied by `handleStageComplete` on FABRIK_STAGE_COMPLETE; present for both pending and failed checks — covers the full CI-await window) |
 | Timeout tracking | In-memory `ReviewWaitTimeout` timer | `FetchLabelAppliedAt` on `fabrik:awaiting-ci` (durable across restarts; label is present from FABRIK_STAGE_COMPLETE onwards) |
 | Cycle counter | `snap.ReviewCycles(stageName)` / `ReviewCycleIncremented` | `snap.CIFixCycles(stageName)` / `CIFixCycleIncremented` |
@@ -3584,29 +3626,29 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
 | PR summary comment | Yes — `"<StageName> (review feedback addressed)"` on linked PR | No |
 | Stage gate config | `wait_for_reviews: true` | `wait_for_ci: true` |
 
-### 6.5 Merge-Conflict Gate and Rebase Reinvoke
+### 6.6 Merge-Conflict Gate and Rebase Reinvoke
 
 The merge-conflict gate is a third prong of the catch-up loop Phase 1, sitting between review reinvoke and the CI gate. It is the direct response to the failure mode in which a base-branch advance during the CI-await window leaves a PR unmergeable — the CI gate alone will happily keep polling check runs on the branch head while the real blocker is a conflict.
 
 **Note:** `attemptMergeOnValidate()` (§5.4, the legacy auto-merge path for stages without `wait_for_ci: true`) now uses the same `snap.RebaseCycles(stage.Name)` + `RebaseCycleIncremented`, `dispatchRebaseReinvoke()`, and `pauseForRebaseCycleLimit()` pattern as the conjunctive gate described in this section. Both paths share the same per-item store field; `MaxRebaseCycles` applies to both.
 
-#### 6.5.1 Gate Mechanics
+#### 6.6.1 Gate Mechanics
 
 `checkMergeabilityGate()` runs only when `stage.WaitForCI` is true (the same opt-in that admits items to the catch-up window via `fabrik:awaiting-ci`). It returns `(blocked, conflict)`:
 
-- `(false, false)` — clear: no linked PR, or `mergeable == true`. Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
-- `(true, false)` — GitHub reports `mergeable == null` (still computing) **or** a transient API error was seen on either REST call. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
-- `(true, true)` — confirmed conflict (`mergeable == false`). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
+- `(false, false)` — clear: `PRMergeNoPR`, `PRMergeTerminal`, or `PRMergeReady` (`mergeable == true` / `mergeable_state ∈ {clean, unstable}`). Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
+- `(true, false)` — `PRMergeUnsettled` (`mergeable == null`, still computing) or `PRMergeBlocked` (PR closed), or transient API error. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
+- `(true, true)` — `PRMergeConflicting` (`mergeable == false`, confirmed conflict). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
 
-Two REST calls are made: `FetchLinkedPR` for the PR number, then `FetchPRMergeable` (hitting `/repos/{owner}/{repo}/pulls/{number}`). The single-PR endpoint is required — the list endpoint used by `FetchLinkedPR` does not return `mergeable`.
+The gate's inputs come from `settlePRMergeState()` (§6.4), called once per Phase 1 iteration before both gates. `FetchPRMergeableFields()` (single-PR endpoint, not the list endpoint used by `FetchLinkedPR`) provides both `mergeable` and `mergeable_state` in one request — the list endpoint does not return `mergeable`.
 
-#### 6.5.2 Ordering Against the CI Gate
+#### 6.6.2 Ordering Against the CI Gate
 
 The merge-conflict gate runs **before** the CI gate so that a confirmed conflict preempts CI-await polling. The rationale: a PR that cannot merge has no reason to wait for CI, and Claude on CI-fix reinvoke cannot productively act on a branch that must first be rebased. When the merge gate emits `conflict`, Phase 1 `continue`s without reaching the CI gate.
 
 When the merge gate clears (`mergeable == true`), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked with no confirmed conflict (`mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
 
-#### 6.5.3 Rebase Reinvoke Mechanics
+#### 6.6.3 Rebase Reinvoke Mechanics
 
 When `checkMergeabilityGate` returns `conflict=true`:
 
@@ -3622,18 +3664,18 @@ When `checkMergeabilityGate` returns `conflict=true`:
 
 **`DatabaseID: 0` guard:** like the CI-fix and review synthetic comments, the rebase synthetic comment uses `DatabaseID: 0` so `processComments()` skips the 👀 and 🚀 reaction steps (no real GitHub comment exists to react to).
 
-#### 6.5.4 Why Claude Rebases (Not the Engine)
+#### 6.6.4 Why Claude Rebases (Not the Engine)
 
 The engine could in principle run `git fetch && git rebase` directly from the worker, but does not. Automatic rebase is *right most of the time* and *catastrophically wrong sometimes*: two PRs independently pick `adr-054.md`, both PRs pick migration slot `0042`, both PRs add a new line at the same point in a shared config file. A mechanical rebase drops one side silently; a Claude-driven rebase can rename, renumber, and keep both contributions. The synthetic comment explicitly flags this — "watch for semantic collisions" — so Claude's judgment is applied where it matters.
 
 The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRebaseCycles` defaults to 3 rather than 5: if Claude cannot rebase cleanly in three attempts the conflict almost certainly needs a human.
 
-#### 6.5.5 Rebase Reinvoke vs CI Fix Reinvoke
+#### 6.6.5 Rebase Reinvoke vs CI Fix Reinvoke
 
 | Aspect | CI Fix Reinvoke | Rebase Reinvoke |
 |--------|-----------------|-----------------|
 | Trigger | CI check runs in failure state | `mergeable == false` on linked PR |
-| Source data | `FetchCheckRuns()` REST call on PR head SHA | `FetchPRMergeable()` REST call on linked PR |
+| Source data | `settle.CheckRuns` from `settlePRMergeState()` (no separate REST call for PR-head checks) | `settle.Status == PRMergeConflicting` from `settlePRMergeState()` (`FetchPRMergeableFields` provides `mergeable`) |
 | Label on waiting | `fabrik:awaiting-ci` (only on confirmed failure) | `fabrik:rebase-needed` (only on confirmed `mergeable == false`) |
 | Order in Phase 1 | After merge-conflict gate | Before CI gate |
 | Cycle counter | `snap.CIFixCycles(stageName)` / `CIFixCycleIncremented` | `snap.RebaseCycles(stageName)` / `RebaseCycleIncremented` |
@@ -3647,7 +3689,7 @@ The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRe
 
 **References:** [ADR-028: Merge-Conflict Gate and Rebase Reinvoke](../adrs/028-merge-conflict-gate-and-rebase-reinvoke.md)
 
-### 6.6 Pre-Implement Spawn Path
+### 6.7 Pre-Implement Spawn Path
 
 **Trigger:** The Implement stage dispatcher calls `preImplement()` before the Claude invocation on every Implement dispatch. `preImplement` is a no-op unless the Plan stage comment contains `FABRIK_SPAWN_CHILD_BEGIN/END` blocks AND the parent issue does not yet have `fabrik:children-spawned`.
 
@@ -3687,7 +3729,7 @@ These blocks persist in the Plan stage comment — they are data, not consumed-a
 
 **References:** [ADR-048: Engine-Side Pre-Implement Spawn](../adrs/048-spawn-child-engine-side.md)
 
-### 6.7 No Work Needed Path
+### 6.8 No Work Needed Path
 
 **Trigger:** Claude outputs both `FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED` in the same invocation output. Expected most commonly from the Plan stage when Research findings show no code or documentation changes are needed.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2764,7 +2764,7 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **Code path:** `poll()` catch-up loop Phase 1 → `settlePRMergeState()` (one combined REST pass for `mergeable`, `mergeable_state`, and check runs) → `checkCIGate()` interprets the `PRSettleResult`:
 - **`PRMergeTerminal` (`pr.Merged == true`):** `addCompleteLabelAndRemoveCI` → gate clears, advance to Done.
-- **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
+- **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
 - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately (`addCompleteLabelAndRemoveCI`); per-check classification is skipped.
 - **`PRMergeUnsettled` with `CheckRuns` populated:** evaluates check run statuses; optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
   - **R3 (empty `CheckRuns` arm, `MergeableState == "blocked"`):** `hadChecks == false`; check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`
@@ -3478,15 +3478,16 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`): `checkMergeabilityGate()` interprets the `PRSettleResult` from the settle call
    - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
    - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
-   - `PRMergeUnsettled` or `PRMergeBlocked`: block this item for the rest of Phase 1 (**no label churn** — mirrors the CI gate's R10c rule)
+   - `PRMergeBlocked` (CI checks failed): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate so `checkCIGate` can classify and dispatch the CI-fix reinvoke
+   - `PRMergeUnsettled`: block this item for the rest of Phase 1 (**no label churn** — ADR-032 R10c)
    - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
      - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
      - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
 7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` interprets the `PRSettleResult` from the settle call for stages with `wait_for_ci: true`
    - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); advance to Done
-   - **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
-   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
-   - **`PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies R1–R6; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
+   - **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
+   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`, or all checks green):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+   - **`PRMergeBlocked` or `PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
    - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
    - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
    - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
@@ -3538,24 +3539,29 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 |---|---|
 | `PRMergeNoPR` | No linked PR on this item; both gates are no-ops |
 | `PRMergeUnsettled` | GitHub has not yet computed a definitive merge state; gates block without label churn |
-| `PRMergeReady` | `mergeable_state ∈ {clean, unstable}` — PR is ready to merge per branch protection |
+| `PRMergeReady` | PR is ready to merge (all checks green, or `mergeable_state ∈ {clean, unstable}`) |
 | `PRMergeConflicting` | `mergeable == false` — confirmed base-branch conflict |
-| `PRMergeBlocked` | PR is closed (not merged); `checkCIGate` dispatches `pauseForPRClosedNotMerged()` |
-| `PRMergeTerminal` | PR is merged; both gates clear immediately |
+| `PRMergeBlocked` | CI checks have failed; `checkCIGate` dispatches `dispatchCIFixReinvoke()` |
+| `PRMergeTerminal` | PR is merged or closed without merging; both gates handle terminal state |
 
 **Settling rules (applied in order):**
 
 1. `FetchLinkedPR()` — if no linked PR: return `PRMergeNoPR`.
 2. PR merged (`pr.Merged == true`): return `PRMergeTerminal`.
-3. PR closed, not merged (`pr.State == "closed"`): return `PRMergeBlocked`.
-4. HeadSHA empty: return `PRMergeUnsettled` (`MergeableState` omitted — see invariant).
-5. `FetchPRMergeableFields()` — fetches `mergeable` (bool ptr) and `mergeable_state` (string) in one REST call (single-PR endpoint; the list endpoint used by `FetchLinkedPR` does not return `mergeable`).
-6. `mergeable_state ∈ {clean, unstable}` (per `MergeableStateAccepted` allowlist): return `PRMergeReady` with `CheckRuns` populated from `FetchCheckRuns()`.
-7. `hadChecks` (store: `LinkedPRState.HasHadChecks`) is true: return `PRMergeUnsettled` with `CheckRuns` populated — `MergeableState` **intentionally omitted** (see invariant).
-8. Post-push dwell active (`LastHeadSHAUpdate` non-zero and `time.Since(LastHeadSHAUpdate) < PostPushDwell`, default 90 s): return `PRMergeUnsettled` — `MergeableState` **intentionally omitted** (see invariant). Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through.
-9. `mergeable == false`: return `PRMergeConflicting`.
-10. `mergeable == nil` or API error: return `PRMergeUnsettled` with `MergeableState` populated.
-11. Fallback with check runs: return `PRMergeUnsettled` with `MergeableState` and `CheckRuns` populated.
+3. PR closed, not merged (`pr.State == "closed"`): return `PRMergeTerminal`.
+4. `FetchPRMergeableFields()` — fetches `mergeable` (bool ptr) and `mergeable_state` (string) in one REST call (single-PR endpoint; the list endpoint used by `FetchLinkedPR` does not return `mergeable`). API error → return `PRMergeUnsettled`.
+5. `mergeable == nil` (GitHub still computing): return `PRMergeUnsettled` (`MergeableState` set).
+6. `mergeable_state == "unknown"` (transient): return `PRMergeUnsettled` (`MergeableState` set).
+7. `mergeable == false`: return `PRMergeConflicting` (`MergeableState` set).
+8. `mergeable_state ∈ {clean, unstable}` (per `MergeableStateAccepted` allowlist): return `PRMergeReady` — per ADR-033, GitHub's branch-protection signal is authoritative; `FetchCheckRuns` is not called.
+9. HeadSHA empty: return `PRMergeUnsettled` (`MergeableState` **intentionally omitted** — see invariant).
+10. `FetchCheckRuns()` — API error → return `PRMergeUnsettled`.
+11. Check runs non-empty: apply `PRChecksObserved` store event (sets `HasHadChecks`).
+12. Check runs empty + `hadChecks` (store: `LinkedPRState.HasHadChecks`): return `PRMergeUnsettled` (`MergeableState` **intentionally omitted** — see invariant).
+13. Check runs empty + post-push dwell active (`LastHeadSHAUpdate` non-zero and `time.Since < PostPushDwell`, default 90 s): return `PRMergeUnsettled` (`MergeableState` **intentionally omitted** — see invariant). Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through.
+14. Check runs empty + `mergeable_state ∉ {"", "unknown"}`: return `PRMergeUnsettled` (`MergeableState` set — R3/branch-protection signal for `checkCIGate`).
+15. Check runs empty + `mergeable_state ∈ {"", "unknown"}`: return `PRMergeReady` (no CI configured).
+16. Check runs non-empty: any failed (`failure`/`timed_out`/`action_required`) → return `PRMergeBlocked` (`CheckRuns` set); any pending (`queued`/`in_progress`) → return `PRMergeUnsettled` (`CheckRuns` set); all green → return `PRMergeReady` (`CheckRuns` set).
 
 **`MergeableState` omission invariant:** `checkCIGate` uses `settle.MergeableState` to detect R3 (OPEN+BLOCKED+no-check-runs+`fabrik:awaiting-ci` elapsed → `pauseForRequiredNeverRunningCheck`). The primitive omits `MergeableState` from the `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases. This prevents R3 from misfiring on cases where `hadChecks == true` (checks have been observed) or where GitHub simply hasn't computed mergeability yet (post-push window). Only a non-empty `MergeableState` in the settle result is genuinely relevant for R3/branch-protection timeout checking.
 
@@ -3636,8 +3642,8 @@ The merge-conflict gate is a third prong of the catch-up loop Phase 1, sitting b
 
 `checkMergeabilityGate()` runs only when `stage.WaitForCI` is true (the same opt-in that admits items to the catch-up window via `fabrik:awaiting-ci`). It returns `(blocked, conflict)`:
 
-- `(false, false)` — clear: `PRMergeNoPR`, `PRMergeTerminal`, or `PRMergeReady` (`mergeable == true` / `mergeable_state ∈ {clean, unstable}`). Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
-- `(true, false)` — `PRMergeUnsettled` (`mergeable == null`, still computing) or `PRMergeBlocked` (PR closed), or transient API error. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
+- `(false, false)` — clear: `PRMergeNoPR`, `PRMergeTerminal`, `PRMergeReady`, or `PRMergeBlocked` (CI failed — no base conflict; deferred to the CI gate). Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
+- `(true, false)` — `PRMergeUnsettled` (`mergeable == null`, still computing, or transient API error). The gate blocks but **no label is applied** — unknown states must not produce label churn (ADR-032 R10c). Caller skips to the next item; the next poll re-evaluates.
 - `(true, true)` — `PRMergeConflicting` (`mergeable == false`, confirmed conflict). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
 
 The gate's inputs come from `settlePRMergeState()` (§6.4), called once per Phase 1 iteration before both gates. `FetchPRMergeableFields()` (single-PR endpoint, not the list endpoint used by `FetchLinkedPR`) provides both `mergeable` and `mergeable_state` in one request — the list endpoint does not return `mergeable`.
@@ -3646,7 +3652,7 @@ The gate's inputs come from `settlePRMergeState()` (§6.4), called once per Phas
 
 The merge-conflict gate runs **before** the CI gate so that a confirmed conflict preempts CI-await polling. The rationale: a PR that cannot merge has no reason to wait for CI, and Claude on CI-fix reinvoke cannot productively act on a branch that must first be rebased. When the merge gate emits `conflict`, Phase 1 `continue`s without reaching the CI gate.
 
-When the merge gate clears (`mergeable == true`), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked with no confirmed conflict (`mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
+When the merge gate clears (`mergeable == true`, CI failed, or no conflict), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked (`PRMergeUnsettled` — `mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
 
 #### 6.6.3 Rebase Reinvoke Mechanics
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -243,12 +243,12 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 **Code path:** `processItem()` → outcome dispatch based on which marker is present
 
 **Effect:**
-- **FABRIK_STAGE_COMPLETE** + **FABRIK_NO_WORK_NEEDED:** `handleNoWorkNeeded()` — adds completion label for emitting stage; adds dummy `stage:<name>:complete` labels and one-line "skipped" comments for each subsequent non-cleanup stage; moves issue directly to Done; no PR created (see §6.7)
+- **FABRIK_STAGE_COMPLETE** + **FABRIK_NO_WORK_NEEDED:** `handleNoWorkNeeded()` — adds completion label for emitting stage; adds dummy `stage:<name>:complete` labels and one-line "skipped" comments for each subsequent non-cleanup stage; moves issue directly to Done; no PR created (see §6.8)
 - **FABRIK_STAGE_COMPLETE:** `handleStageComplete()` — adds completion label, potentially advances to next stage
 - **FABRIK_BLOCKED_ON_INPUT:** `blockOnInput()` — adds `fabrik:paused` + `fabrik:awaiting-input`
 - **None of the above:** cooldown retry path; eventually `escalateFailedStage()` if MaxRetries exceeded
 
-**`FABRIK_SPAWN_CHILD_BEGIN/END` blocks** are not processed inline — they are structured data emitted by the Plan stage and preserved in the Plan stage comment. The engine's `preImplement` step reads them at Implement dispatch time to create child issues. See §6.6.
+**`FABRIK_SPAWN_CHILD_BEGIN/END` blocks** are not processed inline — they are structured data emitted by the Plan stage and preserved in the Plan stage comment. The engine's `preImplement` step reads them at Implement dispatch time to create child issues. See §6.7.
 
 **`FABRIK_PR_CREATE_BEGIN/END` blocks** are processed inline — the engine parses the block during `processItem()`, creates the draft PR with `Closes #N` prepended as the first line, and records the PR number before posting output. See §5.6.
 
@@ -292,19 +292,19 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 ### 2.10 CI Check Completed
 
-**Trigger:** CI check runs on the PR head SHA transition from pending to a terminal state (success, failure, etc.). Fabrik detects this by polling `FetchCheckRuns` (REST) on each catch-up loop iteration — there are no webhooks.
+**Trigger:** CI check runs on the PR head SHA transition from pending to a terminal state (success, failure, etc.). Fabrik detects this by polling on each catch-up loop iteration — there are no webhooks.
 
-**Code path:** `poll()` catch-up loop Phase 1 → `checkCIGate()` → `FetchLinkedPR()` (REST, for head SHA and PR state):
-- **R1:** `pr.Merged == true` → `addCompleteLabelAndRemoveCI` → gate clears, advance to Done. No check run fetch needed.
-- **R2:** `pr.State == "closed"` and `pr.Merged == false` → `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
-- Otherwise (PR open): → `FetchPRMergeableState()` (REST, single-PR endpoint) → if `mergeable_state ∈ {clean, unstable}`: gate clears immediately (`addCompleteLabelAndRemoveCI`); otherwise → `FetchCheckRuns()` (REST) → evaluates check run statuses
-  - **R3 (in `len(checkRuns) == 0` arm):** when `mergeable_state == "blocked"` and `hadChecks == false`: check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`
-  - **New guard (in `len(checkRuns) == 0` arm, after R3):** when `mergeableState ∉ {"", "unknown"}` (e.g. `behind`, `dirty`, `draft`, `has_hooks`) and `hadChecks == false`: checks `FetchLabelAppliedAt` inline — if `fabrik:awaiting-ci` has been present ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)` — `mergeable_state` is actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API); re-evaluate on next poll. Only `mergeableState == ""` or `"unknown"` fall through to the post-push dwell guard below.
-  - **Post-push dwell guard (in `len(checkRuns) == 0` arm, after New guard):** when `mergeableState == ""` or `"unknown"` AND `hadChecks == false` AND `lpr.LastHeadSHAUpdate` is non-zero AND `time.Since(lpr.LastHeadSHAUpdate) < PostPushDwell` (default 90 s): return `(true, false, false)` — GitHub has not yet computed mergeability or started CI for the newly-pushed SHA; re-evaluate after the dwell window elapses. Zero `LastHeadSHAUpdate` (cold start / post-restart — `PRHeadSHAUpdated` not yet fired) falls through to the R5 gate-clear, preserving pre-feature behavior (EC-1). `LastHeadSHAUpdate` is stamped in the Store's `PRHeadSHAUpdated` handler only when the SHA actually changes (idempotent against same-SHA re-deliveries). Configured via `PostPushDwell` in `engine.Config`; set from `--post-push-dwell` flag (seconds) or `FABRIK_POST_PUSH_DWELL` env var; default 90 s.
-  - **R5 (fallthrough — `len(checkRuns) == 0` arm):** `hadChecks == false` + `mergeableState ∈ {"", "unknown"}` + dwell elapsed (or `LastHeadSHAUpdate` zero) → `addCompleteLabelAndRemoveCI` → gate clears as "no CI configured"; `stage:<X>:complete` added
-  - Otherwise: classifies check runs → optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
+**Code path:** `poll()` catch-up loop Phase 1 → `settlePRMergeState()` (one combined REST pass for `mergeable`, `mergeable_state`, and check runs) → `checkCIGate()` interprets the `PRSettleResult`:
+- **`PRMergeTerminal` (`pr.Merged == true`):** `addCompleteLabelAndRemoveCI` → gate clears, advance to Done.
+- **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
+- **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately (`addCompleteLabelAndRemoveCI`); per-check classification is skipped.
+- **`PRMergeUnsettled` with `CheckRuns` populated:** evaluates check run statuses; optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
+  - **R3 (empty `CheckRuns` arm, `MergeableState == "blocked"`):** `hadChecks == false`; check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`
+  - **New guard (empty `CheckRuns` arm, `MergeableState ∉ {"", "unknown"}`):** `hadChecks == false`; checks `FetchLabelAppliedAt` inline — if `fabrik:awaiting-ci` has been present ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)` — `mergeable_state` actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API); re-evaluate on next poll.
+  - **Post-push dwell guard (empty `CheckRuns` arm, `MergeableState ∈ {"", "unknown"}`):** when `hadChecks == false` AND `lpr.LastHeadSHAUpdate` is non-zero AND `time.Since(lpr.LastHeadSHAUpdate) < PostPushDwell` (default 90 s): return `(true, false, false)` — GitHub has not yet computed mergeability or started CI for the newly-pushed SHA; re-evaluate after the dwell window elapses. Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through to R5 immediately (EC-1 preserved). `LastHeadSHAUpdate` is stamped in the Store's `PRHeadSHAUpdated` handler only when the SHA actually changes. Configured via `PostPushDwell` in `engine.Config`; set from `--post-push-dwell` flag (seconds) or `FABRIK_POST_PUSH_DWELL` env var; default 90 s.
+  - **R5 (fallthrough):** `hadChecks == false` + `MergeableState ∈ {"", "unknown"}` + dwell elapsed (or `LastHeadSHAUpdate` zero) → `addCompleteLabelAndRemoveCI` → gate clears as "no CI configured"; `stage:<X>:complete` added
 
-**`mergeable_state` shortcut (v0.0.52):** Before classifying raw check_runs, `checkCIGate` queries GitHub's branch-protection-aware `mergeable_state` on the linked PR. When the value is `clean` (ready to merge per branch protection) or `unstable` (non-required checks failing but still mergeable per `github.MergeableStateAccepted`), the gate clears immediately and the per-check classification is skipped. Other states (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`, empty) fall through to `FetchCheckRuns()`. When check runs are present, the per-check classification applies. When `check_runs == []` and `hadChecks == false`, a new guard returns `(true, false, false)` for any `mergeableState ∉ {"", "unknown"}` — branch protection is actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API). Only `mergeableState == ""` (API error, where the value defaults to the zero string) or `mergeableState == "unknown"` (GitHub has not yet computed mergeability) fall through to the post-push dwell guard: if `LastHeadSHAUpdate` is non-zero and within `PostPushDwell` (default 90 s), the gate is held (`(true, false, false)`) until the dwell window elapses; only then does R5 clear the gate as "no CI configured". This prevents premature gate-clear in the brief post-push window when GitHub has not yet computed mergeability or started CI for the new SHA — the root cause of the 2026-06-16 fantasy incident. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs like `Cleanup artifacts`) do not block merges per branch protection, so Fabrik's gate must not block on them either. The `mergeable_state` field is null on the list endpoint used by `FetchLinkedPR`, so a separate single-PR REST call is required (`FetchPRMergeableState`).
+**Settling primitive consolidation (v0.0.53):** `settlePRMergeState()` reads `mergeable`, `mergeable_state`, and check runs in one pass before both the merge-conflict gate and the CI gate. This eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state. See §6.4 for the full specification. `MergeableState` is intentionally omitted from `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases so that `checkCIGate`'s R3 path (`MergeableState == "blocked"` + empty CheckRuns) cannot misfire on those cases. The `mergeable_state` field is null on the list endpoint used by `FetchLinkedPR`, so `FetchPRMergeableFields()` (a separate single-PR REST call) provides both `mergeable` and `mergeable_state` in one request.
 
 **`(false, false, false)` return semantics:** `checkCIGate` returns `(false, false, false)` for all of the following terminal conditions, which it handles internally (the poll.go call site never sees `ciTimedOut=true` for these): R1 merged PR, R2 closed-not-merged PR, R3 required-never-running check, no linked PR, all-green checks. The caller only needs to call `pauseForCITimeout` when `timedOut=true` (the generic check-runs timeout path).
 
@@ -324,7 +324,7 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **Trigger:** The PR's base branch moves forward (a different PR merges) while this branch is sitting in the post-`stage:Validate:complete` catch-up window. GitHub recomputes `mergeable` on the linked PR; if the new base conflicts with this branch, `mergeable` transitions from `true` (or `null`) to `false`.
 
-**Code path:** `poll()` catch-up loop Phase 1 → `checkMergeabilityGate()` → `FetchLinkedPR()` (REST, for PR number) → `FetchPRMergeable()` (REST, for the single-PR `mergeable` field) → evaluates the flag → optionally dispatches `dispatchRebaseReinvoke()` → async goroutine → `processComments()` with a synthetic rebase-required comment
+**Code path:** `poll()` catch-up loop Phase 1 → `settlePRMergeState()` (combined REST pass: `FetchLinkedPR` + `FetchPRMergeableFields` for `mergeable` and `mergeable_state`) → `checkMergeabilityGate()` interprets `PRSettleResult` → evaluates the flag → optionally dispatches `dispatchRebaseReinvoke()` → async goroutine → `processComments()` with a synthetic rebase-required comment
 
 **Distinct from CI Check Completed because:**
 - Triggered by base-branch movement, not check run status changes
@@ -1006,21 +1006,23 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
      - Calls `processComments()` with the synthetic review comments asynchronously
      - On exit: releases semaphore, applies `WorkerExited`
    - Either way: `continue` — Phase 2 is skipped this cycle; item re-evaluated on next poll
-6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`, the same opt-in as the CI gate): `checkMergeabilityGate()` fetches GitHub's `mergeable` flag for the linked PR
-   - `mergeable == true` (or no PR): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
-   - `mergeable == null` (GitHub still computing) **or** transient API error on either REST call: block this item for the rest of Phase 1 (skip to next item) — re-evaluated on the next poll (**no label churn** — mirrors the CI gate's R10c rule and matches how the CI gate handles its own transient errors)
-   - `mergeable == false` (confirmed conflict): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
+5.5. **Settle call** (runs immediately before the merge-conflict gate and CI gate; only for stages with `wait_for_ci: true`): `settlePRMergeState()` fetches `mergeable`, `mergeable_state`, and check runs in a single pass, returning a typed `PRSettleResult`. Both gates below receive this result and do not make their own REST calls for these fields — eliminating the split-brain where two separate REST calls within one poll cycle could observe different GitHub state. See §6.4 for the full settling primitive specification.
+6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`): `checkMergeabilityGate()` interprets the `PRSettleResult` from the settle call
+   - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
+   - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
+   - `PRMergeUnsettled` or `PRMergeBlocked`: block this item for the rest of Phase 1 (**no label churn** — mirrors the CI gate's R10c rule)
+   - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
      - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
      - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
-7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` evaluates CI for stages with `wait_for_ci: true`
-   - **R1:** `pr.Merged == true` → gate clears immediately (`addCompleteLabelAndRemoveCI`); no check-run fetch needed; advance to Done
-   - **R2:** `pr.State == "closed"` and `pr.Merged == false` → `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`, posts explanatory comment; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
-   - **`mergeable_state` shortcut (v0.0.52):** before fetching check runs, `checkCIGate` queries `FetchPRMergeableState()` on the linked PR. If the value is `clean` or `unstable` (per `github.MergeableStateAccepted`), the gate clears immediately: `addCompleteLabelAndRemoveCI()` adds `stage:<X>:complete` and removes `fabrik:awaiting-ci`; the per-check classification is skipped. Other states (`blocked`, `behind`, `dirty`, `unknown`, `has_hooks`, `draft`, empty) fall through to `FetchCheckRuns()`. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
-   - **R3 (in no-check-runs arm):** when `mergeable_state == "blocked"` and `hadChecks == false`: check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard — first-push window, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct "required check never runs on PR" comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`, returns `(false, false, false)`
-   - **New guard (in no-check-runs arm, after R3):** when `mergeableState ∉ {"", "unknown"}` (e.g. `behind`, `dirty`, `draft`, `has_hooks`) and `hadChecks == false`: checks `FetchLabelAppliedAt` inline — if `fabrik:awaiting-ci` ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)` — `mergeable_state` is actively blocking via a signal Fabrik cannot see via check_runs (e.g. a Commit Status / legacy Statuses API); re-evaluate on next poll. Only `mergeableState == ""` (API error fallback) or `mergeableState == "unknown"` (GitHub not yet computed) fall through to the "no CI configured" gate-clear.
-   - Per-check classification (fallback): fetches `FetchCheckRuns()` and applies R1–R6
-   - Pending/API error: skip (blocked, not failed); item re-evaluated on next poll
-   - Timed out: `pauseForCITimeout()` pauses issue
+7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` interprets the `PRSettleResult` from the settle call for stages with `wait_for_ci: true`
+   - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); advance to Done
+   - **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
+   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+   - **`PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies R1–R6; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
+   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
+   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
+   - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
+   - Timed out (generic path): `pauseForCITimeout()` pauses issue
    - CI failed: **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.CIFixCycles(stage.Name)` vs `MaxCiFixCycles`):
      - If exceeded: `pauseForCIFixCycleLimit()` pauses issue
      - If not exceeded: dispatch `dispatchCIFixReinvoke()`; `continue`
@@ -1051,9 +1053,49 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 | PR summary posting | None | Posts `"<StageName> (review feedback addressed)"` on the linked PR with per-thread footer (one `path:line — resolved` bullet per unique `ReviewThreadID`); skipped when `output == ""` or no linked PR |
 | Worker guard | Uses dispatch loop's `snap.Worker() != nil` | Has its own `snap.Worker() != nil` check in catch-up loop |
 
-### 6.4 CI Gate and CI-Fix Reinvoke
+### 6.4 PR Merge State Settling Primitive
 
-#### 6.4.1 Two-Phase CI Gate
+`settlePRMergeState()` is called **once per catch-up loop Phase 1 iteration — before both the merge-conflict gate and the CI gate** — to read `mergeable`, `mergeable_state`, and check runs in a single pass. Both gates receive this `PRSettleResult` and do not make their own REST calls for these fields; this eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
+
+**Return type:** `PRSettleResult` carries:
+- `Status PRMergeStatus` — one of six typed constants (see below)
+- `PR *gh.PRDetails` — the fetched PR (nil when status is `PRMergeNoPR`)
+- `MergeableState string` — raw `mergeable_state` from GitHub (empty when intentionally omitted — see invariant below)
+- `CheckRuns []gh.CheckRun` — check runs for the PR head SHA (nil when not fetched)
+- `Reason string` — human-readable explanation for the status
+
+**Six status constants:**
+
+| Constant | Meaning |
+|---|---|
+| `PRMergeNoPR` | No linked PR on this item; both gates are no-ops |
+| `PRMergeUnsettled` | GitHub has not yet computed a definitive merge state; gates block without label churn |
+| `PRMergeReady` | `mergeable_state ∈ {clean, unstable}` — PR is ready to merge per branch protection |
+| `PRMergeConflicting` | `mergeable == false` — confirmed base-branch conflict |
+| `PRMergeBlocked` | PR is closed (not merged); `checkCIGate` dispatches `pauseForPRClosedNotMerged()` |
+| `PRMergeTerminal` | PR is merged; both gates clear immediately |
+
+**Settling rules (applied in order):**
+
+1. `FetchLinkedPR()` — if no linked PR: return `PRMergeNoPR`.
+2. PR merged (`pr.Merged == true`): return `PRMergeTerminal`.
+3. PR closed, not merged (`pr.State == "closed"`): return `PRMergeBlocked`.
+4. HeadSHA empty: return `PRMergeUnsettled` (`MergeableState` omitted — see invariant).
+5. `FetchPRMergeableFields()` — fetches `mergeable` (bool ptr) and `mergeable_state` (string) in one REST call (single-PR endpoint; the list endpoint used by `FetchLinkedPR` does not return `mergeable`).
+6. `mergeable_state ∈ {clean, unstable}` (per `MergeableStateAccepted` allowlist): return `PRMergeReady` with `CheckRuns` populated from `FetchCheckRuns()`.
+7. `hadChecks` (store: `LinkedPRState.HasHadChecks`) is true: return `PRMergeUnsettled` with `CheckRuns` populated — `MergeableState` **intentionally omitted** (see invariant).
+8. Post-push dwell active (`LastHeadSHAUpdate` non-zero and `time.Since(LastHeadSHAUpdate) < PostPushDwell`, default 90 s): return `PRMergeUnsettled` — `MergeableState` **intentionally omitted** (see invariant). Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through.
+9. `mergeable == false`: return `PRMergeConflicting`.
+10. `mergeable == nil` or API error: return `PRMergeUnsettled` with `MergeableState` populated.
+11. Fallback with check runs: return `PRMergeUnsettled` with `MergeableState` and `CheckRuns` populated.
+
+**`MergeableState` omission invariant:** `checkCIGate` uses `settle.MergeableState` to detect R3 (OPEN+BLOCKED+no-check-runs+`fabrik:awaiting-ci` elapsed → `pauseForRequiredNeverRunningCheck`). The primitive omits `MergeableState` from the `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases. This prevents R3 from misfiring on cases where `hadChecks == true` (checks have been observed) or where GitHub simply hasn't computed mergeability yet (post-push window). Only a non-empty `MergeableState` in the settle result is genuinely relevant for R3/branch-protection timeout checking.
+
+**`FetchCheckRuns` consolidation:** `buildCIFixComment()` (called inside `dispatchCIFixReinvoke()`) uses `settle.CheckRuns` for the PR-head check runs, eliminating the separate `FetchCheckRuns()` call that previously lived in the CI-fix path. The base-branch `FetchCheckRuns(baseSHA)` inside `buildCIFixComment()` is a **non-gate diagnostic read** — it fetches check runs for the base branch's HEAD SHA for regression-vs-pre-existing classification only, and is structurally independent (different SHA; result is not used by either gate).
+
+### 6.5 CI Gate and CI-Fix Reinvoke
+
+#### 6.5.1 Two-Phase CI Gate
 
 The CI gate has two paths that handle different timing scenarios:
 
@@ -1069,7 +1111,7 @@ The CI gate has two paths that handle different timing scenarios:
 
 **Path 2: Catch-up loop Phase 1 (`checkCIGate()`)**
 - Runs for items with `fabrik:awaiting-ci` on stages with `wait_for_ci: true` (admitted by broadened catch-up loop entry guard: `!hasComplete && !(hasAwaitingCI && isWaitForCI)` — see ADR 032)
-- Has FRESH data from `FetchItemDetails()` and makes targeted REST calls for head SHA and check runs
+- Has FRESH data from `FetchItemDetails()` and receives a `PRSettleResult` from `settlePRMergeState()` (called once per Phase 1 iteration, before both gates) — no separate REST calls for `mergeable`, `mergeable_state`, or PR-head check runs
 - Uses `FetchLabelAppliedAt` on `fabrik:awaiting-ci` for timeout tracking (durable across restarts)
 - Three outcomes:
   - `(ciBlocked=true, ciFailure=false, ciTimedOut=false)` — checks still pending; skip to next item (`fabrik:awaiting-ci` already present — no additional label needed)
@@ -1081,7 +1123,7 @@ The CI gate has two paths that handle different timing scenarios:
 - **Path 1** (merge guard): `itemstate.Store` → `LinkedPRState.CIMergePendingSince`. Acceptable because merge-guard state is transient — engine restarts simply re-evaluate CI on the next poll (store is in-memory only; not persisted across restarts).
 - **Path 2** (catch-up loop): `FetchLabelAppliedAt` REST call on `fabrik:awaiting-ci`. Durable across restarts because the label itself persists. The label is present from the moment Claude emits FABRIK_STAGE_COMPLETE on a `wait_for_ci: true` stage, so timeout tracking is accurate from the start of the CI-await window.
 
-#### 6.4.2 CI Fix Reinvoke Mechanics
+#### 6.5.2 CI Fix Reinvoke Mechanics
 
 The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. When CI has failed:
 
@@ -1091,7 +1133,7 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
    - If not exceeded: increment count, dispatch reinvoke via `dispatchCIFixReinvoke()`:
      - Applies `WorkerEntered` (prevents double-dispatch)
      - Acquires semaphore slot (respects `MaxConcurrent`)
-     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch)
+     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — uses `settle.CheckRuns` for the PR-head check runs (no separate `FetchCheckRuns` call); classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch) by calling `FetchCheckRuns(baseSHA)` for the base-branch HEAD SHA (a **non-gate diagnostic read** — different SHA, independent of the settle result)
      - Calls `processComments()` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if unset)
      - On exit: releases semaphore, applies `WorkerExited`
 
@@ -1099,12 +1141,12 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
 
 **CI-fix cycle counter reset:** `StageState.CIFixCycles[stageName]` is reset to 0 by `clearFailedStage()` (via `EngineCyclesCleared` mutation) when the user removes `fabrik:paused` from a paused-failed item, allowing fresh CI-fix attempts after human intervention. `StageState.RebaseCycles[stageName]` is reset in the same call for the same reason.
 
-#### 6.4.3 CI Fix Reinvoke vs Review Reinvoke
+#### 6.5.3 CI Fix Reinvoke vs Review Reinvoke
 
 | Aspect | Review Reinvoke | CI Fix Reinvoke |
 |--------|-----------------|-----------------|
 | Trigger | Unresolved PR review thread comments | CI check runs with failure/timed_out/action_required conclusion |
-| Source data | `item.LinkedPRReviewThreadComments` | `FetchCheckRuns()` REST call on PR head SHA |
+| Source data | `item.LinkedPRReviewThreadComments` | `settle.CheckRuns` from `settlePRMergeState()` (no separate REST call for PR-head checks) |
 | Label on waiting | `fabrik:awaiting-review` (always applied) | `fabrik:awaiting-ci` (applied by `handleStageComplete` on FABRIK_STAGE_COMPLETE; present for both pending and failed checks — covers the full CI-await window) |
 | Timeout tracking | In-memory `ReviewWaitTimeout` timer | `FetchLabelAppliedAt` on `fabrik:awaiting-ci` (durable across restarts; label is present from FABRIK_STAGE_COMPLETE onwards) |
 | Cycle counter | `snap.ReviewCycles(stageName)` / `ReviewCycleIncremented` | `snap.CIFixCycles(stageName)` / `CIFixCycleIncremented` |
@@ -1116,29 +1158,29 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
 | PR summary comment | Yes — `"<StageName> (review feedback addressed)"` on linked PR | No |
 | Stage gate config | `wait_for_reviews: true` | `wait_for_ci: true` |
 
-### 6.5 Merge-Conflict Gate and Rebase Reinvoke
+### 6.6 Merge-Conflict Gate and Rebase Reinvoke
 
 The merge-conflict gate is a third prong of the catch-up loop Phase 1, sitting between review reinvoke and the CI gate. It is the direct response to the failure mode in which a base-branch advance during the CI-await window leaves a PR unmergeable — the CI gate alone will happily keep polling check runs on the branch head while the real blocker is a conflict.
 
 **Note:** `attemptMergeOnValidate()` (§5.4, the legacy auto-merge path for stages without `wait_for_ci: true`) now uses the same `snap.RebaseCycles(stage.Name)` + `RebaseCycleIncremented`, `dispatchRebaseReinvoke()`, and `pauseForRebaseCycleLimit()` pattern as the conjunctive gate described in this section. Both paths share the same per-item store field; `MaxRebaseCycles` applies to both.
 
-#### 6.5.1 Gate Mechanics
+#### 6.6.1 Gate Mechanics
 
 `checkMergeabilityGate()` runs only when `stage.WaitForCI` is true (the same opt-in that admits items to the catch-up window via `fabrik:awaiting-ci`). It returns `(blocked, conflict)`:
 
-- `(false, false)` — clear: no linked PR, or `mergeable == true`. Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
-- `(true, false)` — GitHub reports `mergeable == null` (still computing) **or** a transient API error was seen on either REST call. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
-- `(true, true)` — confirmed conflict (`mergeable == false`). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
+- `(false, false)` — clear: `PRMergeNoPR`, `PRMergeTerminal`, or `PRMergeReady` (`mergeable == true` / `mergeable_state ∈ {clean, unstable}`). Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
+- `(true, false)` — `PRMergeUnsettled` (`mergeable == null`, still computing) or `PRMergeBlocked` (PR closed), or transient API error. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
+- `(true, true)` — `PRMergeConflicting` (`mergeable == false`, confirmed conflict). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
 
-Two REST calls are made: `FetchLinkedPR` for the PR number, then `FetchPRMergeable` (hitting `/repos/{owner}/{repo}/pulls/{number}`). The single-PR endpoint is required — the list endpoint used by `FetchLinkedPR` does not return `mergeable`.
+The gate's inputs come from `settlePRMergeState()` (§6.4), called once per Phase 1 iteration before both gates. `FetchPRMergeableFields()` (single-PR endpoint, not the list endpoint used by `FetchLinkedPR`) provides both `mergeable` and `mergeable_state` in one request — the list endpoint does not return `mergeable`.
 
-#### 6.5.2 Ordering Against the CI Gate
+#### 6.6.2 Ordering Against the CI Gate
 
 The merge-conflict gate runs **before** the CI gate so that a confirmed conflict preempts CI-await polling. The rationale: a PR that cannot merge has no reason to wait for CI, and Claude on CI-fix reinvoke cannot productively act on a branch that must first be rebased. When the merge gate emits `conflict`, Phase 1 `continue`s without reaching the CI gate.
 
 When the merge gate clears (`mergeable == true`), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked with no confirmed conflict (`mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
 
-#### 6.5.3 Rebase Reinvoke Mechanics
+#### 6.6.3 Rebase Reinvoke Mechanics
 
 When `checkMergeabilityGate` returns `conflict=true`:
 
@@ -1154,18 +1196,18 @@ When `checkMergeabilityGate` returns `conflict=true`:
 
 **`DatabaseID: 0` guard:** like the CI-fix and review synthetic comments, the rebase synthetic comment uses `DatabaseID: 0` so `processComments()` skips the 👀 and 🚀 reaction steps (no real GitHub comment exists to react to).
 
-#### 6.5.4 Why Claude Rebases (Not the Engine)
+#### 6.6.4 Why Claude Rebases (Not the Engine)
 
 The engine could in principle run `git fetch && git rebase` directly from the worker, but does not. Automatic rebase is *right most of the time* and *catastrophically wrong sometimes*: two PRs independently pick `adr-054.md`, both PRs pick migration slot `0042`, both PRs add a new line at the same point in a shared config file. A mechanical rebase drops one side silently; a Claude-driven rebase can rename, renumber, and keep both contributions. The synthetic comment explicitly flags this — "watch for semantic collisions" — so Claude's judgment is applied where it matters.
 
 The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRebaseCycles` defaults to 3 rather than 5: if Claude cannot rebase cleanly in three attempts the conflict almost certainly needs a human.
 
-#### 6.5.5 Rebase Reinvoke vs CI Fix Reinvoke
+#### 6.6.5 Rebase Reinvoke vs CI Fix Reinvoke
 
 | Aspect | CI Fix Reinvoke | Rebase Reinvoke |
 |--------|-----------------|-----------------|
 | Trigger | CI check runs in failure state | `mergeable == false` on linked PR |
-| Source data | `FetchCheckRuns()` REST call on PR head SHA | `FetchPRMergeable()` REST call on linked PR |
+| Source data | `settle.CheckRuns` from `settlePRMergeState()` (no separate REST call for PR-head checks) | `settle.Status == PRMergeConflicting` from `settlePRMergeState()` (`FetchPRMergeableFields` provides `mergeable`) |
 | Label on waiting | `fabrik:awaiting-ci` (only on confirmed failure) | `fabrik:rebase-needed` (only on confirmed `mergeable == false`) |
 | Order in Phase 1 | After merge-conflict gate | Before CI gate |
 | Cycle counter | `snap.CIFixCycles(stageName)` / `CIFixCycleIncremented` | `snap.RebaseCycles(stageName)` / `RebaseCycleIncremented` |
@@ -1179,7 +1221,7 @@ The cost is a re-invocation rather than an inline `exec.Cmd`. This is why `MaxRe
 
 **References:** [ADR-028: Merge-Conflict Gate and Rebase Reinvoke](../adrs/028-merge-conflict-gate-and-rebase-reinvoke.md)
 
-### 6.6 Pre-Implement Spawn Path
+### 6.7 Pre-Implement Spawn Path
 
 **Trigger:** The Implement stage dispatcher calls `preImplement()` before the Claude invocation on every Implement dispatch. `preImplement` is a no-op unless the Plan stage comment contains `FABRIK_SPAWN_CHILD_BEGIN/END` blocks AND the parent issue does not yet have `fabrik:children-spawned`.
 
@@ -1219,7 +1261,7 @@ These blocks persist in the Plan stage comment — they are data, not consumed-a
 
 **References:** [ADR-048: Engine-Side Pre-Implement Spawn](../adrs/048-spawn-child-engine-side.md)
 
-### 6.7 No Work Needed Path
+### 6.8 No Work Needed Path
 
 **Trigger:** Claude outputs both `FABRIK_STAGE_COMPLETE` and `FABRIK_NO_WORK_NEEDED` in the same invocation output. Expected most commonly from the Plan stage when Research findings show no code or documentation changes are needed.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -296,7 +296,7 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **Code path:** `poll()` catch-up loop Phase 1 → `settlePRMergeState()` (one combined REST pass for `mergeable`, `mergeable_state`, and check runs) → `checkCIGate()` interprets the `PRSettleResult`:
 - **`PRMergeTerminal` (`pr.Merged == true`):** `addCompleteLabelAndRemoveCI` → gate clears, advance to Done.
-- **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
+- **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` posts comment naming the PR, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`. Returns `(false, false, false)`.
 - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately (`addCompleteLabelAndRemoveCI`); per-check classification is skipped.
 - **`PRMergeUnsettled` with `CheckRuns` populated:** evaluates check run statuses; optionally dispatches `dispatchCIFixReinvoke()` → async goroutine → `processComments()` with synthetic CI failure comment
   - **R3 (empty `CheckRuns` arm, `MergeableState == "blocked"`):** `hadChecks == false`; check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → return `(true, false, false)` (dwell guard, not yet paused); if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()` posts distinct comment, adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`
@@ -1010,15 +1010,16 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`): `checkMergeabilityGate()` interprets the `PRSettleResult` from the settle call
    - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
    - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
-   - `PRMergeUnsettled` or `PRMergeBlocked`: block this item for the rest of Phase 1 (**no label churn** — mirrors the CI gate's R10c rule)
+   - `PRMergeBlocked` (CI checks failed): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate so `checkCIGate` can classify and dispatch the CI-fix reinvoke
+   - `PRMergeUnsettled`: block this item for the rest of Phase 1 (**no label churn** — ADR-032 R10c)
    - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
      - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
      - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
 7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` interprets the `PRSettleResult` from the settle call for stages with `wait_for_ci: true`
    - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); advance to Done
-   - **`PRMergeBlocked` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
-   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
-   - **`PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies R1–R6; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
+   - **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
+   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`, or all checks green):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+   - **`PRMergeBlocked` or `PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
    - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
    - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
    - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
@@ -1070,24 +1071,29 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 |---|---|
 | `PRMergeNoPR` | No linked PR on this item; both gates are no-ops |
 | `PRMergeUnsettled` | GitHub has not yet computed a definitive merge state; gates block without label churn |
-| `PRMergeReady` | `mergeable_state ∈ {clean, unstable}` — PR is ready to merge per branch protection |
+| `PRMergeReady` | PR is ready to merge (all checks green, or `mergeable_state ∈ {clean, unstable}`) |
 | `PRMergeConflicting` | `mergeable == false` — confirmed base-branch conflict |
-| `PRMergeBlocked` | PR is closed (not merged); `checkCIGate` dispatches `pauseForPRClosedNotMerged()` |
-| `PRMergeTerminal` | PR is merged; both gates clear immediately |
+| `PRMergeBlocked` | CI checks have failed; `checkCIGate` dispatches `dispatchCIFixReinvoke()` |
+| `PRMergeTerminal` | PR is merged or closed without merging; both gates handle terminal state |
 
 **Settling rules (applied in order):**
 
 1. `FetchLinkedPR()` — if no linked PR: return `PRMergeNoPR`.
 2. PR merged (`pr.Merged == true`): return `PRMergeTerminal`.
-3. PR closed, not merged (`pr.State == "closed"`): return `PRMergeBlocked`.
-4. HeadSHA empty: return `PRMergeUnsettled` (`MergeableState` omitted — see invariant).
-5. `FetchPRMergeableFields()` — fetches `mergeable` (bool ptr) and `mergeable_state` (string) in one REST call (single-PR endpoint; the list endpoint used by `FetchLinkedPR` does not return `mergeable`).
-6. `mergeable_state ∈ {clean, unstable}` (per `MergeableStateAccepted` allowlist): return `PRMergeReady` with `CheckRuns` populated from `FetchCheckRuns()`.
-7. `hadChecks` (store: `LinkedPRState.HasHadChecks`) is true: return `PRMergeUnsettled` with `CheckRuns` populated — `MergeableState` **intentionally omitted** (see invariant).
-8. Post-push dwell active (`LastHeadSHAUpdate` non-zero and `time.Since(LastHeadSHAUpdate) < PostPushDwell`, default 90 s): return `PRMergeUnsettled` — `MergeableState` **intentionally omitted** (see invariant). Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through.
-9. `mergeable == false`: return `PRMergeConflicting`.
-10. `mergeable == nil` or API error: return `PRMergeUnsettled` with `MergeableState` populated.
-11. Fallback with check runs: return `PRMergeUnsettled` with `MergeableState` and `CheckRuns` populated.
+3. PR closed, not merged (`pr.State == "closed"`): return `PRMergeTerminal`.
+4. `FetchPRMergeableFields()` — fetches `mergeable` (bool ptr) and `mergeable_state` (string) in one REST call (single-PR endpoint; the list endpoint used by `FetchLinkedPR` does not return `mergeable`). API error → return `PRMergeUnsettled`.
+5. `mergeable == nil` (GitHub still computing): return `PRMergeUnsettled` (`MergeableState` set).
+6. `mergeable_state == "unknown"` (transient): return `PRMergeUnsettled` (`MergeableState` set).
+7. `mergeable == false`: return `PRMergeConflicting` (`MergeableState` set).
+8. `mergeable_state ∈ {clean, unstable}` (per `MergeableStateAccepted` allowlist): return `PRMergeReady` — per ADR-033, GitHub's branch-protection signal is authoritative; `FetchCheckRuns` is not called.
+9. HeadSHA empty: return `PRMergeUnsettled` (`MergeableState` **intentionally omitted** — see invariant).
+10. `FetchCheckRuns()` — API error → return `PRMergeUnsettled`.
+11. Check runs non-empty: apply `PRChecksObserved` store event (sets `HasHadChecks`).
+12. Check runs empty + `hadChecks` (store: `LinkedPRState.HasHadChecks`): return `PRMergeUnsettled` (`MergeableState` **intentionally omitted** — see invariant).
+13. Check runs empty + post-push dwell active (`LastHeadSHAUpdate` non-zero and `time.Since < PostPushDwell`, default 90 s): return `PRMergeUnsettled` (`MergeableState` **intentionally omitted** — see invariant). Zero `LastHeadSHAUpdate` (cold start / post-restart) falls through.
+14. Check runs empty + `mergeable_state ∉ {"", "unknown"}`: return `PRMergeUnsettled` (`MergeableState` set — R3/branch-protection signal for `checkCIGate`).
+15. Check runs empty + `mergeable_state ∈ {"", "unknown"}`: return `PRMergeReady` (no CI configured).
+16. Check runs non-empty: any failed (`failure`/`timed_out`/`action_required`) → return `PRMergeBlocked` (`CheckRuns` set); any pending (`queued`/`in_progress`) → return `PRMergeUnsettled` (`CheckRuns` set); all green → return `PRMergeReady` (`CheckRuns` set).
 
 **`MergeableState` omission invariant:** `checkCIGate` uses `settle.MergeableState` to detect R3 (OPEN+BLOCKED+no-check-runs+`fabrik:awaiting-ci` elapsed → `pauseForRequiredNeverRunningCheck`). The primitive omits `MergeableState` from the `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases. This prevents R3 from misfiring on cases where `hadChecks == true` (checks have been observed) or where GitHub simply hasn't computed mergeability yet (post-push window). Only a non-empty `MergeableState` in the settle result is genuinely relevant for R3/branch-protection timeout checking.
 
@@ -1168,8 +1174,8 @@ The merge-conflict gate is a third prong of the catch-up loop Phase 1, sitting b
 
 `checkMergeabilityGate()` runs only when `stage.WaitForCI` is true (the same opt-in that admits items to the catch-up window via `fabrik:awaiting-ci`). It returns `(blocked, conflict)`:
 
-- `(false, false)` — clear: `PRMergeNoPR`, `PRMergeTerminal`, or `PRMergeReady` (`mergeable == true` / `mergeable_state ∈ {clean, unstable}`). Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
-- `(true, false)` — `PRMergeUnsettled` (`mergeable == null`, still computing) or `PRMergeBlocked` (PR closed), or transient API error. The gate blocks but **no label is applied** — unknown states must not produce label churn (same principle as the CI gate's R10c). Caller skips to the next item; the next poll re-evaluates.
+- `(false, false)` — clear: `PRMergeNoPR`, `PRMergeTerminal`, `PRMergeReady`, or `PRMergeBlocked` (CI failed — no base conflict; deferred to the CI gate). Any stale `fabrik:rebase-needed` label is removed. Caller falls through to the CI gate.
+- `(true, false)` — `PRMergeUnsettled` (`mergeable == null`, still computing, or transient API error). The gate blocks but **no label is applied** — unknown states must not produce label churn (ADR-032 R10c). Caller skips to the next item; the next poll re-evaluates.
 - `(true, true)` — `PRMergeConflicting` (`mergeable == false`, confirmed conflict). `fabrik:rebase-needed` is applied idempotently. The caller in `poll()` dispatches a rebase reinvoke or pauses on the cycle limit.
 
 The gate's inputs come from `settlePRMergeState()` (§6.4), called once per Phase 1 iteration before both gates. `FetchPRMergeableFields()` (single-PR endpoint, not the list endpoint used by `FetchLinkedPR`) provides both `mergeable` and `mergeable_state` in one request — the list endpoint does not return `mergeable`.
@@ -1178,7 +1184,7 @@ The gate's inputs come from `settlePRMergeState()` (§6.4), called once per Phas
 
 The merge-conflict gate runs **before** the CI gate so that a confirmed conflict preempts CI-await polling. The rationale: a PR that cannot merge has no reason to wait for CI, and Claude on CI-fix reinvoke cannot productively act on a branch that must first be rebased. When the merge gate emits `conflict`, Phase 1 `continue`s without reaching the CI gate.
 
-When the merge gate clears (`mergeable == true`), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked with no confirmed conflict (`mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
+When the merge gate clears (`mergeable == true`, CI failed, or no conflict), Phase 1 falls through to the CI gate on the same poll. When the merge gate is blocked (`PRMergeUnsettled` — `mergeable == null` or a transient API error), Phase 1 skips to the next item — the next poll re-evaluates once GitHub has a definite answer or the API recovers.
 
 #### 6.6.3 Rebase Reinvoke Mechanics
 

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -13,265 +13,192 @@ import (
 	"github.com/handarbeit/fabrik/stages"
 )
 
-// checkCIGate inspects CI check runs for the linked PR to determine whether the
+// checkCIGate interprets the pre-fetched settle result to determine whether the
 // CI gate is blocking stage advancement or merge.
 //
-// The gate is only active when stage.WaitForCI is true. It fetches the PR's
-// head SHA via FetchLinkedPR (REST), then fetches check runs via FetchCheckRuns.
+// The gate is only active when stage.WaitForCI is true. All PR state (mergeable
+// fields, check runs) is consumed from the settle parameter — no additional
+// GitHub API calls are made by this function.
 //
 // Returns (blocked, ciFailure, timedOut):
 //
 //   - (false, false, false) — gate cleared; stage:X:complete added, fabrik:awaiting-ci removed.
-//     This includes: no PR found, no check runs when prHasHadChecks is false (R5 — no CI configured), all checks green.
+//     This includes: no PR, PR merged, all checks green, ADR-033 shortcut (clean/unstable).
 //
 //   - (true, false, false)  — gate blocked but no confirmed failure; re-evaluate on next poll.
-//     Covers: checks still pending (in_progress/queued) and not yet timed out;
-//     transient API errors (FetchLinkedPR or FetchCheckRuns fail);
-//     and post-push registration delay — no check runs for new SHA but prHasHadChecks is true (R5).
+//     Covers: checks still pending, transient/unsettled state, R3 dwell not elapsed.
 //     fabrik:awaiting-ci is NOT modified.
 //
 //   - (true, true, false)   — CI failed; fabrik:awaiting-ci applied; caller should dispatch CI-fix.
 //
 //   - (false, false, true)  — CI wait timeout elapsed; caller should pause the issue.
 //     fabrik:awaiting-ci is removed before returning.
-func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) (blocked, ciFailure, timedOut bool) {
+func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult) (blocked, ciFailure, timedOut bool) {
 	if stage.WaitForCI == nil || !*stage.WaitForCI {
 		return false, false, false
 	}
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
+	pr := settle.PR
 
-	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
-	if err != nil {
-		e.logf(item.Number, "ci-gate", "could not fetch linked PR: %v — blocking until API recovers\n", err)
-		return true, false, false // transient error; retry on next poll
+	prNum := 0
+	if pr != nil {
+		prNum = pr.Number
 	}
-	if pr == nil {
+
+	switch settle.Status {
+	case PRMergeNoPR:
 		e.logf(item.Number, "ci-gate", "no linked PR found; CI gate clears (no PR to check)\n")
 		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
 		return false, false, false
-	}
-	if pr.HeadSHA == "" {
-		// PR exists but HeadSHA is not yet populated in the cache (transient state
-		// between PRDetailsUpdated and PRHeadSHAUpdated, or a stale cache record that
-		// Fix C in boardcache.FetchLinkedPR should prevent). Block until SHA is
-		// available rather than silently disarming the CI gate.
-		e.logf(item.Number, "ci-gate", "linked PR #%d has no HeadSHA — blocking until SHA is populated\n", pr.Number)
+
+	case PRMergeTerminal:
+		// R1: merged; R2: closed without merging.
+		if pr != nil && pr.Merged {
+			e.logf(item.Number, "ci-gate", "linked PR #%d is merged — CI gate clears; advancing to Done\n", prNum)
+			e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
+		} else {
+			e.logf(item.Number, "ci-gate", "linked PR #%d closed without merging — pausing\n", prNum)
+			e.pauseForPRClosedNotMerged(board, item, stage, prNum)
+		}
+		return false, false, false
+
+	case PRMergeReady:
+		// ADR-033 shortcut (clean/unstable) or all CI checks green — gate clears.
+		e.logf(item.Number, "ci-gate", "CI gate clears (%s)\n", settle.Reason)
+		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
+		return false, false, false
+
+	case PRMergeConflicting:
+		// Merge gate already applied fabrik:rebase-needed; CI gate just blocks.
 		return true, false, false
 	}
 
-	// R1: PR merged externally while Fabrik was waiting — CI gate clears and the
-	// issue advances to Done. Mirrors checkAutoMergeConvergence's merged-PR detection.
-	if pr.Merged {
-		e.logf(item.Number, "ci-gate", "linked PR #%d is merged — CI gate clears; advancing to Done\n", pr.Number)
-		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
-		return false, false, false
-	}
-	// R2: PR closed without merging — pause with a clear actionable message so the
-	// human knows what happened. fabrik:awaiting-ci is removed (no longer relevant).
-	if pr.State == "closed" {
-		e.logf(item.Number, "ci-gate", "linked PR #%d closed without merging — pausing\n", pr.Number)
-		e.pauseForPRClosedNotMerged(board, item, stage, pr.Number)
-		return false, false, false
-	}
-
-	// Trust GitHub's branch-protection-aware mergeable_state when positive:
-	// "clean" = ready to merge per branch protection; "unstable" = non-required
-	// checks failing but still mergeable. Skip the raw check_runs gate in
-	// those cases — that gate is over-aggressive (any check_run conclusion
-	// in {failure, timed_out, action_required} blocks, including non-required
-	// workflow jobs like "Cleanup artifacts" that GitHub itself does not treat
-	// as merge blockers). Falls through to per-check classification when
-	// mergeable_state is empty/unknown/blocked/etc.
-	//
-	// mergeableState is declared in outer scope so the R3 branch (len(checkRuns)==0
-	// + BLOCKED + !hadChecks) can discriminate without re-fetching.
-	var mergeableState string
-	if ms, msErr := e.readClient.FetchPRMergeableState(owner, repo, pr.Number); msErr != nil {
-		e.logf(item.Number, "warn", "could not fetch mergeable_state: %v — falling back to check-runs gate\n", msErr)
-	} else {
-		mergeableState = ms
-		if gh.MergeableStateAccepted(ms) {
-			e.logf(item.Number, "ci-gate", "mergeable_state=%q — gate clears (skipping check_runs classification)\n", ms)
-			e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
-			return false, false, false
-		}
-	}
-
-	checkRuns, err := e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
-	if err != nil {
-		e.logf(item.Number, "ci-gate", "could not fetch check runs: %v — blocking until API recovers\n", err)
-		return true, false, false // transient error; retry on next poll
-	}
+	// PRMergeUnsettled or PRMergeBlocked: detailed classification using settle.CheckRuns
+	// and settle.MergeableState.
+	checkRuns := settle.CheckRuns
+	mergeableState := settle.MergeableState
 
 	if len(checkRuns) > 0 {
-		e.store.Apply(itemstate.PRChecksObserved{
-			Repo:   itemRepo,
-			Number: item.Number,
-		})
-	}
-
-	// R5: no check runs found. If this PR has had checks before, we're likely in
-	// the post-push registration window — block and wait rather than clearing.
-	if len(checkRuns) == 0 {
-		var hadChecks bool
-		var lpr *itemstate.LinkedPRState
-		if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
-			lpr = snap.LinkedPR()
-			if lpr != nil {
-				hadChecks = lpr.HasHadChecks
+		// Check runs are available: classify pending vs failed, then apply R7 timeout.
+		var pending, failed []gh.CheckRun
+		for _, cr := range checkRuns {
+			switch cr.Status {
+			case "queued", "in_progress":
+				pending = append(pending, cr)
+			case "completed":
+				switch cr.Conclusion {
+				case "failure", "timed_out", "action_required":
+					failed = append(failed, cr)
+				}
 			}
 		}
-		if hadChecks {
-			e.logf(item.Number, "ci-gate", "no check runs for SHA %s — likely post-push registration delay; waiting\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
-			return true, false, false
-		}
-		// R3: OPEN + BLOCKED + no check runs ever observed — a required check is
-		// configured but never triggered by PR events (e.g. converted to
-		// workflow_dispatch while still required by branch protection). Use the
-		// CIWaitTimeout dwell as a false-positive guard: on first PR push, checks
-		// may not have registered yet even though hadChecks is false. Only after the
-		// full timeout window do we treat this as "never-running" and pause distinctly.
-		if mergeableState == "blocked" {
+
+		// R7: CIWaitTimeout applies to the full CI-await window — both pending and
+		// failed checks. Under ADR-032, fabrik:awaiting-ci is present from the moment
+		// handleStageComplete fires, so timeout tracking covers "checks still running"
+		// as well as "checks failed".
+		if hasLabel(item, "fabrik:awaiting-ci") {
 			timeout := e.cfg.CIWaitTimeout
 			if timeout <= 0 {
 				timeout = 30 * time.Minute
 			}
-			if hasLabel(item, "fabrik:awaiting-ci") {
-				appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
-				if err != nil {
-					e.logf(item.Number, "warn", "R3: could not fetch awaiting-ci label timestamp: %v\n", err)
-				} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
-					e.logf(item.Number, "ci-gate", "R3: PR #%d OPEN+BLOCKED with no check runs ever — required check likely never triggers on PRs; pausing\n", pr.Number)
-					e.pauseForRequiredNeverRunningCheck(board, item, stage, pr.Number)
-					return false, false, false
+			appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
+			if err != nil {
+				e.logf(item.Number, "warn", "could not fetch awaiting-ci label timestamp: %v\n", err)
+			} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
+				allNames := make([]string, 0, len(pending)+len(failed))
+				for _, cr := range pending {
+					allNames = append(allNames, cr.Name+" (pending)")
 				}
+				for _, cr := range failed {
+					allNames = append(allNames, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
+				}
+				e.logf(item.Number, "warn", "CI wait timeout elapsed; pausing issue — checks: %s\n", strings.Join(allNames, ", "))
+				e.removeAwaitingCILabel(owner, repo, item)
+				return false, false, true
 			}
-			e.logf(item.Number, "ci-gate", "R3: PR #%d OPEN+BLOCKED with no check runs — dwell not yet elapsed; waiting\n", pr.Number)
+		}
+
+		if len(failed) == 0 {
+			// Checks still running.
+			names := make([]string, 0, len(pending))
+			for _, cr := range pending {
+				names = append(names, cr.Name)
+			}
+			e.logf(item.Number, "ci-gate", "CI still running — pending: %s\n", strings.Join(names, ", "))
 			return true, false, false
 		}
-		// New guard: any actively-blocking mergeable_state that is not "" (API error
-		// fallback, per EC-2) and not "unknown" (GitHub not yet computed, per EC-1)
-		// signals that branch protection is blocking the merge via a signal Fabrik
-		// cannot see via check_runs (e.g. a Commit Status / legacy Statuses API).
-		// Block and re-evaluate on next poll; fall through to CIWaitTimeout escalation
-		// inline so that perpetually-blocking states eventually pause the issue.
-		if mergeableState != "" && mergeableState != "unknown" {
-			timeout := e.cfg.CIWaitTimeout
-			if timeout <= 0 {
-				timeout = 30 * time.Minute
-			}
-			if hasLabel(item, "fabrik:awaiting-ci") {
-				appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
-				if err != nil {
-					e.logf(item.Number, "warn", "could not fetch awaiting-ci label timestamp: %v\n", err)
-				} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
-					e.logf(item.Number, "warn", "CI wait timeout elapsed for mergeable_state=%q with no check_runs — pausing issue\n", mergeableState)
-					e.removeAwaitingCILabel(owner, repo, item)
-					return false, false, true
-				}
-			}
-			e.logf(item.Number, "ci-gate", "mergeable_state=%q blocks merge but no check_runs visible — branch protection likely requires a Commit Status or external signal; blocking\n", mergeableState)
-			return true, false, false
+
+		// CI failed — apply fabrik:awaiting-ci idempotently.
+		failedNames := make([]string, 0, len(failed))
+		for _, cr := range failed {
+			failedNames = append(failedNames, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
 		}
-		// Post-push dwell guard: when mergeable_state is "" or "unknown" and
-		// check_runs is empty, GitHub may not have computed mergeability or started
-		// CI yet for a recently-pushed SHA. Block the gate-clear until the dwell
-		// window has elapsed. Zero LastHeadSHAUpdate (cold start / pre-restart)
-		// falls through to preserve existing behavior (EC-1).
-		if lpr != nil && !lpr.LastHeadSHAUpdate.IsZero() {
-			dwell := e.cfg.PostPushDwell
-			if dwell <= 0 {
-				dwell = 90 * time.Second
-			}
-			if elapsed := time.Since(lpr.LastHeadSHAUpdate); elapsed < dwell {
-				e.logf(item.Number, "ci-gate", "no check runs for SHA %s — post-push dwell window active (%.0fs remaining); waiting\n",
-					pr.HeadSHA[:min(8, len(pr.HeadSHA))],
-					(dwell - elapsed).Seconds())
-				return true, false, false
+		e.logf(item.Number, "ci-gate", "CI check(s) failed: %s\n", strings.Join(failedNames, ", "))
+
+		if !hasLabel(item, "fabrik:awaiting-ci") {
+			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
+				e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 			}
 		}
-		e.logf(item.Number, "ci-gate", "no check runs found for SHA %s; CI gate clears (no CI configured)\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
-		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
-		return false, false, false
+
+		return true, true, false
 	}
 
-	// Classify check runs.
-	var pending, failed []gh.CheckRun
-	for _, cr := range checkRuns {
-		switch cr.Status {
-		case "queued", "in_progress":
-			pending = append(pending, cr)
-		case "completed":
-			switch cr.Conclusion {
-			case "failure", "timed_out", "action_required":
-				failed = append(failed, cr)
-			}
-		}
-	}
+	// No check runs. Use settle.MergeableState to discriminate R3 and
+	// branch-protection signals. settle.MergeableState is intentionally empty
+	// for hadChecks/dwell/HeadSHA-empty cases so those always reach the generic
+	// Unsettled fallback below without triggering R3 or timeout paths.
 
-	// All checks green (no pending, no failed) — gate clears.
-	if len(pending) == 0 && len(failed) == 0 {
-		e.logf(item.Number, "ci-gate", "all CI checks passed for SHA %s\n", pr.HeadSHA[:min(8, len(pr.HeadSHA))])
-		e.addCompleteLabelAndRemoveCI(owner, repo, item, stage)
-		return false, false, false
-	}
-
-	// CIWaitTimeout applies to the full CI-await window — both pending and failed
-	// checks (R7). Under ADR 032, fabrik:awaiting-ci is present from the moment
-	// handleStageComplete fires, so timeout tracking covers "checks still running"
-	// as well as "checks failed". Without this, CI stuck in queued/in_progress
-	// indefinitely would never time out and pause the issue.
-	if hasLabel(item, "fabrik:awaiting-ci") {
+	if mergeableState == "blocked" {
+		// R3: OPEN+BLOCKED+no check runs ever observed — a required check is
+		// configured but never triggered by PR events. Use CIWaitTimeout as a
+		// false-positive guard.
 		timeout := e.cfg.CIWaitTimeout
 		if timeout <= 0 {
 			timeout = 30 * time.Minute
 		}
-		appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
-		if err != nil {
-			e.logf(item.Number, "warn", "could not fetch awaiting-ci label timestamp: %v\n", err)
-		} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
-			allNames := make([]string, 0, len(pending)+len(failed))
-			for _, cr := range pending {
-				allNames = append(allNames, cr.Name+" (pending)")
+		if hasLabel(item, "fabrik:awaiting-ci") {
+			appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
+			if err != nil {
+				e.logf(item.Number, "warn", "R3: could not fetch awaiting-ci label timestamp: %v\n", err)
+			} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
+				e.logf(item.Number, "ci-gate", "R3: PR #%d OPEN+BLOCKED with no check runs ever — required check likely never triggers on PRs; pausing\n", prNum)
+				e.pauseForRequiredNeverRunningCheck(board, item, stage, prNum)
+				return false, false, false
 			}
-			for _, cr := range failed {
-				allNames = append(allNames, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
-			}
-			e.logf(item.Number, "warn", "CI wait timeout elapsed; pausing issue — checks: %s\n", strings.Join(allNames, ", "))
-			e.removeAwaitingCILabel(owner, repo, item)
-			return false, false, true
 		}
-	}
-
-	// Checks still running — gate blocked; fabrik:awaiting-ci already present
-	// from handleStageComplete.
-	if len(failed) == 0 {
-		names := make([]string, 0, len(pending))
-		for _, cr := range pending {
-			names = append(names, cr.Name)
-		}
-		e.logf(item.Number, "ci-gate", "CI still running — pending: %s\n", strings.Join(names, ", "))
+		e.logf(item.Number, "ci-gate", "R3: PR #%d OPEN+BLOCKED with no check runs — dwell not yet elapsed; waiting\n", prNum)
 		return true, false, false
 	}
 
-	// CI failed — apply fabrik:awaiting-ci idempotently and return blocked.
-	failedNames := make([]string, 0, len(failed))
-	for _, cr := range failed {
-		failedNames = append(failedNames, fmt.Sprintf("%s (%s)", cr.Name, cr.Conclusion))
-	}
-	e.logf(item.Number, "ci-gate", "CI check(s) failed: %s\n", strings.Join(failedNames, ", "))
-
-	if !hasLabel(item, "fabrik:awaiting-ci") {
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+	if mergeableState != "" && mergeableState != "unknown" {
+		// Branch-protection blocking via a signal Fabrik cannot see via check_runs
+		// (e.g. Commit Status / legacy Statuses API). Apply CIWaitTimeout.
+		timeout := e.cfg.CIWaitTimeout
+		if timeout <= 0 {
+			timeout = 30 * time.Minute
 		}
+		if hasLabel(item, "fabrik:awaiting-ci") {
+			appliedAt, err := e.client.FetchLabelAppliedAt(owner, repo, item.Number, "fabrik:awaiting-ci")
+			if err != nil {
+				e.logf(item.Number, "warn", "could not fetch awaiting-ci label timestamp: %v\n", err)
+			} else if !appliedAt.IsZero() && time.Since(appliedAt) >= timeout {
+				e.logf(item.Number, "warn", "CI wait timeout elapsed for mergeable_state=%q with no check_runs — pausing issue\n", mergeableState)
+				e.removeAwaitingCILabel(owner, repo, item)
+				return false, false, true
+			}
+		}
+		e.logf(item.Number, "ci-gate", "mergeable_state=%q blocks merge but no check_runs visible — branch protection likely requires a Commit Status or external signal; blocking\n", mergeableState)
+		return true, false, false
 	}
 
-	return true, true, false
+	// Generic Unsettled: hadChecks/dwell/HeadSHA-empty/mergeable=nil/unknown.
+	// Block and re-evaluate on next poll.
+	return true, false, false
 }
 
 // removeAwaitingCILabel removes fabrik:awaiting-ci if present on the item.
@@ -320,21 +247,17 @@ func (e *Engine) addCompleteLabelAndRemoveCI(owner, repo string, item gh.Project
 }
 
 // buildCIFixComment constructs the synthetic comment body for a CI-fix reinvocation.
-// It fetches current PR CI status, fetches base branch CI status for comparison,
-// and formats both into a structured message Claude can use to diagnose failures.
-func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, workDir string) gh.Comment {
+// It uses PR check runs from the settle result and fetches base branch CI status for
+// comparison. The base-branch fetch (different SHA) remains a direct API call.
+func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, workDir string, settle PRSettleResult) gh.Comment {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	var prFailures, baseRuns []gh.CheckRun
+	// Use PR-head check runs already fetched by settlePRMergeState.
+	prFailures := settle.CheckRuns
+	var baseRuns []gh.CheckRun
 	var baseBranch string
 
-	// Fetch PR check runs.
-	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
-	if err == nil && pr != nil && pr.HeadSHA != "" {
-		prFailures, _ = e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
-	}
-
-	// Fetch base branch check runs for comparison.
+	// Fetch base branch check runs for comparison (different SHA — not covered by settle).
 	wm := e.worktreesFor(item.Repo)
 	bb, err := e.baseBranchForItem(item, wm)
 	if err == nil {
@@ -418,7 +341,7 @@ func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, wor
 // processComments with a synthetic CI-failure context comment. It mirrors
 // dispatchReviewReinvoke exactly: marks the item in-flight via WorkerEntered,
 // acquires semaphore, calls processComments, then releases both.
-func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
+func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult) {
 	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
 
 	// Mark in-flight via the Store so the dispatch guard (snap.Worker() != nil) blocks
@@ -458,7 +381,7 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 		workDir := wm.WorktreeDir(item.Number)
 
 		// Build the synthetic comment with CI failure context.
-		syntheticComment := e.buildCIFixComment(item, stage, workDir)
+		syntheticComment := e.buildCIFixComment(item, stage, workDir, settle)
 
 		// Use ci_fix_skill if configured; fall back to comment_skill.
 		ciFixStage := *stage

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -16,81 +16,60 @@ import (
 // ── checkCIGate ──────────────────────────────────────────────────────────────
 
 func TestCheckCIGate_WaitForCIFalse_ClearsImmediately(t *testing.T) {
-	called := false
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			called = true
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate"} // WaitForCI is nil
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, PRSettleResult{})
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected all false when wait_for_ci not set, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
-	}
-	if called {
-		t.Error("should not call FetchLinkedPR when wait_for_ci is not set")
 	}
 }
 
 func TestCheckCIGate_NoPR_ClearsGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{Status: PRMergeNoPR}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected clear when no PR, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
 }
 
 func TestCheckCIGate_NoCheckRuns_ClearsGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha1"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{Status: PRMergeReady, Reason: "no CI configured", PR: &gh.PRDetails{Number: 5, HeadSHA: "sha1"}}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected clear for no check runs (R5), got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
 }
 
 func TestCheckCIGate_PostPushDelay_BlocksGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-new"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil // no checks yet for the new SHA
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
-	// Pre-seed: this issue has previously had check runs registered.
-	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 1})
 
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// hadChecks=true: settle returns "post-push registration delay (hadChecks)"
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "post-push registration delay (hadChecks)",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-new"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when zero check runs after previously seeing checks (post-push delay)")
 	}
@@ -105,45 +84,43 @@ func TestCheckCIGate_PostPushDelay_BlocksGate(t *testing.T) {
 }
 
 func TestCheckCIGate_AllGreen_ClearsGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha2"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "completed", Conclusion: "success"},
-				{Name: "test", Status: "completed", Conclusion: "success"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeReady,
+		Reason: "all CI checks passed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "build", Status: "completed", Conclusion: "success"},
+			{Name: "test", Status: "completed", Conclusion: "success"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha2"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected clear for all-green CI, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
 }
 
 func TestCheckCIGate_Pending_BlocksNoLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha3"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "ci", Status: "in_progress"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "CI checks pending",
+		CheckRuns: []gh.CheckRun{
+			{Name: "ci", Status: "in_progress"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha3"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true for pending CI")
 	}
@@ -171,14 +148,6 @@ func TestCheckCIGate_Pending_BlocksNoLabel(t *testing.T) {
 // timeout tracks the whole pending window, not just confirmed-failure windows.
 func TestCheckCIGate_Pending_TimedOut(t *testing.T) {
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha_pending_timeout"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "slow-ci", Status: "in_progress"},
-			}, nil
-		},
 		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 			// Simulate fabrik:awaiting-ci applied over 1 hour ago — well past any timeout.
 			return time.Now().Add(-2 * time.Hour), nil
@@ -190,7 +159,15 @@ func TestCheckCIGate_Pending_TimedOut(t *testing.T) {
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "CI checks pending",
+		CheckRuns: []gh.CheckRun{
+			{Name: "slow-ci", Status: "in_progress"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha_pending_timeout"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !timedOut {
 		t.Error("expected timedOut=true when CI is pending and CIWaitTimeout elapsed")
 	}
@@ -210,22 +187,21 @@ func TestCheckCIGate_Pending_TimedOut(t *testing.T) {
 }
 
 func TestCheckCIGate_Failed_BlocksAndAddsLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha4"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "lint", Status: "completed", Conclusion: "failure"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "lint", Status: "completed", Conclusion: "failure"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha4"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked || !ciFailure {
 		t.Errorf("expected blocked=true ciFailure=true for failed CI, got blocked=%v ciFailure=%v", blocked, ciFailure)
 	}
@@ -246,14 +222,6 @@ func TestCheckCIGate_Failed_BlocksAndAddsLabel(t *testing.T) {
 func TestCheckCIGate_Failed_AlreadyLabeledWithTimeout_TimesOut(t *testing.T) {
 	appliedAt := time.Now().Add(-2 * time.Hour) // well past any timeout
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha5"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "lint", Status: "completed", Conclusion: "failure"},
-			}, nil
-		},
 		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 			return appliedAt, nil
 		},
@@ -267,7 +235,15 @@ func TestCheckCIGate_Failed_AlreadyLabeledWithTimeout_TimesOut(t *testing.T) {
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "lint", Status: "completed", Conclusion: "failure"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha5"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure {
 		t.Errorf("expected blocked=false ciFailure=false on timeout, got blocked=%v ciFailure=%v", blocked, ciFailure)
 	}
@@ -289,14 +265,6 @@ func TestCheckCIGate_Failed_AlreadyLabeledWithTimeout_TimesOut(t *testing.T) {
 func TestCheckCIGate_Failed_AlreadyLabeledNotYetTimedOut_Blocked(t *testing.T) {
 	appliedAt := time.Now().Add(-1 * time.Minute) // within a 30-min window
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha6"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "lint", Status: "completed", Conclusion: "failure"},
-			}, nil
-		},
 		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 			return appliedAt, nil
 		},
@@ -307,7 +275,15 @@ func TestCheckCIGate_Failed_AlreadyLabeledNotYetTimedOut_Blocked(t *testing.T) {
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "lint", Status: "completed", Conclusion: "failure"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha6"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked || !ciFailure {
 		t.Errorf("expected blocked=true ciFailure=true when not yet timed out, got blocked=%v ciFailure=%v", blocked, ciFailure)
 	}
@@ -321,22 +297,21 @@ func TestCheckCIGate_Failed_AlreadyLabeledNotYetTimedOut_Blocked(t *testing.T) {
 // TestCheckCIGate_AllGreen_AddsCompleteLabel verifies that checkCIGate adds
 // stage:X:complete when all CI checks pass (R5 — gate cleared).
 func TestCheckCIGate_AllGreen_AddsCompleteLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha10"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "completed", Conclusion: "success"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeReady,
+		Reason: "all CI checks passed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "build", Status: "completed", Conclusion: "success"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha10"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected gate cleared, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -364,20 +339,18 @@ func TestCheckCIGate_AllGreen_AddsCompleteLabel(t *testing.T) {
 // TestCheckCIGate_NoCheckRuns_AddsCompleteLabel verifies that checkCIGate adds
 // stage:X:complete when no check runs exist (no CI configured).
 func TestCheckCIGate_NoCheckRuns_AddsCompleteLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha11"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil // no check runs (R5)
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, _, _ := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeReady,
+		Reason: "no CI configured",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha11"},
+	}
+	blocked, _, _ := eng.checkCIGate(nil, item, stage, settle)
 	if blocked {
 		t.Error("expected gate cleared for no check runs (R5)")
 	}
@@ -397,17 +370,14 @@ func TestCheckCIGate_NoCheckRuns_AddsCompleteLabel(t *testing.T) {
 // Regression test: before the fix, fabrik:awaiting-ci was never removed and
 // stage:X:complete was never added when FetchLinkedPR returns nil.
 func TestCheckCIGate_NoPR_AddsCompleteLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return nil, nil // no linked PR
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{Status: PRMergeNoPR}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected gate cleared for no PR, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -434,22 +404,21 @@ func TestCheckCIGate_NoPR_AddsCompleteLabel(t *testing.T) {
 // TestCheckCIGate_Failed_DoesNotAddCompleteLabel verifies that checkCIGate does
 // NOT add stage:X:complete when CI checks have failed.
 func TestCheckCIGate_Failed_DoesNotAddCompleteLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha12"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "lint", Status: "completed", Conclusion: "failure"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	_, ciFailure, _ := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "lint", Status: "completed", Conclusion: "failure"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha12"},
+	}
+	_, ciFailure, _ := eng.checkCIGate(nil, item, stage, settle)
 	if !ciFailure {
 		t.Error("expected ciFailure=true for failed CI")
 	}
@@ -464,23 +433,22 @@ func TestCheckCIGate_Failed_DoesNotAddCompleteLabel(t *testing.T) {
 // checkCIGate uses the correct stage name when adding the completion label
 // (not hard-coded to "Validate").
 func TestCheckCIGate_NonValidateStage_AddsCorrectCompleteLabel(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha13"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "completed", Conclusion: "success"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	// Use a non-Validate stage name
 	stage := &stages.Stage{Name: "Review", WaitForCI: &tr}
 
-	blocked, _, _ := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeReady,
+		Reason: "all CI checks passed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "build", Status: "completed", Conclusion: "success"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha13"},
+	}
+	blocked, _, _ := eng.checkCIGate(nil, item, stage, settle)
 	if blocked {
 		t.Error("expected gate cleared")
 	}
@@ -538,22 +506,21 @@ func TestAddCompleteLabelAndRemoveCI_AddLabelFails_PreservesAwaitingCI(t *testin
 // ── buildCIFixComment ─────────────────────────────────────────────────────────
 
 func TestBuildCIFixComment_IncludesFailedChecks(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha7"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return []gh.CheckRun{
-				{Name: "build", Status: "completed", Conclusion: "failure"},
-			}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	tr := true
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	comment := eng.buildCIFixComment(item, stage, "/tmp")
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		CheckRuns: []gh.CheckRun{
+			{Name: "build", Status: "completed", Conclusion: "failure"},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha7"},
+	}
+	comment := eng.buildCIFixComment(item, stage, "/tmp", settle)
 	if comment.DatabaseID != 0 {
 		t.Error("synthetic comment should have DatabaseID=0")
 	}
@@ -569,17 +536,17 @@ func TestBuildCIFixComment_IncludesFailedChecks(t *testing.T) {
 // FetchLinkedPR API error returns blocked=true rather than clearing the gate,
 // preventing auto-advance when CI status is unknown.
 func TestCheckCIGate_FetchLinkedPRError_BlocksGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return nil, fmt.Errorf("transient network error")
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "FetchLinkedPR error: transient network error",
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when FetchLinkedPR returns an error")
 	}
@@ -594,17 +561,17 @@ func TestCheckCIGate_FetchLinkedPRError_BlocksGate(t *testing.T) {
 // merged, checkCIGate clears the CI gate and adds stage:X:complete without
 // requiring check runs.
 func TestCheckCIGate_MergedPR_ClearsGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-merged", Merged: true, State: "closed"}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeTerminal,
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-merged", Merged: true, State: "closed"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected (false,false,false) for merged PR, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -633,17 +600,17 @@ func TestCheckCIGate_MergedPR_ClearsGate(t *testing.T) {
 // fabrik:awaiting-input and removes fabrik:awaiting-ci. stage:X:complete must
 // NOT be added.
 func TestCheckCIGate_ClosedNotMergedPR_Pauses(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-closed", Merged: false, State: "closed"}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeTerminal,
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-closed", Merged: false, State: "closed"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected (false,false,false) for closed-not-merged PR, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -683,15 +650,6 @@ func TestCheckCIGate_ClosedNotMergedPR_Pauses(t *testing.T) {
 // spurious R3 pauses on first push before checks have registered.
 func TestCheckCIGate_OpenBlockedNoChecks_DwellNotElapsed_StaysBlocked(t *testing.T) {
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-blocked", Merged: false, State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "blocked", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
 		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 			return time.Now().Add(-1 * time.Minute), nil // well within the 30-min default timeout
 		},
@@ -701,7 +659,13 @@ func TestCheckCIGate_OpenBlockedNoChecks_DwellNotElapsed_StaysBlocked(t *testing
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// mergeable_state="blocked" + no check runs: settle returns Unsettled with MergeableState="blocked"
+	settle := PRSettleResult{
+		Status:         PRMergeUnsettled,
+		MergeableState: "blocked",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "sha-blocked", Merged: false, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when OPEN+BLOCKED with no check runs and dwell not elapsed (R3 false-positive guard)")
 	}
@@ -721,15 +685,6 @@ func TestCheckCIGate_OpenBlockedNoChecks_DwellNotElapsed_StaysBlocked(t *testing
 // "required check never runs on PR" message.
 func TestCheckCIGate_OpenBlockedNoChecks_DwellElapsed_Pauses(t *testing.T) {
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-blocked-old", Merged: false, State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "blocked", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
 		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 			return time.Now().Add(-2 * time.Hour), nil // well past the 30-min default timeout
 		},
@@ -740,7 +695,12 @@ func TestCheckCIGate_OpenBlockedNoChecks_DwellElapsed_Pauses(t *testing.T) {
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status:         PRMergeUnsettled,
+		MergeableState: "blocked",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "sha-blocked-old", Merged: false, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected (false,false,false) for R3 dwell-elapsed pause, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -785,25 +745,20 @@ func TestCheckCIGate_OpenBlockedNoChecks_DwellElapsed_Pauses(t *testing.T) {
 // must treat this as a post-push registration delay and return (true, false, false)
 // without triggering R3's "required check never runs" pause.
 func TestCheckCIGate_OpenBlockedNoChecks_HadChecks_Waits(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-blocked-hadchecks", Merged: false, State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "blocked", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
-	// Pre-seed: this issue has previously had check runs registered.
-	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 1})
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// hadChecks=true: settle returns "post-push registration delay (hadChecks)"
+	// with empty MergeableState so R3 path does not fire.
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "post-push registration delay (hadChecks)",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-blocked-hadchecks", Merged: false, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when OPEN+BLOCKED with no check runs but hadChecks=true (R5 preserved)")
 	}
@@ -821,20 +776,18 @@ func TestCheckCIGate_OpenBlockedNoChecks_HadChecks_Waits(t *testing.T) {
 // TestCheckCIGate_FetchCheckRunsError_BlocksGate verifies that a transient
 // FetchCheckRuns API error returns blocked=true rather than clearing the gate.
 func TestCheckCIGate_FetchCheckRunsError_BlocksGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha1"}, nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, fmt.Errorf("GitHub API 503")
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "FetchCheckRuns error: GitHub API 503",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha1"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when FetchCheckRuns returns an error")
 	}
@@ -849,7 +802,7 @@ func TestBuildCIFixComment_SyntheticHasDatabaseIDZero(t *testing.T) {
 	item := gh.ProjectItem{Number: 42}
 	stage := &stages.Stage{Name: "Validate"}
 
-	comment := eng.buildCIFixComment(item, stage, "/tmp")
+	comment := eng.buildCIFixComment(item, stage, "/tmp", PRSettleResult{})
 	if comment.DatabaseID != 0 {
 		t.Errorf("DatabaseID = %d, want 0 (synthetic)", comment.DatabaseID)
 	}
@@ -866,16 +819,6 @@ func TestBuildCIFixComment_SyntheticHasDatabaseIDZero(t *testing.T) {
 func TestCheckCIGate_MergeableStateClean_ClearsGate(t *testing.T) {
 	addCalls := []string{}
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "shaA"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "clean", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			t.Error("FetchCheckRuns must NOT be called when mergeable_state=clean")
-			return nil, nil
-		},
 		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
 			addCalls = append(addCalls, labelName)
 			return nil
@@ -886,7 +829,13 @@ func TestCheckCIGate_MergeableStateClean_ClearsGate(t *testing.T) {
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// mergeable_state=clean → PRMergeReady shortcut (no FetchCheckRuns needed)
+	settle := PRSettleResult{
+		Status:         PRMergeReady,
+		MergeableState: "clean",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "shaA"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected gate clear, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -906,24 +855,19 @@ func TestCheckCIGate_MergeableStateClean_ClearsGate(t *testing.T) {
 // mergeable_state=unstable (non-required checks failing) also clears the gate.
 // This is the "Cleanup artifacts failed but PR is otherwise mergeable" case.
 func TestCheckCIGate_MergeableStateUnstable_ClearsGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "shaB"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "unstable", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			t.Error("FetchCheckRuns must NOT be called when mergeable_state=unstable")
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// mergeable_state=unstable → PRMergeReady shortcut
+	settle := PRSettleResult{
+		Status:         PRMergeReady,
+		MergeableState: "unstable",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "shaB"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("expected gate clear for unstable, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -934,28 +878,20 @@ func TestCheckCIGate_MergeableStateUnstable_ClearsGate(t *testing.T) {
 // classification runs to distinguish failure vs pending and apply the right
 // label/dispatch.
 func TestCheckCIGate_MergeableStateBlocked_FallsThroughToCheckRuns(t *testing.T) {
-	checkRunsCalled := false
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "shaC"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "blocked", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			checkRunsCalled = true
-			return []gh.CheckRun{{Name: "ci", Status: "in_progress"}}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, _ := eng.checkCIGate(nil, item, stage)
-	if !checkRunsCalled {
-		t.Error("FetchCheckRuns must be called when mergeable_state=blocked (fall through)")
+	// mergeable_state=blocked + pending check runs → PRMergeUnsettled with CheckRuns
+	settle := PRSettleResult{
+		Status:         PRMergeUnsettled,
+		MergeableState: "blocked",
+		CheckRuns:      []gh.CheckRun{{Name: "ci", Status: "in_progress"}},
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "shaC"},
 	}
+	blocked, ciFailure, _ := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked || ciFailure {
 		t.Errorf("expected blocked-pending for mergeable_state=blocked + in_progress checks, got blocked=%v ciFailure=%v", blocked, ciFailure)
 	}
@@ -968,18 +904,18 @@ func TestCheckCIGate_MergeableStateBlocked_FallsThroughToCheckRuns(t *testing.T)
 // mechanism. After the fix, a non-nil PR with an empty HeadSHA is treated as
 // "data incomplete — block until SHA is populated" rather than "no PR — gate clears."
 func TestCheckCIGate_EmptyHeadSHA_StaysBlocked(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			// Simulate the stale-cache scenario: PR is known but HeadSHA is empty.
-			return &gh.PRDetails{Number: 5, Title: "My PR", HeadSHA: ""}, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "HeadSHA empty",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: ""},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when PR exists but HeadSHA is empty")
 	}
@@ -1057,23 +993,18 @@ func TestRemoveAwaitingCILabel_ErrNotFound(t *testing.T) {
 // stage:Validate:complete. The "behind" state signals that branch protection is
 // blocking via a signal Fabrik cannot see via check_runs (e.g. up-to-date policy).
 func TestCheckCIGate_BehindNoChecks_Blocks(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-behind", Merged: false, State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "behind", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status:         PRMergeUnsettled,
+		MergeableState: "behind",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "sha-behind", Merged: false, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when mergeable_state=behind with no check_runs and hadChecks=false (new guard)")
 	}
@@ -1093,23 +1024,18 @@ func TestCheckCIGate_BehindNoChecks_Blocks(t *testing.T) {
 // stage:Validate:complete. The "dirty" state signals that branch protection is
 // blocking due to a merge conflict — a signal Fabrik cannot see via check_runs.
 func TestCheckCIGate_DirtyNoChecks_Blocks(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-dirty", Merged: false, State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "dirty", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status:         PRMergeUnsettled,
+		MergeableState: "dirty",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "sha-dirty", Merged: false, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("expected blocked=true when mergeable_state=dirty with no check_runs and hadChecks=false (new guard)")
 	}
@@ -1130,15 +1056,6 @@ func TestCheckCIGate_DirtyNoChecks_Blocks(t *testing.T) {
 // signal Fabrik cannot see via check_runs.
 func TestCheckCIGate_BehindNoChecks_TimeoutElapsed_TimesOut(t *testing.T) {
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-behind-timeout", Merged: false, State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "behind", nil
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
 		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
 			return time.Now().Add(-2 * time.Hour), nil // well past the 30-min default timeout
 		},
@@ -1149,7 +1066,12 @@ func TestCheckCIGate_BehindNoChecks_TimeoutElapsed_TimesOut(t *testing.T) {
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:awaiting-ci"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status:         PRMergeUnsettled,
+		MergeableState: "behind",
+		PR:             &gh.PRDetails{Number: 5, HeadSHA: "sha-behind-timeout", Merged: false, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure {
 		t.Errorf("expected blocked=false ciFailure=false for timed-out new guard, got blocked=%v ciFailure=%v", blocked, ciFailure)
 	}
@@ -1178,30 +1100,20 @@ func TestCheckCIGate_BehindNoChecks_TimeoutElapsed_TimesOut(t *testing.T) {
 // mergeable_state="" + check_runs=[] + hadChecks=false + LastHeadSHAUpdate
 // within dwell → gate must NOT clear (returns true, false, false).
 func TestCheckCIGate_PostPushDwell_WithinDwell_Blocks(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-fresh", State: "open"}, nil
-		},
-		// fetchPRMergeableStateFn not set → returns ("", nil) — GitHub cache miss
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil // no check runs yet for new SHA
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
-	// Seed the prior SHA so the transition to "sha-fresh" is from a non-empty
-	// value — matching real engine behavior (PRHeadSHAUpdated only stamps
-	// LastHeadSHAUpdate when HeadSHA is non-empty, to avoid cold-start false triggers).
-	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-initial"})
-	// Simulate a force-push: apply PRHeadSHAUpdated to set LastHeadSHAUpdate.
-	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-fresh"})
-	// Large dwell so the window has not elapsed.
-	eng.cfg.PostPushDwell = 30 * time.Second
 
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// Post-push dwell active: settlePRMergeState returns Unsettled with "post-push dwell active"
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "post-push dwell active",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-fresh", State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("SC-1: expected blocked=true when check_runs=[] and LastHeadSHAUpdate is within PostPushDwell")
 	}
@@ -1219,32 +1131,20 @@ func TestCheckCIGate_PostPushDwell_WithinDwell_Blocks(t *testing.T) {
 // mergeable_state="unknown" + check_runs=[] + hadChecks=false + dwell elapsed
 // → gate clears as "no CI configured" (existing fallthrough preserved).
 func TestCheckCIGate_PostPushDwell_DwellElapsed_Clears(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-old", State: "open"}, nil
-		},
-		fetchPRMergeableStateFn: func(owner, repo string, prNumber int) (string, error) {
-			return "unknown", nil // GitHub still computing
-		},
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
-	// Seed the prior SHA first so the transition to "sha-old" stamps LastHeadSHAUpdate.
-	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-initial"})
-	// Apply PRHeadSHAUpdated to set LastHeadSHAUpdate.
-	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-old"})
-	// Use a sub-millisecond dwell and sleep briefly to guarantee it elapses even
-	// on low-resolution clocks (e.g. Windows virtualised CI runners).
-	eng.cfg.PostPushDwell = 1 * time.Nanosecond
-	time.Sleep(20 * time.Millisecond)
 
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// Dwell elapsed: settlePRMergeState returns Ready with "no CI configured"
+	settle := PRSettleResult{
+		Status: PRMergeReady,
+		Reason: "no CI configured",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-old", State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("SC-2: expected gate to clear (false,false,false) when dwell elapsed, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -1263,24 +1163,20 @@ func TestCheckCIGate_PostPushDwell_DwellElapsed_Clears(t *testing.T) {
 // mergeable_state="" + LastHeadSHAUpdate zero (PRHeadSHAUpdated never fired)
 // → gate clears (cold-start / post-restart behavior preserved).
 func TestCheckCIGate_PostPushDwell_ZeroTimestamp_Clears(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 5, HeadSHA: "sha-cold", State: "open"}, nil
-		},
-		// fetchPRMergeableStateFn not set → returns ("", nil)
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
-	// Do NOT apply PRHeadSHAUpdated — LastHeadSHAUpdate stays zero.
-	eng.cfg.PostPushDwell = 30 * time.Second // large dwell, but guard must be inactive
 
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	// Zero timestamp: settlePRMergeState returns Ready with "no CI configured"
+	settle := PRSettleResult{
+		Status: PRMergeReady,
+		Reason: "no CI configured",
+		PR:     &gh.PRDetails{Number: 5, HeadSHA: "sha-cold", State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if blocked || ciFailure || timedOut {
 		t.Errorf("SC-3: expected gate to clear (false,false,false) when LastHeadSHAUpdate is zero, got blocked=%v ciFailure=%v timedOut=%v", blocked, ciFailure, timedOut)
 	}
@@ -1291,15 +1187,7 @@ func TestCheckCIGate_PostPushDwell_ZeroTimestamp_Clears(t *testing.T) {
 // immediately by checkCIGate — gate must not clear within the dwell window.
 func TestCheckCIGate_PostPushDwell_Integration(t *testing.T) {
 	const newSHA = "sha-force-pushed"
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 7, HeadSHA: newSHA, State: "open"}, nil
-		},
-		// mergeable_state="" (GitHub hasn't computed mergeability for the new SHA yet)
-		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
-			return nil, nil // CI hasn't started yet
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	eng.cfg.PostPushDwell = 30 * time.Second
 
@@ -1309,11 +1197,17 @@ func TestCheckCIGate_PostPushDwell_Integration(t *testing.T) {
 	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: newSHA})
 
 	// checkCIGate runs immediately (catch-up loop cadence), well within the dwell.
+	// The settle result reflects what settlePRMergeState would return: dwell active.
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
 
-	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage)
+	settle := PRSettleResult{
+		Status: PRMergeUnsettled,
+		Reason: "post-push dwell active",
+		PR:     &gh.PRDetails{Number: 7, HeadSHA: newSHA, State: "open"},
+	}
+	blocked, ciFailure, timedOut := eng.checkCIGate(nil, item, stage, settle)
 	if !blocked {
 		t.Error("SC-4: gate must not clear immediately after PRHeadSHAUpdated while within PostPushDwell")
 	}

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -28,6 +28,7 @@ type GitHubClient interface {
 	GetIssueBody(owner, repo string, issueNumber int) (string, error)
 	FindPRForIssue(owner, repo string, issueNumber int) (int, error)
 	FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)
+	FetchPRMergeableFields(owner, repo string, prNumber int) (mergeable *bool, mergeableState string, err error)
 	FetchPRMergeable(owner, repo string, prNumber int) (*bool, error)
 	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
 	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -19,12 +19,12 @@ import (
 //
 // Returns (blocked, conflict):
 //
-//   - (false, false) — gate clears. No PR, mergeable==true, or wait_for_ci
-//     disabled. Caller falls through to the CI gate on the same poll.
+//   - (false, false) — gate clears. No PR, mergeable==true, CI failed (deferred
+//     to checkCIGate), or wait_for_ci disabled. Caller falls through to the CI gate.
 //
 //   - (true, false)  — blocked but no confirmed conflict. GitHub has not yet
-//     computed mergeability (Unsettled), or the PR is already blocked by CI.
-//     The fabrik:rebase-needed label is not touched.
+//     computed mergeability (PRMergeUnsettled). The fabrik:rebase-needed label
+//     is not touched.
 //
 //   - (true, true)   — confirmed conflict. fabrik:rebase-needed applied
 //     (idempotent). Caller should dispatch a rebase reinvoke.
@@ -38,8 +38,13 @@ func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage,
 	switch settle.Status {
 	case PRMergeNoPR, PRMergeTerminal:
 		return false, false
-	case PRMergeUnsettled, PRMergeBlocked:
+	case PRMergeUnsettled:
 		return true, false
+	case PRMergeBlocked:
+		// CI has failed but there is no base-branch conflict. Clear the merge
+		// gate so checkCIGate can classify the failure and dispatch CI-fix.
+		e.removeRebaseNeededLabel(owner, repo, item)
+		return false, false
 	case PRMergeReady:
 		// Clear a stale label if one is present from an earlier conflict that
 		// has since been resolved.

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -12,80 +12,63 @@ import (
 	"github.com/handarbeit/fabrik/stages"
 )
 
-// checkMergeabilityGate inspects GitHub's mergeable flag on the linked PR to
-// detect a base-branch conflict before the CI gate polls checks. Runs only
-// when stage.WaitForCI is true — the same opt-in signal used by the CI gate,
-// since a PR that cannot merge has no reason to proceed to CI-await.
+// checkMergeabilityGate interprets the pre-fetched settle result to detect a
+// base-branch conflict before the CI gate acts. Runs only when stage.WaitForCI
+// is true — the same opt-in signal used by the CI gate, since a PR that cannot
+// merge has no reason to proceed to CI-await.
 //
 // Returns (blocked, conflict):
 //
 //   - (false, false) — gate clears. No PR, mergeable==true, or wait_for_ci
 //     disabled. Caller falls through to the CI gate on the same poll.
 //
-//   - (true, false)  — blocked but no confirmed conflict. Mergeable is nil
-//     (GitHub has not yet computed it), or a transient API error was seen
-//     while fetching. Caller should skip to next item; the next poll
-//     re-evaluates. The fabrik:rebase-needed label is not touched.
+//   - (true, false)  — blocked but no confirmed conflict. GitHub has not yet
+//     computed mergeability (Unsettled), or the PR is already blocked by CI.
+//     The fabrik:rebase-needed label is not touched.
 //
 //   - (true, true)   — confirmed conflict. fabrik:rebase-needed applied
 //     (idempotent). Caller should dispatch a rebase reinvoke.
-func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage) (blocked, conflict bool) {
+func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult) (blocked, conflict bool) {
 	if stage.WaitForCI == nil || !*stage.WaitForCI {
 		return false, false
 	}
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
-	if err != nil {
-		// Transient API error. Block this item for the rest of Phase 1 so we
-		// don't run the CI gate on stale data (it would make its own REST
-		// call against an unknown mergeability state). Mirrors checkCIGate's
-		// transient-error handling.
-		e.logf(item.Number, "merge-gate", "could not fetch linked PR: %v — blocking until API recovers\n", err)
-		return true, false
-	}
-	if pr == nil || pr.Number == 0 {
+	switch settle.Status {
+	case PRMergeNoPR, PRMergeTerminal:
 		return false, false
-	}
-
-	mergeable, err := e.readClient.FetchPRMergeable(owner, repo, pr.Number)
-	if err != nil {
-		e.logf(item.Number, "merge-gate", "could not fetch mergeable: %v — blocking until API recovers\n", err)
+	case PRMergeUnsettled, PRMergeBlocked:
 		return true, false
-	}
-
-	if mergeable == nil {
-		// GitHub has not yet computed mergeability (null). Asking again triggers
-		// the computation; the next poll will see a definite answer.
-		e.logf(item.Number, "merge-gate", "PR #%d mergeable=null — GitHub still computing, re-checking next poll\n", pr.Number)
-		return true, false
-	}
-
-	if *mergeable {
+	case PRMergeReady:
 		// Clear a stale label if one is present from an earlier conflict that
 		// has since been resolved.
 		e.removeRebaseNeededLabel(owner, repo, item)
 		return false, false
-	}
-
-	// Confirmed conflict. Apply fabrik:rebase-needed (idempotent).
-	e.logf(item.Number, "merge-gate", "PR #%d is not mergeable (base conflict) — rebase required\n", pr.Number)
-	alreadyLabeled := false
-	for _, l := range item.Labels {
-		if l == "fabrik:rebase-needed" {
-			alreadyLabeled = true
-			break
+	case PRMergeConflicting:
+		prNum := 0
+		if settle.PR != nil {
+			prNum = settle.PR.Number
 		}
-	}
-	if !alreadyLabeled {
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); err != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
+		// Confirmed conflict. Apply fabrik:rebase-needed (idempotent).
+		e.logf(item.Number, "merge-gate", "PR #%d is not mergeable (base conflict) — rebase required\n", prNum)
+		alreadyLabeled := false
+		for _, l := range item.Labels {
+			if l == "fabrik:rebase-needed" {
+				alreadyLabeled = true
+				break
+			}
 		}
+		if !alreadyLabeled {
+			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); err != nil {
+				e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", err)
+			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
+			}
+		}
+		return true, true
 	}
-	return true, true
+	return false, false
 }
 
 // removeRebaseNeededLabel clears fabrik:rebase-needed if present.

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -12,38 +12,30 @@ import (
 )
 
 func TestCheckMergeabilityGate_WaitForCIFalse_ClearsImmediately(t *testing.T) {
-	called := false
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			called = true
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate"} // WaitForCI is nil
+	settle := PRSettleResult{Status: PRMergeNoPR}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if blocked || conflict {
 		t.Errorf("expected clear when wait_for_ci not set, got blocked=%v conflict=%v", blocked, conflict)
 	}
-	if called {
-		t.Error("should not call FetchLinkedPR when wait_for_ci is not set")
+	if len(client.addLabelCalls) > 0 || len(client.removeLabelCalls) > 0 {
+		t.Error("should not modify any labels when wait_for_ci is not set")
 	}
 }
 
 func TestCheckMergeabilityGate_NoPR_ClearsGate(t *testing.T) {
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return nil, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	tr := true
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	settle := PRSettleResult{Status: PRMergeNoPR}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if blocked || conflict {
 		t.Errorf("expected clear when no PR found, got blocked=%v conflict=%v", blocked, conflict)
 	}
@@ -51,21 +43,15 @@ func TestCheckMergeabilityGate_NoPR_ClearsGate(t *testing.T) {
 
 func TestCheckMergeabilityGate_Mergeable_ClearsGate_RemovesStaleLabel(t *testing.T) {
 	tr := true
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 42, HeadSHA: "sha"}, nil
-		},
-		fetchPRMergeableFn: func(owner, repo string, prNumber int) (*bool, error) {
-			return &tr, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:rebase-needed"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	settle := PRSettleResult{Status: PRMergeReady, PR: &gh.PRDetails{Number: 42}}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if blocked || conflict {
-		t.Errorf("expected clear when mergeable=true, got blocked=%v conflict=%v", blocked, conflict)
+		t.Errorf("expected clear when PRMergeReady, got blocked=%v conflict=%v", blocked, conflict)
 	}
 	found := false
 	for _, c := range client.removeLabelCalls {
@@ -80,47 +66,35 @@ func TestCheckMergeabilityGate_Mergeable_ClearsGate_RemovesStaleLabel(t *testing
 
 func TestCheckMergeabilityGate_NilMergeable_BlockedNoConflict(t *testing.T) {
 	tr := true
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 42, HeadSHA: "sha"}, nil
-		},
-		fetchPRMergeableFn: func(owner, repo string, prNumber int) (*bool, error) {
-			return nil, nil // GitHub hasn't computed yet
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	// mergeable=null surfaces as PRMergeUnsettled from the primitive.
+	settle := PRSettleResult{Status: PRMergeUnsettled, Reason: "mergeable=null (GitHub computing)"}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if !blocked || conflict {
-		t.Errorf("expected blocked=true conflict=false for mergeable=null, got blocked=%v conflict=%v", blocked, conflict)
+		t.Errorf("expected blocked=true conflict=false for Unsettled, got blocked=%v conflict=%v", blocked, conflict)
 	}
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:rebase-needed" {
-			t.Error("should not add fabrik:rebase-needed when mergeable is unknown")
+			t.Error("should not add fabrik:rebase-needed when settle is Unsettled")
 		}
 	}
 }
 
 func TestCheckMergeabilityGate_FalseMergeable_AppliesLabelAndSignalsConflict(t *testing.T) {
-	fa := false
 	tr := true
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 42, HeadSHA: "sha"}, nil
-		},
-		fetchPRMergeableFn: func(owner, repo string, prNumber int) (*bool, error) {
-			return &fa, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	settle := PRSettleResult{Status: PRMergeConflicting, Reason: "mergeable=false", PR: &gh.PRDetails{Number: 42}}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if !blocked || !conflict {
-		t.Errorf("expected blocked=true conflict=true for mergeable=false, got blocked=%v conflict=%v", blocked, conflict)
+		t.Errorf("expected blocked=true conflict=true for Conflicting, got blocked=%v conflict=%v", blocked, conflict)
 	}
 	found := false
 	for _, c := range client.addLabelCalls {
@@ -134,22 +108,15 @@ func TestCheckMergeabilityGate_FalseMergeable_AppliesLabelAndSignalsConflict(t *
 }
 
 func TestCheckMergeabilityGate_FalseMergeable_LabelIdempotent(t *testing.T) {
-	fa := false
 	tr := true
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 42, HeadSHA: "sha"}, nil
-		},
-		fetchPRMergeableFn: func(owner, repo string, prNumber int) (*bool, error) {
-			return &fa, nil
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	// Label already present — should not be re-added.
 	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:rebase-needed"}}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	settle := PRSettleResult{Status: PRMergeConflicting, PR: &gh.PRDetails{Number: 42}}
 
-	_, conflict := eng.checkMergeabilityGate(item, stage)
+	_, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if !conflict {
 		t.Error("expected conflict=true")
 	}
@@ -162,18 +129,16 @@ func TestCheckMergeabilityGate_FalseMergeable_LabelIdempotent(t *testing.T) {
 
 func TestCheckMergeabilityGate_FetchPRError_BlocksForRetry(t *testing.T) {
 	tr := true
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return nil, errStubTransient
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	// Transient API errors in settlePRMergeState surface as PRMergeUnsettled.
+	settle := PRSettleResult{Status: PRMergeUnsettled, Reason: "FetchLinkedPR error: simulated transient error"}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if !blocked || conflict {
-		t.Errorf("expected blocked=true conflict=false on transient FetchLinkedPR error, got blocked=%v conflict=%v", blocked, conflict)
+		t.Errorf("expected blocked=true conflict=false on Unsettled (transient error), got blocked=%v conflict=%v", blocked, conflict)
 	}
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:rebase-needed" {
@@ -184,21 +149,16 @@ func TestCheckMergeabilityGate_FetchPRError_BlocksForRetry(t *testing.T) {
 
 func TestCheckMergeabilityGate_FetchMergeableError_BlocksForRetry(t *testing.T) {
 	tr := true
-	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 42, HeadSHA: "sha"}, nil
-		},
-		fetchPRMergeableFn: func(owner, repo string, prNumber int) (*bool, error) {
-			return nil, errStubTransient
-		},
-	}
+	client := &mockGitHubClient{}
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 1}
 	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	// FetchPRMergeableFields error surfaces as PRMergeUnsettled from the primitive.
+	settle := PRSettleResult{Status: PRMergeUnsettled, Reason: "FetchPRMergeableFields error: simulated transient error"}
 
-	blocked, conflict := eng.checkMergeabilityGate(item, stage)
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
 	if !blocked || conflict {
-		t.Errorf("expected blocked=true conflict=false on transient mergeable-fetch error, got blocked=%v conflict=%v", blocked, conflict)
+		t.Errorf("expected blocked=true conflict=false on Unsettled (transient error), got blocked=%v conflict=%v", blocked, conflict)
 	}
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:rebase-needed" {

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -127,6 +127,61 @@ func TestCheckMergeabilityGate_FalseMergeable_LabelIdempotent(t *testing.T) {
 	}
 }
 
+func TestCheckMergeabilityGate_CIFailed_ClearsGate(t *testing.T) {
+	// PRMergeBlocked (CI failed) must NOT block the merge gate — it must clear so
+	// checkCIGate can classify the failure and dispatch the CI-fix reinvoke. If the
+	// merge gate returned (true, false) here, poll.go would skip the CI gate and the
+	// issue would get stuck with no CI-fix dispatch.
+	tr := true
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		PR:     &gh.PRDetails{Number: 42},
+		CheckRuns: []gh.CheckRun{
+			{Name: "test", Status: "completed", Conclusion: "failure"},
+		},
+	}
+
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
+	if blocked || conflict {
+		t.Errorf("expected clear when PRMergeBlocked (CI failed), got blocked=%v conflict=%v", blocked, conflict)
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:rebase-needed" {
+			t.Error("should not add fabrik:rebase-needed on CI failure (no base conflict)")
+		}
+	}
+}
+
+func TestCheckMergeabilityGate_CIFailed_RemovesStaleRebaseLabel(t *testing.T) {
+	// When CI has failed (PRMergeBlocked) but a stale fabrik:rebase-needed label
+	// exists from a prior rebase cycle that was resolved, the label should be cleared.
+	tr := true
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1, Labels: []string{"fabrik:rebase-needed"}}
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+	settle := PRSettleResult{Status: PRMergeBlocked, PR: &gh.PRDetails{Number: 42}}
+
+	blocked, conflict := eng.checkMergeabilityGate(item, stage, settle)
+	if blocked || conflict {
+		t.Errorf("expected clear for PRMergeBlocked, got blocked=%v conflict=%v", blocked, conflict)
+	}
+	found := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:rebase-needed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected stale fabrik:rebase-needed label to be removed when PRMergeBlocked (CI failure, no conflict)")
+	}
+}
+
 func TestCheckMergeabilityGate_FetchPRError_BlocksForRetry(t *testing.T) {
 	tr := true
 	client := &mockGitHubClient{}

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -30,6 +30,7 @@ type mockGitHubClient struct {
 	updateProjectItemStatusFn     func(projectID, itemID, statusFieldID, statusOptionID string) error
 	findPRForIssueFn              func(owner, repo string, issueNumber int) (int, error)
 	fetchLinkedPRFn               func(owner, repo string, issueNumber int) (*gh.PRDetails, error)
+	fetchPRMergeableFieldsFn      func(owner, repo string, prNumber int) (*bool, string, error)
 	fetchPRMergeableFn            func(owner, repo string, prNumber int) (*bool, error)
 	fetchPRMergeableStateFn       func(owner, repo string, prNumber int) (string, error)
 	fetchCheckRunsFn              func(owner, repo, sha string) ([]gh.CheckRun, error)
@@ -356,6 +357,16 @@ func (m *mockGitHubClient) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRu
 		return fn(owner, repo, sha)
 	}
 	return nil, nil
+}
+
+func (m *mockGitHubClient) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	m.mu.Lock()
+	fn := m.fetchPRMergeableFieldsFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber)
+	}
+	return nil, "", nil
 }
 
 func (m *mockGitHubClient) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1325,12 +1325,18 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			continue
 		}
 
+		// Fetch all PR merge/CI state in a single pass. Both gates below
+		// consume this result, ensuring they see identical GitHub state within
+		// one poll cycle and eliminating the mergeable vs mergeable_state
+		// split-brain that separate REST calls could produce.
+		settle := e.settlePRMergeState(item, stage)
+
 		// Merge-conflict gate: runs before the CI gate so that a PR made
 		// unmergeable by a base-branch advance is rebased immediately instead
 		// of the engine spinning on CI-await polls while the underlying
 		// blocker is a conflict. Gated by the same wait_for_ci flag — the only
 		// stages that participate in the post-complete catch-up loop.
-		mergeBlocked, mergeConflict := e.checkMergeabilityGate(item, stage)
+		mergeBlocked, mergeConflict := e.checkMergeabilityGate(item, stage, settle)
 		if mergeConflict {
 			iKey := issueKey(item, e.defaultRepo())
 			repoStr := itemOwnerRepoString(item, e.defaultRepo())
@@ -1359,7 +1365,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		// CI gate: evaluate CI status for stages configured with wait_for_ci: true.
 		// This runs in Phase 1 (unconditional) so CI failures are fixed regardless
 		// of auto-advance setting. checkCIGate returns (blocked, ciFailure, timedOut).
-		ciBlocked, ciFailure, ciTimedOut := e.checkCIGate(board, item, stage)
+		ciBlocked, ciFailure, ciTimedOut := e.checkCIGate(board, item, stage, settle)
 		if ciTimedOut {
 			e.pauseForCITimeout(board, item, stage)
 			continue
@@ -1380,7 +1386,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 				e.pauseForCIFixCycleLimit(board, item, stage, cycleCount, maxCycles)
 			} else {
 				e.store.Apply(itemstate.CIFixCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-				e.dispatchCIFixReinvoke(ctx, board, item, stage)
+				e.dispatchCIFixReinvoke(ctx, board, item, stage, settle)
 				advancedItems[iKey] = true
 			}
 			continue

--- a/engine/pr_settle.go
+++ b/engine/pr_settle.go
@@ -94,7 +94,7 @@ func (e *Engine) settlePRMergeState(item gh.ProjectItem, _ *stages.Stage) PRSett
 
 	if pr.HeadSHA == "" {
 		e.logf(item.Number, "settle", "PR #%d HeadSHA empty — treating as unsettled\n", pr.Number)
-		return PRSettleResult{Status: PRMergeUnsettled, Reason: "HeadSHA empty", MergeableState: mergeableState, PR: pr}
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: "HeadSHA empty", PR: pr}
 	}
 
 	checkRuns, err := e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
@@ -124,7 +124,10 @@ func (e *Engine) settlePRMergeState(item gh.ProjectItem, _ *stages.Stage) PRSett
 		if hadChecks {
 			e.logf(item.Number, "settle", "no check runs for SHA %s — post-push registration delay\n",
 				pr.HeadSHA[:min(8, len(pr.HeadSHA))])
-			return PRSettleResult{Status: PRMergeUnsettled, Reason: "post-push registration delay (hadChecks)", MergeableState: mergeableState, PR: pr}
+			// MergeableState intentionally omitted: checkCIGate uses MergeableState to
+			// detect R3 (OPEN+BLOCKED+never-had-checks). This case is hadChecks=true,
+			// so R3 must NOT fire regardless of the raw mergeable_state value.
+			return PRSettleResult{Status: PRMergeUnsettled, Reason: "post-push registration delay (hadChecks)", PR: pr}
 		}
 
 		if lpr != nil && !lpr.LastHeadSHAUpdate.IsZero() {
@@ -135,7 +138,8 @@ func (e *Engine) settlePRMergeState(item gh.ProjectItem, _ *stages.Stage) PRSett
 			if elapsed := time.Since(lpr.LastHeadSHAUpdate); elapsed < dwell {
 				e.logf(item.Number, "settle", "no check runs for SHA %s — post-push dwell active (%.0fs remaining)\n",
 					pr.HeadSHA[:min(8, len(pr.HeadSHA))], (dwell-elapsed).Seconds())
-				return PRSettleResult{Status: PRMergeUnsettled, Reason: "post-push dwell active", MergeableState: mergeableState, PR: pr}
+				// MergeableState intentionally omitted: post-push dwell is not an R3 case.
+				return PRSettleResult{Status: PRMergeUnsettled, Reason: "post-push dwell active", PR: pr}
 			}
 		}
 

--- a/engine/pr_settle.go
+++ b/engine/pr_settle.go
@@ -1,0 +1,175 @@
+package engine
+
+import (
+	"fmt"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// PRMergeStatus classifies the PR merge/CI state returned by settlePRMergeState.
+type PRMergeStatus int
+
+const (
+	// PRMergeNoPR is returned when there is no linked PR (gate clears for both gates).
+	PRMergeNoPR PRMergeStatus = iota
+	// PRMergeUnsettled indicates a transient state; both gates block and re-evaluate
+	// on the next poll without label churn (ADR-032 R10c).
+	PRMergeUnsettled
+	// PRMergeReady indicates CI has passed (or there is no CI); the merge gate clears.
+	PRMergeReady
+	// PRMergeConflicting indicates the PR cannot be merged due to a base-branch
+	// conflict; checkMergeabilityGate applies fabrik:rebase-needed.
+	PRMergeConflicting
+	// PRMergeBlocked indicates CI checks have failed.
+	PRMergeBlocked
+	// PRMergeTerminal indicates the PR is already merged or closed; both gates clear.
+	PRMergeTerminal
+)
+
+// PRSettleResult is the output of settlePRMergeState.
+type PRSettleResult struct {
+	Status         PRMergeStatus
+	Reason         string
+	MergeableState string // raw mergeable_state; used by checkCIGate R3 timeout path
+	CheckRuns      []gh.CheckRun
+	PR             *gh.PRDetails
+}
+
+// settlePRMergeState fetches all PR merge/CI state in a single pass and returns
+// a typed PRSettleResult. Called once per poll cycle from poll.go; both
+// checkMergeabilityGate and checkCIGate receive the result, ensuring they see
+// identical GitHub state within a single poll cycle.
+//
+// The stage parameter is accepted for API consistency (callers already have it)
+// but is not used by the primitive itself; gating on WaitForCI is the caller's
+// responsibility.
+func (e *Engine) settlePRMergeState(item gh.ProjectItem, _ *stages.Stage) PRSettleResult {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
+
+	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
+	if err != nil {
+		e.logf(item.Number, "settle", "could not fetch linked PR: %v — treating as unsettled\n", err)
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: fmt.Sprintf("FetchLinkedPR error: %v", err)}
+	}
+	if pr == nil || pr.Number == 0 {
+		return PRSettleResult{Status: PRMergeNoPR, Reason: "no linked PR"}
+	}
+
+	if pr.Merged {
+		return PRSettleResult{Status: PRMergeTerminal, Reason: fmt.Sprintf("PR #%d already merged", pr.Number), PR: pr}
+	}
+	if pr.State == "closed" {
+		return PRSettleResult{Status: PRMergeTerminal, Reason: fmt.Sprintf("PR #%d closed without merging", pr.Number), PR: pr}
+	}
+
+	mergeable, mergeableState, err := e.readClient.FetchPRMergeableFields(owner, repo, pr.Number)
+	if err != nil {
+		e.logf(item.Number, "settle", "could not fetch PR #%d mergeable fields: %v — treating as unsettled\n", pr.Number, err)
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: fmt.Sprintf("FetchPRMergeableFields error: %v", err), PR: pr}
+	}
+
+	if mergeable == nil {
+		e.logf(item.Number, "settle", "PR #%d mergeable=null — GitHub still computing\n", pr.Number)
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: "mergeable=null (GitHub computing)", MergeableState: mergeableState, PR: pr}
+	}
+	if mergeableState == "unknown" {
+		e.logf(item.Number, "settle", "PR #%d mergeable_state=unknown — transient\n", pr.Number)
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: "mergeable_state=unknown", MergeableState: mergeableState, PR: pr}
+	}
+	if !*mergeable {
+		e.logf(item.Number, "settle", "PR #%d not mergeable (base conflict)\n", pr.Number)
+		return PRSettleResult{Status: PRMergeConflicting, Reason: "mergeable=false", MergeableState: mergeableState, PR: pr}
+	}
+
+	// ADR-033: mergeable_state ∈ {clean, unstable} → branch protection satisfied;
+	// skip per-check classification to avoid blocking on non-required workflows.
+	if gh.MergeableStateAccepted(mergeableState) {
+		e.logf(item.Number, "settle", "PR #%d mergeable_state=%q — ready\n", pr.Number, mergeableState)
+		return PRSettleResult{Status: PRMergeReady, Reason: fmt.Sprintf("mergeable_state=%q", mergeableState), MergeableState: mergeableState, PR: pr}
+	}
+
+	if pr.HeadSHA == "" {
+		e.logf(item.Number, "settle", "PR #%d HeadSHA empty — treating as unsettled\n", pr.Number)
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: "HeadSHA empty", MergeableState: mergeableState, PR: pr}
+	}
+
+	checkRuns, err := e.readClient.FetchCheckRuns(owner, repo, pr.HeadSHA)
+	if err != nil {
+		e.logf(item.Number, "settle", "could not fetch check runs for SHA %s: %v — treating as unsettled\n",
+			pr.HeadSHA[:min(8, len(pr.HeadSHA))], err)
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: fmt.Sprintf("FetchCheckRuns error: %v", err), MergeableState: mergeableState, PR: pr}
+	}
+
+	if len(checkRuns) > 0 {
+		e.store.Apply(itemstate.PRChecksObserved{
+			Repo:   itemRepo,
+			Number: item.Number,
+		})
+	}
+
+	if len(checkRuns) == 0 {
+		var hadChecks bool
+		var lpr *itemstate.LinkedPRState
+		if snap, snapErr := e.store.Get(itemRepo, item.Number); snapErr == nil {
+			lpr = snap.LinkedPR()
+			if lpr != nil {
+				hadChecks = lpr.HasHadChecks
+			}
+		}
+
+		if hadChecks {
+			e.logf(item.Number, "settle", "no check runs for SHA %s — post-push registration delay\n",
+				pr.HeadSHA[:min(8, len(pr.HeadSHA))])
+			return PRSettleResult{Status: PRMergeUnsettled, Reason: "post-push registration delay (hadChecks)", MergeableState: mergeableState, PR: pr}
+		}
+
+		if lpr != nil && !lpr.LastHeadSHAUpdate.IsZero() {
+			dwell := e.cfg.PostPushDwell
+			if dwell <= 0 {
+				dwell = 90 * time.Second
+			}
+			if elapsed := time.Since(lpr.LastHeadSHAUpdate); elapsed < dwell {
+				e.logf(item.Number, "settle", "no check runs for SHA %s — post-push dwell active (%.0fs remaining)\n",
+					pr.HeadSHA[:min(8, len(pr.HeadSHA))], (dwell-elapsed).Seconds())
+				return PRSettleResult{Status: PRMergeUnsettled, Reason: "post-push dwell active", MergeableState: mergeableState, PR: pr}
+			}
+		}
+
+		// R3 (BLOCKED+no-checks) and non-check branch-protection signals: return
+		// Unsettled so checkCIGate can apply its timeout escalation using MergeableState.
+		if mergeableState != "" && mergeableState != "unknown" {
+			e.logf(item.Number, "settle", "no check runs — mergeable_state=%q (R3 / branch-protection signal)\n", mergeableState)
+			return PRSettleResult{Status: PRMergeUnsettled, Reason: fmt.Sprintf("no check runs, mergeable_state=%q", mergeableState), MergeableState: mergeableState, PR: pr}
+		}
+
+		e.logf(item.Number, "settle", "no check runs for SHA %s — no CI configured\n",
+			pr.HeadSHA[:min(8, len(pr.HeadSHA))])
+		return PRSettleResult{Status: PRMergeReady, Reason: "no CI configured", MergeableState: mergeableState, PR: pr}
+	}
+
+	// Classify check runs: pending → Unsettled, any failed → Blocked, all green → Ready.
+	var hasPending, hasFailed bool
+	for _, cr := range checkRuns {
+		switch cr.Status {
+		case "queued", "in_progress":
+			hasPending = true
+		case "completed":
+			switch cr.Conclusion {
+			case "failure", "timed_out", "action_required":
+				hasFailed = true
+			}
+		}
+	}
+
+	if hasFailed {
+		return PRSettleResult{Status: PRMergeBlocked, Reason: "CI checks failed", MergeableState: mergeableState, CheckRuns: checkRuns, PR: pr}
+	}
+	if hasPending {
+		return PRSettleResult{Status: PRMergeUnsettled, Reason: "CI checks pending", MergeableState: mergeableState, CheckRuns: checkRuns, PR: pr}
+	}
+	return PRSettleResult{Status: PRMergeReady, Reason: "all CI checks passed", MergeableState: mergeableState, CheckRuns: checkRuns, PR: pr}
+}

--- a/engine/pr_settle_test.go
+++ b/engine/pr_settle_test.go
@@ -229,9 +229,8 @@ func TestSettle_PostPushHadChecks_ReturnsUnsettled(t *testing.T) {
 }
 
 func TestSettle_PostPushDwellActive_ReturnsUnsettled(t *testing.T) {
-	// SHA updated 5 seconds ago; dwell = 30s → still within window.
-	shaUpdateTime := time.Now().Add(-5 * time.Second)
-
+	// Apply two PRHeadSHAUpdated events to stamp LastHeadSHAUpdate (store only stamps
+	// when SHA actually changes from a non-empty value).
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha-new"}, nil
@@ -246,14 +245,11 @@ func TestSettle_PostPushDwellActive_ReturnsUnsettled(t *testing.T) {
 	eng := testEngineForMerge(t, client)
 	eng.cfg.PostPushDwell = 30 * time.Second
 
-	// Seed LastHeadSHAUpdate via a PRHeadSHAUpdated mutation.
-	eng.store.Apply(itemstate.PRHeadSHAUpdated{
-		Repo:    "owner/repo",
-		Number:  1,
-		HeadSHA: "sha-new",
-		At:      shaUpdateTime,
-	})
+	// Seed initial SHA, then the new SHA — the second apply stamps LastHeadSHAUpdate.
+	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-initial"})
+	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-new"})
 
+	// Call immediately — well within the 30s dwell.
 	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
 	if r.Status != PRMergeUnsettled {
 		t.Errorf("expected PRMergeUnsettled during post-push dwell window, got %v", r.Status)
@@ -261,9 +257,6 @@ func TestSettle_PostPushDwellActive_ReturnsUnsettled(t *testing.T) {
 }
 
 func TestSettle_PostPushDwellElapsed_ReturnsReady(t *testing.T) {
-	// SHA updated 120 seconds ago; dwell = 30s → window elapsed.
-	shaUpdateTime := time.Now().Add(-120 * time.Second)
-
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
 			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha-new"}, nil
@@ -276,14 +269,13 @@ func TestSettle_PostPushDwellElapsed_ReturnsReady(t *testing.T) {
 		},
 	}
 	eng := testEngineForMerge(t, client)
-	eng.cfg.PostPushDwell = 30 * time.Second
+	// Sub-nanosecond dwell so it elapses immediately after stamping.
+	eng.cfg.PostPushDwell = 1 * time.Nanosecond
 
-	eng.store.Apply(itemstate.PRHeadSHAUpdated{
-		Repo:    "owner/repo",
-		Number:  1,
-		HeadSHA: "sha-new",
-		At:      shaUpdateTime,
-	})
+	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-initial"})
+	eng.store.Apply(itemstate.PRHeadSHAUpdated{Repo: "owner/repo", Number: 1, SHA: "sha-new"})
+	// Brief sleep so even low-resolution clocks see the dwell elapsed.
+	time.Sleep(20 * time.Millisecond)
 
 	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
 	if r.Status != PRMergeReady {

--- a/engine/pr_settle_test.go
+++ b/engine/pr_settle_test.go
@@ -1,0 +1,483 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// settleItem returns a minimal ProjectItem for settling tests.
+func settleItem(n int) gh.ProjectItem {
+	return gh.ProjectItem{Number: n, Repo: "owner/repo"}
+}
+
+// ── No PR ─────────────────────────────────────────────────────────────────────
+
+func TestSettle_NoPR_ReturnsNoPR(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeNoPR {
+		t.Errorf("expected PRMergeNoPR, got %v", r.Status)
+	}
+}
+
+func TestSettle_ZeroPR_ReturnsNoPR(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 0}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeNoPR {
+		t.Errorf("expected PRMergeNoPR for PR.Number==0, got %v", r.Status)
+	}
+}
+
+func TestSettle_FetchLinkedPRError_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, errors.New("network error")
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled on FetchLinkedPR error, got %v", r.Status)
+	}
+}
+
+// ── Terminal states ───────────────────────────────────────────────────────────
+
+func TestSettle_PRMerged_ReturnsTerminal(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, Merged: true, State: "closed"}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeTerminal {
+		t.Errorf("expected PRMergeTerminal for merged PR, got %v", r.Status)
+	}
+	if r.PR == nil || r.PR.Number != 5 {
+		t.Error("expected PR details in result")
+	}
+}
+
+func TestSettle_PRClosedNotMerged_ReturnsTerminal(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, Merged: false, State: "closed"}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeTerminal {
+		t.Errorf("expected PRMergeTerminal for closed PR, got %v", r.Status)
+	}
+}
+
+// ── Transient/null mergeable states ──────────────────────────────────────────
+
+func TestSettle_MergeableNil_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return nil, "", nil // GitHub still computing
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled when mergeable=nil, got %v", r.Status)
+	}
+}
+
+func TestSettle_MergeableStateUnknown_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			t2 := true
+			return &t2, "unknown", nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled for mergeable_state=unknown, got %v", r.Status)
+	}
+	if r.MergeableState != "unknown" {
+		t.Errorf("expected MergeableState=unknown, got %q", r.MergeableState)
+	}
+}
+
+func TestSettle_FetchMergeableFieldsError_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return nil, "", errors.New("timeout")
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled on FetchPRMergeableFields error, got %v", r.Status)
+	}
+}
+
+// ── Conflict ──────────────────────────────────────────────────────────────────
+
+func TestSettle_MergeableFalse_ReturnsConflicting(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(false), "dirty", nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeConflicting {
+		t.Errorf("expected PRMergeConflicting for mergeable=false, got %v", r.Status)
+	}
+	if r.MergeableState != "dirty" {
+		t.Errorf("expected MergeableState=dirty, got %q", r.MergeableState)
+	}
+}
+
+// ── ADR-033 shortcut (clean/unstable) ─────────────────────────────────────────
+
+func TestSettle_MergeableStateClean_ReturnsReady(t *testing.T) {
+	fetchCheckRunsCalled := false
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "clean", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			fetchCheckRunsCalled = true
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeReady {
+		t.Errorf("expected PRMergeReady for mergeable_state=clean, got %v", r.Status)
+	}
+	if fetchCheckRunsCalled {
+		t.Error("FetchCheckRuns must NOT be called when mergeable_state=clean (ADR-033 shortcut)")
+	}
+}
+
+func TestSettle_MergeableStateUnstable_ReturnsReady(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "unstable", nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeReady {
+		t.Errorf("expected PRMergeReady for mergeable_state=unstable, got %v", r.Status)
+	}
+}
+
+// ── Post-push dwell and registration delay ────────────────────────────────────
+
+func TestSettle_PostPushHadChecks_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha-new"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil // no checks yet for new SHA
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	// Pre-seed: issue has previously had check runs (hadChecks=true).
+	eng.store.Apply(itemstate.PRChecksObserved{Repo: "owner/repo", Number: 1})
+
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled for post-push registration delay (hadChecks), got %v", r.Status)
+	}
+}
+
+func TestSettle_PostPushDwellActive_ReturnsUnsettled(t *testing.T) {
+	// SHA updated 5 seconds ago; dwell = 30s → still within window.
+	shaUpdateTime := time.Now().Add(-5 * time.Second)
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha-new"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	eng.cfg.PostPushDwell = 30 * time.Second
+
+	// Seed LastHeadSHAUpdate via a PRHeadSHAUpdated mutation.
+	eng.store.Apply(itemstate.PRHeadSHAUpdated{
+		Repo:    "owner/repo",
+		Number:  1,
+		HeadSHA: "sha-new",
+		At:      shaUpdateTime,
+	})
+
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled during post-push dwell window, got %v", r.Status)
+	}
+}
+
+func TestSettle_PostPushDwellElapsed_ReturnsReady(t *testing.T) {
+	// SHA updated 120 seconds ago; dwell = 30s → window elapsed.
+	shaUpdateTime := time.Now().Add(-120 * time.Second)
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha-new"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	eng.cfg.PostPushDwell = 30 * time.Second
+
+	eng.store.Apply(itemstate.PRHeadSHAUpdated{
+		Repo:    "owner/repo",
+		Number:  1,
+		HeadSHA: "sha-new",
+		At:      shaUpdateTime,
+	})
+
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeReady {
+		t.Errorf("expected PRMergeReady after post-push dwell elapsed, got %v", r.Status)
+	}
+}
+
+// ── R3: BLOCKED + no checks ───────────────────────────────────────────────────
+
+func TestSettle_BlockedNoChecks_ReturnsUnsettled(t *testing.T) {
+	// mergeableState=blocked, no checks, no hadChecks, no dwell — R3 path.
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled for BLOCKED+no-checks (R3), got %v", r.Status)
+	}
+	if r.MergeableState != "blocked" {
+		t.Errorf("expected MergeableState=blocked in result, got %q", r.MergeableState)
+	}
+}
+
+// ── No CI configured ─────────────────────────────────────────────────────────
+
+func TestSettle_NoCheckRuns_NoCI_ReturnsReady(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	// No hadChecks, no dwell, mergeableState="" → no CI configured.
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeReady {
+		t.Errorf("expected PRMergeReady for no check runs (no CI), got %v", r.Status)
+	}
+}
+
+// ── FetchCheckRuns error ──────────────────────────────────────────────────────
+
+func TestSettle_FetchCheckRunsError_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return nil, errors.New("API error")
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled on FetchCheckRuns error, got %v", r.Status)
+	}
+}
+
+// ── Check run classification ──────────────────────────────────────────────────
+
+func TestSettle_AllChecksGreen_ReturnsReady(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "completed", Conclusion: "success"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeReady {
+		t.Errorf("expected PRMergeReady for all-green checks, got %v", r.Status)
+	}
+	if len(r.CheckRuns) != 2 {
+		t.Errorf("expected 2 check runs in result, got %d", len(r.CheckRuns))
+	}
+}
+
+func TestSettle_ChecksPending_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "in_progress"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled for pending checks, got %v", r.Status)
+	}
+}
+
+func TestSettle_ChecksFailed_ReturnsBlocked(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "failure"},
+				{Name: "test", Status: "completed", Conclusion: "success"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeBlocked {
+		t.Errorf("expected PRMergeBlocked for failed checks, got %v", r.Status)
+	}
+	if len(r.CheckRuns) != 2 {
+		t.Errorf("expected 2 check runs in result, got %d", len(r.CheckRuns))
+	}
+}
+
+func TestSettle_ChecksFailedWithTimedOut_ReturnsBlocked(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "ci", Status: "completed", Conclusion: "timed_out"},
+			}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeBlocked {
+		t.Errorf("expected PRMergeBlocked for timed_out check, got %v", r.Status)
+	}
+}
+
+// ── PRChecksObserved applied on non-empty check runs ─────────────────────────
+
+func TestSettle_NonEmptyCheckRuns_AppliesPRChecksObserved(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 5, State: "open", HeadSHA: "sha1"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return boolPtr(true), "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{{Name: "build", Status: "completed", Conclusion: "success"}}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+
+	// Verify that HasHadChecks was recorded (PRChecksObserved applied).
+	snap, err := eng.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	lpr := snap.LinkedPR()
+	if lpr == nil || !lpr.HasHadChecks {
+		t.Error("expected HasHadChecks=true after settle with non-empty check runs")
+	}
+}

--- a/github/prs.go
+++ b/github/prs.go
@@ -91,6 +91,23 @@ type PRDetails struct {
 	AutoMergeEnabled bool
 }
 
+// FetchPRMergeableFields fetches both the mergeable flag and mergeable_state for
+// a single PR in one REST call, eliminating the read-after-write window that
+// existed when the two fields were fetched separately by different gate functions.
+//
+// Returns (nil, "", nil) when mergeable is null (GitHub still computing).
+func (c *Client) FetchPRMergeableFields(owner, repo string, prNumber int) (mergeable *bool, mergeableState string, err error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
+	var raw struct {
+		Mergeable      *bool  `json:"mergeable"`
+		MergeableState string `json:"mergeable_state"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		return nil, "", fmt.Errorf("fetching PR #%d mergeable fields: %w", prNumber, err)
+	}
+	return raw.Mergeable, raw.MergeableState, nil
+}
+
 // FetchPRMergeable returns GitHub's mergeable flag for a single PR.
 //
 // The returned pointer is nil when GitHub has not yet computed mergeability


### PR DESCRIPTION
Closes #888

## What this PR does

Introduces `settlePRMergeState()` — a single `Engine` method that reads `mergeable`, `mergeable_state`, and check runs in **one pass** before both the merge-conflict gate and the CI gate. Both gates receive an identical `PRSettleResult` for the same poll cycle, eliminating the split-brain where two separate REST calls could observe different GitHub state.

## Key changes

**New primitive (`engine/pr_settle.go`)**
- `PRMergeStatus` type with six constants: `PRMergeNoPR`, `PRMergeUnsettled`, `PRMergeReady`, `PRMergeConflicting`, `PRMergeBlocked`, `PRMergeTerminal`
- `PRSettleResult` struct carrying `Status`, `Reason`, `CheckRuns`, and `PR`
- `settlePRMergeState()` applies settling rules in order: terminal state → combined `FetchPRMergeableFields` call → `clean`/`unstable` shortcut → hadChecks/dwell guards → conflict/unsettled classification
- `MergeableState` intentionally omitted from hadChecks/dwell/HeadSHA-empty results so R3 cannot misfire on those cases

**Combined REST method (`github/prs.go`, interfaces, boardcache)**
- `FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error)` decodes both `mergeable` and `mergeable_state` in one HTTP call to `/pulls/{N}`, replacing the two separate `FetchPRMergeable`/`FetchPRMergeableState` calls that created the read-after-write window

**Gate refactors**
- `checkMergeabilityGate`: signature adds `settle PRSettleResult`; switches on `settle.Status` instead of making REST calls
- `checkCIGate`: signature adds `settle PRSettleResult`; interprets `settle.Status`, `settle.CheckRuns`, `settle.MergeableState`; all gate-decision REST calls removed
- `dispatchCIFixReinvoke`/`buildCIFixComment`: thread `settle PRSettleResult` so PR-head check runs come from `settle.CheckRuns` (no redundant fetch); base-branch `FetchCheckRuns(baseSHA)` remains as a non-gate diagnostic read
- `poll.go`: calls `settlePRMergeState` once, passes result to both gates

**Tests (`engine/pr_settle_test.go`)**
Unit tests pin all four transient-window scenarios from #779/#845/#855/#871: post-push dwell active/elapsed, `mergeable == nil`, `mergeable == false`, merged/closed PR, blocked+empty+hadChecks, `clean`/`unstable`, checks failed/pending/green.

**Docs**
- `docs/state-machine.md`: new §6.4 "PR Merge State Settling Primitive" (six constants, settling rules table, `MergeableState` omission invariant, `FetchCheckRuns` consolidation note); §6.5–6.8 renumbered from prior §6.4–6.7; §2.10/§2.11 code path descriptions updated
- `docs/llms-full.txt`: regenerated

## Non-gate diagnostic reads (acknowledged, unchanged)
- `engine/ci.go:266` — `buildCIFixComment` fetches base-branch check runs by base SHA for regression classification; structurally independent (different SHA)
- `engine/merge_gate.go:390` — `pauseForConvergenceFailed` inside `checkAutoMergeConvergence` (explicitly out-of-scope per spec)

## How to test
- `go test -race ./engine/... ./github/... ./boardcache/...` — all pass
- `go vet ./...` — clean
- The pre-existing `TestExecute_ConfigYAMLApplied` SIGINT timing failure in `cmd/` is unrelated to this change and reproducible on `main` before any modifications

**References:** ADR-056 (D1 implementation), ADR-033 (unchanged), ADR-032 (R10c preserved), ADR-028 (gate semantics preserved). Sequenced after #828 per dependency graph.