### PR TITLE
test(e2e): add TestCIFixReinvoke and TestCIFixReinvokeCycleLimit

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -56,6 +56,23 @@ These tests assume:
 See `~/fabrik-oss-launch-notes.md` (under "Files and where they live") for
 the canonical setup.
 
+### Additional prerequisites for `TestCIFixReinvoke` and `TestCIFixReinvokeCycleLimit`
+
+5. **`ci-fix-sentinel` enrolled as a required status check** on
+   `handarbeit/fabrik-test-alpha/main`. Both tests skip gracefully (via
+   `t.Skip`) if this check is not enrolled — safe to merge before the sibling
+   sub-issue adds the sentinel CI job.
+6. **`FABRIK_MAX_CI_FIX_CYCLES=2` in the test bed `.env`** (for
+   `TestCIFixReinvokeCycleLimit` only). The test skips with an instructional
+   message if the value is `> 3`. After editing `.env`, restart the test-bed
+   Fabrik instance so the new value takes effect.
+7. **`E2E_TIMEOUT=3h`** when running `TestCIFixReinvoke` in isolation — the
+   inner waits alone total ~75–90 min, which exceeds the default `90m` budget
+   once pipeline setup overhead is included:
+   ```bash
+   E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestCIFixReinvoke
+   ```
+
 ## Running
 
 The recommended entrypoint is the runner script, which sets sensible defaults:
@@ -98,8 +115,10 @@ otherwise).
 | `TestCrossRepoSpawn` | Cross-repo decomposition (spawn child in beta, gate parent, resume on close) | 45–60 min | $1.00–2.00 |
 | `TestYoloAutoMergeLabel` | `fabrik:yolo` auto-advance to Done via GitHub native auto-merge; timeline-verifies `fabrik:auto-merge-enabled` was applied | 20–40 min | $0.50–1.50 |
 | `TestCruiseFullPipeline` | `fabrik:cruise` auto-advances to Validate-complete without auto-merge; PR merged by human closes issue | 30–50 min | $0.80–2.00 |
+| `TestCIFixReinvoke` | CI-fix reinvoke positive path: sentinel fails on first push, Claude fixes, CI passes, issue closes | 75–90 min | $1.00–3.00 |
+| `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | 30–60 min | $0.50–1.50 |
 
-Approximate suite total: ~150 min wall-clock, $4–12 in Claude tokens.
+Approximate suite total: ~250 min wall-clock, $5–17 in Claude tokens (CI-fix tests should be run separately with `E2E_TIMEOUT=3h`).
 
 ### Regression coverage map
 
@@ -112,6 +131,8 @@ Approximate suite total: ~150 min wall-clock, $4–12 in Claude tokens.
 | `TestCrossRepoSpawn` | #797 / #803 (on-demand spawn-target init), v0.0.66 spawn machinery, #800 (addBlockedBy mutation name) |
 | `TestYoloAutoMergeLabel` | #829 (GitHub native auto-merge for yolo), #831/#835/#871 (convergence regression cascade) |
 | `TestCruiseFullPipeline` | #898 (cruise/yolo gate at Validate, `engine/poll.go`); ensures cruise never triggers `checkAutoMergeConvergence` |
+| `TestCIFixReinvoke` | #888 ADR-056 D1 (settling primitive reinterprets CI-gate signals); CI-fix reinvoke loop (engine/ci.go) |
+| `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
 
 Every escape-from-release regression earns a new scenario in this table.
 

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -55,7 +55,13 @@ func TestCIFixReinvoke(t *testing.T) {
 	// 2-minute withheld window: Validate must NOT complete while CI is failing.
 	withheldDeadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(withheldDeadline) {
-		for _, l := range IssueLabels(t, env, env.RepoAlpha, num) {
+		labels, err := tryIssueLabels(env, env.RepoAlpha, num)
+		if err != nil {
+			t.Logf("transient error fetching labels during withheld window: %v (retrying)", err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		for _, l := range labels {
 			if l == "stage:Validate:complete" {
 				t.Fatalf("stage:Validate:complete appeared during withheld window — CI gate did not hold on %s#%d",
 					env.RepoAlpha, num)
@@ -72,8 +78,9 @@ func TestCIFixReinvoke(t *testing.T) {
 		"🏭 **Fabrik — stage: Validate**", 10*time.Minute)
 	t.Logf("CI-fix reinvoke confirmed via second Validate PR comment on #%d", prNumber)
 
-	// Poll until all non-null CI check conclusions are "success".
+	// Poll until all CI check conclusions are "success" (pending = still running).
 	ciDeadline := time.Now().Add(20 * time.Minute)
+	ciPassed := false
 	for time.Now().Before(ciDeadline) {
 		conclusions, err := tryPRCheckRunConclusions(env, env.RepoAlpha, prNumber)
 		if err != nil {
@@ -90,10 +97,14 @@ func TestCIFixReinvoke(t *testing.T) {
 			}
 			if allSuccess {
 				t.Logf("all CI checks passed on PR #%d: %v", prNumber, conclusions)
+				ciPassed = true
 				break
 			}
 		}
 		time.Sleep(30 * time.Second)
+	}
+	if !ciPassed {
+		t.Fatalf("timed out waiting for all CI checks to pass on PR #%d", prNumber)
 	}
 
 	// Issue must close (Validate completes and yolo auto-merges the PR).

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -3,7 +3,9 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -112,6 +114,84 @@ func TestCIFixReinvoke(t *testing.T) {
 	t.Logf("commit count guard passed: %d commits (base=%d + 1 CI-fix)", finalCommits, baseCommits)
 }
 
+// TestCIFixReinvokeCycleLimit is the negative-path regression test for the
+// CI-fix reinvoke cycle limit (engine/ci.go: pauseForCIFixCycleLimit).
+// The sentinel CI job is permanently failing for this issue — Claude cannot fix
+// it — so the engine must exhaust MaxCiFixCycles and pause the issue.
+//
+// Pass criteria:
+//   - fabrik:awaiting-ci appears (CI gate fires).
+//   - fabrik:paused and fabrik:awaiting-input appear (cycle limit reached).
+//   - Issue remains OPEN.
+//   - A "🏭 **Fabrik — CI fix cycle limit reached**" comment appears on the issue.
+//
+// Prerequisite: "ci-fix-sentinel" must be enrolled as a required status check
+// AND FABRIK_MAX_CI_FIX_CYCLES must be ≤ 3 (ideally 2) in the test bed .env.
+// The test skips with an instructional message if either condition is not met.
+//
+// Wall-clock: ~30–60 min. Cost: ~$0.50–1.50.
+func TestCIFixReinvokeCycleLimit(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	assertSentinelCheckRequired(t, env, env.RepoAlpha)
+
+	maxCycles := readEnvFileMaxCiFixCycles(t, env)
+	if maxCycles > 3 {
+		t.Skipf("FABRIK_MAX_CI_FIX_CYCLES=%d in test bed .env (must be ≤3 for this test — set to 2 and restart Fabrik)", maxCycles)
+	}
+	t.Logf("FABRIK_MAX_CI_FIX_CYCLES=%d — cycle limit test will fire after %d failed attempts", maxCycles, maxCycles)
+
+	stamp := time.Now().UTC().Format("20060102-150405")
+	title := fmt.Sprintf("e2e ci-fix-cycle-limit (%s)", stamp)
+
+	num := FileIssue(t, env, env.RepoAlpha, title, ciFixCycleLimitBody, "fabrik:yolo")
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d", env.RepoAlpha, num)
+
+	// CI gate fires, then engine exhausts reinvoke cycles and pauses.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 90*time.Minute)
+	t.Logf("fabrik:awaiting-ci appeared on %s#%d", env.RepoAlpha, num)
+
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:paused", 90*time.Minute)
+	t.Logf("fabrik:paused appeared on %s#%d (cycle limit reached)", env.RepoAlpha, num)
+
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 5*time.Minute)
+	t.Logf("fabrik:awaiting-input appeared on %s#%d", env.RepoAlpha, num)
+
+	if state := IssueState(t, env, env.RepoAlpha, num); state != "OPEN" {
+		t.Fatalf("expected issue OPEN after cycle limit, got %s", state)
+	}
+
+	// The engine posts the cycle-limit message directly to the issue (not the PR).
+	cycleDeadline := time.Now().Add(5 * time.Minute)
+	found := false
+	for time.Now().Before(cycleDeadline) {
+		out, err := ghOutput(env, "issue", "view", fmt.Sprint(num), "-R", env.RepoAlpha,
+			"--json", "comments", "--jq", "[.comments[].body]")
+		if err == nil {
+			var bodies []string
+			if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &bodies); jsonErr == nil {
+				for _, b := range bodies {
+					if strings.Contains(b, "🏭 **Fabrik — CI fix cycle limit reached**") {
+						found = true
+						break
+					}
+				}
+			}
+		}
+		if found {
+			break
+		}
+		time.Sleep(15 * time.Second)
+	}
+	if !found {
+		t.Fatalf("cycle limit comment not found on %s#%d after 5 minutes", env.RepoAlpha, num)
+	}
+	t.Logf("cycle limit comment confirmed on %s#%d — CI-fix cycle limit regression guard passed", env.RepoAlpha, num)
+}
+
 // ciFixReinvokeBody is the issue body for TestCIFixReinvoke. The PR body must
 // contain "ci-fix-sentinel-required" so the test-alpha CI workflow triggers the
 // sentinel check (which fails on the first push, requiring a fix commit).
@@ -153,4 +233,38 @@ ci-fix-sentinel-required
 
 Single file (README.md). No other changes. No decomposition. Plan and Implement
 should be minimal — one commit on the initial push, one CI-fix commit.
+`
+
+// ciFixCycleLimitBody is the issue body for TestCIFixReinvokeCycleLimit. The
+// PR body must contain "ci-fix-sentinel-unfixable" so the test-alpha CI
+// workflow runs a permanently-failing sentinel check regardless of content.
+// Claude will attempt to fix CI on each reinvoke but cannot succeed.
+const ciFixCycleLimitBody = `## Goal
+
+End-to-end regression test for the Fabrik CI-fix cycle limit
+(handarbeit/fabrik#900). This issue is designed to exhaust MaxCiFixCycles
+by running an unfixable CI check.
+
+## The change
+
+Add exactly one new HTML comment to README.md, on its own line, immediately
+after the line containing "# fabrik-test-alpha". The comment must be:
+
+    <!-- ci-fix-cycle-limit-test -->
+
+This is the only change needed. Do NOT attempt to remove or alter the CI
+sentinel marker in the PR body — the sentinel is intentionally unfixable
+at the code level. Make your best effort on each CI-fix reinvoke, but the
+test expects the cycle limit to be reached.
+
+## CI behaviour required
+
+The PR body MUST carry the literal marker below so the test repo's CI
+permanently-failing sentinel fires:
+
+ci-fix-sentinel-unfixable
+
+## Scope
+
+Single file (README.md). Minimal change. No decomposition.
 `

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -1,0 +1,156 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestCIFixReinvoke is the positive-path regression test for the CI-fix
+// reinvoke loop (engine/ci.go). The sentinel CI job "ci-fix-sentinel" in
+// handarbeit/fabrik-test-alpha fails on the first push but passes after a
+// trivial fix commit — exercising the full failure → reinvoke → recovery path.
+//
+// Pass criteria:
+//   - fabrik:awaiting-ci appears after Validate (CI gate holds).
+//   - stage:Validate:complete does NOT appear during the 2-minute withheld window.
+//   - A second "🏭 **Fabrik — stage: Validate**" PR comment appears (reinvoke fired).
+//   - CI eventually passes and the issue closes.
+//   - The PR has exactly baseCommits+1 commits (one CI-fix commit; no rebase storm).
+//
+// Prerequisite: "ci-fix-sentinel" must be enrolled as a required status check
+// on handarbeit/fabrik-test-alpha/main. The test skips gracefully if not.
+//
+// Wall-clock: ~75–90 min when run in isolation. Use E2E_TIMEOUT=3h.
+// Cost: ~$1–3.
+func TestCIFixReinvoke(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	assertSentinelCheckRequired(t, env, env.RepoAlpha)
+
+	stamp := time.Now().UTC().Format("20060102-150405")
+	title := fmt.Sprintf("e2e ci-fix-reinvoke (%s)", stamp)
+
+	num := FileIssue(t, env, env.RepoAlpha, title, ciFixReinvokeBody, "fabrik:yolo")
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d", env.RepoAlpha, num)
+
+	// Wait for Implement to complete, then capture baseline commit count.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Implement:complete", 60*time.Minute)
+	prNumber := LinkedPRNumber(t, env, env.RepoAlpha, num)
+	baseCommits := PRCommitCount(t, env, env.RepoAlpha, prNumber)
+	t.Logf("PR #%d has %d commits at baseline (before Validate)", prNumber, baseCommits)
+
+	// Validate fires, CI fails, engine adds fabrik:awaiting-ci.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 30*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci")
+	t.Logf("fabrik:awaiting-ci confirmed on %s#%d", env.RepoAlpha, num)
+
+	// 2-minute withheld window: Validate must NOT complete while CI is failing.
+	withheldDeadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(withheldDeadline) {
+		for _, l := range IssueLabels(t, env, env.RepoAlpha, num) {
+			if l == "stage:Validate:complete" {
+				t.Fatalf("stage:Validate:complete appeared during withheld window — CI gate did not hold on %s#%d",
+					env.RepoAlpha, num)
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Logf("withheld window passed: CI gate held for 2 minutes on %s#%d", env.RepoAlpha, num)
+
+	// A second Validate comment on the PR confirms the CI-fix reinvoke fired.
+	// (The first "🏭 **Fabrik — stage: Validate**" comment is from the initial
+	// Validate run; the reinvoke posts a second one.)
+	WaitForPRCommentContaining(t, env, env.RepoAlpha, prNumber,
+		"🏭 **Fabrik — stage: Validate**", 10*time.Minute)
+	t.Logf("CI-fix reinvoke confirmed via second Validate PR comment on #%d", prNumber)
+
+	// Poll until all non-null CI check conclusions are "success".
+	ciDeadline := time.Now().Add(20 * time.Minute)
+	for time.Now().Before(ciDeadline) {
+		conclusions, err := tryPRCheckRunConclusions(env, env.RepoAlpha, prNumber)
+		if err != nil {
+			time.Sleep(30 * time.Second)
+			continue
+		}
+		if len(conclusions) > 0 {
+			allSuccess := true
+			for _, c := range conclusions {
+				if c != "success" {
+					allSuccess = false
+					break
+				}
+			}
+			if allSuccess {
+				t.Logf("all CI checks passed on PR #%d: %v", prNumber, conclusions)
+				break
+			}
+		}
+		time.Sleep(30 * time.Second)
+	}
+
+	// Issue must close (Validate completes and yolo auto-merges the PR).
+	WaitForIssueClosed(t, env, env.RepoAlpha, num, 30*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "stage:Validate:complete")
+	t.Logf("%s#%d closed with stage:Validate:complete", env.RepoAlpha, num)
+
+	// Rebase storm guard: expect exactly one CI-fix commit beyond baseline.
+	finalCommits := PRCommitCount(t, env, env.RepoAlpha, prNumber)
+	if finalCommits > baseCommits+1 {
+		t.Fatalf("rebase storm on PR #%d: expected %d commits, got %d",
+			prNumber, baseCommits+1, finalCommits)
+	}
+	if finalCommits != baseCommits+1 {
+		t.Fatalf("expected exactly 1 CI-fix commit on PR #%d: baseCommits=%d, finalCommits=%d",
+			prNumber, baseCommits, finalCommits)
+	}
+	t.Logf("commit count guard passed: %d commits (base=%d + 1 CI-fix)", finalCommits, baseCommits)
+}
+
+// ciFixReinvokeBody is the issue body for TestCIFixReinvoke. The PR body must
+// contain "ci-fix-sentinel-required" so the test-alpha CI workflow triggers the
+// sentinel check (which fails on the first push, requiring a fix commit).
+//
+// Claude is instructed to make a deterministic, reversible change to README.md
+// on the initial push (which will fail the sentinel), then push a second commit
+// that satisfies the sentinel condition when reinvoked.
+const ciFixReinvokeBody = `## Goal
+
+End-to-end regression test for the Fabrik CI-fix reinvoke loop (handarbeit/fabrik#900).
+
+## The change
+
+Add exactly one new HTML comment to README.md, on its own line, immediately
+after the line containing "# fabrik-test-alpha". The comment must be:
+
+    <!-- ci-fix-reinvoke-initial -->
+
+**On the initial Implement commit**: add only the HTML comment above. Do NOT
+make any other changes. The CI sentinel will fail on this commit.
+
+**When the CI-fix reinvoke fires** (you will be prompted with a message about
+CI failure): push a second commit that adds exactly one more line immediately
+below the first comment:
+
+    <!-- ci-fix-sentinel-satisfied -->
+
+This second commit makes the sentinel pass. Do not rebase or squash — the
+two commits must remain distinct so the e2e test can verify the commit count.
+
+## CI behaviour required
+
+The PR body MUST carry the literal marker below so the test repo's CI sentinel
+check fires (and initially fails):
+
+ci-fix-sentinel-required
+
+## Scope
+
+Single file (README.md). No other changes. No decomposition. Plan and Implement
+should be minimal — one commit on the initial push, one CI-fix commit.
+`

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -820,8 +820,9 @@ func WaitForPRCommentContaining(t *testing.T, env *Env, repo string, prNumber in
 }
 
 // tryPRCheckRunConclusions resolves the head SHA of the PR and returns the
-// conclusions for all completed check runs on that SHA. Returns (nil, err) on
-// any failure.
+// conclusion for every check run on that SHA. In-progress or queued runs map
+// to "pending" so callers can detect that checks are not yet settled.
+// Returns (nil, err) on any failure.
 func tryPRCheckRunConclusions(env *Env, repo string, prNumber int) ([]string, error) {
 	owner, name, ok := splitRepo(repo)
 	if !ok {
@@ -834,12 +835,12 @@ func tryPRCheckRunConclusions(env *Env, repo string, prNumber int) ([]string, er
 		return nil, fmt.Errorf("resolve head SHA: %w", err)
 	}
 	sha := strings.TrimSpace(shaOut)
-	if sha == "" {
+	if sha == "" || sha == "null" {
 		return nil, fmt.Errorf("empty head SHA for %s#%d", repo, prNumber)
 	}
 	checkOut, err := ghOutput(env, "api",
 		fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", owner, name, sha),
-		"--jq", "[.check_runs[] | select(.conclusion != null) | .conclusion]")
+		"--jq", "[.check_runs[] | .conclusion // \"pending\"]")
 	if err != nil {
 		return nil, fmt.Errorf("check runs: %w", err)
 	}
@@ -850,8 +851,8 @@ func tryPRCheckRunConclusions(env *Env, repo string, prNumber int) ([]string, er
 	return conclusions, nil
 }
 
-// PRCheckRunConclusions returns the non-null check-run conclusions for the PR's
-// head SHA. Fails the test on error.
+// PRCheckRunConclusions returns the check-run conclusions for the PR's head SHA
+// (in-progress runs appear as "pending"). Fails the test on error.
 func PRCheckRunConclusions(t *testing.T, env *Env, repo string, prNumber int) []string {
 	t.Helper()
 	conclusions, err := tryPRCheckRunConclusions(env, repo, prNumber)

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -776,3 +776,135 @@ func LinkedPRNumber(t *testing.T, env *Env, repo string, issueNumber int) int {
 	t.Fatalf("timed out waiting for linked PR on %s#%d", repo, issueNumber)
 	return 0
 }
+
+// tryPRComments returns the bodies of all comments on the given PR (using the
+// issues comments API, which covers both issues and PRs).
+func tryPRComments(env *Env, repo string, prNumber int) ([]string, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return nil, fmt.Errorf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, name, prNumber),
+		"--jq", "[.[].body]")
+	if err != nil {
+		return nil, err
+	}
+	var bodies []string
+	if uerr := json.Unmarshal([]byte(strings.TrimSpace(out)), &bodies); uerr != nil {
+		return nil, fmt.Errorf("parse PR comments: %w", uerr)
+	}
+	return bodies, nil
+}
+
+// WaitForPRCommentContaining polls PR comments every 15s until one contains
+// the given substring, or timeout expires.
+func WaitForPRCommentContaining(t *testing.T, env *Env, repo string, prNumber int, substring string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		bodies, err := tryPRComments(env, repo, prNumber)
+		if err != nil {
+			t.Logf("WaitForPRCommentContaining: transient error on %s#%d: %v (will retry)", repo, prNumber, err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		for _, b := range bodies {
+			if strings.Contains(b, substring) {
+				return
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for PR comment containing %q on %s#%d", substring, repo, prNumber)
+}
+
+// tryPRCheckRunConclusions resolves the head SHA of the PR and returns the
+// conclusions for all completed check runs on that SHA. Returns (nil, err) on
+// any failure.
+func tryPRCheckRunConclusions(env *Env, repo string, prNumber int) ([]string, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return nil, fmt.Errorf("bad repo: %q", repo)
+	}
+	shaOut, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d", owner, name, prNumber),
+		"--jq", ".head.sha")
+	if err != nil {
+		return nil, fmt.Errorf("resolve head SHA: %w", err)
+	}
+	sha := strings.TrimSpace(shaOut)
+	if sha == "" {
+		return nil, fmt.Errorf("empty head SHA for %s#%d", repo, prNumber)
+	}
+	checkOut, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", owner, name, sha),
+		"--jq", "[.check_runs[] | select(.conclusion != null) | .conclusion]")
+	if err != nil {
+		return nil, fmt.Errorf("check runs: %w", err)
+	}
+	var conclusions []string
+	if uerr := json.Unmarshal([]byte(strings.TrimSpace(checkOut)), &conclusions); uerr != nil {
+		return nil, fmt.Errorf("parse check runs: %w", uerr)
+	}
+	return conclusions, nil
+}
+
+// PRCheckRunConclusions returns the non-null check-run conclusions for the PR's
+// head SHA. Fails the test on error.
+func PRCheckRunConclusions(t *testing.T, env *Env, repo string, prNumber int) []string {
+	t.Helper()
+	conclusions, err := tryPRCheckRunConclusions(env, repo, prNumber)
+	if err != nil {
+		t.Fatalf("PRCheckRunConclusions %s#%d: %v", repo, prNumber, err)
+	}
+	return conclusions
+}
+
+// tryPRCommitCount returns the number of commits on the PR, or (0, err) on
+// failure.
+func tryPRCommitCount(env *Env, repo string, prNumber int) (int, error) {
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		return 0, fmt.Errorf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/%s/pulls/%d/commits", owner, name, prNumber),
+		"--jq", "length")
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse commit count %q: %w", out, err)
+	}
+	return n, nil
+}
+
+// PRCommitCount returns the number of commits on the PR. Fails the test on error.
+func PRCommitCount(t *testing.T, env *Env, repo string, prNumber int) int {
+	t.Helper()
+	n, err := tryPRCommitCount(env, repo, prNumber)
+	if err != nil {
+		t.Fatalf("PRCommitCount %s#%d: %v", repo, prNumber, err)
+	}
+	return n
+}
+
+// readEnvFileMaxCiFixCycles reads FABRIK_MAX_CI_FIX_CYCLES from the test bed's
+// .env file. Returns 5 (the engine default) if the key is absent. Fails the
+// test if the key is present but not a valid integer.
+func readEnvFileMaxCiFixCycles(t *testing.T, env *Env) int {
+	t.Helper()
+	envFile := filepath.Join(env.FabrikTestDir, ".env")
+	val, err := readEnvFileValue(envFile, "FABRIK_MAX_CI_FIX_CYCLES")
+	if err != nil {
+		// Key absent — return engine default.
+		return 5
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(val))
+	if err != nil {
+		t.Fatalf("FABRIK_MAX_CI_FIX_CYCLES in %s is not an integer: %q", envFile, val)
+	}
+	return n
+}

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -717,3 +717,62 @@ func resolveStatusOption(t *testing.T, env *Env, columnName string) (projectID, 
 	t.Fatalf("could not resolve Status option %q", columnName)
 	return "", "", ""
 }
+
+// assertSentinelCheckRequired skips the test if "ci-fix-sentinel" is not a
+// required status check on the repo's main branch. Skips (never fatals) so
+// the test suite remains green before the sentinel CI job is enrolled.
+func assertSentinelCheckRequired(t *testing.T, env *Env, repo string) {
+	t.Helper()
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		t.Fatalf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/%s/branches/main/protection", owner, name),
+		"--jq", ".required_status_checks.contexts[]")
+	if err != nil {
+		t.Skipf("ci-fix-sentinel not enrolled as required check on %s/main (branch protection API error: %v)", repo, err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "ci-fix-sentinel" {
+			return
+		}
+	}
+	t.Skipf("ci-fix-sentinel not in required status checks for %s/main — enroll it before running this test", repo)
+}
+
+// tryLinkedPRNumber returns the PR number for the given issue's feature branch,
+// or (0, err) if not yet created or on transient error.
+func tryLinkedPRNumber(env *Env, repo string, issueNumber int) (int, error) {
+	branch := fmt.Sprintf("fabrik/issue-%d", issueNumber)
+	out, err := ghOutput(env, "pr", "list", "-R", repo, "-H", branch,
+		"--json", "number", "--jq", ".[0].number")
+	if err != nil {
+		return 0, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return 0, fmt.Errorf("no PR for branch %s", branch)
+	}
+	n, err := strconv.Atoi(out)
+	if err != nil {
+		return 0, fmt.Errorf("parse PR number %q: %w", out, err)
+	}
+	return n, nil
+}
+
+// LinkedPRNumber polls until the linked PR for the issue is created, then
+// returns its PR number. Fails the test if no PR appears within 5 minutes.
+func LinkedPRNumber(t *testing.T, env *Env, repo string, issueNumber int) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		n, err := tryLinkedPRNumber(env, repo, issueNumber)
+		if err == nil && n > 0 {
+			return n
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for linked PR on %s#%d", repo, issueNumber)
+	return 0
+}


### PR DESCRIPTION
Closes #900

Adds two end-to-end tests for the CI-fix reinvoke loop (`engine/ci.go`), plus supporting harness helpers and README updates.

## What this PR does

**`tests/e2e/ci_fix_reinvoke_test.go`** (new):
- `TestCIFixReinvoke` — positive path: sentinel CI job fails on first push, engine reinvokes Claude which pushes a fix commit, CI passes, issue closes. Asserts the CI gate held (withheld window), the reinvoke fired (second Validate PR comment), and exactly one CI-fix commit was added (rebase storm guard).
- `TestCIFixReinvokeCycleLimit` — negative path: permanently-failing sentinel exhausts `MaxCiFixCycles`, engine pauses the issue with `fabrik:paused` + `fabrik:awaiting-input` and posts a "CI fix cycle limit reached" comment.

**`tests/e2e/harness.go`** (additions only):
- `assertSentinelCheckRequired` — skips test if `ci-fix-sentinel` is not a required status check on repo/main.
- `tryLinkedPRNumber` / `LinkedPRNumber` — resolve the PR number for an issue's feature branch.
- `tryPRComments` / `WaitForPRCommentContaining` — poll PR comments for a substring.
- `tryPRCheckRunConclusions` / `PRCheckRunConclusions` — resolve head SHA then fetch check-run conclusions.
- `tryPRCommitCount` / `PRCommitCount` — count commits on a PR.
- `readEnvFileMaxCiFixCycles` — read `FABRIK_MAX_CI_FIX_CYCLES` from test bed `.env`.

**`tests/e2e/README.md`**: 2 new scenario rows, 2 new regression coverage rows, prerequisite note for `ci-fix-sentinel` enrollment, `FABRIK_MAX_CI_FIX_CYCLES` requirement, and `E2E_TIMEOUT=3h` guidance.

## Key decision

The spec called for polling PR comments for `"🏭 **Fabrik — CI Fix Required**"`, but research confirmed this string is never posted to GitHub (it's a synthetic in-process prompt). The PR polls for `"🏭 **Fabrik — stage: Validate**"` instead, which is reliably posted by Fabrik's `postStageComment` path. The authoritative reinvoke guard is the `PRCommitCount == baseCommits + 1` assertion.

## Prerequisites to run

- `ci-fix-sentinel` enrolled as required status check on `handarbeit/fabrik-test-alpha/main` (both tests skip gracefully if absent).
- `FABRIK_MAX_CI_FIX_CYCLES=2` in test bed `.env` for `TestCIFixReinvokeCycleLimit`.
- `E2E_TIMEOUT=3h` for `TestCIFixReinvoke` in isolation.

## No engine changes

All changes are test-only (`tests/e2e/`). No engine files, no stage YAMLs, no canonical docs.