### PR TITLE
test(e2e): add TestPausedMergedPRRecovery — paused+merged PR recovery guard (#874 class)

### DIFF
--- a/specs/896-paused-item-merged-pr/spec.md
+++ b/specs/896-paused-item-merged-pr/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: e2e — Paused-Item Merged-PR Recovery (#874 Class Stays Closed, Gate-Label-Agnostic)
+
+**Feature Branch**: `fabrik/issue-896`
+**Created**: 2026-06-18
+**Status**: Draft
+**Input**: User description: "test(e2e): paused-item merged-PR recovery — #874 class stays closed (gate-label-agnostic)"
+
+## Background
+
+The bug class behind #874 — a paused item whose linked PR merges externally strands forever because the recovery loops are kept disjoint by hand-maintained label negations — is the exact failure that issue #887 (settle-owner) closes structurally. #887 installs a single advance owner that heals the paused+merged state regardless of which gate label is present, so no new gate-label variant can slip through.
+
+No e2e scenario currently exercises this recovery path. The existing full-pipeline e2e tests (`TestSmokeSingleRepoFullPipeline`, `TestYoloAutoMergeLabel`, `TestConvergenceRace`, `TestCruiseFullPipeline`) do not synthesize the stuck state — they rely on the engine's happy-path advance. A regression that re-introduces label-specific negation coupling would not be caught.
+
+This issue adds `TestPausedMergedPRRecovery`: the end-to-end regression guard that the #874 class stays closed. The test is parameterized over three gate-label variants (`fabrik:awaiting-ci`, `fabrik:awaiting-review`, and a control with neither). The "neither" control is the load-bearing case: it proves advancement does **not** depend on a specific gate label and would have stranded permanently on a pre-#887 engine.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Recovery with `fabrik:awaiting-ci` Gate Label (Priority: P1)
+
+A Validate-stage issue is in the stuck state: paused, awaiting input, and held behind the CI gate. A human (or auto-merge bot) merges the linked PR externally while the issue is paused. The settle-owner detects the merged PR and heals the issue: it applies `stage:Validate:complete`, removes the gate and pause labels, advances the board to Done, and closes the issue.
+
+**Why this priority**: Regression guard for the #874 subcase where the CI gate label blocks recovery.
+
+**Independent Test**: Drive a cruise issue to Validate, force `fabrik:paused + fabrik:awaiting-input + fabrik:awaiting-ci` via `AddLabel`, merge the PR via `MergePR`, then wait for `stage:Validate:complete` and issue CLOSED.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Validate-stage issue carries `fabrik:paused + fabrik:awaiting-input + fabrik:awaiting-ci`, **When** its linked PR is merged externally by the test harness, **Then** within the poll budget `stage:Validate:complete` is applied, `fabrik:paused`, `fabrik:awaiting-input`, and `fabrik:awaiting-ci` are removed, the board column advances to Done, and the issue is CLOSED.
+
+---
+
+### User Story 2 — Recovery with `fabrik:awaiting-review` Gate Label (Priority: P1)
+
+Same as User Story 1 but the gate label is `fabrik:awaiting-review`. Verifies that the settle-owner heals this variant as well.
+
+**Why this priority**: Regression guard for the review-gate variant of #874.
+
+**Independent Test**: Same flow as User Story 1 with `fabrik:awaiting-review` substituted for `fabrik:awaiting-ci`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Validate-stage issue carries `fabrik:paused + fabrik:awaiting-input + fabrik:awaiting-review`, **When** its linked PR is merged externally, **Then** within the poll budget `stage:Validate:complete` is applied, all three labels are removed, the board advances to Done, and the issue is CLOSED.
+
+---
+
+### User Story 3 — Recovery with No Gate Label (Control Case) (Priority: P1)
+
+Same as User Story 1 but no gate label is applied — only `fabrik:paused + fabrik:awaiting-input`. This is the load-bearing control case: a pre-#887 engine strands this variant forever because no recovery loop matched the label combination.
+
+**Why this priority**: This is the structural proof that advancement is gate-label-agnostic. Without this case, the test only verifies that existing gate-specific paths still work, not that the underlying fix is general.
+
+**Independent Test**: Same flow as User Story 1 with no gate label applied.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Validate-stage issue carries only `fabrik:paused + fabrik:awaiting-input` (no gate label), **When** its linked PR is merged externally, **Then** within the poll budget `stage:Validate:complete` is applied, `fabrik:paused` and `fabrik:awaiting-input` are removed, the board advances to Done, and the issue is CLOSED.
+
+---
+
+### Edge Cases
+
+- Each variant runs as a separate sub-test (`t.Run`) under `TestPausedMergedPRRecovery` so a failure in one variant does not mask the others.
+- `stage:Validate:complete` must appear even though the Validate stage never emitted `FABRIK_STAGE_COMPLETE` during this run — the settle-owner infers completion from the merged PR state.
+- All three sub-tests share the same test-bed Fabrik instance and board; they run sequentially to avoid label-mutation races on the same project board.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A new e2e test `TestPausedMergedPRRecovery` in `tests/e2e/paused_merged_pr_test.go` runs three sequential sub-tests, each parameterized by a `gateLabel` string: `"fabrik:awaiting-ci"`, `"fabrik:awaiting-review"`, and `""` (no gate label).
+- **FR-002**: Each sub-test drives a cruise issue to Validate with a linked, open PR using the existing full-pipeline pattern (file issue → add to board → set Specify → wait for `stage:Validate:complete` via `WaitForIssueLabel`).
+- **FR-003**: After Validate completes in the happy path, each sub-test forces the stuck state by calling `AddLabel` for `fabrik:paused`, `fabrik:awaiting-input`, and (if non-empty) the `gateLabel`.
+- **FR-004**: Each sub-test calls `WaitForLinkedPR` to discover the linked PR number, then `MergePR` to merge it externally, simulating a human/auto-merge while the issue is paused.
+- **FR-005**: After `MergePR`, each sub-test waits for `stage:Validate:complete` via `WaitForIssueLabel` (the label is momentarily removed when the stuck state is forced, then re-applied by the settle-owner) and then for `WaitForIssueClosed`. It then asserts `fabrik:paused` and `fabrik:awaiting-input` are absent via `WaitForLabelAbsent`, and (if non-empty) the `gateLabel` is absent via `WaitForLabelAbsent`.
+- **FR-006**: All harness helpers required for this test (`AddLabel`, `RemoveLabel`, `MergePR`, `WaitForLinkedPR`, `WaitForLabelAbsent`, `WaitForIssueClosed`, `WaitForIssueLabel`) already exist in `tests/e2e/harness.go` — no new helpers are required.
+- **FR-007**: The `tests/e2e/README.md` scenarios table is updated with a row for `TestPausedMergedPRRecovery` (three sub-tests, approx wall-clock ~15–25 min total, cost ~$0.50–1.50).
+- **FR-008**: The `tests/e2e/README.md` regression-coverage table is updated with a row mapping `TestPausedMergedPRRecovery` to the #874 class of bugs (paused+merged stranding), the #887 structural fix, and ADR-056 root cause 1.
+
+### Key Entities
+
+- **Stuck state**: An issue at Validate with `fabrik:paused + fabrik:awaiting-input + [optional gateLabel]` whose linked PR is merged — the recovery that #887 guarantees.
+- **Settle-owner (#887)**: The single engine path that detects a merged PR on a paused/gated issue and heals it by applying `stage:Validate:complete`, removing gate labels, and advancing to Done.
+- **Gate label**: One of `fabrik:awaiting-ci`, `fabrik:awaiting-review`, or absent. The control (absent) is the load-bearing case.
+- **`stage:Validate:complete`**: The label applied by the settle-owner when it heals the issue; it must be present even though the Validate stage never emitted `FABRIK_STAGE_COMPLETE` during this run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `TestPausedMergedPRRecovery` passes all three sub-tests end-to-end: every gateLabel variant sees its issue closed and `stage:Validate:complete` applied after the PR merges while the issue is paused.
+- **SC-002**: No variant ends with `fabrik:paused` or `fabrik:awaiting-input` still present after the budget.
+- **SC-003**: No variant ends with its `gateLabel` still present after the budget.
+- **SC-004**: `go test ./tests/e2e/ -run TestPausedMergedPRRecovery -tags e2e` passes cleanly against the live test bed.
+- **SC-005**: README scenario and regression-coverage tables reference #874, #887, and ADR-056.
+
+## Assumptions
+
+- The test bed Fabrik instance is running with a version that includes the #887 settle-owner fix; this test validates that fix and will fail on a pre-#887 engine (by design — it is a regression guard, not a backport).
+- The settle-owner correctly re-applies `stage:Validate:complete` when the stuck state has the label removed; the test re-waits for that label after forcing the stuck state.
+- The three sub-tests can re-use the same test-bed board and run sequentially without interfering (separate issues, separate worktrees).
+- The test bed GitHub repo does not have branch-protection rules that would prevent the harness from merging without a review approval.
+- `WaitForLinkedPR` is called after `stage:Validate:complete` (first occurrence) so the linked PR is already created by the Implement stage and fully visible via GitHub's GraphQL API.
+
+## Out of Scope
+
+- Verifying that a *non-paused* merged PR is handled correctly (that is the `TestCruiseFullPipeline` / `TestYoloAutoMergeLabel` scenario).
+- Verifying `fabrik:bot-reprompted` behavior or the review-reinvoke gate in detail.
+- Testing what happens when the settle-owner is absent (pre-#887) — the test is a forward regression guard, not a backward compatibility test.
+- Adding `GetIssueStatus` (board column assertion) — already specified in #898; this test uses `WaitForIssueClosed` as the terminal assertion, which is sufficient.
+- Validating ADR-056 root cause 2 (duplicate advance) — that is a separate concern.
+
+## Source References
+
+- `tests/e2e/harness.go` — existing helpers: `AddLabel`, `RemoveLabel`, `MergePR`, `WaitForLinkedPR`, `WaitForLabelAbsent`, `WaitForIssueClosed`, `WaitForIssueLabel`
+- `tests/e2e/auto_merge_test.go` — `TestYoloAutoMergeLabel`: reference for full-pipeline e2e pattern
+- `tests/e2e/cruise_test.go` — `TestCruiseFullPipeline`: reference for cruise+`MergePR` usage after Validate
+- `adrs/056-consolidate-convergence-gate-recovery.md` — D2 (settle-owner) and root cause 1 analysis; explicitly calls for this regression test at line 125
+- `adrs/053-paused-ci-recovery-loop.md` — original #874 amendment; the bug class this test guards against

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -56,6 +56,14 @@ These tests assume:
 See `~/fabrik-oss-launch-notes.md` (under "Files and where they live") for
 the canonical setup.
 
+### Additional prerequisites for `TestPausedMergedPRRecovery`
+
+5. **`fabrik:paused`, `fabrik:awaiting-input`, `fabrik:awaiting-ci`, and `fabrik:awaiting-review` labels seeded** in `handarbeit/fabrik-test-alpha`. These are production labels and should always exist; `AddLabel` will fatal with a clear error if not.
+6. **`E2E_TIMEOUT=3h`** when running `TestPausedMergedPRRecovery` in isolation — three sequential cruise pipelines through Implement total ~60–90 min:
+   ```bash
+   E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
+   ```
+
 ### Additional prerequisites for `TestCIFixReinvoke` and `TestCIFixReinvokeCycleLimit`
 
 5. **`ci-fix-sentinel` enrolled as a required status check** on
@@ -71,18 +79,6 @@ the canonical setup.
    once pipeline setup overhead is included:
    ```bash
    E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestCIFixReinvoke
-   ```
-
-### Additional prerequisites for `TestPausedMergedPRRecovery`
-
-8. **Gate labels seeded** in `handarbeit/fabrik-test-alpha`: `fabrik:awaiting-ci`,
-   `fabrik:awaiting-review`, `fabrik:paused`, and `fabrik:awaiting-input` are
-   production labels that must exist. `AddLabel` fatals immediately if a label is
-   absent — create them manually in the repo if needed.
-9. **`E2E_TIMEOUT=3h`** when running `TestPausedMergedPRRecovery` in isolation —
-   three sequential cruise pipelines (Specify → Implement each) total ~60–90 min:
-   ```bash
-   E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
    ```
 
 ## Running
@@ -129,9 +125,9 @@ otherwise).
 | `TestCruiseFullPipeline` | `fabrik:cruise` auto-advances to Validate-complete without auto-merge; PR merged by human closes issue | 30–50 min | $0.80–2.00 |
 | `TestCIFixReinvoke` | CI-fix reinvoke positive path: sentinel fails on first push, Claude fixes, CI passes, issue closes | 75–90 min | $1.00–3.00 |
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | 30–60 min | $0.50–1.50 |
-| `TestPausedMergedPRRecovery` | #874-class regression guard: paused item + gate label at Validate with externally-merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label) | 60–90 min (use `E2E_TIMEOUT=3h`) | $1.50–4.50 |
+| `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
 
-Approximate suite total: ~325 min wall-clock, $6.50–21.50 in Claude tokens (CI-fix and paused-merged-PR tests should be run separately with `E2E_TIMEOUT=3h`).
+Approximate suite total: ~310 min wall-clock, $6.50–21.50 in Claude tokens (CI-fix tests and `TestPausedMergedPRRecovery` should be run separately with `E2E_TIMEOUT=3h`).
 
 ### Regression coverage map
 
@@ -146,7 +142,7 @@ Approximate suite total: ~325 min wall-clock, $6.50–21.50 in Claude tokens (CI
 | `TestCruiseFullPipeline` | #898 (cruise/yolo gate at Validate, `engine/poll.go`); ensures cruise never triggers `checkAutoMergeConvergence` |
 | `TestCIFixReinvoke` | #888 ADR-056 D1 (settling primitive reinterprets CI-gate signals); CI-fix reinvoke loop (engine/ci.go) |
 | `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
-| `TestPausedMergedPRRecovery` | #874 (paused+merged-PR recovery class stays closed), #887 (settle-owner `runValidatePRTerminalAdvance`), ADR-056 D2 (gate-label-agnostic single-owner PR-terminal advance) |
+| `TestPausedMergedPRRecovery` | #874 (paused+merged PR recovery class), #887 (settle-owner structural fix, `runValidatePRTerminalAdvance`), ADR-056 D2 (single-owner for PR-terminal → Done) |
 
 Every escape-from-release regression earns a new scenario in this table.
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -56,14 +56,6 @@ These tests assume:
 See `~/fabrik-oss-launch-notes.md` (under "Files and where they live") for
 the canonical setup.
 
-### Additional prerequisites for `TestPausedMergedPRRecovery`
-
-5. **`fabrik:paused`, `fabrik:awaiting-input`, `fabrik:awaiting-ci`, and `fabrik:awaiting-review` labels seeded** in `handarbeit/fabrik-test-alpha`. These are production labels and should always exist; `AddLabel` will fatal with a clear error if not.
-6. **`E2E_TIMEOUT=3h`** when running `TestPausedMergedPRRecovery` in isolation — three sequential cruise pipelines through Implement total ~60–90 min:
-   ```bash
-   E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
-   ```
-
 ### Additional prerequisites for `TestCIFixReinvoke` and `TestCIFixReinvokeCycleLimit`
 
 5. **`ci-fix-sentinel` enrolled as a required status check** on
@@ -79,6 +71,18 @@ the canonical setup.
    once pipeline setup overhead is included:
    ```bash
    E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestCIFixReinvoke
+   ```
+
+### Additional prerequisites for `TestPausedMergedPRRecovery`
+
+8. **Gate labels seeded** in `handarbeit/fabrik-test-alpha`: `fabrik:awaiting-ci`,
+   `fabrik:awaiting-review`, `fabrik:paused`, and `fabrik:awaiting-input` are
+   production labels that must exist. `AddLabel` fatals immediately if a label is
+   absent — create them manually in the repo if needed.
+9. **`E2E_TIMEOUT=3h`** when running `TestPausedMergedPRRecovery` in isolation —
+   three sequential cruise pipelines (Specify → Implement each) total ~60–90 min:
+   ```bash
+   E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
    ```
 
 ## Running

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -73,6 +73,18 @@ the canonical setup.
    E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestCIFixReinvoke
    ```
 
+### Additional prerequisites for `TestPausedMergedPRRecovery`
+
+8. **Gate labels seeded** in `handarbeit/fabrik-test-alpha`: `fabrik:awaiting-ci`,
+   `fabrik:awaiting-review`, `fabrik:paused`, and `fabrik:awaiting-input` are
+   production labels that must exist. `AddLabel` fatals immediately if a label is
+   absent — create them manually in the repo if needed.
+9. **`E2E_TIMEOUT=3h`** when running `TestPausedMergedPRRecovery` in isolation —
+   three sequential cruise pipelines (Specify → Implement each) total ~60–90 min:
+   ```bash
+   E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
+   ```
+
 ## Running
 
 The recommended entrypoint is the runner script, which sets sensible defaults:
@@ -117,8 +129,9 @@ otherwise).
 | `TestCruiseFullPipeline` | `fabrik:cruise` auto-advances to Validate-complete without auto-merge; PR merged by human closes issue | 30–50 min | $0.80–2.00 |
 | `TestCIFixReinvoke` | CI-fix reinvoke positive path: sentinel fails on first push, Claude fixes, CI passes, issue closes | 75–90 min | $1.00–3.00 |
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | 30–60 min | $0.50–1.50 |
+| `TestPausedMergedPRRecovery` | #874-class regression guard: paused item + gate label at Validate with externally-merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label) | 60–90 min (use `E2E_TIMEOUT=3h`) | $1.50–4.50 |
 
-Approximate suite total: ~250 min wall-clock, $5–17 in Claude tokens (CI-fix tests should be run separately with `E2E_TIMEOUT=3h`).
+Approximate suite total: ~325 min wall-clock, $6.50–21.50 in Claude tokens (CI-fix and paused-merged-PR tests should be run separately with `E2E_TIMEOUT=3h`).
 
 ### Regression coverage map
 
@@ -133,6 +146,7 @@ Approximate suite total: ~250 min wall-clock, $5–17 in Claude tokens (CI-fix t
 | `TestCruiseFullPipeline` | #898 (cruise/yolo gate at Validate, `engine/poll.go`); ensures cruise never triggers `checkAutoMergeConvergence` |
 | `TestCIFixReinvoke` | #888 ADR-056 D1 (settling primitive reinterprets CI-gate signals); CI-fix reinvoke loop (engine/ci.go) |
 | `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
+| `TestPausedMergedPRRecovery` | #874 (paused+merged-PR recovery class stays closed), #887 (settle-owner `runValidatePRTerminalAdvance`), ADR-056 D2 (gate-label-agnostic single-owner PR-terminal advance) |
 
 Every escape-from-release regression earns a new scenario in this table.
 

--- a/tests/e2e/paused_merged_pr_recovery_test.go
+++ b/tests/e2e/paused_merged_pr_recovery_test.go
@@ -1,0 +1,172 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestPausedMergedPRRecovery is the e2e regression guard for the #874 class of
+// stuck issues: a paused item whose linked PR merges externally while gate
+// labels are present must be healed by the settle-owner
+// (runValidatePRTerminalAdvance, introduced in #887/ADR-056 D2) without any
+// manual intervention.
+//
+// Each sub-test drives a cruise issue through Implement (creating an open PR),
+// then forces the #874-class stuck state by applying fabrik:paused +
+// fabrik:awaiting-input + an optional gate label before moving the board to
+// Validate. After the PR is merged externally, the test asserts that the
+// settle-owner heals the issue: stage:Validate:complete is added, all stuck
+// labels are removed, and the issue closes.
+//
+// Sub-tests (sequential — see R6):
+//   - "awaiting-ci":      gate label fabrik:awaiting-ci    (R1)
+//   - "awaiting-review":  gate label fabrik:awaiting-review (R2)
+//   - "no-gate-label":    no gate label — control case       (R3)
+//
+// R4: No variant ends stranded with fabrik:paused after the poll budget.
+// R5: stage:Validate:complete is added by the settle-owner even though the
+//
+//	Validate stage was never invoked (Validate never ran; the label is absent
+//	until the settle-owner fills it).
+//
+// R6: Sub-tests run sequentially (no t.Parallel inside t.Run) to avoid
+//
+//	label-mutation races on the shared test board.
+//
+// Prerequisites: gate labels fabrik:awaiting-ci and fabrik:awaiting-review
+// must be seeded in handarbeit/fabrik-test-alpha (AddLabel fatals if not).
+//
+// Wall-clock: ~60–90 min (3 sequential sub-tests, ~20–30 min each).
+// Use E2E_TIMEOUT=3h when running this test in isolation:
+//
+//	E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
+//
+// Cost: ~$1.50–4.50 (three cruise pipelines through Specify → Implement).
+//
+// References: #874 (original stuck-state bug class), #887 (settle-owner),
+// ADR-056 D2 (single-owner PR-terminal advance).
+func TestPausedMergedPRRecovery(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	cases := []struct {
+		name      string
+		gateLabel string
+	}{
+		{"awaiting-ci", "fabrik:awaiting-ci"},
+		{"awaiting-review", "fabrik:awaiting-review"},
+		{"no-gate-label", ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Sequential — no t.Parallel() here (R6).
+			stamp := time.Now().UTC().Format("20060102-150405")
+			marker := fmt.Sprintf("paused-merged-pr-%s-%s", tc.name, stamp)
+			body := fmt.Sprintf(pausedMergedPRBodyTemplate, "`", "`", "```", marker, "```")
+
+			num := FileIssue(t, env, env.RepoAlpha,
+				fmt.Sprintf("e2e paused-merged-pr recovery (%s/%s)", tc.name, stamp),
+				body, "fabrik:cruise")
+			itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+			SetIssueStatus(t, env, itemID, "Specify")
+			t.Logf("filed %s#%d at Status=Specify with fabrik:cruise, variant=%s, marker=%s",
+				env.RepoAlpha, num, tc.name, marker)
+
+			// Step 1: Wait for Implement to complete. The PR is created and open at
+			// this point; stage:Validate:complete does not yet exist.
+			WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Implement:complete", 60*time.Minute)
+			t.Logf("%s#%d reached stage:Implement:complete", env.RepoAlpha, num)
+
+			// Step 2: Discover the linked PR. It was created during Implement.
+			prNum := WaitForLinkedPR(t, env, env.RepoAlpha, num, 5*time.Minute)
+			t.Logf("linked PR: %s#%d", env.RepoAlpha, prNum)
+
+			// Step 3: Force the #874-class stuck state.
+			// fabrik:paused first — the Phase 1/2 dispatch loop skips paused items,
+			// closing the race window before Review can be dispatched.
+			AddLabel(t, env, env.RepoAlpha, num, "fabrik:paused")
+			AddLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input")
+			if tc.gateLabel != "" {
+				AddLabel(t, env, env.RepoAlpha, num, tc.gateLabel)
+			}
+			// Move the board to Validate: the settle-owner only processes items
+			// whose board column is Validate.
+			SetIssueStatus(t, env, itemID, "Validate")
+			t.Logf("stuck state applied to %s#%d: fabrik:paused + fabrik:awaiting-input + gate=%q, board=Validate",
+				env.RepoAlpha, num, tc.gateLabel)
+
+			// Step 4: Merge the PR externally. This is the trigger for the
+			// settle-owner. stage:Validate:complete is absent at this point — Validate
+			// was never invoked — so the settle-owner will fill it from scratch (R5).
+			MergePR(t, env, env.RepoAlpha, prNum)
+			t.Logf("merged PR %s#%d — waiting for settle-owner to heal the issue", env.RepoAlpha, prNum)
+
+			// Step 5: Assert recovery. The settle-owner runs on the next Fabrik
+			// poll cycle (up to ~30s after the merge).
+
+			// R5: stage:Validate:complete must be added by the settle-owner.
+			// WaitForIssueLabel polls until the label appears (up to 15 min).
+			WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Validate:complete", 15*time.Minute)
+			// AssertLabelWasApplied provides timeline-level confirmation (survives
+			// the case where Fabrik adds and removes a label faster than polling).
+			AssertLabelWasApplied(t, env, env.RepoAlpha, num, "stage:Validate:complete")
+			t.Logf("stage:Validate:complete confirmed on %s#%d — R5 verified", env.RepoAlpha, num)
+
+			// R1/R2/R3: stuck labels must be cleared.
+			WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:paused", 5*time.Minute)
+			t.Logf("fabrik:paused cleared on %s#%d — R%s verified", env.RepoAlpha, num, rNumber(tc.name))
+			WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 5*time.Minute)
+			if tc.gateLabel != "" {
+				WaitForLabelAbsent(t, env, env.RepoAlpha, num, tc.gateLabel, 5*time.Minute)
+				t.Logf("gate label %q cleared on %s#%d", tc.gateLabel, env.RepoAlpha, num)
+			}
+
+			// R4: issue must close (settle-owner advances board to Done; GitHub
+			// also auto-closes via Closes #N on merge).
+			WaitForIssueClosed(t, env, env.RepoAlpha, num, 5*time.Minute)
+			t.Logf("%s#%d closed — R4 verified (variant=%s full recovery confirmed)", env.RepoAlpha, num, tc.name)
+		})
+	}
+}
+
+// rNumber maps a sub-test name to the spec requirement number for log output.
+func rNumber(name string) string {
+	switch name {
+	case "awaiting-ci":
+		return "1"
+	case "awaiting-review":
+		return "2"
+	default:
+		return "3"
+	}
+}
+
+// pausedMergedPRBodyTemplate is the issue body for TestPausedMergedPRRecovery.
+// The five %s placeholders are: backtick, backtick, codefence, marker, codefence
+// (Go raw strings can't contain backticks).
+const pausedMergedPRBodyTemplate = `## Goal
+
+End-to-end regression guard for the #874 class of stuck issues (paused item
+with merged PR; settle-owner recovery path from #887/ADR-056 D2).
+
+## Trivial change
+
+Append a single HTML comment line to %sREADME.md%s at the very end of the file:
+
+%s
+<!-- %s -->
+%s
+
+That is the entire change. One file, one line. Plan should NOT decompose.
+
+## Scope
+
+Single repo only. This issue verifies that the settle-owner correctly heals
+a paused-and-merged item regardless of which gate label it carries.
+`

--- a/tests/e2e/paused_merged_pr_recovery_test.go
+++ b/tests/e2e/paused_merged_pr_recovery_test.go
@@ -8,46 +8,34 @@ import (
 	"time"
 )
 
-// TestPausedMergedPRRecovery is the e2e regression guard for the #874 class of
-// stuck issues: a paused item whose linked PR merges externally while gate
-// labels are present must be healed by the settle-owner
-// (runValidatePRTerminalAdvance, introduced in #887/ADR-056 D2) without any
-// manual intervention.
+// TestPausedMergedPRRecovery is the e2e regression guard for the #874 bug
+// class: a paused item whose linked PR is merged externally must be healed by
+// the settle-owner (runValidatePRTerminalAdvance, ADR-056 D2) regardless of
+// which gate label it carries.
 //
 // Each sub-test drives a cruise issue through Implement (creating an open PR),
-// then forces the #874-class stuck state by applying fabrik:paused +
-// fabrik:awaiting-input + an optional gate label before moving the board to
-// Validate. After the PR is merged externally, the test asserts that the
-// settle-owner heals the issue: stage:Validate:complete is added, all stuck
-// labels are removed, and the issue closes.
+// forces the #874-class stuck state (fabrik:paused + fabrik:awaiting-input +
+// optional gate label, board at Validate), merges the PR externally, and
+// asserts the settle-owner heals the issue.
 //
-// Sub-tests (sequential — see R6):
-//   - "awaiting-ci":      gate label fabrik:awaiting-ci    (R1)
-//   - "awaiting-review":  gate label fabrik:awaiting-review (R2)
-//   - "no-gate-label":    no gate label — control case       (R3)
+// Requirements covered (R1–R6 from issue #896):
+//   - R1: gate=fabrik:awaiting-ci  → stage:Validate:complete added, gate + pause labels removed, issue CLOSED.
+//   - R2: gate=fabrik:awaiting-review → same recovery as R1.
+//   - R3: no gate label (control) → same recovery; proves advancement is gate-label-agnostic.
+//   - R4: no variant ends stranded after the poll budget.
+//   - R5: stage:Validate:complete is added by the settle-owner (Validate was never invoked).
+//   - R6: three t.Run sub-tests sharing a single TestPausedMergedPRRecovery function.
 //
-// R4: No variant ends stranded with fabrik:paused after the poll budget.
-// R5: stage:Validate:complete is added by the settle-owner even though the
+// Sub-tests run sequentially (no t.Parallel inside t.Run) to avoid label-
+// mutation races on the shared test board.
 //
-//	Validate stage was never invoked (Validate never ran; the label is absent
-//	until the settle-owner fills it).
-//
-// R6: Sub-tests run sequentially (no t.Parallel inside t.Run) to avoid
-//
-//	label-mutation races on the shared test board.
-//
-// Prerequisites: gate labels fabrik:awaiting-ci and fabrik:awaiting-review
-// must be seeded in handarbeit/fabrik-test-alpha (AddLabel fatals if not).
+// Prerequisites: handarbeit/fabrik-test-alpha must have the labels
+// fabrik:cruise, fabrik:paused, fabrik:awaiting-input, fabrik:awaiting-ci, and
+// fabrik:awaiting-review seeded (all are production labels and should exist).
 //
 // Wall-clock: ~60–90 min (3 sequential sub-tests, ~20–30 min each).
-// Use E2E_TIMEOUT=3h when running this test in isolation:
-//
-//	E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
-//
-// Cost: ~$1.50–4.50 (three cruise pipelines through Specify → Implement).
-//
-// References: #874 (original stuck-state bug class), #887 (settle-owner),
-// ADR-056 D2 (single-owner PR-terminal advance).
+// Run with: E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
+// Cost: ~$1.50–4.50.
 func TestPausedMergedPRRecovery(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
@@ -57,93 +45,93 @@ func TestPausedMergedPRRecovery(t *testing.T) {
 		name      string
 		gateLabel string
 	}{
-		{"awaiting-ci", "fabrik:awaiting-ci"},
-		{"awaiting-review", "fabrik:awaiting-review"},
-		{"no-gate-label", ""},
+		{"awaiting-ci", "fabrik:awaiting-ci"},       // R1
+		{"awaiting-review", "fabrik:awaiting-review"}, // R2
+		{"no-gate-label", ""},                         // R3 (control)
 	}
 
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// Sequential — no t.Parallel() here (R6).
 			stamp := time.Now().UTC().Format("20060102-150405")
 			marker := fmt.Sprintf("paused-merged-pr-%s-%s", tc.name, stamp)
 			body := fmt.Sprintf(pausedMergedPRBodyTemplate, "`", "`", "```", marker, "```")
 
 			num := FileIssue(t, env, env.RepoAlpha,
-				fmt.Sprintf("e2e paused-merged-pr recovery (%s/%s)", tc.name, stamp),
+				fmt.Sprintf("e2e paused merged-PR recovery (%s %s)", tc.name, stamp),
 				body, "fabrik:cruise")
 			itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
 			SetIssueStatus(t, env, itemID, "Specify")
-			t.Logf("filed %s#%d at Status=Specify with fabrik:cruise, variant=%s, marker=%s",
+			t.Logf("filed %s#%d at Status=Specify with fabrik:cruise, variant=%s marker=%s",
 				env.RepoAlpha, num, tc.name, marker)
 
-			// Step 1: Wait for Implement to complete. The PR is created and open at
-			// this point; stage:Validate:complete does not yet exist.
+			// Step 1: Wait for stage:Implement:complete — PR is created and open by now.
 			WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Implement:complete", 60*time.Minute)
 			t.Logf("%s#%d reached stage:Implement:complete", env.RepoAlpha, num)
 
-			// Step 2: Discover the linked PR. It was created during Implement.
+			// Step 2: Discover the linked PR. The PR is created during Implement;
+			// 5 minutes is generous for the GraphQL query to surface it.
 			prNum := WaitForLinkedPR(t, env, env.RepoAlpha, num, 5*time.Minute)
-			t.Logf("linked PR: %s#%d", env.RepoAlpha, prNum)
+			t.Logf("linked PR: #%d", prNum)
 
-			// Step 3: Force the #874-class stuck state.
-			// fabrik:paused first — the Phase 1/2 dispatch loop skips paused items,
-			// closing the race window before Review can be dispatched.
+			// Step 3–5: Force the stuck state.
+			//
+			// fabrik:paused is added first — the Phase 1/2 dispatch loop in
+			// poll.go skips all paused items, closing the race window before
+			// Review fires. Only then do we add the other stuck-state labels.
 			AddLabel(t, env, env.RepoAlpha, num, "fabrik:paused")
 			AddLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input")
 			if tc.gateLabel != "" {
 				AddLabel(t, env, env.RepoAlpha, num, tc.gateLabel)
 			}
-			// Move the board to Validate: the settle-owner only processes items
-			// whose board column is Validate.
+			t.Logf("applied stuck-state labels (fabrik:paused, fabrik:awaiting-input, gateLabel=%q)", tc.gateLabel)
+
+			// Step 6: Move the board to Validate. The settle-owner
+			// (runValidatePRTerminalAdvance) only processes items with
+			// item.Status == "Validate". After Implement, cruise mode advances
+			// the board to Review; we override it here manually. The pause
+			// guard set above prevents any dispatch from acting on the column
+			// change before we merge the PR.
 			SetIssueStatus(t, env, itemID, "Validate")
-			t.Logf("stuck state applied to %s#%d: fabrik:paused + fabrik:awaiting-input + gate=%q, board=Validate",
-				env.RepoAlpha, num, tc.gateLabel)
+			t.Logf("moved board to Validate column")
 
-			// Step 4: Merge the PR externally. This is the trigger for the
-			// settle-owner. stage:Validate:complete is absent at this point — Validate
-			// was never invoked — so the settle-owner will fill it from scratch (R5).
+			// Step 7: Merge the PR externally, simulating a human merge.
 			MergePR(t, env, env.RepoAlpha, prNum)
-			t.Logf("merged PR %s#%d — waiting for settle-owner to heal the issue", env.RepoAlpha, prNum)
+			t.Logf("merged PR #%d — waiting for settle-owner to heal", prNum)
 
-			// Step 5: Assert recovery. The settle-owner runs on the next Fabrik
-			// poll cycle (up to ~30s after the merge).
-
-			// R5: stage:Validate:complete must be added by the settle-owner.
-			// WaitForIssueLabel polls until the label appears (up to 15 min).
+			// Step 8 (R5): Wait for stage:Validate:complete.
+			// The settle-owner fills this label because:
+			//   (a) Validate has wait_for_ci: true and wait_for_reviews: true,
+			//       so it is "gate-checked" in the fill loop;
+			//   (b) the label is absent — Validate never ran; and
+			//   (c) the PR is now merged (terminal).
+			// 15 minutes is generous for a single poll cycle to fire.
 			WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Validate:complete", 15*time.Minute)
-			// AssertLabelWasApplied provides timeline-level confirmation (survives
-			// the case where Fabrik adds and removes a label faster than polling).
-			AssertLabelWasApplied(t, env, env.RepoAlpha, num, "stage:Validate:complete")
-			t.Logf("stage:Validate:complete confirmed on %s#%d — R5 verified", env.RepoAlpha, num)
+			t.Logf("stage:Validate:complete applied by settle-owner — R5")
 
-			// R1/R2/R3: stuck labels must be cleared.
+			// Step 9 (R5 timeline confirmation): Verify via issue timeline that
+			// stage:Validate:complete was actually applied (not already present).
+			AssertLabelWasApplied(t, env, env.RepoAlpha, num, "stage:Validate:complete")
+			t.Logf("timeline confirms stage:Validate:complete was applied — R5 verified")
+
+			// Steps 10–12 (R1/R2/R3): Assert the settle-owner cleared the stuck-state labels.
 			WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:paused", 5*time.Minute)
-			t.Logf("fabrik:paused cleared on %s#%d — R%s verified", env.RepoAlpha, num, rNumber(tc.name))
+			t.Logf("fabrik:paused absent — R1/R2/R3")
+
 			WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 5*time.Minute)
+			t.Logf("fabrik:awaiting-input absent — R1/R2/R3")
+
 			if tc.gateLabel != "" {
 				WaitForLabelAbsent(t, env, env.RepoAlpha, num, tc.gateLabel, 5*time.Minute)
-				t.Logf("gate label %q cleared on %s#%d", tc.gateLabel, env.RepoAlpha, num)
+				t.Logf("%q absent — R1/R2", tc.gateLabel)
 			}
 
-			// R4: issue must close (settle-owner advances board to Done; GitHub
-			// also auto-closes via Closes #N on merge).
+			// Step 13 (R4): Issue must be CLOSED.
+			// GitHub auto-closes via "Closes #N" on merge, so this typically
+			// completes within seconds of MergePR.
 			WaitForIssueClosed(t, env, env.RepoAlpha, num, 5*time.Minute)
-			t.Logf("%s#%d closed — R4 verified (variant=%s full recovery confirmed)", env.RepoAlpha, num, tc.name)
+			t.Logf("%s#%d closed — R4 verified (variant=%s)", env.RepoAlpha, num, tc.name)
 		})
-	}
-}
-
-// rNumber maps a sub-test name to the spec requirement number for log output.
-func rNumber(name string) string {
-	switch name {
-	case "awaiting-ci":
-		return "1"
-	case "awaiting-review":
-		return "2"
-	default:
-		return "3"
 	}
 }
 
@@ -152,8 +140,8 @@ func rNumber(name string) string {
 // (Go raw strings can't contain backticks).
 const pausedMergedPRBodyTemplate = `## Goal
 
-End-to-end regression guard for the #874 class of stuck issues (paused item
-with merged PR; settle-owner recovery path from #887/ADR-056 D2).
+End-to-end regression guard for the #874 bug class (paused item + merged PR
+recovery via the settle-owner, ADR-056 D2).
 
 ## Trivial change
 
@@ -167,6 +155,8 @@ That is the entire change. One file, one line. Plan should NOT decompose.
 
 ## Scope
 
-Single repo only. This issue verifies that the settle-owner correctly heals
-a paused-and-merged item regardless of which gate label it carries.
+Single repo only. This issue verifies that when a cruise issue's linked PR is
+merged externally while the issue is in the stuck state (fabrik:paused +
+fabrik:awaiting-input + optional gate label at Validate), the settle-owner
+heals the issue to CLOSED without Validate having been invoked.
 `


### PR DESCRIPTION
Closes #896

## What this PR does

Adds `TestPausedMergedPRRecovery` — the e2e regression guard that proves the #874 class of stuck issues is structurally closed by the settle-owner shipped in #887 (ADR-056 D2).

The test drives three sequential sub-tests, one per gate-label variant:
- `awaiting-ci` — gate label `fabrik:awaiting-ci` (R1)
- `awaiting-review` — gate label `fabrik:awaiting-review` (R2)  
- `no-gate-label` — no gate label, control case (R3)

Each sub-test files a `fabrik:cruise` issue, runs it to `stage:Implement:complete` (PR created and open), forces the stuck state (`fabrik:paused` + `fabrik:awaiting-input` + optional gate label, board moved to Validate), merges the PR externally, then asserts the settle-owner heals the issue: `stage:Validate:complete` added, all stuck labels cleared, issue CLOSED.

## Key decisions

- **Sequential sub-tests** (no `t.Parallel()` inside `t.Run`): avoids label-mutation races on the shared test board.
- **Intercept at `stage:Implement:complete`**: `stage:Validate:complete` is absent at this point — the settle-owner fills it from scratch, making the assertion meaningful (no `RemoveLabel` needed).
- **`fabrik:paused` applied first**: closes the dispatch race window before Review can fire.
- **`SetIssueStatus(itemID, "Validate")` after stuck-state labels**: the settle-owner only processes items at the Validate board column.

## Files changed

- `tests/e2e/paused_merged_pr_recovery_test.go` — new test file (172 lines)
- `tests/e2e/README.md` — prerequisites note, scenario table row, regression coverage row

## How to test

```bash
E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
```

Wall-clock ~60–90 min (3 sequential cruise pipelines through Specify → Implement). Cost ~$1.50–4.50.

Prerequisites: `fabrik:awaiting-ci`, `fabrik:awaiting-review`, `fabrik:paused`, `fabrik:awaiting-input` labels must be seeded in `handarbeit/fabrik-test-alpha`.