### PR TITLE
test(e2e): conjunctive CI∧review gate — joint-clear + no premature completion

### DIFF
--- a/specs/895-conjunctive-ci-review-gate/spec.md
+++ b/specs/895-conjunctive-ci-review-gate/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: e2e — Conjunctive CI∧Review Gate (Joint-Clear + No Premature Completion)
+
+**Feature Branch**: `fabrik/issue-895`
+**Created**: 2026-06-18
+**Status**: Draft
+**Input**: User description: "test(e2e): conjunctive CI∧review gate — joint-clear + no premature completion"
+
+## Background
+
+The Fabrik engine supports a conjunctive gate: a stage configured with both `wait_for_ci: true` and `wait_for_reviews: true` must satisfy **both** conditions before `stage:<X>:complete` is applied and the issue advances. The 2026-06-17 state-machine review (`notes/state-machine-review-2026-06-17.md`) flagged this as the single biggest untested hole in the e2e suite: there is no described joint-clearing path, no test, and a reviewer who comments during the CI-await window is currently unverified to not be silently dropped.
+
+ADR-056 / #887 (settle-owner) defines the single-advance-owner model where both gates must be satisfied before the advance fires. #890 (spec) makes the joint-clear semantics explicit. This issue verifies the consolidated behavior end-to-end against a real Fabrik instance.
+
+The test must not be written against the legacy two-poll handoff — it should be authored after #887 lands so it asserts the settle-owner-consolidated behavior directly.
+
+**Critical setup risk**: GitHub forbids approving your own PR. The bot identity is `@arbeithand`. A second distinct reviewer is required to submit an approving review and satisfy the `wait_for_reviews` half of the gate. Resolving this identity (second PAT, GitHub App, or API workaround) is Research's primary task. If a real second reviewer is infeasible, the test falls back to a reduced scope (ordering/withholding half + review-timeout path only), deferring the full approval assertion.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Gate Withholds Completion Until Both CI and Review Pass (Priority: P1)
+
+An issue advances to a stage configured with both `wait_for_ci: true` and `wait_for_reviews: true`. After `FABRIK_STAGE_COMPLETE` fires, the engine:
+1. Applies `fabrik:awaiting-ci` (withholds `stage:<X>:complete`).
+2. Once CI passes, replaces it with `fabrik:awaiting-review` (still withholds complete).
+3. Once an approving review arrives, clears `fabrik:awaiting-review` and applies `stage:<X>:complete`.
+
+At no point does `stage:<X>:complete` appear while either gate is unsatisfied.
+
+**Why this priority**: This is the entire conjunctive gate contract. A regression where either gate is silently skipped would cause stages to advance on partial signals — a correctness bug.
+
+**Independent Test**: A `TestConjunctiveCIReviewGate` test files an issue through the both-gates stage, then asserts the label sequence and final complete timing.
+
+**Acceptance Scenarios**:
+
+1. **Given** an issue reaches the both-gates stage with a linked PR, **When** `FABRIK_STAGE_COMPLETE` fires (Claude emits the marker), **Then** `fabrik:awaiting-ci` is applied and `stage:<X>:complete` is absent.
+
+2. **Given** `fabrik:awaiting-ci` is present, **When** all required CI checks pass, **Then** `fabrik:awaiting-ci` is cleared and `fabrik:awaiting-review` is applied — `stage:<X>:complete` is still absent.
+
+3. **Given** `fabrik:awaiting-review` is present, **When** an approving review is submitted by a distinct reviewer, **Then** `fabrik:awaiting-review` is cleared, `stage:<X>:complete` is applied, and the issue advances to the next stage.
+
+---
+
+### User Story 2 — Reviewer Comment During CI-Await Window Is Not Dropped (Priority: P1)
+
+A reviewer posts a comment on the PR while `fabrik:awaiting-ci` is still present (CI has not yet passed). The comment must not be silently discarded — it should receive a 👀 reaction (acknowledged) and eventually a 🚀 reaction or a response, once the engine processes comments in that state.
+
+**Why this priority**: The state-machine review flagged that reviewer comments during CI-await may be silently ignored until CI clears. This must be verified.
+
+**Independent Test**: Post a PR comment immediately after `fabrik:awaiting-ci` appears. Then wait for the 👀 reaction or a reply before CI clears (or confirm it appears after CI clears but before gate advances).
+
+**Acceptance Scenarios**:
+
+1. **Given** `fabrik:awaiting-ci` is present and a comment is posted on the PR, **When** the comment is eventually processed (either before or after CI clears), **Then** the comment receives at minimum a 👀 acknowledgment reaction.
+
+---
+
+### User Story 3 — Reduced Scope Fallback When Second Reviewer Is Infeasible (Priority: P2)
+
+If no distinct reviewer identity is available, the test asserts only the ordering/withholding half:
+- `fabrik:awaiting-ci` appears and `stage:<X>:complete` is withheld.
+- After CI passes, `fabrik:awaiting-review` appears and `stage:<X>:complete` remains withheld.
+- The review-timeout path fires (after `FABRIK_REVIEW_WAIT_TIMEOUT`) and `fabrik:awaiting-review` clears naturally, then `stage:<X>:complete` is applied.
+
+The full approval path (Story 1, step 3) is documented as deferred with an explicit note in the test.
+
+**Why this priority**: A test asserting the first two gates is valuable even without proving the third. The timeout path is real behavior that also needs coverage.
+
+**Independent Test**: Set a short `FABRIK_REVIEW_WAIT_TIMEOUT` (e.g. 5 minutes) in the test bed `.env` and wait for the timeout to clear the review gate.
+
+---
+
+### Edge Cases
+
+- If CI passes before the reviewer comment is posted (race condition in the test), the comment must still be acknowledged after the gate transitions to `awaiting-review`. The test should post the comment within a tight window after `awaiting-ci` appears and log a warning if the window is missed.
+- If both `fabrik:awaiting-ci` and `fabrik:awaiting-review` are somehow present simultaneously (implementation bug), the test must fail with a clear diagnostic.
+- The `wait_for_reviews` half uses GitHub's PR review API. The required reviewer must be requested on the PR, not just any commenter. The harness helper `SubmitPRReview` must submit via the Reviews API (not a comment).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A new e2e test `TestConjunctiveCIReviewGate` in `tests/e2e/conjunctive_gate_test.go` files an issue through a stage with both `wait_for_ci: true` and `wait_for_reviews: true`, asserts label transitions in order, and asserts no premature completion.
+- **FR-002**: The both-gates stage must be configured in the test bed (`.fabrik/stages/` of `~/dev/fabrik-test`). Validate is the natural host; alternatively a dedicated test stage named `TestGate` may be added. Research must specify which approach is cleaner given the existing stage config.
+- **FR-003**: A new harness helper `SubmitPRReview(t, env, repo, prNumber, event)` submits a PR review via the GitHub REST API (`POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews`). `event` is `"APPROVE"` or `"REQUEST_CHANGES"`. The helper uses the reviewer PAT (a second identity, if available) or skips with `t.Skip` if no second identity is configured.
+- **FR-004**: A new harness helper `PRReviewDecision(t, env, repo, prNumber)` returns the current PR review decision (`"APPROVED"`, `"CHANGES_REQUESTED"`, `"REVIEW_REQUIRED"`, or `""`). Used to assert the gate has been satisfied.
+- **FR-005**: A new harness helper `WaitForPRReviewDecision(t, env, repo, prNumber, decision, timeout)` polls until the named PR reaches the given review decision, or fails on timeout.
+- **FR-006**: A new harness helper `RequestPRReviewer(t, env, repo, prNumber, reviewer)` requests a specific reviewer on the PR via `POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers`. Needed so `wait_for_reviews` has an actual outstanding reviewer request.
+- **FR-007**: The test posts a PR comment while `fabrik:awaiting-ci` is present and asserts the comment eventually receives a 👀 reaction (or a response), confirming the comment is not silently dropped.
+- **FR-008**: The test asserts `stage:<X>:complete` is absent throughout the CI-await window (a 2-minute withheld check, as in `TestCIFixReinvoke`) and again throughout the review-await window.
+- **FR-009**: Research must resolve the second reviewer identity. If a second PAT for a distinct GitHub account (e.g. a test user) is available, `SubmitPRReview` uses it. If not, `SubmitPRReview` calls `t.Skip` with an instructional message and User Story 3 (timeout fallback) is exercised instead.
+- **FR-010**: `tests/e2e/README.md` scenario and regression-coverage tables are updated with a row for `TestConjunctiveCIReviewGate`, referencing ADR-056 and this issue (#895).
+- **FR-011**: The `ci-fix-sentinel` (or a new sentinel job, per Research's recommendation) must trigger a required CI check on the test PR so the `wait_for_ci` gate fires with a real failing-then-passing check, not a synthetic simulation.
+
+### Key Entities
+
+- **Both-gates stage**: A stage in the test bed configured with `wait_for_ci: true` and `wait_for_reviews: true`. Either the existing Validate stage (modified) or a new `TestGate` stage.
+- **SubmitPRReview (harness)**: A new helper that submits a PR review via the GitHub Reviews REST API using a reviewer PAT (distinct from `@arbeithand`).
+- **Reviewer identity**: A second GitHub account (or GitHub App) capable of submitting an approving review on a PR authored by `@arbeithand`. The main setup risk; resolved by Research.
+- **Joint-clear**: The engine behavior where both `fabrik:awaiting-ci` and `fabrik:awaiting-review` must be cleared before `stage:<X>:complete` is applied — the settlement ADR-056 defines.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `TestConjunctiveCIReviewGate` passes end-to-end: issue reaches `stage:<X>:complete` only after both `fabrik:awaiting-ci` and `fabrik:awaiting-review` have been applied and cleared in order.
+- **SC-002**: `stage:<X>:complete` is never observed while either gate label is present (the withheld-window check never fires).
+- **SC-003**: A reviewer comment posted during the CI-await window receives a 👀 reaction before or after CI clears (not silently dropped).
+- **SC-004**: `SubmitPRReview`, `PRReviewDecision`, `WaitForPRReviewDecision`, and `RequestPRReviewer` helpers are added to `harness.go` and reusable by any future scenario.
+- **SC-005**: If a second reviewer is unavailable, `TestConjunctiveCIReviewGate` passes in reduced scope (fallback path) — the withholding half and review-timeout path pass, with the approval path explicitly skipped via `t.Skip`.
+- **SC-006**: `go test ./tests/e2e/ -run TestConjunctiveCIReviewGate -tags e2e` passes cleanly against the live test bed.
+
+## Assumptions
+
+- The test bed Fabrik instance is running with the same config as all other e2e tests.
+- `ci-fix-sentinel` (or a new dedicated sentinel) is enrolled as a required status check on `handarbeit/fabrik-test-alpha/main` — the same prerequisite as `TestCIFixReinvoke`. The test skips gracefully if not.
+- The issue body for this test can be a minimal trivial change (same template as `TestCIFixReinvoke`) so the full pipeline completes quickly up to the gate stage.
+- If a `TestGate` dedicated stage is introduced, it must be added to the test-bed project board columns; Research must verify this does not break the existing `TestSmokeSingleRepoFullPipeline` path.
+- The review-timeout fallback path assumes `FABRIK_REVIEW_WAIT_TIMEOUT` is configurable in the test bed `.env`. Research must confirm this.
+
+## Out of Scope
+
+- Unit-testing the conjunctive gate logic in isolation (engine unit tests are separate; this is e2e only).
+- Verifying `wait_for_ci` or `wait_for_reviews` individually (each is already exercised by `TestCIFixReinvoke` and the review-gate machinery respectively).
+- Bot-reprompted escalation ladder (`fabrik:bot-reprompted`) — that is a distinct scenario.
+- Verifying the conjunctive gate with `fabrik:cruise` (cruise × gate interaction is out of scope for this issue).
+- ADR changes beyond a note that the conjunctive gate now has e2e coverage.
+
+## Source References
+
+- `tests/e2e/harness.go` — existing helpers; `SubmitPRReview`, `PRReviewDecision`, `WaitForPRReviewDecision`, `RequestPRReviewer` are new additions
+- `tests/e2e/ci_fix_reinvoke_test.go` — pattern for CI-gate wait + withheld-window check
+- `adrs/056-consolidate-convergence-gate-recovery.md` — settle-owner model; conjunctive gate semantics
+- `notes/state-machine-review-2026-06-17.md` — "Angle 1 — high" section that flagged this gap
+- `engine/ci.go` — CI gate implementation
+- `engine/poll.go` — review gate implementation and `checkAwaitingReview`
+- `docs/state-machine.md` — as-built specification for label transitions and gate semantics
+- Issue #887 (settle-owner), #890 (spec for joint-clear) — prerequisites

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -85,6 +85,27 @@ the canonical setup.
    E2E_TIMEOUT=3h scripts/e2e/run.sh -run TestPausedMergedPRRecovery
    ```
 
+### Additional prerequisites for `TestConjunctiveCIReviewGate`
+
+10. **`slow-gate` enrolled as a required status check** on
+    `handarbeit/fabrik-test-alpha/main`. The test skips gracefully (via
+    `t.Skip`) if not enrolled — safe to merge before enrollment.
+11. **One of the following for R5 (joint-clear verification)**:
+    - **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — a GitHub PAT for a
+      non-`@arbeithand` account with write access to `fabrik-test-alpha`. The
+      test uses this token to submit an approving PR review from a second
+      identity (GitHub forbids self-approval). This exercises the full
+      approval-path joint-clear (R5).
+    - **`FABRIK_REVIEW_WAIT_TIMEOUT=2` in the test bed `.env`** — sets the
+      review gate timeout to 2 minutes so the review-timeout fallback path
+      (R5 reduced scope) completes in a reasonable wall-clock budget. If this
+      value exceeds 5 and no reviewer token is present, the test skips with
+      an instructional message. After editing `.env`, restart Fabrik.
+12. **`E2E_TIMEOUT=2h`** when running this test in isolation:
+    ```bash
+    E2E_TIMEOUT=2h scripts/e2e/run.sh -run TestConjunctiveCIReviewGate
+    ```
+
 ## Running
 
 The recommended entrypoint is the runner script, which sets sensible defaults:
@@ -130,8 +151,9 @@ otherwise).
 | `TestCIFixReinvoke` | CI-fix reinvoke positive path: sentinel fails on first push, Claude fixes, CI passes, issue closes | 75–90 min | $1.00–3.00 |
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | 30–60 min | $0.50–1.50 |
 | `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
+| `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
 
-Approximate suite total: ~310 min wall-clock, $6.50–21.50 in Claude tokens (CI-fix tests and `TestPausedMergedPRRecovery` should be run separately with `E2E_TIMEOUT=3h`).
+Approximate suite total: ~470 min wall-clock, $7.50–24 in Claude tokens (CI-fix, `TestPausedMergedPRRecovery`, and conjunctive-gate tests should be run separately with `E2E_TIMEOUT=3h` or `E2E_TIMEOUT=2h` as noted above).
 
 ### Regression coverage map
 
@@ -147,6 +169,7 @@ Approximate suite total: ~310 min wall-clock, $6.50–21.50 in Claude tokens (CI
 | `TestCIFixReinvoke` | #888 ADR-056 D1 (settling primitive reinterprets CI-gate signals); CI-fix reinvoke loop (engine/ci.go) |
 | `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
 | `TestPausedMergedPRRecovery` | #874 (paused+merged PR recovery class), #887 (settle-owner structural fix, `runValidatePRTerminalAdvance`), ADR-056 D2 (single-owner for PR-terminal → Done) |
+| `TestConjunctiveCIReviewGate` | ADR-056 D2 (conjunctive gate joint-clear), #887 (settle-owner), #895 (this scenario) |
 
 Every escape-from-release regression earns a new scenario in this table.
 

--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -75,6 +75,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	// R1 withheld window (2 min): stage:Validate:complete must NOT appear while
 	// fabrik:awaiting-ci is present — CI has not yet passed (slow-gate ~6 min).
 	withheldDeadline := time.Now().Add(2 * time.Minute)
+	r1Checked := false
 	for time.Now().Before(withheldDeadline) {
 		labels, err := tryIssueLabels(env, env.RepoAlpha, num)
 		if err != nil {
@@ -82,6 +83,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 			time.Sleep(15 * time.Second)
 			continue
 		}
+		r1Checked = true
 		for _, l := range labels {
 			if l == "stage:Validate:complete" {
 				t.Fatalf("stage:Validate:complete appeared during CI-await window — CI gate did not hold on %s#%d",
@@ -89,6 +91,9 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 			}
 		}
 		time.Sleep(15 * time.Second)
+	}
+	if !r1Checked {
+		t.Fatalf("failed to fetch labels at least once during the R1 withheld window on %s#%d", env.RepoAlpha, num)
 	}
 	t.Logf("R1 withheld window passed: CI gate held for 2 minutes on %s#%d", env.RepoAlpha, num)
 
@@ -122,6 +127,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	// (current engine behavior: stage:Validate:complete IS added when CI clears, before
 	// the review gate runs — asserting it absent here would be wrong; see #890).
 	noteCompleteLogged := false
+	r4Checked := false
 	reviewWithheldDeadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(reviewWithheldDeadline) {
 		state, err := tryIssueState(env, env.RepoAlpha, num)
@@ -130,6 +136,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 			time.Sleep(15 * time.Second)
 			continue
 		}
+		r4Checked = true
 		if state == "CLOSED" {
 			t.Fatalf("issue %s#%d closed during review-await window — review gate did not hold",
 				env.RepoAlpha, num)
@@ -148,6 +155,9 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 			}
 		}
 		time.Sleep(15 * time.Second)
+	}
+	if !r4Checked {
+		t.Fatalf("failed to fetch issue state at least once during the R4 withheld window on %s#%d", env.RepoAlpha, num)
 	}
 	t.Logf("R4 withheld window passed: review gate held for 2 minutes on %s#%d", env.RepoAlpha, num)
 

--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -1,0 +1,223 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestConjunctiveCIReviewGate is the regression test for the conjunctive
+// CI∧review gate (ADR-056 D2). The Validate stage in the test bed is already
+// configured with both wait_for_ci: true and wait_for_reviews: true.
+//
+// The slow-gate CI check (~6 minutes, enrolled as required on
+// handarbeit/fabrik-test-alpha/main) is triggered by placing "slow-ci-required"
+// in the PR body. This creates a wide CI-await window without triggering the
+// CI-fix reinvoke machinery.
+//
+// Pass criteria (R1–R5):
+//   - R1: fabrik:awaiting-ci is applied after FABRIK_STAGE_COMPLETE; stage:Validate:complete
+//     is absent during CI-await (withheld 2 min window).
+//   - R2: fabrik:awaiting-ci clears when CI passes, then fabrik:awaiting-review appears.
+//   - R3: A PR comment posted during CI-await receives 👀 reaction (not dropped).
+//   - R4: Issue remains OPEN while fabrik:awaiting-review is present (advance suppressed).
+//   - R5 (approval path): SubmitPRReview(APPROVE) clears the review gate; issue closes;
+//     stage:Validate:complete applied; fabrik:paused never applied.
+//   - R5 (timeout fallback): if no FABRIK_REVIEWER_TOKEN, review gate times out;
+//     fabrik:paused + fabrik:awaiting-input appear; issue stays OPEN.
+//
+// Prerequisites:
+//   - "slow-gate" enrolled as a required status check on fabrik-test-alpha/main.
+//     Test skips gracefully if not enrolled.
+//   - FABRIK_REVIEWER_TOKEN in test bed .env for the approval path. If absent AND
+//     FABRIK_REVIEW_WAIT_TIMEOUT > 5, the test skips with an instructional message.
+//     If absent AND FABRIK_REVIEW_WAIT_TIMEOUT ≤ 5, the timeout fallback path runs.
+//   - FABRIK_REVIEW_WAIT_TIMEOUT=2 (minutes) in the test bed .env when using the
+//     timeout fallback path (otherwise the default 15-minute wait is impractical).
+//
+// Wall-clock: ~60–90 min (approval path); ~30–50 min (timeout path). Use E2E_TIMEOUT=2h.
+// Cost: ~$1.00–2.50.
+func TestConjunctiveCIReviewGate(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	assertSlowGateRequired(t, env, env.RepoAlpha)
+
+	reviewerToken := readEnvFileReviewerToken(t, env)
+	reviewWaitTimeout := readEnvFileReviewWaitTimeout(t, env)
+	if reviewerToken == "" && reviewWaitTimeout > 5 {
+		t.Skipf("FABRIK_REVIEWER_TOKEN not set in test bed .env and FABRIK_REVIEW_WAIT_TIMEOUT=%d min (> 5); "+
+			"set FABRIK_REVIEWER_TOKEN to a non-author PAT for the approval path, or "+
+			"set FABRIK_REVIEW_WAIT_TIMEOUT=2 (and restart Fabrik) for the timeout-fallback path",
+			reviewWaitTimeout)
+	}
+
+	stamp := time.Now().UTC().Format("20060102-150405")
+	title := fmt.Sprintf("e2e conjunctive-ci-review-gate (%s)", stamp)
+
+	num := FileIssue(t, env, env.RepoAlpha, title, conjunctiveCIReviewGateBody, "fabrik:yolo")
+	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
+	SetIssueStatus(t, env, itemID, "Specify")
+	t.Logf("filed %s#%d — waiting for Implement to complete", env.RepoAlpha, num)
+
+	// Wait for Implement to complete so the linked PR exists.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Implement:complete", 60*time.Minute)
+	prNumber := LinkedPRNumber(t, env, env.RepoAlpha, num)
+	t.Logf("Implement complete; PR #%d created for %s#%d", prNumber, env.RepoAlpha, num)
+
+	// R1: fabrik:awaiting-ci must appear after Validate fires (CI gate holds).
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 30*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci")
+	t.Logf("fabrik:awaiting-ci confirmed on %s#%d (CI gate is holding)", env.RepoAlpha, num)
+
+	// R1 withheld window (2 min): stage:Validate:complete must NOT appear while
+	// fabrik:awaiting-ci is present — CI has not yet passed (slow-gate ~6 min).
+	withheldDeadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(withheldDeadline) {
+		labels, err := tryIssueLabels(env, env.RepoAlpha, num)
+		if err != nil {
+			t.Logf("transient error fetching labels during R1 withheld window: %v (retrying)", err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		for _, l := range labels {
+			if l == "stage:Validate:complete" {
+				t.Fatalf("stage:Validate:complete appeared during CI-await window — CI gate did not hold on %s#%d",
+					env.RepoAlpha, num)
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Logf("R1 withheld window passed: CI gate held for 2 minutes on %s#%d", env.RepoAlpha, num)
+
+	// R3: Post a regular PR comment while fabrik:awaiting-ci is still present.
+	// The engine must process this comment (adding 👀 reaction) even during CI-await,
+	// because itemNeedsWork returns true for new comments before the CI-gate guard.
+	commentBody := fmt.Sprintf("e2e-conjunctive-gate-ci-await (%s)", stamp)
+	CommentOnPR(t, env, env.RepoAlpha, prNumber, commentBody)
+	t.Logf("posted PR comment %q on #%d during CI-await (R3)", commentBody, prNumber)
+
+	// Wait for CI (slow-gate, ~6 min) to pass — fabrik:awaiting-ci clears when
+	// addCompleteLabelAndRemoveCI runs after checkCIGate returns cleared.
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 20*time.Minute)
+	t.Logf("fabrik:awaiting-ci cleared on %s#%d (CI gate passed)", env.RepoAlpha, num)
+
+	// R3 verify: the PR comment must have received 👀 (eyes) reaction.
+	// This confirms the comment was not silently dropped during CI-await.
+	WaitForPRCommentReaction(t, env, env.RepoAlpha, prNumber, commentBody, "eyes", 10*time.Minute)
+	t.Logf("R3 verified: 👀 reaction on PR comment confirms processing during CI-await on %s#%d",
+		env.RepoAlpha, num)
+
+	// R2: fabrik:awaiting-review must appear after CI clears.
+	// (addCompleteLabelAndRemoveCI adds stage:Validate:complete; next poll
+	// checkReviewGate fires and adds fabrik:awaiting-review — one poll cycle gap.)
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 5*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d (review gate is holding)", env.RepoAlpha, num)
+
+	// R4 withheld window (2 min): advance must NOT occur while fabrik:awaiting-review
+	// is present. Issue must remain OPEN even if stage:Validate:complete is already set
+	// (current engine behavior: stage:Validate:complete IS added when CI clears, before
+	// the review gate runs — asserting it absent here would be wrong; see #890).
+	noteCompleteLogged := false
+	reviewWithheldDeadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(reviewWithheldDeadline) {
+		state, err := tryIssueState(env, env.RepoAlpha, num)
+		if err != nil {
+			t.Logf("transient error fetching issue state during R4 withheld window: %v (retrying)", err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		if state == "CLOSED" {
+			t.Fatalf("issue %s#%d closed during review-await window — review gate did not hold",
+				env.RepoAlpha, num)
+		}
+		// Informational only: stage:Validate:complete is expected to be present during
+		// review-await (current behavior). Not a failure — see issue #890 for reconciliation.
+		if !noteCompleteLogged {
+			if labels, lerr := tryIssueLabels(env, env.RepoAlpha, num); lerr == nil {
+				for _, l := range labels {
+					if l == "stage:Validate:complete" {
+						t.Logf("note: stage:Validate:complete present during review-await (current behavior, not a failure — see #890)")
+						noteCompleteLogged = true
+						break
+					}
+				}
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Logf("R4 withheld window passed: review gate held for 2 minutes on %s#%d", env.RepoAlpha, num)
+
+	if reviewerToken != "" {
+		// R5 — approval path: submit an approving review from the second identity.
+		// GitHub forbids the PR author (@arbeithand) from approving their own PR, so
+		// FABRIK_REVIEWER_TOKEN must be a different GitHub account.
+		SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNumber, "APPROVE")
+		t.Logf("submitted APPROVE review on %s PR #%d using reviewer token", env.RepoAlpha, prNumber)
+
+		// Issue must close (yolo auto-merges after both gates clear).
+		WaitForIssueClosed(t, env, env.RepoAlpha, num, 30*time.Minute)
+		AssertLabelWasApplied(t, env, env.RepoAlpha, num, "stage:Validate:complete")
+		AssertLabelWasNeverApplied(t, env, env.RepoAlpha, num, "fabrik:paused")
+		t.Logf("R5 verified: %s#%d closed after approval; stage:Validate:complete applied, fabrik:paused never applied",
+			env.RepoAlpha, num)
+	} else {
+		// R5 fallback — timeout path: with no second reviewer, the review gate
+		// times out after FABRIK_REVIEW_WAIT_TIMEOUT minutes and pauses the issue.
+		t.Logf("no FABRIK_REVIEWER_TOKEN — using review-timeout fallback path (FABRIK_REVIEW_WAIT_TIMEOUT=%d min)",
+			reviewWaitTimeout)
+		timeoutWait := time.Duration(reviewWaitTimeout+5) * time.Minute
+		WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:paused", timeoutWait)
+		t.Logf("fabrik:paused appeared on %s#%d (review gate timed out)", env.RepoAlpha, num)
+		WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 5*time.Minute)
+		t.Logf("fabrik:awaiting-input appeared on %s#%d", env.RepoAlpha, num)
+		if state := IssueState(t, env, env.RepoAlpha, num); state != "OPEN" {
+			t.Fatalf("expected issue OPEN after review timeout, got %s on %s#%d",
+				state, env.RepoAlpha, num)
+		}
+		t.Logf("R5 timeout path verified: %s#%d paused with fabrik:awaiting-input; review gate held (no premature advance)",
+			env.RepoAlpha, num)
+		t.Logf("NOTE: R5 approval path (joint-clear on review submission) was not exercised — " +
+			"set FABRIK_REVIEWER_TOKEN in the test bed .env to test full joint-clear")
+	}
+}
+
+// conjunctiveCIReviewGateBody is the issue body for TestConjunctiveCIReviewGate.
+// Claude makes a minimal change to README.md and includes "slow-ci-required"
+// in the PR body to trigger the ~6-minute slow-gate required CI check, creating
+// a wide CI-await window for the conjunctive gate test.
+const conjunctiveCIReviewGateBody = `## Goal
+
+End-to-end regression test for the Fabrik conjunctive CI∧review gate
+(handarbeit/fabrik#895, ADR-056 D2). Validates that both the CI gate and the
+review gate must both be satisfied before Validate advances the issue.
+
+## The change
+
+Add exactly one new HTML comment to README.md, on its own line, immediately
+after the line containing "# fabrik-test-alpha". The comment must be EXACTLY:
+
+    <!-- conjunctive-ci-review-gate-test -->
+
+This is the only change needed. No other files should be modified. Do NOT
+reuse any other HTML comment from prior tests — the marker above is unique
+to this test.
+
+## CI behaviour required
+
+The PR body MUST carry the literal marker below so the test repo's CI
+slow-gate check fires (~6 minutes, enrolled as a required check):
+
+slow-ci-required
+
+This creates the CI-await window the test needs to verify the conjunctive gate
+behaviour. Do NOT include ci-fix-sentinel-required in the PR body.
+
+## Scope
+
+Single file (README.md). Minimal one-line change. No decomposition.
+Plan and Implement should be a one-commit change.
+`

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -909,3 +909,128 @@ func readEnvFileMaxCiFixCycles(t *testing.T, env *Env) int {
 	}
 	return n
 }
+
+// assertSlowGateRequired skips the test if "slow-gate" is not a required
+// status check on the repo's main branch. Skips (never fatals) so the test
+// suite remains green before the slow-gate CI job is enrolled.
+func assertSlowGateRequired(t *testing.T, env *Env, repo string) {
+	t.Helper()
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		t.Fatalf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/%s/branches/main/protection", owner, name),
+		"--jq", ".required_status_checks.contexts[]")
+	if err != nil {
+		t.Skipf("slow-gate not enrolled as required check on %s/main (branch protection API error: %v)", repo, err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "slow-gate" {
+			return
+		}
+	}
+	t.Skipf("slow-gate not in required status checks for %s/main — enroll it before running this test", repo)
+}
+
+// CommentOnPR posts a comment on the PR using the test bed's PAT identity.
+// PR numbers differ from issue numbers; use this helper (not CommentOnIssue)
+// when targeting a PR's comment thread.
+func CommentOnPR(t *testing.T, env *Env, repo string, prNumber int, body string) {
+	t.Helper()
+	if _, err := ghOutput(env, "pr", "comment", fmt.Sprint(prNumber), "-R", repo, "--body", body); err != nil {
+		t.Fatalf("post comment on %s PR #%d: %v", repo, prNumber, err)
+	}
+}
+
+// readEnvFileReviewerToken reads FABRIK_REVIEWER_TOKEN from the test bed's
+// .env file. Returns "" if absent — callers branch on the empty string to
+// decide whether to run the approval path or the review-timeout fallback.
+func readEnvFileReviewerToken(t *testing.T, env *Env) string {
+	t.Helper()
+	envFile := filepath.Join(env.FabrikTestDir, ".env")
+	val, err := readEnvFileValue(envFile, "FABRIK_REVIEWER_TOKEN")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(val)
+}
+
+// readEnvFileReviewWaitTimeout reads FABRIK_REVIEW_WAIT_TIMEOUT (minutes)
+// from the test bed's .env file. Returns 15 (the engine default) if absent.
+// Fails the test if the key is present but not a valid integer.
+func readEnvFileReviewWaitTimeout(t *testing.T, env *Env) int {
+	t.Helper()
+	envFile := filepath.Join(env.FabrikTestDir, ".env")
+	val, err := readEnvFileValue(envFile, "FABRIK_REVIEW_WAIT_TIMEOUT")
+	if err != nil {
+		return 15
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(val))
+	if err != nil {
+		t.Fatalf("FABRIK_REVIEW_WAIT_TIMEOUT in %s is not an integer: %q", envFile, val)
+	}
+	return n
+}
+
+// ghOutputWithToken runs gh with a caller-supplied token (overrides GH_TOKEN).
+// Used by SubmitPRReview where the reviewer identity differs from the bot's
+// main PAT stored in *Env.
+func ghOutputWithToken(token string, args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	cmd.Env = append(os.Environ(), "GH_TOKEN="+token)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// SubmitPRReview submits a review on the PR using reviewerToken (a PAT for a
+// non-author identity — GitHub forbids the PR author from approving their own
+// PR). action must be "APPROVE" or "REQUEST_CHANGES" (GitHub API event values).
+// Fails the test on API error (e.g. 422 if reviewerToken == env.GHToken).
+func SubmitPRReview(t *testing.T, env *Env, reviewerToken string, repo string, prNumber int, action string) {
+	t.Helper()
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		t.Fatalf("bad repo: %q", repo)
+	}
+	path := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", owner, name, prNumber)
+	out, err := ghOutputWithToken(reviewerToken, "api", "-X", "POST", path,
+		"-f", "event="+action)
+	if err != nil {
+		t.Fatalf("SubmitPRReview %s on %s PR #%d: %v\n%s", action, repo, prNumber, err, out)
+	}
+}
+
+// WaitForPRCommentReaction polls PR comments (via the issues comments API)
+// every 15s until a comment containing commentSubstring has at least one
+// reaction of type reactionContent (e.g. "eyes" for 👀, "rocket" for 🚀).
+// Returns as soon as the count is > 0; fails the test on timeout.
+func WaitForPRCommentReaction(t *testing.T, env *Env, repo string, prNumber int, commentSubstring string, reactionContent string, timeout time.Duration) {
+	t.Helper()
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		t.Fatalf("bad repo: %q", repo)
+	}
+	// jq: sum the named reaction count across all comments whose body contains
+	// the substring; default 0 when no match.
+	filter := fmt.Sprintf(`[.[] | select(.body | contains("%s")) | .reactions.%s] | add // 0`,
+		strings.ReplaceAll(commentSubstring, `"`, `\"`), reactionContent)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := ghOutput(env, "api",
+			fmt.Sprintf("repos/%s/%s/issues/%d/comments", owner, name, prNumber),
+			"--jq", filter)
+		if err != nil {
+			t.Logf("WaitForPRCommentReaction: transient error on %s PR #%d: %v (will retry)", repo, prNumber, err)
+			time.Sleep(15 * time.Second)
+			continue
+		}
+		count, parseErr := strconv.Atoi(strings.TrimSpace(out))
+		if parseErr == nil && count > 0 {
+			return
+		}
+		time.Sleep(15 * time.Second)
+	}
+	t.Fatalf("timed out waiting for %q reaction on comment containing %q on %s PR #%d",
+		reactionContent, commentSubstring, repo, prNumber)
+}

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1013,8 +1013,10 @@ func WaitForPRCommentReaction(t *testing.T, env *Env, repo string, prNumber int,
 	}
 	// jq: sum the named reaction count across all comments whose body contains
 	// the substring; default 0 when no match.
+	escaped := strings.ReplaceAll(commentSubstring, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 	filter := fmt.Sprintf(`[.[] | select(.body | contains("%s")) | .reactions.%s] | add // 0`,
-		strings.ReplaceAll(commentSubstring, `"`, `\"`), reactionContent)
+		escaped, reactionContent)
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		out, err := ghOutput(env, "api",


### PR DESCRIPTION
Closes #895

## Summary

Add a new e2e test `TestConjunctiveCIReviewGate` that drives an issue through the Validate stage (which already has `wait_for_ci: true` and `wait_for_reviews: true` in the test bed). The test asserts the label ordering, that no premature completion occurs, that a PR comment posted during CI-await is not dropped, and that both gates must be satisfied before the issue advances. A harness helper `SubmitPRReview` must be added to enable submitting a PR approval from a non-`@arbeithand` identity.

## Problem

The e2e suite (`tests/e2e/`) has no scenario for a stage configured with **both** `wait_for_ci: true` **and** `wait_for_reviews: true`. The 2026-06-17 state-machine review (`notes/state-machine-review-2026-06-17.md`) flagged the conjunctive CI∧review gate as the single biggest untested hole: there is no described joint-clearing path, no test, and a reviewer who comments during the CI-await window is currently unverified as to whether the comment is processed. ADR-056 / #887 (settle-owner) and #890 (spec) make the joint-clear explicit; this scenario verifies it end-to-end.

## Approach

### Approach

The test `TestConjunctiveCIReviewGate` drives a real pipeline issue through Validate — the only stage in the test bed that already has both `wait_for_ci: true` and `wait_for_reviews: true`. It uses the `slow-gate` CI check (6-minute pass delay, enrolled as a required check) to create a wide CI-await window without triggering a CI-fix reinvoke. Six new helpers are added to `harness.go`; the test has two explicit paths depending on whether `FABRIK_REVIEWER_TOKEN` is set in the test bed's `.env`.

**Key design decisions:**

1. **CI mechanism: `slow-gate` via `slow-ci-required`, not `ci-fix-sentinel`.** Research confirmed `slow-gate` is enrolled as a required check and runs ~6 min, while `ci-fix-sentinel` is not enrolled. The slow-gate creates a wide CI-await window without triggering the CI-fix reinvoke machinery.

2. **R4 assertion scope: "issue not advanced to Done", not `stage:Validate:complete` absent.** The current code (`addCompleteLabelAndRemoveCI`) unconditionally adds `stage:Validate:complete` when CI clears — before `fabrik:awaiting-review` is applied. R2's stronger requirement (`stage:Validate:complete` only after both gates) belongs to issue #890, which is out of scope here. The test asserts the observable advance-gate behavior (issue stays OPEN while `fabrik:awaiting-review` is present) — not the internal label state. If #890 later defers `stage:Validate:complete`, a follow-on PR can strengthen this assertion.

3. **Two test paths for R5.** If `FABRIK_REVIEWER_TOKEN` is present in the test bed `.env`, `SubmitPRReview` approves the PR and asserts full joint-clear (R5). If absent and `FABRIK_REVIEW_WAIT_TIMEOUT > 5`, the test skips with a clear message. If absent and `FABRIK_REVIEW_WAIT_TIMEOUT ≤ 5`, the test waits for the review gate to timeout and asserts `fabrik:paused` + `fabrik:awaiting-input` (reduced-scope fallback).

4. **R3 verification via reaction count.** GitHub's issues comments API includes inline reaction counts (`reactions.eyes`) in the standard response. `WaitForPRCommentReaction` polls using a single `gh api` call per iteration with a jq filter — no preview header required.

5. **`CommentOnPR` uses `gh pr comment`.** The existing `CommentOnIssue` takes an issue number; PR numbers differ from issue numbers. A separate `CommentOnPR` using `gh pr comment` is explicit and avoids the ambiguity.

6. **`SubmitPRReview` uses a private `ghOutputWithToken`.** Rather than reading the reviewer token inside the helper, the caller passes it explicitly, and the helper calls a private `ghOutputWithToken(token, args...)` that overrides `GH_TOKEN`. This keeps the auth model consistent with the rest of the harness.

7. **No ADR needed.** No codebase-wide architectural constraints are introduced — this is test infrastructure only.

### New/Modified Files

| File | Change |
|------|--------|
| `tests/e2e/harness.go` | Add 6 new helpers: `assertSlowGateRequired`, `CommentOnPR`, `readEnvFileReviewerToken`, `readEnvFileReviewWaitTimeout`, `SubmitPRReview`, `WaitForPRCommentReaction`; add private `ghOutputWithToken` |
| `tests/e2e/conjunctive_ci_review_gate_test.go` | New file: `TestConjunctiveCIReviewGate` + `conjunctiveCIReviewGateBody` const |
| `tests/e2e/README.md` | Add scenario row and regression-coverage row |

### Task Checklist

- [ ] Task 1: Add `assertSlowGateRequired(t *testing.T, env *Env, repo string)` to `harness.go` — mirrors `assertSentinelCheckRequired` but checks for `slow-gate` in the required status checks of `repo/main`; skips (never fatals) if not enrolled.

- [ ] Task 2: Add `CommentOnPR(t *testing.T, env *Env, repo string, prNumber int, body string)` to `harness.go` — posts a comment to the PR using `gh pr comment {prNumber} -R {repo} --body {body}`; fails the test on error.

- [ ] Task 3: Add `readEnvFileReviewerToken(t *testing.T, env *Env) string` and `readEnvFileReviewWaitTimeout(t *testing.T, env *Env) int` to `harness.go`:
  - `readEnvFileReviewerToken`: reads `FABRIK_REVIEWER_TOKEN` from the test bed's `.env`; returns `""` if absent (not an error — the test checks and branches on this).
  - `readEnvFileReviewWaitTimeout`: reads `FABRIK_REVIEW_WAIT_TIMEOUT`; defaults to `15` if absent; `t.Fatalf` if present but not a valid integer.

- [ ] Task 4: Add private `ghOutputWithToken(token string, args ...string) (string, error)` to `harness.go` — same as `ghOutput` but takes a token directly (no `*Env`), sets `GH_TOKEN=token`. Add `SubmitPRReview(t *testing.T, env *Env, reviewerToken string, repo string, prNumber int, action string)` — POSTs to `repos/{owner}/{repo}/pulls/{prNumber}/reviews` using `ghOutputWithToken` with the reviewer token; `action` is `"APPROVE"` or `"REQUEST_CHANGES"` (GitHub API event value); fails the test on error.

- [ ] Task 5: Add `WaitForPRCommentReaction(t *testing.T, env *Env, repo string, prNumber int, commentSubstring string, reactionContent string, timeout time.Duration)` to `harness.go` — polls `repos/{owner}/{repo}/issues/{prNumber}/comments` every 15s; uses jq filter `[.[] | select(.body | contains("{commentSubstring}")) | .reactions.{reactionContent}] | add // 0` to count reactions on matching comments; returns when count > 0; `t.Fatalf` on timeout.

- [ ] Task 6: Create `tests/e2e/conjunctive_ci_review_gate_test.go` with `//go:build e2e`, `TestConjunctiveCIReviewGate`, and `conjunctiveCIReviewGateBody` const. Test structure:
  1. `LoadEnv`, `AssertFabrikRunning`, `assertSlowGateRequired`
  2. Read `reviewerToken` + `reviewWaitTimeout`; skip if `reviewerToken == "" && reviewWaitTimeout > 5` with an instructional message
  3. `FileIssue` with `fabrik:yolo`, `AddIssueToProject`, `SetIssueStatus("Specify")`; `t.Logf`
  4. `WaitForIssueLabel("stage:Implement:complete", 60min)` → `LinkedPRNumber`
  5. `WaitForIssueLabel("fabrik:awaiting-ci", 30min)` + `AssertLabelWasApplied("fabrik:awaiting-ci")` — R1 observed
  6. **R1 withheld window (2 min)**: poll `tryIssueLabels` every 15s; `t.Fatalf` if `stage:Validate:complete` appears
  7. **R3**: `CommentOnPR` with unique body `fmt.Sprintf("e2e-conjunctive-gate-ci-await (%s)", stamp)`
  8. `WaitForLabelAbsent("fabrik:awaiting-ci", 20min)` — CI (slow-gate) passed
  9. **R3 verify**: `WaitForPRCommentReaction(..., "eyes", 10min)` — 👀 reaction confirms comment not dropped
  10. **R2**: `WaitForIssueLabel("fabrik:awaiting-review", 5min)` + `AssertLabelWasApplied("fabrik:awaiting-review")`
  11. **R4 withheld window (2 min)**: poll every 15s; `t.Fatalf` if `IssueState` is `"CLOSED"` (advance not permitted while review gate holds); `t.Logf` if `stage:Validate:complete` is present (informational — current behavior without #890)
  12. **R5 — approval path**: if `reviewerToken != ""`: `SubmitPRReview(..., "APPROVE")` → `WaitForIssueClosed(30min)` → `AssertLabelWasApplied("stage:Validate:complete")` → `AssertLabelWasNeverApplied("fabrik:paused")`
  13. **R5 fallback — timeout path**: else: `WaitForIssueLabel("fabrik:paused", reviewWaitTimeout+5 min)` → `WaitForIssueLabel("fabrik:awaiting-input", 5min)` → assert `IssueState == "OPEN"`; `t.Logf` noting approval path was not exercised

  `conjunctiveCIReviewGateBody` instructs Claude to add one HTML comment to `README.md` and explicitly requires the PR body to contain `slow-ci-required`.

- [ ] Task 7: Update `tests/e2e/README.md` — add one row to the Scenarios table and one row to the Regression coverage map:
  - Scenarios row: `TestConjunctiveCIReviewGate | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, fabrik:awaiting-review holds before approval, PR comment during CI-await not dropped | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50`
  - Coverage row: `TestConjunctiveCIReviewGate | ADR-056 D2 (conjunctive gate joint-clear), #887 (settle-owner), #895 (this test)`
  - Update Prerequisites section with: `TestConjunctiveCIReviewGate` requires `slow-gate` enrolled as required check; optionally `FABRIK_REVIEWER_TOKEN` in `.env` for the approval path; if absent, `FABRIK_REVIEW_WAIT_TIMEOUT≤5` required.

### Risks

1. **`slow-gate` enrollment**: If `slow-gate` is not enrolled as a required check, `assertSlowGateRequired` skips the test. The test infrastructure is correct; operator must enroll the check for the test to run.

2. **R3 reaction polling**: GitHub's reactions API sometimes has a short propagation delay (~5-15s). The 10-minute timeout in `WaitForPRCommentReaction` is sufficient, but the 15-second poll interval means the reaction is detected within ~30 seconds of being applied.

3. **Review gate triggers immediately (no reviewer requested)**: With no configured reviewer on the Validate stage, `checkReviewGate` adds `fabrik:awaiting-review` on the first catch-up poll after CI clears. There's no idle window between CI clearing and the review gate becoming active — this is correct behavior to verify.

4. **`SubmitPRReview` GitHub constraint**: GitHub forbids the PR author (`@arbeithand`) from approving their own PRs. `FABRIK_REVIEWER_TOKEN` must be a different identity. If it's accidentally the same token, `gh api` returns a 422 and the test fails with a `t.Fatalf` from `SubmitPRReview` — this is the correct failure mode.

5. **Wall-clock budget**: Approval path (~60–90 min total): 40-50 min pipeline + 6 min slow-gate + review processing. Timeout fallback (~30-50 min): same pipeline + 6 min slow-gate + `FABRIK_REVIEW_WAIT_TIMEOUT` (2-5 min). Operators should run with `E2E_TIMEOUT=2h`.

---
Used 13/50 turns, 7k input / 13k output tokens.

## Verification

Added `TestConjunctiveCIReviewGate` with five supporting harness helpers to cover the conjunctive CI∧review gate: R1 (CI gate holds with 2-min withheld window), R2 (label ordering after CI clears), R3 (PR comment during CI-await gets 👀), R4 (review gate holds for 2 min), and R5 (approval or timeout fallback). Uses the `slow-gate` CI check (enrolled as required, ~6 min) rather than the ci-fix-sentinel (which is not enrolled). README updated with prerequisites for `FABRIK_REVIEWER_TOKEN` and `FABRIK_REVIEW_WAIT_TIMEOUT`.

---

Closes #895