### PR TITLE
refactor(engine): decompose Phase 1 catch-up loop into ordered handler list

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3457,45 +3457,47 @@ When all outstanding requested reviewers are bots (detected via `ReviewRequest.I
 
 The catch-up loop in `poll()` is split into two phases for every non-paused non-cleanup item that has either `stage:<X>:complete` OR `fabrik:awaiting-ci` (on a `wait_for_ci: true` stage):
 
-**Phase 1 — unconditional (all items, regardless of yolo/cruise/auto_advance):**
-1. `checkDependencies()` — if blocked, skip
-2. `checkReviewGate()` — **only when `stage:<X>:complete` is present** (skipped during the CI-await window when `fabrik:awaiting-ci` is present but `stage:X:complete` is absent — prevents spurious `fabrik:awaiting-review` re-application from stale board data; #617). When run: if awaiting reviewers, skip; if timed out, pause
-3. `buildReviewThreadComments()` collects inline comments from unresolved review threads (no ROCKET reaction, not in `snap.CommentProcessed(c.ID)`)
-4. **Worker guard (`snap.Worker() != nil`):** If a reinvoke goroutine from a previous poll cycle is still running, the entire reinvoke path is skipped (including cycle-limit checks)
-5. **Cycle limit check:** `snap.ReviewCycles(stage.Name)` is compared against `MaxReviewCycles` (default 5)
-   - If exceeded: `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
-   - If not exceeded: increment count, dispatch reinvoke via `dispatchReviewReinvoke()`:
-     - Applies `WorkerEntered` (prevents double-dispatch)
-     - Acquires semaphore slot (respects `MaxConcurrent`)
-     - Calls `processComments()` with the synthetic review comments asynchronously
-     - On exit: releases semaphore, applies `WorkerExited`
-   - Either way: `continue` — Phase 2 is skipped this cycle; item re-evaluated on next poll
-5.5. **Settle call** (runs immediately before the merge-conflict gate and CI gate; only for stages with `wait_for_ci: true`): `settlePRMergeState()` fetches `mergeable`, `mergeable_state`, and check runs in a single pass, returning a typed `PRSettleResult`. Both gates below receive this result and do not make their own REST calls for these fields — eliminating the split-brain where two separate REST calls within one poll cycle could observe different GitHub state. See §6.4 for the full settling primitive specification.
-6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`): `checkMergeabilityGate()` interprets the `PRSettleResult` from the settle call
-   - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
-   - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
-   - `PRMergeBlocked` (CI checks failed): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate so `checkCIGate` can classify and dispatch the CI-fix reinvoke
-   - `PRMergeUnsettled`: block this item for the rest of Phase 1 (**no label churn** — ADR-032 R10c)
-   - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
-     - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
-     - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
-7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` interprets the `PRSettleResult` from the settle call for stages with `wait_for_ci: true`
-   - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); advance to Done
-   - **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
-   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`, or all checks green):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
-   - **`PRMergeBlocked` or `PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
-   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
-   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
-   - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
-   - Timed out (generic path): `pauseForCITimeout()` pauses issue
-   - CI failed: **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.CIFixCycles(stage.Name)` vs `MaxCiFixCycles`):
-     - If exceeded: `pauseForCIFixCycleLimit()` pauses issue
-     - If not exceeded: dispatch `dispatchCIFixReinvoke()`; `continue`
+**Phase 1 — unconditional, ordered handler list (`catchUpPhase1Handlers`):**
+
+Phase 1 is implemented as an explicit ordered slice of named handler methods (`catchUpPhase1Handlers` in `engine/catch_up_handlers.go`). Each handler returns `true` to claim the item — Phase 2 is skipped for this item this cycle — or `false` to pass through to the next handler. **Ordering is structurally enforced by slice position** (ADR-056 D3); a future reorder requires a deliberate code change and triggers a test failure, rather than occurring as an accidental side effect of a `continue` insertion.
+
+**Handler 1: `handleDependencies`** — thin wrapper around `checkDependencies()`. If the item has unresolved blocking dependencies, claims the item (returns true); otherwise passes through.
+
+**Handler 2: `handleReviewGate`** — only active when `stage:<X>:complete` is present (`pctx.hasComplete == true`; skipped during the CI-await window when `fabrik:awaiting-ci` is present but `stage:X:complete` is absent — prevents spurious `fabrik:awaiting-review` re-application from stale board data; #617):
+- `checkReviewGate()`: if awaiting reviewers, records `CooldownRecorded{Reason: "review-blocked"}` so `itemMayNeedWork`'s expiry path re-evaluates the item every 10 × PollSeconds, then claims the item; if timed out, calls `pauseForReviewTimeout()` and claims.
+- If gate cleared, `buildReviewThreadComments()` collects inline comments from unresolved review threads (no ROCKET reaction, not in `snap.CommentProcessed(c.ID)`). If no comments: passes through (returns false).
+- **Worker guard (`snap.Worker() != nil`):** if a reinvoke goroutine from a previous poll cycle is still running, claims the item without dispatching or incrementing the cycle count.
+- **Cycle limit check** (`snap.ReviewCycles(stage.Name)` vs `MaxReviewCycles`, default 5): if exceeded, `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and claims. If not exceeded: increment count via `ReviewCycleIncremented`, dispatch `dispatchReviewReinvoke()` (applies `WorkerEntered`, acquires semaphore, calls `processComments()` asynchronously), set `advancedItems[key] = true`, claim.
+
+**Handler 3: `handleAutoMergeConvergence`** — if the item does not have `fabrik:auto-merge-enabled`, passes through. If it does: calls `checkAutoMergeConvergence()` and claims the item (returns true). All merge/CI gates are bypassed — GitHub owns the merge decision for these items. This handler sits immediately before `handleMergeAndCIGates` to ensure `settlePRMergeState()` is never called for auto-merge items (they return true here before the settle call executes).
+
+**Handler 4: `handleMergeAndCIGates`** — calls `settlePRMergeState()` once (the settle call shared by both gates), then the merge-conflict gate, then the CI gate. Merge runs before CI per ADR-028: a PR made unmergeable by a base-branch advance must be rebased before the engine spins on CI-await polls. See §6.4 for the full settling primitive specification.
+
+- **Settle call:** `settlePRMergeState()` fetches `mergeable`, `mergeable_state`, and check runs in a single pass, returning a typed `PRSettleResult`. Both gates below consume this result and do not make additional REST calls — eliminating the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
+
+- **Merge-conflict gate** (`checkMergeabilityGate()` interprets `PRSettleResult`):
+  - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
+  - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
+  - `PRMergeBlocked` (CI checks failed): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate so `checkCIGate` can classify and dispatch the CI-fix reinvoke
+  - `PRMergeUnsettled`: claims the item, blocking it for the rest of Phase 1 (**no label churn** — ADR-032 R10c)
+  - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
+    - If exceeded: `pauseForRebaseCycleLimit()` pauses issue and claims
+    - If not exceeded: increment count via `RebaseCycleIncremented`, dispatch `dispatchRebaseReinvoke()`, set `advancedItems[key] = true`, claim. The CI gate is never reached while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
+
+- **CI gate** (`checkCIGate()` interprets `PRSettleResult`; only active when `stage.WaitForCI == true`):
+  - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); handler returns false (advance falls through to Phase 2)
+  - **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; handler returns false
+  - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`, or all checks green):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+  - **`PRMergeBlocked` or `PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies; pending → blocked (not failed); CI failed → **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.CIFixCycles(stage.Name)` vs `MaxCiFixCycles`): if exceeded, `pauseForCIFixCycleLimit()` claims; if not exceeded, increment count via `CIFixCycleIncremented`, dispatch `dispatchCIFixReinvoke()`, set `advancedItems[key] = true`, claim
+  - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
+  - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
+  - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
+  - Timed out (generic path): `pauseForCITimeout()` pauses issue
 
 **After Phase 1 + Phase 2 — single-owner Validate advance (`runValidatePRTerminalAdvance`, R4 — ADR-056 D2, ADR-057):** A single authoritative scan iterates `deepFetchCandidates` for all Validate-stage items not in the `fabrik:auto-merge-enabled` convergence flow, regardless of which gate label (`fabrik:awaiting-ci`, `fabrik:awaiting-review`, `fabrik:rebase-needed`, or any future label) is present. For each, `e.client.FetchLinkedPR` is called directly (not `e.readClient` — boardcache may have stale state). When `pr.Merged == true`: iterates all pipeline stages in ascending Order from the stage after the highest already-complete stage up to (but not including) the cleanup-terminal stage, adding `stage:<N>:complete` for every `WaitForCI` or `WaitForReviews` gate-checked stage whose label is absent (with cache write-through; fail-fast on error for idempotent retry). After all labels are added, `removeAwaitingCILabel`, `removeAwaitingReviewLabel`, and `removeRebaseNeededLabel` are called as applicable, `fabrik:paused` + `fabrik:awaiting-input` are removed, and `advanceToNextStage()` is called. Items already in `advancedItems` are skipped (prevents double-advance). This self-heals Validate-stage items merged externally regardless of which gate was active, without requiring a manual unpause. The function never dispatches workers or acquires `e.sem` — label-mutation-only path (see ADR-053 constraints; superseded in structure by ADR-057).
 
 **Phase 2 — gated (yolo/cruise/auto_advance only):**
-- Only runs when no reinvoke was dispatched in Phase 1 (review, rebase, and CI-fix reinvoke all `continue`)
+- Only runs when no Phase 1 handler claimed the item (i.e., all handlers returned false)
 - Gated on: `e.cfg.Yolo` OR `fabrik:yolo` label OR `fabrik:cruise` label OR stage `auto_advance: true`
 - Runs `attemptMergeOnValidate()` (yolo only), skips if unprocessed comments exist, then calls `advanceToNextStage()`
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -989,45 +989,47 @@ When all outstanding requested reviewers are bots (detected via `ReviewRequest.I
 
 The catch-up loop in `poll()` is split into two phases for every non-paused non-cleanup item that has either `stage:<X>:complete` OR `fabrik:awaiting-ci` (on a `wait_for_ci: true` stage):
 
-**Phase 1 — unconditional (all items, regardless of yolo/cruise/auto_advance):**
-1. `checkDependencies()` — if blocked, skip
-2. `checkReviewGate()` — **only when `stage:<X>:complete` is present** (skipped during the CI-await window when `fabrik:awaiting-ci` is present but `stage:X:complete` is absent — prevents spurious `fabrik:awaiting-review` re-application from stale board data; #617). When run: if awaiting reviewers, skip; if timed out, pause
-3. `buildReviewThreadComments()` collects inline comments from unresolved review threads (no ROCKET reaction, not in `snap.CommentProcessed(c.ID)`)
-4. **Worker guard (`snap.Worker() != nil`):** If a reinvoke goroutine from a previous poll cycle is still running, the entire reinvoke path is skipped (including cycle-limit checks)
-5. **Cycle limit check:** `snap.ReviewCycles(stage.Name)` is compared against `MaxReviewCycles` (default 5)
-   - If exceeded: `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and posts comment
-   - If not exceeded: increment count, dispatch reinvoke via `dispatchReviewReinvoke()`:
-     - Applies `WorkerEntered` (prevents double-dispatch)
-     - Acquires semaphore slot (respects `MaxConcurrent`)
-     - Calls `processComments()` with the synthetic review comments asynchronously
-     - On exit: releases semaphore, applies `WorkerExited`
-   - Either way: `continue` — Phase 2 is skipped this cycle; item re-evaluated on next poll
-5.5. **Settle call** (runs immediately before the merge-conflict gate and CI gate; only for stages with `wait_for_ci: true`): `settlePRMergeState()` fetches `mergeable`, `mergeable_state`, and check runs in a single pass, returning a typed `PRSettleResult`. Both gates below receive this result and do not make their own REST calls for these fields — eliminating the split-brain where two separate REST calls within one poll cycle could observe different GitHub state. See §6.4 for the full settling primitive specification.
-6. **Merge-conflict gate** (only reached if no review reinvoke was dispatched in step 5; only runs for stages with `wait_for_ci: true`): `checkMergeabilityGate()` interprets the `PRSettleResult` from the settle call
-   - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
-   - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
-   - `PRMergeBlocked` (CI checks failed): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate so `checkCIGate` can classify and dispatch the CI-fix reinvoke
-   - `PRMergeUnsettled`: block this item for the rest of Phase 1 (**no label churn** — ADR-032 R10c)
-   - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
-     - If exceeded: `pauseForRebaseCycleLimit()` pauses issue
-     - If not exceeded: dispatch `dispatchRebaseReinvoke()`; `continue`. The catch-up loop never reaches the CI gate while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
-7. **CI gate** (only reached if the merge-conflict gate cleared): `checkCIGate()` interprets the `PRSettleResult` from the settle call for stages with `wait_for_ci: true`
-   - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); advance to Done
-   - **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; returns `(false, false, false)` — poll.go does NOT call `pauseForCITimeout`
-   - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`, or all checks green):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
-   - **`PRMergeBlocked` or `PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies; pending → skip (blocked, not failed); CI failed → dispatch `dispatchCIFixReinvoke()` or pause on cycle limit
-   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
-   - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
-   - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
-   - Timed out (generic path): `pauseForCITimeout()` pauses issue
-   - CI failed: **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.CIFixCycles(stage.Name)` vs `MaxCiFixCycles`):
-     - If exceeded: `pauseForCIFixCycleLimit()` pauses issue
-     - If not exceeded: dispatch `dispatchCIFixReinvoke()`; `continue`
+**Phase 1 — unconditional, ordered handler list (`catchUpPhase1Handlers`):**
+
+Phase 1 is implemented as an explicit ordered slice of named handler methods (`catchUpPhase1Handlers` in `engine/catch_up_handlers.go`). Each handler returns `true` to claim the item — Phase 2 is skipped for this item this cycle — or `false` to pass through to the next handler. **Ordering is structurally enforced by slice position** (ADR-056 D3); a future reorder requires a deliberate code change and triggers a test failure, rather than occurring as an accidental side effect of a `continue` insertion.
+
+**Handler 1: `handleDependencies`** — thin wrapper around `checkDependencies()`. If the item has unresolved blocking dependencies, claims the item (returns true); otherwise passes through.
+
+**Handler 2: `handleReviewGate`** — only active when `stage:<X>:complete` is present (`pctx.hasComplete == true`; skipped during the CI-await window when `fabrik:awaiting-ci` is present but `stage:X:complete` is absent — prevents spurious `fabrik:awaiting-review` re-application from stale board data; #617):
+- `checkReviewGate()`: if awaiting reviewers, records `CooldownRecorded{Reason: "review-blocked"}` so `itemMayNeedWork`'s expiry path re-evaluates the item every 10 × PollSeconds, then claims the item; if timed out, calls `pauseForReviewTimeout()` and claims.
+- If gate cleared, `buildReviewThreadComments()` collects inline comments from unresolved review threads (no ROCKET reaction, not in `snap.CommentProcessed(c.ID)`). If no comments: passes through (returns false).
+- **Worker guard (`snap.Worker() != nil`):** if a reinvoke goroutine from a previous poll cycle is still running, claims the item without dispatching or incrementing the cycle count.
+- **Cycle limit check** (`snap.ReviewCycles(stage.Name)` vs `MaxReviewCycles`, default 5): if exceeded, `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and claims. If not exceeded: increment count via `ReviewCycleIncremented`, dispatch `dispatchReviewReinvoke()` (applies `WorkerEntered`, acquires semaphore, calls `processComments()` asynchronously), set `advancedItems[key] = true`, claim.
+
+**Handler 3: `handleAutoMergeConvergence`** — if the item does not have `fabrik:auto-merge-enabled`, passes through. If it does: calls `checkAutoMergeConvergence()` and claims the item (returns true). All merge/CI gates are bypassed — GitHub owns the merge decision for these items. This handler sits immediately before `handleMergeAndCIGates` to ensure `settlePRMergeState()` is never called for auto-merge items (they return true here before the settle call executes).
+
+**Handler 4: `handleMergeAndCIGates`** — calls `settlePRMergeState()` once (the settle call shared by both gates), then the merge-conflict gate, then the CI gate. Merge runs before CI per ADR-028: a PR made unmergeable by a base-branch advance must be rebased before the engine spins on CI-await polls. See §6.4 for the full settling primitive specification.
+
+- **Settle call:** `settlePRMergeState()` fetches `mergeable`, `mergeable_state`, and check runs in a single pass, returning a typed `PRSettleResult`. Both gates below consume this result and do not make additional REST calls — eliminating the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
+
+- **Merge-conflict gate** (`checkMergeabilityGate()` interprets `PRSettleResult`):
+  - `PRMergeNoPR` or `PRMergeTerminal`: no-op; fall through to the CI gate
+  - `PRMergeReady`: clear any stale `fabrik:rebase-needed` label; fall through to the CI gate
+  - `PRMergeBlocked` (CI checks failed): clear any stale `fabrik:rebase-needed` label; fall through to the CI gate so `checkCIGate` can classify and dispatch the CI-fix reinvoke
+  - `PRMergeUnsettled`: claims the item, blocking it for the rest of Phase 1 (**no label churn** — ADR-032 R10c)
+  - `PRMergeConflicting` (`mergeable == false`): apply `fabrik:rebase-needed` idempotently, then **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.RebaseCycles(stage.Name)` vs `MaxRebaseCycles`, default 3):
+    - If exceeded: `pauseForRebaseCycleLimit()` pauses issue and claims
+    - If not exceeded: increment count via `RebaseCycleIncremented`, dispatch `dispatchRebaseReinvoke()`, set `advancedItems[key] = true`, claim. The CI gate is never reached while a conflict is outstanding — there is no point spinning on CI-await when the branch cannot merge.
+
+- **CI gate** (`checkCIGate()` interprets `PRSettleResult`; only active when `stage.WaitForCI == true`):
+  - **`PRMergeTerminal` (merged):** gate clears immediately (`addCompleteLabelAndRemoveCI`); handler returns false (advance falls through to Phase 2)
+  - **`PRMergeTerminal` (closed, not merged):** `pauseForPRClosedNotMerged()` adds `fabrik:paused` + `fabrik:awaiting-input`, removes `fabrik:awaiting-ci`; handler returns false
+  - **`PRMergeReady` (`mergeable_state ∈ {clean, unstable}`, or all checks green):** gate clears immediately via `addCompleteLabelAndRemoveCI()`; per-check classification is skipped. Rationale: GitHub's branch protection is the source of truth for "is this mergeable" — non-required check_run failures (e.g., workflow cleanup jobs) do not block merges per branch protection, so Fabrik must not block on them either.
+  - **`PRMergeBlocked` or `PRMergeUnsettled` with `CheckRuns` populated:** per-check classification applies; pending → blocked (not failed); CI failed → **worker guard (`snap.Worker() != nil`)** + **cycle limit check** (`snap.CIFixCycles(stage.Name)` vs `MaxCiFixCycles`): if exceeded, `pauseForCIFixCycleLimit()` claims; if not exceeded, increment count via `CIFixCycleIncremented`, dispatch `dispatchCIFixReinvoke()`, set `advancedItems[key] = true`, claim
+  - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState == "blocked"`:** R3 — check `FetchLabelAppliedAt` dwell; if < CIWaitTimeout → dwell guard, not yet paused; if ≥ CIWaitTimeout → `pauseForRequiredNeverRunningCheck()`
+  - **`PRMergeUnsettled` with empty `CheckRuns` and `MergeableState ∉ {"", "unknown"}`:** non-empty branch-protection signal (e.g. `behind`, `dirty`, `has_hooks`) with no visible check_runs — checks `FetchLabelAppliedAt` inline; if ≥ CIWaitTimeout, removes `fabrik:awaiting-ci` and returns `(false, false, true)` (caller calls `pauseForCITimeout`); otherwise returns `(true, false, false)`, re-evaluates next poll
+  - **`PRMergeUnsettled` with empty `CheckRuns` and empty `MergeableState`:** hadChecks/dwell/post-push window — re-evaluates next poll; no label churn
+  - Timed out (generic path): `pauseForCITimeout()` pauses issue
 
 **After Phase 1 + Phase 2 — single-owner Validate advance (`runValidatePRTerminalAdvance`, R4 — ADR-056 D2, ADR-057):** A single authoritative scan iterates `deepFetchCandidates` for all Validate-stage items not in the `fabrik:auto-merge-enabled` convergence flow, regardless of which gate label (`fabrik:awaiting-ci`, `fabrik:awaiting-review`, `fabrik:rebase-needed`, or any future label) is present. For each, `e.client.FetchLinkedPR` is called directly (not `e.readClient` — boardcache may have stale state). When `pr.Merged == true`: iterates all pipeline stages in ascending Order from the stage after the highest already-complete stage up to (but not including) the cleanup-terminal stage, adding `stage:<N>:complete` for every `WaitForCI` or `WaitForReviews` gate-checked stage whose label is absent (with cache write-through; fail-fast on error for idempotent retry). After all labels are added, `removeAwaitingCILabel`, `removeAwaitingReviewLabel`, and `removeRebaseNeededLabel` are called as applicable, `fabrik:paused` + `fabrik:awaiting-input` are removed, and `advanceToNextStage()` is called. Items already in `advancedItems` are skipped (prevents double-advance). This self-heals Validate-stage items merged externally regardless of which gate was active, without requiring a manual unpause. The function never dispatches workers or acquires `e.sem` — label-mutation-only path (see ADR-053 constraints; superseded in structure by ADR-057).
 
 **Phase 2 — gated (yolo/cruise/auto_advance only):**
-- Only runs when no reinvoke was dispatched in Phase 1 (review, rebase, and CI-fix reinvoke all `continue`)
+- Only runs when no Phase 1 handler claimed the item (i.e., all handlers returned false)
 - Gated on: `e.cfg.Yolo` OR `fabrik:yolo` label OR `fabrik:cruise` label OR stage `auto_advance: true`
 - Runs `attemptMergeOnValidate()` (yolo only), skips if unprocessed comments exist, then calls `advanceToNextStage()`
 

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -1,0 +1,197 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// phase1Ctx carries all state shared across Phase 1 handler calls for a single
+// catch-up loop item. Using a struct avoids wide function signatures and makes
+// it easy to add future handlers without changing call sites.
+type phase1Ctx struct {
+	ctx           context.Context
+	board         *gh.ProjectBoard
+	item          gh.ProjectItem
+	stage         *stages.Stage
+	hasComplete   bool
+	advancedItems map[string]bool
+}
+
+// catchUpHandler is a named Phase 1 gate/recovery handler. The name field lets
+// tests assert handler precedence by position — a future reorder is a test
+// failure, not a silent behavioral change (ADR-056 D3).
+type catchUpHandler struct {
+	name string
+	run  func(*Engine, *phase1Ctx) bool
+}
+
+// catchUpPhase1Handlers is the ordered list of Phase 1 catch-up handlers.
+// Each handler returns true to claim the item (no further handlers run, Phase 2
+// is skipped for this item) or false to pass through to the next handler.
+//
+// Ordering is structurally enforced by slice position:
+//   - dependencies: blocked items bypass all gates
+//   - reviewGate: review threads addressed before any merge/CI gate evaluation
+//   - autoMergeConvergence: items in GitHub native auto-merge bypass
+//     settlePRMergeState and merge/CI gates (GitHub owns the merge decision)
+//   - mergeAndCIGates: merge-conflict gate runs before the CI gate (ADR-028)
+var catchUpPhase1Handlers = []catchUpHandler{
+	{name: "dependencies", run: (*Engine).handleDependencies},
+	{name: "reviewGate", run: (*Engine).handleReviewGate},
+	{name: "autoMergeConvergence", run: (*Engine).handleAutoMergeConvergence},
+	{name: "mergeAndCIGates", run: (*Engine).handleMergeAndCIGates},
+}
+
+// handleDependencies claims the item when it has unresolved blocking
+// dependencies. checkDependencies handles label mutation and comment posting.
+func (e *Engine) handleDependencies(pctx *phase1Ctx) bool {
+	return e.checkDependencies(pctx.board, pctx.item, pctx.stage)
+}
+
+// handleReviewGate runs the review gate and review reinvoke dispatch. Only
+// active when the stage has genuinely completed (hasComplete == true); during
+// the CI-await window (fabrik:awaiting-ci && !hasComplete) the gate is skipped
+// to prevent spurious fabrik:awaiting-review re-application (#617).
+func (e *Engine) handleReviewGate(pctx *phase1Ctx) bool {
+	if !pctx.hasComplete {
+		return false
+	}
+	blocked, timedOut := e.checkReviewGate(pctx.board, pctx.item, pctx.stage)
+	if blocked {
+		// Record CooldownAt["review-blocked"] so itemMayNeedWork's expiry path
+		// re-evaluates this item every 10 × PollSeconds even when nothing bumps
+		// updatedAt. This lets Phase 1/Phase 2 review-reprompt timers fire on a
+		// non-responsive bot reviewer (issue #495).
+		cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
+		e.store.Apply(itemstate.CooldownRecorded{
+			Repo:   itemOwnerRepoString(pctx.item, e.defaultRepo()),
+			Number: pctx.item.Number,
+			Reason: "review-blocked",
+			Until:  time.Now().Add(cooldown),
+		})
+		return true
+	}
+	if timedOut {
+		e.pauseForReviewTimeout(pctx.board, pctx.item, pctx.stage)
+		return true
+	}
+	// Gate cleared naturally — if reviews with actionable body text were
+	// submitted, re-invoke the stage agent to address the feedback before
+	// advancing. Reviews with empty bodies (e.g. APPROVED with no comment)
+	// have nothing to address; fall through to Phase 2.
+	if syntheticComments := e.buildReviewThreadComments(pctx.item); len(syntheticComments) > 0 {
+		iKey := issueKey(pctx.item, e.defaultRepo())
+		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
+		// Guard: if a goroutine from a previous poll cycle is still running
+		// dispatchReviewReinvoke for this item, skip the entire reinvoke path —
+		// including cycle-limit checks — to avoid pausing an item while valid
+		// work is still in progress. The store Worker field is the semantic
+		// source of truth for in-flight state.
+		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil && snap.Worker() != nil {
+			e.logf(pctx.item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
+			return true
+		}
+		var cycleCount int
+		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+			cycleCount = snap.ReviewCycles(pctx.stage.Name)
+		}
+		maxCycles := e.cfg.MaxReviewCycles
+		if cycleCount >= maxCycles {
+			e.pauseForReviewCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, maxCycles)
+		} else {
+			e.store.Apply(itemstate.ReviewCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
+			e.dispatchReviewReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage)
+			pctx.advancedItems[iKey] = true
+		}
+		return true
+	}
+	return false
+}
+
+// handleAutoMergeConvergence claims items with fabrik:auto-merge-enabled,
+// delegating all PR state monitoring to checkAutoMergeConvergence. All
+// merge/CI gates are bypassed — GitHub owns the merge decision for these items.
+func (e *Engine) handleAutoMergeConvergence(pctx *phase1Ctx) bool {
+	if !hasLabel(pctx.item, "fabrik:auto-merge-enabled") {
+		return false
+	}
+	e.checkAutoMergeConvergence(pctx.ctx, pctx.board, pctx.item, pctx.stage)
+	return true
+}
+
+// handleMergeAndCIGates runs the merge-conflict gate followed by the CI gate,
+// sharing a single settlePRMergeState call. Merge runs before CI per ADR-028:
+// a PR made unmergeable by a base-branch advance must be rebased before the
+// engine spins on CI-await polls while the underlying blocker is a conflict.
+func (e *Engine) handleMergeAndCIGates(pctx *phase1Ctx) bool {
+	// Fetch all PR merge/CI state in a single pass. Both gates below consume
+	// this result, ensuring they see identical GitHub state within one poll
+	// cycle and eliminating the mergeable vs mergeable_state split-brain that
+	// separate REST calls could produce.
+	settle := e.settlePRMergeState(pctx.item, pctx.stage)
+
+	mergeBlocked, mergeConflict := e.checkMergeabilityGate(pctx.item, pctx.stage, settle)
+	if mergeConflict {
+		iKey := issueKey(pctx.item, e.defaultRepo())
+		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
+		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil && snap.Worker() != nil {
+			e.logf(pctx.item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
+			return true
+		}
+		var cycleCount int
+		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+			cycleCount = snap.RebaseCycles(pctx.stage.Name)
+		}
+		maxCycles := e.cfg.MaxRebaseCycles
+		if cycleCount >= maxCycles {
+			e.pauseForRebaseCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, maxCycles)
+		} else {
+			e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
+			e.dispatchRebaseReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage)
+			pctx.advancedItems[iKey] = true
+		}
+		return true
+	}
+	if mergeBlocked {
+		return true // mergeability not yet computed; re-evaluate on next poll
+	}
+
+	// CI gate: evaluate CI status for stages configured with wait_for_ci: true.
+	// Runs in Phase 1 (unconditional) so CI failures are fixed regardless of
+	// auto-advance setting. checkCIGate returns (blocked, ciFailure, timedOut).
+	ciBlocked, ciFailure, ciTimedOut := e.checkCIGate(pctx.board, pctx.item, pctx.stage, settle)
+	if ciTimedOut {
+		e.pauseForCITimeout(pctx.board, pctx.item, pctx.stage)
+		return true
+	}
+	if ciFailure {
+		iKey := issueKey(pctx.item, e.defaultRepo())
+		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
+		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil && snap.Worker() != nil {
+			e.logf(pctx.item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
+			return true
+		}
+		var cycleCount int
+		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+			cycleCount = snap.CIFixCycles(pctx.stage.Name)
+		}
+		maxCycles := e.cfg.MaxCiFixCycles
+		if cycleCount >= maxCycles {
+			e.pauseForCIFixCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, maxCycles)
+		} else {
+			e.store.Apply(itemstate.CIFixCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
+			e.dispatchCIFixReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage, settle)
+			pctx.advancedItems[iKey] = true
+		}
+		return true
+	}
+	if ciBlocked {
+		return true // CI still pending; re-evaluate on next poll
+	}
+
+	return false
+}

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -91,12 +91,12 @@ func (e *Engine) handleReviewGate(pctx *phase1Ctx) bool {
 		// including cycle-limit checks — to avoid pausing an item while valid
 		// work is still in progress. The store Worker field is the semantic
 		// source of truth for in-flight state.
-		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil && snap.Worker() != nil {
-			e.logf(pctx.item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
-			return true
-		}
 		var cycleCount int
 		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+			if snap.Worker() != nil {
+				e.logf(pctx.item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
+				return true
+			}
 			cycleCount = snap.ReviewCycles(pctx.stage.Name)
 		}
 		maxCycles := e.cfg.MaxReviewCycles
@@ -138,12 +138,12 @@ func (e *Engine) handleMergeAndCIGates(pctx *phase1Ctx) bool {
 	if mergeConflict {
 		iKey := issueKey(pctx.item, e.defaultRepo())
 		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
-		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil && snap.Worker() != nil {
-			e.logf(pctx.item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
-			return true
-		}
 		var cycleCount int
 		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+			if snap.Worker() != nil {
+				e.logf(pctx.item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
+				return true
+			}
 			cycleCount = snap.RebaseCycles(pctx.stage.Name)
 		}
 		maxCycles := e.cfg.MaxRebaseCycles
@@ -171,12 +171,12 @@ func (e *Engine) handleMergeAndCIGates(pctx *phase1Ctx) bool {
 	if ciFailure {
 		iKey := issueKey(pctx.item, e.defaultRepo())
 		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
-		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil && snap.Worker() != nil {
-			e.logf(pctx.item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
-			return true
-		}
 		var cycleCount int
 		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+			if snap.Worker() != nil {
+				e.logf(pctx.item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
+				return true
+			}
 			cycleCount = snap.CIFixCycles(pctx.stage.Name)
 		}
 		maxCycles := e.cfg.MaxCiFixCycles

--- a/engine/catch_up_handlers_test.go
+++ b/engine/catch_up_handlers_test.go
@@ -1,0 +1,491 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// TestCatchUpPhase1HandlersOrder asserts the handler precedence order by name.
+// A future reorder of catchUpPhase1Handlers is a test failure, not a silent
+// behavioral change — this directly implements the ADR-056 D3 "ordering as data"
+// invariant. ADR-028 requires merge gate before CI gate; both are inside
+// handleMergeAndCIGates (position 3), which follows handleAutoMergeConvergence
+// (position 2) so that auto-merge items bypass settlePRMergeState entirely.
+func TestCatchUpPhase1HandlersOrder(t *testing.T) {
+	want := []string{
+		"dependencies",
+		"reviewGate",
+		"autoMergeConvergence",
+		"mergeAndCIGates",
+	}
+	if len(catchUpPhase1Handlers) != len(want) {
+		t.Fatalf("catchUpPhase1Handlers has %d entries; want %d", len(catchUpPhase1Handlers), len(want))
+	}
+	for i, h := range catchUpPhase1Handlers {
+		if h.name != want[i] {
+			t.Errorf("catchUpPhase1Handlers[%d].name = %q; want %q", i, h.name, want[i])
+		}
+	}
+}
+
+// ---- handleReviewGate dispatch tests ----
+
+// makeReviewGatePctx returns a phase1Ctx configured for review gate handler tests.
+// The item has stage:Implement:complete and a single unresolved review thread comment.
+func makeReviewGatePctx(board *gh.ProjectBoard, advancedItems map[string]bool) *phase1Ctx {
+	item := gh.ProjectItem{
+		Number: 10,
+		Repo:   "owner/repo",
+		Labels: []string{"stage:Implement:complete"},
+		LinkedPRReviewThreadComments: []gh.Comment{
+			{
+				ID:             "PRRC_handler_1",
+				DatabaseID:     100,
+				Author:         "copilot",
+				Body:           "Please fix this.",
+				ReviewThreadID: "RT_handler_1",
+			},
+		},
+	}
+	// Stage without WaitForReviews so checkReviewGate returns (false, false)
+	// immediately — the handler then proceeds to buildReviewThreadComments which
+	// finds the unresolved thread comment and dispatches a review reinvoke.
+	stage := &stages.Stage{Name: "Implement", Order: 1, Prompt: "implement"}
+	return &phase1Ctx{
+		ctx:           context.Background(),
+		board:         board,
+		item:          item,
+		stage:         stage,
+		hasComplete:   true,
+		advancedItems: advancedItems,
+	}
+}
+
+// TestHandleReviewGate_WorkerInFlight_SkipsDispatch verifies that when a goroutine
+// from a previous poll cycle is still running for an item, handleReviewGate
+// claims the item (returns true) but does NOT increment ReviewCycles or dispatch
+// a new reinvoke — preventing double-dispatch and spurious cycle limit advances.
+func TestHandleReviewGate_WorkerInFlight_SkipsDispatch(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxReviewCycles = 5
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeReviewGatePctx(board, advancedItems)
+
+	// Simulate an in-flight worker from a previous poll cycle.
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo: "owner/repo", Number: 10, StageName: "Implement", StartedAt: time.Now(),
+	})
+
+	got := eng.handleReviewGate(pctx)
+
+	if !got {
+		t.Error("handleReviewGate: expected true (item claimed), got false")
+	}
+	eng.wg.Wait()
+	snap, _ := eng.store.Get("owner/repo", 10)
+	if snap.ReviewCycles("Implement") != 0 {
+		t.Errorf("ReviewCycles(Implement) = %d; want 0 (guard must prevent dispatch)", snap.ReviewCycles("Implement"))
+	}
+	if advancedItems["owner/repo#10"] {
+		t.Error("advancedItems must not be set when worker-in-flight guard fires")
+	}
+}
+
+// TestHandleReviewGate_CycleLimit_Pauses verifies that when ReviewCycles reaches
+// MaxReviewCycles, handleReviewGate pauses the issue (adds fabrik:paused +
+// fabrik:awaiting-input) instead of dispatching another reinvoke.
+func TestHandleReviewGate_CycleLimit_Pauses(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 1, nil
+		},
+	}
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxReviewCycles = 3
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeReviewGatePctx(board, advancedItems)
+
+	// Pre-fill ReviewCycles to the limit.
+	for i := 0; i < eng.cfg.MaxReviewCycles; i++ {
+		eng.store.Apply(itemstate.ReviewCycleIncremented{
+			Repo: "owner/repo", Number: 10, StageName: "Implement",
+		})
+	}
+
+	got := eng.handleReviewGate(pctx)
+
+	if !got {
+		t.Error("handleReviewGate: expected true (item claimed), got false")
+	}
+	eng.wg.Wait()
+	// Pause labels must have been added.
+	client.mu.Lock()
+	labelNames := make([]string, len(client.addLabelCalls))
+	for i, c := range client.addLabelCalls {
+		labelNames[i] = c.labelName
+	}
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labelNames {
+		if l == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Errorf("expected fabrik:paused to be added on cycle limit; labels added: %v", labelNames)
+	}
+	if advancedItems["owner/repo#10"] {
+		t.Error("advancedItems must not be set on cycle limit pause")
+	}
+}
+
+// TestHandleReviewGate_HappyPath_Dispatches verifies the happy path: no worker
+// in-flight, cycle count below limit, unresolved review thread comments present →
+// ReviewCycles incremented, advancedItems set, handler returns true.
+func TestHandleReviewGate_HappyPath_Dispatches(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn:         func(_, _ string, _ int, _ string) (int, error) { return 1, nil },
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxReviewCycles = 5
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeReviewGatePctx(board, advancedItems)
+
+	got := eng.handleReviewGate(pctx)
+
+	if !got {
+		t.Error("handleReviewGate: expected true (item claimed), got false")
+	}
+	// advancedItems is set synchronously before the goroutine runs.
+	if !advancedItems["owner/repo#10"] {
+		t.Error("advancedItems[owner/repo#10] must be set on successful dispatch")
+	}
+	// ReviewCycles incremented synchronously.
+	snap, _ := eng.store.Get("owner/repo", 10)
+	if snap.ReviewCycles("Implement") != 1 {
+		t.Errorf("ReviewCycles(Implement) = %d; want 1", snap.ReviewCycles("Implement"))
+	}
+	eng.wg.Wait()
+}
+
+// ---- handleMergeAndCIGates rebase reinvoke dispatch tests ----
+
+// makeMergeGatePctx returns a phase1Ctx for merge-gate/CI-gate handler tests.
+// The stage has WaitForCI enabled.
+func makeMergeGatePctx(board *gh.ProjectBoard, advancedItems map[string]bool) *phase1Ctx {
+	waitTrue := true
+	item := gh.ProjectItem{
+		Number: 20,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:awaiting-ci"},
+	}
+	stage := &stages.Stage{Name: "Implement", Order: 1, Prompt: "implement", WaitForCI: &waitTrue}
+	return &phase1Ctx{
+		ctx:           context.Background(),
+		board:         board,
+		item:          item,
+		stage:         stage,
+		hasComplete:   false,
+		advancedItems: advancedItems,
+	}
+}
+
+// conflictingSettleClient returns a mockGitHubClient whose FetchLinkedPR +
+// FetchPRMergeableFields produce a PRMergeConflicting result from settlePRMergeState.
+func conflictingSettleClient() *mockGitHubClient {
+	return &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, HeadSHA: "deadbeef", State: "open", Merged: false}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			f := false
+			return &f, "dirty", nil
+		},
+		addCommentFn: func(_, _ string, _ int, _ string) (int, error) { return 1, nil },
+	}
+}
+
+// TestHandleRebaseReinvoke_WorkerInFlight_SkipsDispatch verifies the worker-in-flight
+// guard for the rebase reinvoke path inside handleMergeAndCIGates.
+func TestHandleRebaseReinvoke_WorkerInFlight_SkipsDispatch(t *testing.T) {
+	client := conflictingSettleClient()
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxRebaseCycles = 3
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeMergeGatePctx(board, advancedItems)
+
+	// Simulate an in-flight worker from a previous poll cycle.
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo: "owner/repo", Number: 20, StageName: "Implement", StartedAt: time.Now(),
+	})
+
+	got := eng.handleMergeAndCIGates(pctx)
+
+	if !got {
+		t.Error("handleMergeAndCIGates: expected true (item claimed), got false")
+	}
+	eng.wg.Wait()
+	snap, _ := eng.store.Get("owner/repo", 20)
+	if snap.RebaseCycles("Implement") != 0 {
+		t.Errorf("RebaseCycles(Implement) = %d; want 0 (guard must prevent dispatch)", snap.RebaseCycles("Implement"))
+	}
+	if advancedItems["owner/repo#20"] {
+		t.Error("advancedItems must not be set when worker-in-flight guard fires")
+	}
+}
+
+// TestHandleRebaseReinvoke_CycleLimit_Pauses verifies that when RebaseCycles
+// reaches MaxRebaseCycles, handleMergeAndCIGates pauses the issue.
+func TestHandleRebaseReinvoke_CycleLimit_Pauses(t *testing.T) {
+	client := conflictingSettleClient()
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxRebaseCycles = 2
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeMergeGatePctx(board, advancedItems)
+
+	// Pre-fill RebaseCycles to the limit.
+	for i := 0; i < eng.cfg.MaxRebaseCycles; i++ {
+		eng.store.Apply(itemstate.RebaseCycleIncremented{
+			Repo: "owner/repo", Number: 20, StageName: "Implement",
+		})
+	}
+
+	got := eng.handleMergeAndCIGates(pctx)
+
+	if !got {
+		t.Error("handleMergeAndCIGates: expected true (item claimed), got false")
+	}
+	eng.wg.Wait()
+	client.mu.Lock()
+	labelNames := make([]string, len(client.addLabelCalls))
+	for i, c := range client.addLabelCalls {
+		labelNames[i] = c.labelName
+	}
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labelNames {
+		if l == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Errorf("expected fabrik:paused on rebase cycle limit; labels added: %v", labelNames)
+	}
+	if advancedItems["owner/repo#20"] {
+		t.Error("advancedItems must not be set on cycle limit pause")
+	}
+}
+
+// TestHandleRebaseReinvoke_HappyPath_Dispatches verifies the happy path for rebase
+// reinvoke: PRMergeConflicting, no worker in-flight, cycle below limit →
+// RebaseCycles incremented, advancedItems set, handler returns true.
+func TestHandleRebaseReinvoke_HappyPath_Dispatches(t *testing.T) {
+	client := conflictingSettleClient()
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxRebaseCycles = 3
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeMergeGatePctx(board, advancedItems)
+
+	got := eng.handleMergeAndCIGates(pctx)
+
+	if !got {
+		t.Error("handleMergeAndCIGates: expected true (item claimed), got false")
+	}
+	if !advancedItems["owner/repo#20"] {
+		t.Error("advancedItems[owner/repo#20] must be set on successful rebase dispatch")
+	}
+	snap, _ := eng.store.Get("owner/repo", 20)
+	if snap.RebaseCycles("Implement") != 1 {
+		t.Errorf("RebaseCycles(Implement) = %d; want 1", snap.RebaseCycles("Implement"))
+	}
+	eng.wg.Wait()
+}
+
+// ---- handleMergeAndCIGates CI-fix reinvoke dispatch tests ----
+
+// ciFailureSettleClient returns a mockGitHubClient whose settle sequence produces
+// PRMergeBlocked (a completed CI failure check run, mergeable PR).
+func ciFailureSettleClient() *mockGitHubClient {
+	return &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 43, HeadSHA: "cafebabe", State: "open", Merged: false}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			tr := true
+			return &tr, "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "test", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+		fetchLabelAppliedAtFn: func(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+			// Return the current time so elapsed ≈ 0 — well within the default
+			// 30-minute CIWaitTimeout, preventing the timeout path from firing.
+			return time.Now(), nil
+		},
+		addLabelToIssueFn:    func(_, _ string, _ int, _ string) error { return nil },
+		addCommentFn:         func(_, _ string, _ int, _ string) (int, error) { return 1, nil },
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+}
+
+// TestHandleCIFixReinvoke_WorkerInFlight_SkipsDispatch verifies the worker-in-flight
+// guard for the CI-fix reinvoke path inside handleMergeAndCIGates.
+func TestHandleCIFixReinvoke_WorkerInFlight_SkipsDispatch(t *testing.T) {
+	client := ciFailureSettleClient()
+	waitTrue := true
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement", WaitForCI: &waitTrue},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxCiFixCycles = 3
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeMergeGatePctx(board, advancedItems)
+
+	// Simulate an in-flight worker.
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo: "owner/repo", Number: 20, StageName: "Implement", StartedAt: time.Now(),
+	})
+
+	got := eng.handleMergeAndCIGates(pctx)
+
+	if !got {
+		t.Error("handleMergeAndCIGates: expected true (item claimed), got false")
+	}
+	eng.wg.Wait()
+	snap, _ := eng.store.Get("owner/repo", 20)
+	if snap.CIFixCycles("Implement") != 0 {
+		t.Errorf("CIFixCycles(Implement) = %d; want 0 (guard must prevent dispatch)", snap.CIFixCycles("Implement"))
+	}
+	if advancedItems["owner/repo#20"] {
+		t.Error("advancedItems must not be set when worker-in-flight guard fires")
+	}
+}
+
+// TestHandleCIFixReinvoke_CycleLimit_Pauses verifies that when CIFixCycles
+// reaches MaxCiFixCycles, handleMergeAndCIGates pauses the issue.
+func TestHandleCIFixReinvoke_CycleLimit_Pauses(t *testing.T) {
+	client := ciFailureSettleClient()
+	waitTrue := true
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement", WaitForCI: &waitTrue},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxCiFixCycles = 2
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeMergeGatePctx(board, advancedItems)
+
+	// Pre-fill CIFixCycles to the limit.
+	for i := 0; i < eng.cfg.MaxCiFixCycles; i++ {
+		eng.store.Apply(itemstate.CIFixCycleIncremented{
+			Repo: "owner/repo", Number: 20, StageName: "Implement",
+		})
+	}
+
+	got := eng.handleMergeAndCIGates(pctx)
+
+	if !got {
+		t.Error("handleMergeAndCIGates: expected true (item claimed), got false")
+	}
+	eng.wg.Wait()
+	client.mu.Lock()
+	labelNames := make([]string, len(client.addLabelCalls))
+	for i, c := range client.addLabelCalls {
+		labelNames[i] = c.labelName
+	}
+	client.mu.Unlock()
+	hasPaused := false
+	for _, l := range labelNames {
+		if l == "fabrik:paused" {
+			hasPaused = true
+		}
+	}
+	if !hasPaused {
+		t.Errorf("expected fabrik:paused on CI-fix cycle limit; labels added: %v", labelNames)
+	}
+	if advancedItems["owner/repo#20"] {
+		t.Error("advancedItems must not be set on cycle limit pause")
+	}
+}
+
+// TestHandleCIFixReinvoke_HappyPath_Dispatches verifies the happy path for CI-fix
+// reinvoke: PRMergeBlocked (CI failed), no worker in-flight, cycle below limit →
+// CIFixCycles incremented, advancedItems set, handler returns true.
+func TestHandleCIFixReinvoke_HappyPath_Dispatches(t *testing.T) {
+	client := ciFailureSettleClient()
+	waitTrue := true
+	stgs := []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement", WaitForCI: &waitTrue},
+		{Name: "Review", Order: 2, Prompt: "review"},
+	}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxCiFixCycles = 5
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	advancedItems := make(map[string]bool)
+	pctx := makeMergeGatePctx(board, advancedItems)
+
+	got := eng.handleMergeAndCIGates(pctx)
+
+	if !got {
+		t.Error("handleMergeAndCIGates: expected true (item claimed), got false")
+	}
+	if !advancedItems["owner/repo#20"] {
+		t.Error("advancedItems[owner/repo#20] must be set on successful CI-fix dispatch")
+	}
+	snap, _ := eng.store.Get("owner/repo", 20)
+	if snap.CIFixCycles("Implement") != 1 {
+		t.Errorf("CIFixCycles(Implement) = %d; want 1", snap.CIFixCycles("Implement"))
+	}
+	eng.wg.Wait()
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1256,143 +1256,28 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			continue
 		}
 
-		// Phase 1: unconditional dependency check, review gate, and review reinvoke.
-		if e.checkDependencies(board, item, stage) {
-			continue // blocked; checkDependencies handled label + comment
+		// Phase 1: run the ordered handler list. Each handler returns true to
+		// claim the item (no further handlers run for this item, Phase 2 is
+		// skipped) or false to pass through to the next handler. Ordering is
+		// structurally enforced by slice position in catchUpPhase1Handlers
+		// (ADR-056 D3).
+		pctx := &phase1Ctx{
+			ctx:           ctx,
+			board:         board,
+			item:          item,
+			stage:         stage,
+			hasComplete:   hasComplete,
+			advancedItems: advancedItems,
 		}
-		// Only run the review gate when the stage has genuinely completed
-		// (stage:X:complete present). During the CI-await window
-		// (hasAwaitingCI && !hasComplete), skip the review gate entirely to
-		// prevent spurious fabrik:awaiting-review re-application (#617).
-		if hasComplete {
-			blocked, timedOut := e.checkReviewGate(board, item, stage)
-			if blocked {
-				// Record CooldownAt["review-blocked"] so itemMayNeedWork's expiry path
-				// re-evaluates this item every 10 × PollSeconds even when nothing bumps
-				// updatedAt. This lets Phase 1/Phase 2 review-reprompt timers fire on a
-				// non-responsive bot reviewer (issue #495).
-				cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
-				e.store.Apply(itemstate.CooldownRecorded{
-					Repo:   itemOwnerRepoString(item, e.defaultRepo()),
-					Number: item.Number,
-					Reason: "review-blocked",
-					Until:  time.Now().Add(cooldown),
-				})
-				continue // awaiting reviewers; checkReviewGate handled label
-			}
-			if timedOut {
-				e.pauseForReviewTimeout(board, item, stage)
-				continue
-			}
-			// Gate cleared naturally — if reviews with actionable body text were
-			// submitted, re-invoke the stage agent to address the feedback before
-			// advancing. Reviews with empty bodies (e.g. APPROVED with no comment)
-			// have nothing to address; fall through to Phase 2.
-			if syntheticComments := e.buildReviewThreadComments(item); len(syntheticComments) > 0 {
-				iKey := issueKey(item, e.defaultRepo())
-				repoStr := itemOwnerRepoString(item, e.defaultRepo())
-				// Guard: if a goroutine from a previous poll cycle is still
-				// running dispatchReviewReinvoke for this item, skip the entire
-				// reinvoke path — including cycle-limit checks — to avoid
-				// pausing an item while valid work is still in progress. The
-				// store Worker field is the semantic source of truth for in-flight state.
-				if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
-					e.logf(item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
-					continue
-				}
-				var cycleCount int
-				if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
-					cycleCount = snap.ReviewCycles(stage.Name)
-				}
-				maxCycles := e.cfg.MaxReviewCycles
-				if cycleCount >= maxCycles {
-					e.pauseForReviewCycleLimit(board, item, stage, cycleCount, maxCycles)
-				} else {
-					e.store.Apply(itemstate.ReviewCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-					e.dispatchReviewReinvoke(ctx, board, item, stage)
-					advancedItems[iKey] = true
-				}
-				continue
+		claimed := false
+		for _, h := range catchUpPhase1Handlers {
+			if h.run(e, pctx) {
+				claimed = true
+				break
 			}
 		}
-
-		// Convergence monitor: items with fabrik:auto-merge-enabled are in the
-		// GitHub native auto-merge flow. checkAutoMergeConvergence handles PR
-		// state changes, budget exhaustion, and rebase dispatch. All other
-		// merge/CI gates are bypassed — GitHub owns the merge decision.
-		if hasLabel(item, "fabrik:auto-merge-enabled") {
-			e.checkAutoMergeConvergence(ctx, board, item, stage)
+		if claimed {
 			continue
-		}
-
-		// Fetch all PR merge/CI state in a single pass. Both gates below
-		// consume this result, ensuring they see identical GitHub state within
-		// one poll cycle and eliminating the mergeable vs mergeable_state
-		// split-brain that separate REST calls could produce.
-		settle := e.settlePRMergeState(item, stage)
-
-		// Merge-conflict gate: runs before the CI gate so that a PR made
-		// unmergeable by a base-branch advance is rebased immediately instead
-		// of the engine spinning on CI-await polls while the underlying
-		// blocker is a conflict. Gated by the same wait_for_ci flag — the only
-		// stages that participate in the post-complete catch-up loop.
-		mergeBlocked, mergeConflict := e.checkMergeabilityGate(item, stage, settle)
-		if mergeConflict {
-			iKey := issueKey(item, e.defaultRepo())
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
-				e.logf(item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
-				continue
-			}
-			var cycleCount int
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
-				cycleCount = snap.RebaseCycles(stage.Name)
-			}
-			maxCycles := e.cfg.MaxRebaseCycles
-			if cycleCount >= maxCycles {
-				e.pauseForRebaseCycleLimit(board, item, stage, cycleCount, maxCycles)
-			} else {
-				e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-				e.dispatchRebaseReinvoke(ctx, board, item, stage)
-				advancedItems[iKey] = true
-			}
-			continue
-		}
-		if mergeBlocked {
-			continue // mergeability not yet computed; re-evaluate on next poll
-		}
-
-		// CI gate: evaluate CI status for stages configured with wait_for_ci: true.
-		// This runs in Phase 1 (unconditional) so CI failures are fixed regardless
-		// of auto-advance setting. checkCIGate returns (blocked, ciFailure, timedOut).
-		ciBlocked, ciFailure, ciTimedOut := e.checkCIGate(board, item, stage, settle)
-		if ciTimedOut {
-			e.pauseForCITimeout(board, item, stage)
-			continue
-		}
-		if ciFailure {
-			iKey := issueKey(item, e.defaultRepo())
-			repoStr := itemOwnerRepoString(item, e.defaultRepo())
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
-				e.logf(item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
-				continue
-			}
-			var cycleCount int
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
-				cycleCount = snap.CIFixCycles(stage.Name)
-			}
-			maxCycles := e.cfg.MaxCiFixCycles
-			if cycleCount >= maxCycles {
-				e.pauseForCIFixCycleLimit(board, item, stage, cycleCount, maxCycles)
-			} else {
-				e.store.Apply(itemstate.CIFixCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-				e.dispatchCIFixReinvoke(ctx, board, item, stage, settle)
-				advancedItems[iKey] = true
-			}
-			continue
-		}
-		if ciBlocked {
-			continue // CI still pending; re-evaluate on next poll
 		}
 
 		// Phase 2: gated stage advancement.


### PR DESCRIPTION
Closes #889

## What this PR does

Extracts the four inlined Phase 1 gate/recovery dispatch blocks from `engine/poll.go` into named handler methods on `*Engine`, collected in an explicit `catchUpPhase1Handlers` ordered slice. Precedence is now expressed as **data** (slice position) rather than implicit `continue` fallthrough order — the structural root cause behind regressions in #829/#831/#835/#855/#871.

## Key changes

**`engine/catch_up_handlers.go`** (new):
- `phase1Ctx` struct — shared per-item state for all Phase 1 handlers
- `catchUpHandler{name, run}` struct — named handler for testable position assertions
- `catchUpPhase1Handlers` — ordered slice of four handlers: `dependencies`, `reviewGate`, `autoMergeConvergence`, `mergeAndCIGates`
- Four handler methods extracted from poll.go's inlined blocks; each returns `true` to claim the item or `false` to pass through

**`engine/poll.go`**: Phase 1 loop body reduced to `phase1Ctx` construction + 5-line handler iteration; ~130 lines of inlined dispatch removed

**`engine/catch_up_handlers_test.go`** (new):
- `TestCatchUpPhase1HandlersOrder` — asserts handler names at positions 0–3; a reorder is a test failure (ADR-056 D3)
- 9 dispatch tests covering worker-in-flight guard, cycle limit pause, and happy-path dispatch for each of the three reinvoke paths (review, rebase, CI-fix)

**`docs/state-machine.md`**: §6.2 updated to describe `catchUpPhase1Handlers` by handler name; notes structural ordering enforcement; Phase 2 reference to `continue` updated to "handler returned false"

**`docs/llms-full.txt`**: regenerated

## Testing

- `go test -race ./...` passes (all engine/boardcache/github/stages/internal packages)
- The one failing test (`cmd/TestExecute_ConfigYAMLApplied`) is pre-existing on `main` — confirmed by running `main`'s version of `cmd/root_test.go` and observing the same 5s SIGINT timeout failure
- No behavioral change — this is a pure structural refactor; all existing gate tests pass unchanged

## How to review

- Start with `engine/catch_up_handlers.go` to see the handler definitions and ordering
- Check `engine/poll.go` lines ~1259–1280 to see the handler iteration that replaced ~130 inlined lines
- `engine/catch_up_handlers_test.go` shows the ordering invariant and per-handler dispatch tests