### PR TITLE
feat(engine): route checkAutoMergeConvergence through PRSettleResult + bound rebase cycles

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3273,12 +3273,12 @@ See **section 5.5** for how Fabrik monitors the convergence flow after auto-merg
 
 ### 5.5 Post-Validate Convergence Monitor (yolo issues)
 
-After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iteration of the catch-up loop calls `checkAutoMergeConvergence()` instead of the legacy `checkMergeabilityGate` / `checkCIGate` path. All merge decisions for the issue are delegated to GitHub's server-side auto-merge logic.
+After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iteration of the catch-up loop calls `checkAutoMergeConvergence()` instead of the legacy `checkMergeabilityGate` / `checkCIGate` path. All merge decisions for the issue are delegated to GitHub's server-side auto-merge logic. `handleAutoMergeConvergence` calls `settlePRMergeState()` before forwarding to `checkAutoMergeConvergence()`; the settle result is consumed for merge/CI state interpretation (eliminating the split-brain), though the merge/CI gates remain bypassed — see §6.4.
 
 **Convergence budget:**
 
 - The budget starts when `fabrik:auto-merge-enabled` is applied. The start timestamp is stored durably in GitHub's issue event log (`FetchLabelAppliedAt("fabrik:auto-merge-enabled")`), so it survives engine restarts.
-- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget — Fabrik waits indefinitely for auto-merge to complete (or for the user to disable auto-merge in the GitHub UI). `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates are NOT consulted while `fabrik:auto-merge-enabled` is present.
+- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget — Fabrik waits indefinitely for auto-merge to complete (or for the user to disable auto-merge in the GitHub UI). `MaxCiFixCycles` is not consulted while `fabrik:auto-merge-enabled` is present. `MaxRebaseCycles` IS consulted: the convergence path's rebase dispatch is bounded by the same `MaxRebaseCycles` gate used by `handleMergeAndCIGates`, preventing an unbounded rebase loop when a conflict is unresolvable (see `RebaseCycles vs. budget` below).
 - On each Phase 1 iteration: `elapsed = time.Since(budgetStart)`. If `elapsed > budget`, `pauseForConvergenceFailed()` fires.
 
 **`checkAutoMergeConvergence()` decision tree:**
@@ -3288,15 +3288,15 @@ After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iterat
 | PR merged or closed | Remove `fabrik:auto-merge-enabled` + `fabrik:rebase-needed` (if present); existing machinery advances to Done |
 | `AutoMergeEnabled == false` (user disabled) | Apply `fabrik:paused` + `fabrik:awaiting-input`; remove `fabrik:auto-merge-enabled`; post comment with resume options (prevents Phase 2 from re-enabling auto-merge on the next poll) |
 | Budget exhausted | Call `pauseForConvergenceFailed()` (see below) |
-| `mergeable_state == "unknown"` | Wait — GitHub still computing after a push; re-evaluate next poll |
-| `mergeable_state == "dirty"` (conflict) | Dispatch rebase reinvoke (one per conflict transition); increment `RebaseCycles` for observability only (not a gate); skip if worker in-flight |
-| Any other state (`clean`, `blocked`, `behind`, `unstable`, `has_hooks`) | Wait — GitHub is handling it |
+| `settle.Status == PRMergeUnsettled` | Wait — GitHub still computing after a push (replaces `mergeable_state == "unknown"`); re-evaluate next poll |
+| `settle.Status == PRMergeConflicting` | Worker guard (`snap.Worker() != nil`) → skip if in-flight; cycle-limit check (`snap.RebaseCycles(stage) >= MaxRebaseCycles`) → `pauseForRebaseCycleLimit()`; otherwise increment `RebaseCycles` and dispatch rebase reinvoke |
+| Any other settle status (`PRMergeReady`, `PRMergeBlocked`, `PRMergeTerminal`, `PRMergeNoPR`) | Wait — GitHub is handling it |
 
 **Rebase reinvoke + auto-merge re-enable:**
 GitHub disables auto-merge on every push. After `dispatchRebaseReinvoke()` completes successfully (Claude resolved conflicts, pushed), `EnablePullRequestAutoMerge` is called again to re-arm auto-merge. This is the only scenario where auto-merge is re-enabled without going through `attemptMergeOnValidate`.
 
 **`pauseForConvergenceFailed()` — convergence budget exhausted:**
-Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`, and current rebase cycle count. Posts a structured pause comment containing:
+Uses `settle.PR` (from the pre-fetched `PRSettleResult`) for PR diagnostic fields, `FetchCommitsBehind` for the commits-behind count, `settle.CheckRuns` for the CI summary, and the store for the current rebase cycle count — no independent `FetchLinkedPR` or `FetchCheckRuns` calls. Posts a structured pause comment containing:
 - Total wall-clock elapsed time and configured budget
 - Number of rebase reinvokes dispatched
 - Commits-behind-base count
@@ -3306,7 +3306,7 @@ Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`
 
 Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-merge-enabled`. Does NOT add `fabrik:awaiting-ci` (CI may be healthy; the convergence failure is about the merge window, not CI).
 
-**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, the budget check is skipped entirely — Fabrik waits indefinitely for the PR to be merged or closed.
+**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch. `MaxRebaseCycles` IS consulted as a gate — the same three-step guard used by `handleMergeAndCIGates` (in-flight guard → cycle-limit check → dispatch or `pauseForRebaseCycleLimit`) applies here. When `FABRIK_CONVERGENCE_BUDGET=0`, the time-based budget check is skipped, but `MaxRebaseCycles` still bounds rebase reinvokes — so an unresolvable conflict never produces an unbounded rebase loop.
 
 **State transitions for yolo Validate convergence:**
 
@@ -3314,7 +3314,8 @@ Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-me
 |---|---|---|---|---|
 | Validate, Complete | Poll tick (Phase 2) | Validate, Convergence | `fabrik:auto-merge-enabled` | |
 | Validate, Convergence | PR merged (GitHub) | Done, Pending Cleanup | | `fabrik:auto-merge-enabled`, `fabrik:rebase-needed` |
-| Validate, Convergence | `mergeable_state=dirty` (conflict) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
+| Validate, Convergence | `settle.Status=PRMergeConflicting` (conflict, below `MaxRebaseCycles`) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
+| Validate, Convergence | `settle.Status=PRMergeConflicting` (conflict, at `MaxRebaseCycles` limit) | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | |
 | Validate, Convergence + Rebase in-flight | Rebase push succeeds | Validate, Convergence | | |
 | Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 | Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
@@ -3469,7 +3470,7 @@ Phase 1 is implemented as an explicit ordered slice of named handler methods (`c
 - **Worker guard (`snap.Worker() != nil`):** if a reinvoke goroutine from a previous poll cycle is still running, claims the item without dispatching or incrementing the cycle count.
 - **Cycle limit check** (`snap.ReviewCycles(stage.Name)` vs `MaxReviewCycles`, default 5): if exceeded, `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and claims. If not exceeded: increment count via `ReviewCycleIncremented`, dispatch `dispatchReviewReinvoke()` (applies `WorkerEntered`, acquires semaphore, calls `processComments()` asynchronously), set `advancedItems[key] = true`, claim.
 
-**Handler 3: `handleAutoMergeConvergence`** — if the item does not have `fabrik:auto-merge-enabled`, passes through. If it does: calls `checkAutoMergeConvergence()` and claims the item (returns true). All merge/CI gates are bypassed — GitHub owns the merge decision for these items. This handler sits immediately before `handleMergeAndCIGates` to ensure `settlePRMergeState()` is never called for auto-merge items (they return true here before the settle call executes).
+**Handler 3: `handleAutoMergeConvergence`** — if the item does not have `fabrik:auto-merge-enabled`, passes through. If it does: calls `settlePRMergeState()` to build a `PRSettleResult`, then forwards to `checkAutoMergeConvergence()` which consumes the settle result for `PRMergeUnsettled`/`PRMergeConflicting` branch decisions. Claims the item (returns true). The merge/CI gates remain bypassed — GitHub owns the merge decision for these items — but `checkAutoMergeConvergence()` no longer independently interprets `mergeable_state` or calls `FetchPRMergeableFields`/`FetchCheckRuns`.
 
 **Handler 4: `handleMergeAndCIGates`** — calls `settlePRMergeState()` once (the settle call shared by both gates), then the merge-conflict gate, then the CI gate. Merge runs before CI per ADR-028: a PR made unmergeable by a base-branch advance must be rebased before the engine spins on CI-await polls. See §6.4 for the full settling primitive specification.
 
@@ -3522,7 +3523,12 @@ Phase 1 is implemented as an explicit ordered slice of named handler methods (`c
 
 ### 6.4 PR Merge State Settling Primitive
 
-`settlePRMergeState()` is called **once per catch-up loop Phase 1 iteration — before both the merge-conflict gate and the CI gate** — to read `mergeable`, `mergeable_state`, and check runs in a single pass. Both gates receive this `PRSettleResult` and do not make their own REST calls for these fields; this eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
+`settlePRMergeState()` is called **once per catch-up loop Phase 1 iteration** to read `mergeable`, `mergeable_state`, and check runs in a single pass. It is called from two handlers:
+
+- **`handleAutoMergeConvergence`** (Handler 3): for items with `fabrik:auto-merge-enabled`; `checkAutoMergeConvergence()` consumes the result for unsettled/conflict branch decisions, replacing direct `mergeable_state` interpretation and `FetchCheckRuns` calls. The merge/CI gates remain bypassed.
+- **`handleMergeAndCIGates`** (Handler 4): for all other items; both `checkMergeabilityGate()` and `checkCIGate()` receive the result and do not make their own REST calls for these fields.
+
+In both cases, this eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
 
 **Return type:** `PRSettleResult` carries:
 - `Status PRMergeStatus` — one of six typed constants (see below)
@@ -3563,7 +3569,11 @@ Phase 1 is implemented as an explicit ordered slice of named handler methods (`c
 
 **`MergeableState` omission invariant:** `checkCIGate` uses `settle.MergeableState` to detect R3 (OPEN+BLOCKED+no-check-runs+`fabrik:awaiting-ci` elapsed → `pauseForRequiredNeverRunningCheck`). The primitive omits `MergeableState` from the `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases. This prevents R3 from misfiring on cases where `hadChecks == true` (checks have been observed) or where GitHub simply hasn't computed mergeability yet (post-push window). Only a non-empty `MergeableState` in the settle result is genuinely relevant for R3/branch-protection timeout checking.
 
-**`FetchCheckRuns` consolidation:** `buildCIFixComment()` (called inside `dispatchCIFixReinvoke()`) uses `settle.CheckRuns` for the PR-head check runs, eliminating the separate `FetchCheckRuns()` call that previously lived in the CI-fix path. The base-branch `FetchCheckRuns(baseSHA)` inside `buildCIFixComment()` is a **non-gate diagnostic read** — it fetches check runs for the base branch's HEAD SHA for regression-vs-pre-existing classification only, and is structurally independent (different SHA; result is not used by either gate).
+**`FetchCheckRuns` consolidation:** Two callers consume `settle.CheckRuns` from the `PRSettleResult` instead of making independent `FetchCheckRuns` calls:
+- `buildCIFixComment()` (called inside `dispatchCIFixReinvoke()`) uses `settle.CheckRuns` for the PR-head check runs — eliminating the separate `FetchCheckRuns()` call that previously lived in the CI-fix path.
+- `pauseForConvergenceFailed()` uses `settle.CheckRuns` for the CI summary in the convergence-budget-exhausted pause comment — no independent `FetchCheckRuns` call for the convergence path.
+
+The base-branch `FetchCheckRuns(baseSHA)` inside `buildCIFixComment()` is a **non-gate diagnostic read** — it fetches check runs for the base branch's HEAD SHA for regression-vs-pre-existing classification only, and is structurally independent (different SHA; result is not used by either gate).
 
 ### 6.5 CI Gate and CI-Fix Reinvoke
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -805,12 +805,12 @@ See **section 5.5** for how Fabrik monitors the convergence flow after auto-merg
 
 ### 5.5 Post-Validate Convergence Monitor (yolo issues)
 
-After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iteration of the catch-up loop calls `checkAutoMergeConvergence()` instead of the legacy `checkMergeabilityGate` / `checkCIGate` path. All merge decisions for the issue are delegated to GitHub's server-side auto-merge logic.
+After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iteration of the catch-up loop calls `checkAutoMergeConvergence()` instead of the legacy `checkMergeabilityGate` / `checkCIGate` path. All merge decisions for the issue are delegated to GitHub's server-side auto-merge logic. `handleAutoMergeConvergence` calls `settlePRMergeState()` before forwarding to `checkAutoMergeConvergence()`; the settle result is consumed for merge/CI state interpretation (eliminating the split-brain), though the merge/CI gates remain bypassed — see §6.4.
 
 **Convergence budget:**
 
 - The budget starts when `fabrik:auto-merge-enabled` is applied. The start timestamp is stored durably in GitHub's issue event log (`FetchLabelAppliedAt("fabrik:auto-merge-enabled")`), so it survives engine restarts.
-- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget — Fabrik waits indefinitely for auto-merge to complete (or for the user to disable auto-merge in the GitHub UI). `MaxRebaseCycles` / `MaxCiFixCycles` cycle-count gates are NOT consulted while `fabrik:auto-merge-enabled` is present.
+- The budget is configured via `FABRIK_CONVERGENCE_BUDGET` (Go duration syntax, e.g., `30m`). Default: 30 minutes. Set to `0` to disable the budget — Fabrik waits indefinitely for auto-merge to complete (or for the user to disable auto-merge in the GitHub UI). `MaxCiFixCycles` is not consulted while `fabrik:auto-merge-enabled` is present. `MaxRebaseCycles` IS consulted: the convergence path's rebase dispatch is bounded by the same `MaxRebaseCycles` gate used by `handleMergeAndCIGates`, preventing an unbounded rebase loop when a conflict is unresolvable (see `RebaseCycles vs. budget` below).
 - On each Phase 1 iteration: `elapsed = time.Since(budgetStart)`. If `elapsed > budget`, `pauseForConvergenceFailed()` fires.
 
 **`checkAutoMergeConvergence()` decision tree:**
@@ -820,15 +820,15 @@ After `fabrik:auto-merge-enabled` is applied (section 5.4), every Phase 1 iterat
 | PR merged or closed | Remove `fabrik:auto-merge-enabled` + `fabrik:rebase-needed` (if present); existing machinery advances to Done |
 | `AutoMergeEnabled == false` (user disabled) | Apply `fabrik:paused` + `fabrik:awaiting-input`; remove `fabrik:auto-merge-enabled`; post comment with resume options (prevents Phase 2 from re-enabling auto-merge on the next poll) |
 | Budget exhausted | Call `pauseForConvergenceFailed()` (see below) |
-| `mergeable_state == "unknown"` | Wait — GitHub still computing after a push; re-evaluate next poll |
-| `mergeable_state == "dirty"` (conflict) | Dispatch rebase reinvoke (one per conflict transition); increment `RebaseCycles` for observability only (not a gate); skip if worker in-flight |
-| Any other state (`clean`, `blocked`, `behind`, `unstable`, `has_hooks`) | Wait — GitHub is handling it |
+| `settle.Status == PRMergeUnsettled` | Wait — GitHub still computing after a push (replaces `mergeable_state == "unknown"`); re-evaluate next poll |
+| `settle.Status == PRMergeConflicting` | Worker guard (`snap.Worker() != nil`) → skip if in-flight; cycle-limit check (`snap.RebaseCycles(stage) >= MaxRebaseCycles`) → `pauseForRebaseCycleLimit()`; otherwise increment `RebaseCycles` and dispatch rebase reinvoke |
+| Any other settle status (`PRMergeReady`, `PRMergeBlocked`, `PRMergeTerminal`, `PRMergeNoPR`) | Wait — GitHub is handling it |
 
 **Rebase reinvoke + auto-merge re-enable:**
 GitHub disables auto-merge on every push. After `dispatchRebaseReinvoke()` completes successfully (Claude resolved conflicts, pushed), `EnablePullRequestAutoMerge` is called again to re-arm auto-merge. This is the only scenario where auto-merge is re-enabled without going through `attemptMergeOnValidate`.
 
 **`pauseForConvergenceFailed()` — convergence budget exhausted:**
-Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`, and current rebase cycle count. Posts a structured pause comment containing:
+Uses `settle.PR` (from the pre-fetched `PRSettleResult`) for PR diagnostic fields, `FetchCommitsBehind` for the commits-behind count, `settle.CheckRuns` for the CI summary, and the store for the current rebase cycle count — no independent `FetchLinkedPR` or `FetchCheckRuns` calls. Posts a structured pause comment containing:
 - Total wall-clock elapsed time and configured budget
 - Number of rebase reinvokes dispatched
 - Commits-behind-base count
@@ -838,7 +838,7 @@ Fetches fresh PR state (`FetchLinkedPR`), `FetchCommitsBehind`, `FetchCheckRuns`
 
 Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-merge-enabled`. Does NOT add `fabrik:awaiting-ci` (CI may be healthy; the convergence failure is about the merge window, not CI).
 
-**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch for observability and for inclusion in the pause comment. It is NOT consulted as a gate. `MaxRebaseCycles` has no effect while `fabrik:auto-merge-enabled` is present. When `FABRIK_CONVERGENCE_BUDGET=0`, the budget check is skipped entirely — Fabrik waits indefinitely for the PR to be merged or closed.
+**`RebaseCycles` vs. budget:** Under the convergence flow, `RebaseCycles` is incremented on every rebase dispatch. `MaxRebaseCycles` IS consulted as a gate — the same three-step guard used by `handleMergeAndCIGates` (in-flight guard → cycle-limit check → dispatch or `pauseForRebaseCycleLimit`) applies here. When `FABRIK_CONVERGENCE_BUDGET=0`, the time-based budget check is skipped, but `MaxRebaseCycles` still bounds rebase reinvokes — so an unresolvable conflict never produces an unbounded rebase loop.
 
 **State transitions for yolo Validate convergence:**
 
@@ -846,7 +846,8 @@ Then: applies `fabrik:paused` + `fabrik:awaiting-input`; removes `fabrik:auto-me
 |---|---|---|---|---|
 | Validate, Complete | Poll tick (Phase 2) | Validate, Convergence | `fabrik:auto-merge-enabled` | |
 | Validate, Convergence | PR merged (GitHub) | Done, Pending Cleanup | | `fabrik:auto-merge-enabled`, `fabrik:rebase-needed` |
-| Validate, Convergence | `mergeable_state=dirty` (conflict) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
+| Validate, Convergence | `settle.Status=PRMergeConflicting` (conflict, below `MaxRebaseCycles`) | Validate, Convergence + Rebase in-flight | `fabrik:rebase-needed` | |
+| Validate, Convergence | `settle.Status=PRMergeConflicting` (conflict, at `MaxRebaseCycles` limit) | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | |
 | Validate, Convergence + Rebase in-flight | Rebase push succeeds | Validate, Convergence | | |
 | Validate, Convergence | Budget exhausted | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
 | Validate, Convergence | User disables auto-merge in GitHub UI | Validate, Paused | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:auto-merge-enabled` |
@@ -1001,7 +1002,7 @@ Phase 1 is implemented as an explicit ordered slice of named handler methods (`c
 - **Worker guard (`snap.Worker() != nil`):** if a reinvoke goroutine from a previous poll cycle is still running, claims the item without dispatching or incrementing the cycle count.
 - **Cycle limit check** (`snap.ReviewCycles(stage.Name)` vs `MaxReviewCycles`, default 5): if exceeded, `pauseForReviewCycleLimit()` adds `fabrik:paused` + `fabrik:awaiting-input` and claims. If not exceeded: increment count via `ReviewCycleIncremented`, dispatch `dispatchReviewReinvoke()` (applies `WorkerEntered`, acquires semaphore, calls `processComments()` asynchronously), set `advancedItems[key] = true`, claim.
 
-**Handler 3: `handleAutoMergeConvergence`** — if the item does not have `fabrik:auto-merge-enabled`, passes through. If it does: calls `checkAutoMergeConvergence()` and claims the item (returns true). All merge/CI gates are bypassed — GitHub owns the merge decision for these items. This handler sits immediately before `handleMergeAndCIGates` to ensure `settlePRMergeState()` is never called for auto-merge items (they return true here before the settle call executes).
+**Handler 3: `handleAutoMergeConvergence`** — if the item does not have `fabrik:auto-merge-enabled`, passes through. If it does: calls `settlePRMergeState()` to build a `PRSettleResult`, then forwards to `checkAutoMergeConvergence()` which consumes the settle result for `PRMergeUnsettled`/`PRMergeConflicting` branch decisions. Claims the item (returns true). The merge/CI gates remain bypassed — GitHub owns the merge decision for these items — but `checkAutoMergeConvergence()` no longer independently interprets `mergeable_state` or calls `FetchPRMergeableFields`/`FetchCheckRuns`.
 
 **Handler 4: `handleMergeAndCIGates`** — calls `settlePRMergeState()` once (the settle call shared by both gates), then the merge-conflict gate, then the CI gate. Merge runs before CI per ADR-028: a PR made unmergeable by a base-branch advance must be rebased before the engine spins on CI-await polls. See §6.4 for the full settling primitive specification.
 
@@ -1054,7 +1055,12 @@ Phase 1 is implemented as an explicit ordered slice of named handler methods (`c
 
 ### 6.4 PR Merge State Settling Primitive
 
-`settlePRMergeState()` is called **once per catch-up loop Phase 1 iteration — before both the merge-conflict gate and the CI gate** — to read `mergeable`, `mergeable_state`, and check runs in a single pass. Both gates receive this `PRSettleResult` and do not make their own REST calls for these fields; this eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
+`settlePRMergeState()` is called **once per catch-up loop Phase 1 iteration** to read `mergeable`, `mergeable_state`, and check runs in a single pass. It is called from two handlers:
+
+- **`handleAutoMergeConvergence`** (Handler 3): for items with `fabrik:auto-merge-enabled`; `checkAutoMergeConvergence()` consumes the result for unsettled/conflict branch decisions, replacing direct `mergeable_state` interpretation and `FetchCheckRuns` calls. The merge/CI gates remain bypassed.
+- **`handleMergeAndCIGates`** (Handler 4): for all other items; both `checkMergeabilityGate()` and `checkCIGate()` receive the result and do not make their own REST calls for these fields.
+
+In both cases, this eliminates the split-brain where two separate REST calls within one poll cycle could observe different GitHub state.
 
 **Return type:** `PRSettleResult` carries:
 - `Status PRMergeStatus` — one of six typed constants (see below)

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1101,7 +1101,11 @@ In both cases, this eliminates the split-brain where two separate REST calls wit
 
 **`MergeableState` omission invariant:** `checkCIGate` uses `settle.MergeableState` to detect R3 (OPEN+BLOCKED+no-check-runs+`fabrik:awaiting-ci` elapsed → `pauseForRequiredNeverRunningCheck`). The primitive omits `MergeableState` from the `PRSettleResult` in the hadChecks, post-push dwell, and HeadSHA-empty cases. This prevents R3 from misfiring on cases where `hadChecks == true` (checks have been observed) or where GitHub simply hasn't computed mergeability yet (post-push window). Only a non-empty `MergeableState` in the settle result is genuinely relevant for R3/branch-protection timeout checking.
 
-**`FetchCheckRuns` consolidation:** `buildCIFixComment()` (called inside `dispatchCIFixReinvoke()`) uses `settle.CheckRuns` for the PR-head check runs, eliminating the separate `FetchCheckRuns()` call that previously lived in the CI-fix path. The base-branch `FetchCheckRuns(baseSHA)` inside `buildCIFixComment()` is a **non-gate diagnostic read** — it fetches check runs for the base branch's HEAD SHA for regression-vs-pre-existing classification only, and is structurally independent (different SHA; result is not used by either gate).
+**`FetchCheckRuns` consolidation:** Two callers consume `settle.CheckRuns` from the `PRSettleResult` instead of making independent `FetchCheckRuns` calls:
+- `buildCIFixComment()` (called inside `dispatchCIFixReinvoke()`) uses `settle.CheckRuns` for the PR-head check runs — eliminating the separate `FetchCheckRuns()` call that previously lived in the CI-fix path.
+- `pauseForConvergenceFailed()` uses `settle.CheckRuns` for the CI summary in the convergence-budget-exhausted pause comment — no independent `FetchCheckRuns` call for the convergence path.
+
+The base-branch `FetchCheckRuns(baseSHA)` inside `buildCIFixComment()` is a **non-gate diagnostic read** — it fetches check runs for the base branch's HEAD SHA for regression-vs-pre-existing classification only, and is structurally independent (different SHA; result is not used by either gate).
 
 ### 6.5 CI Gate and CI-Fix Reinvoke
 

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -36,8 +36,9 @@ type catchUpHandler struct {
 // Ordering is structurally enforced by slice position:
 //   - dependencies: blocked items bypass all gates
 //   - reviewGate: review threads addressed before any merge/CI gate evaluation
-//   - autoMergeConvergence: items in GitHub native auto-merge bypass
-//     settlePRMergeState and merge/CI gates (GitHub owns the merge decision)
+//   - autoMergeConvergence: items in GitHub native auto-merge call settlePRMergeState
+//     for merge/CI state (eliminating split-brain) but bypass the merge/CI gates
+//     (GitHub owns the merge decision)
 //   - mergeAndCIGates: merge-conflict gate runs before the CI gate (ADR-028)
 var catchUpPhase1Handlers = []catchUpHandler{
 	{name: "dependencies", run: (*Engine).handleDependencies},
@@ -113,13 +114,16 @@ func (e *Engine) handleReviewGate(pctx *phase1Ctx) bool {
 }
 
 // handleAutoMergeConvergence claims items with fabrik:auto-merge-enabled,
-// delegating all PR state monitoring to checkAutoMergeConvergence. All
-// merge/CI gates are bypassed — GitHub owns the merge decision for these items.
+// delegating all PR state monitoring to checkAutoMergeConvergence.
+// settlePRMergeState is called so the convergence path shares a single settle
+// read per poll cycle with no independent mergeable_state interpretation; the
+// merge/CI gates remain bypassed — GitHub owns the merge decision for these items.
 func (e *Engine) handleAutoMergeConvergence(pctx *phase1Ctx) bool {
 	if !hasLabel(pctx.item, "fabrik:auto-merge-enabled") {
 		return false
 	}
-	e.checkAutoMergeConvergence(pctx.ctx, pctx.board, pctx.item, pctx.stage)
+	settle := e.settlePRMergeState(pctx.item, pctx.stage)
+	e.checkAutoMergeConvergence(pctx.ctx, pctx.board, pctx.item, pctx.stage, settle)
 	return true
 }
 

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -244,8 +244,11 @@ func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBo
 // checkAutoMergeConvergence monitors a yolo issue that has entered the GitHub
 // native auto-merge convergence flow (fabrik:auto-merge-enabled is present).
 // Called from Phase 1 of the catch-up loop; replaces checkMergeabilityGate and
-// checkCIGate for these items. Returns after completing any dispatch or pause.
-func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
+// checkCIGate for these items. settle carries the pre-fetched PR/CI state from
+// settlePRMergeState; it drives the unsettled/conflict branch decisions so that
+// the convergence path no longer independently interprets mergeable_state.
+// Returns after completing any dispatch or pause.
+func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult) {
 	// Phase 1 of the catch-up loop calls this before processItem has had a chance
 	// to register the WorktreeManager for item.Repo. Without this guard,
 	// pauseForConvergenceFailed → worktreesFor would panic on the first poll
@@ -341,44 +344,57 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 			if elapsed > e.cfg.ConvergenceBudget {
 				e.logf(item.Number, "auto-merge", "convergence budget exhausted (%.0fs / %.0fs) — pausing\n",
 					elapsed.Seconds(), e.cfg.ConvergenceBudget.Seconds())
-				e.pauseForConvergenceFailed(ctx, board, item, stage, elapsed)
+				e.pauseForConvergenceFailed(ctx, board, item, stage, settle, elapsed)
 				return
 			}
 		}
 	}
 
-	// GitHub transiently returns "unknown" mergeability after a push. Wait.
-	if pr.MergeableState == "unknown" {
-		e.logf(item.Number, "auto-merge", "PR #%d mergeable_state=unknown — waiting for GitHub to compute\n", pr.Number)
+	// GitHub has not yet computed mergeability: wait.
+	if settle.Status == PRMergeUnsettled {
+		e.logf(item.Number, "auto-merge", "PR #%d settle=unsettled (%s) — waiting for GitHub to compute\n", pr.Number, settle.Reason)
 		return
 	}
 
-	// Confirmed conflict (dirty): dispatch one rebase reinvoke if none is in-flight.
-	// Cycle count is incremented for observability but not consulted as a gate.
-	if pr.MergeableState == "dirty" {
-		if snap, serr := e.store.Get(repoStr, item.Number); serr == nil && snap.Worker() != nil {
-			e.logf(item.Number, "auto-merge", "rebase already in-flight — skipping dispatch\n")
-			return
+	// Confirmed conflict: dispatch rebase reinvoke, bounded by MaxRebaseCycles.
+	// Mirrors the three-step pattern in handleMergeAndCIGates: in-flight guard →
+	// cycle-limit check → dispatch or pauseForRebaseCycleLimit.
+	if settle.Status == PRMergeConflicting {
+		var cycleCount int
+		if snap, serr := e.store.Get(repoStr, item.Number); serr == nil {
+			if snap.Worker() != nil {
+				e.logf(item.Number, "auto-merge", "rebase already in-flight — skipping dispatch\n")
+				return
+			}
+			cycleCount = snap.RebaseCycles(stage.Name)
 		}
-		e.logf(item.Number, "auto-merge", "PR #%d merge conflict — dispatching rebase reinvoke\n", pr.Number)
-		e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-		e.dispatchRebaseReinvoke(ctx, board, item, stage)
+		maxCycles := e.cfg.MaxRebaseCycles
+		if cycleCount >= maxCycles {
+			e.pauseForRebaseCycleLimit(board, item, stage, cycleCount, maxCycles)
+		} else {
+			e.logf(item.Number, "auto-merge", "PR #%d merge conflict — dispatching rebase reinvoke\n", pr.Number)
+			e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+			e.dispatchRebaseReinvoke(ctx, board, item, stage)
+		}
 		return
 	}
 
-	// All other states (clean, blocked, behind, unstable, has_hooks): GitHub is handling it.
-	e.logf(item.Number, "auto-merge", "PR #%d mergeable_state=%q — waiting for GitHub auto-merge\n", pr.Number, pr.MergeableState)
+	// All other settle statuses (PRMergeReady, PRMergeBlocked, PRMergeTerminal, PRMergeNoPR):
+	// GitHub is handling it — auto-merge will fire when conditions are met.
+	e.logf(item.Number, "auto-merge", "PR #%d settle=%s — waiting for GitHub auto-merge\n", pr.Number, settle.Reason)
 }
 
 // pauseForConvergenceFailed is called when the convergence budget exhausts before
 // the yolo PR merges. Posts a structured comment naming the actual current state,
 // applies fabrik:paused + fabrik:awaiting-input, and removes fabrik:auto-merge-enabled.
-func (e *Engine) pauseForConvergenceFailed(_ context.Context, _ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, elapsed time.Duration) {
+// settle carries the pre-fetched PR/CI state from settlePRMergeState; PR diagnostic
+// fields (mergeableState, headSHA) and check run summary come from settle rather
+// than a fresh FetchLinkedPR / FetchCheckRuns call, eliminating the split-brain.
+func (e *Engine) pauseForConvergenceFailed(_ context.Context, _ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult, elapsed time.Duration) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 
-	// Fetch fresh state for the comment.
-	pr, _ := e.client.FetchLinkedPR(owner, repo, item.Number)
+	pr := settle.PR
 	var mergeableState, headSHA, latestCI string
 	var commitsBehind int
 	if pr != nil && pr.Number != 0 {
@@ -391,10 +407,7 @@ func (e *Engine) pauseForConvergenceFailed(_ context.Context, _ *gh.ProjectBoard
 			baseBranch = "main"
 		}
 		commitsBehind, _ = e.client.FetchCommitsBehind(owner, repo, baseBranch, headSHA)
-		if headSHA != "" {
-			runs, _ := e.readClient.FetchCheckRuns(owner, repo, headSHA)
-			latestCI = summarizeCIRuns(runs)
-		}
+		latestCI = summarizeCIRuns(settle.CheckRuns)
 	}
 
 	var rebaseCycles int

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -241,8 +241,9 @@ func TestCheckAutoMergeConvergence_PRMerged_RemovesLabelAndAdvances(t *testing.T
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeTerminal, PR: &gh.PRDetails{Number: 10}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, settle)
 
 	foundRemove := false
 	for _, c := range client.removeLabelCalls {
@@ -277,8 +278,9 @@ func TestCheckAutoMergeConvergence_UserDisabledAutoMerge_PostsCommentRemovesLabe
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled", "fabrik:yolo"}}
 	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeReady, PR: &gh.PRDetails{Number: 10}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage, settle)
 
 	foundRemove := false
 	for _, c := range client.removeLabelCalls {
@@ -324,8 +326,9 @@ func TestCheckAutoMergeConvergence_BudgetExhausted_PausesIssue(t *testing.T) {
 	eng.cfg.ConvergenceBudget = 30 * time.Minute
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeBlocked, PR: &gh.PRDetails{Number: 10, MergeableState: "blocked"}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage, settle)
 
 	foundPaused := false
 	for _, c := range client.addLabelCalls {
@@ -368,8 +371,10 @@ func TestCheckAutoMergeConvergence_BudgetDisabled_NoPause(t *testing.T) {
 	eng.cfg.ConvergenceBudget = 0 // disabled
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	// PRMergeBlocked (CI failure, no conflict): falls through to "waiting for GitHub" log.
+	settle := PRSettleResult{Status: PRMergeBlocked, PR: &gh.PRDetails{Number: 10, MergeableState: "blocked"}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage, settle)
 
 	for _, c := range client.addLabelCalls {
 		if c.labelName == "fabrik:paused" {
@@ -387,8 +392,10 @@ func TestCheckAutoMergeConvergence_UnknownMergeability_Waits(t *testing.T) {
 	eng := testEngineForMerge(t, client)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	// PRMergeUnsettled drives the "wait" branch, replacing pr.MergeableState=="unknown".
+	settle := PRSettleResult{Status: PRMergeUnsettled, Reason: "mergeable_state=unknown"}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage, settle)
 
 	// No labels changed, no comments posted — just waiting.
 	for _, c := range client.addLabelCalls {
@@ -406,10 +413,13 @@ func TestCheckAutoMergeConvergence_DirtyConflict_IncrementsCycleCount(t *testing
 		},
 	}
 	eng := testEngineForMerge(t, client)
+	eng.cfg.MaxRebaseCycles = 3 // allow dispatch (default testEngine sets 0, which would immediately pause)
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	// PRMergeConflicting drives the rebase reinvoke path, replacing pr.MergeableState=="dirty".
+	settle := PRSettleResult{Status: PRMergeConflicting, PR: &gh.PRDetails{Number: 10}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, settle)
 
 	snap, err := eng.store.Get("owner/repo", 42)
 	if err != nil {
@@ -443,8 +453,9 @@ func TestCheckAutoMergeConvergence_DirtyConflict_InFlight_SkipsDispatch(t *testi
 	})
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeConflicting, PR: &gh.PRDetails{Number: 10}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, settle)
 
 	snap, err := eng.store.Get("owner/repo", 42)
 	if err != nil {
@@ -458,7 +469,8 @@ func TestCheckAutoMergeConvergence_DirtyConflict_InFlight_SkipsDispatch(t *testi
 
 // TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain verifies SC-008:
 // after a first rebase reinvoke, if main moves again causing another conflict,
-// a second rebase reinvoke is dispatched. Cycle count is not a gate.
+// a second rebase reinvoke is dispatched. MaxRebaseCycles is set to 3 so the
+// second cycle (count=1) is below the limit and dispatch proceeds.
 func TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
@@ -466,19 +478,21 @@ func TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain(t *testing.T) 
 		},
 	}
 	eng := testEngineForMerge(t, client)
+	eng.cfg.MaxRebaseCycles = 3 // allow second dispatch (count=1 < limit=3)
 	// Simulate prior rebase cycle having completed (no in-flight worker).
 	eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 42, StageName: "Validate"})
 
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeConflicting, PR: &gh.PRDetails{Number: 10}}
 
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, settle)
 
 	snap, err := eng.store.Get("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("store.Get: %v", err)
 	}
-	// Cycle count should now be 2; dispatch was not gated by MaxRebaseCycles.
+	// Cycle count should now be 2; dispatch fires because count(1) < MaxRebaseCycles(3).
 	if snap.RebaseCycles("Validate") != 2 {
 		t.Errorf("expected RebaseCycles=2 after second dispatch, got %d", snap.RebaseCycles("Validate"))
 	}
@@ -487,11 +501,10 @@ func TestCheckAutoMergeConvergence_SecondConflict_DispatchesAgain(t *testing.T) 
 // TestPauseForConvergenceFailed_PostsComment_AppliesLabels verifies that the
 // convergence-failed pause comment contains the expected fields and that
 // fabrik:paused, fabrik:awaiting-input are applied and fabrik:auto-merge-enabled removed.
+// PR diagnostic state (mergeableState, headSHA) now comes from settle.PR rather
+// than a separate FetchLinkedPR call.
 func TestPauseForConvergenceFailed_PostsComment_AppliesLabels(t *testing.T) {
 	client := &mockGitHubClient{
-		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
-			return &gh.PRDetails{Number: 10, State: "open", MergeableState: "dirty", HeadSHA: "abc123"}, nil
-		},
 		fetchCommitsBehindFn: func(owner, repo, base, head string) (int, error) {
 			return 3, nil
 		},
@@ -501,8 +514,12 @@ func TestPauseForConvergenceFailed_PostsComment_AppliesLabels(t *testing.T) {
 	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
 	stage := &stages.Stage{Name: "Validate"}
 	elapsed := 45 * time.Minute
+	settle := PRSettleResult{
+		Status: PRMergeConflicting,
+		PR:     &gh.PRDetails{Number: 10, State: "open", MergeableState: "dirty", HeadSHA: "abc123"},
+	}
 
-	eng.pauseForConvergenceFailed(context.Background(), &gh.ProjectBoard{}, item, stage, elapsed)
+	eng.pauseForConvergenceFailed(context.Background(), &gh.ProjectBoard{}, item, stage, settle, elapsed)
 
 	// Verify pause comment posted.
 	if len(client.addCommentCalls) == 0 {
@@ -534,6 +551,86 @@ func TestPauseForConvergenceFailed_PostsComment_AppliesLabels(t *testing.T) {
 	}
 	if !foundRemove {
 		t.Error("expected fabrik:auto-merge-enabled to be removed on convergence failure")
+	}
+}
+
+// TestCheckAutoMergeConvergence_ConflictAtCycleLimit_PausesInsteadOfDispatch
+// verifies that when RebaseCycles reaches MaxRebaseCycles in the convergence path,
+// pauseForRebaseCycleLimit is called instead of dispatching a new rebase reinvoke.
+// This closes the previously unbounded livelock on unresolvable conflicts.
+func TestCheckAutoMergeConvergence_ConflictAtCycleLimit_PausesInsteadOfDispatch(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	eng.cfg.MaxRebaseCycles = 2
+	// Pre-fill RebaseCycles to the limit.
+	for i := 0; i < eng.cfg.MaxRebaseCycles; i++ {
+		eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 42, StageName: "Validate"})
+	}
+
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeConflicting, PR: &gh.PRDetails{Number: 10}}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, settle)
+
+	eng.wg.Wait()
+	foundPaused := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			foundPaused = true
+		}
+	}
+	if !foundPaused {
+		t.Error("expected fabrik:paused when convergence rebase cycle limit reached")
+	}
+	if len(client.addCommentCalls) == 0 {
+		t.Error("expected a cycle-limit comment to be posted")
+	}
+	// Verify cycle count was not incremented beyond the limit.
+	snap, err := eng.store.Get("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if snap.RebaseCycles("Validate") != 2 {
+		t.Errorf("expected RebaseCycles=2 (unchanged at limit), got %d", snap.RebaseCycles("Validate"))
+	}
+}
+
+// TestCheckAutoMergeConvergence_BudgetZero_ConflictAtCycleLimit_Pauses verifies
+// that MaxRebaseCycles bounds rebase reinvokes even when FABRIK_CONVERGENCE_BUDGET=0
+// (budget disabled). This resolves the unbounded rebase-loop livelock flagged for
+// the BUDGET=0 + unresolvable-conflict case.
+func TestCheckAutoMergeConvergence_BudgetZero_ConflictAtCycleLimit_Pauses(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: true, MergeableState: "dirty"}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	eng.cfg.ConvergenceBudget = 0 // disabled — no time-based pause
+	eng.cfg.MaxRebaseCycles = 1
+	// Pre-fill RebaseCycles to the limit.
+	eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 42, StageName: "Validate"})
+
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled"}}
+	stage := &stages.Stage{Name: "Validate"}
+	settle := PRSettleResult{Status: PRMergeConflicting, PR: &gh.PRDetails{Number: 10}}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, settle)
+
+	eng.wg.Wait()
+	foundPaused := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			foundPaused = true
+		}
+	}
+	if !foundPaused {
+		t.Error("expected fabrik:paused when convergence rebase cycle limit reached (BUDGET=0 case)")
 	}
 }
 
@@ -570,7 +667,8 @@ func TestCheckAutoMergeConvergence_UnregisteredRepo_NoPanic(t *testing.T) {
 	stage := &stages.Stage{Name: "Validate"}
 
 	// Should not panic. Should pause via the clone-failure path.
-	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage)
+	// settle is not reached (ensureRepoReady fails first); pass zero value.
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{ProjectID: "PVT_1"}, item, stage, PRSettleResult{})
 
 	// Verify the clone-failure path ran: a comment was posted and fabrik:paused applied.
 	if len(client.addCommentCalls) == 0 {


### PR DESCRIPTION
## Summary

- Routes `checkAutoMergeConvergence` through a pre-fetched `PRSettleResult` (via `settlePRMergeState()`) instead of independently calling `FetchLinkedPR`/`FetchCheckRuns`/interpreting `mergeable_state` directly — eliminates the split-brain in the yolo/auto-merge convergence path
- Applies the same `MaxRebaseCycles`-bounded rebase dispatch used by `handleMergeAndCIGates`: in-flight guard → cycle-limit check → `pauseForRebaseCycleLimit()` or dispatch; `FABRIK_CONVERGENCE_BUDGET=0` no longer causes an unbounded rebase loop
- Updates `pauseForConvergenceFailed` to use `settle.PR` and `settle.CheckRuns` instead of independent fetches; updates §5.5 and §6.4 of `docs/state-machine.md` to reflect the unified settling primitive, and regenerates `docs/llms-full.txt`

Closes #904