### PR TITLE
fix(comments): honor FABRIK_STAGE_COMPLETE on non-zero exit; record error separately

### DIFF
--- a/engine/comments.go
+++ b/engine/comments.go
@@ -176,11 +176,11 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	// Hard cap is 3× commentMaxTurns across all invocations.
 	var output string
 	var usage TokenUsage
+	var invCompleted bool
 	currentBudget := firstBudget
 	for {
 		invokeOpts.MaxTurnsOverride = currentBudget
 		var invOutput string
-		var invCompleted bool
 		var invUsage TokenUsage
 		invOutput, invCompleted, invUsage, err = e.claude.InvokeForComments(ctx, stage, item, comments, workDir, invokeOpts)
 		output += invOutput
@@ -225,17 +225,29 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		defer e.mu.Unlock()
 		e.totalTokens = addTokenUsage(e.totalTokens, usage)
 	}()
-	// err == nil guards against marking errored invocations as completed in history.
-	completed := err == nil && checkCompletion(stage, output)
+	// Honor FABRIK_STAGE_COMPLETE consistently with stage runs: invCompleted is the
+	// invoke layer's marker-based completion (engine/claude.go), which already treats
+	// the marker as authoritative even when the process exits non-zero (e.g. a timeout
+	// kill after the stage finished) and withholds completion on engine shutdown. A
+	// non-zero exit does NOT veto completion; it is recorded separately via Errored so
+	// the error is still visible in history (JobCompletedEvent.Success=false).
+	completed := invCompleted
 	e.store.Apply(itemstate.InvocationRecorded{
 		Repo:      itemOwnerRepoString(item, e.defaultRepo()),
 		Number:    item.Number,
 		Completed: completed,
+		Errored:   err != nil,
 		Usage:     usage,
 		IsComment: true,
 		Duration:  time.Since(startedAt),
 	})
-	if err != nil {
+	// Bail early ONLY if the stage did not complete. If FABRIK_STAGE_COMPLETE was
+	// emitted before the process exited non-zero (e.g. a timeout kill after the stage
+	// finished, or trailing work that ended non-zero), proceed with the completion path
+	// exactly like a stage run — a non-zero exit must not silently swallow a real
+	// completion. The error is already recorded via Errored above. On engine shutdown,
+	// invCompleted is false (see engine/claude.go), so that case still bails here.
+	if err != nil && !completed {
 		e.removeEditingLabel(owner, repo, item.Number)
 		if ctx.Err() != nil {
 			e.logf(item.Number, "skip", "cancelled during claude comment review\n")
@@ -243,6 +255,9 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		}
 		e.logf(item.Number, "warn", "claude comment review issue: %v\n", err)
 		return err
+	}
+	if err != nil {
+		e.logf(item.Number, "warn", "claude comment review exited with error but stage completed (marker found) — proceeding: %v\n", err)
 	}
 
 	// Capture git metadata for the comment header

--- a/engine/comments_stagecompletion_test.go
+++ b/engine/comments_stagecompletion_test.go
@@ -18,8 +18,8 @@ func TestProcessComments_StageCompleteMarker_TriggersAdvance(t *testing.T) {
 	client := &mockGitHubClient{}
 	claude := &mockClaudeInvoker{
 		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
-			// Output includes the stage complete marker
-			return "All looks good!\nFABRIK_STAGE_COMPLETE", false, TokenUsage{}, nil
+			// Output includes the stage complete marker → InvokeForComments returns completed=true.
+			return "All looks good!\nFABRIK_STAGE_COMPLETE", true, TokenUsage{}, nil
 		},
 	}
 
@@ -127,7 +127,8 @@ func TestProcessComments_SummaryBeforeStrip_VerificationUpdated(t *testing.T) {
 		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
 			// Output includes both FABRIK_STAGE_COMPLETE and FABRIK_SUMMARY_BEGIN...END
 			output := "Changes applied.\nFABRIK_SUMMARY_BEGIN\n" + summaryText + "\nFABRIK_SUMMARY_END\nFABRIK_STAGE_COMPLETE"
-			return output, false, TokenUsage{}, nil
+			// Marker emitted → InvokeForComments returns completed=true (marker-based).
+			return output, true, TokenUsage{}, nil
 		},
 	}
 

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -2,12 +2,66 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/stages"
 )
+
+// TestProcessComments_HonorsCompletionOnNonZeroExit verifies that when a comment
+// invocation emits FABRIK_STAGE_COMPLETE but the Claude process exits non-zero (e.g.
+// a timeout kill after the stage finished), comment processing still completes the
+// stage — consistent with stage runs — and records the error separately rather than
+// vetoing completion. Regression guard for the comment/stage asymmetry (#890 Req 2).
+func TestProcessComments_HonorsCompletionOnNonZeroExit(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Marker emitted (completed=true) AND a non-zero process exit (err != nil).
+			return "done.\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, errors.New("claude exited with status 1")
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1, Completion: stages.CompletionCriteria{Type: "claude"}}
+	item := gh.ProjectItem{Number: 10, Body: "spec"}
+	userComments := []gh.Comment{
+		{ID: "C_1", DatabaseID: 101, Author: "testuser", Body: "finish it"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments returned error despite completion: %v", err)
+	}
+
+	// The stage must have completed (handleStageComplete ran → stage:Research:complete added).
+	var sawComplete bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Research:complete" {
+			sawComplete = true
+		}
+	}
+	if !sawComplete {
+		t.Errorf("expected stage:Research:complete to be added (completion honored on non-zero exit); addLabelCalls=%v", client.addLabelCalls)
+	}
+
+	// History must record BOTH facts: Completed (marker) AND Errored (non-zero exit).
+	snap, err := eng.store.Get("owner/repo", 10)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	st := snap.State()
+	if !st.LastInvocationCompleted {
+		t.Error("LastInvocationCompleted = false, want true (marker honored despite error)")
+	}
+	if !st.LastInvocationErrored {
+		t.Error("LastInvocationErrored = false, want true (non-zero exit recorded)")
+	}
+}
 
 // testEngineWithRepo creates an engine using a real git repo for worktree operations.
 func testEngineWithRepo(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker) *Engine {

--- a/engine/item.go
+++ b/engine/item.go
@@ -1082,6 +1082,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		Number:    item.Number,
 		Completed: completed,
 		Blocked:   blockedOnInput,
+		Errored:   err != nil,
 		Usage:     usage,
 		Duration:  time.Since(workerStartedAt),
 	})

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -103,7 +103,7 @@ func (o *InvocationObserver) OnChange(change itemstate.Change, snap itemstate.Sn
 		StageName:      st.Status,
 		StageModel:     model,
 		IsComment:      st.LastInvocationIsComment,
-		Success:        true, // InvocationRecorded is only applied after Claude returns
+		Success:        !st.LastInvocationErrored, // false when the Claude process exited non-zero
 		Completed:      st.LastInvocationCompleted,
 		BlockedOnInput: st.LastInvocationBlocked,
 		Duration:       st.LastInvocationDuration,

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -105,6 +105,13 @@ type ItemState struct {
 	// Zero when not recorded (comment-processing paths that don't track start time).
 	LastInvocationDuration time.Duration
 
+	// LastInvocationErrored records whether the most recent Claude invocation exited
+	// with a non-zero status (process error, timeout kill, etc.). This is recorded
+	// independently of LastInvocationCompleted: a stage can complete (FABRIK_STAGE_COMPLETE
+	// emitted) even when the process exits non-zero — e.g. a timeout kill after the stage
+	// finished. The error is surfaced as JobCompletedEvent.Success=false in history.
+	LastInvocationErrored bool
+
 	// LastTokenUsage holds token consumption from the most recent Claude invocation.
 	// Replaces engine.lastUsage[iKey].
 	LastTokenUsage TokenUsage

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -505,7 +505,11 @@ type InvocationRecorded struct {
 	Number    int
 	Completed bool
 	Blocked   bool
-	Usage     TokenUsage
+	// Errored is true when the Claude process exited non-zero. Recorded independently
+	// of Completed — the completion marker is authoritative for whether the stage
+	// completed; Errored only records that the process didn't exit cleanly.
+	Errored bool
+	Usage   TokenUsage
 	// IsComment is true when the invocation processed a user comment rather than
 	// running a stage. Stored in ItemState.LastInvocationIsComment so that the
 	// InvocationObserver can forward the correct flag to the TUI.

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -481,6 +481,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case InvocationRecorded:
 		item.LastInvocationCompleted = v.Completed
 		item.LastInvocationBlocked = v.Blocked
+		item.LastInvocationErrored = v.Errored
 		item.LastInvocationIsComment = v.IsComment
 		item.LastInvocationDuration = v.Duration
 		item.LastTokenUsage = v.Usage


### PR DESCRIPTION
## Problem

Comment processing and stage runs disagreed on whether a `FABRIK_STAGE_COMPLETE` marker is honored when the Claude process exits non-zero:

- **Stage runs** honor the marker regardless of exit code (the invoke layer treats it as authoritative — `engine/claude.go`).
- **Comment processing** vetoed it: `comments.go` gated `completed` on `err == nil` **and** returned early on *any* error.

Result: a **silent lost-completion**. A comment that emitted `FABRIK_STAGE_COMPLETE` but whose process then exited non-zero — most commonly a **timeout kill after the stage had already finished**, or trailing work that ended non-zero — failed to advance the issue. The comment looked processed (output posted, 🚀 added) but nothing moved.

This was introduced by `5acf2609`, which added the `err == nil` guard to make the *history* flag honest — but the same variable also gated the *advance* decision, conflating "did the stage complete?" with "did the process exit cleanly?"

## Fix

Make the two paths consistent and stop conflating the two facts:

- **Completion is marker-based** (`completed := invCompleted`) — the invoke layer's value, which already honors the marker on a non-zero exit and *withholds* completion on engine shutdown. Comment processing now proceeds with the completion path instead of bailing early when the stage completed.
- **The exit error is recorded separately** — new `InvocationRecorded.Errored` → `ItemState.LastInvocationErrored` → `JobCompletedEvent.Success = false`, so the non-zero exit still surfaces in `.fabrik/history.json` (the `Success`/`Completed` columns the history model already distinguishes) instead of being hidden behind a flipped completion flag.

So: `Completed` = "stage finished (marker)", `Success` = "process exited cleanly" — both recorded, never conflated, and identical across stage runs and comment runs.

## Tests

- New `TestProcessComments_HonorsCompletionOnNonZeroExit`: marker + non-zero exit → stage completes (`stage:Research:complete` added) and history records `Completed:true`, `Errored:true`.
- Updated two existing comment tests whose mocks emitted the marker but returned `completed=false` — which the real `InvokeForComments` never does — to be faithful (`completed=true`).
- `go test -race ./engine/... ./internal/itemstate/... ./tui/...` green; `go vet ./...` clean.

Refs #890 (Req 2 / `stage-lifecycle.md:502`). The doc update is handled in #890; this PR is the code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
