### PR TITLE
fix(convergence): re-confirm merged state via single-PR endpoint before pausing

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -19,6 +19,7 @@ type ReadClient interface {
 	FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)
 	FetchPRMergeableFields(owner, repo string, prNumber int) (mergeable *bool, mergeableState string, err error)
 	FetchPRMergeable(owner, repo string, prNumber int) (*bool, error)
+	FetchPRMerged(owner, repo string, prNumber int) (bool, error)
 	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
 	FetchLabels(owner, repo string, issueNumber int) ([]string, error)
 	FetchStatusField(projectID string) (*gh.StatusField, error)
@@ -62,6 +63,10 @@ func (a *GitHubAdapter) FetchPRMergeableFields(owner, repo string, prNumber int)
 
 func (a *GitHubAdapter) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
 	return a.client.FetchPRMergeable(owner, repo, prNumber)
+}
+
+func (a *GitHubAdapter) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	return a.client.FetchPRMerged(owner, repo, prNumber)
 }
 
 func (a *GitHubAdapter) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
@@ -786,6 +791,12 @@ func (c *CacheImpl) FetchPRMergeableFields(owner, repo string, prNumber int) (*b
 // FetchPRMergeable always delegates to GitHub — mergeability changes without webhooks.
 func (c *CacheImpl) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
 	return c.fallback.FetchPRMergeable(owner, repo, prNumber)
+}
+
+// FetchPRMerged always delegates to GitHub — the authoritative merged flag must be
+// fresh (the cache/list-endpoint copy lags right after a merge).
+func (c *CacheImpl) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	return c.fallback.FetchPRMerged(owner, repo, prNumber)
 }
 
 // FetchPRMergeableState always delegates to GitHub — mergeability changes without webhooks.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -93,6 +93,10 @@ func (m *mockClient) FetchPRMergeableState(owner, repo string, prNumber int) (st
 	return "", nil
 }
 
+func (m *mockClient) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	return false, nil
+}
+
 func (m *mockClient) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
 	return nil, "", nil
 }

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -84,6 +84,9 @@ func (m *testGitHubUpgradeClient) FetchPRMergeable(owner, repo string, prNumber 
 func (m *testGitHubUpgradeClient) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
 	return "", nil
 }
+func (m *testGitHubUpgradeClient) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	return false, nil
+}
 func (m *testGitHubUpgradeClient) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
 	return nil, "", nil
 }

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -30,6 +30,7 @@ type GitHubClient interface {
 	FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error)
 	FetchPRMergeableFields(owner, repo string, prNumber int) (mergeable *bool, mergeableState string, err error)
 	FetchPRMergeable(owner, repo string, prNumber int) (*bool, error)
+	FetchPRMerged(owner, repo string, prNumber int) (bool, error)
 	FetchPRMergeableState(owner, repo string, prNumber int) (string, error)
 	FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error)
 	FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -32,6 +32,7 @@ type mockGitHubClient struct {
 	fetchLinkedPRFn               func(owner, repo string, issueNumber int) (*gh.PRDetails, error)
 	fetchPRMergeableFieldsFn      func(owner, repo string, prNumber int) (*bool, string, error)
 	fetchPRMergeableFn            func(owner, repo string, prNumber int) (*bool, error)
+	fetchPRMergedFn               func(owner, repo string, prNumber int) (bool, error)
 	fetchPRMergeableStateFn       func(owner, repo string, prNumber int) (string, error)
 	fetchCheckRunsFn              func(owner, repo, sha string) ([]gh.CheckRun, error)
 	getPRBaseFn                   func(owner, repo string, prNumber int) (string, error)
@@ -377,6 +378,16 @@ func (m *mockGitHubClient) FetchPRMergeable(owner, repo string, prNumber int) (*
 		return fn(owner, repo, prNumber)
 	}
 	return nil, nil
+}
+
+func (m *mockGitHubClient) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	m.mu.Lock()
+	fn := m.fetchPRMergedFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber)
+	}
+	return false, nil
 }
 
 func (m *mockGitHubClient) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {

--- a/engine/pr_settle.go
+++ b/engine/pr_settle.go
@@ -63,6 +63,20 @@ func (e *Engine) settlePRMergeState(item gh.ProjectItem, _ *stages.Stage) PRSett
 		return PRSettleResult{Status: PRMergeTerminal, Reason: fmt.Sprintf("PR #%d already merged", pr.Number), PR: pr}
 	}
 	if pr.State == "closed" {
+		// FetchLinkedPR reads the PR *list* endpoint, whose `merged` flag is unreliable
+		// (reports false for several seconds after a merge). Confirm against the
+		// authoritative single-PR endpoint before treating a closed PR as never-merged —
+		// a PR the engine just merged (e.g. the direct-merge fallback) must never be
+		// misclassified as "closed without merging" and used to pause the issue.
+		merged, mErr := e.readClient.FetchPRMerged(owner, repo, pr.Number)
+		if mErr != nil {
+			// Don't pause on an unconfirmable closed state — re-evaluate next poll.
+			return PRSettleResult{Status: PRMergeUnsettled, Reason: fmt.Sprintf("PR #%d closed; merged-state unconfirmed: %v", pr.Number, mErr), PR: pr}
+		}
+		if merged {
+			pr.Merged = true
+			return PRSettleResult{Status: PRMergeTerminal, Reason: fmt.Sprintf("PR #%d merged (confirmed via single-PR endpoint)", pr.Number), PR: pr}
+		}
 		return PRSettleResult{Status: PRMergeTerminal, Reason: fmt.Sprintf("PR #%d closed without merging", pr.Number), PR: pr}
 	}
 

--- a/engine/pr_settle_test.go
+++ b/engine/pr_settle_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,6 +85,75 @@ func TestSettle_PRClosedNotMerged_ReturnsTerminal(t *testing.T) {
 	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
 	if r.Status != PRMergeTerminal {
 		t.Errorf("expected PRMergeTerminal for closed PR, got %v", r.Status)
+	}
+}
+
+// ── Stale list-endpoint merged flag (ConvergenceRace regression) ──────────────
+//
+// FetchLinkedPR reads the PR *list* endpoint, whose `merged` flag reports false
+// for several seconds after a merge. A PR the engine just merged (e.g. the
+// direct-merge fallback) arrives here as {State:"closed", Merged:false}. settle
+// must re-confirm against the authoritative single-PR endpoint before classifying
+// "closed without merging" — otherwise the issue is wrongly paused.
+
+func TestSettle_ClosedButMerged_ConfirmedViaSinglePR(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			// List endpoint lies: merged=false right after a merge.
+			return &gh.PRDetails{Number: 42, Merged: false, State: "closed"}, nil
+		},
+		fetchPRMergedFn: func(owner, repo string, prNumber int) (bool, error) {
+			// Single-PR endpoint is authoritative: the PR was in fact merged.
+			return true, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeTerminal {
+		t.Errorf("expected PRMergeTerminal for stale-list/merged-single PR, got %v", r.Status)
+	}
+	if r.PR == nil || !r.PR.Merged {
+		t.Error("expected r.PR.Merged=true after single-PR re-confirmation")
+	}
+	if strings.Contains(r.Reason, "closed without merging") {
+		t.Errorf("merged PR must NOT be classified as closed-without-merging; got reason %q", r.Reason)
+	}
+}
+
+func TestSettle_ClosedNotMerged_StillTerminal(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, Merged: false, State: "closed"}, nil
+		},
+		fetchPRMergedFn: func(owner, repo string, prNumber int) (bool, error) {
+			// Single-PR endpoint confirms it really was closed without merging.
+			return false, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeTerminal {
+		t.Errorf("expected PRMergeTerminal for genuinely-closed PR, got %v", r.Status)
+	}
+	if !strings.Contains(r.Reason, "closed without merging") {
+		t.Errorf("expected closed-without-merging reason, got %q", r.Reason)
+	}
+}
+
+func TestSettle_ClosedMergedUnconfirmable_ReturnsUnsettled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 42, Merged: false, State: "closed"}, nil
+		},
+		fetchPRMergedFn: func(owner, repo string, prNumber int) (bool, error) {
+			// Single-PR endpoint unreachable — must not pause on an unconfirmable state.
+			return false, errors.New("api timeout")
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	r := eng.settlePRMergeState(settleItem(1), &stages.Stage{Name: "Validate"})
+	if r.Status != PRMergeUnsettled {
+		t.Errorf("expected PRMergeUnsettled when merged-state unconfirmable, got %v", r.Status)
 	}
 }
 

--- a/engine/pr_terminal_advance.go
+++ b/engine/pr_terminal_advance.go
@@ -55,6 +55,19 @@ func (e *Engine) runValidatePRTerminalAdvance(board *gh.ProjectBoard, items []gh
 		if !pr.Merged && pr.State != "closed" {
 			continue // PR is still open; not terminal
 		}
+		// FetchLinkedPR reads the PR list endpoint, whose `merged` flag is unreliable
+		// (false for seconds after a merge). For a closed PR, confirm against the
+		// authoritative single-PR endpoint before deciding advance-vs-pause — otherwise
+		// a PR the engine just merged (e.g. the direct-merge fallback) gets misread as
+		// "closed without merging" and the issue is wrongly paused.
+		if !pr.Merged && pr.State == "closed" {
+			if merged, mErr := e.client.FetchPRMerged(owner, repo, pr.Number); mErr != nil {
+				e.logf(item.Number, "pr-terminal", "PR #%d closed; could not confirm merged state: %v — skipping (re-check next poll)\n", pr.Number, mErr)
+				continue
+			} else if merged {
+				pr.Merged = true
+			}
+		}
 
 		if pr.Merged {
 			e.logf(item.Number, "pr-terminal", "PR #%d merged — filling gate-checked completion labels and advancing to Done\n", pr.Number)

--- a/github/prs.go
+++ b/github/prs.go
@@ -128,6 +128,25 @@ func (c *Client) FetchPRMergeable(owner, repo string, prNumber int) (*bool, erro
 	return raw.Mergeable, nil
 }
 
+// FetchPRMerged returns GitHub's authoritative `merged` flag for a single PR.
+//
+// Only the single-PR endpoint (/pulls/{number}) reports `merged` reliably. The
+// list endpoint used by FetchLinkedPR returns merged=false for several seconds
+// after a merge (and is generally unreliable for this field), so a PR the engine
+// just merged briefly looks like state=closed, merged=false there. Use this to
+// confirm whether a PR observed as closed was actually merged before treating it
+// as "closed without merging".
+func (c *Client) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
+	var raw struct {
+		Merged bool `json:"merged"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		return false, fmt.Errorf("fetching PR #%d merged state: %w", prNumber, err)
+	}
+	return raw.Merged, nil
+}
+
 // FetchPRMergeableState returns GitHub's branch-protection-aware mergeable_state
 // for a single PR (e.g. "clean", "unstable", "blocked", "behind", "dirty",
 // "draft", "has_hooks", "unknown"). Used by Fabrik's CI gate as the


### PR DESCRIPTION
## Problem

The GitHub PR **list** endpoint (used by `FetchLinkedPR` via `/pulls?head=…`) reports `merged: false` for several seconds after a merge completes. Only the **single-PR** endpoint (`/pulls/{number}`) is authoritative.

When the direct-merge fallback merges a PR, the very next poll sees `{state: closed, merged: false}` from the list endpoint, and `settlePRMergeState` / `runValidatePRTerminalAdvance` / `ci.go` classify it as "closed without merging" — **wrongly pausing the issue** with `fabrik:paused`.

This is the real bug behind the `TestConvergenceRace` e2e failure. Test-bed log proved the race:

```
17:35:01 PR #68 merged directly
17:35:01 PR #68 closed without merging — pausing
```

## Fix

Add `FetchPRMerged`, which reads the authoritative single-PR endpoint. For a closed-but-not-merged PR, both the settle primitive and the terminal-advance owner re-confirm against it before deciding advance-vs-pause:

- **merged confirmed** → terminal / advance to Done
- **not merged** → closed-without-merging (pause, unchanged behavior)
- **unconfirmable** (API error) → unsettled; re-evaluate next poll, **never pause**

Wired through the `GitHubClient` interface, boardcache `ReadClient` / `GitHubAdapter` / `CacheImpl`, and all mocks. `ci.go` gets the fix for free via `settle.PR.Merged`.

## Tests

New regression tests in `engine/pr_settle_test.go` cover the stale-list/merged-single, genuinely-closed, and unconfirmable cases. Full `go test -race ./...` and `go vet ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)