### PR TITLE
fix(convergence): admit closed gate-checked items so settle-owner heals paused merges

### DIFF
--- a/adrs/056-consolidate-convergence-gate-recovery.md
+++ b/adrs/056-consolidate-convergence-gate-recovery.md
@@ -135,3 +135,23 @@ close #883/#885 here) → `#889` + `#890` (lock in structure and docs).
 This ADR does not change the human-in-the-loop pause semantics (ADR-008), the rebase-by-Claude
 decision (ADR-028 §6.5.4), the convergence budget concept (ADR-050) — only *where* and *how many
 times* PR-state is interpreted and the board is advanced.
+
+## Addendum (2026-06-19): closed-issue admit gate — the strand lived one layer up
+
+The single settle-owner `runValidatePRTerminalAdvance` is gate-label-agnostic, but it only ever
+iterates items that survive the closed-issue admit gate in `itemMayNeedWork` / `itemNeedsWork`
+(`engine/item.go`). That gate admitted closed items only for `stage:<X>:complete`,
+`fabrik:awaiting-ci`, or `fabrik:auto-merge-enabled`. A PR merged externally while the issue was
+paused at Validate with **`fabrik:awaiting-review`** (or bare `fabrik:paused`, or no gate label)
+closed the issue via `Closes #N`; on the next poll the closed item was dropped at this gate, so the
+settle-owner never saw it and the item stranded (closed, paused, no `stage:Validate:complete`). The
+`awaiting-ci` variant only worked because that one label was already on the allowlist.
+
+This is the same #874 strand the consolidation set out to kill — the label coupling simply survived
+one layer **upstream** of the owner. Consistent with this ADR ("extend the owner, not add a
+scanner"), the fix widens the admit gate rather than adding a recovery loop: a closed item at a
+**gate-checked stage** (`wait_for_ci` / `wait_for_reviews`, via `stageIsGateChecked`) lacking its
+`stage:<X>:complete` label is admitted regardless of gate label, so the owner can observe the
+terminal PR and advance/heal it. Surfaced by `TestPausedMergedPRRecovery` (the awaiting-review and
+no-gate-label variants) once its harness race was removed; guarded by unit tests in
+`engine/closed_admit_settle_test.go`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2740,9 +2740,12 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **Code path:** `itemMayNeedWork()` and `itemNeedsWork()` check `item.IsClosed`
 
-**Effect:** Closed issues are skipped unless:
+**Effect:** Closed issues are skipped unless one of the following holds (any one admits the item):
 1. The current stage is a cleanup stage (`CleanupWorktree: true`) — cleanup can remove the worktree
 2. The current stage has a `stage:<X>:complete` label — the catch-up loop can advance to the next stage (e.g., a PR merge closes an issue sitting in Validate with `stage:Validate:complete`; it needs to move to Done)
+3. `fabrik:awaiting-ci` is present — the CI-gate catch-up can finish the gate after a merge closes the issue
+4. `fabrik:auto-merge-enabled` is present — `checkAutoMergeConvergence` can detect the merged PR and advance to Done
+5. The current stage is **gate-checked** (`wait_for_ci` or `wait_for_reviews` — i.e. Validate) and lacks its `stage:<X>:complete` label — a merge can close the issue while it sits at Validate carrying any gate label (`fabrik:awaiting-review`, `fabrik:paused`) or none; the gate-label-agnostic settle-owner (`runValidatePRTerminalAdvance`, ADR-056 D2) must still observe the terminal PR and advance/heal it. Keying this admit on the gate-checked stage (via `stageIsGateChecked`) rather than a fixed label allowlist removes the label coupling that previously stranded paused / awaiting-review merges one layer upstream of the settle-owner (the #874 class).
 
 ### 2.9 Review Reinvoke
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -272,9 +272,12 @@ Note: within `checkDependencies()`, for each blocker the engine first consults `
 
 **Code path:** `itemMayNeedWork()` and `itemNeedsWork()` check `item.IsClosed`
 
-**Effect:** Closed issues are skipped unless:
+**Effect:** Closed issues are skipped unless one of the following holds (any one admits the item):
 1. The current stage is a cleanup stage (`CleanupWorktree: true`) — cleanup can remove the worktree
 2. The current stage has a `stage:<X>:complete` label — the catch-up loop can advance to the next stage (e.g., a PR merge closes an issue sitting in Validate with `stage:Validate:complete`; it needs to move to Done)
+3. `fabrik:awaiting-ci` is present — the CI-gate catch-up can finish the gate after a merge closes the issue
+4. `fabrik:auto-merge-enabled` is present — `checkAutoMergeConvergence` can detect the merged PR and advance to Done
+5. The current stage is **gate-checked** (`wait_for_ci` or `wait_for_reviews` — i.e. Validate) and lacks its `stage:<X>:complete` label — a merge can close the issue while it sits at Validate carrying any gate label (`fabrik:awaiting-review`, `fabrik:paused`) or none; the gate-label-agnostic settle-owner (`runValidatePRTerminalAdvance`, ADR-056 D2) must still observe the terminal PR and advance/heal it. Keying this admit on the gate-checked stage (via `stageIsGateChecked`) rather than a fixed label allowlist removes the label coupling that previously stranded paused / awaiting-review merges one layer upstream of the settle-owner (the #874 class).
 
 ### 2.9 Review Reinvoke
 

--- a/engine/closed_admit_settle_test.go
+++ b/engine/closed_admit_settle_test.go
@@ -1,0 +1,119 @@
+package engine
+
+import (
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// gateCheckedStages returns a pipeline whose Validate stage is gate-checked
+// (wait_for_ci) and an Implement stage that is not — used to verify the
+// closed-issue admit gate in itemMayNeedWork / itemNeedsWork.
+func gateCheckedStages() []*stages.Stage {
+	tr := true
+	return []*stages.Stage{
+		{Name: "Implement", Order: 1, Prompt: "implement"},
+		{Name: "Validate", Order: 2, Prompt: "validate", WaitForCI: &tr},
+	}
+}
+
+func gateCheckedEngine(t *testing.T) *Engine {
+	t.Helper()
+	return NewWithDeps(
+		Config{Owner: "o", Repo: "r", User: "u", Token: "t", Stages: gateCheckedStages()},
+		&mockGitHubClient{}, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()),
+	)
+}
+
+// A merged PR closes the issue while it sits at the gate-checked Validate stage
+// carrying any gate label (or none). The settle-owner (runValidatePRTerminalAdvance)
+// reads only items admitted by itemMayNeedWork, so the admit gate must let these
+// through regardless of which gate label is present — otherwise the #874-class
+// merge is stranded (the ADR-056 D2 gap this guards).
+
+func TestItemMayNeedWork_ClosedAtValidate_AwaitingReview_Admitted(t *testing.T) {
+	eng := gateCheckedEngine(t)
+	item := gh.ProjectItem{
+		Number:   1,
+		Status:   "Validate",
+		IsClosed: true,
+		Labels:   []string{"fabrik:awaiting-review", "fabrik:paused"},
+	}
+	if !eng.itemMayNeedWork(item) {
+		t.Error("closed Validate item with fabrik:awaiting-review must be admitted so the settle-owner can heal it")
+	}
+}
+
+func TestItemMayNeedWork_ClosedAtValidate_PausedOnly_Admitted(t *testing.T) {
+	eng := gateCheckedEngine(t)
+	item := gh.ProjectItem{
+		Number:   2,
+		Status:   "Validate",
+		IsClosed: true,
+		Labels:   []string{"fabrik:paused", "fabrik:awaiting-input"},
+	}
+	if !eng.itemMayNeedWork(item) {
+		t.Error("closed Validate item with only fabrik:paused must be admitted (no-gate-label / awaiting-review merges)")
+	}
+}
+
+func TestItemMayNeedWork_ClosedAtValidate_NoGateLabel_Admitted(t *testing.T) {
+	eng := gateCheckedEngine(t)
+	item := gh.ProjectItem{
+		Number:   3,
+		Status:   "Validate",
+		IsClosed: true,
+		Labels:   nil,
+	}
+	if !eng.itemMayNeedWork(item) {
+		t.Error("closed Validate item with no gate label must be admitted (gate-label-agnostic settle owner)")
+	}
+}
+
+func TestItemMayNeedWork_ClosedAtValidate_AwaitingCI_StillAdmitted(t *testing.T) {
+	eng := gateCheckedEngine(t)
+	item := gh.ProjectItem{
+		Number:   4,
+		Status:   "Validate",
+		IsClosed: true,
+		Labels:   []string{"fabrik:awaiting-ci"},
+	}
+	if !eng.itemMayNeedWork(item) {
+		t.Error("closed Validate item with fabrik:awaiting-ci must remain admitted (pre-existing behavior)")
+	}
+}
+
+// Regression guard: the fix is scoped to gate-checked stages. A closed item at a
+// non-gate-checked stage with no complete/gate label must still be dropped, so we
+// don't start deep-fetching every closed mid-pipeline issue.
+func TestItemMayNeedWork_ClosedAtNonGateStage_NotAdmitted(t *testing.T) {
+	eng := gateCheckedEngine(t)
+	item := gh.ProjectItem{
+		Number:   5,
+		Status:   "Implement", // not gate-checked
+		IsClosed: true,
+		Labels:   []string{"fabrik:paused"},
+	}
+	if eng.itemMayNeedWork(item) {
+		t.Error("closed item at a non-gate-checked stage with no complete/gate label must NOT be admitted")
+	}
+}
+
+// itemNeedsWork mirror: the closed-issue admit gate keeps the same shape as
+// itemMayNeedWork (the awaiting-ci/auto-merge allowlist lives in both), so the
+// non-gate-stage drop must hold here too. (The full itemNeedsWork still returns
+// false for a closed paused item with no pending work via downstream guards —
+// healing is the settle-owner's job, fed by itemMayNeedWork, not itemNeedsWork.)
+func TestItemNeedsWork_ClosedAtNonGateStage_NotAdmitted(t *testing.T) {
+	eng := gateCheckedEngine(t)
+	item := gh.ProjectItem{
+		Number:   7,
+		Status:   "Implement",
+		IsClosed: true,
+		Labels:   []string{"fabrik:paused", "fabrik:awaiting-input"},
+	}
+	if eng.itemNeedsWork(item) {
+		t.Error("closed item at a non-gate-checked stage must NOT pass itemNeedsWork")
+	}
+}

--- a/engine/item.go
+++ b/engine/item.go
@@ -103,12 +103,19 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 		if stage == nil {
 			return false
 		}
-		// Also admit closed items with fabrik:awaiting-ci so the catch-up loop
-		// can complete the CI gate after a PR merge closes the issue.
-		// Admit fabrik:auto-merge-enabled for the same reason: when GitHub merges
-		// the PR the issue is closed; checkAutoMergeConvergence needs to run to
-		// detect the merged state and advance to Done.
-		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") && !hasLabel(item, "fabrik:auto-merge-enabled") {
+		// Admit closed items so the catch-up loop / settle-owner can advance or
+		// heal them after a PR merge closes the issue. Beyond stage:<stage>:complete
+		// (already past the gate) and fabrik:awaiting-ci / fabrik:auto-merge-enabled
+		// (the CI-gate catch-up and checkAutoMergeConvergence), admit any item at a
+		// gate-checked stage (wait_for_ci / wait_for_reviews — i.e. Validate) that
+		// is not yet complete. A merge can close the issue while it sits at Validate
+		// carrying ANY gate label (fabrik:awaiting-review, fabrik:paused, …) or none;
+		// the gate-label-agnostic settle-owner (runValidatePRTerminalAdvance,
+		// ADR-056 D2) must still observe the terminal PR and advance/heal it. Keying
+		// the admit on the gate-checked stage rather than a fixed label allowlist
+		// removes the label coupling that previously stranded paused / awaiting-review
+		// merges (the #874 class) one layer upstream of the settle-owner.
+		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") && !hasLabel(item, "fabrik:auto-merge-enabled") && !stageIsGateChecked(stage) {
 			return false
 		}
 	}
@@ -165,7 +172,11 @@ func (e *Engine) itemNeedsWork(item gh.ProjectItem) bool {
 		if stage == nil {
 			return false
 		}
-		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") && !hasLabel(item, "fabrik:auto-merge-enabled") {
+		// Mirror of the itemMayNeedWork closed-issue gate: admit closed items at a
+		// gate-checked stage (Validate) lacking stage:complete so the gate-label-
+		// agnostic settle-owner can heal paused / awaiting-review merges (ADR-056 D2,
+		// #874 class) — not only fabrik:awaiting-ci / fabrik:auto-merge-enabled.
+		if !stage.CleanupWorktree && !hasLabel(item, fmt.Sprintf("stage:%s:complete", stage.Name)) && !hasLabel(item, "fabrik:awaiting-ci") && !hasLabel(item, "fabrik:auto-merge-enabled") && !stageIsGateChecked(stage) {
 			return false
 		}
 	}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -46,6 +46,18 @@ func hasUnrestrictedLabel(item gh.ProjectItem) bool {
 	return false
 }
 
+// stageIsGateChecked reports whether a stage gates completion on CI or reviews
+// (wait_for_ci / wait_for_reviews). The Validate stage is the gate-checked stage
+// in the default pipeline; the settle-owner (runValidatePRTerminalAdvance) and
+// the closed-issue admit gates key on this property so a merged PR at a
+// gate-checked stage is advanced/healed regardless of which gate label is set.
+func stageIsGateChecked(stage *stages.Stage) bool {
+	if stage == nil {
+		return false
+	}
+	return (stage.WaitForCI != nil && *stage.WaitForCI) || (stage.WaitForReviews != nil && *stage.WaitForReviews)
+}
+
 func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
 	e.logf(item.Number, "done", "stage %q complete\n", stage.Name)
 


### PR DESCRIPTION
## The bug (found by the e2e suite)

The ADR-056 settle-owner `runValidatePRTerminalAdvance` is **gate-label-agnostic** — but it only iterates items that survive the closed-issue admit gate in `itemMayNeedWork`/`itemNeedsWork` (`engine/item.go`). That gate admitted closed items only for `stage:<X>:complete`, `fabrik:awaiting-ci`, or `fabrik:auto-merge-enabled`.

When a PR is merged externally (human or bot) while the issue is paused at Validate carrying **`fabrik:awaiting-review`** (or bare `fabrik:paused`, or no gate label), `Closes #N` closes the issue. On the next poll the closed item is **dropped at this gate**, so the settle-owner never runs and the item strands: closed, paused, **no `stage:Validate:complete`**.

This is the exact **#874 strand** the convergence consolidation set out to kill — the label coupling simply survived **one layer upstream** of the owner. `awaiting-ci` passed only because it was the one gate label already on the allowlist.

### Evidence
`TestPausedMergedPRRecovery`, once its harness race was removed, reproduced it deterministically: `awaiting-ci` heals (settle-owner fires), `awaiting-review` and `no-gate-label` strand (settle-owner never fires; engine still reports them pre-Validate).

## The fix

Per ADR-056's own guidance ("extend the owner, not add a scanner"): widen the admit gate so a closed item at a **gate-checked stage** (`wait_for_ci`/`wait_for_reviews` → Validate) lacking its `stage:<X>:complete` label is admitted **regardless of gate label** (new `stageIsGateChecked` helper). The settle-owner then observes the terminal PR and advances/heals it.

Scoped to gate-checked stages so we don't start deep-fetching every closed mid-pipeline issue (regression-guarded).

## Tests & docs
- `engine/closed_admit_settle_test.go` — admits closed Validate items with awaiting-review / paused / no-label / awaiting-ci; drops closed non-gate-stage items.
- `go test -race ./...`, `go vet ./...`, `go build ./...` green.
- `docs/state-machine.md` §2.8 updated + `docs/llms-full.txt` regen; **ADR-056 addendum**.

Verified end-to-end against `TestPausedMergedPRRecovery` (see linked harness PR #914 for the test-side determinism fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)