### PR TITLE
test(e2e): un-skip TestConjunctiveCIReviewGate; update slow-gate timing to 600s

### DIFF
--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -12,7 +12,7 @@ import (
 // CI∧review gate (ADR-056 D2). The Validate stage in the test bed is already
 // configured with both wait_for_ci: true and wait_for_reviews: true.
 //
-// The slow-gate CI check (~6 minutes, enrolled as required on
+// The slow-gate CI check (~10 minutes, enrolled as required on
 // handarbeit/fabrik-test-alpha/main) is triggered by placing "slow-ci-required"
 // in the PR body. This creates a wide CI-await window without triggering the
 // CI-fix reinvoke machinery.
@@ -37,18 +37,10 @@ import (
 //   - FABRIK_REVIEW_WAIT_TIMEOUT=2 (minutes) in the test bed .env when using the
 //     timeout fallback path (otherwise the default 15-minute wait is impractical).
 //
-// Wall-clock: ~60–90 min (approval path); ~30–50 min (timeout path). Use E2E_TIMEOUT=2h.
+// Wall-clock: ~65–100 min (approval path); ~35–60 min (timeout path). Use E2E_TIMEOUT=2h.
 // Cost: ~$1.00–2.50.
 func TestConjunctiveCIReviewGate(t *testing.T) {
 	t.Parallel()
-	// Skipped pending handarbeit/fabrik#917. R1 is a timing race: the slow-gate
-	// sleeps SLOW_CI_SECONDS=360 (6 min), but the agent pipeline to Validate can
-	// exceed that, so Validate completes after CI is already green and the
-	// fabrik:awaiting-ci window is too brief to observe. The engine is correct
-	// (applies and clears the gate properly); widening the slow-gate (#917) gives
-	// the margin to make R1 deterministic. The reviewer-request fix below (R2) is
-	// correct and retained.
-	t.Skip("blocked on #917: slow-gate (360s) timing race makes the fabrik:awaiting-ci window non-deterministic")
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 	assertSlowGateRequired(t, env, env.RepoAlpha)
@@ -94,7 +86,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	t.Logf("fabrik:awaiting-ci confirmed on %s#%d (CI gate is holding)", env.RepoAlpha, num)
 
 	// R1 withheld window (2 min): stage:Validate:complete must NOT appear while
-	// fabrik:awaiting-ci is present — CI has not yet passed (slow-gate ~6 min).
+	// fabrik:awaiting-ci is present — CI has not yet passed (~10 min).
 	withheldDeadline := time.Now().Add(2 * time.Minute)
 	r1Checked := false
 	for time.Now().Before(withheldDeadline) {
@@ -125,7 +117,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	CommentOnPR(t, env, env.RepoAlpha, prNumber, commentBody)
 	t.Logf("posted PR comment %q on #%d during CI-await (R3)", commentBody, prNumber)
 
-	// Wait for CI (slow-gate, ~6 min) to pass — fabrik:awaiting-ci clears when
+	// Wait for CI (~10 min) to pass — fabrik:awaiting-ci clears when
 	// addCompleteLabelAndRemoveCI runs after checkCIGate returns cleared.
 	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 20*time.Minute)
 	t.Logf("fabrik:awaiting-ci cleared on %s#%d (CI gate passed)", env.RepoAlpha, num)
@@ -218,7 +210,7 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 
 // conjunctiveCIReviewGateBody is the issue body for TestConjunctiveCIReviewGate.
 // Claude makes a minimal change to README.md and includes "slow-ci-required"
-// in the PR body to trigger the ~6-minute slow-gate required CI check, creating
+// in the PR body to trigger the ~10-minute slow-gate required CI check, creating
 // a wide CI-await window for the conjunctive gate test.
 const conjunctiveCIReviewGateBody = `## Goal
 
@@ -240,7 +232,7 @@ to this test.
 ## CI behaviour required
 
 The PR body MUST carry the literal marker below so the test repo's CI
-slow-gate check fires (~6 minutes, enrolled as a required check):
+slow-gate check fires (~10 minutes, enrolled as a required check):
 
 slow-ci-required
 

--- a/tests/e2e/convergence_race_test.go
+++ b/tests/e2e/convergence_race_test.go
@@ -14,7 +14,7 @@ import (
 // SC-002).
 //
 // The test bed's CI workflow has a required "slow-gate" job that sleeps for
-// ~6 minutes when the PR body contains the literal string "slow-ci-required".
+// ~10 minutes when the PR body contains the literal string "slow-ci-required".
 // We file two yolo issues that BOTH target the same anchor in the same file
 // (the first line of README.md) and BOTH carry the marker. The arrangement
 // makes the race deterministic:
@@ -23,7 +23,7 @@ import (
 //  2. Both PRs open against main from the same base SHA.
 //  3. Validate completes on both; engine enables GitHub native auto-merge on
 //     both PRs (fabrik:auto-merge-enabled is applied).
-//  4. Both PRs wait on the 6-minute slow-gate check.
+//  4. Both PRs wait on the 10-minute slow-gate check.
 //  5. Whichever finishes first merges atomically via GitHub auto-merge. Main
 //     now has a new HTML comment line immediately after the first line.
 //  6. The OTHER PR is now "behind main" AND has a true textual conflict at
@@ -46,7 +46,7 @@ import (
 // its CI run). Before #829, this test would fail with the second PR stuck
 // in fabrik:paused.
 //
-// Wall-clock: ~75-90 min. Cost: ~$2-4.
+// Wall-clock: ~80-100 min. Cost: ~$2-4.
 func TestConvergenceRace(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
@@ -131,7 +131,7 @@ func TestConvergenceRace(t *testing.T) {
 // freedom in where to put the line, the conflict may not materialise.
 //
 // The PR body MUST also contain the literal string "slow-ci-required". The
-// test repo's CI workflow keys on that string to enable the 6-minute
+// test repo's CI workflow keys on that string to enable the 10-minute
 // slow-gate that widens the merge-race window enough for #829's bug to
 // manifest reliably.
 const convergenceBodyTemplate = `## Goal
@@ -164,7 +164,7 @@ slow-gate fires:
 
 slow-ci-required
 
-This is what gives the auto-merge race a deterministic 6-minute window
+This is what gives the auto-merge race a deterministic 10-minute window
 during which main can move under us.
 
 ## Scope

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -445,7 +445,7 @@ func MergePR(t *testing.T, env *Env, repo string, prNumber int) {
 	// --admin bypasses not-yet-green required checks. The test repo has
 	// enforce_admins:false, so an admin merge is permitted, and it faithfully
 	// models the scenario these tests simulate: an external human merging the PR.
-	// Without it, a merge issued before the ~6-min slow-gate (and other required
+	// Without it, a merge issued before the ~10-min slow-gate (and other required
 	// checks) go green is rejected with "the base branch policy prohibits the
 	// merge" — a non-deterministic failure that depends on CI timing.
 	out, err := ghOutput(env, "pr", "merge", fmt.Sprint(prNumber), "-R", repo, "--merge", "--admin")


### PR DESCRIPTION
Closes #918

Remove the `t.Skip` block from `TestConjunctiveCIReviewGate` — the slow-gate in `handarbeit/fabrik-test-alpha` has been widened from 360s to 600s (10 minutes), making the `fabrik:awaiting-ci` window wide enough for R1 to be deterministic.

Update all stale `~6 min` / `360s` / `6-minute` timing comments across three e2e files to reflect the new 10-minute gate duration. No timeout values (`20*time.Minute`, `90*time.Minute`) were changed.

**Files changed:**
- `tests/e2e/conjunctive_ci_review_gate_test.go` — skip block removed; 6 timing comments updated
- `tests/e2e/convergence_race_test.go` — 5 timing comments updated  
- `tests/e2e/harness.go` — 1 timing comment updated

**Verification:**
```
go build ./...  ✓
go vet ./...    ✓
grep -r "6 min\|360s\|6-minute" <targets>  → no matches ✓
```

**Note:** The un-skipped test (`TestConjunctiveCIReviewGate`) requires `SLOW_CI_SECONDS=600` deployed in `handarbeit/fabrik-test-alpha` to run correctly. Normal CI in this repo does not run e2e tests (`//go:build e2e` guard), so this PR is safe to merge independently.