### PR TITLE
feat(ci): embed check output in CI-fix comment; unskip TestCIFixReinvoke

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3651,7 +3651,7 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
    - If not exceeded: increment count, dispatch reinvoke via `dispatchCIFixReinvoke()`:
      - Applies `WorkerEntered` (prevents double-dispatch)
      - Acquires semaphore slot (respects `MaxConcurrent`)
-     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — uses `settle.CheckRuns` for the PR-head check runs (no separate `FetchCheckRuns` call); classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch) by calling `FetchCheckRuns(baseSHA)` for the base-branch HEAD SHA (a **non-gate diagnostic read** — different SHA, independent of the settle result)
+     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — uses `settle.CheckRuns` for the PR-head check runs (no separate `FetchCheckRuns` call); classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch) by calling `FetchCheckRuns(baseSHA)` for the base-branch HEAD SHA (a **non-gate diagnostic read** — different SHA, independent of the settle result); embeds each failing check's `Output.Summary` and `Output.Text` (when non-empty) as a markdown blockquote, with each field independently truncated to 2000 chars — this is the channel through which a per-run nonce from `$GITHUB_STEP_SUMMARY` reaches the agent
      - Calls `processComments()` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if unset)
      - On exit: releases semaphore, applies `WorkerExited`
 
@@ -3670,7 +3670,7 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
 | Cycle counter | `snap.ReviewCycles(stageName)` / `ReviewCycleIncremented` | `snap.CIFixCycles(stageName)` / `CIFixCycleIncremented` |
 | Max cycles | `MaxReviewCycles` (default 5) | `MaxCiFixCycles` (default 5) |
 | Skill | `comment_skill` | `ci_fix_skill` (falls back to `comment_skill`) |
-| Synthetic comment | PR review thread text | Structured CI failure report with NEW REGRESSION classification |
+| Synthetic comment | PR review thread text | Structured CI failure report with NEW REGRESSION classification; failing check `output.summary` / `output.text` embedded as blockquote (≤2000 chars each) |
 | Worker guard | Yes — `snap.Worker() != nil` | Yes — `snap.Worker() != nil` |
 | Thread resolution | Yes — `ResolveReviewThread()` after processing | No |
 | PR summary comment | Yes — `"<StageName> (review feedback addressed)"` on linked PR | No |

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1183,7 +1183,7 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
    - If not exceeded: increment count, dispatch reinvoke via `dispatchCIFixReinvoke()`:
      - Applies `WorkerEntered` (prevents double-dispatch)
      - Acquires semaphore slot (respects `MaxConcurrent`)
-     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — uses `settle.CheckRuns` for the PR-head check runs (no separate `FetchCheckRuns` call); classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch) by calling `FetchCheckRuns(baseSHA)` for the base-branch HEAD SHA (a **non-gate diagnostic read** — different SHA, independent of the settle result)
+     - Calls `buildCIFixComment()` to construct a synthetic `gh.Comment` (`DatabaseID: 0`) with a structured CI failure report — uses `settle.CheckRuns` for the PR-head check runs (no separate `FetchCheckRuns` call); classifies each failed check as **NEW REGRESSION** (not failing on base branch) or **pre-existing** (also failing on base branch) by calling `FetchCheckRuns(baseSHA)` for the base-branch HEAD SHA (a **non-gate diagnostic read** — different SHA, independent of the settle result); embeds each failing check's `Output.Summary` and `Output.Text` (when non-empty) as a markdown blockquote, with each field independently truncated to 2000 chars — this is the channel through which a per-run nonce from `$GITHUB_STEP_SUMMARY` reaches the agent
      - Calls `processComments()` with the synthetic comment and the `ci_fix_skill` (falls back to `comment_skill` if unset)
      - On exit: releases semaphore, applies `WorkerExited`
 
@@ -1202,7 +1202,7 @@ The catch-up loop Phase 1 calls `checkCIGate()` after the review gate check. Whe
 | Cycle counter | `snap.ReviewCycles(stageName)` / `ReviewCycleIncremented` | `snap.CIFixCycles(stageName)` / `CIFixCycleIncremented` |
 | Max cycles | `MaxReviewCycles` (default 5) | `MaxCiFixCycles` (default 5) |
 | Skill | `comment_skill` | `ci_fix_skill` (falls back to `comment_skill`) |
-| Synthetic comment | PR review thread text | Structured CI failure report with NEW REGRESSION classification |
+| Synthetic comment | PR review thread text | Structured CI failure report with NEW REGRESSION classification; failing check `output.summary` / `output.text` embedded as blockquote (≤2000 chars each) |
 | Worker guard | Yes — `snap.Worker() != nil` | Yes — `snap.Worker() != nil` |
 | Thread resolution | Yes — `ResolveReviewThread()` after processing | No |
 | PR summary comment | Yes — `"<StageName> (review feedback addressed)"` on linked PR | No |

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -286,7 +286,14 @@ func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, wor
 				if baseFailedNames[cr.Name] {
 					note = "pre-existing (also fails on base branch)"
 				}
-				failedLines = append(failedLines, fmt.Sprintf("- **%s**: %s [%s]", cr.Name, cr.Conclusion, note))
+				line := fmt.Sprintf("- **%s**: %s [%s]", cr.Name, cr.Conclusion, note)
+				if s := strings.TrimSpace(cr.Output.Summary); s != "" {
+					line += "\n" + truncateOutputField(s, 2000)
+				}
+				if txt := strings.TrimSpace(cr.Output.Text); txt != "" {
+					line += "\n" + truncateOutputField(txt, 2000)
+				}
+				failedLines = append(failedLines, line)
 			}
 		}
 	}
@@ -416,6 +423,27 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 			e.logf(item.Number, "warn", "CI-fix re-invocation failed: %v\n", err)
 		}
 	}()
+}
+
+// truncateOutputField truncates s to at most maxChars characters, appending an
+// ellipsis indicator when truncated, and formats it as a markdown blockquote.
+func truncateOutputField(s string, maxChars int) string {
+	truncated := false
+	if len(s) > maxChars {
+		s = s[:maxChars]
+		truncated = true
+	}
+	// Prefix each line with "> " so it renders as a blockquote in GitHub comments.
+	lines := strings.Split(s, "\n")
+	var quoted []string
+	for _, l := range lines {
+		quoted = append(quoted, "> "+l)
+	}
+	result := strings.Join(quoted, "\n")
+	if truncated {
+		result += "\n> *(truncated)*"
+	}
+	return result
 }
 
 // pauseForCITimeout pauses the issue when the CI wait timeout in the catch-up

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -425,13 +425,24 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 	}()
 }
 
-// truncateOutputField truncates s to at most maxChars characters, appending an
-// ellipsis indicator when truncated, and formats it as a markdown blockquote.
+// truncateOutputField truncates s to at most maxChars Unicode characters,
+// appending an ellipsis indicator when truncated, and formats it as a markdown
+// blockquote. Truncation is rune-based to avoid splitting multi-byte UTF-8
+// sequences; a byte pre-trim (maxChars*4) avoids the cost of converting very
+// large strings to []rune before truncating.
 func truncateOutputField(s string, maxChars int) string {
 	truncated := false
 	if len(s) > maxChars {
-		s = s[:maxChars]
-		truncated = true
+		byteLimit := maxChars * 4
+		if len(s) > byteLimit {
+			s = s[:byteLimit]
+			truncated = true
+		}
+		runes := []rune(s)
+		if len(runes) > maxChars {
+			s = string(runes[:maxChars])
+			truncated = true
+		}
 	}
 	// Prefix each line with "> " so it renders as a blockquote in GitHub comments.
 	lines := strings.Split(s, "\n")

--- a/engine/ci_test.go
+++ b/engine/ci_test.go
@@ -532,6 +532,70 @@ func TestBuildCIFixComment_IncludesFailedChecks(t *testing.T) {
 	}
 }
 
+// TestBuildCIFixComment_EmbedsSummaryOutput verifies that when a failing check
+// has a non-empty Output.Summary (e.g. from $GITHUB_STEP_SUMMARY), its content
+// is embedded in the CI-fix comment body as a blockquote. This is the channel
+// through which the per-run nonce reaches the agent on reinvoke.
+func TestBuildCIFixComment_EmbedsSummaryOutput(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1}
+	tr := true
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		Reason: "CI checks failed",
+		CheckRuns: []gh.CheckRun{
+			{
+				Name:       "ci-fix-sentinel",
+				Status:     "completed",
+				Conclusion: "failure",
+				Output:     gh.CheckRunOutput{Summary: "To satisfy CI, create SENTINEL_FIX containing: 12345678"},
+			},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "sha9"},
+	}
+	comment := eng.buildCIFixComment(item, stage, "/tmp", settle)
+	if !strings.Contains(comment.Body, "ci-fix-sentinel") {
+		t.Error("expected check name 'ci-fix-sentinel' in comment body")
+	}
+	if !strings.Contains(comment.Body, "To satisfy CI, create SENTINEL_FIX containing: 12345678") {
+		t.Error("expected Output.Summary content embedded in comment body")
+	}
+	// Content must be formatted as a markdown blockquote.
+	if !strings.Contains(comment.Body, "> To satisfy CI") {
+		t.Error("expected Output.Summary rendered as blockquote (> prefix) in comment body")
+	}
+}
+
+// TestBuildCIFixComment_TruncatesLongOutput verifies that Output.Summary longer
+// than 2000 chars is truncated (with a "(truncated)" marker) in the CI-fix comment.
+func TestBuildCIFixComment_TruncatesLongOutput(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1}
+	tr := true
+	stage := &stages.Stage{Name: "Validate", WaitForCI: &tr}
+
+	longSummary := strings.Repeat("x", 3000)
+	settle := PRSettleResult{
+		Status: PRMergeBlocked,
+		CheckRuns: []gh.CheckRun{
+			{Name: "build", Status: "completed", Conclusion: "failure",
+				Output: gh.CheckRunOutput{Summary: longSummary}},
+		},
+		PR: &gh.PRDetails{Number: 5, HeadSHA: "shaX"},
+	}
+	comment := eng.buildCIFixComment(item, stage, "/tmp", settle)
+	if strings.Contains(comment.Body, longSummary) {
+		t.Error("expected long Output.Summary to be truncated in comment body")
+	}
+	if !strings.Contains(comment.Body, "*(truncated)*") {
+		t.Error("expected truncation marker in comment body when Output.Summary exceeds 2000 chars")
+	}
+}
+
 // TestCheckCIGate_FetchLinkedPRError_BlocksGate verifies that a transient
 // FetchLinkedPR API error returns blocked=true rather than clearing the gate,
 // preventing auto-advance when CI status is unknown.

--- a/github/prs.go
+++ b/github/prs.go
@@ -197,12 +197,21 @@ func (c *Client) FetchPRDetails(owner, repo string, prNumber int) (*PRDetails, e
 	}, nil
 }
 
+// CheckRunOutput holds the output fields from a GitHub Check Run.
+// Summary corresponds to the job step summary written to $GITHUB_STEP_SUMMARY;
+// Text holds additional long-form output (may be very large in some integrations).
+type CheckRunOutput struct {
+	Summary string
+	Text    string
+}
+
 // CheckRun holds the result of a single CI check run.
 type CheckRun struct {
 	ID         int64 // GitHub check run ID
 	Name       string
 	Status     string // "queued", "in_progress", "completed"
 	Conclusion string // "success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required", or ""
+	Output     CheckRunOutput
 }
 
 // FetchCheckRuns retrieves check runs for a given commit SHA via the REST API.
@@ -214,6 +223,10 @@ func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
 			Name       string `json:"name"`
 			Status     string `json:"status"`
 			Conclusion string `json:"conclusion"`
+			Output     struct {
+				Summary string `json:"summary"`
+				Text    string `json:"text"`
+			} `json:"output"`
 		} `json:"check_runs"`
 	}
 	if err := c.restGetJSON(apiURL, &raw); err != nil {
@@ -221,7 +234,13 @@ func (c *Client) FetchCheckRuns(owner, repo, sha string) ([]CheckRun, error) {
 	}
 	out := make([]CheckRun, len(raw.CheckRuns))
 	for i, cr := range raw.CheckRuns {
-		out[i] = CheckRun{ID: cr.ID, Name: cr.Name, Status: cr.Status, Conclusion: cr.Conclusion}
+		out[i] = CheckRun{
+			ID:         cr.ID,
+			Name:       cr.Name,
+			Status:     cr.Status,
+			Conclusion: cr.Conclusion,
+			Output:     CheckRunOutput{Summary: cr.Output.Summary, Text: cr.Output.Text},
+		}
 	}
 	return out, nil
 }

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -29,14 +29,6 @@ import (
 // Cost: ~$1–3.
 func TestCIFixReinvoke(t *testing.T) {
 	t.Parallel()
-	// Skipped pending handarbeit/fabrik#916. A capable Implement-stage agent makes
-	// CI green on the first push (it satisfies the sentinel during Implement), so
-	// the sentinel never fails and the reinvoke loop never fires. Forcing a
-	// deterministic first failure needs the engine change (surface failing-check
-	// output in buildCIFixComment) + a per-run-nonce sentinel the agent cannot
-	// pre-satisfy. The harness hardening below (SENTINEL_FIX body, no-workflow-edit
-	// guard, sentinel-failure precondition) is retained for when #916 unblocks this.
-	t.Skip("blocked on #916: agent satisfies ci-fix-sentinel during Implement; first failure not yet deterministically forceable")
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 	assertSentinelCheckRequired(t, env, env.RepoAlpha)
@@ -227,15 +219,13 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 
 // ciFixReinvokeBody is the issue body for TestCIFixReinvoke. The PR body must
 // contain "ci-fix-sentinel-required" so the test-alpha CI workflow triggers the
-// ci-fix-sentinel check. That check FAILS until a file named SENTINEL_FIX
-// (at the repo root) contains the line "ci-fix-satisfied" — the only sanctioned
-// way to satisfy it. Claude must create that file ONLY on the CI-fix reinvoke,
-// producing the failure → reinvoke → recovery sequence the test exercises.
+// ci-fix-sentinel check.
 //
-// The SENTINEL_FIX mechanism is deliberately the sole satisfaction path and the
-// workflow is off-limits (see hard constraints) so the agent cannot satisfy or
-// weaken the sentinel prematurely — the historical failure mode that made the
-// sentinel pass before the CI-fix loop ever ran.
+// The sentinel uses a per-run nonce (derived from $GITHUB_RUN_ID) as its pass
+// condition. The nonce is not known until CI runs, so the agent cannot
+// pre-satisfy it during Implement. On the CI-fix reinvoke, the engine embeds
+// the nonce in the reinvoke comment (from the check run's output.summary), and
+// the agent reads it from there to create SENTINEL_FIX with the correct nonce.
 const ciFixReinvokeBody = `## Goal
 
 End-to-end regression test for the Fabrik CI-fix reinvoke loop (handarbeit/fabrik#900).
@@ -248,29 +238,35 @@ README.md, on its own line, immediately after the line containing
 
     <!-- ci-fix-reinvoke-initial -->
 
-Make NO other changes on this commit. In particular do NOT create the
-SENTINEL_FIX file yet. The ci-fix-sentinel check WILL fail on this first push —
-that failure is expected and required.
+Make NO other changes on this commit. In particular do **NOT** create the
+` + "`SENTINEL_FIX`" + ` file. The ci-fix-sentinel check WILL fail on this first push
+because it requires a per-run nonce you cannot know in advance. That failure
+is expected and required.
 
-**When the CI-fix reinvoke fires** (you will be prompted with a message about
-the CI failure), and ONLY then, push a second commit that creates a new file
-named exactly ` + "`SENTINEL_FIX`" + ` at the repository root, containing exactly this
-single line:
+**When the CI-fix reinvoke fires** (you will be prompted with a "🏭 Fabrik — CI
+Fix Required" comment), and ONLY then, push a second commit. Read the nonce
+from the reinvoke comment: look for the blockquote under the
+` + "`ci-fix-sentinel`" + ` check failure. It contains a line like:
 
-    ci-fix-satisfied
+    To satisfy CI, create SENTINEL_FIX containing: <nonce>
 
-That second commit makes the sentinel pass. Do not rebase or squash — the two
-commits must remain distinct so the e2e test can verify the commit count.
+Create a new file named exactly ` + "`SENTINEL_FIX`" + ` at the repository root whose
+contents are **only** that nonce string (no extra text, no trailing newline
+beyond what is necessary). That second commit makes the sentinel pass.
+
+Do not rebase or squash — the two commits must remain distinct so the e2e test
+can verify the commit count.
 
 ## Hard constraints (do NOT violate)
 
 - NEVER modify any file under ` + "`.github/`" + `. The CI workflow — including the
   ci-fix-sentinel job — is immutable test infrastructure. Editing it invalidates
   the test and will fail the run.
-- Do NOT create the SENTINEL_FIX file on the initial commit; create it ONLY on
-  the CI-fix reinvoke.
+- Do NOT create ` + "`SENTINEL_FIX`" + ` on the initial commit; create it ONLY on the
+  CI-fix reinvoke, after reading the nonce from the reinvoke comment.
 - The PR body MUST contain the literal marker ` + "`ci-fix-sentinel-required`" + ` so the
   sentinel fires.
+- Do NOT guess or fabricate the nonce — it must come from the reinvoke comment.
 
 ## CI behaviour required
 
@@ -281,9 +277,9 @@ ci-fix-sentinel-required
 
 ## Scope
 
-README.md on the initial commit; a new SENTINEL_FIX file on the CI-fix reinvoke.
-No other files. No decomposition. One commit on the initial push, one CI-fix
-commit.
+README.md on the initial commit; a new SENTINEL_FIX file (containing the nonce
+from the reinvoke comment) on the CI-fix reinvoke. No other files. No
+decomposition. One commit on the initial push, one CI-fix commit.
 `
 
 // ciFixCycleLimitBody is the issue body for TestCIFixReinvokeCycleLimit. The


### PR DESCRIPTION
Closes #916

## Summary

- **`github/prs.go`**: Add `CheckRunOutput` struct (`Summary`, `Text`) and `Output CheckRunOutput` field to `CheckRun`. Update `FetchCheckRuns` JSON unmarshalling to capture `output.summary` / `output.text` inline from the GitHub Check Runs list response — no extra API call.

- **`engine/ci.go`**: `buildCIFixComment` now embeds each failing check's `Output.Summary` and `Output.Text` (when non-empty) as a markdown blockquote, truncated independently at 2000 chars via a new `truncateOutputField` helper. This is the information channel that delivers the per-run nonce to the agent on CI-fix reinvoke.

- **`engine/ci_test.go`**: Add `TestBuildCIFixComment_EmbedsSummaryOutput` (verifies nonce content appears as a blockquote) and `TestBuildCIFixComment_TruncatesLongOutput` (verifies >2000-char summaries are truncated with a `*(truncated)*` marker).

- **`tests/e2e/ci_fix_reinvoke_test.go`**: Remove `t.Skip` (child issue handarbeit/fabrik-test-alpha#101 is merged). Rewrite `ciFixReinvokeBody` to instruct the agent: (1) initial commit adds only an HTML comment to README.md — no `SENTINEL_FIX`; (2) on CI-fix reinvoke, read the nonce from the blockquote in the reinvoke comment and create `SENTINEL_FIX` containing only that nonce.

- **`docs/state-machine.md`** + **`docs/llms-full.txt`**: Document check output embedding in §6.5.2 and the comparison table; regenerate bundle.

## How to test

Run the affected unit tests: `go test -race ./engine/... ./github/...`

The e2e test (`TestCIFixReinvoke`) requires the test bed running with `fabrik-test-alpha`'s updated nonce-based `ci-fix-sentinel` (handarbeit/fabrik-test-alpha#101, merged).