### PR TITLE
test(e2e): re-skip TestConjunctiveCIReviewGate pending #925

### DIFF
--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -41,6 +41,21 @@ import (
 // Cost: ~$1.00–2.50.
 func TestConjunctiveCIReviewGate(t *testing.T) {
 	t.Parallel()
+	// Skipped pending handarbeit/fabrik#925. R1 (CI gate holds at the 600s slow-gate
+	// — the #917 fix) and R3 (comment processed during CI-await) pass, but R2/R5
+	// (the review-gate approval path) cannot pass in the current test bed due to
+	// three test-harness/environment confounds — none an engine bug:
+	//   1. Engine identity collides with the reviewer: GITHUB_TOKEN=verveguy in the
+	//      engine process env overrides FABRIK_TOKEN=arbeithand (shell env > .env),
+	//      so PRs are authored by verveguy — the same identity as
+	//      FABRIK_REVIEWER_TOKEN. GitHub forbids self-review, so RequestPRReviewer
+	//      is a silent no-op and the R5 approval is impossible.
+	//   2. Dual review gate: both Review and Validate have wait_for_reviews:true, so
+	//      reviews gate at Review — not only at Validate as this test's R2 assumes.
+	//   3. gemini-code-assist auto-reviews every alpha PR, clearing the gate
+	//      (outstanding==0 && hasReviews) before any human approval path runs.
+	// The engine's checkReviewGate logic is correct throughout. See #925.
+	t.Skip("blocked on #925: review-gate approval path has identity/dual-gate/bot-reviewer confounds (engine is correct)")
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 	assertSlowGateRequired(t, env, env.RepoAlpha)


### PR DESCRIPTION
Re-skips `TestConjunctiveCIReviewGate`. Verification (2026-06-20) confirmed **R1** (CI gate holds at the 600s slow-gate — the #917 timing fix) and **R3** (comment processed during CI-await) pass cleanly. The **R2/R5** review-gate approval path cannot pass in the current test bed due to three test-harness/environment confounds — **none an engine bug**:

1. **Identity collision** — `GITHUB_TOKEN=verveguy` overrides `FABRIK_TOKEN=arbeithand` (shell env > .env), so PRs are authored by verveguy, the same identity as `FABRIK_REVIEWER_TOKEN` → GitHub forbids self-review → reviewer request is a silent no-op.
2. **Dual review gate** — Review *and* Validate both have `wait_for_reviews: true`; the test assumes Validate-only.
3. **gemini-code-assist** auto-reviews every alpha PR, clearing the gate (`outstanding==0 && hasReviews`) before any human approval path runs.

The engine's `checkReviewGate` behaved correctly throughout. Full redesign tracked in **#925**.

Closes nothing — #925 remains open for the redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)