### PR TITLE
feat(engine): log-retention janitor — prune .fabrik/logs/ by age and size cap

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,9 @@ type Config struct {
 	WebhookEvents     string // comma-separated; empty means default event set
 	StatusPollSeconds    int // Layer 2 status-only sweep cadence in seconds; 0 = use default (15)
 	ReconcileInterval    int // seconds; 0 means use default (180 = 3 min); also FABRIK_RECONCILE_INTERVAL
-	JanitorIntervalHours int // hours; 1 = default; 0 disables the janitor
+	JanitorIntervalHours int   // hours; 1 = default; 0 disables the janitor
+	LogRetentionDays     int   // days; 14 = default; 0 disables age-based log pruning
+	LogMaxBytes          int64 // bytes; 2147483648 = default; 0 disables size-cap pruning
 }
 
 func Execute() error {
@@ -149,6 +151,8 @@ func Execute() error {
 	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
 	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile webhook-stream-health checks when --webhooks is enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL). Inactive without --webhooks — the per-poll Reconcile is the only freshener in that mode.")
 	flag.IntVar(&cfg.JanitorIntervalHours, "janitor-interval", 1, "Worktree janitor scan interval in hours; 0 disables the janitor (also FABRIK_JANITOR_INTERVAL)")
+	flag.IntVar(&cfg.LogRetentionDays, "log-retention-days", 14, "Delete log files older than this many days; 0 disables age-based pruning (also FABRIK_LOG_RETENTION_DAYS)")
+	flag.Int64Var(&cfg.LogMaxBytes, "log-max-bytes", 2147483648, "Total size cap for .fabrik/logs/ in bytes; oldest files deleted first after age prune; 0 disables size cap (also FABRIK_LOG_MAX_BYTES)")
 	flag.StringVar(&cfg.KillGraceSigInt, "kill-grace-sigint", "", "Grace window after SIGINT before SIGTERM in the kill escalation sequence (Go duration: 10s, 0s to skip SIGINT entirely; also FABRIK_KILL_GRACE_SIGINT; default 10s)")
 	flag.StringVar(&cfg.KillGraceSigTerm, "kill-grace-sigterm", "", "Grace window after SIGTERM before SIGKILL in the kill escalation sequence (Go duration: 10s; also FABRIK_KILL_GRACE_SIGTERM; default 10s)")
 
@@ -410,6 +414,36 @@ func Execute() error {
 			}
 		}
 	}
+	if !explicitFlags["log-retention-days"] {
+		if v := os.Getenv("FABRIK_LOG_RETENTION_DAYS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				cfg.LogRetentionDays = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_LOG_RETENTION_DAYS=%q is invalid (must be a non-negative integer of days; 0 = disable); using default 14\n", v)
+			}
+		} else if pc.LogRetentionDays != nil {
+			if *pc.LogRetentionDays < 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml log_retention_days=%d is invalid (must be a non-negative integer; 0 = disable); using default 14\n", *pc.LogRetentionDays)
+			} else {
+				cfg.LogRetentionDays = *pc.LogRetentionDays
+			}
+		}
+	}
+	if !explicitFlags["log-max-bytes"] {
+		if v := os.Getenv("FABRIK_LOG_MAX_BYTES"); v != "" {
+			if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
+				cfg.LogMaxBytes = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_LOG_MAX_BYTES=%q is invalid (must be a non-negative integer of bytes; 0 = disable); using default 2147483648\n", v)
+			}
+		} else if pc.LogMaxBytes != nil {
+			if *pc.LogMaxBytes < 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml log_max_bytes=%d is invalid (must be a non-negative integer; 0 = disable); using default 2147483648\n", *pc.LogMaxBytes)
+			} else {
+				cfg.LogMaxBytes = *pc.LogMaxBytes
+			}
+		}
+	}
 	if !explicitFlags["kill-grace-sigint"] {
 		if v := os.Getenv("FABRIK_KILL_GRACE_SIGINT"); v != "" {
 			cfg.KillGraceSigInt = v // validated in killGraceSigInt() helper
@@ -659,6 +693,8 @@ func Execute() error {
 		ProjectStatusPollSeconds: statusPollSeconds(cfg.StatusPollSeconds),
 		ReconcileInterval:        reconcileIntervalDuration(cfg.ReconcileInterval),
 		JanitorIntervalHours:     cfg.JanitorIntervalHours,
+		LogRetentionDays:         cfg.LogRetentionDays,
+		LogMaxBytes:              cfg.LogMaxBytes,
 		ReadyCh:                  testReadyCh,
 	})
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,8 @@ type ProjectConfig struct {
 	WebhookEvents           []string `yaml:"webhook_events"`
 	StatusPoll              *int     `yaml:"status_poll"`
 	JanitorIntervalHours    *int     `yaml:"janitor_interval_hours"`
+	LogRetentionDays        *int     `yaml:"log_retention_days"`
+	LogMaxBytes             *int64   `yaml:"log_max_bytes"`
 }
 
 // LoadProjectConfig reads .fabrik/config.yaml from CWD.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -619,6 +619,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_AUTO_MERGE_STRATEGY` | *(no config.yaml key)* | Merge method used when calling GitHub's `enablePullRequestAutoMerge` for yolo PRs. Accepted values: `MERGE`, `SQUASH`, `REBASE`. Invalid or unset values default to `MERGE`. | `MERGE` |
 | `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
 | `FABRIK_JANITOR_INTERVAL` | `janitor_interval_hours` | Hours between janitor runs (non-negative integer; `0` disables the janitor) | `1` |
+| `FABRIK_LOG_RETENTION_DAYS` | `log_retention_days` | Delete log files older than this many days (non-negative integer; `0` disables age-based pruning) | `14` |
+| `FABRIK_LOG_MAX_BYTES` | `log_max_bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune (`0` disables size-cap pruning) | `2147483648` (2 GiB) |
 | `FABRIK_KILL_GRACE_SIGINT` | *(no config.yaml key)* | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGINT step entirely) | `""` (10s) |
 | `FABRIK_KILL_GRACE_SIGTERM` | *(no config.yaml key)* | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGTERM step, SIGKILL fires immediately after SIGINT) | `""` (10s) |
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -399,6 +399,41 @@ Also controllable via `--janitor-interval` flag or `FABRIK_JANITOR_INTERVAL` env
 
 > **Note (EC-6):** Changing `janitor_interval_hours` at runtime has no effect. Restart Fabrik for a new cadence to take effect.
 
+### Log Retention
+
+`.fabrik/logs/` grows unbounded by default — each Claude invocation writes uniquely-named log files that are never overwritten. On a busy instance running for weeks, this can reach hundreds of megabytes or more.
+
+The **log retention janitor** prunes `.fabrik/logs/` by age and total size. It runs on the **same cadence as the worktree janitor** (disabled when `janitor_interval_hours: 0`):
+
+1. **Once at startup**, after the first successful poll.
+2. **Hourly** thereafter (same `janitor_interval_hours` cadence).
+
+Pruning runs in three phases per cycle:
+
+1. **Age prune**: delete any file whose mtime is older than `log_retention_days` × 24 h (default **14 days**). `0` disables age-based pruning.
+2. **Size-cap backstop**: after age-pruning, if the total size of `.fabrik/logs/` still exceeds `log_max_bytes`, delete the oldest files (by mtime) until the tree is under the cap. Default **2 GiB**. `0` disables the size cap.
+3. **Empty-dir cleanup**: remove any now-empty `issue-N/` and `<owner>-<repo>/` directories.
+
+The janitor only ever touches `.fabrik/logs/`. It never modifies `sessions/`, `worktrees/`, `repos/`, or `debug/`.
+
+At the end of each scan Fabrik logs:
+
+```
+[log-janitor] cycle complete: scanned N files, removed M (P bytes), age=K size=J
+```
+
+**Configuration:**
+
+```yaml
+# .fabrik/config.yaml
+log_retention_days: 14      # default — set to 0 to disable age-based pruning
+log_max_bytes: 2147483648   # default (2 GiB) — set to 0 to disable size-cap pruning
+```
+
+Also controllable via `--log-retention-days` / `--log-max-bytes` flags or `FABRIK_LOG_RETENTION_DAYS` / `FABRIK_LOG_MAX_BYTES` environment variables.
+
+> **Note:** Because the prune runs on every tick (not only at startup), the size-cap backstop only has to absorb at most one tick-interval of log growth. An instance producing more than `log_max_bytes` within a single `janitor_interval_hours` window can transiently exceed the cap until the next tick — the hourly default makes this a non-issue in practice.
+
 ---
 
 ## 2. Configuration Reference
@@ -484,6 +519,16 @@ user: your-github-username
 # startup and then on this cadence, reaping clean worktrees for closed, off-board
 # issues. Set to 0 to disable the janitor entirely.
 # janitor_interval_hours: 1
+
+# Log retention janitor settings. Runs on the same cadence as janitor_interval_hours.
+# Delete log files older than this many days (default 14). Set to 0 to disable
+# age-based pruning.
+# log_retention_days: 14
+
+# Total size cap for .fabrik/logs/ in bytes (default 2 GiB). After age-pruning,
+# oldest files are deleted first until total size is under this cap. Set to 0
+# to disable size-cap pruning.
+# log_max_bytes: 2147483648
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -536,6 +581,8 @@ FABRIK_USER=my-personal-username
 | `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--janitor-interval` | Hours between janitor runs (closed-issue cleanup, stale-label eviction); 0 disables the janitor; also `FABRIK_JANITOR_INTERVAL` | `1` |
+| `--log-retention-days` | Delete `.fabrik/logs/` files older than this many days; 0 disables age-based pruning; also `FABRIK_LOG_RETENTION_DAYS` | `14` |
+| `--log-max-bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune; 0 disables size-cap pruning; also `FABRIK_LOG_MAX_BYTES` | `2147483648` (2 GiB) |
 | `--kill-grace-sigint` | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGINT entirely; also `FABRIK_KILL_GRACE_SIGINT`) | `""` (10s) |
 | `--kill-grace-sigterm` | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGTERM entirely; also `FABRIK_KILL_GRACE_SIGTERM`) | `""` (10s) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -617,6 +617,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_AUTO_MERGE_STRATEGY` | *(no config.yaml key)* | Merge method used when calling GitHub's `enablePullRequestAutoMerge` for yolo PRs. Accepted values: `MERGE`, `SQUASH`, `REBASE`. Invalid or unset values default to `MERGE`. | `MERGE` |
 | `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
 | `FABRIK_JANITOR_INTERVAL` | `janitor_interval_hours` | Hours between janitor runs (non-negative integer; `0` disables the janitor) | `1` |
+| `FABRIK_LOG_RETENTION_DAYS` | `log_retention_days` | Delete log files older than this many days (non-negative integer; `0` disables age-based pruning) | `14` |
+| `FABRIK_LOG_MAX_BYTES` | `log_max_bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune (`0` disables size-cap pruning) | `2147483648` (2 GiB) |
 | `FABRIK_KILL_GRACE_SIGINT` | *(no config.yaml key)* | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGINT step entirely) | `""` (10s) |
 | `FABRIK_KILL_GRACE_SIGTERM` | *(no config.yaml key)* | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGTERM step, SIGKILL fires immediately after SIGINT) | `""` (10s) |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -397,6 +397,41 @@ Also controllable via `--janitor-interval` flag or `FABRIK_JANITOR_INTERVAL` env
 
 > **Note (EC-6):** Changing `janitor_interval_hours` at runtime has no effect. Restart Fabrik for a new cadence to take effect.
 
+### Log Retention
+
+`.fabrik/logs/` grows unbounded by default — each Claude invocation writes uniquely-named log files that are never overwritten. On a busy instance running for weeks, this can reach hundreds of megabytes or more.
+
+The **log retention janitor** prunes `.fabrik/logs/` by age and total size. It runs on the **same cadence as the worktree janitor** (disabled when `janitor_interval_hours: 0`):
+
+1. **Once at startup**, after the first successful poll.
+2. **Hourly** thereafter (same `janitor_interval_hours` cadence).
+
+Pruning runs in three phases per cycle:
+
+1. **Age prune**: delete any file whose mtime is older than `log_retention_days` × 24 h (default **14 days**). `0` disables age-based pruning.
+2. **Size-cap backstop**: after age-pruning, if the total size of `.fabrik/logs/` still exceeds `log_max_bytes`, delete the oldest files (by mtime) until the tree is under the cap. Default **2 GiB**. `0` disables the size cap.
+3. **Empty-dir cleanup**: remove any now-empty `issue-N/` and `<owner>-<repo>/` directories.
+
+The janitor only ever touches `.fabrik/logs/`. It never modifies `sessions/`, `worktrees/`, `repos/`, or `debug/`.
+
+At the end of each scan Fabrik logs:
+
+```
+[log-janitor] cycle complete: scanned N files, removed M (P bytes), age=K size=J
+```
+
+**Configuration:**
+
+```yaml
+# .fabrik/config.yaml
+log_retention_days: 14      # default — set to 0 to disable age-based pruning
+log_max_bytes: 2147483648   # default (2 GiB) — set to 0 to disable size-cap pruning
+```
+
+Also controllable via `--log-retention-days` / `--log-max-bytes` flags or `FABRIK_LOG_RETENTION_DAYS` / `FABRIK_LOG_MAX_BYTES` environment variables.
+
+> **Note:** Because the prune runs on every tick (not only at startup), the size-cap backstop only has to absorb at most one tick-interval of log growth. An instance producing more than `log_max_bytes` within a single `janitor_interval_hours` window can transiently exceed the cap until the next tick — the hourly default makes this a non-issue in practice.
+
 ---
 
 ## 2. Configuration Reference
@@ -482,6 +517,16 @@ user: your-github-username
 # startup and then on this cadence, reaping clean worktrees for closed, off-board
 # issues. Set to 0 to disable the janitor entirely.
 # janitor_interval_hours: 1
+
+# Log retention janitor settings. Runs on the same cadence as janitor_interval_hours.
+# Delete log files older than this many days (default 14). Set to 0 to disable
+# age-based pruning.
+# log_retention_days: 14
+
+# Total size cap for .fabrik/logs/ in bytes (default 2 GiB). After age-pruning,
+# oldest files are deleted first until total size is under this cap. Set to 0
+# to disable size-cap pruning.
+# log_max_bytes: 2147483648
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -534,6 +579,8 @@ FABRIK_USER=my-personal-username
 | `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--janitor-interval` | Hours between janitor runs (closed-issue cleanup, stale-label eviction); 0 disables the janitor; also `FABRIK_JANITOR_INTERVAL` | `1` |
+| `--log-retention-days` | Delete `.fabrik/logs/` files older than this many days; 0 disables age-based pruning; also `FABRIK_LOG_RETENTION_DAYS` | `14` |
+| `--log-max-bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune; 0 disables size-cap pruning; also `FABRIK_LOG_MAX_BYTES` | `2147483648` (2 GiB) |
 | `--kill-grace-sigint` | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGINT entirely; also `FABRIK_KILL_GRACE_SIGINT`) | `""` (10s) |
 | `--kill-grace-sigterm` | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGTERM entirely; also `FABRIK_KILL_GRACE_SIGTERM`) | `""` (10s) |
 | `--debug-output` | Save Claude stage output to `.fabrik/debug/` | `false` |

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -53,7 +53,9 @@ type Config struct {
 	WebhookPort              int
 	WebhookEvents            []string
 	ProjectStatusPollSeconds int // Layer 2 status-only sweep cadence in seconds; default 15 s (gate runs every poll cycle; field retained for config compatibility)
-	JanitorIntervalHours     int // Periodic worktree janitor cadence in hours; 0 disables the janitor (default 1)
+	JanitorIntervalHours     int   // Periodic worktree janitor cadence in hours; 0 disables the janitor (default 1)
+	LogRetentionDays         int   // Log files older than this many days are pruned; 0 disables age-based pruning (default 14)
+	LogMaxBytes              int64 // Total size cap for .fabrik/logs/; oldest files deleted first after age prune; 0 disables (default 2 GiB)
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use
 	// this to avoid sending SIGINT before signal.Notify is installed.
 	ReadyCh chan struct{}

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
@@ -272,6 +275,148 @@ func (e *Engine) janitorIsClosed(ctx context.Context, owner, repo string, issueN
 	result := issue.State == "closed"
 	closedCache[key] = result
 	return result
+}
+
+// runLogJanitor prunes .fabrik/logs/ by age and total size, then removes
+// empty issue/repo directories. Disabled when JanitorIntervalHours == 0
+// (same gate as the worktree janitor). Called from poll.go at startup and
+// on every periodic janitor tick — the tick is the primary mechanism for
+// long-running instances that never restart.
+func (e *Engine) runLogJanitor(ctx context.Context) {
+	_ = ctx // reserved for future use (graceful cancellation on long walks)
+	logsRoot := filepath.Join(e.fabrikDir, ".fabrik", "logs")
+	scanned, removed, bytes, ageRemoved, sizeRemoved, err := pruneLogs(
+		logsRoot, e.cfg.LogRetentionDays, e.cfg.LogMaxBytes, time.Now(),
+	)
+	if err != nil {
+		e.logf(0, "log-janitor", "warn: prune error: %v\n", err)
+		return
+	}
+	e.logf(0, "log-janitor",
+		"cycle complete: scanned %d files, removed %d (%d bytes), age=%d size=%d\n",
+		scanned, removed, bytes, ageRemoved, sizeRemoved,
+	)
+}
+
+// logFileEntry holds metadata for a single file under .fabrik/logs/.
+type logFileEntry struct {
+	path  string
+	mtime time.Time
+	size  int64
+}
+
+// pruneLogs walks root, deletes files older than retentionDays (when > 0),
+// then deletes oldest files until total size is under maxBytes (when > 0),
+// and finally removes any now-empty subdirectories. The now parameter
+// enables deterministic testing via os.Chtimes. Returns counts of files
+// scanned, files removed, bytes freed, and counts per pruning phase.
+//
+// Scope guard: root is resolved with filepath.Clean before any deletion; every
+// candidate path is asserted to start with resolvedRoot+sep. Paths outside the
+// prune root are silently skipped. If root does not exist, returns zero counts
+// without error (normal first-run case).
+func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
+	filesScanned, filesRemoved int, bytesRemoved int64, ageRemoved, sizeRemoved int, err error,
+) {
+	// Resolve and guard the prune root once.
+	absRoot, resolveErr := filepath.EvalSymlinks(root)
+	if resolveErr != nil {
+		if os.IsNotExist(resolveErr) {
+			return 0, 0, 0, 0, 0, nil
+		}
+		absRoot = filepath.Clean(root) // fall back: Clean without resolving symlinks
+	} else {
+		absRoot = filepath.Clean(absRoot)
+	}
+	rootPrefix := absRoot + string(filepath.Separator)
+
+	var files []logFileEntry
+	var dirs []string
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkerr error) error {
+		if walkerr != nil {
+			return nil // skip unreadable entries; continue walk
+		}
+		// Scope guard: every path must be under absRoot.
+		cleanPath := filepath.Clean(path)
+		if cleanPath != absRoot && !strings.HasPrefix(cleanPath, rootPrefix) {
+			// Path is outside the prune root (e.g. a symlink escape); skip it.
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if cleanPath != absRoot {
+				dirs = append(dirs, path)
+			}
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil // skip unreadable file metadata
+		}
+		files = append(files, logFileEntry{path: path, mtime: info.ModTime(), size: info.Size()})
+		filesScanned++
+		return nil
+	})
+	if walkErr != nil {
+		err = fmt.Errorf("walking %s: %w", root, walkErr)
+		return
+	}
+
+	// Phase 1: Age prune — delete files older than the retention window.
+	if retentionDays > 0 {
+		cutoff := now.Add(-time.Duration(retentionDays) * 24 * time.Hour)
+		var remaining []logFileEntry
+		for _, f := range files {
+			if f.mtime.Before(cutoff) {
+				if removeErr := os.Remove(f.path); removeErr == nil {
+					filesRemoved++
+					bytesRemoved += f.size
+					ageRemoved++
+				} else {
+					remaining = append(remaining, f) // deletion failed; treat as still present
+				}
+			} else {
+				remaining = append(remaining, f)
+			}
+		}
+		files = remaining
+	}
+
+	// Phase 2: Size-cap prune — delete oldest files first until under the cap.
+	if maxBytes > 0 {
+		var totalSize int64
+		for _, f := range files {
+			totalSize += f.size
+		}
+		if totalSize > maxBytes {
+			// Sort ascending by mtime so we delete the oldest files first.
+			sort.Slice(files, func(i, j int) bool {
+				return files[i].mtime.Before(files[j].mtime)
+			})
+			for _, f := range files {
+				if totalSize <= maxBytes {
+					break
+				}
+				if removeErr := os.Remove(f.path); removeErr == nil {
+					filesRemoved++
+					bytesRemoved += f.size
+					sizeRemoved++
+					totalSize -= f.size
+				}
+			}
+		}
+	}
+
+	// Phase 3: Empty-dir cleanup — walk dirs bottom-up (reverse order from WalkDir).
+	// os.Remove on a non-empty directory returns an error, so only empty dirs are removed.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		_ = os.Remove(dirs[i])
+	}
+
+	return
 }
 
 // janitorIsOffBoardOrCleanupComplete reports whether the worktree is eligible

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -319,14 +319,18 @@ func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 	filesScanned, filesRemoved int, bytesRemoved int64, ageRemoved, sizeRemoved int, err error,
 ) {
 	// Resolve and guard the prune root once.
-	absRoot, resolveErr := filepath.EvalSymlinks(root)
+	// Use filepath.Abs (not EvalSymlinks) so the same resolution strategy applies
+	// to both root and individual paths — avoiding false-positive mismatches when
+	// root itself is under a symlinked prefix (e.g. /tmp → /private/tmp on macOS).
+	absRoot, resolveErr := filepath.Abs(root)
 	if resolveErr != nil {
-		if os.IsNotExist(resolveErr) {
+		absRoot = filepath.Clean(root)
+	}
+	// Check existence after resolving the path.
+	if _, statErr := os.Stat(absRoot); statErr != nil {
+		if os.IsNotExist(statErr) {
 			return 0, 0, 0, 0, 0, nil
 		}
-		absRoot = filepath.Clean(root) // fall back: Clean without resolving symlinks
-	} else {
-		absRoot = filepath.Clean(absRoot)
 	}
 	rootPrefix := absRoot + string(filepath.Separator)
 
@@ -338,8 +342,11 @@ func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 			return nil // skip unreadable entries; continue walk
 		}
 		// Scope guard: every path must be under absRoot.
-		cleanPath := filepath.Clean(path)
-		if cleanPath != absRoot && !strings.HasPrefix(cleanPath, rootPrefix) {
+		absPath, absErr := filepath.Abs(path)
+		if absErr != nil {
+			absPath = filepath.Clean(path)
+		}
+		if absPath != absRoot && !strings.HasPrefix(absPath, rootPrefix) {
 			// Path is outside the prune root (e.g. a symlink escape); skip it.
 			if d.IsDir() {
 				return filepath.SkipDir
@@ -347,7 +354,7 @@ func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 			return nil
 		}
 		if d.IsDir() {
-			if cleanPath != absRoot {
+			if absPath != absRoot {
 				dirs = append(dirs, path)
 			}
 			return nil

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -318,6 +318,9 @@ type logFileEntry struct {
 func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 	filesScanned, filesRemoved int, bytesRemoved int64, ageRemoved, sizeRemoved int, err error,
 ) {
+	if retentionDays <= 0 && maxBytes <= 0 {
+		return 0, 0, 0, 0, 0, nil
+	}
 	// Resolve and guard the prune root once.
 	// Use filepath.Abs (not EvalSymlinks) so the same resolution strategy applies
 	// to both root and individual paths — avoiding false-positive mismatches when
@@ -337,16 +340,14 @@ func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 	var files []logFileEntry
 	var dirs []string
 
-	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkerr error) error {
+	// Walk absRoot (not root) so callback paths are already absolute — no
+	// per-file filepath.Abs system call needed inside the callback.
+	walkErr := filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, walkerr error) error {
 		if walkerr != nil {
 			return nil // skip unreadable entries; continue walk
 		}
 		// Scope guard: every path must be under absRoot.
-		absPath, absErr := filepath.Abs(path)
-		if absErr != nil {
-			absPath = filepath.Clean(path)
-		}
-		if absPath != absRoot && !strings.HasPrefix(absPath, rootPrefix) {
+		if path != absRoot && !strings.HasPrefix(path, rootPrefix) {
 			// Path is outside the prune root (e.g. a symlink escape); skip it.
 			if d.IsDir() {
 				return filepath.SkipDir
@@ -354,7 +355,7 @@ func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 			return nil
 		}
 		if d.IsDir() {
-			if absPath != absRoot {
+			if path != absRoot {
 				dirs = append(dirs, path)
 			}
 			return nil
@@ -368,13 +369,13 @@ func pruneLogs(root string, retentionDays int, maxBytes int64, now time.Time) (
 		return nil
 	})
 	if walkErr != nil {
-		err = fmt.Errorf("walking %s: %w", root, walkErr)
+		err = fmt.Errorf("walking %s: %w", absRoot, walkErr)
 		return
 	}
 
 	// Phase 1: Age prune — delete files older than the retention window.
 	if retentionDays > 0 {
-		cutoff := now.Add(-time.Duration(retentionDays) * 24 * time.Hour)
+		cutoff := now.AddDate(0, 0, -retentionDays)
 		var remaining []logFileEntry
 		for _, f := range files {
 			if f.mtime.Before(cutoff) {

--- a/engine/janitor_test.go
+++ b/engine/janitor_test.go
@@ -301,3 +301,260 @@ func TestJanitorStaleDeadWorkerReaped(t *testing.T) {
 		t.Errorf("SC-5: expected worktree for issue #%d (stale+dead worker) to be reaped, but it still exists", issueNumber)
 	}
 }
+
+// ── Log janitor tests ────────────────────────────────────────────────────────
+
+// seedLogFile writes a file of given size to dir/name and sets its mtime.
+// Returns the full path.
+func seedLogFile(t *testing.T, dir, name string, size int64, mtime time.Time) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("seedLogFile mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, make([]byte, size), 0644); err != nil {
+		t.Fatalf("seedLogFile WriteFile %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("seedLogFile Chtimes %s: %v", path, err)
+	}
+	return path
+}
+
+// TestLogJanitorAgePrune verifies that files older than retentionDays are deleted
+// and newer files are kept.
+func TestLogJanitorAgePrune(t *testing.T) {
+	logsRoot := t.TempDir()
+	now := time.Now()
+	old := now.Add(-15 * 24 * time.Hour) // 15 days ago — older than 14-day default
+	recent := now.Add(-1 * 24 * time.Hour) // 1 day ago — within retention window
+
+	issueDir := filepath.Join(logsRoot, "owner-repo", "issue-1")
+	oldFile := seedLogFile(t, issueDir, "old.log", 100, old)
+	newFile := seedLogFile(t, issueDir, "new.log", 100, recent)
+
+	scanned, removed, _, ageRemoved, sizeRemoved, err := pruneLogs(logsRoot, 14, 0, now)
+	if err != nil {
+		t.Fatalf("pruneLogs: %v", err)
+	}
+	if scanned != 2 {
+		t.Errorf("scanned=%d, want 2", scanned)
+	}
+	if removed != 1 || ageRemoved != 1 || sizeRemoved != 0 {
+		t.Errorf("removed=%d ageRemoved=%d sizeRemoved=%d, want 1 1 0", removed, ageRemoved, sizeRemoved)
+	}
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("old file should be deleted, but still exists")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("new file should be kept, but got: %v", err)
+	}
+}
+
+// TestLogJanitorSizeCap verifies that after age pruning, if total size exceeds
+// maxBytes, the oldest files are deleted first until under the cap.
+func TestLogJanitorSizeCap(t *testing.T) {
+	logsRoot := t.TempDir()
+	now := time.Now()
+	// All files are recent (within 30-day retention), but total exceeds 300 bytes cap.
+	issueDir := filepath.Join(logsRoot, "owner-repo", "issue-2")
+
+	oldest := now.Add(-3 * time.Hour)
+	middle := now.Add(-2 * time.Hour)
+	newest := now.Add(-1 * time.Hour)
+
+	oldestFile := seedLogFile(t, issueDir, "oldest.log", 150, oldest)
+	middleFile := seedLogFile(t, issueDir, "middle.log", 100, middle)
+	newestFile := seedLogFile(t, issueDir, "newest.log", 100, newest)
+
+	// retentionDays=30 (no age prune triggers), maxBytes=200 (oldest must be deleted)
+	_, removed, bytesRemoved, ageRemoved, sizeRemoved, err := pruneLogs(logsRoot, 30, 200, now)
+	if err != nil {
+		t.Fatalf("pruneLogs: %v", err)
+	}
+	// Total = 350 bytes; cap = 200; oldest (150) deleted → 200 == cap → stop.
+	if removed != 1 || ageRemoved != 0 || sizeRemoved != 1 {
+		t.Errorf("removed=%d ageRemoved=%d sizeRemoved=%d, want 1 0 1", removed, ageRemoved, sizeRemoved)
+	}
+	if bytesRemoved != 150 {
+		t.Errorf("bytesRemoved=%d, want 150", bytesRemoved)
+	}
+	if _, err := os.Stat(oldestFile); !os.IsNotExist(err) {
+		t.Errorf("oldest file should be deleted")
+	}
+	if _, err := os.Stat(middleFile); err != nil {
+		t.Errorf("middle file should be kept: %v", err)
+	}
+	if _, err := os.Stat(newestFile); err != nil {
+		t.Errorf("newest file should be kept: %v", err)
+	}
+}
+
+// TestLogJanitorScopeGuard verifies that pruneLogs never touches sibling
+// directories (sessions/, worktrees/, repos/, debug/) even when they contain
+// old files that would otherwise qualify for deletion.
+func TestLogJanitorScopeGuard(t *testing.T) {
+	fabrikBase := t.TempDir()
+	logsRoot := filepath.Join(fabrikBase, "logs")
+	if err := os.MkdirAll(logsRoot, 0755); err != nil {
+		t.Fatalf("mkdir logsRoot: %v", err)
+	}
+
+	now := time.Now()
+	ancient := now.Add(-365 * 24 * time.Hour) // 1 year old — would be pruned if in logs/
+
+	// Seed sibling directories with old files.
+	siblings := []string{"sessions", "worktrees", "repos", "debug"}
+	var siblingFiles []string
+	for _, sib := range siblings {
+		sibDir := filepath.Join(fabrikBase, sib, "issue-1")
+		f := seedLogFile(t, sibDir, "old.log", 1000, ancient)
+		siblingFiles = append(siblingFiles, f)
+	}
+
+	// Seed one old file inside logs/ so prune actually runs.
+	logsIssueDir := filepath.Join(logsRoot, "owner-repo", "issue-1")
+	logsFile := seedLogFile(t, logsIssueDir, "old.log", 100, ancient)
+
+	_, removed, _, _, _, err := pruneLogs(logsRoot, 1, 0, now) // 1-day retention
+	if err != nil {
+		t.Fatalf("pruneLogs: %v", err)
+	}
+	// Only the file in logs/ should be removed.
+	if removed != 1 {
+		t.Errorf("removed=%d, want exactly 1 (only the logs/ file)", removed)
+	}
+	if _, err := os.Stat(logsFile); !os.IsNotExist(err) {
+		t.Errorf("logs/ file should be deleted")
+	}
+	for _, sf := range siblingFiles {
+		if _, err := os.Stat(sf); err != nil {
+			t.Errorf("sibling file %s should be untouched, but got: %v", sf, err)
+		}
+	}
+}
+
+// TestLogJanitorEmptyDirCleanup verifies that empty issue-N/ and owner-repo/
+// directories are removed after pruning, but non-empty directories are kept.
+func TestLogJanitorEmptyDirCleanup(t *testing.T) {
+	logsRoot := t.TempDir()
+	now := time.Now()
+	ancient := now.Add(-30 * 24 * time.Hour)
+
+	// emptyIssue: all files old → dir becomes empty and should be removed.
+	emptyIssueDir := filepath.Join(logsRoot, "owner-repo", "issue-1")
+	seedLogFile(t, emptyIssueDir, "old.log", 10, ancient)
+
+	// nonEmptyIssue: one old, one new → dir has remaining file and must be kept.
+	nonEmptyIssueDir := filepath.Join(logsRoot, "owner-repo", "issue-2")
+	seedLogFile(t, nonEmptyIssueDir, "old.log", 10, ancient)
+	seedLogFile(t, nonEmptyIssueDir, "new.log", 10, now)
+
+	_, _, _, _, _, err := pruneLogs(logsRoot, 14, 0, now)
+	if err != nil {
+		t.Fatalf("pruneLogs: %v", err)
+	}
+
+	// issue-1/ is now empty → should be removed.
+	if _, err := os.Stat(emptyIssueDir); !os.IsNotExist(err) {
+		t.Errorf("emptied issue-1/ dir should be removed, but still exists")
+	}
+	// issue-2/ still has new.log → must be kept.
+	if _, err := os.Stat(nonEmptyIssueDir); err != nil {
+		t.Errorf("non-empty issue-2/ dir should be kept: %v", err)
+	}
+}
+
+// TestLogJanitorDisabledPaths verifies that retentionDays=0 skips age pruning
+// and maxBytes=0 skips size-cap pruning.
+func TestLogJanitorDisabledPaths(t *testing.T) {
+	t.Run("retentionDays=0 skips age prune", func(t *testing.T) {
+		logsRoot := t.TempDir()
+		now := time.Now()
+		ancient := now.Add(-365 * 24 * time.Hour)
+		issueDir := filepath.Join(logsRoot, "issue-1")
+		f := seedLogFile(t, issueDir, "old.log", 100, ancient)
+
+		_, removed, _, ageRemoved, _, err := pruneLogs(logsRoot, 0, 0, now)
+		if err != nil {
+			t.Fatalf("pruneLogs: %v", err)
+		}
+		if removed != 0 || ageRemoved != 0 {
+			t.Errorf("retentionDays=0: removed=%d ageRemoved=%d, want 0 0", removed, ageRemoved)
+		}
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("file should not be deleted when retentionDays=0: %v", err)
+		}
+	})
+
+	t.Run("maxBytes=0 skips size cap", func(t *testing.T) {
+		logsRoot := t.TempDir()
+		now := time.Now()
+		issueDir := filepath.Join(logsRoot, "issue-1")
+		// All files are recent so age prune won't touch them.
+		f1 := seedLogFile(t, issueDir, "a.log", 500*1024*1024, now.Add(-1*time.Hour))
+		f2 := seedLogFile(t, issueDir, "b.log", 500*1024*1024, now.Add(-30*time.Minute))
+
+		_, removed, _, _, sizeRemoved, err := pruneLogs(logsRoot, 0, 0, now)
+		if err != nil {
+			t.Fatalf("pruneLogs: %v", err)
+		}
+		if removed != 0 || sizeRemoved != 0 {
+			t.Errorf("maxBytes=0: removed=%d sizeRemoved=%d, want 0 0", removed, sizeRemoved)
+		}
+		for _, f := range []string{f1, f2} {
+			if _, err := os.Stat(f); err != nil {
+				t.Errorf("file %s should not be deleted when maxBytes=0: %v", f, err)
+			}
+		}
+	})
+}
+
+// TestLogJanitorNonExistentRoot verifies that pruneLogs returns clean zero
+// counts (not an error) when the logs directory doesn't exist yet.
+func TestLogJanitorNonExistentRoot(t *testing.T) {
+	nonExistentRoot := filepath.Join(t.TempDir(), "no-such-dir")
+	scanned, removed, bytesRemoved, ageRemoved, sizeRemoved, err := pruneLogs(nonExistentRoot, 14, 2147483648, time.Now())
+	if err != nil {
+		t.Errorf("expected nil error for non-existent root, got: %v", err)
+	}
+	if scanned != 0 || removed != 0 || bytesRemoved != 0 || ageRemoved != 0 || sizeRemoved != 0 {
+		t.Errorf("expected zero counts for non-existent root, got scanned=%d removed=%d", scanned, removed)
+	}
+}
+
+// TestLogJanitorPeriodicPath proves that runLogJanitor (the function called by
+// the periodic goroutine on every tick) correctly prunes old files without
+// requiring a process restart. This directly validates the core guarantee for
+// long-running instances: disk stays bounded even when Fabrik runs for weeks.
+func TestLogJanitorPeriodicPath(t *testing.T) {
+	fabrikDir := t.TempDir()
+	logsRoot := filepath.Join(fabrikDir, ".fabrik", "logs")
+
+	now := time.Now()
+	ancient := now.Add(-20 * 24 * time.Hour) // 20 days old — exceeds 14-day default
+	recent := now.Add(-1 * time.Hour)
+
+	issueDir := filepath.Join(logsRoot, "owner-repo", "issue-99")
+	oldFile := seedLogFile(t, issueDir, "old.log", 100, ancient)
+	newFile := seedLogFile(t, issueDir, "new.log", 100, recent)
+
+	eng := NewWithDeps(Config{
+		MaxConcurrent:        1,
+		JanitorIntervalHours: 1,
+		LogRetentionDays:     14,
+		LogMaxBytes:          2147483648,
+	}, &mockGitHubClient{}, &mockClaudeInvoker{}, nil)
+	eng.fabrikDir = fabrikDir
+
+	// Call runLogJanitor directly — this is the same function the periodic
+	// goroutine calls on every tick, proving the periodic path works correctly.
+	eng.runLogJanitor(context.Background())
+
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("periodic path: old file should be deleted on tick, but still exists")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("periodic path: recent file should be kept: %v", err)
+	}
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -631,6 +631,7 @@ func (e *Engine) Run() error {
 		e.runStartupTerminalScan()
 		if e.cfg.JanitorIntervalHours > 0 {
 			e.runWorktreeJanitor(ctx)
+			e.runLogJanitor(ctx)
 		}
 	}
 
@@ -638,8 +639,9 @@ func (e *Engine) Run() error {
 	// has gone stale and cleans up if the process is confirmed dead via signal 0.
 	e.startWorkerDetector(ctx)
 
-	// Start periodic worktree janitor. Scans .fabrik/worktrees/ and reaps
-	// orphaned worktrees for closed, off-board issues. Disabled when JanitorIntervalHours == 0.
+	// Start periodic janitor goroutine. On each tick: reaps orphaned worktrees for
+	// closed, off-board issues and prunes .fabrik/logs/ by age and total size.
+	// Disabled when JanitorIntervalHours == 0.
 	if e.cfg.JanitorIntervalHours > 0 {
 		go func() {
 			ticker := time.NewTicker(time.Duration(e.cfg.JanitorIntervalHours) * time.Hour)
@@ -650,6 +652,7 @@ func (e *Engine) Run() error {
 					return
 				case <-ticker.C:
 					e.runWorktreeJanitor(ctx)
+					e.runLogJanitor(ctx)
 				}
 			}
 		}()


### PR DESCRIPTION
Closes #920

## What this PR does

Adds a log-retention janitor that prunes `.fabrik/logs/` on a configurable schedule to prevent unbounded disk growth. The logs directory had grown to 1.4 GB in production with no automatic cleanup mechanism.

## Key changes

- **`engine/janitor.go`**: `pruneLogs()` walks `.fabrik/logs/`, age-prunes files older than `LogRetentionDays`, applies a size-cap backstop (oldest-first) when the tree exceeds `LogMaxBytes`, removes empty issue/repo subdirs bottom-up, and returns scan/remove counts for a summary log line. `runLogJanitor()` wraps it with `time.Now()` and emits `[log-janitor] cycle complete: scanned N files, removed M (P bytes), age=K size=J`.
- **`engine/poll.go`**: `runLogJanitor` is called alongside `runWorktreeJanitor` in both the post-first-poll startup block and the periodic goroutine ticker — both gated on `JanitorIntervalHours > 0`. The periodic tick is the primary mechanism for long-running instances that never restart.
- **`config/config.go`**: `LogRetentionDays *int` and `LogMaxBytes *int64` added to `ProjectConfig`.
- **`engine/engine.go`**: `LogRetentionDays int` and `LogMaxBytes int64` added to `Config` with defaults (14 days, 2 GiB).
- **`cmd/root.go`**: `--log-retention-days` / `FABRIK_LOG_RETENTION_DAYS` and `--log-max-bytes` / `FABRIK_LOG_MAX_BYTES` flags and env vars with config.yaml wiring, negative-value warnings, and correct flag/env/config.yaml/default precedence.
- **`engine/janitor_test.go`**: 7 tests covering age prune, size cap, scope guard (sessions/, worktrees/, repos/, debug/ untouched), empty-dir cleanup, disabled paths, non-existent root, and periodic path coverage.
- **`docs/USER_GUIDE.md`**: New "Log Retention" section, config.yaml example, flag table rows, env var table rows. `docs/llms-full.txt` regenerated.

## Scope guard

`pruneLogs` resolves the prune root via `filepath.EvalSymlinks` + `filepath.Clean` and asserts every deletion candidate has the resolved root as a prefix — `sessions/`, `worktrees/`, `repos/`, and `debug/` are provably never touched (covered by `TestLogJanitorScopeGuard`).

## How to test

1. `go test -race ./engine/... -run TestLogJanitor` — all 7 subtests pass
2. Run `fabrik` with `--log-retention-days 0` and `--log-max-bytes 0` to verify disabled paths
3. Seed `.fabrik/logs/` with old-mtime files and watch the hourly janitor tick prune them