### PR TITLE
refactor(engine): drop redundant -output-*.json write, keep .log as sole stream artifact

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1988,7 +1988,7 @@ Session logs are saved to `.fabrik/logs/<owner>-<repo>/issue-<N>/` (relative to 
 ls -lt .fabrik/logs/<owner>-<repo>/issue-42/
 
 # Render a completed log as human-readable text
-cat .fabrik/logs/<owner>-<repo>/issue-42/<stage>-output-<timestamp>.json | fabrik stream-filter | less -R
+cat .fabrik/logs/<owner>-<repo>/issue-42/<stage>-<timestamp>-<nanos>.log | fabrik stream-filter | less -R
 ```
 
 Logs are namespaced by repository: `.fabrik/logs/<owner>-<repo>/issue-<N>/`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1986,7 +1986,7 @@ Session logs are saved to `.fabrik/logs/<owner>-<repo>/issue-<N>/` (relative to 
 ls -lt .fabrik/logs/<owner>-<repo>/issue-42/
 
 # Render a completed log as human-readable text
-cat .fabrik/logs/<owner>-<repo>/issue-42/<stage>-output-<timestamp>.json | fabrik stream-filter | less -R
+cat .fabrik/logs/<owner>-<repo>/issue-42/<stage>-<timestamp>-<nanos>.log | fabrik stream-filter | less -R
 ```
 
 Logs are namespaced by repository: `.fabrik/logs/<owner>-<repo>/issue-<N>/`.
@@ -5320,7 +5320,7 @@ Context files are available in .fabrik-context/
 
 ### Output Logging
 
-Raw Claude output saved to `~/.fabrik/logs/issue-<N>/<stage>-output-<timestamp>.json` after every invocation. Viewable through the TUI's `l` key (piped through `fabrik _stream-filter` for human-readable display).
+Each invocation writes one NDJSON stream file to `.fabrik/logs/<owner>-<repo>/issue-<N>/` as `<stage>-<timestamp>-<nanos>.log`. This file is written live during execution (tee'd from Claude's stdout) and is the sole on-disk copy of the stream. Viewable via `cat <file> | fabrik stream-filter | less -R` or through the TUI's `l` key.
 
 ### Turn Progress Emission
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -236,7 +236,7 @@ Context files are available in .fabrik-context/
 
 ### Output Logging
 
-Raw Claude output saved to `~/.fabrik/logs/issue-<N>/<stage>-output-<timestamp>.json` after every invocation. Viewable through the TUI's `l` key (piped through `fabrik _stream-filter` for human-readable display).
+Each invocation writes one NDJSON stream file to `.fabrik/logs/<owner>-<repo>/issue-<N>/` as `<stage>-<timestamp>-<nanos>.log`. This file is written live during execution (tee'd from Claude's stdout) and is the sole on-disk copy of the stream. Viewable via `cat <file> | fabrik stream-filter | less -R` or through the TUI's `l` key.
 
 ### Turn Progress Emission
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -669,15 +669,6 @@ func runClaude(ctx context.Context, args []string, prompt string, workDir string
 		runErr = nil
 	}
 
-	// Save the raw NDJSON output to an -output-*.json file for backward compatibility
-	// (e.g., the existing TUI log viewer and stream-filter tooling).
-	if len(rawOutput) > 0 {
-		outputLogPath := filepath.Join(logDir, fmt.Sprintf("%s-output-%s.json", safeLabel, time.Now().UTC().Format("20060102-150405")))
-		if err := os.WriteFile(outputLogPath, rawOutput, 0600); err != nil {
-			claudeLog(issueNumber, "warn", "could not save output log: %v\n", err)
-		}
-	}
-
 	resp, ok := parseClaudeJSON(bytes.TrimSpace(rawOutput))
 	var text string
 	var usage TokenUsage

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -543,6 +543,60 @@ func TestRunClaude_StdoutTeeToLogFile(t *testing.T) {
 	}
 }
 
+// TestRunClaude_NoOutputJsonFile verifies that a standard invocation writes exactly
+// one stream file (.log) to LogDir and does not produce a redundant -output-*.json
+// file. The .log live-tee is the sole on-disk copy of the NDJSON stream.
+func TestRunClaude_NoOutputJsonFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	ndjson := `{"type":"assistant","message":{"content":[{"type":"text","text":"no dup test"}]}}
+{"type":"result","subtype":"success","result":"done\nFABRIK_STAGE_COMPLETE\n","session_id":"sess_nodup","num_turns":1,"total_cost_usd":0.001}
+`
+	ndjsonFile := filepath.Join(binDir, "output.ndjson")
+	if err := os.WriteFile(ndjsonFile, []byte(ndjson), 0600); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\ncat >/dev/null\ncat " + ndjsonFile + "\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "NoDup",
+		Prompt:     "no dup test",
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 210, Title: "No dup test"}
+
+	_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+	if err != nil {
+		t.Fatalf("InvokeClaude: %v", err)
+	}
+
+	logDir := LogDir(210)
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		t.Fatalf("reading log dir %s: %v", logDir, err)
+	}
+
+	// Exactly one file should exist and it must have the .log suffix.
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 file in LogDir, got %d: %v", len(entries), entries)
+	}
+	name := entries[0].Name()
+	if !strings.HasSuffix(name, ".log") {
+		t.Errorf("expected .log file, got %q", name)
+	}
+	// No file with an "output" infix or .json suffix.
+	if strings.Contains(name, "output") || strings.HasSuffix(name, ".json") {
+		t.Errorf("redundant -output-*.json file found: %q", name)
+	}
+}
+
 // TestRunClaude_IssueUpdateInIntermediateTurn verifies that when a fake claude binary
 // emits FABRIK_ISSUE_UPDATE_BEGIN/END in an intermediate assistant turn (not in the
 // result field), runClaude still returns text containing the update block.


### PR DESCRIPTION
Closes #923

## What this PR does

Removes the unconditional second write of the NDJSON stream that happened at the end of every Claude invocation. Previously `runClaude` wrote the same bytes twice:

1. **`.log`** — tee'd live from Claude's stdout during execution (used by `fabrik watch`, TUI, `stream-filter`)
2. **`-output-<timestamp>.json`** — a redundant `os.WriteFile` of the in-memory buffer after `cmd.Wait()` returned

The second copy was a backward-compat concession from ADR-014, citing `tui/model.go` as a consumer. Research confirmed that consumer no longer exists in the codebase, and no other in-tree reader of `-output-*.json` was found. The `.log` file is byte-identical and is already what every live consumer uses.

## Key changes

- **`engine/claude.go`**: Delete the 8-line `os.WriteFile` block (lines 672–679 pre-patch). The `rawOutput bytes.Buffer` is preserved — `parseClaudeJSON` and text-extraction helpers still consume it.
- **`engine/invoke_claude_test.go`**: Add `TestRunClaude_NoOutputJsonFile` — asserts that exactly one file exists in `LogDir` after a standard invocation, it has the `.log` suffix, and no `-output-*.json` is written.
- **`docs/stage-lifecycle.md`**: Update the Output Logging section to describe `.log` as the sole on-disk artifact.
- **`docs/USER_GUIDE.md`**: Update the `stream-filter` manual-inspection example to use `<stage>-<timestamp>-<nanos>.log` instead of `-output-*.json`.
- **`docs/llms-full.txt`**: Regenerated.

## Testing

```
go test -race ./engine/  # all pass
go test -run TestRunClaude_NoOutputJsonFile ./engine/ -v  # PASS
go test -run TestRunClaude_StdoutTeeToLogFile ./engine/ -v  # PASS
```

## Impact on users

Anyone with personal scripts that `cat .fabrik/logs/.../*-output-*.json | fabrik stream-filter` will need to switch to the `.log` file — the content is byte-identical. The updated `USER_GUIDE.md` shows the exact replacement command.