### PR TITLE
feat(merge-queue): add PR queue fields and enqueue/dequeue mutations [ADR-058 step 1]

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -741,13 +741,16 @@ func (c *CacheImpl) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDe
 	if linkedPRNum != 0 && snapErr == nil {
 		if lpr := snap.LinkedPR(); lpr != nil && lpr.Title != "" && lpr.HeadSHA != "" {
 			return &gh.PRDetails{
-				Number:         lpr.Number,
-				Title:          lpr.Title,
-				State:          lpr.State,
-				Merged:         lpr.Merged,
-				Draft:          lpr.Draft,
-				HeadSHA:        lpr.HeadSHA,
-				MergeableState: lpr.MergeableState,
+				Number:              lpr.Number,
+				Title:               lpr.Title,
+				State:               lpr.State,
+				Merged:              lpr.Merged,
+				Draft:               lpr.Draft,
+				HeadSHA:             lpr.HeadSHA,
+				MergeableState:      lpr.MergeableState,
+				IsMergeQueueEnabled: lpr.IsMergeQueueEnabled,
+				IsInMergeQueue:      lpr.IsInMergeQueue,
+				MergeQueueEntry:     lpr.MergeQueueEntry,
 			}, nil
 		}
 	}

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -159,6 +159,12 @@ func (m *testGitHubUpgradeClient) DeleteForwardingHooks(owner, repo string) erro
 func (m *testGitHubUpgradeClient) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
 	return nil
 }
+func (m *testGitHubUpgradeClient) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error {
+	return nil
+}
+func (m *testGitHubUpgradeClient) DequeuePullRequest(owner, repo string, prNumber int) error {
+	return nil
+}
 func (m *testGitHubUpgradeClient) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
 	return 0, nil
 }

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -50,6 +50,8 @@ type GitHubClient interface {
 	DeleteReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error
 	FetchLatestRelease(owner, repo string) (*gh.LatestRelease, error)
+	EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error
+	DequeuePullRequest(owner, repo string, prNumber int) error
 	FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error)
 	FetchAllowAutoMerge(owner, repo string) (bool, error)
 	FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error)

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -58,6 +58,8 @@ type mockGitHubClient struct {
 	addProjectV2ItemByIdFn              func(projectID, contentNodeID string) (string, error)
 	addBlockedByIssueFn                 func(issueNodeID, blockerNodeID string) error
 	enablePullRequestAutoMergeFn        func(owner, repo string, prNumber int, strategy string) error
+	enqueuePullRequestFn                func(owner, repo string, prNumber int, expectedHeadOID string) error
+	dequeuePullRequestFn                func(owner, repo string, prNumber int) error
 	fetchCommitsBehindFn                func(owner, repo, base, head string) (int, error)
 	fetchAllowAutoMergeFn               func(owner, repo string) (bool, error)
 	fetchIssueFn                        func(owner, repo string, issueNumber int) (*gh.IssueData, error)
@@ -100,6 +102,8 @@ type mockGitHubClient struct {
 	addProjectV2ItemCalls               []addProjectV2ItemCall
 	addBlockedByIssueCalls              []addBlockedByIssueCall
 	enablePullRequestAutoMergeCalls     []enablePullRequestAutoMergeCall
+	enqueuePullRequestCalls             []enqueuePullRequestCall
+	dequeuePullRequestCalls             []dequeuePullRequestCall
 	fetchCommitsBehindCalls             []fetchCommitsBehindCall
 }
 
@@ -663,6 +667,17 @@ type fetchCommitsBehindCall struct {
 	owner, repo, base, head string
 }
 
+type enqueuePullRequestCall struct {
+	owner, repo     string
+	prNumber        int
+	expectedHeadOID string
+}
+
+type dequeuePullRequestCall struct {
+	owner, repo string
+	prNumber    int
+}
+
 func (m *mockGitHubClient) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
 	m.mu.Lock()
 	m.enablePullRequestAutoMergeCalls = append(m.enablePullRequestAutoMergeCalls, enablePullRequestAutoMergeCall{owner, repo, prNumber, strategy})
@@ -670,6 +685,28 @@ func (m *mockGitHubClient) EnablePullRequestAutoMerge(owner, repo string, prNumb
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(owner, repo, prNumber, strategy)
+	}
+	return nil
+}
+
+func (m *mockGitHubClient) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error {
+	m.mu.Lock()
+	m.enqueuePullRequestCalls = append(m.enqueuePullRequestCalls, enqueuePullRequestCall{owner, repo, prNumber, expectedHeadOID})
+	fn := m.enqueuePullRequestFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber, expectedHeadOID)
+	}
+	return nil
+}
+
+func (m *mockGitHubClient) DequeuePullRequest(owner, repo string, prNumber int) error {
+	m.mu.Lock()
+	m.dequeuePullRequestCalls = append(m.dequeuePullRequestCalls, dequeuePullRequestCall{owner, repo, prNumber})
+	fn := m.dequeuePullRequestFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(owner, repo, prNumber)
 	}
 	return nil
 }

--- a/github/project.go
+++ b/github/project.go
@@ -58,9 +58,18 @@ type itemNode struct {
 		} `json:"labels"`
 		LinkedPRs *struct {
 			Nodes []struct {
-				UpdatedAt  string `json:"updatedAt"`
-				Number     int    `json:"number"`
-				HeadRefOid string `json:"headRefOid"`
+				UpdatedAt           string `json:"updatedAt"`
+				Number              int    `json:"number"`
+				HeadRefOid          string `json:"headRefOid"`
+				IsMergeQueueEnabled bool   `json:"isMergeQueueEnabled"`
+				IsInMergeQueue      bool   `json:"isInMergeQueue"`
+				MergeQueueEntry     *struct {
+					State         string `json:"state"`
+					Position      int    `json:"position"`
+					Enqueuer      *struct {
+						Login string `json:"login"`
+					} `json:"enqueuer"`
+				} `json:"mergeQueueEntry"`
 			} `json:"nodes"`
 		} `json:"closedByPullRequestsReferences"`
 	} `json:"content"`
@@ -201,6 +210,13 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
                   updatedAt
                   number
                   headRefOid
+                  isMergeQueueEnabled
+                  isInMergeQueue
+                  mergeQueueEntry {
+                    state
+                    position
+                    enqueuer { login }
+                  }
                 }
               }
             }
@@ -325,8 +341,21 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 				}
 			}
 			if len(node.Content.LinkedPRs.Nodes) > 0 {
-				item.LinkedPRNumberShallow = node.Content.LinkedPRs.Nodes[0].Number
-				item.LinkedPRHeadSHA = node.Content.LinkedPRs.Nodes[0].HeadRefOid
+				pr0 := node.Content.LinkedPRs.Nodes[0]
+				item.LinkedPRNumberShallow = pr0.Number
+				item.LinkedPRHeadSHA = pr0.HeadRefOid
+				item.LinkedPRIsMergeQueueEnabled = pr0.IsMergeQueueEnabled
+				item.LinkedPRIsInMergeQueue = pr0.IsInMergeQueue
+				if pr0.MergeQueueEntry != nil {
+					entry := &MergeQueueEntry{
+						State:    pr0.MergeQueueEntry.State,
+						Position: pr0.MergeQueueEntry.Position,
+					}
+					if pr0.MergeQueueEntry.Enqueuer != nil {
+						entry.EnqueuerLogin = pr0.MergeQueueEntry.Enqueuer.Login
+					}
+					item.LinkedPRMergeQueueEntry = entry
+				}
 			}
 		}
 
@@ -457,6 +486,13 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
                   number
                   updatedAt
                   headRefOid
+                  isMergeQueueEnabled
+                  isInMergeQueue
+                  mergeQueueEntry {
+                    state
+                    position
+                    enqueuer { login }
+                  }
                 }
               }
             }
@@ -627,6 +663,13 @@ query($id: ID!) {
           id
           number
           headRefOid
+          isMergeQueueEnabled
+          isInMergeQueue
+          mergeQueueEntry {
+            state
+            position
+            enqueuer { login }
+          }
           comments(first: 100) {
             nodes {
               id
@@ -764,10 +807,19 @@ query($id: ID!) {
 				} `json:"comments"`
 				LinkedPRs *struct {
 					Nodes []struct {
-						ID         string `json:"id"`
-						Number     int    `json:"number"`
-						HeadRefOid string `json:"headRefOid"`
-						Comments   struct {
+						ID                  string `json:"id"`
+						Number              int    `json:"number"`
+						HeadRefOid          string `json:"headRefOid"`
+						IsMergeQueueEnabled bool   `json:"isMergeQueueEnabled"`
+						IsInMergeQueue      bool   `json:"isInMergeQueue"`
+						MergeQueueEntry     *struct {
+							State    string `json:"state"`
+							Position int    `json:"position"`
+							Enqueuer *struct {
+								Login string `json:"login"`
+							} `json:"enqueuer"`
+						} `json:"mergeQueueEntry"`
+						Comments struct {
 							Nodes    []commentNodeData `json:"nodes"`
 							PageInfo struct {
 								HasNextPage bool   `json:"hasNextPage"`
@@ -885,6 +937,9 @@ query($id: ID!) {
 	item.LinkedPRReviews = nil
 	item.LinkedPRReviewThreadComments = nil
 	item.LinkedPRResolvedThreadCount = 0
+	item.LinkedPRIsMergeQueueEnabled = false
+	item.LinkedPRIsInMergeQueue = false
+	item.LinkedPRMergeQueueEntry = nil
 
 	// Process issue/PR comments
 	commentNodes := node.Comments.Nodes
@@ -902,10 +957,24 @@ query($id: ID!) {
 	// Merge comments, review requests, and reviews from linked PRs
 	if node.LinkedPRs != nil {
 		for i, pr := range node.LinkedPRs.Nodes {
-			// Record the first linked PR's number and head SHA for REST re-request and CI gate calls.
+			// Record the first linked PR's number, head SHA, and queue state for
+			// REST re-request, CI gate calls, and merge-queue integration.
 			if i == 0 {
 				item.LinkedPRNumber = pr.Number
 				item.LinkedPRHeadSHA = pr.HeadRefOid
+				item.LinkedPRIsMergeQueueEnabled = pr.IsMergeQueueEnabled
+				item.LinkedPRIsInMergeQueue = pr.IsInMergeQueue
+				item.LinkedPRMergeQueueEntry = nil
+				if pr.MergeQueueEntry != nil {
+					entry := &MergeQueueEntry{
+						State:    pr.MergeQueueEntry.State,
+						Position: pr.MergeQueueEntry.Position,
+					}
+					if pr.MergeQueueEntry.Enqueuer != nil {
+						entry.EnqueuerLogin = pr.MergeQueueEntry.Enqueuer.Login
+					}
+					item.LinkedPRMergeQueueEntry = entry
+				}
 			}
 			prCommentNodes := pr.Comments.Nodes
 			if pr.Comments.PageInfo.HasNextPage {

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -256,3 +256,137 @@ func TestLookupIssueProjectItem(t *testing.T) {
 		}
 	})
 }
+
+// minimalLinkedPRNode builds the shared fields for a linked-PR node in the
+// FetchItemDetails GraphQL mock response, avoiding repetition across sub-tests.
+func minimalLinkedPRNode(id string, number int, extra map[string]interface{}) map[string]interface{} {
+	node := map[string]interface{}{
+		"id":         id,
+		"number":     number,
+		"headRefOid": "sha" + id,
+		"comments":   map[string]interface{}{"nodes": []interface{}{}, "pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""}},
+		"reviewRequests": map[string]interface{}{"nodes": []interface{}{}},
+		"latestReviews":  map[string]interface{}{"nodes": []interface{}{}},
+		"reviewThreads":  map[string]interface{}{"nodes": []interface{}{}},
+	}
+	for k, v := range extra {
+		node[k] = v
+	}
+	return node
+}
+
+// minimalFetchItemDetailsResponse builds a complete FetchItemDetails GraphQL
+// response wrapping the given linked-PR nodes.
+func minimalFetchItemDetailsResponse(linkedPRNodes []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"node": map[string]interface{}{
+				"number": 5,
+				"title":  "Test issue",
+				"body":   "",
+				"url":    "https://github.com/test/repo/issues/5",
+				"author": map[string]interface{}{"login": "alice"},
+				"labels": map[string]interface{}{
+					"nodes":    []interface{}{},
+					"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+				},
+				"assignees": map[string]interface{}{"nodes": []interface{}{}},
+				"comments": map[string]interface{}{
+					"nodes":    []interface{}{},
+					"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+				},
+				"closedByPullRequestsReferences": map[string]interface{}{
+					"nodes": linkedPRNodes,
+				},
+			},
+		},
+	}
+}
+
+func TestFetchItemDetailsQueueFields(t *testing.T) {
+	t.Run("queue fields are populated when mergeQueueEntry is non-null", func(t *testing.T) {
+		prNode := minimalLinkedPRNode("PR_xyz", 7, map[string]interface{}{
+			"isMergeQueueEnabled": true,
+			"isInMergeQueue":      true,
+			"mergeQueueEntry": map[string]interface{}{
+				"state":    "QUEUED",
+				"position": 1,
+				"enqueuer": map[string]interface{}{"login": "bob"},
+			},
+		})
+		_, client := makeLookupServer(t, func() interface{} {
+			return minimalFetchItemDetailsResponse([]interface{}{prNode})
+		})
+
+		item := &ProjectItem{ID: "ISSUE_id", Number: 5}
+		if err := client.FetchItemDetails(item); err != nil {
+			t.Fatalf("FetchItemDetails: %v", err)
+		}
+
+		if !item.LinkedPRIsMergeQueueEnabled {
+			t.Error("LinkedPRIsMergeQueueEnabled = false, want true")
+		}
+		if !item.LinkedPRIsInMergeQueue {
+			t.Error("LinkedPRIsInMergeQueue = false, want true")
+		}
+		if item.LinkedPRMergeQueueEntry == nil {
+			t.Fatal("LinkedPRMergeQueueEntry = nil, want non-nil")
+		}
+		if item.LinkedPRMergeQueueEntry.State != "QUEUED" {
+			t.Errorf("MergeQueueEntry.State = %q, want %q", item.LinkedPRMergeQueueEntry.State, "QUEUED")
+		}
+		if item.LinkedPRMergeQueueEntry.Position != 1 {
+			t.Errorf("MergeQueueEntry.Position = %d, want 1", item.LinkedPRMergeQueueEntry.Position)
+		}
+		if item.LinkedPRMergeQueueEntry.EnqueuerLogin != "bob" {
+			t.Errorf("MergeQueueEntry.EnqueuerLogin = %q, want %q", item.LinkedPRMergeQueueEntry.EnqueuerLogin, "bob")
+		}
+	})
+
+	t.Run("queue fields are zero when mergeQueueEntry is null", func(t *testing.T) {
+		prNode := minimalLinkedPRNode("PR_abc", 8, map[string]interface{}{
+			"isMergeQueueEnabled": false,
+			"isInMergeQueue":      false,
+			"mergeQueueEntry":     nil,
+		})
+		_, client := makeLookupServer(t, func() interface{} {
+			return minimalFetchItemDetailsResponse([]interface{}{prNode})
+		})
+
+		item := &ProjectItem{ID: "ISSUE_id2", Number: 6}
+		if err := client.FetchItemDetails(item); err != nil {
+			t.Fatalf("FetchItemDetails: %v", err)
+		}
+
+		if item.LinkedPRIsMergeQueueEnabled {
+			t.Error("LinkedPRIsMergeQueueEnabled = true, want false")
+		}
+		if item.LinkedPRIsInMergeQueue {
+			t.Error("LinkedPRIsInMergeQueue = true, want false")
+		}
+		if item.LinkedPRMergeQueueEntry != nil {
+			t.Errorf("LinkedPRMergeQueueEntry = %+v, want nil", item.LinkedPRMergeQueueEntry)
+		}
+	})
+
+	t.Run("queue fields are zero when no linked PR", func(t *testing.T) {
+		_, client := makeLookupServer(t, func() interface{} {
+			return minimalFetchItemDetailsResponse([]interface{}{})
+		})
+
+		item := &ProjectItem{ID: "ISSUE_id3", Number: 7}
+		if err := client.FetchItemDetails(item); err != nil {
+			t.Fatalf("FetchItemDetails: %v", err)
+		}
+
+		if item.LinkedPRIsMergeQueueEnabled {
+			t.Error("LinkedPRIsMergeQueueEnabled = true, want false (no PR)")
+		}
+		if item.LinkedPRIsInMergeQueue {
+			t.Error("LinkedPRIsInMergeQueue = true, want false (no PR)")
+		}
+		if item.LinkedPRMergeQueueEntry != nil {
+			t.Errorf("LinkedPRMergeQueueEntry non-nil when no PR: %+v", item.LinkedPRMergeQueueEntry)
+		}
+	})
+}

--- a/github/prs.go
+++ b/github/prs.go
@@ -536,6 +536,9 @@ func isAutoMergeAlreadyCleanError(err error) bool {
 // Uses the same two-step pattern as MarkPRReady: fetch the PR node ID via
 // GraphQL, then call the enqueuePullRequest mutation.
 func (c *Client) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error {
+	if expectedHeadOID == "" {
+		return fmt.Errorf("expectedHeadOID cannot be empty")
+	}
 	fetchQuery := `
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {

--- a/github/prs.go
+++ b/github/prs.go
@@ -528,6 +528,116 @@ func isAutoMergeAlreadyCleanError(err error) bool {
 	return strings.Contains(err.Error(), "Pull request is in clean status")
 }
 
+// EnqueuePullRequest adds a pull request to the repository's merge queue.
+// expectedHeadOID is the current head SHA of the PR; if the PR has been
+// force-pushed since the caller read the SHA, the mutation fails safely
+// (optimistic concurrency).
+//
+// Uses the same two-step pattern as MarkPRReady: fetch the PR node ID via
+// GraphQL, then call the enqueuePullRequest mutation.
+func (c *Client) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error {
+	fetchQuery := `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}`
+	fetchVars := map[string]interface{}{
+		"owner":  owner,
+		"repo":   repo,
+		"number": prNumber,
+	}
+	var fetchResult struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ID string `json:"id"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
+		return fmt.Errorf("fetching PR node ID: %w", err)
+	}
+	nodeID := fetchResult.Data.Repository.PullRequest.ID
+	if nodeID == "" {
+		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	}
+
+	mutation := `
+mutation($prId: ID!, $expectedHeadOid: GitObjectID!) {
+  enqueuePullRequest(input: { pullRequestId: $prId, expectedHeadOid: $expectedHeadOid }) {
+    mergeQueueEntry {
+      id
+    }
+  }
+}`
+	mutVars := map[string]interface{}{
+		"prId":            nodeID,
+		"expectedHeadOid": expectedHeadOID,
+	}
+	var mutResult struct{}
+	if err := c.graphqlRequest(mutation, mutVars, &mutResult); err != nil {
+		return fmt.Errorf("enqueueing PR #%d: %w", prNumber, err)
+	}
+	return nil
+}
+
+// DequeuePullRequest removes a pull request from the repository's merge queue.
+//
+// Uses the same two-step pattern as MarkPRReady: fetch the PR node ID via
+// GraphQL, then call the dequeuePullRequest mutation.
+func (c *Client) DequeuePullRequest(owner, repo string, prNumber int) error {
+	fetchQuery := `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}`
+	fetchVars := map[string]interface{}{
+		"owner":  owner,
+		"repo":   repo,
+		"number": prNumber,
+	}
+	var fetchResult struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ID string `json:"id"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
+		return fmt.Errorf("fetching PR node ID: %w", err)
+	}
+	nodeID := fetchResult.Data.Repository.PullRequest.ID
+	if nodeID == "" {
+		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	}
+
+	mutation := `
+mutation($prId: ID!) {
+  dequeuePullRequest(input: { id: $prId }) {
+    mergeQueueEntry {
+      id
+    }
+  }
+}`
+	mutVars := map[string]interface{}{
+		"prId": nodeID,
+	}
+	var mutResult struct{}
+	if err := c.graphqlRequest(mutation, mutVars, &mutResult); err != nil {
+		return fmt.Errorf("dequeueing PR #%d: %w", prNumber, err)
+	}
+	return nil
+}
+
 // FetchCommitsBehind returns how many commits base is ahead of head using the
 // GitHub compare API. A positive result means head is that many commits behind
 // base. Returns 0, nil when head is up to date.

--- a/github/prs.go
+++ b/github/prs.go
@@ -89,6 +89,17 @@ type PRDetails struct {
 	// the PR (auto_merge field is non-null). False when the user or engine
 	// has disabled it, or when it was never enabled.
 	AutoMergeEnabled bool
+
+	// IsMergeQueueEnabled is true when the repository has the merge queue feature
+	// enabled. Always false when populated via REST (GraphQL-only field).
+	IsMergeQueueEnabled bool
+	// IsInMergeQueue is true when the PR is currently in the merge queue.
+	// Always false when populated via REST (GraphQL-only field).
+	IsInMergeQueue bool
+	// MergeQueueEntry holds the queue position and state when the PR is enqueued.
+	// Nil when not in queue or populated via REST. Pointer because GitHub returns
+	// null after dequeueing and Go's json decoder maps null to nil only on pointers.
+	MergeQueueEntry *MergeQueueEntry
 }
 
 // FetchPRMergeableFields fetches both the mergeable flag and mergeable_state for

--- a/github/prs_test.go
+++ b/github/prs_test.go
@@ -509,3 +509,87 @@ func TestReClosingKeyword_MixedCase(t *testing.T) {
 		t.Errorf("want [5], got %v", nums)
 	}
 }
+
+// makeTwoStepGraphQLServer creates an httptest server that handles two sequential
+// POST /graphql calls. The first call returns the PR node ID; the second call
+// invokes checkFn to verify the mutation variables and returns a success response.
+func makeTwoStepGraphQLServer(t *testing.T, prNodeID string, checkFn func(t *testing.T, vars map[string]interface{})) (*httptest.Server, *Client) {
+	t.Helper()
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" || r.Method != "POST" {
+			http.NotFound(w, r)
+			return
+		}
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		switch callCount {
+		case 1:
+			// First call: return the PR node ID
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"pullRequest": map[string]interface{}{
+							"id": prNodeID,
+						},
+					},
+				},
+			})
+		case 2:
+			// Second call: verify mutation variables and return success
+			vars := readVars(r)
+			checkFn(t, vars)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{},
+			})
+		default:
+			t.Errorf("unexpected call #%d to /graphql", callCount)
+			http.Error(w, "unexpected call", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(func() {
+		srv.Close()
+		if callCount != 2 {
+			t.Errorf("expected 2 GraphQL calls, got %d", callCount)
+		}
+	})
+	return srv, NewClientWithBaseURL("test-token", srv.URL)
+}
+
+func TestEnqueuePullRequest(t *testing.T) {
+	const prNodeID = "PR_testnode"
+	const expectedHeadOID = "deadbeef1234"
+
+	_, c := makeTwoStepGraphQLServer(t, prNodeID, func(t *testing.T, vars map[string]interface{}) {
+		t.Helper()
+		if got, ok := vars["prId"].(string); !ok || got != prNodeID {
+			t.Errorf("mutation vars[prId] = %v, want %q", vars["prId"], prNodeID)
+		}
+		if got, ok := vars["expectedHeadOid"].(string); !ok || got != expectedHeadOID {
+			t.Errorf("mutation vars[expectedHeadOid] = %v, want %q", vars["expectedHeadOid"], expectedHeadOID)
+		}
+	})
+
+	if err := c.EnqueuePullRequest("owner", "repo", 42, expectedHeadOID); err != nil {
+		t.Fatalf("EnqueuePullRequest: %v", err)
+	}
+}
+
+func TestDequeuePullRequest(t *testing.T) {
+	const prNodeID = "PR_testnode2"
+
+	_, c := makeTwoStepGraphQLServer(t, prNodeID, func(t *testing.T, vars map[string]interface{}) {
+		t.Helper()
+		if got, ok := vars["prId"].(string); !ok || got != prNodeID {
+			t.Errorf("mutation vars[prId] = %v, want %q", vars["prId"], prNodeID)
+		}
+		// DequeuePullRequest must NOT send expectedHeadOid.
+		if _, present := vars["expectedHeadOid"]; present {
+			t.Errorf("DequeuePullRequest sent unexpected expectedHeadOid: %v", vars["expectedHeadOid"])
+		}
+	})
+
+	if err := c.DequeuePullRequest("owner", "repo", 42); err != nil {
+		t.Fatalf("DequeuePullRequest: %v", err)
+	}
+}

--- a/github/types.go
+++ b/github/types.go
@@ -65,6 +65,14 @@ type PRReview struct {
 	DatabaseID int    // Numeric PR review ID (0 if not fetched or unavailable)
 }
 
+// MergeQueueEntry holds the merge-queue position and state for a pull request.
+// The pointer on ProjectItem and PRDetails is nil when no merge queue entry exists.
+type MergeQueueEntry struct {
+	State        string // e.g. "QUEUED", "AWAITING_CHECKS", "MERGEABLE", "UNMERGEABLE"
+	Position     int    // 1-indexed position in the queue; 0 when not yet positioned
+	EnqueuerLogin string // GitHub login of the user who enqueued the PR
+}
+
 // ProjectItem represents an issue or pull request card on the project board.
 type ProjectItem struct {
 	ID             string
@@ -100,6 +108,15 @@ type ProjectItem struct {
 	// LinkedPRResolvedThreadCount is the number of review threads on the linked PR
 	// that are currently resolved. Used by progress detection during turn extension.
 	LinkedPRResolvedThreadCount int
+
+	// LinkedPRIsMergeQueueEnabled is true when the repository has the merge queue
+	// feature enabled. Zero (false) when no queue exists or the field was not fetched.
+	LinkedPRIsMergeQueueEnabled bool
+	// LinkedPRIsInMergeQueue is true when the linked PR is currently in the merge queue.
+	LinkedPRIsInMergeQueue bool
+	// LinkedPRMergeQueueEntry holds the queue position and state when the PR is
+	// enqueued. Nil when the PR is not in the queue or mergeQueueEntry was null.
+	LinkedPRMergeQueueEntry *MergeQueueEntry
 }
 
 // Comment represents a comment on an issue or linked PR.

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -141,6 +141,15 @@ type LinkedPRState struct {
 	ResolvedThreadCount int
 	CheckRuns           []gh.CheckRun
 
+	// IsMergeQueueEnabled is true when the repository has the merge queue feature
+	// enabled. Populated from GraphQL via FetchItemDetails; zero until first deep fetch.
+	IsMergeQueueEnabled bool
+	// IsInMergeQueue is true when the PR is currently in the merge queue.
+	IsInMergeQueue bool
+	// MergeQueueEntry holds queue position and state when the PR is enqueued.
+	// Nil when not in queue; set to nil again after dequeueing.
+	MergeQueueEntry *gh.MergeQueueEntry
+
 	// HasHadChecks records whether this PR has ever had CI check runs reported.
 	// Replaces engine.prHasHadChecks[iKey].
 	HasHadChecks bool

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -860,7 +860,10 @@ func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 			!reflect.DeepEqual(lpr.Reviews, pi.LinkedPRReviews) ||
 			!reflect.DeepEqual(lpr.ReviewRequests, pi.LinkedPRReviewRequests) ||
 			!reflect.DeepEqual(lpr.ThreadComments, pi.LinkedPRReviewThreadComments) ||
-			lpr.ResolvedThreadCount != pi.LinkedPRResolvedThreadCount {
+			lpr.ResolvedThreadCount != pi.LinkedPRResolvedThreadCount ||
+			lpr.IsMergeQueueEnabled != pi.LinkedPRIsMergeQueueEnabled ||
+			lpr.IsInMergeQueue != pi.LinkedPRIsInMergeQueue ||
+			!reflect.DeepEqual(lpr.MergeQueueEntry, pi.LinkedPRMergeQueueEntry) {
 			if lpr.Number != pi.LinkedPRNumber {
 				lpr.Number = pi.LinkedPRNumber
 				flags |= LinkedPRChanged
@@ -879,6 +882,18 @@ func applyProjectItem(item *ItemState, pi gh.ProjectItem) ChangeFlags {
 			}
 			if lpr.ResolvedThreadCount != pi.LinkedPRResolvedThreadCount {
 				lpr.ResolvedThreadCount = pi.LinkedPRResolvedThreadCount
+				flags |= LinkedPRChanged
+			}
+			if lpr.IsMergeQueueEnabled != pi.LinkedPRIsMergeQueueEnabled {
+				lpr.IsMergeQueueEnabled = pi.LinkedPRIsMergeQueueEnabled
+				flags |= LinkedPRChanged
+			}
+			if lpr.IsInMergeQueue != pi.LinkedPRIsInMergeQueue {
+				lpr.IsInMergeQueue = pi.LinkedPRIsInMergeQueue
+				flags |= LinkedPRChanged
+			}
+			if !reflect.DeepEqual(lpr.MergeQueueEntry, pi.LinkedPRMergeQueueEntry) {
+				lpr.MergeQueueEntry = pi.LinkedPRMergeQueueEntry
 				flags |= LinkedPRChanged
 			}
 		}


### PR DESCRIPTION
Closes #938

## What this PR does

Adds the GitHub merge-queue data surface to Fabrik's GitHub client — the read-only GraphQL fields and two write mutations needed by ADR-058's enqueue-on-yolo integration (chain issues 2–5). Nothing reads or acts on these fields yet; this PR is purely additive.

## Key changes

**New type** (`github/types.go`):
- `MergeQueueEntry` struct (`State`, `Position`, `EnqueuerLogin`)

**`github/project.go`** — all three `closedByPullRequestsReferences` GraphQL blocks now request `isMergeQueueEnabled`, `isInMergeQueue`, and `mergeQueueEntry { state position enqueuer { login } }`. Deep-fetch and shallow-board parse structs are extended to deserialise and populate these fields; probe parse struct is intentionally left unchanged (probe discards PR state by design).

**`github/prs.go`**:
- `PRDetails` gains `IsMergeQueueEnabled bool`, `IsInMergeQueue bool`, `MergeQueueEntry *MergeQueueEntry`
- `EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error` — two-step fetch-node-ID → mutation, passes `expectedHeadOid` for optimistic concurrency
- `DequeuePullRequest(owner, repo string, prNumber int) error` — same two-step pattern, no `expectedHeadOid`

**Cache pipeline** (`internal/itemstate/itemstate.go`, `internal/itemstate/store.go`, `boardcache/boardcache.go`):
- `LinkedPRState` gains the three queue fields
- `applyProjectItem` syncs them from `ProjectItem` into `LinkedPRState`
- `CacheImpl.FetchLinkedPR` copies them into the returned `PRDetails`

**Interface & mocks** (`engine/interfaces.go`, `engine/mocks_test.go`, `cmd/cmd_extra_test.go`):
- `GitHubClient` gains `EnqueuePullRequest` and `DequeuePullRequest`
- All test mocks updated with fn fields, call-tracking slices, and method stubs

## Tests

- `TestFetchItemDetailsQueueFields` — three sub-cases: non-null entry populated, null entry yields nil pointer, no linked PR yields zero values
- `TestEnqueuePullRequest` / `TestDequeuePullRequest` — httptest two-call counter pattern verifying node-ID fetch → correct mutation variables (including `expectedHeadOid` present on enqueue, absent on dequeue)

## Zero-value guarantee

Every new field is zero/nil when no merge queue is configured. No existing behavior changes.