### PR TITLE
feat(merge-queue): add MergeQueue config, enqueue path in attemptMergeOnValidate

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ type Config struct {
 	MaxRebaseCycles      int    // 0 means use default (3)
 	ConvergenceBudget    string // Go duration string; "" means use default (30m); "0" means disabled
 	AutoMergeStrategy    string // MERGE, SQUASH, or REBASE; "" means use default (MERGE)
+	MergeQueue           string // auto or off; "" means use default (auto)
 	ClaudeWaitDelay      int    // seconds; 0 means use default (30)
 	PostPushDwell        int    // seconds; 0 means use default (90)
 	KillGraceSigInt      string // Go duration string; "" means use default (10s); "0s" skips SIGINT step
@@ -139,6 +140,7 @@ func Execute() error {
 	flag.IntVar(&cfg.MaxRebaseCycles, "max-rebase-cycles", 0, "Maximum number of rebase-reinvoke cycles per issue before pausing (0 = use default of 3; also FABRIK_MAX_REBASE_CYCLES)")
 	flag.StringVar(&cfg.ConvergenceBudget, "convergence-budget", "", "Wall-clock budget for post-Validate yolo convergence (Go duration: 30m, 1h; \"0\" disables; also FABRIK_CONVERGENCE_BUDGET)")
 	flag.StringVar(&cfg.AutoMergeStrategy, "auto-merge-strategy", "", "Merge method for GitHub auto-merge: MERGE, SQUASH, or REBASE (also FABRIK_AUTO_MERGE_STRATEGY; default MERGE)")
+	flag.StringVar(&cfg.MergeQueue, "merge-queue", "", "Merge queue routing for yolo path: auto (enqueue when repo uses merge queue) or off (skip enqueue; direct merge may fail on queue-required repos; also FABRIK_MERGE_QUEUE; default auto)")
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.IntVar(&cfg.PostPushDwell, "post-push-dwell", 0, "Seconds to wait after a PR force-push before clearing the CI gate as 'no CI configured' (0 = use default of 90; also FABRIK_POST_PUSH_DWELL)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
@@ -362,6 +364,11 @@ func Execute() error {
 	if !explicitFlags["auto-merge-strategy"] {
 		if v := os.Getenv("FABRIK_AUTO_MERGE_STRATEGY"); v != "" {
 			cfg.AutoMergeStrategy = v // validated in autoMergeStrategy() helper
+		}
+	}
+	if !explicitFlags["merge-queue"] {
+		if v := os.Getenv("FABRIK_MERGE_QUEUE"); v != "" {
+			cfg.MergeQueue = v // validated in mergeQueueMode() helper
 		}
 	}
 	if !explicitFlags["claude-wait-delay"] {
@@ -679,6 +686,7 @@ func Execute() error {
 		MaxRebaseCycles:          maxRebaseCycles(cfg.MaxRebaseCycles),
 		ConvergenceBudget:        convergenceBudget(cfg.ConvergenceBudget),
 		AutoMergeStrategy:        autoMergeStrategy(cfg.AutoMergeStrategy),
+		MergeQueue:               mergeQueueMode(cfg.MergeQueue),
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		KillGraceSigInt:          killGraceSigInt(cfg.KillGraceSigInt),
 		KillGraceSigTerm:         killGraceSigTerm(cfg.KillGraceSigTerm),
@@ -909,6 +917,23 @@ func autoMergeStrategy(s string) string {
 	default:
 		fmt.Fprintf(os.Stderr, "[warn] FABRIK_AUTO_MERGE_STRATEGY=%q is invalid (must be MERGE, SQUASH, or REBASE); using default MERGE\n", s)
 		return "MERGE"
+	}
+}
+
+// mergeQueueMode normalizes the --merge-queue / FABRIK_MERGE_QUEUE value.
+// Valid values are "auto" and "off" (case-insensitive). An empty string defaults to "auto".
+// Unrecognized values produce a warning and fall back to "auto".
+func mergeQueueMode(s string) string {
+	if s == "" {
+		return "auto"
+	}
+	lower := strings.ToLower(s)
+	switch lower {
+	case "auto", "off":
+		return lower
+	default:
+		fmt.Fprintf(os.Stderr, "[warn] FABRIK_MERGE_QUEUE=%q is invalid (must be auto or off); using default auto\n", s)
+		return "auto"
 	}
 }
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -587,6 +587,7 @@ FABRIK_USER=my-personal-username
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--convergence-budget` | Wall-clock budget for post-Validate yolo PR convergence (Go duration: `30m`, `1h`; `0` disables the budget entirely; also `FABRIK_CONVERGENCE_BUDGET`) | `30m` |
 | `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
+| `--merge-queue` | Merge queue routing for yolo path: `auto` (enqueue when repo requires merge queue) or `off` (disable enqueue; yolo merges may fail with HTTP 405 on queue-required repos). Also `FABRIK_MERGE_QUEUE` | `auto` |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--janitor-interval` | Hours between janitor runs (closed-issue cleanup, stale-label eviction); 0 disables the janitor; also `FABRIK_JANITOR_INTERVAL` | `1` |
 | `--log-retention-days` | Delete `.fabrik/logs/` files older than this many days; 0 disables age-based pruning; also `FABRIK_LOG_RETENTION_DAYS` | `14` |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -585,6 +585,7 @@ FABRIK_USER=my-personal-username
 | `--max-rebase-cycles` | Maximum number of rebase re-invocation cycles per issue before pausing (0 = use default of 3; also `FABRIK_MAX_REBASE_CYCLES`) | `0` (3 cycles) |
 | `--convergence-budget` | Wall-clock budget for post-Validate yolo PR convergence (Go duration: `30m`, `1h`; `0` disables the budget entirely; also `FABRIK_CONVERGENCE_BUDGET`) | `30m` |
 | `--auto-merge-strategy` | Merge method for GitHub native auto-merge on yolo PRs: `MERGE`, `SQUASH`, or `REBASE` (also `FABRIK_AUTO_MERGE_STRATEGY`) | `MERGE` |
+| `--merge-queue` | Merge queue routing for yolo path: `auto` (enqueue when repo requires merge queue) or `off` (disable enqueue; yolo merges may fail with HTTP 405 on queue-required repos). Also `FABRIK_MERGE_QUEUE` | `auto` |
 | `--claude-wait-delay` | Seconds to wait after Claude exits before recovering buffered output; prevents worker goroutines from blocking when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits (0 = use built-in default of 30 sec; also `FABRIK_CLAUDE_WAIT_DELAY`) | `0` (30 sec) |
 | `--janitor-interval` | Hours between janitor runs (closed-issue cleanup, stale-label eviction); 0 disables the janitor; also `FABRIK_JANITOR_INTERVAL` | `1` |
 | `--log-retention-days` | Delete `.fabrik/logs/` files older than this many days; 0 disables age-based pruning; also `FABRIK_LOG_RETENTION_DAYS` | `14` |

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -40,6 +40,7 @@ type Config struct {
 	MaxRebaseCycles          int           // Max rebase re-invocation cycles per issue before pausing (default 3)
 	ConvergenceBudget        time.Duration // Wall-clock budget for post-Validate yolo convergence (default 30m; 0 = disabled, waits indefinitely)
 	AutoMergeStrategy        string        // Merge method for enablePullRequestAutoMerge: MERGE, SQUASH, or REBASE (default MERGE)
+	MergeQueue               string        // Merge queue routing for yolo path: "auto" (enqueue when repo uses merge queue) or "off" (skip enqueue)
 	KillGraceSigInt          time.Duration // Grace window after SIGINT before SIGTERM (default 10s; 0 = skip SIGINT step)
 	KillGraceSigTerm         time.Duration // Grace window after SIGTERM before SIGKILL (default 10s)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -299,6 +299,14 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 	// User manually disabled auto-merge: pause the issue to prevent the next poll
 	// from re-enabling auto-merge via Phase 2 (yoloActive=true + no label → attemptMergeOnValidate).
 	if !pr.AutoMergeEnabled {
+		// EnqueuePullRequest does not set auto_merge on the PR, so AutoMergeEnabled
+		// is false even for PRs correctly waiting in the merge queue. settle.PR.IsInMergeQueue
+		// (populated from GraphQL via FetchProjectBoard → boardcache) is the authoritative
+		// signal: if the PR is in the queue, skip the pause and wait for the queue to merge.
+		if settle.PR != nil && settle.PR.IsInMergeQueue {
+			e.logf(item.Number, "auto-merge", "PR #%d is in merge queue — waiting for queue to merge\n", pr.Number)
+			return
+		}
 		e.logf(item.Number, "auto-merge", "PR #%d auto-merge disabled by user — pausing\n", pr.Number)
 		msg := fmt.Sprintf("🏭 **Fabrik — auto-merge disabled**\n\n" +
 			"Fabrik detected that GitHub auto-merge was disabled on the linked PR. " +

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -312,6 +312,41 @@ func TestCheckAutoMergeConvergence_UserDisabledAutoMerge_PostsCommentRemovesLabe
 	}
 }
 
+// TestCheckAutoMergeConvergence_IsInMergeQueue_NoPause verifies that when the PR is
+// actively in the merge queue (IsInMergeQueue=true in settle), checkAutoMergeConvergence
+// does not trigger the "user disabled auto-merge" pause even though AutoMergeEnabled
+// is false (EnqueuePullRequest does not set auto_merge on the PR).
+func TestCheckAutoMergeConvergence_IsInMergeQueue_NoPause(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			// AutoMergeEnabled=false because EnqueuePullRequest was used (not EnablePullRequestAutoMerge).
+			return &gh.PRDetails{Number: 10, State: "open", AutoMergeEnabled: false}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 42, Repo: "owner/repo", Labels: []string{"fabrik:auto-merge-enabled", "fabrik:yolo"}}
+	stage := &stages.Stage{Name: "Validate"}
+	// settle.PR.IsInMergeQueue=true indicates the PR is waiting in the merge queue.
+	settle := PRSettleResult{Status: PRMergeReady, PR: &gh.PRDetails{Number: 10, IsInMergeQueue: true}}
+
+	eng.checkAutoMergeConvergence(context.Background(), &gh.ProjectBoard{}, item, stage, settle)
+
+	// The pause path must NOT fire.
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" || c.labelName == "fabrik:awaiting-input" {
+			t.Errorf("expected no pause when IsInMergeQueue=true, but label %q was added", c.labelName)
+		}
+	}
+	if len(client.addCommentCalls) != 0 {
+		t.Errorf("expected no comment when IsInMergeQueue=true, got %d comment(s)", len(client.addCommentCalls))
+	}
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			t.Error("expected fabrik:auto-merge-enabled NOT to be removed when PR is in merge queue")
+		}
+	}
+}
+
 func TestCheckAutoMergeConvergence_BudgetExhausted_PausesIssue(t *testing.T) {
 	client := &mockGitHubClient{
 		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -264,6 +264,25 @@ func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, i
 		return false, nil
 	}
 
+	// Enqueue path: when the repo requires a merge queue and merge-queue routing is not disabled.
+	if e.cfg.MergeQueue != "off" && pr.IsMergeQueueEnabled {
+		if err := e.client.EnqueuePullRequest(owner, repo, pr.Number, pr.HeadSHA); err != nil {
+			return false, fmt.Errorf("enqueue PR #%d: %w", pr.Number, err)
+		}
+		if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
+			}
+		}
+		e.logf(item.Number, "info", "PR #%d enqueued into merge queue — awaiting GitHub merge\n", pr.Number)
+		return true, nil
+	}
+
 	strategy := e.cfg.AutoMergeStrategy
 	if strategy == "" {
 		strategy = "MERGE"

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -400,3 +400,128 @@ func TestAdvanceToNextStage_WritesThrough_Cache(t *testing.T) {
 		t.Errorf("cache Status = %q after advanceToNextStage, want %q", found.Status, "Plan")
 	}
 }
+
+// TestAttemptMergeOnValidate_EnqueueOnYoloWithQueueEnabled verifies that when
+// IsMergeQueueEnabled is true and MergeQueue != "off", EnqueuePullRequest is called,
+// MergePR is not called, fabrik:auto-merge-enabled is applied, and (true, nil) is returned.
+func TestAttemptMergeOnValidate_EnqueueOnYoloWithQueueEnabled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "abc123", IsMergeQueueEnabled: true}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected autoMergeEnabled=true, got false")
+	}
+	if len(client.enqueuePullRequestCalls) != 1 {
+		t.Fatalf("expected EnqueuePullRequest called once, got %d", len(client.enqueuePullRequestCalls))
+	}
+	if client.enqueuePullRequestCalls[0].prNumber != 10 {
+		t.Errorf("EnqueuePullRequest called with PR %d, want 10", client.enqueuePullRequestCalls[0].prNumber)
+	}
+	if client.enqueuePullRequestCalls[0].expectedHeadOID != "abc123" {
+		t.Errorf("EnqueuePullRequest called with head OID %q, want %q", client.enqueuePullRequestCalls[0].expectedHeadOID, "abc123")
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("MergePR must not be called in enqueue path, got %d call(s)", len(client.mergePRCalls))
+	}
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Errorf("EnablePullRequestAutoMerge must not be called in enqueue path, got %d call(s)", len(client.enablePullRequestAutoMergeCalls))
+	}
+	foundLabel := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			foundLabel = true
+		}
+	}
+	if !foundLabel {
+		t.Error("expected fabrik:auto-merge-enabled label to be applied")
+	}
+}
+
+// TestAttemptMergeOnValidate_NoEnqueueWhenQueueNotEnabled verifies that when
+// IsMergeQueueEnabled is false, the existing auto-merge path is taken (no enqueue call).
+func TestAttemptMergeOnValidate_NoEnqueueWhenQueueNotEnabled(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "sha1", IsMergeQueueEnabled: false}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected autoMergeEnabled=true via existing path")
+	}
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("EnqueuePullRequest must not be called when IsMergeQueueEnabled=false, got %d call(s)", len(client.enqueuePullRequestCalls))
+	}
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge called once (existing path), got %d", len(client.enablePullRequestAutoMergeCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_CruiseDoesNotEnqueue verifies that a cruise-labeled item
+// does not call EnqueuePullRequest or MergePR even when IsMergeQueueEnabled is true.
+func TestAttemptMergeOnValidate_CruiseDoesNotEnqueue(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "sha1", IsMergeQueueEnabled: true}, nil
+		},
+	}
+	eng := testEngineForMerge(t, client)
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error for cruise item: %v", err)
+	}
+	if enabled {
+		t.Error("expected autoMergeEnabled=false for cruise item")
+	}
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("EnqueuePullRequest must not be called for cruise items, got %d call(s)", len(client.enqueuePullRequestCalls))
+	}
+	if len(client.mergePRCalls) != 0 {
+		t.Errorf("MergePR must not be called for cruise items, got %d call(s)", len(client.mergePRCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_MergeQueueOffDoesNotEnqueue verifies that when
+// MergeQueue == "off", the existing auto-merge path is taken even if IsMergeQueueEnabled is true.
+func TestAttemptMergeOnValidate_MergeQueueOffDoesNotEnqueue(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "sha1", IsMergeQueueEnabled: true}, nil
+		},
+	}
+	stgs := testStagesWithValidate()
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MergeQueue = "off"
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), &gh.ProjectBoard{}, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected autoMergeEnabled=true via existing path when MergeQueue=off")
+	}
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("EnqueuePullRequest must not be called when MergeQueue=off, got %d call(s)", len(client.enqueuePullRequestCalls))
+	}
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge called once (existing path), got %d", len(client.enablePullRequestAutoMergeCalls))
+	}
+}


### PR DESCRIPTION
Closes #934

Implements ADR-058 D1+D2: auto-detect merge queue via `IsMergeQueueEnabled` and route yolo path through `EnqueuePullRequest` when the repo requires a merge queue.

## What this PR does

- Adds `MergeQueue string` field to `engine.Config` (`"auto"` or `"off"`; default `"auto"`)
- Adds `--merge-queue` CLI flag and `FABRIK_MERGE_QUEUE` env var in `cmd/root.go`, with a `mergeQueueMode()` normalizer helper
- In `attemptMergeOnValidate`: when `MergeQueue != "off"` and `pr.IsMergeQueueEnabled`, calls `EnqueuePullRequest(owner, repo, pr.Number, pr.HeadSHA)` instead of `EnablePullRequestAutoMerge`/`MergePR`; applies `fabrik:auto-merge-enabled` label with the same cache+webhook pattern as the existing auto-merge path
- Cruise and no-auto-advance paths are unaffected (cruise early-return fires before the enqueue branch)
- When `IsMergeQueueEnabled` is false, all existing behavior is byte-for-byte unchanged

## Tests

Four new unit tests in `engine/stages_test.go`:
- `TestAttemptMergeOnValidate_EnqueueOnYoloWithQueueEnabled` — enqueue path fires, MergePR not called, label applied
- `TestAttemptMergeOnValidate_NoEnqueueWhenQueueNotEnabled` — existing auto-merge path unchanged when queue not enabled
- `TestAttemptMergeOnValidate_CruiseDoesNotEnqueue` — cruise + queue-enabled → neither enqueue nor merge called
- `TestAttemptMergeOnValidate_MergeQueueOffDoesNotEnqueue` — `MergeQueue: "off"` → existing path taken even with queue enabled

## How to test

1. `go build ./...` and `go vet ./...` — both clean
2. `go test -race ./...` — all packages pass (pre-existing flaky `TestExecute_ConfigYAMLApplied` in `cmd/` is unrelated to this PR, fails on main too)
3. On a repo with merge queue required: set `yolo` and verify Fabrik enqueues the PR instead of calling direct merge
4. `fabrik --merge-queue off` to opt out of queue routing