### PR TITLE
feat(merge-train): Queued board status + stage skeleton [ADR-059]

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ type Config struct {
 	ConvergenceBudget    string // Go duration string; "" means use default (30m); "0" means disabled
 	AutoMergeStrategy    string // MERGE, SQUASH, or REBASE; "" means use default (MERGE)
 	MergeQueue           string // auto or off; "" means use default (auto)
+	MergeTrain           string // on or off; "" means use default (off)
 	ClaudeWaitDelay      int    // seconds; 0 means use default (30)
 	PostPushDwell        int    // seconds; 0 means use default (90)
 	KillGraceSigInt      string // Go duration string; "" means use default (10s); "0s" skips SIGINT step
@@ -143,6 +144,7 @@ func Execute() error {
 	flag.StringVar(&cfg.ConvergenceBudget, "convergence-budget", "", "Wall-clock budget for post-Validate yolo convergence (Go duration: 30m, 1h; \"0\" disables; also FABRIK_CONVERGENCE_BUDGET)")
 	flag.StringVar(&cfg.AutoMergeStrategy, "auto-merge-strategy", "", "Merge method for GitHub auto-merge: MERGE, SQUASH, or REBASE (also FABRIK_AUTO_MERGE_STRATEGY; default MERGE)")
 	flag.StringVar(&cfg.MergeQueue, "merge-queue", "", "Merge queue routing for yolo path: auto (enqueue when repo uses merge queue) or off (skip enqueue; direct merge may fail on queue-required repos; also FABRIK_MERGE_QUEUE; default auto)")
+	flag.StringVar(&cfg.MergeTrain, "merge-train", "", "Fabrik-internal merge train: on (advance yolo Validate completions to Queued column for batched landing) or off (also FABRIK_MERGE_TRAIN; default off)")
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.IntVar(&cfg.PostPushDwell, "post-push-dwell", 0, "Seconds to wait after a PR force-push before clearing the CI gate as 'no CI configured' (0 = use default of 90; also FABRIK_POST_PUSH_DWELL)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
@@ -380,6 +382,11 @@ func Execute() error {
 	if !explicitFlags["merge-queue"] {
 		if v := os.Getenv("FABRIK_MERGE_QUEUE"); v != "" {
 			cfg.MergeQueue = v // validated in mergeQueueMode() helper
+		}
+	}
+	if !explicitFlags["merge-train"] {
+		if v := os.Getenv("FABRIK_MERGE_TRAIN"); v != "" {
+			cfg.MergeTrain = v // validated in mergeTrainMode() helper
 		}
 	}
 	if !explicitFlags["claude-wait-delay"] {
@@ -699,6 +706,7 @@ func Execute() error {
 		ConvergenceBudget:        convergenceBudget(cfg.ConvergenceBudget),
 		AutoMergeStrategy:        autoMergeStrategy(cfg.AutoMergeStrategy),
 		MergeQueue:               mergeQueueMode(cfg.MergeQueue),
+		MergeTrain:               mergeTrainMode(cfg.MergeTrain),
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		KillGraceSigInt:          killGraceSigInt(cfg.KillGraceSigInt),
 		KillGraceSigTerm:         killGraceSigTerm(cfg.KillGraceSigTerm),
@@ -956,6 +964,23 @@ func mergeQueueMode(s string) string {
 	default:
 		fmt.Fprintf(os.Stderr, "[warn] FABRIK_MERGE_QUEUE=%q is invalid (must be auto or off); using default auto\n", s)
 		return "auto"
+	}
+}
+
+// mergeTrainMode normalizes the --merge-train / FABRIK_MERGE_TRAIN value.
+// Valid values are "on" and "off" (case-insensitive). An empty string defaults to "off".
+// Unrecognized values produce a warning and fall back to "off".
+func mergeTrainMode(s string) string {
+	if s == "" {
+		return "off"
+	}
+	lower := strings.ToLower(s)
+	switch lower {
+	case "on", "off":
+		return lower
+	default:
+		fmt.Fprintf(os.Stderr, "[warn] FABRIK_MERGE_TRAIN=%q is invalid (must be on or off); using default off\n", s)
+		return "off"
 	}
 }
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2616,7 +2616,7 @@ This document is the formal specification of Fabrik's issue-level state machine:
 Issues traverse a linear pipeline of stages, each corresponding to a column on the GitHub Project board:
 
 ```
-Specify → Research → Plan → Implement → Review → Validate → Done
+Specify → Research → Plan → Implement → Review → Validate → [Queued†] → Done
 ```
 
 | Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | WaitForReviews | CleanupWorktree |
@@ -2627,9 +2627,12 @@ Specify → Research → Plan → Implement → Review → Validate → Done
 | Implement | 3 | No | Yes | Yes | Yes | No | No |
 | Review | 4 | No | Yes | No | Yes | Yes* | No |
 | Validate | 5 | No | Yes | No | No | Yes* | No |
+| Queued† | 6 | — | — | — | — | — | — |
 | Done | 99 | N/A | No | No | No | No | Yes |
 
 \* All flags in this table reflect the **default stage configuration** shipped in `.fabrik/stages/`. Each flag is opt-in per stage YAML and may differ in custom configurations. `wait_for_reviews` is enabled for Review and Validate in the defaults.
+
+† **Queued** is a *holding stage* (`holding_stage: true`) active only when `merge_train: on`. Items enter Queued when `attemptMergeOnValidate` routes to `advanceToQueued` instead of GitHub auto-merge. Per-item dispatch is suppressed (`itemMayNeedWork` / `itemNeedsWork` return false for holding stages); the batch handler `handleMergeTrainBatch` snapshots all Queued items once per poll cycle (D1 skeleton — no landing logic yet). The Queued column must exist on the GitHub Project board when `merge_train: on`; it is validated at startup.
 
 ---
 
@@ -2707,6 +2710,16 @@ Each active stage column has the same set of reachable sub-states:
 | **Pending Cleanup** | (none) | Worktree exists; engine will remove it |
 | **Complete** | `stage:Done:complete` | Worktree removed; terminal state |
 | **Paused** | `fabrik:paused` | Manually paused; cleanup skipped |
+
+#### Queued (Holding Stage — `merge_train: on` only)
+
+> This stage is a no-op for per-item dispatch. It exists solely as a batching rendezvous point for the merge train.
+
+| Sub-State | Labels Present | Description |
+|-----------|---------------|-------------|
+| **Waiting** | `stage:Validate:complete` | Item moved to Queued column; `advanceToQueued` added `stage:Validate:complete` atomically. Awaiting `handleMergeTrainBatch` to form a landing batch (D2–D5, not yet implemented). |
+
+`itemMayNeedWork` and `itemNeedsWork` both return `false` for any stage with `holding_stage: true`, so these items are never dispatched to a per-item worker. `processItem` also short-circuits on `stage.HoldingStage` as a defense-in-depth guard. The catch-up loop skips holding stages for the same reason.
 
 ### 1.4 Label Semantics Reference
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -33,7 +33,7 @@ This document is the formal specification of Fabrik's issue-level state machine:
 Issues traverse a linear pipeline of stages, each corresponding to a column on the GitHub Project board:
 
 ```
-Specify → Research → Plan → Implement → Review → Validate → Done
+Specify → Research → Plan → Implement → Review → Validate → [Queued†] → Done
 ```
 
 | Stage | Order | Read-Only | PostToPR | CreateDraftPR | MarkPRReady | WaitForReviews | CleanupWorktree |
@@ -44,9 +44,12 @@ Specify → Research → Plan → Implement → Review → Validate → Done
 | Implement | 3 | No | Yes | Yes | Yes | No | No |
 | Review | 4 | No | Yes | No | Yes | Yes* | No |
 | Validate | 5 | No | Yes | No | No | Yes* | No |
+| Queued† | 6 | — | — | — | — | — | — |
 | Done | 99 | N/A | No | No | No | No | Yes |
 
 \* All flags in this table reflect the **default stage configuration** shipped in `.fabrik/stages/`. Each flag is opt-in per stage YAML and may differ in custom configurations. `wait_for_reviews` is enabled for Review and Validate in the defaults.
+
+† **Queued** is a *holding stage* (`holding_stage: true`) active only when `merge_train: on`. Items enter Queued when `attemptMergeOnValidate` routes to `advanceToQueued` instead of GitHub auto-merge. Per-item dispatch is suppressed (`itemMayNeedWork` / `itemNeedsWork` return false for holding stages); the batch handler `handleMergeTrainBatch` snapshots all Queued items once per poll cycle (D1 skeleton — no landing logic yet). The Queued column must exist on the GitHub Project board when `merge_train: on`; it is validated at startup.
 
 ---
 
@@ -124,6 +127,16 @@ Each active stage column has the same set of reachable sub-states:
 | **Pending Cleanup** | (none) | Worktree exists; engine will remove it |
 | **Complete** | `stage:Done:complete` | Worktree removed; terminal state |
 | **Paused** | `fabrik:paused` | Manually paused; cleanup skipped |
+
+#### Queued (Holding Stage — `merge_train: on` only)
+
+> This stage is a no-op for per-item dispatch. It exists solely as a batching rendezvous point for the merge train.
+
+| Sub-State | Labels Present | Description |
+|-----------|---------------|-------------|
+| **Waiting** | `stage:Validate:complete` | Item moved to Queued column; `advanceToQueued` added `stage:Validate:complete` atomically. Awaiting `handleMergeTrainBatch` to form a landing batch (D2–D5, not yet implemented). |
+
+`itemMayNeedWork` and `itemNeedsWork` both return `false` for any stage with `holding_stage: true`, so these items are never dispatched to a per-item worker. `processItem` also short-circuits on `stage.HoldingStage` as a defense-in-depth guard. The catch-up loop skips holding stages for the same reason.
 
 ### 1.4 Label Semantics Reference
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -42,6 +42,7 @@ type Config struct {
 	ConvergenceBudget        time.Duration // Wall-clock budget for post-Validate yolo convergence (default 30m; 0 = disabled, waits indefinitely)
 	AutoMergeStrategy        string        // Merge method for enablePullRequestAutoMerge: MERGE, SQUASH, or REBASE (default MERGE)
 	MergeQueue               string        // Merge queue routing for yolo path: "auto" (enqueue when repo uses merge queue) or "off" (skip enqueue)
+	MergeTrain               string        // Fabrik-internal merge train: "on" (advance yolo Validate completions to Queued) or "off" (default; existing auto-merge path unchanged)
 	KillGraceSigInt          time.Duration // Grace window after SIGINT before SIGTERM (default 10s; 0 = skip SIGINT step)
 	KillGraceSigTerm         time.Duration // Grace window after SIGTERM before SIGKILL (default 10s)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)

--- a/engine/item.go
+++ b/engine/item.go
@@ -124,6 +124,12 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 		return false
 	}
 
+	// Holding stages are batch-scoped (handled by handleMergeTrainBatch in poll.go),
+	// not per-item. Never dispatch individual items at a holding stage.
+	if stage.HoldingStage {
+		return false
+	}
+
 	// Cleanup stages bypass the updatedAt cache — their trigger is worktree
 	// existence (a local filesystem check), not issue/PR changes. Board column
 	// moves (Validate→Done by a human) don't always bump updatedAt, so cleanup
@@ -182,6 +188,11 @@ func (e *Engine) itemNeedsWork(item gh.ProjectItem) bool {
 	}
 
 	if stage == nil {
+		return false
+	}
+
+	// Holding stages are batch-scoped; never dispatch individual items.
+	if stage.HoldingStage {
 		return false
 	}
 
@@ -395,6 +406,12 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			Reason: "dep-blocked",
 			Until:  time.Now().Add(cooldown),
 		})
+		return nil
+	}
+
+	// Holding stage: batch-managed by handleMergeTrainBatch in poll.go, never per-item.
+	// itemMayNeedWork/itemNeedsWork should have filtered these out; this is a safety net.
+	if stage.HoldingStage {
 		return nil
 	}
 

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -278,6 +278,14 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 
+	// Merge-train warning: this item carries fabrik:auto-merge-enabled but merge_train: on
+	// is now active. The item entered auto-merge convergence before merge_train was enabled.
+	// Let convergence complete rather than interrupting mid-flight PR state. New items will
+	// route through advanceToQueued instead (ADR-059 D6 resolves this interaction properly).
+	if e.cfg.MergeTrain == "on" {
+		e.logf(item.Number, "warn", "merge_train: on but item is in auto-merge convergence path (fabrik:auto-merge-enabled present from before merge_train was enabled); letting convergence complete\n")
+	}
+
 	// Use e.client (direct GitHub API) rather than e.readClient (boardcache) so
 	// that pr.AutoMergeEnabled reflects the live GitHub state. The boardcache
 	// LinkedPRState does not persist AutoMergeEnabled; a cache hit would return

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1627,13 +1627,17 @@ doneDispatching:
 	}, nil
 }
 
-// handleMergeTrainBatch snapshots all items currently in the Queued column and
+// handleMergeTrainBatch snapshots all items currently in the holding stage column and
 // logs the batch that the merge train would form on this poll cycle. This is the
 // ADR-059 D1 skeleton — no trial branch, no landing logic yet (D2–D5 follow).
 func (e *Engine) handleMergeTrainBatch(_ context.Context, board *gh.ProjectBoard) {
+	hs := holdingStage(e.cfg)
+	if hs == nil {
+		return
+	}
 	var batch []gh.ProjectItem
 	for _, item := range board.Items {
-		if item.Status == "Queued" {
+		if item.Status == hs.Name {
 			batch = append(batch, item)
 		}
 	}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1551,6 +1551,12 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	}
 doneDispatching:
 
+	// Merge-train batch snapshot: log all items currently in the Queued column.
+	// Runs every poll cycle when merge_train: on. No dispatch, no mutation — D1 skeleton only.
+	if e.cfg.MergeTrain == "on" {
+		e.handleMergeTrainBatch(ctx, board)
+	}
+
 	// Remove stale fabrik:locked labels from closed issues. This handles the case
 	// where an issue was closed while a stage was in-flight, leaving the lock label
 	// behind. We do this every poll so it also catches locks from prior Fabrik runs.
@@ -1619,6 +1625,26 @@ doneDispatching:
 		Dispatched: dispatched,
 		SeenRepos:  seenRepos,
 	}, nil
+}
+
+// handleMergeTrainBatch snapshots all items currently in the Queued column and
+// logs the batch that the merge train would form on this poll cycle. This is the
+// ADR-059 D1 skeleton — no trial branch, no landing logic yet (D2–D5 follow).
+func (e *Engine) handleMergeTrainBatch(_ context.Context, board *gh.ProjectBoard) {
+	var batch []gh.ProjectItem
+	for _, item := range board.Items {
+		if item.Status == "Queued" {
+			batch = append(batch, item)
+		}
+	}
+	if len(batch) == 0 {
+		return
+	}
+	var parts []string
+	for _, item := range batch {
+		parts = append(parts, fmt.Sprintf("#%d %q", item.Number, item.Title))
+	}
+	e.logf(0, "merge-train", "batch snapshot: %d item(s) — %s\n", len(batch), strings.Join(parts, ", "))
 }
 
 func gitRevParse(dir, ref string) (string, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1265,7 +1265,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			continue
 		}
 		stage := stages.FindStage(e.cfg.Stages, item.Status)
-		if stage == nil || stage.CleanupWorktree {
+		if stage == nil || stage.CleanupWorktree || stage.HoldingStage {
 			continue
 		}
 		completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3328,8 +3328,11 @@ func TestCIAndReviewGate_JointClearingHandoff(t *testing.T) {
 }
 
 func TestHandleMergeTrainBatch_LogsQueuedItems(t *testing.T) {
+	// Use a holding stage named "BatchHold" (not "Queued") to verify that
+	// handleMergeTrainBatch is driven by the HoldingStage field, not a hardcoded name.
 	client := &mockGitHubClient{}
-	eng := testEngine(t, client, &mockClaudeInvoker{})
+	stgs := testStagesWithValidateAndHolding()
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MergeTrain = "on"
 
 	events := make(chan tui.Event, 10)
@@ -3338,9 +3341,9 @@ func TestHandleMergeTrainBatch_LogsQueuedItems(t *testing.T) {
 	board := &gh.ProjectBoard{
 		ProjectID: "PVT_1",
 		Items: []gh.ProjectItem{
-			{Number: 42, Title: "fix the bug",    Status: "Queued"},
+			{Number: 42, Title: "fix the bug",    Status: "BatchHold"},
 			{Number: 43, Title: "add the feature", Status: "Implement"},
-			{Number: 44, Title: "another ready",   Status: "Queued"},
+			{Number: 44, Title: "another ready",   Status: "BatchHold"},
 		},
 	}
 
@@ -3362,10 +3365,10 @@ func TestHandleMergeTrainBatch_LogsQueuedItems(t *testing.T) {
 		t.Errorf("expected 'batch snapshot: 2 item(s)' in log message, got: %q", msg)
 	}
 	if !strings.Contains(msg, "#42") || !strings.Contains(msg, "#44") {
-		t.Errorf("expected both queued issue numbers in log message, got: %q", msg)
+		t.Errorf("expected both holding-stage issue numbers in log message, got: %q", msg)
 	}
 	if strings.Contains(msg, "#43") {
-		t.Errorf("non-Queued item #43 must not appear in batch snapshot, got: %q", msg)
+		t.Errorf("non-holding-stage item #43 must not appear in batch snapshot, got: %q", msg)
 	}
 	if logged[0].Tag != "merge-train" {
 		t.Errorf("expected tag 'merge-train', got %q", logged[0].Tag)
@@ -3373,8 +3376,11 @@ func TestHandleMergeTrainBatch_LogsQueuedItems(t *testing.T) {
 }
 
 func TestHandleMergeTrainBatch_SilentWhenEmpty(t *testing.T) {
+	// Use a holding stage so the engine has a configured holding column; none of the
+	// board items have that status — the batch snapshot must be silent.
 	client := &mockGitHubClient{}
-	eng := testEngine(t, client, &mockClaudeInvoker{})
+	stgs := testStagesWithValidateAndHolding()
+	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MergeTrain = "on"
 
 	events := make(chan tui.Event, 10)
@@ -3391,6 +3397,6 @@ func TestHandleMergeTrainBatch_SilentWhenEmpty(t *testing.T) {
 	eng.handleMergeTrainBatch(context.Background(), board)
 
 	if len(events) != 0 {
-		t.Errorf("expected no log events when Queued column is empty, got %d", len(events))
+		t.Errorf("expected no log events when holding stage column is empty, got %d", len(events))
 	}
 }

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3326,3 +3326,71 @@ func TestCIAndReviewGate_JointClearingHandoff(t *testing.T) {
 		t.Error("poll 2: expected handleReviewGate to add fabrik:awaiting-review for outstanding reviewer after CI clears")
 	}
 }
+
+func TestHandleMergeTrainBatch_LogsQueuedItems(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.cfg.MergeTrain = "on"
+
+	events := make(chan tui.Event, 10)
+	eng.events = events
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 42, Title: "fix the bug",    Status: "Queued"},
+			{Number: 43, Title: "add the feature", Status: "Implement"},
+			{Number: 44, Title: "another ready",   Status: "Queued"},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	var logged []tui.LogEvent
+	for len(events) > 0 {
+		ev := <-events
+		if le, ok := ev.(tui.LogEvent); ok {
+			logged = append(logged, le)
+		}
+	}
+
+	if len(logged) == 0 {
+		t.Fatal("expected at least one log event from handleMergeTrainBatch, got none")
+	}
+	msg := logged[0].Message
+	if !strings.Contains(msg, "batch snapshot: 2 item(s)") {
+		t.Errorf("expected 'batch snapshot: 2 item(s)' in log message, got: %q", msg)
+	}
+	if !strings.Contains(msg, "#42") || !strings.Contains(msg, "#44") {
+		t.Errorf("expected both queued issue numbers in log message, got: %q", msg)
+	}
+	if strings.Contains(msg, "#43") {
+		t.Errorf("non-Queued item #43 must not appear in batch snapshot, got: %q", msg)
+	}
+	if logged[0].Tag != "merge-train" {
+		t.Errorf("expected tag 'merge-train', got %q", logged[0].Tag)
+	}
+}
+
+func TestHandleMergeTrainBatch_SilentWhenEmpty(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.cfg.MergeTrain = "on"
+
+	events := make(chan tui.Event, 10)
+	eng.events = events
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 10, Title: "in progress", Status: "Implement"},
+			{Number: 11, Title: "reviewing",   Status: "Review"},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	if len(events) != 0 {
+		t.Errorf("expected no log events when Queued column is empty, got %d", len(events))
+	}
+}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -475,26 +475,40 @@ func (e *Engine) handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 	}
 }
 
-// advanceToQueued moves an item from Validate to the Queued holding column when
-// merge_train: on. It sets the board status to Queued and adds stage:Validate:complete
+// holdingStage returns the first stage in cfg with HoldingStage: true, or nil if none.
+func holdingStage(cfg Config) *stages.Stage {
+	for _, s := range cfg.Stages {
+		if s.HoldingStage {
+			return s
+		}
+	}
+	return nil
+}
+
+// advanceToQueued moves an item from Validate to the configured holding stage column
+// when merge_train: on. It sets the board status and adds stage:Validate:complete
 // so the Phase 2 catch-up loop does not re-dispatch Validate on the next poll.
 func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item gh.ProjectItem, owner, repo string) error {
+	hs := holdingStage(e.cfg)
+	if hs == nil {
+		return fmt.Errorf("merge_train: on but no holding stage (HoldingStage: true) configured in stages")
+	}
 	if e.statusField == nil {
-		return fmt.Errorf("status field metadata not available; cannot advance to Queued")
+		return fmt.Errorf("status field metadata not available; cannot advance to %s", hs.Name)
 	}
 
-	optionID, ok := e.statusField.Options["Queued"]
+	optionID, ok := e.statusField.Options[hs.Name]
 	if !ok {
-		return fmt.Errorf("no status option %q found on project board (available: %v); is the Queued column missing?",
-			"Queued", mapKeys(e.statusField.Options))
+		return fmt.Errorf("no status option %q found on project board (available: %v); is the %s column missing?",
+			hs.Name, mapKeys(e.statusField.Options), hs.Name)
 	}
 
-	e.logf(item.Number, "merge-train", "advancing to Queued for merge train batching\n")
+	e.logf(item.Number, "merge-train", "advancing to %s for merge train batching\n", hs.Name)
 	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
-		return fmt.Errorf("move to Queued: %w", err)
+		return fmt.Errorf("move to %s: %w", hs.Name, err)
 	}
 	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
-		cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Queued")
+		cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), hs.Name)
 	}
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
@@ -503,7 +517,7 @@ func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item
 	// Add stage:Validate:complete so the Phase 2 catch-up loop does not re-dispatch Validate.
 	completeLabel := "stage:Validate:complete"
 	if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); lerr != nil {
-		e.logf(item.Number, "warn", "advanced to Queued but could not add %s label: %v — will retry on next poll\n", completeLabel, lerr)
+		e.logf(item.Number, "warn", "advanced to %s but could not add %s label: %v — will retry on next poll\n", hs.Name, completeLabel, lerr)
 		return fmt.Errorf("add %s label: %w", completeLabel, lerr)
 	}
 	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
@@ -513,7 +527,7 @@ func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item
 		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
 	}
 
-	e.logf(item.Number, "merge-train", "queued for merge train — waiting for batch\n")
+	e.logf(item.Number, "merge-train", "holding in %s — waiting for batch\n", hs.Name)
 	return nil
 }
 

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -240,7 +240,7 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 // when no action is needed (cruise label, no linked PR), and (false, err) on
 // failure. The fabrik:auto-merge-enabled label serves as both the idempotency
 // guard and the budget-start anchor read by checkAutoMergeConvergence.
-func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, item gh.ProjectItem, _ *stages.Stage) (bool, error) {
+func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, _ *stages.Stage) (bool, error) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
 	// cruise > yolo: when cruise is present, auto-merge is suppressed regardless of yolo.
@@ -252,6 +252,13 @@ func (e *Engine) attemptMergeOnValidate(_ context.Context, _ *gh.ProjectBoard, i
 	// Idempotency: auto-merge was already enabled on a prior run.
 	if hasLabel(item, "fabrik:auto-merge-enabled") {
 		return true, nil
+	}
+
+	// Merge-train gate: when merge_train: on, advance to Queued instead of enabling auto-merge.
+	// Cruise items always bypass this (handled above). New items never reach fabrik:auto-merge-enabled
+	// when merge_train: on, so this gate fires exactly once per qualifying Validate completion.
+	if e.cfg.MergeTrain == "on" {
+		return false, e.advanceToQueued(ctx, board, item, owner, repo)
 	}
 
 	pr, err := e.readClient.FetchLinkedPR(owner, repo, item.Number)
@@ -466,6 +473,48 @@ func (e *Engine) handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 			e.logf(item.Number, "done", "closed issue (no work needed)\n")
 		}
 	}
+}
+
+// advanceToQueued moves an item from Validate to the Queued holding column when
+// merge_train: on. It sets the board status to Queued and adds stage:Validate:complete
+// so the Phase 2 catch-up loop does not re-dispatch Validate on the next poll.
+func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item gh.ProjectItem, owner, repo string) error {
+	if e.statusField == nil {
+		return fmt.Errorf("status field metadata not available; cannot advance to Queued")
+	}
+
+	optionID, ok := e.statusField.Options["Queued"]
+	if !ok {
+		return fmt.Errorf("no status option %q found on project board (available: %v); is the Queued column missing?",
+			"Queued", mapKeys(e.statusField.Options))
+	}
+
+	e.logf(item.Number, "merge-train", "advancing to Queued for merge train batching\n")
+	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
+		return fmt.Errorf("move to Queued: %w", err)
+	}
+	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
+		cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Queued")
+	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
+	}
+
+	// Add stage:Validate:complete so the Phase 2 catch-up loop does not re-dispatch Validate.
+	completeLabel := "stage:Validate:complete"
+	if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); lerr != nil {
+		e.logf(item.Number, "warn", "advanced to Queued but could not add %s label: %v — will retry on next poll\n", completeLabel, lerr)
+		return fmt.Errorf("add %s label: %w", completeLabel, lerr)
+	}
+	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
+		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+	}
+	if e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
+	}
+
+	e.logf(item.Number, "merge-train", "queued for merge train — waiting for batch\n")
+	return nil
 }
 
 func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem, currentStage *stages.Stage) error {

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -525,3 +525,124 @@ func TestAttemptMergeOnValidate_MergeQueueOffDoesNotEnqueue(t *testing.T) {
 		t.Fatalf("expected EnablePullRequestAutoMerge called once (existing path), got %d", len(client.enablePullRequestAutoMergeCalls))
 	}
 }
+
+// testStagesWithValidateAndQueued returns stages including Validate and Queued,
+// for merge-train advancement tests.
+func testStagesWithValidateAndQueued() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Research", Order: 1, Prompt: "research"},
+		{Name: "Plan", Order: 2, Prompt: "plan"},
+		{Name: "Implement", Order: 3, Prompt: "implement"},
+		{Name: "Validate", Order: 4, Prompt: "validate"},
+		{Name: "Queued", Order: 6, HoldingStage: true},
+		{Name: "Done", Order: 99, CleanupWorktree: true},
+	}
+}
+
+// TestAttemptMergeOnValidate_MergeTrainOn_AdvancesToQueued verifies that when
+// merge_train: on, a yolo Validate completion advances the item to Queued,
+// adds stage:Validate:complete, and does NOT call auto-merge or enqueue.
+func TestAttemptMergeOnValidate_MergeTrainOn_AdvancesToQueued(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := testStagesWithValidateAndQueued()
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MergeTrain = "on"
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Repo: "owner/repo"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), board, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected enabled=false when advancing to Queued (not auto-merge path)")
+	}
+
+	// Must have called UpdateProjectItemStatus with the Queued option ID.
+	if len(client.updateStatusCalls) != 1 {
+		t.Fatalf("expected 1 UpdateProjectItemStatus call, got %d", len(client.updateStatusCalls))
+	}
+	if client.updateStatusCalls[0].optionID != "OPT_Queued" {
+		t.Errorf("UpdateProjectItemStatus called with option %q, want %q",
+			client.updateStatusCalls[0].optionID, "OPT_Queued")
+	}
+
+	// Must have added stage:Validate:complete.
+	var foundCompleteLabel bool
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Validate:complete" {
+			foundCompleteLabel = true
+		}
+	}
+	if !foundCompleteLabel {
+		t.Error("expected stage:Validate:complete label to be added")
+	}
+
+	// Must NOT have enabled auto-merge or enqueued.
+	if len(client.enablePullRequestAutoMergeCalls) != 0 {
+		t.Errorf("EnablePullRequestAutoMerge must not be called when merge_train: on, got %d call(s)",
+			len(client.enablePullRequestAutoMergeCalls))
+	}
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("EnqueuePullRequest must not be called when merge_train: on, got %d call(s)",
+			len(client.enqueuePullRequestCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_MergeTrainOff_UsesExistingPath verifies that when
+// merge_train: off (default), the existing auto-merge path runs unchanged.
+func TestAttemptMergeOnValidate_MergeTrainOff_UsesExistingPath(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
+		},
+	}
+	stgs := testStagesWithValidateAndQueued()
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MergeTrain = "off"
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1"}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), board, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected enabled=true via existing auto-merge path when merge_train: off")
+	}
+
+	// Must NOT have moved the item to Queued.
+	for _, c := range client.updateStatusCalls {
+		if c.optionID == "OPT_Queued" {
+			t.Errorf("UpdateProjectItemStatus must not target Queued when merge_train: off")
+		}
+	}
+
+	// Must have used the existing auto-merge path.
+	if len(client.enablePullRequestAutoMergeCalls) != 1 {
+		t.Fatalf("expected EnablePullRequestAutoMerge called once (existing path), got %d",
+			len(client.enablePullRequestAutoMergeCalls))
+	}
+}
+
+// TestAttemptMergeOnValidate_MergeTrainOn_CruiseBypasses verifies that cruise
+// items are unaffected when merge_train: on — cruise early-return fires first.
+func TestAttemptMergeOnValidate_MergeTrainOn_CruiseBypasses(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := testStagesWithValidateAndQueued()
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MergeTrain = "on"
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 1, ItemID: "PVTI_1", Labels: []string{"fabrik:cruise"}}
+
+	enabled, err := eng.attemptMergeOnValidate(context.Background(), board, item, &stages.Stage{Name: "Validate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled {
+		t.Fatal("expected enabled=false for cruise item")
+	}
+	if len(client.updateStatusCalls) != 0 {
+		t.Errorf("cruise item must not be advanced to Queued, got %d status update(s)", len(client.updateStatusCalls))
+	}
+}

--- a/engine/stages_test.go
+++ b/engine/stages_test.go
@@ -526,25 +526,26 @@ func TestAttemptMergeOnValidate_MergeQueueOffDoesNotEnqueue(t *testing.T) {
 	}
 }
 
-// testStagesWithValidateAndQueued returns stages including Validate and Queued,
-// for merge-train advancement tests.
-func testStagesWithValidateAndQueued() []*stages.Stage {
+// testStagesWithValidateAndHolding returns stages including Validate and a holding
+// stage named "BatchHold" (deliberately not "Queued") to verify behavior is driven
+// by the HoldingStage field, not the column name.
+func testStagesWithValidateAndHolding() []*stages.Stage {
 	return []*stages.Stage{
 		{Name: "Research", Order: 1, Prompt: "research"},
 		{Name: "Plan", Order: 2, Prompt: "plan"},
 		{Name: "Implement", Order: 3, Prompt: "implement"},
 		{Name: "Validate", Order: 4, Prompt: "validate"},
-		{Name: "Queued", Order: 6, HoldingStage: true},
+		{Name: "BatchHold", Order: 6, HoldingStage: true},
 		{Name: "Done", Order: 99, CleanupWorktree: true},
 	}
 }
 
 // TestAttemptMergeOnValidate_MergeTrainOn_AdvancesToQueued verifies that when
-// merge_train: on, a yolo Validate completion advances the item to Queued,
+// merge_train: on, a yolo Validate completion advances the item to the holding stage,
 // adds stage:Validate:complete, and does NOT call auto-merge or enqueue.
 func TestAttemptMergeOnValidate_MergeTrainOn_AdvancesToQueued(t *testing.T) {
 	client := &mockGitHubClient{}
-	stgs := testStagesWithValidateAndQueued()
+	stgs := testStagesWithValidateAndHolding()
 	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MergeTrain = "on"
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -555,16 +556,18 @@ func TestAttemptMergeOnValidate_MergeTrainOn_AdvancesToQueued(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if enabled {
-		t.Fatal("expected enabled=false when advancing to Queued (not auto-merge path)")
+		t.Fatal("expected enabled=false when advancing to holding stage (not auto-merge path)")
 	}
 
-	// Must have called UpdateProjectItemStatus with the Queued option ID.
+	// Must have called UpdateProjectItemStatus with the holding stage option ID.
 	if len(client.updateStatusCalls) != 1 {
 		t.Fatalf("expected 1 UpdateProjectItemStatus call, got %d", len(client.updateStatusCalls))
 	}
-	if client.updateStatusCalls[0].optionID != "OPT_Queued" {
+	// The holding stage is named "BatchHold" (not "Queued") — option ID must match the
+	// HoldingStage field, not a hardcoded name.
+	if client.updateStatusCalls[0].optionID != "OPT_BatchHold" {
 		t.Errorf("UpdateProjectItemStatus called with option %q, want %q",
-			client.updateStatusCalls[0].optionID, "OPT_Queued")
+			client.updateStatusCalls[0].optionID, "OPT_BatchHold")
 	}
 
 	// Must have added stage:Validate:complete.
@@ -597,7 +600,7 @@ func TestAttemptMergeOnValidate_MergeTrainOff_UsesExistingPath(t *testing.T) {
 			return &gh.PRDetails{Number: 10, HeadSHA: "sha1"}, nil
 		},
 	}
-	stgs := testStagesWithValidateAndQueued()
+	stgs := testStagesWithValidateAndHolding()
 	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MergeTrain = "off"
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -611,10 +614,10 @@ func TestAttemptMergeOnValidate_MergeTrainOff_UsesExistingPath(t *testing.T) {
 		t.Fatal("expected enabled=true via existing auto-merge path when merge_train: off")
 	}
 
-	// Must NOT have moved the item to Queued.
+	// Must NOT have moved the item to the holding stage.
 	for _, c := range client.updateStatusCalls {
-		if c.optionID == "OPT_Queued" {
-			t.Errorf("UpdateProjectItemStatus must not target Queued when merge_train: off")
+		if c.optionID == "OPT_BatchHold" {
+			t.Errorf("UpdateProjectItemStatus must not target holding stage when merge_train: off")
 		}
 	}
 
@@ -629,7 +632,7 @@ func TestAttemptMergeOnValidate_MergeTrainOff_UsesExistingPath(t *testing.T) {
 // items are unaffected when merge_train: on — cruise early-return fires first.
 func TestAttemptMergeOnValidate_MergeTrainOn_CruiseBypasses(t *testing.T) {
 	client := &mockGitHubClient{}
-	stgs := testStagesWithValidateAndQueued()
+	stgs := testStagesWithValidateAndHolding()
 	eng := testEngineWithStages(t, client, stgs)
 	eng.cfg.MergeTrain = "on"
 	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
@@ -643,6 +646,6 @@ func TestAttemptMergeOnValidate_MergeTrainOn_CruiseBypasses(t *testing.T) {
 		t.Fatal("expected enabled=false for cruise item")
 	}
 	if len(client.updateStatusCalls) != 0 {
-		t.Errorf("cruise item must not be advanced to Queued, got %d status update(s)", len(client.updateStatusCalls))
+		t.Errorf("cruise item must not be advanced to holding stage, got %d status update(s)", len(client.updateStatusCalls))
 	}
 }

--- a/engine/startup.go
+++ b/engine/startup.go
@@ -53,12 +53,19 @@ func (e *Engine) checkStageColumnAlignment(ctx context.Context) error {
 	e.statusField = sf
 	e.mu.Unlock()
 
-	// Build the set of non-cleanup stage names.
+	// Build the required stage set for column validation.
+	// Cleanup stages are always excluded (they have no board column requirement).
+	// Holding stages are excluded when merge_train is off — they only require a
+	// board column when merge_train is on (the operator must add the Queued column).
 	var checkStages []*stageNameOrder
 	for _, s := range e.cfg.Stages {
-		if !s.CleanupWorktree {
-			checkStages = append(checkStages, &stageNameOrder{name: s.Name, order: s.Order})
+		if s.CleanupWorktree {
+			continue
 		}
+		if s.HoldingStage && e.cfg.MergeTrain != "on" {
+			continue
+		}
+		checkStages = append(checkStages, &stageNameOrder{name: s.Name, order: s.Order, holdingStage: s.HoldingStage})
 	}
 	// Sort by Order for deterministic mismatch report output.
 	sort.Slice(checkStages, func(i, j int) bool {
@@ -133,12 +140,22 @@ func (e *Engine) checkStageColumnAlignment(ctx context.Context) error {
 	fmt.Fprintf(os.Stderr, "\nBoard columns found:\n  %s\n\n", strings.Join(allCols, ", "))
 	fmt.Fprintf(os.Stderr, "Fix: add the missing columns to your GitHub Project board, or update\n")
 	fmt.Fprintf(os.Stderr, ".fabrik/stages/ to match your board column names (case-sensitive).\n")
+	for _, s := range missing {
+		if s.holdingStage {
+			fmt.Fprintf(os.Stderr, "\nNote: %q is a holding stage required by merge_train: on.\n", s.name)
+			fmt.Fprintf(os.Stderr, "Add a `%s` column to your GitHub Project board between `Validate` and `Done`,\n", s.name)
+			fmt.Fprintf(os.Stderr, "then restart. See docs/state-machine.md for setup steps.\n")
+			fmt.Fprintf(os.Stderr, "If you copied queued.yaml from a new Fabrik installation, ensure the column\n")
+			fmt.Fprintf(os.Stderr, "name on the board matches the 'name' field in the YAML (case-sensitive).\n")
+		}
+	}
 
 	return fmt.Errorf("startup check failed: stage/board column mismatch")
 }
 
 // stageNameOrder is a helper for sorting and reporting stage names.
 type stageNameOrder struct {
-	name  string
-	order int
+	name         string
+	order        int
+	holdingStage bool
 }

--- a/engine/startup_test.go
+++ b/engine/startup_test.go
@@ -380,3 +380,104 @@ func TestDriftScan_NonCleanupStage_NoWarning(t *testing.T) {
 		}
 	}
 }
+
+// testStagesWithQueued returns stages including a Queued holding stage, for merge-train tests.
+func testStagesWithQueued() []*stages.Stage {
+	return []*stages.Stage{
+		{Name: "Research", Order: 1, Prompt: "research"},
+		{Name: "Plan", Order: 2, Prompt: "plan"},
+		{Name: "Implement", Order: 3, Prompt: "implement"},
+		{Name: "Validate", Order: 4, Prompt: "validate"},
+		{Name: "Queued", Order: 6, HoldingStage: true},
+		{Name: "Done", Order: 99, CleanupWorktree: true},
+	}
+}
+
+// TestCheckStageColumnAlignment_HoldingStageRequiredWhenMergeTrainOn verifies
+// that a missing Queued column is a fatal error when merge_train is on.
+func TestCheckStageColumnAlignment_HoldingStageRequiredWhenMergeTrainOn(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: boardWithColumns("proj-1"),
+		// Board has all stages except Queued.
+		fetchStatusFieldFn: statusFieldWithOptions("Research", "Plan", "Implement", "Validate"),
+	}
+	e := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStagesWithQueued(),
+			MergeTrain:    "on",
+		},
+		client,
+		&mockClaudeInvoker{},
+		NewWorktreeManager(t.TempDir()),
+	)
+	err := e.checkStageColumnAlignment(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing Queued column when merge_train: on, got nil")
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error should mention mismatch, got: %v", err)
+	}
+}
+
+// TestCheckStageColumnAlignment_HoldingStageExcludedWhenMergeTrainOff verifies
+// that a missing Queued column is not a fatal error when merge_train is off (default).
+func TestCheckStageColumnAlignment_HoldingStageExcludedWhenMergeTrainOff(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: boardWithColumns("proj-1"),
+		// Board does NOT have a Queued column — fine when merge_train is off.
+		fetchStatusFieldFn: statusFieldWithOptions("Research", "Plan", "Implement", "Validate"),
+	}
+	e := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStagesWithQueued(),
+			MergeTrain:    "off",
+		},
+		client,
+		&mockClaudeInvoker{},
+		NewWorktreeManager(t.TempDir()),
+	)
+	err := e.checkStageColumnAlignment(context.Background())
+	if err != nil {
+		t.Fatalf("holding stage missing from board should not be fatal when merge_train: off, got: %v", err)
+	}
+}
+
+// TestCheckStageColumnAlignment_HoldingStagePresent verifies that when merge_train: on
+// and the Queued column exists on the board, startup succeeds.
+func TestCheckStageColumnAlignment_HoldingStagePresent(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: boardWithColumns("proj-1"),
+		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan", "Implement", "Validate", "Queued"),
+	}
+	e := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStagesWithQueued(),
+			MergeTrain:    "on",
+		},
+		client,
+		&mockClaudeInvoker{},
+		NewWorktreeManager(t.TempDir()),
+	)
+	err := e.checkStageColumnAlignment(context.Background())
+	if err != nil {
+		t.Fatalf("startup should succeed when Queued column present: %v", err)
+	}
+}

--- a/stages/examples/queued.yaml
+++ b/stages/examples/queued.yaml
@@ -1,0 +1,3 @@
+name: Queued
+order: 6
+holding_stage: true

--- a/stages/stages.go
+++ b/stages/stages.go
@@ -104,6 +104,13 @@ type Stage struct {
 	// Use this for terminal stages like "Done" to reclaim disk space.
 	CleanupWorktree bool `yaml:"cleanup_worktree,omitempty"`
 
+	// HoldingStage marks this stage as an engine-managed holding stage that
+	// requires no Claude invocation and no worktree cleanup. Items in a holding
+	// stage are never individually dispatched; the engine handles them in batch
+	// (e.g., the Queued merge-train stage). When true, the prompt/skill requirement
+	// is waived and no Claude completion type is assigned.
+	HoldingStage bool `yaml:"holding_stage,omitempty"`
+
 	// DisableAdaptiveThinking controls whether Claude Code's adaptive (auto-reduced)
 	// thinking budget is disabled. nil means use the default (disabled). When nil or
 	// true, CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1 is injected into the subprocess
@@ -211,7 +218,7 @@ func loadOne(path string) (*Stage, error) {
 		return nil, fmt.Errorf("stage must have a 'name' field")
 	}
 
-	if !s.CleanupWorktree {
+	if !s.CleanupWorktree && !s.HoldingStage {
 		if s.Prompt == "" && s.Skill == "" {
 			return nil, fmt.Errorf("stage %q must have a 'prompt' or 'skill' field", s.Name)
 		}

--- a/stages/stages_test.go
+++ b/stages/stages_test.go
@@ -236,6 +236,66 @@ func TestFindStage(t *testing.T) {
 	}
 }
 
+// TestLoadAll_HoldingStage verifies that a stage with holding_stage: true
+// loads successfully without a prompt or skill, and has no Claude completion type.
+func TestLoadAll_HoldingStage(t *testing.T) {
+	dir := t.TempDir()
+	writeStageFile(t, dir, "queued.yaml", `
+name: Queued
+order: 6
+holding_stage: true
+`)
+
+	ss, err := LoadAll(dir)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("expected 1 stage, got %d", len(ss))
+	}
+	s := ss[0]
+	if !s.HoldingStage {
+		t.Error("HoldingStage should be true")
+	}
+	if s.Completion.Type != "" {
+		t.Errorf("holding stage should have no completion type, got %q", s.Completion.Type)
+	}
+}
+
+// TestLoadAll_MissingPromptNotHolding is a regression guard: a stage without
+// cleanup_worktree or holding_stage and without a prompt/skill must be rejected.
+func TestLoadAll_MissingPromptNotHolding(t *testing.T) {
+	dir := t.TempDir()
+	writeStageFile(t, dir, "bad.yaml", `
+name: BadStage
+order: 3
+`)
+
+	_, err := LoadAll(dir)
+	if err == nil {
+		t.Fatal("expected error for stage missing prompt/skill/cleanup_worktree/holding_stage")
+	}
+}
+
+// TestLoadAll_CleanupWorktreeNoPrompt_Regression verifies that cleanup_worktree:true
+// stages still load without a prompt (regression guard for the prior bypass).
+func TestLoadAll_CleanupWorktreeNoPrompt_Regression(t *testing.T) {
+	dir := t.TempDir()
+	writeStageFile(t, dir, "done.yaml", `
+name: Done
+order: 99
+cleanup_worktree: true
+`)
+
+	ss, err := LoadAll(dir)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(ss) != 1 || !ss[0].CleanupWorktree {
+		t.Errorf("expected 1 cleanup stage, got %+v", ss)
+	}
+}
+
 func TestLoadAll_ReadError(t *testing.T) {
 	dir := t.TempDir()
 	// Create a directory named bad.yaml so os.ReadFile fails deterministically


### PR DESCRIPTION
Closes #946

## What this PR does

Lands the ADR-059 D1 foundation for Fabrik's internal merge train: the `Queued` holding stage, the `Validate → Queued` advancement gate, and the per-poll batch-snapshot handler. No batching or landing logic yet — those follow in subsequent chain issues. The full capability is inert until `merge_train: on`.

## Key changes

**Stage model** (`stages/stages.go`, `stages/examples/queued.yaml`): adds `holding_stage: true` as a third stage category alongside `cleanup_worktree` and Claude-invocation stages. `loadOne` skips the prompt/skill requirement and `Completion.Type` defaulting for holding stages.

**Config** (`cmd/root.go`, `engine/engine.go`): `--merge-train on|off` flag + `FABRIK_MERGE_TRAIN` env var; default `off`. Mirrors the `MergeQueue` pattern exactly.

**Dispatch suppression** (`engine/item.go`): `itemMayNeedWork`, `itemNeedsWork`, and `processItem` all early-return for `HoldingStage` stages. Catch-up loop also skips them.

**`advanceToQueued`** (`engine/stages.go`): sets board status to `Queued`, adds `stage:Validate:complete`. Called from `attemptMergeOnValidate` when `merge_train: on`, after cruise/idempotency early-returns (new items never enter the auto-merge convergence path when `merge_train: on`).

**`handleMergeTrainBatch`** (`engine/poll.go`): snapshots all Queued items each poll cycle and logs `[merge-train] batch snapshot: N item(s) — #X "title", …`; no-op when empty.

**Startup validation** (`engine/startup.go`): Queued column is optional when `merge_train: off`; required (fatal startup error) when `merge_train: on`.

**Docs** (`docs/state-machine.md`, `docs/llms-full.txt`): Pipeline Overview table updated with Queued (order 6); holding-stage lifecycle section added; llms-full.txt regenerated.

## How to test

```bash
go build ./... && go vet ./... && go test -race ./...
# (TestExecute_ConfigYAMLApplied in cmd/ is a pre-existing SIGINT timing flake — fails on main too)
```

To exercise the merge-train path manually:
1. Add a `Queued` column to your GitHub Project board between `Validate` and `Done`.
2. Start Fabrik with `--merge-train on`.
3. Advance an issue to Validate with `fabrik:yolo` — it should land in `Queued` instead of triggering auto-merge.
4. Each poll cycle logs `[merge-train] batch snapshot: 1 item(s) — #N "title"`.

## Backward compatibility

All code paths are unchanged when `merge_train: off` (the default). The `Queued` YAML is embedded in the binary but excluded from startup board validation unless `merge_train: on`.