### PR TITLE
feat(merge-train): trial integration branch builder + Claude conflict resolution (ADR-059 D3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ CI's `docs-drift` workflow (`.github/workflows/docs-drift.yml`) runs the regen a
 - `engine/repo.go` — Per-repo identity helpers (parseOwnerRepo, repoName, issueKey)
 - `engine/claude.go` — Claude Code invocation, prompt building, marker extraction
 - `engine/worktree.go` — Git worktree lifecycle (create, update, push, cleanup)
+- `engine/merge_train.go` — Merge-train worker: trial branch assembly, inline conflict resolution, integration PR creation and CI polling (ADR-059 D3)
 - `engine/interfaces.go` — GitHubClient and ClaudeInvoker interfaces (for testing)
 - `github/project.go` — GraphQL board fetching (single query for all items + comments + linked PRs)
 - `github/client.go` — HTTP client construction and shared request helpers

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -707,6 +707,7 @@ func Execute() error {
 		AutoMergeStrategy:        autoMergeStrategy(cfg.AutoMergeStrategy),
 		MergeQueue:               mergeQueueMode(cfg.MergeQueue),
 		MergeTrain:               mergeTrainMode(cfg.MergeTrain),
+		MaxMergeTrainEjections:   3, // ADR-059 default
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		KillGraceSigInt:          killGraceSigInt(cfg.KillGraceSigInt),
 		KillGraceSigTerm:         killGraceSigTerm(cfg.KillGraceSigTerm),

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -43,6 +43,7 @@ type Config struct {
 	AutoMergeStrategy        string        // Merge method for enablePullRequestAutoMerge: MERGE, SQUASH, or REBASE (default MERGE)
 	MergeQueue               string        // Merge queue routing for yolo path: "auto" (enqueue when repo uses merge queue) or "off" (skip enqueue)
 	MergeTrain               string        // Fabrik-internal merge train: "on" (advance yolo Validate completions to Queued) or "off" (default; existing auto-merge path unchanged)
+	MaxMergeTrainEjections   int           // Max merge-train ejections before pausing a member (default 3; ADR-059)
 	KillGraceSigInt          time.Duration // Grace window after SIGINT before SIGTERM (default 10s; 0 = skip SIGINT step)
 	KillGraceSigTerm         time.Duration // Grace window after SIGTERM before SIGKILL (default 10s)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
@@ -97,6 +98,9 @@ type Engine struct {
 	sem                   chan struct{}        // semaphore bounding concurrent workers across poll cycles
 	wg                    sync.WaitGroup       // tracks in-flight workers for graceful shutdown
 	cloneInFlight         sync.Map             // key: "owner/repo" string, value: *cloneCall; per-repo bare-clone coordination
+	mergeTrainInFlight       sync.Map        // key: "owner/repo", value: *mergeTrainWorkerState; per-repo train dispatch guard
+	mergeTrainEjectionsMu   sync.Mutex      // guards mergeTrainEjectionCounts
+	mergeTrainEjectionCounts map[string]int  // key: "owner/repo#N", ejection count per member
 	issueCtxs             sync.Map             // key: issueKey string, value: issueCtxEntry; per-issue context for kill-reason propagation
 	baseBranchWarnedSet   sync.Map             // key: "owner/repo#N:branch"; prevents repeated fallback comments for bad base: labels
 	events                chan tui.Event       // nil in tests / plain-text mode; TUI goroutine consumes
@@ -164,16 +168,17 @@ func New(cfg Config) (*Engine, error) {
 	worktreeRoot := filepath.Join(fabrikDir, ".fabrik", "worktrees")
 	sharedStore := itemstate.NewStore(nil)
 	eng := &Engine{
-		cfg:                   cfg,
-		client:                gh.NewClient(cfg.Token),
-		claude:                &RealClaudeInvoker{DebugOutput: cfg.DebugOutput},
-		worktreeManagers:      make(map[string]*WorktreeManager),
-		fabrikDir:             fabrikDir,
-		store:                 sharedStore,
-		mayNeedWork:           make(map[string]bool),
-		seededRepos:           make(map[string]bool),
-		checkedAutoMergeRepos: make(map[string]bool),
-		sem:                   make(chan struct{}, cfg.MaxConcurrent),
+		cfg:                      cfg,
+		client:                   gh.NewClient(cfg.Token),
+		claude:                   &RealClaudeInvoker{DebugOutput: cfg.DebugOutput},
+		worktreeManagers:         make(map[string]*WorktreeManager),
+		fabrikDir:                fabrikDir,
+		store:                    sharedStore,
+		mayNeedWork:              make(map[string]bool),
+		seededRepos:              make(map[string]bool),
+		checkedAutoMergeRepos:    make(map[string]bool),
+		sem:                      make(chan struct{}, cfg.MaxConcurrent),
+		mergeTrainEjectionCounts: make(map[string]int),
 	}
 
 	// Migrate any old-style worktrees (issue-N/) to the new per-repo layout.
@@ -218,15 +223,16 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 	}
 	wms := make(map[string]*WorktreeManager)
 	eng := &Engine{
-		cfg:                   cfg,
-		client:                client,
-		claude:                claude,
-		worktreeManagers:      wms,
-		store:                 itemstate.NewStore(nil),
-		mayNeedWork:           make(map[string]bool),
-		seededRepos:           make(map[string]bool),
-		checkedAutoMergeRepos: make(map[string]bool),
-		sem:                   make(chan struct{}, maxConcurrent),
+		cfg:                      cfg,
+		client:                   client,
+		claude:                   claude,
+		worktreeManagers:         wms,
+		store:                    itemstate.NewStore(nil),
+		mayNeedWork:              make(map[string]bool),
+		seededRepos:              make(map[string]bool),
+		checkedAutoMergeRepos:    make(map[string]bool),
+		sem:                      make(chan struct{}, maxConcurrent),
+		mergeTrainEjectionCounts: make(map[string]int),
 	}
 	if worktrees != nil {
 		worktrees.logfFn = eng.logf

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -1,0 +1,456 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// TrainCIResult is the typed outcome of the combined-Validate CI poll.
+type TrainCIResult int
+
+const (
+	TrainCIPending TrainCIResult = iota // CI not yet resolved (timeout or still running)
+	TrainCIGreen                        // all required checks passed
+	TrainCIRed                          // at least one required check failed
+)
+
+// mergeTrainWorkerState tracks an in-flight or completed merge-train worker.
+// Stored in Engine.mergeTrainInFlight keyed by "owner/repo".
+type mergeTrainWorkerState struct {
+	assembling     bool          // true while building the trial branch; false once PR is open
+	prNum          int           // integration PR number (set after PR is created)
+	trialBranchSHA string        // HEAD SHA of the trial branch (set after push)
+	CIResult       TrainCIResult // final CI result (set by pollTrainCI on exit)
+	trialName      string        // unique trial name (e.g. "merge-train-main-1751234567")
+}
+
+// sanitizeBranchName replaces characters that are invalid in directory names
+// (particularly '/') so trialName can be used as both a directory segment and
+// as the suffix of the trial branch name.
+func sanitizeBranchName(s string) string {
+	return strings.ReplaceAll(s, "/", "-")
+}
+
+// dispatchMergeTrainWorker checks whether a train worker is already in-flight for
+// the batch's repo and, if not, starts one. Safe to call from the poll goroutine.
+func (e *Engine) dispatchMergeTrainWorker(ctx context.Context, batch []gh.ProjectItem) {
+	if len(batch) == 0 {
+		return
+	}
+	owner, repo := itemOwnerRepo(batch[0], e.defaultRepo())
+	repoKey := owner + "/" + repo
+
+	if existing, loaded := e.mergeTrainInFlight.Load(repoKey); loaded {
+		state := existing.(*mergeTrainWorkerState)
+		if state.assembling {
+			e.logf(0, "merge-train", "train worker already assembling for %s — skipping\n", repoKey)
+		} else {
+			switch state.CIResult {
+			case TrainCIGreen:
+				e.logf(0, "merge-train", "train CI green for %s (PR #%d) — awaiting landing step\n", repoKey, state.prNum)
+			case TrainCIRed:
+				e.logf(0, "merge-train", "train CI red for %s (PR #%d) — needs attention\n", repoKey, state.prNum)
+			default:
+				e.logf(0, "merge-train", "train CI pending for %s (PR #%d) — still polling\n", repoKey, state.prNum)
+			}
+		}
+		return
+	}
+
+	trialName := fmt.Sprintf("merge-train-%s-%d", sanitizeBranchName(repo), time.Now().Unix())
+	state := &mergeTrainWorkerState{
+		assembling: true,
+		trialName:  trialName,
+	}
+	e.mergeTrainInFlight.Store(repoKey, state)
+	e.wg.Add(1)
+
+	go func() {
+		defer e.wg.Done()
+		e.runMergeTrainWorker(ctx, state, owner, repo, batch)
+	}()
+}
+
+// runMergeTrainWorker is the main body of the merge-train goroutine.
+// It acquires the semaphore, assembles the trial branch, resolves conflicts,
+// pushes, opens a draft integration PR, polls CI, and records the result.
+func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorkerState, owner, repo string, batch []gh.ProjectItem) {
+	repoKey := owner + "/" + repo
+
+	select {
+	case e.sem <- struct{}{}:
+	case <-ctx.Done():
+		e.logf(0, "merge-train", "context cancelled before semaphore acquired for %s\n", repoKey)
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+	defer func() { <-e.sem }()
+
+	// Use batch[0] as the repo anchor for ensureRepoReady.
+	if err := e.ensureRepoReady(ctx, batch[0]); err != nil {
+		if errors.Is(err, ErrSkipItem) {
+			e.logf(0, "merge-train", "repo %s not ready, aborting train\n", repoKey)
+		} else {
+			e.logf(0, "merge-train", "ensureRepoReady failed for %s: %v\n", repoKey, err)
+		}
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+
+	wm := e.worktreesFor(repoKey)
+	baseBranch, err := wm.DefaultBaseBranch()
+	if err != nil {
+		e.logf(0, "merge-train", "cannot determine base branch for %s: %v\n", repoKey, err)
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+
+	trialName := state.trialName
+	e.logf(0, "merge-train", "building trial branch %q for %s (%d members)\n", trialName, repoKey, len(batch))
+
+	wtDir, err := wm.EnsureTrainWorktree(trialName, baseBranch)
+	if err != nil {
+		e.logf(0, "merge-train", "cannot create trial worktree for %s: %v\n", repoKey, err)
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+
+	// Fetch all objects so git merge <sha> can resolve them.
+	fetchCmd := exec.Command("git", "fetch", "origin")
+	fetchCmd.Dir = wtDir
+	fetchCmd.Env = nonInteractiveGitEnv()
+	if out, err := fetchCmd.CombinedOutput(); err != nil {
+		e.logf(0, "merge-train", "warn: fetch origin in trial worktree failed: %s\n", strings.TrimSpace(string(out)))
+	}
+
+	holdingStg := holdingStage(e.cfg)
+	if holdingStg == nil {
+		e.logf(0, "merge-train", "no holding stage configured — aborting train\n")
+		wm.CleanupTrainWorktree(trialName, true) // best-effort
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+
+	// Check if any batch member has fabrik:extend-turns — if so, double max_turns.
+	extendTurns := false
+	for _, m := range batch {
+		if hasLabel(m, "fabrik:extend-turns") {
+			extendTurns = true
+			break
+		}
+	}
+	maxTurnsOverride := 0
+	if extendTurns && holdingStg.MaxTurns > 0 {
+		maxTurnsOverride = holdingStg.MaxTurns * 2
+	}
+
+	// Sequential merge loop.
+	var survivors []gh.ProjectItem
+	for _, member := range batch {
+		pr, fetchErr := e.client.FetchLinkedPR(owner, repo, member.Number)
+		if fetchErr != nil || pr == nil {
+			e.logf(member.Number, "merge-train", "cannot fetch linked PR for #%d: %v — ejecting\n", member.Number, fetchErr)
+			e.ejectMember(ctx, owner, repo, member, fmt.Sprintf("ejected from merge-train — could not fetch linked PR: %v", fetchErr))
+			continue
+		}
+		if pr.HeadSHA == "" {
+			e.logf(member.Number, "merge-train", "#%d has no PR head SHA — ejecting\n", member.Number)
+			e.ejectMember(ctx, owner, repo, member, "ejected from merge-train — linked PR has no head SHA")
+			continue
+		}
+
+		mergeCmd := exec.Command("git", "merge", "--no-ff", "--no-edit", pr.HeadSHA)
+		mergeCmd.Dir = wtDir
+		mergeOut, mergeErr := mergeCmd.CombinedOutput()
+
+		if mergeErr == nil {
+			// Clean merge.
+			survivors = append(survivors, member)
+			e.logf(member.Number, "merge-train", "merged #%d cleanly into trial branch\n", member.Number)
+			continue
+		}
+
+		// Conflict — attempt Claude resolution.
+		e.logf(member.Number, "merge-train", "merge conflict for #%d: %s — attempting Claude resolution\n", member.Number, strings.TrimSpace(string(mergeOut)))
+		opts := InvokeOptions{
+			BaseBranch:       baseBranch,
+			MaxTurnsOverride: maxTurnsOverride,
+		}
+		resolved := e.resolveConflictWithClaude(ctx, member, wtDir, holdingStg, pr.HeadSHA, opts)
+		if resolved {
+			survivors = append(survivors, member)
+			e.logf(member.Number, "merge-train", "conflict for #%d resolved by Claude\n", member.Number)
+			continue
+		}
+
+		// Unresolvable — abort merge and eject.
+		abortCmd := exec.Command("git", "merge", "--abort")
+		abortCmd.Dir = wtDir
+		abortCmd.CombinedOutput() // best-effort
+		e.logf(member.Number, "merge-train", "cannot resolve conflict for #%d — ejecting\n", member.Number)
+		e.ejectMember(ctx, owner, repo, member, fmt.Sprintf("ejected from merge-train batch — unresolvable conflict (PR SHA %s)", pr.HeadSHA))
+	}
+
+	// FR-6: zero survivors.
+	if len(survivors) == 0 {
+		e.logf(0, "merge-train", "entire batch ejected, %d member(s) need attention\n", len(batch))
+		wm.CleanupTrainWorktree(trialName, true) // best-effort
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+
+	// Push trial branch to origin.
+	if err := wm.PushTrainBranch(trialName); err != nil {
+		e.logf(0, "merge-train", "cannot push trial branch for %s: %v\n", repoKey, err)
+		wm.CleanupTrainWorktree(trialName, true) // best-effort
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+
+	// Capture trial branch HEAD SHA.
+	trialSHA, err := gitRevParse(wtDir, "HEAD")
+	if err != nil {
+		e.logf(0, "merge-train", "cannot read trial branch SHA for %s: %v\n", repoKey, err)
+		wm.CleanupTrainWorktree(trialName, true) // best-effort
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+	state.trialBranchSHA = trialSHA
+
+	// Build integration PR body listing survivors.
+	var memberRefs []string
+	for _, s := range survivors {
+		memberRefs = append(memberRefs, fmt.Sprintf("#%d", s.Number))
+	}
+	prTitle := fmt.Sprintf("chore(merge-train): trial integration for %s", strings.Join(memberRefs, " "))
+	prBody := fmt.Sprintf("🏭 **Fabrik merge-train integration PR** (trial → %s)\n\n"+
+		"This is a disposable trial branch combining the following Queued member PRs:\n%s\n\n"+
+		"Do not merge this PR manually — Fabrik manages the landing step.\n"+
+		"Orphaned integration PRs (if the train worker crashed) can be closed manually via the GitHub UI.",
+		baseBranch, strings.Join(memberRefs, "\n"))
+
+	trialBranch := "fabrik/merge-train/" + trialName
+	prNum, err := e.client.CreateDraftPR(owner, repo, prTitle, trialBranch, baseBranch, prBody, 0)
+	if err != nil {
+		e.logf(0, "merge-train", "cannot create integration PR for %s: %v\n", repoKey, err)
+		wm.CleanupTrainWorktree(trialName, true) // best-effort
+		e.mergeTrainInFlight.Delete(repoKey)
+		return
+	}
+	state.prNum = prNum
+	state.assembling = false
+	e.logf(0, "merge-train", "opened draft integration PR #%d for %s (%d survivors)\n", prNum, repoKey, len(survivors))
+
+	// Clean up local worktree — trial branch is now on origin.
+	if cleanErr := wm.CleanupTrainWorktree(trialName, false); cleanErr != nil {
+		e.logf(0, "merge-train", "warn: could not clean up trial worktree for %s: %v\n", repoKey, cleanErr)
+	}
+
+	// Poll CI — this blocks inside the goroutine.
+	ciResult := e.pollTrainCI(ctx, owner, repo, prNum, trialSHA)
+	state.CIResult = ciResult
+
+	switch ciResult {
+	case TrainCIGreen:
+		e.logf(0, "merge-train", "CI green for integration PR #%d (%s) — ready for landing\n", prNum, repoKey)
+	case TrainCIRed:
+		e.logf(0, "merge-train", "CI red for integration PR #%d (%s) — batch needs attention\n", prNum, repoKey)
+	default:
+		e.logf(0, "merge-train", "CI timed out / pending for integration PR #%d (%s)\n", prNum, repoKey)
+	}
+	// Do NOT delete in-flight entry — leave for #948 landing step to consume.
+}
+
+// buildTrainConflictComment constructs a synthetic comment instructing Claude to
+// resolve merge conflict markers in the current worktree (inline, without a rebase).
+func buildTrainConflictComment(memberItem gh.ProjectItem, prSHA, baseBranch string) gh.Comment {
+	body := fmt.Sprintf(
+		"🏭 **Fabrik merge-train — conflict resolution required**\n\n"+
+			"The merge of PR head `%s` (issue #%d) into the trial integration branch has left "+
+			"conflict markers in the working tree. Resolve them and commit the resolution.\n\n"+
+			"**Instructions:**\n"+
+			"1. Run `git status` to identify conflicted files.\n"+
+			"2. Open each conflicted file and resolve every `<<<<<<< / ======= / >>>>>>>` marker.\n"+
+			"   Resolve **semantically** — understand what each side contributes and produce the "+
+			"correct merged result (do not blindly pick one side).\n"+
+			"   Watch for **semantic collisions** (two PRs chose the same counter value, migration "+
+			"ID, or ADR number): keep both contributions with the correct identifiers.\n"+
+			"3. `git add -A` to stage all resolved files.\n"+
+			"4. `git commit -m \"chore(merge-train): resolve conflict for #%d\"` to finalize.\n"+
+			"5. Run the project's build + test commands (`go build ./...` and `go vet ./...` at minimum).\n"+
+			"6. **Do NOT emit `FABRIK_STAGE_COMPLETE`.** The merge-train engine takes over after resolution.\n\n"+
+			"If the conflict cannot be resolved safely (ambiguous intent, requires human judgment), "+
+			"abort with `git merge --abort` and explain in your response why resolution is not possible.\n",
+		prSHA, memberItem.Number, memberItem.Number,
+	)
+	_ = baseBranch
+	return gh.Comment{
+		ID:         "merge-train-conflict-synthetic",
+		DatabaseID: 0,
+		Body:       body,
+		Author:     "fabrik",
+	}
+}
+
+// resolveConflictWithClaude invokes Claude inline to resolve merge conflicts in the
+// trial branch worktree. Returns true if resolution succeeded (no conflict markers remain
+// and the resolution is committed).
+func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.ProjectItem, trainWorkDir string, holdingStg *stages.Stage, prSHA string, opts InvokeOptions) bool {
+	comment := buildTrainConflictComment(memberItem, prSHA, opts.BaseBranch)
+
+	output, _, _, err := e.claude.InvokeForComments(ctx, holdingStg, memberItem, []gh.Comment{comment}, trainWorkDir, opts)
+	if err != nil {
+		e.logf(memberItem.Number, "merge-train", "Claude conflict resolution failed: %v\n", err)
+		return false
+	}
+	_ = output
+
+	// Check whether conflicts remain after Claude's work.
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = trainWorkDir
+	statusOut, _ := statusCmd.CombinedOutput()
+	if strings.Contains(string(statusOut), "UU") || strings.Contains(string(statusOut), "AA") || strings.Contains(string(statusOut), "DD") {
+		e.logf(memberItem.Number, "merge-train", "conflict markers remain after Claude resolution\n")
+		return false
+	}
+
+	// Check that there are no staged conflict markers in the diff.
+	diffCmd := exec.Command("git", "diff", "--check")
+	diffCmd.Dir = trainWorkDir
+	if out, diffErr := diffCmd.CombinedOutput(); diffErr != nil {
+		e.logf(memberItem.Number, "merge-train", "git diff --check reports conflicts: %s\n", strings.TrimSpace(string(out)))
+		return false
+	}
+
+	// Verify git considers merge done (index clean or committed).
+	checkMergeHead := exec.Command("git", "rev-parse", "--verify", "MERGE_HEAD")
+	checkMergeHead.Dir = trainWorkDir
+	if err := checkMergeHead.Run(); err == nil {
+		// MERGE_HEAD still exists — merge not committed. Try to commit now.
+		e.logf(memberItem.Number, "merge-train", "MERGE_HEAD still present after Claude resolution — attempting commit\n")
+		addCmd := exec.Command("git", "add", "-A")
+		addCmd.Dir = trainWorkDir
+		addCmd.CombinedOutput()
+		commitCmd := exec.Command("git", "commit", "--no-edit", "-m",
+			fmt.Sprintf("chore(merge-train): resolve conflict for #%d", memberItem.Number))
+		commitCmd.Dir = trainWorkDir
+		if out, commitErr := commitCmd.CombinedOutput(); commitErr != nil {
+			e.logf(memberItem.Number, "merge-train", "could not commit resolution: %s\n", strings.TrimSpace(string(out)))
+			return false
+		}
+	}
+
+	return true
+}
+
+// ejectMember posts an ejection comment on the member issue, increments the ejection
+// counter, and pauses the member after MaxMergeTrainEjections.
+func (e *Engine) ejectMember(ctx context.Context, owner, repo string, memberItem gh.ProjectItem, reason string) {
+	_ = ctx
+	msg := fmt.Sprintf("🏭 **Fabrik merge-train — ejected**\n\n%s\n\n"+
+		"This issue remains in the Queued column and will be retried in a future train with a different composition.",
+		reason)
+	if _, commentErr := e.client.AddComment(owner, repo, memberItem.Number, msg); commentErr != nil {
+		e.logf(memberItem.Number, "merge-train", "warn: could not post ejection comment: %v\n", commentErr)
+	}
+
+	counterKey := fmt.Sprintf("%s/%s#%d", owner, repo, memberItem.Number)
+	e.mergeTrainEjectionsMu.Lock()
+	e.mergeTrainEjectionCounts[counterKey]++
+	count := e.mergeTrainEjectionCounts[counterKey]
+	e.mergeTrainEjectionsMu.Unlock()
+
+	maxEjections := e.cfg.MaxMergeTrainEjections
+	if maxEjections <= 0 {
+		maxEjections = 3
+	}
+	if count >= maxEjections {
+		e.logf(memberItem.Number, "merge-train", "#%d ejected %d time(s) — pausing\n", memberItem.Number, count)
+		pauseMsg := fmt.Sprintf("🏭 **Fabrik merge-train — pausing after %d ejections**\n\n"+
+			"This issue has been ejected from the merge-train %d consecutive times. "+
+			"Manual intervention is required. Remove `fabrik:paused` after resolving the underlying conflict.",
+			count, count)
+		if _, err := e.client.AddComment(owner, repo, memberItem.Number, pauseMsg); err != nil {
+			e.logf(memberItem.Number, "merge-train", "warn: could not post pause comment: %v\n", err)
+		}
+		if err := e.client.AddLabelToIssue(owner, repo, memberItem.Number, "fabrik:paused"); err != nil {
+			e.logf(memberItem.Number, "warn", "could not add fabrik:paused: %v\n", err)
+		}
+		if err := e.client.AddLabelToIssue(owner, repo, memberItem.Number, "fabrik:awaiting-input"); err != nil {
+			e.logf(memberItem.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+		}
+	}
+}
+
+// pollTrainCI polls the integration PR's required CI checks, returning the typed result.
+// Blocks until the result is known or the CIWaitTimeout elapses.
+func (e *Engine) pollTrainCI(ctx context.Context, owner, repo string, prNum int, trialSHA string) TrainCIResult {
+	ciWaitTimeout := e.cfg.CIWaitTimeout
+	if ciWaitTimeout <= 0 {
+		ciWaitTimeout = 30 * time.Minute
+	}
+	deadline := time.Now().Add(ciWaitTimeout)
+
+	for {
+		select {
+		case <-ctx.Done():
+			e.logf(0, "merge-train", "context cancelled during CI poll for integration PR #%d\n", prNum)
+			return TrainCIPending
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			e.logf(0, "merge-train", "CI wait timeout for integration PR #%d\n", prNum)
+			return TrainCIPending
+		}
+
+		// ADR-033 shortcut: check mergeable_state first.
+		_, mergeableState, err := e.client.FetchPRMergeableFields(owner, repo, prNum)
+		if err != nil {
+			e.logf(0, "merge-train", "warn: FetchPRMergeableFields failed for PR #%d: %v\n", prNum, err)
+		} else if gh.MergeableStateAccepted(mergeableState) {
+			return TrainCIGreen
+		} else if mergeableState == "dirty" {
+			return TrainCIRed
+		}
+
+		// Check individual check runs.
+		checkRuns, err := e.client.FetchCheckRuns(owner, repo, trialSHA)
+		if err != nil {
+			e.logf(0, "merge-train", "warn: FetchCheckRuns failed for %s: %v\n", trialSHA, err)
+		} else if len(checkRuns) > 0 {
+			var pending, failed int
+			for _, cr := range checkRuns {
+				switch cr.Status {
+				case "queued", "in_progress":
+					pending++
+				case "completed":
+					switch cr.Conclusion {
+					case "failure", "timed_out", "action_required":
+						failed++
+					}
+				}
+			}
+			if failed > 0 {
+				return TrainCIRed
+			}
+			if pending == 0 {
+				return TrainCIGreen
+			}
+		}
+
+		// Poll again after 30 seconds.
+		select {
+		case <-ctx.Done():
+			return TrainCIPending
+		case <-time.After(30 * time.Second):
+		}
+	}
+}

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
@@ -23,12 +24,14 @@ const (
 
 // mergeTrainWorkerState tracks an in-flight or completed merge-train worker.
 // Stored in Engine.mergeTrainInFlight keyed by "owner/repo".
+// mu guards all fields that the poll loop reads while the goroutine writes them.
 type mergeTrainWorkerState struct {
+	mu             sync.RWMutex
 	assembling     bool          // true while building the trial branch; false once PR is open
 	prNum          int           // integration PR number (set after PR is created)
 	trialBranchSHA string        // HEAD SHA of the trial branch (set after push)
 	CIResult       TrainCIResult // final CI result (set by pollTrainCI on exit)
-	trialName      string        // unique trial name (e.g. "merge-train-main-1751234567")
+	trialName      string        // unique trial name (set once before goroutine starts; immutable after)
 }
 
 // sanitizeBranchName replaces characters that are invalid in directory names
@@ -49,25 +52,28 @@ func (e *Engine) dispatchMergeTrainWorker(ctx context.Context, batch []gh.Projec
 
 	if existing, loaded := e.mergeTrainInFlight.Load(repoKey); loaded {
 		state := existing.(*mergeTrainWorkerState)
-		if state.assembling {
+		state.mu.RLock()
+		assembling := state.assembling
+		prNum := state.prNum
+		ciResult := state.CIResult
+		state.mu.RUnlock()
+		if assembling {
 			e.logf(0, "merge-train", "train worker already assembling for %s — skipping\n", repoKey)
 		} else {
-			switch state.CIResult {
+			switch ciResult {
 			case TrainCIGreen:
-				e.logf(0, "merge-train", "train CI green for %s (PR #%d) — awaiting landing step\n", repoKey, state.prNum)
+				e.logf(0, "merge-train", "train CI green for %s (PR #%d) — awaiting landing step\n", repoKey, prNum)
 			case TrainCIRed:
-				e.logf(0, "merge-train", "train CI red for %s (PR #%d) — needs attention\n", repoKey, state.prNum)
+				e.logf(0, "merge-train", "train CI red for %s (PR #%d) — needs attention\n", repoKey, prNum)
 			default:
-				e.logf(0, "merge-train", "train CI pending for %s (PR #%d) — still polling\n", repoKey, state.prNum)
+				e.logf(0, "merge-train", "train CI pending for %s (PR #%d) — still polling\n", repoKey, prNum)
 			}
 		}
 		return
 	}
 
-	trialName := fmt.Sprintf("merge-train-%s-%d", sanitizeBranchName(repo), time.Now().Unix())
 	state := &mergeTrainWorkerState{
 		assembling: true,
-		trialName:  trialName,
 	}
 	e.mergeTrainInFlight.Store(repoKey, state)
 	e.wg.Add(1)
@@ -112,7 +118,10 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 		return
 	}
 
-	trialName := state.trialName
+	// Generate trial name here (after baseBranch is known) so the branch name
+	// reflects the target base (e.g. "merge-train-main-1751234567"), matching FR-1.
+	trialName := fmt.Sprintf("merge-train-%s-%d", sanitizeBranchName(baseBranch), time.Now().Unix())
+	state.trialName = trialName
 	e.logf(0, "merge-train", "building trial branch %q for %s (%d members)\n", trialName, repoKey, len(batch))
 
 	wtDir, err := wm.EnsureTrainWorktree(trialName, baseBranch)
@@ -222,7 +231,9 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 		e.mergeTrainInFlight.Delete(repoKey)
 		return
 	}
+	state.mu.Lock()
 	state.trialBranchSHA = trialSHA
+	state.mu.Unlock()
 
 	// Build integration PR body listing survivors.
 	var memberRefs []string
@@ -244,8 +255,10 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 		e.mergeTrainInFlight.Delete(repoKey)
 		return
 	}
+	state.mu.Lock()
 	state.prNum = prNum
 	state.assembling = false
+	state.mu.Unlock()
 	e.logf(0, "merge-train", "opened draft integration PR #%d for %s (%d survivors)\n", prNum, repoKey, len(survivors))
 
 	// Clean up local worktree — trial branch is now on origin.
@@ -255,7 +268,9 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 
 	// Poll CI — this blocks inside the goroutine.
 	ciResult := e.pollTrainCI(ctx, owner, repo, prNum, trialSHA)
+	state.mu.Lock()
 	state.CIResult = ciResult
+	state.mu.Unlock()
 
 	switch ciResult {
 	case TrainCIGreen:

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -50,7 +50,11 @@ func (e *Engine) dispatchMergeTrainWorker(ctx context.Context, batch []gh.Projec
 	owner, repo := itemOwnerRepo(batch[0], e.defaultRepo())
 	repoKey := owner + "/" + repo
 
-	if existing, loaded := e.mergeTrainInFlight.Load(repoKey); loaded {
+	// Use LoadOrStore so the check-and-register is atomic: two concurrent callers
+	// can never both pass the "not loaded" path and launch duplicate workers.
+	candidate := &mergeTrainWorkerState{assembling: true}
+	existing, loaded := e.mergeTrainInFlight.LoadOrStore(repoKey, candidate)
+	if loaded {
 		state := existing.(*mergeTrainWorkerState)
 		state.mu.RLock()
 		assembling := state.assembling
@@ -72,10 +76,8 @@ func (e *Engine) dispatchMergeTrainWorker(ctx context.Context, batch []gh.Projec
 		return
 	}
 
-	state := &mergeTrainWorkerState{
-		assembling: true,
-	}
-	e.mergeTrainInFlight.Store(repoKey, state)
+	// candidate was atomically stored — launch the worker with it.
+	state := candidate
 	e.wg.Add(1)
 
 	go func() {
@@ -275,12 +277,17 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 	switch ciResult {
 	case TrainCIGreen:
 		e.logf(0, "merge-train", "CI green for integration PR #%d (%s) — ready for landing\n", prNum, repoKey)
+		// Leave in-flight entry intact — #948 landing step reads prNum and trialBranchSHA from it.
 	case TrainCIRed:
 		e.logf(0, "merge-train", "CI red for integration PR #%d (%s) — batch needs attention\n", prNum, repoKey)
+		// Clear so the next poll cycle can dispatch a fresh train rather than
+		// logging "needs attention" forever with no way to restart.
+		e.mergeTrainInFlight.Delete(repoKey)
 	default:
 		e.logf(0, "merge-train", "CI timed out / pending for integration PR #%d (%s)\n", prNum, repoKey)
+		// Same: clear so a new worker can rebuild the trial branch on the next poll.
+		e.mergeTrainInFlight.Delete(repoKey)
 	}
-	// Do NOT delete in-flight entry — leave for #948 landing step to consume.
 }
 
 // buildTrainConflictComment constructs a synthetic comment instructing Claude to
@@ -328,12 +335,20 @@ func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.Pr
 	_ = output
 
 	// Check whether conflicts remain after Claude's work.
+	// Parse line-by-line to avoid false positives from file paths containing
+	// "UU", "AA", or "DD" as substrings. Also covers additional unmerged states.
 	statusCmd := exec.Command("git", "status", "--porcelain")
 	statusCmd.Dir = trainWorkDir
 	statusOut, _ := statusCmd.CombinedOutput()
-	if strings.Contains(string(statusOut), "UU") || strings.Contains(string(statusOut), "AA") || strings.Contains(string(statusOut), "DD") {
-		e.logf(memberItem.Number, "merge-train", "conflict markers remain after Claude resolution\n")
-		return false
+	for _, line := range strings.Split(string(statusOut), "\n") {
+		if len(line) >= 2 {
+			code := line[:2]
+			if code == "UU" || code == "AA" || code == "DD" ||
+				code == "AU" || code == "UD" || code == "UA" || code == "DU" {
+				e.logf(memberItem.Number, "merge-train", "conflict markers remain after Claude resolution\n")
+				return false
+			}
+		}
 	}
 
 	// Check that there are no staged conflict markers in the diff.
@@ -387,6 +402,12 @@ func (e *Engine) ejectMember(ctx context.Context, owner, repo string, memberItem
 		maxEjections = 3
 	}
 	if count >= maxEjections {
+		// Reset the counter so that if the user manually unpauses the issue,
+		// it gets a fresh set of N attempts before being paused again.
+		e.mergeTrainEjectionsMu.Lock()
+		e.mergeTrainEjectionCounts[counterKey] = 0
+		e.mergeTrainEjectionsMu.Unlock()
+
 		e.logf(memberItem.Number, "merge-train", "#%d ejected %d time(s) — pausing\n", memberItem.Number, count)
 		pauseMsg := fmt.Sprintf("🏭 **Fabrik merge-train — pausing after %d ejections**\n\n"+
 			"This issue has been ejected from the merge-train %d consecutive times. "+

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -446,6 +446,13 @@ func (e *Engine) pollTrainCI(ctx context.Context, owner, repo string, prNum int,
 			}
 		}
 
+		// Check deadline again before the sleep so a short CIWaitTimeout doesn't
+		// block unnecessarily in the poll interval when the deadline has already elapsed.
+		if time.Now().After(deadline) {
+			e.logf(0, "merge-train", "CI wait timeout for integration PR #%d\n", prNum)
+			return TrainCIPending
+		}
+
 		// Poll again after 30 seconds.
 		select {
 		case <-ctx.Done():

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -1,0 +1,856 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// trainTestEngine builds an Engine wired with the given mock client and invoker.
+// It configures a Queued holding stage for merge-train use and sets a short
+// CIWaitTimeout so CI-polling tests terminate quickly.
+func trainTestEngine(t *testing.T, client *mockGitHubClient, claude *mockClaudeInvoker, wm *WorktreeManager) *Engine {
+	t.Helper()
+	holdingStageConfig := &stages.Stage{
+		Name:         "Queued",
+		Order:        10,
+		HoldingStage: true,
+		MaxTurns:     10,
+	}
+	eng := NewWithDeps(
+		Config{
+			Owner:                  "owner",
+			Repo:                   "repo",
+			ProjectNum:             1,
+			User:                   "testuser",
+			Token:                  "token",
+			MaxConcurrent:          5,
+			MaxMergeTrainEjections: 3,
+			MergeTrain:             "on",
+			CIWaitTimeout:          100 * time.Millisecond, // fast timeout for tests
+			Stages: []*stages.Stage{
+				{Name: "Research", Order: 1, Prompt: "Do research"},
+				{Name: "Plan", Order: 2, Prompt: "Make a plan"},
+				{Name: "Implement", Order: 3, Prompt: "Implement it"},
+				holdingStageConfig,
+			},
+		},
+		client,
+		claude,
+		wm,
+	)
+	return eng
+}
+
+// makeTrainItem creates a minimal ProjectItem for a batch member.
+func makeTrainItem(number int, title string) gh.ProjectItem {
+	return gh.ProjectItem{
+		Number: number,
+		Title:  title,
+		Repo:   "owner/repo",
+		Status: "Queued",
+	}
+}
+
+// setupBareRepoForTrain creates a bare git repo with an initial commit on main
+// and returns (bareDir, worktreeRoot). It configures git user.name/email so commits
+// don't fail due to missing identity.
+func setupBareRepoForTrain(t *testing.T) (bareDir, worktreeRoot string) {
+	t.Helper()
+	skipIfNoGit(t)
+
+	tmp := t.TempDir()
+	bareDir = filepath.Join(tmp, "repo.git")
+	worktreeRoot = filepath.Join(tmp, "worktrees")
+
+	// Create a source repo to clone from.
+	srcDir := filepath.Join(tmp, "src")
+	mustGit(t, srcDir, "init", "-b", "main")
+	mustGit(t, srcDir, "config", "user.email", "test@test.com")
+	mustGit(t, srcDir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(srcDir, "README.md"), "# hello\n")
+	mustGit(t, srcDir, "add", "-A")
+	mustGit(t, srcDir, "commit", "-m", "initial commit")
+
+	// Bare clone.
+	cmd := exec.Command("git", "clone", "--bare", srcDir, bareDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bare clone: %s: %v", out, err)
+	}
+
+	// Set fetch refspec and refresh HEAD.
+	mustGitDir(t, bareDir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	mustGitDir(t, bareDir, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	mustGitDir(t, bareDir, "remote", "set-head", "origin", "--auto")
+	mustGitDir(t, bareDir, "config", "user.email", "test@test.com")
+	mustGitDir(t, bareDir, "config", "user.name", "Test")
+
+	return bareDir, worktreeRoot
+}
+
+// addBranchToRepo creates a branch on the src repo (not bare) and pushes to bare.
+// srcDir must already exist as a clone of bareDir.
+func addMemberBranch(t *testing.T, srcDir, bareDir, branchName, fileName, content string) string {
+	t.Helper()
+	mustGit(t, srcDir, "checkout", "-b", branchName)
+	writeFile(t, filepath.Join(srcDir, fileName), content)
+	mustGit(t, srcDir, "add", "-A")
+	mustGit(t, srcDir, "commit", "-m", "add "+fileName)
+	mustGit(t, srcDir, "push", bareDir, branchName)
+	sha := strings.TrimSpace(gitOutputDir(t, srcDir, "rev-parse", "HEAD"))
+	mustGit(t, srcDir, "checkout", "main")
+	return sha
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	if _, err := os.Stat(dir); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %s: %v", args, dir, strings.TrimSpace(string(out)), err)
+	}
+}
+
+func mustGitDir(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Logf("git %v (best-effort): %s", args, strings.TrimSpace(string(out)))
+	}
+}
+
+func gitOutputDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v", args, dir, err)
+	}
+	return string(out)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// ── pollTrainCI tests (Task 11f) ──────────────────────────────────────────────
+
+func TestPollTrainCI_MergeableStateClean_ReturnsGreen(t *testing.T) {
+	tr := true
+	client := &mockGitHubClient{
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return &tr, "clean", nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result := eng.pollTrainCI(ctx, "owner", "repo", 42, "sha123")
+	if result != TrainCIGreen {
+		t.Errorf("expected TrainCIGreen for clean mergeable_state, got %v", result)
+	}
+}
+
+func TestPollTrainCI_MergeableStateUnstable_ReturnsGreen(t *testing.T) {
+	tr := true
+	client := &mockGitHubClient{
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return &tr, "unstable", nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result := eng.pollTrainCI(ctx, "owner", "repo", 42, "sha123")
+	if result != TrainCIGreen {
+		t.Errorf("expected TrainCIGreen for unstable mergeable_state, got %v", result)
+	}
+}
+
+func TestPollTrainCI_FailedCheckRun_ReturnsRed(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return nil, "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result := eng.pollTrainCI(ctx, "owner", "repo", 42, "sha123")
+	if result != TrainCIRed {
+		t.Errorf("expected TrainCIRed for failed check run, got %v", result)
+	}
+}
+
+func TestPollTrainCI_AllChecksPass_ReturnsGreen(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return nil, "blocked", nil // not clean — falls through to check runs
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "test", Status: "completed", Conclusion: "success"},
+			}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result := eng.pollTrainCI(ctx, "owner", "repo", 42, "sha123")
+	if result != TrainCIGreen {
+		t.Errorf("expected TrainCIGreen when all checks pass, got %v", result)
+	}
+}
+
+func TestPollTrainCI_Timeout_ReturnsPending(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			// Small sleep ensures at least 10ms passes so the 1ms deadline fires
+			// after the API call — triggering the post-API deadline check.
+			time.Sleep(10 * time.Millisecond)
+			return nil, "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{{Name: "build", Status: "in_progress"}}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := NewWithDeps(
+		Config{
+			Owner:                  "owner",
+			Repo:                   "repo",
+			MaxConcurrent:          5,
+			MaxMergeTrainEjections: 3,
+			CIWaitTimeout:          1 * time.Millisecond, // expires during first API call
+			Stages: []*stages.Stage{
+				{Name: "Queued", Order: 10, HoldingStage: true, MaxTurns: 10},
+			},
+		},
+		client, claude, NewWorktreeManager(t.TempDir()),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result := eng.pollTrainCI(ctx, "owner", "repo", 42, "sha123")
+	if result != TrainCIPending {
+		t.Errorf("expected TrainCIPending on CIWaitTimeout, got %v", result)
+	}
+}
+
+func TestPollTrainCI_ContextCancelled_ReturnsPending(t *testing.T) {
+	var callCount int
+	var mu sync.Mutex
+	client := &mockGitHubClient{
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			mu.Lock()
+			callCount++
+			mu.Unlock()
+			return nil, "blocked", nil
+		},
+		fetchCheckRunsFn: func(owner, repo, sha string) ([]gh.CheckRun, error) {
+			return []gh.CheckRun{{Name: "build", Status: "in_progress"}}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	result := eng.pollTrainCI(ctx, "owner", "repo", 42, "sha123")
+	if result != TrainCIPending {
+		t.Errorf("expected TrainCIPending when context cancelled, got %v", result)
+	}
+}
+
+// ── ejectMember tests (Task 11d) ─────────────────────────────────────────────
+
+func TestEjectMember_PostsComment(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	member := makeTrainItem(1, "Test Issue")
+	eng.ejectMember(context.Background(), "owner", "repo", member, "conflict with #2")
+
+	client.mu.Lock()
+	calls := client.addCommentCalls
+	client.mu.Unlock()
+
+	if len(calls) == 0 {
+		t.Fatal("expected ejection comment to be posted")
+	}
+	if !strings.Contains(calls[0].body, "ejected") {
+		t.Errorf("ejection comment should mention 'ejected', got: %s", calls[0].body)
+	}
+}
+
+func TestEjectMember_PausesAfterMaxEjections(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+	// MaxMergeTrainEjections = 3
+
+	member := makeTrainItem(5, "Problem Issue")
+	ctx := context.Background()
+
+	// First two ejections should not add pause labels.
+	eng.ejectMember(ctx, "owner", "repo", member, "conflict")
+	eng.ejectMember(ctx, "owner", "repo", member, "conflict")
+
+	client.mu.Lock()
+	pauseCount := 0
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pauseCount++
+		}
+	}
+	client.mu.Unlock()
+	if pauseCount != 0 {
+		t.Errorf("expected no pause labels after 2 ejections, got %d", pauseCount)
+	}
+
+	// Third ejection should trigger pause.
+	eng.ejectMember(ctx, "owner", "repo", member, "conflict")
+
+	client.mu.Lock()
+	pauseCount = 0
+	awaitCount := 0
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pauseCount++
+		}
+		if c.labelName == "fabrik:awaiting-input" {
+			awaitCount++
+		}
+	}
+	client.mu.Unlock()
+
+	if pauseCount == 0 {
+		t.Error("expected fabrik:paused after 3 ejections")
+	}
+	if awaitCount == 0 {
+		t.Error("expected fabrik:awaiting-input after 3 ejections")
+	}
+}
+
+func TestEjectMember_EjectionCountIsPerMember(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	member1 := makeTrainItem(1, "Issue 1")
+	member2 := makeTrainItem(2, "Issue 2")
+	ctx := context.Background()
+
+	// Eject member 1 three times and member 2 once.
+	eng.ejectMember(ctx, "owner", "repo", member1, "conflict")
+	eng.ejectMember(ctx, "owner", "repo", member1, "conflict")
+	eng.ejectMember(ctx, "owner", "repo", member1, "conflict") // triggers pause for #1
+	eng.ejectMember(ctx, "owner", "repo", member2, "conflict") // should NOT trigger pause for #2
+
+	client.mu.Lock()
+	pausedIssues := make(map[int]bool)
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedIssues[c.issueNumber] = true
+		}
+	}
+	client.mu.Unlock()
+
+	if !pausedIssues[1] {
+		t.Error("expected issue #1 to be paused after 3 ejections")
+	}
+	if pausedIssues[2] {
+		t.Error("expected issue #2 NOT to be paused after only 1 ejection")
+	}
+}
+
+// ── dispatch guard tests ──────────────────────────────────────────────────────
+
+func TestDispatchMergeTrainWorker_SkipsWhenAlreadyAssembling(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	// Pre-populate in-flight state.
+	existingState := &mergeTrainWorkerState{assembling: true, trialName: "existing"}
+	eng.mergeTrainInFlight.Store("owner/repo", existingState)
+
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1")}
+	eng.dispatchMergeTrainWorker(context.Background(), batch)
+
+	// No goroutine should have been launched (wg count stays 0).
+	done := make(chan struct{})
+	go func() {
+		eng.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Good — no workers launched.
+	case <-time.After(100 * time.Millisecond):
+		t.Error("wg.Wait() timed out — a goroutine was unexpectedly launched")
+	}
+}
+
+func TestDispatchMergeTrainWorker_LogsGreenState(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	// Pre-populate with green CI result.
+	existingState := &mergeTrainWorkerState{assembling: false, prNum: 99, CIResult: TrainCIGreen}
+	eng.mergeTrainInFlight.Store("owner/repo", existingState)
+
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1")}
+	// Just verify it doesn't panic or launch a worker.
+	eng.dispatchMergeTrainWorker(context.Background(), batch)
+}
+
+func TestDispatchMergeTrainWorker_EmptyBatch_NoOp(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	eng.dispatchMergeTrainWorker(context.Background(), nil)
+	eng.dispatchMergeTrainWorker(context.Background(), []gh.ProjectItem{})
+	// Should not panic or store anything.
+}
+
+// ── sanitizeBranchName test ──────────────────────────────────────────────────
+
+func TestSanitizeBranchName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"main", "main"},
+		{"release/v1", "release-v1"},
+		{"feature/foo/bar", "feature-foo-bar"},
+		{"no-slashes", "no-slashes"},
+	}
+	for _, tc := range cases {
+		got := sanitizeBranchName(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeBranchName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── Integration tests (Tasks 11a-e + Task 12, real git) ──────────────────────
+
+// setupTrainRepo creates a bare clone with main configured and a source clone for
+// creating branches, returning (bareDir, srcDir, worktreeRoot, WorktreeManager).
+func setupTrainRepo(t *testing.T) (bareDir, srcDir, worktreeRoot string, wm *WorktreeManager) {
+	t.Helper()
+	skipIfNoGit(t)
+
+	tmp := t.TempDir()
+	srcDir = filepath.Join(tmp, "src")
+	bareDir = filepath.Join(tmp, "repo.git")
+	worktreeRoot = filepath.Join(tmp, "worktrees")
+
+	// Create the source repo.
+	mustGit(t, srcDir, "init", "-b", "main")
+	mustGit(t, srcDir, "config", "user.email", "test@test.com")
+	mustGit(t, srcDir, "config", "user.name", "Test")
+	writeFile(t, filepath.Join(srcDir, "counter.txt"), "0\n")
+	mustGit(t, srcDir, "add", "-A")
+	mustGit(t, srcDir, "commit", "-m", "initial")
+
+	// Bare clone.
+	cmd := exec.Command("git", "clone", "--bare", srcDir, bareDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bare clone: %s: %v", out, err)
+	}
+	mustGitDir(t, bareDir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	mustGitDir(t, bareDir, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	mustGitDir(t, bareDir, "remote", "set-head", "origin", "--auto")
+	mustGitDir(t, bareDir, "config", "user.email", "test@test.com")
+	mustGitDir(t, bareDir, "config", "user.name", "Test")
+
+	wm = NewWorktreeManagerForRepo(bareDir, worktreeRoot, "test-repo")
+	wm.logfFn = func(n int, tag, format string, args ...any) {
+		t.Logf("[#%d %s] "+format, append([]any{n, tag}, args...)...)
+	}
+	return bareDir, srcDir, worktreeRoot, wm
+}
+
+// pushBranchToBare creates a branch in srcDir, writes a file, commits, and pushes to bareDir.
+// Returns the HEAD SHA.
+func pushBranchToBare(t *testing.T, srcDir, bareDir, branchName, fileName, content string) string {
+	t.Helper()
+	mustGit(t, srcDir, "checkout", "main")
+	mustGit(t, srcDir, "checkout", "-b", branchName)
+	writeFile(t, filepath.Join(srcDir, fileName), content)
+	mustGit(t, srcDir, "add", "-A")
+	mustGit(t, srcDir, "commit", "-m", "add "+fileName)
+	mustGit(t, srcDir, "push", bareDir, branchName+":"+branchName)
+	sha := strings.TrimSpace(gitOutputDir(t, srcDir, "rev-parse", "HEAD"))
+	mustGit(t, srcDir, "checkout", "main")
+	mustGit(t, srcDir, "branch", "-D", branchName)
+	return sha
+}
+
+// TestMergeTrainWorker_CleanBatch verifies that a batch of members that all merge
+// cleanly produces a draft integration PR (Task 11a).
+func TestMergeTrainWorker_CleanBatch(t *testing.T) {
+	skipIfNoGit(t)
+	_, srcDir, _, wm := setupTrainRepo(t)
+
+	// Create two member branches with non-conflicting changes.
+	sha1 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-1", "file1.txt", "content1\n")
+	sha2 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-2", "file2.txt", "content2\n")
+
+	var createdPRs []createDraftPRCall
+	var mu sync.Mutex
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			switch issueNumber {
+			case 1:
+				return &gh.PRDetails{Number: 10, HeadSHA: sha1, State: "open"}, nil
+			case 2:
+				return &gh.PRDetails{Number: 11, HeadSHA: sha2, State: "open"}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			mu.Lock()
+			createdPRs = append(createdPRs, createDraftPRCall{owner, repo, title, head, base, body, issueNumber})
+			mu.Unlock()
+			return 99, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			tr := true
+			return &tr, "clean", nil // CI green immediately
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, wm)
+	// Register the WM.
+	eng.mu.Lock()
+	eng.worktreeManagers["owner/repo"] = wm
+	eng.mu.Unlock()
+
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1"), makeTrainItem(2, "Issue 2")}
+	state := &mergeTrainWorkerState{assembling: true, trialName: fmt.Sprintf("merge-train-repo-%d", time.Now().Unix())}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	mu.Lock()
+	n := len(createdPRs)
+	mu.Unlock()
+	if n != 1 {
+		t.Errorf("expected 1 draft PR, got %d", n)
+	}
+	mu.Lock()
+	if n > 0 && !strings.Contains(createdPRs[0].head, "merge-train") {
+		t.Errorf("draft PR head %q should contain 'merge-train'", createdPRs[0].head)
+	}
+	mu.Unlock()
+
+	// In-flight entry should remain (for #948 to consume).
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); !ok {
+		t.Error("expected mergeTrainInFlight entry to persist after CI resolved")
+	}
+	if state.CIResult != TrainCIGreen {
+		t.Errorf("expected TrainCIGreen, got %v", state.CIResult)
+	}
+}
+
+// TestMergeTrainWorker_UnresolvableConflict verifies ejection when Claude cannot
+// resolve a conflict (Task 11c).
+func TestMergeTrainWorker_UnresolvableConflict(t *testing.T) {
+	skipIfNoGit(t)
+	_, srcDir, _, wm := setupTrainRepo(t)
+
+	// Both branches modify the same line — guaranteed conflict.
+	sha1 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-1", "counter.txt", "branch1-value\n")
+	sha2 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-2", "counter.txt", "branch2-value\n")
+
+	var addCommentIssues []int
+	var createdPRs int
+	var mu sync.Mutex
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			switch issueNumber {
+			case 1:
+				return &gh.PRDetails{Number: 10, HeadSHA: sha1, State: "open"}, nil
+			case 2:
+				return &gh.PRDetails{Number: 11, HeadSHA: sha2, State: "open"}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			mu.Lock()
+			addCommentIssues = append(addCommentIssues, issueNumber)
+			mu.Unlock()
+			return 1, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			mu.Lock()
+			createdPRs++
+			mu.Unlock()
+			return 99, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			tr := true
+			return &tr, "clean", nil
+		},
+	}
+	// Claude returns success but doesn't actually fix the conflict (simulates failure).
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Don't fix the conflict — return success but leave conflict markers.
+			return "unable to resolve", false, TokenUsage{}, nil
+		},
+	}
+	eng := trainTestEngine(t, client, claude, wm)
+	eng.mu.Lock()
+	eng.worktreeManagers["owner/repo"] = wm
+	eng.mu.Unlock()
+
+	// member 1 merges cleanly, member 2 conflicts.
+	// Since both modify counter.txt, the first merge goes in, second conflicts.
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1"), makeTrainItem(2, "Issue 2")}
+	state := &mergeTrainWorkerState{assembling: true, trialName: fmt.Sprintf("merge-train-repo-%d", time.Now().Unix())}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	mu.Lock()
+	prs := createdPRs
+	comments := append([]int(nil), addCommentIssues...)
+	mu.Unlock()
+
+	// One draft PR should be created (for the survivor — issue #1).
+	if prs != 1 {
+		t.Errorf("expected 1 draft PR (for survivor #1), got %d", prs)
+	}
+	// Issue #2 should have received an ejection comment.
+	ejectedIssue2 := false
+	for _, n := range comments {
+		if n == 2 {
+			ejectedIssue2 = true
+		}
+	}
+	if !ejectedIssue2 {
+		t.Error("expected ejection comment on issue #2")
+	}
+}
+
+// TestMergeTrainWorker_ZeroSurvivors verifies FR-6: when FetchLinkedPR fails for
+// all members (ejecting each one), no draft PR is created and the in-flight entry
+// is cleared (Task 11e).
+func TestMergeTrainWorker_ZeroSurvivors(t *testing.T) {
+	skipIfNoGit(t)
+	_, _, _, wm := setupTrainRepo(t)
+
+	var createdPRs int
+	var mu sync.Mutex
+
+	// All FetchLinkedPR calls return an error → all members ejected immediately.
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return nil, fmt.Errorf("PR not found for issue #%d", issueNumber)
+		},
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 1, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			mu.Lock()
+			createdPRs++
+			mu.Unlock()
+			return 99, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, wm)
+	eng.mu.Lock()
+	eng.worktreeManagers["owner/repo"] = wm
+	eng.mu.Unlock()
+
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1"), makeTrainItem(2, "Issue 2")}
+	state := &mergeTrainWorkerState{assembling: true, trialName: fmt.Sprintf("merge-train-repo-%d", time.Now().Unix())}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	mu.Lock()
+	prs := createdPRs
+	mu.Unlock()
+
+	if prs != 0 {
+		t.Errorf("expected 0 draft PRs for zero-survivor batch, got %d", prs)
+	}
+	// In-flight entry must be cleared (FR-6: no silent abandonment).
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); ok {
+		t.Error("expected mergeTrainInFlight to be cleared after zero-survivor batch")
+	}
+}
+
+// TestMergeTrainWorker_ConflictResolvedByClaude verifies Task 11b: Claude resolves
+// a textual conflict and the resolved member appears in survivors (Task 12).
+func TestMergeTrainWorker_ConflictResolvedByClaude(t *testing.T) {
+	skipIfNoGit(t)
+	_, srcDir, _, wm := setupTrainRepo(t)
+
+	// Both branches modify counter.txt — but Claude will fix it.
+	sha1 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-1", "counter.txt", "from-branch-1\n")
+	sha2 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-2", "counter.txt", "from-branch-2\n")
+
+	var createdPRs []createDraftPRCall
+	var mu sync.Mutex
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			switch issueNumber {
+			case 1:
+				return &gh.PRDetails{Number: 10, HeadSHA: sha1, State: "open"}, nil
+			case 2:
+				return &gh.PRDetails{Number: 11, HeadSHA: sha2, State: "open"}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 1, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			mu.Lock()
+			createdPRs = append(createdPRs, createDraftPRCall{owner, repo, title, head, base, body, issueNumber})
+			mu.Unlock()
+			return 99, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			tr := true
+			return &tr, "clean", nil
+		},
+	}
+
+	// Claude resolves the conflict by writing a resolved file and committing.
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Write the resolved file (no conflict markers).
+			resolvedContent := "from-branch-1\nfrom-branch-2\n"
+			if err := os.WriteFile(filepath.Join(workDir, "counter.txt"), []byte(resolvedContent), 0644); err != nil {
+				return "", false, TokenUsage{}, fmt.Errorf("write resolved file: %w", err)
+			}
+			// Stage and commit.
+			addCmd := exec.Command("git", "add", "-A")
+			addCmd.Dir = workDir
+			if out, err := addCmd.CombinedOutput(); err != nil {
+				return fmt.Sprintf("git add failed: %s", out), false, TokenUsage{}, nil
+			}
+			commitCmd := exec.Command("git", "commit", "--no-edit", "-m",
+				fmt.Sprintf("chore(merge-train): resolve conflict for #%d", issue.Number))
+			commitCmd.Dir = workDir
+			if out, err := commitCmd.CombinedOutput(); err != nil {
+				return fmt.Sprintf("git commit failed: %s", out), false, TokenUsage{}, nil
+			}
+			return "resolved successfully", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := trainTestEngine(t, client, claude, wm)
+	eng.mu.Lock()
+	eng.worktreeManagers["owner/repo"] = wm
+	eng.mu.Unlock()
+
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1"), makeTrainItem(2, "Issue 2")}
+	state := &mergeTrainWorkerState{assembling: true, trialName: fmt.Sprintf("merge-train-repo-%d", time.Now().Unix())}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	mu.Lock()
+	n := len(createdPRs)
+	mu.Unlock()
+
+	// Both members should be in the draft PR (conflict resolved → both survive).
+	if n != 1 {
+		t.Fatalf("expected 1 draft PR after Claude resolution, got %d", n)
+	}
+	mu.Lock()
+	body := createdPRs[0].body
+	mu.Unlock()
+	if !strings.Contains(body, "#1") || !strings.Contains(body, "#2") {
+		t.Errorf("PR body should reference both members, got: %s", body)
+	}
+}
+
+// TestEnsureTrainWorktree verifies the WorktreeManager train methods (Task 2 integration).
+func TestEnsureTrainWorktree(t *testing.T) {
+	skipIfNoGit(t)
+	_, srcDir, worktreeRoot, _ := setupTrainRepo(t)
+
+	bareDir := filepath.Join(filepath.Dir(srcDir), "repo.git")
+	wm := NewWorktreeManagerForRepo(bareDir, worktreeRoot, "test-repo")
+	wm.logfFn = func(n int, tag, format string, args ...any) {
+		t.Logf("[#%d %s] "+format, append([]any{n, tag}, args...)...)
+	}
+
+	wtDir, err := wm.EnsureTrainWorktree("test-trial-123", "main")
+	if err != nil {
+		t.Fatalf("EnsureTrainWorktree: %v", err)
+	}
+	if _, err := os.Stat(wtDir); err != nil {
+		t.Errorf("train worktree directory not created: %v", err)
+	}
+
+	// Branch should be fabrik/merge-train/test-trial-123.
+	out := strings.TrimSpace(gitOutputDir(t, wtDir, "rev-parse", "--abbrev-ref", "HEAD"))
+	if out != "fabrik/merge-train/test-trial-123" {
+		t.Errorf("expected branch fabrik/merge-train/test-trial-123, got %s", out)
+	}
+
+	// Cleanup.
+	if err := wm.CleanupTrainWorktree("test-trial-123", true); err != nil {
+		t.Errorf("CleanupTrainWorktree: %v", err)
+	}
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1627,10 +1627,10 @@ doneDispatching:
 	}, nil
 }
 
-// handleMergeTrainBatch snapshots all items currently in the holding stage column and
-// logs the batch that the merge train would form on this poll cycle. This is the
-// ADR-059 D1 skeleton — no trial branch, no landing logic yet (D2–D5 follow).
-func (e *Engine) handleMergeTrainBatch(_ context.Context, board *gh.ProjectBoard) {
+// handleMergeTrainBatch processes the current Queued batch for the merge train.
+// On first call with a new batch, dispatches a merge-train worker goroutine.
+// On subsequent calls, logs the current worker state without re-dispatching.
+func (e *Engine) handleMergeTrainBatch(ctx context.Context, board *gh.ProjectBoard) {
 	hs := holdingStage(e.cfg)
 	if hs == nil {
 		return
@@ -1649,6 +1649,7 @@ func (e *Engine) handleMergeTrainBatch(_ context.Context, board *gh.ProjectBoard
 		parts = append(parts, fmt.Sprintf("#%d %q", item.Number, item.Title))
 	}
 	e.logf(0, "merge-train", "batch snapshot: %d item(s) — %s\n", len(batch), strings.Join(parts, ", "))
+	e.dispatchMergeTrainWorker(ctx, batch)
 }
 
 func gitRevParse(dir, ref string) (string, error) {

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -338,6 +338,11 @@ func (wm *WorktreeManager) EnsureTrainWorktree(name, baseBranch string) (string,
 		rmCmd.Dir = wm.baseDir
 		rmCmd.CombinedOutput() // best-effort
 	}
+	// Prune stale worktree metadata so a prior crash doesn't leave an
+	// "already exists" tombstone that blocks the new worktree add.
+	pruneCmd := exec.Command("git", "worktree", "prune")
+	pruneCmd.Dir = wm.baseDir
+	pruneCmd.Run() // best-effort
 
 	// Ensure root directory exists.
 	if err := os.MkdirAll(wm.rootDir, 0755); err != nil {

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -305,6 +305,110 @@ func (wm *WorktreeManager) WorktreeDir(issueNumber int) string {
 	return wm.worktreeDir(issueNumber)
 }
 
+// trainWorktreeDir returns the path to a merge-train worktree directory.
+func (wm *WorktreeManager) trainWorktreeDir(name string) string {
+	if wm.repoName != "" {
+		return filepath.Join(wm.rootDir, wm.repoName, name)
+	}
+	return filepath.Join(wm.rootDir, name)
+}
+
+func (wm *WorktreeManager) trainBranchName(name string) string {
+	return "fabrik/merge-train/" + name
+}
+
+// TrainWorktreeDir returns the path to a merge-train worktree (whether it exists or not).
+func (wm *WorktreeManager) TrainWorktreeDir(name string) string {
+	return wm.trainWorktreeDir(name)
+}
+
+// EnsureTrainWorktree creates a worktree for the trial branch, forking fresh from
+// origin/<baseBranch>. Unlike EnsureWorktree it never reuses an existing worktree
+// (trial branches are disposable) and never updates from main (the fork is always fresh).
+func (wm *WorktreeManager) EnsureTrainWorktree(name, baseBranch string) (string, error) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	wtDir := wm.trainWorktreeDir(name)
+	branch := wm.trainBranchName(name)
+
+	// Remove any pre-existing worktree at this path (e.g. from a crashed previous run).
+	if _, err := os.Stat(wtDir); err == nil {
+		rmCmd := exec.Command("git", "worktree", "remove", "--force", wtDir)
+		rmCmd.Dir = wm.baseDir
+		rmCmd.CombinedOutput() // best-effort
+	}
+
+	// Ensure root directory exists.
+	if err := os.MkdirAll(wm.rootDir, 0755); err != nil {
+		return "", fmt.Errorf("creating worktree root: %w", err)
+	}
+
+	// Delete the branch if it already exists (stale from a prior crashed run).
+	if wm.branchExists(branch) {
+		delCmd := exec.Command("git", "branch", "-D", branch)
+		delCmd.Dir = wm.baseDir
+		delCmd.CombinedOutput() // best-effort
+	}
+
+	// Fork from origin/<baseBranch>.
+	baseRef := "refs/remotes/origin/" + baseBranch
+	if !wm.branchExists("origin/" + baseBranch) {
+		baseRef = baseBranch
+	}
+	cmd := exec.Command("git", "branch", branch, baseRef)
+	cmd.Dir = wm.baseDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("creating trial branch %s from %s: %s: %w", branch, baseRef, string(out), err)
+	}
+
+	// Create the worktree.
+	cmd = exec.Command("git", "worktree", "add", "-f", wtDir, branch)
+	cmd.Dir = wm.baseDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("creating train worktree: %s: %w", string(out), err)
+	}
+
+	return wtDir, nil
+}
+
+// PushTrainBranch pushes the trial branch to origin.
+func (wm *WorktreeManager) PushTrainBranch(name string) error {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	wtDir := wm.trainWorktreeDir(name)
+	branch := wm.trainBranchName(name)
+	cmd := exec.Command("git", "push", "-u", "origin", branch)
+	cmd.Dir = wtDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("pushing trial branch %s: %s: %w", branch, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// CleanupTrainWorktree removes the trial branch worktree and optionally its branch.
+func (wm *WorktreeManager) CleanupTrainWorktree(name string, deleteBranch bool) error {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	wtDir := wm.trainWorktreeDir(name)
+
+	cmd := exec.Command("git", "worktree", "remove", "--force", wtDir)
+	cmd.Dir = wm.baseDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("removing train worktree: %s: %w", string(out), err)
+	}
+
+	if deleteBranch {
+		branch := wm.trainBranchName(name)
+		cmd := exec.Command("git", "branch", "-D", branch)
+		cmd.Dir = wm.baseDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("deleting trial branch %s: %s: %w", branch, string(out), err)
+		}
+	}
+	return nil
+}
+
 func (wm *WorktreeManager) worktreeDir(issueNumber int) string {
 	if wm.repoName != "" {
 		return filepath.Join(wm.rootDir, wm.repoName, fmt.Sprintf("issue-%d", issueNumber))


### PR DESCRIPTION
Closes #947

## What this PR does

Implements the mechanical core of Fabrik's internal merge train (ADR-059 D3): a single async worker that builds a `fabrik/merge-train/<base>-<timestamp>` trial branch by sequentially merging each Queued member's PR head, resolves conflicts inline with Claude (semantic resolution, not just "pick a side"), ejects unresolvable members with a comment and bounded-retry pause, pushes the trial branch, opens a draft integration PR to trigger CI, and polls the PR's required checks — returning a typed `TrainCIResult` (green/red/pending) for the landing step (next issue, #948).

## Key changes

**`engine/merge_train.go`** (new, ~460 lines) — full worker: `TrainCIResult` enum, `mergeTrainWorkerState`, `dispatchMergeTrainWorker`, `runMergeTrainWorker`, `resolveConflictWithClaude`, `ejectMember`, `pollTrainCI`.

**`engine/worktree.go`** — added six string-keyed WorktreeManager methods for train worktrees: `EnsureTrainWorktree`, `PushTrainBranch`, `CleanupTrainWorktree`, `TrainWorktreeDir`, `trainWorktreeDir`, `trainBranchName`. Reuses the existing WM mutex for git-config safety.

**`engine/engine.go`** — `MaxMergeTrainEjections int` added to `Config` (default 3); `mergeTrainInFlight sync.Map`, `mergeTrainEjectionsMu sync.Mutex`, `mergeTrainEjectionCounts map[string]int` added to `Engine`.

**`engine/poll.go`** — `handleMergeTrainBatch` upgraded from log-only skeleton to full dispatch: checks in-flight guard (assembling → skip; CI-green → log "awaiting landing"; no entry → dispatch worker).

**`engine/merge_train_test.go`** (new, ~430 lines) — 20 tests covering all paths: CI polling (green/red/pending/timeout/cancel), member ejection (comment, pause-after-max, per-member count), dispatch guard, zero-survivors, `sanitizeBranchName`, and integration tests with real git (clean batch, unresolvable conflict, zero-survivors, Claude-resolved conflict).

**`CLAUDE.md`** — architecture table updated with `engine/merge_train.go` entry.

## Boundary shift vs. original plan

The #947/#948 boundary was adjusted per spec: **this issue opens the draft integration PR** (trial → base) as the reliable CI vehicle. Issue #948 picks up from the existing draft PR, marks it ready, merges it, and runs the member lifecycle. This is noted in the spec's Scope section.

## How to test

- `go test ./engine/... -run TestPollTrainCI` — CI polling paths
- `go test ./engine/... -run TestEjectMember` — ejection with comment + pause-after-N
- `go test ./engine/... -run TestMergeTrainWorker` — integration (requires `git` in PATH)
- `go test -race ./...` — full suite with race detector