### PR TITLE
fix(engine): run reconcile independent of webhooks; detect fabrik label drift (#955)

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -1,6 +1,7 @@
 package boardcache
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1092,6 +1093,7 @@ func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType
 	type entry struct {
 		status    string
 		updatedAt time.Time
+		gateLabel string
 	}
 
 	// Snapshot current cache items. Store.All() handles its own locking.
@@ -1102,6 +1104,7 @@ func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType
 		cached[itemKey(snap.Repo(), snap.Number())] = entry{
 			status:    s.Status,
 			updatedAt: s.UpdatedAt,
+			gateLabel: fabrikManagedLabelKey(s.Labels),
 		}
 	}
 
@@ -1122,7 +1125,18 @@ func (c *CacheImpl) LightReconcile(owner, repo string, projectNum int, ownerType
 			driftedKeys = append(driftedKeys, key)
 			continue
 		}
-		if e.status != pi.Status || !e.updatedAt.Equal(pi.UpdatedAt) {
+		// Compare status, updatedAt, AND the fabrik-managed label set. Label
+		// comparison is scoped to fabrik: / stage: labels (the ones that gate
+		// dispatch) rather than the full set: the board query truncates labels
+		// (first: 30), so comparing all labels would false-positive for issues
+		// with many labels (#641). The gate-label subset is small and never
+		// truncated. Including it here closes the hole where a store label set
+		// diverges from GitHub with a matching updatedAt (e.g. updatedAt laundered
+		// by a deep-fetch that syncs updatedAt but not labels), which otherwise
+		// strands an item at a gate forever on webhook-less deployments (#955).
+		if e.status != pi.Status ||
+			!e.updatedAt.Equal(pi.UpdatedAt) ||
+			e.gateLabel != fabrikManagedLabelKey(pi.Labels) {
 			driftCount++
 			driftedKeys = append(driftedKeys, key)
 		}
@@ -1171,6 +1185,22 @@ func copyDeepFields(dst, src *gh.ProjectItem) {
 	dst.LinkedPRReviews = clonePRReviews(src.LinkedPRReviews)
 	dst.LinkedPRReviewThreadComments = cloneComments(src.LinkedPRReviewThreadComments)
 	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
+}
+
+// fabrikManagedLabelKey returns an order-independent canonical key of the
+// fabrik-managed labels (fabrik: / stage: prefixes) in the slice — the labels
+// that gate dispatch. Used by LightReconcile to detect gate-label drift between
+// the cache and GitHub without false-positiving on the board query's label
+// truncation (only these few labels are compared, and they never exceed the cap).
+func fabrikManagedLabelKey(labels []string) string {
+	managed := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if strings.HasPrefix(l, "fabrik:") || strings.HasPrefix(l, "stage:") {
+			managed = append(managed, l)
+		}
+	}
+	sort.Strings(managed)
+	return strings.Join(managed, "\n")
 }
 
 func cloneStrings(s []string) []string {

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -1193,6 +1193,9 @@ func copyDeepFields(dst, src *gh.ProjectItem) {
 // the cache and GitHub without false-positiving on the board query's label
 // truncation (only these few labels are compared, and they never exceed the cap).
 func fabrikManagedLabelKey(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
 	managed := make([]string, 0, len(labels))
 	for _, l := range labels {
 		if strings.HasPrefix(l, "fabrik:") || strings.HasPrefix(l, "stage:") {

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -2246,6 +2246,61 @@ func TestLightReconcile_DriftDetected(t *testing.T) {
 	}
 }
 
+// TestLightReconcile_FabrikManagedLabelDriftDetected is the #955 regression: a
+// store whose fabrik-managed label set diverged from GitHub (here the store is
+// missing fabrik:awaiting-ci) with a MATCHING updatedAt — the exact condition that
+// stranded shadoworg/fantasy#1479 — must be detected as drift so Reconcile repairs
+// the label set. A non-fabrik label change with matching updatedAt must NOT drift
+// (preserving #641's fix against board-query label truncation false-positives).
+func TestLightReconcile_FabrikManagedLabelDriftDetected(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second)
+
+	seedBoard := &gh.ProjectBoard{
+		ProjectID: "PID",
+		Items: []gh.ProjectItem{
+			// #1 seeded WITHOUT fabrik:awaiting-ci (the drifted store state).
+			{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Validate", Labels: []string{"fabrik:cruise", "stage:Review:complete"}, UpdatedAt: t1},
+			// #2 seeded with a user label.
+			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: []string{"user-label"}, UpdatedAt: t1},
+		},
+	}
+	mc := &mockClient{}
+	c := NewCacheImpl(mc, itemstate.NewStore(nil), nopLog)
+	testBootstrapFromBoard(c, seedBoard)
+
+	// Fresh board: SAME status + updatedAt for both. #1 gained fabrik:awaiting-ci
+	// (a fabrik-managed gate label) — must be drift. #2 changed a user label only —
+	// must NOT be drift (label truncation false-positive guard, #641).
+	mc.projectBoardResult = &gh.ProjectBoard{
+		ProjectID: "PID",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", Number: 1, Repo: "owner/repo", Status: "Validate", Labels: []string{"fabrik:cruise", "stage:Review:complete", "fabrik:awaiting-ci"}, UpdatedAt: t1},
+			{ID: "I_2", Number: 2, Repo: "owner/repo", Status: "Plan", Labels: []string{"different-user-label"}, UpdatedAt: t1},
+		},
+	}
+
+	driftCount, driftedKeys, freshBoard, err := c.LightReconcile("owner", "repo", 1, "organization")
+	if err != nil {
+		t.Fatalf("LightReconcile returned unexpected error: %v", err)
+	}
+	if freshBoard == nil {
+		t.Error("freshBoard should not be nil on success")
+	}
+	seen := make(map[string]bool)
+	for _, k := range driftedKeys {
+		seen[k] = true
+	}
+	if !seen["owner/repo#1"] {
+		t.Errorf("fabrik-managed label drift on #1 not detected; driftedKeys = %v", driftedKeys)
+	}
+	if seen["owner/repo#2"] {
+		t.Errorf("non-fabrik label change on #2 must not drift (truncation guard); driftedKeys = %v", driftedKeys)
+	}
+	if driftCount != 1 {
+		t.Errorf("driftCount = %d, want 1 (only #1); driftedKeys: %v", driftCount, driftedKeys)
+	}
+}
+
 func TestLightReconcile_RemovedItemIsDrift(t *testing.T) {
 	t1 := time.Now().Truncate(time.Second)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4185,7 +4185,9 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 
 Webhooks continue to apply deltas to the cache via `ApplyDelta` but no longer drive health state. Event silence does not produce health transitions — only `LightReconcile` drift detection does.
 
-**Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
+**The reconcile ticker runs independent of webhooks (poll-only correctness backstop).** `reconcileLoop` (`engine/poll.go`) is launched unconditionally whenever the cache is active — it is *not* nested in the webhook-manager start path. This is required because webhooks are an optimization, not a correctness requirement: on a webhook-less deployment (or when the `gh webhook forward` subprocess fails to start), the reconcile ticker is the only mechanism that re-syncs the cache with GitHub, and it must still run. When the webhook manager is present it also receives the health-state transitions above; when it is absent (`wm == nil`) the drift detection and `Pause → Reconcile → Resume` repair still run, only the health-state signaling is skipped. `LightReconcile` drift detection compares `status`, `updatedAt`, and the **fabrik-managed label set** (`fabrik:*` / `stage:*` labels only — the board query truncates labels at 30, so the full set is not compared; the gate-label subset is small and never truncated). Comparing the gate-label subset closes the case where a store label set diverges from GitHub with a matching `updatedAt` (e.g. `updatedAt` advanced by a deep-fetch that syncs `updatedAt` but not labels), which would otherwise strand an item at a gate (e.g. `fabrik:awaiting-ci` missing from the store) indefinitely on a webhook-less deployment.
+
+**Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop (and the reconcile ticker) continues normally.
 
 **References:** [ADR-032: Webhook-Driven Event Delivery](../adrs/032-webhook-event-delivery.md)
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1602,7 +1602,9 @@ When the webhook stream is healthy or starting up, steady-state polling is suppr
 
 Webhooks continue to apply deltas to the cache via `ApplyDelta` but no longer drive health state. Event silence does not produce health transitions — only `LightReconcile` drift detection does.
 
-**Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop continues normally.
+**The reconcile ticker runs independent of webhooks (poll-only correctness backstop).** `reconcileLoop` (`engine/poll.go`) is launched unconditionally whenever the cache is active — it is *not* nested in the webhook-manager start path. This is required because webhooks are an optimization, not a correctness requirement: on a webhook-less deployment (or when the `gh webhook forward` subprocess fails to start), the reconcile ticker is the only mechanism that re-syncs the cache with GitHub, and it must still run. When the webhook manager is present it also receives the health-state transitions above; when it is absent (`wm == nil`) the drift detection and `Pause → Reconcile → Resume` repair still run, only the health-state signaling is skipped. `LightReconcile` drift detection compares `status`, `updatedAt`, and the **fabrik-managed label set** (`fabrik:*` / `stage:*` labels only — the board query truncates labels at 30, so the full set is not compared; the gate-label subset is small and never truncated). Comparing the gate-label subset closes the case where a store label set diverges from GitHub with a matching `updatedAt` (e.g. `updatedAt` advanced by a deep-fetch that syncs `updatedAt` but not labels), which would otherwise strand an item at a gate (e.g. `fabrik:awaiting-ci` missing from the store) indefinitely on a webhook-less deployment.
+
+**Webhook mode is always non-fatal.** If the `gh webhook forward` subprocess fails to start, the stream state stays `Unhealthy` and the 5-minute idle cap applies. The poll loop (and the reconcile ticker) continues normally.
 
 **References:** [ADR-032: Webhook-Driven Event Delivery](../adrs/032-webhook-event-delivery.md)
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -476,46 +476,22 @@ func (e *Engine) Run() error {
 		if err := wm.Start(ctx, e.cfg.WebhookPort); err == nil {
 			e.webhookMgr = wm
 			defer wm.Stop()
-
-			if cacheImpl != nil {
-				reconcileInterval := e.cfg.ReconcileInterval
-				if reconcileInterval <= 0 {
-					reconcileInterval = lightReconcileInterval
-				}
-				go func() {
-					ticker := time.NewTicker(reconcileInterval)
-					defer ticker.Stop()
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						case <-ticker.C:
-							driftCount, driftedKeys, freshBoard, err := cacheImpl.LightReconcile(
-								e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType,
-							)
-							if err != nil {
-								e.logf(0, "reconcile", "light reconcile failed (no health state change): %v\n", err)
-								continue
-							}
-							if driftCount == 0 {
-								wm.transitionHealthState(WebhookStreamHealthy, "")
-							} else {
-								keyStr := fmt.Sprintf("%v", driftedKeys)
-								if len(driftedKeys) > 5 {
-									keyStr = fmt.Sprintf("%v … %d more", driftedKeys[:5], len(driftedKeys)-5)
-								}
-								e.logf(0, "reconcile", "light reconcile: %d item(s) drifted (%s) — reconciling cache\n", driftCount, keyStr)
-								wm.transitionHealthState(WebhookStreamUnhealthy, fmt.Sprintf("%d item(s) drifted", driftCount))
-								cacheImpl.Pause()
-								cacheImpl.Reconcile(freshBoard)
-								cacheImpl.Resume()
-								wm.transitionHealthState(WebhookStreamHealthy, "drift reconciled")
-							}
-						}
-					}
-				}()
-			}
 		}
+		// NOTE: the reconcile ticker is intentionally NOT started here. It is the
+		// poll-only correctness backstop and must run whether or not the webhook
+		// manager started (#955) — it is launched unconditionally below.
+	}
+
+	// Reconcile ticker: the poll-only correctness backstop that re-syncs the cache
+	// from GitHub on drift — notably fabrik-managed label state, whose divergence
+	// (e.g. a store missing fabrik:awaiting-ci while GitHub has it) otherwise
+	// strands an item at a gate forever. This MUST run independent of webhooks
+	// (#955): webhooks are an optimization, not a requirement, so drift repair may
+	// not be gated on the webhook manager starting. e.webhookMgr is nil when
+	// webhooks are disabled or failed to start; reconcileLoop skips health-state
+	// signaling in that case.
+	if cacheImpl != nil {
+		go e.reconcileLoop(ctx, cacheImpl, e.webhookMgr)
 	}
 
 	if e.events == nil {
@@ -2318,6 +2294,57 @@ func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
 		return
 	}
 	cache.Reconcile(board)
+}
+
+// reconcileLoop is the poll-only correctness backstop for cache/GitHub divergence.
+// It periodically runs LightReconcile (a fresh shallow board fetch + drift compare)
+// and, on drift, reconciles the cache — re-syncing shallow fields including the
+// fabrik-managed label set. It MUST run whether or not the webhook manager started
+// (#955): a webhook-less (or webhook-failed) deployment must still self-heal, so
+// this loop is launched unconditionally rather than nested in the webhook-start
+// path. wm may be nil (webhooks off/failed); webhook health-state transitions are
+// skipped in that case, but drift detection and repair still run.
+func (e *Engine) reconcileLoop(ctx context.Context, cacheImpl *boardcache.CacheImpl, wm *webhookManager) {
+	reconcileInterval := e.cfg.ReconcileInterval
+	if reconcileInterval <= 0 {
+		reconcileInterval = lightReconcileInterval
+	}
+	ticker := time.NewTicker(reconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			driftCount, driftedKeys, freshBoard, err := cacheImpl.LightReconcile(
+				e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType,
+			)
+			if err != nil {
+				e.logf(0, "reconcile", "light reconcile failed (no health state change): %v\n", err)
+				continue
+			}
+			if driftCount == 0 {
+				if wm != nil {
+					wm.transitionHealthState(WebhookStreamHealthy, "")
+				}
+				continue
+			}
+			keyStr := fmt.Sprintf("%v", driftedKeys)
+			if len(driftedKeys) > 5 {
+				keyStr = fmt.Sprintf("%v … %d more", driftedKeys[:5], len(driftedKeys)-5)
+			}
+			e.logf(0, "reconcile", "light reconcile: %d item(s) drifted (%s) — reconciling cache\n", driftCount, keyStr)
+			if wm != nil {
+				wm.transitionHealthState(WebhookStreamUnhealthy, fmt.Sprintf("%d item(s) drifted", driftCount))
+			}
+			cacheImpl.Pause()
+			cacheImpl.Reconcile(freshBoard)
+			cacheImpl.Resume()
+			if wm != nil {
+				wm.transitionHealthState(WebhookStreamHealthy, "drift reconciled")
+			}
+		}
+	}
 }
 
 // applyLayer1StatusRefresh handles the Layer 1 opportunistic per-event Status

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3400,3 +3400,62 @@ func TestHandleMergeTrainBatch_SilentWhenEmpty(t *testing.T) {
 		t.Errorf("expected no log events when holding stage column is empty, got %d", len(events))
 	}
 }
+
+// TestReconcileLoop_RunsWithoutWebhookManager is the #955 regression for the
+// architectural fix: the reconcile ticker must run — and repair label drift — even
+// when the webhook manager is nil (webhooks disabled or wm.Start failed).
+// Previously the ticker was nested inside the webhook-start block, so a webhook-less
+// deployment never reconciled and could not self-heal a drifted fabrik label set,
+// stranding items at gates (e.g. fabrik:awaiting-ci missing from the store forever).
+func TestReconcileLoop_RunsWithoutWebhookManager(t *testing.T) {
+	t1 := time.Now().Truncate(time.Second)
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.cfg.ReconcileInterval = 10 * time.Millisecond
+
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	// Seed #1 at Validate WITHOUT fabrik:awaiting-ci — the drifted store state.
+	testBootstrapFromBoard(cache, &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Validate", Labels: []string{"fabrik:cruise"}, UpdatedAt: t1},
+		},
+	})
+	eng.readClient = cache
+
+	// GitHub's fresh board: same status + updatedAt, but WITH fabrik:awaiting-ci.
+	// Only the fabrik-managed label differs — exactly the #1479 stranding condition.
+	client.fetchProjectBoardFn = func(_, _ string, _ int, _ string) (*gh.ProjectBoard, error) {
+		return &gh.ProjectBoard{
+			ProjectID: "PVT_1",
+			Items: []gh.ProjectItem{
+				{ID: "I_1", ItemID: "PVTI_1", Number: 1, Repo: "owner/repo", Status: "Validate", Labels: []string{"fabrik:cruise", "fabrik:awaiting-ci"}, UpdatedAt: t1},
+			},
+		}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// nil webhook manager — the whole point: reconcile must run anyway.
+	go eng.reconcileLoop(ctx, cache, nil)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snap, err := eng.store.Get("owner/repo", 1)
+		if err == nil {
+			for _, l := range snap.Labels() {
+				if l == "fabrik:awaiting-ci" {
+					return // success: reconcile ran with nil wm and synced the gate label
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			var labels []string
+			if err == nil {
+				labels = snap.Labels()
+			}
+			t.Fatalf("reconcileLoop did not sync fabrik:awaiting-ci within 2s (nil wm); labels = %v", labels)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the state-machine hole proven in #955: the boardcache's only poll-driven label-repair path (the `LightReconcile → Reconcile` ticker) was gated on the webhook manager starting, so a **webhook-less deployment never re-synced the store's label set from GitHub**. Once a label diverged (store missing `fabrik:awaiting-ci` while GitHub had it), nothing repaired it — the catch-up CI gate read the stale labels, computed `hasAwaitingCI=false`, skipped `settle`, and the issue was stranded at the gate forever (live case: `shadoworg/fantasy#1479`, idle ~2 days on a red CI it should have been fixing). This made webhooks a **correctness requirement rather than an optimization**, inverting the intended architecture.

## Root cause

- The reconcile ticker was lexically nested in `if e.cfg.Webhooks { if wm.Start(...) == nil { ... } }` (`engine/poll.go`). `Reconcile` (the only path that re-syncs labels via `ShallowBoardItemUpdated`) is called from exactly that one spot; the standalone `reconcileCache` helper is dead code.
- Even when the ticker ran, `LightReconcile` compared only `status` + `updatedAt` (label comparison was dropped in #641 to dodge the board query's 30-label truncation false-positives), relying on *"every label change bumps `updatedAt`."* The deep-fetch path launders that invariant by syncing `updatedAt` into the store without labels — so a label divergence with a matching `updatedAt` is invisible.

## Fix (two jointly-required parts)

1. **`engine/poll.go`** — extract the ticker into `reconcileLoop(ctx, cacheImpl, wm)` and launch it **unconditionally** whenever the cache is active, out of the webhook-start nest. `wm` is nil-able: health-state signaling is skipped when webhooks are absent, but drift detection and `Pause → Reconcile → Resume` repair always run. Webhooks become a pure optimization.
2. **`boardcache/boardcache.go`** — `LightReconcile` now also compares the **fabrik-managed label subset** (`fabrik:*` / `stage:*`) via `fabrikManagedLabelKey`. The gate-label subset is small and never truncated, so this detects the drift that matters without reintroducing #641's false positives.

Part 1 makes reconcile *run* without webhooks; Part 2 makes it *detect* the specific label drift that stranded #1479. Each is necessary.

## Tests

- `TestReconcileLoop_RunsWithoutWebhookManager` — reproduces #1479 (nil `wm`, matching `updatedAt`, store missing `fabrik:awaiting-ci`) → reconcile fires and repairs. Fails without Part 1.
- `TestLightReconcile_FabrikManagedLabelDriftDetected` — gate-label drift caught; a non-fabrik label change ignored. Fails without Part 2.
- Existing `TestLightReconcile_DriftDetected` (encoding #641's decision) passes unchanged.

`go build`, `go vet`, and `go test -race ./...` all green. `docs/state-machine.md` updated (webhook-independent reconcile backstop + fabrik-managed drift scope) with `docs/llms-full.txt` regenerated.

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)
