### PR TITLE
feat(merge-train): compose ADR-058 native queue with ADR-059 internal train (D6)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -906,6 +906,43 @@ The stall comment is posted once per event — subsequent polls skip the paused 
 
 **Re-enqueue cap:** To prevent a queue-thrash loop (enqueue → eject → re-enqueue → eject), each re-enqueue attempt is counted. When the count reaches `MaxEnqueueCycles` (default 5; `--max-enqueue-cycles` / `FABRIK_MAX_ENQUEUE_CYCLES`), Fabrik pauses the issue for human intervention.
 
+### Merge Train / Queued
+
+GitHub's native merge queue (above) is only available on GitHub Enterprise Cloud and org-owned public repos. On the common target — private **GitHub Team** repos and personal-account repos with `strict` branch protection — the native queue **cannot run**, yet these are exactly the repos that suffer the O(N²) rebase-and-retest cascade when several ready PRs land serially: each merge invalidates every other ready PR's "up-to-date + green" status, forcing a rebase and a full required-check re-run before the next merge.
+
+Fabrik's **internal merge train** (ADR-059) is the plan-agnostic, host-agnostic answer. It batches ready PRs, validates the combined batch **once**, and lands them together — collapsing the cascade. It is opt-in via `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+
+**One board column, two landing engines.** When `merge_train: on`, every yolo Validate completion advances into a single **`Queued`** board column instead of merging immediately. Each poll, the `Queued` handler picks the landing engine **per repo** (a `Queued` column can hold items from several repos at once), so you see one board model, not two parallel merge paths:
+
+| Repo has a native merge queue? | Landing engine |
+|---|---|
+| **Yes** (`isMergeQueueEnabled`) | GitHub's **native merge queue** (ADR-058) — Fabrik enqueues each PR; GitHub does the speculative-parallel batching. |
+| **No** | Fabrik's **internal merge train** (ADR-059) — one trial branch per repo, a single combined Validate, then a batched land. |
+
+Both engines drain the same `Queued` column and advance their members to **Done** on land; only *who batches* differs. This means **queue-enabled repos still use GitHub's native queue even under `merge_train: on`** — the train never overrides an available native queue (a direct/train merge on a queue-required branch returns HTTP 405).
+
+**Precedence** (per repo, highest first):
+1. **Native merge queue present** → GitHub's queue (ADR-058), regardless of `merge_train`.
+2. **Else `merge_train: on`** → the internal train (ADR-059).
+3. **Else** → legacy per-PR serial auto-merge (the pre-merge-train default).
+
+**Operator setup — add the `Queued` column.** The train stages ready PRs on a board column whose name matches a stage with `holding_stage: true` (named `Queued` in the default stages). Before enabling the train you must:
+
+1. **Add a `Queued` column** to your GitHub Project board (a new single-select "Status" option). Its name must exactly match the holding stage's `name`.
+2. **Add the holding stage** to your `.fabrik/stages/` config if it is not already present (`fabrik refresh-stages` surfaces it as a missing default). A minimal holding stage:
+   ```yaml
+   name: Queued
+   order: 6            # after Validate, before Done
+   holding_stage: true
+   ```
+3. **Enable the train**: `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+
+> **Startup requirement.** When `merge_train: on`, the `Queued` board column is **mandatory** — Fabrik fails startup if it is missing (the same board-validation that guards every non-cleanup stage). This is why the train is **off by default**: flipping it on globally would break startup on every board that has not yet added the column. Enable it per deployment only after step 1.
+
+**Batch tuning.** `--max-batch-size` (default 5) caps how many `Queued` items land in one batch, **per repo**. A red batch (a genuine cross-PR conflict — rare, since every member already passed Validate alone) is isolated by halving bisection, bounded by `--max-bisect-validations`; the poisoner is ejected and the survivors re-form. If the base branch moves under an in-flight batch (an external push), the trial is rebased and re-validated up to `--max-train-rebase-cycles` times before the batch dissolves back to `Queued`. See the flag reference above for all knobs.
+
+**Scope note.** In v1 the train batches **yolo** `Queued` items only. `fabrik:cruise` and manual-merge items return early at Validate (before the train gate) and never enter the train — batching human-merge items behind an explicit "go" is a planned fast-follow.
+
 ### Draft PR Workflow
 
 The Implement stage creates a **draft PR** linked to the issue when `create_draft_pr: true` is set (the default for Implement). This gives you a place to review incrementally. The Review stage then rebases, reviews, fixes, and pushes — turning the draft into a review-ready PR.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -904,6 +904,43 @@ The stall comment is posted once per event — subsequent polls skip the paused 
 
 **Re-enqueue cap:** To prevent a queue-thrash loop (enqueue → eject → re-enqueue → eject), each re-enqueue attempt is counted. When the count reaches `MaxEnqueueCycles` (default 5; `--max-enqueue-cycles` / `FABRIK_MAX_ENQUEUE_CYCLES`), Fabrik pauses the issue for human intervention.
 
+### Merge Train / Queued
+
+GitHub's native merge queue (above) is only available on GitHub Enterprise Cloud and org-owned public repos. On the common target — private **GitHub Team** repos and personal-account repos with `strict` branch protection — the native queue **cannot run**, yet these are exactly the repos that suffer the O(N²) rebase-and-retest cascade when several ready PRs land serially: each merge invalidates every other ready PR's "up-to-date + green" status, forcing a rebase and a full required-check re-run before the next merge.
+
+Fabrik's **internal merge train** (ADR-059) is the plan-agnostic, host-agnostic answer. It batches ready PRs, validates the combined batch **once**, and lands them together — collapsing the cascade. It is opt-in via `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+
+**One board column, two landing engines.** When `merge_train: on`, every yolo Validate completion advances into a single **`Queued`** board column instead of merging immediately. Each poll, the `Queued` handler picks the landing engine **per repo** (a `Queued` column can hold items from several repos at once), so you see one board model, not two parallel merge paths:
+
+| Repo has a native merge queue? | Landing engine |
+|---|---|
+| **Yes** (`isMergeQueueEnabled`) | GitHub's **native merge queue** (ADR-058) — Fabrik enqueues each PR; GitHub does the speculative-parallel batching. |
+| **No** | Fabrik's **internal merge train** (ADR-059) — one trial branch per repo, a single combined Validate, then a batched land. |
+
+Both engines drain the same `Queued` column and advance their members to **Done** on land; only *who batches* differs. This means **queue-enabled repos still use GitHub's native queue even under `merge_train: on`** — the train never overrides an available native queue (a direct/train merge on a queue-required branch returns HTTP 405).
+
+**Precedence** (per repo, highest first):
+1. **Native merge queue present** → GitHub's queue (ADR-058), regardless of `merge_train`.
+2. **Else `merge_train: on`** → the internal train (ADR-059).
+3. **Else** → legacy per-PR serial auto-merge (the pre-merge-train default).
+
+**Operator setup — add the `Queued` column.** The train stages ready PRs on a board column whose name matches a stage with `holding_stage: true` (named `Queued` in the default stages). Before enabling the train you must:
+
+1. **Add a `Queued` column** to your GitHub Project board (a new single-select "Status" option). Its name must exactly match the holding stage's `name`.
+2. **Add the holding stage** to your `.fabrik/stages/` config if it is not already present (`fabrik refresh-stages` surfaces it as a missing default). A minimal holding stage:
+   ```yaml
+   name: Queued
+   order: 6            # after Validate, before Done
+   holding_stage: true
+   ```
+3. **Enable the train**: `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+
+> **Startup requirement.** When `merge_train: on`, the `Queued` board column is **mandatory** — Fabrik fails startup if it is missing (the same board-validation that guards every non-cleanup stage). This is why the train is **off by default**: flipping it on globally would break startup on every board that has not yet added the column. Enable it per deployment only after step 1.
+
+**Batch tuning.** `--max-batch-size` (default 5) caps how many `Queued` items land in one batch, **per repo**. A red batch (a genuine cross-PR conflict — rare, since every member already passed Validate alone) is isolated by halving bisection, bounded by `--max-bisect-validations`; the poisoner is ejected and the survivors re-form. If the base branch moves under an in-flight batch (an external push), the trial is rebased and re-validated up to `--max-train-rebase-cycles` times before the batch dissolves back to `Queued`. See the flag reference above for all knobs.
+
+**Scope note.** In v1 the train batches **yolo** `Queued` items only. `fabrik:cruise` and manual-merge items return early at Validate (before the train gate) and never enter the train — batching human-merge items behind an explicit "go" is a planned fast-follow.
+
 ### Draft PR Workflow
 
 The Implement stage creates a **draft PR** linked to the issue when `create_draft_pr: true` is set (the default for Implement). This gives you a place to review incrementally. The Review stage then rebases, reviews, fixes, and pushes — turning the draft into a review-ready PR.
@@ -2721,7 +2758,7 @@ Each active stage column has the same set of reachable sub-states:
 
 #### Queued (Holding Stage — `merge_train: on` only)
 
-> This stage is a no-op for per-item dispatch. It exists solely as a batching rendezvous point for the merge train.
+> This stage is a no-op for per-item dispatch. It is the **universal landing rendezvous**: every yolo Validate completion advances here under `merge_train: on`, and the `Queued` handler then picks the landing engine per repo (ADR-059 D6 — see [Engine Selection](#engine-selection-058-native-queue-vs-059-internal-train-adr-059-d6) below).
 
 | Sub-State | Labels Present | Description |
 |-----------|---------------|-------------|
@@ -2730,6 +2767,23 @@ Each active stage column has the same set of reachable sub-states:
 | **Done** | *(none — advanced by `advanceToNextStage`)* | Integration PR merged; member advanced to Done column via `advanceToNextStage`; member PR closed with batch reference comment. |
 
 `itemMayNeedWork` and `itemNeedsWork` both return `false` for any stage with `holding_stage: true`, so these items are never dispatched to a per-item worker. `processItem` also short-circuits on `stage.HoldingStage` as a defense-in-depth guard. The catch-up loop skips holding stages for the same reason.
+
+##### Engine Selection: 058 Native Queue vs 059 Internal Train (ADR-059 D6)
+
+`Queued` is **one board column served by two landing engines**. The single convergence owner `handleMergeTrainBatch` (ADR-056 — there is **no** parallel scanner) picks the engine **per repo** each poll, because `isMergeQueueEnabled` is a per-PR/per-repo signal and the `Queued` column may hold items from several repos at once.
+
+**Selection algorithm.** `handleMergeTrainBatch` groups the current Queued snapshot by `owner/repo` (`groupQueuedByRepo`, preserving first-seen repo order and per-repo entry order), then `routeQueuedGroup` routes each group by the **poll-native** `LinkedPRIsMergeQueueEnabled` signal (populated by the GraphQL board query — never a REST `pulls` fetch, which always reports `false` for the queue flag, and never a webhook payload):
+
+- **Queue-enabled repo** (`MergeQueue != "off" && LinkedPRIsMergeQueueEnabled`) → the **ADR-058 enqueue path**, invoked per item via `enqueueForQueue` (the same helper `attemptMergeOnValidate` uses on the `merge_train: off` path). It calls `EnqueuePullRequest` with the poll-native `LinkedPRHeadSHA` as the expected-OID guard and applies `fabrik:auto-merge-enabled` (idempotency + convergence anchor). `checkAutoMergeConvergence` then drains each enqueued item `Queued → Done` (it claims any `fabrik:auto-merge-enabled` item regardless of its column). Two guards: an item already carrying `fabrik:auto-merge-enabled` is mid-convergence and is **not** re-enqueued; an item whose `LinkedPRNumber`/`LinkedPRHeadSHA` is empty (cache miss) is **skipped this poll and retried next** (no REST fetch).
+- **Non-queue repo** → the **ADR-059 internal merge train**: the group's remaining items form one per-repo batch dispatched to a single `dispatchMergeTrainWorker` (already keyed `owner/repo` via `mergeTrainInFlight`), which lands members `Queued → Done` via `landMergeTrainBatch`.
+
+Both engines drain the same `Queued` column and advance their members to `Done` on land; only **who batches** differs (GitHub's queue vs Fabrik's trial branch). `max_batch_size` caps the internal-train subset **per repo group**, not the flat cross-repo batch — so a large repo A never starves repo B, and repo B's items can never be shoved into repo A's trial branch (the pre-D6 `batch[0]`-anchored latent multi-repo bug, now hardened by grouping).
+
+**Precedence (FR-3).** For any item reaching a landing decision:
+
+1. **Native merge queue present on the repo** (`MergeQueue != "off" && LinkedPRIsMergeQueueEnabled`) → **058 enqueue path**, *regardless of* `merge_train`. The queue always wins: a direct or trial-branch merge on a queue-required branch returns HTTP 405. Under `merge_train: off` this fires inline in `attemptMergeOnValidate`; under `merge_train: on` it fires from the `Queued` handler.
+2. **Else `merge_train: on`** → the **internal train** (from the `Queued` handler).
+3. **Else** → **legacy per-PR serial auto-merge** (`attemptMergeOnValidate`'s native-auto-merge / direct-merge fallback), unchanged from pre-merge-train behavior.
 
 ##### Merge-Train Landing Lifecycle (ADR-059 D3)
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -130,7 +130,7 @@ Each active stage column has the same set of reachable sub-states:
 
 #### Queued (Holding Stage — `merge_train: on` only)
 
-> This stage is a no-op for per-item dispatch. It exists solely as a batching rendezvous point for the merge train.
+> This stage is a no-op for per-item dispatch. It is the **universal landing rendezvous**: every yolo Validate completion advances here under `merge_train: on`, and the `Queued` handler then picks the landing engine per repo (ADR-059 D6 — see [Engine Selection](#engine-selection-058-native-queue-vs-059-internal-train-adr-059-d6) below).
 
 | Sub-State | Labels Present | Description |
 |-----------|---------------|-------------|
@@ -139,6 +139,23 @@ Each active stage column has the same set of reachable sub-states:
 | **Done** | *(none — advanced by `advanceToNextStage`)* | Integration PR merged; member advanced to Done column via `advanceToNextStage`; member PR closed with batch reference comment. |
 
 `itemMayNeedWork` and `itemNeedsWork` both return `false` for any stage with `holding_stage: true`, so these items are never dispatched to a per-item worker. `processItem` also short-circuits on `stage.HoldingStage` as a defense-in-depth guard. The catch-up loop skips holding stages for the same reason.
+
+##### Engine Selection: 058 Native Queue vs 059 Internal Train (ADR-059 D6)
+
+`Queued` is **one board column served by two landing engines**. The single convergence owner `handleMergeTrainBatch` (ADR-056 — there is **no** parallel scanner) picks the engine **per repo** each poll, because `isMergeQueueEnabled` is a per-PR/per-repo signal and the `Queued` column may hold items from several repos at once.
+
+**Selection algorithm.** `handleMergeTrainBatch` groups the current Queued snapshot by `owner/repo` (`groupQueuedByRepo`, preserving first-seen repo order and per-repo entry order), then `routeQueuedGroup` routes each group by the **poll-native** `LinkedPRIsMergeQueueEnabled` signal (populated by the GraphQL board query — never a REST `pulls` fetch, which always reports `false` for the queue flag, and never a webhook payload):
+
+- **Queue-enabled repo** (`MergeQueue != "off" && LinkedPRIsMergeQueueEnabled`) → the **ADR-058 enqueue path**, invoked per item via `enqueueForQueue` (the same helper `attemptMergeOnValidate` uses on the `merge_train: off` path). It calls `EnqueuePullRequest` with the poll-native `LinkedPRHeadSHA` as the expected-OID guard and applies `fabrik:auto-merge-enabled` (idempotency + convergence anchor). `checkAutoMergeConvergence` then drains each enqueued item `Queued → Done` (it claims any `fabrik:auto-merge-enabled` item regardless of its column). Two guards: an item already carrying `fabrik:auto-merge-enabled` is mid-convergence and is **not** re-enqueued; an item whose `LinkedPRNumber`/`LinkedPRHeadSHA` is empty (cache miss) is **skipped this poll and retried next** (no REST fetch).
+- **Non-queue repo** → the **ADR-059 internal merge train**: the group's remaining items form one per-repo batch dispatched to a single `dispatchMergeTrainWorker` (already keyed `owner/repo` via `mergeTrainInFlight`), which lands members `Queued → Done` via `landMergeTrainBatch`.
+
+Both engines drain the same `Queued` column and advance their members to `Done` on land; only **who batches** differs (GitHub's queue vs Fabrik's trial branch). `max_batch_size` caps the internal-train subset **per repo group**, not the flat cross-repo batch — so a large repo A never starves repo B, and repo B's items can never be shoved into repo A's trial branch (the pre-D6 `batch[0]`-anchored latent multi-repo bug, now hardened by grouping).
+
+**Precedence (FR-3).** For any item reaching a landing decision:
+
+1. **Native merge queue present on the repo** (`MergeQueue != "off" && LinkedPRIsMergeQueueEnabled`) → **058 enqueue path**, *regardless of* `merge_train`. The queue always wins: a direct or trial-branch merge on a queue-required branch returns HTTP 405. Under `merge_train: off` this fires inline in `attemptMergeOnValidate`; under `merge_train: on` it fires from the `Queued` handler.
+2. **Else `merge_train: on`** → the **internal train** (from the `Queued` handler).
+3. **Else** → **legacy per-PR serial auto-merge** (`attemptMergeOnValidate`'s native-auto-merge / direct-merge fallback), unchanged from pre-merge-train behavior.
 
 ##### Merge-Train Landing Lifecycle (ADR-059 D3)
 

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -278,12 +278,16 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 
-	// Merge-train warning: this item carries fabrik:auto-merge-enabled but merge_train: on
-	// is now active. The item entered auto-merge convergence before merge_train was enabled.
-	// Let convergence complete rather than interrupting mid-flight PR state. New items will
-	// route through advanceToQueued instead (ADR-059 D6 resolves this interaction properly).
+	// ADR-059 D6: under merge_train: on, fabrik:auto-merge-enabled is the expected anchor
+	// for queue-enabled repos. handleMergeTrainBatch routes each Queued item to its landing
+	// engine per repo: queue-enabled repos take the ADR-058 enqueue path (which applies this
+	// label), and this convergence monitor then drains them Queued → Done. Non-queue repos go
+	// to the internal train and never reach this path. So an item here under merge_train: on is
+	// the intended 058-from-Queued convergence (or a pre-merge_train straggler); either way, let
+	// convergence complete rather than interrupting mid-flight PR state. This is a debug trace,
+	// not a warning — the interaction is now resolved by design.
 	if e.cfg.MergeTrain == "on" {
-		e.logf(item.Number, "warn", "merge_train: on but item is in auto-merge convergence path (fabrik:auto-merge-enabled present from before merge_train was enabled); letting convergence complete\n")
+		e.logf(item.Number, "auto-merge", "merge_train: on — item in auto-merge convergence (ADR-058 enqueue path from Queued handler); letting convergence complete\n")
 	}
 
 	// Use e.client (direct GitHub API) rather than e.readClient (boardcache) so

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1603,35 +1603,111 @@ doneDispatching:
 	}, nil
 }
 
-// handleMergeTrainBatch processes the current Queued batch for the merge train.
-// On first call with a new batch, dispatches a merge-train worker goroutine.
-// On subsequent calls, logs the current worker state without re-dispatching.
+// queuedRepoGroup is the Queued-column subset for a single owner/repo, preserving
+// the board entry order of its members. ADR-059 D6 routes each group to its landing
+// engine independently (isMergeQueueEnabled is a per-PR/per-repo signal).
+type queuedRepoGroup struct {
+	repoKey string // "owner/repo"
+	items   []gh.ProjectItem
+}
+
+// groupQueuedByRepo collects board items in the holding (Queued) column and groups
+// them by owner/repo, preserving first-seen repo order and per-repo entry order. This
+// replaces the former flat cross-repo batch (which anchored the whole set on batch[0]'s
+// repo and would shove repo B's items into repo A's trial branch — a latent multi-repo
+// bug that per-repo grouping also hardens; ADR-059 D-3).
+func groupQueuedByRepo(items []gh.ProjectItem, holdingStatus, defaultRepo string) []queuedRepoGroup {
+	var order []string
+	byRepo := make(map[string][]gh.ProjectItem)
+	for _, item := range items {
+		if item.Status != holdingStatus {
+			continue
+		}
+		key := itemOwnerRepoString(item, defaultRepo)
+		if _, seen := byRepo[key]; !seen {
+			order = append(order, key)
+		}
+		byRepo[key] = append(byRepo[key], item)
+	}
+	groups := make([]queuedRepoGroup, 0, len(order))
+	for _, key := range order {
+		groups = append(groups, queuedRepoGroup{repoKey: key, items: byRepo[key]})
+	}
+	return groups
+}
+
+// handleMergeTrainBatch is the ADR-059 D6 "one board column, two landing engines"
+// composition point: the single convergence owner (ADR-056 — no parallel scanner) that
+// picks the landing engine per repo for the current Queued batch. Each poll it groups
+// the Queued snapshot by owner/repo and routes each group by the poll-native
+// isMergeQueueEnabled signal (FR-1/FR-3 precedence):
+//
+//  1. Native merge queue present (MergeQueue != "off" && LinkedPRIsMergeQueueEnabled) →
+//     ADR-058 enqueue path (GitHub batches), regardless of merge_train. checkAutoMergeConvergence
+//     then drains each enqueued item Queued → Done. Queue always wins (a direct/train merge on a
+//     queue-required branch returns HTTP 405).
+//  2. Else (merge_train: on, which is the only way items reach Queued) → the ADR-059 internal
+//     merge train: one per-repo worker builds a trial branch, runs combined Validate, and lands
+//     members Queued → Done.
+//
+// Both engines drain the same Queued column and advance their members to Done on land; only
+// who batches differs.
 func (e *Engine) handleMergeTrainBatch(ctx context.Context, board *gh.ProjectBoard) {
 	hs := holdingStage(e.cfg)
 	if hs == nil {
 		return
 	}
-	var batch []gh.ProjectItem
-	for _, item := range board.Items {
-		if item.Status == hs.Name {
-			batch = append(batch, item)
-		}
+	for _, g := range groupQueuedByRepo(board.Items, hs.Name, e.defaultRepo()) {
+		e.routeQueuedGroup(ctx, g.repoKey, g.items, board.ProjectID)
 	}
-	if len(batch) == 0 {
+}
+
+// routeQueuedGroup applies the FR-1 per-repo engine selection to a single repo's Queued
+// subset: queue-enabled items take the ADR-058 enqueue path (per item), the remainder form
+// one internal-train batch (per repo) dispatched to a single worker. Runs in the poll
+// goroutine; the enqueue is a per-item GitHub mutation idempotent via fabrik:auto-merge-enabled.
+func (e *Engine) routeQueuedGroup(ctx context.Context, repoKey string, items []gh.ProjectItem, projectID string) {
+	var trainItems []gh.ProjectItem
+	for _, item := range items {
+		// Precedence rule 1 (FR-3): native merge queue present → ADR-058 enqueue path.
+		if e.cfg.MergeQueue != "off" && item.LinkedPRIsMergeQueueEnabled {
+			// Idempotency: an item already carrying the label is mid-convergence — the
+			// convergence monitor owns it. Don't re-enqueue.
+			if hasLabel(item, "fabrik:auto-merge-enabled") {
+				continue
+			}
+			// Signal source is poll-native (FR-1): the linked-PR number and head SHA come from
+			// the GraphQL-populated item fields, never a REST re-fetch. On a cache miss, skip
+			// this item this poll and retry next — enqueue needs the head SHA for the expected-OID guard.
+			if item.LinkedPRNumber == 0 || item.LinkedPRHeadSHA == "" {
+				e.logf(item.Number, "merge-train", "queue-enabled item missing poll-native linked-PR state (number=%d, headSHA=%q) — skipping enqueue this poll, will retry\n", item.LinkedPRNumber, item.LinkedPRHeadSHA)
+				continue
+			}
+			owner, repo := itemOwnerRepo(item, e.defaultRepo())
+			if _, err := e.enqueueForQueue(owner, repo, item, item.LinkedPRNumber, item.LinkedPRHeadSHA); err != nil {
+				e.logf(item.Number, "warn", "enqueue from Queued handler failed: %v — will retry next poll\n", err)
+			}
+			continue
+		}
+		// Precedence rule 2 (FR-3): else the internal merge train.
+		trainItems = append(trainItems, item)
+	}
+
+	if len(trainItems) == 0 {
 		return
 	}
-	// FR-4: cap the batch to the first N Queued items by entry order (ADR-059 D2).
-	// Log the truncation explicitly so operators can see it — never silent.
-	if maxBatch := e.effectiveMaxBatchSize(); len(batch) > maxBatch {
-		e.logf(0, "merge-train", "batch capped: %d Queued item(s) exceed max_batch_size=%d — landing first %d by entry order\n", len(batch), maxBatch, maxBatch)
-		batch = capBatch(batch, maxBatch)
+	// FR-4: cap the internal-train batch to the first N items by entry order (ADR-059 D2),
+	// applied PER repo group. Log the truncation explicitly so operators can see it — never silent.
+	if maxBatch := e.effectiveMaxBatchSize(); len(trainItems) > maxBatch {
+		e.logf(0, "merge-train", "batch capped for %s: %d Queued item(s) exceed max_batch_size=%d — landing first %d by entry order\n", repoKey, len(trainItems), maxBatch, maxBatch)
+		trainItems = capBatch(trainItems, maxBatch)
 	}
 	var parts []string
-	for _, item := range batch {
+	for _, item := range trainItems {
 		parts = append(parts, fmt.Sprintf("#%d %q", item.Number, item.Title))
 	}
-	e.logf(0, "merge-train", "batch snapshot: %d item(s) — %s\n", len(batch), strings.Join(parts, ", "))
-	e.dispatchMergeTrainWorker(ctx, batch, board.ProjectID)
+	e.logf(0, "merge-train", "batch snapshot for %s: %d item(s) — %s\n", repoKey, len(trainItems), strings.Join(parts, ", "))
+	e.dispatchMergeTrainWorker(ctx, trainItems, projectID)
 }
 
 func gitRevParse(dir, ref string) (string, error) {

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3361,8 +3361,8 @@ func TestHandleMergeTrainBatch_LogsQueuedItems(t *testing.T) {
 		t.Fatal("expected at least one log event from handleMergeTrainBatch, got none")
 	}
 	msg := logged[0].Message
-	if !strings.Contains(msg, "batch snapshot: 2 item(s)") {
-		t.Errorf("expected 'batch snapshot: 2 item(s)' in log message, got: %q", msg)
+	if !strings.Contains(msg, "batch snapshot for owner/repo: 2 item(s)") {
+		t.Errorf("expected 'batch snapshot for owner/repo: 2 item(s)' in log message, got: %q", msg)
 	}
 	if !strings.Contains(msg, "#42") || !strings.Contains(msg, "#44") {
 		t.Errorf("expected both holding-stage issue numbers in log message, got: %q", msg)

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3401,6 +3401,290 @@ func TestHandleMergeTrainBatch_SilentWhenEmpty(t *testing.T) {
 	}
 }
 
+// drainLogMessages collects all LogEvent messages currently buffered on the channel.
+func drainLogMessages(events chan tui.Event) []string {
+	var msgs []string
+	for len(events) > 0 {
+		if le, ok := (<-events).(tui.LogEvent); ok {
+			msgs = append(msgs, le.Message)
+		}
+	}
+	return msgs
+}
+
+func anyContains(msgs []string, sub string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// fillSem fills the engine semaphore to capacity so any merge-train worker goroutine
+// launched by dispatchMergeTrainWorker parks at its select (sem full, ctx live) instead
+// of running real git work — keeping routing tests hermetic while still proving that
+// the LoadOrStore registration (which happens synchronously, before the goroutine) fired.
+func fillSem(eng *Engine) {
+	for i := 0; i < cap(eng.sem); i++ {
+		eng.sem <- struct{}{}
+	}
+}
+
+// TestHandleMergeTrainBatch_QueueEnabledRepo_Enqueues is the ADR-059 D6 FR-1 routing
+// assertion for a queue-enabled repo: Queued items take the ADR-058 enqueue path, NOT the
+// internal train. EnqueuePullRequest is called with the poll-native linked-PR SHA,
+// fabrik:auto-merge-enabled is applied, and no train worker is registered.
+func TestHandleMergeTrainBatch_QueueEnabledRepo_Enqueues(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndHolding())
+	eng.cfg.MergeTrain = "on"
+
+	events := make(chan tui.Event, 20)
+	eng.events = events
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 42, Title: "a", Status: "BatchHold", Repo: "owner/repo",
+				LinkedPRIsMergeQueueEnabled: true, LinkedPRNumber: 142, LinkedPRHeadSHA: "sha42"},
+			{Number: 43, Title: "b", Status: "BatchHold", Repo: "owner/repo",
+				LinkedPRIsMergeQueueEnabled: true, LinkedPRNumber: 143, LinkedPRHeadSHA: "sha43"},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	if len(client.enqueuePullRequestCalls) != 2 {
+		t.Fatalf("expected 2 EnqueuePullRequest calls (058 path), got %d", len(client.enqueuePullRequestCalls))
+	}
+	if client.enqueuePullRequestCalls[0].prNumber != 142 || client.enqueuePullRequestCalls[0].expectedHeadOID != "sha42" {
+		t.Errorf("enqueue #0 = PR %d @ %q, want 142 @ sha42", client.enqueuePullRequestCalls[0].prNumber, client.enqueuePullRequestCalls[0].expectedHeadOID)
+	}
+	// fabrik:auto-merge-enabled applied to both items (idempotency + convergence anchor).
+	var labelAdds int
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:auto-merge-enabled" {
+			labelAdds++
+		}
+	}
+	if labelAdds != 2 {
+		t.Errorf("expected 2 fabrik:auto-merge-enabled label adds, got %d", labelAdds)
+	}
+	// No internal train worker for a queue-enabled repo.
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); ok {
+		t.Error("queue-enabled repo must NOT dispatch an internal train worker")
+	}
+	if msgs := drainLogMessages(events); anyContains(msgs, "batch snapshot") {
+		t.Errorf("queue-enabled repo must not log an internal-train batch snapshot; got %v", msgs)
+	}
+}
+
+// TestHandleMergeTrainBatch_NonQueueRepo_DispatchesTrain is the FR-1 routing assertion for
+// a non-queue repo: Queued items take the internal merge train, NOT the enqueue path. A train
+// worker is registered in mergeTrainInFlight and EnqueuePullRequest is never called.
+func TestHandleMergeTrainBatch_NonQueueRepo_DispatchesTrain(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndHolding())
+	eng.cfg.MergeTrain = "on"
+	fillSem(eng) // park the worker goroutine at the semaphore; no real git work.
+
+	events := make(chan tui.Event, 20)
+	eng.events = events
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 50, Title: "x", Status: "BatchHold", Repo: "owner/repo", LinkedPRIsMergeQueueEnabled: false},
+			{Number: 51, Title: "y", Status: "BatchHold", Repo: "owner/repo", LinkedPRIsMergeQueueEnabled: false},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	// Train worker registered (LoadOrStore fires synchronously before the goroutine).
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); !ok {
+		t.Error("non-queue repo must dispatch an internal train worker (mergeTrainInFlight entry expected)")
+	}
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("non-queue repo must NOT call EnqueuePullRequest, got %d", len(client.enqueuePullRequestCalls))
+	}
+	if msgs := drainLogMessages(events); !anyContains(msgs, "batch snapshot for owner/repo: 2 item(s)") {
+		t.Errorf("expected internal-train batch snapshot for the repo; got %v", msgs)
+	}
+}
+
+// TestHandleMergeTrainBatch_MixedRepoBatch_RoutesPerRepo is the FR-1 D-3 mixed-repo assertion:
+// a Queued column holding items from a queue-enabled repo A and a non-queue repo B routes each
+// repo's subset to the correct engine — A enqueues, B trains — and B's items never enter A's batch.
+func TestHandleMergeTrainBatch_MixedRepoBatch_RoutesPerRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndHolding())
+	eng.cfg.MergeTrain = "on"
+	fillSem(eng)
+
+	events := make(chan tui.Event, 30)
+	eng.events = events
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			// Repo A: queue-enabled -> enqueue.
+			{Number: 60, Title: "a1", Status: "BatchHold", Repo: "owner/repo-a",
+				LinkedPRIsMergeQueueEnabled: true, LinkedPRNumber: 160, LinkedPRHeadSHA: "shaA"},
+			// Repo B: non-queue -> internal train.
+			{Number: 70, Title: "b1", Status: "BatchHold", Repo: "owner/repo-b", LinkedPRIsMergeQueueEnabled: false},
+			{Number: 71, Title: "b2", Status: "BatchHold", Repo: "owner/repo-b", LinkedPRIsMergeQueueEnabled: false},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	// Repo A: exactly one enqueue (its single item), no train worker.
+	if len(client.enqueuePullRequestCalls) != 1 || client.enqueuePullRequestCalls[0].prNumber != 160 {
+		t.Fatalf("expected exactly one enqueue for repo A PR #160, got %+v", client.enqueuePullRequestCalls)
+	}
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo-a"); ok {
+		t.Error("queue-enabled repo A must NOT dispatch an internal train worker")
+	}
+	// Repo B: train worker registered, and its snapshot mentions only B's items (#70,#71) — never A's #60.
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo-b"); !ok {
+		t.Error("non-queue repo B must dispatch an internal train worker")
+	}
+	msgs := drainLogMessages(events)
+	if !anyContains(msgs, "batch snapshot for owner/repo-b: 2 item(s)") {
+		t.Errorf("expected repo B train snapshot with 2 items; got %v", msgs)
+	}
+	for _, m := range msgs {
+		if strings.Contains(m, "batch snapshot") && strings.Contains(m, "#60") {
+			t.Errorf("repo A's item #60 must never appear in an internal-train batch snapshot; got %q", m)
+		}
+	}
+}
+
+// TestHandleMergeTrainBatch_Idempotency_SkipsAlreadyEnqueued verifies the FR-1 idempotency
+// guard: a queue-enabled Queued item already carrying fabrik:auto-merge-enabled is mid-
+// convergence and must not be re-enqueued.
+func TestHandleMergeTrainBatch_Idempotency_SkipsAlreadyEnqueued(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndHolding())
+	eng.cfg.MergeTrain = "on"
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 80, Title: "already", Status: "BatchHold", Repo: "owner/repo",
+				LinkedPRIsMergeQueueEnabled: true, LinkedPRNumber: 180, LinkedPRHeadSHA: "sha80",
+				Labels: []string{"fabrik:auto-merge-enabled"}},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("item already carrying fabrik:auto-merge-enabled must not be re-enqueued, got %d enqueue call(s)", len(client.enqueuePullRequestCalls))
+	}
+}
+
+// TestHandleMergeTrainBatch_QueueEnabled_CacheMissSkips verifies the FR-1 poll-native
+// cache-miss guard: a queue-enabled item missing its linked-PR number/head SHA is skipped
+// this poll (no enqueue, no REST fetch) and retried next.
+func TestHandleMergeTrainBatch_QueueEnabled_CacheMissSkips(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndHolding())
+	eng.cfg.MergeTrain = "on"
+
+	events := make(chan tui.Event, 10)
+	eng.events = events
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 90, Title: "no-sha", Status: "BatchHold", Repo: "owner/repo",
+				LinkedPRIsMergeQueueEnabled: true, LinkedPRNumber: 190, LinkedPRHeadSHA: ""},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	if len(client.enqueuePullRequestCalls) != 0 {
+		t.Errorf("cache-miss item (empty head SHA) must not be enqueued, got %d", len(client.enqueuePullRequestCalls))
+	}
+	if msgs := drainLogMessages(events); !anyContains(msgs, "missing poll-native linked-PR state") {
+		t.Errorf("expected cache-miss skip log; got %v", msgs)
+	}
+}
+
+// TestHandleMergeTrainBatch_PerGroupMaxBatchSize verifies FR-4 as realized in D6: max_batch_size
+// caps each repo's internal-train subset INDEPENDENTLY, not the flat cross-repo batch.
+func TestHandleMergeTrainBatch_PerGroupMaxBatchSize(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStagesWithValidateAndHolding())
+	eng.cfg.MergeTrain = "on"
+	eng.cfg.MaxBatchSize = 2
+	fillSem(eng)
+
+	events := make(chan tui.Event, 40)
+	eng.events = events
+
+	// Repo A: 3 non-queue items (exceeds cap 2). Repo B: 1 non-queue item (under cap).
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 1, Title: "a1", Status: "BatchHold", Repo: "owner/repo-a"},
+			{Number: 2, Title: "a2", Status: "BatchHold", Repo: "owner/repo-a"},
+			{Number: 3, Title: "a3", Status: "BatchHold", Repo: "owner/repo-a"},
+			{Number: 4, Title: "b1", Status: "BatchHold", Repo: "owner/repo-b"},
+		},
+	}
+
+	eng.handleMergeTrainBatch(context.Background(), board)
+
+	msgs := drainLogMessages(events)
+	// Repo A capped to 2 (its own group), logged explicitly (never silent).
+	if !anyContains(msgs, "batch capped for owner/repo-a") {
+		t.Errorf("expected per-group cap log for repo A; got %v", msgs)
+	}
+	if !anyContains(msgs, "batch snapshot for owner/repo-a: 2 item(s)") {
+		t.Errorf("expected repo A snapshot of 2 items after cap; got %v", msgs)
+	}
+	// Repo B (1 item) is under the cap — no cap log, snapshot of 1.
+	if anyContains(msgs, "batch capped for owner/repo-b") {
+		t.Errorf("repo B (1 item) must not be capped; got %v", msgs)
+	}
+	if !anyContains(msgs, "batch snapshot for owner/repo-b: 1 item(s)") {
+		t.Errorf("expected repo B snapshot of 1 item; got %v", msgs)
+	}
+}
+
+// TestGroupQueuedByRepo verifies the D-3 grouping helper: only holding-stage items are
+// collected, grouped by owner/repo, preserving first-seen repo order and per-repo entry order.
+func TestGroupQueuedByRepo(t *testing.T) {
+	items := []gh.ProjectItem{
+		{Number: 1, Status: "BatchHold", Repo: "owner/repo-b"},
+		{Number: 2, Status: "Implement", Repo: "owner/repo-a"}, // not holding — excluded
+		{Number: 3, Status: "BatchHold", Repo: "owner/repo-a"},
+		{Number: 4, Status: "BatchHold", Repo: "owner/repo-b"},
+		{Number: 5, Status: "BatchHold", Repo: ""}, // defaults to owner/repo
+	}
+	groups := groupQueuedByRepo(items, "BatchHold", "owner/repo")
+
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 repo groups, got %d: %+v", len(groups), groups)
+	}
+	// First-seen order: repo-b, repo-a, then the default repo.
+	if groups[0].repoKey != "owner/repo-b" || groups[1].repoKey != "owner/repo-a" || groups[2].repoKey != "owner/repo" {
+		t.Errorf("unexpected group order: %q, %q, %q", groups[0].repoKey, groups[1].repoKey, groups[2].repoKey)
+	}
+	// repo-b keeps entry order #1 then #4; the non-holding #2 is excluded.
+	if len(groups[0].items) != 2 || groups[0].items[0].Number != 1 || groups[0].items[1].Number != 4 {
+		t.Errorf("repo-b group wrong: %+v", groups[0].items)
+	}
+	if len(groups[1].items) != 1 || groups[1].items[0].Number != 3 {
+		t.Errorf("repo-a group wrong: %+v", groups[1].items)
+	}
+}
+
 // TestReconcileLoop_RunsWithoutWebhookManager is the #955 regression for the
 // architectural fix: the reconcile ticker must run — and repair label drift — even
 // when the webhook manager is nil (webhooks disabled or wm.Start failed).

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -359,7 +359,11 @@ func (e *Engine) enqueueForQueue(owner, repo string, item gh.ProjectItem, prNumb
 		e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+			// Use the resolved owner/repo (not item.Repo, which may be empty when it
+			// defaults to the default repo) so the cache key matches the stored entry
+			// and the write-through actually lands on the right item — consistent with
+			// the webhook-echo key below.
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:auto-merge-enabled")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -281,21 +281,7 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 	// kill-switch), an operator's explicit choice. No separate guard is required at the
 	// MergePR site; this early-return is the audit evidence.
 	if e.cfg.MergeQueue != "off" && pr.IsMergeQueueEnabled {
-		if err := e.client.EnqueuePullRequest(owner, repo, pr.Number, pr.HeadSHA); err != nil {
-			return false, fmt.Errorf("enqueue PR #%d: %w", pr.Number, err)
-		}
-		if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
-			}
-		}
-		e.logf(item.Number, "info", "PR #%d enqueued into merge queue — awaiting GitHub merge\n", pr.Number)
-		return true, nil
+		return e.enqueueForQueue(owner, repo, item, pr.Number, pr.HeadSHA)
 	}
 
 	strategy := e.cfg.AutoMergeStrategy
@@ -344,6 +330,42 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 	}
 
 	e.logf(item.Number, "info", "GitHub auto-merge enabled on PR #%d (%s) — awaiting GitHub atomic merge\n", pr.Number, strategy)
+	return true, nil
+}
+
+// enqueueForQueue enqueues a linked PR into the repository's native merge queue
+// (ADR-058) and applies the fabrik:auto-merge-enabled label as both idempotency
+// guard and the convergence anchor read by checkAutoMergeConvergence. It performs
+// the boardcache write-through and webhook echo so the label is visible without a
+// GitHub round-trip. Returns (true, nil) on successful enqueue, (false, err) if the
+// enqueue mutation fails (a label-add failure is non-fatal: logged and swallowed).
+//
+// This is the ADR-058 enqueue path, extracted from attemptMergeOnValidate so it can
+// be invoked from two convergence-owner call sites (ADR-059 D6 "invoke, don't
+// relocate"): (1) attemptMergeOnValidate on the merge_train: off precedence path,
+// and (2) handleMergeTrainBatch's per-repo engine selection for queue-enabled repos
+// when merge_train: on. Both callers apply the MergeQueue != "off" && merge-queue-
+// enabled guard before calling; the guard is deliberately kept at the call sites (it
+// doubles as the HTTP-405 direct-merge audit evidence noted in attemptMergeOnValidate).
+//
+// The head SHA is passed by the caller from poll-native state (pr.HeadSHA or the
+// GraphQL-populated item.LinkedPRHeadSHA) — never from a REST re-fetch of the queue
+// flag, per ADR-058/ADR-059 FR-1.
+func (e *Engine) enqueueForQueue(owner, repo string, item gh.ProjectItem, prNumber int, headSHA string) (bool, error) {
+	if err := e.client.EnqueuePullRequest(owner, repo, prNumber, headSHA); err != nil {
+		return false, fmt.Errorf("enqueue PR #%d: %w", prNumber, err)
+	}
+	if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
+		e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
+		}
+	}
+	e.logf(item.Number, "info", "PR #%d enqueued into merge queue — awaiting GitHub merge\n", prNumber)
 	return true, nil
 }
 


### PR DESCRIPTION
Closes #951

## What this does

Implements ADR-059 **D6** — "one board column, two landing engines." Makes the `Queued`-column handler the single point of per-repo landing-engine selection, so operators see one board model rather than two parallel merge paths. Closes the ADR-059 build chain (D1–D5 already shipped).

Previously, with `merge_train: on`, every `Queued` item was unconditionally dispatched to the **internal** train and a queue-enabled repo's PRs never reached GitHub's native queue. D6 adds per-repo routing in the existing convergence owner.

## Key changes

- **`engine/poll.go`** — `handleMergeTrainBatch` now groups the `Queued` snapshot by `owner/repo` (`groupQueuedByRepo`) and routes each group by the poll-native `LinkedPRIsMergeQueueEnabled` signal (`routeQueuedGroup`):
  - Queue-enabled repo (`MergeQueue != "off" && LinkedPRIsMergeQueueEnabled`) → **ADR-058 enqueue path** per item; `checkAutoMergeConvergence` drains them `Queued → Done`.
  - Non-queue repo → **ADR-059 internal train**, one per-repo worker.
  - Idempotency: items already carrying `fabrik:auto-merge-enabled` are not re-enqueued. Cache-miss (empty `LinkedPRNumber`/`LinkedPRHeadSHA`) → skip-and-retry, no REST fetch. `max_batch_size` is applied **per repo group** — which also hardens a latent `batch[0]`-anchored multi-repo bug.
- **`engine/stages.go`** — extracted the 058 enqueue block into `enqueueForQueue`, invoked from both `attemptMergeOnValidate` (merge_train off) and the `Queued` handler (merge_train on). The `merge_train: off` path is behaviorally unchanged.
- **`engine/merge_gate.go`** — reworded the D6 placeholder comment/log; convergence ladder behavior unchanged (#913 terminal-first guard intact).
- **Precedence (FR-3):** native queue present → 058 (regardless of `merge_train`, avoids HTTP 405); else `merge_train: on` → internal train; else → legacy serial auto-merge.
- **Default rollout (FR-4/D-4):** default stays `off`; the rollout switch (`--merge-train on` after adding the `Queued` column) is documented rather than hard-flipped, preserving startup backward-compat.
- **Docs (FR-5):** `state-machine.md` engine-selection + precedence; `USER_GUIDE.md` operator section; `llms-full.txt` regenerated.

## How to test

- `go build ./...`, `go vet ./...`, `go test -race ./engine/` — all green.
- New routing tests in `engine/poll_test.go`: `TestHandleMergeTrainBatch_QueueEnabledRepo_Enqueues`, `_NonQueueRepo_DispatchesTrain`, `_MixedRepoBatch_RoutesPerRepo`, `_Idempotency_SkipsAlreadyEnqueued`, `_QueueEnabled_CacheMissSkips`, `_PerGroupMaxBatchSize`, `TestGroupQueuedByRepo`.

Note: FR-6 (real-batch e2e on `handarbeit/fabrik-mergetrain-spike`) is an operator-owned manual gate per D-6 and does not block this PR.