### PR TITLE
fix(merge-train): land the draft CI PR instead of colliding on a 2nd PR; add e2e scenarios

### DIFF
--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -475,11 +475,15 @@ func (e *Engine) assembleAndValidate(ctx context.Context, p trialParams, members
 		memberRefs = append(memberRefs, fmt.Sprintf("#%d", s.item.Number))
 	}
 	prTitle := fmt.Sprintf("chore(merge-train): trial integration for %s", strings.Join(memberRefs, " "))
+	// The draft CI PR IS the landing integration PR (same trial branch → base). It
+	// carries mergeTrainBatchMarker so the landing step's findIntegrationPR reuses
+	// it (marking it ready) rather than trying to CreatePR a second PR on the same
+	// branch — which GitHub rejects with a 422 "a pull request already exists".
 	prBody := fmt.Sprintf("🏭 **Fabrik merge-train integration PR** (trial → %s)\n\n"+
 		"This is a disposable trial branch combining the following Queued member PRs:\n%s\n\n"+
 		"Do not merge this PR manually — Fabrik manages the landing step.\n"+
-		"Orphaned integration PRs (if the train worker crashed) can be closed manually via the GitHub UI.",
-		p.baseBranch, strings.Join(memberRefs, "\n"))
+		"Orphaned integration PRs (if the train worker crashed) can be closed manually via the GitHub UI.\n\n%s",
+		p.baseBranch, strings.Join(memberRefs, "\n"), mergeTrainBatchMarker)
 
 	trialBranch := "fabrik/merge-train/" + trialName
 	prNum, err := e.client.CreateDraftPR(p.owner, p.repo, prTitle, trialBranch, p.baseBranch, prBody, 0)
@@ -1020,7 +1024,16 @@ func (e *Engine) landMergeTrainBatch(ctx context.Context, state *mergeTrainWorke
 	if integrationPR != nil {
 		integrationPRNum = integrationPR.Number
 		alreadyMerged = integrationPR.Merged
-		e.logf(0, "merge-train", "found existing integration PR #%d (merged=%v) for %s\n", integrationPRNum, alreadyMerged, repoKey)
+		e.logf(0, "merge-train", "found existing integration PR #%d (merged=%v, draft=%v) for %s\n", integrationPRNum, alreadyMerged, integrationPR.Draft, repoKey)
+		// The reused PR is the trial's draft CI PR — promote it to ready-for-review
+		// so it can be merged (GitHub refuses to merge a draft).
+		if integrationPR.Draft && !alreadyMerged {
+			if rerr := e.client.MarkPRReady(owner, repo, integrationPRNum); rerr != nil {
+				e.logf(0, "merge-train", "cannot mark integration PR #%d ready for %s: %v — leaving members in Queued\n", integrationPRNum, repoKey, rerr)
+				return
+			}
+			e.logf(0, "merge-train", "marked integration PR #%d ready for landing (%s)\n", integrationPRNum, repoKey)
+		}
 	} else {
 		// FR-1: open the landing integration PR (not a draft).
 		title := buildIntegrationPRTitle(survivors)

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -1133,6 +1133,71 @@ func TestLandMergeTrainBatch_ExistingOpenPR_SkipsFR1(t *testing.T) {
 	}
 }
 
+// TestLandMergeTrainBatch_ReusesDraftCIPR_MarksReady is the regression for the
+// landing bug the e2e caught: the trial's draft CI PR carries mergeTrainBatchMarker
+// and IS the landing integration PR, so findIntegrationPR must reuse it — and
+// because it is a draft, landing must MarkPRReady before merging (GitHub refuses to
+// merge a draft). Before the fix, the draft body lacked the marker so findIntegrationPR
+// returned nil and landing tried to CreatePR a second PR on the same trial branch,
+// which GitHub rejects with a 422 ("a pull request already exists").
+func TestLandMergeTrainBatch_ReusesDraftCIPR_MarksReady(t *testing.T) {
+	survivors := []trainMember{makeQueuedMember(1, 10, "Issue One")}
+
+	createPRCalled := false
+	client := &mockGitHubClient{
+		listPRsFn: func(owner, repo string) ([]gh.PRDetails, error) {
+			return []gh.PRDetails{
+				{Number: 200, State: "open", Merged: false, Draft: true, Body: "draft CI PR " + mergeTrainBatchMarker},
+			}, nil
+		},
+		createPRFn: func(owner, repo, title, head, base, body string) (int, error) {
+			createPRCalled = true
+			return 999, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			tr := true
+			return &tr, "clean", nil
+		},
+		mergePRFn:    func(owner, repo string, prNumber int) error { return nil },
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) { return 1, nil },
+	}
+
+	claude := &mockClaudeInvoker{}
+	wm := NewWorktreeManager(t.TempDir())
+	eng := trainTestEngine(t, client, claude, wm)
+	state := &mergeTrainWorkerState{trialName: "merge-train-main-12345", projectID: "PVT_test"}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	eng.landMergeTrainBatch(context.Background(), state, "owner", "repo", "main", survivors, wm)
+
+	if createPRCalled {
+		t.Error("CreatePR must not be called — the draft CI PR must be reused (regression: 422 collision)")
+	}
+	client.mu.Lock()
+	ready := client.markPRReadyCalls
+	merged := client.mergePRCalls
+	client.mu.Unlock()
+
+	readyOK := false
+	for _, c := range ready {
+		if c.prNumber == 200 {
+			readyOK = true
+		}
+	}
+	if !readyOK {
+		t.Errorf("draft integration PR #200 must be MarkPRReady'd before merge; got %+v", ready)
+	}
+	mergedOK := false
+	for _, c := range merged {
+		if c.prNumber == 200 {
+			mergedOK = true
+		}
+	}
+	if !mergedOK {
+		t.Errorf("integration PR #200 must be merged; got %+v", merged)
+	}
+}
+
 // TestLandMergeTrainBatch_AlreadyMergedPR_SkipsFR2 verifies restart idempotency:
 // if the found integration PR is already merged, FR-2 (MergePR) is skipped and
 // FR-3 (member advancement) proceeds.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -106,6 +106,42 @@ the canonical setup.
     E2E_TIMEOUT=2h scripts/e2e/run.sh -run TestConjunctiveCIReviewGate
     ```
 
+### Additional prerequisites for the merge-train scenarios (ADR-059)
+
+`TestMergeTrainHappyPathLanding`, `TestMergeTrainBisectionEjectsPoisoner`, and
+`TestMergeTrainRestartSafety` need one-time bed setup. They **skip cleanly**
+(`requireTrainBed`) if the `Queued` column is absent, so they are safe to merge
+before the bed is set up.
+
+13. **`Queued` board column** on `handarbeit/projects/2`, positioned between
+    `Validate` and `Done` (ADR-059 D1 — the durable train queue). Add it in the
+    Project's Status field options.
+14. **`queued.yaml` holding stage** in the bed's `.fabrik/stages/`, e.g.:
+    ```yaml
+    name: Queued
+    order: 8            # after Validate, before Done
+    holding_stage: true # engine-managed; no Claude invocation
+    ```
+    Copy from `stages/examples/queued.yaml` (`fabrik init` / `fabrik refresh-stages`).
+15. **Train-capable binary** in the bed, built from `main` (the release does not
+    yet carry ADR-059). Run it **without `--auto-upgrade`** so it is not reverted
+    to a release mid-suite:
+    ```bash
+    (cd ~/dev/fabrik && go build -o ~/dev/fabrik-test/fabrik .)
+    # on macOS/Apple Silicon a copied binary may be SIGKILL'd; build in place or:
+    #   xattr -cr ~/dev/fabrik-test/fabrik && codesign --force --sign - ~/dev/fabrik-test/fabrik
+    ```
+16. **`train-poison-guard` required check** on `fabrik-test-alpha` — only for
+    `TestMergeTrainBisectionEjectsPoisoner`. Commit
+    `tests/e2e/testdata/train-poison-guard.yml` to the repo as
+    `.github/workflows/train-poison-guard.yml` and mark the `train-poison-guard`
+    check REQUIRED on branch protection, so the combined-Validate poll gates on it.
+    The bisection test skips this check indirectly — if the guard is absent the
+    combined batch is green and no bisection occurs, failing the `bisecting`
+    log-line wait; run it only after the guard is enrolled.
+17. **`E2E_TIMEOUT=2h`** (happy/bisect) or **`E2E_TIMEOUT=3h`** (restart — two
+    sequential landings) when running these in isolation.
+
 ## Running
 
 The recommended entrypoint is the runner script, which sets sensible defaults:
@@ -152,6 +188,9 @@ otherwise).
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | 30–60 min | $0.50–1.50 |
 | `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
 | `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
+| `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | 10–25 min | low (no Claude) |
+| `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | 20–40 min | low–moderate |
+| `TestMergeTrainRestartSafety` | ADR-059 D5 / #960: after a landing, a restart with the historical merged integration PR present does NOT stall the next batch (reconstruct proceeds fresh). **Not parallel** — restarts the bed | 25–50 min | low |
 
 Approximate suite total: ~470 min wall-clock, $7.50–24 in Claude tokens (CI-fix, `TestPausedMergedPRRecovery`, and conjunctive-gate tests should be run separately with `E2E_TIMEOUT=3h` or `E2E_TIMEOUT=2h` as noted above).
 
@@ -170,6 +209,9 @@ Approximate suite total: ~470 min wall-clock, $7.50–24 in Claude tokens (CI-fi
 | `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
 | `TestPausedMergedPRRecovery` | #874 (paused+merged PR recovery class), #887 (settle-owner structural fix, `runValidatePRTerminalAdvance`), ADR-056 D2 (single-owner for PR-terminal → Done) |
 | `TestConjunctiveCIReviewGate` | ADR-056 D2 (conjunctive gate joint-clear), #887 (settle-owner), #895 (this scenario) |
+| `TestMergeTrainHappyPathLanding` | ADR-059 D1/D3 (#946, #947, #948) — Queued column, trial-branch build, integration-PR landing + member lifecycle |
+| `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4 (#949) — halving bisection, ejection, one-at-a-time fallback |
+| `TestMergeTrainRestartSafety` | ADR-059 D5 (#950) + PR #960 (reconstruct must not stall on a historical merged PR) |
 
 Every escape-from-release regression earns a new scenario in this table.
 

--- a/tests/e2e/lifecycle.go
+++ b/tests/e2e/lifecycle.go
@@ -1,0 +1,143 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Fabrik test-bed lifecycle management. Until now the harness assumed an
+// externally-started Fabrik (AssertFabrikRunning skips if it isn't up). The
+// restart-safety scenario needs to actually stop and start the bed to exercise
+// reconstructTrainState against durable artifacts with an empty in-memory map
+// (the definition of a restart). These helpers own that lifecycle.
+//
+// Design constraints honored:
+//   - The started process is DETACHED (new process group, released, stdio to
+//     /dev/null) so it survives the test process exiting — the bed is a persistent
+//     instance, and later tests / manual use expect it up.
+//   - It launches WITHOUT --auto-upgrade (a train-capable dev binary must not be
+//     reverted to a release mid-suite) and WITH GITHUB_TOKEN stripped from the
+//     child env, so Fabrik resolves its identity from the bed's own .env
+//     (FABRIK_TOKEN = @arbeithand) instead of an ambient token.
+
+// fabrikLockPath returns the bed's lock file path.
+func fabrikLockPath(env *Env) string {
+	return filepath.Join(env.FabrikTestDir, ".fabrik", "fabrik.lock")
+}
+
+// lockedPID reads the bed lock and returns the pid, or 0 if no live-locked Fabrik.
+func lockedPID(env *Env) int {
+	contents, err := os.ReadFile(fabrikLockPath(env))
+	if err != nil {
+		return 0
+	}
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(contents)), "%d", &pid); err != nil || pid <= 0 {
+		return 0
+	}
+	if syscallSignalZero(pid) != nil {
+		return 0
+	}
+	return pid
+}
+
+// StopFabrikTestBed stops the running bed (SIGTERM to the locked pid) and waits
+// for the lock to clear (graceful shutdown unlinks it). No-op if not running.
+func StopFabrikTestBed(t *testing.T, env *Env) {
+	t.Helper()
+	pid := lockedPID(env)
+	if pid == 0 {
+		t.Logf("StopFabrikTestBed: no running bed (no live lock) — nothing to stop")
+		return
+	}
+	if p, err := os.FindProcess(pid); err == nil {
+		if serr := p.Signal(syscall.SIGTERM); serr != nil {
+			t.Fatalf("SIGTERM pid %d: %v", pid, serr)
+		}
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if lockedPID(env) == 0 {
+			t.Logf("StopFabrikTestBed: bed pid %d stopped, lock cleared", pid)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bed pid %d did not release lock within 30s", pid)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// StartFabrikTestBed launches a fresh detached bed from the bed's own binary and
+// waits for it to acquire the lock. No-op if already running.
+func StartFabrikTestBed(t *testing.T, env *Env) {
+	t.Helper()
+	if lockedPID(env) != 0 {
+		t.Logf("StartFabrikTestBed: bed already running — nothing to start")
+		return
+	}
+	bin := filepath.Join(env.FabrikTestDir, "fabrik")
+	if _, err := os.Stat(bin); err != nil {
+		t.Fatalf("bed binary not found at %s: %v", bin, err)
+	}
+
+	cmd := exec.Command(bin, "-notui")
+	cmd.Dir = env.FabrikTestDir
+	// Strip GITHUB_TOKEN so Fabrik uses FABRIK_TOKEN (@arbeithand) from the bed's
+	// .env — an ambient token must not hijack the bed's identity.
+	cmd.Env = stripEnv(os.Environ(), "GITHUB_TOKEN")
+	// Detach: new process group + /dev/null stdio so the child outlives the test.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if devnull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0); err == nil {
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = devnull, devnull, devnull
+		defer devnull.Close()
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start bed Fabrik (%s): %v", bin, err)
+	}
+	// Release so the test never becomes its reaper; the OS reparents it on exit.
+	_ = cmd.Process.Release()
+
+	deadline := time.Now().Add(40 * time.Second)
+	for {
+		if pid := lockedPID(env); pid != 0 {
+			t.Logf("StartFabrikTestBed: bed up (pid %d)", pid)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bed Fabrik did not acquire lock within 40s of launch")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// RestartFabrikTestBed stops then starts the bed, simulating a process restart
+// with an empty in-memory state map. Registers a cleanup that guarantees the bed
+// is left running even if the test fails mid-restart.
+func RestartFabrikTestBed(t *testing.T, env *Env) {
+	t.Helper()
+	t.Cleanup(func() { StartFabrikTestBed(t, env) }) // ensure the bed is up at test end
+	StopFabrikTestBed(t, env)
+	StartFabrikTestBed(t, env)
+}
+
+// stripEnv returns environ with any KEY=... entry for key removed.
+func stripEnv(environ []string, key string) []string {
+	pfx := key + "="
+	out := environ[:0:0]
+	for _, kv := range environ {
+		if strings.HasPrefix(kv, pfx) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}

--- a/tests/e2e/mergetrain_bisect_test.go
+++ b/tests/e2e/mergetrain_bisect_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMergeTrainBisectionEjectsPoisoner is the e2e proof of ADR-059 D4: when a
+// batch validates RED, the train halving-bisects to isolate the single poisoning
+// member, ejects it, and lands the survivors — instead of O(N) per-member retests.
+//
+// Construction: three members with DISTINCT file paths (so the combined batch
+// merges cleanly — this is a *semantic* cross-PR failure, not a textual conflict).
+// Two are clean; one writes a file containing the sentinel "POISON". The test
+// repo's required "train-poison-guard" check fails iff any file under
+// e2e/train/entries/ contains "POISON", so:
+//   - each clean member's own PR is green,
+//   - the combined trial branch is RED (the poison file is present),
+//   - bisection isolates the poison member, ejects it (back to Queued / paused),
+//     and the two survivors re-form and land Queued → Done.
+//
+// Prerequisites (Phase-B bed setup): the Queued column + train-capable binary AND
+// the `train-poison-guard` required check on fabrik-test-alpha (workflow committed
+// from tests/e2e/testdata/train-poison-guard.yml — see README "Merge-train
+// scenarios"). Skips cleanly if the Queued column is absent.
+//
+// Wall-clock: ~20–40 min (combined validate + O(log N) bisection rounds, each a
+// full trial CI). Cost: low-moderate (no conflict resolution; bisection is git +
+// CI only).
+func TestMergeTrainBisectionEjectsPoisoner(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	requireTrainBed(t, env)
+
+	const base = "main"
+	logStart := LogOffset(t, env)
+
+	clean1Issue, clean1PR := QueueMember(t, env, env.RepoAlpha, base, "clean1", "e2e/train/entries/clean1.txt", "clean entry 1\n")
+	clean2Issue, clean2PR := QueueMember(t, env, env.RepoAlpha, base, "clean2", "e2e/train/entries/clean2.txt", "clean entry 2\n")
+	poisonIssue, _ := QueueMember(t, env, env.RepoAlpha, base, "poison", "e2e/train/entries/poison.txt", "POISON — this member fails the combined check\n")
+	t.Logf("queued 2 clean (#%d,#%d) + 1 poison (#%d); awaiting bisection", clean1Issue, clean2Issue, poisonIssue)
+
+	// Bisection must run (combined batch is red) — the strongest internal signal.
+	WaitForLogLine(t, env, "bisecting to isolate the poisoner", logStart, 25*time.Minute)
+	t.Logf("bisection engaged on the red batch")
+
+	// The poison member is ejected — asserted via the ejection comment the engine
+	// posts on the member issue (posted on every ejection path: halving-isolated,
+	// isolation-fail, and one-at-a-time fallback), so this is path-independent.
+	WaitForIssueComment(t, env, env.RepoAlpha, poisonIssue, "merge-train — ejected", 25*time.Minute)
+	t.Logf("poison member #%d ejected", poisonIssue)
+
+	// The two survivors re-form and land Queued → Done, PRs closed.
+	for _, m := range []struct {
+		issue, pr int
+	}{{clean1Issue, clean1PR}, {clean2Issue, clean2PR}} {
+		WaitForProjectStatus(t, env, env.RepoAlpha, m.issue, "Done", 25*time.Minute)
+		waitForPRClosed(t, env, env.RepoAlpha, m.pr, 5*time.Minute)
+		t.Logf("survivor #%d landed (Done, PR #%d closed)", m.issue, m.pr)
+	}
+
+	// The poison member must NOT have landed: it is back in Queued (retry) or
+	// paused after repeated ejection — never Done.
+	if st := projectStatus(t, env, env.RepoAlpha, poisonIssue); st == "Done" {
+		t.Fatalf("poison member #%d reached Done — bisection failed to eject it", poisonIssue)
+	} else {
+		t.Logf("poison member #%d correctly not landed (status=%q)", poisonIssue, st)
+	}
+
+	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)
+	t.Logf("bisection contract verified: red batch → O(log N) bisect → poisoner ejected → survivors landed")
+}

--- a/tests/e2e/mergetrain_happy_test.go
+++ b/tests/e2e/mergetrain_happy_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMergeTrainHappyPathLanding is the e2e proof of the ADR-059 internal merge
+// train's core contract: a clean batch of Queued members is assembled onto one
+// trial branch, validated once, landed via a single integration PR through normal
+// branch protection, and every member is advanced Queued → Done with its PR
+// closed. This is the O(N²) → ~O(1) guarantee the train exists to provide, proven
+// end-to-end against real GitHub (not the unit-test seam).
+//
+// Setup shortcut: members are placed directly in Queued with real linked PRs
+// (QueueMember) rather than run through the full Specify→Validate pipeline — the
+// train is column-driven (D1), so this is a faithful batch. Distinct file paths
+// per member make the batch conflict-free (the happy path); conflict/bisection
+// behaviour is covered by the sibling scenarios.
+//
+// Prerequisites: the test board must have a Queued column and the test-bed Fabrik
+// must run a train-capable binary with the Queued holding stage configured (see
+// tests/e2e/README.md → "Merge-train scenarios"). Skips cleanly otherwise.
+//
+// Wall-clock: ~10–25 min (one combined validation + integration-PR CI). Cost: low
+// (no Claude invocations on the happy path — no conflicts to resolve).
+func TestMergeTrainHappyPathLanding(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	requireTrainBed(t, env)
+
+	const base = "main"
+	logStart := LogOffset(t, env)
+
+	// Three clean members — distinct paths so the combined batch has no conflicts.
+	type member struct {
+		issue int
+		pr    int
+	}
+	var members []member
+	for _, m := range []struct{ marker, path, content string }{
+		{"alpha", "e2e/train/alpha.txt", "alpha member\n"},
+		{"bravo", "e2e/train/bravo.txt", "bravo member\n"},
+		{"charlie", "e2e/train/charlie.txt", "charlie member\n"},
+	} {
+		iss, pr := QueueMember(t, env, env.RepoAlpha, base, m.marker, m.path, m.content)
+		members = append(members, member{iss, pr})
+	}
+	t.Logf("queued %d clean members; awaiting train assembly + landing", len(members))
+
+	// Proof the internal train landed a batch: the engine logs "landing complete …
+	// (integration PR #N, M members)" after merging the single integration PR and
+	// advancing members. Read from logStart so only THIS run's landing matches.
+	WaitForLogLine(t, env, "landing complete", logStart, 30*time.Minute)
+	t.Logf("train landed a batch")
+
+	// Every member advances Queued → Done and its member PR is closed (the member
+	// PR is closed, not merged — the changes land via the integration PR). Board=Done
+	// + PR-closed is the definitive per-member landed signal; issue closure is a
+	// downstream Done-stage cleanup and is not asserted here to avoid timing flakiness.
+	for _, m := range members {
+		WaitForProjectStatus(t, env, env.RepoAlpha, m.issue, "Done", 10*time.Minute)
+		waitForPRClosed(t, env, env.RepoAlpha, m.pr, 10*time.Minute)
+		t.Logf("member #%d landed: Done + member PR #%d closed", m.issue, m.pr)
+	}
+
+	// No stale train branches/PRs should remain after the landing.
+	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)
+	t.Logf("happy-path land verified: 3 members → 1 integration PR → all Done, no O(N²) per-member retests")
+}

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -1,0 +1,273 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Merge-train e2e helpers (ADR-059). These build member PRs directly via the
+// GitHub API and place issues straight into the Queued column, so a train
+// scenario does not have to run the full 45-minute Specify→Validate pipeline for
+// every member. The train is column-driven (ADR-059 D1: "the train's input set is
+// every item in Queued"), so an externally-placed Queued item with a linked PR is
+// a valid member — which is exactly what these helpers construct.
+
+// requireTrainBed skips the test unless the test board has a "Queued" column —
+// the one-time operator setup the merge train needs (ADR-059 D1). Keeps train
+// scenarios from failing on a bed that predates the train rollout.
+func requireTrainBed(t *testing.T, env *Env) {
+	t.Helper()
+	// Retry on transient errors (e.g. GraphQL rate-limit exhaustion — gh project runs
+	// on GraphQL). A persistent read failure FAILS the test rather than silently
+	// skipping, so a rate-limited run does not masquerade as "bed not set up".
+	var out string
+	var err error
+	for attempt := 0; attempt < 6; attempt++ {
+		out, err = ghOutput(env, "project", "field-list", fmt.Sprint(env.ProjectNumber),
+			"--owner", env.ProjectOwner, "--format", "json",
+			"--jq", `.fields[] | select(.name=="Status") | .options[]?.name`)
+		if err == nil {
+			for _, line := range strings.Split(out, "\n") {
+				if strings.TrimSpace(line) == "Queued" {
+					return
+				}
+			}
+			t.Skipf("test board %s/#%d has no Queued column — merge-train bed not set up (see tests/e2e/README.md)",
+				env.ProjectOwner, env.ProjectNumber)
+		}
+		t.Logf("requireTrainBed: transient board-read error (attempt %d/6): %v\n%s", attempt+1, err, out)
+		time.Sleep(20 * time.Second)
+	}
+	t.Fatalf("could not read board columns after 6 attempts (last: %v) — GraphQL rate limit or API issue, not a skip condition", err)
+}
+
+// defaultBranchSHA returns the head commit SHA of the repo's default branch.
+func defaultBranchSHA(t *testing.T, env *Env, repo, baseBranch string) string {
+	t.Helper()
+	out, err := ghOutput(env, "api",
+		fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, baseBranch),
+		"--jq", ".object.sha")
+	if err != nil {
+		t.Fatalf("resolve %s default branch (%s) sha: %v\n%s", repo, baseBranch, err, out)
+	}
+	sha := lastNonEmpty(out)
+	if sha == "" {
+		t.Fatalf("empty sha for %s/%s", repo, baseBranch)
+	}
+	return sha
+}
+
+// CreateMemberPR builds a real member PR on repo: it branches off baseBranch,
+// writes content to path on that branch, and opens a PR whose body contains
+// "Closes #issueNum" (so Fabrik discovers the issue↔PR linkage). Returns the PR
+// number. Registers cleanup to delete the branch at test end.
+//
+// path/content let the caller shape the batch: distinct paths → a clean batch;
+// the same path with divergent content → a textual conflict for the bisection /
+// conflict-resolution scenarios.
+func CreateMemberPR(t *testing.T, env *Env, repo, baseBranch, branch, path, content, issueTitle string, issueNum int) int {
+	t.Helper()
+	baseSHA := defaultBranchSHA(t, env, repo, baseBranch)
+
+	// Create the branch ref off the base head.
+	if out, err := ghOutput(env, "api", "--method", "POST",
+		fmt.Sprintf("repos/%s/git/refs", repo),
+		"-f", "ref=refs/heads/"+branch,
+		"-f", "sha="+baseSHA); err != nil {
+		t.Fatalf("create branch %s on %s: %v\n%s", branch, repo, err, out)
+	}
+	t.Cleanup(func() {
+		_, _ = ghOutput(env, "api", "--method", "DELETE",
+			fmt.Sprintf("repos/%s/git/refs/heads/%s", repo, branch))
+	})
+
+	// Write the file on the new branch (single commit).
+	enc := base64.StdEncoding.EncodeToString([]byte(content))
+	if out, err := ghOutput(env, "api", "--method", "PUT",
+		fmt.Sprintf("repos/%s/contents/%s", repo, path),
+		"-f", fmt.Sprintf("message=e2e merge-train member for #%d", issueNum),
+		"-f", "content="+enc,
+		"-f", "branch="+branch); err != nil {
+		t.Fatalf("write %s on %s@%s: %v\n%s", path, repo, branch, err, out)
+	}
+
+	// Open the PR with the Closes #N linkage.
+	body := fmt.Sprintf("e2e merge-train member.\n\nCloses #%d\n", issueNum)
+	out, err := ghOutput(env, "pr", "create", "-R", repo,
+		"--base", baseBranch, "--head", branch,
+		"--title", issueTitle, "--body", body)
+	if err != nil {
+		t.Fatalf("create member PR for #%d on %s: %v\n%s", issueNum, repo, err, out)
+	}
+	prNum := parseIssueNumberFromURL(lastNonEmpty(out))
+	if prNum == 0 {
+		t.Fatalf("could not parse member PR number from %q", out)
+	}
+	t.Logf("created member PR #%d (issue #%d, branch %s, path %s)", prNum, issueNum, branch, path)
+	return prNum
+}
+
+// QueueMember files an issue, adds it to the project, creates its member PR, and
+// places the issue directly in the Queued column. Returns (issueNum, prNum). The
+// caller controls path/content to make the batch clean or conflicting.
+func QueueMember(t *testing.T, env *Env, repo, baseBranch, marker, path, content string) (int, int) {
+	t.Helper()
+	stamp := time.Now().UTC().Format("150405.000")
+	title := fmt.Sprintf("e2e merge-train member %s (%s)", marker, stamp)
+	num := FileIssue(t, env, repo, title,
+		fmt.Sprintf("e2e merge-train member. marker=%s", marker))
+	itemID := AddIssueToProject(t, env, repo, num)
+	// The engine resolves a member's linked PR strictly by the fabrik/issue-<N>
+	// branch convention (github.Client.FetchLinkedPR queries pulls?head=fabrik/issue-N),
+	// NOT by the "Closes #N" body — so the member PR MUST live on that branch or the
+	// train cannot find it and ejects the member. (The Closes #N body still drives
+	// GitHub's issue auto-close on merge; both are set.)
+	// Make the file path unique per run. A landed batch MERGES its member files into
+	// main, so a fixed path collides with the existing file on the next run (GitHub's
+	// contents API requires the existing blob sha to update, which we don't supply).
+	// The fresh issue number guarantees uniqueness; the directory is preserved so the
+	// bisection poison-guard (which scans e2e/train/entries/) still sees the file.
+	uPath := uniqueMemberPath(path, num)
+	branch := fmt.Sprintf("fabrik/issue-%d", num)
+	prNum := CreateMemberPR(t, env, repo, baseBranch, branch, uPath, content, title, num)
+	// Confirm the PR is resolvable by that branch (mirrors the engine's resolver)
+	// BEFORE placing the item in Queued, so the train's first poll can fetch it.
+	LinkedPRNumber(t, env, repo, num)
+	// Placing directly in Queued: the train is column-driven, so this is a valid
+	// member without running the full pipeline.
+	SetIssueStatus(t, env, itemID, "Queued")
+	t.Logf("queued member: issue #%d, PR #%d, at Status=Queued", num, prNum)
+	return num, prNum
+}
+
+// WaitForIntegrationPR polls the repo for the merge-train integration PR (head
+// branch carries the "merge-train-" prefix), up to timeout. Returns the number of
+// the most recently created one.
+func WaitForIntegrationPR(t *testing.T, env *Env, repo string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := ghOutput(env, "pr", "list", "-R", repo, "--state", "all",
+			"--json", "number,headRefName,createdAt",
+			"--jq", `[.[] | select(.headRefName | startswith("fabrik/merge-train/"))] | sort_by(.createdAt) | last | .number`)
+		if err == nil {
+			if n := parseFirstInt(lastNonEmpty(out)); n > 0 {
+				return n
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no merge-train integration PR appeared on %s within %s", repo, timeout)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// projectStatus returns the current board Status column of an issue, or "" if the
+// item is not found on the board.
+func projectStatus(t *testing.T, env *Env, repo string, issueNumber int) string {
+	t.Helper()
+	out, err := ghOutput(env, "project", "item-list", fmt.Sprint(env.ProjectNumber),
+		"--owner", env.ProjectOwner, "--format", "json", "--limit", "200",
+		"--jq", fmt.Sprintf(`.items[] | select(.content.number==%d and (.content.repository|ascii_downcase)==("%s"|ascii_downcase)) | .status`, issueNumber, repo))
+	if err != nil {
+		t.Logf("projectStatus: gh error for %s#%d: %v", repo, issueNumber, err)
+		return ""
+	}
+	return strings.TrimSpace(lastNonEmpty(out))
+}
+
+// WaitForIssueComment polls the issue's comments until one contains substring, or
+// timeout expires. Used to assert engine-posted lifecycle comments (e.g. the
+// merge-train ejection notice) that are posted on every code path.
+func WaitForIssueComment(t *testing.T, env *Env, repo string, issueNumber int, substring string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := ghOutput(env, "issue", "view", fmt.Sprint(issueNumber), "-R", repo,
+			"--json", "comments", "--jq", ".comments[].body")
+		if err == nil && strings.Contains(out, substring) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for comment containing %q on %s#%d", substring, repo, issueNumber)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// uniqueMemberPath inserts "-<num>" before the file extension so each run's member
+// file is unique (landed files persist on main). "e2e/train/entries/clean1.txt" +
+// 42 → "e2e/train/entries/clean1-42.txt".
+func uniqueMemberPath(path string, num int) string {
+	slash := strings.LastIndex(path, "/")
+	dot := strings.LastIndex(path, ".")
+	if dot <= slash { // no extension in the basename
+		return fmt.Sprintf("%s-%d", path, num)
+	}
+	return fmt.Sprintf("%s-%d%s", path[:dot], num, path[dot:])
+}
+
+// parseFirstInt extracts a leading integer from s (jq may emit "null").
+func parseFirstInt(s string) int {
+	s = strings.TrimSpace(s)
+	var n int
+	if _, err := fmt.Sscanf(s, "%d", &n); err != nil {
+		return 0
+	}
+	return n
+}
+
+// waitForPRClosed polls until the PR is CLOSED or MERGED (both are terminal for
+// a member PR the train has landed), up to timeout.
+func waitForPRClosed(t *testing.T, env *Env, repo string, prNumber int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
+			"--json", "state", "--jq", ".state")
+		if err == nil {
+			switch strings.TrimSpace(out) {
+			case "CLOSED", "MERGED":
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("member PR #%d on %s not closed within %s (last state: %q, err: %v)", prNumber, repo, timeout, strings.TrimSpace(out), err)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// assertPRMerged fails unless the PR is in the MERGED state.
+func assertPRMerged(t *testing.T, env *Env, repo string, prNumber int) {
+	t.Helper()
+	out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
+		"--json", "state", "--jq", ".state")
+	if err != nil {
+		t.Fatalf("could not read state of integration PR #%d: %v\n%s", prNumber, err, out)
+	}
+	if got := strings.TrimSpace(out); got != "MERGED" {
+		t.Fatalf("integration PR #%d state = %q, want MERGED (batch did not land atomically)", prNumber, got)
+	}
+}
+
+// assertNoStaleTrainArtifacts fails if the repo still has open merge-train
+// integration PRs after a scenario — a guard against the reconstruction bugs
+// (permanent stall / orphaned remnants) surviving cleanup.
+func assertNoStaleTrainArtifacts(t *testing.T, env *Env, repo string) {
+	t.Helper()
+	out, err := ghOutput(env, "pr", "list", "-R", repo, "--state", "open",
+		"--json", "headRefName", "--jq", `[.[] | select(.headRefName | startswith("fabrik/merge-train/"))] | length`)
+	if err != nil {
+		t.Logf("warn: could not check for stale train PRs on %s: %v", repo, err)
+		return
+	}
+	if n := parseFirstInt(lastNonEmpty(out)); n > 0 {
+		t.Errorf("found %d open merge-train integration PR(s) still on %s after scenario", n, repo)
+	}
+}

--- a/tests/e2e/mergetrain_restart_test.go
+++ b/tests/e2e/mergetrain_restart_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMergeTrainRestartSafety is the e2e proof of ADR-059 D5 restart-safety: the
+// train reconstructs durable state after a process restart (empty in-memory
+// in-flight map) instead of stalling or duplicating work. It targets the severe
+// reconstruction bug fixed in PR #960: after a batch lands, its MERGED integration
+// PR persists (ListPRs state=all, newest-first) and still carries the batch
+// marker — a naive reconstruct would pick it, complete-deferred would find no
+// still-Queued members, and the worker would exit, PERMANENTLY stalling the train
+// after the first landing. This asserts that a restart with exactly that
+// historical artifact present does NOT stall the next batch.
+//
+// Flow:
+//  1. Land batch 1 (clean) → a merged integration PR now exists as history.
+//  2. Restart the bed (clears the in-memory in-flight map — the definition of a
+//     restart) using the harness lifecycle helpers.
+//  3. Queue batch 2 (clean).
+//  4. Assert batch 2 lands Queued → Done — proving reconstruct skips the historical
+//     merged PR and proceeds fresh.
+//
+// NOT t.Parallel(): it restarts the shared bed, so it must not run concurrently
+// with the other train scenarios. Go runs non-parallel tests to completion before
+// resuming parallel ones, so this runs in isolation and leaves the bed up.
+//
+// Wall-clock: ~25–50 min (two full batch landings + a restart). Cost: low.
+func TestMergeTrainRestartSafety(t *testing.T) {
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	requireTrainBed(t, env)
+
+	const base = "main"
+
+	// --- Batch 1: land it fully so a merged integration PR becomes history. ---
+	logStart1 := LogOffset(t, env)
+	b1a, b1aPR := QueueMember(t, env, env.RepoAlpha, base, "r1a", "e2e/train/restart/r1a.txt", "restart batch1 a\n")
+	b1b, b1bPR := QueueMember(t, env, env.RepoAlpha, base, "r1b", "e2e/train/restart/r1b.txt", "restart batch1 b\n")
+	WaitForLogLine(t, env, "landing complete", logStart1, 30*time.Minute)
+	for _, m := range [][2]int{{b1a, b1aPR}, {b1b, b1bPR}} {
+		WaitForProjectStatus(t, env, env.RepoAlpha, m[0], "Done", 10*time.Minute)
+		waitForPRClosed(t, env, env.RepoAlpha, m[1], 10*time.Minute)
+	}
+	t.Logf("batch 1 landed — a merged integration PR is now history on the repo")
+
+	// --- Restart: clears the in-memory in-flight map; historical merged PR remains. ---
+	RestartFabrikTestBed(t, env)
+	t.Logf("bed restarted — in-memory train state cleared, historical merged integration PR still on the repo")
+
+	// --- Batch 2: must land despite the historical merged PR (no permanent stall). ---
+	// logStart2 is taken AFTER the restart, so the "landing complete" wait matches
+	// batch 2's landing, not batch 1's — proving reconstruct skipped the historical
+	// merged PR and formed a fresh batch (the severe #960 bug this scenario targets).
+	logStart2 := LogOffset(t, env)
+	b2a, b2aPR := QueueMember(t, env, env.RepoAlpha, base, "r2a", "e2e/train/restart/r2a.txt", "restart batch2 a\n")
+	b2b, b2bPR := QueueMember(t, env, env.RepoAlpha, base, "r2b", "e2e/train/restart/r2b.txt", "restart batch2 b\n")
+	WaitForLogLine(t, env, "landing complete", logStart2, 30*time.Minute)
+	for _, m := range [][2]int{{b2a, b2aPR}, {b2b, b2bPR}} {
+		WaitForProjectStatus(t, env, env.RepoAlpha, m[0], "Done", 10*time.Minute)
+		waitForPRClosed(t, env, env.RepoAlpha, m[1], 10*time.Minute)
+	}
+	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)
+	t.Logf("restart-safety verified: batch 2 landed after restart — no stall from the historical merged PR")
+}

--- a/tests/e2e/testdata/train-poison-guard.yml
+++ b/tests/e2e/testdata/train-poison-guard.yml
@@ -1,0 +1,33 @@
+# Merge-train e2e bisection fixture — commit this to fabrik-test-alpha as
+# .github/workflows/train-poison-guard.yml and mark the "train-poison-guard"
+# check REQUIRED on branch protection (so the internal train's combined-Validate
+# poll gates on it).
+#
+# It fails iff any file under e2e/train/entries/ contains the sentinel "POISON".
+# TestMergeTrainBisectionEjectsPoisoner relies on this: clean members' files pass;
+# a single "poison" member's file makes the COMBINED trial branch red (the files
+# merge cleanly — this is a semantic cross-PR failure, exactly what bisection is
+# for), so the train must halving-bisect, isolate the poison member, eject it, and
+# land the survivors.
+#
+# Scoped so it never disrupts other e2e scenarios: it is a fast grep, and green
+# whenever no poison entry is present (the common case).
+name: train-poison-guard
+
+on:
+  pull_request:
+
+jobs:
+  train-poison-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject POISON entries in the combined tree
+        run: |
+          dir="e2e/train/entries"
+          if [ -d "$dir" ] && grep -rlq "POISON" "$dir"; then
+            echo "::error::found POISON sentinel in $dir — combined batch is red (bisection fixture)"
+            grep -rl "POISON" "$dir" || true
+            exit 1
+          fi
+          echo "no POISON entries — train-poison-guard green"


### PR DESCRIPTION
## Summary

The internal merge train (ADR-059) **could not land a single batch against real GitHub.** The e2e scenarios in this PR caught it; the fix makes the train land end-to-end, and all three scenarios pass on the test bed.

## The bug

The train opens a **draft CI PR** on the trial branch to run the combined Validate. That draft PR **is** the landing integration PR (same trial branch → base). But its body omitted `mergeTrainBatchMarker`, so `findIntegrationPR` (which keys on that marker) returned nil, and `landMergeTrainBatch` fell through to `CreatePR` — trying to open a **second** PR on the same trial branch. GitHub rejects that with:

```
422 Validation Failed — A pull request already exists for handarbeit:fabrik/merge-train/merge-train-main-…
```

The worker then retried every poll, never landing. **Unit tests mocked `CreatePR`** (which never returns a real 422) and the **manual de-risk spike created one PR by hand**, so both missed it — only an end-to-end run against live GitHub surfaces it. Had we flipped a fleet repo to the train, it would have silently failed to land anything.

## Fix (`engine/merge_train.go`)

1. The draft CI PR body now carries `mergeTrainBatchMarker`, so `findIntegrationPR` **reuses** it during landing instead of creating a colliding second PR.
2. The reused PR is a draft, so landing **`MarkPRReady`s** it before `MergePR` (GitHub won't merge a draft).

Unit regression: `TestLandMergeTrainBatch_ReusesDraftCIPR_MarksReady`.

## e2e scenarios (`tests/e2e/`, `//go:build e2e`) — all green

| Scenario | Proves | Result |
|---|---|---|
| `TestMergeTrainHappyPathLanding` | 3 clean members → 1 integration PR → all Queued→Done, member PRs closed | ✅ 149s |
| `TestMergeTrainRestartSafety` (D5 / #960) | restart with a historical merged integration PR present does not stall the next batch | ✅ 218s |
| `TestMergeTrainBisectionEjectsPoisoner` (D4) | red combined batch → halving bisection isolates + ejects the poison member → survivors land | ✅ 222s |

New harness: `lifecycle.go` (Start/Stop/Restart the test-bed Fabrik — needed for the restart scenario), merge-train helpers (member PRs on the `fabrik/issue-N` convention placed directly in Queued; log/board assertions), the `train-poison-guard` workflow fixture, and README setup docs (Queued column, `queued.yaml`, train binary, poison-guard required check).

The e2e are build-tagged out of the default `go test ./...` and skip cleanly on a bed without the Queued column, so they're safe to land immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
