### PR TITLE
feat(merge-train): runaway guard — rolling trial counter with two-hook pause (ADR-059 D8)

### DIFF
--- a/adrs/059-internal-merge-train.md
+++ b/adrs/059-internal-merge-train.md
@@ -121,6 +121,26 @@ personal — the internal-train branch is always taken.)
   (a label or sub-state), preserving cruise's "human decides to merge" contract — now batched.
   (v1 may scope the train to yolo `Queued` items and treat cruise batching as a fast-follow.)
 
+### D8 — Runaway guard (composition-agnostic trial rate cap)
+
+**Problem.** On 2026-07-06, a billing-blocked CI on `handarbeit/fabrik-test-alpha` produced 2,730 GitHub Actions workflow runs in a single day (~1,400 trial PRs × 2 required checks). The root cause: GitHub reports a billing-blocked job as plain `conclusion: failure`, indistinguishable from a content-red batch without parsing the per-step annotation text ("recent account payments have failed"). The train therefore treated the infra fault as a persistent poisoner, bisected and ejected every member (up to `MaxMergeTrainEjections` rounds each), and re-formed a fresh batch on every poll cycle — burning ~1 trial family per 60 seconds until the account was exhausted.
+
+**Why not classify failure causes?** Parsing per-check annotations to distinguish "infra failure" from "code failure" would require fetching the check run's step annotations on every red result — extra API traffic, fragile to GitHub annotation format changes, and still not complete (a broken base branch or a test suite permanently broken by a merged commit looks exactly like a content-red to annotation parsing). This path is deferred as a potential future fast-path but is not taken here.
+
+**Decision: composition-agnostic trial rate cap.** Add a cross-poll-cycle rolling-window counter keyed `owner/repo` (parallel to `mergeTrainEjectionCounts`). If a repo creates ≥ `MaxTrainTrialsPerWindow` trial branches with **zero successful landings** within a rolling `TrainTrialWindowDuration` window, pause all Queued members for that repo and stop dispatching until a human clears the labels.
+
+**Design:**
+- `recordTrial(repoKey)` is called at the top of `assembleAndValidate` (the single site where all trial branches are created) before the test-seam branch, so every trial — initial batch, bisection sub-trials, and one-at-a-time singletons — counts.
+- `resetTrialCounter(repoKey)` is called from `landMergeTrainBatch` and `landSingleton` after a successful merge. A train where survivors do land (normal poison bisection) never accumulates toward the cap.
+- Two hooks ensure all Queued members are paused, not just the active batch: **Hook 1** inside `runMergeTrainWorker` (pauses the active batch immediately when the guard fires); **Hook 2** in `routeQueuedGroup` before dispatch (pauses any beyond-cap Queued members on the next poll). The one-poll-cycle gap for beyond-cap members is acceptable because they cannot form a new batch while the worker goroutine is still active.
+- `fireRunawayGuard` logs at the `merge-train` tag, applies `fabrik:paused` + `fabrik:awaiting-input` to each member, and posts an alert comment explaining the trial count, window, and remediation steps.
+
+**Defaults:** `MaxTrainTrialsPerWindow = 20`, `TrainTrialWindowDuration = 60 min`.
+
+Derivation: worst-case legitimate bisection (MaxBatchSize=5) resets the counter at or before trial 8 (a bisection that isolates a poisoner, plus one green re-form trial). The one-at-a-time fallback with a cross-PR interaction accumulates at most 7 trials before the first singleton lands and resets. N=20 is well above both: a billing-blocked repo accumulates 20 trials in seconds (CI fails immediately); a healthy repo lands members and resets before reaching 20. The 60-min window covers slow CI (30 min/check × 2 checks = 60 min for one real trial) while billing-blocked CI hits the cap in under a minute.
+
+**Restart semantics:** the counter is in-memory and resets on engine restart. `fabrik:paused` labels persist on GitHub, so the poison-well exclusion (`groupQueuedByRepo`) continues preventing re-formation after a restart. The only gap is a simultaneous restart + manual unpause while infra is still broken — this is acceptable per the spec (R6).
+
 ## Consequences
 
 **Positive:**

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,10 +49,12 @@ type Config struct {
 	AutoMergeStrategy    string // MERGE, SQUASH, or REBASE; "" means use default (MERGE)
 	MergeQueue           string // auto or off; "" means use default (auto)
 	MergeTrain           string // on or off; "" means use default (off)
-	MaxBatchSize         int    // 0 means use default (5)
-	MaxBisectValidations int    // 0 means derive default (2·⌈log₂(MaxBatchSize)⌉+1)
-	MaxTrainRebaseCycles int    // 0 means use default (3)
-	ClaudeWaitDelay      int    // seconds; 0 means use default (30)
+	MaxBatchSize             int    // 0 means use default (5)
+	MaxBisectValidations     int    // 0 means derive default (2·⌈log₂(MaxBatchSize)⌉+1)
+	MaxTrainRebaseCycles     int    // 0 means use default (3)
+	MaxTrainTrialsPerWindow  int    // 0 means use default (20)
+	TrainTrialWindowMinutes  int    // 0 means use default (60)
+	ClaudeWaitDelay          int    // seconds; 0 means use default (30)
 	PostPushDwell        int    // seconds; 0 means use default (90)
 	KillGraceSigInt      string // Go duration string; "" means use default (10s); "0s" skips SIGINT step
 	KillGraceSigTerm     string // Go duration string; "" means use default (10s)
@@ -151,6 +153,8 @@ func Execute() error {
 	flag.IntVar(&cfg.MaxBatchSize, "max-batch-size", 0, "Maximum Queued items landed in a single merge-train batch, ordered by entry (0 = use default of 5; smaller = cheaper worst-case bisection, fewer N² savings; also FABRIK_MAX_BATCH_SIZE)")
 	flag.IntVar(&cfg.MaxBisectValidations, "max-bisect-validations", 0, "Maximum combined validations per red merge-train batch before degrading to one-at-a-time landing (0 = derive 2·⌈log₂(max-batch-size)⌉+1, ≈7 at the default batch size; also FABRIK_MAX_BISECT_VALIDATIONS)")
 	flag.IntVar(&cfg.MaxTrainRebaseCycles, "max-train-rebase-cycles", 0, "Maximum main-moved rebase+revalidate cycles for a merge-train batch before dissolving it back to Queued (0 = use default of 3; also FABRIK_MAX_TRAIN_REBASE_CYCLES)")
+	flag.IntVar(&cfg.MaxTrainTrialsPerWindow, "max-train-trials-per-window", 0, "Runaway guard: maximum trial-branch creations with zero successful lands within the window before pausing all Queued members (0 = use default of 20; also FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW)")
+	flag.IntVar(&cfg.TrainTrialWindowMinutes, "train-trial-window", 0, "Runaway guard: rolling window in minutes over which max-train-trials-per-window is measured (0 = use default of 60; also FABRIK_TRAIN_TRIAL_WINDOW)")
 	flag.IntVar(&cfg.ClaudeWaitDelay, "claude-wait-delay", 0, "Seconds to wait after Claude exits before recovering buffered output when grandchildren hold stdout pipe open (0 = use default of 30; also FABRIK_CLAUDE_WAIT_DELAY)")
 	flag.IntVar(&cfg.PostPushDwell, "post-push-dwell", 0, "Seconds to wait after a PR force-push before clearing the CI gate as 'no CI configured' (0 = use default of 90; also FABRIK_POST_PUSH_DWELL)")
 	flag.BoolVar(&cfg.DebugOutput, "debug-output", false, "Save Claude stage output to .fabrik/debug/ for debugging")
@@ -419,6 +423,24 @@ func Execute() error {
 				cfg.MaxTrainRebaseCycles = n
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_TRAIN_REBASE_CYCLES=%q is invalid (must be a positive integer); using default 3\n", v)
+			}
+		}
+	}
+	if !explicitFlags["max-train-trials-per-window"] {
+		if v := os.Getenv("FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.MaxTrainTrialsPerWindow = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW=%q is invalid (must be a positive integer); using default 20\n", v)
+			}
+		}
+	}
+	if !explicitFlags["train-trial-window"] {
+		if v := os.Getenv("FABRIK_TRAIN_TRIAL_WINDOW"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.TrainTrialWindowMinutes = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_TRAIN_TRIAL_WINDOW=%q is invalid (must be a positive integer of minutes); using default 60\n", v)
 			}
 		}
 	}
@@ -741,9 +763,11 @@ func Execute() error {
 		MergeQueue:               mergeQueueMode(cfg.MergeQueue),
 		MergeTrain:               mergeTrainMode(cfg.MergeTrain),
 		MaxMergeTrainEjections:   3, // ADR-059 default
-		MaxBatchSize:             cfg.MaxBatchSize,         // 0 = derive default (5) in engine
-		MaxBisectValidations:     cfg.MaxBisectValidations, // 0 = derive default in engine
-		MaxTrainRebaseCycles:     cfg.MaxTrainRebaseCycles, // 0 = derive default (3) in engine
+		MaxBatchSize:             cfg.MaxBatchSize,                                // 0 = derive default (5) in engine
+		MaxBisectValidations:     cfg.MaxBisectValidations,                        // 0 = derive default in engine
+		MaxTrainRebaseCycles:     cfg.MaxTrainRebaseCycles,                        // 0 = derive default (3) in engine
+		MaxTrainTrialsPerWindow:  cfg.MaxTrainTrialsPerWindow,                     // 0 = derive default (20) in engine
+		TrainTrialWindowDuration: trainTrialWindowDuration(cfg.TrainTrialWindowMinutes), // 0 = derive default (60m) in engine
 		ClaudeWaitDelay:          claudeWaitDelay(cfg.ClaudeWaitDelay),
 		KillGraceSigInt:          killGraceSigInt(cfg.KillGraceSigInt),
 		KillGraceSigTerm:         killGraceSigTerm(cfg.KillGraceSigTerm),
@@ -839,6 +863,16 @@ func ciWaitTimeout(minutes int) time.Duration {
 func workerStaleTimeout(minutes int) time.Duration {
 	if minutes <= 0 {
 		return 5 * time.Minute
+	}
+	return time.Duration(minutes) * time.Minute
+}
+
+// trainTrialWindowDuration converts a TrainTrialWindowMinutes config value (minutes) to a
+// time.Duration for the runaway guard rolling window (ADR-059 D8). When minutes is 0
+// (unset), returns 0 so the engine applies its own default of 60 minutes.
+func trainTrialWindowDuration(minutes int) time.Duration {
+	if minutes <= 0 {
+		return 0
 	}
 	return time.Duration(minutes) * time.Minute
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2840,7 +2840,7 @@ A batch is **usually green**: every member already passed Validate individually,
 
 The one-poll-cycle gap between Hook 1 firing and Hook 2 handling beyond-cap members is acceptable: beyond-cap members cannot form their own batch while the worker goroutine is still active.
 
-**Operator resume:** once the runaway guard fires, all affected members have `fabrik:paused` and are therefore excluded from `groupQueuedByRepo` on every subsequent poll. No re-formation occurs until a human manually removes `fabrik:paused` from each affected member. Before doing so, the operator should investigate the infra root cause (GitHub Actions billing, required-check configuration, base-branch health). The in-memory trial counter resets to zero on engine restart, but `fabrik:paused` labels persist on GitHub — so a restart alone does not re-enable the train; the labels must be cleared explicitly.
+**Operator resume:** once the runaway guard fires, all affected members have `fabrik:paused` and `fabrik:awaiting-input` applied and are therefore excluded from `groupQueuedByRepo` on every subsequent poll. No re-formation occurs until a human manually removes both `fabrik:paused` and `fabrik:awaiting-input` from each affected member. Before doing so, the operator should investigate the infra root cause (GitHub Actions billing, required-check configuration, base-branch health). The in-memory trial counter resets to zero on engine restart, but `fabrik:paused` labels persist on GitHub — so a restart alone does not re-enable the train; the labels must be cleared explicitly.
 
 ##### Merge-Train Serialization + Main-Moved Recovery (ADR-059 D5)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2825,6 +2825,23 @@ A batch is **usually green**: every member already passed Validate individually,
 
 **Dispatch-guard logging:** `state.bisecting` (set for the duration of `handleRedBatch`) makes `dispatchMergeTrainWorker` log "bisecting red batch" for a re-dispatch attempt during bisection, rather than the misleading "CI red — needs attention".
 
+**Runaway guard (ADR-059 D8):** a composition-agnostic rate cap that fires when a repo creates ≥ `MaxTrainTrialsPerWindow` trial branches (default 20) with **zero successful landings** within a rolling `TrainTrialWindowDuration` window (default 60 min). The guard is distinct from the poison-well guard (which terminates the loop) and the bisect cost cap (which degrades to one-at-a-time within one goroutine run): it bounds the cross-poll-cycle burst that occurs when infra is broken and every trial fails.
+
+**Counter:** `recordTrial(repoKey)` is called at the start of **every** `assembleAndValidate` call — the single site where all trial branches are created, covering both bisection sub-trials and one-at-a-time singletons. The counter is a rolling window (slice of `time.Time`) keyed `owner/repo`, protected by `mergeTrainTrialsMu`. `resetTrialCounter(repoKey)` deletes the entry; it is called from both `landMergeTrainBatch` and `landSingleton` after a successful merge, so any train where survivors do land never accumulates toward the cap.
+
+**Guard fires:** when `isRunawayTripped(repoKey)` returns `true` (count ≥ N within M minutes with zero resets), `fireRunawayGuard` is called. It:
+- Logs the event at the `merge-train` tag (never silent): repo key, trial count, window duration, and member count.
+- Applies `fabrik:paused` + `fabrik:awaiting-input` to **every current Queued member** passed to it.
+- Posts an alert comment on each member explaining the trial count seen, the window, and operator instructions.
+
+**Two-hook dispatch:** the guard is checked at two complementary points to cover both the active batch and any beyond-cap Queued members:
+1. **Hook 1 (worker-side, `runMergeTrainWorker`):** after the initial re-form trial and after `handleRedBatch` returns `runaway=true` (propagated from `bisect` or `landOneAtATime`). Pauses the active batch members (`membersToItems(survivors)` — the survivors of the initial trial assembly, which are all members when the guard trips during bisect before any ejection).
+2. **Hook 2 (poll-side, `routeQueuedGroup`):** before `dispatchMergeTrainWorker` is called. If the counter is already tripped (from a prior worker run), pauses all `trainItems` in the current Queued snapshot and skips dispatch. This handles beyond-cap members that Hook 1 could not reach.
+
+The one-poll-cycle gap between Hook 1 firing and Hook 2 handling beyond-cap members is acceptable: beyond-cap members cannot form their own batch while the worker goroutine is still active.
+
+**Operator resume:** once the runaway guard fires, all affected members have `fabrik:paused` and are therefore excluded from `groupQueuedByRepo` on every subsequent poll. No re-formation occurs until a human manually removes `fabrik:paused` from each affected member. Before doing so, the operator should investigate the infra root cause (GitHub Actions billing, required-check configuration, base-branch health). The in-memory trial counter resets to zero on engine restart, but `fabrik:paused` labels persist on GitHub — so a restart alone does not re-enable the train; the labels must be cleared explicitly.
+
 ##### Merge-Train Serialization + Main-Moved Recovery (ADR-059 D5)
 
 The batch validates a *combined batch* against `main` once; its correctness rests on **the `main` the batch validated against being the `main` it lands on**. Serializing the train (one batch in flight per repo) keeps `main` from moving under a validating batch; the only remaining mover is an **external direct push by a human**, which is detected and recovered. D5 adds two things without weakening the atomic `LoadOrStore` guard on `mergeTrainInFlight`.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -197,6 +197,23 @@ A batch is **usually green**: every member already passed Validate individually,
 
 **Dispatch-guard logging:** `state.bisecting` (set for the duration of `handleRedBatch`) makes `dispatchMergeTrainWorker` log "bisecting red batch" for a re-dispatch attempt during bisection, rather than the misleading "CI red — needs attention".
 
+**Runaway guard (ADR-059 D8):** a composition-agnostic rate cap that fires when a repo creates ≥ `MaxTrainTrialsPerWindow` trial branches (default 20) with **zero successful landings** within a rolling `TrainTrialWindowDuration` window (default 60 min). The guard is distinct from the poison-well guard (which terminates the loop) and the bisect cost cap (which degrades to one-at-a-time within one goroutine run): it bounds the cross-poll-cycle burst that occurs when infra is broken and every trial fails.
+
+**Counter:** `recordTrial(repoKey)` is called at the start of **every** `assembleAndValidate` call — the single site where all trial branches are created, covering both bisection sub-trials and one-at-a-time singletons. The counter is a rolling window (slice of `time.Time`) keyed `owner/repo`, protected by `mergeTrainTrialsMu`. `resetTrialCounter(repoKey)` deletes the entry; it is called from both `landMergeTrainBatch` and `landSingleton` after a successful merge, so any train where survivors do land never accumulates toward the cap.
+
+**Guard fires:** when `isRunawayTripped(repoKey)` returns `true` (count ≥ N within M minutes with zero resets), `fireRunawayGuard` is called. It:
+- Logs the event at the `merge-train` tag (never silent): repo key, trial count, window duration, and member count.
+- Applies `fabrik:paused` + `fabrik:awaiting-input` to **every current Queued member** passed to it.
+- Posts an alert comment on each member explaining the trial count seen, the window, and operator instructions.
+
+**Two-hook dispatch:** the guard is checked at two complementary points to cover both the active batch and any beyond-cap Queued members:
+1. **Hook 1 (worker-side, `runMergeTrainWorker`):** after the initial re-form trial and after `handleRedBatch` returns `runaway=true` (propagated from `bisect` or `landOneAtATime`). Pauses the active batch members (`membersToItems(survivors)` — the survivors of the initial trial assembly, which are all members when the guard trips during bisect before any ejection).
+2. **Hook 2 (poll-side, `routeQueuedGroup`):** before `dispatchMergeTrainWorker` is called. If the counter is already tripped (from a prior worker run), pauses all `trainItems` in the current Queued snapshot and skips dispatch. This handles beyond-cap members that Hook 1 could not reach.
+
+The one-poll-cycle gap between Hook 1 firing and Hook 2 handling beyond-cap members is acceptable: beyond-cap members cannot form their own batch while the worker goroutine is still active.
+
+**Operator resume:** once the runaway guard fires, all affected members have `fabrik:paused` and are therefore excluded from `groupQueuedByRepo` on every subsequent poll. No re-formation occurs until a human manually removes `fabrik:paused` from each affected member. Before doing so, the operator should investigate the infra root cause (GitHub Actions billing, required-check configuration, base-branch health). The in-memory trial counter resets to zero on engine restart, but `fabrik:paused` labels persist on GitHub — so a restart alone does not re-enable the train; the labels must be cleared explicitly.
+
 ##### Merge-Train Serialization + Main-Moved Recovery (ADR-059 D5)
 
 The batch validates a *combined batch* against `main` once; its correctness rests on **the `main` the batch validated against being the `main` it lands on**. Serializing the train (one batch in flight per repo) keeps `main` from moving under a validating batch; the only remaining mover is an **external direct push by a human**, which is detected and recovered. D5 adds two things without weakening the atomic `LoadOrStore` guard on `mergeTrainInFlight`.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -212,7 +212,7 @@ A batch is **usually green**: every member already passed Validate individually,
 
 The one-poll-cycle gap between Hook 1 firing and Hook 2 handling beyond-cap members is acceptable: beyond-cap members cannot form their own batch while the worker goroutine is still active.
 
-**Operator resume:** once the runaway guard fires, all affected members have `fabrik:paused` and are therefore excluded from `groupQueuedByRepo` on every subsequent poll. No re-formation occurs until a human manually removes `fabrik:paused` from each affected member. Before doing so, the operator should investigate the infra root cause (GitHub Actions billing, required-check configuration, base-branch health). The in-memory trial counter resets to zero on engine restart, but `fabrik:paused` labels persist on GitHub — so a restart alone does not re-enable the train; the labels must be cleared explicitly.
+**Operator resume:** once the runaway guard fires, all affected members have `fabrik:paused` and `fabrik:awaiting-input` applied and are therefore excluded from `groupQueuedByRepo` on every subsequent poll. No re-formation occurs until a human manually removes both `fabrik:paused` and `fabrik:awaiting-input` from each affected member. Before doing so, the operator should investigate the infra root cause (GitHub Actions billing, required-check configuration, base-branch health). The in-memory trial counter resets to zero on engine restart, but `fabrik:paused` labels persist on GitHub — so a restart alone does not re-enable the train; the labels must be cleared explicitly.
 
 ##### Merge-Train Serialization + Main-Moved Recovery (ADR-059 D5)
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -47,6 +47,8 @@ type Config struct {
 	MaxBatchSize             int           // Max Queued items snapshotted into one merge-train batch (0 = derive default 5; ADR-059 D4/D-f)
 	MaxBisectValidations     int           // Max combined validations per red batch before the one-at-a-time fallback (0 = derive 2·⌈log₂(MaxBatchSize)⌉+1; ADR-059 D4/D-f)
 	MaxTrainRebaseCycles     int           // Max main-moved rebase+revalidate cycles per merge-train batch before dissolving (0 = default 3; ADR-059 D5)
+	MaxTrainTrialsPerWindow  int           // Runaway guard: max trial-branch creations with zero successful lands before pausing all Queued members (0 = default 20; ADR-059 D8)
+	TrainTrialWindowDuration time.Duration // Runaway guard: rolling window over which MaxTrainTrialsPerWindow is measured (0 = default 60m; ADR-059 D8)
 	KillGraceSigInt          time.Duration // Grace window after SIGINT before SIGTERM (default 10s; 0 = skip SIGINT step)
 	KillGraceSigTerm         time.Duration // Grace window after SIGTERM before SIGKILL (default 10s)
 	ClaudeWaitDelay          time.Duration // How long to wait after Claude exits before giving up on pipe drain and recovering output (default 30s)
@@ -104,6 +106,8 @@ type Engine struct {
 	mergeTrainInFlight       sync.Map        // key: "owner/repo", value: *mergeTrainWorkerState; per-repo train dispatch guard
 	mergeTrainEjectionsMu   sync.Mutex      // guards mergeTrainEjectionCounts
 	mergeTrainEjectionCounts map[string]int  // key: "owner/repo#N", ejection count per member
+	mergeTrainTrialsMu      sync.Mutex      // guards mergeTrainTrials
+	mergeTrainTrials        map[string][]time.Time // key: "owner/repo", trial timestamps for runaway guard (ADR-059 D8)
 	issueCtxs             sync.Map             // key: issueKey string, value: issueCtxEntry; per-issue context for kill-reason propagation
 	baseBranchWarnedSet   sync.Map             // key: "owner/repo#N:branch"; prevents repeated fallback comments for bad base: labels
 	events                chan tui.Event       // nil in tests / plain-text mode; TUI goroutine consumes
@@ -187,6 +191,7 @@ func New(cfg Config) (*Engine, error) {
 		checkedAutoMergeRepos:    make(map[string]bool),
 		sem:                      make(chan struct{}, cfg.MaxConcurrent),
 		mergeTrainEjectionCounts: make(map[string]int),
+		mergeTrainTrials:         make(map[string][]time.Time),
 	}
 
 	// Migrate any old-style worktrees (issue-N/) to the new per-repo layout.
@@ -241,6 +246,7 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		checkedAutoMergeRepos:    make(map[string]bool),
 		sem:                      make(chan struct{}, maxConcurrent),
 		mergeTrainEjectionCounts: make(map[string]int),
+		mergeTrainTrials:         make(map[string][]time.Time),
 	}
 	if worktrees != nil {
 		worktrees.logfFn = eng.logf

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -892,7 +892,7 @@ func (e *Engine) effectiveTrialWindow() (int, time.Duration) {
 // recordTrial appends a timestamp for repoKey, prunes entries older than the window,
 // and returns the current count. Called at the start of every assembleAndValidate.
 func (e *Engine) recordTrial(repoKey string) int {
-	n, m := e.effectiveTrialWindow()
+	_, m := e.effectiveTrialWindow()
 	now := time.Now()
 	cutoff := now.Add(-m)
 	e.mergeTrainTrialsMu.Lock()
@@ -907,7 +907,6 @@ func (e *Engine) recordTrial(repoKey string) int {
 	e.mergeTrainTrials[repoKey] = pruned
 	count := len(pruned)
 	e.mergeTrainTrialsMu.Unlock()
-	_ = n
 	return count
 }
 
@@ -955,7 +954,7 @@ func (e *Engine) fireRunawayGuard(ctx context.Context, owner, repo string, items
 			"**What to do:**\n"+
 			"1. Investigate the infra root cause (check GitHub Actions billing, required check configuration, base branch health).\n"+
 			"2. Resolve the underlying issue.\n"+
-			"3. Manually remove `fabrik:paused` from each affected Queued member to re-enable the merge-train.",
+			"3. Manually remove `fabrik:paused` and `fabrik:awaiting-input` from each affected Queued member to re-enable the merge-train.",
 			count, repoKey, m)
 		if _, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
 			e.logf(item.Number, "merge-train", "warn: could not post runaway guard comment: %v\n", commentErr)

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -549,6 +549,9 @@ func (e *Engine) bisect(ctx context.Context, p trialParams, red []trainMember, u
 		e.cleanupTrialArtifacts(p.wm, trialName)
 		if err != nil {
 			e.logf(0, "merge-train", "bisection trial failed to assemble: %v — degrading to one-at-a-time fallback\n", err)
+			if _, tripped := e.isRunawayTripped(repoKey); tripped {
+				return nil, false, true
+			}
 			return nil, true, false
 		}
 		if _, tripped := e.isRunawayTripped(repoKey); tripped {
@@ -628,6 +631,9 @@ func (e *Engine) landOneAtATime(ctx context.Context, state *mergeTrainWorkerStat
 		if err != nil || len(survivors) == 0 {
 			e.logf(m.item.Number, "merge-train", "could not assemble #%d in isolation: %v — leaving in Queued\n", m.item.Number, err)
 			e.cleanupTrialArtifacts(p.wm, trialName)
+			if _, tripped := e.isRunawayTripped(repoKey); tripped {
+				return true
+			}
 			continue
 		}
 		if _, tripped := e.isRunawayTripped(repoKey); tripped {
@@ -923,7 +929,11 @@ func (e *Engine) isRunawayTripped(repoKey string) (int, bool) {
 			pruned = append(pruned, t)
 		}
 	}
-	e.mergeTrainTrials[repoKey] = pruned
+	if len(pruned) == 0 {
+		delete(e.mergeTrainTrials, repoKey)
+	} else {
+		e.mergeTrainTrials[repoKey] = pruned
+	}
 	count := len(pruned)
 	e.mergeTrainTrialsMu.Unlock()
 	return count, count >= n

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -321,6 +321,14 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 			return
 		}
 
+		// Hook 1: check runaway guard after the initial re-form trial (ADR-059 D8).
+		if count, tripped := e.isRunawayTripped(repoKey); tripped {
+			e.cleanupTrialArtifacts(p.wm, trialName)
+			e.fireRunawayGuard(ctx, p.owner, p.repo, membersToItems(current), count)
+			e.mergeTrainInFlight.Delete(repoKey)
+			return
+		}
+
 		state.mu.Lock()
 		state.prNum = prNum
 		state.assembling = false
@@ -348,10 +356,17 @@ func (e *Engine) runMergeTrainWorker(ctx context.Context, state *mergeTrainWorke
 			state.mu.Lock()
 			state.bisecting = true
 			state.mu.Unlock()
-			nextSurvivors, fellBack := e.handleRedBatch(ctx, state, p, survivors)
+			nextSurvivors, fellBack, runaway := e.handleRedBatch(ctx, state, p, survivors)
 			state.mu.Lock()
 			state.bisecting = false
 			state.mu.Unlock()
+			if runaway {
+				// Runaway guard fired inside bisect or landOneAtATime.
+				count, _ := e.isRunawayTripped(repoKey)
+				e.fireRunawayGuard(ctx, p.owner, p.repo, membersToItems(survivors), count)
+				e.mergeTrainInFlight.Delete(repoKey)
+				return
+			}
 			if fellBack {
 				// The one-at-a-time fallback already landed/ejected every member.
 				e.mergeTrainInFlight.Delete(repoKey)
@@ -457,6 +472,7 @@ func (e *Engine) assembleTrialBranch(ctx context.Context, p trialParams, members
 // alone (ADR-059 D4 test seam). This is the ONLY combined validation on the common path — a
 // green result must never trigger bisection (D-d).
 func (e *Engine) assembleAndValidate(ctx context.Context, p trialParams, members []trainMember, trialName string) ([]trainMember, TrainCIResult, int, error) {
+	e.recordTrial(p.owner + "/" + p.repo)
 	if e.trainValidateFn != nil {
 		return members, e.trainValidateFn(ctx, members), 0, nil
 	}
@@ -511,20 +527,21 @@ func (e *Engine) assembleAndValidate(ctx context.Context, p trialParams, members
 // bisect recursively halves a known-red member set to isolate the single poisoning member
 // (ADR-059 D4 / FR-1), reusing assembleAndValidate for each trial in the bors-ng test order
 // (test half A; if red recurse into A; else test half B; if red recurse into B). It returns
-// the isolated poisoner, or (nil, true) when the redness is a non-isolable cross-PR
+// the isolated poisoner, (nil, true, false) when the redness is a non-isolable cross-PR
 // interaction (both halves green) or the per-episode cost budget (*used vs costCap) is
-// exhausted — either of which degrades to the FR-5 one-at-a-time fallback (D-e). red is
-// assumed to be a validated-red set (its redness established by the caller).
-func (e *Engine) bisect(ctx context.Context, p trialParams, red []trainMember, used *int, costCap int) (*trainMember, bool) {
+// exhausted — either degrades to the FR-5 one-at-a-time fallback (D-e) — or (nil, false, true)
+// when the runaway guard fires. red is assumed to be a validated-red set.
+func (e *Engine) bisect(ctx context.Context, p trialParams, red []trainMember, used *int, costCap int) (*trainMember, bool, bool) {
 	if len(red) == 1 {
-		return &red[0], false
+		return &red[0], false, false
 	}
 
+	repoKey := p.owner + "/" + p.repo
 	mid := len(red) / 2
 	for _, half := range [][]trainMember{red[:mid], red[mid:]} {
 		if *used >= costCap {
 			e.logf(0, "merge-train", "bisection cost cap (%d validations) reached — degrading to one-at-a-time fallback\n", costCap)
-			return nil, true
+			return nil, true, false
 		}
 		trialName := p.nextTrialName()
 		survivors, result, _, err := e.assembleAndValidate(ctx, p, half, trialName)
@@ -532,7 +549,10 @@ func (e *Engine) bisect(ctx context.Context, p trialParams, red []trainMember, u
 		e.cleanupTrialArtifacts(p.wm, trialName)
 		if err != nil {
 			e.logf(0, "merge-train", "bisection trial failed to assemble: %v — degrading to one-at-a-time fallback\n", err)
-			return nil, true
+			return nil, true, false
+		}
+		if _, tripped := e.isRunawayTripped(repoKey); tripped {
+			return nil, false, true
 		}
 		if result == TrainCIRed && len(survivors) > 0 {
 			return e.bisect(ctx, p, survivors, used, costCap)
@@ -540,25 +560,29 @@ func (e *Engine) bisect(ctx context.Context, p trialParams, red []trainMember, u
 	}
 
 	// Both halves green: the redness spans the split — a non-isolable interaction (D-e).
-	return nil, true
+	return nil, true, false
 }
 
 // handleRedBatch bisects a red batch to isolate and eject the poisoning member (FR-1/FR-2),
 // then returns the surviving members for the main loop to re-form and re-validate (FR-3).
 // When bisection cannot isolate a single culprit within the cost budget (a non-isolable
 // interaction or cost-cap exhaustion), it degrades to the one-at-a-time fallback (FR-5),
-// which lands/ejects every member itself, and returns (nil, true). The cost budget is
-// per red-batch episode: it starts at 1 (the initial red validation) and is capped at
-// effectiveBisectCap().
-func (e *Engine) handleRedBatch(ctx context.Context, state *mergeTrainWorkerState, p trialParams, red []trainMember) ([]trainMember, bool) {
+// which lands/ejects every member itself, and returns (nil, true, false). Returns
+// (nil, false, true) when the runaway guard fires inside bisect or landOneAtATime. The
+// cost budget is per red-batch episode: it starts at 1 (the initial red validation) and
+// is capped at effectiveBisectCap().
+func (e *Engine) handleRedBatch(ctx context.Context, state *mergeTrainWorkerState, p trialParams, red []trainMember) ([]trainMember, bool, bool) {
 	used := 1 // the initial red validation counts toward the per-episode budget
 	costCap := e.effectiveBisectCap()
 
-	poisoner, fellBack := e.bisect(ctx, p, red, &used, costCap)
+	poisoner, fellBack, runaway := e.bisect(ctx, p, red, &used, costCap)
+	if runaway {
+		return nil, false, true
+	}
 	if fellBack {
 		e.logf(0, "merge-train", "could not isolate a single poisoner for %s/%s (%d/%d validations used) — degrading to one-at-a-time landing of %d member(s)\n", p.owner, p.repo, used, costCap, len(red))
-		e.landOneAtATime(ctx, state, p, red)
-		return nil, true
+		runaway = e.landOneAtATime(ctx, state, p, red)
+		return nil, true, runaway
 	}
 
 	// Eject the isolated poisoner (D-a shared counter, D-c comment, cap→pause reuse).
@@ -572,18 +596,20 @@ func (e *Engine) handleRedBatch(ctx context.Context, state *mergeTrainWorkerStat
 			survivors = append(survivors, red[i])
 		}
 	}
-	return survivors, false
+	return survivors, false, false
 }
 
 // landOneAtATime is the FR-5 fallback: it validates and lands each member as its own
 // singleton batch, which dissolves any cross-PR interaction by construction (no two members
 // co-reside). A green singleton lands via landSingleton; a red singleton fails even in
-// isolation and is ejected; a pending singleton is left in Queued to retry. In the real path
-// the base is re-pinned to the current origin/<base> before each singleton so a prior land is
-// visible to the next member's validation (this is what actually dissolves a genuine
-// interaction); under the test seam this git step is skipped (the membership-keyed fn is
-// stateless — see the ADR-059 D4 landOneAtATime note in docs/state-machine.md).
-func (e *Engine) landOneAtATime(ctx context.Context, state *mergeTrainWorkerState, p trialParams, members []trainMember) {
+// isolation and is ejected; a pending singleton is left in Queued to retry. Returns true if
+// the runaway guard fires during processing. In the real path the base is re-pinned to the
+// current origin/<base> before each singleton so a prior land is visible to the next member's
+// validation (this is what actually dissolves a genuine interaction); under the test seam this
+// git step is skipped (the membership-keyed fn is stateless — see the ADR-059 D4
+// landOneAtATime note in docs/state-machine.md).
+func (e *Engine) landOneAtATime(ctx context.Context, state *mergeTrainWorkerState, p trialParams, members []trainMember) bool {
+	repoKey := p.owner + "/" + p.repo
 	e.logf(0, "merge-train", "one-at-a-time fallback: processing %d member(s) as singleton batches\n", len(members))
 	for _, m := range members {
 		if e.trainValidateFn == nil {
@@ -604,6 +630,10 @@ func (e *Engine) landOneAtATime(ctx context.Context, state *mergeTrainWorkerStat
 			e.cleanupTrialArtifacts(p.wm, trialName)
 			continue
 		}
+		if _, tripped := e.isRunawayTripped(repoKey); tripped {
+			e.cleanupTrialArtifacts(p.wm, trialName)
+			return true
+		}
 
 		switch result {
 		case TrainCIGreen:
@@ -618,6 +648,7 @@ func (e *Engine) landOneAtATime(ctx context.Context, state *mergeTrainWorkerStat
 			e.logf(m.item.Number, "merge-train", "combined Validate pending for singleton #%d — leaving in Queued\n", m.item.Number)
 		}
 	}
+	return false
 }
 
 // landSingleton lands a single member from its own validated-green trial branch. It creates a
@@ -685,6 +716,7 @@ func (e *Engine) landSingleton(ctx context.Context, state *mergeTrainWorkerState
 	}
 
 	e.resetEjectionCount(p.owner, p.repo, m.item.Number)
+	e.resetTrialCounter(p.owner + "/" + p.repo)
 }
 
 // cleanupTrialArtifacts removes a trial's local worktree and its local+remote branch (which
@@ -841,6 +873,100 @@ func (e *Engine) resetEjectionCount(owner, repo string, memberNum int) {
 	e.mergeTrainEjectionsMu.Lock()
 	delete(e.mergeTrainEjectionCounts, counterKey)
 	e.mergeTrainEjectionsMu.Unlock()
+}
+
+// effectiveTrialWindow returns the runaway-guard threshold (N) and rolling window (M),
+// applying zero-means-default semantics: N=20, M=60min (ADR-059 D8).
+func (e *Engine) effectiveTrialWindow() (int, time.Duration) {
+	n := e.cfg.MaxTrainTrialsPerWindow
+	if n <= 0 {
+		n = 20
+	}
+	m := e.cfg.TrainTrialWindowDuration
+	if m <= 0 {
+		m = 60 * time.Minute
+	}
+	return n, m
+}
+
+// recordTrial appends a timestamp for repoKey, prunes entries older than the window,
+// and returns the current count. Called at the start of every assembleAndValidate.
+func (e *Engine) recordTrial(repoKey string) int {
+	n, m := e.effectiveTrialWindow()
+	now := time.Now()
+	cutoff := now.Add(-m)
+	e.mergeTrainTrialsMu.Lock()
+	ts := e.mergeTrainTrials[repoKey]
+	ts = append(ts, now)
+	pruned := ts[:0]
+	for _, t := range ts {
+		if !t.Before(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	e.mergeTrainTrials[repoKey] = pruned
+	count := len(pruned)
+	e.mergeTrainTrialsMu.Unlock()
+	_ = n
+	return count
+}
+
+// isRunawayTripped returns the current pruned trial count for repoKey and whether it has
+// reached the threshold. Called after each trial-producing operation.
+func (e *Engine) isRunawayTripped(repoKey string) (int, bool) {
+	n, m := e.effectiveTrialWindow()
+	cutoff := time.Now().Add(-m)
+	e.mergeTrainTrialsMu.Lock()
+	ts := e.mergeTrainTrials[repoKey]
+	pruned := ts[:0]
+	for _, t := range ts {
+		if !t.Before(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	e.mergeTrainTrials[repoKey] = pruned
+	count := len(pruned)
+	e.mergeTrainTrialsMu.Unlock()
+	return count, count >= n
+}
+
+// resetTrialCounter clears the trial counter for repoKey after a successful landing,
+// so normal poison bisection (where survivors do land) never accumulates toward the cap.
+func (e *Engine) resetTrialCounter(repoKey string) {
+	e.mergeTrainTrialsMu.Lock()
+	delete(e.mergeTrainTrials, repoKey)
+	e.mergeTrainTrialsMu.Unlock()
+}
+
+// fireRunawayGuard pauses all Queued members for the repo, posts an alert comment on each,
+// and logs the event. Called when the trial counter reaches the runaway threshold (ADR-059 D8).
+func (e *Engine) fireRunawayGuard(ctx context.Context, owner, repo string, items []gh.ProjectItem, count int) {
+	_, m := e.effectiveTrialWindow()
+	repoKey := owner + "/" + repo
+	e.logf(0, "merge-train", "runaway guard fired for %s: %d trial(s) with zero successful lands within %s — pausing %d Queued member(s)\n",
+		repoKey, count, m, len(items))
+	for _, item := range items {
+		msg := fmt.Sprintf("🏭 **Fabrik merge-train — runaway guard tripped**\n\n"+
+			"The merge-train has created **%d trial branches** for `%s` within the last %s "+
+			"with **zero successful landings**. This indicates a persistent infra failure "+
+			"(e.g. billing-blocked CI, broken base branch, or all required checks erroring) "+
+			"rather than a code-composition issue.\n\n"+
+			"**Actions taken:** `fabrik:paused` and `fabrik:awaiting-input` applied to all Queued members.\n\n"+
+			"**What to do:**\n"+
+			"1. Investigate the infra root cause (check GitHub Actions billing, required check configuration, base branch health).\n"+
+			"2. Resolve the underlying issue.\n"+
+			"3. Manually remove `fabrik:paused` from each affected Queued member to re-enable the merge-train.",
+			count, repoKey, m)
+		if _, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
+			e.logf(item.Number, "merge-train", "warn: could not post runaway guard comment: %v\n", commentErr)
+		}
+		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:paused (runaway guard): %v\n", err)
+		}
+		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
+			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input (runaway guard): %v\n", err)
+		}
+	}
 }
 
 // mergeTrainBatchMarker is the idempotency marker embedded in integration PR bodies.
@@ -1145,6 +1271,7 @@ func (e *Engine) landMergeTrainBatch(ctx context.Context, state *mergeTrainWorke
 		// from earlier trains must not count toward the pause cap on future trains.
 		e.resetEjectionCount(owner, repo, m.item.Number)
 	}
+	e.resetTrialCounter(repoKey)
 	e.logf(0, "merge-train", "landing complete for %s (integration PR #%d, %d members)\n", repoKey, integrationPRNum, len(survivors))
 }
 

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -2457,3 +2457,268 @@ func TestBuildIntegrationPRBody_ClosesMembers(t *testing.T) {
 		t.Errorf("body must Closes the issue numbers (7,9), not the PR numbers (70,90)\n%s", body)
 	}
 }
+
+// ── ADR-059 D8: runaway guard ─────────────────────────────────────────────────
+
+// TestEffectiveTrialWindow_Defaults verifies zero-means-default: N=20, M=60min.
+func TestEffectiveTrialWindow_Defaults(t *testing.T) {
+	eng := &Engine{cfg: Config{}, mergeTrainTrials: make(map[string][]time.Time)}
+	n, m := eng.effectiveTrialWindow()
+	if n != 20 {
+		t.Errorf("effectiveTrialWindow() N = %d, want 20", n)
+	}
+	if m != 60*time.Minute {
+		t.Errorf("effectiveTrialWindow() M = %v, want 60m", m)
+	}
+}
+
+// TestEffectiveTrialWindow_Override verifies explicit config values are respected.
+func TestEffectiveTrialWindow_Override(t *testing.T) {
+	eng := &Engine{cfg: Config{MaxTrainTrialsPerWindow: 5, TrainTrialWindowDuration: 30 * time.Minute}, mergeTrainTrials: make(map[string][]time.Time)}
+	n, m := eng.effectiveTrialWindow()
+	if n != 5 {
+		t.Errorf("effectiveTrialWindow() N = %d, want 5", n)
+	}
+	if m != 30*time.Minute {
+		t.Errorf("effectiveTrialWindow() M = %v, want 30m", m)
+	}
+}
+
+// TestRecordTrial_Increments verifies recordTrial appends timestamps and returns
+// the growing count. isRunawayTripped returns false below the threshold.
+func TestRecordTrial_Increments(t *testing.T) {
+	eng := &Engine{cfg: Config{MaxTrainTrialsPerWindow: 3, TrainTrialWindowDuration: time.Hour}, mergeTrainTrials: make(map[string][]time.Time)}
+	const key = "owner/repo"
+
+	for i := 1; i <= 2; i++ {
+		count := eng.recordTrial(key)
+		if count != i {
+			t.Errorf("recordTrial iteration %d: count = %d, want %d", i, count, i)
+		}
+		if _, tripped := eng.isRunawayTripped(key); tripped {
+			t.Errorf("isRunawayTripped should be false before threshold (iteration %d)", i)
+		}
+	}
+}
+
+// TestIsRunawayTripped_AtThreshold verifies the guard trips at exactly N trials.
+func TestIsRunawayTripped_AtThreshold(t *testing.T) {
+	const N = 3
+	eng := &Engine{cfg: Config{MaxTrainTrialsPerWindow: N, TrainTrialWindowDuration: time.Hour}, mergeTrainTrials: make(map[string][]time.Time)}
+	const key = "owner/repo"
+
+	for i := 0; i < N-1; i++ {
+		eng.recordTrial(key)
+	}
+	if _, tripped := eng.isRunawayTripped(key); tripped {
+		t.Error("guard must not trip before reaching N trials")
+	}
+	eng.recordTrial(key)
+	count, tripped := eng.isRunawayTripped(key)
+	if !tripped {
+		t.Errorf("guard must trip at N=%d trials, count=%d", N, count)
+	}
+	if count != N {
+		t.Errorf("count = %d, want %d", count, N)
+	}
+}
+
+// TestResetTrialCounter clears the counter so isRunawayTripped returns false.
+func TestResetTrialCounter(t *testing.T) {
+	const N = 3
+	eng := &Engine{cfg: Config{MaxTrainTrialsPerWindow: N, TrainTrialWindowDuration: time.Hour}, mergeTrainTrials: make(map[string][]time.Time)}
+	const key = "owner/repo"
+
+	for i := 0; i < N; i++ {
+		eng.recordTrial(key)
+	}
+	if _, tripped := eng.isRunawayTripped(key); !tripped {
+		t.Fatal("precondition: guard should be tripped before reset")
+	}
+	eng.resetTrialCounter(key)
+	if _, tripped := eng.isRunawayTripped(key); tripped {
+		t.Error("guard must not be tripped after reset")
+	}
+}
+
+// TestRunawayGuard_Fires verifies that when the trial counter reaches N with no
+// successful lands, the guard pauses all batch members and posts an alert comment.
+// N=2: trial 1 (initial batch), trial 2 (bisect half) → guard trips during bisect
+// while all members are still in the active survivors set from the initial red trial.
+func TestRunawayGuard_Fires(t *testing.T) {
+	skipIfNoGit(t)
+	_, _, _, wm := setupTrainRepo(t)
+	// Always red — no member ever lands.
+	eng, client, _ := seamTrainEngine(t, wm, func(map[int]bool) bool { return true })
+	eng.cfg.MaxTrainTrialsPerWindow = 2
+	eng.cfg.TrainTrialWindowDuration = time.Hour
+
+	batch := makeSeamBatch(3)
+	state := &mergeTrainWorkerState{assembling: true, projectID: "PVT_test"}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+
+	// All 3 batch members must have fabrik:paused + fabrik:awaiting-input applied.
+	for _, issueNum := range []int{1, 2, 3} {
+		paused, awaiting := false, false
+		for _, c := range client.addLabelCalls {
+			if c.issueNumber == issueNum && c.labelName == "fabrik:paused" {
+				paused = true
+			}
+			if c.issueNumber == issueNum && c.labelName == "fabrik:awaiting-input" {
+				awaiting = true
+			}
+		}
+		if !paused {
+			t.Errorf("member #%d: expected fabrik:paused (runaway guard)", issueNum)
+		}
+		if !awaiting {
+			t.Errorf("member #%d: expected fabrik:awaiting-input (runaway guard)", issueNum)
+		}
+		// Alert comment posted on each member.
+		hasAlert := false
+		for _, c := range client.addCommentCalls {
+			if c.issueNumber == issueNum && strings.Contains(c.body, "runaway guard") {
+				hasAlert = true
+			}
+		}
+		if !hasAlert {
+			t.Errorf("member #%d: expected runaway guard alert comment", issueNum)
+		}
+	}
+
+	// mergeTrainInFlight must be cleared after the guard fires.
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); ok {
+		t.Error("expected mergeTrainInFlight cleared after runaway guard fires")
+	}
+}
+
+// TestRunawayGuard_NormalBisectionNotTripped verifies R7: a batch with a single real
+// poisoner isolates the poisoner, lands the survivors, and never trips the guard,
+// because a successful landing resets the counter.
+func TestRunawayGuard_NormalBisectionNotTripped(t *testing.T) {
+	skipIfNoGit(t)
+	_, _, _, wm := setupTrainRepo(t)
+	// Red iff #3 is present; #3 is the sole poisoner.
+	eng, client, _ := seamTrainEngine(t, wm, func(p map[int]bool) bool { return p[3] })
+	// Low threshold — still must not trip because survivors land and reset the counter.
+	eng.cfg.MaxTrainTrialsPerWindow = 10
+	eng.cfg.TrainTrialWindowDuration = time.Hour
+
+	batch := makeSeamBatch(5)
+	state := &mergeTrainWorkerState{assembling: true, projectID: "PVT_test"}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+
+	// #3 ejected (poisoner), survivors land — no member should have fabrik:paused
+	// from the runaway guard (the ejection-pause from MaxMergeTrainEjections is a
+	// different code path; here MaxMergeTrainEjections=3 so #3 gets paused by ejectMember
+	// after the first ejection only when the counter is pre-seeded — it won't here).
+	for _, issueNum := range []int{1, 2, 4, 5} {
+		for _, c := range client.addLabelCalls {
+			if c.issueNumber == issueNum && c.labelName == "fabrik:paused" {
+				// Only look for "runaway guard" comments — ejection-pause is a distinct path.
+				for _, cc := range client.addCommentCalls {
+					if cc.issueNumber == issueNum && strings.Contains(cc.body, "runaway guard") {
+						t.Errorf("survivor #%d got a runaway guard alert — guard must not fire when survivors land", issueNum)
+					}
+				}
+			}
+		}
+	}
+
+	// Survivors integration PR must be merged exactly once.
+	merges := len(client.mergePRCalls)
+	if merges != 1 {
+		t.Errorf("expected survivors to land (1 merge), got %d merges", merges)
+	}
+}
+
+// TestMergeTrainRunawayGuard is the e2e runaway guard test: a persistently-red batch
+// where every trial fails and no member ever lands trips the guard within N trials,
+// pausing all Queued members. Follows the pattern of TestMergeTrainBisect_CostCapFallbackLogs.
+// N=2 so the guard trips during the first bisection sub-trial, before any member is ejected,
+// ensuring all original batch members are still in survivors when fireRunawayGuard is called.
+func TestMergeTrainRunawayGuard(t *testing.T) {
+	skipIfNoGit(t)
+	_, _, _, wm := setupTrainRepo(t)
+	// All batches always red — no member ever lands.
+	eng, client, rv := seamTrainEngine(t, wm, func(map[int]bool) bool { return true })
+	eng.cfg.MaxTrainTrialsPerWindow = 2
+	eng.cfg.TrainTrialWindowDuration = time.Hour
+
+	batch := makeSeamBatch(3)
+	state := &mergeTrainWorkerState{assembling: true, projectID: "PVT_test"}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out := captureStdout(func() {
+		eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+	})
+
+	// Guard must fire within the configured trial bound.
+	if rv.count() > 2 {
+		t.Errorf("guard must fire within N=2 trials, got %d trials", rv.count())
+	}
+
+	// Log must mention the runaway guard.
+	if !strings.Contains(out, "runaway guard") {
+		t.Errorf("expected 'runaway guard' in log output; stdout was:\n%s", out)
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+
+	// All 3 members must be paused + awaiting-input.
+	for _, issueNum := range []int{1, 2, 3} {
+		paused, awaiting := false, false
+		for _, c := range client.addLabelCalls {
+			if c.issueNumber == issueNum && c.labelName == "fabrik:paused" {
+				paused = true
+			}
+			if c.issueNumber == issueNum && c.labelName == "fabrik:awaiting-input" {
+				awaiting = true
+			}
+		}
+		if !paused {
+			t.Errorf("e2e: member #%d must have fabrik:paused (runaway guard)", issueNum)
+		}
+		if !awaiting {
+			t.Errorf("e2e: member #%d must have fabrik:awaiting-input (runaway guard)", issueNum)
+		}
+		hasAlert := false
+		for _, c := range client.addCommentCalls {
+			if c.issueNumber == issueNum && strings.Contains(c.body, "runaway guard") {
+				hasAlert = true
+			}
+		}
+		if !hasAlert {
+			t.Errorf("e2e: member #%d: expected runaway guard alert comment", issueNum)
+		}
+	}
+
+	// No integration PR should be created (guard fires before landing).
+	for _, c := range client.createPRCalls {
+		if strings.Contains(c.title, "[merge-train] batch") {
+			t.Errorf("e2e: integration landing PR must not be created when guard fires, got PR: %q", c.title)
+		}
+	}
+
+	// mergeTrainInFlight must be cleared.
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); ok {
+		t.Error("e2e: expected mergeTrainInFlight cleared after runaway guard fires")
+	}
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1714,10 +1714,11 @@ func (e *Engine) routeQueuedGroup(ctx context.Context, repoKey string, items []g
 	}
 	// Hook 2: pre-dispatch runaway guard check (ADR-059 D8). Handles beyond-cap Queued
 	// members that the in-flight worker couldn't reach during Hook 1 (one-poll-cycle gap).
+	// Uses the uncapped `items` slice so all Queued members are paused, not just the batch cap.
 	if count, tripped := e.isRunawayTripped(repoKey); tripped {
 		owner, repo := parseOwnerRepo(repoKey)
-		e.logf(0, "merge-train", "runaway guard already tripped for %s (%d trial(s)) — pausing %d Queued member(s) before dispatch\n", repoKey, count, len(trainItems))
-		e.fireRunawayGuard(ctx, owner, repo, trainItems, count)
+		e.logf(0, "merge-train", "runaway guard already tripped for %s (%d trial(s)) — pausing %d Queued member(s) before dispatch\n", repoKey, count, len(items))
+		e.fireRunawayGuard(ctx, owner, repo, items, count)
 		return
 	}
 	var parts []string

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1712,6 +1712,14 @@ func (e *Engine) routeQueuedGroup(ctx context.Context, repoKey string, items []g
 		e.logf(0, "merge-train", "batch capped for %s: %d Queued item(s) exceed max_batch_size=%d — landing first %d by entry order\n", repoKey, len(trainItems), maxBatch, maxBatch)
 		trainItems = capBatch(trainItems, maxBatch)
 	}
+	// Hook 2: pre-dispatch runaway guard check (ADR-059 D8). Handles beyond-cap Queued
+	// members that the in-flight worker couldn't reach during Hook 1 (one-poll-cycle gap).
+	if count, tripped := e.isRunawayTripped(repoKey); tripped {
+		owner, repo := parseOwnerRepo(repoKey)
+		e.logf(0, "merge-train", "runaway guard already tripped for %s (%d trial(s)) — pausing %d Queued member(s) before dispatch\n", repoKey, count, len(trainItems))
+		e.fireRunawayGuard(ctx, owner, repo, trainItems, count)
+		return
+	}
 	var parts []string
 	for _, item := range trainItems {
 		parts = append(parts, fmt.Sprintf("#%d %q", item.Number, item.Title))


### PR DESCRIPTION
## Summary

- Adds a composition-agnostic runaway guard to the internal merge-train: a rolling-window trial counter per `owner/repo` that fires if ≥N trial branches are created with zero successful landings within M minutes (defaults: N=20, M=60min)
- Implements two-hook dispatch: Hook 1 in `runMergeTrainWorker` pauses the active batch; Hook 2 in `routeQueuedGroup` catches any beyond-cap Queued members on the next poll
- `recordTrial` is called at the top of `assembleAndValidate` (the single trial-creation site) so all trials — initial batch, bisection sub-trials, one-at-a-time singletons — count; `resetTrialCounter` fires on every successful land
- Documents D8 decision in ADR-059 (billing-blocked CI incident 2026-07-06: 2,730 workflow runs, ~1,400 trial PRs) and adds Runaway Guard section to `docs/state-machine.md`

## Test plan

- [ ] `go test ./engine/ -run TestEffectiveTrialWindow` — default and override config
- [ ] `go test ./engine/ -run TestRecordTrial` — counter increments correctly
- [ ] `go test ./engine/ -run TestIsRunawayTripped` — threshold check at N
- [ ] `go test ./engine/ -run TestResetTrialCounter` — counter clears on land
- [ ] `go test ./engine/ -run TestRunawayGuard_Fires` — N=2, guard fires before bisect ejects any member; all 3 members paused
- [ ] `go test ./engine/ -run TestRunawayGuard_NormalBisectionNotTripped` — N=10, normal poison bisection completes without tripping guard
- [ ] `go test ./engine/ -run TestMergeTrainRunawayGuard` — e2e: always-red batch trips guard with N=2, 3 members paused

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)