### PR TITLE
feat(plugin/fabrik): ship reusable board/issue/comments helpers

### DIFF
--- a/plugin/fabrik/.claude-plugin/plugin.json
+++ b/plugin/fabrik/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fabrik",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Ambient awareness of Fabrik (the GitHub-Project-driven SDLC pipeline orchestrator) for the human's interactive Claude Code session. Turns Claude into a product-management buddy and supervisor for projects that use Fabrik to automate issue processing.",
   "author": {
     "name": "Tenacious Ventures",

--- a/plugin/fabrik/skills/fabrik/SKILL.md
+++ b/plugin/fabrik/skills/fabrik/SKILL.md
@@ -179,7 +179,7 @@ This skill ships small bash scripts for the queries you'll run every session. **
 - `issue.sh` shows column, labels, updated time, comment count with last-comment metadata, and linked PRs — enough to answer 90% of "what's happening with `#N`?" without a second call.
 - `comments.sh` truncates bodies to 500 chars and shows reaction counts including 👀 and 🚀 so you can see comment-processing state at a glance. Pass `--full` when the user needs the whole thing.
 - `stage-output.sh` finds the last comment starting with `🏭 **Fabrik — stage: <StageName>**` and prints it — this is how Fabrik marks stage output. Also matches variants like `Fabrik — stage: Review (review feedback addressed)`.
-- All scripts support `--json` (or emit raw JSON in `stage-output.sh`'s case with jq itself) if you need to chain further. `board.sh --json` returns the full `gh project item-list` payload.
+- `board.sh`, `issue.sh`, and `comments.sh` support `--json` when you need to chain further. `board.sh --json` returns the full `gh project item-list` payload. `stage-output.sh` prints text only — if you need JSON, `comments.sh <N> --json` and filter for the marker yourself.
 - Multi-repo mode (`repo:` unset in `config.yaml`): the scripts resolve the issue's repo from the project board automatically. If you already know the repo, pass `-r owner/repo` to skip the lookup — meaningful only on large boards.
 
 **Fallback:** if a script fails (missing `gh`, unusual config), the underlying commands are simple enough to inline — but do the debugging *once* and fix the script rather than routing around it every session.

--- a/plugin/fabrik/skills/fabrik/SKILL.md
+++ b/plugin/fabrik/skills/fabrik/SKILL.md
@@ -160,7 +160,29 @@ Don't intervene when:
 
 ### Reading the board with the user
 
-If the user asks "what's going on?" or similar, suggest `/fabrik:status` (this plugin's slash command). It summarises in-flight issues, worker processes, and worktrees with uncommitted changes. For deeper inspection: `gh project item-list ...` or open the Project board in a browser.
+If the user asks "what's going on?" or similar, suggest `/fabrik:status` (this plugin's slash command). It summarises in-flight issues, worker processes, and worktrees with uncommitted changes. For deeper inspection: use the reusable helpers below, `gh project item-list ...`, or open the Project board in a browser.
+
+## Reusable helpers — prefer these over hand-rolled `gh` + `jq`
+
+This skill ships small bash scripts for the queries you'll run every session. **Use them.** Hand-rolling a GraphQL query for each request wastes tokens and drifts in shape between answers. All scripts auto-locate `.fabrik/config.yaml` by walking up from `$PWD` and handle both org- and user-owned projects. They live in `${CLAUDE_PLUGIN_ROOT}/skills/fabrik/scripts/` (or, if you can't resolve that, adjacent to this SKILL.md at `scripts/`).
+
+| When the user asks… | Run |
+|---|---|
+| "what's on the board?", "what's in flight?" | `scripts/board.sh` |
+| "show me `#N`", "status of `#N`", "which column is `#N` in?" | `scripts/issue.sh <N>` (add `--body` when you actually need the spec) |
+| "what did `<stage>` say on `#N`?", "show me the Research output" | `scripts/stage-output.sh <N> <StageName>` |
+| "what are the recent comments on `#N`?", "did my comment get processed?" | `scripts/comments.sh <N> --last 5` (add `--pr` for the linked PR's comments) |
+
+**Design notes:**
+
+- `board.sh` hides Done items and `stage:*:complete` labels by default (they're pipeline noise). Pass `--all` and `--raw-labels` when the user genuinely wants the full picture; pass `--column <Name>` or `--label <substring>` to slice.
+- `issue.sh` shows column, labels, updated time, comment count with last-comment metadata, and linked PRs — enough to answer 90% of "what's happening with `#N`?" without a second call.
+- `comments.sh` truncates bodies to 500 chars and shows reaction counts including 👀 and 🚀 so you can see comment-processing state at a glance. Pass `--full` when the user needs the whole thing.
+- `stage-output.sh` finds the last comment starting with `🏭 **Fabrik — stage: <StageName>**` and prints it — this is how Fabrik marks stage output. Also matches variants like `Fabrik — stage: Review (review feedback addressed)`.
+- All scripts support `--json` (or emit raw JSON in `stage-output.sh`'s case with jq itself) if you need to chain further. `board.sh --json` returns the full `gh project item-list` payload.
+- Multi-repo mode (`repo:` unset in `config.yaml`): the scripts resolve the issue's repo from the project board automatically. If you already know the repo, pass `-r owner/repo` to skip the lookup — meaningful only on large boards.
+
+**Fallback:** if a script fails (missing `gh`, unusual config), the underlying commands are simple enough to inline — but do the debugging *once* and fix the script rather than routing around it every session.
 
 ## Pointers — link the user, don't paraphrase
 

--- a/plugin/fabrik/skills/fabrik/scripts/board.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/board.sh
@@ -17,6 +17,11 @@ set -euo pipefail
 HERE=$(cd "$(dirname "$0")" && pwd)
 . "$HERE/lib.sh"
 
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+  exit 0
+fi
+
 fabrik_load_config
 
 JSON=false

--- a/plugin/fabrik/skills/fabrik/scripts/board.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/board.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Compact one-line-per-issue view of the Fabrik project board.
+#
+# By default, hides items in the Done column (usually noise) and hides the
+# ubiquitous `stage:*:complete` labels — pass --all / --raw-labels to unhide.
+#
+# Usage: board.sh [--json] [--all] [--raw-labels] [--column NAME] [--label PATTERN] [--limit N]
+#   --json           emit raw JSON from `gh project item-list`
+#   --all            include items in the Done column
+#   --raw-labels     don't hide `stage:*:complete` labels
+#   --column NAME    filter to a single column (e.g. Implement)
+#   --label PATTERN  filter to issues whose labels contain PATTERN (substring)
+#   --limit N        max items to fetch from the project (default 300)
+#
+# Output columns:  <Column>  #N  <Title>  [<active fabrik/stage/model/effort/base labels>]
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+. "$HERE/lib.sh"
+
+fabrik_load_config
+
+JSON=false
+FILTER_COL=""
+FILTER_LABEL=""
+INCLUDE_DONE=false
+RAW_LABELS=false
+LIMIT=300
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json)        JSON=true ;;
+    --all)         INCLUDE_DONE=true ;;
+    --raw-labels)  RAW_LABELS=true ;;
+    --column)      shift; FILTER_COL=${1:-} ;;
+    --label)       shift; FILTER_LABEL=${1:-} ;;
+    --limit)       shift; LIMIT=${1:-300} ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0 ;;
+    *) echo "board.sh: unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# Push the Done filter server-side when possible; --column overrides.
+query=""
+if ! $INCLUDE_DONE && [ -z "$FILTER_COL" ]; then
+  query="-status:Done"
+elif [ -n "$FILTER_COL" ]; then
+  query="status:\"$FILTER_COL\""
+fi
+
+if [ -n "$query" ]; then
+  raw=$(gh project item-list "$FABRIK_PROJECT" --owner "$FABRIK_OWNER" \
+    --limit "$LIMIT" --format json --query "$query")
+else
+  raw=$(gh project item-list "$FABRIK_PROJECT" --owner "$FABRIK_OWNER" \
+    --limit "$LIMIT" --format json)
+fi
+
+if $JSON; then
+  printf '%s\n' "$raw"
+  exit 0
+fi
+
+printf '%s\n' "$raw" | jq -r \
+  --arg lbl "$FILTER_LABEL" \
+  --argjson raw "$RAW_LABELS" '
+  .items // []
+  | map(select(.content.number != null))
+  | map({
+      num:    .content.number,
+      title:  (.content.title // ""),
+      repo:   (.content.repository // ""),
+      labels: (.labels // []),
+      column: (.status // "-")
+    })
+  | (if $lbl != "" then map(select(.labels | any(contains($lbl)))) else . end)
+  | sort_by(.column, .num)
+  | .[]
+  | (
+      .labels
+      | map(select(startswith("fabrik:") or startswith("stage:") or startswith("model:") or startswith("effort:") or startswith("base:")))
+      | (if $raw then . else map(select(endswith(":complete") | not)) end)
+      | join(",")
+    ) as $flags
+  | "\(.column)\t#\(.num)\t\(.title | .[0:70])\t[\($flags)]"
+' | awk -F'\t' '{ printf "%-12s %-6s %-70s %s\n", $1, $2, $3, $4 }'

--- a/plugin/fabrik/skills/fabrik/scripts/comments.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/comments.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# List comments on an issue (or its linked PR) with author, timestamp, reactions.
+#
+# Usage: comments.sh <N> [--pr] [--last K] [--full] [--json] [-r owner/repo]
+#   --pr           list comments on the issue's linked PR instead of the issue itself
+#   --last K       show only last K comments (default 10; 0 = all)
+#   --full         show full comment bodies (default: truncate to 500 chars)
+#   --json         emit raw REST JSON
+#   -r owner/repo  override repo lookup (skip project-board search)
+#
+# Reactions column shows: 👀 (eyes) 🚀 (rocket) 👍 (thumbs up).
+# 👀→🚀 is Fabrik's durable "comment processed" state.
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+. "$HERE/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+  exit 0
+fi
+
+fabrik_load_config
+
+N=${1:-}
+if [ -z "$N" ]; then
+  echo "usage: comments.sh <N> [--pr] [--last K] [--full] [--json] [-r owner/repo]" >&2
+  exit 2
+fi
+shift
+
+USE_PR=false; LAST=10; FULL=false; JSON=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr)   USE_PR=true ;;
+    --last) shift; LAST=${1:-10} ;;
+    --full) FULL=true ;;
+    --json) JSON=true ;;
+    -r)     shift; export FABRIK_ISSUE_REPO=${1:-} ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0 ;;
+    *) echo "comments.sh: unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+fabrik_resolve_repo "$N"
+
+TARGET=$N
+if $USE_PR; then
+  pr=$(gh api graphql -f query="
+    query {
+      repository(owner: \"$ISSUE_OWNER\", name: \"$ISSUE_REPO\") {
+        issue(number: $N) {
+          closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
+            nodes { number }
+          }
+        }
+      }
+    }" --jq '.data.repository.issue.closedByPullRequestsReferences.nodes[0].number // empty')
+  if [ -z "$pr" ]; then
+    echo "no linked PR for issue #$N" >&2
+    exit 1
+  fi
+  TARGET=$pr
+fi
+
+raw=$(gh api "repos/$ISSUE_OWNER/$ISSUE_REPO/issues/$TARGET/comments?per_page=100" --paginate)
+
+if $JSON; then
+  printf '%s\n' "$raw"
+  exit 0
+fi
+
+printf '%s\n' "$raw" | jq -r --argjson last "$LAST" --argjson full "$FULL" '
+  (if $last > 0 then .[-$last:] else . end)
+  | .[]
+  | "── \(.created_at)  \(.user.login)  [👀\(.reactions.eyes // 0) 🚀\(.reactions.rocket // 0) 👍\(.reactions["+1"] // 0)]",
+    (if $full then (.body // "") else ((.body // "") | if length > 500 then .[0:500] + "…" else . end) end),
+    ""
+'

--- a/plugin/fabrik/skills/fabrik/scripts/comments.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/comments.sh
@@ -72,10 +72,14 @@ if $JSON; then
   exit 0
 fi
 
-printf '%s\n' "$raw" | jq -r --argjson last "$LAST" --argjson full "$FULL" '
-  (if $last > 0 then .[-$last:] else . end)
+# `gh api --paginate` concatenates one JSON array per page; slurp + flatten
+# so --last operates across the whole comment history, not per page. Also
+# handle deleted users (author == null) gracefully.
+printf '%s\n' "$raw" | jq -s -r --argjson last "$LAST" --argjson full "$FULL" '
+  add
+  | (if $last > 0 then .[-$last:] else . end)
   | .[]
-  | "── \(.created_at)  \(.user.login)  [👀\(.reactions.eyes // 0) 🚀\(.reactions.rocket // 0) 👍\(.reactions["+1"] // 0)]",
+  | "── \(.created_at)  \(((.user | .login) // "ghost"))  [👀\(.reactions.eyes // 0) 🚀\(.reactions.rocket // 0) 👍\(.reactions["+1"] // 0)]",
     (if $full then (.body // "") else ((.body // "") | if length > 500 then .[0:500] + "…" else . end) end),
     ""
 '

--- a/plugin/fabrik/skills/fabrik/scripts/issue.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/issue.sh
@@ -81,13 +81,13 @@ raw=$(gh api graphql \
 
 # Extract just the issue node, augmented with the resolved column for
 # this specific project (from projectItems).
-issue=$(printf '%s\n' "$raw" | jq --arg proj_owner "$FABRIK_OWNER" --argjson proj_num "$FABRIK_PROJECT" '
+issue=$(printf '%s\n' "$raw" | jq --arg proj_owner "$FABRIK_OWNER" --arg proj_num "$FABRIK_PROJECT" '
   .data.repository.issue // null
   | if . == null then null
     else . + {
       column: (
         [.projectItems.nodes[]?
-         | select(.project.number == $proj_num and .project.owner.login == $proj_owner)
+         | select((.project.number | tostring) == $proj_num and .project.owner.login == $proj_owner)
          | .fieldValues.nodes[]?
          | select(.field.name == "Status")
          | .name
@@ -114,7 +114,7 @@ printf '%s\n' "$issue" | jq -r --argjson body "$BODY" \
   def lastcomm:
     (.comments.nodes[0]) as $c
     | if $c == null then "none"
-      else "last by \($c.author.login // "-") at \($c.createdAt)"
+      else "last by \((($c.author | .login) // "ghost")) at \($c.createdAt)"
       end;
   "#\(.number)  \(.title)",
   "State:      \(.state)",

--- a/plugin/fabrik/skills/fabrik/scripts/issue.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/issue.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Details for a single issue on the Fabrik project board.
+#
+# Usage: issue.sh <N> [--body] [--json] [-r owner/repo]
+#   --body        include the issue body in the output
+#   --json        emit raw GraphQL JSON
+#   -r owner/repo override repo lookup (skip project-board search)
+#
+# Fields shown: title, state, repo, column, labels, URL, updated time,
+# comment count + last-comment metadata, linked PRs.
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+. "$HERE/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+  exit 0
+fi
+
+fabrik_load_config
+
+N=${1:-}
+if [ -z "$N" ]; then
+  echo "usage: issue.sh <N> [--body] [--json] [-r owner/repo]" >&2
+  exit 2
+fi
+shift
+
+BODY=false; JSON=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --body) BODY=true ;;
+    --json) JSON=true ;;
+    -r)     shift; export FABRIK_ISSUE_REPO=${1:-} ;;
+    -h|--help)
+      awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+      exit 0 ;;
+    *) echo "issue.sh: unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+fabrik_resolve_repo "$N"
+
+query='
+query($owner: String!, $repo: String!, $n: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $n) {
+      number title state url body createdAt updatedAt
+      labels(first: 30) { nodes { name } }
+      comments(last: 1) { totalCount nodes { author { login } createdAt } }
+      closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
+        nodes { number url state isDraft }
+      }
+      projectItems(first: 10) {
+        nodes {
+          project {
+            number
+            owner {
+              ... on Organization { login }
+              ... on User         { login }
+            }
+          }
+          fieldValues(first: 20) {
+            nodes {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2SingleSelectField { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+raw=$(gh api graphql \
+  -F owner="$ISSUE_OWNER" -F repo="$ISSUE_REPO" -F n="$N" \
+  -f query="$query")
+
+# Extract just the issue node, augmented with the resolved column for
+# this specific project (from projectItems).
+issue=$(printf '%s\n' "$raw" | jq --arg proj_owner "$FABRIK_OWNER" --argjson proj_num "$FABRIK_PROJECT" '
+  .data.repository.issue // null
+  | if . == null then null
+    else . + {
+      column: (
+        [.projectItems.nodes[]?
+         | select(.project.number == $proj_num and .project.owner.login == $proj_owner)
+         | .fieldValues.nodes[]?
+         | select(.field.name == "Status")
+         | .name
+        ][0] // "-"
+      )
+    }
+    end
+')
+
+if [ "$issue" = "null" ]; then
+  echo "issue #$N not found in $ISSUE_OWNER/$ISSUE_REPO" >&2
+  exit 1
+fi
+
+if $JSON; then
+  printf '%s\n' "$issue"
+  exit 0
+fi
+
+printf '%s\n' "$issue" | jq -r --argjson body "$BODY" \
+  --arg repo "$ISSUE_OWNER/$ISSUE_REPO" '
+  def prstr:
+    "#\(.number) [\(.state)\(if .isDraft then ",draft" else "" end)] \(.url)";
+  def lastcomm:
+    (.comments.nodes[0]) as $c
+    | if $c == null then "none"
+      else "last by \($c.author.login // "-") at \($c.createdAt)"
+      end;
+  "#\(.number)  \(.title)",
+  "State:      \(.state)",
+  "Repo:       \($repo)",
+  "Column:     \(.column)",
+  "Labels:     \(.labels.nodes | map(.name) | join(", "))",
+  "URL:        \(.url)",
+  "Updated:    \(.updatedAt)",
+  "Comments:   \(.comments.totalCount) (\(lastcomm))",
+  "Linked PRs: \((.closedByPullRequestsReferences.nodes | map(prstr) | if length == 0 then ["none"] else . end | join("; ")))",
+  (if $body then "\n--- BODY ---\n\(.body // "(empty)")" else empty end)
+'

--- a/plugin/fabrik/skills/fabrik/scripts/lib.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/lib.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Shared helpers for fabrik plugin scripts.
+# Source from a sibling script:
+#   HERE=$(cd "$(dirname "$0")" && pwd) && . "$HERE/lib.sh"
+#
+# After sourcing, call `fabrik_load_config` to populate:
+#   FABRIK_ROOT         — dir containing .fabrik/
+#   FABRIK_OWNER        — GitHub org/user that owns the project
+#   FABRIK_PROJECT      — project number (integer, as string)
+#   FABRIK_OWNER_TYPE   — "organization" (default) or "user"
+#   FABRIK_REPO         — repo name, or empty in multi-repo mode
+#
+# `fabrik_resolve_repo <N>` sets ISSUE_OWNER / ISSUE_REPO for issue N:
+# uses config's repo if set, otherwise looks it up from the project board.
+
+set -euo pipefail
+
+fabrik_find_root() {
+  local d="$PWD"
+  while [ "$d" != "/" ]; do
+    if [ -f "$d/.fabrik/config.yaml" ]; then
+      printf '%s\n' "$d"
+      return 0
+    fi
+    d=$(dirname "$d")
+  done
+  echo "fabrik: no .fabrik/config.yaml found from $PWD upward" >&2
+  return 1
+}
+
+# Extract a top-level `key: value` from a simple YAML file.
+# Ignores commented lines; strips trailing comments and surrounding quotes.
+fabrik_config_get() {
+  local key=$1 file=$2
+  awk -v k="$key" '
+    BEGIN { pat = "^[[:space:]]*" k "[[:space:]]*:" }
+    /^[[:space:]]*#/ { next }
+    $0 ~ pat {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      sub(/[[:space:]]+#.*$/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^"|"$/, "")
+      gsub(/^'\''|'\''$/, "")
+      if ($0 != "") { print; exit }
+    }
+  ' "$file"
+}
+
+fabrik_load_config() {
+  FABRIK_ROOT=$(fabrik_find_root)
+  local f="$FABRIK_ROOT/.fabrik/config.yaml"
+  FABRIK_OWNER=$(fabrik_config_get owner "$f")
+  FABRIK_PROJECT=$(fabrik_config_get project "$f")
+  FABRIK_OWNER_TYPE=$(fabrik_config_get owner_type "$f")
+  FABRIK_REPO=$(fabrik_config_get repo "$f")
+  : "${FABRIK_OWNER_TYPE:=organization}"
+  if [ -z "${FABRIK_OWNER:-}" ] || [ -z "${FABRIK_PROJECT:-}" ]; then
+    echo "fabrik: config.yaml at $f is missing owner or project" >&2
+    return 1
+  fi
+  export FABRIK_ROOT FABRIK_OWNER FABRIK_PROJECT FABRIK_OWNER_TYPE FABRIK_REPO
+}
+
+fabrik_scope_field() {
+  case "${FABRIK_OWNER_TYPE:-organization}" in
+    user) printf 'user' ;;
+    *)    printf 'organization' ;;
+  esac
+}
+
+fabrik_resolve_repo() {
+  local n=${1:-}
+  if [ -z "$n" ]; then
+    echo "fabrik_resolve_repo: issue number required" >&2
+    return 2
+  fi
+  # Env override lets callers skip the board lookup entirely.
+  if [ -n "${FABRIK_ISSUE_REPO:-}" ]; then
+    ISSUE_OWNER=${FABRIK_ISSUE_REPO%/*}
+    ISSUE_REPO=${FABRIK_ISSUE_REPO#*/}
+    export ISSUE_OWNER ISSUE_REPO
+    return 0
+  fi
+  if [ -n "${FABRIK_REPO:-}" ]; then
+    ISSUE_OWNER=$FABRIK_OWNER
+    ISSUE_REPO=$FABRIK_REPO
+    export ISSUE_OWNER ISSUE_REPO
+    return 0
+  fi
+  # Multi-repo mode: look the issue up on the project. `gh project item-list`
+  # paginates via --limit, so this works for large boards.
+  local nw
+  nw=$(gh project item-list "$FABRIK_PROJECT" --owner "$FABRIK_OWNER" \
+        --limit 500 --format json \
+        --jq ".items[] | select(.content.number == $n) | .content.repository" 2>/dev/null || true)
+  if [ -z "$nw" ]; then
+    echo "fabrik: issue #$n not found on project $FABRIK_OWNER/$FABRIK_PROJECT (set repo: in config.yaml or FABRIK_ISSUE_REPO=owner/repo)" >&2
+    return 1
+  fi
+  ISSUE_OWNER=${nw%/*}
+  ISSUE_REPO=${nw#*/}
+  export ISSUE_OWNER ISSUE_REPO
+}

--- a/plugin/fabrik/skills/fabrik/scripts/lib.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/lib.sh
@@ -33,7 +33,7 @@ fabrik_find_root() {
 fabrik_config_get() {
   local key=$1 file=$2
   awk -v k="$key" '
-    BEGIN { pat = "^[[:space:]]*" k "[[:space:]]*:" }
+    BEGIN { pat = "^" k "[[:space:]]*:" }
     /^[[:space:]]*#/ { next }
     $0 ~ pat {
       sub(/^[^:]*:[[:space:]]*/, "")
@@ -89,10 +89,13 @@ fabrik_resolve_repo() {
   fi
   # Multi-repo mode: look the issue up on the project. `gh project item-list`
   # paginates via --limit, so this works for large boards.
+  # Two issues with the same number can exist in different repos on one project;
+  # take the first match. Don't swallow gh errors — let auth/network/missing-gh
+  # failures surface with their real message.
   local nw
   nw=$(gh project item-list "$FABRIK_PROJECT" --owner "$FABRIK_OWNER" \
         --limit 500 --format json \
-        --jq ".items[] | select(.content.number == $n) | .content.repository" 2>/dev/null || true)
+        --jq "[.items[] | select(.content.number == $n) | .content.repository][0] // empty")
   if [ -z "$nw" ]; then
     echo "fabrik: issue #$n not found on project $FABRIK_OWNER/$FABRIK_PROJECT (set repo: in config.yaml or FABRIK_ISSUE_REPO=owner/repo)" >&2
     return 1

--- a/plugin/fabrik/skills/fabrik/scripts/stage-output.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/stage-output.sh
@@ -35,15 +35,22 @@ done
 
 fabrik_resolve_repo "$N"
 
-marker="Fabrik — stage: $STAGE"
+# Anchor to the actual marker line Fabrik emits at the top of every stage
+# output comment: `🏭 **Fabrik — stage: <StageName>**`. Trailing content
+# (e.g. " (comment review)", " (review feedback addressed)") after the
+# stage name is allowed — we match the prefix, not the whole line.
+marker="🏭 **Fabrik — stage: $STAGE"
 
+# `gh api --paginate` returns one JSON array per page; slurp + flatten so
+# .[-1] picks the true latest comment across all pages, not per-page.
 gh api "repos/$ISSUE_OWNER/$ISSUE_REPO/issues/$N/comments?per_page=100" --paginate \
-  | jq -r --arg m "$marker" '
-      map(select((.body // "") | contains($m)))
+  | jq -s -r --arg m "$marker" '
+      add
+      | map(select((.body // "") | startswith($m)))
       | if length == 0 then
           "no comment matching \"\($m)\" on this issue"
         else
           .[-1] as $c
-          | "── \($c.created_at)  \($c.user.login)\n\n\($c.body)"
+          | "── \($c.created_at)  \((($c.user | .login) // "ghost"))\n\n\($c.body)"
         end
     '

--- a/plugin/fabrik/skills/fabrik/scripts/stage-output.sh
+++ b/plugin/fabrik/skills/fabrik/scripts/stage-output.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Show the most recent Fabrik stage-output comment on an issue.
+#
+# Every Fabrik stage output comment starts with a marker line like:
+#   🏭 **Fabrik — stage: Research**
+# This script finds the last comment matching the marker for the given stage
+# and prints its body — useful for "what did Research find on #N?".
+#
+# Usage: stage-output.sh <N> <StageName> [-r owner/repo]
+# Example: stage-output.sh 852 Plan
+set -euo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+. "$HERE/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR==1{next} /^#/{sub(/^# ?/, ""); print; next} {exit}' "$0"
+  exit 0
+fi
+
+fabrik_load_config
+
+N=${1:-}; STAGE=${2:-}
+if [ -z "$N" ] || [ -z "$STAGE" ]; then
+  echo "usage: stage-output.sh <N> <StageName> [-r owner/repo]" >&2
+  exit 2
+fi
+shift 2
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r) shift; export FABRIK_ISSUE_REPO=${1:-} ;;
+    *)  echo "stage-output.sh: unknown flag: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+fabrik_resolve_repo "$N"
+
+marker="Fabrik — stage: $STAGE"
+
+gh api "repos/$ISSUE_OWNER/$ISSUE_REPO/issues/$N/comments?per_page=100" --paginate \
+  | jq -r --arg m "$marker" '
+      map(select((.body // "") | contains($m)))
+      | if length == 0 then
+          "no comment matching \"\($m)\" on this issue"
+        else
+          .[-1] as $c
+          | "── \($c.created_at)  \($c.user.login)\n\n\($c.body)"
+        end
+    '


### PR DESCRIPTION
## Summary

- Adds five bash scripts under `plugin/fabrik/skills/fabrik/scripts/` so the interactive Fabrik supervisor skill can answer common "what's on the board?" / "status of #N?" / "what did Research say?" queries by calling a script instead of hand-rolling `gh` + GraphQL every turn.
- Updates `SKILL.md` with a "Reusable helpers" section that maps common asks to scripts, so future Claudes reach for them first.
- Bumps the `fabrik` Claude Code plugin from `0.1.1` → `0.2.0`.

## What's in `scripts/`

| Script | Purpose |
|---|---|
| `lib.sh` | Walks up for `.fabrik/config.yaml`; resolves the issue's repo (uses `gh project item-list` in multi-repo mode so it isn't capped at GraphQL's 100-item `projectV2` window). |
| `board.sh` | One-line-per-issue view; hides Done and `stage:*:complete` labels by default. Flags: `--all`, `--raw-labels`, `--column`, `--label`, `--json`, `--limit`. |
| `issue.sh` | Single-issue GraphQL scoped to repo+issue (via `projectItems`) so it works on boards of any size. Shows column / labels / URL / last-comment / linked PRs. |
| `comments.sh` | Issue or PR comments with inline 👀 / 🚀 / 👍 reaction counts — comment-processing state at a glance. Flags: `--pr`, `--last K`, `--full`, `--json`. |
| `stage-output.sh` | Greps for the `🏭 **Fabrik — stage: <Stage>**` marker and prints the matching comment body. |

All scripts:

- Auto-locate `.fabrik/config.yaml` by walking up from `$PWD`.
- Handle both organization- and user-owned projects transparently.
- Support `-h`/`--help`.
- Support `-r owner/repo` (or `FABRIK_ISSUE_REPO` env) to skip the multi-repo lookup when the caller already knows the repo.

## Why

Previously every "status of #N?" turn cost tokens for Claude to re-derive the GraphQL query — often incorrectly, or with slightly different shape each time. Shipping stable scripts:

- Cuts per-turn tokens (the SKILL.md pointer is small; the script bodies aren't loaded into context unless run).
- Gives consistent output shape across sessions.
- Encodes hard-won details once (100-item projectV2 window, the `stage:*:complete` label noise, the `🏭` marker format).

## Test plan

- [x] `board.sh` — Done-filter and label-cleanup work; `--column Specify`, `--label awaiting-input` slice correctly.
- [x] `issue.sh 916` — column, labels, linked PR, last-comment metadata all correct on a large board.
- [x] `comments.sh 916 --last 3` — reactions rendered with 👀/🚀/👍 counts.
- [x] `stage-output.sh 916 Research` — finds and prints the Research output comment body.
- [x] All four scripts' `--help` exit cleanly with usage-only output.
- [ ] Verify on a user-owned project (only tested against `handarbeit/1`, an org).
- [ ] Verify multi-repo mode: `fabrik_resolve_repo` picks the right repo when `repo:` is unset in `config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s3VzVVakR3Y1VdRYAGpBZ