### PR TITLE
fix(engine): don't warn Backlog/Done as unmatched board columns

### DIFF
--- a/engine/startup.go
+++ b/engine/startup.go
@@ -80,14 +80,22 @@ func (e *Engine) checkStageColumnAlignment(ctx context.Context) error {
 		}
 	}
 
-	// Find extra board columns (column not matching any non-cleanup stage).
-	stageNames := make(map[string]bool, len(checkStages))
-	for _, s := range checkStages {
-		stageNames[s.name] = true
+	// Find extra board columns: columns that no configured stage backs and that
+	// are not a well-known unmanaged column. Unlike the missing-column check
+	// above, this recognizes EVERY configured stage — including cleanup stages
+	// (e.g. Done) and holding stages (e.g. Queued) — because those columns are
+	// legitimately backed by a stage even though they don't require one. The
+	// "Backlog" entry column is intentionally unmanaged (Fabrik ignores it), so
+	// it is never reported as extra. A genuine typo'd column matches neither and
+	// is still surfaced.
+	recognized := make(map[string]bool, len(e.cfg.Stages)+1)
+	for _, s := range e.cfg.Stages {
+		recognized[s.Name] = true
 	}
+	recognized["Backlog"] = true
 	var extra []string
 	for colName := range sf.Options {
-		if !stageNames[colName] {
+		if !recognized[colName] {
 			extra = append(extra, colName)
 		}
 	}

--- a/engine/startup_test.go
+++ b/engine/startup_test.go
@@ -60,20 +60,68 @@ func TestCheckStageColumnAlignment_MissingStage(t *testing.T) {
 }
 
 func TestCheckStageColumnAlignment_ExtraColumns(t *testing.T) {
-	// Board has all stages plus extra columns (Triage, Backlog).
+	// Board has all stages plus extra columns (Triage, Backlog). Extra columns
+	// are a warning, never fatal.
 	client := &mockGitHubClient{
 		fetchProjectBoardFn: boardWithColumns("proj-1"),
 		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan", "Implement", "Triage", "Backlog"),
 	}
-	var logged []string
 	e := testEngine(t, client, &mockClaudeInvoker{})
-	// Capture logf output by overriding the events channel (nil = direct print).
-	// We can't easily intercept logf in plain-text mode, so just verify no error.
 	err := e.checkStageColumnAlignment(context.Background())
 	if err != nil {
 		t.Fatalf("extra board columns should not be fatal, got: %v", err)
 	}
-	_ = logged // checked via no-error
+}
+
+// TestCheckStageColumnAlignment_BacklogAndDoneNotExtra verifies that the
+// "no matching stage" warning excludes the conventional unmanaged Backlog
+// column and the Done column (which is backed by a cleanup stage), while still
+// surfacing a genuinely unrecognized column.
+func TestCheckStageColumnAlignment_BacklogAndDoneNotExtra(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: boardWithColumns("proj-1"),
+		fetchStatusFieldFn:  statusFieldWithOptions("Research", "Plan", "Implement", "Done", "Backlog", "Triage"),
+	}
+	e := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStagesWithCleanup(),
+		},
+		client,
+		&mockClaudeInvoker{},
+		NewWorktreeManager(t.TempDir()),
+	)
+	events := make(chan tui.Event, 32)
+	e.events = events
+
+	if err := e.checkStageColumnAlignment(context.Background()); err != nil {
+		t.Fatalf("extra columns should not be fatal, got: %v", err)
+	}
+	close(events)
+
+	var extraWarn string
+	for ev := range events {
+		if le, ok := ev.(tui.LogEvent); ok && strings.Contains(le.Message, "no matching stage") {
+			extraWarn = le.Message
+		}
+	}
+	if extraWarn == "" {
+		t.Fatal("expected a 'no matching stage' warning for the genuine extra column")
+	}
+	if !strings.Contains(extraWarn, "Triage") {
+		t.Errorf("genuine extra column Triage should be warned, got: %q", extraWarn)
+	}
+	if strings.Contains(extraWarn, "Backlog") {
+		t.Errorf("Backlog (unmanaged entry column) must not be flagged as extra, got: %q", extraWarn)
+	}
+	if strings.Contains(extraWarn, "Done") {
+		t.Errorf("Done (backed by a cleanup stage) must not be flagged as extra, got: %q", extraWarn)
+	}
 }
 
 func TestCheckStageColumnAlignment_FetchBoardError(t *testing.T) {


### PR DESCRIPTION
## Problem

On every startup Fabrik logged `warning: board has columns with no matching stage: Backlog, Done`. Both are false positives:

- **Backlog** — Fabrik's conventional unmanaged entry column; it has no stage YAML by design.
- **Done** — backed by the `Done` cleanup stage (`done.yaml`, `cleanup_worktree: true`), but the extra-column check built its recognized-set from `checkStages`, which *excludes* cleanup stages — so the Done column looked unrecognized.

## Fix

Build the recognized-set from **every** configured stage (including cleanup and holding stages like Done/Queued), plus the conventional `Backlog` entry column. A genuinely mistyped column still matches nothing and is surfaced exactly as before.

## Tests

- New `TestCheckStageColumnAlignment_BacklogAndDoneNotExtra`: asserts `Backlog` and `Done` are not flagged while a genuine extra column (`Triage`) still warns — captured via the engine events channel.
- Tidied the stale `TestCheckStageColumnAlignment_ExtraColumns` (removed dead capture var / misleading comment).
- `go build ./...`, `go vet ./engine/`, `gofmt`, and `go test ./engine/ -race` (minus the known-hang `TestExtendTurns_PersistsAcrossMultipleStages`) all green.

## Follow-up

A declarative `unmanaged: true` stage type (making Backlog a first-class stage like Done/Queued, rename-safe, generalizing to other parking columns) is filed separately. This PR keeps the hardcoded `Backlog` recognition as the backwards-compat net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCLVYrfe9W9wG6YdS1UDXh