### PR TITLE
fix(stages): name the missing key(s) in stage-drift warning title

### DIFF
--- a/stages/drift.go
+++ b/stages/drift.go
@@ -96,13 +96,20 @@ func warnDriftFrom(userStages []*Stage, version string, w io.Writer, defaults fs
 		_ = warnings.Record(warnings.Entry{
 			Key:       "stage_drift:" + name,
 			Type:      "stage_drift",
-			Title:     fmt.Sprintf("%s has %d missing field(s)", userStage.FilePath, len(missing)),
+			Title:     driftTitle(userStage.FilePath, missing),
 			Detail:    fmt.Sprintf("%s is missing fields present in %s defaults: %s\n\nFix: fabrik refresh-stages --apply", userStage.FilePath, version, strings.Join(missing, ", ")),
 			FixAction: "fabrik_command",
 			FixParams: map[string]string{"args": "refresh-stages --apply"},
 		})
 		return nil
 	})
+}
+
+// driftTitle builds the one-line warnings-panel title for a stage-drift entry.
+// It names the missing keys (not just their count) so the summary is actionable
+// without drilling into the detail view.
+func driftTitle(filePath string, missing []string) string {
+	return fmt.Sprintf("%s missing %d field(s): %s", filePath, len(missing), strings.Join(missing, ", "))
 }
 
 // MissingTopLevelKeys reads the YAML file at userPath and returns a sorted slice

--- a/stages/drift_test.go
+++ b/stages/drift_test.go
@@ -229,3 +229,19 @@ func TestMissingTopLevelKeys_SortedOutput(t *testing.T) {
 		t.Errorf("expected sorted output [apple mango zebra], got: %v", missing)
 	}
 }
+
+func TestDriftTitle_NamesMissingFields(t *testing.T) {
+	// The summary title must name the missing key(s), not just their count, so
+	// the warnings panel is actionable without opening the detail view.
+	got := driftTitle(".fabrik/stages/implement.yaml", []string{"kill_grace"})
+	want := ".fabrik/stages/implement.yaml missing 1 field(s): kill_grace"
+	if got != want {
+		t.Errorf("driftTitle = %q, want %q", got, want)
+	}
+
+	// Multiple missing fields are all named.
+	multi := driftTitle("review.yaml", []string{"kill_grace", "wait_for_ci"})
+	if !strings.Contains(multi, "kill_grace, wait_for_ci") {
+		t.Errorf("expected both fields named, got %q", multi)
+	}
+}


### PR DESCRIPTION
## Problem

The startup stage-drift warnings panel summarized each entry as `<file> has N missing field(s)` — the count, but not *which* fields. The names were already present in the warning `Detail` and the startup log line (e.g. `... missing fields present in ... defaults: kill_grace`), so users had to open the detail view to learn the key was `kill_grace`.

## Fix

Build the summary title from the key names via a small `driftTitle()` helper:

- Before: `.fabrik/stages/implement.yaml has 1 missing field(s)`
- After:  `.fabrik/stages/implement.yaml missing 1 field(s): kill_grace`

Purely presentational — same detection, same `Detail`, same fix action. Added `TestDriftTitle_NamesMissingFields` to pin the behavior.

## Tests

`gofmt`, `go build ./...`, `go vet ./stages/`, and `go test ./stages/ -run Drift` all green.