### PR TITLE
fix(stages): name the missing key(s) in stage-drift warning title

### DIFF
--- a/stages/drift.go
+++ b/stages/drift.go
@@ -116,13 +116,20 @@ func warnDriftFrom(userStages []*Stage, version string, w io.Writer, defaults fs
 		_ = warnings.Record(warnings.Entry{
 			Key:       "stage_drift:" + name,
 			Type:      "stage_drift",
-			Title:     fmt.Sprintf("%s has %d missing field(s)", userStage.FilePath, len(missing)),
+			Title:     driftTitle(userStage.FilePath, missing),
 			Detail:    fmt.Sprintf("%s is missing fields present in %s defaults: %s\n\nFix: fabrik refresh-stages --apply", userStage.FilePath, version, strings.Join(missing, ", ")),
 			FixAction: "fabrik_command",
 			FixParams: map[string]string{"args": "refresh-stages --apply"},
 		})
 		return nil
 	})
+}
+
+// driftTitle builds the one-line warnings-panel title for a stage-drift entry.
+// It names the missing keys (not just their count) so the summary is actionable
+// without drilling into the detail view.
+func driftTitle(filePath string, missing []string) string {
+	return fmt.Sprintf("%s missing %d field(s): %s", filePath, len(missing), strings.Join(missing, ", "))
 }
 
 // MissingTopLevelKeys reads the YAML file at userPath and returns a sorted slice

--- a/stages/drift_test.go
+++ b/stages/drift_test.go
@@ -295,3 +295,19 @@ func TestMissingTopLevelKeys_SortedOutput(t *testing.T) {
 		t.Errorf("expected sorted output [apple mango zebra], got: %v", missing)
 	}
 }
+
+func TestDriftTitle_NamesMissingFields(t *testing.T) {
+	// The summary title must name the missing key(s), not just their count, so
+	// the warnings panel is actionable without opening the detail view.
+	got := driftTitle(".fabrik/stages/implement.yaml", []string{"kill_grace"})
+	want := ".fabrik/stages/implement.yaml missing 1 field(s): kill_grace"
+	if got != want {
+		t.Errorf("driftTitle = %q, want %q", got, want)
+	}
+
+	// Multiple missing fields are all named.
+	multi := driftTitle("review.yaml", []string{"kill_grace", "wait_for_ci"})
+	if !strings.Contains(multi, "kill_grace, wait_for_ci") {
+		t.Errorf("expected both fields named, got %q", multi)
+	}
+}


### PR DESCRIPTION
Names the missing keys in the stage-drift warnings-panel **title** (`<file> missing N field(s): <keys>`) instead of just counting them (`<file> has N missing field(s)`), so the summary is actionable without drilling into the detail view. Adds a `driftTitle()` helper + a focused test.

### Why this is a standalone PR
This change was written 2026-07-12 (commit `50a1221d`) but fell through the cracks — #977's body listed it as "already merged (PR #974)", but no such PR ever existed and the change never reached `main`. Found as an orphaned local commit during v0.0.71 release prep; cherry-picked cleanly onto current `main` (no conflict with #979's value-aware drift work, which touches different lines).

Complements #979: #979 stops the *needless* drift warnings (no-op default knobs); this makes the *remaining* ones more actionable.

### Test plan
- [x] `go test ./stages/...` — new title test passes alongside #979's `drift_rules` tests
- [x] `go build ./...`, `go vet ./stages/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lcq7UwGXeUtF5PpFDUqdGC
