### PR TITLE
feat(config): add merge_train config.yaml key with full flag > env > config > default precedence

### DIFF
--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -190,3 +190,181 @@ func TestExecute_StreamFilterSubcommand(t *testing.T) {
 		t.Fatalf("Execute stream-filter: %v", err)
 	}
 }
+
+// executeWithConfigHook runs Execute() with testResolvedConfigHook installed,
+// capturing the fully-resolved Config right before engine.New would be
+// called. The hook makes Execute return immediately once resolution
+// completes, so no engine startup or SIGINT dance is needed.
+func executeWithConfigHook(t *testing.T) Config {
+	t.Helper()
+	var captured Config
+	var called bool
+	testResolvedConfigHook = func(cfg Config) {
+		captured = cfg
+		called = true
+	}
+	defer func() { testResolvedConfigHook = nil }()
+
+	if err := Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !called {
+		t.Fatal("testResolvedConfigHook was not invoked")
+	}
+	return captured
+}
+
+func TestExecute_MergeTrainConfigOnly(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("merge_train: on\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if got := mergeTrainMode(cfg.MergeTrain); got != "on" {
+		t.Errorf("resolved merge train mode = %q, want on (config.yaml should enable it)", got)
+	}
+}
+
+func TestExecute_MergeTrainFlagBeatsConfig(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("merge_train: on\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir, "--merge-train", "off"}
+
+	cfg := executeWithConfigHook(t)
+	if got := mergeTrainMode(cfg.MergeTrain); got != "off" {
+		t.Errorf("resolved merge train mode = %q, want off (explicit flag should beat config.yaml)", got)
+	}
+}
+
+func TestExecute_MergeTrainEnvBeatsConfig(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("merge_train: on\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	t.Setenv("FABRIK_MERGE_TRAIN", "off")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if got := mergeTrainMode(cfg.MergeTrain); got != "off" {
+		t.Errorf("resolved merge train mode = %q, want off (env var should beat config.yaml)", got)
+	}
+}
+
+func TestExecute_MergeTrainInvalidConfigValue(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("merge_train: maybe\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MergeTrain != "maybe" {
+		t.Errorf("cfg.MergeTrain = %q, want raw config.yaml value %q to flow through unvalidated", cfg.MergeTrain, "maybe")
+	}
+	if got := mergeTrainMode(cfg.MergeTrain); got != "off" {
+		t.Errorf("mergeTrainMode(%q) = %q, want off (invalid value falls back to default)", cfg.MergeTrain, got)
+	}
+}
+
+func TestMergeTrainMode(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", "off"},
+		{"on", "on"},
+		{"ON", "on"},
+		{"off", "off"},
+		{"maybe", "off"},
+	}
+	for _, c := range cases {
+		if got := mergeTrainMode(c.in); got != c.want {
+			t.Errorf("mergeTrainMode(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExecute_MaxBatchSizeConfigOnly(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("max_batch_size: 8\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MaxBatchSize != 8 {
+		t.Errorf("cfg.MaxBatchSize = %d, want 8 from config.yaml", cfg.MaxBatchSize)
+	}
+}
+
+func TestExecute_MaxBatchSizeEnvBeatsConfig(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("max_batch_size: 8\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	t.Setenv("FABRIK_MAX_BATCH_SIZE", "12")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MaxBatchSize != 12 {
+		t.Errorf("cfg.MaxBatchSize = %d, want 12 (env var should beat config.yaml)", cfg.MaxBatchSize)
+	}
+}
+
+func TestExecute_MaxBatchSizeFlagBeatsConfig(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("max_batch_size: 8\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir, "--max-batch-size", "3"}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MaxBatchSize != 3 {
+		t.Errorf("cfg.MaxBatchSize = %d, want 3 (explicit flag should beat config.yaml)", cfg.MaxBatchSize)
+	}
+}
+
+func TestExecute_MaxBatchSizeInvalidConfigValue(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("max_batch_size: 0\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MaxBatchSize != 0 {
+		t.Errorf("cfg.MaxBatchSize = %d, want 0 (invalid config.yaml value falls back to default)", cfg.MaxBatchSize)
+	}
+}
+
+func TestExecute_TrainTrialWindowConfigOnly(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("train_trial_window: 45\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.TrainTrialWindowMinutes != 45 {
+		t.Errorf("cfg.TrainTrialWindowMinutes = %d, want 45 from config.yaml", cfg.TrainTrialWindowMinutes)
+	}
+}

--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -368,3 +368,33 @@ func TestExecute_TrainTrialWindowConfigOnly(t *testing.T) {
 		t.Errorf("cfg.TrainTrialWindowMinutes = %d, want 45 from config.yaml", cfg.TrainTrialWindowMinutes)
 	}
 }
+
+func TestExecute_MaxBisectValidationsConfigZeroMeansDerive(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("max_bisect_validations: 0\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MaxBisectValidations != 0 {
+		t.Errorf("cfg.MaxBisectValidations = %d, want 0 (config.yaml 0 means derive default, not invalid)", cfg.MaxBisectValidations)
+	}
+}
+
+func TestExecute_MaxBisectValidationsConfigNegativeIsInvalid(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	os.MkdirAll(filepath.Join(dir, ".fabrik"), 0755)
+	os.WriteFile(filepath.Join(dir, ".fabrik", "config.yaml"), []byte("max_bisect_validations: -1\n"), 0644)
+	resetFlags()
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+
+	cfg := executeWithConfigHook(t)
+	if cfg.MaxBisectValidations != 0 {
+		t.Errorf("cfg.MaxBisectValidations = %d, want 0 (negative config.yaml value falls back to default)", cfg.MaxBisectValidations)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -429,8 +429,8 @@ func Execute() error {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_BISECT_VALIDATIONS=%q is invalid (must be a positive integer); using derived default\n", v)
 			}
 		} else if pc.MaxBisectValidations != nil {
-			if *pc.MaxBisectValidations <= 0 {
-				fmt.Fprintf(os.Stderr, "[warn] config.yaml max_bisect_validations=%d is invalid (must be a positive integer); using derived default\n", *pc.MaxBisectValidations)
+			if *pc.MaxBisectValidations < 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml max_bisect_validations=%d is invalid (must be a non-negative integer); using derived default\n", *pc.MaxBisectValidations)
 			} else {
 				cfg.MaxBisectValidations = *pc.MaxBisectValidations
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,11 @@ import (
 // signal.Notify is installed, which would terminate the process.
 var testReadyCh chan struct{}
 
+// testResolvedConfigHook is set by tests to observe the fully-resolved Config
+// immediately before engine.New is called. When set, Execute returns nil
+// right after invoking it, short-circuiting before the engine is constructed.
+var testResolvedConfigHook func(Config)
+
 type Config struct {
 	Owner             string
 	Repo              string
@@ -397,6 +402,8 @@ func Execute() error {
 	if !explicitFlags["merge-train"] {
 		if v := os.Getenv("FABRIK_MERGE_TRAIN"); v != "" {
 			cfg.MergeTrain = v // validated in mergeTrainMode() helper
+		} else if pc.MergeTrain != "" {
+			cfg.MergeTrain = pc.MergeTrain // validated in mergeTrainMode() helper
 		}
 	}
 	if !explicitFlags["max-batch-size"] {
@@ -405,6 +412,12 @@ func Execute() error {
 				cfg.MaxBatchSize = n
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_BATCH_SIZE=%q is invalid (must be a positive integer); using default 5\n", v)
+			}
+		} else if pc.MaxBatchSize != nil {
+			if *pc.MaxBatchSize <= 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml max_batch_size=%d is invalid (must be a positive integer); using default 5\n", *pc.MaxBatchSize)
+			} else {
+				cfg.MaxBatchSize = *pc.MaxBatchSize
 			}
 		}
 	}
@@ -415,6 +428,12 @@ func Execute() error {
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_BISECT_VALIDATIONS=%q is invalid (must be a positive integer); using derived default\n", v)
 			}
+		} else if pc.MaxBisectValidations != nil {
+			if *pc.MaxBisectValidations <= 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml max_bisect_validations=%d is invalid (must be a positive integer); using derived default\n", *pc.MaxBisectValidations)
+			} else {
+				cfg.MaxBisectValidations = *pc.MaxBisectValidations
+			}
 		}
 	}
 	if !explicitFlags["max-train-rebase-cycles"] {
@@ -423,6 +442,12 @@ func Execute() error {
 				cfg.MaxTrainRebaseCycles = n
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_TRAIN_REBASE_CYCLES=%q is invalid (must be a positive integer); using default 3\n", v)
+			}
+		} else if pc.MaxTrainRebaseCycles != nil {
+			if *pc.MaxTrainRebaseCycles <= 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml max_train_rebase_cycles=%d is invalid (must be a positive integer); using default 3\n", *pc.MaxTrainRebaseCycles)
+			} else {
+				cfg.MaxTrainRebaseCycles = *pc.MaxTrainRebaseCycles
 			}
 		}
 	}
@@ -433,6 +458,12 @@ func Execute() error {
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW=%q is invalid (must be a positive integer); using default 20\n", v)
 			}
+		} else if pc.MaxTrainTrialsPerWindow != nil {
+			if *pc.MaxTrainTrialsPerWindow <= 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml max_train_trials_per_window=%d is invalid (must be a positive integer); using default 20\n", *pc.MaxTrainTrialsPerWindow)
+			} else {
+				cfg.MaxTrainTrialsPerWindow = *pc.MaxTrainTrialsPerWindow
+			}
 		}
 	}
 	if !explicitFlags["train-trial-window"] {
@@ -441,6 +472,12 @@ func Execute() error {
 				cfg.TrainTrialWindowMinutes = n
 			} else {
 				fmt.Fprintf(os.Stderr, "[warn] FABRIK_TRAIN_TRIAL_WINDOW=%q is invalid (must be a positive integer of minutes); using default 60\n", v)
+			}
+		} else if pc.TrainTrialWindow != nil {
+			if *pc.TrainTrialWindow <= 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml train_trial_window=%d is invalid (must be a positive integer of minutes); using default 60\n", *pc.TrainTrialWindow)
+			} else {
+				cfg.TrainTrialWindowMinutes = *pc.TrainTrialWindow
 			}
 		}
 	}
@@ -734,6 +771,11 @@ func Execute() error {
 		}
 	} else if len(pc.WebhookEvents) > 0 {
 		webhookEvents = pc.WebhookEvents
+	}
+
+	if testResolvedConfigHook != nil {
+		testResolvedConfigHook(*cfg)
+		return nil
 	}
 
 	eng, err := engine.New(engine.Config{

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,12 @@ type ProjectConfig struct {
 	JanitorIntervalHours    *int     `yaml:"janitor_interval_hours"`
 	LogRetentionDays        *int     `yaml:"log_retention_days"`
 	LogMaxBytes             *int64   `yaml:"log_max_bytes"`
+	MergeTrain              string   `yaml:"merge_train"`
+	MaxBatchSize            *int     `yaml:"max_batch_size"`
+	MaxBisectValidations    *int     `yaml:"max_bisect_validations"`
+	MaxTrainRebaseCycles    *int     `yaml:"max_train_rebase_cycles"`
+	MaxTrainTrialsPerWindow *int     `yaml:"max_train_trials_per_window"`
+	TrainTrialWindow        *int     `yaml:"train_trial_window"`
 }
 
 // LoadProjectConfig reads .fabrik/config.yaml from CWD.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -543,6 +543,28 @@ user: your-github-username
 # oldest files are deleted first until total size is under this cap. Set to 0
 # to disable size-cap pruning.
 # log_max_bytes: 2147483648
+
+# Fabrik-internal merge train (ADR-059). When "on", yolo Validate completions
+# advance into the Queued column for batched landing with a single combined
+# Validate instead of merging one PR at a time. Off by default — see the
+# "Merge Train" section below before enabling.
+# merge_train: off
+
+# Merge-train batch-tuning knobs (only consulted when merge_train: on).
+# Maximum Queued items landed in a single batch.
+# max_batch_size: 5
+# Maximum combined validations per red batch before degrading to landing
+# members one-at-a-time. Unset derives 2*ceil(log2(max_batch_size))+1.
+# max_bisect_validations: 0
+# Maximum main-moved rebase+revalidate cycles before a batch is dissolved
+# back to Queued.
+# max_train_rebase_cycles: 3
+# Runaway guard (ADR-059 §D8): maximum trial-branch creations with zero
+# successful lands within the rolling window before pausing all Queued members.
+# max_train_trials_per_window: 20
+# Runaway guard (ADR-059 §D8): rolling window in minutes over which
+# max_train_trials_per_window is measured.
+# train_trial_window: 60
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -639,12 +661,12 @@ FABRIK_USER=my-personal-username
 | `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
 | `FABRIK_MAX_ENQUEUE_CYCLES` | *(no config.yaml key)* | Maximum number of merge-queue re-enqueue cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5). Bounds a queue-thrash loop (a yolo PR repeatedly ejected from GitHub's merge queue and re-enqueued without merging), independently of the rebase/CI-fix caps that the ejection sub-paths increment. | `5` |
 | `FABRIK_MERGE_QUEUE` | *(no config.yaml key)* | Merge queue routing for the yolo path: `auto` (enqueue when the repo requires GitHub's native merge queue) or `off` (disable enqueue; yolo merges may fail with HTTP 405 on queue-required repos). Invalid or unset values default to `auto`. See `--merge-queue`. | `auto` |
-| `FABRIK_MERGE_TRAIN` | *(no config.yaml key)* | Fabrik-internal merge train (ADR-059): `on` advances yolo Validate completions into the Queued column for batched landing with a single combined Validate; `off` keeps the existing per-PR auto-merge path. Invalid or unset values default to `off`. See `--merge-train`. | `off` |
-| `FABRIK_MAX_BATCH_SIZE` | *(no config.yaml key)* | Maximum Queued items landed in a single merge-train batch, ordered by entry (positive integer; invalid or unset values default to 5). Smaller = cheaper worst-case red-batch bisection but fewer N² CI savings; larger = more savings but costlier worst-case bisection. See `--max-batch-size`. | `5` |
-| `FABRIK_MAX_BISECT_VALIDATIONS` | *(no config.yaml key)* | Maximum combined validations per red merge-train batch before degrading to one-at-a-time landing (positive integer; invalid or unset values derive `2·⌈log₂(max_batch_size)⌉ + 1`, ≈ 7 at the default batch size). The fallback is logged, never silent. See `--max-bisect-validations`. | derived (≈7) |
-| `FABRIK_MAX_TRAIN_REBASE_CYCLES` | *(no config.yaml key)* | Maximum main-moved rebase+revalidate cycles for a merge-train batch before dissolving it back to Queued (positive integer; invalid or unset values default to 3). On exhaustion the batch's integration PR is closed and trial branch deleted, members remain in Queued, and a fresh train forms next poll. See `--max-train-rebase-cycles`. | `3` |
-| `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` | *(no config.yaml key)* | Runaway guard (ADR-059 §D8): maximum trial-branch creations with zero successful lands within the rolling window before pausing all `Queued` members (positive integer; invalid or unset values default to 20). See `--max-train-trials-per-window`. | `20` |
-| `FABRIK_TRAIN_TRIAL_WINDOW` | *(no config.yaml key)* | Runaway guard (ADR-059 §D8): rolling window in minutes over which `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` is measured (positive integer; invalid or unset values default to 60). See `--train-trial-window`. | `60` |
+| `FABRIK_MERGE_TRAIN` | `merge_train` | Fabrik-internal merge train (ADR-059): `on` advances yolo Validate completions into the Queued column for batched landing with a single combined Validate; `off` keeps the existing per-PR auto-merge path. Invalid or unset values default to `off`. See `--merge-train`. | `off` |
+| `FABRIK_MAX_BATCH_SIZE` | `max_batch_size` | Maximum Queued items landed in a single merge-train batch, ordered by entry (positive integer; invalid or unset values default to 5). Smaller = cheaper worst-case red-batch bisection but fewer N² CI savings; larger = more savings but costlier worst-case bisection. See `--max-batch-size`. | `5` |
+| `FABRIK_MAX_BISECT_VALIDATIONS` | `max_bisect_validations` | Maximum combined validations per red merge-train batch before degrading to one-at-a-time landing (positive integer; invalid or unset values derive `2·⌈log₂(max_batch_size)⌉ + 1`, ≈ 7 at the default batch size). The fallback is logged, never silent. See `--max-bisect-validations`. | derived (≈7) |
+| `FABRIK_MAX_TRAIN_REBASE_CYCLES` | `max_train_rebase_cycles` | Maximum main-moved rebase+revalidate cycles for a merge-train batch before dissolving it back to Queued (positive integer; invalid or unset values default to 3). On exhaustion the batch's integration PR is closed and trial branch deleted, members remain in Queued, and a fresh train forms next poll. See `--max-train-rebase-cycles`. | `3` |
+| `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` | `max_train_trials_per_window` | Runaway guard (ADR-059 §D8): maximum trial-branch creations with zero successful lands within the rolling window before pausing all `Queued` members (positive integer; invalid or unset values default to 20). See `--max-train-trials-per-window`. | `20` |
+| `FABRIK_TRAIN_TRIAL_WINDOW` | `train_trial_window` | Runaway guard (ADR-059 §D8): rolling window in minutes over which `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` is measured (positive integer; invalid or unset values default to 60). See `--train-trial-window`. | `60` |
 | `FABRIK_CONVERGENCE_BUDGET` | *(no config.yaml key)* | Wall-clock budget for post-Validate yolo PR convergence (Go duration syntax: `30m`, `1h`, `2h30m`; `0` disables; invalid values default to 30 min). When the budget expires and the PR has not merged, Fabrik pauses the issue with `fabrik:awaiting-input`. | `30m` |
 | `FABRIK_AUTO_MERGE_STRATEGY` | *(no config.yaml key)* | Merge method used when calling GitHub's `enablePullRequestAutoMerge` for yolo PRs. Accepted values: `MERGE`, `SQUASH`, `REBASE`. Invalid or unset values default to `MERGE`. | `MERGE` |
 | `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -943,7 +943,7 @@ The stall comment is posted once per event — subsequent polls skip the paused 
 
 GitHub's native merge queue (above) is only available on GitHub Enterprise Cloud and org-owned public repos. On the common target — private **GitHub Team** repos and personal-account repos with `strict` branch protection — the native queue **cannot run**, yet these are exactly the repos that suffer the O(N²) rebase-and-retest cascade when several ready PRs land serially: each merge invalidates every other ready PR's "up-to-date + green" status, forcing a rebase and a full required-check re-run before the next merge.
 
-Fabrik's **internal merge train** (ADR-059) is the plan-agnostic, host-agnostic answer. It batches ready PRs, validates the combined batch **once**, and lands them together — collapsing the cascade. It is opt-in via `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+Fabrik's **internal merge train** (ADR-059) is the plan-agnostic, host-agnostic answer. It batches ready PRs, validates the combined batch **once**, and lands them together — collapsing the cascade. It is opt-in via `--merge-train on`, `FABRIK_MERGE_TRAIN=on`, or `merge_train: on` in `.fabrik/config.yaml` (flag > env var > config.yaml > default `off`).
 
 **One board column, two landing engines.** When `merge_train: on`, every yolo Validate completion advances into a single **`Queued`** board column instead of merging immediately. Each poll, the `Queued` handler picks the landing engine **per repo** (a `Queued` column can hold items from several repos at once), so you see one board model, not two parallel merge paths:
 
@@ -968,7 +968,7 @@ Both engines drain the same `Queued` column and advance their members to **Done*
    order: 6            # after Validate, before Done
    holding_stage: true
    ```
-3. **Enable the train**: `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+3. **Enable the train**: `--merge-train on`, `FABRIK_MERGE_TRAIN=on`, or `merge_train: on` in `.fabrik/config.yaml`.
 
 > **Startup requirement.** When `merge_train: on`, the `Queued` board column is **mandatory** — Fabrik fails startup if it is missing (the same board-validation that guards every non-cleanup stage). This is why the train is **off by default**: flipping it on globally would break startup on every board that has not yet added the column. Enable it per deployment only after step 1.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -541,6 +541,28 @@ user: your-github-username
 # oldest files are deleted first until total size is under this cap. Set to 0
 # to disable size-cap pruning.
 # log_max_bytes: 2147483648
+
+# Fabrik-internal merge train (ADR-059). When "on", yolo Validate completions
+# advance into the Queued column for batched landing with a single combined
+# Validate instead of merging one PR at a time. Off by default — see the
+# "Merge Train" section below before enabling.
+# merge_train: off
+
+# Merge-train batch-tuning knobs (only consulted when merge_train: on).
+# Maximum Queued items landed in a single batch.
+# max_batch_size: 5
+# Maximum combined validations per red batch before degrading to landing
+# members one-at-a-time. Unset derives 2*ceil(log2(max_batch_size))+1.
+# max_bisect_validations: 0
+# Maximum main-moved rebase+revalidate cycles before a batch is dissolved
+# back to Queued.
+# max_train_rebase_cycles: 3
+# Runaway guard (ADR-059 §D8): maximum trial-branch creations with zero
+# successful lands within the rolling window before pausing all Queued members.
+# max_train_trials_per_window: 20
+# Runaway guard (ADR-059 §D8): rolling window in minutes over which
+# max_train_trials_per_window is measured.
+# train_trial_window: 60
 ```
 
 **Multi-repo mode:** When `repo:` is commented out or omitted, Fabrik processes issues from *all* repositories on the project board. Use this when your project board spans multiple repos (cross-org collaborations, monorepos with independent sub-repos, or a single board managing several distinct services). To restrict Fabrik to one repository, uncomment and set `repo:`.
@@ -637,12 +659,12 @@ FABRIK_USER=my-personal-username
 | `FABRIK_MAX_REBASE_CYCLES` | *(no config.yaml key)* | Maximum number of rebase re-invocation cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 3). Lower than CI/review because rebase either succeeds in one shot or needs human judgment for a semantic conflict. | `3` |
 | `FABRIK_MAX_ENQUEUE_CYCLES` | *(no config.yaml key)* | Maximum number of merge-queue re-enqueue cycles per issue before pausing with `fabrik:awaiting-input` (positive integer; invalid or unset values default to 5). Bounds a queue-thrash loop (a yolo PR repeatedly ejected from GitHub's merge queue and re-enqueued without merging), independently of the rebase/CI-fix caps that the ejection sub-paths increment. | `5` |
 | `FABRIK_MERGE_QUEUE` | *(no config.yaml key)* | Merge queue routing for the yolo path: `auto` (enqueue when the repo requires GitHub's native merge queue) or `off` (disable enqueue; yolo merges may fail with HTTP 405 on queue-required repos). Invalid or unset values default to `auto`. See `--merge-queue`. | `auto` |
-| `FABRIK_MERGE_TRAIN` | *(no config.yaml key)* | Fabrik-internal merge train (ADR-059): `on` advances yolo Validate completions into the Queued column for batched landing with a single combined Validate; `off` keeps the existing per-PR auto-merge path. Invalid or unset values default to `off`. See `--merge-train`. | `off` |
-| `FABRIK_MAX_BATCH_SIZE` | *(no config.yaml key)* | Maximum Queued items landed in a single merge-train batch, ordered by entry (positive integer; invalid or unset values default to 5). Smaller = cheaper worst-case red-batch bisection but fewer N² CI savings; larger = more savings but costlier worst-case bisection. See `--max-batch-size`. | `5` |
-| `FABRIK_MAX_BISECT_VALIDATIONS` | *(no config.yaml key)* | Maximum combined validations per red merge-train batch before degrading to one-at-a-time landing (positive integer; invalid or unset values derive `2·⌈log₂(max_batch_size)⌉ + 1`, ≈ 7 at the default batch size). The fallback is logged, never silent. See `--max-bisect-validations`. | derived (≈7) |
-| `FABRIK_MAX_TRAIN_REBASE_CYCLES` | *(no config.yaml key)* | Maximum main-moved rebase+revalidate cycles for a merge-train batch before dissolving it back to Queued (positive integer; invalid or unset values default to 3). On exhaustion the batch's integration PR is closed and trial branch deleted, members remain in Queued, and a fresh train forms next poll. See `--max-train-rebase-cycles`. | `3` |
-| `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` | *(no config.yaml key)* | Runaway guard (ADR-059 §D8): maximum trial-branch creations with zero successful lands within the rolling window before pausing all `Queued` members (positive integer; invalid or unset values default to 20). See `--max-train-trials-per-window`. | `20` |
-| `FABRIK_TRAIN_TRIAL_WINDOW` | *(no config.yaml key)* | Runaway guard (ADR-059 §D8): rolling window in minutes over which `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` is measured (positive integer; invalid or unset values default to 60). See `--train-trial-window`. | `60` |
+| `FABRIK_MERGE_TRAIN` | `merge_train` | Fabrik-internal merge train (ADR-059): `on` advances yolo Validate completions into the Queued column for batched landing with a single combined Validate; `off` keeps the existing per-PR auto-merge path. Invalid or unset values default to `off`. See `--merge-train`. | `off` |
+| `FABRIK_MAX_BATCH_SIZE` | `max_batch_size` | Maximum Queued items landed in a single merge-train batch, ordered by entry (positive integer; invalid or unset values default to 5). Smaller = cheaper worst-case red-batch bisection but fewer N² CI savings; larger = more savings but costlier worst-case bisection. See `--max-batch-size`. | `5` |
+| `FABRIK_MAX_BISECT_VALIDATIONS` | `max_bisect_validations` | Maximum combined validations per red merge-train batch before degrading to one-at-a-time landing (positive integer; invalid or unset values derive `2·⌈log₂(max_batch_size)⌉ + 1`, ≈ 7 at the default batch size). The fallback is logged, never silent. See `--max-bisect-validations`. | derived (≈7) |
+| `FABRIK_MAX_TRAIN_REBASE_CYCLES` | `max_train_rebase_cycles` | Maximum main-moved rebase+revalidate cycles for a merge-train batch before dissolving it back to Queued (positive integer; invalid or unset values default to 3). On exhaustion the batch's integration PR is closed and trial branch deleted, members remain in Queued, and a fresh train forms next poll. See `--max-train-rebase-cycles`. | `3` |
+| `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` | `max_train_trials_per_window` | Runaway guard (ADR-059 §D8): maximum trial-branch creations with zero successful lands within the rolling window before pausing all `Queued` members (positive integer; invalid or unset values default to 20). See `--max-train-trials-per-window`. | `20` |
+| `FABRIK_TRAIN_TRIAL_WINDOW` | `train_trial_window` | Runaway guard (ADR-059 §D8): rolling window in minutes over which `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW` is measured (positive integer; invalid or unset values default to 60). See `--train-trial-window`. | `60` |
 | `FABRIK_CONVERGENCE_BUDGET` | *(no config.yaml key)* | Wall-clock budget for post-Validate yolo PR convergence (Go duration syntax: `30m`, `1h`, `2h30m`; `0` disables; invalid values default to 30 min). When the budget expires and the PR has not merged, Fabrik pauses the issue with `fabrik:awaiting-input`. | `30m` |
 | `FABRIK_AUTO_MERGE_STRATEGY` | *(no config.yaml key)* | Merge method used when calling GitHub's `enablePullRequestAutoMerge` for yolo PRs. Accepted values: `MERGE`, `SQUASH`, `REBASE`. Invalid or unset values default to `MERGE`. | `MERGE` |
 | `FABRIK_CLAUDE_WAIT_DELAY` | *(no config.yaml key)* | Seconds to wait after Claude exits before recovering buffered output (non-negative integer; `0` or unset uses the default of 30; invalid values default to 30). Prevents worker goroutines from blocking indefinitely when Claude uses `run_in_background` or the Monitor tool, which can hold stdout open after the main Claude process exits. | `30` |
@@ -919,7 +941,7 @@ The stall comment is posted once per event — subsequent polls skip the paused 
 
 GitHub's native merge queue (above) is only available on GitHub Enterprise Cloud and org-owned public repos. On the common target — private **GitHub Team** repos and personal-account repos with `strict` branch protection — the native queue **cannot run**, yet these are exactly the repos that suffer the O(N²) rebase-and-retest cascade when several ready PRs land serially: each merge invalidates every other ready PR's "up-to-date + green" status, forcing a rebase and a full required-check re-run before the next merge.
 
-Fabrik's **internal merge train** (ADR-059) is the plan-agnostic, host-agnostic answer. It batches ready PRs, validates the combined batch **once**, and lands them together — collapsing the cascade. It is opt-in via `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+Fabrik's **internal merge train** (ADR-059) is the plan-agnostic, host-agnostic answer. It batches ready PRs, validates the combined batch **once**, and lands them together — collapsing the cascade. It is opt-in via `--merge-train on`, `FABRIK_MERGE_TRAIN=on`, or `merge_train: on` in `.fabrik/config.yaml` (flag > env var > config.yaml > default `off`).
 
 **One board column, two landing engines.** When `merge_train: on`, every yolo Validate completion advances into a single **`Queued`** board column instead of merging immediately. Each poll, the `Queued` handler picks the landing engine **per repo** (a `Queued` column can hold items from several repos at once), so you see one board model, not two parallel merge paths:
 
@@ -944,7 +966,7 @@ Both engines drain the same `Queued` column and advance their members to **Done*
    order: 6            # after Validate, before Done
    holding_stage: true
    ```
-3. **Enable the train**: `--merge-train on` (or `FABRIK_MERGE_TRAIN=on`).
+3. **Enable the train**: `--merge-train on`, `FABRIK_MERGE_TRAIN=on`, or `merge_train: on` in `.fabrik/config.yaml`.
 
 > **Startup requirement.** When `merge_train: on`, the `Queued` board column is **mandatory** — Fabrik fails startup if it is missing (the same board-validation that guards every non-cleanup stage). This is why the train is **off by default**: flipping it on globally would break startup on every board that has not yet added the column. Enable it per deployment only after step 1.
 


### PR DESCRIPTION
Closes #992

## Summary

Adds a `merge_train` key to `.fabrik/config.yaml`, giving it the same full `flag > env > config.yaml > default` precedence resolution that every other persistent Fabrik setting (`poll`, `max_concurrent`, `max_retries`, etc.) already has. Previously `merge_train` could only be set via `--merge-train` or `FABRIK_MERGE_TRAIN`, stopping at the env layer — an inconsistency the issue calls out, made worse by USER_GUIDE prose that already wrote `merge_train: on` as if it were a real config.yaml key when it was silently ignored there.

Also covers the five sibling batch-tuning knobs (`max_batch_size`, `max_bisect_validations`, `max_train_rebase_cycles`, `max_train_trials_per_window`, `train_trial_window`) with the same mechanical pattern, since each is a near-identical ~9-line block with no added design complexity.

## Key changes

- **`config/config.go`**: `ProjectConfig` gains `MergeTrain string` plus five `*int` fields for the batch knobs (pointer types preserve the "absent" vs. "explicitly 0" distinction, matching the existing `Poll`/`MaxConcurrent`/`MaxRetries` fields).
- **`cmd/root.go`**: each of the six `explicitFlags`-gated env blocks gets an `else if pc.X != nil/!= ""` branch that falls back to the config.yaml value. `mergeTrainMode()` is untouched — the config-sourced string flows through the exact same normalization/validation call as the flag/env-sourced string, so an invalid `merge_train: maybe` warns and falls back to `off` exactly like an invalid flag or env value does today. Also adds a `testResolvedConfigHook` seam (mirrors the existing `testReadyCh` pattern) so tests can observe the fully-resolved `Config` immediately before `engine.New` runs, without needing to spin up the engine or handle signals.
- **`cmd/cmd_envvar_test.go`**: new tests covering config-only enable, flag-beats-config, env-beats-config, and invalid-config-value fallback for `merge_train`, plus the `*int` nil-vs-invalid-zero distinction for `max_batch_size` (config-only, env-beats-config, flag-beats-config, invalid-value) and one more batch knob for config-only resolution.
- **`docs/USER_GUIDE.md`**: config.yaml example block gains commented entries for `merge_train` and the five batch knobs; the Environment Variables table's `*(no config.yaml key)*` markers are replaced with the real key names; the Merge Train section's opt-in prose now lists `merge_train: on` in `.fabrik/config.yaml` as a real third option alongside the flag and env var.
- **`docs/llms-full.txt`**: regenerated via `scripts/generate-llms-full.sh`.

## Out of scope

`FABRIK_MERGE_QUEUE` has the identical "no config.yaml key" gap but is not covered by this issue's requirements — worth a follow-up issue, not addressed here. No merge-train runtime behavior (ADR-058/059) changed; this is purely the configuration-resolution surface.

## How to test

- `go test -race ./...` — full suite passes except a pre-existing `TestExecute_ConfigYAMLApplied` failure caused by no network access to GitHub's GraphQL API in this sandbox (confirmed to fail identically on the base commit before this change).
- `go vet ./...` — clean.
- Manually: put `merge_train: on` in `.fabrik/config.yaml` with no flag/env set and confirm the train activates; set `FABRIK_MERGE_TRAIN=off` alongside it and confirm the env var wins; pass `--merge-train off` and confirm the flag wins over both.