### PR TITLE
fix: report Main.Version for `go install pkg@vX.Y.Z` builds instead of "dev"

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,15 +15,22 @@ func init() {
 }
 
 // versionWithSHA returns v unchanged if it is not "dev" (i.e. a real release
-// version was injected). For "dev" builds it appends the short VCS SHA from
-// the build info, producing e.g. "dev(abc1234)". If VCS info is unavailable
-// it returns "dev" unchanged.
+// version was injected). For "dev" builds it first checks info.Main.Version:
+// `go install pkg@vX.Y.Z` builds populate this with the resolved module
+// version (but have no vcs.revision), so that value is reported directly.
+// Local checkout builds (go build/go run) set Main.Version to the "(devel)"
+// sentinel instead, so those fall through to the existing VCS SHA
+// enrichment, producing e.g. "dev(abc1234)". If no VCS info is available
+// either, it returns "dev" unchanged.
 func versionWithSHA(v string, info *debug.BuildInfo, ok bool) string {
 	if v != "dev" {
 		return v
 	}
 	if !ok || info == nil {
 		return v
+	}
+	if mv := info.Main.Version; mv != "" && mv != "(devel)" {
+		return mv
 	}
 	var revision string
 	for _, s := range info.Settings {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -13,6 +13,12 @@ func buildInfoWithRevision(rev string) *debug.BuildInfo {
 	}
 }
 
+func buildInfoWithMainVersion(mv string) *debug.BuildInfo {
+	return &debug.BuildInfo{
+		Main: debug.Module{Version: mv},
+	}
+}
+
 func TestVersionWithSHA(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -60,6 +66,25 @@ func TestVersionWithSHA(t *testing.T) {
 			name:     "dev with exactly 7 char SHA",
 			v:        "dev",
 			info:     buildInfoWithRevision("abcdef1"),
+			ok:       true,
+			expected: "dev(abcdef1)",
+		},
+		{
+			name:     "go install pkg@vX.Y.Z reports Main.Version",
+			v:        "dev",
+			info:     buildInfoWithMainVersion("v0.0.71"),
+			ok:       true,
+			expected: "v0.0.71",
+		},
+		{
+			name: "local checkout with (devel) Main.Version falls through to VCS SHA",
+			v:    "dev",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "abcdef1234567"},
+				},
+			},
 			ok:       true,
 			expected: "dev(abcdef1)",
 		},


### PR DESCRIPTION
Closes #994

## What
`fabrik --version` reported `"dev"` for binaries installed via `go install github.com/handarbeit/fabrik@vX.Y.Z`, even though the requested tag was correctly resolved and built. This made the documented `go install` instructions look like they produced a dev build.

## Root cause
`versionWithSHA` in `cmd/version.go` only enriched the `"dev"` default using `info.Settings["vcs.revision"]`. That setting is only present for VCS-stamped builds (`go build`/`go run` inside a checkout) — `go install pkg@vX.Y.Z` has no `vcs.revision` but does populate `debug.BuildInfo.Main.Version` with the resolved module version.

## Fix
`versionWithSHA` now checks `info.Main.Version` before falling back to the VCS-SHA logic:
- If `Main.Version` is a real value (not empty, not the `"(devel)"` local-checkout sentinel), return it directly — this is the `go install pkg@vX.Y.Z` case.
- Otherwise, fall through unchanged to the existing `vcs.revision`-based `dev(<sha>)` enrichment (local checkout builds) or plain `"dev"` (no VCS info at all).
- goreleaser ldflags-injected builds are unaffected — they short-circuit at the top of the function since `Version != "dev"`.

## Testing
- Added `buildInfoWithMainVersion` helper and two new table-driven cases to `cmd/version_test.go`:
  - `Main.Version = "v0.0.71"`, no `vcs.revision` → expects `"v0.0.71"`
  - `Main.Version = "(devel)"` with a `vcs.revision` present → expects fallthrough to `"dev(abcdef1)"`, confirming local-checkout behavior is unchanged
- `go test ./cmd/...` — all `TestVersionWithSHA` cases pass
- `go test ./...` — full suite passes except one pre-existing, unrelated flaky test (`TestExecute_ConfigYAMLApplied`, a SIGINT-handling test unrelated to version logic — confirmed it fails identically with these changes stashed out)
- `go vet ./...` clean, `gofmt` clean