### PR TITLE
docs: sync README merge-train opt-in with USER_GUIDE three-tier phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ On a repo with `strict` branch protection, landing several ready PRs serially pr
 Two landing engines share one `Queued` board column, and Fabrik picks per repo:
 
 - **GitHub's native merge queue** (ADR-058) — used automatically when the repo has one enabled (Enterprise Cloud or org-owned public repos). Kill-switch: `--merge-queue off`.
-- **Fabrik's internal merge train** (ADR-059) — the plan- and host-agnostic fallback for private Team and personal-account repos where GitHub's native queue isn't available. It stages a trial branch per repo, runs one combined Validate, and lands the batch atomically; a red batch is isolated via halving bisection so a single poisoner doesn't block the rest. Opt-in via `--merge-train on`.
+- **Fabrik's internal merge train** (ADR-059) — the plan- and host-agnostic fallback for private Team and personal-account repos where GitHub's native queue isn't available. It stages a trial branch per repo, runs one combined Validate, and lands the batch atomically; a red batch is isolated via halving bisection so a single poisoner doesn't block the rest. It is opt-in via `--merge-train on`, `FABRIK_MERGE_TRAIN=on`, or `merge_train: on` in `.fabrik/config.yaml`.
 
 Native queue routing defaults to `auto` (it only engages on repos where GitHub's native queue is already enabled); the merge train defaults to `off`. Both leave the existing serial auto-merge path untouched unless explicitly turned on. See [Merge Queue](docs/USER_GUIDE.md#merge-queue) and [Merge Train / Queued](docs/USER_GUIDE.md#merge-train--queued) in the User Guide for setup (including the required `Queued` board column) and tuning knobs.
 


### PR DESCRIPTION
Closes #997

## What

Brings README.md's "Merge Train & Merge Queue (Optional)" section in line with `docs/USER_GUIDE.md`'s already-updated (v0.0.72, commit `4b88840e`) three-tier opt-in phrasing for merge-train.

## Changes

- `README.md` § Merge Train & Merge Queue: expanded "Opt-in via `--merge-train on`." to "It is opt-in via `--merge-train on`, `FABRIK_MERGE_TRAIN=on`, or `merge_train: on` in `.fabrik/config.yaml`.", mirroring the exact wording pattern in `docs/USER_GUIDE.md` § Merge Train / Queued.

## Verified out of scope (no changes needed)

- README.md Flags table (`--merge-train` row) — format intentionally has no config.yaml column across all rows; unaffected by this release.
- `docs/index.md` merge-train feature card — generic description, no flag/env/config specifics to update.
- `docs/USER_GUIDE.md` — already complete for v0.0.72 (config.yaml example, env var table, three-tier prose all landed in `4b88840e`).
- `docs/llms-full.txt` — README.md is not part of the canonical doc bundle (`scripts/generate-llms-full.sh`'s `ORDERED` list is `USER_GUIDE.md`, `state-machine.md`, `stage-lifecycle.md`, `positioning.md`), so no regeneration is needed since no canonical page changed.

## How to test

Read the updated paragraph in README.md § "Merge Train & Merge Queue (Optional)" and compare against `docs/USER_GUIDE.md` § "Merge Train / Queued" — the opt-in mechanism phrasing should now match.