### PR TITLE
docs(readme): add License section (Apache-2.0, no CLA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,3 +506,7 @@ See [adrs/](adrs/) for documented decisions and their rationale. Of particular n
   - Fine-grained tokens (`github_pat_...`) are **not supported** — GitHub Projects v2 GraphQL requires a classic PAT
   - Create one at: https://github.com/settings/tokens (select "Tokens (classic)")
 - A GitHub Project (v2) with board columns matching your stage names
+
+## License
+
+[Apache License 2.0](LICENSE). Contributions are accepted under the same license (see [CONTRIBUTING.md](CONTRIBUTING.md)) — no CLA required.


### PR DESCRIPTION
The README had no license mention at all — a conspicuous gap for a public repo. Adds a standard `## License` section pointing to the Apache-2.0 `LICENSE` and `CONTRIBUTING.md`, and states explicitly that no CLA is required (Apache-2.0 §5 covers the inbound grant).

LICENSE is already full Apache-2.0 text; no stray MIT references anywhere on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)