### PR TITLE
fix(engine): inject engine's resolved GitHub token into Claude worker env

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5856,6 +5856,10 @@ Context files are available in .fabrik-context/
 --allowedTools <tool> ...     (if restricted)
 ```
 
+### Worker Environment: GitHub Identity
+
+The Claude worker subprocess's environment is assembled as `mergeEnv(os.Environ(), extraEnv)` — the base is the engine process's own environment, with `extraEnv` entries taking precedence on key collision (last-wins). Alongside `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` and `CLAUDE_CODE_EFFORT_LEVEL`, `extraEnv` includes `GH_TOKEN` and `GITHUB_TOKEN`, both set to the engine's resolved GitHub token (`Config.Token`, the same value used for the engine's own `gh.NewClient` calls). This guarantees the worker's `gh` invocations (available via the default `Bash(gh:*)` allowed tool) always authenticate as the same identity as the engine itself, regardless of what `GH_TOKEN`/`GITHUB_TOKEN` the launching shell happens to export. Injection is skipped only when the engine's resolved token is empty, which should not occur in practice since a token is mandatory at startup.
+
 ### Output Logging
 
 Each invocation writes one NDJSON stream file to `.fabrik/logs/<owner>-<repo>/issue-<N>/` as `<stage>-<timestamp>-<nanos>.log`. This file is written live during execution (tee'd from Claude's stdout) and is the sole on-disk copy of the stream. Viewable via `cat <file> | fabrik stream-filter | less -R` or through the TUI's `l` key.

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -236,6 +236,10 @@ Context files are available in .fabrik-context/
 --allowedTools <tool> ...     (if restricted)
 ```
 
+### Worker Environment: GitHub Identity
+
+The Claude worker subprocess's environment is assembled as `mergeEnv(os.Environ(), extraEnv)` — the base is the engine process's own environment, with `extraEnv` entries taking precedence on key collision (last-wins). Alongside `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` and `CLAUDE_CODE_EFFORT_LEVEL`, `extraEnv` includes `GH_TOKEN` and `GITHUB_TOKEN`, both set to the engine's resolved GitHub token (`Config.Token`, the same value used for the engine's own `gh.NewClient` calls). This guarantees the worker's `gh` invocations (available via the default `Bash(gh:*)` allowed tool) always authenticate as the same identity as the engine itself, regardless of what `GH_TOKEN`/`GITHUB_TOKEN` the launching shell happens to export. Injection is skipped only when the engine's resolved token is empty, which should not occur in practice since a token is mandatory at startup.
+
 ### Output Logging
 
 Each invocation writes one NDJSON stream file to `.fabrik/logs/<owner>-<repo>/issue-<N>/` as `<stage>-<timestamp>-<nanos>.log`. This file is written live during execution (tee'd from Claude's stdout) and is the sole on-disk copy of the stream. Viewable via `cat <file> | fabrik stream-filter | less -R` or through the TUI's `l` key.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -89,6 +89,13 @@ var claudeKillGraceSigInt = 10 * time.Second
 // Default 10s; set from Config.KillGraceSigTerm in New().
 var claudeKillGraceSigTerm = 10 * time.Second
 
+// claudeGHToken is the engine's resolved GitHub token (Config.Token). Set by
+// the Engine during construction. Injected into every Claude worker's
+// environment as GH_TOKEN and GITHUB_TOKEN so the worker's gh invocations
+// always authenticate as the same identity as the engine itself, regardless
+// of the launching shell's ambient environment. Empty skips injection.
+var claudeGHToken string
+
 // killReasonCtxKey is the context key for kill reason annotation.
 type killReasonCtxKey struct{}
 
@@ -420,6 +427,9 @@ func buildClaudeEnv(stage *stages.Stage, effortOverride string) []string {
 		level = "high"
 	}
 	env = append(env, "CLAUDE_CODE_EFFORT_LEVEL="+level)
+	if claudeGHToken != "" {
+		env = append(env, "GH_TOKEN="+claudeGHToken, "GITHUB_TOKEN="+claudeGHToken)
+	}
 	return env
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -177,6 +177,7 @@ func New(cfg Config) (*Engine, error) {
 	} else {
 		claudeKillGraceSigTerm = 10 * time.Second
 	}
+	claudeGHToken = cfg.Token
 	worktreeRoot := filepath.Join(fabrikDir, ".fabrik", "worktrees")
 	sharedStore := itemstate.NewStore(nil)
 	eng := &Engine{

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -1049,6 +1049,7 @@ printf '%%s\n' '{"result":"gh token test\nFABRIK_STAGE_COMPLETE\n","session_id":
 	}
 
 	t.Run("token injected as GH_TOKEN and GITHUB_TOKEN", func(t *testing.T) {
+		_ = os.Remove(envFile)
 		claudeGHToken = "engine-token"
 		t.Cleanup(func() { claudeGHToken = "" })
 
@@ -1071,6 +1072,7 @@ printf '%%s\n' '{"result":"gh token test\nFABRIK_STAGE_COMPLETE\n","session_id":
 	})
 
 	t.Run("engine token wins over ambient shell value", func(t *testing.T) {
+		_ = os.Remove(envFile)
 		claudeGHToken = "engine-token"
 		t.Cleanup(func() { claudeGHToken = "" })
 		t.Setenv("GH_TOKEN", "wrong-ambient-gh")
@@ -1098,6 +1100,7 @@ printf '%%s\n' '{"result":"gh token test\nFABRIK_STAGE_COMPLETE\n","session_id":
 	})
 
 	t.Run("no token configured skips injection", func(t *testing.T) {
+		_ = os.Remove(envFile)
 		claudeGHToken = ""
 		// Unset ambient GH_TOKEN/GITHUB_TOKEN for this subtest so the
 		// assertion below isn't confounded by whatever the host environment

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -1020,6 +1020,117 @@ printf '%%s\n' '{"result":"env test\nFABRIK_STAGE_COMPLETE\n","session_id":"sess
 	})
 }
 
+// TestInvokeClaude_GHTokenInjected verifies that the engine's resolved GitHub
+// token (claudeGHToken, set from Config.Token in Engine.New) is injected into
+// the worker's environment as both GH_TOKEN and GITHUB_TOKEN, that the
+// injection wins over an ambient value already present in the base
+// environment, and that injection is skipped when no token is configured.
+func TestInvokeClaude_GHTokenInjected(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	envFile := filepath.Join(binDir, "env.txt")
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := fmt.Sprintf(`#!/bin/sh
+cat >/dev/null
+env > %s
+printf '%%s\n' '{"result":"gh token test\nFABRIK_STAGE_COMPLETE\n","session_id":"sess_ghtoken","num_turns":1,"total_cost_usd":0.0}'
+`, envFile)
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "Research",
+		Prompt:     "Do research",
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+
+	t.Run("token injected as GH_TOKEN and GITHUB_TOKEN", func(t *testing.T) {
+		claudeGHToken = "engine-token"
+		t.Cleanup(func() { claudeGHToken = "" })
+
+		issue := gh.ProjectItem{Number: 200, Title: "GH token test"}
+		_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		if err != nil {
+			t.Fatalf("InvokeClaude: %v", err)
+		}
+		data, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("reading env file: %v", err)
+		}
+		env := string(data)
+		if !strings.Contains(env, "\nGH_TOKEN=engine-token\n") {
+			t.Errorf("expected GH_TOKEN=engine-token in env, got:\n%s", env)
+		}
+		if !strings.Contains(env, "\nGITHUB_TOKEN=engine-token\n") {
+			t.Errorf("expected GITHUB_TOKEN=engine-token in env, got:\n%s", env)
+		}
+	})
+
+	t.Run("engine token wins over ambient shell value", func(t *testing.T) {
+		claudeGHToken = "engine-token"
+		t.Cleanup(func() { claudeGHToken = "" })
+		t.Setenv("GH_TOKEN", "wrong-ambient-gh")
+		t.Setenv("GITHUB_TOKEN", "wrong-ambient-github")
+
+		issue := gh.ProjectItem{Number: 201, Title: "GH token override test"}
+		_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		if err != nil {
+			t.Fatalf("InvokeClaude: %v", err)
+		}
+		data, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("reading env file: %v", err)
+		}
+		env := string(data)
+		if !strings.Contains(env, "\nGH_TOKEN=engine-token\n") {
+			t.Errorf("expected GH_TOKEN=engine-token to win over ambient value, got:\n%s", env)
+		}
+		if !strings.Contains(env, "\nGITHUB_TOKEN=engine-token\n") {
+			t.Errorf("expected GITHUB_TOKEN=engine-token to win over ambient value, got:\n%s", env)
+		}
+		if strings.Contains(env, "wrong-ambient") {
+			t.Errorf("expected ambient GH_TOKEN/GITHUB_TOKEN values to be fully overridden, got:\n%s", env)
+		}
+	})
+
+	t.Run("no token configured skips injection", func(t *testing.T) {
+		claudeGHToken = ""
+		// Unset ambient GH_TOKEN/GITHUB_TOKEN for this subtest so the
+		// assertion below isn't confounded by whatever the host environment
+		// (e.g. a developer's own gh auth) happens to export.
+		origGH, hadGH := os.LookupEnv("GH_TOKEN")
+		origGithub, hadGithub := os.LookupEnv("GITHUB_TOKEN")
+		os.Unsetenv("GH_TOKEN")
+		os.Unsetenv("GITHUB_TOKEN")
+		t.Cleanup(func() {
+			if hadGH {
+				os.Setenv("GH_TOKEN", origGH)
+			}
+			if hadGithub {
+				os.Setenv("GITHUB_TOKEN", origGithub)
+			}
+		})
+
+		issue := gh.ProjectItem{Number: 202, Title: "GH token empty test"}
+		_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		if err != nil {
+			t.Fatalf("InvokeClaude: %v", err)
+		}
+		data, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("reading env file: %v", err)
+		}
+		env := string(data)
+		if strings.Contains(env, "GH_TOKEN=") || strings.Contains(env, "GITHUB_TOKEN=") {
+			t.Errorf("expected neither GH_TOKEN nor GITHUB_TOKEN to be present when claudeGHToken is empty, got:\n%s", env)
+		}
+	})
+}
+
 // TestBuildClaudeArgs_PermissionModeDontAsk verifies that --permission-mode dontAsk
 // is passed for non-unrestricted invocations.
 func TestBuildClaudeArgs_PermissionModeDontAsk(t *testing.T) {


### PR DESCRIPTION
Closes #1009

## What this does

The Fabrik engine resolves its GitHub token via `config.Token()` and uses it for all its own API calls, but the Claude worker subprocess it spawns never received that token — it inherited whatever `GH_TOKEN`/`GITHUB_TOKEN` happened to be in the engine's ambient shell. When those differ, the worker's `gh` calls (available via the default `Bash(gh:*)` allowed tool) silently authenticate as the wrong identity.

This PR injects the engine's resolved token into every Claude worker subprocess's environment as both `GH_TOKEN` and `GITHUB_TOKEN`, so the worker always matches the engine's identity regardless of the launching shell.

## Key changes

- `engine/claude.go`: new package-level var `claudeGHToken`, set once per Engine instance (mirroring the existing `claudePluginDir`/`claudeKillGraceSigInt` pattern). `buildClaudeEnv` appends `GH_TOKEN=`/`GITHUB_TOKEN=` when the var is non-empty. `mergeEnv`'s existing last-wins semantics ensure this overrides any ambient shell value.
- `engine/engine.go`: `New()` sets `claudeGHToken = cfg.Token` alongside the other engine-construction-set package vars.
- This is a package-var approach (not threaded through `InvokeOptions`), so it automatically covers all three worker invocation sites — stage-run, comment-review, and merge-train's inline conflict resolution — with zero call-site wiring and no risk of a missed site.
- `docs/stage-lifecycle.md`: documents the new worker environment behavior; `docs/llms-full.txt` regenerated per project convention.

## How to test

- `engine/invoke_claude_test.go`: new `TestInvokeClaude_GHTokenInjected` with three subtests — token injected when configured, injected value wins over an ambient `GH_TOKEN`/`GITHUB_TOKEN` already in the environment, and injection is a no-op when no token is configured.
- `go build -o fabrik .`, `go test -race ./...`, `go vet ./...` all pass (one pre-existing, unrelated flaky test — `TestExecute_ConfigYAMLApplied`, a network-dependent GraphQL fetch — fails identically on the unmodified branch).