### PR TITLE
tui: hide warnings pane when there are no warnings

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -371,7 +371,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case paneActive:
 				m.focusPane = paneHistory
 			case paneHistory:
-				m.focusPane = paneWarnings
+				// Skip the warnings pane when it is empty (hidden), so tab
+				// never lands focus on an invisible pane.
+				if m.warnings.IsEmpty() {
+					m.focusPane = paneActive
+				} else {
+					m.focusPane = paneWarnings
+				}
 			default:
 				m.focusPane = paneActive
 			}

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/handarbeit/fabrik/warnings"
 )
 
 func TestNew(t *testing.T) {
@@ -97,11 +98,15 @@ func TestUpdate_QuitKey(t *testing.T) {
 	}
 }
 
-// TestUpdate_TabKey_SwitchesPanes verifies tab cycles through all three panes.
+// TestUpdate_TabKey_SwitchesPanes verifies tab cycles through all three panes
+// when the warnings pane has content.
 func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
 	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
 	m.width = 80
 	m.height = 24
+	// Seed a warning so the warnings pane is non-empty and participates in the
+	// focus cycle.
+	m.warnings.entries = []warnings.Entry{{Key: "k1", Title: "a warning"}}
 	if m.focusPane != paneActive {
 		t.Fatal("expected initial pane to be active")
 	}
@@ -122,6 +127,28 @@ func TestUpdate_TabKey_SwitchesPanes(t *testing.T) {
 	nm3 := next3.(Model)
 	if nm3.focusPane != paneActive {
 		t.Error("expected pane to switch back to active after third tab")
+	}
+}
+
+// TestUpdate_TabKey_SkipsEmptyWarningsPane verifies tab skips the warnings pane
+// when it is empty (hidden), so focus never lands on an invisible pane.
+func TestUpdate_TabKey_SkipsEmptyWarningsPane(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	m.width = 80
+	m.height = 24
+	m.warnings.entries = nil // no warnings → pane hidden
+	if !m.warnings.IsEmpty() {
+		t.Fatal("expected warnings pane to be empty")
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	nm := next.(Model)
+	if nm.focusPane != paneHistory {
+		t.Fatalf("expected history after first tab, got %v", nm.focusPane)
+	}
+	next2, _ := nm.Update(tea.KeyMsg{Type: tea.KeyTab})
+	nm2 := next2.(Model)
+	if nm2.focusPane != paneActive {
+		t.Errorf("expected active after second tab (warnings skipped), got %v", nm2.focusPane)
 	}
 }
 

--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -133,6 +133,17 @@ func (c WarningsPaneComponent) visibleEntries() []warnings.Entry {
 	return out
 }
 
+// dismissedCount returns the number of dismissed entries.
+func (c WarningsPaneComponent) dismissedCount() int {
+	n := 0
+	for _, e := range c.entries {
+		if e.Dismissed {
+			n++
+		}
+	}
+	return n
+}
+
 // currentVisible returns the currently selected visible entry, or nil.
 func (c WarningsPaneComponent) currentVisible() *warnings.Entry {
 	visible := c.visibleEntries()
@@ -140,6 +151,13 @@ func (c WarningsPaneComponent) currentVisible() *warnings.Entry {
 		return nil
 	}
 	return &visible[c.curIdx]
+}
+
+// IsEmpty reports whether the pane has nothing to render — no active
+// warnings and no dismissed ones to advertise. Used to skip it in the focus
+// cycle so tab never lands on an invisible pane.
+func (c WarningsPaneComponent) IsEmpty() bool {
+	return len(c.visibleEntries()) == 0 && c.dismissedCount() == 0
 }
 
 // SelectedEntry returns the currently selected entry, or nil if none.
@@ -165,6 +183,12 @@ func (c WarningsPaneComponent) Height() int {
 	}
 	visible := c.visibleEntries()
 	if len(visible) == 0 {
+		// No active warnings: collapse the pane entirely so it consumes no
+		// space. Keep a single hint line only when dismissed warnings exist,
+		// so they remain discoverable.
+		if c.dismissedCount() == 0 {
+			return 0
+		}
 		return 1
 	}
 	rows := min(len(visible), maxWarningRows)
@@ -196,18 +220,14 @@ func (c WarningsPaneComponent) View(width int) string {
 	visible := c.visibleEntries()
 
 	if len(visible) == 0 {
-		// Count dismissed entries for the footer hint.
-		dismissedCount := 0
-		for _, e := range c.entries {
-			if e.Dismissed {
-				dismissedCount++
-			}
+		// No active warnings: render nothing so the pane consumes no space.
+		// Keep a single hint line only when dismissed warnings exist, so they
+		// remain discoverable.
+		dismissedCount := c.dismissedCount()
+		if dismissedCount == 0 {
+			return ""
 		}
-		msg := "  Warnings: none"
-		if dismissedCount > 0 {
-			msg = fmt.Sprintf("  Warnings: none (%d dismissed, press tab + S to show)", dismissedCount)
-		}
-		return dimStyle.Render(msg)
+		return dimStyle.Render(fmt.Sprintf("  Warnings: none (%d dismissed, press tab + S to show)", dismissedCount))
 	}
 
 	innerWidth := max(width-6, 20)


### PR DESCRIPTION
## Problem

The TUI warnings pane always rendered a `Warnings: none` line and reserved a row even when there was nothing to show, consuming a line of vertical space in the common (no-warnings) case.

## Change

- Collapse the pane entirely (`Height() == 0`, `View() == ""`) when there are no active warnings **and** no dismissed ones to advertise.
- Keep the single-line `Warnings: none (N dismissed, press tab + S to show)` hint **only** when dismissed warnings exist, so they remain discoverable.
- Skip the warnings pane in the `tab` focus cycle when it is empty, so focus never lands on an invisible pane.

The existing `model.View()` already guards the pane with `warningsView != ""`, so a zero-height/empty pane cleanly consumes no space.

## Tests

- Updated `TestUpdate_TabKey_SwitchesPanes` to seed a warning so it exercises the real three-pane cycle.
- Added `TestUpdate_TabKey_SkipsEmptyWarningsPane` verifying tab skips the hidden pane.
- `go build ./...`, `go test ./tui/` (186 passed), `go vet ./tui/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)