### PR TITLE
tui: simplify WarningsPaneComponent.IsEmpty

### DIFF
--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -157,7 +157,10 @@ func (c WarningsPaneComponent) currentVisible() *warnings.Entry {
 // warnings and no dismissed ones to advertise. Used to skip it in the focus
 // cycle so tab never lands on an invisible pane.
 func (c WarningsPaneComponent) IsEmpty() bool {
-	return len(c.visibleEntries()) == 0 && c.dismissedCount() == 0
+	// Any entry — active or dismissed — means the pane renders something (a
+	// warning row, or the "none (N dismissed…)" hint), so it's only truly
+	// empty when there are no entries at all.
+	return len(c.entries) == 0
 }
 
 // SelectedEntry returns the currently selected entry, or nil if none.


### PR DESCRIPTION
Follow-up to #1011 (which auto-merged before this review nit could be pushed).

Addresses the Gemini review on #1011: `IsEmpty()` is equivalent to `len(c.entries) == 0` — any entry, active or dismissed, means the pane renders something (a warning row, or the `none (N dismissed…)` hint). This drops the `visibleEntries()` slice allocation and double iteration on the layout/tab hot paths.

`go build ./...`, `go test ./tui/` (186 passed), `go vet ./tui/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)