### PR TITLE
feat(engine): add worktree cwd-rooted process reaper for setsid'd descendants

### DIFF
--- a/adrs/063-worktree-cwd-rooted-process-reaper.md
+++ b/adrs/063-worktree-cwd-rooted-process-reaper.md
@@ -1,0 +1,81 @@
+# ADR 063: Worktree cwd-Rooted Process Reaper
+
+**Date**: 2026-07-19
+**Status**: Accepted
+**Issue**: #975 — bug(cleanup): orphaned child processes survive stage teardown — PGID-scoped 'grandchild cleanup' misses setsid'd descendants (e.g. dev servers)
+
+## Context
+
+Fabrik's existing subprocess cleanup (`killProcGroup`, `engine/procattr_unix.go`, documented in ADR 054) sends `SIGKILL` to the Claude worker's entire process group — `kill(-workerPGID, SIGKILL)` — immediately before a worktree directory is removed. This reaches any grandchild that stayed in the worker's process group (e.g. `tail -f` from the Monitor tool).
+
+It does not reach a descendant that calls `setsid()`. This is exactly what happens when a Claude worker backgrounds a long-lived process to verify the app under test — `npm run dev`, `vite`, `next dev` — via Claude Code's background-bash tool, which detaches the process into its own session (and therefore its own process group) so it survives across tool calls. A production run against `verveguy/concept-maps` issue #155 confirmed this exact failure mode: the worker's PGID (73452) was killed as logged, but the dev server's PGID (76028) — a different group entirely, its leader already dead, members still running — survived, reparented to `launchd` (PID 1 equivalent), `cwd` still pointing at a worktree directory removed 25 minutes earlier, port 5174 still bound.
+
+`git worktree remove` deletes the directory; it does not touch processes that happen to have their cwd rooted there. These orphans accumulate — potentially one per issue whose worker starts a long-lived server — most visible on a developer machine running the TUI locally across many issues, manifesting as port exhaustion and unbounded resource growth on a long-running engine.
+
+## Decision
+
+Add `reapWorktreeProcesses(wtDir string, issueNumber int, logf func(int, string, string, ...any))`, a cwd-rooted process reaper that enumerates every live process whose current working directory is the given worktree path or a subdirectory of it, and sends `SIGKILL` to each. It runs immediately before every worktree directory removal, as a complement to (not a replacement for) the existing PGID-scoped `killProcGroup` — the PGID kill still handles the common case of grandchildren that stayed in the worker's process group; this reaper extends coverage to the `setsid`'d case by keying off cwd instead of process-group membership.
+
+### Package-level function, not a `WorktreeManager` method
+
+Of the four worktree-directory-removal call sites in the codebase, one — the worktree janitor's `os.RemoveAll` fallback (`engine/janitor.go`), which fires when the bare repo for a stranded worktree is missing — has no `WorktreeManager` instance available at all; that is exactly why it falls back to raw `os.RemoveAll` instead of `WorktreeManager.CleanupWorktree`. A method on `WorktreeManager` structurally cannot be called from this site. `reapWorktreeProcesses` is therefore a free function, parameterized by a `logf func(int, string, string, ...any)` callback — a signature both `WorktreeManager.logf` and `Engine.logf` already share, so both call it directly with no adapter.
+
+### Every removal call site routes through the same primitive
+
+Rather than reaping inline inside just `CleanupWorktree` and `CleanupTrainWorktree` (the two sites the issue's own requirements text named), all four removal call sites call `reapWorktreeProcesses` immediately before their own removal operation:
+
+1. `WorktreeManager.CleanupWorktree` (`engine/worktree.go`) — issue worktree teardown, called from both the Done-stage teardown (`engine/item.go`) and the periodic janitor (`engine/janitor.go`).
+2. `WorktreeManager.ensureTrainWorktreeFromRef`'s stale-worktree removal (`engine/worktree.go`) — crash-recovery cleanup of a leftover trial worktree before a merge-train trial branch is recreated under the same name. A crashed trial's detached server (e.g. from a build/CI command) would otherwise still be running with cwd rooted in the worktree that is about to be reused.
+3. `WorktreeManager.CleanupTrainWorktree` (`engine/worktree.go`) — merge-train trial worktree teardown.
+4. The worktree janitor's `os.RemoveAll` fallback (`engine/janitor.go`) — the site that motivated the package-level-function decision above.
+
+This was a load-bearing finding from a hard-look steering pass before implementation: the issue's own requirements text enumerated only sites 1 and 3, but sites 2 and 4 are equally directory-removal paths where orphaned processes are expected. A narrower fix — reaping only inside `CleanupWorktree`/`CleanupTrainWorktree` — would have left both gaps open. Routing every site through one shared primitive, rather than hand-maintaining a longer enumeration, satisfies "every code path that removes a worktree directory" by construction: a future removal site added elsewhere in the codebase without also calling `reapWorktreeProcesses` would be an obvious, greppable omission rather than a silent gap.
+
+### Platform implementation
+
+Two-way build tag split (`engine/reaper_unix.go` tagged `!windows`, `engine/reaper_windows.go` tagged `windows`), matching the existing `procattr_unix.go`/`procattr_windows.go` precedent exactly rather than introducing a three-way darwin/linux/windows split with no precedent in this package. `reaper_unix.go` branches internally on `runtime.GOOS` (already used elsewhere in the engine package, e.g. `engine/upgrade.go`) between the Linux and macOS implementations:
+
+- **Linux**: scans `/proc/*/cwd` symlinks via `os.ReadDir("/proc")` + `os.Readlink`, prefix-matching each resolved cwd against the worktree directory. No external dependency, fast. Before killing a match, it re-reads `/proc/<pid>/cwd` one more time to close the TOCTOU window in which the pid could have been recycled for an unrelated process between the initial enumeration and the kill.
+- **macOS**: runs `lsof -a -d cwd -n -P -Fpcn`. This was a deliberate choice over the issue's own suggested `lsof +D <worktree>`: `+D` recursively inspects every open file descriptor of every process under the entire directory tree, which is slow and prone to hanging on a `node_modules`-heavy worktree or a stale mount — unacceptable on a synchronous teardown path that runs on every worktree removal. `-d cwd` inspects only each process's cwd file descriptor. `-F` (with `pcn`: pid, command, name/path fields) gives stable, parseable field-per-line output instead of fragile column-width parsing. macOS has no `/proc`-equivalent cheap per-pid re-check primitive, so unlike Linux, the reaper does not re-verify cwd immediately before killing on this platform — the small PID-reuse TOCTOU window here is accepted and documented rather than mitigated.
+- **Windows**: no-op, matching `killProcGroup`'s existing documented Windows precedent (`procattr_windows.go`) — process-group and cwd-enumeration primitives here are Unix-specific with no direct Windows equivalent wired up.
+
+Both platform paths resolve symlinks in the worktree directory once, via `filepath.EvalSymlinks`, before matching. This was found necessary during implementation: `/proc/*/cwd` (Linux) and `lsof`'s reported path (macOS) both report the fully-resolved real path — e.g. macOS resolves `/tmp` → `/private/tmp` and `/var` → `/private/var` — which silently defeated a literal string-prefix match against `t.TempDir()`-style paths (themselves under `/var/folders/...` on macOS, without the `/private` prefix) in initial testing.
+
+### Non-fatal by construction
+
+`reapWorktreeProcesses` returns nothing and never propagates an error. Enumeration failures (`lsof` not installed, a `/proc/<pid>/cwd` read racing process exit, permission errors) and kill failures other than `ESRCH` (already-exited, an expected race) are logged as warnings via the `logf` callback; the caller's subsequent `git worktree remove` / `os.RemoveAll` always proceeds regardless of the reap's outcome, per the issue's explicit requirement that this must never block or fail worktree teardown.
+
+### Logging
+
+Each kill reuses the existing `[#N kill] ...` log tag (`"kill"`), not a new tag, so it appears in the same grep/log-scanning workflows as `killProcGroup`'s grandchild-cleanup line: `[#N kill] sending SIGKILL to PID <pid> (<comm>) rooted in <wtDir> (worktree cwd cleanup)` — the `(worktree cwd cleanup)` parenthetical mirrors the existing `(grandchild cleanup)` style so the two mechanisms are visually distinguishable but recognizably related in the log stream.
+
+## Rationale
+
+### Why cwd, not a full process-tree walk from the worker's PID?
+
+A descendant-tree walk (e.g. via `PR_SET_CHILD_SUBREAPER` on Linux, reparenting orphans to the engine instead of `PID 1`) would also catch fd-only holders and processes that `chdir` away after starting — a strictly larger class of leak. It was considered and explicitly deferred: it is Linux-only, the reported evidence for this issue is macOS, and cwd-based detection is portable and directly matches the reported failure mode (a process whose cwd is the deleted worktree). Noted here as possible future hardening, not undertaken in this issue.
+
+### Why not extend `killProcGroup` itself?
+
+`killProcGroup` operates on a single already-known PGID (the worker's own). Reaching a `setsid`'d descendant requires system-wide process enumeration keyed on a different property (cwd) entirely — a fundamentally different operation, not a variant of a PGID kill. Keeping them as two separate, composable mechanisms (one PGID-scoped and immediate, one cwd-scoped and worktree-removal-scoped) keeps each simple and independently testable, and preserves `killProcGroup`'s existing, unrelated call sites (kill escalation during `max_wall_time`/inactivity timeouts) untouched.
+
+## Consequences
+
+**Positive:**
+- Detached dev servers and similar `setsid`'d descendants no longer survive worktree teardown and outlive their deleted worktree directory — the specific, evidenced leak class this issue reports is closed for all newly-removed worktrees.
+- All four worktree-directory-removal call sites are covered by construction (one shared primitive, not a hand-maintained enumeration), so a future removal site is unlikely to silently reintroduce the gap.
+- Fully non-fatal: a missing `lsof`, a permission error, or a `/proc` race degrades gracefully to "no reap, just a warning" rather than blocking or failing worktree cleanup.
+
+**Negative / Trade-offs:**
+- **PID-reuse TOCTOU window on macOS**: accepted, not mitigated (no cheap re-check primitive without `/proc`). In practice the window is the time between one `lsof` invocation's output line and the immediately following `kill` call — very small, but not zero.
+- **`chdir`'d descendants are not caught**: a dev-server framework that opens resources in the worktree and then `chdir`s elsewhere still leaks under this design. Explicitly out of scope per the issue; the portable, evidence-matching cwd approach was chosen deliberately over a broader (and Linux-only) descendant-tree walk.
+- **Not a retroactive sweep**: this only prevents *new* leaks going forward. Processes already orphaned by worktrees removed before this fix shipped are not reaped by it; operators must clean those up manually. Explicitly scoped out by the issue.
+- **Worker-side hygiene is a separate, complementary fix**: #976 tracks having workers avoid leaving detached servers running in the first place. This engine-side reaper is the more robust fix because it catches leaks regardless of worker behavior, but the two are independent and both worth having.
+
+## Related Work
+
+- [ADR 054: SIGINT Kill Escalation and Reason Propagation](054-sigint-kill-escalation-and-reason-propagation.md) — the PGID-scoped mechanism this reaper complements; see `docs/stage-lifecycle.md` § Subprocess Cleanup.
+- [ADR 055: Periodic Worktree Janitor](055-worktree-janitor.md) — reaps orphaned worktree *directories*; this reaper is its immediate-teardown counterpart for orphaned *processes*, and automatically benefits the janitor's own `CleanupWorktree`/`os.RemoveAll` paths.
+- Companion issue **#976** — worker-side hygiene (verify steps shouldn't leave detached servers running), filed as defense-in-depth alongside this engine-side fix.
+
+**References:** [docs/stage-lifecycle.md § Worktree Teardown Process Reaping](../docs/stage-lifecycle.md), [docs/state-machine.md § 11.3 Reaping Gate](../docs/state-machine.md)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5184,6 +5184,10 @@ condition is left in place and counted toward the `skipped` total.
 **Cleanup path (FR-6):**  
 `WorktreeManager.CleanupWorktree(number, false)` — the same path used by the Done stage.
 If the bare repo is absent (manually deleted), falls back to `os.RemoveAll` with a warning.
+Both paths now run the cwd-rooted process reaper immediately before removing the directory
+(including the `os.RemoveAll` fallback) — see
+[stage-lifecycle.md § Worktree Teardown Process Reaping](stage-lifecycle.md#worktree-teardown-process-reaping)
+for detail.
 
 ### 11.4 Owner/Repo Resolution
 
@@ -5899,6 +5903,31 @@ After `cmd.Run()` returns, two cleanup steps run unconditionally:
    After `cmd.Wait()` returns, a second unconditional `SIGKILL` is sent to the process group to clean up any grandchildren (e.g. `tail -f` from the Monitor tool) that survived the Claude subprocess exit. This grandchild cleanup fires regardless of how the main subprocess exited.
 
 2. **WaitDelay bound**: `cmd.WaitDelay` is set to 30s (configurable via `--claude-wait-delay` / `FABRIK_CLAUDE_WAIT_DELAY`). When grandchild processes hold the stdout pipe open after Claude exits, Go's `cmd.Wait()` would otherwise block indefinitely. With `WaitDelay`, Go forcibly closes its end of the pipe after the deadline and returns `exec.ErrWaitDelay`. The engine detects this error, logs a diagnostic warning, clears the error, and processes the buffered output normally — including any `FABRIK_STAGE_COMPLETE` marker. This prevents the worker goroutine from being permanently stuck when Claude uses `run_in_background` or the Monitor tool.
+
+### Worktree Teardown Process Reaping
+
+The grandchild cleanup above is **PGID-scoped**: it can only reach descendants that stayed in the worker's process group. A descendant that calls `setsid()` — exactly what Claude Code's background-bash tool does to keep a backgrounded process (e.g. `npm run dev`) alive across tool calls — leaves the worker's process group entirely, taking on a fresh PGID equal to its own PID. `kill(-workerPGID, SIGKILL)` cannot reach it, so it survives Claude's exit and outlives the worktree directory it was started in.
+
+`reapWorktreeProcesses` (`engine/reaper_unix.go`) closes this gap with a **cwd-rooted** reaper, run immediately before every worktree directory removal: it enumerates live processes whose current working directory is the worktree path or a subdirectory of it — regardless of process-group membership — and sends SIGKILL to each. It is a package-level function (not a `WorktreeManager` method), so it can be called from contexts with no `WorktreeManager` instance available.
+
+**Platform implementations:**
+- **Linux**: scans `/proc/*/cwd` symlinks and prefix-matches each against the worktree directory. Immediately before killing a match, it re-reads `/proc/<pid>/cwd` to close the TOCTOU window in which the pid could have been recycled for an unrelated process between enumeration and kill.
+- **macOS**: runs `lsof -a -d cwd -n -P -Fpcn`, which inspects only each process's cwd file descriptor (not every open fd, unlike `lsof +D`) — kept fast and non-hanging on the synchronous teardown path even for a `node_modules`-heavy worktree. macOS has no `/proc`-equivalent cheap re-check primitive, so the same TOCTOU window is accepted rather than mitigated here.
+- **Windows**: no-op (`engine/reaper_windows.go`), matching `killProcGroup`'s existing Windows precedent.
+
+Both platform paths resolve symlinks in the worktree directory before matching (`filepath.EvalSymlinks`), since `/proc/*/cwd` and `lsof`'s reported path are both fully-resolved real paths (e.g. macOS resolves `/tmp` → `/private/tmp`), which would otherwise defeat a literal prefix match.
+
+Each kill is logged via the existing `[#N kill] ...` convention: `[#N kill] sending SIGKILL to PID <pid> (<comm>) rooted in <wtDir> (worktree cwd cleanup)`, alongside the `(grandchild cleanup)` PGID-kill log line so both are visible in the same log stream. Enumeration and kill failures (missing `lsof`, a `/proc/<pid>/cwd` read racing process exit, permission errors) are always non-fatal: logged as a warning, never blocking the caller's own worktree removal.
+
+**Call sites** (every path that removes a worktree directory):
+- `WorktreeManager.CleanupWorktree` — issue worktree teardown (Done-stage teardown, periodic janitor)
+- `WorktreeManager.ensureTrainWorktreeFromRef`'s stale-worktree removal — crash-recovery cleanup before a merge-train trial worktree is recreated under the same name
+- `WorktreeManager.CleanupTrainWorktree` — merge-train trial worktree teardown
+- The worktree janitor's `os.RemoveAll` fallback (`engine/janitor.go`), which fires when no `WorktreeManager` is available for the repo (bare repo missing) — this is why the reaper is a free function rather than a `WorktreeManager` method
+
+**Documented residual risks** (see ADR 063):
+- **PID-reuse TOCTOU on macOS**: unlike Linux, there is no cheap re-check between enumeration and kill, so a small window exists where a recycled pid could receive an unintended SIGKILL.
+- **`chdir`'d descendants are not caught**: this reaper is cwd-based by design (matching the issue's reported failure mode); a process that opened a file in the worktree and then `chdir`'d elsewhere is out of scope and will still leak.
 
 ### Progress Baseline Snapshot
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -280,6 +280,31 @@ After `cmd.Run()` returns, two cleanup steps run unconditionally:
 
 2. **WaitDelay bound**: `cmd.WaitDelay` is set to 30s (configurable via `--claude-wait-delay` / `FABRIK_CLAUDE_WAIT_DELAY`). When grandchild processes hold the stdout pipe open after Claude exits, Go's `cmd.Wait()` would otherwise block indefinitely. With `WaitDelay`, Go forcibly closes its end of the pipe after the deadline and returns `exec.ErrWaitDelay`. The engine detects this error, logs a diagnostic warning, clears the error, and processes the buffered output normally — including any `FABRIK_STAGE_COMPLETE` marker. This prevents the worker goroutine from being permanently stuck when Claude uses `run_in_background` or the Monitor tool.
 
+### Worktree Teardown Process Reaping
+
+The grandchild cleanup above is **PGID-scoped**: it can only reach descendants that stayed in the worker's process group. A descendant that calls `setsid()` — exactly what Claude Code's background-bash tool does to keep a backgrounded process (e.g. `npm run dev`) alive across tool calls — leaves the worker's process group entirely, taking on a fresh PGID equal to its own PID. `kill(-workerPGID, SIGKILL)` cannot reach it, so it survives Claude's exit and outlives the worktree directory it was started in.
+
+`reapWorktreeProcesses` (`engine/reaper_unix.go`) closes this gap with a **cwd-rooted** reaper, run immediately before every worktree directory removal: it enumerates live processes whose current working directory is the worktree path or a subdirectory of it — regardless of process-group membership — and sends SIGKILL to each. It is a package-level function (not a `WorktreeManager` method), so it can be called from contexts with no `WorktreeManager` instance available.
+
+**Platform implementations:**
+- **Linux**: scans `/proc/*/cwd` symlinks and prefix-matches each against the worktree directory. Immediately before killing a match, it re-reads `/proc/<pid>/cwd` to close the TOCTOU window in which the pid could have been recycled for an unrelated process between enumeration and kill.
+- **macOS**: runs `lsof -a -d cwd -n -P -Fpcn`, which inspects only each process's cwd file descriptor (not every open fd, unlike `lsof +D`) — kept fast and non-hanging on the synchronous teardown path even for a `node_modules`-heavy worktree. macOS has no `/proc`-equivalent cheap re-check primitive, so the same TOCTOU window is accepted rather than mitigated here.
+- **Windows**: no-op (`engine/reaper_windows.go`), matching `killProcGroup`'s existing Windows precedent.
+
+Both platform paths resolve symlinks in the worktree directory before matching (`filepath.EvalSymlinks`), since `/proc/*/cwd` and `lsof`'s reported path are both fully-resolved real paths (e.g. macOS resolves `/tmp` → `/private/tmp`), which would otherwise defeat a literal prefix match.
+
+Each kill is logged via the existing `[#N kill] ...` convention: `[#N kill] sending SIGKILL to PID <pid> (<comm>) rooted in <wtDir> (worktree cwd cleanup)`, alongside the `(grandchild cleanup)` PGID-kill log line so both are visible in the same log stream. Enumeration and kill failures (missing `lsof`, a `/proc/<pid>/cwd` read racing process exit, permission errors) are always non-fatal: logged as a warning, never blocking the caller's own worktree removal.
+
+**Call sites** (every path that removes a worktree directory):
+- `WorktreeManager.CleanupWorktree` — issue worktree teardown (Done-stage teardown, periodic janitor)
+- `WorktreeManager.ensureTrainWorktreeFromRef`'s stale-worktree removal — crash-recovery cleanup before a merge-train trial worktree is recreated under the same name
+- `WorktreeManager.CleanupTrainWorktree` — merge-train trial worktree teardown
+- The worktree janitor's `os.RemoveAll` fallback (`engine/janitor.go`), which fires when no `WorktreeManager` is available for the repo (bare repo missing) — this is why the reaper is a free function rather than a `WorktreeManager` method
+
+**Documented residual risks** (see ADR 063):
+- **PID-reuse TOCTOU on macOS**: unlike Linux, there is no cheap re-check between enumeration and kill, so a small window exists where a recycled pid could receive an unintended SIGKILL.
+- **`chdir`'d descendants are not caught**: this reaper is cwd-based by design (matching the issue's reported failure mode); a process that opened a file in the worktree and then `chdir`'d elsewhere is out of scope and will still leak.
+
 ### Progress Baseline Snapshot
 
 Immediately before the first invocation, `snapshotBaseline` captures observable progress state for this stage:

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2518,6 +2518,10 @@ condition is left in place and counted toward the `skipped` total.
 **Cleanup path (FR-6):**  
 `WorktreeManager.CleanupWorktree(number, false)` — the same path used by the Done stage.
 If the bare repo is absent (manually deleted), falls back to `os.RemoveAll` with a warning.
+Both paths now run the cwd-rooted process reaper immediately before removing the directory
+(including the `os.RemoveAll` fallback) — see
+[stage-lifecycle.md § Worktree Teardown Process Reaping](stage-lifecycle.md#worktree-teardown-process-reaping)
+for detail.
 
 ### 11.4 Owner/Repo Resolution
 

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -150,6 +150,7 @@ func (e *Engine) runWorktreeJanitor(ctx context.Context) {
 			} else {
 				// Bare repo absent — fall back to direct removal.
 				e.logf(0, "janitor", "warn: bare repo not found for %s — using os.RemoveAll for #%d\n", dirName, issueNumber)
+				reapWorktreeProcesses(wtPath, issueNumber, e.logf)
 				if err := os.RemoveAll(wtPath); err != nil {
 					reason := fmt.Sprintf("removeall error: %v", err)
 					skipReasons = append(skipReasons, reason)

--- a/engine/reaper_unix.go
+++ b/engine/reaper_unix.go
@@ -103,6 +103,12 @@ func reapWorktreeProcessesLinux(wtDir string, issueNumber int, logf func(int, st
 			// (e.g. a different user's process) — both are expected and non-fatal.
 			continue
 		}
+		// The kernel appends " (deleted)" to the readlink target when the cwd's
+		// underlying directory has been unlinked (e.g. a crashed prior run left
+		// a process whose worktree was partially removed) — strip it before
+		// matching, or the prefix check silently fails on exactly the orphans
+		// this reaper exists to catch.
+		cwd = strings.TrimSuffix(cwd, " (deleted)")
 		if !isUnderWorktreeDir(cwd, wtDir) {
 			continue
 		}
@@ -111,7 +117,11 @@ func reapWorktreeProcessesLinux(wtDir string, issueNumber int, logf func(int, st
 		// window in which this pid could have been recycled for a different,
 		// unrelated process since the check above.
 		cwd2, readErr2 := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
-		if readErr2 != nil || !isUnderWorktreeDir(cwd2, wtDir) {
+		if readErr2 != nil {
+			continue
+		}
+		cwd2 = strings.TrimSuffix(cwd2, " (deleted)")
+		if !isUnderWorktreeDir(cwd2, wtDir) {
 			continue
 		}
 

--- a/engine/reaper_unix.go
+++ b/engine/reaper_unix.go
@@ -1,0 +1,178 @@
+//go:build !windows
+
+package engine
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// reapWorktreeProcesses enumerates every live process whose cwd is wtDir or a
+// subdirectory of it and sends SIGKILL to each. It runs immediately before a
+// worktree directory is removed, complementing the PGID-scoped killProcGroup:
+// a descendant that called setsid() (e.g. a dev server backgrounded via
+// Claude Code's background-bash tool) leaves the worker's process group and
+// survives killProcGroup's kill(-PGID, SIGKILL), but still has its cwd rooted
+// in the worktree — which this reaper catches instead.
+//
+// This is a package-level function, not a WorktreeManager method, so the
+// worktree janitor's os.RemoveAll fallback (which runs when no WorktreeManager
+// is available for the repo) can call it too.
+//
+// Enumeration and kill failures are always non-fatal: they are logged via logf
+// as warnings, and the caller proceeds with its own removal (git worktree
+// remove / os.RemoveAll) regardless of outcome here.
+func reapWorktreeProcesses(wtDir string, issueNumber int, logf func(int, string, string, ...any)) {
+	if wtDir == "" {
+		return
+	}
+	// Resolve symlinks so wtDir matches the resolved cwd paths reported by
+	// /proc/*/cwd (Linux) and lsof's -Fn field (macOS) — both report the real
+	// path, e.g. macOS resolves /tmp → /private/tmp and /var → /private/var,
+	// which would otherwise defeat isUnderWorktreeDir's prefix match.
+	if resolved, err := filepath.EvalSymlinks(wtDir); err == nil {
+		wtDir = resolved
+	}
+	switch runtime.GOOS {
+	case "linux":
+		reapWorktreeProcessesLinux(wtDir, issueNumber, logf)
+	case "darwin":
+		reapWorktreeProcessesDarwin(wtDir, issueNumber, logf)
+	default:
+		// Other Unix-likes: no known-good enumeration primitive. Non-fatal no-op.
+	}
+}
+
+// isUnderWorktreeDir reports whether path is wtDir itself or a descendant of it.
+// Both inputs are expected to already be absolute, clean paths (callers resolve
+// wtDir once via filepath.Clean and cwd values come pre-cleaned from readlink/lsof).
+func isUnderWorktreeDir(path, wtDir string) bool {
+	if path == "" || wtDir == "" {
+		return false
+	}
+	path = filepath.Clean(path)
+	wtDir = filepath.Clean(wtDir)
+	if path == wtDir {
+		return true
+	}
+	return strings.HasPrefix(path, wtDir+string(filepath.Separator))
+}
+
+// killWorktreeProcess sends SIGKILL to pid, skipping the engine's own process,
+// treating ESRCH (already exited — a natural PID-reuse/race outcome) as
+// silent, and logging unexpected errors as warnings via logf. On success, logs
+// the kill using the existing "[#N kill] ..." convention so it is auditable
+// alongside killProcGroup's grandchild-cleanup log line.
+func killWorktreeProcess(pid int, comm, wtDir string, issueNumber int, logf func(int, string, string, ...any)) {
+	if pid <= 0 || pid == os.Getpid() {
+		return
+	}
+	if comm == "" {
+		comm = "?"
+	}
+	logf(issueNumber, "kill", "sending SIGKILL to PID %d (%s) rooted in %s (worktree cwd cleanup)\n", pid, comm, wtDir)
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		logf(issueNumber, "kill", "warn: could not kill PID %d (%s): %v\n", pid, comm, err)
+	}
+}
+
+// reapWorktreeProcessesLinux scans /proc/*/cwd symlinks for processes whose
+// cwd is rooted under wtDir. Immediately before killing a match, it re-reads
+// /proc/<pid>/cwd to close the TOCTOU window where the pid could have been
+// reused for an unrelated process between enumeration and kill.
+func reapWorktreeProcessesLinux(wtDir string, issueNumber int, logf func(int, string, string, ...any)) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		logf(issueNumber, "kill", "warn: worktree process reap: could not read /proc: %v\n", err)
+		return
+	}
+	wtDir = filepath.Clean(wtDir)
+	for _, entry := range entries {
+		pid, convErr := strconv.Atoi(entry.Name())
+		if convErr != nil {
+			continue // not a pid directory
+		}
+		cwd, readErr := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
+		if readErr != nil {
+			// Process exited between ReadDir and Readlink, or we lack permission
+			// (e.g. a different user's process) — both are expected and non-fatal.
+			continue
+		}
+		if !isUnderWorktreeDir(cwd, wtDir) {
+			continue
+		}
+
+		// TOCTOU re-check: re-read cwd immediately before killing to shrink the
+		// window in which this pid could have been recycled for a different,
+		// unrelated process since the check above.
+		cwd2, readErr2 := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
+		if readErr2 != nil || !isUnderWorktreeDir(cwd2, wtDir) {
+			continue
+		}
+
+		comm := readComm(pid)
+		killWorktreeProcess(pid, comm, wtDir, issueNumber, logf)
+	}
+}
+
+// readComm returns the command name for pid from /proc/<pid>/comm, or "" if
+// unavailable. Best-effort only — used for log readability.
+func readComm(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "comm"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// reapWorktreeProcessesDarwin enumerates processes whose cwd file descriptor
+// is rooted under wtDir via `lsof -a -d cwd -n -P -Fpcn`. This inspects only
+// each process's cwd fd (not every open fd, unlike `lsof +D`), which keeps
+// the call fast and non-hanging on a synchronous teardown path even for a
+// node_modules-heavy worktree.
+//
+// macOS has no cheap per-pid re-check primitive equivalent to /proc, so unlike
+// the Linux path this does not re-verify cwd immediately before killing —
+// the small PID-reuse TOCTOU window here is accepted, not mitigated.
+func reapWorktreeProcessesDarwin(wtDir string, issueNumber int, logf func(int, string, string, ...any)) {
+	wtDir = filepath.Clean(wtDir)
+	cmd := exec.Command("lsof", "-a", "-d", "cwd", "-n", "-P", "-Fpcn")
+	out, err := cmd.Output()
+	if err != nil {
+		// lsof exits non-zero when it finds no matching processes at all, which
+		// is a normal empty result rather than a failure — only warn when there
+		// is no output to work with (e.g. lsof missing, permission failure).
+		if len(out) == 0 {
+			logf(issueNumber, "kill", "warn: worktree process reap: lsof failed: %v\n", err)
+			return
+		}
+	}
+
+	var pid int
+	var comm string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line == "" {
+			continue
+		}
+		switch line[0] {
+		case 'p':
+			// Start of a new process record — flush is not needed since fields
+			// for a given pid arrive in p, c, n order.
+			pid, _ = strconv.Atoi(line[1:])
+			comm = ""
+		case 'c':
+			comm = line[1:]
+		case 'n':
+			cwd := line[1:]
+			if pid > 0 && isUnderWorktreeDir(cwd, wtDir) {
+				killWorktreeProcess(pid, comm, wtDir, issueNumber, logf)
+			}
+			pid = 0
+		}
+	}
+}

--- a/engine/reaper_unix_test.go
+++ b/engine/reaper_unix_test.go
@@ -1,0 +1,141 @@
+//go:build !windows
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// spawnSetsidProcess starts a long-lived process detached into its own
+// session (and therefore its own process group — the classic escape path for
+// PGID-scoped killProcGroup), with its cwd set to dir. It returns the started
+// *exec.Cmd; the caller is responsible for reaping/cleanup.
+func spawnSetsidProcess(t *testing.T, dir string) *exec.Cmd {
+	t.Helper()
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not found in PATH")
+	}
+	cmd := exec.Command("sleep", "60")
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting setsid process: %v", err)
+	}
+	// Reap the child as soon as it exits, exactly as init (PID 1) would for a
+	// real orphaned descendant. Without this, a killed child lingers as a
+	// zombie until Wait()'d, and kill(pid, 0) reports zombies as "alive" —
+	// which would make the liveness check below meaningless.
+	go func() { _ = cmd.Wait() }()
+	return cmd
+}
+
+// waitForPGID polls until syscall.Getpgid(pid) succeeds, returning the PGID.
+// A freshly setsid'd process needs a moment before its PGID is queryable.
+func waitForPGID(t *testing.T, pid int) int {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		pgid, err := syscall.Getpgid(pid)
+		if err == nil {
+			return pgid
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("could not read pgid for pid %d: %v", pid, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func testLogf(logs *[]string) func(int, string, string, ...any) {
+	return func(issueNumber int, tag, format string, args ...any) {
+		*logs = append(*logs, fmt.Sprintf("[#%d %s] "+format, append([]any{issueNumber, tag}, args...)...))
+	}
+}
+
+// TestReapWorktreeProcesses_KillsSetsidDescendant exercises the actual bug
+// this reaper fixes: a descendant that called setsid() lands in its own
+// process group and is invisible to killProcGroup's PGID-scoped kill. A test
+// that only spawned an ordinary child would pass under the pre-fix code too
+// and would prove nothing about this change.
+func TestReapWorktreeProcesses_KillsSetsidDescendant(t *testing.T) {
+	wtDir := t.TempDir()
+	cmd := spawnSetsidProcess(t, wtDir)
+	pid := cmd.Process.Pid
+	// The spawning goroutine's Wait() reaps the process; calling Wait() again
+	// here would race with it, so cleanup only needs to ensure it's dead.
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+	})
+
+	childPGID := waitForPGID(t, pid)
+	callerPGID, err := syscall.Getpgid(os.Getpid())
+	if err != nil {
+		t.Fatalf("Getpgid(self): %v", err)
+	}
+	if childPGID == callerPGID {
+		t.Fatalf("expected setsid child to have escaped the caller's PGID, both are %d", callerPGID)
+	}
+	if childPGID != pid {
+		t.Fatalf("expected setsid child's PGID to equal its own PID, got pgid=%d pid=%d", childPGID, pid)
+	}
+
+	var logs []string
+	reapWorktreeProcesses(wtDir, 42, testLogf(&logs))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return // reaped
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("setsid descendant (pid %d) still alive after reapWorktreeProcesses; logs: %v", pid, logs)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestReapWorktreeProcesses_LeavesProcessesOutsideWorktree proves precision,
+// not just breadth: a process whose cwd is outside the reaped worktree must
+// survive even though it is (deliberately) also setsid'd, so a coincidental
+// PGID match could never explain a false-positive kill.
+func TestReapWorktreeProcesses_LeavesProcessesOutsideWorktree(t *testing.T) {
+	wtDir := t.TempDir()
+	outsideDir := t.TempDir()
+	cmd := spawnSetsidProcess(t, outsideDir)
+	pid := cmd.Process.Pid
+	// The spawning goroutine's Wait() reaps the process; calling Wait() again
+	// here would race with it, so cleanup only needs to ensure it's dead.
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+	})
+	waitForPGID(t, pid)
+
+	var logs []string
+	reapWorktreeProcesses(wtDir, 42, testLogf(&logs))
+
+	// Give the (non-)reap a moment to have taken effect, then assert the
+	// process is still alive.
+	time.Sleep(100 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("process outside the reaped worktree should have survived, got: %v; logs: %v", err, logs)
+	}
+}
+
+// TestReapWorktreeProcesses_NonFatalOnEnumerationFailure confirms the
+// non-fatal contract: enumeration failures (lsof missing on darwin, a
+// nonexistent worktree directory) must never panic or block — the caller's
+// subsequent worktree removal always proceeds regardless of reap outcome.
+func TestReapWorktreeProcesses_NonFatalOnEnumerationFailure(t *testing.T) {
+	t.Setenv("PATH", "") // hides `lsof` on darwin
+	nonexistent := filepath.Join(t.TempDir(), "does-not-exist")
+
+	var logs []string
+	reapWorktreeProcesses(nonexistent, 7, testLogf(&logs))
+	// Reaching here without panicking/hanging is the assertion.
+}

--- a/engine/reaper_windows.go
+++ b/engine/reaper_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package engine
+
+// reapWorktreeProcesses is a no-op on Windows, mirroring killProcGroup's
+// existing Windows precedent (procattr_windows.go): process enumeration by
+// cwd uses Unix-specific primitives (/proc, lsof) with no direct Windows
+// equivalent wired up here.
+func reapWorktreeProcesses(wtDir string, issueNumber int, logf func(int, string, string, ...any)) {}

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -280,6 +280,11 @@ func (wm *WorktreeManager) CleanupWorktree(issueNumber int, deleteBranch bool) e
 	defer wm.mu.Unlock()
 	wtDir := wm.worktreeDir(issueNumber)
 
+	// Reap any process still rooted in this worktree's cwd (e.g. a setsid'd dev
+	// server that escaped the worker's process group) before the directory is
+	// removed. Non-fatal by construction — proceeds regardless of outcome.
+	reapWorktreeProcesses(wtDir, issueNumber, wm.logf)
+
 	// Remove the worktree
 	cmd := exec.Command("git", "worktree", "remove", "--force", wtDir)
 	cmd.Dir = wm.baseDir
@@ -357,6 +362,9 @@ func (wm *WorktreeManager) ensureTrainWorktreeFromRef(name, baseRef string) (str
 
 	// Remove any pre-existing worktree at this path (e.g. from a crashed previous run).
 	if _, err := os.Stat(wtDir); err == nil {
+		// A crashed prior trial's detached server (e.g. from a build/CI command)
+		// may still be running with cwd rooted here. Reap it before reuse.
+		reapWorktreeProcesses(wtDir, 0, wm.logf)
 		rmCmd := exec.Command("git", "worktree", "remove", "--force", wtDir)
 		rmCmd.Dir = wm.baseDir
 		rmCmd.CombinedOutput() // best-effort
@@ -417,6 +425,10 @@ func (wm *WorktreeManager) CleanupTrainWorktree(name string, deleteBranch bool) 
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
 	wtDir := wm.trainWorktreeDir(name)
+
+	// Reap any process still rooted in this trial worktree's cwd before removal —
+	// a build/CI command run during the trial may have started a detached server.
+	reapWorktreeProcesses(wtDir, 0, wm.logf)
 
 	// Best-effort local worktree removal — may already be gone.
 	rmCmd := exec.Command("git", "worktree", "remove", "--force", wtDir)


### PR DESCRIPTION
Closes #975

## What this does

Fabrik's existing subprocess cleanup (`killProcGroup`) SIGKILLs the Claude worker's process group before a worktree directory is removed. That's PGID-scoped, so it can't reach a descendant that called `setsid()` — exactly what happens when a worker backgrounds a dev server (`npm run dev`, `vite`, etc.) via Claude Code's background-bash tool. That descendant escapes into its own process group, survives the worker's kill, and is left running with `cwd` pointing at a worktree directory that gets deleted out from under it — leaking the process and pinning its port indefinitely.

This adds `reapWorktreeProcesses` (`engine/reaper_unix.go`/`engine/reaper_windows.go`), a **cwd-rooted** reaper that runs immediately before every worktree directory removal: it enumerates live processes whose cwd is rooted under the worktree path (regardless of process-group membership) and SIGKILLs them directly.

## Key implementation points

- **Package-level function, not a `WorktreeManager` method** — the worktree janitor's `os.RemoveAll` fallback (fires when the bare repo is missing) has no `WorktreeManager` instance, so a method couldn't cover that site.
- **Wired into all four worktree-removal call sites** (not just the two named in the issue): `CleanupWorktree`, `ensureTrainWorktreeFromRef`'s stale-worktree removal, `CleanupTrainWorktree`, and the janitor's `os.RemoveAll` fallback — routed through one shared primitive so "every path" holds by construction.
- **Linux**: `/proc/*/cwd` readlink scan with a TOCTOU re-check immediately before kill.
- **macOS**: `lsof -a -d cwd -n -P -Fpcn` (deliberately not `lsof +D`, which walks every fd of every process and would be slow/hang-prone on a synchronous teardown path). No cheap re-check primitive exists here, so the TOCTOU window is accepted and documented rather than mitigated.
- **Windows**: no-op, matching `killProcGroup`'s existing precedent.
- Both platforms resolve symlinks in the worktree path before matching (`filepath.EvalSymlinks`) — needed because `/proc`/`lsof` report fully-resolved paths (e.g. macOS `/tmp` → `/private/tmp`), which would otherwise silently defeat the prefix match. This was caught by the tests, not by inspection.
- Non-fatal by construction: enumeration/kill failures are logged as warnings and never block the caller's own `git worktree remove` / `os.RemoveAll`.
- Kills are logged via the existing `[#N kill] ...` convention alongside the PGID-kill's `(grandchild cleanup)` line, tagged `(worktree cwd cleanup)`.

## Out of scope (documented, not silently dropped)

- Retroactive sweep of processes already orphaned by worktrees removed before this ships.
- Processes that `chdir` away after starting (cwd-based detection only, matching the reported failure mode).
- Worker-side hygiene — tracked separately in #976.

See `adrs/063-worktree-cwd-rooted-process-reaper.md` for the full design rationale, and `docs/stage-lifecycle.md` § "Worktree Teardown Process Reaping" for the as-built behavior.

## How to test

- `engine/reaper_unix_test.go` adds three tests: `TestReapWorktreeProcesses_KillsSetsidDescendant` (spawns a real `setsid`'d process, asserts its PGID differs from the caller's, and asserts the reaper kills it — this is the test that would fail under the old PGID-only kill), `TestReapWorktreeProcesses_LeavesProcessesOutsideWorktree` (precision check), and `TestReapWorktreeProcesses_NonFatalOnEnumerationFailure`.
- `go test -race ./engine/...` — all 1365 tests pass, including the existing `TestCleanupWorktree*` tests unmodified.
- `go build ./... && go vet ./...` clean.