### PR TITLE
feat(workflows): warn worker skills against orphaned detached dev servers in verify steps

### DIFF
--- a/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
@@ -37,6 +37,24 @@ After making the change:
 
 Good commit message: `Apply user feedback: use interface X instead of concrete type Y`
 
+### Verifying with a live server
+
+If the user's requested change needs a running instance of the managed app to verify (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call. Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls — and outlives the stage. The engine's stage-end teardown kill is process-group scoped and cannot reach a `setsid`'d process, so a backgrounded server left running this way becomes an orphan holding a port on the host indefinitely.
+
+In preference order:
+
+1. **Prefer one-shot verification.** Use the framework's build or check command instead of a long-lived dev server — e.g. `npm run build` (or the framework's equivalent), or a bounded-lifetime preview command like `vite preview`.
+2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown:
+   ```bash
+   npm run dev --port "$PORT" & DEV=$!
+   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   # health-check / curl / run the verification here
+   ```
+3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:
+   ```bash
+   timeout --signal=KILL <N> npm run dev …
+   ```
+
 ### Update the task checklist
 
 If the user's change affects task completion status (e.g., a previously checked task needs to be reopened, or a new sub-task is implied), update the Plan stage comment accordingly.
@@ -72,6 +90,7 @@ This applies when you are using `#N` as an ordinal label for your own numbered c
 - **Do not skip compilation and test verification** before committing
 - **Do not make unrelated changes** while applying the requested fix
 - **Do not leave uncommitted changes** — always commit and push before returning
+- **Never background a dev server and continue in a later tool call to verify a change** — it detaches via `setsid` and outlives the stage, becoming an orphaned process holding a port. See "Verifying with a live server" above.
 - **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
 
   Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.

--- a/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
@@ -47,7 +47,7 @@ In preference order:
 2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown:
    ```bash
    npm run dev --port "$PORT" & DEV=$!
-   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   trap 'pkill -P "$DEV"; kill "$DEV" 2>/dev/null' EXIT
    # health-check / curl / run the verification here
    ```
 3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -167,7 +167,7 @@ In preference order:
 2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown, so it never needs to detach and can't outlive the check:
    ```bash
    npm run dev --port "$PORT" & DEV=$!
-   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   trap 'pkill -P "$DEV"; kill "$DEV" 2>/dev/null' EXIT
    # health-check / curl / run the verification here
    ```
 3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -157,6 +157,24 @@ Before signaling completion:
 - `go vet` (or equivalent linter) is clean
 - All changes committed and pushed
 
+### Verifying with a live server
+
+If a task needs a running instance of the managed app to verify a change (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call. Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls — and outlives the stage. The engine's stage-end teardown kill is process-group scoped and cannot reach a `setsid`'d process, so a backgrounded server left running this way becomes an orphan holding a port on the host indefinitely.
+
+In preference order:
+
+1. **Prefer one-shot verification.** Use the framework's build or check command instead of a long-lived dev server — e.g. `npm run build` (or the framework's equivalent), or a bounded-lifetime preview command like `vite preview` — rather than standing up a persistent server just to confirm a change works.
+2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown, so it never needs to detach and can't outlive the check:
+   ```bash
+   npm run dev --port "$PORT" & DEV=$!
+   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   # health-check / curl / run the verification here
+   ```
+3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:
+   ```bash
+   timeout --signal=KILL <N> npm run dev …
+   ```
+
 ## What You Do NOT Do
 
 - **Do not redesign the approach** — the Plan stage made those decisions. If something seems wrong, note it but implement the plan.
@@ -165,6 +183,7 @@ Before signaling completion:
 - **Do not refactor unrelated code** — stay focused on the task list
 - **Do not add features not in the plan** — no scope creep
 - **Do not leave the branch in a broken state** — every push should compile and pass tests
+- **Never background a dev server and continue in a later tool call to verify a change** — it detaches via `setsid` and outlives the stage, becoming an orphaned process holding a port. See "Verifying with a live server" above.
 - **Do not defer documentation** — if the change is user-facing, update the docs in the same PR. A doc update that gets "tracked as a follow-up" is a doc update that never happens.
 - **Never call `gh pr create` directly.** Use the `FABRIK_PR_CREATE_BEGIN/END` marker instead. The engine creates the PR and guarantees the `Closes #N` closing line. A direct `gh pr create` bypasses this guarantee and will break downstream gates.
 - **Never write `Closes #N`, `Fixes #N`, `Resolves #N`, or any closing keyword referencing the issue number in a PR body.** The engine generates this line as the first line of the PR body. Writing one yourself either duplicates it (harmless but messy) or, if you called `gh pr create` directly and omitted it, breaks every downstream gate. The engine owns this line — you don't.

--- a/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
@@ -86,7 +86,7 @@ In preference order:
 2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown:
    ```bash
    npm run dev --port "$PORT" & DEV=$!
-   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   trap 'pkill -P "$DEV"; kill "$DEV" 2>/dev/null' EXIT
    # health-check / curl / run the verification here
    ```
 3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:

--- a/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
@@ -76,6 +76,24 @@ After applying any fixes:
 2. Commit with a clear message
 3. Push to the remote branch
 
+### Verifying with a live server
+
+If confirming a fix needs a running instance of the managed app (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call. Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls — and outlives the stage. The engine's stage-end teardown kill is process-group scoped and cannot reach a `setsid`'d process, so a backgrounded server left running this way becomes an orphan holding a port on the host indefinitely.
+
+In preference order:
+
+1. **Prefer one-shot verification.** Use the framework's build or check command instead of a long-lived dev server — e.g. `npm run build` (or the framework's equivalent), or a bounded-lifetime preview command like `vite preview`.
+2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown:
+   ```bash
+   npm run dev --port "$PORT" & DEV=$!
+   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   # health-check / curl / run the verification here
+   ```
+3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:
+   ```bash
+   timeout --signal=KILL <N> npm run dev …
+   ```
+
 ## Numbering findings in your output
 
 When you list or summarize multiple review findings (e.g., distinguishing one Copilot comment from another, or grouping Gemini suggestions), **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.
@@ -98,6 +116,7 @@ Do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Review returns cont
 - **Do not leave uncommitted changes** — always commit and push before returning
 - **Do not re-run the full review** — focus on the specific findings the user addressed
 - **Do not make unrelated changes** while applying fixes
+- **Never background a dev server and continue in a later tool call to verify a fix** — it detaches via `setsid` and outlives the stage, becoming an orphaned process holding a port. See "Verifying with a live server" above.
 - **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
 
   Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.

--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -141,7 +141,7 @@ In preference order:
 2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown, so it never needs to detach and can't outlive the check:
    ```bash
    npm run dev --port "$PORT" & DEV=$!
-   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   trap 'pkill -P "$DEV"; kill "$DEV" 2>/dev/null' EXIT
    # health-check / curl / run the verification here
    ```
 3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:

--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -131,6 +131,24 @@ go vet ./...          # linter
 git push
 ```
 
+### Verifying with a live server
+
+If confirming a fix needs a running instance of the managed app (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call. Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls — and outlives the stage. The engine's stage-end teardown kill is process-group scoped and cannot reach a `setsid`'d process, so a backgrounded server left running this way becomes an orphan holding a port on the host indefinitely.
+
+In preference order:
+
+1. **Prefer one-shot verification.** Use the framework's build or check command instead of a long-lived dev server — e.g. `npm run build` (or the framework's equivalent), or a bounded-lifetime preview command like `vite preview` — rather than standing up a persistent server just to confirm a fix works.
+2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown, so it never needs to detach and can't outlive the check:
+   ```bash
+   npm run dev --port "$PORT" & DEV=$!
+   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   # health-check / curl / run the verification here
+   ```
+3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:
+   ```bash
+   timeout --signal=KILL <N> npm run dev …
+   ```
+
 ## Output
 
 The engine captures your stdout and posts it on the PR (when `post_to_pr: true`). A brief summary is posted on the issue.
@@ -180,6 +198,7 @@ This applies anywhere in your output that reaches a GitHub comment body — Revi
 - **Do not add features** — review what's there, not what could be there
 - **Do not nitpick style** unless it violates project conventions
 - **Do not approve if something is wrong** — if you can't fix an issue, do NOT signal completion. Describe the blocker clearly.
+- **Never background a dev server and continue in a later tool call to verify a fix** — it detaches via `setsid` and outlives the stage, becoming an orphaned process holding a port. See "Verifying with a live server" above.
 - **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
 
   Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -25,6 +25,13 @@ Read the user's comment carefully to understand what they're requesting:
 **Re-run checks**: The user wants validation checks re-executed (e.g., after a recent fix).
 - **Fetch the target base branch first** — run `git fetch origin "$(gh pr view --json baseRefName --jq .baseRefName)"` before any comparison of branch CI failures to base-branch state. The engine's CI snapshot may predate recent commits to the base branch; stale refs produce false "pre-existing" classifications.
 - Run the relevant checks (tests, linting, build)
+- If re-verification needs a running instance of the managed app (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call — Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls and outlives the stage, and the engine's process-group-scoped teardown kill cannot reach it. In preference order: prefer one-shot verification (e.g. `npm run build`, or a bounded-lifetime `vite preview`); if a live server is genuinely needed, bracket it in a single command with guaranteed teardown:
+  ```bash
+  npm run dev --port "$PORT" & DEV=$!
+  trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+  # health-check / curl / run the verification here
+  ```
+  or, if a persistent server is unavoidable, bound it with `timeout --signal=KILL <N> npm run dev …` so it self-terminates.
 - Update the validation report with the new results
 
 **Apply a minor fix**: The user has identified a small issue to address before closing.
@@ -72,6 +79,7 @@ This applies to ordinal numbering in any output that reaches a GitHub comment bo
 - **Do not apply fixes beyond what the user requested** — minimal targeted changes only
 - **Do not leave uncommitted changes** — always commit and push before returning
 - **Do not re-run the full validation suite** unless the user specifically requests it — focus on the checks relevant to their feedback
+- **Never background a dev server and continue in a later tool call to re-verify a change** — it detaches via `setsid` and outlives the stage, becoming an orphaned process holding a port. See "Re-run checks" above.
 - **Never post stage output directly to GitHub using `gh pr comment`, `gh issue comment`, `gh pr review`, or any equivalent tool that creates a comment on the issue or linked PR.** Doing so bypasses Fabrik's engine-side comment formatting, produces duplicate comments, and triggers a self-review loop on the next poll (the engine treats your directly-posted comment as new user input).
 
   Write all stage output to stdout only. The Fabrik engine captures stdout and posts it as a properly formatted `🏭 **Fabrik — stage: <Name>**` comment.

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -28,7 +28,7 @@ Read the user's comment carefully to understand what they're requesting:
 - If re-verification needs a running instance of the managed app (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call — Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls and outlives the stage, and the engine's process-group-scoped teardown kill cannot reach it. In preference order: prefer one-shot verification (e.g. `npm run build`, or a bounded-lifetime `vite preview`); if a live server is genuinely needed, bracket it in a single command with guaranteed teardown:
   ```bash
   npm run dev --port "$PORT" & DEV=$!
-  trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+  trap 'pkill -P "$DEV"; kill "$DEV" 2>/dev/null' EXIT
   # health-check / curl / run the verification here
   ```
   or, if a persistent server is unavoidable, bound it with `timeout --signal=KILL <N> npm run dev …` so it self-terminates.

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -68,6 +68,24 @@ Create a verification checklist:
 - [ ] Requirement 3: FAILED — describe what's wrong
 ```
 
+### Verifying with a live server
+
+If confirming a requirement needs a running instance of the managed app (e.g. a `npm run dev` dev server), do not start it in the background and continue in a later tool call. Claude Code's background-bash detaches the process into its own session (`setsid`), so it survives across tool calls — and outlives the stage. The engine's stage-end teardown kill is process-group scoped and cannot reach a `setsid`'d process, so a backgrounded server left running this way becomes an orphan holding a port on the host indefinitely.
+
+In preference order:
+
+1. **Prefer one-shot verification.** Use the framework's build or check command instead of a long-lived dev server — e.g. `npm run build` (or the framework's equivalent), or a bounded-lifetime preview command like `vite preview` — rather than standing up a persistent server just to confirm a requirement is met.
+2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown, so it never needs to detach and can't outlive the check:
+   ```bash
+   npm run dev --port "$PORT" & DEV=$!
+   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   # health-check / curl / run the verification here
+   ```
+3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:
+   ```bash
+   timeout --signal=KILL <N> npm run dev …
+   ```
+
 ### Test suite
 
 Run the full test suite. **Always include a per-test timeout** appropriate to the project's test framework (e.g., `pytest --timeout=60`, `go test -timeout 5m`, `jest --testTimeout=30000`). Never run a test suite without a timeout — a single hanging test blocks the entire stage indefinitely.
@@ -277,3 +295,4 @@ When you receive this comment:
 - **Re-reviewing instead of validating**: You're not doing another code review. You're verifying the implementation meets the spec.
 - **Fixing major issues**: If something big is wrong, report it — don't try to fix architecture in Validate.
 - **Forgetting to rebase**: Main may have moved since Review. Always rebase first.
+- **Backgrounding a dev server to verify a requirement**: Never background it and continue in a later tool call — it detaches via `setsid` and outlives the stage, becoming an orphaned process holding a port. See "Verifying with a live server" above.

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -78,7 +78,7 @@ In preference order:
 2. **If a live server is genuinely needed** (e.g. an HTTP health check), bracket it in a single command with guaranteed teardown, so it never needs to detach and can't outlive the check:
    ```bash
    npm run dev --port "$PORT" & DEV=$!
-   trap 'kill -- -$(ps -o pgid= -p "$DEV" | tr -d " ") 2>/dev/null' EXIT
+   trap 'pkill -P "$DEV"; kill "$DEV" 2>/dev/null' EXIT
    # health-check / curl / run the verification here
    ```
 3. **If a persistent server is unavoidable, bound it with a timeout** so it self-terminates:


### PR DESCRIPTION
Closes #976

## What this does

Adds explicit guidance to the six `fabrik-workflows` worker skills whose stages might bring up a live instance of the managed app to verify a change — instructing the worker not to background a dev server and continue in a later tool call, since that detaches the process via `setsid` and leaves it running past stage-end teardown (which is process-group scoped and can't reach a `setsid`'d descendant).

This is the worker-side companion to the engine-side cwd-rooted process reaper shipped in #975 — that reaper remains the safety net; this change reduces how often it needs to fire by discouraging the pattern that creates the orphan in the first place.

## Files changed

- `plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md`
- `plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md`
- `plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md`
- `plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md`
- `plugin/fabrik-workflows/skills/fabrik-review/SKILL.md`
- `plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md`

Each gets:
1. A "Verifying with a live server" subsection (or, for the two shorter comment-reviewer files with no existing verify section, an inline addition at the natural point in the flow) presenting the three-tier preference order: prefer one-shot verification (build/bounded preview) → bracket a live server in a single command with a `trap`-guaranteed teardown → fall back to a `timeout`-bounded persistent server if unavoidable.
2. A one-line reinforcing bullet in "What You Do NOT Do" (or "Common Pitfalls" for Validate, which has no such section) so the warning survives a skim under context pressure.

`fabrik-plan`, `fabrik-specify`, `fabrik-research` (and their `-comment` counterparts) are unaffected — they're read-only/design-only stages that never execute build/run commands.

## Scope

Purely a worker-facing prompt/skill text change. No `engine/`, `stages/`, or `docs/` files touched — confirmed no documentation-bundle regeneration is required since these skill files aren't among the four canonical doc pages.

## How to test

- `go build ./...` and `go test -race -timeout 5m ./...` pass (one pre-existing, environment-related failure in `cmd.TestExecute_ConfigYAMLApplied` reproduces identically on a clean `main` checkout — unrelated to this change).
- `go vet ./...` is clean.
- Manual read-through of all six modified `SKILL.md` files for consistent heading style, code-fence usage, and cross-references between the full subsection and its reinforcing bullet.