### PR TITLE
docs: update USER_GUIDE.md for v0.0.74 (closed-issue auto-advance, warnings panel)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1567,7 +1567,7 @@ When an issue reaches Done, Fabrik:
 
 **Note:** Auto-archive is currently disabled. It was removing items from the board before users could see them, and is being reworked to track actual Done stage completion time. Items will remain in the Done column until auto-archive is re-enabled in a future release. When re-enabled, archived items will not be deleted — they will remain accessible via the project board's "Archive" view in GitHub.
 
-**Closed-issue auto-advance:** In auto-advance mode (`--yolo`, `fabrik:yolo`, or `fabrik:cruise`), if an issue is closed externally (for example, a PR merge closes it) while it is still in an intermediate stage column with a `stage:<name>:complete` label already applied, Fabrik automatically advances it to Done on the next poll. No manual board move is required — Fabrik detects the closed state and runs the normal catch-up path. This typically happens when a PR merge closes an issue sitting in the Validate column. Without auto-advance, closed issues with a stage-complete label are not moved automatically; you can drag the card to Done manually.
+**Closed-issue auto-advance:** If an issue is closed externally (for example, a PR merge closes it) while its board item sits at any column other than Done, Fabrik automatically advances it to Done. This runs unconditionally on every poll — regardless of yolo, cruise, or plain manual mode — and requires no `stage:<name>:complete` label or any other label at all. It applies to any non-Done column whose resolved stage isn't a cleanup, holding, or gate-checked stage, including columns with no matching stage config at all (for example, a stranded item in Backlog). No manual board move is required. Validate is excluded from this scan — a closed issue at Validate is handled separately by the existing PR-terminal-advance/auto-merge path described above.
 
 ### Customizing Stages
 
@@ -2012,7 +2012,7 @@ dialog instead of a simple y/N prompt (see [Customizing Skills](#customizing-ski
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Cycle focus: In Progress → History → Warnings → (repeat) |
+| `Tab` | Cycle focus: In Progress → History → Warnings → (repeat); the Warnings pane is skipped whenever it's empty (hidden), so focus never lands on an invisible pane |
 | `Up/Down` or `j/k` | Navigate items within the focused pane |
 | `l` | Open `fabrik watch` for selected issue (live Claude output, stage tabs, PR/CI status) |
 | `s` | Stop selected active job and apply `fabrik:paused` (In Progress pane only; shows `[y/N]` confirmation first; posts an audit comment on the issue) |
@@ -2074,7 +2074,7 @@ cost, and issue title. Status icons:
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
 
-**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no non-dismissed entries, the panel collapses to a single `Warnings: none` line so History retains maximum vertical space.
+**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no active warnings and no dismissed ones, the panel renders nothing at all (zero height), so History retains maximum vertical space. When there are no active warnings but dismissed entries exist, the panel collapses to a single hint line: `Warnings: none (N dismissed, press tab + S to show)`.
 
 Tab into the Warnings panel to take action:
 - **F** — run the fix command in the foreground (tears down the TUI, executes, re-renders)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1567,7 +1567,13 @@ When an issue reaches Done, Fabrik:
 
 **Note:** Auto-archive is currently disabled. It was removing items from the board before users could see them, and is being reworked to track actual Done stage completion time. Items will remain in the Done column until auto-archive is re-enabled in a future release. When re-enabled, archived items will not be deleted — they will remain accessible via the project board's "Archive" view in GitHub.
 
-**Closed-issue auto-advance:** If an issue is closed externally (for example, a PR merge closes it) while its board item sits at any column other than Done, Fabrik automatically advances it to Done. This runs unconditionally on every poll — regardless of yolo, cruise, or plain manual mode — and requires no `stage:<name>:complete` label or any other label at all. It applies to any non-Done column whose resolved stage isn't a cleanup, holding, or gate-checked stage, including columns with no matching stage config at all (for example, a stranded item in Backlog). No manual board move is required. Validate is excluded from this scan — a closed issue at Validate is handled separately by the existing PR-terminal-advance/auto-merge path described above.
+**Closed-issue auto-advance:** If an issue is closed externally (for example, a PR merge closes it) while its board item sits at any column other than Done, Fabrik automatically advances it to Done. This process has the following properties:
+
+- **Unconditional:** It runs on every poll — regardless of yolo, cruise, or plain manual mode.
+- **No labels required:** It requires no `stage:<name>:complete` label or any other label at all.
+- **Broadly applicable:** It applies to any non-Done column whose resolved stage isn't a cleanup, holding, or gate-checked stage, including columns with no matching stage config at all (for example, a stranded item in Backlog).
+- **No manual board move is required.**
+- **Validate is excluded:** A closed issue at Validate is handled separately by the existing PR-terminal-advance/auto-merge path described above.
 
 ### Customizing Stages
 
@@ -2074,7 +2080,10 @@ cost, and issue title. Status icons:
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
 
-**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no active warnings and no dismissed ones, the panel renders nothing at all (zero height), so History retains maximum vertical space. When there are no active warnings but dismissed entries exist, the panel collapses to a single hint line: `Warnings: none (N dismissed, press tab + S to show)`.
+**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. The panel's appearance when there are no active warnings depends on whether there are dismissed warnings:
+
+- **No active and no dismissed warnings:** The panel renders nothing at all (zero height), so History retains maximum vertical space.
+- **No active warnings but dismissed entries exist:** The panel collapses to a single hint line: `Warnings: none (N dismissed, press tab + S to show)`.
 
 Tab into the Warnings panel to take action:
 - **F** — run the fix command in the foreground (tears down the TUI, executes, re-renders)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1565,7 +1565,7 @@ When an issue reaches Done, Fabrik:
 
 **Note:** Auto-archive is currently disabled. It was removing items from the board before users could see them, and is being reworked to track actual Done stage completion time. Items will remain in the Done column until auto-archive is re-enabled in a future release. When re-enabled, archived items will not be deleted — they will remain accessible via the project board's "Archive" view in GitHub.
 
-**Closed-issue auto-advance:** In auto-advance mode (`--yolo`, `fabrik:yolo`, or `fabrik:cruise`), if an issue is closed externally (for example, a PR merge closes it) while it is still in an intermediate stage column with a `stage:<name>:complete` label already applied, Fabrik automatically advances it to Done on the next poll. No manual board move is required — Fabrik detects the closed state and runs the normal catch-up path. This typically happens when a PR merge closes an issue sitting in the Validate column. Without auto-advance, closed issues with a stage-complete label are not moved automatically; you can drag the card to Done manually.
+**Closed-issue auto-advance:** If an issue is closed externally (for example, a PR merge closes it) while its board item sits at any column other than Done, Fabrik automatically advances it to Done. This runs unconditionally on every poll — regardless of yolo, cruise, or plain manual mode — and requires no `stage:<name>:complete` label or any other label at all. It applies to any non-Done column whose resolved stage isn't a cleanup, holding, or gate-checked stage, including columns with no matching stage config at all (for example, a stranded item in Backlog). No manual board move is required. Validate is excluded from this scan — a closed issue at Validate is handled separately by the existing PR-terminal-advance/auto-merge path described above.
 
 ### Customizing Stages
 
@@ -2010,7 +2010,7 @@ dialog instead of a simple y/N prompt (see [Customizing Skills](#customizing-ski
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Cycle focus: In Progress → History → Warnings → (repeat) |
+| `Tab` | Cycle focus: In Progress → History → Warnings → (repeat); the Warnings pane is skipped whenever it's empty (hidden), so focus never lands on an invisible pane |
 | `Up/Down` or `j/k` | Navigate items within the focused pane |
 | `l` | Open `fabrik watch` for selected issue (live Claude output, stage tabs, PR/CI status) |
 | `s` | Stop selected active job and apply `fabrik:paused` (In Progress pane only; shows `[y/N]` confirmation first; posts an audit comment on the issue) |
@@ -2072,7 +2072,7 @@ cost, and issue title. Status icons:
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
 
-**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no non-dismissed entries, the panel collapses to a single `Warnings: none` line so History retains maximum vertical space.
+**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no active warnings and no dismissed ones, the panel renders nothing at all (zero height), so History retains maximum vertical space. When there are no active warnings but dismissed entries exist, the panel collapses to a single hint line: `Warnings: none (N dismissed, press tab + S to show)`.
 
 Tab into the Warnings panel to take action:
 - **F** — run the fix command in the foreground (tears down the TUI, executes, re-renders)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1565,7 +1565,13 @@ When an issue reaches Done, Fabrik:
 
 **Note:** Auto-archive is currently disabled. It was removing items from the board before users could see them, and is being reworked to track actual Done stage completion time. Items will remain in the Done column until auto-archive is re-enabled in a future release. When re-enabled, archived items will not be deleted — they will remain accessible via the project board's "Archive" view in GitHub.
 
-**Closed-issue auto-advance:** If an issue is closed externally (for example, a PR merge closes it) while its board item sits at any column other than Done, Fabrik automatically advances it to Done. This runs unconditionally on every poll — regardless of yolo, cruise, or plain manual mode — and requires no `stage:<name>:complete` label or any other label at all. It applies to any non-Done column whose resolved stage isn't a cleanup, holding, or gate-checked stage, including columns with no matching stage config at all (for example, a stranded item in Backlog). No manual board move is required. Validate is excluded from this scan — a closed issue at Validate is handled separately by the existing PR-terminal-advance/auto-merge path described above.
+**Closed-issue auto-advance:** If an issue is closed externally (for example, a PR merge closes it) while its board item sits at any column other than Done, Fabrik automatically advances it to Done. This process has the following properties:
+
+- **Unconditional:** It runs on every poll — regardless of yolo, cruise, or plain manual mode.
+- **No labels required:** It requires no `stage:<name>:complete` label or any other label at all.
+- **Broadly applicable:** It applies to any non-Done column whose resolved stage isn't a cleanup, holding, or gate-checked stage, including columns with no matching stage config at all (for example, a stranded item in Backlog).
+- **No manual board move is required.**
+- **Validate is excluded:** A closed issue at Validate is handled separately by the existing PR-terminal-advance/auto-merge path described above.
 
 ### Customizing Stages
 
@@ -2072,7 +2078,10 @@ cost, and issue title. Status icons:
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
 
-**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. When there are no active warnings and no dismissed ones, the panel renders nothing at all (zero height), so History retains maximum vertical space. When there are no active warnings but dismissed entries exist, the panel collapses to a single hint line: `Warnings: none (N dismissed, press tab + S to show)`.
+**Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. The panel's appearance when there are no active warnings depends on whether there are dismissed warnings:
+
+- **No active and no dismissed warnings:** The panel renders nothing at all (zero height), so History retains maximum vertical space.
+- **No active warnings but dismissed entries exist:** The panel collapses to a single hint line: `Warnings: none (N dismissed, press tab + S to show)`.
 
 Tab into the Warnings panel to take action:
 - **F** — run the fix command in the foreground (tears down the TUI, executes, re-renders)


### PR DESCRIPTION
Closes #1032

Corrects two stale passages in `docs/USER_GUIDE.md` that described pre-v0.0.74 behavior, and regenerates `docs/llms-full.txt`.

## Changes

- **Closed-issue auto-advance** (Done Stage and Archiving section): previously described this as scoped to auto-advance mode (`--yolo`/`fabrik:yolo`/`fabrik:cruise`) and gated on a `stage:<name>:complete` label. As of `settleClosedItemsToDone` (v0.0.74, `engine/closed_item_advance_settle.go`), this runs unconditionally every poll regardless of mode, requires no label, and covers any non-Done column whose resolved stage isn't a cleanup/holding/gate-checked stage — including unconfigured columns like Backlog. Validate is excluded (handled by the separate PR-terminal-advance path). Rewritten to match `docs/state-machine.md` §6.11 at user-guide altitude.
- **Warnings panel** (TUI Dashboard § What's Displayed): previously said the panel always collapses to a `Warnings: none` line when empty. As of v0.0.74 (#1012), the panel renders at zero height when there are no active and no dismissed warnings, and only shows a hint line (`Warnings: none (N dismissed, press tab + S to show)`) when dismissed entries exist.
- **Tab shortcut row** (Keyboard Shortcuts table): noted that Tab skips the Warnings pane in the focus cycle whenever it's empty/hidden.
- Regenerated `docs/llms-full.txt` via `scripts/generate-llms-full.sh` (required by CI's `docs-drift` check).

`README.md` and `docs/index.md` were re-verified against the v0.0.74 diff and found to need no changes (confirmed during Research and re-checked here).

## Test plan

- [x] `go build -o fabrik .` — passes
- [x] `go vet ./...` — clean
- [x] `docs/llms-full.txt` regenerated and matches `docs/USER_GUIDE.md` (no docs-drift)
- [x] Manual read-through of both corrected passages against source (`engine/closed_item_advance_settle.go`, `tui/warnings.go`, `tui/model.go`)