### PR TITLE
Fix eight cache/echo correctness bugs from idiom drift

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -973,11 +973,9 @@ func (c *CacheImpl) ApplyIssueClosed(key string) {
 // identified by key. No-op when the key is not in the cache.
 // Safe for concurrent use.
 //
-// Note: LocalCommentAdded is a raw append (not idempotent by DatabaseID).
+// Note: LocalCommentAdded dedups by DatabaseID, mirroring IssueCommentCreated.
 // If a webhook echo for the same comment arrives before the next Reconcile,
-// the comment may appear twice in the cache until Reconcile replaces it.
-// This is acceptable because dispatch-relevant comment checks use rocket-reaction
-// detection rather than DatabaseID uniqueness.
+// the repeated LocalCommentAdded is a no-op rather than a duplicate append.
 func (c *CacheImpl) ApplyCommentAdded(key string, comment gh.Comment) {
 	repo, number, ok := parseItemKey(key)
 	if !ok {

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -612,8 +612,8 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	// Auto-heal: resolve PR linkage via REST or authoritative index.
 	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
-	c.mu.Lock()
 	if !found {
+		c.mu.Lock()
 		if healErr == nil {
 			c.recentMissCache[mk] = time.Now()
 		}
@@ -621,8 +621,11 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 		c.logFn("[cache] dropped pull_request delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	// Confirm item still in Store before proceeding.
-	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
+	// Confirm item still in Store before proceeding. Must not hold c.mu while
+	// calling any Store method (boardcache.go struct-doc invariant).
+	_, storeErr := c.store.Get(repo, resolvedIssNum)
+	c.mu.Lock()
+	if storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -719,8 +719,8 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 	// Auto-heal: resolve PR linkage via REST or authoritative index.
 	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
-	c.mu.Lock()
 	if !found {
+		c.mu.Lock()
 		if healErr == nil {
 			c.recentMissCache[mk] = time.Now()
 		}
@@ -728,7 +728,11 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 		c.logFn("[cache] dropped pull_request_review delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
+	// Confirm item still in Store before proceeding. Must not hold c.mu while
+	// calling any Store method (boardcache.go struct-doc invariant).
+	_, storeErr := c.store.Get(repo, resolvedIssNum)
+	c.mu.Lock()
+	if storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return
@@ -833,8 +837,8 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 	// Auto-heal: resolve PR linkage via REST or authoritative index.
 	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
-	c.mu.Lock()
 	if !found {
+		c.mu.Lock()
 		if healErr == nil {
 			c.recentMissCache[mk] = time.Now()
 		}
@@ -842,7 +846,11 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 		c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: no closing issue in cache\n", prNum)
 		return
 	}
-	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
+	// Confirm item still in Store before proceeding. Must not hold c.mu while
+	// calling any Store method (boardcache.go struct-doc invariant).
+	_, storeErr := c.store.Get(repo, resolvedIssNum)
+	c.mu.Lock()
+	if storeErr != nil {
 		c.recentMissCache[mk] = time.Now()
 		c.mu.Unlock()
 		return
@@ -949,8 +957,8 @@ func (c *CacheImpl) applyCheckRunDelta(payload []byte) {
 	// Auto-heal step 2: resolve which issue the PR closes.
 	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
 
-	c.mu.Lock()
 	if !found {
+		c.mu.Lock()
 		if healErr == nil {
 			c.recentMissCache[msha] = time.Now()
 		}
@@ -958,7 +966,11 @@ func (c *CacheImpl) applyCheckRunDelta(payload []byte) {
 		c.logFn("[cache] dropped check_run delta for SHA %s: no closing issue in cache for PR #%d\n", sha, prNum)
 		return
 	}
-	if _, storeErr := c.store.Get(repo, resolvedIssNum); storeErr != nil {
+	// Confirm item still in Store before proceeding. Must not hold c.mu while
+	// calling any Store method (boardcache.go struct-doc invariant).
+	_, storeErr := c.store.Get(repo, resolvedIssNum)
+	c.mu.Lock()
+	if storeErr != nil {
 		c.recentMissCache[msha] = time.Now()
 		c.mu.Unlock()
 		return

--- a/boardcache/delta_lock_invariant_test.go
+++ b/boardcache/delta_lock_invariant_test.go
@@ -1,0 +1,176 @@
+package boardcache
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestDeltaHealPaths_DoNotCallStoreWhileLocked statically enforces the
+// CacheImpl struct-doc invariant (boardcache.go: "NEVER hold mu while calling
+// any Store method — this prevents deadlock if Store observers call back
+// into CacheImpl"). Store.Get is read-only today, so no test can trigger an
+// actual deadlock; this test instead parses delta.go's own source and walks
+// each of the four auto-heal functions' control flow, tracking whether c.mu
+// is held at each c.store.* call site. A plain textual scan is not enough
+// here — these functions use "Lock(); if cond { ...; Unlock(); return };
+// <store call>" shapes, where an early-return branch's Unlock must not be
+// mistaken for the one guarding the store call that follows it.
+func TestDeltaHealPaths_DoNotCallStoreWhileLocked(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "delta.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing delta.go: %v", err)
+	}
+
+	funcNames := []string{
+		"applyPullRequestDelta",
+		"applyPullRequestReviewDelta",
+		"applyPullRequestReviewCommentDelta",
+		"applyCheckRunDelta",
+	}
+
+	for _, name := range funcNames {
+		t.Run(name, func(t *testing.T) {
+			fn := findFuncDecl(file, name)
+			if fn == nil {
+				t.Fatalf("could not locate function %s in delta.go", name)
+			}
+			var violations []string
+			checkLockInvariant(fset, fn.Body.List, false, &violations)
+			for _, v := range violations {
+				t.Error(v)
+			}
+		})
+	}
+}
+
+func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != name {
+			continue
+		}
+		if fn.Recv == nil {
+			continue
+		}
+		return fn
+	}
+	return nil
+}
+
+// checkLockInvariant walks stmts in sequence, tracking whether c.mu is held
+// (starting from the given locked state), and records a violation for every
+// c.store.* call reached while locked. It returns the locked state after the
+// last statement and whether the sequence unconditionally terminates (via a
+// return reached on every path), so callers (if-statement handling) can tell
+// whether a branch's ending lock state propagates to code after the branch.
+func checkLockInvariant(fset *token.FileSet, stmts []ast.Stmt, locked bool, violations *[]string) (finalLocked, terminates bool) {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.ReturnStmt:
+			return locked, true
+
+		case *ast.IfStmt:
+			if s.Init != nil {
+				recordStoreCallViolations(fset, s.Init, locked, violations)
+			}
+			bodyLocked, bodyTerm := checkLockInvariant(fset, s.Body.List, locked, violations)
+			elseLocked, elseTerm := locked, false
+			if s.Else != nil {
+				switch e := s.Else.(type) {
+				case *ast.BlockStmt:
+					elseLocked, elseTerm = checkLockInvariant(fset, e.List, locked, violations)
+				case *ast.IfStmt:
+					elseLocked, elseTerm = checkLockInvariant(fset, []ast.Stmt{e}, locked, violations)
+				}
+			}
+			switch {
+			case bodyTerm && elseTerm:
+				return locked, true
+			case bodyTerm && !elseTerm:
+				locked = elseLocked
+			case !bodyTerm && elseTerm:
+				locked = bodyLocked
+			default:
+				// Neither branch terminates. Conservatively treat the merge
+				// point as locked if either branch left it locked, so a
+				// disagreement is surfaced as violations downstream rather
+				// than silently swallowed.
+				locked = bodyLocked || elseLocked
+			}
+
+		case *ast.BlockStmt:
+			l, term := checkLockInvariant(fset, s.List, locked, violations)
+			if term {
+				return l, true
+			}
+			locked = l
+
+		default:
+			if name, ok := muCallName(s); ok {
+				switch name {
+				case "Lock":
+					locked = true
+				case "Unlock":
+					locked = false
+				}
+				continue
+			}
+			recordStoreCallViolations(fset, stmt, locked, violations)
+		}
+	}
+	return locked, false
+}
+
+// muCallName reports the method name if stmt is a bare `c.mu.<Method>()` call.
+func muCallName(stmt ast.Stmt) (string, bool) {
+	es, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return "", false
+	}
+	call, ok := es.X.(*ast.CallExpr)
+	if !ok {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	recv, ok := sel.X.(*ast.SelectorExpr)
+	if !ok || recv.Sel.Name != "mu" {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// recordStoreCallViolations scans node for any c.store.<Method>(...) call and
+// records a violation if locked is true. It is used both for whole statements
+// and for if-statement init clauses (which always execute regardless of the
+// branch taken).
+func recordStoreCallViolations(fset *token.FileSet, node ast.Node, locked bool, violations *[]string) {
+	if !locked {
+		return
+	}
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		recv, ok := sel.X.(*ast.SelectorExpr)
+		if !ok || recv.Sel.Name != "store" {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		*violations = append(*violations, fmt.Sprintf(
+			"%s:%d: calls c.store.%s while c.mu is held (violates boardcache.go CacheImpl struct-doc invariant)",
+			pos.Filename, pos.Line, sel.Sel.Name))
+		return true
+	})
+}

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -239,9 +239,11 @@ func TestRunUpgrade_DevBuildSkipsBinaryCheck(t *testing.T) {
 	}
 }
 
-// TestRunUpgrade_NetworkFailureFallsThrough verifies that when the release API
-// returns an error, runUpgrade still falls through and refreshes plugin skills.
-func TestRunUpgrade_NetworkFailureFallsThrough(t *testing.T) {
+// TestRunUpgrade_NetworkFailureHaltsBeforePluginRefresh verifies that when the
+// release API returns an error, runUpgrade halts (returning the wrapped error)
+// before reaching plugin refresh — a failed release upgrade attempt must
+// surface as a command error rather than being silently swallowed.
+func TestRunUpgrade_NetworkFailureHaltsBeforePluginRefresh(t *testing.T) {
 	dir := t.TempDir()
 	chdirTest(t, dir)
 
@@ -256,25 +258,21 @@ func TestRunUpgrade_NetworkFailureFallsThrough(t *testing.T) {
 	Version = "v0.0.1"
 	t.Cleanup(func() { Version = orig })
 
-	if err := runUpgrade(nil); err != nil {
-		t.Fatalf("runUpgrade should not fail on network error, got: %v", err)
+	if err := runUpgrade(nil); err == nil {
+		t.Fatal("runUpgrade should fail when the release upgrade fails")
 	}
 
-	// Plugin files should still have been written despite the network error.
-	entries, err := os.ReadDir(filepath.Join(dir, ".fabrik", "plugin"))
-	if err != nil {
-		t.Fatalf(".fabrik/plugin not created: %v", err)
-	}
-	if len(entries) == 0 {
-		t.Error("expected plugin files to be written even when binary upgrade fails")
+	// Plugin refresh must not have run.
+	if _, err := os.Stat(filepath.Join(dir, ".fabrik", "plugin")); !os.IsNotExist(err) {
+		t.Error("expected plugin files not to be written when the release upgrade fails")
 	}
 }
 
-// TestRunUpgrade_BinaryUpgrade_DownloadAttempted verifies that when a newer
-// release exists with a platform-matching asset, the download URL is hit. The
-// server returns 500 so the upgrade fails gracefully and plugin refresh still
-// runs.
-func TestRunUpgrade_BinaryUpgrade_DownloadAttempted(t *testing.T) {
+// TestRunUpgrade_BinaryUpgrade_DownloadFailureHaltsBeforePluginRefresh verifies
+// that when a newer release exists with a platform-matching asset, the download
+// URL is hit; when the download fails (server returns 500), runUpgrade halts
+// with an error before reaching plugin refresh.
+func TestRunUpgrade_BinaryUpgrade_DownloadFailureHaltsBeforePluginRefresh(t *testing.T) {
 	dir := t.TempDir()
 	chdirTest(t, dir)
 
@@ -302,21 +300,17 @@ func TestRunUpgrade_BinaryUpgrade_DownloadAttempted(t *testing.T) {
 	Version = "v0.0.1"
 	t.Cleanup(func() { Version = orig })
 
-	if err := runUpgrade(nil); err != nil {
-		t.Fatalf("runUpgrade should not fail on download error, got: %v", err)
+	if err := runUpgrade(nil); err == nil {
+		t.Fatal("runUpgrade should fail when the binary download fails")
 	}
 
 	if !downloaded {
 		t.Error("download server was not hit even though a matching asset was provided")
 	}
 
-	// Plugin files should still have been written despite the failed download.
-	entries, err := os.ReadDir(filepath.Join(dir, ".fabrik", "plugin"))
-	if err != nil {
-		t.Fatalf(".fabrik/plugin not created: %v", err)
-	}
-	if len(entries) == 0 {
-		t.Error("expected plugin files to be written even when binary download fails")
+	// Plugin refresh must not have run.
+	if _, err := os.Stat(filepath.Join(dir, ".fabrik", "plugin")); !os.IsNotExist(err) {
+		t.Error("expected plugin files not to be written when the binary download fails")
 	}
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -348,7 +348,9 @@ func runInit(args []string) error {
 	// If running inside a git repo, add .fabrik working directories to
 	// .git/info/exclude so they don't pollute the user's git status.
 	// This is a no-op in non-git directories (the recommended setup).
-	writeGitExclude()
+	if err := writeGitExclude(); err != nil {
+		return err
+	}
 
 	fmt.Println("\nFabrik is ready. Stage configs and plugin skills are in .fabrik/")
 	fmt.Println("Edit .fabrik/config.yaml with your project settings, then run fabrik.")
@@ -358,10 +360,10 @@ func runInit(args []string) error {
 // writeGitExclude adds Fabrik working directories to .git/info/exclude
 // if running inside a git repository. Idempotent — skips entries that
 // already exist. Does nothing if not in a git repo.
-func writeGitExclude() {
+func writeGitExclude() error {
 	excludePath := filepath.Join(".git", "info", "exclude")
 	if _, err := os.Stat(filepath.Join(".git", "info")); os.IsNotExist(err) {
-		return // not in a git repo
+		return nil // not in a git repo
 	}
 
 	entries := []string{
@@ -388,7 +390,10 @@ func writeGitExclude() {
 	}
 
 	if added > 0 {
-		os.WriteFile(excludePath, []byte(content), 0644)
+		if err := os.WriteFile(excludePath, []byte(content), 0644); err != nil {
+			return fmt.Errorf("writing .git/info/exclude: %w", err)
+		}
 		fmt.Printf("  git exclude: %d entries added to .git/info/exclude\n", added)
 	}
+	return nil
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -548,3 +548,57 @@ func TestRunInit_DriftClean(t *testing.T) {
 		t.Errorf("expected zero drift warnings for freshly-init'd stages, got: %q", got)
 	}
 }
+
+// TestWriteGitExclude_WriteFailurePropagates verifies that a failure writing
+// .git/info/exclude is surfaced as an error rather than silently discarded.
+// Pre-fix, writeGitExclude ignored the os.WriteFile error entirely.
+func TestWriteGitExclude_WriteFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint
+
+	if err := os.Mkdir(".git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Make .git/info a regular file (not a directory), so os.Stat(".git/info")
+	// succeeds (the "not a git repo" early-return doesn't fire) but
+	// os.WriteFile(".git/info/exclude", ...) fails with ENOTDIR.
+	if err := os.WriteFile(".git/info", []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeGitExclude(); err == nil {
+		t.Fatal("expected writeGitExclude to return an error when the write fails")
+	}
+}
+
+// TestRunInit_HaltsOnGitExcludeFailure verifies runInit propagates a
+// writeGitExclude failure instead of reporting success.
+func TestRunInit_HaltsOnGitExcludeFailure(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(orig) //nolint
+
+	if err := os.Mkdir(".git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(".git/info", []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInit([]string{}); err == nil {
+		t.Fatal("expected runInit to fail when writeGitExclude fails")
+	}
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -62,9 +62,11 @@ func runUpgrade(args []string) error {
 		if client == nil {
 			client = gh.NewClient(token)
 		}
-		engine.PerformReleaseUpgrade(client, Version, token, nil, func(format string, args ...any) {
+		if err := engine.PerformReleaseUpgrade(client, Version, token, nil, func(format string, args ...any) {
 			fmt.Printf(format, args...)
-		})
+		}); err != nil {
+			return fmt.Errorf("release upgrade: %w", err)
+		}
 	}
 
 	if force {

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -261,16 +261,21 @@ func logDirForItem(issue gh.ProjectItem) string {
 	return filepath.Join(cwd, ".fabrik", "logs", repoPart, issuePart)
 }
 
-// sessionFile returns the path to the session ID file for a given issue+stage.
-// stageName is sanitized to prevent path traversal: filepath.Base strips directory
-// components, and an additional check rejects names that are empty, ".", or the
-// path separator (e.g. filepath.Base("/") == "/"), falling back to "default".
-func sessionFile(issueNumber int, stageName string) string {
+// sanitizeStageName sanitizes a stage name for use as a session-file basename,
+// preventing path traversal: filepath.Base strips directory components, and an
+// additional check rejects names that are empty, ".", or the path separator
+// (e.g. filepath.Base("/") == "/"), falling back to "default".
+func sanitizeStageName(stageName string) string {
 	base := filepath.Base(stageName)
 	if base == "" || base == "." || base == "/" || base == string(filepath.Separator) {
 		base = "default"
 	}
-	return filepath.Join(SessionDir(issueNumber), base+".session")
+	return base
+}
+
+// sessionFile returns the path to the session ID file for a given issue+stage.
+func sessionFile(issueNumber int, stageName string) string {
+	return filepath.Join(SessionDir(issueNumber), sanitizeStageName(stageName)+".session")
 }
 
 // ReadSessionID reads the session ID for a given repo, issue, and stage name.
@@ -278,10 +283,7 @@ func sessionFile(issueNumber int, stageName string) string {
 // Returns the session ID string, or empty string if the file does not exist,
 // is unreadable, or is empty.
 func ReadSessionID(repo string, issueNumber int, stageName string) string {
-	base := filepath.Base(stageName)
-	if base == "" || base == "." || base == "/" || base == string(filepath.Separator) {
-		base = "default"
-	}
+	base := sanitizeStageName(stageName)
 	cwd, _ := os.Getwd()
 	issuePart := fmt.Sprintf("issue-%d", issueNumber)
 	var sessDir string
@@ -312,7 +314,7 @@ func InvokeClaude(ctx context.Context, stage *stages.Stage, issue gh.ProjectItem
 		return "", false, TokenUsage{}, fmt.Errorf("setting session dir permissions: %w", err)
 	}
 
-	sessFilePath := filepath.Join(sessDir, filepath.Base(stage.Name)+".session")
+	sessFilePath := filepath.Join(sessDir, sanitizeStageName(stage.Name)+".session")
 	ld := logDirForItem(issue)
 
 	prompt := buildPrompt(stage, issue, newComments, opts.BaseBranch)
@@ -345,7 +347,7 @@ func InvokeClaudeForComments(ctx context.Context, stage *stages.Stage, issue gh.
 		return "", false, TokenUsage{}, fmt.Errorf("setting session dir permissions: %w", err)
 	}
 
-	sessFilePath := filepath.Join(sessDir, filepath.Base(stage.Name)+".session")
+	sessFilePath := filepath.Join(sessDir, sanitizeStageName(stage.Name)+".session")
 	ld := logDirForItem(issue)
 
 	prompt := buildCommentReviewPrompt(stage, issue, comments, opts.BaseBranch)

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -1442,3 +1442,79 @@ printf '%%s\n' '{"result":"ok","session_id":"sess_ur","num_turns":1,"total_cost_
 		t.Error("expected --permission-mode NOT to be present for unrestricted issue")
 	}
 }
+
+// ── fix #5 regression tests (issue #1024) ───────────────────────────────────
+//
+// InvokeClaude/InvokeClaudeForComments built the session-file path inline with
+// only filepath.Base(stage.Name), bypassing the sanitizer that sessionFile/
+// ReadSessionID use — which additionally substitutes "default" when the
+// sanitized name is empty, ".", or a path separator. A pathological stage name
+// (here, "") would write a session file the read path never looks for. Both
+// invocation entry points now route through the same sanitizeStageName helper.
+
+func TestInvokeClaude_PathologicalStageName_SessionRoundTrips(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := `#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"result":"done\nFABRIK_STAGE_COMPLETE\n","session_id":"sess_pathological","num_turns":1,"total_cost_usd":0.001}'
+`
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "", // pathological: empty stage name
+		Prompt:     "test",
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 909, Title: "T"}
+
+	_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+	if err != nil {
+		t.Fatalf("InvokeClaude: %v", err)
+	}
+
+	// ReadSessionID must find the session written by the write path above —
+	// both must resolve the same sanitized ("default") basename.
+	got := ReadSessionID("", 909, "")
+	if got != "sess_pathological" {
+		t.Errorf("ReadSessionID(\"\", 909, \"\") = %q, want %q — write/read path basename mismatch", got, "sess_pathological")
+	}
+}
+
+func TestInvokeClaudeForComments_PathologicalStageName_SessionRoundTrips(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := `#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"result":"comment done","session_id":"sess_cmt_pathological","num_turns":1,"total_cost_usd":0.001}'
+`
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "", // pathological: empty stage name
+		Prompt:     "test",
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 910, Title: "T"}
+	comments := []gh.Comment{{Author: "user", Body: "please fix", CreatedAt: time.Now()}}
+
+	_, _, _, err := InvokeClaudeForComments(context.Background(), stage, issue, comments, workDir, InvokeOptions{})
+	if err != nil {
+		t.Fatalf("InvokeClaudeForComments: %v", err)
+	}
+
+	got := ReadSessionID("", 910, "")
+	if got != "sess_cmt_pathological" {
+		t.Errorf("ReadSessionID(\"\", 910, \"\") = %q, want %q — write/read path basename mismatch", got, "sess_cmt_pathological")
+	}
+}

--- a/engine/item.go
+++ b/engine/item.go
@@ -392,7 +392,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 					e.logf(item.Number, "warn", "could not remove fabrik:paused label: %v\n", err)
 				} else {
 					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 					}
 					if e.webhookMgr != nil {
 						e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
@@ -473,7 +473,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
 		} else {
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), completeLabel)
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
@@ -491,7 +491,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			e.logf(item.Number, "warn", "could not remove extend-turns label: %v\n", removeErr)
 		} else if removeErr == nil {
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:extend-turns")
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:extend-turns")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:extend-turns")
@@ -607,7 +607,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt, LastSignAt: workerStartedAt},
 		})
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), lockLabel)
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+lockLabel)
@@ -694,7 +694,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	} else {
 		inProgressAdded = true
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), inProgressLabel)
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), inProgressLabel)
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+inProgressLabel)
@@ -980,7 +980,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
 				e.logf(item.Number, "warn", "could not post FABRIK_PR_CREATE error comment: %v\n", commentErr)
 			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
@@ -1034,7 +1034,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
 			} else {
 				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 					})
 				}
@@ -1089,7 +1089,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			e.logf(item.Number, "warn", "could not post empty-output warning: %v\n", commentErr)
 		} else {
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 					DatabaseID: dbID, Body: warnComment, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
@@ -1236,7 +1236,7 @@ func (e *Engine) escalatePRCreationFailure(item gh.ProjectItem, stage *stages.St
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
@@ -1253,7 +1253,7 @@ func (e *Engine) escalatePRCreationFailure(item gh.ProjectItem, stage *stages.St
 		e.logf(item.Number, "warn", "could not post PR escalation comment: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 			})
 		}
@@ -1282,7 +1282,7 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
@@ -1299,7 +1299,7 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 		e.logf(item.Number, "warn", "could not post escalation comment: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 			})
 		}
@@ -1329,7 +1329,7 @@ func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 		e.logf(item.Number, "warn", "could not remove failed label: %v\n", err)
 	} else if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), failedLabel)
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), failedLabel)
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+failedLabel)
@@ -1505,7 +1505,7 @@ func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage, output s
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
@@ -1515,7 +1515,7 @@ func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage, output s
 		e.logf(item.Number, "warn", "could not add awaiting-input label: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
@@ -1531,7 +1531,7 @@ func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage, output s
 		e.logf(item.Number, "warn", "could not post awaiting-input notification comment: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 			})
 		}
@@ -1553,7 +1553,7 @@ func (e *Engine) unblockAwaitingInput(item gh.ProjectItem, stage *stages.Stage) 
 		e.logf(item.Number, "warn", "could not remove paused label: %v\n", err)
 	} else if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
@@ -1564,7 +1564,7 @@ func (e *Engine) unblockAwaitingInput(item gh.ProjectItem, stage *stages.Stage) 
 		e.logf(item.Number, "warn", "could not remove awaiting-input label: %v\n", err)
 	} else if err == nil {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
@@ -1687,7 +1687,7 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 			e.logf(item.Number, "warn", "could not post base branch fallback comment: %v\n", err)
 		} else {
 			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 					DatabaseID: dbID, Body: body, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
@@ -2056,7 +2056,7 @@ func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, ite
 		e.logf(item.Number, "warn", "could not post boundary violation comment: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
 			})
 		}
@@ -2072,7 +2072,7 @@ func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, ite
 		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
 	} else {
 		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/stages"
 )
@@ -868,9 +869,23 @@ func (e *Engine) ejectMember(ctx context.Context, owner, repo string, memberItem
 		}
 		if err := e.client.AddLabelToIssue(owner, repo, memberItem.Number, "fabrik:paused"); err != nil {
 			e.logf(memberItem.Number, "warn", "could not add fabrik:paused: %v\n", err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, memberItem.Number), "fabrik:paused")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, memberItem.Number)+"+"+"fabrik:paused")
+			}
 		}
 		if err := e.client.AddLabelToIssue(owner, repo, memberItem.Number, "fabrik:awaiting-input"); err != nil {
 			e.logf(memberItem.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, memberItem.Number), "fabrik:awaiting-input")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, memberItem.Number)+"+"+"fabrik:awaiting-input")
+			}
 		}
 	}
 }
@@ -974,9 +989,23 @@ func (e *Engine) fireRunawayGuard(ctx context.Context, owner, repo string, items
 		}
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:paused (runaway guard): %v\n", err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+			}
 		}
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input (runaway guard): %v\n", err)
+		} else {
+			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
+			}
 		}
 	}
 }

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/stages"
 )
@@ -410,6 +411,105 @@ func TestEjectMember_EjectionCountIsPerMember(t *testing.T) {
 	}
 	if pausedIssues[2] {
 		t.Error("expected issue #2 NOT to be paused after only 1 ejection")
+	}
+}
+
+// TestEjectMember_PauseVisibleToCacheAndEcho verifies that when ejectMember pauses a
+// member after MaxMergeTrainEjections, the pause labels are mirrored into the board
+// cache and registered as pending webhook echoes — not just posted to GitHub. Before
+// the fix, ejectMember called AddLabelToIssue with no ApplyLabelAdded/RegisterEcho,
+// leaving the cached snapshot stale until the next full board fetch.
+func TestEjectMember_PauseVisibleToCacheAndEcho(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.BootstrapFromProbe([]gh.BoardProbeItem{
+		{ContentID: "I_005", ItemID: "PVTI_005", Number: 5, Repo: "owner/repo", Status: "Queued"},
+	}, "PVT_1")
+	eng.readClient = cache
+
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	member := makeTrainItem(5, "Problem Issue")
+	ctx := context.Background()
+
+	eng.ejectMember(ctx, "owner", "repo", member, "conflict")
+	eng.ejectMember(ctx, "owner", "repo", member, "conflict")
+	eng.ejectMember(ctx, "owner", "repo", member, "conflict") // triggers pause
+
+	labels, err := cache.FetchLabels("owner", "repo", 5)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	labelSet := map[string]bool{}
+	for _, l := range labels {
+		labelSet[l] = true
+	}
+	if !labelSet["fabrik:paused"] {
+		t.Error("expected fabrik:paused to be write-through applied to the cache")
+	}
+	if !labelSet["fabrik:awaiting-input"] {
+		t.Error("expected fabrik:awaiting-input to be write-through applied to the cache")
+	}
+
+	wm.mu.Lock()
+	_, pausedEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 5)+"+"+"fabrik:paused")]
+	_, awaitingEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 5)+"+"+"fabrik:awaiting-input")]
+	wm.mu.Unlock()
+	if !pausedEcho {
+		t.Error("expected fabrik:paused webhook echo to be registered")
+	}
+	if !awaitingEcho {
+		t.Error("expected fabrik:awaiting-input webhook echo to be registered")
+	}
+}
+
+// TestFireRunawayGuard_PauseVisibleToCacheAndEcho verifies the same cache/echo
+// write-through for the runaway-guard pause path.
+func TestFireRunawayGuard_PauseVisibleToCacheAndEcho(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := trainTestEngine(t, client, claude, NewWorktreeManager(t.TempDir()))
+
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.BootstrapFromProbe([]gh.BoardProbeItem{
+		{ContentID: "I_007", ItemID: "PVTI_007", Number: 7, Repo: "owner/repo", Status: "Queued"},
+	}, "PVT_1")
+	eng.readClient = cache
+
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	member := makeTrainItem(7, "Runaway Issue")
+	eng.fireRunawayGuard(context.Background(), "owner", "repo", []gh.ProjectItem{member}, 20)
+
+	labels, err := cache.FetchLabels("owner", "repo", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	labelSet := map[string]bool{}
+	for _, l := range labels {
+		labelSet[l] = true
+	}
+	if !labelSet["fabrik:paused"] {
+		t.Error("expected fabrik:paused to be write-through applied to the cache")
+	}
+	if !labelSet["fabrik:awaiting-input"] {
+		t.Error("expected fabrik:awaiting-input to be write-through applied to the cache")
+	}
+
+	wm.mu.Lock()
+	_, pausedEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 7)+"+"+"fabrik:paused")]
+	_, awaitingEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 7)+"+"+"fabrik:awaiting-input")]
+	wm.mu.Unlock()
+	if !pausedEcho {
+		t.Error("expected fabrik:paused webhook echo to be registered")
+	}
+	if !awaitingEcho {
+		t.Error("expected fabrik:awaiting-input webhook echo to be registered")
 	}
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -2318,7 +2318,10 @@ func (e *Engine) checkReleaseUpgrade() {
 	logf := func(format string, args ...any) {
 		e.logf(0, "upgrade", format, args...)
 	}
-	PerformReleaseUpgrade(e.client, e.cfg.Version, e.cfg.Token, []string{"FABRIK_AUTO_UPGRADED=1"}, logf)
+	// Error discarded intentionally: failures are logged by PerformReleaseUpgrade
+	// itself via logf, and this caller's contract is non-fatal — the poll loop
+	// continues regardless (unlike the foreground `fabrik upgrade` command).
+	_ = PerformReleaseUpgrade(e.client, e.cfg.Version, e.cfg.Token, []string{"FABRIK_AUTO_UPGRADED=1"}, logf)
 }
 
 // captureGitMeta captures the current branch name, short commit SHA,

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -287,14 +287,28 @@ func (e *Engine) removeAwaitingReviewLabel(owner, repo string, item gh.ProjectIt
 	for _, l := range item.Labels {
 		if l == "fabrik:awaiting-review" {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
-				e.logf(item.Number, "warn", "could not remove fabrik:awaiting-review label: %v\n", err)
+				if errors.Is(err, gh.ErrNotFound) {
+					// Label already absent on GitHub — desired end state achieved; sync cache.
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
+					}
+				} else {
+					e.logf(item.Number, "warn", "could not remove fabrik:awaiting-review label: %v\n", err)
+				}
 			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 			}
 		}
 		if l == botRepromptedLabel {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, l); err != nil {
-				e.logf(item.Number, "warn", "could not remove %s label: %v\n", l, err)
+				if errors.Is(err, gh.ErrNotFound) {
+					// Label already absent on GitHub — desired end state achieved; sync cache.
+					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
+					}
+				} else {
+					e.logf(item.Number, "warn", "could not remove %s label: %v\n", l, err)
+				}
 			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
 				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
 			}

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -290,13 +290,13 @@ func (e *Engine) removeAwaitingReviewLabel(owner, repo string, item gh.ProjectIt
 				if errors.Is(err, gh.ErrNotFound) {
 					// Label already absent on GitHub — desired end state achieved; sync cache.
 					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-review")
 					}
 				} else {
 					e.logf(item.Number, "warn", "could not remove fabrik:awaiting-review label: %v\n", err)
 				}
 			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-review")
 			}
 		}
 		if l == botRepromptedLabel {
@@ -304,13 +304,13 @@ func (e *Engine) removeAwaitingReviewLabel(owner, repo string, item gh.ProjectIt
 				if errors.Is(err, gh.ErrNotFound) {
 					// Label already absent on GitHub — desired end state achieved; sync cache.
 					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
+						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), l)
 					}
 				} else {
 					e.logf(item.Number, "warn", "could not remove %s label: %v\n", l, err)
 				}
 			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
+				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), l)
 			}
 		}
 	}

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -960,6 +960,11 @@ func TestRemoveAwaitingReviewLabel_CleansRepromptedLabels(t *testing.T) {
 // GitHub) and the cache synced accordingly — mirroring removeAwaitingCILabel's
 // ErrNotFound branch exactly. Before the fix, an ErrNotFound just logged a
 // warning and left the cache believing the label was still present.
+//
+// The item is constructed with an empty Repo (relying on the defaultRepo()
+// fallback to "owner/repo") so the item.Repo-vs-resolved-owner/repo cache key
+// mismatch is also observable here — a test using an explicit non-empty
+// item.Repo would not catch that bug class.
 func TestRemoveAwaitingReviewLabel_ErrNotFound(t *testing.T) {
 	var calls int
 	client := &mockGitHubClient{
@@ -981,7 +986,6 @@ func TestRemoveAwaitingReviewLabel_ErrNotFound(t *testing.T) {
 
 	item := gh.ProjectItem{
 		Number: 10,
-		Repo:   "owner/repo",
 		Labels: []string{"fabrik:awaiting-review"},
 	}
 

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
@@ -950,6 +952,53 @@ func TestRemoveAwaitingReviewLabel_CleansRepromptedLabels(t *testing.T) {
 	}
 	if !removedLabels["fabrik:bot-reprompted"] {
 		t.Error("expected fabrik:bot-reprompted to be removed")
+	}
+}
+
+// TestRemoveAwaitingReviewLabel_ErrNotFound verifies fix #4 (issue #1024): a 404
+// from RemoveLabelFromIssue must be treated as success (label already absent on
+// GitHub) and the cache synced accordingly — mirroring removeAwaitingCILabel's
+// ErrNotFound branch exactly. Before the fix, an ErrNotFound just logged a
+// warning and left the cache believing the label was still present.
+func TestRemoveAwaitingReviewLabel_ErrNotFound(t *testing.T) {
+	var calls int
+	client := &mockGitHubClient{
+		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			if labelName == "fabrik:awaiting-review" {
+				calls++
+				return fmt.Errorf("GitHub API returned 404: label not found: %w", gh.ErrNotFound)
+			}
+			return nil
+		},
+	}
+	eng := reviewTestEngine(t, client)
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	cache.BootstrapFromProbe([]gh.BoardProbeItem{
+		{ContentID: "I_010", ItemID: "PVTI_010", Number: 10, Repo: "owner/repo", Status: "Review"},
+	}, "PVT_1")
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 10), "fabrik:awaiting-review")
+	eng.readClient = cache
+
+	item := gh.ProjectItem{
+		Number: 10,
+		Repo:   "owner/repo",
+		Labels: []string{"fabrik:awaiting-review"},
+	}
+
+	eng.removeAwaitingReviewLabel("owner", "repo", item)
+
+	if calls != 1 {
+		t.Errorf("expected exactly 1 RemoveLabelFromIssue call for ErrNotFound, got %d", calls)
+	}
+
+	labels, err := cache.FetchLabels("owner", "repo", 10)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	for _, l := range labels {
+		if l == "fabrik:awaiting-review" {
+			t.Error("expected fabrik:awaiting-review to be removed from cache after ErrNotFound — cache is stuck believing the label is still present")
+		}
 	}
 }
 

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -412,12 +412,18 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 	return true, nil
 }
 
-// addPausedLabelToItem adds fabrik:paused to the given item, with cache write-through.
+// addPausedLabelToItem adds fabrik:paused to the given item, with cache write-through
+// and webhook echo registration.
 func (e *Engine) addPausedLabelToItem(owner, repo string, item gh.ProjectItem) {
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
+	} else {
+		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
+		}
+		if e.webhookMgr != nil {
+			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
+		}
 	}
 }
 

--- a/engine/upgrade.go
+++ b/engine/upgrade.go
@@ -115,22 +115,26 @@ func ExtractBinaryFromTarball(tarballPath, destDir string) (string, error) {
 // re-execs with os.Args. extraEnv is appended to the environment for the
 // re-exec (e.g. []string{"FABRIK_AUTO_UPGRADED=1"}); pass nil for no extras.
 //
-// All failures are non-fatal: logf is called with a warning and the function
-// returns so the caller can fall through to its normal operation.
-func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv []string, logf func(string, ...any)) {
+// logf is always called with a warning on failure; the returned error lets
+// callers decide whether a failure should be fatal (e.g. a foreground `fabrik
+// upgrade` command halting before plugin refresh) or non-fatal (e.g. the
+// background poll loop, which must continue regardless — see
+// engine/poll.go's checkReleaseUpgrade). "Already up to date" and "no release
+// object" are not failures and return nil.
+func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv []string, logf func(string, ...any)) error {
 	release, err := client.FetchLatestRelease(fabrikOwner, fabrikRepo)
 	if err != nil {
 		logf("could not fetch latest release: %v\n", err)
-		return
+		return fmt.Errorf("fetching latest release: %w", err)
 	}
 	if release == nil {
-		return
+		return nil
 	}
 
 	latestTag := release.TagName
 	if !SemverGreater(latestTag, version) {
 		// Up to date; log nothing.
-		return
+		return nil
 	}
 
 	logf("new release available: %s (running %s) — upgrading\n", latestTag, version)
@@ -152,19 +156,19 @@ func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv 
 	}
 	if downloadURL == "" {
 		logf("no matching asset for %s/%s (want %s) — skipping\n", runtime.GOOS, runtime.GOARCH, wantName)
-		return
+		return fmt.Errorf("no matching release asset for %s/%s (want %s)", runtime.GOOS, runtime.GOARCH, wantName)
 	}
 
 	// Determine current executable path.
 	exe, err := os.Executable()
 	if err != nil {
 		logf("could not determine executable path: %v\n", err)
-		return
+		return fmt.Errorf("determining executable path: %w", err)
 	}
 	exe, err = filepath.EvalSymlinks(exe)
 	if err != nil {
 		logf("could not resolve symlinks for executable: %v\n", err)
-		return
+		return fmt.Errorf("resolving executable symlinks: %w", err)
 	}
 
 	logf("downloading %s\n", downloadURL)
@@ -174,7 +178,7 @@ func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv 
 	tarballTmp, err := os.CreateTemp(filepath.Dir(exe), "fabrik-download-*")
 	if err != nil {
 		logf("could not create download temp file: %v\n", err)
-		return
+		return fmt.Errorf("creating download temp file: %w", err)
 	}
 	tarballPath := tarballTmp.Name()
 	defer os.Remove(tarballPath)
@@ -194,29 +198,29 @@ func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv 
 	if err != nil {
 		tarballTmp.Close()
 		logf("download failed: %v\n", err)
-		return
+		return fmt.Errorf("downloading release asset: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		tarballTmp.Close()
 		logf("download returned HTTP %d\n", resp.StatusCode)
-		return
+		return fmt.Errorf("downloading release asset: HTTP %d", resp.StatusCode)
 	}
 	if _, err := io.Copy(tarballTmp, resp.Body); err != nil {
 		tarballTmp.Close()
 		logf("writing download: %v\n", err)
-		return
+		return fmt.Errorf("writing downloaded asset: %w", err)
 	}
 	if err := tarballTmp.Close(); err != nil {
 		logf("closing download: %v\n", err)
-		return
+		return fmt.Errorf("closing downloaded asset: %w", err)
 	}
 
 	// Extract the binary from the tarball.
 	newBin, err := ExtractBinaryFromTarball(tarballPath, filepath.Dir(exe))
 	if err != nil {
 		logf("extracting binary: %v\n", err)
-		return
+		return fmt.Errorf("extracting binary from tarball: %w", err)
 	}
 
 	// Atomically replace the running binary; only remove newBin if rename fails.
@@ -228,7 +232,7 @@ func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv 
 	}()
 	if err := os.Rename(newBin, exe); err != nil {
 		logf("replacing binary: %v\n", err)
-		return
+		return fmt.Errorf("replacing running binary: %w", err)
 	}
 	renamed = true
 
@@ -245,5 +249,7 @@ func PerformReleaseUpgrade(client GitHubClient, version, token string, extraEnv 
 	env := append(os.Environ(), extraEnv...)
 	if err := syscall.Exec(exe, os.Args, env); err != nil {
 		logf("exec failed: %v\n", err)
+		return fmt.Errorf("re-executing upgraded binary: %w", err)
 	}
+	return nil
 }

--- a/engine/write_through_test.go
+++ b/engine/write_through_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
 )
 
 // TestLabelWriteThrough verifies that successful label mutations are immediately
@@ -221,4 +222,110 @@ func containsCommentByID(comments []gh.Comment, dbID int) bool {
 		}
 	}
 	return false
+}
+
+// ── fix #2 regression tests (issue #1024) ───────────────────────────────────
+//
+// Several engine/item.go call sites keyed the board-cache write-through on the
+// raw item.Repo field while the adjacent webhook-echo registration correctly
+// used the resolved owner+"/"+repo. Since item.Repo is empty for default-repo
+// items, the two beats produced different cache keys and the write-through
+// silently landed on a key nothing ever reads. Every item below is constructed
+// with an empty Repo (relying on defaultRepo() fallback) so the pre-fix bug is
+// actually observable — a test using an explicit non-empty item.Repo would not
+// catch this.
+
+func TestEscalatePRCreationFailure_CacheKeyUsesResolvedRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1} // empty Repo — must fall back to defaultRepo() "owner/repo"
+	stage := &stages.Stage{Name: "Implement", Order: 3, Prompt: "implement"}
+
+	eng.escalatePRCreationFailure(item, stage, "main")
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused to be write-through applied to the cache under the resolved owner/repo key, got %v", labels)
+	}
+}
+
+func TestEscalateFailedStage_CacheKeyUsesResolvedRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Implement", Order: 3, Prompt: "implement"}
+
+	eng.escalateFailedStage(item, stage)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused to be write-through applied to the cache under the resolved owner/repo key, got %v", labels)
+	}
+}
+
+func TestBlockOnInputAndUnblock_CacheKeyUsesResolvedRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Implement", Order: 3, Prompt: "implement"}
+
+	eng.blockOnInput(item, stage, "need input please")
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused to be write-through applied to the cache, got %v", labels)
+	}
+	if !containsLabel(labels, "fabrik:awaiting-input") {
+		t.Errorf("expected fabrik:awaiting-input to be write-through applied to the cache, got %v", labels)
+	}
+
+	// unblockAwaitingInput removes both labels; verify the removal also lands on
+	// the resolved owner/repo key (not item.Repo) so the cache actually clears.
+	eng.unblockAwaitingInput(item, stage)
+
+	labels, err = cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if containsLabel(labels, "fabrik:paused") || containsLabel(labels, "fabrik:awaiting-input") {
+		t.Errorf("expected pause labels removed from the cache, got %v", labels)
+	}
+}
+
+func TestHandleBoundaryViolation_CacheKeyUsesResolvedRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1}
+	stage := &stages.Stage{Name: "Implement", Order: 3, Prompt: "implement"}
+
+	eng.handleBoundaryViolation("owner", "repo", "owner/repo", item, stage, []string{"pushed to origin/main"}, func() {})
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused to be write-through applied to the cache under the resolved owner/repo key, got %v", labels)
+	}
 }

--- a/engine/write_through_test.go
+++ b/engine/write_through_test.go
@@ -329,3 +329,36 @@ func TestHandleBoundaryViolation_CacheKeyUsesResolvedRepo(t *testing.T) {
 		t.Errorf("expected fabrik:paused to be write-through applied to the cache under the resolved owner/repo key, got %v", labels)
 	}
 }
+
+// ── fix #3 regression test (issue #1024) ────────────────────────────────────
+//
+// addPausedLabelToItem (spawn.go) did the label add + cache write-through but
+// never called RegisterEcho, so a stale inbound webhook could re-clear the
+// cached paused state. It also had the same item.Repo-vs-resolved-owner/repo
+// key mismatch as fix #2, fixed in the same edit since both live in the exact
+// same few lines.
+func TestAddPausedLabelToItem_CacheKeyAndEcho(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1} // empty Repo — must fall back to the passed-in owner/repo
+
+	eng.addPausedLabelToItem("owner", "repo", item)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused to be write-through applied to the cache under the resolved owner/repo key, got %v", labels)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
+	wm.mu.Unlock()
+	if !gotEcho {
+		t.Error("expected fabrik:paused webhook echo to be registered")
+	}
+}

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -197,6 +197,31 @@ func TestApplyLocalCommentAdded(t *testing.T) {
 	}
 }
 
+func TestApplyLocalCommentAdded_DedupsByDatabaseID(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	c := gh.Comment{ID: "local1", DatabaseID: 42, Body: "Fabrik posted"}
+	applyExpect(t, s, LocalCommentAdded{Repo: testRepo, Number: 1, Comment: c}, CommentsChanged)
+	// Re-applying the same local add (e.g. a retried mutation after a crash)
+	// must not duplicate the comment.
+	snap, changes, err := s.Apply(LocalCommentAdded{Repo: testRepo, Number: 1, Comment: c})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("re-applying an existing local comment produced changes %v; want none", changes)
+	}
+	st := snap.State()
+	count := 0
+	for _, got := range st.Comments {
+		if got.DatabaseID == 42 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Comments has %d entries with DatabaseID 42; want 1", count)
+	}
+}
+
 // ---- LocalLockAcquired / LocalLockReleased ----
 
 func TestApplyLocalLockAcquired(t *testing.T) {

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -149,6 +149,7 @@ func (s *Store) Get(repo string, number int) (Snapshot, error) {
 	}
 	fetched, err := s.fallback.FetchItem(repo, number)
 	if err != nil {
+		s.logf("itemstate: FetchItem(%s#%d) failed, returning ErrNotFound: %v\n", repo, number, err)
 		return Snapshot{}, ErrNotFound
 	}
 	fetched.Repo = repo
@@ -342,6 +343,12 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		return LabelsChanged
 
 	case LocalCommentAdded:
+		// Idempotent: skip if comment with this DatabaseID already exists.
+		for _, existing := range item.Comments {
+			if existing.DatabaseID == v.Comment.DatabaseID && v.Comment.DatabaseID != 0 {
+				return 0
+			}
+		}
 		item.Comments = append(item.Comments, v.Comment)
 		return CommentsChanged
 

--- a/internal/itemstate/store_test.go
+++ b/internal/itemstate/store_test.go
@@ -2,6 +2,8 @@ package itemstate
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -160,6 +162,38 @@ func TestCacheMissFallbackErrorReturnsErrNotFound(t *testing.T) {
 	_, err := s.Get(testRepo, 1)
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("Get returned %v; want ErrNotFound", err)
+	}
+}
+
+// TestCacheMissFallbackErrorIsLogged verifies that a real FetchItem error
+// (network/auth/rate-limit) is logged before being flattened to ErrNotFound,
+// so an outage is not silently indistinguishable from "issue doesn't exist".
+func TestCacheMissFallbackErrorIsLogged(t *testing.T) {
+	underlying := errors.New("rate limited")
+	fb := &stubFallback{err: underlying}
+	var mu sync.Mutex
+	var logged []string
+	s := NewStore(fb, WithLogger(func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		logged = append(logged, fmt.Sprintf(format, args...))
+	}))
+	if _, err := s.Get(testRepo, 1); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get returned %v; want ErrNotFound", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(logged) == 0 {
+		t.Fatal("Get did not log the underlying fallback error")
+	}
+	found := false
+	for _, l := range logged {
+		if strings.Contains(l, underlying.Error()) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("logged messages %v do not mention underlying error %q", logged, underlying)
 	}
 }
 


### PR DESCRIPTION
Closes #1024

## Summary

Fixes eight independently-verifiable correctness defects found by a code-health audit of the "mutate GitHub → mirror into board cache → register webhook echo" idiom (ADR-042), which is hand-inlined at hundreds of call sites across the engine.

1. **Merge-train pauses invisible to cache** — `ejectMember`/`fireRunawayGuard` (`engine/merge_train.go`) now write through to the board cache and register a webhook echo when adding `fabrik:paused`/`fabrik:awaiting-input`, matching every sibling pause site.
2. **Cache key vs echo key mismatch** — 21 sites in `engine/item.go` keyed the cache write-through on raw `item.Repo` (empty for default-repo items) while the adjacent echo correctly used the resolved `owner/repo`. All 21 now use the same resolved string for both.
3. **Child-placement pause skips the echo** — `addPausedLabelToItem` (`engine/spawn.go`) now registers the `fabrik:paused` echo and fixes the same `item.Repo` key bug (it shares the function with fix #2's bug class, at 9 call sites).
4. **Missing idempotency on review-label removal** — `removeAwaitingReviewLabel` now treats `gh.ErrNotFound` as success (cache synced) exactly like its `removeAwaitingCILabel` twin.
5. **Session-file write/read path mismatch** — `InvokeClaude`/`InvokeClaudeForComments` now route through the same sanitized-stage-name builder as `sessionFile`/`ReadSessionID`, so a pathological stage name can't produce a session file `ReadSessionID` never finds.
6. **Locking-invariant violation in delta heal paths** — the four `boardcache/delta.go` heal paths no longer call `store.Get` while holding `c.mu`, restoring the documented `CacheImpl` invariant. A static source-scan test asserts no `store.Get` call appears inside a `mu.Lock()`/`mu.Unlock()` span.
7. **Duplicate comments from `LocalCommentAdded`** — now dedups by `DatabaseID`, matching `IssueCommentCreated`; the stale "acceptable duplication" doc comment on `ApplyCommentAdded` is updated to describe the new behavior.
8. **Swallowed operational failures** — `Store.Get` now logs the real `FetchItem` error before flattening to `ErrNotFound`; `cmd/upgrade.go` checks and halts before plugin refresh on a failed release upgrade (`PerformReleaseUpgrade` now returns `error`; the background poll-loop caller intentionally discards it, preserving its non-fatal contract); `cmd/init.go`'s `writeGitExclude` now returns and propagates its `os.WriteFile` error instead of discarding it.

No structural refactor or shared-helper extraction — that's deliberately deferred to a follow-up issue. Each fix is the minimal change restoring already-documented intended behavior.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (2313 tests pass)
- [x] Each fix has a dedicated regression test that fails before and passes after (or, for the locking invariant, a static assertion that the lock is not held across `store.Get`)