### PR TITLE
Code health: delete confirmed dead code

### DIFF
--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -1178,22 +1178,6 @@ func copyDeepFieldsFromState(dst *gh.ProjectItem, s itemstate.ItemState) {
 	}
 }
 
-// copyDeepFields overlays the deep fields from src onto dst.
-// Shallow fields (Labels, Status, Title, UpdatedAt) are left unchanged in dst.
-func copyDeepFields(dst, src *gh.ProjectItem) {
-	dst.Body = src.Body
-	dst.URL = src.URL
-	dst.Author = src.Author
-	dst.Assignees = cloneStrings(src.Assignees)
-	dst.BlockedBy = cloneDependencies(src.BlockedBy)
-	dst.Comments = cloneComments(src.Comments)
-	dst.LinkedPRNumber = src.LinkedPRNumber
-	dst.LinkedPRReviewRequests = cloneReviewRequests(src.LinkedPRReviewRequests)
-	dst.LinkedPRReviews = clonePRReviews(src.LinkedPRReviews)
-	dst.LinkedPRReviewThreadComments = cloneComments(src.LinkedPRReviewThreadComments)
-	dst.LinkedPRResolvedThreadCount = src.LinkedPRResolvedThreadCount
-}
-
 // fabrikManagedLabelKey returns an order-independent canonical key of the
 // fabrik-managed labels (fabrik: / stage: prefixes) in the slice — the labels
 // that gate dispatch. Used by LightReconcile to detect gate-label drift between

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mattn/go-isatty"
 	"github.com/handarbeit/fabrik/config"
 	"github.com/handarbeit/fabrik/engine"
 	gh "github.com/handarbeit/fabrik/github"
@@ -105,17 +104,12 @@ func runUpgrade(args []string) error {
 	return nil
 }
 
-// checkPluginSkills compares embedded plugin files against on-disk files in
-// pluginDir. If any differ and stdin is a TTY, the user is prompted to upgrade.
-// In non-interactive mode a warning is printed to stderr and execution continues.
-// Returns nil if the directory does not exist (no fabrik init done yet).
-func checkPluginSkills(pluginDir string) error {
-	isTTY := isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
-	return checkPluginSkillsWithReader(pluginDir, isTTY, os.Stdin)
-}
-
-// checkPluginSkillsWithReader is the testable implementation of checkPluginSkills.
-// isTTY and r control interactive-prompt behaviour without requiring a real PTY.
+// checkPluginSkillsWithReader compares embedded plugin files against on-disk
+// files in pluginDir. If any differ and isTTY is true, the user is prompted
+// to upgrade. In non-interactive mode a warning is printed to stderr and
+// execution continues. Returns nil if the directory does not exist (no
+// fabrik init done yet). isTTY and r control interactive-prompt behaviour
+// without requiring a real PTY.
 func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) error {
 	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
 		return nil

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4390,7 +4390,7 @@ This is a deliberately fragile-by-design, best-effort mechanism: a parameterized
 
 **Deliberately label-state-agnostic.** Unlike every other settle-owner, this scan is **not** conditioned on `fabrik:paused`, `fabrik:awaiting-input`, `fabrik:blocked`, or any other in-flight label. A closed issue at a non-terminal column is itself a terminal state that supersedes any gate/lock label — no further pipeline work can occur on a closed issue sitting outside Done regardless of what else is set on it, so there is nothing for those labels to protect against here (ADR-064).
 
-**Code path:** the settle scan, `settleClosedItemsToDone` (`engine/closed_item_advance_settle.go`), called unconditionally every poll from `poll.go`, immediately after the child board-placement settle scan (§6.9) and before the (currently disabled) `archiveDoneCompleteItems` call.
+**Code path:** the settle scan, `settleClosedItemsToDone` (`engine/closed_item_advance_settle.go`), called unconditionally every poll from `poll.go`, immediately after the child board-placement settle scan (§6.9). Auto-archiving of Done items is not currently implemented (tracked separately by #1035).
 
 **Flow:**
 1. Resolve the cleanup (Done) stage via `cleanupStage(e.cfg)` — the lowest-`Order` stage with `CleanupWorktree: true`, mirroring `holdingStage`'s shape but by explicit min-`Order` scan (the same convention `settleNoWorkNeeded` uses) rather than first-encountered, since `e.cfg.Stages` could theoretically contain more than one cleanup-flagged stage. If none is configured, the scan is a no-op for the whole poll — no panic.
@@ -4399,7 +4399,7 @@ This is a deliberately fragile-by-design, best-effort mechanism: a parameterized
 4. Otherwise call `advanceClosedItemToDone`, which mirrors `advanceToQueued`'s shape: look up the cleanup stage's status option, call `UpdateProjectItemStatus`, write through `boardcache.CacheImpl.UpdateItemStatus`, and register the webhook echo. No completion label is added — unlike `advanceToQueued`'s `stage:Validate:complete`, this scan has no per-stage bookkeeping to do; landing the item at the cleanup column is sufficient for the existing `CleanupWorktree` dispatch branch (`engine/item.go:439`) to take over unmodified on the next poll (worktree reaping, `stage:Done:complete` labeling).
 5. On any failure (`e.statusField == nil`, no matching status option, or the API call itself failing), log a warning and move on — no retry counter, no escalation. The next poll re-derives the same predicate from `board.Items` and retries automatically; there is nothing to lose between polls, so a bare retry-forever loop is sufficient (ADR-064; contrast with §6.7–6.10's `MaxRetries`/escalation machinery, which exists to protect an at-risk *sequence* of calls or a durable marker this scan does not have).
 
-**Downstream: unmodified.** Once an item lands at the cleanup column via this scan, no new logic runs — the existing `CleanupWorktree` dispatch branch reaps the worktree and adds `stage:Done:complete` exactly as it already does for every other route into Done (§6.10, the normal pipeline advance, `settleNoWorkNeeded`). `archiveDoneCompleteItems` remains disabled in production (`engine/poll.go`, tracked separately by #687) — this scan closes the *reachability* gap (worktree leak, permanent dispatch stall) but not the *archival* gap: a previously-stranded closed item now gets cleaned up and reaches a `stage:Done:complete`, terminal-skip-eligible state, but still occupies a board row (a cheap one, skipped on every subsequent poll) until #687 ships or an operator manually archives it.
+**Downstream: unmodified.** Once an item lands at the cleanup column via this scan, no new logic runs — the existing `CleanupWorktree` dispatch branch reaps the worktree and adds `stage:Done:complete` exactly as it already does for every other route into Done (§6.10, the normal pipeline advance, `settleNoWorkNeeded`). Auto-archiving of Done items is not currently implemented (tracked separately by #1035) — this scan closes the *reachability* gap (worktree leak, permanent dispatch stall) but not the *archival* gap: a previously-stranded closed item now gets cleaned up and reaches a `stage:Done:complete`, terminal-skip-eligible state, but still occupies a board row (a cheap one, skipped on every subsequent poll) until #1035 ships or an operator manually archives it.
 
 **State transitions:**
 
@@ -5187,9 +5187,9 @@ The worktree janitor reaps orphaned git worktrees left behind when issues exit t
 managed lifecycle without triggering the normal `cleanup_worktree: true` Done-stage path.
 Three scenarios produce stranded worktrees:
 
-1. **Off-board items** — issues removed from the project board (archived, deleted, or
-   removed by `archiveDoneCompleteItems`) are no longer iterated by the poll loop; their
-   worktrees persist indefinitely.
+1. **Off-board items** — issues removed from the project board (archived manually by an
+   operator, or deleted) are no longer iterated by the poll loop; their worktrees
+   persist indefinitely.
 2. **Narrow restart window** — Fabrik dies after `attemptMergeOnValidate` advances the
    board to Done but before the next poll dispatches the Done stage.
 3. **Stage YAML drift** — an operator who renames or removes the Done stage from their
@@ -5530,7 +5530,7 @@ Terminal state is stored as a `Terminal bool` field in `ItemState` and set/clear
 
 **Full reconcile — drift-recovery (webhook mode)**
 
-`LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. `reconcileCache` (the older full-fetch-and-reconcile helper) is retained but is no longer called by the engine.
+`LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. The older full-fetch-and-reconcile helper (`reconcileCache`) has been removed; `reconcileLoop`'s `LightReconcile` path is the sole reconciliation mechanism.
 
 `Reconcile` performs a deep partial update:
 - For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1715,7 +1715,7 @@ This is a deliberately fragile-by-design, best-effort mechanism: a parameterized
 
 **Deliberately label-state-agnostic.** Unlike every other settle-owner, this scan is **not** conditioned on `fabrik:paused`, `fabrik:awaiting-input`, `fabrik:blocked`, or any other in-flight label. A closed issue at a non-terminal column is itself a terminal state that supersedes any gate/lock label — no further pipeline work can occur on a closed issue sitting outside Done regardless of what else is set on it, so there is nothing for those labels to protect against here (ADR-064).
 
-**Code path:** the settle scan, `settleClosedItemsToDone` (`engine/closed_item_advance_settle.go`), called unconditionally every poll from `poll.go`, immediately after the child board-placement settle scan (§6.9) and before the (currently disabled) `archiveDoneCompleteItems` call.
+**Code path:** the settle scan, `settleClosedItemsToDone` (`engine/closed_item_advance_settle.go`), called unconditionally every poll from `poll.go`, immediately after the child board-placement settle scan (§6.9). Auto-archiving of Done items is not currently implemented (tracked separately by #1035).
 
 **Flow:**
 1. Resolve the cleanup (Done) stage via `cleanupStage(e.cfg)` — the lowest-`Order` stage with `CleanupWorktree: true`, mirroring `holdingStage`'s shape but by explicit min-`Order` scan (the same convention `settleNoWorkNeeded` uses) rather than first-encountered, since `e.cfg.Stages` could theoretically contain more than one cleanup-flagged stage. If none is configured, the scan is a no-op for the whole poll — no panic.
@@ -1724,7 +1724,7 @@ This is a deliberately fragile-by-design, best-effort mechanism: a parameterized
 4. Otherwise call `advanceClosedItemToDone`, which mirrors `advanceToQueued`'s shape: look up the cleanup stage's status option, call `UpdateProjectItemStatus`, write through `boardcache.CacheImpl.UpdateItemStatus`, and register the webhook echo. No completion label is added — unlike `advanceToQueued`'s `stage:Validate:complete`, this scan has no per-stage bookkeeping to do; landing the item at the cleanup column is sufficient for the existing `CleanupWorktree` dispatch branch (`engine/item.go:439`) to take over unmodified on the next poll (worktree reaping, `stage:Done:complete` labeling).
 5. On any failure (`e.statusField == nil`, no matching status option, or the API call itself failing), log a warning and move on — no retry counter, no escalation. The next poll re-derives the same predicate from `board.Items` and retries automatically; there is nothing to lose between polls, so a bare retry-forever loop is sufficient (ADR-064; contrast with §6.7–6.10's `MaxRetries`/escalation machinery, which exists to protect an at-risk *sequence* of calls or a durable marker this scan does not have).
 
-**Downstream: unmodified.** Once an item lands at the cleanup column via this scan, no new logic runs — the existing `CleanupWorktree` dispatch branch reaps the worktree and adds `stage:Done:complete` exactly as it already does for every other route into Done (§6.10, the normal pipeline advance, `settleNoWorkNeeded`). `archiveDoneCompleteItems` remains disabled in production (`engine/poll.go`, tracked separately by #687) — this scan closes the *reachability* gap (worktree leak, permanent dispatch stall) but not the *archival* gap: a previously-stranded closed item now gets cleaned up and reaches a `stage:Done:complete`, terminal-skip-eligible state, but still occupies a board row (a cheap one, skipped on every subsequent poll) until #687 ships or an operator manually archives it.
+**Downstream: unmodified.** Once an item lands at the cleanup column via this scan, no new logic runs — the existing `CleanupWorktree` dispatch branch reaps the worktree and adds `stage:Done:complete` exactly as it already does for every other route into Done (§6.10, the normal pipeline advance, `settleNoWorkNeeded`). Auto-archiving of Done items is not currently implemented (tracked separately by #1035) — this scan closes the *reachability* gap (worktree leak, permanent dispatch stall) but not the *archival* gap: a previously-stranded closed item now gets cleaned up and reaches a `stage:Done:complete`, terminal-skip-eligible state, but still occupies a board row (a cheap one, skipped on every subsequent poll) until #1035 ships or an operator manually archives it.
 
 **State transitions:**
 
@@ -2512,9 +2512,9 @@ The worktree janitor reaps orphaned git worktrees left behind when issues exit t
 managed lifecycle without triggering the normal `cleanup_worktree: true` Done-stage path.
 Three scenarios produce stranded worktrees:
 
-1. **Off-board items** — issues removed from the project board (archived, deleted, or
-   removed by `archiveDoneCompleteItems`) are no longer iterated by the poll loop; their
-   worktrees persist indefinitely.
+1. **Off-board items** — issues removed from the project board (archived manually by an
+   operator, or deleted) are no longer iterated by the poll loop; their worktrees
+   persist indefinitely.
 2. **Narrow restart window** — Fabrik dies after `attemptMergeOnValidate` advances the
    board to Done but before the next poll dispatches the Done stage.
 3. **Stage YAML drift** — an operator who renames or removes the Done stage from their
@@ -2855,7 +2855,7 @@ Terminal state is stored as a `Terminal bool` field in `ItemState` and set/clear
 
 **Full reconcile — drift-recovery (webhook mode)**
 
-`LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. `reconcileCache` (the older full-fetch-and-reconcile helper) is retained but is no longer called by the engine.
+`LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. The older full-fetch-and-reconcile helper (`reconcileCache`) has been removed; `reconcileLoop`'s `LightReconcile` path is the sole reconciliation mechanism.
 
 `Reconcile` performs a deep partial update:
 - For each item in the fresh board snapshot: update shallow fields (`Status`, shallow `Labels`, `UpdatedAt`, etc.) in-place. Deep fields (`Comments`, `LinkedPR*`, etc.) are **preserved** from the existing cache entry to avoid triggering a burst of FetchItemDetails calls after each reconciliation.

--- a/engine/item.go
+++ b/engine/item.go
@@ -498,9 +498,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			}
 		}
 
-		// Archive is handled by archiveDoneCompleteItems in the poll loop,
-		// which enforces the 24-hour grace period so completed items remain
-		// visible on the board.
+		// Auto-archiving of Done items is not currently performed (see #1035).
 
 		// Record CooldownAt["periodic-re-eval"] so itemMayNeedWork suppresses
 		// deep-fetches for this terminal item during the cooldown window.

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -831,51 +831,6 @@ func (e *Engine) cleanupClosedIssueTransientLabels(board *gh.ProjectBoard) {
 	}
 }
 
-// archiveDoneCompleteItems archives board items in a cleanup (Done) stage that
-// have the stage:<Name>:complete label. Handles both legacy items (pre-archive
-// feature) and ongoing cleanup. Uses shallow board data — labels(first:15) is
-// sufficient to see stage:Done:complete even on issues with many labels.
-// Idempotent: archived items disappear from subsequent board queries.
-// archiveGracePeriod is how long a completed Done item stays visible on the
-// board before being archived. This gives users time to see what completed
-// while they were away, especially in yolo mode.
-const archiveGracePeriod = 24 * time.Hour
-
-func (e *Engine) archiveDoneCompleteItems(projectID string, items []gh.ProjectItem) {
-	archived := 0
-	for _, item := range items {
-		st := stages.FindStage(e.cfg.Stages, item.Status)
-		if st == nil || !st.CleanupWorktree {
-			continue
-		}
-		completeLabel := fmt.Sprintf("stage:%s:complete", st.Name)
-		hasComplete := false
-		for _, l := range item.Labels {
-			if l == completeLabel {
-				hasComplete = true
-				break
-			}
-		}
-		if !hasComplete {
-			continue
-		}
-		// Let completed items stay visible for 24 hours so users can see
-		// what finished while they were away. If UpdatedAt is unknown (zero),
-		// don't archive — we can't tell how old it is.
-		if item.UpdatedAt.IsZero() || time.Since(item.UpdatedAt) < archiveGracePeriod {
-			continue
-		}
-		if err := e.client.ArchiveProjectItem(projectID, item.ItemID); err != nil {
-			e.logf(item.Number, "warn", "could not archive done item: %v\n", err)
-			continue
-		}
-		archived++
-	}
-	if archived > 0 {
-		e.logf(0, "poll", "archived %d done item(s) from board\n", archived)
-	}
-}
-
 type pollResult struct {
 	Active     bool
 	ItemCount  int
@@ -1600,16 +1555,6 @@ doneDispatching:
 	// runValidatePRTerminalAdvance, to avoid double-advance/racing between the
 	// two settle-owners.
 	e.settleClosedItemsToDone(board)
-
-	// Archive any Done+complete items (lazy migration + ongoing cleanup).
-	// Uses shallow board data — labels(first:15) is sufficient to see
-	// stage:Done:complete. Idempotent: archived items disappear from board
-	// results, so this converges to a no-op after legacy items are cleaned up.
-	// Auto-archive disabled — too aggressive in practice, removing items
-	// before users can see what completed. Re-enable once the timing logic
-	// is reworked to track when the Done stage actually completed rather
-	// than relying on UpdatedAt.
-	// e.archiveDoneCompleteItems(board.ProjectID, board.Items)
 
 	// Report cumulative token consumption only when new cost has accrued since
 	// the last print, to avoid repeated log noise on idle polls.
@@ -2448,17 +2393,6 @@ func (e *Engine) checkURLRewrite() bool {
 		}
 	}
 	return false
-}
-
-// reconcileCache fetches a fresh board snapshot from GitHub and applies it to
-// the in-memory cache, preserving deep fields already fetched for individual items.
-func (e *Engine) reconcileCache(cache *boardcache.CacheImpl) {
-	board, err := e.client.FetchProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
-	if err != nil {
-		e.logf(0, "cache", "reconciliation fetch failed: %v\n", err)
-		return
-	}
-	cache.Reconcile(board)
 }
 
 // reconcileLoop is the poll-only correctness backstop for cache/GitHub divergence.

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -513,37 +513,6 @@ func TestPoll_RateLimitWarning(t *testing.T) {
 	}
 }
 
-// TestArchiveDoneCompleteItems_ArchivesCompleteItems verifies that items in a
-// CleanupWorktree stage with the stage:<Name>:complete label are archived.
-func TestArchiveDoneCompleteItems_ArchivesCompleteItems(t *testing.T) {
-	client := &mockGitHubClient{}
-	eng := testEngine(t, client, &mockClaudeInvoker{})
-	eng.cfg.Stages = testStagesWithCleanup()
-
-	board := &gh.ProjectBoard{
-		ProjectID: "PVT_test",
-		Items: []gh.ProjectItem{
-			{
-				Number:    10,
-				ItemID:    "PVTI_10",
-				Status:    "Done",
-				Labels:    []string{"stage:Done:complete"},
-				UpdatedAt: time.Now().Add(-48 * time.Hour), // older than 24h grace period
-			},
-		},
-	}
-
-	eng.archiveDoneCompleteItems(board.ProjectID, board.Items)
-
-	if len(client.archiveProjectItemCalls) != 1 {
-		t.Fatalf("expected 1 ArchiveProjectItem call, got %d", len(client.archiveProjectItemCalls))
-	}
-	got := client.archiveProjectItemCalls[0]
-	if got.projectID != "PVT_test" || got.itemID != "PVTI_10" {
-		t.Errorf("ArchiveProjectItem(%q, %q), want (PVT_test, PVTI_10)", got.projectID, got.itemID)
-	}
-}
-
 // ── Bug A: catch-up loop review-gate guard (#617) ────────────────────────────
 
 // TestCatchupLoop_SkipsReviewGate_WhenAwaitingCIWithoutComplete verifies that
@@ -788,32 +757,6 @@ func TestCleanupClosedIssueTransientLabels_APIErrorContinues(t *testing.T) {
 	}
 }
 
-// TestArchiveDoneCompleteItems_SkipsIncompleteItems verifies that Done items
-// without the stage:Done:complete label are not archived.
-func TestArchiveDoneCompleteItems_SkipsIncompleteItems(t *testing.T) {
-	client := &mockGitHubClient{}
-	eng := testEngine(t, client, &mockClaudeInvoker{})
-	eng.cfg.Stages = testStagesWithCleanup()
-
-	board := &gh.ProjectBoard{
-		ProjectID: "PVT_test",
-		Items: []gh.ProjectItem{
-			{
-				Number: 20,
-				ItemID: "PVTI_20",
-				Status: "Done",
-				Labels: []string{"enhancement"}, // no complete label
-			},
-		},
-	}
-
-	eng.archiveDoneCompleteItems(board.ProjectID, board.Items)
-
-	if len(client.archiveProjectItemCalls) != 0 {
-		t.Errorf("expected no ArchiveProjectItem calls for incomplete item, got %d", len(client.archiveProjectItemCalls))
-	}
-}
-
 // TestYoloCatchUpEnablesAutoMerge verifies that when an item sits in the
 // Validate column with stage:Validate:complete + fabrik:yolo, the catch-up loop
 // calls EnablePullRequestAutoMerge (not MergePR) and does NOT immediately advance
@@ -1003,32 +946,6 @@ func TestYoloCatchUpSkipsAdvanceOnUnprocessedComment(t *testing.T) {
 
 	if advances != 0 {
 		t.Errorf("expected no UpdateProjectItemStatus when unprocessed comment exists, got %d", advances)
-	}
-}
-
-// TestArchiveDoneCompleteItems_SkipsNonCleanupStages verifies that items in
-// non-cleanup stages are not archived even if they have complete labels.
-func TestArchiveDoneCompleteItems_SkipsNonCleanupStages(t *testing.T) {
-	client := &mockGitHubClient{}
-	eng := testEngine(t, client, &mockClaudeInvoker{})
-	eng.cfg.Stages = testStagesWithCleanup()
-
-	board := &gh.ProjectBoard{
-		ProjectID: "PVT_test",
-		Items: []gh.ProjectItem{
-			{
-				Number: 30,
-				ItemID: "PVTI_30",
-				Status: "Research",
-				Labels: []string{"stage:Research:complete"},
-			},
-		},
-	}
-
-	eng.archiveDoneCompleteItems(board.ProjectID, board.Items)
-
-	if len(client.archiveProjectItemCalls) != 0 {
-		t.Errorf("expected no ArchiveProjectItem calls for non-cleanup stage, got %d", len(client.archiveProjectItemCalls))
 	}
 }
 

--- a/engine/process_item_test.go
+++ b/engine/process_item_test.go
@@ -1004,10 +1004,10 @@ func TestProcessItem_CleanupStage_CleanWorktree(t *testing.T) {
 		t.Errorf("completion label = %q, want stage:Done:complete", addedLabel)
 	}
 
-	// ArchiveProjectItem should NOT be called inline — archiving is deferred to
-	// archiveDoneCompleteItems which enforces the 24-hour grace period.
+	// ArchiveProjectItem should NOT be called inline — auto-archiving of Done
+	// items is not currently performed.
 	if len(client.archiveProjectItemCalls) != 0 {
-		t.Errorf("expected no ArchiveProjectItem calls (deferred to grace period), got %d", len(client.archiveProjectItemCalls))
+		t.Errorf("expected no ArchiveProjectItem calls, got %d", len(client.archiveProjectItemCalls))
 	}
 
 	// CooldownAt["periodic-re-eval"] should be set so itemMayNeedWork suppresses future deep-fetches
@@ -1126,9 +1126,10 @@ func TestProcessItem_CleanupStage_PRItem(t *testing.T) {
 	if len(client.addLabelCalls) != 1 || client.addLabelCalls[0].labelName != "stage:Done:complete" {
 		t.Errorf("expected stage:Done:complete label, got %v", client.addLabelCalls)
 	}
-	// ArchiveProjectItem should NOT be called inline — deferred to grace period.
+	// ArchiveProjectItem should NOT be called inline — auto-archiving of Done
+	// items is not currently performed.
 	if len(client.archiveProjectItemCalls) != 0 {
-		t.Errorf("expected no ArchiveProjectItem calls for PR item (deferred), got %d", len(client.archiveProjectItemCalls))
+		t.Errorf("expected no ArchiveProjectItem calls for PR item, got %d", len(client.archiveProjectItemCalls))
 	}
 	if len(claude.calls) != 0 {
 		t.Error("should not invoke claude for cleanup stage PR item")

--- a/engine/worktree.go
+++ b/engine/worktree.go
@@ -322,11 +322,6 @@ func (wm *WorktreeManager) trainBranchName(name string) string {
 	return "fabrik/merge-train/" + name
 }
 
-// TrainWorktreeDir returns the path to a merge-train worktree (whether it exists or not).
-func (wm *WorktreeManager) TrainWorktreeDir(name string) string {
-	return wm.trainWorktreeDir(name)
-}
-
 // EnsureTrainWorktree creates a worktree for the trial branch, forking fresh from
 // origin/<baseBranch>. Unlike EnsureWorktree it never reuses an existing worktree
 // (trial branches are disposable) and never updates from main (the fork is always fresh).

--- a/tui/footer.go
+++ b/tui/footer.go
@@ -74,16 +74,6 @@ func supportsOSC8() bool {
 	return false
 }
 
-// applyOSC8 wraps the first occurrence of title in plain with an OSC 8 hyperlink
-// pointing to boardURL. If title or boardURL is empty, or if the terminal does not
-// support OSC 8, plain is returned unchanged.
-func applyOSC8(plain, title, boardURL string) string {
-	if title == "" || boardURL == "" || !supportsOSC8() {
-		return plain
-	}
-	return strings.Replace(plain, title, termenv.Hyperlink(boardURL, title), 1)
-}
-
 // renderWithOSC8 applies dimStyle to plain text but preserves OSC 8 hyperlinks.
 // Renders the entire string in dim first, then replaces the plain title with
 // the OSC 8 hyperlinked version so SGR codes flow through naturally.


### PR DESCRIPTION
Closes #1025

Removes six confirmed-dead functions identified by the 2026-07-20 code-health audit, plus their now-unused helpers. No behavior change — deletions only.

**Deleted:**
- `copyDeepFields` (`boardcache/boardcache.go`) — near-duplicate of the live `copyDeepFieldsFromState`
- `reconcileCache` (`engine/poll.go`) — fully superseded by `reconcileLoop`'s `LightReconcile` → `cacheImpl.Reconcile` path
- `TrainWorktreeDir` (`engine/worktree.go`) — exported wrapper; the only caller uses the unexported `trainWorktreeDir` directly
- `checkPluginSkills` (`cmd/upgrade.go`) — wrapper; all real callers use `checkPluginSkillsWithReader` directly
- `applyOSC8` (`tui/footer.go`) — zero callers; siblings `renderWithOSC8`/`injectIssueLink` duplicate the logic inline
- `archiveDoneCompleteItems` + its `archiveGracePeriod` const (`engine/poll.go`) — the only call site was already commented out; auto-archiving of Done items is disabled pending a timing rework tracked separately as #1035

**Also removed:** the three direct unit tests for `archiveDoneCompleteItems` in `engine/poll_test.go` (each test's sole purpose was exercising the deleted function), and stale comments in `engine/item.go` and `engine/process_item_test.go` that named the deleted function.

**Kept (not dead):** `WithLogger` (`internal/itemstate/store.go`) — the issue's dead-code audit predates #1024, which added a live test (`TestCacheMissFallbackErrorIsLogged`) exercising this helper.

**Docs:** updated `docs/state-machine.md`'s four mentions of `reconcileCache`/`archiveDoneCompleteItems` to describe removal instead of "retained"/"disabled", and regenerated `docs/llms-full.txt` per the docs-drift requirement.

**Testing:**
- `go build ./...`, `go vet ./...` clean
- `go test -race ./...` — 2310/2310 passing (one test, `TestExecute_ConfigYAMLApplied`, is confirmed pre-existing-flaky in this sandbox — reproduced independently on the pre-change base commit, unrelated to this diff, likely due to no network access for its GraphQL startup probe)
- `deadcode ./...` shows none of the six deleted functions remain reachable/present, and no new unreachable code was introduced by the edits — the only "unreachable" functions reported are pre-existing test-only helpers (`NewWithDeps`, `NewWorktreeManager`, `NewClientWithBaseURL`, `WithLogger`, etc.) explicitly out of scope per the issue

**To test:** `go build ./... && go vet ./... && go test -race ./...`