### PR TITLE
refactor(engine): consolidate GitHub-mutation helpers (label/comment/pause)

### DIFF
--- a/adrs/065-consolidated-mutation-helpers.md
+++ b/adrs/065-consolidated-mutation-helpers.md
@@ -1,0 +1,67 @@
+# ADR 065: Consolidated GitHub-Mutation Helpers (label/comment/pause)
+
+## Status
+
+Accepted
+
+## Context
+
+Every state change the engine makes to GitHub follows the same three-beat idiom: mutate on GitHub, mirror the result into the board cache (`boardcache.CacheImpl`), and register a webhook echo so the mutation echo-check (ADR-042) can detect stream failures. Before this change, that idiom was hand-typed at every call site rather than encapsulated behind a helper:
+
+- ~170 inline `if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok { ... }` type assertions
+- ~115 `ApplyLabelAdded`/`ApplyLabelRemoved` write-through call sites
+- ~81 `RegisterEcho` call sites
+- ~44 `ApplyCommentAdded` call sites
+- 11 `pauseFor*` functions sharing an ~25-line tail (post a comment, add `fabrik:paused` + `fabrik:awaiting-input`), plus 2 `escalate*` functions with a related but non-identical tail
+
+Because no helper enforced the sequence, hand-copied sites drifted from each other. The most damaging drift was inconsistent repo-key derivation: some sites resolved the repo via `item.Repo` directly, others via `itemOwnerRepo(item, e.defaultRepo())`, and a mismatch between the two meant a mutation could be applied to one repo while the cache write used a different key — silently corrupting cache state for multi-repo boards. This was the root cause of several correctness bugs fixed in the P0 issue immediately preceding this one in the code-health chain.
+
+## Decision
+
+Introduce a small set of `Engine` methods in `engine/mutate.go` that encapsulate the mutate → cache-write-through → webhook-echo idiom, and route existing call sites through them.
+
+### Layered design: private echo-parameterized cores + always-on public wrappers
+
+- `e.cache() *boardcache.CacheImpl` — the cast-or-nil accessor, replacing every inline type assertion.
+- `e.applyLabelAdd(item, label, echo bool)` / `e.applyLabelRemove(item, label, echo bool)` — private cores performing the GitHub mutation, cache write-through, and a webhook echo *conditional on `echo`*. `applyLabelRemove` treats `gh.ErrNotFound` as success and still syncs the cache, but never echoes on `ErrNotFound` (nothing changed on GitHub to echo).
+- `e.addLabel(item, label)` / `e.removeLabel(item, label)` — the always-echoing public wrappers (`echo: true`), used by the great majority of call sites.
+- `e.syncLabelAdd(item, label, echo bool)` / `e.syncLabelRemoval(item, label, echo bool)` — the cache-write-through-plus-conditional-echo *tail* only, split out of the cores above. Some call sites must perform the GitHub mutation themselves because other logic (e.g. a local `lockAcquired` boolean, a retry-with-backoff loop) is gated on the mutation's own success/failure — those sites call the raw client method directly and then call the shared tail instead of re-inlining it.
+- `e.postComment(item, body string, react, echo bool) (int, error)` / `e.postItemComment(item, body string, react bool) int` — the same core/wrapper split for comment posting: `AddComment` → cache write-through via `ApplyCommentAdded` → conditional `RegisterEcho("issue_comment", "created", ...)` → optional rocket reaction.
+
+The `echo`-parameterized cores exist for two reasons: (1) sites that never had a `RegisterEcho` call must not gain one silently — a "behavior must stay byte-for-byte identical" mandate — and (2) `pauseIssue` (below) needs to suppress echo entirely at some call sites.
+
+The repo string is resolved exactly once, inside each helper, via `itemOwnerRepo(item, e.defaultRepo())` — the same canonical resolution used everywhere else in the engine. A caller only ever passes `item`; it cannot accidentally use `item.Repo` in one place and a separately-resolved `owner, repo` in another. This structurally forecloses the repo-key divergence bug class described above. Where an existing call site had this exact divergence (e.g. one site posted a comment via `e.cfg.Owner`/`e.cfg.Repo` while the cache write already used the item-resolved owner/repo), routing it through the helper both fixes the divergence and satisfies the acceptance criterion that such a site can no longer recur.
+
+### `pauseIssue` and the `pauseOpts` escape hatch
+
+`pauseIssue(item, comment string, opts pauseOpts)` collapses the shared tail of the 11 `pauseFor*` functions and the pause portion of 2 `escalate*` functions: post the comment, add `fabrik:paused`, optionally add `fabrik:awaiting-input`, optionally remove `fabrik:auto-merge-enabled`.
+
+A single `bool` cannot describe every call site's behavior, because reading all 13+ call sites end-to-end turned up three genuinely distinct, pre-existing patterns:
+
+| Pattern | Sites | `awaiting-input` | comment reaction | label echo | comment echo |
+|---|---|---|---|---|---|
+| A | most `pauseFor*` functions | yes | yes | no | no |
+| B | the 2 `escalate*` functions | no | yes | yes | yes |
+| C | `pauseForBrokenLinkage` | no | no | yes | no |
+
+`pauseOpts` makes each axis an explicit field (`awaitingInput`, `reactRocket`, `labelEcho`, `commentEcho`, `removeAutoMerge`), so every call site passes a literal matching its own row in the table above — auditable, and impossible to silently unify. The `RegisterEcho` asymmetry between `pauseFor*` (never echoes) and `escalate*` (always echoes) is a genuine pre-existing inconsistency, not something this refactor is chartered to fix; `pauseOpts` preserves it exactly rather than picking a side.
+
+### `bumpLocalDeltaAt` re-inlining
+
+Separately, `boardcache/boardcache.go` had 7 mutator methods that re-inlined the `now := time.Now(); c.mu.Lock(); c.localDeltaAt[key] = now; c.mu.Unlock()` sequence instead of calling the existing `bumpLocalDeltaAt` helper (already used correctly 23 times in `boardcache/delta.go`). These were collapsed to `c.bumpLocalDeltaAt(key)` calls as part of the same cleanup, since it is the same "helper exists but isn't used everywhere" problem this ADR addresses, just for a cache-internal idiom rather than an engine-to-GitHub one.
+
+## Consequences
+
+**Benefits:**
+- The `item.Repo`-vs-`owner/repo` repo-key divergence bug class is structurally impossible at any routed call site — the helper resolves the repo once, internally.
+- New call sites default to the correct three-beat idiom by construction instead of by developer diligence.
+- The mechanical diff is large (~20 files touched) but every commit in the sequence leaves the tree building, vetting, and testing green — there is no "helpers added but nothing routed yet" intermediate state that's broken.
+
+**Drawbacks / risks:**
+- `pauseOpts` is an extra layer of indirection a future contributor must learn before adding a 14th pause site; the per-pattern table above (and `pauseOpts`'s doc comment in `engine/mutate.go`) is the reference.
+- A handful of call sites could not be routed through the always-echoing public wrappers because they either (a) have local control flow gated on the raw mutation's success/failure, or (b) never echoed/reacted before and must not gain that behavior silently. These use the private `applyLabelAdd`/`applyLabelRemove`/`postComment` cores directly with an explicit `echo`/`react` argument — slightly more verbose than the wrapper, but still eliminates the repeated cache-assertion boilerplate and keeps repo resolution canonical.
+- One deliberate, small, sanctioned behavior change: `removeLabel`'s ErrNotFound-still-syncs-the-cache behavior is now applied uniformly, including at sites that previously skipped the cache sync on `ErrNotFound` entirely. This was called out explicitly as in-scope by the parent issue (it's the same bug class the issue exists to eliminate), unlike the `pauseFor*`/`escalate*` echo asymmetry, which is preserved rather than unified.
+
+## Related ADRs
+
+- [ADR-042: Mutation Echo-Check for Webhook Health Detection](042-mutation-echo-check.md) — defines *why* `RegisterEcho` calls matter and what a missed one costs (delayed silent-webhook-failure detection); this ADR defines *how* to call it consistently so call sites can't drift out of sync with that mechanism.

--- a/adrs/065-consolidated-mutation-helpers.md
+++ b/adrs/065-consolidated-mutation-helpers.md
@@ -46,6 +46,8 @@ A single `bool` cannot describe every call site's behavior, because reading all 
 
 `pauseOpts` makes each axis an explicit field (`awaitingInput`, `reactRocket`, `labelEcho`, `commentEcho`, `removeAutoMerge`), so every call site passes a literal matching its own row in the table above — auditable, and impossible to silently unify. The `RegisterEcho` asymmetry between `pauseFor*` (never echoes) and `escalate*` (always echoes) is a genuine pre-existing inconsistency, not something this refactor is chartered to fix; `pauseOpts` preserves it exactly rather than picking a side.
 
+A fourth axis surfaced during review: *order*. Pattern A's `pauseFor*` functions historically posted their comment before adding `fabrik:paused`; Patterns B and C added the label first. `pauseOpts.labelFirst` (default `false`, matching Pattern A) reproduces each site's original ordering — Patterns B and C set it to `true`. `TestPauseIssue_PatternA_CommentBeforeLabel` and the order assertions in the Pattern B/C tests pin this down.
+
 ### `bumpLocalDeltaAt` re-inlining
 
 Separately, `boardcache/boardcache.go` had 7 mutator methods that re-inlined the `now := time.Now(); c.mu.Lock(); c.localDeltaAt[key] = now; c.mu.Unlock()` sequence instead of calling the existing `bumpLocalDeltaAt` helper (already used correctly 23 times in `boardcache/delta.go`). These were collapsed to `c.bumpLocalDeltaAt(key)` calls as part of the same cleanup, since it is the same "helper exists but isn't used everywhere" problem this ADR addresses, just for a cache-internal idiom rather than an engine-to-GitHub one.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -27,3 +27,4 @@ contributors and future maintainers.
 | [030](030-progress-based-turn-extension.md) | Progress-Based Turn Extension | Accepted |
 | [039](039-cycleset-excludes-worker-lifecycle.md) | cycleSetFlags excludes WorkerLifecycleChanged | Accepted |
 | [056](056-consolidate-convergence-gate-recovery.md) | Consolidate the convergence / gate / recovery architecture | Accepted |
+| [065](065-consolidated-mutation-helpers.md) | Consolidated GitHub-mutation helpers (label/comment/pause) | Accepted |

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -884,10 +884,7 @@ func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
 		// Status unchanged.
 		return
 	}
-	now := time.Now()
-	c.mu.Lock()
-	c.localDeltaAt[key] = now
-	c.mu.Unlock()
+	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyLabelAdded updates the cached label list for the item identified by key,
@@ -911,10 +908,7 @@ func (c *CacheImpl) ApplyLabelAdded(key, label string) {
 	if len(changes) == 0 {
 		return
 	}
-	now := time.Now()
-	c.mu.Lock()
-	c.localDeltaAt[key] = now
-	c.mu.Unlock()
+	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyLabelRemoved updates the cached label list for the item identified by key,
@@ -938,10 +932,7 @@ func (c *CacheImpl) ApplyLabelRemoved(key, label string) {
 	if len(changes) == 0 {
 		return
 	}
-	now := time.Now()
-	c.mu.Lock()
-	c.localDeltaAt[key] = now
-	c.mu.Unlock()
+	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyIssueClosed marks the item identified by key as closed in the store.
@@ -963,10 +954,7 @@ func (c *CacheImpl) ApplyIssueClosed(key string) {
 	if len(changes) == 0 {
 		return
 	}
-	now := time.Now()
-	c.mu.Lock()
-	c.localDeltaAt[key] = now
-	c.mu.Unlock()
+	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyCommentAdded appends comment to the cached comment list for the item
@@ -994,10 +982,7 @@ func (c *CacheImpl) ApplyCommentAdded(key string, comment gh.Comment) {
 	if len(changes) == 0 {
 		return
 	}
-	now := time.Now()
-	c.mu.Lock()
-	c.localDeltaAt[key] = now
-	c.mu.Unlock()
+	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyStatusBatch updates Status for items identified by project-item node IDs.
@@ -1013,10 +998,7 @@ func (c *CacheImpl) ApplyStatusBatch(updates map[string]string) {
 			continue
 		}
 		key := itemKey(snap.Repo(), snap.Number())
-		now := time.Now()
-		c.mu.Lock()
-		c.localDeltaAt[key] = now
-		c.mu.Unlock()
+		c.bumpLocalDeltaAt(key)
 	}
 }
 
@@ -1044,10 +1026,7 @@ func (c *CacheImpl) RegisterItemID(key, itemID string) {
 	if len(changes) == 0 {
 		return
 	}
-	now := time.Now()
-	c.mu.Lock()
-	c.localDeltaAt[key] = now
-	c.mu.Unlock()
+	c.bumpLocalDeltaAt(key)
 }
 
 // GetItemID returns the project-item node ID (PVTI_...) for the given cache key.

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -439,7 +439,6 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 // loop elapses. It posts an explanatory comment and applies fabrik:paused +
 // fabrik:awaiting-input.
 func (e *Engine) pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "ci-timeout", "CI wait timeout elapsed — pausing for human intervention\n")
 
 	msg := fmt.Sprintf(
@@ -447,35 +446,15 @@ func (e *Engine) pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, 
 			"Fabrik has paused this issue. Please check the PR's CI status, address any failures, and then remove the `fabrik:paused` label to resume.",
 		stage.Name,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post CI timeout comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // pauseForCIFixCycleLimit pauses the issue when the maximum CI-fix
 // re-invocation cycle count is reached.
 func (e *Engine) pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "ci-cycles", "CI-fix cycle limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
@@ -486,29 +465,10 @@ func (e *Engine) pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.Project
 			"remove the `fabrik:paused` label to resume.",
 		stage.Name, cycleCount, maxCycles,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post CI cycle limit comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // pauseForPRClosedNotMerged pauses the issue when the linked PR was closed
@@ -526,28 +486,10 @@ func (e *Engine) pauseForPRClosedNotMerged(_ *gh.ProjectBoard, item gh.ProjectIt
 			"- Close this issue if the work is no longer needed.",
 		prNumber, stage.Name,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post PR-closed comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 	e.removeAwaitingCILabel(owner, repo, item)
 }
 
@@ -571,27 +513,9 @@ func (e *Engine) pauseForRequiredNeverRunningCheck(_ *gh.ProjectBoard, item gh.P
 			"- Remove the check from the branch protection required-status list if it should no longer be required.",
 		prNumber, stage.Name,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post required-never-running comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 	e.removeAwaitingCILabel(owner, repo, item)
 }

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -136,11 +136,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 		e.logf(item.Number, "ci-gate", "CI check(s) failed: %s\n", strings.Join(failedNames, ", "))
 
 		if !hasLabel(item, "fabrik:awaiting-ci") {
-			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
-				e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
-			}
+			e.applyLabelAdd(item, "fabrik:awaiting-ci", false)
 		}
 
 		return true, true, false
@@ -203,18 +199,7 @@ func (e *Engine) checkCIGate(board *gh.ProjectBoard, item gh.ProjectItem, stage 
 func (e *Engine) removeAwaitingCILabel(owner, repo string, item gh.ProjectItem) {
 	for _, l := range item.Labels {
 		if l == "fabrik:awaiting-ci" {
-			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
-				if errors.Is(err, gh.ErrNotFound) {
-					// Label already absent on GitHub — desired end state achieved; sync cache.
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
-					}
-				} else {
-					e.logf(item.Number, "warn", "could not remove fabrik:awaiting-ci label: %v\n", err)
-				}
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
-			}
+			e.applyLabelRemove(item, "fabrik:awaiting-ci", false)
 			return
 		}
 	}
@@ -229,8 +214,8 @@ func (e *Engine) addCompleteLabelAndRemoveCI(owner, repo string, item gh.Project
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label %s: %v\n", completeLabel, err)
 		return // preserve fabrik:awaiting-ci so the next poll retries
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+	} else if c := e.cache(); c != nil {
+		c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 	}
 	if stage.Name == "Validate" {
 		repoStr := owner + "/" + repo

--- a/engine/closed_item_advance_settle.go
+++ b/engine/closed_item_advance_settle.go
@@ -74,8 +74,8 @@ func (e *Engine) advanceClosedItemToDone(board *gh.ProjectBoard, item gh.Project
 		e.logf(item.Number, "warn", "closed-item advance: could not move to %s: %v — will retry next poll\n", cleanupName, err)
 		return
 	}
-	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
-		cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), cleanupName)
+	if c := e.cache(); c != nil {
+		c.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), cleanupName)
 	}
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -115,12 +115,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:editing"); err != nil {
 		return fmt.Errorf("adding editing label: %w", err)
 	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:editing")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:editing")
-		}
+		e.syncLabelAdd(item, "fabrik:editing", true)
 	}
 
 	// Step 3: Ensure worktree
@@ -297,22 +292,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	if output != "" {
 		if stage.PostToPR {
 			comment := formatOutputComment(stage.Name+" (comment review)", output, "", branch, commit, mainSHA, timestamp)
-			if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
-			} else {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-					})
-				}
-				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-				}
-				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-				}
-			}
+			e.postItemComment(item, comment, true)
 		} else {
 			existing := findStageComment(item.Comments, stage.Name)
 			stageComment := formatOutputComment(stage.Name, output, "", branch, commit, mainSHA, timestamp)
@@ -322,22 +302,7 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 					e.logf(item.Number, "warn", "could not update stage comment: %v\n", err)
 				}
 			} else {
-				if dbID, err := e.client.AddComment(owner, repo, item.Number, stageComment); err != nil {
-					e.logf(item.Number, "warn", "could not post stage comment: %v\n", err)
-				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-							DatabaseID: dbID, Body: stageComment, Author: e.cfg.User, CreatedAt: time.Now(),
-						})
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-					}
-					// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-					if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-						e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-					}
-				}
+				e.postItemComment(item, stageComment, true)
 			}
 		}
 	}

--- a/engine/compliance_test.go
+++ b/engine/compliance_test.go
@@ -1,7 +1,10 @@
 package engine
 
 // TestAddCommentCompliance verifies that every AddComment call site in the
-// engine source passes a body that begins with the canonical "🏭 **Fabrik"
+// engine source — plus every body/comment argument passed through the
+// e.postComment / e.postItemComment / e.pauseIssue mutation helpers (which
+// funnel into the single canonical e.client.AddComment call inside
+// postComment) — passes a body that begins with the canonical "🏭 **Fabrik"
 // header.  This ensures findNewComments' prefix dedup in comments.go catches
 // all engine-generated comments and prevents Fabrik from processing its own
 // output on the next poll.
@@ -13,6 +16,11 @@ package engine
 //   - It is a local variable where any assignment in the same function scope
 //     is compliant (i.e. a fmt.Sprintf whose format string starts with
 //     "🏭 **Fabrik", or a call to the canonical formatters).
+//
+// The e.client.AddComment call inside postComment itself (mutate.go) is
+// exempt from the literal check — it passes through postComment's own body
+// parameter, and callers of postComment/postItemComment/pauseIssue are
+// checked instead, at their own body/comment argument.
 //
 // Test files (*_test.go) are excluded because mock AddComment implementations
 // may accept arbitrary bodies.
@@ -52,15 +60,51 @@ func TestAddCommentCompliance(t *testing.T) {
 			if !ok || fd.Body == nil {
 				continue
 			}
-			checkAddCommentBody(t, fset, fd.Body)
+			// Each function in the funnel (postComment -> postItemComment,
+			// postComment -> pauseIssue) passes its own body/comment parameter
+			// straight through to the next call — that inner call is exempt
+			// from the literal check because the funnel function's callers are
+			// already checked at their own body/comment argument (see
+			// bodyBearingCalls below), so the exemption doesn't create a gap.
+			var skipCall string
+			if fd.Name != nil {
+				skipCall = funnelSkips[fd.Name.Name]
+			}
+			checkAddCommentBody(t, fset, fd.Body, skipCall)
 		}
 	}
 }
 
-// checkAddCommentBody walks a function body, finds all AddComment calls, and
-// reports any whose body argument is non-compliant.  It recurses into nested
-// function literals with their own assignment context.
-func checkAddCommentBody(t *testing.T, fset *token.FileSet, body *ast.BlockStmt) {
+// bodyBearingCalls maps the selector name of a body/comment-bearing call to
+// the index of its body/comment argument, covering the canonical
+// e.client.AddComment plus the e.postComment -> e.postItemComment /
+// e.pauseIssue mutation-helper call graph that funnels into it.
+var bodyBearingCalls = map[string]int{
+	"AddComment":      3, // (owner, repo string, issueNumber int, body string)
+	"postComment":     1, // (item, body string, react, echo bool)
+	"postItemComment": 1, // (item, body string, react bool)
+	"pauseIssue":      1, // (item, comment string, opts pauseOpts)
+}
+
+// funnelSkips maps a function name to the single body-bearing call name that
+// function is exempt from checking on itself, because that call passes
+// through the function's own body/comment parameter — a pass-through, not a
+// new body. The funnel is: postComment (raw AddComment) <- postItemComment
+// (postComment) <- pauseIssue (postComment). Every function's *callers* are
+// still checked normally via bodyBearingCalls.
+var funnelSkips = map[string]string{
+	"postComment":     "AddComment",
+	"postItemComment": "postComment",
+	"pauseIssue":      "postComment",
+}
+
+// checkAddCommentBody walks a function body, finds all AddComment (and
+// postComment/postItemComment/pauseIssue) calls, and reports any whose
+// body/comment argument is non-compliant.  It recurses into nested function
+// literals with their own assignment context. skipCall, when non-empty,
+// exempts that one call name from the check (used only for a funnel
+// function's own pass-through call, whose callers are checked instead).
+func checkAddCommentBody(t *testing.T, fset *token.FileSet, body *ast.BlockStmt, skipCall string) {
 	t.Helper()
 
 	// Collect all variable assignments within this function scope (excluding
@@ -72,25 +116,30 @@ func checkAddCommentBody(t *testing.T, fset *token.FileSet, body *ast.BlockStmt)
 		switch v := n.(type) {
 		case *ast.FuncLit:
 			// Recurse with a fresh assignment scope for the nested function.
-			checkAddCommentBody(t, fset, v.Body)
+			checkAddCommentBody(t, fset, v.Body, "")
 			return false // prevent outer Inspect from also walking into this body
 
 		case *ast.CallExpr:
 			sel, ok := v.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "AddComment" {
+			if !ok {
 				return true
 			}
-			// AddComment signature: (owner, repo string, issueNumber int, body string)
-			// body is the 4th argument (index 3).
-			if len(v.Args) < 4 {
+			argIdx, tracked := bodyBearingCalls[sel.Sel.Name]
+			if !tracked {
 				return true
 			}
-			bodyArg := v.Args[3]
+			if skipCall != "" && sel.Sel.Name == skipCall {
+				return true
+			}
+			if len(v.Args) <= argIdx {
+				return true
+			}
+			bodyArg := v.Args[argIdx]
 			if !isCompliantAddCommentArg(bodyArg, assigns) {
 				pos := fset.Position(v.Pos())
 				t.Errorf(
-					"non-compliant AddComment body at %s:%d — body must start with %q or go through formatOutputComment/formatPRSummaryComment/formatReviewFeedbackComment/buildAwaitingInputComment",
-					pos.Filename, pos.Line, "🏭 **Fabrik",
+					"non-compliant %s body at %s:%d — body must start with %q or go through formatOutputComment/formatPRSummaryComment/formatReviewFeedbackComment/buildAwaitingInputComment",
+					sel.Sel.Name, pos.Filename, pos.Line, "🏭 **Fabrik",
 				)
 			}
 		}

--- a/engine/dependencies.go
+++ b/engine/dependencies.go
@@ -147,18 +147,7 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 		// All dependencies resolved (or none exist) — remove fabrik:blocked if present.
 		for _, l := range item.Labels {
 			if l == "fabrik:blocked" {
-				if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:blocked"); err != nil {
-					if errors.Is(err, gh.ErrNotFound) {
-						// Label already absent on GitHub — desired end state achieved; sync cache.
-						if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-							cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
-						}
-					} else {
-						e.logf(item.Number, "warn", "could not remove fabrik:blocked label: %v\n", err)
-					}
-				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
-				}
+				e.applyLabelRemove(item, "fabrik:blocked", false)
 				break
 			}
 		}
@@ -194,48 +183,22 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 		if detectCycle(e.store, itemRepo, item.Number, openDeps, 4) {
 			e.logf(item.Number, "warn", "cycle detected in blockedBy graph — pausing issue\n")
 			cycleMsg := fmt.Sprintf("🏭 **Fabrik — cycle detected**\n\nIssue #%d has a cyclic `blockedBy` dependency: it is waiting for issues that are themselves (transitively) waiting for this issue. Fabrik cannot make progress. Remove the cycle manually and then remove `fabrik:paused` to continue.", item.Number)
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, cycleMsg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post cycle-detected comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: cycleMsg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-				e.logf(item.Number, "warn", "could not add fabrik:paused for cycle: %v\n", err)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-			}
+			e.postComment(item, cycleMsg, false, false) //nolint:errcheck // failure already logged by postComment
+			e.applyLabelAdd(item, "fabrik:paused", false)
 			return false
 		}
 
 		// First-time block: post the comment and add the label.
-		if dbID, err := e.client.AddComment(owner, repo, item.Number, newComment); err != nil {
-			e.logf(item.Number, "warn", "could not post blocked comment: %v\n", err)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: newComment, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-			}
-		}
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:blocked"); err != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:blocked label: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:blocked")
-		}
+		e.postItemComment(item, newComment, true)
+		e.applyLabelAdd(item, "fabrik:blocked", false)
 	} else {
 		// Already blocked: edit the existing comment in-place if the dep list changed.
 		existing := findBlockedComment(item.Comments, e.cfg.User)
 		if existing != nil && existing.Body != newComment {
 			if err := e.client.UpdateComment(owner, repo, existing.DatabaseID, newComment); err != nil {
 				e.logf(item.Number, "warn", "could not update blocked comment: %v\n", err)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
+			} else if c := e.cache(); c != nil {
+				c.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
 					DatabaseID: existing.DatabaseID, Body: newComment, Author: e.cfg.User, CreatedAt: time.Now(),
 				})
 			}
@@ -266,15 +229,15 @@ func (e *Engine) removeBlockedIfResolved(owner, repo string, issueNumber int) {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, "fabrik:blocked")
 		if err == nil {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:blocked")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:blocked")
 			}
 			return
 		}
 		if errors.Is(err, gh.ErrNotFound) {
 			// Label already absent — treat as success and sync cache.
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:blocked")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:blocked")
 			}
 			return
 		}

--- a/engine/dependencies.go
+++ b/engine/dependencies.go
@@ -183,8 +183,7 @@ func (e *Engine) checkDependencies(board *gh.ProjectBoard, item gh.ProjectItem, 
 		if detectCycle(e.store, itemRepo, item.Number, openDeps, 4) {
 			e.logf(item.Number, "warn", "cycle detected in blockedBy graph — pausing issue\n")
 			cycleMsg := fmt.Sprintf("🏭 **Fabrik — cycle detected**\n\nIssue #%d has a cyclic `blockedBy` dependency: it is waiting for issues that are themselves (transitively) waiting for this issue. Fabrik cannot make progress. Remove the cycle manually and then remove `fabrik:paused` to continue.", item.Number)
-			e.postComment(item, cycleMsg, false, false) //nolint:errcheck // failure already logged by postComment
-			e.applyLabelAdd(item, "fabrik:paused", false)
+			e.pauseIssue(item, cycleMsg, pauseOpts{})
 			return false
 		}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -478,29 +478,9 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 		e.cloneInFlight.Delete(nameWithOwner)
 
 		msg := fmt.Sprintf("🏭 **Fabrik — cannot clone repo**\n\nFailed to clone `%s/%s`:\n```\n%v\n```\nHuman intervention required. Fix the clone issue and remove `fabrik:paused` to retry.", owner, repo, err)
-		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post clone-failure comment: %v\n", commentErr)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-			}
-		}
-		if labelErr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); labelErr != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", labelErr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-		}
-		if labelErr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); labelErr != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", labelErr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-		}
+		e.postItemComment(item, msg, true)
+		e.applyLabelAdd(item, "fabrik:paused", false)
+		e.applyLabelAdd(item, "fabrik:awaiting-input", false)
 		// Append a history entry so the TUI records the failure.
 		hist := tui.LoadHistory()
 		hist = append(hist, tui.HistoryEntry{
@@ -602,22 +582,8 @@ func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, target
 func (e *Engine) postSpawnCloneError(parentOwner, parentRepo string, parentItem gh.ProjectItem, targetOwner, targetRepo string, cloneErr error) {
 	msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to clone spawn target `%s/%s`:\n```\n%v\n```\nFix the clone issue (SSH key, PAT access) and remove `fabrik:paused` to retry.",
 		targetOwner, targetRepo, cloneErr)
-	if dbID, commentErr := e.client.AddComment(parentOwner, parentRepo, parentItem.Number, msg); commentErr != nil {
-		e.logf(parentItem.Number, "warn", "could not post spawn clone-failure comment: %v\n", commentErr)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyCommentAdded(boardcache.ItemKey(parentItem.Repo, parentItem.Number), gh.Comment{
-			DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-		})
-	}
-	if labelErr := e.client.AddLabelToIssue(parentOwner, parentRepo, parentItem.Number, "fabrik:paused"); labelErr != nil {
-		e.logf(parentItem.Number, "warn", "could not add fabrik:paused: %v\n", labelErr)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(parentItem.Repo, parentItem.Number), "fabrik:paused")
-	}
-	if labelErr := e.client.AddLabelToIssue(parentOwner, parentRepo, parentItem.Number, "fabrik:awaiting-input"); labelErr != nil {
-		e.logf(parentItem.Number, "warn", "could not add fabrik:awaiting-input: %v\n", labelErr)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(parentItem.Repo, parentItem.Number), "fabrik:awaiting-input")
-	}
+	e.postItemComment(parentItem, msg, false)
+	e.applyLabelAdd(parentItem, "fabrik:paused", false)
+	e.applyLabelAdd(parentItem, "fabrik:awaiting-input", false)
 	e.logf(parentItem.Number, "error", "cannot clone spawn target %s/%s: %v — pausing parent\n", targetOwner, targetRepo, cloneErr)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -478,9 +478,10 @@ func (e *Engine) ensureRepoReady(ctx context.Context, item gh.ProjectItem) error
 		e.cloneInFlight.Delete(nameWithOwner)
 
 		msg := fmt.Sprintf("🏭 **Fabrik — cannot clone repo**\n\nFailed to clone `%s/%s`:\n```\n%v\n```\nHuman intervention required. Fix the clone issue and remove `fabrik:paused` to retry.", owner, repo, err)
-		e.postItemComment(item, msg, true)
-		e.applyLabelAdd(item, "fabrik:paused", false)
-		e.applyLabelAdd(item, "fabrik:awaiting-input", false)
+		e.pauseIssue(item, msg, pauseOpts{
+			awaitingInput: true,
+			reactRocket:   true,
+		})
 		// Append a history entry so the TUI records the failure.
 		hist := tui.LoadHistory()
 		hist = append(hist, tui.HistoryEntry{
@@ -582,8 +583,8 @@ func (e *Engine) ensureSpawnTargetReady(ctx context.Context, targetOwner, target
 func (e *Engine) postSpawnCloneError(parentOwner, parentRepo string, parentItem gh.ProjectItem, targetOwner, targetRepo string, cloneErr error) {
 	msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to clone spawn target `%s/%s`:\n```\n%v\n```\nFix the clone issue (SSH key, PAT access) and remove `fabrik:paused` to retry.",
 		targetOwner, targetRepo, cloneErr)
-	e.postItemComment(parentItem, msg, false)
-	e.applyLabelAdd(parentItem, "fabrik:paused", false)
-	e.applyLabelAdd(parentItem, "fabrik:awaiting-input", false)
+	e.pauseIssue(parentItem, msg, pauseOpts{
+		awaitingInput: true,
+	})
 	e.logf(parentItem.Number, "error", "cannot clone spawn target %s/%s: %v — pausing parent\n", targetOwner, targetRepo, cloneErr)
 }

--- a/engine/item.go
+++ b/engine/item.go
@@ -1165,6 +1165,7 @@ func (e *Engine) escalatePRCreationFailure(item gh.ProjectItem, stage *stages.St
 		reactRocket: true,
 		labelEcho:   true,
 		commentEcho: true,
+		labelFirst:  true,
 	})
 	e.addFailedLabel(owner, repo, item.Number, stage.Name)
 
@@ -1188,6 +1189,7 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 		reactRocket: true,
 		labelEcho:   true,
 		commentEcho: true,
+		labelFirst:  true,
 	})
 	e.addFailedLabel(owner, repo, item.Number, stage.Name)
 

--- a/engine/item.go
+++ b/engine/item.go
@@ -388,16 +388,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			newComments := e.findNewComments(item)
 			if len(newComments) > 0 {
 				e.logf(item.Number, "unpause", "user commented on paused issue — unpausing\n")
-				if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-					e.logf(item.Number, "warn", "could not remove fabrik:paused label: %v\n", err)
-				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-					}
-				}
+				e.removeLabel(item, "fabrik:paused")
 				// Also clear any failed label so the stage retries cleanly
 				e.clearFailedStage(item, stage)
 				break // fall through to comment processing below
@@ -469,34 +460,16 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			}
 		}
 
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
-			e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), completeLabel)
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
-			}
-		}
+		e.addLabel(item, completeLabel)
 
 		// Remove fabrik:extend-turns at cleanup (Done) stage — this is the designated
 		// removal site. The label persists across all intermediate stages so the operator
 		// can apply it once and have it take effect on every stage until Done.
 		// Called unconditionally (not guarded by hasLabel) because cleanup items are
 		// dispatched from shallow board items (labels(first:15)) and the label may be
-		// present on GitHub without appearing in item.Labels. ErrNotFound = already gone.
-		if removeErr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:extend-turns"); removeErr != nil &&
-			!errors.Is(removeErr, gh.ErrNotFound) {
-			e.logf(item.Number, "warn", "could not remove extend-turns label: %v\n", removeErr)
-		} else if removeErr == nil {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:extend-turns")
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:extend-turns")
-			}
-		}
+		// present on GitHub without appearing in item.Labels. ErrNotFound = already gone
+		// (removeLabel treats it as success and still syncs the cache).
+		e.removeLabel(item, "fabrik:extend-turns")
 
 		// Auto-archiving of Done items is not currently performed (see #1035).
 
@@ -1679,25 +1652,24 @@ func isTransientError(err error) bool {
 	return false
 }
 
+// removeEditingLabel removes fabrik:editing, retrying up to 3 times with
+// exponential backoff on transient errors. The GitHub mutation is performed
+// directly here (not via removeLabel) so the retry loop can inspect the raw
+// error and decide whether to retry; the shared cache write-through + echo
+// tail is delegated to syncLabelRemoval so the idiom itself isn't re-typed.
 func (e *Engine) removeEditingLabel(owner, repo string, issueNumber int) {
+	item := gh.ProjectItem{Number: issueNumber, Repo: owner + "/" + repo}
 	const maxAttempts = 3
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, "fabrik:editing")
 		if err == nil {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:editing")
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+"fabrik:editing")
-			}
+			e.syncLabelRemoval(item, "fabrik:editing", true)
 			return
 		}
 		if errors.Is(err, gh.ErrNotFound) {
-			// Label already absent — treat as success and sync cache.
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), "fabrik:editing")
-			}
+			// Label already absent — treat as success and sync cache (no echo).
+			e.syncLabelRemoval(item, "fabrik:editing", false)
 			return
 		}
 		if !isTransientError(err) {
@@ -1714,61 +1686,19 @@ func (e *Engine) removeEditingLabel(owner, repo string, issueNumber int) {
 }
 
 func (e *Engine) removeLockLabel(owner, repo string, issueNumber int, label string) {
-	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, label); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(issueNumber, "warn", "could not remove lock label: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
-		}
-	}
+	e.removeLabel(gh.ProjectItem{Number: issueNumber, Repo: owner + "/" + repo}, label)
 }
 
 func (e *Engine) removeInProgressLabel(owner, repo string, issueNumber int, stageName string) {
-	label := fmt.Sprintf("stage:%s:in_progress", stageName)
-	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, label); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(issueNumber, "warn", "could not remove in_progress label: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
-		}
-	}
+	e.removeLabel(gh.ProjectItem{Number: issueNumber, Repo: owner + "/" + repo}, fmt.Sprintf("stage:%s:in_progress", stageName))
 }
 
 func (e *Engine) addFailedLabel(owner, repo string, issueNumber int, stageName string) {
-	label := fmt.Sprintf("stage:%s:failed", stageName)
-	if err := e.client.AddLabelToIssue(owner, repo, issueNumber, label); err != nil {
-		e.logf(issueNumber, "warn", "could not add failed label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
-		}
-	}
+	e.addLabel(gh.ProjectItem{Number: issueNumber, Repo: owner + "/" + repo}, fmt.Sprintf("stage:%s:failed", stageName))
 }
 
 func (e *Engine) removeFailedLabel(owner, repo string, issueNumber int, stageName string) {
-	label := fmt.Sprintf("stage:%s:failed", stageName)
-	if err := e.client.RemoveLabelFromIssue(owner, repo, issueNumber, label); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(issueNumber, "warn", "could not remove failed label: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, issueNumber), label)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, issueNumber)+"+"+label)
-		}
-	}
+	e.removeLabel(gh.ProjectItem{Number: issueNumber, Repo: owner + "/" + repo}, fmt.Sprintf("stage:%s:failed", stageName))
 }
 
 // commitWIP commits any uncommitted changes in the worktree as a partial-progress

--- a/engine/item.go
+++ b/engine/item.go
@@ -1230,39 +1230,16 @@ func (e *Engine) escalatePRCreationFailure(item gh.ProjectItem, stage *stages.St
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
-
-	e.addFailedLabel(owner, repo, item.Number, stage.Name)
-
 	comment := fmt.Sprintf(
 		"🏭 **Fabrik — PR creation failed**\n\nStage **%s** completed successfully but the draft PR could not be created after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh pr create --head fabrik/issue-%d --base %s --body \"Closes #%d\"\n```\n\nThen remove the `fabrik:paused` label to resume.",
 		stage.Name, e.cfg.MaxRetries, item.Number, baseBranch, item.Number,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post PR escalation comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
+	e.pauseIssue(item, comment, pauseOpts{
+		reactRocket: true,
+		labelEcho:   true,
+		commentEcho: true,
+	})
+	e.addFailedLabel(owner, repo, item.Number, stage.Name)
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
@@ -1276,39 +1253,16 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
-
-	e.addFailedLabel(owner, repo, item.Number, stage.Name)
-
 	comment := fmt.Sprintf(
 		"🏭 **Fabrik — stage failed**\n\nStage **%s** failed to complete after %d attempt(s). The issue has been paused (`fabrik:paused`).\n\nTo retry: investigate the failure, make any needed fixes, then remove the `fabrik:paused` label.",
 		stage.Name, e.cfg.MaxRetries,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post escalation comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
+	e.pauseIssue(item, comment, pauseOpts{
+		reactRocket: true,
+		labelEcho:   true,
+		commentEcho: true,
+	})
+	e.addFailedLabel(owner, repo, item.Number, stage.Name)
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})

--- a/engine/item.go
+++ b/engine/item.go
@@ -577,12 +577,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			AcquiredAt: workerStartedAt,
 			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt, LastSignAt: workerStartedAt},
 		})
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), lockLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+lockLabel)
-		}
+		e.syncLabelAdd(item, lockLabel, true)
 		workerDone = make(chan struct{})
 		e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
 	}
@@ -664,12 +659,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		e.logf(item.Number, "warn", "could not add in_progress label: %v\n", err)
 	} else {
 		inProgressAdded = true
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), inProgressLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+inProgressLabel)
-		}
+		e.syncLabelAdd(item, inProgressLabel, true)
 	}
 
 	// Ensure the WorktreeManager for this item's repo is ready.
@@ -948,13 +938,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		prBlock, prBlockErr := ParsePRCreateBlock(output)
 		if prBlockErr != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — malformed FABRIK_PR_CREATE marker**\n\n%v\n\nRemove `fabrik:paused` after fixing the skill output to retry.", prBlockErr)
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post FABRIK_PR_CREATE error comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
+			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			e.addPausedLabelToItem(owner, repo, item)
 			releaseLock()
 			return nil
@@ -1001,22 +985,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			e.postOutputToPR(item, stage.Name, postOutput, footer, branch, commit, mainSHA, timestamp)
 		} else {
 			comment := formatOutputComment(stage.Name, postOutput, footer, branch, commit, mainSHA, timestamp)
-			if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-				e.logf(item.Number, "warn", "could not post comment: %v\n", err)
-			} else {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-						DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-					})
-				}
-				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-				}
-				// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-				if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-					e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-				}
-			}
+			e.postItemComment(item, comment, true)
 		}
 	}
 
@@ -1056,22 +1025,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	if claudeRan && err == nil && strings.TrimSpace(output) == "" {
 		e.logf(item.Number, "warn", "stage %q ran without error but produced no output\n", stage.Name)
 		warnComment := fmt.Sprintf("🏭 **Fabrik — empty stage output**\n\nStage **%s** ran without error but produced no output.", stage.Name)
-		if dbID, commentErr := e.client.AddComment(e.cfg.Owner, e.cfg.Repo, item.Number, warnComment); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post empty-output warning: %v\n", commentErr)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: warnComment, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-			}
-			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-			if reactErr := e.client.AddCommentReaction(e.cfg.Owner, e.cfg.Repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-			}
-		}
+		e.postItemComment(item, warnComment, true)
 	}
 
 	// Commit any uncommitted changes so partial work isn't lost (e.g., max_turns reached).
@@ -1247,19 +1201,8 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	e.logf(item.Number, "unpause", "clearing failed stage %q after manual unpause\n", stage.Name)
 
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	failedLabel := fmt.Sprintf("stage:%s:failed", stage.Name)
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, failedLabel); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove failed label: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), failedLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+failedLabel)
-		}
-	}
+	e.removeLabel(item, failedLabel)
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
@@ -1291,9 +1234,7 @@ func (e *Engine) handleRevalidateLabel(item gh.ProjectItem, owner, repo string) 
 		if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, lbl); err != nil {
 			if errors.Is(err, gh.ErrNotFound) {
 				// Label already absent — desired state achieved; sync cache.
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), lbl)
-				}
+				e.syncLabelRemoval(item, lbl, false)
 				continue
 			}
 			e.logf(item.Number, "warn", "revalidate: could not remove %s: %v\n", lbl, err)
@@ -1301,12 +1242,7 @@ func (e *Engine) handleRevalidateLabel(item gh.ProjectItem, owner, repo string) 
 			continue
 		}
 		e.logf(item.Number, "revalidate", "removed label %s\n", lbl)
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), lbl)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(repoStr, item.Number)+"+"+lbl)
-		}
+		e.syncLabelRemoval(item, lbl, true)
 	}
 
 	if hasError {
@@ -1316,21 +1252,14 @@ func (e *Engine) handleRevalidateLabel(item gh.ProjectItem, owner, repo string) 
 
 	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:revalidate"); err != nil {
 		if errors.Is(err, gh.ErrNotFound) {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
-			}
+			e.syncLabelRemoval(item, "fabrik:revalidate", false)
 		} else {
 			e.logf(item.Number, "warn", "revalidate: could not remove trigger label: %v\n", err)
 			return
 		}
 	} else {
 		e.logf(item.Number, "revalidate", "removed trigger label fabrik:revalidate\n")
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(repoStr, item.Number)+"+"+"fabrik:revalidate")
-		}
+		e.syncLabelRemoval(item, "fabrik:revalidate", true)
 	}
 
 	e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: "Validate"})
@@ -1362,9 +1291,7 @@ func (e *Engine) handleValidateSHAInvalidation(item gh.ProjectItem, owner, repo 
 	for _, lbl := range labelsToRemove {
 		if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, lbl); err != nil {
 			if errors.Is(err, gh.ErrNotFound) {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), lbl)
-				}
+				e.syncLabelRemoval(item, lbl, false)
 				continue
 			}
 			e.logf(item.Number, "warn", "validate-sha: could not remove %s: %v\n", lbl, err)
@@ -1372,12 +1299,7 @@ func (e *Engine) handleValidateSHAInvalidation(item gh.ProjectItem, owner, repo 
 			break
 		}
 		e.logf(item.Number, "validate-sha", "removed label %s\n", lbl)
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), lbl)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(repoStr, item.Number)+"+"+lbl)
-		}
+		e.syncLabelRemoval(item, lbl, true)
 	}
 
 	if hasError {
@@ -1425,45 +1347,15 @@ func buildAwaitingInputComment(user, stageName, summary string) string {
 func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage, output string) {
 	e.logf(item.Number, "block", "stage %q needs user input — pausing with awaiting-input\n", stage.Name)
 
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add awaiting-input label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
-		}
-	}
+	e.addLabel(item, "fabrik:paused")
+	e.addLabel(item, "fabrik:awaiting-input")
 
 	// Post a dedicated @mention notification comment so GitHub delivers a mobile
 	// push to the operator. No rocket reaction — this is engine-generated, not
 	// Claude output, so the reaction-based reprocessing guard should not apply.
 	summary := extractSummary(output)
 	comment := buildAwaitingInputComment(e.cfg.User, stage.Name, summary)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post awaiting-input notification comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-	}
+	e.postItemComment(item, comment, false)
 }
 
 // unblockAwaitingInput is called when a user comment arrives on an issue that
@@ -1472,29 +1364,8 @@ func (e *Engine) blockOnInput(item gh.ProjectItem, stage *stages.Stage, output s
 func (e *Engine) unblockAwaitingInput(item gh.ProjectItem, stage *stages.Stage) {
 	e.logf(item.Number, "unblock", "user comment received — removing awaiting-input pause\n")
 
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:paused"); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove paused label: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove awaiting-input label: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
-		}
-	}
+	e.removeLabel(item, "fabrik:paused")
+	e.removeLabel(item, "fabrik:awaiting-input")
 
 	// Clear LastAttemptAt so the stage re-runs immediately after comment processing,
 	// and reset retry/pause state that may have accumulated before the block.
@@ -1608,22 +1479,7 @@ func (e *Engine) baseBranchForItem(item gh.ProjectItem, wm *WorktreeManager) (st
 	warnKey := fmt.Sprintf("%s/%s#%d:%s", owner, repo, item.Number, candidate)
 	if _, alreadyWarned := e.baseBranchWarnedSet.LoadOrStore(warnKey, true); !alreadyWarned {
 		body := fmt.Sprintf("🏭 **Fabrik — base branch not found**\n\nFabrik could not find branch `%s` on the remote (from `base:%s` label). Falling back to the repository default branch.", candidate, candidate)
-		if dbID, err := e.client.AddComment(owner, repo, item.Number, body); err != nil {
-			e.logf(item.Number, "warn", "could not post base branch fallback comment: %v\n", err)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: body, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-			}
-			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-			}
-		}
+		e.postItemComment(item, body, true)
 	}
 	return wm.DefaultBaseBranch()
 }
@@ -1934,32 +1790,12 @@ func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, ite
 		stage.Name, violationList,
 	)
 
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post boundary violation comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-	}
+	e.postItemComment(item, comment, false)
 
 	// Add fabrik:paused so itemNeedsWork skips this issue until the user
 	// removes it. Without fabrik:paused the clearFailedStage path in
 	// processItem would auto-clear the failed label on the next poll cycle.
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
+	e.addLabel(item, "fabrik:paused")
 
 	e.addFailedLabel(owner, repo, item.Number, stage.Name)
 
@@ -2002,47 +1838,18 @@ func (e *Engine) handleStopRequest(ctx context.Context, req tui.StopRequest) {
 		e.logf(req.IssueNumber, "stop", "no in-flight worker for %s — applying labels only\n", iKey)
 	}
 
-	owner, repo, _ := strings.Cut(repoStr, "/")
+	item := gh.ProjectItem{Number: req.IssueNumber, Repo: repoStr}
 
 	// Apply fabrik:paused with cache write-through + webhook echo.
-	if err := e.client.AddLabelToIssue(owner, repo, req.IssueNumber, "fabrik:paused"); err != nil {
-		e.logf(req.IssueNumber, "warn", "stop: could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(repoStr, req.IssueNumber), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(repoStr, req.IssueNumber)+"+"+"fabrik:paused")
-		}
-	}
+	e.addLabel(item, "fabrik:paused")
 
 	// Apply fabrik:awaiting-input with cache write-through + webhook echo.
-	if err := e.client.AddLabelToIssue(owner, repo, req.IssueNumber, "fabrik:awaiting-input"); err != nil {
-		e.logf(req.IssueNumber, "warn", "stop: could not add awaiting-input label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(repoStr, req.IssueNumber), "fabrik:awaiting-input")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(repoStr, req.IssueNumber)+"+"+"fabrik:awaiting-input")
-		}
-	}
+	e.addLabel(item, "fabrik:awaiting-input")
 
 	// Post explanatory comment so there is a durable audit trail.
 	comment := fmt.Sprintf(
 		"🏭 **Fabrik — stopped from TUI by %s**\n\nStage **%s** was stopped manually from the TUI. Remove `fabrik:paused` to resume.",
 		e.cfg.User, req.StageName,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, req.IssueNumber, comment); err != nil {
-		e.logf(req.IssueNumber, "warn", "stop: could not post stop comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(repoStr, req.IssueNumber), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(repoStr, req.IssueNumber))
-		}
-	}
+	e.postItemComment(item, comment, false)
 }

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -555,34 +555,11 @@ func (e *Engine) pauseForConvergenceFailed(_ context.Context, _ *gh.ProjectBoard
 		mergeableState, headSHA, latestCI,
 	)
 
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post convergence-failed pause comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to convergence-failed comment: %v\n", reactErr)
-		}
-	}
-
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); err != nil {
-		e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput:   true,
+		reactRocket:     true,
+		removeAutoMerge: true,
+	})
 }
 
 // summarizeCIRuns produces a brief human-readable summary of check run results.
@@ -614,7 +591,6 @@ func summarizeCIRuns(runs []gh.CheckRun) string {
 // been attempted too many times — usually a signal that the conflict needs
 // human judgment.
 func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "rebase-cycles", "rebase cycle limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
@@ -627,29 +603,10 @@ func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.Projec
 			"`fabrik:rebase-needed` labels to resume.",
 		stage.Name, cycleCount, maxCycles,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post rebase cycle limit comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // advanceConvergedPRToDone removes the convergence labels and advances a merged
@@ -751,7 +708,6 @@ func (e *Engine) reEnqueueOrPause(board *gh.ProjectBoard, item gh.ProjectItem, s
 // fabrik:paused + fabrik:awaiting-input (write-through). The EnqueueCycles counter
 // is cleared by clearFailedStage (EngineCyclesCleared) when the user unpauses.
 func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "enqueue-cycles", "merge-queue re-enqueue limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
@@ -762,29 +718,10 @@ func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectIt
 			"Fabrik has paused this issue. Investigate the merge-queue failures, then remove the `fabrik:paused` label to resume.",
 		stage.Name, cycleCount, maxCycles,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post enqueue cycle limit comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // pauseForMergeGroupStall pauses the issue when the linked PR has been in the
@@ -798,7 +735,6 @@ func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectIt
 // label with a fresh timestamp — preventing the stall check from re-firing
 // immediately on resume (the dwell anchor would otherwise already be elapsed).
 func (e *Engine) pauseForMergeGroupStall(item gh.ProjectItem, prNumber int) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	dwellMinutes := int(e.cfg.CIWaitTimeout.Round(time.Minute).Minutes())
 	e.logf(item.Number, "merge-queue", "stall detected on PR #%d after %d minutes — pausing with instructional comment\n", prNumber, dwellMinutes)
 
@@ -810,31 +746,9 @@ func (e *Engine) pauseForMergeGroupStall(item gh.ProjectItem, prNumber int) {
 			"then re-queue the PR. Remove `fabrik:paused` to resume.",
 		dwellMinutes,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post merge-group stall comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to merge-group stall comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); err != nil {
-		e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput:   true,
+		reactRocket:     true,
+		removeAutoMerge: true,
+	})
 }

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
@@ -70,11 +69,7 @@ func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage,
 			}
 		}
 		if !alreadyLabeled {
-			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:rebase-needed"); err != nil {
-				e.logf(item.Number, "warn", "could not add fabrik:rebase-needed label: %v\n", err)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
-			}
+			e.applyLabelAdd(item, "fabrik:rebase-needed", false)
 		}
 		return true, true
 	}
@@ -85,11 +80,7 @@ func (e *Engine) checkMergeabilityGate(item gh.ProjectItem, stage *stages.Stage,
 func (e *Engine) removeRebaseNeededLabel(owner, repo string, item gh.ProjectItem) {
 	for _, l := range item.Labels {
 		if l == "fabrik:rebase-needed" {
-			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:rebase-needed"); err != nil {
-				e.logf(item.Number, "warn", "could not remove fabrik:rebase-needed label: %v\n", err)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:rebase-needed")
-			}
+			e.applyLabelRemove(item, "fabrik:rebase-needed", false)
 			return
 		}
 	}
@@ -367,30 +358,10 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 			"- **Keep cruise behavior**: Remove `fabrik:paused` and `fabrik:yolo`. Fabrik will keep the branch up-to-date but leave merging to you.\n" +
 			"- **Re-enable auto-merge**: Remove `fabrik:paused`. Fabrik will re-enable auto-merge on the next poll cycle.\n" +
 			"- **Leave as-is**: Take no action. The PR remains open and unmerged until you act.")
-		if dbID, cerr := e.client.AddComment(owner, repo, item.Number, msg); cerr != nil {
-			e.logf(item.Number, "warn", "could not post auto-merge disabled comment: %v\n", cerr)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-		}
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-		}
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-		}
-		if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); rerr != nil {
-			e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", rerr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
-		}
+		e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
+		e.applyLabelAdd(item, "fabrik:paused", false)
+		e.applyLabelAdd(item, "fabrik:awaiting-input", false)
+		e.applyLabelRemove(item, "fabrik:auto-merge-enabled", false)
 		return
 	}
 
@@ -620,11 +591,7 @@ func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.Projec
 func (e *Engine) advanceConvergedPRToDone(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, prNumber int) {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "auto-merge", "PR #%d merged or closed — advancing to Done\n", prNumber)
-	if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); rerr != nil {
-		e.logf(item.Number, "warn", "could not remove fabrik:auto-merge-enabled: %v\n", rerr)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
-	}
+	e.applyLabelRemove(item, "fabrik:auto-merge-enabled", false)
 	e.removeRebaseNeededLabel(owner, repo, item)
 	if err := e.advanceToNextStage(board, item, stage); err != nil {
 		e.logf(item.Number, "warn", "could not advance to Done after PR merge: %v\n", err)

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -358,10 +358,10 @@ func (e *Engine) checkAutoMergeConvergence(ctx context.Context, board *gh.Projec
 			"- **Keep cruise behavior**: Remove `fabrik:paused` and `fabrik:yolo`. Fabrik will keep the branch up-to-date but leave merging to you.\n" +
 			"- **Re-enable auto-merge**: Remove `fabrik:paused`. Fabrik will re-enable auto-merge on the next poll cycle.\n" +
 			"- **Leave as-is**: Take no action. The PR remains open and unmerged until you act.")
-		e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
-		e.applyLabelAdd(item, "fabrik:paused", false)
-		e.applyLabelAdd(item, "fabrik:awaiting-input", false)
-		e.applyLabelRemove(item, "fabrik:auto-merge-enabled", false)
+		e.pauseIssue(item, msg, pauseOpts{
+			awaitingInput:   true,
+			removeAutoMerge: true,
+		})
 		return
 	}
 

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -870,8 +870,8 @@ func (e *Engine) ejectMember(ctx context.Context, owner, repo string, memberItem
 		if err := e.client.AddLabelToIssue(owner, repo, memberItem.Number, "fabrik:paused"); err != nil {
 			e.logf(memberItem.Number, "warn", "could not add fabrik:paused: %v\n", err)
 		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, memberItem.Number), "fabrik:paused")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, memberItem.Number), "fabrik:paused")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, memberItem.Number)+"+"+"fabrik:paused")
@@ -880,8 +880,8 @@ func (e *Engine) ejectMember(ctx context.Context, owner, repo string, memberItem
 		if err := e.client.AddLabelToIssue(owner, repo, memberItem.Number, "fabrik:awaiting-input"); err != nil {
 			e.logf(memberItem.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
 		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, memberItem.Number), "fabrik:awaiting-input")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, memberItem.Number), "fabrik:awaiting-input")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, memberItem.Number)+"+"+"fabrik:awaiting-input")
@@ -990,8 +990,8 @@ func (e *Engine) fireRunawayGuard(ctx context.Context, owner, repo string, items
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:paused (runaway guard): %v\n", err)
 		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
@@ -1000,8 +1000,8 @@ func (e *Engine) fireRunawayGuard(ctx context.Context, owner, repo string, items
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:awaiting-input (runaway guard): %v\n", err)
 		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-input")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")

--- a/engine/merge_train_member_close_settle.go
+++ b/engine/merge_train_member_close_settle.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
@@ -34,16 +33,7 @@ func (e *Engine) markMergeTrainMemberCloseOutstanding(item gh.ProjectItem, owner
 	if hasLabel(item, mergeTrainAwaitingMemberCloseLabel) {
 		return
 	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, mergeTrainAwaitingMemberCloseLabel); err != nil {
-		e.logf(item.Number, "merge-train", "warn: could not add %s marker: %v\n", mergeTrainAwaitingMemberCloseLabel, err)
-		return
-	}
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), mergeTrainAwaitingMemberCloseLabel)
-	}
-	if e.webhookMgr != nil {
-		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+mergeTrainAwaitingMemberCloseLabel)
-	}
+	e.addLabel(item, mergeTrainAwaitingMemberCloseLabel)
 }
 
 // settleMergeTrainMemberCloses is the per-poll settle scan for the merge-train member-issue
@@ -81,8 +71,8 @@ func (e *Engine) settleMergeTrainMemberClose(item gh.ProjectItem) {
 		return
 	}
 
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyIssueClosed(boardcache.ItemKey(item.Repo, item.Number))
+	if c := e.cache(); c != nil {
+		c.ApplyIssueClosed(boardcache.ItemKey(item.Repo, item.Number))
 	}
 	e.logf(item.Number, "merge-train", "closed member issue #%d (retry)\n", item.Number)
 	e.clearMergeTrainMemberCloseMarker(item, owner, repo)
@@ -119,49 +109,14 @@ func (e *Engine) escalateMergeTrainMemberCloseFailure(item gh.ProjectItem) {
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
-
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, mergeTrainAwaitingMemberCloseLabel); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", mergeTrainAwaitingMemberCloseLabel, err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), mergeTrainAwaitingMemberCloseLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+mergeTrainAwaitingMemberCloseLabel)
-		}
-	}
+	e.addLabel(item, "fabrik:paused")
+	e.applyLabelRemove(item, mergeTrainAwaitingMemberCloseLabel, true)
 
 	comment := fmt.Sprintf(
 		"🏭 **Fabrik — merge-train member-issue close failed**\n\nThis issue landed successfully via the merge-train singleton path, but closing the issue itself could not be completed after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh issue close %d --repo %s/%s\n```\nThen remove the `fabrik:paused` label.",
 		e.cfg.MaxRetries, item.Number, owner, repo,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post merge-train member-close escalation comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
+	e.postItemComment(item, comment, true)
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: mergeTrainMemberCloseRetryStage})
@@ -176,12 +131,7 @@ func (e *Engine) clearMergeTrainMemberCloseMarker(item gh.ProjectItem, owner, re
 		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", mergeTrainAwaitingMemberCloseLabel, err)
 		return
 	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), mergeTrainAwaitingMemberCloseLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+mergeTrainAwaitingMemberCloseLabel)
-		}
+		e.syncLabelRemoval(item, mergeTrainAwaitingMemberCloseLabel, true)
 	}
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())

--- a/engine/mutate.go
+++ b/engine/mutate.go
@@ -148,6 +148,13 @@ type pauseOpts struct {
 	labelEcho       bool // RegisterEcho after the paused/awaiting-input/auto-merge label writes
 	commentEcho     bool // RegisterEcho after the comment write
 	removeAutoMerge bool // also remove fabrik:auto-merge-enabled
+	// labelFirst preserves call-site ordering: the 10 Pattern-A pauseFor*
+	// functions historically posted their comment before adding fabrik:paused,
+	// while escalatePRCreationFailure, escalateFailedStage, and
+	// pauseForBrokenLinkage added fabrik:paused first. The Scope section
+	// requires "no change to when labels/comments/pauses happen," so pauseIssue
+	// must reproduce each call site's original ordering rather than pick one.
+	labelFirst bool
 }
 
 // pauseIssue posts the given comment and applies fabrik:paused (plus,
@@ -158,6 +165,21 @@ type pauseOpts struct {
 // pauseForPRClosedNotMerged's fabrik:awaiting-ci removal) do so themselves
 // around this call — those steps are outside the shared pause tail.
 func (e *Engine) pauseIssue(item gh.ProjectItem, comment string, opts pauseOpts) {
+	// Note: the two branches below are intentionally not factored into a
+	// shared closure — TestAddCommentCompliance's funnel-skip exemption for
+	// pauseIssue's postComment call is keyed off this function's own name and
+	// does not follow calls into a nested function literal.
+	if opts.labelFirst {
+		e.applyLabelAdd(item, "fabrik:paused", opts.labelEcho)
+		if opts.awaitingInput {
+			e.applyLabelAdd(item, "fabrik:awaiting-input", opts.labelEcho)
+		}
+		if opts.removeAutoMerge {
+			e.applyLabelRemove(item, "fabrik:auto-merge-enabled", opts.labelEcho)
+		}
+		e.postComment(item, comment, opts.reactRocket, opts.commentEcho) //nolint:errcheck // failure already logged by postComment
+		return
+	}
 	e.postComment(item, comment, opts.reactRocket, opts.commentEcho) //nolint:errcheck // failure already logged by postComment
 	e.applyLabelAdd(item, "fabrik:paused", opts.labelEcho)
 	if opts.awaitingInput {

--- a/engine/mutate.go
+++ b/engine/mutate.go
@@ -20,6 +20,22 @@ func (e *Engine) cache() *boardcache.CacheImpl {
 	return c
 }
 
+// syncLabelAdd mirrors a label addition into the cache and, when echo is
+// true, registers a webhook echo. Split out from applyLabelAdd, symmetric to
+// syncLabelRemoval, so callers that must perform the GitHub mutation
+// themselves (e.g. lock/in-progress label sites that gate further side
+// effects on success) can still share the write-through + echo tail instead
+// of re-typing it.
+func (e *Engine) syncLabelAdd(item gh.ProjectItem, label string, echo bool) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	if c := e.cache(); c != nil {
+		c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), label)
+	}
+	if echo && e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+label)
+	}
+}
+
 // applyLabelAdd performs the three-beat label-add idiom: GitHub mutation ->
 // cache write-through -> conditional webhook echo. The repo is resolved once,
 // canonically, via itemOwnerRepo so a caller can never accidentally use
@@ -32,12 +48,7 @@ func (e *Engine) applyLabelAdd(item gh.ProjectItem, label string, echo bool) {
 		e.logf(item.Number, "warn", "could not add label %q: %v\n", label, err)
 		return
 	}
-	if c := e.cache(); c != nil {
-		c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), label)
-	}
-	if echo && e.webhookMgr != nil {
-		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+label)
-	}
+	e.syncLabelAdd(item, label, echo)
 }
 
 // addLabel is the always-echoing public entry point for applyLabelAdd, used by

--- a/engine/mutate.go
+++ b/engine/mutate.go
@@ -1,0 +1,158 @@
+package engine
+
+import (
+	"errors"
+	"time"
+
+	"github.com/handarbeit/fabrik/boardcache"
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// cache returns e.readClient cast to *boardcache.CacheImpl, or nil when the
+// engine is running against a plain read-only client (e.g. in tests that don't
+// wire a cache). Centralizes the cast-or-nil check that was previously
+// re-typed at every call site as `if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok`.
+func (e *Engine) cache() *boardcache.CacheImpl {
+	c, ok := e.readClient.(*boardcache.CacheImpl)
+	if !ok {
+		return nil
+	}
+	return c
+}
+
+// applyLabelAdd performs the three-beat label-add idiom: GitHub mutation ->
+// cache write-through -> conditional webhook echo. The repo is resolved once,
+// canonically, via itemOwnerRepo so a caller can never accidentally use
+// item.Repo in one place and a resolved owner/repo elsewhere. echo controls
+// whether a webhook echo is registered on success; it exists only so
+// pauseIssue can suppress it for callers that historically didn't echo.
+func (e *Engine) applyLabelAdd(item gh.ProjectItem, label string, echo bool) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, label); err != nil {
+		e.logf(item.Number, "warn", "could not add label %q: %v\n", label, err)
+		return
+	}
+	if c := e.cache(); c != nil {
+		c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), label)
+	}
+	if echo && e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+label)
+	}
+}
+
+// addLabel is the always-echoing public entry point for applyLabelAdd, used by
+// every call site except pauseIssue's non-echoing pauseFor* pattern.
+func (e *Engine) addLabel(item gh.ProjectItem, label string) {
+	e.applyLabelAdd(item, label, true)
+}
+
+// syncLabelRemoval mirrors a label removal into the cache and, when echo is
+// true, registers a webhook echo. It is split out from applyLabelRemove so
+// callers that must perform the GitHub mutation themselves (e.g.
+// removeEditingLabel's retry-with-backoff loop) can still share the
+// write-through + echo tail instead of re-typing it.
+func (e *Engine) syncLabelRemoval(item gh.ProjectItem, label string, echo bool) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	if c := e.cache(); c != nil {
+		c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), label)
+	}
+	if echo && e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+label)
+	}
+}
+
+// applyLabelRemove performs the three-beat label-remove idiom, with
+// gh.ErrNotFound treated as success: the label is already absent on GitHub, so
+// the cache is synced to match (this is the canonical fix for sites that used
+// to skip the cache sync on ErrNotFound). echo is never applied on ErrNotFound,
+// matching removeEditingLabel's pre-existing ErrNotFound behavior.
+func (e *Engine) applyLabelRemove(item gh.ProjectItem, label string, echo bool) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, label)
+	if err != nil && !errors.Is(err, gh.ErrNotFound) {
+		e.logf(item.Number, "warn", "could not remove label %q: %v\n", label, err)
+		return
+	}
+	e.syncLabelRemoval(item, label, echo && err == nil)
+}
+
+// removeLabel is the always-echoing (on success) public entry point for
+// applyLabelRemove, used by every call site except pauseIssue's non-echoing
+// pauseFor* pattern.
+func (e *Engine) removeLabel(item gh.ProjectItem, label string) {
+	e.applyLabelRemove(item, label, true)
+}
+
+// postComment performs the three/four-beat comment-post idiom: AddComment ->
+// cache write-through -> conditional webhook echo -> optional rocket reaction.
+// Returns the posted comment's database id, or (0, err) on failure. echo
+// exists only so pauseIssue can suppress it for callers that historically
+// didn't echo their pause comment.
+func (e *Engine) postComment(item gh.ProjectItem, body string, react, echo bool) (int, error) {
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+	dbID, err := e.client.AddComment(owner, repo, item.Number, body)
+	if err != nil {
+		e.logf(item.Number, "warn", "could not post comment: %v\n", err)
+		return 0, err
+	}
+	if c := e.cache(); c != nil {
+		c.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
+			DatabaseID: dbID, Body: body, Author: e.cfg.User, CreatedAt: time.Now(),
+		})
+	}
+	if echo && e.webhookMgr != nil {
+		e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+	}
+	if react {
+		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+		}
+	}
+	return dbID, nil
+}
+
+// postItemComment is the always-echoing public entry point for postComment,
+// used by every call site except pauseIssue's parameterized pattern. It
+// swallows the AddComment error (already logged by postComment) and returns 0.
+func (e *Engine) postItemComment(item gh.ProjectItem, body string, react bool) int {
+	dbID, err := e.postComment(item, body, react, true)
+	if err != nil {
+		return 0
+	}
+	return dbID
+}
+
+// pauseOpts parameterizes pauseIssue's three independent axes of divergence
+// across its 13 call sites (10 pauseFor* + escalatePRCreationFailure +
+// escalateFailedStage + pauseForBrokenLinkage). A single bool cannot express
+// this: the 10 "Pattern A" pauseFor* sites add fabrik:awaiting-input and never
+// echo; the 2 "Pattern B" escalate* sites don't add awaiting-input but do
+// echo both the label and comment writes; "Pattern C" (pauseForBrokenLinkage)
+// adds neither awaiting-input nor a comment reaction/echo. See ADR for the
+// full per-site table.
+type pauseOpts struct {
+	awaitingInput   bool // add fabrik:awaiting-input alongside fabrik:paused
+	reactRocket     bool // rocket-react the posted comment
+	labelEcho       bool // RegisterEcho after the paused/awaiting-input/auto-merge label writes
+	commentEcho     bool // RegisterEcho after the comment write
+	removeAutoMerge bool // also remove fabrik:auto-merge-enabled
+}
+
+// pauseIssue posts the given comment and applies fabrik:paused (plus,
+// depending on opts, fabrik:awaiting-input and a fabrik:auto-merge-enabled
+// removal), collapsing the shared tail of the 11 pauseFor* functions and the
+// pause portion of the 2 escalate* functions. Callers that also need to apply
+// additional labels (e.g. escalate*'s stage:<name>:failed, or
+// pauseForPRClosedNotMerged's fabrik:awaiting-ci removal) do so themselves
+// around this call — those steps are outside the shared pause tail.
+func (e *Engine) pauseIssue(item gh.ProjectItem, comment string, opts pauseOpts) {
+	e.postComment(item, comment, opts.reactRocket, opts.commentEcho) //nolint:errcheck // failure already logged by postComment
+	e.applyLabelAdd(item, "fabrik:paused", opts.labelEcho)
+	if opts.awaitingInput {
+		e.applyLabelAdd(item, "fabrik:awaiting-input", opts.labelEcho)
+	}
+	if opts.removeAutoMerge {
+		e.applyLabelRemove(item, "fabrik:auto-merge-enabled", opts.labelEcho)
+	}
+}

--- a/engine/mutate_test.go
+++ b/engine/mutate_test.go
@@ -1,0 +1,454 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/handarbeit/fabrik/boardcache"
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// ── cache() ──────────────────────────────────────────────────────────────
+
+func TestCache_ReturnsNilWithoutCacheImpl(t *testing.T) {
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	if c := eng.cache(); c != nil {
+		t.Errorf("expected nil cache when readClient is not *boardcache.CacheImpl, got %v", c)
+	}
+}
+
+func TestCache_ReturnsCacheImplWhenWired(t *testing.T) {
+	eng, cache := testEngineWithCache(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	if got := eng.cache(); got != cache {
+		t.Errorf("expected cache() to return the wired *CacheImpl, got %v want %v", got, cache)
+	}
+}
+
+// ── applyLabelAdd / addLabel ─────────────────────────────────────────────
+
+func TestApplyLabelAdd_WriteThroughAndEcho(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelAdd(item, "fabrik:paused", true)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused in cache, got %v", labels)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
+	wm.mu.Unlock()
+	if !gotEcho {
+		t.Error("expected webhook echo to be registered when echo=true")
+	}
+}
+
+func TestApplyLabelAdd_NoEchoWhenSuppressed(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelAdd(item, "fabrik:paused", false)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected cache write-through regardless of echo, got %v", labels)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
+	wm.mu.Unlock()
+	if gotEcho {
+		t.Error("expected no webhook echo when echo=false")
+	}
+}
+
+func TestApplyLabelAdd_ErrorSkipsWriteThrough(t *testing.T) {
+	client := &mockGitHubClient{
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			return errors.New("api error")
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelAdd(item, "fabrik:paused", true)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected cache unchanged on API failure, got %v", labels)
+	}
+}
+
+func TestAddLabel_UsesResolvedRepoNotItemRepo(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	// Empty item.Repo — must fall back to e.defaultRepo() ("owner/repo" in tests).
+	item := gh.ProjectItem{Number: 1}
+	eng.addLabel(item, "fabrik:paused")
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused under the resolved owner/repo cache key, got %v", labels)
+	}
+}
+
+// ── applyLabelRemove / removeLabel ───────────────────────────────────────
+
+func TestApplyLabelRemove_WriteThroughAndEcho(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:blocked")
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelRemove(item, "fabrik:blocked", true)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if containsLabel(labels, "fabrik:blocked") {
+		t.Errorf("expected fabrik:blocked removed from cache, got %v", labels)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issues", "unlabeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:blocked")]
+	wm.mu.Unlock()
+	if !gotEcho {
+		t.Error("expected webhook echo to be registered on successful removal")
+	}
+}
+
+func TestApplyLabelRemove_ErrNotFoundSyncsCacheButNeverEchoes(t *testing.T) {
+	client := &mockGitHubClient{
+		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			return gh.ErrNotFound
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:editing")
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	// echo=true requested, but ErrNotFound must never echo — this is the
+	// removeEditingLabel behavior Requirement 1 calls out explicitly.
+	eng.applyLabelRemove(item, "fabrik:editing", true)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if containsLabel(labels, "fabrik:editing") {
+		t.Errorf("expected cache synced (label absent) on ErrNotFound idempotent removal, got %v", labels)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issues", "unlabeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:editing")]
+	wm.mu.Unlock()
+	if gotEcho {
+		t.Error("expected no webhook echo on ErrNotFound removal, even with echo=true requested")
+	}
+}
+
+func TestApplyLabelRemove_NonNotFoundErrorSkipsWriteThrough(t *testing.T) {
+	client := &mockGitHubClient{
+		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			return errors.New("network error")
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:blocked")
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelRemove(item, "fabrik:blocked", true)
+
+	labels, err := cache.FetchLabels("owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !containsLabel(labels, "fabrik:blocked") {
+		t.Errorf("expected cache unchanged on non-ErrNotFound API failure, got %v", labels)
+	}
+}
+
+// ── postComment / postItemComment ────────────────────────────────────────
+
+func TestPostComment_WriteThroughEchoAndReact(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 42, nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	// Warm up the deep-fetch cache so FetchItemDetails returns from cache after
+	// the write-through (mirrors TestCommentWriteThrough's setup).
+	if err := cache.FetchItemDetails(&item); err != nil {
+		t.Fatalf("FetchItemDetails warm-up: %v", err)
+	}
+	dbID, err := eng.postComment(item, "hello", true, true)
+	if err != nil {
+		t.Fatalf("postComment: %v", err)
+	}
+	if dbID != 42 {
+		t.Errorf("expected dbID 42, got %d", dbID)
+	}
+
+	itemAfter := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if err := cache.FetchItemDetails(&itemAfter); err != nil {
+		t.Fatalf("FetchItemDetails: %v", err)
+	}
+	if !containsCommentByID(itemAfter.Comments, 42) {
+		t.Errorf("expected comment 42 in cache, got %v", itemAfter.Comments)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issue_comment", "created", boardcache.ItemKey("owner/repo", 1))]
+	wm.mu.Unlock()
+	if !gotEcho {
+		t.Error("expected webhook echo to be registered when echo=true")
+	}
+
+	if len(client.addCommentReactionCalls) != 1 {
+		t.Errorf("expected 1 rocket-react call when react=true, got %d", len(client.addCommentReactionCalls))
+	}
+}
+
+func TestPostComment_NoEchoNoReactWhenSuppressed(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 42, nil
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if _, err := eng.postComment(item, "hello", false, false); err != nil {
+		t.Fatalf("postComment: %v", err)
+	}
+
+	wm.mu.Lock()
+	_, gotEcho := wm.pendingEchoes[echoKey("issue_comment", "created", boardcache.ItemKey("owner/repo", 1))]
+	wm.mu.Unlock()
+	if gotEcho {
+		t.Error("expected no webhook echo when echo=false")
+	}
+	if len(client.addCommentReactionCalls) != 0 {
+		t.Errorf("expected no rocket-react call when react=false, got %d", len(client.addCommentReactionCalls))
+	}
+}
+
+func TestPostComment_ErrorSkipsWriteThrough(t *testing.T) {
+	apiErr := errors.New("rate limited")
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, apiErr
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	dbID, err := eng.postComment(item, "hello", true, true)
+	if !errors.Is(err, apiErr) {
+		t.Errorf("expected apiErr, got %v", err)
+	}
+	if dbID != 0 {
+		t.Errorf("expected dbID 0 on error, got %d", dbID)
+	}
+	if len(client.addCommentReactionCalls) != 0 {
+		t.Error("expected no reaction attempt when AddComment failed")
+	}
+}
+
+func TestPostItemComment_AlwaysEchoesAndSwallowsError(t *testing.T) {
+	apiErr := errors.New("rate limited")
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, apiErr
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if got := eng.postItemComment(item, "hello", false); got != 0 {
+		t.Errorf("expected 0 on AddComment failure, got %d", got)
+	}
+}
+
+// ── pauseIssue ────────────────────────────────────────────────────────────
+
+// Pattern A: 10 of the 11 pauseFor* functions — awaiting-input added, comment
+// rocket-reacted, neither label nor comment echoed, auto-merge untouched.
+func TestPauseIssue_PatternA(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 7, nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.pauseIssue(item, "paused message", pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+		labelEcho:     false,
+		commentEcho:   false,
+	})
+
+	labels, _ := cache.FetchLabels("owner", "repo", 1)
+	if !containsLabel(labels, "fabrik:paused") || !containsLabel(labels, "fabrik:awaiting-input") {
+		t.Errorf("expected both fabrik:paused and fabrik:awaiting-input in cache, got %v", labels)
+	}
+	if len(client.addCommentReactionCalls) != 1 {
+		t.Errorf("expected 1 rocket-react call, got %d", len(client.addCommentReactionCalls))
+	}
+
+	wm.mu.Lock()
+	_, labelEchoed := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
+	_, commentEchoed := wm.pendingEchoes[echoKey("issue_comment", "created", boardcache.ItemKey("owner/repo", 1))]
+	wm.mu.Unlock()
+	if labelEchoed {
+		t.Error("Pattern A must not echo label writes")
+	}
+	if commentEchoed {
+		t.Error("Pattern A must not echo the comment write")
+	}
+}
+
+// Pattern B: escalatePRCreationFailure / escalateFailedStage — no
+// awaiting-input, comment rocket-reacted, both label and comment echoed.
+func TestPauseIssue_PatternB(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 7, nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.pauseIssue(item, "escalation message", pauseOpts{
+		awaitingInput: false,
+		reactRocket:   true,
+		labelEcho:     true,
+		commentEcho:   true,
+	})
+
+	labels, _ := cache.FetchLabels("owner", "repo", 1)
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused in cache, got %v", labels)
+	}
+	if containsLabel(labels, "fabrik:awaiting-input") {
+		t.Errorf("Pattern B must not add fabrik:awaiting-input, got %v", labels)
+	}
+
+	wm.mu.Lock()
+	_, labelEchoed := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
+	_, commentEchoed := wm.pendingEchoes[echoKey("issue_comment", "created", boardcache.ItemKey("owner/repo", 1))]
+	wm.mu.Unlock()
+	if !labelEchoed {
+		t.Error("Pattern B must echo the label write")
+	}
+	if !commentEchoed {
+		t.Error("Pattern B must echo the comment write")
+	}
+}
+
+// Pattern C: pauseForBrokenLinkage — no awaiting-input, no rocket reaction, no
+// comment echo, but the label write is still echoed (via addPausedLabelToItem).
+func TestPauseIssue_PatternC(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 7, nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	wm, _ := newTestWebhookManager(t)
+	eng.webhookMgr = wm
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.pauseIssue(item, "broken linkage message", pauseOpts{
+		awaitingInput: false,
+		reactRocket:   false,
+		labelEcho:     true,
+		commentEcho:   false,
+	})
+
+	labels, _ := cache.FetchLabels("owner", "repo", 1)
+	if !containsLabel(labels, "fabrik:paused") {
+		t.Errorf("expected fabrik:paused in cache, got %v", labels)
+	}
+	if containsLabel(labels, "fabrik:awaiting-input") {
+		t.Errorf("Pattern C must not add fabrik:awaiting-input, got %v", labels)
+	}
+	if len(client.addCommentReactionCalls) != 0 {
+		t.Errorf("Pattern C must not rocket-react, got %d calls", len(client.addCommentReactionCalls))
+	}
+
+	wm.mu.Lock()
+	_, labelEchoed := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
+	_, commentEchoed := wm.pendingEchoes[echoKey("issue_comment", "created", boardcache.ItemKey("owner/repo", 1))]
+	wm.mu.Unlock()
+	if !labelEchoed {
+		t.Error("Pattern C must still echo the label write")
+	}
+	if commentEchoed {
+		t.Error("Pattern C must not echo the comment write")
+	}
+}
+
+func TestPauseIssue_RemoveAutoMerge(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 7, nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:auto-merge-enabled")
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.pauseIssue(item, "convergence failed", pauseOpts{
+		awaitingInput:   true,
+		reactRocket:     true,
+		removeAutoMerge: true,
+	})
+
+	labels, _ := cache.FetchLabels("owner", "repo", 1)
+	if containsLabel(labels, "fabrik:auto-merge-enabled") {
+		t.Errorf("expected fabrik:auto-merge-enabled removed from cache, got %v", labels)
+	}
+	if !containsLabel(labels, "fabrik:paused") || !containsLabel(labels, "fabrik:awaiting-input") {
+		t.Errorf("expected pause labels present, got %v", labels)
+	}
+}

--- a/engine/mutate_test.go
+++ b/engine/mutate_test.go
@@ -346,11 +346,19 @@ func TestPauseIssue_PatternA(t *testing.T) {
 }
 
 // Pattern B: escalatePRCreationFailure / escalateFailedStage — no
-// awaiting-input, comment rocket-reacted, both label and comment echoed.
+// awaiting-input, comment rocket-reacted, both label and comment echoed,
+// fabrik:paused added *before* the comment is posted (labelFirst) — matching
+// the original hand-inlined order at these two call sites.
 func TestPauseIssue_PatternB(t *testing.T) {
+	var order []string
 	client := &mockGitHubClient{
 		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			order = append(order, "comment")
 			return 7, nil
+		},
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			order = append(order, "label:"+labelName)
+			return nil
 		},
 	}
 	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
@@ -363,6 +371,7 @@ func TestPauseIssue_PatternB(t *testing.T) {
 		reactRocket:   true,
 		labelEcho:     true,
 		commentEcho:   true,
+		labelFirst:    true,
 	})
 
 	labels, _ := cache.FetchLabels("owner", "repo", 1)
@@ -371,6 +380,10 @@ func TestPauseIssue_PatternB(t *testing.T) {
 	}
 	if containsLabel(labels, "fabrik:awaiting-input") {
 		t.Errorf("Pattern B must not add fabrik:awaiting-input, got %v", labels)
+	}
+
+	if want := []string{"label:fabrik:paused", "comment"}; len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Errorf("Pattern B must add fabrik:paused before posting the comment, got order %v", order)
 	}
 
 	wm.mu.Lock()
@@ -386,11 +399,19 @@ func TestPauseIssue_PatternB(t *testing.T) {
 }
 
 // Pattern C: pauseForBrokenLinkage — no awaiting-input, no rocket reaction, no
-// comment echo, but the label write is still echoed (via addPausedLabelToItem).
+// comment echo, but the label write is still echoed (via addPausedLabelToItem),
+// and fabrik:paused is added *before* the comment is posted (labelFirst) —
+// matching the original hand-inlined order at this call site.
 func TestPauseIssue_PatternC(t *testing.T) {
+	var order []string
 	client := &mockGitHubClient{
 		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			order = append(order, "comment")
 			return 7, nil
+		},
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			order = append(order, "label:"+labelName)
+			return nil
 		},
 	}
 	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
@@ -403,6 +424,7 @@ func TestPauseIssue_PatternC(t *testing.T) {
 		reactRocket:   false,
 		labelEcho:     true,
 		commentEcho:   false,
+		labelFirst:    true,
 	})
 
 	labels, _ := cache.FetchLabels("owner", "repo", 1)
@@ -416,6 +438,10 @@ func TestPauseIssue_PatternC(t *testing.T) {
 		t.Errorf("Pattern C must not rocket-react, got %d calls", len(client.addCommentReactionCalls))
 	}
 
+	if want := []string{"label:fabrik:paused", "comment"}; len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Errorf("Pattern C must add fabrik:paused before posting the comment, got order %v", order)
+	}
+
 	wm.mu.Lock()
 	_, labelEchoed := wm.pendingEchoes[echoKey("issues", "labeled", boardcache.ItemKey("owner/repo", 1)+"+"+"fabrik:paused")]
 	_, commentEchoed := wm.pendingEchoes[echoKey("issue_comment", "created", boardcache.ItemKey("owner/repo", 1))]
@@ -425,6 +451,41 @@ func TestPauseIssue_PatternC(t *testing.T) {
 	}
 	if commentEchoed {
 		t.Error("Pattern C must not echo the comment write")
+	}
+}
+
+// Pattern A order: the 10 pauseFor* functions historically posted their
+// comment before adding fabrik:paused — pauseIssue's default (labelFirst:
+// false) must preserve that order.
+func TestPauseIssue_PatternA_CommentBeforeLabel(t *testing.T) {
+	var order []string
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			order = append(order, "comment")
+			return 7, nil
+		},
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			order = append(order, "label:"+labelName)
+			return nil
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.pauseIssue(item, "paused message", pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
+
+	if want := []string{"comment", "label:fabrik:paused", "label:fabrik:awaiting-input"}; len(order) != len(want) {
+		t.Fatalf("Pattern A order mismatch, got %v want %v", order, want)
+	} else {
+		for i := range want {
+			if order[i] != want[i] {
+				t.Errorf("Pattern A order mismatch at index %d: got %v want %v", i, order, want)
+				break
+			}
+		}
 	}
 }
 

--- a/engine/no_work_needed_settle.go
+++ b/engine/no_work_needed_settle.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
@@ -67,12 +66,7 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 				e.logf(item.Number, "warn", "could not remove awaiting-input label: %v\n", err)
 				allStepsOK = false
 			} else if err == nil {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-				}
-				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
-				}
+				e.syncLabelRemoval(item, "fabrik:awaiting-input", true)
 			}
 		}
 
@@ -83,12 +77,7 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 				e.logf(item.Number, "warn", "could not add completion label for stage %q: %v\n", stage.Name, err)
 				allStepsOK = false
 			} else {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
-				}
-				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
-				}
+				e.syncLabelAdd(item, completeLabel, true)
 				if stage.Name == "Validate" {
 					repoStr := itemOwnerRepoString(item, e.defaultRepo())
 					wm := e.worktreesFor(item.Repo)
@@ -133,28 +122,13 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 					e.logf(item.Number, "warn", "could not add skip label for stage %q: %v\n", s.Name, err)
 					allStepsOK = false
 				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), skipLabel)
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+skipLabel)
-					}
+					e.syncLabelAdd(item, skipLabel, true)
 				}
 			}
 			// Post the "skipped" comment — no rocket reaction, this is engine-generated metadata.
 			if !alreadyPostedSkipComments {
-				if dbID, err := e.client.AddComment(owner, repo, item.Number, skippedComment); err != nil {
-					e.logf(item.Number, "warn", "could not post skipped comment for stage %q: %v\n", s.Name, err)
+				if _, err := e.postComment(item, skippedComment, false, true); err != nil {
 					allStepsOK = false
-				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-							DatabaseID: dbID, Body: skippedComment, Author: e.cfg.User, CreatedAt: time.Now(),
-						})
-					}
-					if e.webhookMgr != nil {
-						e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-					}
 				}
 			}
 		}
@@ -186,8 +160,8 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 			e.recordNoWorkNeededRetry(item)
 			return
 		}
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Done")
+		if c := e.cache(); c != nil {
+			c.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), "Done")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
@@ -204,8 +178,8 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 			e.recordNoWorkNeededRetry(item)
 			return
 		}
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyIssueClosed(boardcache.ItemKey(item.Repo, item.Number))
+		if c := e.cache(); c != nil {
+			c.ApplyIssueClosed(boardcache.ItemKey(item.Repo, item.Number))
 		}
 		e.logf(item.Number, "done", "closed issue (no work needed)\n")
 	}
@@ -244,49 +218,14 @@ func (e *Engine) escalateNoWorkNeededFailure(item gh.ProjectItem) {
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add paused label: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
-
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-done"); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove awaiting-done marker: %v\n", err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-done")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-done")
-		}
-	}
+	e.addLabel(item, "fabrik:paused")
+	e.applyLabelRemove(item, "fabrik:awaiting-done", true)
 
 	comment := fmt.Sprintf(
 		"🏭 **Fabrik — no-work-needed completion failed**\n\nThis issue was determined to need no code or documentation changes, but the board move to Done and/or the issue close could not be completed after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh issue close %d --repo %s/%s\n```\nThen move the issue's project-board column to Done yourself (no `gh` one-liner exists for Projects-v2 status fields).\n\nThen remove the `fabrik:paused` label. Do not remove it without completing the above — removing the `fabrik:paused` label without completing these steps may cause the issue to re-enter the normal pipeline unexpectedly.",
 		e.cfg.MaxRetries, item.Number, owner, repo,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post no-work-needed escalation comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
+	e.postItemComment(item, comment, true)
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: noWorkNeededRetryStage})
@@ -301,12 +240,7 @@ func (e *Engine) clearNoWorkNeededMarker(item gh.ProjectItem, owner, repo string
 		e.logf(item.Number, "warn", "could not remove awaiting-done marker: %v\n", err)
 		return
 	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-done")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-done")
-		}
+		e.syncLabelRemoval(item, "fabrik:awaiting-done", true)
 	}
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -738,8 +738,8 @@ func (e *Engine) cleanupLockedIssues() {
 			e.logf(num, "warn", "could not remove lock label during shutdown: %v\n", err)
 		} else {
 			e.logf(num, "shutdown", "removed lock label\n")
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, num), lockLabel)
+			if c := e.cache(); c != nil {
+				c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, num), lockLabel)
 			}
 		}
 		e.store.Apply(itemstate.LocalLockReleased{Repo: snap.Repo(), Number: num})
@@ -773,8 +773,8 @@ func (e *Engine) cleanupClosedIssueLocks(board *gh.ProjectBoard) {
 			}
 		} else {
 			e.logf(num, "poll", "removed stale lock label from closed issue\n")
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
+			if c := e.cache(); c != nil {
+				c.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), lockLabel)
 			}
 		}
 	}
@@ -815,16 +815,16 @@ func (e *Engine) cleanupClosedIssueTransientLabels(board *gh.ProjectBoard) {
 			if err := e.client.RemoveLabelFromIssue(owner, repo, num, label); err != nil {
 				if errors.Is(err, gh.ErrNotFound) {
 					// Label already absent on GitHub — desired state achieved; sync cache.
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoKey, num), label)
+					if c := e.cache(); c != nil {
+						c.ApplyLabelRemoved(boardcache.ItemKey(repoKey, num), label)
 					}
 				} else {
 					e.logf(num, "warn", "could not remove transient label %q from closed issue: %v\n", label, err)
 				}
 			} else {
 				e.logf(num, "poll", "removed transient label %q from closed issue\n", label)
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoKey, num), label)
+				if c := e.cache(); c != nil {
+					c.ApplyLabelRemoved(boardcache.ItemKey(repoKey, num), label)
 				}
 			}
 		}
@@ -840,7 +840,7 @@ type pollResult struct {
 
 func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	e.emitStructural(tui.PollStartedEvent{Owner: e.cfg.Owner, Repo: e.cfg.Repo, Project: e.cfg.ProjectNum})
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && cacheImpl.IsBootstrapped() && !cacheImpl.IsPaused() {
+	if c := e.cache(); c != nil && c.IsBootstrapped() && !c.IsPaused() {
 		e.logf(0, "poll", "reading project board from cache: %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
 	} else {
 		e.logf(0, "poll", "fetching project board from GitHub: %s/%s#%d\n", e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum)
@@ -850,8 +850,8 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// holds fresh Status values when poll() processes items this cycle.
 	// Only active when the in-memory cache is bootstrapped (cacheImpl != nil and
 	// ProjectID is known); skipped on the very first cycle when cache is unset.
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && cacheImpl.ProjectID() != "" {
-		projectID := cacheImpl.ProjectID()
+	if c := e.cache(); c != nil && c.ProjectID() != "" {
+		projectID := c.ProjectID()
 		updatedAt, gateErr := e.client.FetchProjectUpdatedAt(projectID)
 		if gateErr != nil {
 			e.logf(0, "cache", "layer2 gate: FetchProjectUpdatedAt failed: %v; running batch as fallback\n", gateErr)
@@ -861,7 +861,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			if err != nil {
 				e.logf(0, "cache", "layer2 status sweep failed: %v\n", err)
 			} else {
-				cacheImpl.ApplyStatusBatch(updates)
+				c.ApplyStatusBatch(updates)
 				if gateErr == nil {
 					e.lastProjectUpdatedAt = updatedAt
 				}
@@ -888,20 +888,20 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// repo-level projects (and only sometimes for org-level projects with the
 	// right permissions). The Layer 2 status sweep above must continue running
 	// regardless of webhook state — it is the only delivery path for Status.
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+	if c := e.cache(); c != nil {
 		switch {
-		case cacheImpl.IsPaused():
+		case c.IsPaused():
 			// Paused: FetchProjectBoard below falls through to GitHub directly.
-		case cacheImpl.IsBootstrapped() || cacheImpl.ProjectID() != "":
+		case c.IsBootstrapped() || c.ProjectID() != "":
 			// Bootstrapped: use probe-driven refresh (avoids full shallow fetch cost).
-			e.runProbeAndDeepFetch(cacheImpl)
+			e.runProbeAndDeepFetch(c)
 		default:
 			// Virgin: probe bootstrap (~250 nodes vs ~2350 for full shallow fetch).
 			probeItems, projectID, refreshErr := e.client.ProbeProjectBoard(e.cfg.Owner, e.cfg.Repo, e.cfg.ProjectNum, e.cfg.OwnerType)
 			if refreshErr != nil {
 				e.logf(0, "cache", "initial board probe failed (using empty cache): %v\n", refreshErr)
 			} else if projectID != "" && len(probeItems) > 0 {
-				cacheImpl.BootstrapFromProbe(probeItems, projectID)
+				c.BootstrapFromProbe(probeItems, projectID)
 				e.seedTerminalFromProbeItems(probeItems)
 			} else if projectID != "" {
 				// Probe succeeded but returned 0 items — possible transient indexer hiccup.
@@ -1133,7 +1133,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
 			continue
 		}
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok && !cacheImpl.IsPaused() && cacheImpl.IsItemCacheFresh(board.Items[i].Repo, board.Items[i].Number, board.Items[i].UpdatedAt) {
+		if c := e.cache(); c != nil && !c.IsPaused() && c.IsItemCacheFresh(board.Items[i].Repo, board.Items[i].Number, board.Items[i].UpdatedAt) {
 			e.logf(0, "poll", "reading details for #%d from cache\n", board.Items[i].Number)
 		} else {
 			e.logf(0, "poll", "deep-fetching details for #%d from GitHub\n", board.Items[i].Number)
@@ -1331,15 +1331,15 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			e.logf(item.Number, "warn", "fabrik:revalidate applied to non-Validate stage %q — removing label, no action\n", stageName)
 			if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:revalidate"); rerr != nil {
 				if errors.Is(rerr, gh.ErrNotFound) {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
+					if c := e.cache(); c != nil {
+						c.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
 					}
 				} else {
 					e.logf(item.Number, "warn", "revalidate: could not remove label from non-Validate issue: %v\n", rerr)
 				}
 			} else {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
+				if c := e.cache(); c != nil {
+					c.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
 				}
 				if e.webhookMgr != nil {
 					e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(repoStr, item.Number)+"+"+"fabrik:revalidate")

--- a/engine/pr.go
+++ b/engine/pr.go
@@ -49,8 +49,8 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) (int, err
 			// An open PR already exists — use it.
 			e.logf(item.Number, "pr", "PR #%d already exists (branch: %s, sha: %s), ensuring issue link\n", pr.Number, head, pr.HeadSHA)
 			e.ensurePRLinksIssue(item, pr.Number)
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.RecordPRLinkage(owner+"/"+repo, pr.Number, item.Number)
+			if c := e.cache(); c != nil {
+				c.RecordPRLinkage(owner+"/"+repo, pr.Number, item.Number)
 			}
 			return pr.Number, nil
 		}
@@ -95,8 +95,8 @@ func (e *Engine) ensureDraftPR(item gh.ProjectItem, baseBranch string) (int, err
 		}
 		headSHA, _ := gitHeadSHA(workDir)
 		e.logf(item.Number, "pr", "created draft PR #%d (branch: %s, sha: %s)\n", prNum, head, headSHA)
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
+		if c := e.cache(); c != nil {
+			c.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("pull_request", "opened", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNum))
@@ -327,42 +327,12 @@ func (e *Engine) postOutputToPR(item gh.ProjectItem, stageName, output, footer, 
 
 		// Post brief summary on the issue
 		summary := formatPRSummaryComment(stageName, prNumber, output, branch, commit, mainSHA, timestamp)
-		if dbID, err := e.client.AddComment(owner, repo, item.Number, summary); err != nil {
-			e.logf(item.Number, "warn", "could not post summary: %v\n", err)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: summary, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-			}
-			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-			}
-		}
+		e.postItemComment(item, summary, true)
 	} else {
 		// No PR found — fall back to posting on the issue
 		e.logf(item.Number, "warn", "no open PR found, posting on issue instead\n")
 		comment := formatOutputComment(stageName, output, footer, branch, commit, mainSHA, timestamp)
-		if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-			e.logf(item.Number, "warn", "could not post comment: %v\n", err)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: comment, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-			}
-			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-			}
-		}
+		e.postItemComment(item, comment, true)
 	}
 }
 

--- a/engine/pr_terminal_advance.go
+++ b/engine/pr_terminal_advance.go
@@ -107,8 +107,8 @@ func (e *Engine) runValidatePRTerminalAdvance(board *gh.ProjectBoard, items []gh
 					e.logf(item.Number, "warn", "pr-terminal: could not add %s: %v — skipping item\n", completeLabel, addErr)
 					fillFailed = true
 					break
-				} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), completeLabel)
+				} else if c := e.cache(); c != nil {
+					c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), completeLabel)
 				}
 				e.logf(item.Number, "pr-terminal", "added %s\n", completeLabel)
 			}
@@ -131,14 +131,14 @@ func (e *Engine) runValidatePRTerminalAdvance(board *gh.ProjectBoard, items []gh
 					if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, lbl); rerr != nil {
 						if errors.Is(rerr, gh.ErrNotFound) {
 							// Label already absent on GitHub — desired end state achieved; sync cache.
-							if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-								cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), lbl)
+							if c := e.cache(); c != nil {
+								c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), lbl)
 							}
 						} else {
 							e.logf(item.Number, "warn", "pr-terminal: could not remove %s: %v\n", lbl, rerr)
 						}
-					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), lbl)
+					} else if c := e.cache(); c != nil {
+						c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), lbl)
 					}
 				}
 			}

--- a/engine/prcreate.go
+++ b/engine/prcreate.go
@@ -329,6 +329,7 @@ func (e *Engine) pauseForBrokenLinkage(item gh.ProjectItem, prNumber int, closin
 		prNumber, item.Number, reason, prNumber, closingLine, prNumber,
 	)
 	e.pauseIssue(item, msg, pauseOpts{
-		labelEcho: true,
+		labelEcho:  true,
+		labelFirst: true,
 	})
 }

--- a/engine/prcreate.go
+++ b/engine/prcreate.go
@@ -135,13 +135,7 @@ func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem,
 			block.TargetRepo, owner, repo,
 		)
 		e.addPausedLabelToItem(owner, repo, item)
-		if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-			e.logf(item.Number, "warn", "could not post cross-repo PR error comment: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
+		e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 		return 0, fmt.Errorf("cross-repo PR creation not supported (target: %s)", block.TargetRepo)
 	}
 
@@ -151,8 +145,8 @@ func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem,
 	existingPR, err := e.client.FetchLinkedPR(owner, repo, item.Number)
 	if err == nil && existingPR != nil && existingPR.State == "open" && !existingPR.Merged {
 		e.logf(item.Number, "pr", "FABRIK_PR_CREATE: PR #%d already exists — using existing PR\n", existingPR.Number)
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.RecordPRLinkage(owner+"/"+repo, existingPR.Number, item.Number)
+		if c := e.cache(); c != nil {
+			c.RecordPRLinkage(owner+"/"+repo, existingPR.Number, item.Number)
 		}
 		return existingPR.Number, nil
 	}
@@ -194,21 +188,15 @@ func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem,
 			item.Number, maxAttempts, lastErr,
 		)
 		e.addPausedLabelToItem(owner, repo, item)
-		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post PR creation error comment: %v\n", commentErr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
+		e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 		return 0, fmt.Errorf("creating PR via FABRIK_PR_CREATE: %w", lastErr)
 	}
 
 	e.logf(item.Number, "pr", "FABRIK_PR_CREATE: created draft PR #%d (title: %q)\n", prNum, block.Title)
 
 	// Cache write-through.
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
+	if c := e.cache(); c != nil {
+		c.RecordPRLinkage(owner+"/"+repo, prNum, item.Number)
 	}
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEcho("pull_request", "opened", fmt.Sprintf("%s/%s#pr%d", owner, repo, prNum))
@@ -216,18 +204,7 @@ func (e *Engine) processPRCreateMarker(ctx context.Context, item gh.ProjectItem,
 
 	// Acknowledgement comment on the issue.
 	ackMsg := fmt.Sprintf("🏭 **Fabrik** — opened PR #%d", prNum)
-	if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, ackMsg); commentErr != nil {
-		e.logf(item.Number, "warn", "could not post PR-opened acknowledgement: %v\n", commentErr)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: ackMsg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-	}
+	e.postComment(item, ackMsg, false, true) //nolint:errcheck // failure already logged by postComment
 
 	return prNum, nil
 }
@@ -318,31 +295,14 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 		e.logf(item.Number, "warn", "verifyAndHealLinkage: re-verification FetchItemDetails failed: %v\n", err)
 		// Can't confirm — treat as success (heal likely took effect; GitHub may lag).
 		healMsg := fmt.Sprintf("🏭 **Fabrik** — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference). Re-verification fetch failed; please confirm linkage.", closingLine)
-		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, healMsg); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post heal confirmation comment: %v\n", commentErr)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: healMsg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
+		e.postComment(item, healMsg, false, false) //nolint:errcheck // failure already logged by postComment
 		return true
 	}
 
 	if item.LinkedPRNumber != 0 {
 		e.logf(item.Number, "pr", "verifyAndHealLinkage: linkage confirmed for PR #%d\n", pr.Number)
 		healMsg := fmt.Sprintf("🏭 **Fabrik** — PR body auto-corrected: `%s` prepended (PR was opened without the closing reference).", closingLine)
-		if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, healMsg); commentErr != nil {
-			e.logf(item.Number, "warn", "could not post heal confirmation comment: %v\n", commentErr)
-		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: healMsg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
-			if e.webhookMgr != nil {
-				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-			}
-		}
+		e.postComment(item, healMsg, false, true) //nolint:errcheck // failure already logged by postComment
 		return true
 	}
 

--- a/engine/prcreate.go
+++ b/engine/prcreate.go
@@ -270,7 +270,7 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 	currentBody, fetchErr := e.client.GetIssueBody(owner, repo, pr.Number)
 	if fetchErr != nil {
 		e.logf(item.Number, "warn", "verifyAndHealLinkage: could not fetch PR #%d body: %v\n", pr.Number, fetchErr)
-		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "could not fetch PR body for auto-heal")
+		e.pauseForBrokenLinkage(item, pr.Number, closingLine, "could not fetch PR body for auto-heal")
 		return false
 	}
 
@@ -278,7 +278,7 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 	const maxBodyLen = 65300
 	if len(currentBody)+len(closingLine)+2 > maxBodyLen {
 		e.logf(item.Number, "warn", "verifyAndHealLinkage: PR #%d body is too long (%d chars) to prepend closing keyword\n", pr.Number, len(currentBody))
-		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "PR body too long for auto-heal")
+		e.pauseForBrokenLinkage(item, pr.Number, closingLine, "PR body too long for auto-heal")
 		return false
 	}
 
@@ -286,7 +286,7 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 	snap, _ := e.store.Get(repoStr, item.Number)
 	if snap.LinkageHealAttempted(stage.Name, prSHA) {
 		e.logf(item.Number, "warn", "verifyAndHealLinkage: heal already attempted for PR #%d (SHA %s) — pausing\n", pr.Number, prSHA)
-		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "auto-heal was already attempted once but linkage is still missing")
+		e.pauseForBrokenLinkage(item, pr.Number, closingLine, "auto-heal was already attempted once but linkage is still missing")
 		return false
 	}
 
@@ -305,7 +305,7 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 	// no write-through: excluded — issue body is not read from cache for dispatch decisions
 	if err := e.client.UpdateIssueBody(owner, repo, pr.Number, healedBody); err != nil {
 		e.logf(item.Number, "warn", "verifyAndHealLinkage: could not update PR #%d body: %v\n", pr.Number, err)
-		e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, fmt.Sprintf("UpdateIssueBody failed: %v", err))
+		e.pauseForBrokenLinkage(item, pr.Number, closingLine, fmt.Sprintf("UpdateIssueBody failed: %v", err))
 		return false
 	}
 	if e.webhookMgr != nil {
@@ -348,13 +348,13 @@ func (e *Engine) verifyAndHealLinkage(ctx context.Context, item gh.ProjectItem, 
 
 	// Still not linked after heal — pause with recovery commands.
 	e.logf(item.Number, "warn", "verifyAndHealLinkage: linkage still missing after heal — pausing\n")
-	e.pauseForBrokenLinkage(owner, repo, item, pr.Number, closingLine, "auto-heal completed but GitHub still reports no closing-issue linkage")
+	e.pauseForBrokenLinkage(item, pr.Number, closingLine, "auto-heal completed but GitHub still reports no closing-issue linkage")
 	return false
 }
 
 // pauseForBrokenLinkage pauses the issue with fabrik:paused and posts a comment
 // naming the failure mode and providing a copy-paste recovery command.
-func (e *Engine) pauseForBrokenLinkage(owner, repo string, item gh.ProjectItem, prNumber int, closingLine, reason string) {
+func (e *Engine) pauseForBrokenLinkage(item gh.ProjectItem, prNumber int, closingLine, reason string) {
 	msg := fmt.Sprintf(
 		"🏭 **Fabrik — broken PR↔issue linkage**\n\n"+
 			"PR #%d exists but is not linked to issue #%d via a closing keyword (`closingIssuesReferences` is empty). "+
@@ -368,12 +368,7 @@ func (e *Engine) pauseForBrokenLinkage(owner, repo string, item gh.ProjectItem, 
 			"Then remove `fabrik:paused` to resume.",
 		prNumber, item.Number, reason, prNumber, closingLine, prNumber,
 	)
-	e.addPausedLabelToItem(owner, repo, item)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post broken-linkage comment: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-			DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-		})
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		labelEcho: true,
+	})
 }

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -100,8 +100,10 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 				pr.Number, item.Number, item.Number,
 				pr.Number, item.Number, pr.Number,
 			)
-			e.addPausedLabelToItem(owner, repo, item)
-			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
+			e.pauseIssue(item, msg, pauseOpts{
+				labelEcho:  true,
+				labelFirst: true,
+			})
 			// Return (false, false): the gate did not time out — it paused for a different reason.
 			// The catch-up loop will not reapply fabrik:awaiting-review.
 			return false, false

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -352,7 +352,6 @@ func (e *Engine) buildReviewThreadComments(item gh.ProjectItem) []gh.Comment {
 // captured before checkReviewGate removed it), Phase 2 context is detected and a
 // more specific "after re-prompt" message is posted.
 func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "review-timeout", "review wait timeout elapsed — pausing for human intervention\n")
 
 	// Build pending-reviewer list with bot/human tags for the pause comment.
@@ -418,29 +417,10 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 		)
 	}
 
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post review timeout comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // dispatchReviewReinvoke spawns a goroutine to re-invoke the stage agent via
@@ -528,7 +508,6 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 // cycle count is reached. It applies fabrik:paused + fabrik:awaiting-input and
 // posts an explanatory comment.
 func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
-	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	e.logf(item.Number, "review-cycles", "review cycle limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
@@ -539,29 +518,10 @@ func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.Projec
 			"remove the `fabrik:paused` label to resume.",
 		stage.Name, cycleCount, maxCycles,
 	)
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, msg); err != nil {
-		e.logf(item.Number, "warn", "could not post review cycle limit comment: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-			})
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:paused")
-	}
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-input"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:awaiting-input: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
-	}
+	e.pauseIssue(item, msg, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // botMentionHandle maps copilot-* logins to "copilot" — GitHub's canonical mention surface for the reviewer bot.

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
@@ -102,13 +101,7 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 				pr.Number, item.Number, pr.Number,
 			)
 			e.addPausedLabelToItem(owner, repo, item)
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post broken-linkage comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
+			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			// Return (false, false): the gate did not time out — it paused for a different reason.
 			// The catch-up loop will not reapply fabrik:awaiting-review.
 			return false, false
@@ -178,11 +171,7 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 				// can still detect Phase 2 context from it after we return.
 				for _, l := range item.Labels {
 					if l == botRepromptedLabel || l == "fabrik:awaiting-review" {
-						if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, l); err != nil {
-							e.logf(item.Number, "warn", "phase 2: could not remove %s: %v\n", l, err)
-						} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-							cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), l)
-						}
+						e.applyLabelRemove(item, l, false)
 					}
 				}
 				return false, true
@@ -226,11 +215,7 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 						}
 						repromptedLogins = append(repromptedLogins, login)
 					}
-					if err := e.client.AddLabelToIssue(owner, repo, item.Number, botRepromptedLabel); err != nil {
-						e.logf(item.Number, "warn", "phase 1: could not add %s: %v\n", botRepromptedLabel, err)
-					} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), botRepromptedLabel)
-					}
+					e.applyLabelAdd(item, botRepromptedLabel, false)
 					e.logf(item.Number, "review-gate", "phase 1: re-prompted bot reviewer(s): %s\n", strings.Join(repromptedLogins, ", "))
 					return true, false
 				}
@@ -271,11 +256,7 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 		}
 	}
 	if !alreadyWaiting {
-		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
-			e.logf(item.Number, "warn", "could not add fabrik:awaiting-review label: %v\n", err)
-		} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
-		}
+		e.applyLabelAdd(item, "fabrik:awaiting-review", false)
 	}
 
 	return true, false
@@ -286,32 +267,10 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 func (e *Engine) removeAwaitingReviewLabel(owner, repo string, item gh.ProjectItem) {
 	for _, l := range item.Labels {
 		if l == "fabrik:awaiting-review" {
-			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
-				if errors.Is(err, gh.ErrNotFound) {
-					// Label already absent on GitHub — desired end state achieved; sync cache.
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-review")
-					}
-				} else {
-					e.logf(item.Number, "warn", "could not remove fabrik:awaiting-review label: %v\n", err)
-				}
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:awaiting-review")
-			}
+			e.applyLabelRemove(item, "fabrik:awaiting-review", false)
 		}
 		if l == botRepromptedLabel {
-			if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, l); err != nil {
-				if errors.Is(err, gh.ErrNotFound) {
-					// Label already absent on GitHub — desired end state achieved; sync cache.
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), l)
-					}
-				} else {
-					e.logf(item.Number, "warn", "could not remove %s label: %v\n", l, err)
-				}
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), l)
-			}
+			e.applyLabelRemove(item, l, false)
 		}
 	}
 }

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -415,16 +415,7 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 // addPausedLabelToItem adds fabrik:paused to the given item, with cache write-through
 // and webhook echo registration.
 func (e *Engine) addPausedLabelToItem(owner, repo string, item gh.ProjectItem) {
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:paused"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:paused: %v\n", err)
-	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:paused")
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:paused")
-		}
-	}
+	e.addLabel(gh.ProjectItem{Number: item.Number, Repo: owner + "/" + repo}, "fabrik:paused")
 }
 
 // parseOwnerRepoStr splits "owner/repo" into owner and repo. Returns false if

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
 )
@@ -302,13 +301,7 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if !ok {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nInvalid repo in spawn block #%d: `%s`. Created so far: %s\n\nRemove `fabrik:paused` after fixing the Plan output to retry.",
 				i+1, block.Repo, formatSpawnedList(spawned))
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post spawn error comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
+			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			e.addPausedLabelToItem(owner, repo, item)
 			return false, fmt.Errorf("pre-implement: invalid repo %q in block %d", block.Repo, i+1)
 		}
@@ -318,13 +311,7 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to create child issue %d/%d in `%s`: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				i+1, len(blocks), block.Repo, err, formatSpawnedList(spawned))
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post spawn error comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
+			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			e.addPausedLabelToItem(owner, repo, item)
 			return false, fmt.Errorf("pre-implement: creating child %d: %w", i+1, err)
 		}
@@ -336,13 +323,7 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to add child %s/%s#%d to project board: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				childOwner, childRepo, childNumber, err, formatSpawnedList(spawned))
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post spawn error comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
+			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			e.addPausedLabelToItem(owner, repo, item)
 			return false, fmt.Errorf("pre-implement: adding child %s#%d to project: %w", block.Repo, childNumber, err)
 		}
@@ -352,13 +333,7 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if err := e.client.AddBlockedByIssue(item.ID, childNodeID); err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to link child %s/%s#%d as blocked-by of parent: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				childOwner, childRepo, childNumber, err, formatSpawnedList(spawned))
-			if dbID, commentErr := e.client.AddComment(owner, repo, item.Number, msg); commentErr != nil {
-				e.logf(item.Number, "warn", "could not post spawn error comment: %v\n", commentErr)
-			} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyCommentAdded(boardcache.ItemKey(item.Repo, item.Number), gh.Comment{
-					DatabaseID: dbID, Body: msg, Author: e.cfg.User, CreatedAt: time.Now(),
-				})
-			}
+			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			e.addPausedLabelToItem(owner, repo, item)
 			return false, fmt.Errorf("pre-implement: linking child %s#%d as blocked-by: %w", block.Repo, childNumber, err)
 		}
@@ -402,11 +377,8 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 	}
 
 	// All children spawned successfully — mark parent with idempotency guard.
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:children-spawned"); err != nil {
-		e.logf(item.Number, "warn", "could not add fabrik:children-spawned: %v\n", err)
-	} else if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:children-spawned")
-	}
+	// No webhook echo here — preserving prior behavior (never echoed at this site).
+	e.applyLabelAdd(item, "fabrik:children-spawned", false)
 
 	e.logf(item.Number, "spawn", "pre-Implement: spawned %d child(ren); parent will be gated until all close\n", len(blocks))
 	return true, nil

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -301,8 +301,9 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if !ok {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nInvalid repo in spawn block #%d: `%s`. Created so far: %s\n\nRemove `fabrik:paused` after fixing the Plan output to retry.",
 				i+1, block.Repo, formatSpawnedList(spawned))
-			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
-			e.addPausedLabelToItem(owner, repo, item)
+			e.pauseIssue(item, msg, pauseOpts{
+				labelEcho: true,
+			})
 			return false, fmt.Errorf("pre-implement: invalid repo %q in block %d", block.Repo, i+1)
 		}
 
@@ -311,8 +312,9 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to create child issue %d/%d in `%s`: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				i+1, len(blocks), block.Repo, err, formatSpawnedList(spawned))
-			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
-			e.addPausedLabelToItem(owner, repo, item)
+			e.pauseIssue(item, msg, pauseOpts{
+				labelEcho: true,
+			})
 			return false, fmt.Errorf("pre-implement: creating child %d: %w", i+1, err)
 		}
 		e.logf(item.Number, "spawn", "created child %s/%s#%d\n", childOwner, childRepo, childNumber)
@@ -323,8 +325,9 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to add child %s/%s#%d to project board: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				childOwner, childRepo, childNumber, err, formatSpawnedList(spawned))
-			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
-			e.addPausedLabelToItem(owner, repo, item)
+			e.pauseIssue(item, msg, pauseOpts{
+				labelEcho: true,
+			})
 			return false, fmt.Errorf("pre-implement: adding child %s#%d to project: %w", block.Repo, childNumber, err)
 		}
 
@@ -333,8 +336,9 @@ func (e *Engine) spawnChildren(ctx context.Context, board *gh.ProjectBoard, item
 		if err := e.client.AddBlockedByIssue(item.ID, childNodeID); err != nil {
 			msg := fmt.Sprintf("🏭 **Fabrik — pre-Implement spawn failed**\n\nFailed to link child %s/%s#%d as blocked-by of parent: `%v`\n\nCreated so far: %s\n\nManually close any orphaned children, remove `fabrik:paused`, then re-advance to retry.",
 				childOwner, childRepo, childNumber, err, formatSpawnedList(spawned))
-			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
-			e.addPausedLabelToItem(owner, repo, item)
+			e.pauseIssue(item, msg, pauseOpts{
+				labelEcho: true,
+			})
 			return false, fmt.Errorf("pre-implement: linking child %s#%d as blocked-by: %w", block.Repo, childNumber, err)
 		}
 

--- a/engine/spawn_settle.go
+++ b/engine/spawn_settle.go
@@ -40,16 +40,7 @@ var childParentFooterRe = regexp.MustCompile(`Spawned by Fabrik from parent issu
 // resolves to no configured stage, so itemMayNeedWork/itemNeedsWork would
 // never revisit it via the ordinary dispatch path.
 func (e *Engine) recordChildPlacementFailure(childOwner, childRepo string, childNumber int) {
-	if err := e.client.AddLabelToIssue(childOwner, childRepo, childNumber, childPlacementLabel); err != nil {
-		e.logf(childNumber, "warn", "could not add %s marker to %s/%s#%d: %v\n", childPlacementLabel, childOwner, childRepo, childNumber, err)
-		return
-	}
-	if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(childOwner+"/"+childRepo, childNumber), childPlacementLabel)
-	}
-	if e.webhookMgr != nil {
-		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(childOwner+"/"+childRepo, childNumber)+"+"+childPlacementLabel)
-	}
+	e.addLabel(gh.ProjectItem{Repo: childOwner + "/" + childRepo, Number: childNumber}, childPlacementLabel)
 }
 
 // settleChildPlacement retries a spawned child's outstanding project Status
@@ -119,27 +110,21 @@ func (e *Engine) escalateChildPlacementFailure(item gh.ProjectItem) {
 
 	e.addPausedLabelToItem(owner, repo, item)
 
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, childPlacementLabel); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", childPlacementLabel, err)
-	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), childPlacementLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+childPlacementLabel)
-		}
-	}
+	e.applyLabelRemove(item, childPlacementLabel, true)
 
 	comment := fmt.Sprintf(
 		"🏭 **Fabrik — spawned child board placement failed**\n\nThis issue was spawned as a sub-issue, but Fabrik could not place it into the `Specify` (or first processing) column on the project board after %d attempt(s). It may still be sitting in `Backlog` or wherever GitHub defaulted it. The issue has been paused.\n\nManual fix:\nMove this issue's project-board column to `Specify` (or the first processing stage) yourself, then remove the `fabrik:paused` label to let Fabrik pick it up.\n\nIf no suitable column exists on the board, this may indicate a board-configuration problem — check that a `Specify` (or equivalent first-stage) column exists.",
 		e.cfg.MaxRetries,
 	)
+	// NOTE: this comment-post's cache write-through deliberately omits CreatedAt
+	// (unlike postComment, which always stamps time.Now()) to preserve this
+	// site's pre-existing behavior exactly; using e.cache() directly here
+	// (rather than postComment/postItemComment) keeps that omission intact.
 	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
 		e.logf(item.Number, "warn", "could not post child-placement escalation comment: %v\n", err)
 	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
+		if c := e.cache(); c != nil {
+			c.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
 				DatabaseID: dbID, Body: comment, Author: e.cfg.User,
 			})
 		}
@@ -167,12 +152,7 @@ func (e *Engine) clearChildPlacementMarker(item gh.ProjectItem, owner, repo stri
 		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", childPlacementLabel, err)
 		return
 	} else if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), childPlacementLabel)
-		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+childPlacementLabel)
-		}
+		e.syncLabelRemoval(item, childPlacementLabel, true)
 	}
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -80,8 +80,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 			!errors.Is(err, gh.ErrNotFound) {
 			e.logf(item.Number, "warn", "could not remove awaiting-input label: %v\n", err)
 		} else if err == nil {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelRemoved(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-input")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-input")
@@ -134,8 +134,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 			if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-ci"); err != nil {
 				e.logf(item.Number, "warn", "could not add fabrik:awaiting-ci label: %v\n", err)
 			} else {
-				if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-					cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
+				if c := e.cache(); c != nil {
+					c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-ci")
 				}
 				if e.webhookMgr != nil {
 					e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-ci")
@@ -153,8 +153,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 	if err := e.client.AddLabelToIssue(owner, repo, item.Number, completeLabel); err != nil {
 		e.logf(item.Number, "warn", "could not add completion label: %v\n", err)
 	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+		if c := e.cache(); c != nil {
+			c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
@@ -213,8 +213,8 @@ func (e *Engine) handleStageComplete(ctx context.Context, board *gh.ProjectBoard
 				if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-review"); err != nil {
 					e.logf(item.Number, "warn", "could not add fabrik:awaiting-review label: %v\n", err)
 				} else {
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
+					if c := e.cache(); c != nil {
+						c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-review")
 					}
 					if e.webhookMgr != nil {
 						e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-review")
@@ -304,8 +304,8 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 		if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
 			e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
 		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
@@ -319,8 +319,8 @@ func (e *Engine) attemptMergeOnValidate(ctx context.Context, board *gh.ProjectBo
 	if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
 	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
+		if c := e.cache(); c != nil {
+			c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:auto-merge-enabled")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
@@ -356,12 +356,12 @@ func (e *Engine) enqueueForQueue(owner, repo string, item gh.ProjectItem, prNumb
 	if lerr := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:auto-merge-enabled"); lerr != nil {
 		e.logf(item.Number, "warn", "could not add fabrik:auto-merge-enabled label: %v\n", lerr)
 	} else {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
+		if c := e.cache(); c != nil {
 			// Use the resolved owner/repo (not item.Repo, which may be empty when it
 			// defaults to the default repo) so the cache key matches the stored entry
 			// and the write-through actually lands on the right item — consistent with
 			// the webhook-echo key below.
-			cacheImpl.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:auto-merge-enabled")
+			c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), "fabrik:auto-merge-enabled")
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:auto-merge-enabled")
@@ -388,8 +388,8 @@ func (e *Engine) handleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 		if err := e.client.AddLabelToIssue(owner, repo, item.Number, "fabrik:awaiting-done"); err != nil {
 			e.logf(item.Number, "warn", "could not add awaiting-done marker: %v\n", err)
 		} else {
-			if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-				cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-done")
+			if c := e.cache(); c != nil {
+				c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), "fabrik:awaiting-done")
 			}
 			if e.webhookMgr != nil {
 				e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+"fabrik:awaiting-done")
@@ -445,8 +445,8 @@ func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item
 	if err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID); err != nil {
 		return fmt.Errorf("move to %s: %w", hs.Name, err)
 	}
-	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
-		cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), hs.Name)
+	if c := e.cache(); c != nil {
+		c.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), hs.Name)
 	}
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
@@ -458,8 +458,8 @@ func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item
 		e.logf(item.Number, "warn", "advanced to %s but could not add %s label: %v — will retry on next poll\n", hs.Name, completeLabel, lerr)
 		return fmt.Errorf("add %s label: %w", completeLabel, lerr)
 	}
-	if cacheImpl, ok2 := e.readClient.(*boardcache.CacheImpl); ok2 {
-		cacheImpl.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
+	if c := e.cache(); c != nil {
+		c.ApplyLabelAdded(boardcache.ItemKey(item.Repo, item.Number), completeLabel)
 	}
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+completeLabel)
@@ -487,11 +487,11 @@ func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem,
 	}
 
 	e.logf(item.Number, "advance", "moving to stage %q\n", next.Name)
-	// write-through: already covered by cacheImpl.UpdateItemStatus call in the else block below
+	// write-through: already covered by c.UpdateItemStatus call in the else block below
 	err := e.client.UpdateProjectItemStatus(board.ProjectID, item.ItemID, e.statusField.FieldID, optionID)
 	if err == nil {
-		if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-			cacheImpl.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), next.Name)
+		if c := e.cache(); c != nil {
+			c.UpdateItemStatus(boardcache.ItemKey(item.Repo, item.Number), next.Name)
 		}
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)

--- a/engine/worker_liveness.go
+++ b/engine/worker_liveness.go
@@ -172,8 +172,8 @@ func (e *Engine) runStartupCleanup() {
 					e.logf(number, "warn", "could not remove stale in_progress label %q: %v\n", label, err)
 				} else {
 					e.logf(number, "startup", "removed stale label %q\n", label)
-					if cacheImpl, ok := e.readClient.(*boardcache.CacheImpl); ok {
-						cacheImpl.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repoName, number), label)
+					if c := e.cache(); c != nil {
+						c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repoName, number), label)
 					}
 				}
 			}


### PR DESCRIPTION
Closes #1026

## Summary

Every state change the engine makes to GitHub follows the same three-beat idiom — mutate on GitHub, mirror into the board cache, register a webhook echo — and that idiom was hand-typed at nearly every call site rather than encapsulated. This PR introduces a small set of `Engine` methods in `engine/mutate.go` (`cache()`, `addLabel`/`removeLabel`, `postItemComment`/`postComment`, `pauseIssue`) and routes the existing call sites through them.

## Key changes

- **`engine/mutate.go`**: `cache()` cast-or-nil accessor; `addLabel`/`removeLabel` (always-echoing) plus private `applyLabelAdd`/`applyLabelRemove` cores (echo-parameterized) and `syncLabelAdd`/`syncLabelRemoval` tails for sites that must perform the raw mutation themselves; `postItemComment`/`postComment` for the comment-post idiom; `pauseIssue` with a `pauseOpts` struct (not a single bool — three distinct pre-existing patterns across the 13 pause/escalate call sites required it).
- Routed ~170 raw `(*boardcache.CacheImpl)` type assertions, ~115 `ApplyLabelAdded`/`ApplyLabelRemoved` sites, and 44 `ApplyCommentAdded` sites down to 3/28/3 respectively (the remainder are calls made through the new `cache()` accessor, not raw assertions).
- Collapsed 7 inline `localDeltaAt` lock/write/unlock blocks in `boardcache/boardcache.go` to the existing `bumpLocalDeltaAt` helper.
- Centralized repo-key derivation via `itemOwnerRepo`, structurally eliminating the `item.Repo`-vs-`owner/repo` divergence bug class (one real instance of this divergence — a comment posted via `cfg.Owner`/`cfg.Repo` while cached under the item-resolved key — was fixed as part of routing it through the helper).
- One deliberate, sanctioned behavior change: `removeLabel` now syncs the cache on `gh.ErrNotFound` uniformly, including at several sites that previously skipped it. The `pauseFor*`/`escalate*` `RegisterEcho` asymmetry is preserved exactly (not unified) via `pauseOpts`, per the issue's explicit scope note.
- Added `adrs/065-consolidated-mutation-helpers.md` documenting the idiom and the `pauseOpts` escape hatch.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — 2326/2327 pass; the one failure (`cmd.TestExecute_ConfigYAMLApplied`) reproduces identically on the pre-refactor baseline (confirmed via `git stash`) and is unrelated to this change
- [x] `engine/mutate_test.go` covers cache write-through, echo on/off, `ErrNotFound` idempotency, rocket-react on/off, and each `pauseOpts` pattern (A/B/C)