### PR TITLE
Code health: extract shared settle-scan and reinvoke-dispatch helpers

### DIFF
--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -89,32 +89,74 @@ func (e *Engine) handleReviewGate(pctx *phase1Ctx) bool {
 	// advancing. Reviews with empty bodies (e.g. APPROVED with no comment)
 	// have nothing to address; fall through to Phase 2.
 	if syntheticComments := e.buildReviewThreadComments(pctx.item); len(syntheticComments) > 0 {
-		iKey := issueKey(pctx.item, e.defaultRepo())
-		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
 		// Guard: if a goroutine from a previous poll cycle is still running
 		// dispatchReviewReinvoke for this item, skip the entire reinvoke path —
 		// including cycle-limit checks — to avoid pausing an item while valid
 		// work is still in progress. The store Worker field is the semantic
-		// source of truth for in-flight state.
-		var cycleCount int
-		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
-			if snap.Worker() != nil {
-				e.logf(pctx.item.Number, "review-reinvoke", "skipping dispatch — review reinvoke already in-flight\n")
-				return true
-			}
-			cycleCount = snap.ReviewCycles(pctx.stage.Name)
-		}
-		maxCycles := e.cfg.MaxReviewCycles
-		if cycleCount >= maxCycles {
-			e.pauseForReviewCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, maxCycles)
-		} else {
-			e.store.Apply(itemstate.ReviewCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
-			e.dispatchReviewReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage)
-			pctx.advancedItems[iKey] = true
-		}
-		return true
+		// source of truth for in-flight state. (Enforced by
+		// dispatchWithCycleLimit's in-flight bail.)
+		return e.dispatchWithCycleLimit(
+			pctx,
+			"review-reinvoke",
+			func(snap itemstate.Snapshot) int { return snap.ReviewCycles(pctx.stage.Name) },
+			e.cfg.MaxReviewCycles,
+			nil,
+			func(repoStr string) {
+				e.store.Apply(itemstate.ReviewCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
+			},
+			func() { e.dispatchReviewReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage) },
+			func(cycleCount int) {
+				e.pauseForReviewCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, e.cfg.MaxReviewCycles)
+			},
+		)
 	}
 	return false
+}
+
+// dispatchWithCycleLimit implements the cycle-limit dispatch pattern shared
+// by the review, rebase, and CI-fix reinvoke paths: read the item's store
+// snapshot, bail if a reinvoke is already in-flight, read the current cycle
+// count, apply an optional short-circuit (CI-fix's no-op-SHA debounce; nil
+// for review/rebase, which have no such check), then either pause at the
+// cycle limit or increment-and-dispatch. shortCircuit and the snapshot read
+// are skipped together on a store-read error, mirroring each original
+// block's behavior (cycleCount defaults to 0, and a short-circuit keyed off
+// snapshot state can never fire without a snapshot). Always returns true —
+// callers only reach this after already deciding a reinvoke condition holds
+// (blocked review, merge conflict, CI failure).
+func (e *Engine) dispatchWithCycleLimit(
+	pctx *phase1Ctx,
+	tag string,
+	cycles func(itemstate.Snapshot) int,
+	maxCycles int,
+	shortCircuit func(itemstate.Snapshot) bool,
+	increment func(repoStr string),
+	dispatch func(),
+	pause func(cycleCount int),
+) bool {
+	iKey := issueKey(pctx.item, e.defaultRepo())
+	repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
+
+	var cycleCount int
+	if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
+		if snap.Worker() != nil {
+			e.logf(pctx.item.Number, tag, "skipping dispatch — reinvoke already in-flight\n")
+			return true
+		}
+		cycleCount = cycles(snap)
+		if shortCircuit != nil && shortCircuit(snap) {
+			return true
+		}
+	}
+
+	if cycleCount >= maxCycles {
+		pause(cycleCount)
+	} else {
+		increment(repoStr)
+		dispatch()
+		pctx.advancedItems[iKey] = true
+	}
+	return true
 }
 
 // handleAutoMergeConvergence claims items with fabrik:auto-merge-enabled,
@@ -158,25 +200,20 @@ func (e *Engine) handleMergeAndCIGates(pctx *phase1Ctx) bool {
 			e.logf(pctx.item.Number, "merge-queue", "PR in merge queue — deferring rebase to queue\n")
 			return true
 		}
-		iKey := issueKey(pctx.item, e.defaultRepo())
-		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
-		var cycleCount int
-		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
-			if snap.Worker() != nil {
-				e.logf(pctx.item.Number, "rebase-reinvoke", "skipping dispatch — rebase reinvoke already in-flight\n")
-				return true
-			}
-			cycleCount = snap.RebaseCycles(pctx.stage.Name)
-		}
-		maxCycles := e.cfg.MaxRebaseCycles
-		if cycleCount >= maxCycles {
-			e.pauseForRebaseCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, maxCycles)
-		} else {
-			e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
-			e.dispatchRebaseReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage)
-			pctx.advancedItems[iKey] = true
-		}
-		return true
+		return e.dispatchWithCycleLimit(
+			pctx,
+			"rebase-reinvoke",
+			func(snap itemstate.Snapshot) int { return snap.RebaseCycles(pctx.stage.Name) },
+			e.cfg.MaxRebaseCycles,
+			nil,
+			func(repoStr string) {
+				e.store.Apply(itemstate.RebaseCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
+			},
+			func() { e.dispatchRebaseReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage) },
+			func(cycleCount int) {
+				e.pauseForRebaseCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, e.cfg.MaxRebaseCycles)
+			},
+		)
 	}
 	if mergeBlocked {
 		return true // mergeability not yet computed; re-evaluate on next poll
@@ -191,36 +228,32 @@ func (e *Engine) handleMergeAndCIGates(pctx *phase1Ctx) bool {
 		return true
 	}
 	if ciFailure {
-		iKey := issueKey(pctx.item, e.defaultRepo())
-		repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
-		var cycleCount int
-		var lastNoOpSHA string
-		if snap, snapErr := e.store.Get(repoStr, pctx.item.Number); snapErr == nil {
-			if snap.Worker() != nil {
-				e.logf(pctx.item.Number, "ci-fix-reinvoke", "skipping dispatch — CI-fix reinvoke already in-flight\n")
+		return e.dispatchWithCycleLimit(
+			pctx,
+			"ci-fix-reinvoke",
+			func(snap itemstate.Snapshot) int { return snap.CIFixCycles(pctx.stage.Name) },
+			e.cfg.MaxCiFixCycles,
+			func(snap itemstate.Snapshot) bool {
+				lastNoOpSHA := snap.LastCIFixNoOpSHA()
+				if settle.PR == nil || lastNoOpSHA == "" || lastNoOpSHA != settle.PR.HeadSHA {
+					return false
+				}
+				// The last CI-fix reinvoke for this exact head SHA pushed no new
+				// commit — dispatching again would just repeat the same no-op
+				// and burn cycle budget for nothing. Wait for the SHA to advance
+				// (a genuine fix) or for CIWaitTimeout to fire (#958 leg 2).
+				e.logf(pctx.item.Number, "ci-fix-reinvoke", "skipping dispatch — no-op already recorded for head %s\n",
+					lastNoOpSHA[:min(8, len(lastNoOpSHA))])
 				return true
-			}
-			cycleCount = snap.CIFixCycles(pctx.stage.Name)
-			lastNoOpSHA = snap.LastCIFixNoOpSHA()
-		}
-		if settle.PR != nil && lastNoOpSHA != "" && lastNoOpSHA == settle.PR.HeadSHA {
-			// The last CI-fix reinvoke for this exact head SHA pushed no new
-			// commit — dispatching again would just repeat the same no-op
-			// and burn cycle budget for nothing. Wait for the SHA to advance
-			// (a genuine fix) or for CIWaitTimeout to fire (#958 leg 2).
-			e.logf(pctx.item.Number, "ci-fix-reinvoke", "skipping dispatch — no-op already recorded for head %s\n",
-				lastNoOpSHA[:min(8, len(lastNoOpSHA))])
-			return true
-		}
-		maxCycles := e.cfg.MaxCiFixCycles
-		if cycleCount >= maxCycles {
-			e.pauseForCIFixCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, maxCycles)
-		} else {
-			e.store.Apply(itemstate.CIFixCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
-			e.dispatchCIFixReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage, settle)
-			pctx.advancedItems[iKey] = true
-		}
-		return true
+			},
+			func(repoStr string) {
+				e.store.Apply(itemstate.CIFixCycleIncremented{Repo: repoStr, Number: pctx.item.Number, StageName: pctx.stage.Name})
+			},
+			func() { e.dispatchCIFixReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage, settle) },
+			func(cycleCount int) {
+				e.pauseForCIFixCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, e.cfg.MaxCiFixCycles)
+			},
+		)
 	}
 	if ciBlocked {
 		return true // CI still pending; re-evaluate on next poll

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -326,98 +325,44 @@ func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, wor
 // acquires semaphore, calls processComments, then releases both.
 func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult) {
 	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
+	var headBefore string
 
-	// Mark in-flight via the Store so the dispatch guard (snap.Worker() != nil) blocks
-	// double-dispatch before the goroutine starts. WorkerExited is deferred inside the
-	// goroutine so any early exit also clears it.
-	e.store.Apply(itemstate.WorkerEntered{
-		Repo:      itemRepo,
-		Number:    item.Number,
-		StageName: stage.Name,
-		StartedAt: time.Now(),
-	})
-	e.wg.Add(1)
-
-	go func() {
-		defer e.wg.Done()
-		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
-
-		select {
-		case e.sem <- struct{}{}:
-		case <-ctx.Done():
-			e.logf(item.Number, "ci-fix-reinvoke", "context cancelled before semaphore acquired\n")
-			return
-		}
-		defer func() { <-e.sem }()
-
-		if err := e.ensureRepoReady(ctx, item); err != nil {
-			if errors.Is(err, ErrSkipItem) {
-				e.logf(item.Number, "ci-fix-reinvoke", "repo not ready, skipping reinvoke\n")
+	e.dispatchReinvoke(ctx, board, item, stage, reinvokeOpts{
+		tag: "ci-fix-reinvoke",
+		build: func(workDir string) []gh.Comment {
+			// Snapshot HEAD before reinvoking so a no-op reinvoke (nothing to
+			// push because the fix is already in) can be recorded and debounced
+			// on the next poll instead of burning further CI-fix cycle budget
+			// while the current head's CI is still resolving (#958 leg 2).
+			headBefore, _ = gitHeadSHA(workDir)
+			return []gh.Comment{e.buildCIFixComment(item, stage, workDir, settle)}
+		},
+		stageVariant: func(s *stages.Stage) *stages.Stage {
+			// Use ci_fix_skill if configured; fall back to comment_skill.
+			if s.CIFixSkill == "" {
+				return s
+			}
+			variant := *s
+			variant.CommentSkill = s.CIFixSkill
+			variant.CommentPrompt = ""
+			return &variant
+		},
+		after: func(workDir string, err error) {
+			// Only record a no-op when the reinvoke actually completed: a failed
+			// processComments (transient network issue, rate limit, workspace
+			// lock) also leaves HEAD unchanged, but recording a no-op for that
+			// case would wrongly debounce a retry that never got a chance to push
+			// a real fix.
+			if err != nil {
 				return
 			}
-			e.logf(item.Number, "warn", "ci-fix reinvoke: ensureRepoReady failed: %v\n", err)
-			return
-		}
-
-		// Get worktree path for base branch CI comparison.
-		wm := e.worktreesFor(item.Repo)
-		workDir := wm.WorktreeDir(item.Number)
-
-		// Snapshot HEAD before reinvoking so a no-op reinvoke (nothing to
-		// push because the fix is already in) can be recorded and debounced
-		// on the next poll instead of burning further CI-fix cycle budget
-		// while the current head's CI is still resolving (#958 leg 2).
-		headBefore, _ := gitHeadSHA(workDir)
-
-		// Build the synthetic comment with CI failure context.
-		syntheticComment := e.buildCIFixComment(item, stage, workDir, settle)
-
-		// Use ci_fix_skill if configured; fall back to comment_skill.
-		ciFixStage := *stage
-		if stage.CIFixSkill != "" {
-			ciFixStage.CommentSkill = stage.CIFixSkill
-			ciFixStage.CommentPrompt = ""
-		}
-
-		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
-		now := time.Now()
-		e.store.Apply(itemstate.LocalLockAcquired{
-			Repo:       itemRepo,
-			Number:     item.Number,
-			User:       e.cfg.User,
-			AcquiredAt: now,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
-		})
-		done := make(chan struct{})
-		defer close(done)
-		e.startHeartbeat(ctx, itemRepo, item.Number, done)
-		onPIDReady := func(pid int) {
-			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
-		}
-
-		e.logf(item.Number, "ci-fix-reinvoke", "re-invoking stage %q via comment processing with CI failure context\n", stage.Name)
-		err := e.processComments(ctx, board, item, &ciFixStage, []gh.Comment{syntheticComment}, onPIDReady)
-
-		// Only record a no-op when the reinvoke actually completed: a failed
-		// processComments (transient network issue, rate limit, workspace
-		// lock) also leaves HEAD unchanged, but recording a no-op for that
-		// case would wrongly debounce a retry that never got a chance to push
-		// a real fix.
-		if err == nil {
 			if headAfter, hErr := gitHeadSHA(workDir); hErr == nil && headBefore != "" && headAfter == headBefore {
 				e.logf(item.Number, "ci-fix-reinvoke", "no new commit pushed (HEAD still %s) — recording no-op for this head\n",
 					headAfter[:min(8, len(headAfter))])
 				e.store.Apply(itemstate.CIFixNoOpRecorded{Repo: itemRepo, Number: item.Number, SHA: headAfter})
 			}
-		}
-
-		if err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			e.logf(item.Number, "warn", "CI-fix re-invocation failed: %v\n", err)
-		}
-	}()
+		},
+	})
 }
 
 // pauseForCITimeout pauses the issue when the CI wait timeout in the catch-up

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -319,10 +319,11 @@ func (e *Engine) buildCIFixComment(item gh.ProjectItem, stage *stages.Stage, wor
 	}
 }
 
-// dispatchCIFixReinvoke spawns a goroutine to re-invoke the stage agent via
-// processComments with a synthetic CI-failure context comment. It mirrors
-// dispatchReviewReinvoke exactly: marks the item in-flight via WorkerEntered,
-// acquires semaphore, calls processComments, then releases both.
+// dispatchCIFixReinvoke re-invokes the stage agent via processComments with a
+// synthetic CI-failure context comment. A thin wrapper over dispatchReinvoke,
+// supplying only the CI-fix-specific comment builder (which also snapshots
+// HEAD before the reinvoke), the CIFixSkill stage variant, and the post-run
+// no-op-SHA recording — the shared goroutine scaffold lives in reinvoke.go.
 func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, settle PRSettleResult) {
 	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
 	var headBefore string

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -124,10 +124,11 @@ func (e *Engine) buildRebaseComment(item gh.ProjectItem, stage *stages.Stage, ba
 	}
 }
 
-// dispatchRebaseReinvoke spawns a goroutine that re-invokes the stage agent
-// with a synthetic rebase-required comment. Mirrors dispatchCIFixReinvoke /
-// dispatchReviewReinvoke: marks the item in-flight via WorkerEntered, acquires
-// the semaphore, calls processComments, then releases both.
+// dispatchRebaseReinvoke re-invokes the stage agent with a synthetic
+// rebase-required comment. A thin wrapper over dispatchReinvoke, supplying
+// only the rebase-specific comment builder, the RebaseSkill stage variant,
+// and the post-run auto-merge re-enablement — the shared goroutine scaffold
+// lives in reinvoke.go.
 func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
 	e.dispatchReinvoke(ctx, board, item, stage, reinvokeOpts{
 		tag: "rebase-reinvoke",

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -129,116 +129,68 @@ func (e *Engine) buildRebaseComment(item gh.ProjectItem, stage *stages.Stage, ba
 // dispatchReviewReinvoke: marks the item in-flight via WorkerEntered, acquires
 // the semaphore, calls processComments, then releases both.
 func (e *Engine) dispatchRebaseReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
-	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
-
-	// Mark in-flight via the Store so the dispatch guard (snap.Worker() != nil) blocks
-	// double-dispatch before the goroutine starts. WorkerExited is deferred inside the
-	// goroutine so any early exit also clears it.
-	e.store.Apply(itemstate.WorkerEntered{
-		Repo:      itemRepo,
-		Number:    item.Number,
-		StageName: stage.Name,
-		StartedAt: time.Now(),
-	})
-	e.wg.Add(1)
-
-	go func() {
-		defer e.wg.Done()
-		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
-
-		select {
-		case e.sem <- struct{}{}:
-		case <-ctx.Done():
-			e.logf(item.Number, "rebase-reinvoke", "context cancelled before semaphore acquired\n")
-			return
-		}
-		defer func() { <-e.sem }()
-
-		if err := e.ensureRepoReady(ctx, item); err != nil {
-			if errors.Is(err, ErrSkipItem) {
-				e.logf(item.Number, "rebase-reinvoke", "repo not ready, skipping reinvoke\n")
+	e.dispatchReinvoke(ctx, board, item, stage, reinvokeOpts{
+		tag: "rebase-reinvoke",
+		build: func(workDir string) []gh.Comment {
+			// Resolve the base branch for the rebase instructions. Failure here is
+			// not fatal — the synthetic comment falls back to "main".
+			wm := e.worktreesFor(item.Repo)
+			baseBranch, _ := e.baseBranchForItem(item, wm)
+			return []gh.Comment{e.buildRebaseComment(item, stage, baseBranch)}
+		},
+		stageVariant: func(s *stages.Stage) *stages.Stage {
+			if s.RebaseSkill == "" {
+				return s
+			}
+			variant := *s
+			variant.CommentSkill = s.RebaseSkill
+			variant.CommentPrompt = ""
+			return &variant
+		},
+		after: func(workDir string, err error) {
+			if err != nil {
 				return
 			}
-			e.logf(item.Number, "warn", "rebase reinvoke: ensureRepoReady failed: %v\n", err)
-			return
-		}
 
-		// Resolve the base branch for the rebase instructions. Failure here is
-		// not fatal — the synthetic comment falls back to "main".
-		wm := e.worktreesFor(item.Repo)
-		baseBranch, _ := e.baseBranchForItem(item, wm)
-
-		syntheticComment := e.buildRebaseComment(item, stage, baseBranch)
-
-		rebaseStage := *stage
-		if stage.RebaseSkill != "" {
-			rebaseStage.CommentSkill = stage.RebaseSkill
-			rebaseStage.CommentPrompt = ""
-		}
-
-		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
-		now := time.Now()
-		e.store.Apply(itemstate.LocalLockAcquired{
-			Repo:       itemRepo,
-			Number:     item.Number,
-			User:       e.cfg.User,
-			AcquiredAt: now,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
-		})
-		done := make(chan struct{})
-		defer close(done)
-		e.startHeartbeat(ctx, itemRepo, item.Number, done)
-		onPIDReady := func(pid int) {
-			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
-		}
-
-		e.logf(item.Number, "rebase-reinvoke", "re-invoking stage %q via comment processing with rebase context\n", stage.Name)
-		owner, repo := itemOwnerRepo(item, e.defaultRepo())
-		err := e.processComments(ctx, board, item, &rebaseStage, []gh.Comment{syntheticComment}, onPIDReady)
-
-		if err != nil {
-			if ctx.Err() != nil {
+			// GitHub disables auto-merge on every push. Re-enable it if this issue is in
+			// the convergence flow (fabrik:auto-merge-enabled present at dispatch time) —
+			// but NOT on a merge-queue repo (ADR-058 D4): there the recovery path is
+			// re-enqueue, not native auto-merge, and the convergence monitor re-enqueues
+			// the resolved PR once it re-derives clean. Re-enabling auto-merge here would
+			// fight the queue model.
+			if !hasLabel(item, "fabrik:auto-merge-enabled") || item.LinkedPRIsMergeQueueEnabled {
 				return
 			}
-			e.logf(item.Number, "warn", "rebase re-invocation failed: %v\n", err)
-			return
-		}
 
-		// GitHub disables auto-merge on every push. Re-enable it if this issue is in
-		// the convergence flow (fabrik:auto-merge-enabled present at dispatch time) —
-		// but NOT on a merge-queue repo (ADR-058 D4): there the recovery path is
-		// re-enqueue, not native auto-merge, and the convergence monitor re-enqueues
-		// the resolved PR once it re-derives clean. Re-enabling auto-merge here would
-		// fight the queue model.
-		if hasLabel(item, "fabrik:auto-merge-enabled") && !item.LinkedPRIsMergeQueueEnabled {
+			owner, repo := itemOwnerRepo(item, e.defaultRepo())
 			pr, prErr := e.client.FetchLinkedPR(owner, repo, item.Number)
 			if prErr != nil || pr == nil || pr.Number == 0 {
 				e.logf(item.Number, "warn", "rebase reinvoke: could not fetch linked PR for auto-merge re-enable: %v\n", prErr)
-			} else {
-				strategy := e.cfg.AutoMergeStrategy
-				if strategy == "" {
-					strategy = "MERGE"
-				}
-				if rerr := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, strategy); rerr != nil {
-					if errors.Is(rerr, gh.ErrAutoMergeAlreadyClean) {
-						// PR is already CLEAN after the rebase push — merge directly.
-						// Without this, checkAutoMergeConvergence sees AutoMergeEnabled=false
-						// and incorrectly pauses the issue as "user disabled auto-merge".
-						e.logf(item.Number, "info", "PR #%d is already in clean status after rebase — falling back to direct merge\n", pr.Number)
-						if mergeErr := e.client.MergePR(owner, repo, pr.Number); mergeErr != nil {
-							e.logf(item.Number, "warn", "direct merge fallback after rebase failed: %v\n", mergeErr)
-						} else {
-							e.logf(item.Number, "info", "PR #%d merged directly after rebase push (already-clean fallback)\n", pr.Number)
-						}
+				return
+			}
+			strategy := e.cfg.AutoMergeStrategy
+			if strategy == "" {
+				strategy = "MERGE"
+			}
+			if rerr := e.client.EnablePullRequestAutoMerge(owner, repo, pr.Number, strategy); rerr != nil {
+				if errors.Is(rerr, gh.ErrAutoMergeAlreadyClean) {
+					// PR is already CLEAN after the rebase push — merge directly.
+					// Without this, checkAutoMergeConvergence sees AutoMergeEnabled=false
+					// and incorrectly pauses the issue as "user disabled auto-merge".
+					e.logf(item.Number, "info", "PR #%d is already in clean status after rebase — falling back to direct merge\n", pr.Number)
+					if mergeErr := e.client.MergePR(owner, repo, pr.Number); mergeErr != nil {
+						e.logf(item.Number, "warn", "direct merge fallback after rebase failed: %v\n", mergeErr)
 					} else {
-						e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
+						e.logf(item.Number, "info", "PR #%d merged directly after rebase push (already-clean fallback)\n", pr.Number)
 					}
 				} else {
-					e.logf(item.Number, "auto-merge", "re-enabled auto-merge on PR #%d after rebase push\n", pr.Number)
+					e.logf(item.Number, "warn", "auto-merge re-enable after rebase failed: %v\n", rerr)
 				}
+			} else {
+				e.logf(item.Number, "auto-merge", "re-enabled auto-merge on PR #%d after rebase push\n", pr.Number)
 			}
-		}
-	}()
+		},
+	})
 }
 
 // checkAutoMergeConvergence monitors a yolo issue that has entered the GitHub

--- a/engine/merge_train_member_close_settle.go
+++ b/engine/merge_train_member_close_settle.go
@@ -1,12 +1,10 @@
 package engine
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
-	"github.com/handarbeit/fabrik/internal/itemstate"
 )
 
 // mergeTrainAwaitingMemberCloseLabel marks a merge-train singleton landing (landSingleton)
@@ -84,18 +82,7 @@ func (e *Engine) settleMergeTrainMemberClose(item gh.ProjectItem) {
 // reached. Mirrors recordNoWorkNeededRetry, including its MaxRetries<=0 (unlimited retries,
 // never escalate) guard.
 func (e *Engine) recordMergeTrainMemberCloseRetry(item gh.ProjectItem) {
-	if e.cfg.MaxRetries <= 0 {
-		return
-	}
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: mergeTrainMemberCloseRetryStage})
-	var count int
-	if snap, err := e.store.Get(repoStr, item.Number); err == nil {
-		count = snap.Attempts(mergeTrainMemberCloseRetryStage)
-	}
-	if count >= e.cfg.MaxRetries {
-		e.escalateMergeTrainMemberCloseFailure(item)
-	}
+	e.recordSettleRetry(item, mergeTrainMemberCloseRetryStage, e.escalateMergeTrainMemberCloseFailure)
 }
 
 // escalateMergeTrainMemberCloseFailure is called when the outstanding merge-train
@@ -109,31 +96,18 @@ func (e *Engine) escalateMergeTrainMemberCloseFailure(item gh.ProjectItem) {
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	e.addLabel(item, "fabrik:paused")
-	e.applyLabelRemove(item, mergeTrainAwaitingMemberCloseLabel, true)
-
-	comment := fmt.Sprintf(
-		"🏭 **Fabrik — merge-train member-issue close failed**\n\nThis issue landed successfully via the merge-train singleton path, but closing the issue itself could not be completed after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh issue close %d --repo %s/%s\n```\nThen remove the `fabrik:paused` label.",
-		e.cfg.MaxRetries, item.Number, owner, repo,
-	)
-	e.postItemComment(item, comment, true)
-
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: mergeTrainMemberCloseRetryStage})
+	e.escalateSettle(item, mergeTrainAwaitingMemberCloseLabel, mergeTrainMemberCloseRetryStage, func(item gh.ProjectItem) {
+		comment := fmt.Sprintf(
+			"🏭 **Fabrik — merge-train member-issue close failed**\n\nThis issue landed successfully via the merge-train singleton path, but closing the issue itself could not be completed after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh issue close %d --repo %s/%s\n```\nThen remove the `fabrik:paused` label.",
+			e.cfg.MaxRetries, item.Number, owner, repo,
+		)
+		e.postItemComment(item, comment, true)
+	})
 }
 
 // clearMergeTrainMemberCloseMarker removes the awaiting-member-close marker and clears the
 // retry counter once the member issue is confirmed closed (by us or by GitHub's own
 // Closes #N auto-close).
 func (e *Engine) clearMergeTrainMemberCloseMarker(item gh.ProjectItem, owner, repo string) {
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, mergeTrainAwaitingMemberCloseLabel); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", mergeTrainAwaitingMemberCloseLabel, err)
-		return
-	} else if err == nil {
-		e.syncLabelRemoval(item, mergeTrainAwaitingMemberCloseLabel, true)
-	}
-
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: mergeTrainMemberCloseRetryStage})
+	e.clearSettleMarker(item, owner, repo, mergeTrainAwaitingMemberCloseLabel, mergeTrainMemberCloseRetryStage)
 }

--- a/engine/no_work_needed_settle.go
+++ b/engine/no_work_needed_settle.go
@@ -193,18 +193,7 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 // constant (not the emitting stage's real name — see the ADR for rationale).
 // Escalates via escalateNoWorkNeededFailure once e.cfg.MaxRetries is reached.
 func (e *Engine) recordNoWorkNeededRetry(item gh.ProjectItem) {
-	if e.cfg.MaxRetries <= 0 {
-		return
-	}
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: noWorkNeededRetryStage})
-	var count int
-	if snap, err := e.store.Get(repoStr, item.Number); err == nil {
-		count = snap.Attempts(noWorkNeededRetryStage)
-	}
-	if count >= e.cfg.MaxRetries {
-		e.escalateNoWorkNeededFailure(item)
-	}
+	e.recordSettleRetry(item, noWorkNeededRetryStage, e.escalateNoWorkNeededFailure)
 }
 
 // escalateNoWorkNeededFailure is called when the outstanding no-work-needed
@@ -218,31 +207,18 @@ func (e *Engine) escalateNoWorkNeededFailure(item gh.ProjectItem) {
 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 
-	e.addLabel(item, "fabrik:paused")
-	e.applyLabelRemove(item, "fabrik:awaiting-done", true)
-
-	comment := fmt.Sprintf(
-		"🏭 **Fabrik — no-work-needed completion failed**\n\nThis issue was determined to need no code or documentation changes, but the board move to Done and/or the issue close could not be completed after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh issue close %d --repo %s/%s\n```\nThen move the issue's project-board column to Done yourself (no `gh` one-liner exists for Projects-v2 status fields).\n\nThen remove the `fabrik:paused` label. Do not remove it without completing the above — removing the `fabrik:paused` label without completing these steps may cause the issue to re-enter the normal pipeline unexpectedly.",
-		e.cfg.MaxRetries, item.Number, owner, repo,
-	)
-	e.postItemComment(item, comment, true)
-
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: noWorkNeededRetryStage})
+	e.escalateSettle(item, "fabrik:awaiting-done", noWorkNeededRetryStage, func(item gh.ProjectItem) {
+		comment := fmt.Sprintf(
+			"🏭 **Fabrik — no-work-needed completion failed**\n\nThis issue was determined to need no code or documentation changes, but the board move to Done and/or the issue close could not be completed after %d attempt(s). The issue has been paused.\n\nManual fix:\n```\ngh issue close %d --repo %s/%s\n```\nThen move the issue's project-board column to Done yourself (no `gh` one-liner exists for Projects-v2 status fields).\n\nThen remove the `fabrik:paused` label. Do not remove it without completing the above — removing the `fabrik:paused` label without completing these steps may cause the issue to re-enter the normal pipeline unexpectedly.",
+			e.cfg.MaxRetries, item.Number, owner, repo,
+		)
+		e.postItemComment(item, comment, true)
+	})
 }
 
 // clearNoWorkNeededMarker removes the fabrik:awaiting-done marker and clears the
 // retry counter once settleNoWorkNeeded has fully succeeded (status moved to Done
 // and the issue closed).
 func (e *Engine) clearNoWorkNeededMarker(item gh.ProjectItem, owner, repo string) {
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:awaiting-done"); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove awaiting-done marker: %v\n", err)
-		return
-	} else if err == nil {
-		e.syncLabelRemoval(item, "fabrik:awaiting-done", true)
-	}
-
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: noWorkNeededRetryStage})
+	e.clearSettleMarker(item, owner, repo, "fabrik:awaiting-done", noWorkNeededRetryStage)
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1294,96 +1294,15 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	e.runValidatePRTerminalAdvance(board, deepFetchCandidates, advancedItems)
 
 	// No-work-needed settle scan: retries the outstanding Done-move/close for any
-	// item carrying fabrik:awaiting-done, independent of item.Status (the board move
-	// may still be sitting at whichever column the emitting stage ran in — see
-	// itemMayNeedWork/itemNeedsWork, which suppress normal dispatch for these items).
-	// Paused items are skipped: either escalateNoWorkNeededFailure already handled
-	// them (marker removed) or an operator is investigating a paused item for an
-	// unrelated reason and this scan must not fight them.
-	for _, item := range deepFetchCandidates {
-		if !hasLabel(item, "fabrik:awaiting-done") || hasLabel(item, "fabrik:paused") {
-			continue
-		}
-		stage := stages.FindStage(e.cfg.Stages, item.Status)
-		if stage == nil {
-			e.logf(item.Number, "warn", "no-work-needed settle: no stage matches board column %q — will retry next poll\n", item.Status)
-			e.recordNoWorkNeededRetry(item)
-			continue
-		}
-		e.settleNoWorkNeeded(board, item, stage)
-	}
+	// item carrying fabrik:awaiting-done, independent of item.Status.
+	e.settleNoWorkNeededScan(board, deepFetchCandidates)
 
 	// Revalidate scan: operator-facing fabrik:revalidate label re-entry.
-	// Runs on ALL deepFetchCandidates unconditionally (paused items included — FR-5).
-	// Uses next-poll dispatch: does not mutate deepFetchCandidates in place.
-	for _, item := range deepFetchCandidates {
-		if !hasLabel(item, "fabrik:revalidate") {
-			continue
-		}
-		owner, repo := itemOwnerRepo(item, e.defaultRepo())
-		repoStr := itemOwnerRepoString(item, e.defaultRepo())
-		stage := stages.FindStage(e.cfg.Stages, item.Status)
-		if stage == nil || stage.Name != "Validate" {
-			stageName := item.Status
-			if stage != nil {
-				stageName = stage.Name
-			}
-			e.logf(item.Number, "warn", "fabrik:revalidate applied to non-Validate stage %q — removing label, no action\n", stageName)
-			if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:revalidate"); rerr != nil {
-				if errors.Is(rerr, gh.ErrNotFound) {
-					if c := e.cache(); c != nil {
-						c.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
-					}
-				} else {
-					e.logf(item.Number, "warn", "revalidate: could not remove label from non-Validate issue: %v\n", rerr)
-				}
-			} else {
-				if c := e.cache(); c != nil {
-					c.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
-				}
-				if e.webhookMgr != nil {
-					e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(repoStr, item.Number)+"+"+"fabrik:revalidate")
-				}
-			}
-			continue
-		}
-		// In-flight guard: do not interrupt an active Validate worker (FR-4).
-		if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
-			e.logf(item.Number, "revalidate", "Validate worker in-flight — deferring revalidate to next poll\n")
-			continue
-		}
-		e.handleRevalidateLabel(item, owner, repo)
-	}
+	e.settleRevalidateScan(deepFetchCandidates)
 
 	// SHA-invalidation scan: detect force-pushes or external commits that change
 	// the linked PR's HEAD SHA after stage:Validate:complete was recorded.
-	// Runs on ALL deepFetchCandidates where stage:Validate:complete is present.
-	for _, item := range deepFetchCandidates {
-		if !hasLabel(item, "stage:Validate:complete") {
-			continue
-		}
-		owner, repo := itemOwnerRepo(item, e.defaultRepo())
-		repoStr := itemOwnerRepoString(item, e.defaultRepo())
-		snap, snapErr := e.store.Get(repoStr, item.Number)
-		if snapErr != nil {
-			continue
-		}
-		completedSHA := snap.ValidateCompletedSHA()
-		if completedSHA == "" {
-			// FR-5: no recorded SHA (pre-feature item or worktree HEAD unavailable) — do nothing.
-			continue
-		}
-		lpr := snap.LinkedPR()
-		if lpr == nil || lpr.HeadSHA == "" || lpr.HeadSHA == completedSHA {
-			continue
-		}
-		// FR-6: in-flight guard — let the active Validate worker finish.
-		if snap.Worker() != nil {
-			e.logf(item.Number, "validate-sha", "Validate worker in-flight — deferring SHA invalidation to next poll\n")
-			continue
-		}
-		e.handleValidateSHAInvalidation(item, owner, repo)
-	}
+	e.settleSHAInvalidationScan(deepFetchCandidates)
 
 	var dispatched int
 	// Dispatch only items from deepFetchCandidates — items that passed
@@ -1523,27 +1442,8 @@ doneDispatching:
 	e.cleanupClosedIssueTransientLabels(board)
 
 	// Child board-placement settle scan: retries the outstanding project Status
-	// placement for any spawned child carrying fabrik:awaiting-placement, independent
-	// of stage dispatch. Sourced from board.Items directly, NOT deepFetchCandidates —
-	// a stranded child sits in a column (typically Backlog) with no matching configured
-	// stage, so it never passes itemMayNeedWork's stage == nil guard and never reaches
-	// deepFetchCandidates (see engine/spawn_settle.go). Paused items are skipped: either
-	// escalateChildPlacementFailure already handled them (marker removed) or an operator
-	// is investigating for an unrelated reason and this scan must not fight them.
-	for _, item := range board.Items {
-		if !hasLabel(item, childPlacementLabel) || hasLabel(item, "fabrik:paused") {
-			continue
-		}
-		if item.IsClosed {
-			// A closed child needs no further board dispatch — the only purpose of
-			// correct placement was to let the pipeline process it, which no longer
-			// applies. Clear the marker without attempting placement or escalation.
-			owner, repo := itemOwnerRepo(item, e.defaultRepo())
-			e.clearChildPlacementMarker(item, owner, repo)
-			continue
-		}
-		e.settleChildPlacement(board, item)
-	}
+	// placement for any spawned child carrying fabrik:awaiting-placement.
+	e.settleChildPlacements(board)
 
 	// Closed-item-at-any-stage advance to Done (ADR-064): a closed issue sitting
 	// at any non-Done, non-Holding, non-cleanup, non-gate-checked column never

--- a/engine/poll_settle.go
+++ b/engine/poll_settle.go
@@ -1,0 +1,133 @@
+package engine
+
+import (
+	"errors"
+
+	"github.com/handarbeit/fabrik/boardcache"
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// settleNoWorkNeededScan retries the outstanding Done-move/close for any
+// item carrying fabrik:awaiting-done, independent of item.Status (the board
+// move may still be sitting at whichever column the emitting stage ran in —
+// see itemMayNeedWork/itemNeedsWork, which suppress normal dispatch for
+// these items). Paused items are skipped: either escalateNoWorkNeededFailure
+// already handled them (marker removed) or an operator is investigating a
+// paused item for an unrelated reason and this scan must not fight them.
+func (e *Engine) settleNoWorkNeededScan(board *gh.ProjectBoard, candidates []gh.ProjectItem) {
+	for _, item := range candidates {
+		if !hasLabel(item, "fabrik:awaiting-done") || hasLabel(item, "fabrik:paused") {
+			continue
+		}
+		stage := stages.FindStage(e.cfg.Stages, item.Status)
+		if stage == nil {
+			e.logf(item.Number, "warn", "no-work-needed settle: no stage matches board column %q — will retry next poll\n", item.Status)
+			e.recordNoWorkNeededRetry(item)
+			continue
+		}
+		e.settleNoWorkNeeded(board, item, stage)
+	}
+}
+
+// settleRevalidateScan handles operator-facing fabrik:revalidate label
+// re-entry. Runs on ALL candidates unconditionally (paused items included —
+// FR-5). Uses next-poll dispatch: does not mutate candidates in place.
+func (e *Engine) settleRevalidateScan(candidates []gh.ProjectItem) {
+	for _, item := range candidates {
+		if !hasLabel(item, "fabrik:revalidate") {
+			continue
+		}
+		owner, repo := itemOwnerRepo(item, e.defaultRepo())
+		repoStr := itemOwnerRepoString(item, e.defaultRepo())
+		stage := stages.FindStage(e.cfg.Stages, item.Status)
+		if stage == nil || stage.Name != "Validate" {
+			stageName := item.Status
+			if stage != nil {
+				stageName = stage.Name
+			}
+			e.logf(item.Number, "warn", "fabrik:revalidate applied to non-Validate stage %q — removing label, no action\n", stageName)
+			if rerr := e.client.RemoveLabelFromIssue(owner, repo, item.Number, "fabrik:revalidate"); rerr != nil {
+				if errors.Is(rerr, gh.ErrNotFound) {
+					if c := e.cache(); c != nil {
+						c.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
+					}
+				} else {
+					e.logf(item.Number, "warn", "revalidate: could not remove label from non-Validate issue: %v\n", rerr)
+				}
+			} else {
+				if c := e.cache(); c != nil {
+					c.ApplyLabelRemoved(boardcache.ItemKey(repoStr, item.Number), "fabrik:revalidate")
+				}
+				if e.webhookMgr != nil {
+					e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(repoStr, item.Number)+"+"+"fabrik:revalidate")
+				}
+			}
+			continue
+		}
+		// In-flight guard: do not interrupt an active Validate worker (FR-4).
+		if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil && snap.Worker() != nil {
+			e.logf(item.Number, "revalidate", "Validate worker in-flight — deferring revalidate to next poll\n")
+			continue
+		}
+		e.handleRevalidateLabel(item, owner, repo)
+	}
+}
+
+// settleSHAInvalidationScan detects force-pushes or external commits that
+// change the linked PR's HEAD SHA after stage:Validate:complete was
+// recorded. Runs on ALL candidates where stage:Validate:complete is present.
+func (e *Engine) settleSHAInvalidationScan(candidates []gh.ProjectItem) {
+	for _, item := range candidates {
+		if !hasLabel(item, "stage:Validate:complete") {
+			continue
+		}
+		owner, repo := itemOwnerRepo(item, e.defaultRepo())
+		repoStr := itemOwnerRepoString(item, e.defaultRepo())
+		snap, snapErr := e.store.Get(repoStr, item.Number)
+		if snapErr != nil {
+			continue
+		}
+		completedSHA := snap.ValidateCompletedSHA()
+		if completedSHA == "" {
+			// FR-5: no recorded SHA (pre-feature item or worktree HEAD unavailable) — do nothing.
+			continue
+		}
+		lpr := snap.LinkedPR()
+		if lpr == nil || lpr.HeadSHA == "" || lpr.HeadSHA == completedSHA {
+			continue
+		}
+		// FR-6: in-flight guard — let the active Validate worker finish.
+		if snap.Worker() != nil {
+			e.logf(item.Number, "validate-sha", "Validate worker in-flight — deferring SHA invalidation to next poll\n")
+			continue
+		}
+		e.handleValidateSHAInvalidation(item, owner, repo)
+	}
+}
+
+// settleChildPlacements retries the outstanding project Status placement for
+// any spawned child carrying fabrik:awaiting-placement, independent of stage
+// dispatch. Sourced from board.Items directly, NOT deepFetchCandidates — a
+// stranded child sits in a column (typically Backlog) with no matching
+// configured stage, so it never passes itemMayNeedWork's stage == nil guard
+// and never reaches deepFetchCandidates (see engine/spawn_settle.go). Paused
+// items are skipped: either escalateChildPlacementFailure already handled
+// them (marker removed) or an operator is investigating for an unrelated
+// reason and this scan must not fight them.
+func (e *Engine) settleChildPlacements(board *gh.ProjectBoard) {
+	for _, item := range board.Items {
+		if !hasLabel(item, childPlacementLabel) || hasLabel(item, "fabrik:paused") {
+			continue
+		}
+		if item.IsClosed {
+			// A closed child needs no further board dispatch — the only purpose of
+			// correct placement was to let the pipeline process it, which no longer
+			// applies. Clear the marker without attempting placement or escalation.
+			owner, repo := itemOwnerRepo(item, e.defaultRepo())
+			e.clearChildPlacementMarker(item, owner, repo)
+			continue
+		}
+		e.settleChildPlacement(board, item)
+	}
+}

--- a/engine/reinvoke.go
+++ b/engine/reinvoke.go
@@ -1,0 +1,129 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// reinvokeOpts parameterizes dispatchReinvoke's per-call-site divergences.
+// The three reinvoke dispatchers (CI-fix, review, rebase) share an identical
+// goroutine scaffold (WorkerEntered -> semaphore -> ensureRepoReady -> build
+// synthetic comment(s) -> optional stage variant -> heartbeat/lock ->
+// processComments -> optional post-processing); only these fields differ
+// per call site.
+type reinvokeOpts struct {
+	// tag is the log-message prefix (e.g. "ci-fix-reinvoke", "review-reinvoke",
+	// "rebase-reinvoke").
+	tag string
+	// precheck, if non-nil, runs synchronously before WorkerEntered/goroutine
+	// dispatch; returning false skips the reinvoke entirely with no worker
+	// bookkeeping. Used by review's pre-dispatch emptiness check, which has no
+	// workDir dependency and must not incur ensureRepoReady/WorkerEntered churn
+	// for a same-poll no-op.
+	precheck func() bool
+	// build constructs the synthetic comment(s) to feed into processComments.
+	// Runs inside the goroutine, after ensureRepoReady, so it may use workDir.
+	build func(workDir string) []gh.Comment
+	// stageVariant, if non-nil, returns a modified stage to pass to
+	// processComments (e.g. swapping in CIFixSkill/RebaseSkill over
+	// CommentSkill). nil means use the stage unmodified.
+	stageVariant func(*stages.Stage) *stages.Stage
+	// after, if non-nil, runs after processComments completes, receiving the
+	// worktree dir and the processComments error. Used for CI's no-op-SHA
+	// recording and rebase's auto-merge re-enablement.
+	after func(workDir string, err error)
+}
+
+// dispatchReinvoke is the shared goroutine scaffold for all three reinvoke
+// dispatchers (dispatchCIFixReinvoke, dispatchReviewReinvoke,
+// dispatchRebaseReinvoke). It performs: optional precheck -> WorkerEntered ->
+// semaphore acquire -> ensureRepoReady (ErrSkipItem skips silently) ->
+// opts.build -> optional opts.stageVariant -> LocalLockAcquired + heartbeat +
+// onPIDReady -> processComments -> optional opts.after -> error logging
+// (ctx.Err() short-circuit) -> deferred WorkerExited.
+func (e *Engine) dispatchReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, opts reinvokeOpts) {
+	if opts.precheck != nil && !opts.precheck() {
+		e.logf(item.Number, opts.tag, "precheck failed; skipping re-invocation\n")
+		return
+	}
+
+	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
+
+	// Mark in-flight via the Store so the dispatch guard (snap.Worker() != nil) blocks
+	// double-dispatch before the goroutine starts. WorkerExited is deferred inside the
+	// goroutine so any early exit also clears it.
+	e.store.Apply(itemstate.WorkerEntered{
+		Repo:      itemRepo,
+		Number:    item.Number,
+		StageName: stage.Name,
+		StartedAt: time.Now(),
+	})
+	e.wg.Add(1)
+
+	go func() {
+		defer e.wg.Done()
+		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
+
+		select {
+		case e.sem <- struct{}{}:
+		case <-ctx.Done():
+			e.logf(item.Number, opts.tag, "context cancelled before semaphore acquired\n")
+			return
+		}
+		defer func() { <-e.sem }()
+
+		if err := e.ensureRepoReady(ctx, item); err != nil {
+			if errors.Is(err, ErrSkipItem) {
+				e.logf(item.Number, opts.tag, "repo not ready, skipping reinvoke\n")
+				return
+			}
+			e.logf(item.Number, "warn", "%s: ensureRepoReady failed: %v\n", opts.tag, err)
+			return
+		}
+
+		wm := e.worktreesFor(item.Repo)
+		workDir := wm.WorktreeDir(item.Number)
+
+		comments := opts.build(workDir)
+
+		reinvokeStage := stage
+		if opts.stageVariant != nil {
+			reinvokeStage = opts.stageVariant(stage)
+		}
+
+		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
+		now := time.Now()
+		e.store.Apply(itemstate.LocalLockAcquired{
+			Repo:       itemRepo,
+			Number:     item.Number,
+			User:       e.cfg.User,
+			AcquiredAt: now,
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
+		})
+		done := make(chan struct{})
+		defer close(done)
+		e.startHeartbeat(ctx, itemRepo, item.Number, done)
+		onPIDReady := func(pid int) {
+			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
+		}
+
+		e.logf(item.Number, opts.tag, "re-invoking stage %q via comment processing\n", stage.Name)
+		err := e.processComments(ctx, board, item, reinvokeStage, comments, onPIDReady)
+
+		if opts.after != nil {
+			opts.after(workDir, err)
+		}
+
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			e.logf(item.Number, "warn", "%s re-invocation failed: %v\n", opts.tag, err)
+		}
+	}()
+}

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -382,11 +382,11 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 	})
 }
 
-// dispatchReviewReinvoke spawns a goroutine to re-invoke the stage agent via
-// processComments with synthetic review comments. It marks the item in-flight,
-// acquires the semaphore, calls processComments, then releases both.
-// This allows the catch-up loop to remain non-blocking while the Claude
-// invocation runs asynchronously.
+// dispatchReviewReinvoke re-invokes the stage agent via processComments with
+// synthetic review comments. A thin wrapper over dispatchReinvoke, supplying
+// only review's pre-dispatch emptiness precheck and its comment builder —
+// the shared goroutine scaffold (WorkerEntered/semaphore/processComments)
+// lives in reinvoke.go.
 func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
 	e.dispatchReinvoke(ctx, board, item, stage, reinvokeOpts{
 		tag: "review-reinvoke",

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -2,13 +2,11 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
-	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
 
@@ -390,79 +388,18 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 // This allows the catch-up loop to remain non-blocking while the Claude
 // invocation runs asynchronously.
 func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) {
-	syntheticComments := e.buildReviewThreadComments(item)
-	if len(syntheticComments) == 0 {
-		e.logf(item.Number, "review-reinvoke", "no review bodies to process; skipping re-invocation\n")
-		return
-	}
-
-	// Mark in-flight via the Store so the dispatch guard (snap.Worker() != nil) blocks
-	// double-dispatch before the goroutine starts. WorkerExited is deferred inside the
-	// goroutine so any early exit (context cancel, ensureRepoReady failure) also clears it.
-	itemRepo := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.WorkerEntered{
-		Repo:      itemRepo,
-		Number:    item.Number,
-		StageName: stage.Name,
-		StartedAt: time.Now(),
+	e.dispatchReinvoke(ctx, board, item, stage, reinvokeOpts{
+		tag: "review-reinvoke",
+		// precheck runs synchronously before WorkerEntered/goroutine dispatch —
+		// buildReviewThreadComments needs no workDir, so there's no reason to
+		// incur ensureRepoReady/WorkerEntered churn for a same-poll no-op.
+		precheck: func() bool {
+			return len(e.buildReviewThreadComments(item)) > 0
+		},
+		build: func(workDir string) []gh.Comment {
+			return e.buildReviewThreadComments(item)
+		},
 	})
-	e.wg.Add(1)
-
-	go func() {
-		defer e.wg.Done()
-		defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
-
-		// Acquire semaphore slot (respects MaxConcurrent; blocks until available).
-		select {
-		case e.sem <- struct{}{}:
-		case <-ctx.Done():
-			e.logf(item.Number, "review-reinvoke", "context cancelled before semaphore acquired\n")
-			return
-		}
-		defer func() { <-e.sem }()
-
-		// Ensure the repo's WorktreeManager is registered before processComments
-		// tries to use it. Phase 1 of the catch-up loop dispatches reinvokes
-		// independently of the main dispatch loop, so this may be the first time
-		// we touch this repo in the current session — processItem's ensureRepoReady
-		// call cannot be relied on here. Without this, processComments panics at
-		// worktreesFor() on a freshly-started Fabrik.
-		if err := e.ensureRepoReady(ctx, item); err != nil {
-			if errors.Is(err, ErrSkipItem) {
-				e.logf(item.Number, "review-reinvoke", "repo not ready (clone failed elsewhere), skipping reinvoke\n")
-				return
-			}
-			e.logf(item.Number, "warn", "review reinvoke: ensureRepoReady failed: %v\n", err)
-			return
-		}
-
-		// Register WorkerHandle so the heartbeat/liveness system tracks this goroutine.
-		now := time.Now()
-		e.store.Apply(itemstate.LocalLockAcquired{
-			Repo:       itemRepo,
-			Number:     item.Number,
-			User:       e.cfg.User,
-			AcquiredAt: now,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: now, LastSignAt: now},
-		})
-		done := make(chan struct{})
-		defer close(done)
-		e.startHeartbeat(ctx, itemRepo, item.Number, done)
-		onPIDReady := func(pid int) {
-			e.store.Apply(itemstate.WorkerPIDSet{Repo: itemRepo, Number: item.Number, PID: pid})
-		}
-
-		e.logf(item.Number, "review-reinvoke", "re-invoking stage %q via comment processing with %d synthetic review comment(s)\n",
-			stage.Name, len(syntheticComments))
-		err := e.processComments(ctx, board, item, stage, syntheticComments, onPIDReady)
-
-		if err != nil {
-			if ctx.Err() != nil {
-				return // context cancelled; normal shutdown
-			}
-			e.logf(item.Number, "warn", "review re-invocation failed: %v\n", err)
-		}
-	}()
 }
 
 // pauseForReviewCycleLimit pauses the issue when the maximum review re-invocation

--- a/engine/settle.go
+++ b/engine/settle.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"errors"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+)
+
+// recordSettleRetry increments the in-memory retry counter for a stalled
+// settle-scan operation, keyed by the caller's dedicated retryStage constant
+// (a synthetic, double-underscore-wrapped name — never a real configured
+// stage — so it can't collide with a stage's own retry count). Escalates via
+// onEscalate once e.cfg.MaxRetries is reached. Shared by the three settle
+// scans (no-work-needed, child-placement, merge-train member-close); each
+// passes its own retryStage constant and escalate function so the counters
+// never conflate across scans.
+func (e *Engine) recordSettleRetry(item gh.ProjectItem, retryStage string, onEscalate func(gh.ProjectItem)) {
+	if e.cfg.MaxRetries <= 0 {
+		return
+	}
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: retryStage})
+	var count int
+	if snap, err := e.store.Get(repoStr, item.Number); err == nil {
+		count = snap.Attempts(retryStage)
+	}
+	if count >= e.cfg.MaxRetries {
+		onEscalate(item)
+	}
+}
+
+// clearSettleMarker removes a settle scan's durable marker label and clears
+// its retry counter once the underlying operation has fully succeeded.
+// Shared by the three settle scans; each passes its own marker label and
+// retryStage constant.
+func (e *Engine) clearSettleMarker(item gh.ProjectItem, owner, repo, markerLabel, retryStage string) {
+	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, markerLabel); err != nil &&
+		!errors.Is(err, gh.ErrNotFound) {
+		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", markerLabel, err)
+		return
+	} else if err == nil {
+		e.syncLabelRemoval(item, markerLabel, true)
+	}
+
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: retryStage})
+}
+
+// escalateSettle is called when a settle scan's outstanding operation has
+// failed MaxRetries times. It pauses the issue (fabrik:paused) so it stops
+// being retried silently forever, removes the scan's durable marker label
+// (dispatch/retry suppression is no longer needed once fabrik:paused takes
+// over), invokes postComment to post an explanatory comment (a hook rather
+// than a plain string so callers with divergent comment-posting behavior —
+// e.g. escalateChildPlacementFailure's CreatedAt-omitting raw AddComment —
+// can express that divergence at their own call site instead of leaking it
+// into this shared helper), and records the pause in the Store. Shared by
+// the three settle scans; each passes its own marker label, retryStage
+// constant, and comment-posting closure.
+func (e *Engine) escalateSettle(item gh.ProjectItem, markerLabel, retryStage string, postComment func(gh.ProjectItem)) {
+	e.addLabel(item, "fabrik:paused")
+	e.applyLabelRemove(item, markerLabel, true)
+	postComment(item)
+
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: retryStage})
+}

--- a/engine/settle_test.go
+++ b/engine/settle_test.go
@@ -1,0 +1,136 @@
+package engine
+
+import (
+	gh "github.com/handarbeit/fabrik/github"
+	"testing"
+)
+
+// testSettleRetryStage is a synthetic retry-stage constant for exercising the
+// generic settle-trio helpers directly, independent of any real settle
+// scan's constant.
+const testSettleRetryStage = "__test_settle__"
+
+const testSettleMarkerLabel = "fabrik:test-settle-marker"
+
+// TestRecordSettleRetry_EscalatesAtMaxRetries verifies that recordSettleRetry
+// invokes onEscalate only once the attempt counter reaches e.cfg.MaxRetries,
+// not before — mirroring the per-scan escalation-after-MaxRetries tests
+// (TestRecordNoWorkNeededRetry_EscalatesAtMaxRetries and siblings) but against
+// the shared helper directly.
+func TestRecordSettleRetry_EscalatesAtMaxRetries(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.cfg.MaxRetries = 3
+
+	item := gh.ProjectItem{Number: 5, Repo: "owner/repo"}
+
+	var escalations int
+	onEscalate := func(gh.ProjectItem) { escalations++ }
+
+	for i := 1; i < eng.cfg.MaxRetries; i++ {
+		eng.recordSettleRetry(item, testSettleRetryStage, onEscalate)
+		if escalations != 0 {
+			t.Fatalf("expected no escalation before MaxRetries reached (attempt %d), got %d escalation(s)", i, escalations)
+		}
+	}
+
+	eng.recordSettleRetry(item, testSettleRetryStage, onEscalate)
+	if escalations != 1 {
+		t.Fatalf("expected exactly 1 escalation once MaxRetries reached, got %d", escalations)
+	}
+}
+
+// TestRecordSettleRetry_MaxRetriesDisabled verifies the MaxRetries<=0 guard:
+// no counter increment and no escalation, mirroring recordNoWorkNeededRetry's
+// original unlimited-retries behavior.
+func TestRecordSettleRetry_MaxRetriesDisabled(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.cfg.MaxRetries = 0
+
+	item := gh.ProjectItem{Number: 5, Repo: "owner/repo"}
+
+	var escalations int
+	onEscalate := func(gh.ProjectItem) { escalations++ }
+
+	for i := 0; i < 10; i++ {
+		eng.recordSettleRetry(item, testSettleRetryStage, onEscalate)
+	}
+	if escalations != 0 {
+		t.Fatalf("expected no escalation when MaxRetries <= 0, got %d", escalations)
+	}
+}
+
+// TestClearSettleMarker_RemovesLabelAndClearsCounter verifies clearSettleMarker
+// removes the marker label from GitHub and resets the retry counter.
+func TestClearSettleMarker_RemovesLabelAndClearsCounter(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	eng.cfg.MaxRetries = 5
+
+	item := gh.ProjectItem{Number: 5, Repo: "owner/repo"}
+
+	// Bump the retry counter without reaching MaxRetries.
+	eng.recordSettleRetry(item, testSettleRetryStage, func(gh.ProjectItem) {
+		t.Fatal("onEscalate must not fire before MaxRetries")
+	})
+
+	eng.clearSettleMarker(item, "owner", "repo", testSettleMarkerLabel, testSettleRetryStage)
+
+	found := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == testSettleMarkerLabel {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected RemoveLabelFromIssue(%q) to be called", testSettleMarkerLabel)
+	}
+
+	snap, err := eng.store.Get("owner/repo", item.Number)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.Attempts(testSettleRetryStage); got != 0 {
+		t.Errorf("expected retry counter cleared to 0, got %d", got)
+	}
+}
+
+// TestEscalateSettle_PausesAndPostsComment verifies escalateSettle pauses the
+// issue, removes the marker label, and invokes the postComment hook exactly
+// once — the sequence every settle scan's escalate* function delegates to.
+func TestEscalateSettle_PausesAndPostsComment(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 5, Repo: "owner/repo"}
+
+	var postCommentCalls int
+	eng.escalateSettle(item, testSettleMarkerLabel, testSettleRetryStage, func(gh.ProjectItem) {
+		postCommentCalls++
+	})
+
+	if postCommentCalls != 1 {
+		t.Fatalf("expected postComment hook to be invoked exactly once, got %d", postCommentCalls)
+	}
+
+	pausedAdded := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedAdded = true
+		}
+	}
+	if !pausedAdded {
+		t.Error("expected fabrik:paused to be added")
+	}
+
+	markerRemoved := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == testSettleMarkerLabel {
+			markerRemoved = true
+		}
+	}
+	if !markerRemoved {
+		t.Errorf("expected marker label %q to be removed", testSettleMarkerLabel)
+	}
+}

--- a/engine/spawn_settle.go
+++ b/engine/spawn_settle.go
@@ -1,13 +1,11 @@
 package engine
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
-	"github.com/handarbeit/fabrik/internal/itemstate"
 )
 
 // childPlacementLabel is the durable marker recording that a spawned child
@@ -79,18 +77,7 @@ func (e *Engine) settleChildPlacement(board *gh.ProjectBoard, item gh.ProjectIte
 // (not any real stage name — see the ADR for rationale). Escalates via
 // escalateChildPlacementFailure once e.cfg.MaxRetries is reached.
 func (e *Engine) recordChildPlacementRetry(item gh.ProjectItem) {
-	if e.cfg.MaxRetries <= 0 {
-		return
-	}
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: childPlacementRetryStage})
-	var count int
-	if snap, err := e.store.Get(repoStr, item.Number); err == nil {
-		count = snap.Attempts(childPlacementRetryStage)
-	}
-	if count >= e.cfg.MaxRetries {
-		e.escalateChildPlacementFailure(item)
-	}
+	e.recordSettleRetry(item, childPlacementRetryStage, e.escalateChildPlacementFailure)
 }
 
 // escalateChildPlacementFailure is called when a spawned child's outstanding
@@ -108,37 +95,32 @@ func (e *Engine) escalateChildPlacementFailure(item gh.ProjectItem) {
 
 	e.logf(item.Number, "escalate", "child board placement on %s/%s#%d failed %d time(s) — pausing issue\n", owner, repo, item.Number, e.cfg.MaxRetries)
 
-	e.addPausedLabelToItem(owner, repo, item)
-
-	e.applyLabelRemove(item, childPlacementLabel, true)
-
-	comment := fmt.Sprintf(
-		"🏭 **Fabrik — spawned child board placement failed**\n\nThis issue was spawned as a sub-issue, but Fabrik could not place it into the `Specify` (or first processing) column on the project board after %d attempt(s). It may still be sitting in `Backlog` or wherever GitHub defaulted it. The issue has been paused.\n\nManual fix:\nMove this issue's project-board column to `Specify` (or the first processing stage) yourself, then remove the `fabrik:paused` label to let Fabrik pick it up.\n\nIf no suitable column exists on the board, this may indicate a board-configuration problem — check that a `Specify` (or equivalent first-stage) column exists.",
-		e.cfg.MaxRetries,
-	)
-	// NOTE: this comment-post's cache write-through deliberately omits CreatedAt
-	// (unlike postComment, which always stamps time.Now()) to preserve this
-	// site's pre-existing behavior exactly; using e.cache() directly here
-	// (rather than postComment/postItemComment) keeps that omission intact.
-	if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
-		e.logf(item.Number, "warn", "could not post child-placement escalation comment: %v\n", err)
-	} else {
-		if c := e.cache(); c != nil {
-			c.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
-				DatabaseID: dbID, Body: comment, Author: e.cfg.User,
-			})
+	e.escalateSettle(item, childPlacementLabel, childPlacementRetryStage, func(item gh.ProjectItem) {
+		comment := fmt.Sprintf(
+			"🏭 **Fabrik — spawned child board placement failed**\n\nThis issue was spawned as a sub-issue, but Fabrik could not place it into the `Specify` (or first processing) column on the project board after %d attempt(s). It may still be sitting in `Backlog` or wherever GitHub defaulted it. The issue has been paused.\n\nManual fix:\nMove this issue's project-board column to `Specify` (or the first processing stage) yourself, then remove the `fabrik:paused` label to let Fabrik pick it up.\n\nIf no suitable column exists on the board, this may indicate a board-configuration problem — check that a `Specify` (or equivalent first-stage) column exists.",
+			e.cfg.MaxRetries,
+		)
+		// NOTE: this comment-post's cache write-through deliberately omits CreatedAt
+		// (unlike postComment, which always stamps time.Now()) to preserve this
+		// site's pre-existing behavior exactly; using e.cache() directly here
+		// (rather than postComment/postItemComment) keeps that omission intact.
+		if dbID, err := e.client.AddComment(owner, repo, item.Number, comment); err != nil {
+			e.logf(item.Number, "warn", "could not post child-placement escalation comment: %v\n", err)
+		} else {
+			if c := e.cache(); c != nil {
+				c.ApplyCommentAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), gh.Comment{
+					DatabaseID: dbID, Body: comment, Author: e.cfg.User,
+				})
+			}
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
+			}
+			// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
+			if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
+				e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
+			}
 		}
-		if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
-		}
-		// no write-through: excluded — AddCommentReaction does not affect dispatch-relevant cache state
-		if reactErr := e.client.AddCommentReaction(owner, repo, dbID, "rocket"); reactErr != nil {
-			e.logf(item.Number, "warn", "could not add 🚀 to posted comment: %v\n", reactErr)
-		}
-	}
-
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: childPlacementRetryStage})
+	})
 
 	e.notifyParentOfStalledChild(owner, repo, item)
 }
@@ -147,16 +129,7 @@ func (e *Engine) escalateChildPlacementFailure(item gh.ProjectItem) {
 // the retry counter once settleChildPlacement has succeeded (or the closed-
 // child short-circuit in the poll.go settle scan applies).
 func (e *Engine) clearChildPlacementMarker(item gh.ProjectItem, owner, repo string) {
-	if err := e.client.RemoveLabelFromIssue(owner, repo, item.Number, childPlacementLabel); err != nil &&
-		!errors.Is(err, gh.ErrNotFound) {
-		e.logf(item.Number, "warn", "could not remove %s marker: %v\n", childPlacementLabel, err)
-		return
-	} else if err == nil {
-		e.syncLabelRemoval(item, childPlacementLabel, true)
-	}
-
-	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: childPlacementRetryStage})
+	e.clearSettleMarker(item, owner, repo, childPlacementLabel, childPlacementRetryStage)
 }
 
 // notifyParentOfStalledChild makes a best-effort attempt to post a comment on


### PR DESCRIPTION
Closes #1027

## Summary

Extract shared helpers for (a) the settle-scan retry/clear/escalate trio, (b) the worker-reinvoke goroutine scaffold, and (c) the cycle-limit dispatch pattern, then route the existing call sites through them.

## Problem

The code-health audit (2026-07-20) found that Fabrik's recovery/settle machinery and its worker-reinvoke dispatch paths are copy-pasted across files rather than abstracted. There are five `*_settle.go` scans and several reinvoke/dispatch paths that share a near-identical skeleton; the copies drift (e.g. one settle path has ADR-061 close-failure recovery its twin lacks, and a CI-fix no-op-SHA short-circuit is easy to omit in one of three copies). This is the second-largest duplication cluster after the mutation idiom.

## Approach

### Approach

Three independent generic-helper extractions, each routing existing call sites through the new helper while preserving documented per-site divergences via explicit parameters (never by re-duplicating logic or by silently unifying behavior that ADRs deliberately kept distinct).

**1. Settle-scan trio** (`engine/settle.go`, new file): extract `recordSettleRetry`, `clearSettleMarker`, `escalateSettle`. The three existing `recordXRetry`/`clearXMarker`/`escalateXFailure` functions become thin wrappers that call the shared helpers with their own constants — their exported names stay so all existing call sites (poll.go, the three settle files themselves, existing tests) need zero changes beyond the body becoming a one-line delegation.

`escalateChildPlacementFailure`'s two divergences (a raw `AddComment` that intentionally omits `CreatedAt` on the cache write, plus the trailing `notifyParentOfStalledChild` call) don't fit a plain `comment string` parameter. `escalateSettle` takes a `postComment func(gh.ProjectItem)` hook instead of a string: the two uniform callers pass a one-line closure wrapping `postItemComment`, and `escalateChildPlacementFailure` passes a closure containing its existing raw-AddComment + reaction + `notifyParentOfStalledChild` logic verbatim. This keeps the divergence visible at its own call site instead of leaking into the shared helper.

**2. Reinvoke scaffold** (`engine/reinvoke.go`, new file): extract `dispatchReinvoke(ctx, board, item, stage, opts reinvokeOpts)`. Covers all **three** reinvoke dispatchers — `dispatchCIFixReinvoke`, `dispatchReviewReinvoke`, **and `dispatchRebaseReinvoke`** (Research flagged this third copy as sharing the identical scaffold despite not being named in the issue text; leaving it out would leave a third of the cluster unaddressed, so it's in scope here).

`reinvokeOpts` fields, each an explicit parameter so no caller's divergence gets silently dropped:
- `tag string` — log-message prefix (unifies minor log wording across the three; not behavior)
- `precheck func() bool` (optional) — review's pre-`WorkerEntered` emptiness check; nil for CI/rebase, which have no such check and always proceed
- `build func(workDir string) []gh.Comment` (required) — constructs the synthetic comment(s); CI's closure also snapshots `headBefore` as a side effect (captured in an outer var) since it needs `workDir`, which is only available inside the goroutine
- `stageVariant func(*stages.Stage) *stages.Stage` (optional) — CI's `CIFixSkill`/rebase's `RebaseSkill` swap over `CommentSkill`; nil for review (uses the stage unmodified)
- `after func(workDir string, err error)` (optional) — CI's no-op-SHA recording and rebase's auto-merge re-enablement, both of which need the post-`processComments` outcome; nil for review

**3. Cycle-limit dispatch** (extend `engine/catch_up_handlers.go`): extract `dispatchWithCycleLimit(pctx, tag, cycles func(itemstate.Snapshot) int, maxCycles int, shortCircuit func(itemstate.Snapshot) bool, incrementAndDispatch func(), pause func(cycleCount int)) bool`. `shortCircuit` is nil for review/rebase and is the CI-fix no-op-SHA check for CI — an explicit, named parameter so it can't be silently added to the other two paths or dropped from CI's.

**4. Poll-loop wrappers** (`engine/poll_settle.go`, new file): move the three still-inline `for` loop bodies out of `poll()` into named methods — `settleNoWorkNeededScan(board, candidates)`, `settleRevalidateScan(candidates)`, `settleSHAInvalidationScan(candidates)` (all take the pre-computed `deepFetchCandidates` slice, since that's poll-local) — plus `settleChildPlacements(board)` (loops `board.Items` internally, mirroring the existing `settleMergeTrainMemberCloses(board)` convention). `settleMergeTrainMemberCloses` and `settleClosedItemsToDone` already comply and need no change. Each scan's existing item-source (`deepFetchCandidates` vs `board.Items`) and paused-item skip logic is preserved exactly — only the loop's home moves, not its sourcing.

No ADR is needed: Research found no prior ADR names this duplication, but the extraction is a straightforward generic-parameterization of already-ADR-documented per-site behavior (ADR-060/061/062 for settle, ADR-058 for rebase/auto-merge), not a new architectural decision a future contributor needs to discover independently — the code comments on each thin wrapper carry the necessary context.

### New/Modified Files

| File | Change |
|------|--------|
| `engine/settle.go` (new) | `recordSettleRetry`, `clearSettleMarker`, `escalateSettle` |
| `engine/no_work_needed_settle.go` | `recordNoWorkNeededRetry`/`clearNoWorkNeededMarker`/`escalateNoWorkNeededFailure` become thin wrappers over the shared helpers |
| `engine/spawn_settle.go` | `recordChildPlacementRetry`/`clearChildPlacementMarker`/`escalateChildPlacementFailure` become thin wrappers (escalate keeps its raw-comment + notify-parent closure) |
| `engine/merge_train_member_close_settle.go` | `recordMergeTrainMemberCloseRetry`/`clearMergeTrainMemberCloseMarker`/`escalateMergeTrainMemberCloseFailure` become thin wrappers |
| `engine/reinvoke.go` (new) | `reinvokeOpts`, `dispatchReinvoke` |
| `engine/ci.go` | `dispatchCIFixReinvoke` becomes a thin wrapper calling `dispatchReinvoke` |
| `engine/reviews.go` | `dispatchReviewReinvoke` becomes a thin wrapper calling `dispatchReinvoke` |
| `engine/merge_gate.go` | `dispatchRebaseReinvoke` becomes a thin wrapper calling `dispatchReinvoke` |
| `engine/catch_up_handlers.go` | add `dispatchWithCycleLimit`; `handleReviewGate` and the two `handleMergeAndCIGates` blocks (rebase, CI-fix) route through it |
| `engine/poll_settle.go` (new) | `settleNoWorkNeededScan`, `settleRevalidateScan`, `settleSHAInvalidationScan`, `settleChildPlacements` |
| `engine/poll.go` | five call sites replaced with named-method calls; inline loop bodies removed |
| `engine/settle_test.go` (new) | unit tests for the generic settle-trio helpers, including escalation-after-`MaxRetries` |

No documentation changes: this is a purely internal, no-behavior-change refactor. All touched function names (`dispatchCIFixReinvoke`, `dispatchReviewReinvoke`, `dispatchRebaseReinvoke`, `settleNoWorkNeeded`, `settleMergeTrainMemberCloses`) — the names `docs/state-machine.md` references — are preserved as entry points, so no doc content changes are needed. Do not rename or remove any of these entry points during implementation; if a rename becomes unavoidable, `docs/state-machine.md` and `docs/llms-full.txt` must be updated in the same commit per CLAUDE.md.

### Key Decisions

- **`escalateSettle` takes a `postComment func(gh.ProjectItem)` hook, not a plain string.** A string can't express child-placement's raw-`AddComment`/no-`CreatedAt`/`notifyParentOfStalledChild` divergence from the other two callers' uniform `postItemComment`. A hook keeps that divergence visible and owned by its own call site instead of forcing an if-branch into the shared helper.
- **`dispatchReinvoke` covers all three reinvoke paths, including rebase**, even though the issue's Requirement 2 text names only CI-fix and review. Research confirmed `dispatchRebaseReinvoke` shares the identical ~60-line scaffold, and Requirement 3 already treats rebase symmetrically with review/CI-fix for cycle-limit dispatch — leaving it out would leave a third of this exact duplication cluster unaddressed.
- **Review's pre-dispatch emptiness check stays synchronous, via an optional `precheck`**, rather than moving inside the goroutine after `ensureRepoReady`. Moving it would incur `WorkerEntered`/`ensureRepoReady` churn for what is currently a same-poll no-op — a real (if small) behavior change the issue's "no behavioral divergence" scope excludes. `precheck` recomputes `buildReviewThreadComments(item)` a second time inside `build`; that function is a pure, in-memory computation over already-fetched review data, so the double call is free and not worth threading through a shared variable.
- **No new ADR.** The extraction generalizes existing ADR-documented per-site behavior (ADR-058/060/061/062) rather than introducing a new architectural decision; the reasoning lives in code comments on the thin wrappers.
- **Minor log-text unification is accepted as a non-behavioral side effect.** The generic `dispatchReinvoke`/`dispatchWithCycleLimit` scaffolds use a single `tag`-based message template instead of each site's slightly different wording (e.g. review's "repo not ready (clone failed elsewhere)" vs CI/rebase's "repo not ready"). This changes log text only, not control flow, state, or GitHub-visible behavior — logs aren't covered by "no behavioral divergence" in the acceptance criteria.
- **Existing per-scan tests are kept as-is, exercising the old function names.** `no_work_needed_test.go`, `spawn_settle_test.go`, `merge_train_member_close_settle_test.go`, and the extensive `catch_up_handlers_test.go` suite (already covering in-flight-skip, cycle-limit-pause, happy-path-dispatch, and CI's no-op-debounce per path) continue to pass unmodified against the thin wrappers — this is itself the regression safety net proving no behavioral divergence. A new `engine/settle_test.go` adds tests against the generic helper directly, since no test today exercises it in isolation from a specific scan's constants.

### Task Checklist

- [ ] Create `engine/settle.go` with `recordSettleRetry(item, retryStage string, onEscalate func(gh.ProjectItem))`, `clearSettleMarker(item, owner, repo, markerLabel, retryStage string)`, and `escalateSettle(item, markerLabel, retryStage string, postComment func(gh.ProjectItem))`.
- [ ] Add `engine/settle_test.go` with unit tests for the three new helpers, including a `TestRecordSettleRetry_EscalatesAtMaxRetries` case using a dummy retry-stage constant and a spy `onEscalate`, plus a test asserting `clearSettleMarker` removes the label and clears the counter, and one asserting `escalateSettle` pauses, removes the marker, and invokes `postComment` exactly once.
- [ ] Route `engine/no_work_needed_settle.go`'s `recordNoWorkNeededRetry`/`clearNoWorkNeededMarker`/`escalateNoWorkNeededFailure` through the new helpers (thin wrappers, same exported names and signatures); run `go test ./engine/... -run NoWorkNeeded` to confirm no regression.
- [ ] Route `engine/spawn_settle.go`'s `recordChildPlacementRetry`/`clearChildPlacementMarker`/`escalateChildPlacementFailure` through the new helpers, preserving the raw-`AddComment`/no-`CreatedAt`/`notifyParentOfStalledChild` divergence inside `escalateChildPlacementFailure`'s `postComment` closure; run `go test ./engine/... -run ChildPlacement`.
- [ ] Route `engine/merge_train_member_close_settle.go`'s `recordMergeTrainMemberCloseRetry`/`clearMergeTrainMemberCloseMarker`/`escalateMergeTrainMemberCloseFailure` through the new helpers; run `go test ./engine/... -run MergeTrainMemberClose`.
- [ ] Create `engine/reinvoke.go` with `reinvokeOpts` and `dispatchReinvoke(ctx, board, item, stage, opts)`, implementing the shared goroutine scaffold (`WorkerEntered` → semaphore → `ensureRepoReady`/`ErrSkipItem` → `build` → `stageVariant` → `LocalLockAcquired`/heartbeat/`onPIDReady` → `processComments` → error log → `after`).
- [ ] Rewrite `dispatchCIFixReinvoke` (`engine/ci.go`) as a thin wrapper: `build` snapshots `headBefore` and calls `buildCIFixComment`; `stageVariant` swaps in `CIFixSkill`; `after` records `CIFixNoOpRecorded` when HEAD is unchanged.
- [ ] Rewrite `dispatchReviewReinvoke` (`engine/reviews.go`) as a thin wrapper: `precheck` returns `len(buildReviewThreadComments(item)) > 0`; `build` returns `buildReviewThreadComments(item)`; no `stageVariant`/`after`.
- [ ] Rewrite `dispatchRebaseReinvoke` (`engine/merge_gate.go`) as a thin wrapper: `build` resolves `baseBranch` via `worktreesFor`/`baseBranchForItem` and calls `buildRebaseComment`; `stageVariant` swaps in `RebaseSkill`; `after` re-enables auto-merge (including the merge-queue exclusion and `CLEAN`-status direct-merge fallback) when `err == nil`.
- [ ] Run `go test ./engine/... -run 'Reinvoke|CatchUpLoop|CIAndReviewGate'` to confirm the reinvoke-path tests in `catch_up_handlers_test.go`, `review_phase_test.go`, and `poll_test.go` still pass unmodified.
- [ ] Add `dispatchWithCycleLimit(pctx *phase1Ctx, tag string, cycles func(itemstate.Snapshot) int, maxCycles int, shortCircuit func(itemstate.Snapshot) bool, incrementAndDispatch func(), pause func(cycleCount int)) bool` to `engine/catch_up_handlers.go`.
- [ ] Route `handleReviewGate`'s cycle-limit block through it (`shortCircuit: nil`).
- [ ] Route `handleMergeAndCIGates`'s rebase cycle-limit block through it (`shortCircuit: nil`).
- [ ] Route `handleMergeAndCIGates`'s CI-fix cycle-limit block through it, with `shortCircuit` implementing the `LastCIFixNoOpSHA` == `settle.PR.HeadSHA` check.
- [ ] Run `go test ./engine/... -run CatchUpHandlers|HandleReviewGate|HandleRebaseReinvoke|HandleCIFixReinvoke` to confirm all existing in-flight/cycle-limit/happy-path/no-op-debounce tests in `catch_up_handlers_test.go` still pass unmodified.
- [ ] Create `engine/poll_settle.go` with `settleNoWorkNeededScan(board, candidates)`, `settleRevalidateScan(candidates)`, `settleSHAInvalidationScan(candidates)`, and `settleChildPlacements(board)`, moving each loop body verbatim out of `poll()`.
- [ ] Update `engine/poll.go` to call the four new named methods in place of the inline loops (no change to `settleMergeTrainMemberCloses`/`settleClosedItemsToDone` call sites).
- [ ] Run `go build -o fabrik .`, `go vet ./...`, and `go test -race ./...` for the full suite.

### Risks

- The `escalateSettle`/`postComment`-hook design must not let child-placement's `notifyParentOfStalledChild` or `CreatedAt`-omission bleed into the other two escalate paths (or vice versa) — mitigated by keeping those two extra steps entirely inside child-placement's own closure, never inside `escalateSettle` itself.
- The CI-fix no-op-SHA `shortCircuit` must remain nil for review/rebase — verified by the existing `TestHandleCIFixReinvoke_NoOpDebounce_SkipsDispatch` test (CI-specific) continuing to pass while `TestHandleReviewGate_CycleLimit_Pauses`/`TestHandleRebaseReinvoke_CycleLimit_Pauses` show no new short-circuit behavior.
- `dispatchReinvoke`'s `build` closures capturing outer variables (e.g. CI's `headBefore`) is a slightly more implicit data flow than the original inline code — mitigated by keeping each thin wrapper short (under ~20 lines) so the capture is locally obvious.
- Concurrency-sensitive code (goroutine scaffolding, semaphore, `itemstate.Store` mutations) — `go test -race ./...` is mandatory before considering any task done, not just at the end.

---
Used 19/100 turns, 0k input / 21k output tokens.

## Verification

Verified and completed the prior session's work: all settle-trio, reinvoke-scaffold, and cycle-limit-dispatch extractions are in place and route correctly through shared helpers with divergences preserved as explicit parameters. Fixed three stale doc comments left over from the refactor. Confirmed the one failing `cmd` test is a pre-existing, environment-specific flake unrelated to this change (verified against the pre-Implement baseline). Build, vet, and the full engine test suite (race-enabled) pass.

---

Closes #1027