### PR TITLE
refactor: extract github client & boardcache request boilerplate

### DIFF
--- a/adrs/066-consolidated-github-request-helpers.md
+++ b/adrs/066-consolidated-github-request-helpers.md
@@ -1,0 +1,90 @@
+# ADR 066: Consolidated GitHub-Client Request Helpers (REST core, paginator, boardcache mutation/heal)
+
+## Status
+
+Accepted
+
+## Context
+
+The `github` client and the `boardcache` layer accumulated copy-pasted request/response scaffolding — lower-risk than the engine-side mutation duplication fixed in [ADR-065](065-consolidated-mutation-helpers.md), but it inflated two of the largest files in the codebase (`github/project.go`, `boardcache/delta.go`) and meant cross-cutting changes (auth headers, retry policy, negative-cache protocol) required edits in many places:
+
+- Four `github/prs.go` mutations (`MarkPRReady`, `EnablePullRequestAutoMerge`, `EnqueuePullRequest`, `DequeuePullRequest`) each opened with a byte-for-byte identical ~28-line "fetch PR node id via GraphQL" block.
+- The six `github/rest.go` REST helpers each repeated `NewRequest` → set headers → `Do` → `defer Close` → `updateRestStats` → status-code handling, with an *asymmetric* sentinel mapping: only some helpers mapped 405/422, only some mapped 404, none did both consistently.
+- `fetchProjectBoardOnce`, `probeProjectBoardOnce`, and `FetchProjectItemStatusBatch` each hand-rolled the cursor-pagination loop; `fetchProjectBoard` and `probeProjectBoard` each hand-rolled an identical 3-attempt retry-on-empty wrapper around their `*Once` sibling.
+- The comment-selection GraphQL fragment was hand-written 5 times across `project.go`; `*MergeQueueEntry` construction was duplicated at 2 sites.
+- Six `boardcache.CacheImpl` mutators shared an identical `parseItemKey` → invalid-key log → phantom-guard → `store.Apply` → change-check → bump-sequence preamble.
+- Four `boardcache/delta.go` auto-heal handlers each repeated a ~20-line negative-cache-miss → `resolvePRLinkage` → `store.Get`-outside-`c.mu` confirmation → heal-log sequence.
+
+This is the same "helper doesn't exist yet, so every call site reinvents it slightly differently" problem ADR-065 addressed for the engine's GitHub-mutation idiom, applied here to the client and cache layers.
+
+## Decision
+
+Introduce six focused helpers, one per duplication point, and route the existing call sites through them mechanically — no change to request semantics, retry counts, or on-wire behavior beyond the two additive exceptions called out below.
+
+### `c.prNodeID` (github/prs.go)
+
+A single `c.prNodeID(owner, repo string, prNumber int) (string, error)` replaces the four copy-pasted "fetch PR node id" blocks. All four mutations (`MarkPRReady`, `EnablePullRequestAutoMerge`, `EnqueuePullRequest`, `DequeuePullRequest`) call it before their one-line mutation.
+
+### `c.do()` REST core (github/rest.go) — uniform sentinel mapping
+
+`c.do(method, url string, body interface{}) (*http.Response, []byte, error)` is the single place that sets headers, executes the request, records rate-limit stats, and maps status codes to sentinels (404 → `ErrNotFound`, 405 → `ErrMethodNotAllowed`, 422 → `ErrUnprocessableEntity`). All six typed REST helpers (`restRequest`, `restGetJSON`, `restGet`, `restPostWithResponse`, `restPutWithResponse`, `restDelete`) become thin decode wrappers around it.
+
+This **uniformly applies the full sentinel mapping to all six helpers**, including the four that previously mapped none or only some of the three codes. This is the one deliberate, additive-only behavior change in this ADR: no existing caller relied on *not* getting a sentinel-wrapped error (verified — no `errors.Is` call anywhere assumed a generic error from one of the previously-unmapped paths), so no `errors.Is` check anywhere changes behavior, and no on-wire request changes. It is the literal reading of the parent issue's acceptance criterion that "the 405/422/404 sentinel mapping lives in exactly one place."
+
+`graphqlRequest` (`github/client.go`) is **not** routed through `do()`. It diverges structurally enough that forcing it through the same primitive would cost more than it saves: it always POSTs to `/graphql` only, never sets an `Accept` header (adding one would be a real on-wire change, out of scope), treats `!= 200` as its success boundary rather than `>= 400`, and must additionally unmarshal the body a second time looking for a GraphQL-level `errors[]` array even on HTTP 200 — something no REST helper needs. `graphqlRequest` already shares `updateRestStats`/`parseRateLimitHeaders`/`authErrorHint` with the REST path; the one piece left that it can't safely absorb is exactly the piece that differs.
+
+`do()` sets `Content-Type` only when `body != nil`, exactly reproducing each wrapper's pre-existing header behavior, and each wrapper keeps its own pre-existing decode-error-wrapping asymmetry (`restGetJSON` stays unwrapped; the others stay wrapped) rather than standardizing it — that asymmetry wasn't in scope.
+
+### `paginateGraphQL[T]` / `retryOnEmpty[T]` (github/project.go) — split, not one generic paginator
+
+Rather than one fully-generic paginator that understands every response envelope, this is **two separable generics**:
+
+- `paginateGraphQL[T any](opLabel string, fetchPage func(cursor string) (nodes []T, hasNextPage bool, endCursor string, totalCount int, err error)) ([]T, int, error)` — loop-only. It accumulates nodes, tracks the largest `totalCount` observed, and verifies the `hasNextPage`/`endCursor` invariant. It has no knowledge of GraphQL response envelopes; each call site (`fetchProjectBoardOnce`, `probeProjectBoardOnce`, `FetchProjectItemStatusBatch`) keeps its own query text, response struct, and per-node post-processing, and passes a closure that unwraps *its own* envelope into the four generic return values.
+- `retryOnEmpty[T any](opLabel string, fetch func(attempt int) (result T, rawCount, totalCount int, err error)) (T, error)` — the pre-existing 3-attempt linear-backoff wrapper, now shared by `fetchProjectBoard` and `probeProjectBoard` instead of hand-rolled twice. `probeProjectBoard` returns two values where `retryOnEmpty` expects one `T`; a local `probeBoardResult{Items []BoardProbeItem; ProjectID string}` closes that gap without widening the generic's contract.
+
+The split exists because `fetchProjectBoardOnce`, `probeProjectBoardOnce`, and `FetchProjectItemStatusBatch` build materially different GraphQL queries and populate materially different response structs (full item fields with labels vs. minimal probe fields vs. a bare `node(id:)` lookup with no `totalCount` at all). Forcing all three into one struct-aware paginator would have required an artificial common envelope wide enough to be harder to read than the status quo — the Research/Plan stages for this issue flagged this as the highest-effort, highest-risk item, and the loop-only/envelope-separate split is what kept it from needing a child issue. `FetchProjectItemStatusBatch` gets `paginateGraphQL` but not `retryOnEmpty` — it never had a retry wrapper before, and adding one is a bigger behavior change than a mechanical routing pass should make silently.
+
+### `commentSelectionFragment` + `toMergeQueueEntry` (github/project.go)
+
+`commentSelectionFragment` is a single-line `const` GraphQL field-selection string, concatenated into the 5 query sites that previously hand-wrote it (GraphQL is whitespace-insensitive, so this is not an on-wire change). `mergeQueueEntryData` promotes the two previously-inline anonymous `MergeQueueEntry` struct types to one named type, and `toMergeQueueEntry(*mergeQueueEntryData) *MergeQueueEntry` replaces the 2 duplicated construction sites. `FetchItemDetails` itself is not restructured — only its inline query/struct fragments are routed through the new helpers, per the parent issue's explicit scope boundary (the function's own decomposition is a separate, later issue).
+
+### `c.applyKeyedMutation` (boardcache/boardcache.go) — 5-of-6 scope, not 6-of-6
+
+```go
+func (c *CacheImpl) applyKeyedMutation(key, opName string, build func(repo string, number int) itemstate.Mutation)
+```
+
+`UpdateItemStatus`, `ApplyLabelAdded`, `ApplyLabelRemoved`, `ApplyIssueClosed`, and `ApplyCommentAdded` collapse to one-line calls through this helper. `ApplyStatusBatch` is **deliberately excluded**: it resolves its cache key from the mutation's own returned snapshot, once per map entry, rather than from an input key — it never had the `parseItemKey` → phantom-guard shape the other five share, so forcing it through `applyKeyedMutation` would mean inventing a fake key argument to fit a helper contract it doesn't need. The parent issue's prose lumps "the six mutators" together loosely; this ADR's scoping call follows the actual code shape, not the issue's rounding.
+
+As part of this change, the invalid-key log wording is standardized to `"invalid"` across all 5 routed methods (previously only `UpdateItemStatus` said `"not found"`; the other four already said `"invalid"`). This is a small, sanctioned wording normalization — no test asserted on the old string, and it follows the same "call out the one deliberate tweak explicitly" pattern ADR-065 established for its `removeLabel` ErrNotFound change.
+
+### `c.resolveOrHealPRLinkage` (boardcache/delta.go) — scope boundary against the AST lock-invariant test
+
+```go
+func (c *CacheImpl) resolveOrHealPRLinkage(owner, repoName, repo string, prNum int, missCacheKey, notFoundMsg string) (key string, issNum int, healed, ok bool)
+```
+
+`applyPullRequestDelta`, `applyPullRequestReviewDelta`, `applyPullRequestReviewCommentDelta`, and `applyCheckRunDelta` each repeated: call `resolvePRLinkage` → on not-found, record a negative-cache miss and log a drop message → on found, confirm the resolved issue still exists in the Store via `store.Get` performed **outside** `c.mu` (a pre-existing fix from a prior code-health pass, preserved here) → on confirm-failure, record another negative-cache miss. `resolveOrHealPRLinkage` extracts exactly this block. Each handler still owns 100% of its own post-resolution `store.Apply` calls and `healed`-branch logging — those differ per handler and stay inline.
+
+Two scope boundaries were deliberate, not oversights:
+
+1. **The PR-scoped negative-cache pre-check stays inline in each caller**, rather than folding into the shared helper. `applyPullRequestDelta`, `applyPullRequestReviewDelta`, and `applyPullRequestReviewCommentDelta` all have one (checking `recentMissCache[missKey(repo, prNum)]` before ever calling `resolvePRLinkage`); `applyCheckRunDelta` does not, because it already performs its own SHA-keyed negative-cache check earlier, before its `FetchPRsForSHA` call. Folding the PR-scoped pre-check into `resolveOrHealPRLinkage` would silently add a check-run code path that doesn't exist today.
+2. **The extraction moves a `c.mu`-adjacent sequence out of the four named functions that `boardcache/delta_lock_invariant_test.go`'s `TestDeltaHealPaths_DoNotCallStoreWhileLocked` statically walks.** That test parses `delta.go` and inspects only the literal AST bodies of the four handlers for `c.store.*` calls made while `c.mu` is (locally) tracked as held — it does not recurse into helpers those bodies call. Left unaddressed, extracting the `store.Get`-outside-`c.mu` sequence into `resolveOrHealPRLinkage` would silently stop the test from observing it: not a false pass, but a coverage gap in a test whose entire purpose is guarding this exact invariant. The fix is one line — `resolveOrHealPRLinkage` is added to the test's `funcNames` slice, so the AST walk now also covers the extracted helper directly. This keeps the invariant meaningfully enforced against the code that actually performs the lock-sensitive sequence now, rather than against code that used to but no longer does.
+
+## Consequences
+
+**Benefits:**
+- The 404/405/422 sentinel mapping now lives in exactly one place (`do()`), closing the pre-existing asymmetry where different REST helpers mapped different subsets of status codes.
+- `prNodeID`, `applyKeyedMutation`, and `resolveOrHealPRLinkage` mean new call sites default to the correct request/mutation/heal idiom by construction rather than by copy-pasting an existing site and hoping nothing was missed.
+- The paginator split keeps the largest single extraction in this issue reviewable as "did the loop body move without changing" rather than "did three materially different functions get redesigned into one."
+- Every commit in the implementation sequence left `go build`, `go vet`, and `go test -race` green — no "helper added but nothing routed" intermediate state.
+
+**Drawbacks / risks:**
+- `do()`'s uniform sentinel mapping, while additive-only today, means any future REST helper added to `github/rest.go` inherits sentinel mapping automatically — a future author who wants to *not* get a sentinel-wrapped error for some new endpoint needs to know to bypass `do()` deliberately, not just add a new thin wrapper.
+- `applyKeyedMutation`'s 5-of-6 scope and `resolveOrHealPRLinkage`'s pre-check/lock-sequence boundary are both judgment calls a future contributor could get wrong by assuming the helper covers more than it does. This ADR, plus each helper's doc comment, is the reference for exactly where the boundary sits and why.
+- `paginateGraphQL`/`retryOnEmpty` being two generics instead of one means a future fourth pagination call site must decide which one (or both) it needs, rather than reaching for a single paginator — a small extra decision, traded for not forcing three already-divergent envelopes into one artificial shape.
+
+## Related ADRs
+
+- [ADR-034: Boardcache Event-Sourced Delta Architecture](034-boardcache-event-sourced-delta.md) — defines the delta-function architecture `resolveOrHealPRLinkage` operates within (auto-heal via REST/regex fallback when the authoritative `prToKey` index misses); this ADR is a pure internal refactor of that already-decided architecture, not a change to it.
+- [ADR-065: Consolidated GitHub-Mutation Helpers (label/comment/pause)](065-consolidated-mutation-helpers.md) — the immediately-preceding code-health issue in the same audit, establishing the house style this ADR follows: layered private-core/public-wrapper helpers, an explicit "byte-for-byte identical behavior" mandate for the mechanical routing pass, and calling out each deliberate behavior tweak by name rather than letting it hide in a diff.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -28,3 +28,4 @@ contributors and future maintainers.
 | [039](039-cycleset-excludes-worker-lifecycle.md) | cycleSetFlags excludes WorkerLifecycleChanged | Accepted |
 | [056](056-consolidate-convergence-gate-recovery.md) | Consolidate the convergence / gate / recovery architecture | Accepted |
 | [065](065-consolidated-mutation-helpers.md) | Consolidated GitHub-mutation helpers (label/comment/pause) | Accepted |
+| [066](066-consolidated-github-request-helpers.md) | Consolidated GitHub-client request helpers (REST core, paginator, boardcache mutation/heal) | Accepted |

--- a/boardcache/boardcache.go
+++ b/boardcache/boardcache.go
@@ -863,98 +863,61 @@ func (c *CacheImpl) RateLimitStats() (rest, graphql gh.RateLimitStats) {
 	return c.fallback.RateLimitStats()
 }
 
-// UpdateItemStatus updates the Status field for the item identified by key.
-// No-op when the key is not in the cache. Safe for concurrent use.
-func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
+// applyKeyedMutation is the shared preamble for the five key-addressed
+// mutators below: parse key → log and no-op on invalid key → guard against
+// creating a phantom Store entry for a key that was never bootstrapped →
+// apply the mutation built by build(repo, number) → bump the local delta
+// timestamp only if the mutation actually changed anything. opName is used
+// only in the invalid-key log line.
+func (c *CacheImpl) applyKeyedMutation(key, opName string, build func(repo string, number int) itemstate.Mutation) {
 	repo, number, ok := parseItemKey(key)
 	if !ok {
-		c.logFn("[cache] UpdateItemStatus: key %q not found — no-op\n", key)
+		c.logFn("[cache] %s: key %q invalid — no-op\n", opName, key)
 		return
 	}
 	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
 	if _, err := c.store.Get(repo, number); err != nil {
 		return
 	}
-	_, changes, _ := c.store.Apply(itemstate.LocalStatusUpdated{
-		Repo:      repo,
-		Number:    number,
-		NewStatus: newStatus,
-	})
+	_, changes, _ := c.store.Apply(build(repo, number))
 	if len(changes) == 0 {
-		// Status unchanged.
 		return
 	}
 	c.bumpLocalDeltaAt(key)
+}
+
+// UpdateItemStatus updates the Status field for the item identified by key.
+// No-op when the key is not in the cache. Safe for concurrent use.
+func (c *CacheImpl) UpdateItemStatus(key, newStatus string) {
+	c.applyKeyedMutation(key, "UpdateItemStatus", func(repo string, number int) itemstate.Mutation {
+		return itemstate.LocalStatusUpdated{Repo: repo, Number: number, NewStatus: newStatus}
+	})
 }
 
 // ApplyLabelAdded updates the cached label list for the item identified by key,
 // appending label if not already present. No-op when the key is not in the cache.
 // Safe for concurrent use.
 func (c *CacheImpl) ApplyLabelAdded(key, label string) {
-	repo, number, ok := parseItemKey(key)
-	if !ok {
-		c.logFn("[cache] ApplyLabelAdded: key %q invalid — no-op\n", key)
-		return
-	}
-	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
-	if _, err := c.store.Get(repo, number); err != nil {
-		return
-	}
-	_, changes, _ := c.store.Apply(itemstate.LocalLabelAdded{
-		Repo:   repo,
-		Number: number,
-		Label:  label,
+	c.applyKeyedMutation(key, "ApplyLabelAdded", func(repo string, number int) itemstate.Mutation {
+		return itemstate.LocalLabelAdded{Repo: repo, Number: number, Label: label}
 	})
-	if len(changes) == 0 {
-		return
-	}
-	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyLabelRemoved updates the cached label list for the item identified by key,
 // removing label if present. No-op when the key is not in the cache or label is absent.
 // Safe for concurrent use.
 func (c *CacheImpl) ApplyLabelRemoved(key, label string) {
-	repo, number, ok := parseItemKey(key)
-	if !ok {
-		c.logFn("[cache] ApplyLabelRemoved: key %q invalid — no-op\n", key)
-		return
-	}
-	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
-	if _, err := c.store.Get(repo, number); err != nil {
-		return
-	}
-	_, changes, _ := c.store.Apply(itemstate.LocalLabelRemoved{
-		Repo:   repo,
-		Number: number,
-		Label:  label,
+	c.applyKeyedMutation(key, "ApplyLabelRemoved", func(repo string, number int) itemstate.Mutation {
+		return itemstate.LocalLabelRemoved{Repo: repo, Number: number, Label: label}
 	})
-	if len(changes) == 0 {
-		return
-	}
-	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyIssueClosed marks the item identified by key as closed in the store.
 // No-op when the key is not in the cache. Safe for concurrent use.
 func (c *CacheImpl) ApplyIssueClosed(key string) {
-	repo, number, ok := parseItemKey(key)
-	if !ok {
-		c.logFn("[cache] ApplyIssueClosed: key %q invalid — no-op\n", key)
-		return
-	}
-	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
-	if _, err := c.store.Get(repo, number); err != nil {
-		return
-	}
-	_, changes, _ := c.store.Apply(itemstate.IssueClosed{
-		Repo:   repo,
-		Number: number,
+	c.applyKeyedMutation(key, "ApplyIssueClosed", func(repo string, number int) itemstate.Mutation {
+		return itemstate.IssueClosed{Repo: repo, Number: number}
 	})
-	if len(changes) == 0 {
-		return
-	}
-	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyCommentAdded appends comment to the cached comment list for the item
@@ -965,24 +928,9 @@ func (c *CacheImpl) ApplyIssueClosed(key string) {
 // If a webhook echo for the same comment arrives before the next Reconcile,
 // the repeated LocalCommentAdded is a no-op rather than a duplicate append.
 func (c *CacheImpl) ApplyCommentAdded(key string, comment gh.Comment) {
-	repo, number, ok := parseItemKey(key)
-	if !ok {
-		c.logFn("[cache] ApplyCommentAdded: key %q invalid — no-op\n", key)
-		return
-	}
-	// Guard: do not create a phantom Store entry for a key that was never bootstrapped.
-	if _, err := c.store.Get(repo, number); err != nil {
-		return
-	}
-	_, changes, _ := c.store.Apply(itemstate.LocalCommentAdded{
-		Repo:    repo,
-		Number:  number,
-		Comment: comment,
+	c.applyKeyedMutation(key, "ApplyCommentAdded", func(repo string, number int) itemstate.Mutation {
+		return itemstate.LocalCommentAdded{Repo: repo, Number: number, Comment: comment}
 	})
-	if len(changes) == 0 {
-		return
-	}
-	c.bumpLocalDeltaAt(key)
 }
 
 // ApplyStatusBatch updates Status for items identified by project-item node IDs.

--- a/boardcache/boardcache_test.go
+++ b/boardcache/boardcache_test.go
@@ -3,6 +3,7 @@ package boardcache
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -1490,7 +1491,7 @@ func TestAutoHealCheckRunCompleted(t *testing.T) {
 
 func TestAutoHealDropsWhenNoPRClosingKeyword(t *testing.T) {
 	var logBuf strings.Builder
-	logFn := func(format string, args ...any) { logBuf.WriteString(format) }
+	logFn := func(format string, args ...any) { fmt.Fprintf(&logBuf, format, args...) }
 
 	mc := &mockClient{
 		fetchPRClosingIssuesFn: func(owner, repo string, prNumber int) ([]int, error) {

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -271,13 +271,12 @@ func (c *CacheImpl) resolveOrHealPRLinkage(owner, repoName, repo string, prNum i
 	// Confirm item still in Store before proceeding. Must not hold c.mu while
 	// calling any Store method (boardcache.go struct-doc invariant).
 	_, storeErr := c.store.Get(repo, issNum)
-	c.mu.Lock()
 	if storeErr != nil {
+		c.mu.Lock()
 		c.recentMissCache[missCacheKey] = time.Now()
 		c.mu.Unlock()
 		return "", 0, false, false
 	}
-	c.mu.Unlock()
 	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 	return key, issNum, healed, true
 }

--- a/boardcache/delta.go
+++ b/boardcache/delta.go
@@ -239,6 +239,49 @@ func (c *CacheImpl) ensureIssueInStore(owner, fullRepo string, issNum int) error
 	return nil
 }
 
+// resolveOrHealPRLinkage resolves the closing issue for PR #prNum in
+// owner/repoName, auto-healing via c.resolvePRLinkage when the PR isn't yet
+// in the Store's prToKey index. On failure to resolve, records a negative-
+// cache miss at missCacheKey (skipped when resolvePRLinkage itself errored,
+// so a transient REST failure is retried on the next webhook rather than
+// suppressed for recentMissTTL) and logs notFoundMsg. On success, it
+// additionally confirms the resolved issue still exists in the Store —
+// store.Get is called deliberately outside c.mu, preserving the
+// boardcache.go struct-doc invariant that Store methods must never be called
+// while c.mu is held (a Store observer callback into CacheImpl would
+// deadlock otherwise). Returns ok=false if resolution or confirmation
+// failed; callers must not proceed with any store.Apply in that case.
+//
+// The PR-scoped negative-cache pre-check (checking recentMissCache[missCacheKey]
+// before calling this) stays inline in each caller that has one —
+// applyCheckRunDelta doesn't, since it already performs its own SHA-keyed
+// negative-cache check earlier (before FetchPRsForSHA), so folding a PR-keyed
+// pre-check in here would add a code path that doesn't exist for that handler.
+func (c *CacheImpl) resolveOrHealPRLinkage(owner, repoName, repo string, prNum int, missCacheKey, notFoundMsg string) (key string, issNum int, healed, ok bool) {
+	key, issNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
+	if !found {
+		c.mu.Lock()
+		if healErr == nil {
+			c.recentMissCache[missCacheKey] = time.Now()
+		}
+		c.mu.Unlock()
+		c.logFn("[cache] %s\n", notFoundMsg)
+		return "", 0, false, false
+	}
+	// Confirm item still in Store before proceeding. Must not hold c.mu while
+	// calling any Store method (boardcache.go struct-doc invariant).
+	_, storeErr := c.store.Get(repo, issNum)
+	c.mu.Lock()
+	if storeErr != nil {
+		c.recentMissCache[missCacheKey] = time.Now()
+		c.mu.Unlock()
+		return "", 0, false, false
+	}
+	c.mu.Unlock()
+	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
+	return key, issNum, healed, true
+}
+
 // ---------------------------------------------------------------------------
 // Delta functions
 // ---------------------------------------------------------------------------
@@ -610,28 +653,11 @@ func (c *CacheImpl) applyPullRequestDelta(payload []byte) {
 	c.mu.RUnlock()
 
 	// Auto-heal: resolve PR linkage via REST or authoritative index.
-	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
-
-	if !found {
-		c.mu.Lock()
-		if healErr == nil {
-			c.recentMissCache[mk] = time.Now()
-		}
-		c.mu.Unlock()
-		c.logFn("[cache] dropped pull_request delta for PR #%d: no closing issue in cache\n", prNum)
+	key, resolvedIssNum, healed, ok := c.resolveOrHealPRLinkage(owner, repoName, repo, prNum, mk,
+		fmt.Sprintf("dropped pull_request delta for PR #%d: no closing issue in cache", prNum))
+	if !ok {
 		return
 	}
-	// Confirm item still in Store before proceeding. Must not hold c.mu while
-	// calling any Store method (boardcache.go struct-doc invariant).
-	_, storeErr := c.store.Get(repo, resolvedIssNum)
-	c.mu.Lock()
-	if storeErr != nil {
-		c.recentMissCache[mk] = time.Now()
-		c.mu.Unlock()
-		return
-	}
-	c.mu.Unlock()
-	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	c.store.Apply(itemstate.PRDetailsUpdated{
 		Repo:     repo,
@@ -717,28 +743,11 @@ func (c *CacheImpl) applyPullRequestReviewDelta(payload []byte) {
 	c.mu.RUnlock()
 
 	// Auto-heal: resolve PR linkage via REST or authoritative index.
-	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
-
-	if !found {
-		c.mu.Lock()
-		if healErr == nil {
-			c.recentMissCache[mk] = time.Now()
-		}
-		c.mu.Unlock()
-		c.logFn("[cache] dropped pull_request_review delta for PR #%d: no closing issue in cache\n", prNum)
+	key, resolvedIssNum, healed, ok := c.resolveOrHealPRLinkage(owner, repoName, repo, prNum, mk,
+		fmt.Sprintf("dropped pull_request_review delta for PR #%d: no closing issue in cache", prNum))
+	if !ok {
 		return
 	}
-	// Confirm item still in Store before proceeding. Must not hold c.mu while
-	// calling any Store method (boardcache.go struct-doc invariant).
-	_, storeErr := c.store.Get(repo, resolvedIssNum)
-	c.mu.Lock()
-	if storeErr != nil {
-		c.recentMissCache[mk] = time.Now()
-		c.mu.Unlock()
-		return
-	}
-	c.mu.Unlock()
-	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
@@ -835,28 +844,11 @@ func (c *CacheImpl) applyPullRequestReviewCommentDelta(payload []byte) {
 	c.mu.RUnlock()
 
 	// Auto-heal: resolve PR linkage via REST or authoritative index.
-	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
-
-	if !found {
-		c.mu.Lock()
-		if healErr == nil {
-			c.recentMissCache[mk] = time.Now()
-		}
-		c.mu.Unlock()
-		c.logFn("[cache] dropped pull_request_review_comment delta for PR #%d: no closing issue in cache\n", prNum)
+	key, resolvedIssNum, healed, ok := c.resolveOrHealPRLinkage(owner, repoName, repo, prNum, mk,
+		fmt.Sprintf("dropped pull_request_review_comment delta for PR #%d: no closing issue in cache", prNum))
+	if !ok {
 		return
 	}
-	// Confirm item still in Store before proceeding. Must not hold c.mu while
-	// calling any Store method (boardcache.go struct-doc invariant).
-	_, storeErr := c.store.Get(repo, resolvedIssNum)
-	c.mu.Lock()
-	if storeErr != nil {
-		c.recentMissCache[mk] = time.Now()
-		c.mu.Unlock()
-		return
-	}
-	c.mu.Unlock()
-	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	c.store.Apply(itemstate.PRHeadSHAUpdated{
 		Repo:        repo,
@@ -955,28 +947,11 @@ func (c *CacheImpl) applyCheckRunDelta(payload []byte) {
 	prNum := prNums[0]
 
 	// Auto-heal step 2: resolve which issue the PR closes.
-	key, resolvedIssNum, found, healed, healErr := c.resolvePRLinkage(owner, repoName, prNum)
-
-	if !found {
-		c.mu.Lock()
-		if healErr == nil {
-			c.recentMissCache[msha] = time.Now()
-		}
-		c.mu.Unlock()
-		c.logFn("[cache] dropped check_run delta for SHA %s: no closing issue in cache for PR #%d\n", sha, prNum)
+	key, resolvedIssNum, healed, ok := c.resolveOrHealPRLinkage(owner, repoName, repo, prNum, msha,
+		fmt.Sprintf("dropped check_run delta for SHA %s: no closing issue in cache for PR #%d", sha, prNum))
+	if !ok {
 		return
 	}
-	// Confirm item still in Store before proceeding. Must not hold c.mu while
-	// calling any Store method (boardcache.go struct-doc invariant).
-	_, storeErr := c.store.Get(repo, resolvedIssNum)
-	c.mu.Lock()
-	if storeErr != nil {
-		c.recentMissCache[msha] = time.Now()
-		c.mu.Unlock()
-		return
-	}
-	c.mu.Unlock()
-	// prToKey is populated by PRHeadSHAUpdated via updateIndexes — no explicit write needed.
 
 	// Update Store: set LinkedPRNum + SHA (updates shaToKey index). PRHeadSHAUpdated
 	// drains any pendingCheckRuns[sha] into the item's LinkedPR.CheckRuns automatically

--- a/boardcache/delta_lock_invariant_test.go
+++ b/boardcache/delta_lock_invariant_test.go
@@ -30,6 +30,7 @@ func TestDeltaHealPaths_DoNotCallStoreWhileLocked(t *testing.T) {
 		"applyPullRequestReviewDelta",
 		"applyPullRequestReviewCommentDelta",
 		"applyCheckRunDelta",
+		"resolveOrHealPRLinkage",
 	}
 
 	for _, name := range funcNames {

--- a/github/comments.go
+++ b/github/comments.go
@@ -12,7 +12,7 @@ func (c *Client) AddComment(owner, repo string, issueNumber int, body string) (i
 		ID int `json:"id"`
 	}
 	if err := c.restPostWithResponse(apiURL, payload, &resp); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("adding comment to %s/%s#%d: %w", owner, repo, issueNumber, err)
 	}
 	if resp.ID <= 0 {
 		return 0, fmt.Errorf("github: add comment response missing valid id")
@@ -29,7 +29,10 @@ func (c *Client) AddCommentReaction(owner, repo string, commentDatabaseID int, c
 	payload := map[string]interface{}{
 		"content": content,
 	}
-	return c.restPost(apiURL, payload)
+	if err := c.restPost(apiURL, payload); err != nil {
+		return fmt.Errorf("adding %q reaction to comment %d on %s/%s: %w", content, commentDatabaseID, owner, repo, err)
+	}
+	return nil
 }
 
 // AddPRReviewCommentReaction adds a reaction to a PR review thread (inline)
@@ -40,7 +43,10 @@ func (c *Client) AddPRReviewCommentReaction(owner, repo string, commentDatabaseI
 	payload := map[string]interface{}{
 		"content": content,
 	}
-	return c.restPost(apiURL, payload)
+	if err := c.restPost(apiURL, payload); err != nil {
+		return fmt.Errorf("adding %q reaction to PR review comment %d on %s/%s: %w", content, commentDatabaseID, owner, repo, err)
+	}
+	return nil
 }
 
 // ResolveReviewThread marks a PR review thread as resolved ("Resolve
@@ -64,7 +70,10 @@ mutation($threadId: ID!) {
 			} `json:"resolveReviewThread"`
 		} `json:"data"`
 	}
-	return c.graphqlRequest(query, vars, &result)
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return fmt.Errorf("resolving review thread %s: %w", threadID, err)
+	}
+	return nil
 }
 
 // UpdateComment replaces the body of an existing issue comment.
@@ -73,7 +82,10 @@ func (c *Client) UpdateComment(owner, repo string, commentDatabaseID int, body s
 	payload := map[string]interface{}{
 		"body": body,
 	}
-	return c.restPatch(apiURL, payload)
+	if err := c.restPatch(apiURL, payload); err != nil {
+		return fmt.Errorf("updating comment %d on %s/%s: %w", commentDatabaseID, owner, repo, err)
+	}
+	return nil
 }
 
 // UpdateIssueBody updates the body of an issue.
@@ -82,7 +94,10 @@ func (c *Client) UpdateIssueBody(owner, repo string, issueNumber int, body strin
 	payload := map[string]interface{}{
 		"body": body,
 	}
-	return c.restPatch(apiURL, payload)
+	if err := c.restPatch(apiURL, payload); err != nil {
+		return fmt.Errorf("updating body of %s/%s#%d: %w", owner, repo, issueNumber, err)
+	}
+	return nil
 }
 
 // GetIssueBody fetches the body of an issue (or PR, since PRs are issues on the REST API).
@@ -92,7 +107,7 @@ func (c *Client) GetIssueBody(owner, repo string, issueNumber int) (string, erro
 		Body string `json:"body"`
 	}
 	if err := c.restGetJSON(apiURL, &result); err != nil {
-		return "", err
+		return "", fmt.Errorf("fetching body of %s/%s#%d: %w", owner, repo, issueNumber, err)
 	}
 	return result.Body, nil
 }

--- a/github/labels.go
+++ b/github/labels.go
@@ -99,7 +99,7 @@ func (c *Client) FetchLabels(owner, repo string, issueNumber int) ([]string, err
 		Name string `json:"name"`
 	}
 	if err := c.restGetJSON(apiURL, &labels); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetching labels for %s/%s#%d: %w", owner, repo, issueNumber, err)
 	}
 	names := make([]string, len(labels))
 	for i, l := range labels {
@@ -113,7 +113,7 @@ func (c *Client) AddLabelToIssue(owner, repo string, issueNumber int, labelName 
 	desc, color := labelDefFor(labelName)
 	// First ensure the label exists with the right description and color.
 	if err := c.ensureLabel(owner, repo, labelName, desc, color); err != nil {
-		return err
+		return fmt.Errorf("ensuring label %q exists on %s/%s: %w", labelName, owner, repo, err)
 	}
 
 	// Use REST API for simplicity — add label to issue
@@ -121,13 +121,19 @@ func (c *Client) AddLabelToIssue(owner, repo string, issueNumber int, labelName 
 	body := map[string]interface{}{
 		"labels": []string{labelName},
 	}
-	return c.restPost(apiURL, body)
+	if err := c.restPost(apiURL, body); err != nil {
+		return fmt.Errorf("adding label %q to %s/%s#%d: %w", labelName, owner, repo, issueNumber, err)
+	}
+	return nil
 }
 
 // RemoveLabelFromIssue removes a label from an issue.
 func (c *Client) RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels/%s", c.baseURL, owner, repo, issueNumber, url.PathEscape(labelName))
-	return c.restDelete(apiURL)
+	if err := c.restDelete(apiURL); err != nil {
+		return fmt.Errorf("removing label %q from %s/%s#%d: %w", labelName, owner, repo, issueNumber, err)
+	}
+	return nil
 }
 
 // FetchLabelAppliedAt returns the time when labelName was last applied to the
@@ -181,7 +187,7 @@ func (c *Client) ensureLabel(owner, repo, name, description, color string) error
 	}
 	// Ignore 422 (label already exists); propagate all other errors.
 	if err := c.restPost(apiURL, body); err != nil && !errors.Is(err, ErrUnprocessableEntity) {
-		return err
+		return fmt.Errorf("creating label %q on %s/%s: %w", name, owner, repo, err)
 	}
 	return nil
 }
@@ -259,11 +265,11 @@ func (c *Client) seedOneLabel(owner, repo string, d labelDef) error {
 				"description": d.description,
 			}
 			if postErr := c.restPost(createURL, body); postErr != nil && !errors.Is(postErr, ErrUnprocessableEntity) {
-				return postErr
+				return fmt.Errorf("creating label %q on %s/%s: %w", d.name, owner, repo, postErr)
 			}
 			return nil
 		}
-		return err
+		return fmt.Errorf("fetching label %q on %s/%s: %w", d.name, owner, repo, err)
 	}
 
 	// Label exists. Enforce color; backfill description only if currently empty.
@@ -280,5 +286,8 @@ func (c *Client) seedOneLabel(owner, repo string, d labelDef) error {
 		patch["color"] = d.color
 	}
 	patchURL := fmt.Sprintf("%s/repos/%s/%s/labels/%s", c.baseURL, owner, repo, url.PathEscape(d.name))
-	return c.restPatch(patchURL, patch)
+	if err := c.restPatch(patchURL, patch); err != nil {
+		return fmt.Errorf("patching label %q on %s/%s: %w", d.name, owner, repo, err)
+	}
+	return nil
 }

--- a/github/paginate_test.go
+++ b/github/paginate_test.go
@@ -1,0 +1,169 @@
+package github
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPaginateGraphQL_SinglePage(t *testing.T) {
+	calls := 0
+	nodes, totalCount, err := paginateGraphQL("test op", func(cursor string) ([]int, bool, string, int, error) {
+		calls++
+		if cursor != "" {
+			t.Errorf("expected empty cursor on first call, got %q", cursor)
+		}
+		return []int{1, 2, 3}, false, "", 3, nil
+	})
+	if err != nil {
+		t.Fatalf("paginateGraphQL: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+	if len(nodes) != 3 {
+		t.Errorf("nodes = %v, want 3 items", nodes)
+	}
+	if totalCount != 3 {
+		t.Errorf("totalCount = %d, want 3", totalCount)
+	}
+}
+
+func TestPaginateGraphQL_MultiPageAccumulatesAndTracksMaxTotalCount(t *testing.T) {
+	pages := [][]int{{1, 2}, {3}}
+	cursors := []string{"", "cursor-1"}
+	call := 0
+	nodes, totalCount, err := paginateGraphQL("test op", func(cursor string) ([]int, bool, string, int, error) {
+		if cursor != cursors[call] {
+			t.Errorf("call %d: cursor = %q, want %q", call, cursor, cursors[call])
+		}
+		page := pages[call]
+		hasNext := call < len(pages)-1
+		endCursor := ""
+		if hasNext {
+			endCursor = "cursor-1"
+		}
+		call++
+		return page, hasNext, endCursor, 3, nil
+	})
+	if err != nil {
+		t.Fatalf("paginateGraphQL: %v", err)
+	}
+	if call != 2 {
+		t.Errorf("expected 2 page fetches, got %d", call)
+	}
+	if len(nodes) != 3 || nodes[0] != 1 || nodes[1] != 2 || nodes[2] != 3 {
+		t.Errorf("nodes = %v, want [1 2 3]", nodes)
+	}
+	if totalCount != 3 {
+		t.Errorf("totalCount = %d, want 3", totalCount)
+	}
+}
+
+func TestPaginateGraphQL_HasNextPageWithEmptyEndCursorErrors(t *testing.T) {
+	_, _, err := paginateGraphQL("fetching widgets", func(cursor string) ([]int, bool, string, int, error) {
+		return []int{1}, true, "", 1, nil
+	})
+	if err == nil {
+		t.Fatal("expected error for hasNextPage=true with empty endCursor")
+	}
+	want := "fetching widgets: hasNextPage=true but endCursor is empty"
+	if err.Error() != want {
+		t.Errorf("err = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestPaginateGraphQL_FetchPageErrorPropagates(t *testing.T) {
+	fetchErr := errors.New("boom")
+	_, _, err := paginateGraphQL("test op", func(cursor string) ([]int, bool, string, int, error) {
+		return nil, false, "", 0, fetchErr
+	})
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("expected wrapped fetchErr, got %v", err)
+	}
+}
+
+func TestRetryOnEmpty_SucceedsFirstAttempt(t *testing.T) {
+	calls := 0
+	result, err := retryOnEmpty("test op", func(attempt int) (string, int, int, error) {
+		calls++
+		return "ok", 5, 5, nil
+	})
+	if err != nil {
+		t.Fatalf("retryOnEmpty: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should not retry a healthy response)", calls)
+	}
+	if result != "ok" {
+		t.Errorf("result = %q, want ok", result)
+	}
+}
+
+func TestRetryOnEmpty_RetriesOnEmptyThenSucceeds(t *testing.T) {
+	calls := 0
+	result, err := retryOnEmpty("test op", func(attempt int) (string, int, int, error) {
+		calls++
+		if attempt < 2 {
+			return "", 0, 0, nil // empty + zero totalCount: inconsistent, retry
+		}
+		return "recovered", 3, 3, nil
+	})
+	if err != nil {
+		t.Fatalf("retryOnEmpty: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+	if result != "recovered" {
+		t.Errorf("result = %q, want recovered", result)
+	}
+}
+
+func TestRetryOnEmpty_ExhaustsAttemptsReturnsLastResult(t *testing.T) {
+	calls := 0
+	result, err := retryOnEmpty("test op", func(attempt int) (string, int, int, error) {
+		calls++
+		return "empty-result", 0, 0, nil
+	})
+	if err != nil {
+		t.Fatalf("retryOnEmpty: %v", err)
+	}
+	if calls != projectBoardFetchAttempts {
+		t.Errorf("calls = %d, want %d", calls, projectBoardFetchAttempts)
+	}
+	if result != "empty-result" {
+		t.Errorf("result = %q, want empty-result", result)
+	}
+}
+
+func TestRetryOnEmpty_ErrorReturnsImmediatelyWithoutRetry(t *testing.T) {
+	calls := 0
+	fetchErr := errors.New("transport failure")
+	_, err := retryOnEmpty("test op", func(attempt int) (string, int, int, error) {
+		calls++
+		return "", 0, 0, fetchErr
+	})
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("expected fetchErr, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (errors must not retry)", calls)
+	}
+}
+
+func TestRetryOnEmpty_NonZeroRawCountAcceptedEvenWithZeroTotalCount(t *testing.T) {
+	calls := 0
+	result, err := retryOnEmpty("test op", func(attempt int) (string, int, int, error) {
+		calls++
+		return "legacy-shape", 2, 0, nil // rawCount > 0 alone is sufficient
+	})
+	if err != nil {
+		t.Fatalf("retryOnEmpty: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+	if result != "legacy-shape" {
+		t.Errorf("result = %q, want legacy-shape", result)
+	}
+}

--- a/github/project.go
+++ b/github/project.go
@@ -127,40 +127,74 @@ func projectBoardFetchBackoff(attempt int) time.Duration {
 	return time.Duration(attempt-1) * time.Second
 }
 
-func (c *Client) fetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*ProjectBoard, error) {
-	var lastBoard *ProjectBoard
+// retryOnEmpty wraps a single-pass fetch with the project-board empty/
+// inconsistent-response retry policy: if fetch reports fewer raw items than
+// the server's totalCount (or zero items and zero totalCount — an indexer
+// hiccup indistinguishable at the API level from a genuinely empty project),
+// retry with linear backoff up to projectBoardFetchAttempts times before
+// accepting the last observed result. Errors from fetch return immediately —
+// retry is for empty/inconsistent successes, not transport failures. opLabel
+// only affects the retry log line's wording.
+func retryOnEmpty[T any](opLabel string, fetch func(attempt int) (result T, rawCount, totalCount int, err error)) (T, error) {
+	var lastResult T
 	for attempt := 1; attempt <= projectBoardFetchAttempts; attempt++ {
 		if d := projectBoardFetchBackoff(attempt); d > 0 {
 			time.Sleep(d)
 		}
-		board, rawNodeCount, totalCount, err := c.fetchProjectBoardOnce(owner, repo, projectNum, ownerType)
+		result, rawCount, totalCount, err := fetch(attempt)
 		if err != nil {
-			// Errors return immediately — retry is for empty/inconsistent
-			// successes, not transport failures (the caller may want to
-			// fall back to a different ownerType on error).
-			return nil, err
+			var zero T
+			return zero, err
 		}
-		lastBoard = board
-		// Healthy response: either we collected at least totalCount nodes (the
-		// indexer-agrees-with-itself case, using >= because totalCount can
-		// shift if items are added/removed between page fetches), or we have
-		// nodes at all (handles older/test responses where totalCount may not
-		// be present — degraded responses always return both rawNodeCount=0
-		// AND totalCount=0 together, so "nodes present" is sufficient).
-		if (totalCount > 0 && rawNodeCount >= totalCount) || rawNodeCount > 0 {
-			return board, nil
+		lastResult = result
+		if (totalCount > 0 && rawCount >= totalCount) || rawCount > 0 {
+			return result, nil
 		}
-		// Inconsistent response: zero raw nodes AND zero totalCount. Could be
-		// a genuinely empty project, or the indexer briefly forgot the project
-		// (observed during GitHub Projects degradation). Worth retrying; if
-		// every attempt agrees, accept it as genuinely empty.
 		if attempt < projectBoardFetchAttempts {
 			logf(0, "warn",
-				"project board fetch returned %d items, totalCount=%d (attempt %d/%d) — retrying in case of indexer hiccup\n",
-				rawNodeCount, totalCount, attempt, projectBoardFetchAttempts)
+				"%s returned %d items, totalCount=%d (attempt %d/%d) — retrying in case of indexer hiccup\n",
+				opLabel, rawCount, totalCount, attempt, projectBoardFetchAttempts)
 		}
 	}
-	return lastBoard, nil
+	return lastResult, nil
+}
+
+// paginateGraphQL accumulates all nodes across a cursor-paginated GraphQL
+// query. fetchPage is called once per page with the current cursor ("" for
+// the first page) and must return that page's nodes plus the pagination
+// envelope (hasNextPage, endCursor) and the totalCount the server reported
+// for this query (0 if the query doesn't report one). Returns the
+// concatenated nodes and the largest totalCount observed across pages.
+// opLabel is used only to build the hasNextPage-with-no-cursor error message.
+func paginateGraphQL[T any](opLabel string, fetchPage func(cursor string) (nodes []T, hasNextPage bool, endCursor string, totalCount int, err error)) ([]T, int, error) {
+	var allNodes []T
+	maxTotalCount := 0
+	cursor := ""
+	for {
+		nodes, hasNextPage, endCursor, totalCount, err := fetchPage(cursor)
+		if err != nil {
+			return nil, 0, err
+		}
+		if totalCount > maxTotalCount {
+			maxTotalCount = totalCount
+		}
+		allNodes = append(allNodes, nodes...)
+
+		if !hasNextPage {
+			break
+		}
+		if endCursor == "" {
+			return nil, 0, fmt.Errorf("%s: hasNextPage=true but endCursor is empty", opLabel)
+		}
+		cursor = endCursor
+	}
+	return allNodes, maxTotalCount, nil
+}
+
+func (c *Client) fetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*ProjectBoard, error) {
+	return retryOnEmpty("project board fetch", func(attempt int) (*ProjectBoard, int, int, error) {
+		return c.fetchProjectBoardOnce(owner, repo, projectNum, ownerType)
+	})
 }
 
 // fetchProjectBoardOnce performs one full pagination pass and returns the
@@ -243,14 +277,8 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 
 	var projectID string
 	var projectTitle string
-	var allNodes []itemNode
-	// maxTotalCount tracks the largest totalCount observed across pages.
-	// Compared to len(allNodes) post-pagination to detect partial fetches.
-	maxTotalCount := 0
 
-	// Paginate over items.
-	cursor := ""
-	for {
+	allNodes, maxTotalCount, err := paginateGraphQL("fetching project board", func(cursor string) ([]itemNode, bool, string, int, error) {
 		vars := map[string]interface{}{
 			"owner":      owner,
 			"projectNum": projectNum,
@@ -277,30 +305,22 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 		}
 
 		if err := c.graphqlRequest(query, vars, &result); err != nil {
-			return nil, 0, 0, fmt.Errorf("fetching project board: %w", err)
+			return nil, false, "", 0, fmt.Errorf("fetching project board: %w", err)
 		}
 
 		ownerData, ok := result.Data[ownerType]
 		if !ok {
-			return nil, 0, 0, fmt.Errorf("fetching project board: no %s data in response", ownerType)
+			return nil, false, "", 0, fmt.Errorf("fetching project board: no %s data in response", ownerType)
 		}
 		proj := ownerData.ProjectV2
 		if projectID == "" {
 			projectID = proj.ID
 			projectTitle = proj.Title
 		}
-		if proj.Items.TotalCount > maxTotalCount {
-			maxTotalCount = proj.Items.TotalCount
-		}
-		allNodes = append(allNodes, proj.Items.Nodes...)
-
-		if !proj.Items.PageInfo.HasNextPage {
-			break
-		}
-		if proj.Items.PageInfo.EndCursor == "" {
-			return nil, 0, 0, fmt.Errorf("fetching project board: hasNextPage=true but endCursor is empty")
-		}
-		cursor = proj.Items.PageInfo.EndCursor
+		return proj.Items.Nodes, proj.Items.PageInfo.HasNextPage, proj.Items.PageInfo.EndCursor, proj.Items.TotalCount, nil
+	})
+	if err != nil {
+		return nil, 0, 0, err
 	}
 
 	board := &ProjectBoard{ProjectID: projectID, Title: projectTitle, OwnerType: ownerType}
@@ -426,29 +446,22 @@ func (c *Client) ProbeProjectBoard(owner, repo string, projectNum int, ownerType
 	return items, projectID, err
 }
 
+// probeBoardResult bundles probeProjectBoardOnce's two success values so
+// retryOnEmpty's single-result-type contract can carry both through retries.
+type probeBoardResult struct {
+	Items     []BoardProbeItem
+	ProjectID string
+}
+
 func (c *Client) probeProjectBoard(owner, repo string, projectNum int, ownerType string) ([]BoardProbeItem, string, error) {
-	var lastItems []BoardProbeItem
-	var lastProjectID string
-	for attempt := 1; attempt <= projectBoardFetchAttempts; attempt++ {
-		if d := projectBoardFetchBackoff(attempt); d > 0 {
-			time.Sleep(d)
-		}
+	result, err := retryOnEmpty("project board probe", func(attempt int) (probeBoardResult, int, int, error) {
 		items, projectID, rawNodeCount, totalCount, err := c.probeProjectBoardOnce(owner, repo, projectNum, ownerType)
-		if err != nil {
-			return nil, "", err
-		}
-		lastItems = items
-		lastProjectID = projectID
-		if (totalCount > 0 && rawNodeCount >= totalCount) || rawNodeCount > 0 {
-			return items, projectID, nil
-		}
-		if attempt < projectBoardFetchAttempts {
-			logf(0, "warn",
-				"project board probe returned %d items, totalCount=%d (attempt %d/%d) — retrying in case of indexer hiccup\n",
-				rawNodeCount, totalCount, attempt, projectBoardFetchAttempts)
-		}
+		return probeBoardResult{Items: items, ProjectID: projectID}, rawNodeCount, totalCount, err
+	})
+	if err != nil {
+		return nil, "", err
 	}
-	return lastItems, lastProjectID, nil
+	return result.Items, result.ProjectID, nil
 }
 
 func (c *Client) probeProjectBoardOnce(owner, repo string, projectNum int, ownerType string) ([]BoardProbeItem, string, int, int, error) {
@@ -512,11 +525,8 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 }`, ownerType)
 
 	var projectID string
-	var allNodes []probeItemNode
-	maxTotalCount := 0
 
-	cursor := ""
-	for {
+	allNodes, maxTotalCount, err := paginateGraphQL("probing project board", func(cursor string) ([]probeItemNode, bool, string, int, error) {
 		vars := map[string]interface{}{
 			"owner":      owner,
 			"projectNum": projectNum,
@@ -542,29 +552,21 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 		}
 
 		if err := c.graphqlRequest(query, vars, &result); err != nil {
-			return nil, "", 0, 0, fmt.Errorf("probing project board: %w", err)
+			return nil, false, "", 0, fmt.Errorf("probing project board: %w", err)
 		}
 
 		ownerData, ok := result.Data[ownerType]
 		if !ok {
-			return nil, "", 0, 0, fmt.Errorf("probing project board: no %s data in response", ownerType)
+			return nil, false, "", 0, fmt.Errorf("probing project board: no %s data in response", ownerType)
 		}
 		proj := ownerData.ProjectV2
 		if projectID == "" {
 			projectID = proj.ID
 		}
-		if proj.Items.TotalCount > maxTotalCount {
-			maxTotalCount = proj.Items.TotalCount
-		}
-		allNodes = append(allNodes, proj.Items.Nodes...)
-
-		if !proj.Items.PageInfo.HasNextPage {
-			break
-		}
-		if proj.Items.PageInfo.EndCursor == "" {
-			return nil, "", 0, 0, fmt.Errorf("probing project board: hasNextPage=true but endCursor is empty")
-		}
-		cursor = proj.Items.PageInfo.EndCursor
+		return proj.Items.Nodes, proj.Items.PageInfo.HasNextPage, proj.Items.PageInfo.EndCursor, proj.Items.TotalCount, nil
+	})
+	if err != nil {
+		return nil, "", 0, 0, err
 	}
 
 	var items []BoardProbeItem
@@ -1342,10 +1344,7 @@ query($id: ID!, $cursor: String) {
 		} `json:"fieldValueByName"`
 	}
 
-	out := make(map[string]string)
-	cursor := ""
-
-	for {
+	nodes, _, err := paginateGraphQL("fetching project item status batch", func(cursor string) ([]statusNode, bool, string, int, error) {
 		vars := map[string]interface{}{"id": projectID}
 		if cursor != "" {
 			vars["cursor"] = cursor
@@ -1366,27 +1365,25 @@ query($id: ID!, $cursor: String) {
 		}
 
 		if err := c.graphqlRequest(query, vars, &result); err != nil {
-			return nil, fmt.Errorf("fetching project item status batch: %w", err)
+			return nil, false, "", 0, fmt.Errorf("fetching project item status batch: %w", err)
 		}
 		if result.Data.Node == nil {
-			return nil, fmt.Errorf("fetching project item status batch: project not found or not a ProjectV2")
+			return nil, false, "", 0, fmt.Errorf("fetching project item status batch: project not found or not a ProjectV2")
 		}
 
-		for _, n := range result.Data.Node.Items.Nodes {
-			if n.FieldValueByName != nil {
-				out[n.ID] = n.FieldValueByName.Name
-			} else {
-				out[n.ID] = ""
-			}
-		}
+		return result.Data.Node.Items.Nodes, result.Data.Node.Items.PageInfo.HasNextPage, result.Data.Node.Items.PageInfo.EndCursor, 0, nil
+	})
+	if err != nil {
+		return nil, err
+	}
 
-		if !result.Data.Node.Items.PageInfo.HasNextPage {
-			break
+	out := make(map[string]string)
+	for _, n := range nodes {
+		if n.FieldValueByName != nil {
+			out[n.ID] = n.FieldValueByName.Name
+		} else {
+			out[n.ID] = ""
 		}
-		if result.Data.Node.Items.PageInfo.EndCursor == "" {
-			return nil, fmt.Errorf("fetching project item status batch: hasNextPage=true but endCursor is empty")
-		}
-		cursor = result.Data.Node.Items.PageInfo.EndCursor
 	}
 
 	return out, nil

--- a/github/project.go
+++ b/github/project.go
@@ -1513,5 +1513,8 @@ mutation($issueId: ID!, $blockingIssueId: ID!) {
 	}
 
 	var result struct{}
-	return c.graphqlRequest(query, vars, &result)
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return fmt.Errorf("adding blocked-by edge %s -> %s: %w", issueNodeID, blockerNodeID, err)
+	}
+	return nil
 }

--- a/github/project.go
+++ b/github/project.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+// commentSelectionFragment is the GraphQL field selection for a plain issue/PR
+// comment, decoded into commentNodeData. It is hand-inlined into every query
+// that fetches a comment list (GraphQL has no query-level fragment reuse
+// across separately-constructed query strings, so this is Go-level dedup).
+// It intentionally does not include the extra location fields (diffHunk,
+// path, line, originalLine) that PR review-thread comments carry — that
+// selection is a strict superset and stays hand-written where it's used.
+const commentSelectionFragment = `id databaseId author { login } body createdAt reactionGroups { content reactors { totalCount } }`
+
 // commentNodeData holds the raw data for a comment returned from the API.
 type commentNodeData struct {
 	ID         string `json:"id"`
@@ -29,6 +38,34 @@ type commentNodeData struct {
 	Path         string `json:"path"`
 	Line         *int   `json:"line"`
 	OriginalLine *int   `json:"originalLine"`
+}
+
+// mergeQueueEntryData holds the raw merge-queue state/position/enqueuer for a
+// linked pull request, shared by the two response shapes (itemNode's shallow
+// LinkedPRs and FetchItemDetails' LinkedPRs) that both decode a
+// mergeQueueEntry field with this exact shape.
+type mergeQueueEntryData struct {
+	State    string `json:"state"`
+	Position int    `json:"position"`
+	Enqueuer *struct {
+		Login string `json:"login"`
+	} `json:"enqueuer"`
+}
+
+// toMergeQueueEntry converts raw merge-queue data decoded from the GraphQL
+// response into the public MergeQueueEntry type. Returns nil if raw is nil.
+func toMergeQueueEntry(raw *mergeQueueEntryData) *MergeQueueEntry {
+	if raw == nil {
+		return nil
+	}
+	entry := &MergeQueueEntry{
+		State:    raw.State,
+		Position: raw.Position,
+	}
+	if raw.Enqueuer != nil {
+		entry.EnqueuerLogin = raw.Enqueuer.Login
+	}
+	return entry
 }
 
 // itemNode mirrors one element of items.nodes in the FetchProjectBoard query.
@@ -58,18 +95,12 @@ type itemNode struct {
 		} `json:"labels"`
 		LinkedPRs *struct {
 			Nodes []struct {
-				UpdatedAt           string `json:"updatedAt"`
-				Number              int    `json:"number"`
-				HeadRefOid          string `json:"headRefOid"`
-				IsMergeQueueEnabled bool   `json:"isMergeQueueEnabled"`
-				IsInMergeQueue      bool   `json:"isInMergeQueue"`
-				MergeQueueEntry     *struct {
-					State         string `json:"state"`
-					Position      int    `json:"position"`
-					Enqueuer      *struct {
-						Login string `json:"login"`
-					} `json:"enqueuer"`
-				} `json:"mergeQueueEntry"`
+				UpdatedAt           string               `json:"updatedAt"`
+				Number              int                  `json:"number"`
+				HeadRefOid          string               `json:"headRefOid"`
+				IsMergeQueueEnabled bool                 `json:"isMergeQueueEnabled"`
+				IsInMergeQueue      bool                 `json:"isInMergeQueue"`
+				MergeQueueEntry     *mergeQueueEntryData `json:"mergeQueueEntry"`
 			} `json:"nodes"`
 		} `json:"closedByPullRequestsReferences"`
 	} `json:"content"`
@@ -366,16 +397,7 @@ query($owner: String!, $projectNum: Int!, $cursor: String) {
 				item.LinkedPRHeadSHA = pr0.HeadRefOid
 				item.LinkedPRIsMergeQueueEnabled = pr0.IsMergeQueueEnabled
 				item.LinkedPRIsInMergeQueue = pr0.IsInMergeQueue
-				if pr0.MergeQueueEntry != nil {
-					entry := &MergeQueueEntry{
-						State:    pr0.MergeQueueEntry.State,
-						Position: pr0.MergeQueueEntry.Position,
-					}
-					if pr0.MergeQueueEntry.Enqueuer != nil {
-						entry.EnqueuerLogin = pr0.MergeQueueEntry.Enqueuer.Login
-					}
-					item.LinkedPRMergeQueueEntry = entry
-				}
+				item.LinkedPRMergeQueueEntry = toMergeQueueEntry(pr0.MergeQueueEntry)
 			}
 		}
 
@@ -647,17 +669,7 @@ query($id: ID!) {
         }
       }
       comments(first: 100) {
-        nodes {
-          id
-          databaseId
-          author { login }
-          body
-          createdAt
-          reactionGroups {
-            content
-            reactors { totalCount }
-          }
-        }
+        nodes { ` + commentSelectionFragment + ` }
         pageInfo { hasNextPage endCursor }
       }
       closedByPullRequestsReferences(first: 10) {
@@ -673,17 +685,7 @@ query($id: ID!) {
             enqueuer { login }
           }
           comments(first: 100) {
-            nodes {
-              id
-              databaseId
-              author { login }
-              body
-              createdAt
-              reactionGroups {
-                content
-                reactors { totalCount }
-              }
-            }
+            nodes { ` + commentSelectionFragment + ` }
             pageInfo { hasNextPage endCursor }
           }
           reviewRequests(first: 10) {
@@ -746,17 +748,7 @@ query($id: ID!) {
         nodes { login }
       }
       comments(first: 100) {
-        nodes {
-          id
-          databaseId
-          author { login }
-          body
-          createdAt
-          reactionGroups {
-            content
-            reactors { totalCount }
-          }
-        }
+        nodes { ` + commentSelectionFragment + ` }
         pageInfo { hasNextPage endCursor }
       }
     }
@@ -809,19 +801,13 @@ query($id: ID!) {
 				} `json:"comments"`
 				LinkedPRs *struct {
 					Nodes []struct {
-						ID                  string `json:"id"`
-						Number              int    `json:"number"`
-						HeadRefOid          string `json:"headRefOid"`
-						IsMergeQueueEnabled bool   `json:"isMergeQueueEnabled"`
-						IsInMergeQueue      bool   `json:"isInMergeQueue"`
-						MergeQueueEntry     *struct {
-							State    string `json:"state"`
-							Position int    `json:"position"`
-							Enqueuer *struct {
-								Login string `json:"login"`
-							} `json:"enqueuer"`
-						} `json:"mergeQueueEntry"`
-						Comments struct {
+						ID                  string               `json:"id"`
+						Number              int                  `json:"number"`
+						HeadRefOid          string               `json:"headRefOid"`
+						IsMergeQueueEnabled bool                 `json:"isMergeQueueEnabled"`
+						IsInMergeQueue      bool                 `json:"isInMergeQueue"`
+						MergeQueueEntry     *mergeQueueEntryData `json:"mergeQueueEntry"`
+						Comments            struct {
 							Nodes    []commentNodeData `json:"nodes"`
 							PageInfo struct {
 								HasNextPage bool   `json:"hasNextPage"`
@@ -966,17 +952,7 @@ query($id: ID!) {
 				item.LinkedPRHeadSHA = pr.HeadRefOid
 				item.LinkedPRIsMergeQueueEnabled = pr.IsMergeQueueEnabled
 				item.LinkedPRIsInMergeQueue = pr.IsInMergeQueue
-				item.LinkedPRMergeQueueEntry = nil
-				if pr.MergeQueueEntry != nil {
-					entry := &MergeQueueEntry{
-						State:    pr.MergeQueueEntry.State,
-						Position: pr.MergeQueueEntry.Position,
-					}
-					if pr.MergeQueueEntry.Enqueuer != nil {
-						entry.EnqueuerLogin = pr.MergeQueueEntry.Enqueuer.Login
-					}
-					item.LinkedPRMergeQueueEntry = entry
-				}
+				item.LinkedPRMergeQueueEntry = toMergeQueueEntry(pr.MergeQueueEntry)
 			}
 			prCommentNodes := pr.Comments.Nodes
 			if pr.Comments.PageInfo.HasNextPage {
@@ -1064,21 +1040,7 @@ query($id: ID!, $cursor: String) {
   node(id: $id) {
     ... on Issue {
       comments(first: 100, after: $cursor) {
-        nodes {
-          id
-          databaseId
-          author {
-            login
-          }
-          body
-          createdAt
-          reactionGroups {
-            content
-            reactors {
-              totalCount
-            }
-          }
-        }
+        nodes { ` + commentSelectionFragment + ` }
         pageInfo {
           hasNextPage
           endCursor
@@ -1087,21 +1049,7 @@ query($id: ID!, $cursor: String) {
     }
     ... on PullRequest {
       comments(first: 100, after: $cursor) {
-        nodes {
-          id
-          databaseId
-          author {
-            login
-          }
-          body
-          createdAt
-          reactionGroups {
-            content
-            reactors {
-              totalCount
-            }
-          }
-        }
+        nodes { ` + commentSelectionFragment + ` }
         pageInfo {
           hasNextPage
           endCursor

--- a/github/prs.go
+++ b/github/prs.go
@@ -375,11 +375,11 @@ func (c *Client) ListPRs(owner, repo string) ([]PRDetails, error) {
 	return out, nil
 }
 
-// MarkPRReady transitions a draft PR to ready-for-review.
-// Uses the GraphQL markPullRequestReadyForReview mutation, which is the supported
-// path — REST PATCH does not reliably support draft→ready transitions.
-func (c *Client) MarkPRReady(owner, repo string, prNumber int) error {
-	// Fetch the PR node ID (required for the GraphQL mutation)
+// prNodeID fetches the GraphQL node ID of a pull request by its REST number.
+// The node ID is required by every GraphQL mutation that operates on a PR
+// (markPullRequestReadyForReview, enablePullRequestAutoMerge, enqueuePullRequest,
+// dequeuePullRequest) since none of them accept a plain PR number.
+func (c *Client) prNodeID(owner, repo string, prNumber int) (string, error) {
 	fetchQuery := `
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -403,11 +403,22 @@ query($owner: String!, $repo: String!, $number: Int!) {
 		} `json:"data"`
 	}
 	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
-		return fmt.Errorf("fetching PR node ID: %w", err)
+		return "", fmt.Errorf("fetching PR node ID: %w", err)
 	}
 	nodeID := fetchResult.Data.Repository.PullRequest.ID
 	if nodeID == "" {
-		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+		return "", fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	}
+	return nodeID, nil
+}
+
+// MarkPRReady transitions a draft PR to ready-for-review.
+// Uses the GraphQL markPullRequestReadyForReview mutation, which is the supported
+// path — REST PATCH does not reliably support draft→ready transitions.
+func (c *Client) MarkPRReady(owner, repo string, prNumber int) error {
+	nodeID, err := c.prNodeID(owner, repo, prNumber)
+	if err != nil {
+		return err
 	}
 
 	mutation := `
@@ -511,35 +522,9 @@ var ErrAutoMergeAlreadyClean = errors.New("PR is already in clean status — mer
 //
 // Returns ErrAutoMergeNotEnabled when the repository setting is disabled.
 func (c *Client) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
-	// Fetch the PR node ID (required for the GraphQL mutation).
-	fetchQuery := `
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      id
-    }
-  }
-}`
-	fetchVars := map[string]interface{}{
-		"owner":  owner,
-		"repo":   repo,
-		"number": prNumber,
-	}
-	var fetchResult struct {
-		Data struct {
-			Repository struct {
-				PullRequest struct {
-					ID string `json:"id"`
-				} `json:"pullRequest"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
-		return fmt.Errorf("fetching PR node ID: %w", err)
-	}
-	nodeID := fetchResult.Data.Repository.PullRequest.ID
-	if nodeID == "" {
-		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	nodeID, err := c.prNodeID(owner, repo, prNumber)
+	if err != nil {
+		return err
 	}
 
 	mutation := `
@@ -602,34 +587,9 @@ func (c *Client) EnqueuePullRequest(owner, repo string, prNumber int, expectedHe
 	if expectedHeadOID == "" {
 		return fmt.Errorf("expectedHeadOID cannot be empty")
 	}
-	fetchQuery := `
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      id
-    }
-  }
-}`
-	fetchVars := map[string]interface{}{
-		"owner":  owner,
-		"repo":   repo,
-		"number": prNumber,
-	}
-	var fetchResult struct {
-		Data struct {
-			Repository struct {
-				PullRequest struct {
-					ID string `json:"id"`
-				} `json:"pullRequest"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
-		return fmt.Errorf("fetching PR node ID: %w", err)
-	}
-	nodeID := fetchResult.Data.Repository.PullRequest.ID
-	if nodeID == "" {
-		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	nodeID, err := c.prNodeID(owner, repo, prNumber)
+	if err != nil {
+		return err
 	}
 
 	mutation := `
@@ -656,34 +616,9 @@ mutation($prId: ID!, $expectedHeadOid: GitObjectID!) {
 // Uses the same two-step pattern as MarkPRReady: fetch the PR node ID via
 // GraphQL, then call the dequeuePullRequest mutation.
 func (c *Client) DequeuePullRequest(owner, repo string, prNumber int) error {
-	fetchQuery := `
-query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      id
-    }
-  }
-}`
-	fetchVars := map[string]interface{}{
-		"owner":  owner,
-		"repo":   repo,
-		"number": prNumber,
-	}
-	var fetchResult struct {
-		Data struct {
-			Repository struct {
-				PullRequest struct {
-					ID string `json:"id"`
-				} `json:"pullRequest"`
-			} `json:"repository"`
-		} `json:"data"`
-	}
-	if err := c.graphqlRequest(fetchQuery, fetchVars, &fetchResult); err != nil {
-		return fmt.Errorf("fetching PR node ID: %w", err)
-	}
-	nodeID := fetchResult.Data.Repository.PullRequest.ID
-	if nodeID == "" {
-		return fmt.Errorf("PR #%d not found in repository %s/%s", prNumber, owner, repo)
+	nodeID, err := c.prNodeID(owner, repo, prNumber)
+	if err != nil {
+		return err
 	}
 
 	mutation := `

--- a/github/prs_test.go
+++ b/github/prs_test.go
@@ -556,6 +556,102 @@ func makeTwoStepGraphQLServer(t *testing.T, prNodeID string, checkFn func(t *tes
 	return srv, NewClientWithBaseURL("test-token", srv.URL)
 }
 
+func TestPRNodeID_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"repository": map[string]interface{}{
+					"pullRequest": map[string]interface{}{
+						"id": "PR_abc123",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	id, err := c.prNodeID("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("prNodeID: %v", err)
+	}
+	if id != "PR_abc123" {
+		t.Errorf("prNodeID = %q, want PR_abc123", id)
+	}
+}
+
+func TestPRNodeID_EmptyIDReturnsNotFoundError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"repository": map[string]interface{}{
+					"pullRequest": map[string]interface{}{
+						"id": "",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	_, err := c.prNodeID("owner", "repo", 42)
+	if err == nil {
+		t.Fatal("expected error for empty PR node id")
+	}
+	if !strings.Contains(err.Error(), "PR #42 not found in repository owner/repo") {
+		t.Errorf("error = %q, want PR-not-found message", err.Error())
+	}
+}
+
+func TestPRNodeID_GraphQLErrorWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	_, err := c.prNodeID("owner", "repo", 42)
+	if err == nil || !strings.Contains(err.Error(), "fetching PR node ID") {
+		t.Errorf("expected wrapped 'fetching PR node ID' error, got %v", err)
+	}
+}
+
+func TestMarkPRReady(t *testing.T) {
+	const prNodeID = "PR_readynode"
+
+	_, c := makeTwoStepGraphQLServer(t, prNodeID, func(t *testing.T, vars map[string]interface{}) {
+		t.Helper()
+		if got, ok := vars["prId"].(string); !ok || got != prNodeID {
+			t.Errorf("mutation vars[prId] = %v, want %q", vars["prId"], prNodeID)
+		}
+	})
+
+	if err := c.MarkPRReady("owner", "repo", 42); err != nil {
+		t.Fatalf("MarkPRReady: %v", err)
+	}
+}
+
+func TestEnablePullRequestAutoMerge(t *testing.T) {
+	const prNodeID = "PR_automergenode"
+
+	_, c := makeTwoStepGraphQLServer(t, prNodeID, func(t *testing.T, vars map[string]interface{}) {
+		t.Helper()
+		if got, ok := vars["prId"].(string); !ok || got != prNodeID {
+			t.Errorf("mutation vars[prId] = %v, want %q", vars["prId"], prNodeID)
+		}
+		if got, ok := vars["method"].(string); !ok || got != "SQUASH" {
+			t.Errorf("mutation vars[method] = %v, want SQUASH", vars["method"])
+		}
+	})
+
+	if err := c.EnablePullRequestAutoMerge("owner", "repo", 42, "SQUASH"); err != nil {
+		t.Fatalf("EnablePullRequestAutoMerge: %v", err)
+	}
+}
+
 func TestEnqueuePullRequest(t *testing.T) {
 	const prNodeID = "PR_testnode"
 	const expectedHeadOID = "deadbeef1234"

--- a/github/rest.go
+++ b/github/rest.go
@@ -44,67 +44,72 @@ func authErrorHint(statusCode int) string {
 	return ""
 }
 
-func (c *Client) restRequest(method, url string, body interface{}) error {
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("marshaling request: %w", err)
+// do is the shared REST request core. It marshals body (when non-nil), sets
+// auth/content-type/accept headers, executes the request, records rate-limit
+// stats, and maps 404/405/422 responses to their sentinel errors uniformly
+// across every REST verb. body may be nil for GET/DELETE-without-body calls;
+// Content-Type is only set when body is non-nil, matching what each verb sent
+// before this helper existed. The full response body is always read and
+// returned so typed callers can decode it themselves.
+func (c *Client) do(method, url string, body interface{}) (*http.Response, []byte, error) {
+	var reader io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshaling request: %w", err)
+		}
+		reader = bytes.NewReader(jsonBody)
 	}
 
-	req, err := http.NewRequest(method, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequest(method, url, reader)
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return nil, nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
+		return nil, nil, fmt.Errorf("executing request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	c.updateRestStats(resp.Header)
 
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		switch resp.StatusCode {
-		case 405:
-			return fmt.Errorf("GitHub API returned 405: %s: %w", string(respBody), ErrMethodNotAllowed)
-		case 422:
-			return fmt.Errorf("GitHub API returned 422: %s: %w", string(respBody), ErrUnprocessableEntity)
-		}
-		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading response: %w", err)
 	}
 
-	return nil
+	if resp.StatusCode >= 400 {
+		switch resp.StatusCode {
+		case 404:
+			return resp, respBody, fmt.Errorf("GitHub API returned 404: %s: %w", string(respBody), ErrNotFound)
+		case 405:
+			return resp, respBody, fmt.Errorf("GitHub API returned 405: %s: %w", string(respBody), ErrMethodNotAllowed)
+		case 422:
+			return resp, respBody, fmt.Errorf("GitHub API returned 422: %s: %w", string(respBody), ErrUnprocessableEntity)
+		}
+		return resp, respBody, fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
+	}
+
+	return resp, respBody, nil
+}
+
+func (c *Client) restRequest(method, url string, body interface{}) error {
+	_, _, err := c.do(method, url, body)
+	return err
 }
 
 func (c *Client) restGetJSON(url string, result interface{}) error {
-	req, err := http.NewRequest("GET", url, nil)
+	_, respBody, err := c.do("GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
+		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	c.updateRestStats(resp.Header)
-
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode == 404 {
-			return fmt.Errorf("GitHub API returned 404: %s: %w", string(respBody), ErrNotFound)
-		}
-		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
-	}
-
-	return json.NewDecoder(resp.Body).Decode(result)
+	return json.Unmarshal(respBody, result)
 }
 
 // SearchResult represents the response from GitHub's search API.
@@ -115,28 +120,12 @@ type SearchResult struct {
 }
 
 func (c *Client) restGet(url string) (*SearchResult, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	_, respBody, err := c.do("GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	c.updateRestStats(resp.Header)
-
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
-	}
-
 	var result SearchResult
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 	return &result, nil
@@ -148,33 +137,11 @@ func (c *Client) restPost(url string, body interface{}) error {
 
 // restPostWithResponse POSTs and decodes the response body into the provided target.
 func (c *Client) restPostWithResponse(url string, body interface{}, target interface{}) error {
-	jsonBody, err := json.Marshal(body)
+	_, respBody, err := c.do("POST", url, body)
 	if err != nil {
-		return fmt.Errorf("marshaling request: %w", err)
+		return err
 	}
-
-	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	c.updateRestStats(resp.Header)
-
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+	if err := json.Unmarshal(respBody, target); err != nil {
 		return fmt.Errorf("decoding response: %w", err)
 	}
 	return nil
@@ -186,67 +153,17 @@ func (c *Client) restPatch(url string, body interface{}) error {
 
 // restPutWithResponse PUTs and decodes the response body into the provided target.
 func (c *Client) restPutWithResponse(url string, body interface{}, target interface{}) error {
-	jsonBody, err := json.Marshal(body)
+	_, respBody, err := c.do("PUT", url, body)
 	if err != nil {
-		return fmt.Errorf("marshaling request: %w", err)
+		return err
 	}
-
-	req, err := http.NewRequest("PUT", url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	c.updateRestStats(resp.Header)
-
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		switch resp.StatusCode {
-		case 405:
-			return fmt.Errorf("GitHub API returned 405: %s: %w", string(respBody), ErrMethodNotAllowed)
-		case 422:
-			return fmt.Errorf("GitHub API returned 422: %s: %w", string(respBody), ErrUnprocessableEntity)
-		}
-		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+	if err := json.Unmarshal(respBody, target); err != nil {
 		return fmt.Errorf("decoding response: %w", err)
 	}
 	return nil
 }
 
 func (c *Client) restDelete(url string) error {
-	req, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	c.updateRestStats(resp.Header)
-
-	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode == 404 {
-			return fmt.Errorf("GitHub API returned 404: %s: %w", string(respBody), ErrNotFound)
-		}
-		return fmt.Errorf("GitHub API returned %d: %s%s", resp.StatusCode, string(respBody), authErrorHint(resp.StatusCode))
-	}
-
-	return nil
+	_, _, err := c.do("DELETE", url, nil)
+	return err
 }

--- a/github/rest_test.go
+++ b/github/rest_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -213,6 +214,214 @@ func TestRestPost_500NoHint(t *testing.T) {
 	}
 	if containsStr(err.Error(), "classic personal access token") {
 		t.Errorf("500 error should not contain auth hint, got: %q", err.Error())
+	}
+}
+
+func TestDo_SuccessBodyPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("test-token", srv.URL)
+	resp, body, err := c.do("GET", srv.URL+"/test", nil)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", string(body), `{"ok":true}`)
+	}
+}
+
+func TestDo_ContentTypeOnlyWhenBodyNonNil(t *testing.T) {
+	var gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if _, _, err := c.do("GET", srv.URL+"/test", nil); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if gotCT != "" {
+		t.Errorf("Content-Type = %q, want empty for nil body", gotCT)
+	}
+
+	if _, _, err := c.do("POST", srv.URL+"/test", map[string]string{"k": "v"}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json for non-nil body", gotCT)
+	}
+}
+
+func TestDo_404MapsToErrNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, _, err := c.do("GET", srv.URL+"/test", nil)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("do: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDo_405MapsToErrMethodNotAllowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(405)
+		w.Write([]byte(`{"message":"Not Allowed"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, _, err := c.do("PUT", srv.URL+"/test", map[string]string{"k": "v"})
+	if !errors.Is(err, ErrMethodNotAllowed) {
+		t.Fatalf("do: expected ErrMethodNotAllowed, got %v", err)
+	}
+}
+
+func TestDo_422MapsToErrUnprocessableEntity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+		w.Write([]byte(`{"message":"Validation Failed"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, _, err := c.do("POST", srv.URL+"/test", map[string]string{"k": "v"})
+	if !errors.Is(err, ErrUnprocessableEntity) {
+		t.Fatalf("do: expected ErrUnprocessableEntity, got %v", err)
+	}
+}
+
+func TestDo_Generic5xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`Internal Server Error`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, _, err := c.do("GET", srv.URL+"/test", nil)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if errors.Is(err, ErrNotFound) || errors.Is(err, ErrMethodNotAllowed) || errors.Is(err, ErrUnprocessableEntity) {
+		t.Errorf("500 should not map to a sentinel, got %v", err)
+	}
+}
+
+func TestDo_AuthHintOn401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, _, err := c.do("GET", srv.URL+"/test", nil)
+	if err == nil || !containsStr(err.Error(), "classic personal access token") {
+		t.Fatalf("expected auth hint in error, got %v", err)
+	}
+}
+
+func TestDo_RateLimitHeaderCapture(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4999")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if _, _, err := c.do("GET", srv.URL+"/test", nil); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	rest, _ := c.RateLimitStats()
+	if rest.Limit != 5000 {
+		t.Errorf("rest.Limit = %d, want 5000", rest.Limit)
+	}
+}
+
+func TestDo_MarshalError(t *testing.T) {
+	c := NewClientWithBaseURL("token", "http://example.com")
+	_, _, err := c.do("POST", "http://example.com/test", make(chan int))
+	if err == nil {
+		t.Fatal("expected marshal error for unsupported body type")
+	}
+}
+
+func TestDo_RequestCreationError(t *testing.T) {
+	c := NewClientWithBaseURL("token", "http://example.com")
+	_, _, err := c.do("GET", "://invalid-url", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+// Sentinel-mapping coverage for helpers that did not check these codes before
+// the do() core unified the mapping (restGet, restPostWithResponse never
+// mapped 404/405/422; restGetJSON/restDelete never mapped 405/422).
+
+func TestRestGet_404MapsToErrNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	_, err := c.restGet(srv.URL + "/test")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("restGet: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRestPostWithResponse_404MapsToErrNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	var target struct{}
+	err := c.restPostWithResponse(srv.URL+"/test", map[string]string{}, &target)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("restPostWithResponse: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRestGetJSON_405MapsToErrMethodNotAllowed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(405)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	var target struct{}
+	err := c.restGetJSON(srv.URL+"/test", &target)
+	if !errors.Is(err, ErrMethodNotAllowed) {
+		t.Fatalf("restGetJSON: expected ErrMethodNotAllowed, got %v", err)
+	}
+}
+
+func TestRestDelete_422MapsToErrUnprocessableEntity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(422)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	err := c.restDelete(srv.URL + "/test")
+	if !errors.Is(err, ErrUnprocessableEntity) {
+		t.Fatalf("restDelete: expected ErrUnprocessableEntity, got %v", err)
 	}
 }
 

--- a/github/status.go
+++ b/github/status.go
@@ -32,7 +32,10 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
 	}
 
 	var result struct{}
-	return c.graphqlRequest(query, vars, &result)
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return fmt.Errorf("updating status for item %s on project %s: %w", itemID, projectID, err)
+	}
+	return nil
 }
 
 // ArchiveProjectItem archives a project item so it no longer appears in paginated board results.
@@ -50,7 +53,10 @@ mutation($projectId: ID!, $itemId: ID!) {
 	}
 
 	var result struct{}
-	return c.graphqlRequest(query, vars, &result)
+	if err := c.graphqlRequest(query, vars, &result); err != nil {
+		return fmt.Errorf("archiving item %s on project %s: %w", itemID, projectID, err)
+	}
+	return nil
 }
 
 // FetchStatusField retrieves the Status field ID and its option IDs for a project.
@@ -90,7 +96,7 @@ query($projectId: ID!) {
 	}
 
 	if err := c.graphqlRequest(query, vars, &result); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetching status field for project %s: %w", projectID, err)
 	}
 
 	if result.Data.Node.Field == nil || result.Data.Node.Field.ID == "" {


### PR DESCRIPTION
Closes #1028

Extracts six shared helpers to eliminate copy-pasted request/response scaffolding in the `github` client and `boardcache` layer, per the 2026-07-20 code-health audit.

## What changed

**`github` package:**
- `c.prNodeID(owner, repo string, prNumber int) (string, error)` — replaces four identical ~28-line "fetch PR node id" blocks in `prs.go` (`MarkPRReady`, `EnablePullRequestAutoMerge`, `EnqueuePullRequest`, `DequeuePullRequest`).
- `c.do(method, url string, body interface{}) (*http.Response, []byte, error)` — a single REST core in `rest.go` that sets headers, executes, records stats, and maps status codes to sentinels (404/405/422). All six REST helpers (`restRequest`, `restGetJSON`, `restGet`, `restPostWithResponse`, `restPutWithResponse`, `restDelete`) become thin decode wrappers around it. This uniformly applies sentinel mapping across all six — the one deliberate additive-only behavior change (no caller relied on *not* getting a sentinel, verified via grep).
- `paginateGraphQL[T]` / `retryOnEmpty[T]` in `project.go` — a loop-only generic paginator plus the pre-existing 3-attempt retry-on-empty wrapper, now shared by `fetchProjectBoardOnce`/`probeProjectBoardOnce`/`FetchProjectItemStatusBatch` and `fetchProjectBoard`/`probeProjectBoard` respectively. Kept as two separate generics rather than one fully-generic paginator since the three call sites have materially different response envelopes.
- `commentSelectionFragment` const + `toMergeQueueEntry` — collapse 5 hand-written comment-selection query fragments and 2 duplicated `MergeQueueEntry` construction sites.
- Bare error returns wrapped with `%w` + operation context in `labels.go`, `comments.go`, `status.go`, and `project.go`'s `AddBlockedByIssue`, per `.claude/rules/golang.md`. All existing `errors.Is` sentinel checks preserved.

**`boardcache` package:**
- `c.applyKeyedMutation(key, opName string, build func(repo, number) itemstate.Mutation)` — collapses the shared parse-key/phantom-guard/apply/bump preamble for 5 of 6 `CacheImpl` mutators (`ApplyStatusBatch` is excluded — it resolves its key differently and doesn't fit the same shape).
- `c.resolveOrHealPRLinkage(...)` — extracts the ~20-line negative-cache/resolve/confirm block shared by the four delta auto-heal handlers (`applyPullRequestDelta`, `applyPullRequestReviewDelta`, `applyPullRequestReviewCommentDelta`, `applyCheckRunDelta`). The pre-existing invariant that `store.Get` is called outside `c.mu` is preserved, and the AST-based `TestDeltaHealPaths_DoNotCallStoreWhileLocked` test now also walks this extracted helper so the invariant stays enforced.

**Docs:**
- `adrs/066-consolidated-github-request-helpers.md` — new ADR documenting the `do()` core's uniform sentinel mapping, the paginator split rationale, `applyKeyedMutation`'s 5-of-6 scope, and `resolveOrHealPRLinkage`'s scope boundary against the AST lock-invariant test.

## How to test

- `go build ./...` and `go vet ./...` are clean.
- `go test -race ./...` passes, with one exception: `TestExecute_ConfigYAMLApplied` in `cmd/` fails deterministically in this environment — verified this is pre-existing by running it against the base commit before this branch's changes, where it fails identically. It depends on a live network round-trip to the GitHub API completing within 5s of a SIGINT, which this sandbox's network conditions don't satisfy; unrelated to this refactor.
- `go test ./boardcache/... -run TestDeltaHealPaths_DoNotCallStoreWhileLocked -v` passes, including the newly-added `resolveOrHealPRLinkage` subtest.
- No behavior/on-wire changes beyond the two called-out additive exceptions (uniform REST sentinel mapping, standardized "invalid" log wording in `applyKeyedMutation` callers).