### PR TITLE
refactor: decompose processItem, poll, and Execute into named helpers

### DIFF
--- a/cmd/resolve_helpers_test.go
+++ b/cmd/resolve_helpers_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import "testing"
+
+// Focused tests for the resolveBool/resolveInt/resolveDuration helpers
+// extracted out of Execute (#1029). These call the helpers directly instead
+// of driving all of Execute (flag parsing, stage loading, engine construction)
+// per env-var precedence case, which is exactly the isolated testability the
+// decomposition enables.
+
+func TestResolveBool_EnvTruthyValues(t *testing.T) {
+	cases := []struct {
+		env  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"yes", true},
+		{"false", false},
+		{"0", false},
+		{"no", false},
+		{"garbage", false},
+	}
+	for _, c := range cases {
+		t.Setenv("FABRIK_TEST_BOOL", c.env)
+		if got := resolveBool("FABRIK_TEST_BOOL", false); got != c.want {
+			t.Errorf("resolveBool(%q, false) = %v, want %v", c.env, got, c.want)
+		}
+	}
+}
+
+func TestResolveBool_FallsBackToProjectConfig(t *testing.T) {
+	t.Setenv("FABRIK_TEST_BOOL_UNSET", "")
+	if got := resolveBool("FABRIK_TEST_BOOL_UNSET", true); got != true {
+		t.Errorf("resolveBool with unset env = %v, want fallback true", got)
+	}
+	if got := resolveBool("FABRIK_TEST_BOOL_UNSET", false); got != false {
+		t.Errorf("resolveBool with unset env = %v, want fallback false", got)
+	}
+}
+
+func TestResolveInt_ValidEnvOverridesCurrent(t *testing.T) {
+	t.Setenv("FABRIK_TEST_INT", "42")
+	if got := resolveInt(0, "FABRIK_TEST_INT", "", 5); got != 42 {
+		t.Errorf("resolveInt = %d, want 42", got)
+	}
+}
+
+func TestResolveInt_InvalidEnvKeepsCurrentAndWarns(t *testing.T) {
+	t.Setenv("FABRIK_TEST_INT", "-1")
+	if got := resolveInt(7, "FABRIK_TEST_INT", "", 5); got != 7 {
+		t.Errorf("resolveInt with invalid env = %d, want unchanged current 7", got)
+	}
+	t.Setenv("FABRIK_TEST_INT", "not-a-number")
+	if got := resolveInt(7, "FABRIK_TEST_INT", "", 5); got != 7 {
+		t.Errorf("resolveInt with non-numeric env = %d, want unchanged current 7", got)
+	}
+}
+
+func TestResolveInt_UnsetEnvKeepsCurrent(t *testing.T) {
+	t.Setenv("FABRIK_TEST_INT_UNSET", "")
+	if got := resolveInt(3, "FABRIK_TEST_INT_UNSET", "", 5); got != 3 {
+		t.Errorf("resolveInt with unset env = %d, want unchanged current 3", got)
+	}
+}
+
+func TestResolveDuration_EnvOverridesCurrent(t *testing.T) {
+	t.Setenv("FABRIK_TEST_DURATION", "20s")
+	if got := resolveDuration("10s", "FABRIK_TEST_DURATION"); got != "20s" {
+		t.Errorf("resolveDuration = %q, want %q", got, "20s")
+	}
+}
+
+func TestResolveDuration_UnsetEnvKeepsCurrent(t *testing.T) {
+	t.Setenv("FABRIK_TEST_DURATION_UNSET", "")
+	if got := resolveDuration("10s", "FABRIK_TEST_DURATION_UNSET"); got != "10s" {
+		t.Errorf("resolveDuration with unset env = %q, want unchanged %q", got, "10s")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,20 +261,10 @@ func Execute() error {
 		}
 	}
 	if !cfg.Yolo {
-		if v := os.Getenv("FABRIK_YOLO"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.Yolo = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.Yolo {
-			cfg.Yolo = true
-		}
+		cfg.Yolo = resolveBool("FABRIK_YOLO", pc.Yolo)
 	}
 	if !cfg.GitSSH {
-		if v := os.Getenv("FABRIK_GIT_SSH"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.GitSSH = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.GitSSH {
-			cfg.GitSSH = true
-		}
+		cfg.GitSSH = resolveBool("FABRIK_GIT_SSH", pc.GitSSH)
 	}
 	if cfg.PollSeconds == 30 {
 		if v := os.Getenv("FABRIK_POLL"); v != "" {
@@ -322,72 +312,28 @@ func Execute() error {
 		}
 	}
 	if !explicitFlags["review-wait-timeout"] {
-		if v := os.Getenv("FABRIK_REVIEW_WAIT_TIMEOUT"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.ReviewWaitTimeout = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_REVIEW_WAIT_TIMEOUT=%q is invalid (must be a positive integer of minutes); using default 15\n", v)
-			}
-		}
+		cfg.ReviewWaitTimeout = resolveInt(cfg.ReviewWaitTimeout, "FABRIK_REVIEW_WAIT_TIMEOUT", "of minutes", 15)
 	}
 	if !explicitFlags["max-review-cycles"] {
-		if v := os.Getenv("FABRIK_MAX_REVIEW_CYCLES"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.MaxReviewCycles = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_REVIEW_CYCLES=%q is invalid (must be a positive integer); using default 5\n", v)
-			}
-		}
+		cfg.MaxReviewCycles = resolveInt(cfg.MaxReviewCycles, "FABRIK_MAX_REVIEW_CYCLES", "", 5)
 	}
 	if !explicitFlags["ci-wait-timeout"] {
-		if v := os.Getenv("FABRIK_CI_WAIT_TIMEOUT"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.CIWaitTimeout = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_CI_WAIT_TIMEOUT=%q is invalid (must be a positive integer of minutes); using default 30\n", v)
-			}
-		}
+		cfg.CIWaitTimeout = resolveInt(cfg.CIWaitTimeout, "FABRIK_CI_WAIT_TIMEOUT", "of minutes", 30)
 	}
 	if !explicitFlags["worker-stale-timeout"] {
-		if v := os.Getenv("FABRIK_WORKER_STALE_TIMEOUT"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.WorkerStaleMins = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_WORKER_STALE_TIMEOUT=%q is invalid (must be a positive integer of minutes); using default 5\n", v)
-			}
-		}
+		cfg.WorkerStaleMins = resolveInt(cfg.WorkerStaleMins, "FABRIK_WORKER_STALE_TIMEOUT", "of minutes", 5)
 	}
 	if !explicitFlags["max-ci-fix-cycles"] {
-		if v := os.Getenv("FABRIK_MAX_CI_FIX_CYCLES"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.MaxCiFixCycles = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_CI_FIX_CYCLES=%q is invalid (must be a positive integer); using default 5\n", v)
-			}
-		}
+		cfg.MaxCiFixCycles = resolveInt(cfg.MaxCiFixCycles, "FABRIK_MAX_CI_FIX_CYCLES", "", 5)
 	}
 	if !explicitFlags["max-rebase-cycles"] {
-		if v := os.Getenv("FABRIK_MAX_REBASE_CYCLES"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.MaxRebaseCycles = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_REBASE_CYCLES=%q is invalid (must be a positive integer); using default 3\n", v)
-			}
-		}
+		cfg.MaxRebaseCycles = resolveInt(cfg.MaxRebaseCycles, "FABRIK_MAX_REBASE_CYCLES", "", 3)
 	}
 	if !explicitFlags["max-enqueue-cycles"] {
-		if v := os.Getenv("FABRIK_MAX_ENQUEUE_CYCLES"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.MaxEnqueueCycles = n
-			} else {
-				fmt.Fprintf(os.Stderr, "[warn] FABRIK_MAX_ENQUEUE_CYCLES=%q is invalid (must be a positive integer); using default 5\n", v)
-			}
-		}
+		cfg.MaxEnqueueCycles = resolveInt(cfg.MaxEnqueueCycles, "FABRIK_MAX_ENQUEUE_CYCLES", "", 5)
 	}
 	if !explicitFlags["convergence-budget"] {
-		if v := os.Getenv("FABRIK_CONVERGENCE_BUDGET"); v != "" {
-			cfg.ConvergenceBudget = v // validated in convergenceBudget() helper
-		}
+		cfg.ConvergenceBudget = resolveDuration(cfg.ConvergenceBudget, "FABRIK_CONVERGENCE_BUDGET")
 	}
 	if !explicitFlags["auto-merge-strategy"] {
 		if v := os.Getenv("FABRIK_AUTO_MERGE_STRATEGY"); v != "" {
@@ -562,22 +508,13 @@ func Execute() error {
 		}
 	}
 	if !explicitFlags["kill-grace-sigint"] {
-		if v := os.Getenv("FABRIK_KILL_GRACE_SIGINT"); v != "" {
-			cfg.KillGraceSigInt = v // validated in killGraceSigInt() helper
-		}
+		cfg.KillGraceSigInt = resolveDuration(cfg.KillGraceSigInt, "FABRIK_KILL_GRACE_SIGINT") // validated in killGraceSigInt() helper
 	}
 	if !explicitFlags["kill-grace-sigterm"] {
-		if v := os.Getenv("FABRIK_KILL_GRACE_SIGTERM"); v != "" {
-			cfg.KillGraceSigTerm = v // validated in killGraceSigTerm() helper
-		}
+		cfg.KillGraceSigTerm = resolveDuration(cfg.KillGraceSigTerm, "FABRIK_KILL_GRACE_SIGTERM") // validated in killGraceSigTerm() helper
 	}
 	if !cfg.AutoUpgrade {
-		if v := os.Getenv("FABRIK_AUTO_UPGRADE"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.AutoUpgrade = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.AutoUpgrade {
-			cfg.AutoUpgrade = true
-		}
+		cfg.AutoUpgrade = resolveBool("FABRIK_AUTO_UPGRADE", pc.AutoUpgrade)
 	}
 	cfg.TUI = true // default on
 	if noTUI {
@@ -591,28 +528,13 @@ func Execute() error {
 		cfg.TUI = false
 	}
 	if !cfg.DebugOutput {
-		if v := os.Getenv("FABRIK_DEBUG_OUTPUT"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.DebugOutput = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.DebugOutput {
-			cfg.DebugOutput = true
-		}
+		cfg.DebugOutput = resolveBool("FABRIK_DEBUG_OUTPUT", pc.DebugOutput)
 	}
 	if !cfg.SymlinkEnv {
-		if v := os.Getenv("FABRIK_SYMLINK_ENV"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.SymlinkEnv = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.SymlinkEnv {
-			cfg.SymlinkEnv = true
-		}
+		cfg.SymlinkEnv = resolveBool("FABRIK_SYMLINK_ENV", pc.SymlinkEnv)
 	}
 	if !explicitFlags["worktree-boundary-audit"] {
-		if v := os.Getenv("FABRIK_WORKTREE_BOUNDARY_AUDIT"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.WorktreeBoundaryAudit = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.WorktreeBoundaryAudit {
-			cfg.WorktreeBoundaryAudit = true
-		}
+		cfg.WorktreeBoundaryAudit = resolveBool("FABRIK_WORKTREE_BOUNDARY_AUDIT", pc.WorktreeBoundaryAudit)
 	}
 	if cfg.PluginDir == "" {
 		if v := os.Getenv("FABRIK_PLUGIN_DIR"); v != "" {
@@ -620,12 +542,7 @@ func Execute() error {
 		}
 	}
 	if !explicitFlags["webhooks"] {
-		if v := os.Getenv("FABRIK_WEBHOOKS"); v != "" {
-			lv := strings.ToLower(v)
-			cfg.Webhooks = lv == "true" || lv == "1" || lv == "yes"
-		} else if pc.Webhooks {
-			cfg.Webhooks = true
-		}
+		cfg.Webhooks = resolveBool("FABRIK_WEBHOOKS", pc.Webhooks)
 	}
 	if !explicitFlags["webhook-port"] {
 		if v := os.Getenv("FABRIK_WEBHOOK_PORT"); v != "" {
@@ -718,47 +635,11 @@ func Execute() error {
 	}
 	fmt.Printf("  debug-output: %v\n", cfg.DebugOutput)
 
-	// If the process was re-exec'd after an auto-upgrade, conditionally refresh
-	// embedded plugin skills. Three-way comparison: skip refresh when operator
-	// has local customizations (disk ≠ installed-version).
-	if os.Getenv("FABRIK_AUTO_UPGRADED") == "1" {
-		os.Unsetenv("FABRIK_AUTO_UPGRADED")
-		customWorkflowOnReexec, upgradeNeededOnReexec, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
-		if stateErr != nil {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed: %v\n", stateErr)
-		} else if customWorkflowOnReexec {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
-		} else if upgradeNeededOnReexec {
-			if _, err := fabrikplugin.RefreshPlugin(); err != nil {
-				fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed: %v\n", err)
-			} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
-				fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed: %v\n", err)
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
-		}
-	}
-
-	// If the process was re-exec'd by a SIGHUP restart, conditionally refresh
-	// plugin skills using the same three-way comparison. The env var is unset
-	// immediately so Claude child processes do not inherit it.
-	if os.Getenv("FABRIK_SIGHUP_RESTART") == "1" {
-		os.Unsetenv("FABRIK_SIGHUP_RESTART")
-		customWorkflowOnSighup, upgradeNeededOnSighup, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
-		if stateErr != nil {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed after SIGHUP restart: %v\n", stateErr)
-		} else if customWorkflowOnSighup {
-			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
-		} else if upgradeNeededOnSighup {
-			if _, err := fabrikplugin.RefreshPlugin(); err != nil {
-				fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed after SIGHUP restart: %v\n", err)
-			} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
-				fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed after SIGHUP restart: %v\n", err)
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
-		}
-	}
+	// If the process was re-exec'd after an auto-upgrade or a SIGHUP restart,
+	// conditionally refresh embedded plugin skills (three-way comparison: skip
+	// refresh when the operator has local customizations).
+	handleReexecPluginRefresh("FABRIK_AUTO_UPGRADED", "")
+	handleReexecPluginRefresh("FABRIK_SIGHUP_RESTART", " after SIGHUP restart")
 
 	// Parse webhook events from comma-separated string.
 	var webhookEvents []string
@@ -871,6 +752,79 @@ func Execute() error {
 		}
 	}
 	return eng.Run()
+}
+
+// resolveBool resolves a boolean config value from an environment variable
+// (truthy values: "true", "1", "yes", case-insensitive) when set, falling back
+// to the project-config value otherwise. Callers gate the call on whichever
+// precedence condition applies (an already-false flag value, or an
+// unspecified flag via explicitFlags) — resolveBool only handles the
+// env-or-config-file half of the flag > env > config.yaml precedence chain.
+func resolveBool(envVar string, pcVal bool) bool {
+	if v := os.Getenv(envVar); v != "" {
+		lv := strings.ToLower(v)
+		return lv == "true" || lv == "1" || lv == "yes"
+	}
+	return pcVal
+}
+
+// resolveInt resolves an integer config value from an environment variable
+// requiring a positive integer, returning current unchanged (and printing a
+// warning naming defaultVal) when the variable is unset or invalid. unit, when
+// non-empty, is inserted into the warning message (e.g. "of minutes"). Callers
+// gate the call on explicitFlags so an explicit flag value is never overridden.
+func resolveInt(current int, envVar, unit string, defaultVal int) int {
+	v := os.Getenv(envVar)
+	if v == "" {
+		return current
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return n
+	}
+	unitSuffix := ""
+	if unit != "" {
+		unitSuffix = " " + unit
+	}
+	fmt.Fprintf(os.Stderr, "[warn] %s=%q is invalid (must be a positive integer%s); using default %d\n", envVar, v, unitSuffix, defaultVal)
+	return current
+}
+
+// resolveDuration resolves a raw duration-string config value (validated later
+// by its dedicated helper, e.g. killGraceSigInt or convergenceBudget) from an
+// environment variable, returning current unchanged when unset.
+func resolveDuration(current string, envVar string) string {
+	if v := os.Getenv(envVar); v != "" {
+		return v
+	}
+	return current
+}
+
+// handleReexecPluginRefresh checks and unsets envVar (a re-exec marker set
+// before this process replaced itself via syscall.Exec, or before a SIGHUP
+// restart), then conditionally refreshes embedded plugin skills using a
+// three-way comparison: skip when the operator has local customizations (disk
+// ≠ installed-version). msgSuffix is appended to warning messages to
+// distinguish the auto-upgrade re-exec path from the SIGHUP-restart path
+// (e.g. "" or " after SIGHUP restart").
+func handleReexecPluginRefresh(envVar, msgSuffix string) {
+	if os.Getenv(envVar) != "1" {
+		return
+	}
+	os.Unsetenv(envVar)
+	customWorkflow, upgradeNeeded, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+	if stateErr != nil {
+		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed%s: %v\n", msgSuffix, stateErr)
+	} else if customWorkflow {
+		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+	} else if upgradeNeeded {
+		if _, err := fabrikplugin.RefreshPlugin(); err != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed%s: %v\n", msgSuffix, err)
+		} else if err := fabrikplugin.WriteInstalledVersion(".fabrik/plugin"); err != nil {
+			fmt.Fprintf(os.Stderr, "[upgrade] warning: writing installed version failed%s: %v\n", msgSuffix, err)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
+	}
 }
 
 // reviewWaitTimeout converts a ReviewWaitTimeout config value (minutes) to a

--- a/engine/item.go
+++ b/engine/item.go
@@ -428,66 +428,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// Runs before new-comment check — cleanup stages are terminal and should not route
 	// comments to processComments. Also handles PR items (no worktree to remove, just label).
 	if stage.CleanupWorktree {
-		completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
-		for _, label := range item.Labels {
-			if label == completeLabel {
-				return nil
-			}
-		}
-
-		// Issues have worktrees; PRs on the board do not — skip the removal for PRs.
-		if !item.IsPR {
-			wm := e.worktreesFor(item.Repo)
-			wtDir := wm.WorktreeDir(item.Number)
-			statusCmd := exec.Command("git", "status", "--porcelain")
-			statusCmd.Dir = wtDir
-			if out, err := statusCmd.Output(); err == nil {
-				for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-					if line == "" {
-						continue
-					}
-					path := strings.TrimSpace(line[2:])
-					if isEngineManagedPath(path) {
-						continue
-					}
-					e.logf(item.Number, "warn", "worktree dirty at cleanup — uncommitted changes will be discarded\n")
-					break
-				}
-			}
-
-			if err := wm.CleanupWorktree(item.Number, false); err != nil {
-				e.logf(item.Number, "warn", "could not clean up worktree: %v\n", err)
-			}
-		}
-
-		e.addLabel(item, completeLabel)
-
-		// Remove fabrik:extend-turns at cleanup (Done) stage — this is the designated
-		// removal site. The label persists across all intermediate stages so the operator
-		// can apply it once and have it take effect on every stage until Done.
-		// Called unconditionally (not guarded by hasLabel) because cleanup items are
-		// dispatched from shallow board items (labels(first:15)) and the label may be
-		// present on GitHub without appearing in item.Labels. ErrNotFound = already gone
-		// (removeLabel treats it as success and still syncs the cache).
-		e.removeLabel(item, "fabrik:extend-turns")
-
-		// Auto-archiving of Done items is not currently performed (see #1035).
-
-		// Record CooldownAt["periodic-re-eval"] so itemMayNeedWork suppresses
-		// deep-fetches for this terminal item during the cooldown window.
-		cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
-		e.store.Apply(itemstate.CooldownRecorded{
-			Repo:   repoStr,
-			Number: item.Number,
-			Reason: "periodic-re-eval",
-			Until:  time.Now().Add(cooldown),
-		})
-		e.store.Apply(itemstate.InvocationRecorded{
-			Repo:      itemOwnerRepoString(item, e.defaultRepo()),
-			Number:    item.Number,
-			Completed: true,
-		})
-
+		e.handleCleanupStage(item, stage, repoStr)
 		return nil
 	}
 
@@ -563,24 +504,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// the stage completes or is permanently abandoned — NOT on every
 	// processItem return. This keeps the issue locked through cooldown
 	// retries so other instances don't pick it up.
-	lockAcquired := false
-	var workerDone chan struct{}
-	workerStartedAt := time.Now()
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, lockLabel); err != nil {
-		e.logf(item.Number, "warn", "could not add lock label: %v\n", err)
-	} else {
-		lockAcquired = true
-		e.store.Apply(itemstate.LocalLockAcquired{
-			Repo:       repoStr,
-			Number:     item.Number,
-			User:       e.cfg.User,
-			AcquiredAt: workerStartedAt,
-			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt, LastSignAt: workerStartedAt},
-		})
-		e.syncLabelAdd(item, lockLabel, true)
-		workerDone = make(chan struct{})
-		e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
-	}
+	releaseLock, workerStartedAt, workerDone, ok := e.acquireLockAndVerify(ctx, item, stage, owner, repo, repoStr, lockLabel)
 	defer func() {
 		if workerDone != nil {
 			close(workerDone)
@@ -605,61 +529,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		Skipped:     true,
 	})
 
-	inProgressLabel := fmt.Sprintf("stage:%s:in_progress", stage.Name)
-	inProgressAdded := false
-
-	// releaseLock is called when we're truly done with this issue+stage
-	// (completed, permanently failed, or paused). NOT called on cooldown retry.
-	// Defined here (before in_progress is added) so the lock-then-verify loser
-	// path can call it safely with inProgressAdded still false.
-	releaseLock := func() {
-		if lockAcquired {
-			e.removeLockLabel(owner, repo, item.Number, lockLabel)
-			e.store.Apply(itemstate.LocalLockReleased{
-				Repo:   itemOwnerRepoString(item, e.defaultRepo()),
-				Number: item.Number,
-			})
-		}
-		if inProgressAdded {
-			e.removeInProgressLabel(owner, repo, item.Number, stage.Name)
-		}
-	}
-
-	// Lock-then-verify: after acquiring our lock, wait briefly to let a
-	// competing instance place its own lock, then re-check. If another
-	// fabrik:locked:* label is present, apply lexicographic tie-breaking:
-	// lower username wins (keeps lock and proceeds); higher username loses
-	// (releases lock and skips this cycle). This is deterministic — exactly
-	// one instance wins any conflict. Note: identical usernames are unsupported
-	// and treated as "win" (both proceed), consistent with single-instance use.
-	if lockAcquired {
-		time.Sleep(lockVerifyDelay)
-		// Lock verification needs live labels, not cached state — another instance
-		// may have written its lock label in the window since we read from cache.
-		labels, err := e.client.FetchLabels(owner, repo, item.Number)
-		if err != nil {
-			e.logf(item.Number, "warn", "could not re-fetch labels for lock verify: %v\n", err)
-		} else {
-			for _, label := range labels {
-				if strings.HasPrefix(label, "fabrik:locked:") && label != lockLabel {
-					competing := strings.TrimPrefix(label, "fabrik:locked:")
-					if e.cfg.User > competing {
-						e.logf(item.Number, "skip", "lock conflict with %q — yielding (lexicographic tie-break)\n", competing)
-						releaseLock()
-						return nil
-					}
-					e.logf(item.Number, "info", "lock conflict with %q — proceeding as winner\n", competing)
-					break
-				}
-			}
-		}
-	}
-
-	if err := e.client.AddLabelToIssue(owner, repo, item.Number, inProgressLabel); err != nil {
-		e.logf(item.Number, "warn", "could not add in_progress label: %v\n", err)
-	} else {
-		inProgressAdded = true
-		e.syncLabelAdd(item, inProgressLabel, true)
+	if !ok {
+		// Lock-then-verify tie-break was lost — acquireLockAndVerify already
+		// released whatever it had acquired.
+		return nil
 	}
 
 	// Ensure the WorktreeManager for this item's repo is ready.
@@ -775,7 +648,216 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		}
 	}
 
-	// Invoke Claude Code in the issue's worktree
+	// Invoke Claude Code in the issue's worktree.
+	resume := !lastAttempt.IsZero() // resume session if we've processed this before
+
+	// Pre-audit snapshot: capture refs in all registered repos before Claude runs.
+	// Only taken for non-read-only, non-unrestricted stages (write-capable stages).
+	// In single-repo projects this produces a one-entry map; crossRepoViolations
+	// filters out the active repo, so no false positives are generated.
+	var preAuditSnapshot map[string]map[string]string
+	if !stage.ReadOnly && !hasUnrestrictedLabel(item) && e.cfg.WorktreeBoundaryAudit {
+		preAuditSnapshot = e.snapshotAllRepoRefs(item.Number)
+	}
+
+	output, completed, usage, totalMultiple, err := e.runInvocationWithExtension(ctx, item, stage, baseBranch, workDir, resume)
+
+	// Post-audit: compare ref snapshot taken before Claude ran against current state.
+	// Any new or changed ref in a non-active repo is a boundary violation.
+	if preAuditSnapshot != nil {
+		postAuditSnapshot := e.snapshotAllRepoRefs(item.Number)
+		if violations := crossRepoViolations(preAuditSnapshot, postAuditSnapshot, repoStr); len(violations) > 0 {
+			e.handleBoundaryViolation(owner, repo, repoStr, item, stage, violations, releaseLock)
+			return nil
+		}
+	}
+	// Report cumulative budget across all extensions in stats footer.
+	usage.MaxTurns = totalMultiple * stage.MaxTurns
+
+	e.finalizeStageOutcome(stageOutcomeParams{
+		ctx:             ctx,
+		board:           board,
+		item:            item,
+		stage:           stage,
+		owner:           owner,
+		repo:            repo,
+		repoStr:         repoStr,
+		baseBranch:      baseBranch,
+		workDir:         workDir,
+		output:          output,
+		completed:       completed,
+		usage:           usage,
+		invokeErr:       err,
+		release:         releaseLock,
+		stashed:         stashed,
+		workerStartedAt: workerStartedAt,
+	})
+
+	return nil
+}
+
+// handleCleanupStage handles a cleanup-stage item: removes the worktree (if this is
+// an issue, not a PR), marks the stage complete, and clears the fabrik:extend-turns
+// label (this is the designated removal site — the label persists across all
+// intermediate stages so the operator can apply it once and have it take effect
+// until Done). No lock, no Claude invocation, no comment processing is needed for
+// cleanup stages; the caller returns immediately after this call.
+func (e *Engine) handleCleanupStage(item gh.ProjectItem, stage *stages.Stage, repoStr string) {
+	completeLabel := fmt.Sprintf("stage:%s:complete", stage.Name)
+	for _, label := range item.Labels {
+		if label == completeLabel {
+			return
+		}
+	}
+
+	// Issues have worktrees; PRs on the board do not — skip the removal for PRs.
+	if !item.IsPR {
+		wm := e.worktreesFor(item.Repo)
+		wtDir := wm.WorktreeDir(item.Number)
+		statusCmd := exec.Command("git", "status", "--porcelain")
+		statusCmd.Dir = wtDir
+		if out, err := statusCmd.Output(); err == nil {
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if line == "" {
+					continue
+				}
+				path := strings.TrimSpace(line[2:])
+				if isEngineManagedPath(path) {
+					continue
+				}
+				e.logf(item.Number, "warn", "worktree dirty at cleanup — uncommitted changes will be discarded\n")
+				break
+			}
+		}
+
+		if err := wm.CleanupWorktree(item.Number, false); err != nil {
+			e.logf(item.Number, "warn", "could not clean up worktree: %v\n", err)
+		}
+	}
+
+	e.addLabel(item, completeLabel)
+
+	// Called unconditionally (not guarded by hasLabel) because cleanup items are
+	// dispatched from shallow board items (labels(first:15)) and the label may be
+	// present on GitHub without appearing in item.Labels. ErrNotFound = already gone
+	// (removeLabel treats it as success and still syncs the cache).
+	e.removeLabel(item, "fabrik:extend-turns")
+
+	// Auto-archiving of Done items is not currently performed (see #1035).
+
+	// Record CooldownAt["periodic-re-eval"] so itemMayNeedWork suppresses
+	// deep-fetches for this terminal item during the cooldown window.
+	cooldown := time.Duration(e.cfg.PollSeconds*10) * time.Second
+	e.store.Apply(itemstate.CooldownRecorded{
+		Repo:   repoStr,
+		Number: item.Number,
+		Reason: "periodic-re-eval",
+		Until:  time.Now().Add(cooldown),
+	})
+	e.store.Apply(itemstate.InvocationRecorded{
+		Repo:      itemOwnerRepoString(item, e.defaultRepo()),
+		Number:    item.Number,
+		Completed: true,
+	})
+}
+
+// acquireLockAndVerify acquires the per-issue lock label and starts the heartbeat,
+// resolves any lock conflict via lock-then-verify lexicographic tie-break, and
+// finally adds the stage's in_progress label. release is idempotent and removes
+// whichever of the lock/in_progress labels were actually acquired; the caller must
+// invoke it when fully done with this issue+stage (completed, permanently failed,
+// or paused) — NOT on every processItem return, so the issue stays locked through
+// cooldown retries. workerDone is non-nil only when the lock label was acquired;
+// the caller owns closing it (heartbeat shutdown) once processing ends. When ok is
+// false, this instance lost the lock-then-verify tie-break against a competing
+// instance and release has already been called — the caller must return immediately
+// without calling release again.
+func (e *Engine) acquireLockAndVerify(ctx context.Context, item gh.ProjectItem, stage *stages.Stage, owner, repo, repoStr, lockLabel string) (release func(), workerStartedAt time.Time, workerDone chan struct{}, ok bool) {
+	lockAcquired := false
+	workerStartedAt = time.Now()
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, lockLabel); err != nil {
+		e.logf(item.Number, "warn", "could not add lock label: %v\n", err)
+	} else {
+		lockAcquired = true
+		e.store.Apply(itemstate.LocalLockAcquired{
+			Repo:       repoStr,
+			Number:     item.Number,
+			User:       e.cfg.User,
+			AcquiredAt: workerStartedAt,
+			Worker:     &itemstate.WorkerHandle{StageName: stage.Name, StartedAt: workerStartedAt, LastSignAt: workerStartedAt},
+		})
+		e.syncLabelAdd(item, lockLabel, true)
+		workerDone = make(chan struct{})
+		e.startHeartbeat(ctx, repoStr, item.Number, workerDone)
+	}
+
+	inProgressLabel := fmt.Sprintf("stage:%s:in_progress", stage.Name)
+	inProgressAdded := false
+
+	// release is called when we're truly done with this issue+stage (completed,
+	// permanently failed, or paused). Defined here (before in_progress is added)
+	// so the lock-then-verify loser path can call it safely with inProgressAdded
+	// still false.
+	release = func() {
+		if lockAcquired {
+			e.removeLockLabel(owner, repo, item.Number, lockLabel)
+			e.store.Apply(itemstate.LocalLockReleased{
+				Repo:   itemOwnerRepoString(item, e.defaultRepo()),
+				Number: item.Number,
+			})
+		}
+		if inProgressAdded {
+			e.removeInProgressLabel(owner, repo, item.Number, stage.Name)
+		}
+	}
+
+	// Lock-then-verify: after acquiring our lock, wait briefly to let a
+	// competing instance place its own lock, then re-check. If another
+	// fabrik:locked:* label is present, apply lexicographic tie-breaking:
+	// lower username wins (keeps lock and proceeds); higher username loses
+	// (releases lock and skips this cycle). This is deterministic — exactly
+	// one instance wins any conflict. Note: identical usernames are unsupported
+	// and treated as "win" (both proceed), consistent with single-instance use.
+	if lockAcquired {
+		time.Sleep(lockVerifyDelay)
+		// Lock verification needs live labels, not cached state — another instance
+		// may have written its lock label in the window since we read from cache.
+		labels, err := e.client.FetchLabels(owner, repo, item.Number)
+		if err != nil {
+			e.logf(item.Number, "warn", "could not re-fetch labels for lock verify: %v\n", err)
+		} else {
+			for _, label := range labels {
+				if strings.HasPrefix(label, "fabrik:locked:") && label != lockLabel {
+					competing := strings.TrimPrefix(label, "fabrik:locked:")
+					if e.cfg.User > competing {
+						e.logf(item.Number, "skip", "lock conflict with %q — yielding (lexicographic tie-break)\n", competing)
+						release()
+						return release, workerStartedAt, workerDone, false
+					}
+					e.logf(item.Number, "info", "lock conflict with %q — proceeding as winner\n", competing)
+					break
+				}
+			}
+		}
+	}
+
+	if err := e.client.AddLabelToIssue(owner, repo, item.Number, inProgressLabel); err != nil {
+		e.logf(item.Number, "warn", "could not add in_progress label: %v\n", err)
+	} else {
+		inProgressAdded = true
+		e.syncLabelAdd(item, inProgressLabel, true)
+	}
+
+	return release, workerStartedAt, workerDone, true
+}
+
+// runInvocationWithExtension resolves invocation options (model/effort overrides,
+// kill-grace windows, initial turn budget) and runs the Claude invocation loop,
+// re-invoking with --resume when max_turns is hit and progress is detected. The
+// hard cap is 3× stage.MaxTurns total across all invocations. totalMultiple
+// reports how many budget multiples were ultimately used, so the caller can
+// compute a cumulative-budget stats footer.
+func (e *Engine) runInvocationWithExtension(ctx context.Context, item gh.ProjectItem, stage *stages.Stage, baseBranch, workDir string, resume bool) (output string, completed bool, usage TokenUsage, totalMultiple int, err error) {
 	modelOverride := e.extractModelOverride(item.Number, item.Labels)
 	if modelOverride != "" {
 		e.logf(item.Number, "model", "using model override %q\n", modelOverride)
@@ -784,7 +866,6 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	if effortOverride != "" {
 		e.logf(item.Number, "effort", "using effort override %q\n", effortOverride)
 	}
-	resume := !lastAttempt.IsZero() // resume session if we've processed this before
 	// Resolve effective kill-grace windows for this stage. Stage-level values override
 	// engine defaults; -1 is the sentinel for "skip this signal step" (sigint: 0s in YAML).
 	sigIntGrace := stage.KillGrace.SigInt
@@ -799,6 +880,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	} else if sigTermGrace == 0 {
 		sigTermGrace = -1 // "0s" explicit → skip SIGTERM (sentinel)
 	}
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	opts := InvokeOptions{
 		ModelOverride:  modelOverride,
 		EffortOverride: effortOverride,
@@ -816,27 +898,13 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// Determine initial turn budget. When fabrik:extend-turns is present the first
 	// invocation gets a 2× budget (pre-granted extension, no progress check needed).
 	firstBudget := stage.MaxTurns
-	totalMultiple := 1
+	totalMultiple = 1
 	if hadExtendTurnsLabel && stage.MaxTurns > 0 {
 		firstBudget = 2 * stage.MaxTurns
 		totalMultiple = 2
 	}
 	baseline := snapshotBaseline(stage, item, workDir)
 
-	// Pre-audit snapshot: capture refs in all registered repos before Claude runs.
-	// Only taken for non-read-only, non-unrestricted stages (write-capable stages).
-	// In single-repo projects this produces a one-entry map; crossRepoViolations
-	// filters out the active repo, so no false positives are generated.
-	var preAuditSnapshot map[string]map[string]string
-	if !stage.ReadOnly && !hasUnrestrictedLabel(item) && e.cfg.WorktreeBoundaryAudit {
-		preAuditSnapshot = e.snapshotAllRepoRefs(item.Number)
-	}
-
-	// Extension loop: re-invoke with --resume when max_turns is hit and progress is detected.
-	// Hard cap is 3× stage.MaxTurns total across all invocations.
-	var output string
-	var completed bool
-	var usage TokenUsage
 	currentBudget := firstBudget
 	for {
 		opts.MaxTurnsOverride = currentBudget
@@ -867,17 +935,47 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		resume = true
 	}
 
-	// Post-audit: compare ref snapshot taken before Claude ran against current state.
-	// Any new or changed ref in a non-active repo is a boundary violation.
-	if preAuditSnapshot != nil {
-		postAuditSnapshot := e.snapshotAllRepoRefs(item.Number)
-		if violations := crossRepoViolations(preAuditSnapshot, postAuditSnapshot, repoStr); len(violations) > 0 {
-			e.handleBoundaryViolation(owner, repo, repoStr, item, stage, violations, releaseLock)
-			return nil
-		}
-	}
-	// Report cumulative budget across all extensions in stats footer.
-	usage.MaxTurns = totalMultiple * stage.MaxTurns
+	return output, completed, usage, totalMultiple, err
+}
+
+// stageOutcomeParams bundles the inputs finalizeStageOutcome needs to interpret a
+// completed Claude invocation and drive the issue to its next state (PR creation,
+// stage completion, blocked-on-input, or retry/escalation).
+type stageOutcomeParams struct {
+	ctx             context.Context
+	board           *gh.ProjectBoard
+	item            gh.ProjectItem
+	stage           *stages.Stage
+	owner, repo     string
+	repoStr         string
+	baseBranch      string
+	workDir         string
+	output          string
+	completed       bool
+	usage           TokenUsage
+	invokeErr       error
+	release         func()
+	stashed         bool
+	workerStartedAt time.Time
+}
+
+// finalizeStageOutcome runs everything that happens after a Claude invocation
+// returns: stats logging, restoring any stash, recording attempt/invocation state,
+// posting output, handling the FABRIK_PR_CREATE marker, and routing to PR
+// creation, stage completion, blocked-on-input, or retry/escalation depending on
+// how the stage concluded.
+func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
+	item := p.item
+	stage := p.stage
+	owner, repo := p.owner, p.repo
+	repoStr := p.repoStr
+	baseBranch := p.baseBranch
+	workDir := p.workDir
+	output := p.output
+	completed := p.completed
+	usage := p.usage
+	err := p.invokeErr
+	releaseLock := p.release
 
 	if usage.TurnsUsed > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
 		if usage.MaxTurns > 0 {
@@ -895,7 +993,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	}()
 
 	// Restore any stashed changes now that the read-only stage has finished.
-	if stashed {
+	if p.stashed {
 		popCmd := exec.Command("git", "stash", "pop")
 		popCmd.Dir = workDir
 		if popOut, popErr := popCmd.CombinedOutput(); popErr != nil {
@@ -905,10 +1003,10 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		}
 	}
 	if err != nil {
-		if ctx.Err() != nil {
+		if p.ctx.Err() != nil {
 			e.logf(item.Number, "skip", "cancelled during claude invocation\n")
 			releaseLock()
-			return nil
+			return
 		}
 		e.logf(item.Number, "warn", "claude invocation issue: %v\n", err)
 	}
@@ -941,13 +1039,13 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			e.postComment(item, msg, false, false) //nolint:errcheck // failure already logged by postComment
 			e.addPausedLabelToItem(owner, repo, item)
 			releaseLock()
-			return nil
+			return
 		} else if prBlock != nil {
-			createdPRNum, createErr := e.processPRCreateMarker(ctx, item, prBlock, owner, repo, baseBranch, repoStr)
+			createdPRNum, createErr := e.processPRCreateMarker(p.ctx, item, prBlock, owner, repo, baseBranch, repoStr)
 			if createErr != nil {
 				// processPRCreateMarker already paused the issue and posted a comment.
 				releaseLock()
-				return nil
+				return
 			}
 			prNumber = createdPRNum
 			// Strip the marker block from output so it is not posted as a comment.
@@ -1041,6 +1139,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// acceptable: queue entry happens at Validate completion, so stages rarely run while
 	// queued. No-op on non-queue repos (FR-3).
 	if claudeRan {
+		wm := e.worktreesFor(item.Repo)
 		if pushErr := e.pushBranchUnlessQueued(item, wm); pushErr != nil {
 			e.logf(item.Number, "warn", "could not push branch: %v\n", pushErr)
 		}
@@ -1070,7 +1169,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		Blocked:   blockedOnInput,
 		Errored:   err != nil,
 		Usage:     usage,
-		Duration:  time.Since(workerStartedAt),
+		Duration:  time.Since(p.workerStartedAt),
 	})
 
 	if completed && noWorkNeeded {
@@ -1079,7 +1178,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		releaseLock()
 		e.store.Apply(itemstate.StageRetryCleared{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 		e.store.Apply(itemstate.EngineUnpaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-		e.handleNoWorkNeeded(board, item, stage)
+		e.handleNoWorkNeeded(p.board, item, stage)
 	} else if completed {
 		// Post-stage: create draft PR and/or mark ready now that commits exist.
 		// prNumber may already be set if the early guard above ran (PostToPR + CreateDraftPR path).
@@ -1099,23 +1198,23 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 						if count >= e.cfg.MaxRetries {
 							e.escalatePRCreationFailure(item, stage, baseBranch)
 							releaseLock()
-							return nil
+							return
 						}
 					}
 					// Below MaxRetries threshold — record flag so next poll retries PR creation
 					// before re-invoking Claude, then release lock and let cooldown expire.
 					e.store.Apply(itemstate.PRCreationFailedRecorded{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 					releaseLock()
-					return nil
+					return
 				}
 			}
 			e.updatePRVerification(item, prNumber, extractSummary(output))
 			// Verify that the PR's closingIssuesReferences includes this issue.
 			// If missing, attempt one auto-heal before advancing to handleStageComplete.
 			// Returns false only when linkage cannot be established — issue is already paused.
-			if !e.verifyAndHealLinkage(ctx, item, prNumber, stage, owner, repo, repoStr) {
+			if !e.verifyAndHealLinkage(p.ctx, item, prNumber, stage, owner, repo, repoStr) {
 				releaseLock()
-				return nil
+				return
 			}
 		}
 		// PR creation succeeded (or not required) — advance the stage.
@@ -1125,7 +1224,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		if stage.MarkPRReadyOnComplete {
 			e.markPRReady(item, prNumber)
 		}
-		e.handleStageComplete(ctx, board, item, stage)
+		e.handleStageComplete(p.ctx, p.board, item, stage)
 	} else if blockedOnInput {
 		releaseLock()
 		e.blockOnInput(item, stage, output)
@@ -1144,8 +1243,6 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 			}
 		}
 	}
-
-	return nil
 }
 
 // escalatePRCreationFailure is called when create_draft_pr: true and ensureDraftPR

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1064,114 +1064,7 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		return s
 	}()
 
-	var deepFetched int
-	for i := range board.Items {
-		if repoFilter != "" && board.Items[i].Repo != "" && board.Items[i].Repo != repoFilter {
-			continue
-		}
-		// Pre-filter: skip items that haven't changed since the last poll cycle.
-		// An item is eligible for deep-fetch evaluation if:
-		//   (a) it is in cycleSet (an observer saw a relevant Store change), OR
-		//   (b) it is a cleanup stage (checks local filesystem, not board state), OR
-		//   (c) it has a bypass label (awaiting-ci, awaiting-review, or rebase-needed need per-poll eval), OR
-		//   (d) it has an expired CooldownAt (periodic re-evaluation gate has passed), OR
-		//   (e) it is not yet recorded in the engine store (first poll / fresh startup).
-		// Items with an active CooldownAt but no other signal are suppressed.
-		item := board.Items[i]
-		iKey := issueKey(item, e.defaultRepo())
-		// Terminal skip: skip items flagged terminal while still in the same cleanup
-		// stage — external board activity (label-bot, PR comments, GitHub bookkeeping)
-		// bumps updatedAt but Fabrik has nothing left to do for them.
-		// item.Status == admitSnap.Status() guards against items that moved between two
-		// cleanup stages: in that case we must process normally to update the store.
-		if admitSnap, admitErr := e.store.Get(itemOwnerRepoString(item, e.defaultRepo()), item.Number); admitErr == nil {
-			if admitSnap.IsTerminal() {
-				if pst := stages.FindStage(e.cfg.Stages, item.Status); pst != nil && pst.CleanupWorktree && item.Status == admitSnap.Status() {
-					continue // terminal + still in same cleanup stage: skip entirely
-				}
-				// Status changed (left cleanup or moved to a different cleanup stage) —
-				// clear the flag and fall through.
-				e.store.Apply(itemstate.TerminalFlagSet{
-					Repo:     itemOwnerRepoString(item, e.defaultRepo()),
-					Number:   item.Number,
-					Terminal: false,
-				})
-				e.logf(item.Number, "poll", "terminal flag cleared (status drifted to %q)\n", item.Status)
-			}
-		}
-		if !cycleSet[iKey] {
-			stage := stages.FindStage(e.cfg.Stages, item.Status)
-			isCleanup := stage != nil && stage.CleanupWorktree
-			hasAwaitingLabel := hasLabel(item, "fabrik:awaiting-ci") || hasLabel(item, "fabrik:rebase-needed") || hasLabel(item, "fabrik:awaiting-review") || hasLabel(item, "fabrik:auto-merge-enabled") || hasLabel(item, "fabrik:revalidate")
-			var hasExpiredCooldown, notInStore bool
-			if !isCleanup && !hasAwaitingLabel {
-				repo := itemOwnerRepoString(item, e.defaultRepo())
-				if snap, snapErr := e.store.Get(repo, item.Number); snapErr == nil {
-					now := time.Now()
-					hasExpiredCooldown = snap.HasExpiredCooldown(now)
-					if snap.HasActiveCooldown(now) && !hasExpiredCooldown {
-						continue // within cooldown window: no change + no expired window
-					}
-				} else {
-					// Item not yet recorded in the engine store (first poll or fresh startup):
-					// let it through so the deep-fetch path can populate the store.
-					notInStore = true
-				}
-			}
-			if !isCleanup && !hasAwaitingLabel && !hasExpiredCooldown && !notInStore {
-				continue // no state change, no bypass — skip this cycle
-			}
-		}
-		if !e.itemMayNeedWork(board.Items[i]) {
-			continue
-		}
-		// Cleanup stages don't need comments or linked-PR data — skip FetchItemDetails
-		// to avoid wasting GraphQL points on items that only need a worktree existence
-		// check and a completion label.
-		if st := stages.FindStage(e.cfg.Stages, board.Items[i].Status); st != nil && st.CleanupWorktree {
-			e.logf(0, "poll", "skipping deep-fetch for cleanup-stage item #%d\n", board.Items[i].Number)
-			deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
-			continue
-		}
-		if c := e.cache(); c != nil && !c.IsPaused() && c.IsItemCacheFresh(board.Items[i].Repo, board.Items[i].Number, board.Items[i].UpdatedAt) {
-			e.logf(0, "poll", "reading details for #%d from cache\n", board.Items[i].Number)
-		} else {
-			e.logf(0, "poll", "deep-fetching details for #%d from GitHub\n", board.Items[i].Number)
-		}
-		if err := e.readClient.FetchItemDetails(&board.Items[i]); err != nil {
-			e.logf(0, "warn", "could not fetch details for #%d: %v\n", board.Items[i].Number, err)
-			e.store.Apply(itemstate.DeepFetchFailed{
-				Repo:   itemOwnerRepoString(board.Items[i], e.defaultRepo()),
-				Number: board.Items[i].Number,
-				At:     time.Now(),
-			})
-			// Skip appending to deepFetchCandidates.
-			// The next poll will retry the deep-fetch for this item.
-			continue
-		}
-		admitRepo := itemOwnerRepoString(board.Items[i], e.defaultRepo())
-		admitPreSnap, admitPreErr := e.store.Get(admitRepo, board.Items[i].Number)
-		// Capture prior-poll merge-queue membership BEFORE ItemDeepFetched
-		// overwrites it (ADR-058 D4 OQ-3 — the "left the queue" edge is otherwise lost).
-		priorInQueue[iKey] = admitPreErr == nil && admitPreSnap.LinkedPR() != nil && admitPreSnap.LinkedPR().IsInMergeQueue
-		e.store.Apply(itemstate.ItemDeepFetched{
-			Repo:       admitRepo,
-			Number:     board.Items[i].Number,
-			FreshState: board.Items[i],
-		})
-		// After a successful deep-fetch, check if this item just became terminal.
-		if isTerminalPredicate(board.Items[i].Labels, board.Items[i].Status, e.cfg.Stages) {
-			if admitPreErr != nil || !admitPreSnap.IsTerminal() {
-				e.logf(board.Items[i].Number, "poll", "terminal flag set\n")
-			}
-			e.store.Apply(itemstate.TerminalFlagSet{Repo: admitRepo, Number: board.Items[i].Number, Terminal: true})
-		}
-		deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
-		deepFetched++
-	}
-	if deepFetched > 0 {
-		e.logf(0, "poll", "deep-fetched details for %d item(s)\n", deepFetched)
-	}
+	deepFetchCandidates, deepFetched := e.selectDeepFetchCandidates(board, repoFilter, cycleSet, priorInQueue)
 
 	// Catch-up loop: operates only on deepFetchCandidates so the full label set is available.
 	//
@@ -1304,122 +1197,13 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// the linked PR's HEAD SHA after stage:Validate:complete was recorded.
 	e.settleSHAInvalidationScan(deepFetchCandidates)
 
-	var dispatched int
 	// Dispatch only items from deepFetchCandidates — items that passed
 	// itemMayNeedWork and (for non-cleanup stages) had FetchItemDetails called to
 	// populate the full label set. Iterating board.Items here instead would
 	// incorrectly pass shallow-label items (labels(first:5) only) to itemNeedsWork,
 	// which could miss stage-complete labels beyond position 5 and re-dispatch
 	// already-completed items on every poll after their updatedAt settles.
-	// Check for duplicate items in deepFetchCandidates
-	seenItems := make(map[string]int)
-	for _, item := range deepFetchCandidates {
-		k := issueKey(item, e.defaultRepo())
-		seenItems[k]++
-		if seenItems[k] > 1 {
-			debugLog("DUPLICATE-IN-CANDIDATES", map[string]interface{}{
-				"key": k, "count": seenItems[k], "number": item.Number,
-			})
-			e.logf(item.Number, "BUG", "item appears %d times in deepFetchCandidates\n", seenItems[k])
-		}
-	}
-
-	for _, item := range deepFetchCandidates {
-		item := item
-		iKey := issueKey(item, e.defaultRepo())
-		itemRepo := itemOwnerRepoString(item, e.defaultRepo())
-		debugLog("dispatch-check", map[string]interface{}{
-			"number": item.Number, "key": iKey, "status": item.Status,
-		})
-		// Full check including comments (populated by deep fetch above).
-		if !e.itemNeedsWork(item) {
-			debugLog("dispatch-skip-no-work", map[string]interface{}{"number": item.Number})
-			continue
-		}
-		// Skip issues already being processed by a previous poll cycle's worker.
-		// Use the Store-backed Worker field (set by WorkerEntered before goroutine launch)
-		// so this check is consistent with the observer pipeline.
-		//
-		// Do NOT cancel the in-flight context here. Every stage adds
-		// stage:X:in_progress when it starts, which fires a webhook, marks the cache
-		// stale, and triggers a new poll while the worker is still running. Cancelling
-		// on every re-encounter creates a tight dispatch → label → webhook → poll →
-		// cancel → respawn feedback loop that prevents any stage from completing a
-		// turn. Genuine "supplant on new event" semantics need to distinguish
-		// self-generated label changes from external ones — left as future work.
-		if snap, err := e.store.Get(itemRepo, item.Number); err == nil && snap.Worker() != nil {
-			debugLog("dispatch-skip-inflight", map[string]interface{}{"number": item.Number})
-			continue
-		}
-		debugLog("dispatch-WILL-DISPATCH", map[string]interface{}{
-			"number": item.Number, "key": iKey,
-		})
-		// Acquire semaphore slot, but abort if the context is cancelled so we
-		// don't block indefinitely when all slots are taken at shutdown time.
-		select {
-		case e.sem <- struct{}{}:
-		case <-ctx.Done():
-			goto doneDispatching
-		}
-		// Capture stage name and start time for job tracking.
-		var stageName string
-		if s := stages.FindStage(e.cfg.Stages, item.Status); s != nil {
-			stageName = s.Name
-		}
-		startTime := time.Now()
-		// Apply WorkerEntered synchronously before the goroutine starts so that
-		// snap.Worker() != nil is immediately true for any concurrent dispatch check.
-		e.store.Apply(itemstate.WorkerEntered{
-			Repo:      itemRepo,
-			Number:    item.Number,
-			StageName: stageName,
-			StartedAt: startTime,
-		})
-		// Create a per-issue context so kill-reason annotation can propagate from
-		// the cancellation path (daemon shutdown, supplant) to the kill log.
-		// The holder is read in cmd.Cancel to derive the reason string.
-		issueHolder := &killReasonHolder{}
-		issueCtx, issueCancel := context.WithCancel(context.WithValue(ctx, killReasonCtxKey{}, issueHolder))
-		e.issueCtxs.Store(iKey, issueCtxEntry{cancel: issueCancel, holder: issueHolder})
-		e.wg.Add(1)
-		dispatched++
-		go func(issueCtx context.Context, issueCancel context.CancelFunc, iKey string, holder *killReasonHolder) {
-			defer e.wg.Done()
-			// Remove per-issue context entry on any exit path (success, panic, cancel).
-			// Guard with holder pointer equality: if a supplant-cancel raced a new dispatch
-			// between WorkerExited (which clears snap.Worker) and this delete, the new entry
-			// would have a different holder and must not be removed.
-			// issueCancel must also be called to release context resources even if the
-			// parent ctx already cancelled (Go context semantics require explicit cancel call).
-			defer func() {
-				if current, ok := e.issueCtxs.Load(iKey); ok && current.(issueCtxEntry).holder == holder {
-					e.issueCtxs.Delete(iKey)
-				}
-				issueCancel()
-			}()
-			// WorkerExited must be deferred at the goroutine top level so it fires on
-			// every exit path, including processItem early-returns (paused, blocked,
-			// awaiting-input, locked-by-other, stage-complete, etc.). The defer inside
-			// processItem (item.go, after lock acquired) is reached only after ~14
-			// early-return guards; any of them would leak the Worker entry and
-			// permanently block re-dispatch via the snap.Worker() != nil guard. Same
-			// pattern as the reinvoke dispatchers in reviews.go, ci.go, and
-			// merge_gate.go.
-			//
-			// Ordering: WorkerExited must fire AFTER the semaphore release so the wake
-			// it triggers does not race a fresh dispatch into a still-occupied slot.
-			// Defers run LIFO; declaring WorkerExited BEFORE the sem-release defer
-			// means sem-release runs first on exit, then WorkerExited fires its wake
-			// against a freed slot.
-			defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
-			defer func() { <-e.sem }()
-			err := e.processItem(issueCtx, board, item)
-			if err != nil {
-				e.logf(item.Number, "error", "%v\n", err)
-			}
-		}(issueCtx, issueCancel, iKey, issueHolder)
-	}
-doneDispatching:
+	dispatched := e.dispatchCandidates(ctx, board, deepFetchCandidates)
 
 	// Merge-train batch snapshot: log all items currently in the Queued column.
 	// Runs every poll cycle when merge_train: on. No dispatch, no mutation — D1 skeleton only.
@@ -1507,6 +1291,247 @@ doneDispatching:
 		Dispatched: dispatched,
 		SeenRepos:  seenRepos,
 	}, nil
+}
+
+// dispatchCandidates checks each deep-fetch candidate against itemNeedsWork and
+// the in-flight worker guard, then dispatches a goroutine per admitted item,
+// gated on an available e.sem slot. It aborts early (without blocking further)
+// if ctx is cancelled while waiting for a slot. Returns the number of items
+// dispatched this cycle.
+func (e *Engine) dispatchCandidates(ctx context.Context, board *gh.ProjectBoard, deepFetchCandidates []gh.ProjectItem) int {
+	var dispatched int
+
+	// Check for duplicate items in deepFetchCandidates.
+	seenItems := make(map[string]int)
+	for _, item := range deepFetchCandidates {
+		k := issueKey(item, e.defaultRepo())
+		seenItems[k]++
+		if seenItems[k] > 1 {
+			debugLog("DUPLICATE-IN-CANDIDATES", map[string]interface{}{
+				"key": k, "count": seenItems[k], "number": item.Number,
+			})
+			e.logf(item.Number, "BUG", "item appears %d times in deepFetchCandidates\n", seenItems[k])
+		}
+	}
+
+	for _, item := range deepFetchCandidates {
+		item := item
+		iKey := issueKey(item, e.defaultRepo())
+		itemRepo := itemOwnerRepoString(item, e.defaultRepo())
+		debugLog("dispatch-check", map[string]interface{}{
+			"number": item.Number, "key": iKey, "status": item.Status,
+		})
+		// Full check including comments (populated by deep fetch above).
+		if !e.itemNeedsWork(item) {
+			debugLog("dispatch-skip-no-work", map[string]interface{}{"number": item.Number})
+			continue
+		}
+		// Skip issues already being processed by a previous poll cycle's worker.
+		// Use the Store-backed Worker field (set by WorkerEntered before goroutine launch)
+		// so this check is consistent with the observer pipeline.
+		//
+		// Do NOT cancel the in-flight context here. Every stage adds
+		// stage:X:in_progress when it starts, which fires a webhook, marks the cache
+		// stale, and triggers a new poll while the worker is still running. Cancelling
+		// on every re-encounter creates a tight dispatch → label → webhook → poll →
+		// cancel → respawn feedback loop that prevents any stage from completing a
+		// turn. Genuine "supplant on new event" semantics need to distinguish
+		// self-generated label changes from external ones — left as future work.
+		if snap, err := e.store.Get(itemRepo, item.Number); err == nil && snap.Worker() != nil {
+			debugLog("dispatch-skip-inflight", map[string]interface{}{"number": item.Number})
+			continue
+		}
+		debugLog("dispatch-WILL-DISPATCH", map[string]interface{}{
+			"number": item.Number, "key": iKey,
+		})
+		// Acquire semaphore slot, but abort if the context is cancelled so we
+		// don't block indefinitely when all slots are taken at shutdown time.
+		select {
+		case e.sem <- struct{}{}:
+		case <-ctx.Done():
+			return dispatched
+		}
+		// Capture stage name and start time for job tracking.
+		var stageName string
+		if s := stages.FindStage(e.cfg.Stages, item.Status); s != nil {
+			stageName = s.Name
+		}
+		startTime := time.Now()
+		// Apply WorkerEntered synchronously before the goroutine starts so that
+		// snap.Worker() != nil is immediately true for any concurrent dispatch check.
+		e.store.Apply(itemstate.WorkerEntered{
+			Repo:      itemRepo,
+			Number:    item.Number,
+			StageName: stageName,
+			StartedAt: startTime,
+		})
+		// Create a per-issue context so kill-reason annotation can propagate from
+		// the cancellation path (daemon shutdown, supplant) to the kill log.
+		// The holder is read in cmd.Cancel to derive the reason string.
+		issueHolder := &killReasonHolder{}
+		issueCtx, issueCancel := context.WithCancel(context.WithValue(ctx, killReasonCtxKey{}, issueHolder))
+		e.issueCtxs.Store(iKey, issueCtxEntry{cancel: issueCancel, holder: issueHolder})
+		e.wg.Add(1)
+		dispatched++
+		go func(issueCtx context.Context, issueCancel context.CancelFunc, iKey string, holder *killReasonHolder) {
+			defer e.wg.Done()
+			// Remove per-issue context entry on any exit path (success, panic, cancel).
+			// Guard with holder pointer equality: if a supplant-cancel raced a new dispatch
+			// between WorkerExited (which clears snap.Worker) and this delete, the new entry
+			// would have a different holder and must not be removed.
+			// issueCancel must also be called to release context resources even if the
+			// parent ctx already cancelled (Go context semantics require explicit cancel call).
+			defer func() {
+				if current, ok := e.issueCtxs.Load(iKey); ok && current.(issueCtxEntry).holder == holder {
+					e.issueCtxs.Delete(iKey)
+				}
+				issueCancel()
+			}()
+			// WorkerExited must be deferred at the goroutine top level so it fires on
+			// every exit path, including processItem early-returns (paused, blocked,
+			// awaiting-input, locked-by-other, stage-complete, etc.). The defer inside
+			// processItem (item.go, after lock acquired) is reached only after ~14
+			// early-return guards; any of them would leak the Worker entry and
+			// permanently block re-dispatch via the snap.Worker() != nil guard. Same
+			// pattern as the reinvoke dispatchers in reviews.go, ci.go, and
+			// merge_gate.go.
+			//
+			// Ordering: WorkerExited must fire AFTER the semaphore release so the wake
+			// it triggers does not race a fresh dispatch into a still-occupied slot.
+			// Defers run LIFO; declaring WorkerExited BEFORE the sem-release defer
+			// means sem-release runs first on exit, then WorkerExited fires its wake
+			// against a freed slot.
+			defer e.store.Apply(itemstate.WorkerExited{Repo: itemRepo, Number: item.Number})
+			defer func() { <-e.sem }()
+			err := e.processItem(issueCtx, board, item)
+			if err != nil {
+				e.logf(item.Number, "error", "%v\n", err)
+			}
+		}(issueCtx, issueCancel, iKey, issueHolder)
+	}
+
+	return dispatched
+}
+
+// selectDeepFetchCandidates runs the deep-fetch pre-filter loop: for each board
+// item that passes the shallow admission checks (cycleSet membership, cleanup
+// stage, bypass label, expired cooldown, or not-yet-recorded-in-store), it calls
+// FetchItemDetails to populate the full label/comment/linked-PR set and appends
+// the item to the returned slice. Cleanup-stage items are admitted without a
+// deep-fetch (they only need a worktree existence check). priorInQueue is
+// populated in place with each item's previous-poll merge-queue membership,
+// captured before ItemDeepFetched overwrites the store (ADR-058 D4 OQ-3).
+func (e *Engine) selectDeepFetchCandidates(board *gh.ProjectBoard, repoFilter string, cycleSet map[string]bool, priorInQueue map[string]bool) ([]gh.ProjectItem, int) {
+	var deepFetchCandidates []gh.ProjectItem
+	var deepFetched int
+	for i := range board.Items {
+		if repoFilter != "" && board.Items[i].Repo != "" && board.Items[i].Repo != repoFilter {
+			continue
+		}
+		// Pre-filter: skip items that haven't changed since the last poll cycle.
+		// An item is eligible for deep-fetch evaluation if:
+		//   (a) it is in cycleSet (an observer saw a relevant Store change), OR
+		//   (b) it is a cleanup stage (checks local filesystem, not board state), OR
+		//   (c) it has a bypass label (awaiting-ci, awaiting-review, or rebase-needed need per-poll eval), OR
+		//   (d) it has an expired CooldownAt (periodic re-evaluation gate has passed), OR
+		//   (e) it is not yet recorded in the engine store (first poll / fresh startup).
+		// Items with an active CooldownAt but no other signal are suppressed.
+		item := board.Items[i]
+		iKey := issueKey(item, e.defaultRepo())
+		// Terminal skip: skip items flagged terminal while still in the same cleanup
+		// stage — external board activity (label-bot, PR comments, GitHub bookkeeping)
+		// bumps updatedAt but Fabrik has nothing left to do for them.
+		// item.Status == admitSnap.Status() guards against items that moved between two
+		// cleanup stages: in that case we must process normally to update the store.
+		if admitSnap, admitErr := e.store.Get(itemOwnerRepoString(item, e.defaultRepo()), item.Number); admitErr == nil {
+			if admitSnap.IsTerminal() {
+				if pst := stages.FindStage(e.cfg.Stages, item.Status); pst != nil && pst.CleanupWorktree && item.Status == admitSnap.Status() {
+					continue // terminal + still in same cleanup stage: skip entirely
+				}
+				// Status changed (left cleanup or moved to a different cleanup stage) —
+				// clear the flag and fall through.
+				e.store.Apply(itemstate.TerminalFlagSet{
+					Repo:     itemOwnerRepoString(item, e.defaultRepo()),
+					Number:   item.Number,
+					Terminal: false,
+				})
+				e.logf(item.Number, "poll", "terminal flag cleared (status drifted to %q)\n", item.Status)
+			}
+		}
+		if !cycleSet[iKey] {
+			stage := stages.FindStage(e.cfg.Stages, item.Status)
+			isCleanup := stage != nil && stage.CleanupWorktree
+			hasAwaitingLabel := hasLabel(item, "fabrik:awaiting-ci") || hasLabel(item, "fabrik:rebase-needed") || hasLabel(item, "fabrik:awaiting-review") || hasLabel(item, "fabrik:auto-merge-enabled") || hasLabel(item, "fabrik:revalidate")
+			var hasExpiredCooldown, notInStore bool
+			if !isCleanup && !hasAwaitingLabel {
+				repo := itemOwnerRepoString(item, e.defaultRepo())
+				if snap, snapErr := e.store.Get(repo, item.Number); snapErr == nil {
+					now := time.Now()
+					hasExpiredCooldown = snap.HasExpiredCooldown(now)
+					if snap.HasActiveCooldown(now) && !hasExpiredCooldown {
+						continue // within cooldown window: no change + no expired window
+					}
+				} else {
+					// Item not yet recorded in the engine store (first poll or fresh startup):
+					// let it through so the deep-fetch path can populate the store.
+					notInStore = true
+				}
+			}
+			if !isCleanup && !hasAwaitingLabel && !hasExpiredCooldown && !notInStore {
+				continue // no state change, no bypass — skip this cycle
+			}
+		}
+		if !e.itemMayNeedWork(board.Items[i]) {
+			continue
+		}
+		// Cleanup stages don't need comments or linked-PR data — skip FetchItemDetails
+		// to avoid wasting GraphQL points on items that only need a worktree existence
+		// check and a completion label.
+		if st := stages.FindStage(e.cfg.Stages, board.Items[i].Status); st != nil && st.CleanupWorktree {
+			e.logf(0, "poll", "skipping deep-fetch for cleanup-stage item #%d\n", board.Items[i].Number)
+			deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
+			continue
+		}
+		if c := e.cache(); c != nil && !c.IsPaused() && c.IsItemCacheFresh(board.Items[i].Repo, board.Items[i].Number, board.Items[i].UpdatedAt) {
+			e.logf(0, "poll", "reading details for #%d from cache\n", board.Items[i].Number)
+		} else {
+			e.logf(0, "poll", "deep-fetching details for #%d from GitHub\n", board.Items[i].Number)
+		}
+		if err := e.readClient.FetchItemDetails(&board.Items[i]); err != nil {
+			e.logf(0, "warn", "could not fetch details for #%d: %v\n", board.Items[i].Number, err)
+			e.store.Apply(itemstate.DeepFetchFailed{
+				Repo:   itemOwnerRepoString(board.Items[i], e.defaultRepo()),
+				Number: board.Items[i].Number,
+				At:     time.Now(),
+			})
+			// Skip appending to deepFetchCandidates.
+			// The next poll will retry the deep-fetch for this item.
+			continue
+		}
+		admitRepo := itemOwnerRepoString(board.Items[i], e.defaultRepo())
+		admitPreSnap, admitPreErr := e.store.Get(admitRepo, board.Items[i].Number)
+		// Capture prior-poll merge-queue membership BEFORE ItemDeepFetched
+		// overwrites it (ADR-058 D4 OQ-3 — the "left the queue" edge is otherwise lost).
+		priorInQueue[iKey] = admitPreErr == nil && admitPreSnap.LinkedPR() != nil && admitPreSnap.LinkedPR().IsInMergeQueue
+		e.store.Apply(itemstate.ItemDeepFetched{
+			Repo:       admitRepo,
+			Number:     board.Items[i].Number,
+			FreshState: board.Items[i],
+		})
+		// After a successful deep-fetch, check if this item just became terminal.
+		if isTerminalPredicate(board.Items[i].Labels, board.Items[i].Status, e.cfg.Stages) {
+			if admitPreErr != nil || !admitPreSnap.IsTerminal() {
+				e.logf(board.Items[i].Number, "poll", "terminal flag set\n")
+			}
+			e.store.Apply(itemstate.TerminalFlagSet{Repo: admitRepo, Number: board.Items[i].Number, Terminal: true})
+		}
+		deepFetchCandidates = append(deepFetchCandidates, board.Items[i])
+		deepFetched++
+	}
+	if deepFetched > 0 {
+		e.logf(0, "poll", "deep-fetched details for %d item(s)\n", deepFetched)
+	}
+	return deepFetchCandidates, deepFetched
 }
 
 // queuedRepoGroup is the Queued-column subset for a single owner/repo, preserving

--- a/engine/poll_helpers_test.go
+++ b/engine/poll_helpers_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+)
+
+// Focused tests for the deep-fetch pre-filter loop and dispatch loop extracted
+// out of poll() (#1029). These call the helpers directly instead of driving the
+// whole poll() cycle (board fetch, cache refresh, rate-limit stats, catch-up
+// loop), which is exactly the isolated testability the decomposition enables.
+
+func TestSelectDeepFetchCandidates_CleanupStageSkipsDeepFetch(t *testing.T) {
+	var fetchDetailsCalled bool
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			fetchDetailsCalled = true
+			return nil
+		},
+	}
+
+	// itemMayNeedWork admits a cleanup-stage item only when its worktree
+	// directory exists on disk — create one so the item reaches the loop body.
+	rootDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rootDir, "issue-42"), 0o755); err != nil {
+		t.Fatalf("create worktree dir: %v", err)
+	}
+	wm := NewWorktreeManagerWithRoot(t.TempDir(), rootDir)
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			Stages: testStagesWithCleanup()},
+		client, &mockClaudeInvoker{}, wm,
+	)
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 42, Title: "Done item", Status: "Done"},
+		},
+	}
+
+	candidates, deepFetched := eng.selectDeepFetchCandidates(board, "", map[string]bool{}, map[string]bool{})
+
+	if fetchDetailsCalled {
+		t.Error("FetchItemDetails must not be called for cleanup-stage items")
+	}
+	if deepFetched != 0 {
+		t.Errorf("deepFetched = %d, want 0 (cleanup-stage admission doesn't count as a deep-fetch)", deepFetched)
+	}
+	if len(candidates) != 1 || candidates[0].Number != 42 {
+		t.Fatalf("expected the cleanup-stage item to be admitted as a candidate, got %+v", candidates)
+	}
+}
+
+func TestSelectDeepFetchCandidates_DeepFetchesEligibleItem(t *testing.T) {
+	var fetchedNumber int
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			fetchedNumber = item.Number
+			item.Labels = []string{"stage:Research:in_progress"}
+			return nil
+		},
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 7, Title: "New item", Status: "Research"},
+		},
+	}
+	// cycleSet marks the item as changed, so it passes the pre-filter regardless
+	// of store/cooldown state.
+	cycleSet := map[string]bool{issueKey(board.Items[0], eng.defaultRepo()): true}
+
+	candidates, deepFetched := eng.selectDeepFetchCandidates(board, "", cycleSet, map[string]bool{})
+
+	if fetchedNumber != 7 {
+		t.Errorf("FetchItemDetails was not called for the eligible item (fetchedNumber=%d)", fetchedNumber)
+	}
+	if deepFetched != 1 {
+		t.Errorf("deepFetched = %d, want 1", deepFetched)
+	}
+	if len(candidates) != 1 || candidates[0].Number != 7 {
+		t.Fatalf("expected item #7 to be a candidate, got %+v", candidates)
+	}
+}
+
+func TestSelectDeepFetchCandidates_RepoFilterExcludesOtherRepos(t *testing.T) {
+	var fetchDetailsCalled bool
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			fetchDetailsCalled = true
+			return nil
+		},
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 1, Title: "Other repo item", Status: "Research", Repo: "other/repo"},
+		},
+	}
+	cycleSet := map[string]bool{issueKey(board.Items[0], eng.defaultRepo()): true}
+
+	candidates, _ := eng.selectDeepFetchCandidates(board, "owner/repo", cycleSet, map[string]bool{})
+
+	if fetchDetailsCalled {
+		t.Error("FetchItemDetails must not be called for items outside repoFilter")
+	}
+	if len(candidates) != 0 {
+		t.Errorf("expected no candidates from a filtered-out repo, got %d", len(candidates))
+	}
+}
+
+func TestDispatchCandidates_DispatchesEligibleItem(t *testing.T) {
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(t, &mockGitHubClient{}, claude)
+	eng.cfg.MaxConcurrent = 1
+	eng.sem = make(chan struct{}, 1)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 3, Title: "Test", Status: "Research"}
+
+	dispatched := eng.dispatchCandidates(context.Background(), board, []gh.ProjectItem{item})
+	eng.wg.Wait()
+
+	if dispatched != 1 {
+		t.Errorf("dispatched = %d, want 1", dispatched)
+	}
+}
+
+func TestDispatchCandidates_SkipsInFlightWorker(t *testing.T) {
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(t, &mockGitHubClient{}, claude)
+	eng.cfg.MaxConcurrent = 1
+	eng.sem = make(chan struct{}, 1)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 9, Title: "Test", Status: "Research"}
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo:      itemOwnerRepoString(item, eng.defaultRepo()),
+		Number:    item.Number,
+		StageName: "Research",
+		StartedAt: time.Now(),
+	})
+
+	dispatched := eng.dispatchCandidates(context.Background(), board, []gh.ProjectItem{item})
+
+	if dispatched != 0 {
+		t.Errorf("dispatched = %d, want 0 (item already has an in-flight worker)", dispatched)
+	}
+}

--- a/engine/process_item_helpers_test.go
+++ b/engine/process_item_helpers_test.go
@@ -1,0 +1,164 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// Focused tests for the helpers extracted out of processItem (#1029). These call
+// the helpers directly rather than driving the whole processItem pipeline
+// (worktree setup, dependency checks, Claude invocation), which is exactly the
+// isolated testability the decomposition is meant to enable.
+
+func TestAcquireLockAndVerify_TieBreakLoss(t *testing.T) {
+	// Competing lock from "aardvark" — lexicographically before "testuser" — wins
+	// the tie-break, so this instance must yield and release what it acquired.
+	client := &mockGitHubClient{
+		fetchLabelsFn: func(owner, repo string, issueNumber int) ([]string, error) {
+			return []string{"fabrik:locked:testuser", "fabrik:locked:aardvark"}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(t, client, claude)
+
+	stage := &stages.Stage{Name: "Research"}
+	item := gh.ProjectItem{Number: 10, Title: "Test issue"}
+
+	release, _, workerDone, ok := eng.acquireLockAndVerify(context.Background(), item, stage, "owner", "repo", "owner/repo", "fabrik:locked:testuser")
+	if ok {
+		t.Fatal("expected ok=false on lost tie-break")
+	}
+	if release == nil {
+		t.Fatal("expected a non-nil release closure")
+	}
+	if workerDone == nil {
+		t.Error("workerDone should be the heartbeat channel even on a lost tie-break (caller still owns closing it)")
+	} else {
+		close(workerDone)
+	}
+
+	var lockRemoved, inProgressAdded bool
+	for _, call := range client.removeLabelCalls {
+		if call.labelName == "fabrik:locked:testuser" {
+			lockRemoved = true
+		}
+	}
+	for _, call := range client.addLabelCalls {
+		if call.labelName == "stage:Research:in_progress" {
+			inProgressAdded = true
+		}
+	}
+	if !lockRemoved {
+		t.Error("lock label should have been removed by the lost tie-break")
+	}
+	if inProgressAdded {
+		t.Error("in_progress label should NOT be added when the tie-break is lost")
+	}
+
+	// release must be idempotent-safe to call again without panicking (processItem
+	// never calls it twice on this path, but the closure itself must tolerate it).
+	release()
+}
+
+func TestAcquireLockAndVerify_NoConflict_AddsInProgress(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLabelsFn: func(owner, repo string, issueNumber int) ([]string, error) {
+			return []string{"fabrik:locked:testuser"}, nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(t, client, claude)
+
+	stage := &stages.Stage{Name: "Research"}
+	item := gh.ProjectItem{Number: 11, Title: "Test issue"}
+
+	release, workerStartedAt, workerDone, ok := eng.acquireLockAndVerify(context.Background(), item, stage, "owner", "repo", "owner/repo", "fabrik:locked:testuser")
+	if workerDone != nil {
+		defer close(workerDone)
+	}
+	if !ok {
+		t.Fatal("expected ok=true when there is no competing lock")
+	}
+	if workerStartedAt.IsZero() {
+		t.Error("expected a non-zero workerStartedAt")
+	}
+
+	var inProgressAdded bool
+	for _, call := range client.addLabelCalls {
+		if call.labelName == "stage:Research:in_progress" {
+			inProgressAdded = true
+		}
+	}
+	if !inProgressAdded {
+		t.Error("expected stage:Research:in_progress to be added")
+	}
+
+	release()
+	var inProgressRemoved bool
+	for _, call := range client.removeLabelCalls {
+		if call.labelName == "stage:Research:in_progress" {
+			inProgressRemoved = true
+		}
+	}
+	if !inProgressRemoved {
+		t.Error("release() should remove the in_progress label that was acquired")
+	}
+}
+
+func TestHandleCleanupStage_Direct(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	if _, err := wm.EnsureWorktree(42, "main", false); err != nil {
+		t.Fatalf("EnsureWorktree: %v", err)
+	}
+
+	var addedLabel string
+	client := &mockGitHubClient{
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			addedLabel = labelName
+			return nil
+		},
+	}
+	claude := &mockClaudeInvoker{}
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token"},
+		client, claude, wm,
+	)
+
+	stage := &stages.Stage{Name: "Done", CleanupWorktree: true}
+	item := gh.ProjectItem{Number: 42, Title: "Test", ItemID: "PVTI_42"}
+
+	eng.handleCleanupStage(item, stage, "owner/repo")
+
+	if _, err := os.Stat(wm.WorktreeDir(42)); !os.IsNotExist(err) {
+		t.Error("worktree directory should have been removed")
+	}
+	if addedLabel != "stage:Done:complete" {
+		t.Errorf("completion label = %q, want stage:Done:complete", addedLabel)
+	}
+	snap, _ := eng.store.Get("owner/repo", 42)
+	if snap.CooldownAt("periodic-re-eval").IsZero() {
+		t.Error("CooldownAt[periodic-re-eval] should be set after cleanup stage")
+	}
+}
+
+func TestHandleCleanupStage_AlreadyComplete_NoOp(t *testing.T) {
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := testEngine(t, client, claude)
+
+	stage := &stages.Stage{Name: "Done", CleanupWorktree: true}
+	item := gh.ProjectItem{Number: 5, Title: "Test", Labels: []string{"stage:Done:complete"}}
+
+	eng.handleCleanupStage(item, stage, "owner/repo")
+
+	if len(client.addLabelCalls) != 0 {
+		t.Errorf("expected no label calls when already complete, got %d", len(client.addLabelCalls))
+	}
+}


### PR DESCRIPTION
Closes #1029

## Summary

Decomposes three oversized orchestrator functions identified by the 2026-07-20 code-health audit into named, single-responsibility helpers. Pure code-motion — no behavior changes.

- **`processItem`** (`engine/item.go`, ~817 lines): extracted `handleCleanupStage`, `acquireLockAndVerify`, `runInvocationWithExtension`, and `finalizeStageOutcome`. The PR-creation retry logic stays inline in the orchestrator per explicit scope.
- **`poll`** (`engine/poll.go`, ~670 lines): extracted `selectDeepFetchCandidates` (deep-fetch pre-filter loop) and `dispatchCandidates` (dispatch loop). No file-level split — that's deferred.
- **`Execute`** (`cmd/root.go`, ~795 lines): extracted typed `resolveBool`/`resolveInt`/`resolveDuration` helpers to replace ~17 of the most uniform flag>env>config precedence blocks, plus `handleReexecPluginRefresh` for the re-exec/plugin-refresh logic. The remaining heterogeneous-validation blocks were deliberately left inline (a generalized resolver would over-engineer for their shape).

## Scope note

This issue's Plan stage intended to spawn 9 per-file child issues (this decomposition plus 7 others), but the spawn markers never fired, so nothing was ever created. The operator resolved this mid-Implement by scoping the issue down to direct implementation of just these three genuine god-functions. The remaining 7 items (poll.go file split, `FetchItemDetails`, `processComments`, `applyToItem`/store.go split, `runMergeTrainWorker`, `runClaude`, `supervise`/`checkCIGate`/`checkReviewGate`) are tracked in follow-up issue #1040.

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./...` — 2376 passed, 1 failed (`TestExecute_ConfigYAMLApplied`); confirmed this failure is pre-existing and reproduces identically on unmodified `main` (network-dependent SIGINT timing, unrelated to this change)
- Each new helper has a focused direct-call test