### PR TITLE
Suppress false linkage-drift cache invalidation for base:<branch> items

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5553,7 +5553,9 @@ The probe loop:
 
 4. **New item** (not in store): seeds minimal state via `IssueOpened`, then calls `FetchItemDetails` unconditionally to populate labels and deep fields.
 
-5. **Linkage drift** (`probe.linkedPRNumber ≠ cached LinkedPR.Number`): applies `DeepFetchInvalidated` to reset `LastSeenSourceUpdatedAt`, then falls through to the staleness check.
+5. **Linkage drift** (`probe.linkedPRNumber ≠ cached LinkedPR.Number`) — on a warm cache (`LastDeepFetchAt` set), applies `DeepFetchInvalidated` to reset `LastSeenSourceUpdatedAt`, then falls through to the staleness check.
+
+   **base:`<branch>` suppression**: `closedByPullRequestsReferences` is only populated by GitHub for PRs targeting the repository's *default* branch, so the shallow probe structurally always reports `LinkedPRNumber == 0` for an item whose linked PR targets a non-default `base:<branch>`, even while the warm deep cache correctly holds the real PR number (resolved via the base-independent linkage path). To avoid perpetual false-positive invalidation on every poll, the drift check is suppressed — left as a true no-op, no `DeepFetchInvalidated` and no `PRDetailsUpdated` — when all three hold: the probe reports `LinkedPRNumber == 0`, the cached `LinkedPR.Number` is non-zero, and the cached item (read from the Store's `ItemState.Labels`, never from the probe item — probe items carry no `Labels` field) satisfies `itemHasBaseLabel`. A probe reporting a *different non-zero* PR number on a base-labeled item is still treated as genuine drift and invalidates as usual. Default-branch behavior (no `base:` label) is unaffected — the suppression can never fire since `itemHasBaseLabel` is false.
 
 6. Applies `ProbeBoardItemUpdated` (updates `IsClosed`, `State`, `IsPR`, `Status`, `UpdatedAt`; **explicitly skips `Labels`** to preserve the cached label set populated by prior deep-fetches or webhook deltas).
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2874,7 +2874,9 @@ The probe loop:
 
 4. **New item** (not in store): seeds minimal state via `IssueOpened`, then calls `FetchItemDetails` unconditionally to populate labels and deep fields.
 
-5. **Linkage drift** (`probe.linkedPRNumber ≠ cached LinkedPR.Number`): applies `DeepFetchInvalidated` to reset `LastSeenSourceUpdatedAt`, then falls through to the staleness check.
+5. **Linkage drift** (`probe.linkedPRNumber ≠ cached LinkedPR.Number`) — on a warm cache (`LastDeepFetchAt` set), applies `DeepFetchInvalidated` to reset `LastSeenSourceUpdatedAt`, then falls through to the staleness check.
+
+   **base:`<branch>` suppression**: `closedByPullRequestsReferences` is only populated by GitHub for PRs targeting the repository's *default* branch, so the shallow probe structurally always reports `LinkedPRNumber == 0` for an item whose linked PR targets a non-default `base:<branch>`, even while the warm deep cache correctly holds the real PR number (resolved via the base-independent linkage path). To avoid perpetual false-positive invalidation on every poll, the drift check is suppressed — left as a true no-op, no `DeepFetchInvalidated` and no `PRDetailsUpdated` — when all three hold: the probe reports `LinkedPRNumber == 0`, the cached `LinkedPR.Number` is non-zero, and the cached item (read from the Store's `ItemState.Labels`, never from the probe item — probe items carry no `Labels` field) satisfies `itemHasBaseLabel`. A probe reporting a *different non-zero* PR number on a base-labeled item is still treated as genuine drift and invalidates as usual. Default-branch behavior (no `base:` label) is unaffected — the suppression can never fire since `itemHasBaseLabel` is false.
 
 6. Applies `ProbeBoardItemUpdated` (updates `IsClosed`, `State`, `IsPR`, `Status`, `UpdatedAt`; **explicitly skips `Labels`** to preserve the cached label set populated by prior deep-fetches or webhook deltas).
 

--- a/engine/terminal.go
+++ b/engine/terminal.go
@@ -121,6 +121,15 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 					Number:   pi.Number,
 					PRNumber: pi.LinkedPRNumber,
 				})
+			} else if pi.LinkedPRNumber == 0 && cachedPRNum != 0 && itemHasBaseLabel(gh.ProjectItem{Labels: s.Labels}) {
+				// base:<branch> item: closedByPullRequestsReferences is only populated
+				// for PRs targeting the repo's default branch, so the shallow probe
+				// structurally always reports 0 here even though a real linked PR
+				// exists in the warm deep cache. This is not real drift — leave the
+				// deep cache untouched (no-op: applying PRDetailsUpdated with 0 would
+				// wipe the correct cached LinkedPR.Number). Read labels from the
+				// cached state (s), never the probe item pi — probe items never
+				// carry labels (see doc comment above).
 			} else {
 				// Warm cache (has been deep-fetched): real linkage drift — invalidate.
 				e.logf(pi.Number, "cache", "probe: linkage drift (was PR #%d, now PR #%d) — invalidating deep cache\n",

--- a/engine/terminal.go
+++ b/engine/terminal.go
@@ -121,7 +121,7 @@ func (e *Engine) runProbeAndDeepFetch(cacheImpl *boardcache.CacheImpl) {
 					Number:   pi.Number,
 					PRNumber: pi.LinkedPRNumber,
 				})
-			} else if pi.LinkedPRNumber == 0 && cachedPRNum != 0 && itemHasBaseLabel(gh.ProjectItem{Labels: s.Labels}) {
+			} else if pi.LinkedPRNumber == 0 && itemHasBaseLabel(gh.ProjectItem{Labels: s.Labels}) {
 				// base:<branch> item: closedByPullRequestsReferences is only populated
 				// for PRs targeting the repo's default branch, so the shallow probe
 				// structurally always reports 0 here even though a real linked PR

--- a/engine/terminal_test.go
+++ b/engine/terminal_test.go
@@ -920,6 +920,89 @@ func TestRunProbeAndDeepFetch_LinkageDrift_InvalidatesAndDeepFetches(t *testing.
 	}
 }
 
+// TestRunProbeAndDeepFetch_BaseLabeledItem_ZeroProbeSuppressesDrift verifies
+// that for a base:<branch>-labeled item, a probe reporting LinkedPRNumber == 0
+// against a warm cache holding a nonzero linked PR is NOT treated as linkage
+// drift: FetchItemDetails must not be called and the cached LinkedPR.Number
+// must survive unchanged. This is the structurally-expected case where
+// closedByPullRequestsReferences is empty because the PR targets a non-default
+// base branch.
+func TestRunProbeAndDeepFetch_BaseLabeledItem_ZeroProbeSuppressesDrift(t *testing.T) {
+	T1 := time.Now().Add(-time.Hour).Truncate(time.Second)
+	var deepFetchCalls int
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				// Structurally-expected probe value of 0 for a base:<branch> item.
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo", Status: "Research", EffectiveUpdatedAt: T1, LinkedPRNumber: 0},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			return nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	// Warm cache: prior deep-fetch resolved the real PR #42 via the
+	// base-independent linkage path, and the item carries a base: label.
+	eng.store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 1,
+		FreshState: gh.ProjectItem{
+			ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", UpdatedAt: T1,
+			LinkedPRNumber: 42,
+			Labels:         []string{"base:release"},
+		},
+	})
+	eng.runProbeAndDeepFetch(cache)
+	if deepFetchCalls != 0 {
+		t.Errorf("expected 0 FetchItemDetails calls (suppressed base-label drift); got %d", deepFetchCalls)
+	}
+	snap, err := eng.store.Get("owner/repo", 1)
+	if err != nil {
+		t.Fatalf("store.Get failed: %v", err)
+	}
+	st := snap.State()
+	if st.LinkedPR == nil || st.LinkedPR.Number != 42 {
+		t.Errorf("expected cached LinkedPR.Number to remain 42, got %+v", st.LinkedPR)
+	}
+}
+
+// TestRunProbeAndDeepFetch_BaseLabeledItem_GenuineDriftStillInvalidates
+// verifies that for a base:<branch>-labeled item, a probe reporting a
+// *different nonzero* linked PR than the cache still triggers real linkage
+// drift (invalidate + re-deep-fetch) — only the 0-vs-nonzero case is
+// suppressed.
+func TestRunProbeAndDeepFetch_BaseLabeledItem_GenuineDriftStillInvalidates(t *testing.T) {
+	T1 := time.Now().Add(-time.Hour).Truncate(time.Second)
+	var deepFetchCalls int
+	client := &mockGitHubClient{
+		probeProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+			return []gh.BoardProbeItem{
+				{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo", Status: "Research", EffectiveUpdatedAt: T1, LinkedPRNumber: 99},
+			}, "PVT_1", nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			deepFetchCalls++
+			return nil
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	eng.store.Apply(itemstate.ItemDeepFetched{
+		Repo:   "owner/repo",
+		Number: 1,
+		FreshState: gh.ProjectItem{
+			ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", UpdatedAt: T1,
+			LinkedPRNumber: 42,
+			Labels:         []string{"base:release"},
+		},
+	})
+	eng.runProbeAndDeepFetch(cache)
+	if deepFetchCalls == 0 {
+		t.Error("expected FetchItemDetails called after genuine drift on base-labeled item (PR #42 → #99); got 0 calls")
+	}
+}
+
 // TestRunProbeAndDeepFetch_ItemGone_RemovedFromStore verifies that an item
 // present in the store but absent from probe results is removed from the store.
 func TestRunProbeAndDeepFetch_ItemGone_RemovedFromStore(t *testing.T) {


### PR DESCRIPTION
Closes #1056

## What

`runProbeAndDeepFetch` (`engine/terminal.go`) treats any mismatch between the shallow probe's `LinkedPRNumber` and the cached `LinkedPR.Number` as "linkage drift" and invalidates the warm deep cache, forcing a re-deep-fetch. For `base:<branch>` items, GitHub's `closedByPullRequestsReferences` is only populated for PRs targeting the repo's default branch, so the probe *always* reports `LinkedPRNumber == 0` even when the deep cache correctly holds the real linked PR (resolved via the base-independent path added in #1047). This produced perpetual false-positive invalidation on every poll — observed as hundreds of "linkage drift (was PR #3609, now PR #0)" log lines and delayed close-on-merge for `base:<branch>` issues.

## Changes

- `engine/terminal.go`: in the warm-cache linkage-drift branch, added a guard that treats a probe value of `0` against a non-zero cached PR as structurally expected (not real drift) when the cached item (read from Store state, not the probe item) satisfies `itemHasBaseLabel`. In that case the check is a true no-op — no `DeepFetchInvalidated`, no `PRDetailsUpdated` — so the correct cached PR number survives. A genuinely different non-zero probe PR on a base-labeled item still invalidates as real drift. Default-branch behavior is unchanged since the guard can never fire without a `base:` label.
- `engine/terminal_test.go`: two new tests — `TestRunProbeAndDeepFetch_BaseLabeledItem_ZeroProbeSuppressesDrift` (suppression case, asserts no `FetchItemDetails` call and cached PR number survives) and `TestRunProbeAndDeepFetch_BaseLabeledItem_GenuineDriftStillInvalidates` (different non-zero PR still invalidates). Existing default-branch drift test passes unmodified.
- `docs/state-machine.md`: extended the "Linkage drift" step of the per-poll probe description to document the new base-labeled suppression case; regenerated `docs/llms-full.txt`.

## How to test

`go build ./... && go vet ./... && go test -race ./...` — full suite passes (2433 tests). The two new tests directly exercise the suppression and genuine-drift-still-fires paths.

References #1046, #1047, #1050, #1053 (this is the fourth `base:<branch>` surface fix; unblocks #1053's e2e close-on-merge assertion).