### PR TITLE
fix(e2e): assert merge-train landing on durable Done-or-closed signal, not transient board status

### DIFF
--- a/tests/e2e/mergetrain_bisect_test.go
+++ b/tests/e2e/mergetrain_bisect_test.go
@@ -57,7 +57,7 @@ func TestMergeTrainBisectionEjectsPoisoner(t *testing.T) {
 	for _, m := range []struct {
 		issue, pr int
 	}{{clean1Issue, clean1PR}, {clean2Issue, clean2PR}} {
-		WaitForProjectStatus(t, env, env.RepoAlpha, m.issue, "Done", 25*time.Minute)
+		WaitForMemberLanded(t, env, env.RepoAlpha, m.issue, 25*time.Minute)
 		waitForPRClosed(t, env, env.RepoAlpha, m.pr, 5*time.Minute)
 		t.Logf("survivor #%d landed (Done, PR #%d closed)", m.issue, m.pr)
 	}

--- a/tests/e2e/mergetrain_happy_test.go
+++ b/tests/e2e/mergetrain_happy_test.go
@@ -63,7 +63,7 @@ func TestMergeTrainHappyPathLanding(t *testing.T) {
 	// landing's explicit fallback close — NOT via the member PR. Asserting issue
 	// closure here is the regression guard for the connectivity fix.
 	for _, m := range members {
-		WaitForProjectStatus(t, env, env.RepoAlpha, m.issue, "Done", 10*time.Minute)
+		WaitForMemberLanded(t, env, env.RepoAlpha, m.issue, 10*time.Minute)
 		waitForPRClosed(t, env, env.RepoAlpha, m.pr, 10*time.Minute)
 		WaitForIssueClosed(t, env, env.RepoAlpha, m.issue, 10*time.Minute)
 		t.Logf("member #%d landed: Done + issue closed + member PR #%d closed", m.issue, m.pr)

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -181,6 +181,39 @@ func projectStatus(t *testing.T, env *Env, repo string, issueNumber int) string 
 	return strings.TrimSpace(lastNonEmpty(out))
 }
 
+// WaitForMemberLanded polls until a landed member reaches the durable landing
+// signal: board Status == "Done" OR the issue is CLOSED. The two are not
+// equivalent — this repo's project has a native "archive item when issue
+// closes" automation that runs near-instantly after a member's issue closes
+// (via the integration PR's Closes #N), and an archived board item drops out
+// of `gh project item-list` entirely (status reads "" thereafter). A poll keyed
+// solely on Status=="Done" can therefore miss a member that closes-and-archives
+// between two poll ticks, even though the train landed it correctly. Closed is
+// itself a durable, un-missable terminal state, so racing both signals and
+// accepting whichever is observed first eliminates the miss.
+func WaitForMemberLanded(t *testing.T, env *Env, repo string, issueNumber int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastStatus, lastState string
+	for time.Now().Before(deadline) {
+		lastStatus = projectStatus(t, env, repo, issueNumber)
+		if lastStatus == "Done" {
+			return
+		}
+		if state, err := tryIssueState(env, repo, issueNumber); err == nil {
+			lastState = state
+			if state == "CLOSED" {
+				return
+			}
+		} else {
+			t.Logf("WaitForMemberLanded: transient gh error reading issue state for %s#%d: %v (will retry)", repo, issueNumber, err)
+		}
+		time.Sleep(10 * time.Second)
+	}
+	t.Fatalf("timed out waiting for %s#%d to land (last observed status %q, issue state %q)",
+		repo, issueNumber, lastStatus, lastState)
+}
+
 // WaitForIssueComment polls the issue's comments until one contains substring, or
 // timeout expires. Used to assert engine-posted lifecycle comments (e.g. the
 // merge-train ejection notice) that are posted on every code path.

--- a/tests/e2e/mergetrain_restart_test.go
+++ b/tests/e2e/mergetrain_restart_test.go
@@ -43,7 +43,7 @@ func TestMergeTrainRestartSafety(t *testing.T) {
 	b1b, b1bPR := QueueMember(t, env, env.RepoAlpha, base, "r1b", "e2e/train/restart/r1b.txt", "restart batch1 b\n")
 	WaitForLogLine(t, env, "landing complete", logStart1, 30*time.Minute)
 	for _, m := range [][2]int{{b1a, b1aPR}, {b1b, b1bPR}} {
-		WaitForProjectStatus(t, env, env.RepoAlpha, m[0], "Done", 10*time.Minute)
+		WaitForMemberLanded(t, env, env.RepoAlpha, m[0], 10*time.Minute)
 		waitForPRClosed(t, env, env.RepoAlpha, m[1], 10*time.Minute)
 	}
 	t.Logf("batch 1 landed — a merged integration PR is now history on the repo")
@@ -61,7 +61,7 @@ func TestMergeTrainRestartSafety(t *testing.T) {
 	b2b, b2bPR := QueueMember(t, env, env.RepoAlpha, base, "r2b", "e2e/train/restart/r2b.txt", "restart batch2 b\n")
 	WaitForLogLine(t, env, "landing complete", logStart2, 30*time.Minute)
 	for _, m := range [][2]int{{b2a, b2aPR}, {b2b, b2bPR}} {
-		WaitForProjectStatus(t, env, env.RepoAlpha, m[0], "Done", 10*time.Minute)
+		WaitForMemberLanded(t, env, env.RepoAlpha, m[0], 10*time.Minute)
 		waitForPRClosed(t, env, env.RepoAlpha, m[1], 10*time.Minute)
 	}
 	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)


### PR DESCRIPTION
Closes #1059

## What this does

Hardens the merge-train e2e scenarios against a real harness race: `WaitForProjectStatus(..., "Done", ...)` can miss a member that lands correctly, because this test bed's project has a native "archive item when issue closes" automation that removes a closed issue's board item from `gh project item-list` almost instantly after the integration PR's `Closes #N` closes it. A poll can observe status flip straight from `Queued`/blank to `""` without ever catching `"Done"` in between ticks — a pure harness timing gap, not an engine defect (confirmed in the linked issue: the engine landed the batch correctly, closing all members within ~1s).

### Changes

- Added `WaitForMemberLanded(t, env, repo, issueNumber, timeout)` to `tests/e2e/mergetrain_helpers.go`. It races two signals each poll tick — board `Status == "Done"` and issue `state == "CLOSED"` — and returns on whichever durable terminal state is observed first. `WaitForProjectStatus` itself is untouched (it's still correctly used elsewhere, e.g. a genuinely non-terminal `"Validate"` wait in `paused_merged_pr_recovery_test.go`, where weakening its timeout semantics would mask real regressions).
- Routed `mergetrain_happy_test.go`, `mergetrain_bisect_test.go`, and `mergetrain_restart_test.go` through the new helper, replacing their `WaitForProjectStatus(..., "Done", ...)` landing-wait call sites.
  - `mergetrain_happy_test.go` keeps its separate, explicitly-commented `WaitForIssueClosed` call after `WaitForMemberLanded` — that assertion is a named regression guard for a prior connectivity fix and stays visible even though `WaitForMemberLanded` would also observe `CLOSED` internally.
- Audited `mergetrain_runaway_test.go`: no change needed. It only ever asserts the *negative* (`status != "Done"`) via the already archive-tolerant `projectStatus` helper, so it was never exposed to this race.

### Deferred (not in this PR)

The issue also covers a second, independent race in `TestBaseBranchPipeline` (base:<branch> setup race). That test's file, `tests/e2e/basebranch_test.go`, only exists on the still-open PR #1054 (`fabrik/issue-1053`) and does not exist on `main` yet — confirmed both at Research/Plan time and re-confirmed immediately before this PR (`gh pr view 1054` → `OPEN`, `mergeable: MERGEABLE`). Per the issue's own explicit risk-handling instructions, this half is deferred to a follow-up once #1054 merges rather than blocking or attempting to recreate the file from scratch. The merge-train fix is fully independent and ships now.

## How to test

- `go vet -tags=e2e ./tests/e2e/...` — clean.
- `go build ./...` && `go vet ./...` — clean (full-repo sanity check, since the e2e package is build-tag-gated).
- Full local `go test ./...` — all passing except one pre-existing, unrelated failure (`cmd.TestExecute_ConfigYAMLApplied`, a network-dependent test failing due to sandbox network restrictions; untouched by this change).
- The actual race this fixes is sub-second and timing-sensitive to reproduce on demand; confidence comes from code review of `WaitForMemberLanded`'s logic (structurally tolerant of an empty/archived status, races both signals correctly) rather than repeatedly triggering the exact window in a live run. The next live `TestMergeTrainHappyPathLanding`/bisect/restart run will exercise it under real conditions.