### PR TITLE
docs: correct stale auto-archive status in README for v0.0.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Plan can also decompose an oversized issue autonomously. It emits `FABRIK_SPAWN_
 
 See the [USER_GUIDE §3 — Dependency-Based Sequencing (Formations)](docs/USER_GUIDE.md#dependency-based-sequencing-formations) for the full recipe, diagram, and behavior callouts.
 
-When an issue reaches Done, it remains on the board in the Done column until auto-archive removes it. Auto-archive is **on by default**: once an item has sat in Done for at least `--archive-after` (default `168h` / one week, also `FABRIK_ARCHIVE_AFTER`), anchored to when it settled into Done, Fabrik archives it off the project board. Archived items are not deleted — they remain accessible and recoverable via the project board's "Archive" view in GitHub. Set `--archive-done off` (also `FABRIK_ARCHIVE_DONE=off`) to disable auto-archival and leave Done items on the board indefinitely.
+When an issue reaches Done, it remains on the board in the Done column until auto-archive removes it. Auto-archive is **on by default**: once an item has sat in Done for at least `--archive-after` (default `168h` / one week, also `FABRIK_ARCHIVE_AFTER`), anchored to when the completion label (`stage:<Done>:complete`) was applied, Fabrik archives it off the project board. Archived items are not deleted — they remain accessible and recoverable via the project board's "Archive" view in GitHub. Set `--archive-done off` (also `FABRIK_ARCHIVE_DONE=off`) to disable auto-archival and leave Done items on the board indefinitely.
 
 ## The Self-Evolving Factory
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Plan can also decompose an oversized issue autonomously. It emits `FABRIK_SPAWN_
 
 See the [USER_GUIDE §3 — Dependency-Based Sequencing (Formations)](docs/USER_GUIDE.md#dependency-based-sequencing-formations) for the full recipe, diagram, and behavior callouts.
 
-When an issue reaches Done, it remains on the board in the Done column. Auto-archive is currently disabled — it was removing items from the board before users could see them. It will be re-enabled once the timing logic is reworked to track actual Done stage completion time.
+When an issue reaches Done, it remains on the board in the Done column until auto-archive removes it. Auto-archive is **on by default**: once an item has sat in Done for at least `--archive-after` (default `168h` / one week, also `FABRIK_ARCHIVE_AFTER`), anchored to when it settled into Done, Fabrik archives it off the project board. Archived items are not deleted — they remain accessible and recoverable via the project board's "Archive" view in GitHub. Set `--archive-done off` (also `FABRIK_ARCHIVE_DONE=off`) to disable auto-archival and leave Done items on the board indefinitely.
 
 ## The Self-Evolving Factory
 


### PR DESCRIPTION
Closes #1061

## What this does

Corrects a stale claim in `README.md`'s Formations section (line 461) that said auto-archive was disabled pending a timing-logic rework. That work shipped in v0.0.75 (ADR-068) — auto-archive is on by default, anchored to when an item settles into Done, with a 168h (one week) grace period.

## Changes

- `README.md`: rewrote the auto-archive paragraph to match the accurate description already present in `docs/USER_GUIDE.md` (§"Done Stage and Archiving") — on by default, `--archive-after`/`FABRIK_ARCHIVE_AFTER` grace period, `--archive-done`/`FABRIK_ARCHIVE_DONE` toggle, and archived items remain recoverable via GitHub's Archive view rather than being deleted.

## Investigation notes (from Research/Plan/Implement)

- Repo-wide scan confirmed `README.md`'s only stale auto-archive reference was this one paragraph; the existing `--archive-after`/`--archive-done` flag-table rows (327–328) were already correct and required no change.
- `docs/USER_GUIDE.md`'s auto-archive and `base:<branch>` sections were audited and found already accurate against v0.0.75 behavior — no edit needed, so `docs/llms-full.txt` regeneration is not triggered by this PR.
- `docs/index.md` was evaluated for a possible `base:<branch>` / two-branch-trunk feature card. Decision: not added — the release notes frame that work as a fix to existing functionality rather than a new capability, and it's already covered in `USER_GUIDE.md`.

## How to test

- Read the updated paragraph in `README.md`'s Formations section and confirm it matches `docs/USER_GUIDE.md`'s "Done Stage and Archiving" section and the CLI flag table (`--archive-after`, `--archive-done`).
- `go build -o fabrik .` and `go vet ./...` pass cleanly (docs-only change, no code touched).