### PR TITLE
build: gitignore goreleaser dist/ so release artifacts aren't stamped +dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 .env
 /fabrik
 /print-plugin-hash
+# goreleaser build output — must be ignored or Go's buildvcs stamps release
+# artifacts +dirty (untracked dist/ makes the tree "modified" at build time).
+/dist/
 *.exe
 .DS_Store
 tmp/


### PR DESCRIPTION
## Problem

Every released binary reports its module version as `vX.Y.Z+dirty` (confirmed on v0.0.73, v0.0.74, v0.0.75). The `+dirty` suffix means Go's `buildvcs` saw a modified working tree at build time — defeating the whole point of the `+dirty` integrity signal.

## Root cause

The goreleaser release workflow writes its build output to `dist/`, which was **not** in `.gitignore`. Go's `buildvcs` runs `git status --porcelain`, which lists the untracked `dist/`, so the toolchain stamps `vcs.modified=true` on the artifacts.

Proven by isolation on a clean tag checkout:

| Tree state | `vcs.modified` |
|---|---|
| clean | `false` |
| untracked `dist/` present | `true` |

The code itself was built from the correct clean tag commit (`vcs.revision` matches the tag), so this is an integrity-*signal* bug, not corrupted binaries.

## Fix

Add `/dist/` to `.gitignore`. goreleaser still writes there; Go's VCS check no longer sees it, so release artifacts build clean.

Refs #1069 (the dirty-release observation; the separate `--auto-upgrade` re-exec bug in that report is tracked separately).