### PR TITLE
chore(reviews): scope Gemini Code Assist to substantive PRs via .gemini/config.yaml

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,21 @@
+# Gemini Code Assist repo-level configuration.
+# Schema reference (re-verify before editing — has drifted before):
+# https://docs.cloud.google.com/gemini/docs/code-review/customize-repo-review
+#
+# Scope: keeps automatic review enabled, but skips it on draft PRs and on
+# PRs that touch only dependency-manifest files (go.mod, go.sum). This is a
+# deliberate subset of the original request — see adrs/069-gemini-review-scope-defers-docs-exclusion.md
+# for why docs/**-only PRs are NOT excluded here.
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: false
+
+ignore_patterns:
+  - go.mod
+  - go.sum

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,67 @@
+# Fabrik Style Guide (for Gemini Code Assist)
+
+Fabrik is a Go CLI that orchestrates Claude Code through an SDLC pipeline. This
+guide summarizes the conventions reviewers should hold code to. Full detail
+lives in `CLAUDE.md` and `.claude/rules/golang.md` — this is a condensed
+version for automated review context.
+
+## Error handling
+
+- Always check errors. Don't discard an error with `_ = err` unless the
+  function's own comment says the error is intentionally ignored (e.g. a
+  best-effort `ensureLabel` call).
+- Wrap errors with context: `fmt.Errorf("doing X: %w", err)`.
+- Non-fatal errors in the engine should be logged via `logf` and the caller
+  should continue, not return early — the poll loop must stay resilient to
+  per-issue failures.
+
+## Naming
+
+- Standard Go conventions: `MixedCaps`, not `snake_case`.
+- Interface names describe behavior, not implementation: `GitHubClient`,
+  `ClaudeInvoker`.
+- Test helpers follow established names: `testEngine()`, `skipIfNoGit()`.
+
+## Testing
+
+- Stdlib `testing` only — no testify or other external test frameworks.
+- Use `t.TempDir()` for temp files, `httptest.NewServer` for HTTP mocks,
+  `t.Setenv()` for environment variables (auto-restores, survives panics).
+- Don't rely on external network access for failure-injection tests — use
+  local tricks instead (e.g. `ENAMETOOLONG` via a very long path).
+- The real `git` binary is acceptable in tests, guarded by `skipIfNoGit`.
+- Mock Claude invocations via the `ClaudeInvoker` interface, not a fake
+  binary on disk.
+- `go test -race ./...` should pass — flag anything that looks like a data
+  race on shared state.
+
+## Concurrency
+
+- Shared state is protected by `sync.Mutex`; critical sections should stay
+  small.
+- Simple shared counters use `sync/atomic`.
+- Git operations that write `.git/config` (e.g. worktree creation) must be
+  serialized — git config access is not concurrency-safe.
+
+## Logging
+
+- Per-issue engine output goes through `logf(issueNumber, tag, format, ...)`,
+  which prefixes `[#N tag]` for readability under concurrent workers.
+- `fmt.Printf("[poll] ...")` is reserved for poll-level (not per-issue)
+  messages.
+
+## Dependencies
+
+- Minimize external dependencies — currently only `gopkg.in/yaml.v3` beyond
+  stdlib.
+- Prefer stdlib for HTTP, JSON, testing, and temp files.
+
+## PR conventions worth flagging
+
+- Every PR linked to a Fabrik issue must include a `Closes #N` line in the
+  body (added by the engine, not authored by hand in Fabrik-generated PRs).
+- Changes touching engine behavior described in `docs/state-machine.md` or
+  `docs/stage-lifecycle.md` should update those docs in the same PR — they
+  are as-built specs, not historical notes.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `refactor:`,
+  `test:`, `docs:`, `chore:`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,14 @@ The `docs-drift` workflow will fail the PR otherwise.
 - Code style: standard Go conventions (`gofmt`), `MixedCaps` naming, stdlib-first.
 - Engine-behavior changes must update the corresponding as-built doc (`docs/state-machine.md` or `docs/stage-lifecycle.md`) in the same PR — these are authoritative specs, not afterthought notes.
 
+## Automated review
+
+Gemini Code Assist (`.gemini/config.yaml`) automatically reviews substantive
+pull requests, but skips draft PRs and PRs that touch only `go.mod`/`go.sum`.
+PRs that touch only `docs/**` or `**/*.md` are still reviewed for now — that
+exclusion is intentionally deferred, not an oversight; see
+[ADR-069](adrs/069-gemini-review-scope-defers-docs-exclusion.md) for why.
+
 ## Reporting bugs
 
 Open an issue on [the issue tracker](https://github.com/handarbeit/fabrik/issues). If the bug involves a stage run, attach the relevant section of `.fabrik/logs/fabrik.log` (redact any tokens first).

--- a/adrs/069-gemini-review-scope-defers-docs-exclusion.md
+++ b/adrs/069-gemini-review-scope-defers-docs-exclusion.md
@@ -1,0 +1,79 @@
+# ADR 069: Gemini Review Scoping Defers docs/** Exclusion
+
+**Date**: 2026-07-25
+**Status**: Accepted
+**Issue**: #1067 — scope Gemini Code Assist to substantive PRs via `.gemini/config.yaml`
+**Related**: #1071 (open, undecided) — de-fragilize the review gate's single-source dependency on formal-review bots
+
+## Context
+
+#1067 asked for `.gemini/config.yaml` to skip Gemini Code Assist's automatic
+review on draft PRs, docs-only PRs, and lockfile/manifest-only PRs — reducing
+consumption of Gemini's per-installation daily quota on PRs where its
+*diverse second opinion* adds least value.
+
+Research for #1067 found that Fabrik's own `wait_for_reviews: true` gate
+(`checkReviewGate`, `engine/reviews.go`) clears only when at least one
+non-dismissed formal `pull_request_review` exists, from *any* source. In this
+repo that source is Gemini and Gemini alone: there is no `CODEOWNERS`, no
+auto-reviewer-request mechanism, Copilot signups are closed, and Claude's own
+review integrations don't submit formal `pull_request_review` objects (per
+#1071's findings). At the time of Research, issues #1058 and #1065 were
+*already paused* on exactly this quota-exhaustion failure mode — proof the
+SPOF is live, not hypothetical.
+
+Excluding `docs/**` from Gemini's `ignore_patterns`, as originally specified,
+would mean every docs-only Fabrik PR (produced routinely by the
+`audit-documentation` skill) has zero possible source of `hasReviews`. Such a
+PR would time out at the Review and/or Validate gate and pause for manual
+intervention every single time, with no natural clearing path, until #1071
+lands a gate fix. That is a direct regression traded for the quota
+improvement this issue set out to make.
+
+The lockfile/manifest class (`go.mod`, `go.sum`) does not carry the same
+risk: this repo has no Dependabot or Renovate configured, so there is
+currently no automated producer of lockfile-only PRs. The exposure is limited
+to a human manually bumping a dependency alone — rarer and lower-stakes than
+the docs-only case, which runs on a schedule via an existing skill.
+
+## Decision
+
+Ship `.gemini/config.yaml` with `include_drafts: false` and
+`ignore_patterns: [go.mod, go.sum]` only. Do **not** add `docs/**` or
+`**/*.md` to `ignore_patterns` yet.
+
+`include_drafts: false` carries no comparable gate risk: Fabrik's PRs are
+created as drafts and marked ready before Review runs, and Gemini's
+automatic review already fires on the ready-for-review transition (observed
+on ~9 of the last 12 merged PRs at Research time) — so excluding drafts
+doesn't remove Gemini's only opportunity to review a Fabrik-authored PR the
+way excluding `docs/**` would.
+
+This is a deliberate, scoped reduction from #1067's literal spec — decided
+rather than blocked, consistent with how #1067's own Specify stage handled
+its own schema-gap discovery (documented and resolved, not left open).
+
+## Revisit condition
+
+Once #1071 lands a fix that gives this repo a review-gate clearing path
+independent of Gemini (e.g. a CODEOWNERS-based reviewer, an alternate formal
+review source, or a gate redesign that no longer requires a formal
+`pull_request_review`), revisit this scope and add `docs/**` / `**/*.md` to
+`.gemini/config.yaml`'s `ignore_patterns` to fully satisfy #1067's original
+request.
+
+**Do not add `docs/**` to `ignore_patterns` before #1071 resolves the gate
+dependency** — doing so silently reintroduces the exact deadlock this ADR
+exists to avoid, for every docs-only Fabrik PR the `audit-documentation`
+skill produces.
+
+## Consequences
+
+- Docs-only PRs continue to consume Gemini review quota until #1071 lands.
+  This is the accepted tradeoff, not a defect.
+- `go.mod`/`go.sum`-only PRs no longer trigger automatic Gemini review, and
+  draft PRs are skipped until marked ready — the portion of #1067's request
+  that carries no gate risk ships immediately.
+- No author-based or title-based filtering exists in Gemini's current
+  config schema regardless of this decision (a separate, unrelated schema
+  limitation documented in #1067 itself).

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -30,3 +30,4 @@ contributors and future maintainers.
 | [065](065-consolidated-mutation-helpers.md) | Consolidated GitHub-mutation helpers (label/comment/pause) | Accepted |
 | [066](066-consolidated-github-request-helpers.md) | Consolidated GitHub-client request helpers (REST core, paginator, boardcache mutation/heal) | Accepted |
 | [067](067-merge-train-centralized-inflight-cleanup.md) | Centralized Merge-Train In-Flight Marker Cleanup | Accepted |
+| [069](069-gemini-review-scope-defers-docs-exclusion.md) | Gemini Review Scoping Defers docs/** Exclusion | Accepted |


### PR DESCRIPTION
Closes #1067

## Summary

Adds `.gemini/config.yaml` and `.gemini/styleguide.md` to reduce Gemini Code Assist's quota consumption on low-value PRs, while keeping automatic review enabled overall.

- `code_review.pull_request_opened.include_drafts: false` — skip automatic review on draft PRs.
- `ignore_patterns: [go.mod, go.sum]` — skip PRs touching only dependency-manifest files.
- `code_review.disable: false`, `comment_severity_threshold: MEDIUM` — review stays on, default threshold unchanged.
- `.gemini/styleguide.md` — freeform repo-convention summary (from `.claude/rules/golang.md` and `CLAUDE.md`) to sharpen review quality on the PRs that do get reviewed.

Schema re-verified against the live Gemini Code Assist docs at implementation time (`docs.cloud.google.com/gemini/docs/code-review/customize-repo-review`) — unchanged since Research's original snapshot.

## Two limitations reviewers should not mistake for oversights

1. **No author- or title-based filtering.** Gemini's current config schema has no `ignore_authors`/`exclude_bots` key and no title/label matching — only draft-status and path-glob filtering exist. This was confirmed against the current docs and is a schema limitation, not a design gap here.

2. **`docs/**`/`**/*.md` is deliberately *not* in `ignore_patterns` yet**, even though the original issue asked for it. Research found that this repo's `wait_for_reviews` gate (`engine/reviews.go`) currently clears *only* via a formal review from Gemini — there's no CODEOWNERS, no auto-reviewer-request, and Claude's own review integrations don't submit formal `pull_request_review` objects. Excluding `docs/**` would mean every docs-only Fabrik PR (routinely produced by the `audit-documentation` skill) has zero possible source of a clearing review, and would pause for manual intervention every time. Issues #1058 and #1065 were already paused on this exact quota-exhaustion failure mode when Research ran. See [ADR-069](adrs/069-gemini-review-scope-defers-docs-exclusion.md) for the full rationale and the condition for revisiting this once #1071 lands a gate fix.

## Files changed

- `.gemini/config.yaml` — new
- `.gemini/styleguide.md` — new
- `adrs/069-gemini-review-scope-defers-docs-exclusion.md` — new
- `adrs/README.md` — index entry for ADR-069
- `CONTRIBUTING.md` — short note on Gemini's automatic-review scope

## Test plan

- `.gemini/config.yaml` validated as syntactically correct YAML (`python3 -c "import yaml; yaml.safe_load(open('.gemini/config.yaml'))"`).
- `go build ./...` and `go vet ./...` clean (no Go code changed; config/doc-only PR).
- No canonical Fabrik doc (`docs/state-machine.md`, `docs/stage-lifecycle.md`, `docs/USER_GUIDE.md`, `docs/positioning.md`) touched, so no `docs/llms-full.txt` regen is required.