### PR TITLE
ci: drop synchronize trigger from Claude review (prevents review/fix loop)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,8 +6,13 @@ name: Claude PR Review
 # PR's reviews array — the signal Fabrik's checkReviewGate waits on (engine/reviews.go).
 
 on:
+  # NOTE: 'synchronize' is deliberately excluded. Fabrik auto-fixes review
+  # findings and pushes, which would re-trigger a review, which finds more,
+  # which triggers another fix — an unbounded review/fix loop (observed on
+  # handarbeit/fabrik#1078: 18 reviews before FABRIK_MAX_REVIEW_CYCLES tripped).
+  # Review once when the PR is ready; a human merges.
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes `synchronize` from the Claude review workflow triggers.

With Fabrik auto-fixing review findings and pushing, `synchronize` re-triggers a review on every fix commit — which finds new things, which triggers another fix. Observed on handarbeit/fabrik#1078: **18 Opus reviews** on one PR before `FABRIK_MAX_REVIEW_CYCLES=5` tripped and paused the issue.

Now: review once when the PR opens / is marked ready, Fabrik fixes, human merges. No loop, ~1 review per PR instead of 18.