### PR TITLE
Filter non-actionable bot service-notices and suppress no-work-needed replies

### DIFF
--- a/adrs/070-bot-service-notice-filter.md
+++ b/adrs/070-bot-service-notice-filter.md
@@ -1,0 +1,65 @@
+# ADR 070: Bot Service-Notice Filter and No-Work-Needed Reply Suppression
+
+**Date**: 2026-07-26
+**Status**: Accepted
+**Issue**: #1088 — Runaway-loop fix (2/4): don't spawn a worker or reply for non-actionable bot service-notices
+
+## Context
+
+Incident #1083: `gemini-code-assist[bot]` ran out of daily quota and auto-replied to thread activity with a `[!WARNING] You have reached your daily quota limit.` banner. Each such comment (a new ID every time) was indistinguishable from any other bot comment to `findNewComments` — it admitted the comment, `processComments` spawned a full comment-processing worker (~506k cache-read tokens/iteration), and Fabrik posted a "not actionable" reply. That reply then (a) externally re-triggered the bot to reply again, restarting the cycle, and (b) bumped the issue's `updatedAt`, forcing an immediate re-poll. The loop ran ~995 times for roughly $210 before it was noticed. ADR-069 (fix 1/4, #1087) closed the ability of this pattern to silently defeat an operator's `fabrik:paused`, but did nothing to stop the loop from running in the first place in the default (non-paused/cruise) case — that is this issue's scope.
+
+## Decision
+
+Two independent, complementary mechanisms:
+
+**1. Pre-admission filter.** `isBotServiceNotice(c gh.Comment) bool` (`engine/comments.go`) classifies a comment as non-actionable bot noise when `gh.IsBotLogin(c.Author)` is true **and** the lowercased body contains one of a small, literal pattern list (`botServiceNoticePatterns`): `"daily quota limit"`, `"you have reached your daily quota"`, `"rate limit exceeded"`, `"you have reached your rate limit"`, `"you have exceeded your rate limit"`, `"api rate limit"`. This is wired in as a fourth exclusion inside `findNewComments`, alongside the existing `CommentProcessed`/Fabrik-prefix/rocket-reaction checks. Because `findNewComments` is the single function underlying all comment-processing entry points (normal dispatch, the paused/awaiting-input resume decision via `humanNewComments`, and the catch-up stage-advance check in `poll.go`), adding the check there gives "no worker spawned, no reply" uniformly, with no per-call-site duplication.
+
+**2. Watermarking via a settle scan, not inline.** A bot-notice comment excluded by `findNewComments` never reaches `processComments`, so nothing gated on dispatch (👀 reaction, `fabrik:editing`, the eventual 🚀ᅠreaction + `CommentProcessed` write) ever runs for it — left alone, the comment would re-qualify as "bot-notice-shaped" on every future poll forever (harmless, since it's still excluded, but never actually watermarked). `settleBotServiceNotices` (`engine/bot_notice_settle.go`) runs unconditionally every poll over the raw `board.Items` snapshot — mirroring `settleMergeTrainMemberCloses`'s (ADR-061) precedent for scanning outside `deepFetchCandidates`/dispatch-gated state — and applies the same 🚀 reaction + `CommentProcessed` watermark `finalizeComments` would have applied, for every comment matching `isBotServiceNotice` that isn't already watermarked. Unlike the merge-train scan, it carries no retry/escalate/label machinery: a missed reaction this poll is harmless (the comment stays both unprocessed and unreacted) and simply retries next poll for free.
+
+**3. Reply suppression on `FABRIK_NO_WORK_NEEDED`.** Independent of the pre-admission filter — this covers the case where a comment *is* admitted and processed, but Claude's verdict is "no action needed." `publishCommentOutput` (`engine/comments.go`) now captures `noWorkNeeded := CheckNoWorkNeeded(output)` immediately after computing `summary`, before any markers are stripped (`CheckNoWorkNeeded` matches the raw marker line). All three existing reply-post branches — the issue stage comment create/rewrite, the `post_to_pr` issue comment, and the review-reinvoke PR summary — are gated on `!noWorkNeeded`. The issue-body update (`FABRIK_ISSUE_UPDATE`), `fabrik:editing` removal, 🚀 reactions, `CommentProcessed` watermarking, and `FABRIK_STAGE_COMPLETE`-driven completion handling in `finalizeComments` are all unaffected — only the reply post itself is suppressed. This directly targets the incident's second pump: posting *any* reply, even a "not actionable" one, is what re-triggered the subscribed bot.
+
+## Rationale
+
+### Why can't the watermark side-effect live inside `findNewComments`?
+
+`findNewComments` is a deliberately pure, `e.client`-free function reused by 7+ call sites and constructed directly (`&Engine{cfg, store}`, no client) by several existing unit tests (`TestFindNewCommentsFiltering`, `TestHumanNewComments*`). Adding a network call (`AddCommentReaction`) or store write inside it would nil-panic those tests and, even if guarded, would fire redundantly — `findNewComments` runs 2–4× per item per poll (the dispatch gate, `processItem`'s own check, the catch-up loop, plus the pause/awaiting-input branches), so the same comment would be reacted-to and watermarked multiple times in a single poll pass.
+
+### Why can't the watermark side-effect live inside `processComments` instead?
+
+Once `findNewComments` excludes bot-notice comments, `itemNeedsWork` sees zero new comments for a bot-notice-only backlog and never dispatches `processItem` at all — there is no invocation of `processComments` for the watermark step to live inside. A settle scan sourced from the raw board snapshot is the only place that reaches these comments regardless of dispatch outcome.
+
+### Why a narrow, literal pattern list instead of a bare `"quota"`/`"rate"` substring?
+
+Two reasons, both concrete rather than hypothetical. First, the issue's own false-positive risk: a broad substring could catch genuine bot review prose that happens to discuss rate limiting (e.g. a review comment suggesting a rate-limit fix). Second, `engine/blocked_on_input_test.go` has five existing fixtures using the literal bot-authored body `"quota notice"` (ADR-069's own test suite, exercising the human-only resume gate) that must **not** be caught by this filter — they test a different concern (bot chatter must still be admitted and processed together with a resuming human comment) and a collision would silently break that coverage. None of the six chosen patterns match `"quota notice"`, verified both by inspection and by a dedicated unit test case (`TestIsBotServiceNotice`'s "existing quota notice fixture body must not collide") and by running the full existing suite unchanged.
+
+### Why scope classification to `item.Comments` only, not `item.LinkedPRReviewThreadComments`?
+
+The incident and every acceptance criterion concern conversation-thread bot replies, not inline PR review comments. Inline review comments are substantive-by-construction (they always carry a specific finding tied to a diff location) and excluding them from this filter is the conservative choice the issue's "must not skip genuine review content" requirement calls for.
+
+### Why capture `noWorkNeeded` before stripping markers, not after?
+
+`CheckNoWorkNeeded` matches `^FABRIK_NO_WORK_NEEDED$` against the raw output. `publishCommentOutput` strips that exact line a few statements later (to keep it out of the posted comment even when a reply *is* posted, e.g. on the stage-invocation path elsewhere in the engine). Checking after stripping would always observe `false`.
+
+### Why does the stage-invocation meaning of `FABRIK_NO_WORK_NEEDED` (advance to Done) stay untouched?
+
+This ADR only extends the marker's handling on the **comment-processing** path — a different code path (`processComments`/`publishCommentOutput`) than the stage-invocation path (`processItem`'s stage-run branch, ADR-045/ADR-060) that treats the same marker as "skip remaining stages, move to Done." The issue scopes this explicitly, and the two paths don't share code that would make this ambiguous — `publishCommentOutput` is only ever called from `processComments`.
+
+## Consequences
+
+**Positive:**
+- A gemini quota-notice comment (or any future bot service-notice matching the pattern list) now spawns no worker, posts no reply, and is watermarked within one poll cycle — the two halves of the #1083 pump (worker cost, reply-triggered bot re-ping) are both closed for this specific comment shape.
+- The two mechanisms are independent and additive: the pre-admission filter stops the *known* notice shapes before any cost is incurred; the reply-suppression mechanism is a second line of defense for *any* comment (bot-notice or otherwise) where Claude itself concludes no action is needed, closing the loop even for notice phrasings the pattern list doesn't yet cover.
+- No new labels, no new config/YAML surface, no change to `github.IsBotLogin` — purely additive, low-blast-radius changes confined to `engine/comments.go`, a new `engine/bot_notice_settle.go`, and one new call in the poll loop.
+
+**Negative / Trade-offs:**
+- **False negatives are accepted by design.** The pattern list is deliberately narrow; a differently-worded quota/rate-limit message from a different bot will not be caught by the pre-admission filter (though it may still be caught by the reply-suppression mechanism if Claude classifies it as no-action-needed during processing — at the cost of one worker invocation instead of zero). Extending the pattern list is a follow-up, not a blocker.
+- **The settle scan is a second unconditional per-poll pass over all board items**, alongside `settleNoWorkNeededScan`, `settleRevalidateScan`, and `settleMergeTrainMemberCloses`. The cost is in-memory string matching over already-fetched data (no additional GitHub API calls except the reaction/watermark writes themselves, which only fire once per matching comment) — the same justification ADR-061 already established for its sibling scan.
+- **A bot-notice comment that arrives during a pause is now silently dropped from the "process together on resume" backlog** (ADR-069) rather than included — this is the correct behavior (it's non-actionable regardless of pause state) but is a deliberate behavior change from ADR-069's "all accumulated bot chatter is processed together with the resuming human comment" framing for this one comment shape.
+
+## Related Work
+
+- Incident #1083 (human incident report — not modified by this ADR or its issue).
+- ADR-069 / #1087 — fix 1/4, the direct predecessor; establishes `github.IsBotLogin` as load-bearing for comment-author filtering and the precedent this issue's pattern-matching layers on top of.
+- #1089, #1090 — fixes 3/4 and 4/4 of the same runaway-loop remediation series (comment-processing circuit breaker; decoupling Fabrik's own writes from cache invalidation/re-poll).
+
+**References:** [docs/state-machine.md §4.1, §4.2, §4.4](../docs/state-machine.md)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2532,9 +2532,12 @@ Multiple users and multiple Fabrik instances can safely share a project board.
 
 **Comment processing**: Fabrik processes comments from *any* author, not just the
 configured `--user`. Human colleagues, code-review bots (Copilot, Gemini), and
-other Fabrik instances all trigger comment processing. Only two categories are
-skipped: comments that start with `🏭 **Fabrik` (Fabrik's own output) and comments
-that already carry a 🚀 rocket reaction (already processed).
+other Fabrik instances all trigger comment processing. Three categories are
+skipped: comments that start with `🏭 **Fabrik` (Fabrik's own output), comments
+that already carry a 🚀 rocket reaction (already processed), and non-actionable
+bot service-notices — e.g. a quota-exhaustion or rate-limit banner from a
+review bot — which are watermarked as processed without ever spawning a worker
+or receiving a reply, so they can't re-trigger the bot into a reply loop.
 
 **Multi-instance locking**: The `fabrik:locked:<user>` label is still the
 concurrency guard, but acquisition now uses a **lock-then-verify** protocol:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2530,9 +2530,12 @@ Multiple users and multiple Fabrik instances can safely share a project board.
 
 **Comment processing**: Fabrik processes comments from *any* author, not just the
 configured `--user`. Human colleagues, code-review bots (Copilot, Gemini), and
-other Fabrik instances all trigger comment processing. Only two categories are
-skipped: comments that start with `🏭 **Fabrik` (Fabrik's own output) and comments
-that already carry a 🚀 rocket reaction (already processed).
+other Fabrik instances all trigger comment processing. Three categories are
+skipped: comments that start with `🏭 **Fabrik` (Fabrik's own output), comments
+that already carry a 🚀 rocket reaction (already processed), and non-actionable
+bot service-notices — e.g. a quota-exhaustion or rate-limit banner from a
+review bot — which are watermarked as processed without ever spawning a worker
+or receiving a reply, so they can't re-trigger the bot into a reply loop.
 
 **Multi-instance locking**: The `fabrik:locked:<user>` label is still the
 concurrency guard, but acquisition now uses a **lock-then-verify** protocol:
@@ -3490,17 +3493,19 @@ When new comments are detected on an issue (or synthetic review comments on a PR
 
 ### 4.1 Comment Detection
 
-`findNewComments()` filters `item.Comments` to find unprocessed comments using three independent dedup signals:
+`findNewComments()` filters `item.Comments` to find unprocessed comments using four independent dedup signals:
 
 1. **In-memory `CommentProcessed` in `itemstate.Store`** (session-scoped) — skip comments whose ID is recorded via `snap.CommentProcessed(c.ID)` (written by `CommentProcessed` mutation). Fast but lost on restart.
 2. **`🏭 **Fabrik` body prefix** (engine-authored output convention) — skip comments whose body starts with this header. Durable but requires the header to be present.
 3. **🚀 ROCKET reaction** (durable, cross-restart) — skip comments that already have a rocket reaction. Applied to user comments by `processComments` step 10 after processing; **also applied by the engine to every comment it posts** immediately after `AddComment` succeeds.
+4. **Bot service-notice pattern** (content-based, `isBotServiceNotice`) — skip comments whose author matches `github.IsBotLogin` **and** whose body matches a known quota/rate-limit service-notice pattern (e.g. "daily quota limit", "you have reached your rate limit"). Unlike signals 1–3, this is a content classification rather than a watermark: it must hold on every poll's raw fetch, so a matching comment never reaches `processComments` in the first place — no 👀 reaction, no worktree/Claude invocation, no reply. Because this signal excludes the comment before signal 1's watermark would ever be recorded by the normal `processComments` flow, `settleBotServiceNotices` — an unconditional per-poll scan over the raw board snapshot, independent of dispatch state — separately applies the 🚀 reaction and `CommentProcessed` watermark so the comment doesn't need to re-qualify via this pattern check on every future poll. Introduced to stop a runaway reply loop where a bot's quota-exhaustion auto-reply triggered a Fabrik "not actionable" reply, which in turn re-triggered the bot (#1083/#1088).
 
-Any single signal catching the comment is sufficient to skip it. The three signals are orthogonal — any two can fail independently without triggering the self-review loop.
+Any single signal catching the comment is sufficient to skip it. The four signals are orthogonal — any combination can fail independently without triggering the self-review loop.
 
 **Dedup coverage by comment type:**
 - **Engine-authored comments**: carry signals (2) and (3) — the `🏭 **Fabrik` prefix (when formatted via `formatOutputComment`) and a 🚀 reaction added by the engine at post time.
 - **User comments**: carry signals (1) and (3) after processing — the `CommentProcessed` entry added to `itemstate.Store` during `processComments`, and the 🚀 reaction added at step 10.
+- **Bot service-notice comments**: carry signal (4) immediately, then signals (1) and (3) once `settleBotServiceNotices` watermarks them on a later poll.
 
 > **Invariant:** every engine-emitted `AddComment` call must start with `🏭 **Fabrik — <context>**`. This is an engine-wide convention enforced by `TestAddCommentCompliance` in `engine/compliance_test.go`, not just a detection heuristic.
 
@@ -3516,7 +3521,7 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
 | 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Applied unconditionally when markers are present; stripped from output regardless |
 | 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_NO_WORK_NEEDED, FABRIK_SUMMARY_BEGIN/END |
-| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
+| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. **Suppressed on `FABRIK_NO_WORK_NEEDED` (#1088):** when the invocation output contains `FABRIK_NO_WORK_NEEDED` (checked before markers are stripped), none of the three reply paths above post — no stage comment, no `post_to_pr` comment, no review-reinvoke PR summary. Posting *any* reply is what re-triggers a subscribed bot into a loop, so silence replaces the old "not actionable" message. Steps 6 (issue-body update), 9 (editing-label removal), 10 (🚀 reactions), and 11 (stage-complete handling) are unaffected — only the reply post itself is gated. |
 | 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |
 | 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
 | 11 | If FABRIK_STAGE_COMPLETE was detected: handle completion | `handleStageComplete()` | Same completion flow as a normal stage invocation (advance, PR ops, etc.) |
@@ -3563,7 +3568,9 @@ Comments can trigger processing through three paths in `processItem()`:
 2. **Paused unpause:** `fabrik:paused` present + new **human** comments (`humanNewComments()`) → remove `fabrik:paused`, `clearFailedStage()` → fall through → `processComments()`
 3. **Normal comment processing:** Item is not paused → `findNewComments()` finds comments (human or bot) → `processComments()`
 
-In paths 1 and 2, `humanNewComments()` only gates *whether* to resume — once a human comment authorizes it, the raw (unfiltered) comment set from `findNewComments()` is what's actually handed to `processComments()`, in the same `processItem` invocation. Any bot comments that accumulated while paused/awaiting-input are processed together with the resuming human comment, not deferred to a later poll (#1083).
+In paths 1 and 2, `humanNewComments()` only gates *whether* to resume — once a human comment authorizes it, the raw (unfiltered) comment set from `findNewComments()` is what's actually handed to `processComments()`, in the same `processItem` invocation. Any bot comments that accumulated while paused/awaiting-input are processed together with the resuming human comment, not deferred to a later poll (#1083) — except bot service-notice comments (§4.1 signal 4), which `findNewComments()` excludes from that raw set entirely regardless of pause state, since they are non-actionable either way.
+
+All three paths ultimately source their candidate comments from `findNewComments()` (paths 1–2 via `humanNewComments()`'s wrapping, path 3 directly), so the bot service-notice exclusion (§4.1 signal 4) applies uniformly across all of them — a quota/rate-limit bot notice never reaches `processComments()` via any path.
 
 ### 4.5 markCommentsSeenByStage
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -797,17 +797,19 @@ When new comments are detected on an issue (or synthetic review comments on a PR
 
 ### 4.1 Comment Detection
 
-`findNewComments()` filters `item.Comments` to find unprocessed comments using three independent dedup signals:
+`findNewComments()` filters `item.Comments` to find unprocessed comments using four independent dedup signals:
 
 1. **In-memory `CommentProcessed` in `itemstate.Store`** (session-scoped) — skip comments whose ID is recorded via `snap.CommentProcessed(c.ID)` (written by `CommentProcessed` mutation). Fast but lost on restart.
 2. **`🏭 **Fabrik` body prefix** (engine-authored output convention) — skip comments whose body starts with this header. Durable but requires the header to be present.
 3. **🚀 ROCKET reaction** (durable, cross-restart) — skip comments that already have a rocket reaction. Applied to user comments by `processComments` step 10 after processing; **also applied by the engine to every comment it posts** immediately after `AddComment` succeeds.
+4. **Bot service-notice pattern** (content-based, `isBotServiceNotice`) — skip comments whose author matches `github.IsBotLogin` **and** whose body matches a known quota/rate-limit service-notice pattern (e.g. "daily quota limit", "you have reached your rate limit"). Unlike signals 1–3, this is a content classification rather than a watermark: it must hold on every poll's raw fetch, so a matching comment never reaches `processComments` in the first place — no 👀 reaction, no worktree/Claude invocation, no reply. Because this signal excludes the comment before signal 1's watermark would ever be recorded by the normal `processComments` flow, `settleBotServiceNotices` — an unconditional per-poll scan over the raw board snapshot, independent of dispatch state — separately applies the 🚀 reaction and `CommentProcessed` watermark so the comment doesn't need to re-qualify via this pattern check on every future poll. Introduced to stop a runaway reply loop where a bot's quota-exhaustion auto-reply triggered a Fabrik "not actionable" reply, which in turn re-triggered the bot (#1083/#1088).
 
-Any single signal catching the comment is sufficient to skip it. The three signals are orthogonal — any two can fail independently without triggering the self-review loop.
+Any single signal catching the comment is sufficient to skip it. The four signals are orthogonal — any combination can fail independently without triggering the self-review loop.
 
 **Dedup coverage by comment type:**
 - **Engine-authored comments**: carry signals (2) and (3) — the `🏭 **Fabrik` prefix (when formatted via `formatOutputComment`) and a 🚀 reaction added by the engine at post time.
 - **User comments**: carry signals (1) and (3) after processing — the `CommentProcessed` entry added to `itemstate.Store` during `processComments`, and the 🚀 reaction added at step 10.
+- **Bot service-notice comments**: carry signal (4) immediately, then signals (1) and (3) once `settleBotServiceNotices` watermarks them on a later poll.
 
 > **Invariant:** every engine-emitted `AddComment` call must start with `🏭 **Fabrik — <context>**`. This is an engine-wide convention enforced by `TestAddCommentCompliance` in `engine/compliance_test.go`, not just a detection heuristic.
 
@@ -823,7 +825,7 @@ Any single signal catching the comment is sufficient to skip it. The three signa
 | 5 | Check for FABRIK_STAGE_COMPLETE in output | `checkCompletion()` | Determines if comment processing resolved the stage |
 | 6 | Extract and apply FABRIK_ISSUE_UPDATE if present | `extractUpdatedBody()` | Applied unconditionally when markers are present; stripped from output regardless |
 | 7 | Strip all Fabrik markers from output | `stripLine()` calls | Removes FABRIK_STAGE_COMPLETE, FABRIK_BLOCKED_ON_INPUT, FABRIK_NO_WORK_NEEDED, FABRIK_SUMMARY_BEGIN/END |
-| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. |
+| 8 | Post or update stage comment | `AddComment()` / `UpdateComment()` | For `post_to_pr` stages: always posts new comment on issue (labeled as "comment review"); for other stages: rewrites existing stage comment or creates new one. **Review-reinvoke branch (Step 8b):** when the input batch is all-`ReviewThreadID` comments (`isReviewReinvoke` == true) and `output != ""`, also posts a Fabrik-marked `"<StageName> (review feedback addressed)"` comment on the linked PR (via `FindPRForIssue`); includes per-thread footer with path:line for each addressed thread; skipped if no linked PR is found (logs warning). The issue comment is always posted first; the PR comment is additive. **Suppressed on `FABRIK_NO_WORK_NEEDED` (#1088):** when the invocation output contains `FABRIK_NO_WORK_NEEDED` (checked before markers are stripped), none of the three reply paths above post — no stage comment, no `post_to_pr` comment, no review-reinvoke PR summary. Posting *any* reply is what re-triggers a subscribed bot into a loop, so silence replaces the old "not actionable" message. Steps 6 (issue-body update), 9 (editing-label removal), 10 (🚀 reactions), and 11 (stage-complete handling) are unaffected — only the reply post itself is gated. |
 | 9 | Remove `fabrik:editing` label | `RemoveLabelFromIssue("fabrik:editing")` | Releases the editing mutex |
 | 10 | React with 🚀 to all processed comments + resolve review threads | `AddCommentReaction("rocket")` / `AddPRReviewCommentReaction("rocket")` + `ResolveReviewThread()` | Marks comments as processed (durable); resolves addressed review threads |
 | 11 | If FABRIK_STAGE_COMPLETE was detected: handle completion | `handleStageComplete()` | Same completion flow as a normal stage invocation (advance, PR ops, etc.) |
@@ -870,7 +872,9 @@ Comments can trigger processing through three paths in `processItem()`:
 2. **Paused unpause:** `fabrik:paused` present + new **human** comments (`humanNewComments()`) → remove `fabrik:paused`, `clearFailedStage()` → fall through → `processComments()`
 3. **Normal comment processing:** Item is not paused → `findNewComments()` finds comments (human or bot) → `processComments()`
 
-In paths 1 and 2, `humanNewComments()` only gates *whether* to resume — once a human comment authorizes it, the raw (unfiltered) comment set from `findNewComments()` is what's actually handed to `processComments()`, in the same `processItem` invocation. Any bot comments that accumulated while paused/awaiting-input are processed together with the resuming human comment, not deferred to a later poll (#1083).
+In paths 1 and 2, `humanNewComments()` only gates *whether* to resume — once a human comment authorizes it, the raw (unfiltered) comment set from `findNewComments()` is what's actually handed to `processComments()`, in the same `processItem` invocation. Any bot comments that accumulated while paused/awaiting-input are processed together with the resuming human comment, not deferred to a later poll (#1083) — except bot service-notice comments (§4.1 signal 4), which `findNewComments()` excludes from that raw set entirely regardless of pause state, since they are non-actionable either way.
+
+All three paths ultimately source their candidate comments from `findNewComments()` (paths 1–2 via `humanNewComments()`'s wrapping, path 3 directly), so the bot service-notice exclusion (§4.1 signal 4) applies uniformly across all of them — a quota/rate-limit bot notice never reaches `processComments()` via any path.
 
 ### 4.5 markCommentsSeenByStage
 

--- a/engine/bot_notice_settle.go
+++ b/engine/bot_notice_settle.go
@@ -1,0 +1,68 @@
+package engine
+
+import (
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+)
+
+// settleBotServiceNotices is the per-poll settle scan that watermarks
+// non-actionable bot service-notice comments (#1083/#1088) excluded by
+// findNewComments' isBotServiceNotice check. It cannot live inside
+// findNewComments (which must stay a pure, client-free function reused by
+// several test call sites) or inside processComments (a bot-notice-only
+// backlog never reaches processComments once findNewComments excludes it —
+// itemNeedsWork sees zero new comments and never dispatches). Runs
+// unconditionally every poll over the raw board snapshot, mirroring
+// settleMergeTrainMemberCloses: a missed reaction/watermark this poll is
+// harmless and simply retries next poll, since the comment remains both
+// unprocessed and unreacted — no retry/escalate machinery is warranted for
+// a cosmetic, idempotent side effect.
+func (e *Engine) settleBotServiceNotices(board *gh.ProjectBoard) {
+	for _, item := range board.Items {
+		e.settleBotServiceNoticesForItem(item)
+	}
+}
+
+// settleBotServiceNoticesForItem watermarks (🚀 reaction + CommentProcessed)
+// every not-yet-processed bot service-notice comment on item. Comments that
+// don't classify as a bot service-notice, are already rocket-reacted, or are
+// already recorded as CommentProcessed are left untouched.
+func (e *Engine) settleBotServiceNoticesForItem(item gh.ProjectItem) {
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	snap, _ := e.store.Get(repoStr, item.Number)
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	for _, c := range item.Comments {
+		if !isBotServiceNotice(c) {
+			continue
+		}
+		if !snap.CommentProcessed(c.ID).IsZero() {
+			continue
+		}
+		if c.HasReaction("ROCKET") {
+			// Already reacted (e.g. by a previous settle pass whose store write
+			// didn't persist) — just record the watermark, no duplicate reaction.
+			e.store.Apply(itemstate.CommentProcessed{Repo: repoStr, Number: item.Number, CommentID: c.ID, At: time.Now()})
+			continue
+		}
+		if c.DatabaseID == 0 {
+			e.logf(item.Number, "debug", "skipping bot-notice watermark for synthetic comment %s (no DatabaseID)\n", c.ID)
+			continue
+		}
+
+		var reactErr error
+		if c.ReviewThreadID != "" {
+			reactErr = e.client.AddPRReviewCommentReaction(owner, repo, c.DatabaseID, "rocket")
+		} else {
+			reactErr = e.client.AddCommentReaction(owner, repo, c.DatabaseID, "rocket")
+		}
+		if reactErr != nil {
+			e.logf(item.Number, "warn", "could not add 🚀 to bot service-notice comment %s: %v\n", c.ID, reactErr)
+			continue
+		}
+		e.store.Apply(itemstate.CommentProcessed{Repo: repoStr, Number: item.Number, CommentID: c.ID, At: time.Now()})
+		e.logf(item.Number, "comments", "watermarked bot service-notice comment %s (author %s) — no worker spawned, no reply posted\n", c.ID, c.Author)
+	}
+}

--- a/engine/bot_notice_settle_test.go
+++ b/engine/bot_notice_settle_test.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// TestSettleBotServiceNotices_WatermarksQuotaNotice verifies that a bot
+// quota-notice comment excluded by findNewComments gets a 🚀 reaction and a
+// recorded CommentProcessed watermark from the settle scan, so it never
+// re-admits on a later poll (#1083/#1088).
+func TestSettleBotServiceNotices_WatermarksQuotaNotice(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 30,
+		Comments: []gh.Comment{
+			{ID: "C_quota", DatabaseID: 601, Author: "gemini-code-assist[bot]", Body: "You have reached your daily quota limit."},
+		},
+	}
+	board := &gh.ProjectBoard{Items: []gh.ProjectItem{item}}
+
+	eng.settleBotServiceNotices(board)
+
+	if len(client.addCommentReactionCalls) != 1 {
+		t.Fatalf("expected 1 AddCommentReaction call, got %d: %v", len(client.addCommentReactionCalls), client.addCommentReactionCalls)
+	}
+	if client.addCommentReactionCalls[0].content != "rocket" {
+		t.Errorf("expected rocket reaction, got %q", client.addCommentReactionCalls[0].content)
+	}
+	snap, err := eng.store.Get("owner/repo", 30)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if snap.CommentProcessed("C_quota").IsZero() {
+		t.Error("expected C_quota to be recorded as CommentProcessed")
+	}
+}
+
+// TestSettleBotServiceNotices_AlreadyProcessed_NoOp verifies idempotency: a
+// comment already watermarked as CommentProcessed is not re-reacted.
+func TestSettleBotServiceNotices_AlreadyProcessed_NoOp(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 31,
+		Comments: []gh.Comment{
+			{ID: "C_quota", DatabaseID: 602, Author: "gemini-code-assist[bot]", Body: "You have reached your daily quota limit."},
+		},
+	}
+	board := &gh.ProjectBoard{Items: []gh.ProjectItem{item}}
+
+	// First pass watermarks it.
+	eng.settleBotServiceNotices(board)
+	if len(client.addCommentReactionCalls) != 1 {
+		t.Fatalf("expected 1 AddCommentReaction call after first pass, got %d", len(client.addCommentReactionCalls))
+	}
+
+	// Second pass over the same (unmutated) board must be a no-op.
+	eng.settleBotServiceNotices(board)
+	if len(client.addCommentReactionCalls) != 1 {
+		t.Errorf("expected still 1 AddCommentReaction call after second pass (idempotent), got %d", len(client.addCommentReactionCalls))
+	}
+}
+
+// TestSettleBotServiceNotices_NonNoticeComments_Untouched verifies that human
+// comments and genuine bot review comments are never watermarked by this scan
+// — only comment-processing's normal flow handles those.
+func TestSettleBotServiceNotices_NonNoticeComments_Untouched(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error {
+			t.Fatal("AddCommentReaction should not be called for non-notice comments")
+			return nil
+		},
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 32,
+		Comments: []gh.Comment{
+			{ID: "C_human", DatabaseID: 603, Author: "humanuser", Body: "please continue"},
+			{ID: "C_review", DatabaseID: 604, Author: "gemini-code-assist[bot]", Body: "CHANGES_REQUESTED: this loop never terminates."},
+		},
+	}
+	board := &gh.ProjectBoard{Items: []gh.ProjectItem{item}}
+
+	eng.settleBotServiceNotices(board)
+
+	snap, _ := eng.store.Get("owner/repo", 32)
+	if !snap.CommentProcessed("C_human").IsZero() {
+		t.Error("expected C_human to remain unprocessed")
+	}
+	if !snap.CommentProcessed("C_review").IsZero() {
+		t.Error("expected C_review to remain unprocessed")
+	}
+}
+
+// TestSettleBotServiceNotices_ReactionFailure_LeavesUnwatermarked verifies
+// that a failed AddCommentReaction call leaves the comment unwatermarked (so
+// it retries on the next poll) rather than panicking or recording a false
+// CommentProcessed watermark.
+func TestSettleBotServiceNotices_ReactionFailure_LeavesUnwatermarked(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return errors.New("rate limited") },
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 33,
+		Comments: []gh.Comment{
+			{ID: "C_quota", DatabaseID: 605, Author: "gemini-code-assist[bot]", Body: "You have reached your daily quota limit."},
+		},
+	}
+	board := &gh.ProjectBoard{Items: []gh.ProjectItem{item}}
+
+	eng.settleBotServiceNotices(board)
+
+	snap, _ := eng.store.Get("owner/repo", 33)
+	if !snap.CommentProcessed("C_quota").IsZero() {
+		t.Error("expected C_quota to remain unprocessed after a failed reaction call, so it retries next poll")
+	}
+}

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -366,6 +366,9 @@ func (e *Engine) publishCommentOutput(owner, repo string, item gh.ProjectItem, s
 	branch, commit, mainSHA, timestamp := captureGitMeta(workDir, baseBranch)
 
 	summary := extractSummary(output)
+	// Captured before markers are stripped below — CheckNoWorkNeeded matches the
+	// raw marker line, which stripLine removes a few lines down.
+	noWorkNeeded := CheckNoWorkNeeded(output)
 
 	// Strip FABRIK_ISSUE_UPDATE block from output, then update issue body.
 	if updatedBody := extractUpdatedBody(output); updatedBody != "" {
@@ -390,7 +393,13 @@ func (e *Engine) publishCommentOutput(owner, repo string, item gh.ProjectItem, s
 	// Rewrite or create the stage comment (unless post_to_pr). For post_to_pr
 	// stages the stage output lives on the PR; comment processing output on
 	// such stages is posted as a new comment on the issue as before.
-	if output != "" {
+	// Suppressed entirely on a "no action needed" verdict (#1088) — posting any
+	// reply is what re-triggers a subscribed bot into a runaway reply loop
+	// (#1083), so silence is the correct response here, not a "not actionable"
+	// message.
+	if output != "" && noWorkNeeded {
+		e.logf(item.Number, "comments", "suppressing reply for %s — verdict was FABRIK_NO_WORK_NEEDED\n", stage.Name)
+	} else if output != "" {
 		if stage.PostToPR {
 			comment := formatOutputComment(stage.Name+" (comment review)", output, "", branch, commit, mainSHA, timestamp)
 			e.postItemComment(item, comment, true)
@@ -412,8 +421,8 @@ func (e *Engine) publishCommentOutput(owner, repo string, item gh.ProjectItem, s
 	// comments), also post a Fabrik-marked summary on the linked PR. The
 	// existing issue comment above is unchanged (R4). Gate: output != "" and a
 	// linked PR exists. No post_to_pr check — linked-PR existence is the only
-	// gate (R5).
-	if isReviewReinvoke(comments) && output != "" {
+	// gate (R5). Also suppressed on a "no action needed" verdict, same as above.
+	if isReviewReinvoke(comments) && output != "" && !noWorkNeeded {
 		prNumber, prErr := e.client.FindPRForIssue(owner, repo, item.Number)
 		if prErr != nil {
 			e.logf(item.Number, "warn", "review reinvoke: could not find PR for issue: %v\n", prErr)

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -30,9 +30,53 @@ func (e *Engine) findNewComments(item gh.ProjectItem) []gh.Comment {
 		if c.HasReaction("ROCKET") {
 			continue
 		}
+		// Skip non-actionable bot service-notices (e.g. quota/rate-limit banners) —
+		// admitting these spawns a comment-processing worker and, if replied to,
+		// re-triggers the subscribed bot into an unbounded reply loop (#1083, #1088).
+		// Watermarking these so they don't re-admit on a later poll is handled
+		// separately by settleBotServiceNotices, since a bot-notice-only backlog
+		// never reaches processComments once excluded here.
+		if isBotServiceNotice(c) {
+			continue
+		}
 		newComments = append(newComments, c)
 	}
 	return newComments
+}
+
+// botServiceNoticePatterns are literal, case-insensitive substrings identifying
+// non-actionable bot service/status notices (quota exhaustion, rate limiting)
+// as opposed to genuine bot review content. Deliberately narrow: a bare
+// "quota"/"rate limit" substring would risk matching genuine review prose that
+// discusses rate limiting, and would collide with this repo's own test
+// fixtures (e.g. the literal body "quota notice" used across
+// blocked_on_input_test.go to exercise the human-only resume gate, ADR-069).
+var botServiceNoticePatterns = []string{
+	"daily quota limit",
+	"you have reached your daily quota",
+	"rate limit exceeded",
+	"you have reached your rate limit",
+	"you have exceeded your rate limit",
+	"api rate limit",
+}
+
+// isBotServiceNotice reports whether c is a non-actionable bot service/status
+// notice (e.g. "you have reached your daily quota limit") rather than genuine
+// bot review content. Both the bot-login check and a pattern match are
+// required — a human comment mentioning the same phrasing is not classified
+// as a notice, and a bot comment that doesn't match a known pattern (e.g. a
+// CHANGES_REQUESTED review body) is left for normal processing.
+func isBotServiceNotice(c gh.Comment) bool {
+	if !gh.IsBotLogin(c.Author) {
+		return false
+	}
+	lower := strings.ToLower(c.Body)
+	for _, pattern := range botServiceNoticePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 // filterHuman filters a comment slice down to comments authored by a human —

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -296,6 +296,90 @@ func TestFindNewComments_SkipsRocketReactedComment(t *testing.T) {
 	}
 }
 
+// TestIsBotServiceNotice covers the classifier's decision boundary: bot login
+// AND a known quota/rate-limit pattern must both hold. Regression guard for
+// #1083/#1088 (gemini-code-assist quota-exhaustion runaway loop).
+func TestIsBotServiceNotice(t *testing.T) {
+	tests := []struct {
+		name string
+		c    gh.Comment
+		want bool
+	}{
+		{
+			name: "gemini quota banner",
+			c:    gh.Comment{Author: "gemini-code-assist[bot]", Body: "[!WARNING]\nYou have reached your daily quota limit."},
+			want: true,
+		},
+		{
+			name: "rate limit banner",
+			c:    gh.Comment{Author: "some-bot[bot]", Body: "You have reached your rate limit. Please try again later."},
+			want: true,
+		},
+		{
+			name: "genuine bot review body",
+			c:    gh.Comment{Author: "gemini-code-assist[bot]", Body: "CHANGES_REQUESTED\n\nline 42: this loop never terminates when the slice is empty."},
+			want: false,
+		},
+		{
+			name: "human authored quota-sounding text",
+			c:    gh.Comment{Author: "humanuser", Body: "You have reached your daily quota limit for this API — worth noting in the docs."},
+			want: false,
+		},
+		{
+			name: "existing quota notice fixture body must not collide",
+			c:    gh.Comment{Author: "gemini-code-assist", Body: "quota notice"},
+			want: false,
+		},
+		{
+			name: "bot with unrelated body",
+			c:    gh.Comment{Author: "dependabot[bot]", Body: "Bumps foo from 1.0.0 to 1.0.1."},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBotServiceNotice(tt.c); got != tt.want {
+				t.Errorf("isBotServiceNotice(%+v) = %v, want %v", tt.c, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindNewComments_SkipsBotServiceNotice verifies the pre-admission filter
+// excludes a quota/rate-limit bot notice while still admitting a genuine bot
+// review comment and a human comment in the same batch.
+func TestFindNewComments_SkipsBotServiceNotice(t *testing.T) {
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 21,
+		Comments: []gh.Comment{
+			{ID: "C_quota", DatabaseID: 501, Author: "gemini-code-assist[bot]", Body: "You have reached your daily quota limit."},
+			{ID: "C_review", DatabaseID: 502, Author: "gemini-code-assist[bot]", Body: "CHANGES_REQUESTED: this loop never terminates."},
+			{ID: "C_human", DatabaseID: 503, Author: "humanuser", Body: "please address the review feedback"},
+		},
+	}
+
+	newComments := eng.findNewComments(item)
+	var gotIDs []string
+	for _, c := range newComments {
+		gotIDs = append(gotIDs, c.ID)
+	}
+	if len(newComments) != 2 {
+		t.Fatalf("expected 2 new comments (quota notice excluded), got %d: %v", len(newComments), gotIDs)
+	}
+	for _, want := range []string{"C_review", "C_human"} {
+		found := false
+		for _, id := range gotIDs {
+			if id == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected %q to be admitted, got %v", want, gotIDs)
+		}
+	}
+}
+
 // TestAddComment_ReactsWithRocket verifies that processComments adds a 🚀 reaction
 // to every comment it posts via AddComment, using the returned database ID.
 func TestAddComment_ReactsWithRocket(t *testing.T) {

--- a/engine/comments_test.go
+++ b/engine/comments_test.go
@@ -265,6 +265,167 @@ func TestProcessComments_UpdatesIssueBodyOnMarker(t *testing.T) {
 	}
 }
 
+// TestProcessComments_NoWorkNeeded_SuppressesStageComment verifies that a
+// comment-processing invocation whose output contains FABRIK_NO_WORK_NEEDED
+// posts no reply comment (neither a new comment nor a rewrite of the
+// existing stage comment) — silence, not a "not actionable" message,
+// prevents re-triggering a subscribed bot into a runaway loop (#1083/#1088).
+func TestProcessComments_NoWorkNeeded_SuppressesStageComment(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "not actionable.\nFABRIK_NO_WORK_NEEDED\n", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{
+		Number:   14,
+		Body:     "spec",
+		Comments: []gh.Comment{},
+	}
+	userComments := []gh.Comment{
+		{ID: "C_quota", DatabaseID: 401, Author: "gemini-code-assist[bot]", Body: "unrelated bot chatter"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	if len(client.addCommentCalls) > 0 {
+		t.Errorf("expected no AddComment call on FABRIK_NO_WORK_NEEDED verdict, got: %v", client.addCommentCalls)
+	}
+	if len(client.updateCommentCalls) > 0 {
+		t.Errorf("expected no UpdateComment call on FABRIK_NO_WORK_NEEDED verdict, got: %v", client.updateCommentCalls)
+	}
+}
+
+// TestProcessComments_NoWorkNeeded_SuppressesPostToPRComment covers the
+// post_to_pr reply path — also gated on FABRIK_NO_WORK_NEEDED.
+func TestProcessComments_NoWorkNeeded_SuppressesPostToPRComment(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "not actionable.\nFABRIK_NO_WORK_NEEDED\n", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Review", Order: 4, PostToPR: true}
+	item := gh.ProjectItem{
+		Number: 15,
+		Body:   "spec",
+	}
+	userComments := []gh.Comment{
+		{ID: "C_quota", DatabaseID: 402, Author: "gemini-code-assist[bot]", Body: "unrelated bot chatter"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	if len(client.addCommentCalls) > 0 {
+		t.Errorf("expected no AddComment call on FABRIK_NO_WORK_NEEDED verdict for post_to_pr stage, got: %v", client.addCommentCalls)
+	}
+}
+
+// TestProcessComments_NoWorkNeeded_SuppressesReviewFeedbackSummary covers the
+// review-reinvoke PR summary path — also gated on FABRIK_NO_WORK_NEEDED. All
+// comments carry a ReviewThreadID so isReviewReinvoke is true; a linked PR
+// exists via FindPRForIssue, so absent the fix this would post a summary.
+func TestProcessComments_NoWorkNeeded_SuppressesReviewFeedbackSummary(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{
+		findPRForIssueFn: func(owner, repo string, issueNumber int) (int, error) { return 900, nil },
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "addressed, but nothing to do.\nFABRIK_NO_WORK_NEEDED\n", false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Review", Order: 4}
+	item := gh.ProjectItem{
+		Number: 16,
+		Body:   "spec",
+	}
+	reviewComments := []gh.Comment{
+		{ID: "C_thread", DatabaseID: 403, Author: "copilot-bot", Body: "consider handling nil here", ReviewThreadID: "RT_1"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, reviewComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	if len(client.addCommentCalls) > 0 {
+		t.Errorf("expected no PR review-feedback summary on FABRIK_NO_WORK_NEEDED verdict, got: %v", client.addCommentCalls)
+	}
+}
+
+// TestProcessComments_NoWorkNeeded_IssueBodyAndReactionsStillApply verifies
+// that FABRIK_NO_WORK_NEEDED suppresses only the reply comment — the issue
+// body update (FABRIK_ISSUE_UPDATE), 🚀 reactions marking input comments
+// processed, and the editing-label removal must all still occur.
+func TestProcessComments_NoWorkNeeded_IssueBodyAndReactionsStillApply(t *testing.T) {
+	skipIfNoGit(t)
+
+	var updatedBody string
+	client := &mockGitHubClient{
+		updateIssueBodyFn: func(owner, repo string, issueNumber int, body string) error {
+			updatedBody = body
+			return nil
+		},
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			output := "FABRIK_ISSUE_UPDATE_BEGIN\nno actual change needed\nFABRIK_ISSUE_UPDATE_END\nnothing to do here.\nFABRIK_NO_WORK_NEEDED\n"
+			return output, false, TokenUsage{}, nil
+		},
+	}
+
+	eng := testEngineWithRepo(t, client, claude)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{
+		Number: 17,
+		Body:   "old spec",
+	}
+	userComments := []gh.Comment{
+		{ID: "C_u", DatabaseID: 404, Author: "testuser", Body: "is there anything left to do?"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments: %v", err)
+	}
+
+	if updatedBody != "no actual change needed" {
+		t.Errorf("updatedBody = %q, want issue body update to still apply", updatedBody)
+	}
+	sawRocket := false
+	for _, rc := range client.addCommentReactionCalls {
+		if rc.content == "rocket" {
+			sawRocket = true
+		}
+	}
+	if !sawRocket {
+		t.Errorf("expected the input comment to still get a 🚀 reaction, got: %v", client.addCommentReactionCalls)
+	}
+	if len(client.addCommentCalls) > 0 {
+		t.Errorf("expected no reply comment despite issue-body update, got: %v", client.addCommentCalls)
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1057,6 +1057,13 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 	// Revalidate scan: operator-facing fabrik:revalidate label re-entry.
 	e.settleRevalidateScan(deepFetchCandidates)
 
+	// Bot service-notice settle scan (#1083/#1088): watermarks non-actionable bot
+	// quota/rate-limit comments excluded by findNewComments so they never re-admit.
+	// Runs over the raw board snapshot, not deepFetchCandidates — a bot-notice-only
+	// backlog never dispatches (itemNeedsWork sees zero new comments), so it would
+	// never appear in deepFetchCandidates.
+	e.settleBotServiceNotices(board)
+
 	// SHA-invalidation scan: detect force-pushes or external commits that change
 	// the linked PR's HEAD SHA after stage:Validate:complete was recorded.
 	e.settleSHAInvalidationScan(deepFetchCandidates)


### PR DESCRIPTION
Closes #1088

## Summary

Fix 2/4 in the #1083 runaway-loop remediation series. Adds two independent defenses against the bot quota-notice reply loop described in the incident:

1. **Pre-admission filter** — `findNewComments` now excludes comments that are both bot-authored (`github.IsBotLogin`) and match a known service/status pattern (quota-exhaustion, rate-limit banners). These comments never spawn a comment-processing worker and never receive a reply. A new per-poll settle scan (`settleBotServiceNotices`, mirroring `settleMergeTrainMemberCloses`) watermarks them (🚀 reaction + `CommentProcessed`) so they never re-admit — this can't happen inline in `findNewComments` (which must stay pure/client-free) or in `processComments` (a notice-only backlog never dispatches once excluded).
2. **Reply suppression on `FABRIK_NO_WORK_NEEDED`** — when a comment-processing invocation's output carries this marker, none of the three reply paths (issue stage comment, `post_to_pr` comment, review-reinvoke PR summary) post anything. Issue-body updates, 🚀 reactions, editing-label removal, and stage-complete handling are unaffected — only the reply itself is suppressed, since posting *any* reply (even "not actionable") is what re-triggered the bot in the incident.

The bot-notice pattern list is deliberately narrow and literal to avoid catching genuine bot review content and to avoid colliding with this repo's own `"quota notice"` test fixtures (`blocked_on_input_test.go`, from ADR-069) that intentionally exercise letting bot chatter through during a paused/awaiting-input resume.

## Key changes

- `engine/comments.go`: `isBotServiceNotice` classifier + wiring into `findNewComments`; `publishCommentOutput` gates all three reply paths on `!CheckNoWorkNeeded(output)`.
- `engine/bot_notice_settle.go` (new): `settleBotServiceNotices`, wired into the poll loop in `engine/poll.go`.
- Docs: `docs/state-machine.md` §4.1/§4.2/§4.4, `docs/USER_GUIDE.md`'s Multi-User/Multi-Instance section, `docs/llms-full.txt` regenerated.
- `adrs/070-bot-service-notice-filter.md`: design rationale, including why the settle-scan placement was chosen over embedding in `findNewComments`/`processItem`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./engine/...` — 1529 tests pass
- [x] New unit tests: classifier true/false cases (including the existing `"quota notice"` fixture body, confirmed non-colliding), `findNewComments` exclusion, settle-scan watermarking/idempotency/failure-retry, and all three reply-suppression paths plus confirmation that issue-body updates/reactions still apply
- [x] Confirmed no regression in `blocked_on_input_test.go`'s bot-chatter-during-pause fixtures (still admitted per ADR-069)