### PR TITLE
ci: auto-route community issues to the public triage board

### DIFF
--- a/.github/workflows/route-community-issues.yml
+++ b/.github/workflows/route-community-issues.yml
@@ -1,0 +1,56 @@
+name: Route community issues to triage board
+
+# Automatically place issues opened by non-maintainers onto the public
+# "Fabrik — Triage & Roadmap" board (project #3) at Status = Triage.
+#
+# Issues we (or the Fabrik bot) open are NOT routed here: maintainer/bot issues
+# carry author_association OWNER / MEMBER / COLLABORATOR, which the `if` below
+# excludes. Community issues carry NONE / CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR.
+# Our own work issues continue to be added to the private working board (#1)
+# explicitly, so they never land on the public roadmap.
+#
+# Requires a repo secret ADD_TO_PROJECT_PAT: a PAT with `project` (write) scope
+# for the handarbeit org — the default GITHUB_TOKEN cannot write org-level
+# Projects. Without the secret the job fails loudly (it never silently no-ops).
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  route:
+    # Community only. OWNER/MEMBER/COLLABORATOR = us or the Fabrik bot → skip.
+    if: ${{ !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to Triage & Roadmap board (project #3)
+        id: add
+        uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/handarbeit/projects/3
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
+      - name: Set Status = Triage
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          ITEM_ID: ${{ steps.add.outputs.itemId }}
+        # Board #3 identifiers (stable):
+        #   project PVT_kwDOENB0Ac4BeRx-  |  Status field PVTSSF_lADOENB0Ac4BeRx-zhYtNVE
+        #   Triage option 8d9b1d82
+        run: |
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $opt: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project,
+                itemId: $item,
+                fieldId: $field,
+                value: { singleSelectOptionId: $opt }
+              }) { projectV2Item { id } }
+            }' \
+            -f project="PVT_kwDOENB0Ac4BeRx-" \
+            -f item="$ITEM_ID" \
+            -f field="PVTSSF_lADOENB0Ac4BeRx-zhYtNVE" \
+            -f opt="8d9b1d82"


### PR DESCRIPTION
## What

Adds `.github/workflows/route-community-issues.yml` — on `issues: opened`, any issue opened by a **non-maintainer** is added to the public **Fabrik — Triage & Roadmap** board (project #3) at **Status = Triage**. Retires the manual step of hand-adding community reports (as was done for #1095).

## How the split works

Routing keys off GitHub's `author_association`, validated against real issues:

| Issue | Author | `author_association` | Routed to #3? |
|---|---|---|---|
| #1095 | bdueck (community) | `NONE` | ✅ yes |
| #1096 | arbeithand (us) | `MEMBER` | ❌ no |
| #1083 | verveguy (bot) | `MEMBER` | ❌ no |

The job's `if:` excludes `OWNER`/`MEMBER`/`COLLABORATOR`, so **our own spec-kit/work issues and engine-spawned children never land on the public roadmap** — they continue to be added to the private working board (#1) explicitly. No hardcoded usernames; new maintainers/bots are covered automatically by their org association.

`Status = Triage` is set **in-repo** via a GraphQL mutation on the item id returned by `actions/add-to-project@v2.0.0`, so placement doesn't depend on a UI-side project workflow toggle.

## Required before this works: one repo secret

`ADD_TO_PROJECT_PAT` — a PAT with **`project` (write)** scope for the `handarbeit` org. The default `GITHUB_TOKEN` cannot write org-level Projects. If the secret is absent the job **fails loudly** (it never silently no-ops), so a missing/expired token is visible in the Actions tab rather than causing issues to quietly stop routing.

Suggested: a fine-grained PAT scoped to Projects (read/write) only, long expiry, to minimize rotation churn.

## Scope / notes

- Forward-only: fires on newly opened issues, not retroactively (existing community issues like #1095 stay as-placed).
- Does not touch the private working board (#1); confirm #1 has no blanket "auto-add every repo issue" workflow that would scoop up community issues in parallel.
- Not pipelined through Fabrik — CI/ops config, reviewed directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)