### PR TITLE
test(e2e): replace point-in-time stale-train-PR check with a bounded poll

### DIFF
--- a/tests/e2e/mergetrain_bisect_test.go
+++ b/tests/e2e/mergetrain_bisect_test.go
@@ -70,6 +70,6 @@ func TestMergeTrainBisectionEjectsPoisoner(t *testing.T) {
 		t.Logf("poison member #%d correctly not landed (status=%q)", poisonIssue, st)
 	}
 
-	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)
+	WaitForNoStaleTrainArtifacts(t, env, env.RepoAlpha, 2*time.Minute)
 	t.Logf("bisection contract verified: red batch → O(log N) bisect → poisoner ejected → survivors landed")
 }

--- a/tests/e2e/mergetrain_happy_test.go
+++ b/tests/e2e/mergetrain_happy_test.go
@@ -70,6 +70,6 @@ func TestMergeTrainHappyPathLanding(t *testing.T) {
 	}
 
 	// No stale train branches/PRs should remain after the landing.
-	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)
+	WaitForNoStaleTrainArtifacts(t, env, env.RepoAlpha, 2*time.Minute)
 	t.Logf("happy-path land verified: 3 members → 1 integration PR → all Done, no O(N²) per-member retests")
 }

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -289,18 +289,36 @@ func assertPRMerged(t *testing.T, env *Env, repo string, prNumber int) {
 	}
 }
 
-// assertNoStaleTrainArtifacts fails if the repo still has open merge-train
-// integration PRs after a scenario — a guard against the reconstruction bugs
-// (permanent stall / orphaned remnants) surviving cleanup.
-func assertNoStaleTrainArtifacts(t *testing.T, env *Env, repo string) {
+// WaitForNoStaleTrainArtifacts polls until the repo has no open merge-train
+// integration PRs, up to timeout — a guard against the reconstruction bugs
+// (permanent stall / orphaned remnants) surviving cleanup. This is a
+// point-in-time condition racing the engine's own poll-cycle cleanup: a
+// batch's terminal event (e.g. the runaway guard firing) pauses/alerts
+// synchronously, but the orphaned trial/integration PR is reclaimed by the
+// normal train-reconcile logic on a subsequent poll cycle, so a bare
+// single-shot check can observe a PR that is already correctly scheduled for
+// (but hasn't yet completed) cleanup.
+func WaitForNoStaleTrainArtifacts(t *testing.T, env *Env, repo string, timeout time.Duration) {
 	t.Helper()
-	out, err := ghOutput(env, "pr", "list", "-R", repo, "--state", "open",
-		"--json", "headRefName", "--jq", `[.[] | select(.headRefName | startswith("fabrik/merge-train/"))] | length`)
-	if err != nil {
-		t.Logf("warn: could not check for stale train PRs on %s: %v", repo, err)
-		return
-	}
-	if n := parseFirstInt(lastNonEmpty(out)); n > 0 {
-		t.Errorf("found %d open merge-train integration PR(s) still on %s after scenario", n, repo)
+	deadline := time.Now().Add(timeout)
+	var lastCount int
+	var lastErr error
+	for {
+		out, err := ghOutput(env, "pr", "list", "-R", repo, "--state", "open",
+			"--json", "headRefName", "--jq", `[.[] | select(.headRefName | startswith("fabrik/merge-train/"))] | length`)
+		lastErr = err
+		if err == nil {
+			lastCount = parseFirstInt(lastNonEmpty(out))
+			if lastCount == 0 {
+				return
+			}
+			t.Logf("WaitForNoStaleTrainArtifacts: %d open merge-train integration PR(s) still on %s (will retry)", lastCount, repo)
+		} else {
+			t.Logf("WaitForNoStaleTrainArtifacts: transient gh error checking for stale train PRs on %s: %v (will retry)", repo, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("found %d open merge-train integration PR(s) still on %s after %s (last err: %v)", lastCount, repo, timeout, lastErr)
+		}
+		time.Sleep(10 * time.Second)
 	}
 }

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -303,11 +303,13 @@ func WaitForNoStaleTrainArtifacts(t *testing.T, env *Env, repo string, timeout t
 	deadline := time.Now().Add(timeout)
 	var lastCount int
 	var lastErr error
+	var sawReading bool
 	for {
 		out, err := ghOutput(env, "pr", "list", "-R", repo, "--state", "open",
 			"--json", "headRefName", "--jq", `[.[] | select(.headRefName | startswith("fabrik/merge-train/"))] | length`)
 		lastErr = err
 		if err == nil {
+			sawReading = true
 			lastCount = parseFirstInt(lastNonEmpty(out))
 			if lastCount == 0 {
 				return
@@ -317,7 +319,10 @@ func WaitForNoStaleTrainArtifacts(t *testing.T, env *Env, repo string, timeout t
 			t.Logf("WaitForNoStaleTrainArtifacts: transient gh error checking for stale train PRs on %s: %v (will retry)", repo, err)
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("found %d open merge-train integration PR(s) still on %s after %s (last err: %v)", lastCount, repo, timeout, lastErr)
+			if !sawReading {
+				t.Fatalf("could not check for stale merge-train PRs on %s after %s — no successful reading (last err: %v)", repo, timeout, lastErr)
+			}
+			t.Fatalf("found %d open merge-train integration PR(s) still on %s after %s", lastCount, repo, timeout)
 		}
 		time.Sleep(10 * time.Second)
 	}

--- a/tests/e2e/mergetrain_restart_test.go
+++ b/tests/e2e/mergetrain_restart_test.go
@@ -64,6 +64,6 @@ func TestMergeTrainRestartSafety(t *testing.T) {
 		WaitForMemberLanded(t, env, env.RepoAlpha, m[0], 10*time.Minute)
 		waitForPRClosed(t, env, env.RepoAlpha, m[1], 10*time.Minute)
 	}
-	assertNoStaleTrainArtifacts(t, env, env.RepoAlpha)
+	WaitForNoStaleTrainArtifacts(t, env, env.RepoAlpha, 2*time.Minute)
 	t.Logf("restart-safety verified: batch 2 landed after restart — no stall from the historical merged PR")
 }

--- a/tests/e2e/mergetrain_runaway_test.go
+++ b/tests/e2e/mergetrain_runaway_test.go
@@ -84,6 +84,6 @@ func TestMergeTrainRunawayGuardPausesBatch(t *testing.T) {
 		}
 	}
 
-	assertNoStaleTrainArtifacts(t, env, env.RepoBeta)
+	WaitForNoStaleTrainArtifacts(t, env, env.RepoBeta, 2*time.Minute)
 	t.Logf("runaway guard contract verified: all-poison batch → guard fires at cap → all Queued members paused → no member reaches Done")
 }


### PR DESCRIPTION
Closes #987

## Summary

`assertNoStaleTrainArtifacts` checked, once and immediately, whether a repo still had open `fabrik/merge-train/*` integration PRs after an e2e scenario. But the engine's cleanup of an orphaned trial/integration PR after a batch's terminal event (e.g. the runaway guard firing) happens on a *subsequent poll cycle*, not synchronously with the event itself. The point-in-time check raced this cleanup and could fail even though the engine's behavior was correct — confirmed by a captured run where the check failed but `gh pr list` showed zero stale PRs immediately afterward.

## Changes

- Replaced `assertNoStaleTrainArtifacts` (unexported, single-shot, `t.Errorf`) with `WaitForNoStaleTrainArtifacts` (exported, polling, `t.Fatalf`) in `tests/e2e/mergetrain_helpers.go`, following the same `deadline := time.Now().Add(timeout)` / 10s-sleep loop pattern already used by sibling `WaitFor*` helpers (`WaitForIntegrationPR`, `WaitForMemberLanded`).
- Preserved the original soft-fail-on-transient-`gh`-error behavior (log and retry) but folded it into the retry loop instead of an early return, so a single flaky `gh` call no longer burns the whole check.
- Updated all four call sites to the new helper with a 2-minute timeout:
  - `tests/e2e/mergetrain_happy_test.go`
  - `tests/e2e/mergetrain_restart_test.go`
  - `tests/e2e/mergetrain_bisect_test.go`
  - `tests/e2e/mergetrain_runaway_test.go`

No engine changes — `fireRunawayGuard`'s synchronous pause/alert + asynchronous next-poll cleanup ordering is confirmed correct and out of scope.

## Test plan

- `go build -tags e2e ./...` — clean
- `go vet -tags e2e ./...` — clean
- `go build ./...`, `go vet ./...`, `go test ./...` (full non-e2e suite) — all pass
- `gofmt -l` on all touched files — no diffs
- Live e2e run against real GitHub repos (the actual flake repro) is out of scope for this environment; correctness rests on matching the already-proven `WaitForIntegrationPR` polling pattern exactly.