### PR TITLE
test(e2e): make TestYoloAutoMergeLabel train-mode aware

### DIFF
--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -9,22 +9,34 @@ import (
 )
 
 // TestYoloAutoMergeLabel is the regression test for #829 — replacing Fabrik's
-// poll-merge loop with GitHub's native auto-merge for yolo issues.
+// poll-merge loop with GitHub's native auto-merge for yolo issues — and, per
+// #980, for the ADR-059 merge-train's own yolo landing contract.
 //
-// The headline observable behaviour change: after Validate completes for a
-// fabrik:yolo issue, the engine calls enablePullRequestAutoMerge once and
-// tags the issue with fabrik:auto-merge-enabled. GitHub then merges the PR
-// atomically when CI passes and the PR is mergeable, eliminating the
-// HTTP 405 spam and race window that the poll-merge loop produced.
+// The test auto-detects the bed's configured FABRIK_MERGE_TRAIN mode (via the
+// bed's .env file) and asserts whichever contract that mode implies, since
+// the two are mutually exclusive at the engine level (attemptMergeOnValidate
+// diverts every yolo Validate completion straight to advanceToQueued before
+// the fabrik:auto-merge-enabled label site is ever reached when the train is
+// on):
 //
-// What this test verifies (FR-004, FR-005, SC-001 from the #829 spec):
-//   - fabrik:auto-merge-enabled is applied at some point during the issue's
-//     lifetime (observed via the issue timeline, so we don't miss a fast
-//     add-then-remove cycle on a trivial PR).
-//   - The issue ultimately closes — i.e. GitHub auto-merge actually merged
-//     the PR end-to-end.
-//   - fabrik:auto-merge-enabled is NOT present on the closed issue (FR-005:
-//     removed once the PR merges).
+//   - Train mode "off" (including default/unset) — unchanged from #829:
+//     after Validate completes, the engine calls enablePullRequestAutoMerge
+//     once and tags the issue with fabrik:auto-merge-enabled. GitHub then
+//     merges the PR atomically when CI passes and the PR is mergeable.
+//     Verifies FR-004/FR-005/SC-001: fabrik:auto-merge-enabled is applied at
+//     some point (via the issue timeline), the issue closes, and the label
+//     is absent afterward (removed once the PR merges).
+//
+//   - Train mode "on" (ADR-059 D6/D7) — the yolo item advances Validate →
+//     Queued and lands via the merge train's own batch (landGreenBatch →
+//     landMergeTrainBatch) or singleton (landSingleton) landing path, both of
+//     which close-not-merge the member's own PR and land the change via a
+//     separate integration/singleton PR. Verifies: the issue reaches Done
+//     (board Status "Done" or issue CLOSED, whichever is observed first —
+//     the same race-tolerant pattern WaitForMemberLanded uses elsewhere),
+//     the member's own linked PR ends CLOSED (not MERGED), a "landing
+//     complete" bed-log line appears after the issue was filed, and
+//     fabrik:auto-merge-enabled is never applied at any point.
 //
 // Out of scope here (better suited to unit/integration tests because
 // provoking them deterministically in e2e is hard):
@@ -39,10 +51,14 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 
+	trainMode := readEnvFileMergeTrainMode(t, env)
+	t.Logf("bed train mode: %s", trainMode)
+
 	stamp := time.Now().UTC().Format("20060102-150405")
 	marker := fmt.Sprintf("auto-merge-yolo-%s", stamp)
 	body := fmt.Sprintf(autoMergeBodyTemplate, "`", "`", "```", marker, "```")
 
+	logStart := LogOffset(t, env)
 	num := FileIssue(t, env, env.RepoAlpha,
 		fmt.Sprintf("e2e yolo auto-merge (%s)", stamp),
 		body, "fabrik:yolo")
@@ -50,24 +66,49 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 	SetIssueStatus(t, env, itemID, "Specify")
 	t.Logf("filed %s#%d at Status=Specify, marker=%s", env.RepoAlpha, num, marker)
 
-	// Wait for the full pipeline to land the merge. On trivial PRs with no
-	// branch protection or required reviews, GitHub may merge within seconds
-	// of auto-merge being enabled — so we don't poll for the transient
-	// fabrik:auto-merge-enabled label here. We let the issue close and then
-	// audit the timeline.
-	WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
-	t.Logf("%s#%d closed — checking the auto-merge path was taken", env.RepoAlpha, num)
+	// Captured once, before branching: the member's own PR closes shortly
+	// after Validate completes in both modes (native auto-merge or the
+	// train's close-not-merge landing), and WaitForLinkedPR only finds it
+	// while still open.
+	prNum := WaitForLinkedPR(t, env, env.RepoAlpha, num, 30*time.Minute)
 
-	// Race-free verification that auto-merge enablement happened: scan the
-	// issue's timeline for a labeled-with-fabrik:auto-merge-enabled event.
-	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
-	t.Logf("fabrik:auto-merge-enabled was applied at some point — GitHub native auto-merge path verified")
+	if trainMode == "on" {
+		t.Run("train-mode=on", func(t *testing.T) {
+			WaitForMemberLanded(t, env, env.RepoAlpha, num, 45*time.Minute)
+			t.Logf("%s#%d landed (Done or closed) — checking the merge-train path was taken", env.RepoAlpha, num)
 
-	// FR-005: the label must be removed when the PR merges. Fabrik needs
-	// 1-2 poll cycles (~30-60s) after the merge to observe it and remove the
-	// label — checking immediately races the cleanup poll.
-	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled", 5*time.Minute)
-	t.Logf("fabrik:auto-merge-enabled was cleaned up after merge — FR-005 verified")
+			waitForPRClosedNotMerged(t, env, env.RepoAlpha, prNum, 5*time.Minute)
+			t.Logf("member PR #%d closed without being merged — train landing contract verified", prNum)
+
+			WaitForLogLine(t, env, "landing complete", logStart, 5*time.Minute)
+			t.Logf("bed log shows a completed train landing")
+
+			AssertLabelWasNeverApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
+			t.Logf("fabrik:auto-merge-enabled was never applied — train-on contract verified")
+		})
+		return
+	}
+
+	t.Run("train-mode=off", func(t *testing.T) {
+		// Wait for the full pipeline to land the merge. On trivial PRs with no
+		// branch protection or required reviews, GitHub may merge within seconds
+		// of auto-merge being enabled — so we don't poll for the transient
+		// fabrik:auto-merge-enabled label here. We let the issue close and then
+		// audit the timeline.
+		WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
+		t.Logf("%s#%d closed — checking the auto-merge path was taken", env.RepoAlpha, num)
+
+		// Race-free verification that auto-merge enablement happened: scan the
+		// issue's timeline for a labeled-with-fabrik:auto-merge-enabled event.
+		AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
+		t.Logf("fabrik:auto-merge-enabled was applied at some point — GitHub native auto-merge path verified")
+
+		// FR-005: the label must be removed when the PR merges. Fabrik needs
+		// 1-2 poll cycles (~30-60s) after the merge to observe it and remove the
+		// label — checking immediately races the cleanup poll.
+		WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled", 5*time.Minute)
+		t.Logf("fabrik:auto-merge-enabled was cleaned up after merge — FR-005 verified")
+	})
 }
 
 // autoMergeBodyTemplate is the issue body for TestYoloAutoMergeLabel. The five

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1059,6 +1059,28 @@ func readEnvFileMaxCiFixCycles(t *testing.T, env *Env) int {
 	return n
 }
 
+// readEnvFileMergeTrainMode reads FABRIK_MERGE_TRAIN from the test bed's .env
+// file, normalizing exactly like cmd/root.go's mergeTrainMode: missing/empty
+// or unrecognized values default to "off" (logged via t.Logf, not stderr),
+// and only an exact case-insensitive "on" returns "on".
+func readEnvFileMergeTrainMode(t *testing.T, env *Env) string {
+	t.Helper()
+	envFile := filepath.Join(env.FabrikTestDir, ".env")
+	val, err := readEnvFileValue(envFile, "FABRIK_MERGE_TRAIN")
+	if err != nil {
+		return "off"
+	}
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "on":
+		return "on"
+	case "off", "":
+		return "off"
+	default:
+		t.Logf("FABRIK_MERGE_TRAIN=%q in %s is invalid (must be on or off); using default off", val, envFile)
+		return "off"
+	}
+}
+
 // assertTrainPoisonGuardRequired skips the test if "train-poison-guard" is not
 // a required status check on the repo's main branch. Accepts repo as a
 // parameter so it works for both Alpha and Beta repos. Skips (never fatals) so

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -276,6 +276,33 @@ func waitForPRClosed(t *testing.T, env *Env, repo string, prNumber int, timeout 
 	}
 }
 
+// waitForPRClosedNotMerged polls until the PR reaches a terminal state, up to
+// timeout. Fails immediately on MERGED — for callers that need the stricter
+// "landed via a separate PR, not by GitHub merging this one" contract (e.g.
+// the merge-train's close-not-merge landing of a member's own PR), where
+// waitForPRClosed's permissive CLOSED-or-MERGED semantics would silently
+// accept the wrong outcome.
+func waitForPRClosedNotMerged(t *testing.T, env *Env, repo string, prNumber int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
+			"--json", "state", "--jq", ".state")
+		if err == nil {
+			switch strings.TrimSpace(out) {
+			case "CLOSED":
+				return
+			case "MERGED":
+				t.Fatalf("member PR #%d on %s was MERGED, want CLOSED (should land via a separate integration/singleton PR, not by merging the member's own PR)", prNumber, repo)
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("member PR #%d on %s not closed within %s (last state: %q, err: %v)", prNumber, repo, timeout, strings.TrimSpace(out), err)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
 // assertPRMerged fails unless the PR is in the MERGED state.
 func assertPRMerged(t *testing.T, env *Env, repo string, prNumber int) {
 	t.Helper()


### PR DESCRIPTION
Closes #980

## What

`TestYoloAutoMergeLabel` previously hard-coded the pre-ADR-059 native-auto-merge contract (Validate completes → `fabrik:auto-merge-enabled` applied → GitHub auto-merges → label removed). On a bed running with `FABRIK_MERGE_TRAIN=on`, that path is never taken by design — `attemptMergeOnValidate` diverts every yolo Validate completion to `advanceToQueued` before the auto-merge label site is reached, so the test failed with a false negative even when the pipeline behaved correctly (see #3418 in the issue).

This PR makes the test detect the bed's actual merge-train mode and assert the contract that mode implies, so the suite is green on either bed configuration with the same invocation.

## Key changes

- `tests/e2e/harness.go`: new `readEnvFileMergeTrainMode` helper, reading `FABRIK_MERGE_TRAIN` from the bed's `.env` (same mechanism as the existing `readEnvFile*` siblings). Missing/empty/unrecognized values default to `"off"`, matching `cmd/root.go`'s own default.
- `tests/e2e/mergetrain_helpers.go`: new `waitForPRClosedNotMerged` helper — polls a PR until CLOSED, but fails immediately (not just times out) if it observes MERGED, since the train-on contract requires the member's own PR to be closed-not-merged.
- `tests/e2e/auto_merge_test.go`: `TestYoloAutoMergeLabel` now detects train mode up front, captures the linked PR number before branching, and splits into two subtests:
  - `train-mode=off`: unchanged contract — `fabrik:auto-merge-enabled` applied at some point, issue closes, label absent after close (FR-005).
  - `train-mode=on`: issue reaches Done (board Done or issue CLOSED, race-tolerant), member's own PR ends CLOSED not MERGED, a `"landing complete"` bed-log line appears, and `fabrik:auto-merge-enabled` is never applied.

No engine/production code is touched — `attemptMergeOnValidate`, `advanceToQueued`, `landGreenBatch`, and `landSingleton` are unmodified.

## How to test

- `go build -tags e2e ./tests/e2e/...` and `go vet -tags e2e ./tests/e2e/...` — compiles and vets cleanly (no live bed available in this environment to run the e2e suite itself).
- `go build ./...`, `go vet ./...`, `go test ./...` — all non-e2e packages pass (2 unrelated, pre-existing flaky timing tests in `engine/grandchild_test.go` pass in isolation and are untouched by this change).