### PR TITLE
Annotate turn-cap retry successors with a provenance notice

### DIFF
--- a/adrs/071-turn-cap-retry-provenance.md
+++ b/adrs/071-turn-cap-retry-provenance.md
@@ -1,0 +1,73 @@
+# ADR 071: Turn-Cap Retry Provenance
+
+**Date**: 2026-07-26
+**Status**: Accepted
+**Issue**: #1081 — A turn-cap kill produces an untrustworthy retry: the successor reports work it never performed
+
+## Context
+
+When a stage hits `max_turns`, the Claude CLI's own `--max-turns` self-termination exits non-zero (`completed=false`, `err != nil`). This falls through the progress-based extension loop (ADR-030) — which requires `err == nil` — straight to the cooldown/retry path: a later poll re-invokes the same stage with `resume=true`, against a worktree and Claude session that already carry the killed run's partial work.
+
+The retry mechanism itself is correct and often cheap. The problem is trust: the successor's posted comment is indistinguishable from a normal, from-scratch completion. In the reported incident, a Review stage was killed at 51/50 turns and its retry "completed" in 2 turns with a full gate table (`npm run check`, `eslint`, `prettier`, `npm run test:unit`) — four commands, each costing a turn, reported from a two-turn run. A second, independent installation corroborated the same pattern concentrated in Implement (6 of 19 runs capped, all `Completed: false`), including cases where the successor's own summary named the situation outright ("Found the implementation already complete from a prior interrupted session") while still reporting verification as first-hand. Nothing in the posted output, `history.json`, or the board state signals that a predecessor died mid-stage.
+
+## Decision
+
+**1. Stage-scoped capped-run signal, not item-scoped.** `StageState.LastRunCapped map[string]bool` (keyed by stage name) records whether the most recently finalized invocation of that stage was turn-capped. It is written via a new `StageCappedRunRecorded` mutation, applied unconditionally in `finalizeStageOutcome` on every finalized invocation — so a normal completion clears a stale flag, and a chain of consecutive capped runs (the reported `51/51/23/18/18` case) keeps annotating each successor, not just the first.
+
+**2. Detection condition drops `err == nil`.** The flag is set from `usage.MaxTurns > 0 && usage.TurnsUsed >= usage.MaxTurns && !completed` — independent of `err`. Reusing the extension loop's `hitLimit` condition (which requires `err == nil`) would silently never fire for the real-world turn-cap kill, since that process exits non-zero.
+
+**3. Comment-only annotation; nothing injected into the resumed session's prompt.** `processItem` reads `snap.StageCapped(stage.Name)` at dispatch time — before the current invocation runs — and when true, `finalizeStageOutcome` prepends a one-line callout to the posted output (shared by both the issue-comment and PR-comment paths):
+
+> ⚠️ **Provenance notice:** the previous attempt at this stage was stopped after hitting its turn limit. This run resumed that session — treat any claims about freshly-run commands or verification accordingly.
+
+The annotation carries no turn numbers and is skipped when `postOutput` is empty (degenerate output is never annotated).
+
+**4. `history.json` field, not just a log line.** `InvocationRecorded.AfterCappedRun` mirrors the same pre-dispatch flag into `ItemState.LastInvocationAfterCappedRun`, forwarded by `InvocationObserver` into `tui.JobCompletedEvent`/`tui.HistoryEntry` — rendered as a dim `⚠cap` marker in the History pane and available to `fabrik watch` for free.
+
+**5. Two log-only "suspicious shape" heuristics, exploratory and non-gating:** a successor that resumed after a capped predecessor, completed, and used under a quarter of the stage's turn budget logs a warning; and stage output naming the inherited-work situation via a small phrase list ("prior session", "interrupted session", "prior attempt", etc.) logs a separate warning. Neither writes new persisted state — both are precedented by #448's "always-on diagnostic logging, not behind a debug flag."
+
+**6. Scoped to full-stage invocations only.** The structurally identical comment-processing retry path (`engine/comments.go`, `comment_max_turns`) shares the same mechanism but is out of scope here — comment review already has a human reading the thread who is generally aware a reply is a continuation. Extending parity there is a separate, deliberately unbundled follow-up.
+
+## Rationale
+
+### Why stage-scoped storage instead of reusing the existing item-scoped `ItemState.LastInvocationCompleted`/`LastTokenUsage`?
+
+Those fields are overwritten by *any* invocation for the item, including a comment-processing run that lands between a capped run and its retry, or a different stage's own invocation. A naive read of "the last recorded invocation" before dispatching stage X could pick up an unrelated invocation rather than stage X's own capped predecessor — reproducing a milder version of the exact "untrustworthy, unverifiable output" problem this ADR closes. `StageState` already carries several per-stage maps (`Attempts`, `LastAttemptAt`, `PausedByEngine`) that follow this same stage-keyed pattern.
+
+### Why not gate the detection on `err == nil` like the extension loop does?
+
+Because the real-world turn-cap kill exits non-zero — the extension loop's `hitLimit` condition was designed for a different purpose (deciding whether to `--resume` within the same `processItem` call) and happens to require `err == nil` for that purpose. Copying it verbatim here would make the annotation never fire for the exact scenario the issue reports.
+
+### Why annotate the comment instead of injecting a heads-up into the resumed session's own context?
+
+The issue frames this explicitly as a reader-facing provenance marker, "without judging the retry's content," and lists refusing the retry or auto-raising `max_turns` as deliberately out of scope. Injecting a notice into the resumed session's prompt would be a behavior change to the retry itself — the model might over-hedge or refuse to verify at all — and isn't needed to solve the stated problem: a human reading the comment needs to know the provenance is uncertain; the model's own behavior on the retry is unconstrained by this fix.
+
+### Why no exact turn numbers in the annotation text?
+
+Rendering the predecessor's own turn count (e.g. "51/50") would require a second stage-scoped field capturing the predecessor's usage, reintroducing the same mis-scoping surface this ADR is designed to avoid, for no functional gain — the annotation's job is to flag discontinuity, not restate stats already visible in the predecessor's own stats footer.
+
+### Why leave the comment-processing retry path out of scope?
+
+The issue's examples (Review, Implement) are both full-stage runs. Comment review is a separate, structurally parallel retry path (`comments.go`, governed by `comment_max_turns`) with a human actively reading the thread in real time — the "silent, indistinguishable-from-normal" trust gap this ADR closes is weaker there. Bundling parity in would widen this change's surface (item-state model, comments.go, its own tests) without being required by the reported incidents.
+
+## Consequences
+
+**Positive:**
+- The successor's posted comment now visibly flags when it resumed a turn-capped predecessor, closing the exact trust gap in the issue: a human reviewing the PR (or `cruise` advancing automatically) has a durable signal that verification claims in that comment may be inherited rather than freshly performed.
+- `history.json` and the TUI History pane make the condition queryable rather than inferable from adjacent `TurnsUsed`/`MaxTurns` rows, for both the shipped TUI and `fabrik watch`.
+- Stage-scoped storage generalizes correctly to multi-run capped chains and is immune to intervening comment-processing invocations.
+- No new labels, no new config/YAML surface — purely additive to the item-state model, the invocation-finalization path, and the TUI event/history pipeline.
+
+**Negative / Trade-offs:**
+- **The two "suspicious shape" heuristics are log-only and accept false negatives by design.** The few-turn threshold (`< stage.MaxTurns/4`) and the phrase list are both deliberately conservative; broader detection is a follow-up, not a blocker, per the issue's own "optionally" framing.
+- **Comment-processing retries do not get the same annotation.** A capped comment-processing run's retry carries the same underlying risk but is not flagged — an explicit, scoped gap rather than an oversight.
+- **The annotation's absence of exact turn numbers** means a reader must still consult `history.json`/the History pane for the predecessor's own stats if they want them — the comment only signals that discontinuity occurred, not its magnitude.
+
+## Related Work
+
+- Issue #1081 (this issue) and its corroborating RallyRaffle installation report (comment thread).
+- ADR-030 — Progress-Based Turn Extension: the `err == nil`-gated intra-dispatch loop this ADR's detection condition deliberately does not reuse.
+- #847 — History under-counts time & cost (fixed the `history.json` append-dedup bug this ADR's new field builds on top of).
+- #448 — Investigate why progress-based extension did not fire on Implement run that hit max_turns (established the "always-on diagnostic logging, not behind a debug flag" precedent this ADR's log-only heuristics follow).
+
+**References:** [docs/state-machine.md § Turn-Cap Retry Provenance](../docs/state-machine.md), [docs/USER_GUIDE.md § History pane icon table](../docs/USER_GUIDE.md)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2097,6 +2097,7 @@ cost, and issue title. Status icons:
 | `?` | Stage blocked / awaiting user input |
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
+| `⚠cap` | This run resumed a same-stage predecessor that was stopped at its turn limit — treat claims about freshly-run commands or verification with caution (see Turn-Cap Retry Provenance in `state-machine.md`) |
 
 **Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. The panel's appearance when there are no active warnings depends on whether there are dismissed warnings:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2095,6 +2095,7 @@ cost, and issue title. Status icons:
 | `?` | Stage blocked / awaiting user input |
 | `↻` | Stage retrying |
 | `💬` | Issue has unprocessed comments |
+| `⚠cap` | This run resumed a same-stage predecessor that was stopped at its turn limit — treat claims about freshly-run commands or verification with caution (see Turn-Cap Retry Provenance in `state-machine.md`) |
 
 **Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. The panel's appearance when there are no active warnings depends on whether there are dismissed warnings:
 
@@ -3425,6 +3426,36 @@ The "baseline clean AND working tree dirty" guard for Implement prevents a pre-e
 | Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; treated as turn-limit failure; `CooldownAt("periodic-re-eval")` recorded; WIP commit + push |
 | Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; treated as turn-limit failure; `CooldownAt("periodic-re-eval")` recorded; WIP commit + push |
 | Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE (any extension) | `completed = true` | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Normal completion flow; extend-turns label persists to next stage |
+
+#### Turn-Cap Retry Provenance
+
+The extension loop above only engages when `err == nil` — but a real-world turn-cap kill (the Claude CLI's own `--max-turns` self-termination) exits **non-zero**, so `completed = false` and `err != nil` together. That combination falls straight through to the cooldown/retry path (§ Cooldown Retry and Failed Stage Escalation): a later poll re-invokes the same stage with `resume=true`, against a worktree and a resumed Claude session that already carry the killed run's partial work. Without a marker, the successor's posted comment reads identically to a normal, from-scratch completion — a reader has no way to tell it may be reporting on inherited work as first-hand.
+
+**Detection condition (independent of `err`):** `usage.MaxTurns > 0 && usage.TurnsUsed >= usage.MaxTurns && !completed`. This deliberately does not require `err == nil` — copying the extension loop's `hitLimit` condition here would never fire for the real-world case above.
+
+**Storage:** `StageState.LastRunCapped map[string]bool`, keyed by stage name — stage-scoped, not item-scoped. This is unconditionally overwritten in `finalizeStageOutcome` on every finalized invocation of the stage (applied via the `StageCappedRunRecorded` mutation), so:
+- a normal completion clears a stale capped flag from an earlier run, and
+- a chain of consecutive capped runs (e.g. 51/51/23/18/18 turns across five Implement invocations) keeps the flag set for each successor in the chain, not just the first.
+
+Stage-scoping matters because `ItemState.LastInvocationCompleted`/`LastTokenUsage` are overwritten by *any* invocation for the item, including a comment-processing run that happens to land between a capped run and its retry — those item-scoped fields would silently pick up the wrong invocation.
+
+**Read timing:** `processItem` reads `snap.StageCapped(stage.Name)` at dispatch time, before the current invocation runs — this captures whether the *immediately preceding* finalized invocation of this stage was capped, independent of how the current invocation itself turns out.
+
+**Annotation:** When the pre-dispatch read is `true`, `finalizeStageOutcome` prepends a one-line callout to the stage's posted output (both the issue-comment and PR-comment paths share the same `postOutput` value, so both carry it):
+
+> ⚠️ **Provenance notice:** the previous attempt at this stage was stopped after hitting its turn limit. This run resumed that session — treat any claims about freshly-run commands or verification accordingly.
+
+The annotation carries no turn numbers (reproducing the predecessor's own usage would require a second stage-scoped field for no functional gain) and is only prepended when `postOutput` is non-empty (a degenerate/suppressed output is never annotated). It is comment-only — nothing is injected into the resumed session's own prompt context, so the retry's behavior is unaffected; this is a reader-facing provenance marker, not a behavior change to the retry itself.
+
+**`history.json` field:** `InvocationRecorded.AfterCappedRun` (mirrored into `ItemState.LastInvocationAfterCappedRun`) records the same pre-dispatch flag, forwarded by `InvocationObserver` into `tui.JobCompletedEvent.AfterCappedRun` and `tui.HistoryEntry.AfterCappedRun`. The History pane renders a dim `⚠cap` marker alongside the existing `↻` retry indicator when set (§ USER_GUIDE.md History pane table); `fabrik watch` picks up the same field for free since it consumes `tui.HistoryEntry` directly.
+
+**Log-only "suspicious shape" heuristics** (exploratory corroborating signals; neither gates behavior, both accept false negatives):
+- A successor invocation that itself resumed after a capped predecessor, completed, and used under a quarter of the stage's turn budget (`completed && afterCapped && usage.TurnsUsed < stage.MaxTurns/4`) logs a `[#N warn]` line — the "few turns to report on commands that each cost a turn" signature from the issue's Observed section.
+- Stage output containing language naming the inherited-work situation outright (a conservative, case-insensitive substring match against phrases like "prior session", "interrupted session", "prior attempt") logs a separate `[#N warn]` line — the successor is aware it inherited prior work and still reports on it as first-hand.
+
+**Scope:** Full-stage invocations only (`finalizeStageOutcome`). The structurally identical comment-processing retry path (`engine/comments.go`, governed by `comment_max_turns`) is not covered — comment review already has a human in the loop reading the thread, and extending parity there is a deliberately separate follow-up.
+
+See ADR-071 for the rationale behind stage-scoped storage, comment-only annotation, and the full-stage-only scope decision.
 
 #### Cleanup Stage
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -730,6 +730,36 @@ The "baseline clean AND working tree dirty" guard for Implement prevents a pre-e
 | Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; treated as turn-limit failure; `CooldownAt("periodic-re-eval")` recorded; WIP commit + push |
 | Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE (any extension) | `completed = true` | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Normal completion flow; extend-turns label persists to next stage |
 
+#### Turn-Cap Retry Provenance
+
+The extension loop above only engages when `err == nil` — but a real-world turn-cap kill (the Claude CLI's own `--max-turns` self-termination) exits **non-zero**, so `completed = false` and `err != nil` together. That combination falls straight through to the cooldown/retry path (§ Cooldown Retry and Failed Stage Escalation): a later poll re-invokes the same stage with `resume=true`, against a worktree and a resumed Claude session that already carry the killed run's partial work. Without a marker, the successor's posted comment reads identically to a normal, from-scratch completion — a reader has no way to tell it may be reporting on inherited work as first-hand.
+
+**Detection condition (independent of `err`):** `usage.MaxTurns > 0 && usage.TurnsUsed >= usage.MaxTurns && !completed`. This deliberately does not require `err == nil` — copying the extension loop's `hitLimit` condition here would never fire for the real-world case above.
+
+**Storage:** `StageState.LastRunCapped map[string]bool`, keyed by stage name — stage-scoped, not item-scoped. This is unconditionally overwritten in `finalizeStageOutcome` on every finalized invocation of the stage (applied via the `StageCappedRunRecorded` mutation), so:
+- a normal completion clears a stale capped flag from an earlier run, and
+- a chain of consecutive capped runs (e.g. 51/51/23/18/18 turns across five Implement invocations) keeps the flag set for each successor in the chain, not just the first.
+
+Stage-scoping matters because `ItemState.LastInvocationCompleted`/`LastTokenUsage` are overwritten by *any* invocation for the item, including a comment-processing run that happens to land between a capped run and its retry — those item-scoped fields would silently pick up the wrong invocation.
+
+**Read timing:** `processItem` reads `snap.StageCapped(stage.Name)` at dispatch time, before the current invocation runs — this captures whether the *immediately preceding* finalized invocation of this stage was capped, independent of how the current invocation itself turns out.
+
+**Annotation:** When the pre-dispatch read is `true`, `finalizeStageOutcome` prepends a one-line callout to the stage's posted output (both the issue-comment and PR-comment paths share the same `postOutput` value, so both carry it):
+
+> ⚠️ **Provenance notice:** the previous attempt at this stage was stopped after hitting its turn limit. This run resumed that session — treat any claims about freshly-run commands or verification accordingly.
+
+The annotation carries no turn numbers (reproducing the predecessor's own usage would require a second stage-scoped field for no functional gain) and is only prepended when `postOutput` is non-empty (a degenerate/suppressed output is never annotated). It is comment-only — nothing is injected into the resumed session's own prompt context, so the retry's behavior is unaffected; this is a reader-facing provenance marker, not a behavior change to the retry itself.
+
+**`history.json` field:** `InvocationRecorded.AfterCappedRun` (mirrored into `ItemState.LastInvocationAfterCappedRun`) records the same pre-dispatch flag, forwarded by `InvocationObserver` into `tui.JobCompletedEvent.AfterCappedRun` and `tui.HistoryEntry.AfterCappedRun`. The History pane renders a dim `⚠cap` marker alongside the existing `↻` retry indicator when set (§ USER_GUIDE.md History pane table); `fabrik watch` picks up the same field for free since it consumes `tui.HistoryEntry` directly.
+
+**Log-only "suspicious shape" heuristics** (exploratory corroborating signals; neither gates behavior, both accept false negatives):
+- A successor invocation that itself resumed after a capped predecessor, completed, and used under a quarter of the stage's turn budget (`completed && afterCapped && usage.TurnsUsed < stage.MaxTurns/4`) logs a `[#N warn]` line — the "few turns to report on commands that each cost a turn" signature from the issue's Observed section.
+- Stage output containing language naming the inherited-work situation outright (a conservative, case-insensitive substring match against phrases like "prior session", "interrupted session", "prior attempt") logs a separate `[#N warn]` line — the successor is aware it inherited prior work and still reports on it as first-hand.
+
+**Scope:** Full-stage invocations only (`finalizeStageOutcome`). The structurally identical comment-processing retry path (`engine/comments.go`, governed by `comment_max_turns`) is not covered — comment review already has a human in the loop reading the thread, and extending parity there is a deliberately separate follow-up.
+
+See ADR-071 for the rationale behind stage-scoped storage, comment-only annotation, and the full-stage-only scope decision.
+
 #### Cleanup Stage
 
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |

--- a/engine/capped_run_test.go
+++ b/engine/capped_run_test.go
@@ -1,0 +1,489 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+	"github.com/handarbeit/fabrik/tui"
+)
+
+// turnCapExitErr mimics the real-world turn-cap kill from issue #1081: the Claude
+// CLI's own --max-turns self-termination exits non-zero, so completed=false AND
+// err != nil together — the exact combination that must NOT be masked by an
+// err == nil requirement (that's why the existing intra-dispatch hitLimit check
+// never fires for this case; see interpretClaudeResult).
+var turnCapExitErr = errors.New("claude exited with error: exit status 1")
+
+// TestCappedRun_AnnotatesSuccessorAfterCappedPredecessor verifies the core fix:
+// a stage invocation that is turn-capped does not carry the annotation on its own
+// comment (it has no predecessor), but the very next invocation of the same stage
+// does — and the annotation is recorded in ItemState.LastInvocationAfterCappedRun
+// (the field the InvocationObserver forwards into history.json).
+func TestCappedRun_AnnotatesSuccessorAfterCappedPredecessor(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				return "predecessor output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+			case 2:
+				return "successor output\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{TurnsUsed: 20}, nil
+			default:
+				t.Errorf("unexpected invocation #%d", callCount)
+				return "", false, TokenUsage{}, nil
+			}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:      "owner",
+			Repo:       "repo",
+			ProjectNum: 1,
+			User:       "testuser",
+			Token:      "token",
+			Stages:     implementStages(50),
+		},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 101, Title: "Capped Run Test", Status: "Implement", ItemID: "PVTI_101"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (predecessor): %v", err)
+	}
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (successor): %v", err)
+	}
+
+	if callCount != 2 {
+		t.Fatalf("expected 2 claude invocations, got %d", callCount)
+	}
+	if len(client.addCommentCalls) != 2 {
+		t.Fatalf("expected 2 posted comments, got %d", len(client.addCommentCalls))
+	}
+	predecessorComment := client.addCommentCalls[0].body
+	successorComment := client.addCommentCalls[1].body
+
+	if strings.Contains(predecessorComment, "Provenance notice") {
+		t.Errorf("predecessor's own comment should not carry the annotation (no prior capped run): %q", predecessorComment)
+	}
+	if !strings.Contains(successorComment, "Provenance notice") {
+		t.Errorf("successor comment missing provenance annotation: %q", successorComment)
+	}
+	if !strings.Contains(successorComment, "successor output") {
+		t.Errorf("successor comment missing its own content: %q", successorComment)
+	}
+	if idx1, idx2 := strings.Index(successorComment, "Provenance notice"), strings.Index(successorComment, "successor output"); idx1 > idx2 {
+		t.Errorf("annotation should precede the stage's own content, got annotation at %d, content at %d", idx1, idx2)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 101)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if !snap.State().LastInvocationAfterCappedRun {
+		t.Error("ItemState.LastInvocationAfterCappedRun not set on the successor invocation")
+	}
+}
+
+// TestCappedRun_NoAnnotationOnFirstRun verifies a stage's very first invocation —
+// which by definition has no predecessor — never carries the annotation, even when
+// that first run is itself turn-capped.
+func TestCappedRun_NoAnnotationOnFirstRun(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "first run output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 102, Title: "First Run Test", Status: "Implement", ItemID: "PVTI_102"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected 1 posted comment, got %d", len(client.addCommentCalls))
+	}
+	if strings.Contains(client.addCommentCalls[0].body, "Provenance notice") {
+		t.Errorf("first-ever run should never carry the annotation: %q", client.addCommentCalls[0].body)
+	}
+}
+
+// TestCappedRun_AnnotationPersistsAcrossInterveningCommentInvocation verifies the
+// mis-scoping risk Research flagged: a comment-processing invocation for the same
+// issue (which overwrites the item-scoped LastInvocationCompleted/LastTokenUsage
+// fields) must NOT clear the stage-scoped capped-run signal. This directly
+// exercises the read site in processItem (snap.StageCapped(stage.Name)) against a
+// store that has had an intervening, unrelated InvocationRecorded mutation applied
+// — the realistic shape of "a user commented between the capped run and the retry."
+func TestCappedRun_AnnotationPersistsAcrossInterveningCommentInvocation(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				return "predecessor output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+			case 2:
+				return "successor output\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{TurnsUsed: 20}, nil
+			default:
+				t.Errorf("unexpected invocation #%d", callCount)
+				return "", false, TokenUsage{}, nil
+			}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 103, Title: "Intervening Comment Test", Status: "Implement", ItemID: "PVTI_103"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (predecessor): %v", err)
+	}
+
+	// Simulate a comment-processing invocation completing for this issue in between
+	// the capped run and the retry — this is exactly the item-scoped mutation that
+	// would clobber a naive "last invocation" read.
+	if _, _, err := eng.store.Apply(itemstate.InvocationRecorded{
+		Repo:      "owner/repo",
+		Number:    103,
+		Completed: true,
+		IsComment: true,
+	}); err != nil {
+		t.Fatalf("simulate intervening comment invocation: %v", err)
+	}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (successor): %v", err)
+	}
+
+	if len(client.addCommentCalls) != 2 {
+		t.Fatalf("expected 2 posted comments, got %d", len(client.addCommentCalls))
+	}
+	successorComment := client.addCommentCalls[1].body
+	if !strings.Contains(successorComment, "Provenance notice") {
+		t.Errorf("annotation was lost across an intervening comment-processing invocation: %q", successorComment)
+	}
+}
+
+// TestCappedRun_AnnotationReappearsAcrossCappedChain verifies that a chain of
+// consecutive capped runs (the RallyRaffle 51/51/23/18/18 case from the issue)
+// annotates every successor, not just the second run in the chain: the flag is
+// read-then-unconditionally-overwritten on every finalize, so it correctly
+// tracks "immediately preceding," not "ever capped."
+func TestCappedRun_AnnotationReappearsAcrossCappedChain(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				return "run1 output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+			case 2:
+				return "run2 output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+			case 3:
+				return "run3 output\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{TurnsUsed: 18}, nil
+			default:
+				t.Errorf("unexpected invocation #%d", callCount)
+				return "", false, TokenUsage{}, nil
+			}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 104, Title: "Capped Chain Test", Status: "Implement", ItemID: "PVTI_104"}
+
+	for i := 0; i < 3; i++ {
+		if err := eng.processItem(context.Background(), board, item); err != nil {
+			t.Fatalf("processItem run %d: %v", i+1, err)
+		}
+	}
+
+	if len(client.addCommentCalls) != 3 {
+		t.Fatalf("expected 3 posted comments, got %d", len(client.addCommentCalls))
+	}
+	run1, run2, run3 := client.addCommentCalls[0].body, client.addCommentCalls[1].body, client.addCommentCalls[2].body
+
+	if strings.Contains(run1, "Provenance notice") {
+		t.Errorf("run 1 (no predecessor) should not carry the annotation: %q", run1)
+	}
+	if !strings.Contains(run2, "Provenance notice") {
+		t.Errorf("run 2 (predecessor run 1 capped) missing annotation: %q", run2)
+	}
+	if !strings.Contains(run3, "Provenance notice") {
+		t.Errorf("run 3 (predecessor run 2 capped) missing annotation: %q", run3)
+	}
+}
+
+// TestCappedRun_FewTurnCompletionLogsWarning verifies the first "suspicious shape"
+// heuristic: a run that completes after a capped predecessor using well under a
+// quarter of the stage's turn budget logs a warning (log-only signal, no gate).
+func TestCappedRun_FewTurnCompletionLogsWarning(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				return "predecessor output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+			case 2:
+				// 2 turns against a 50-turn budget — far under the MaxTurns/4 threshold.
+				return "successor output\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{TurnsUsed: 2}, nil
+			default:
+				t.Errorf("unexpected invocation #%d", callCount)
+				return "", false, TokenUsage{}, nil
+			}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+	ch := make(chan tui.Event, 200)
+	eng.SetEvents(ch)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 105, Title: "Few Turn Test", Status: "Implement", ItemID: "PVTI_105"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (predecessor): %v", err)
+	}
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (successor): %v", err)
+	}
+	close(ch)
+
+	var found bool
+	for ev := range ch {
+		if le, ok := ev.(tui.LogEvent); ok && le.IssueNumber == 105 && le.Tag == "warn" &&
+			strings.Contains(le.Message, "immediately after a turn-capped predecessor") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a 'warn' log event for a few-turn completion after a capped predecessor")
+	}
+}
+
+// TestCappedRun_NoFewTurnWarningWithoutCappedPredecessor verifies the few-turn
+// heuristic does not fire on a normal low-turn completion that has no capped
+// predecessor — it must not become a generic "stage finished quickly" warning.
+func TestCappedRun_NoFewTurnWarningWithoutCappedPredecessor(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "output\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{TurnsUsed: 2}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+	ch := make(chan tui.Event, 200)
+	eng.SetEvents(ch)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 106, Title: "No Predecessor Few Turn Test", Status: "Implement", ItemID: "PVTI_106"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+	close(ch)
+
+	for ev := range ch {
+		if le, ok := ev.(tui.LogEvent); ok && le.Tag == "warn" &&
+			strings.Contains(le.Message, "immediately after a turn-capped predecessor") {
+			t.Errorf("unexpected few-turn warning without a capped predecessor: %q", le.Message)
+		}
+	}
+}
+
+// TestCappedRun_SelfAdmissionLanguageLogsWarning verifies the second "suspicious
+// shape" heuristic: output naming the exact failure mode of issue #1081 (the
+// model is aware it resumed a prior interrupted session, but still reports
+// verification as first-hand) logs a warning when it follows a capped predecessor.
+func TestCappedRun_SelfAdmissionLanguageLogsWarning(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			switch callCount {
+			case 1:
+				return "predecessor output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+			case 2:
+				return "Verified the prior session's implementation is complete and correct.\nFABRIK_STAGE_COMPLETE\n",
+					true, TokenUsage{TurnsUsed: 30}, nil
+			default:
+				t.Errorf("unexpected invocation #%d", callCount)
+				return "", false, TokenUsage{}, nil
+			}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+	ch := make(chan tui.Event, 200)
+	eng.SetEvents(ch)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 107, Title: "Self Admission Test", Status: "Implement", ItemID: "PVTI_107"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (predecessor): %v", err)
+	}
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (successor): %v", err)
+	}
+	close(ch)
+
+	var found bool
+	for ev := range ch {
+		if le, ok := ev.(tui.LogEvent); ok && le.IssueNumber == 107 && le.Tag == "warn" &&
+			strings.Contains(le.Message, "inheriting a prior interrupted session") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a 'warn' log event for self-admission language after a capped predecessor")
+	}
+}
+
+// TestCappedRun_NoSelfAdmissionWarningWithoutCappedPredecessor verifies the
+// self-admission heuristic is gated on afterCapped — coincidentally similar
+// phrasing in ordinary output (no capped predecessor) must not trigger it.
+func TestCappedRun_NoSelfAdmissionWarningWithoutCappedPredecessor(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "Verified the prior session's implementation is complete and correct.\nFABRIK_STAGE_COMPLETE\n",
+				true, TokenUsage{TurnsUsed: 30}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+	ch := make(chan tui.Event, 200)
+	eng.SetEvents(ch)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 108, Title: "No Predecessor Self Admission Test", Status: "Implement", ItemID: "PVTI_108"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+	close(ch)
+
+	for ev := range ch {
+		if le, ok := ev.(tui.LogEvent); ok && le.Tag == "warn" &&
+			strings.Contains(le.Message, "inheriting a prior interrupted session") {
+			t.Errorf("unexpected self-admission warning without a capped predecessor: %q", le.Message)
+		}
+	}
+}
+
+// TestCappedRun_RecordedDespiteGenericInvocationError verifies StageCappedRunRecorded
+// still fires when the invocation returns a generic (non-start-failure) error —
+// matching the real turn-cap kill, which is the CLI exiting non-zero, not a start
+// failure like exec.Error or os.PathError. This is the exact condition the existing
+// intra-dispatch hitLimit check gets wrong (it requires err == nil); the fix here
+// must not repeat that mistake.
+func TestCappedRun_RecordedDespiteGenericInvocationError(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "output", false, TokenUsage{TurnsUsed: 50}, turnCapExitErr
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token", Stages: implementStages(50)},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 109, Title: "Unrelated Error Test", Status: "Implement", ItemID: "PVTI_109"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 109)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if !snap.StageCapped("Implement") {
+		t.Error("StageCapped(Implement) should be true after a turn-cap-shaped error (non-start-failure)")
+	}
+}

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -1003,6 +1003,40 @@ func formatStatsFooter(usage TokenUsage, completed bool) string {
 		usage.TurnsUsed, usage.InputTokens/1000, usage.OutputTokens/1000, completion)
 }
 
+// cappedRunAnnotation is prepended to a stage's posted comment when the immediately
+// preceding invocation of the same stage was turn-capped (hit max_turns without
+// completing). It deliberately carries no turn numbers — reproducing the
+// predecessor's own usage would require a second stage-scoped field for no
+// functional gain; the annotation's job is to flag discontinuity, not restate
+// stats already visible in the predecessor's own footer (see issue #1081).
+const cappedRunAnnotation = "⚠️ **Provenance notice:** the previous attempt at this stage was stopped after hitting its turn limit. This run resumed that session — treat any claims about freshly-run commands or verification accordingly."
+
+// inheritedWorkPhrases is a conservative, case-insensitive substring list used by
+// containsInheritedWorkLanguage to flag stage output that names the exact failure
+// mode of issue #1081: the successor is aware it inherited a prior interrupted
+// session's work, yet still reports on it as first-hand. Log-only signal — never
+// gates behavior, so false negatives here are expected and acceptable.
+var inheritedWorkPhrases = []string{
+	"prior session",
+	"previous session",
+	"interrupted session",
+	"prior attempt",
+	"resumed from a prior",
+}
+
+// containsInheritedWorkLanguage reports whether output contains language suggesting
+// the model is aware it resumed a prior interrupted session, per the second
+// detection signature in issue #1081.
+func containsInheritedWorkLanguage(output string) bool {
+	lower := strings.ToLower(output)
+	for _, phrase := range inheritedWorkPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
 // extractBetweenMarkers extracts content between a BEGIN/END marker pair.
 // Returns empty string if markers are not found.
 func extractBetweenMarkers(output, beginMarker, endMarker string) string {

--- a/engine/item.go
+++ b/engine/item.go
@@ -506,8 +506,15 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 	// actually runs — never refreshed by observation — so it accurately reflects
 	// real invocation recency and prevents hot-looping after an incomplete run.
 	var lastAttempt time.Time
+	var afterCapped bool
 	if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
 		lastAttempt = snap.LastAttemptAt(stage.Name)
+		// StageCapped reflects the immediately preceding finalized invocation of THIS
+		// stage — stage-scoped so an intervening comment-processing run (or another
+		// stage's own capped record) can't clobber it. Read here, before dispatch, so
+		// the eventual finalize call carries "was my predecessor capped" independently
+		// of whatever this run's own outcome turns out to be.
+		afterCapped = snap.StageCapped(stage.Name)
 	}
 	if !lastAttempt.IsZero() {
 		// If stage completed, the completion label above would have caught it.
@@ -721,6 +728,7 @@ func (e *Engine) processItem(ctx context.Context, board *gh.ProjectBoard, item g
 		release:         releaseLock,
 		stashed:         stashed,
 		workerStartedAt: workerStartedAt,
+		afterCapped:     afterCapped,
 	})
 
 	return nil
@@ -987,6 +995,11 @@ type stageOutcomeParams struct {
 	release         func()
 	stashed         bool
 	workerStartedAt time.Time
+	// afterCapped is true when the immediately preceding finalized invocation of
+	// this stage was turn-capped (StageState.LastRunCapped[stage.Name] as of
+	// dispatch time) — drives the posted-comment provenance annotation and the
+	// two log-only "suspicious shape" heuristics.
+	afterCapped bool
 }
 
 // finalizeStageOutcome runs everything that happens after a Claude invocation
@@ -1120,6 +1133,27 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 		prNumber, _ = e.ensureDraftPR(item, baseBranch)
 	}
 
+	// Log-only "suspicious shape" heuristics (issue #1081): both are corroborating
+	// signals that this run may be reporting inherited work as first-hand, but
+	// neither gates behavior — false negatives are expected and acceptable.
+	if completed && p.afterCapped && stage.MaxTurns > 0 && usage.TurnsUsed < stage.MaxTurns/4 {
+		e.logf(item.Number, "warn", "stage %q completed in %d turns immediately after a turn-capped predecessor (budget %d) — treat verification claims with caution\n",
+			stage.Name, usage.TurnsUsed, stage.MaxTurns)
+	}
+	if p.afterCapped && containsInheritedWorkLanguage(postOutput) {
+		e.logf(item.Number, "warn", "stage %q output names inheriting a prior interrupted session while still reporting the work as first-hand\n", stage.Name)
+	}
+
+	// Provenance annotation (issue #1081): when the immediately preceding invocation
+	// of this stage was turn-capped, prepend a reader-facing callout so a human
+	// reviewing the comment knows this run resumed a truncated session — without
+	// judging the retry's content. Leading placement, not a footer addition, so
+	// it's the first thing a reader sees. Applied after the degenerate-output guard
+	// so a suppressed (empty) postOutput is never annotated.
+	if p.afterCapped && postOutput != "" {
+		postOutput = cappedRunAnnotation + "\n\n" + postOutput
+	}
+
 	// Post Claude's output
 	if postOutput != "" {
 		footer := formatStatsFooter(usage, completed)
@@ -1159,6 +1193,18 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 			Number:    item.Number,
 			StageName: stage.Name,
 			At:        time.Now(),
+		})
+		// Record whether THIS invocation itself was turn-capped, independent of err —
+		// the real-world turn-cap kill exits non-zero (see issue #1081), so this
+		// condition deliberately does not require err == nil like the existing
+		// intra-dispatch hitLimit check does. Unconditional overwrite (not set-once)
+		// so a normal completion clears a stale capped flag, and a chain of
+		// consecutive capped runs keeps the flag set for each successor.
+		e.store.Apply(itemstate.StageCappedRunRecorded{
+			Repo:      repoStr,
+			Number:    item.Number,
+			StageName: stage.Name,
+			Capped:    usage.MaxTurns > 0 && usage.TurnsUsed >= usage.MaxTurns && !completed,
 		})
 	}
 
@@ -1207,13 +1253,14 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 
 	// Store completion/blocked/usage state for TUI event emission in poll.go.
 	e.store.Apply(itemstate.InvocationRecorded{
-		Repo:      itemOwnerRepoString(item, e.defaultRepo()),
-		Number:    item.Number,
-		Completed: completed,
-		Blocked:   blockedOnInput,
-		Errored:   err != nil,
-		Usage:     usage,
-		Duration:  time.Since(p.workerStartedAt),
+		Repo:           itemOwnerRepoString(item, e.defaultRepo()),
+		Number:         item.Number,
+		Completed:      completed,
+		Blocked:        blockedOnInput,
+		Errored:        err != nil,
+		Usage:          usage,
+		Duration:       time.Since(p.workerStartedAt),
+		AfterCappedRun: p.afterCapped,
 	})
 
 	if completed && noWorkNeeded {

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -111,6 +111,7 @@ func (o *InvocationObserver) OnChange(change itemstate.Change, snap itemstate.Sn
 		TurnsUsed:      st.LastTokenUsage.TurnsUsed,
 		MaxTurns:       st.LastTokenUsage.MaxTurns,
 		CostUSD:        st.LastTokenUsage.CostUSD,
+		AfterCappedRun: st.LastInvocationAfterCappedRun,
 	})
 }
 

--- a/engine/observers_test.go
+++ b/engine/observers_test.go
@@ -304,6 +304,41 @@ func TestInvocationObserver_FiresJobCompletedEventOnInvocationChanged(t *testing
 	}
 }
 
+// TestInvocationObserver_ForwardsAfterCappedRun verifies AfterCappedRun (issue
+// #1081) flows from InvocationRecorded through to the emitted JobCompletedEvent,
+// the plumbing history.json relies on to surface the provenance annotation state.
+func TestInvocationObserver_ForwardsAfterCappedRun(t *testing.T) {
+	var emitted []tui.Event
+	obs := &InvocationObserver{
+		Stages: nil,
+		Emit: func(e tui.Event) {
+			emitted = append(emitted, e)
+		},
+	}
+
+	store := newTestStore()
+	unsub := store.Subscribe(obs)
+	defer unsub()
+
+	store.Apply(itemstate.InvocationRecorded{
+		Repo:           "owner/repo",
+		Number:         6,
+		Completed:      true,
+		AfterCappedRun: true,
+	})
+
+	if len(emitted) == 0 {
+		t.Fatal("expected JobCompletedEvent to be emitted")
+	}
+	ev, ok := emitted[len(emitted)-1].(tui.JobCompletedEvent)
+	if !ok {
+		t.Fatalf("expected JobCompletedEvent, got %T", emitted[len(emitted)-1])
+	}
+	if !ev.AfterCappedRun {
+		t.Error("AfterCappedRun: got false, want true")
+	}
+}
+
 func TestInvocationObserver_SkipsStatusChanged(t *testing.T) {
 	var emitted []tui.Event
 	obs := &InvocationObserver{

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -116,6 +116,12 @@ type ItemState struct {
 	// Replaces engine.lastUsage[iKey].
 	LastTokenUsage TokenUsage
 
+	// LastInvocationAfterCappedRun records whether the most recent stage invocation
+	// was dispatched immediately after a turn-capped predecessor for the same stage
+	// (StageState.LastRunCapped[stage] was true at dispatch time). Mirrors
+	// InvocationRecorded.AfterCappedRun for TUI/history display.
+	LastInvocationAfterCappedRun bool
+
 	// BaseBranchWarned tracks which base-branch overrides have already produced a
 	// "branch not found" warning comment. Replaces engine.baseBranchWarnedSet.
 	BaseBranchWarned map[string]bool
@@ -229,6 +235,15 @@ type StageState struct {
 	// auto-heal was attempted. In-memory only — does not survive restart. Keyed by
 	// stage name so force-push (new SHA) clears the guard naturally.
 	LinkageHealAttempted map[string]string
+	// LastRunCapped records, per stage, whether the most recently finalized invocation
+	// of that stage was turn-capped: usage.MaxTurns > 0 && usage.TurnsUsed >= usage.MaxTurns
+	// && !completed — independent of whether the process also exited with an error, which
+	// is the real-world shape of a Claude CLI turn-cap kill (exit status 1, non-nil err).
+	// Stage-scoped (not item-scoped) so an intervening comment-processing invocation or a
+	// different stage's run does not clobber the signal. Overwritten unconditionally on
+	// every finalized invocation of the stage, so a chain of consecutive capped runs keeps
+	// annotating each successor, not just the first.
+	LastRunCapped map[string]bool
 }
 
 // LockState describes who holds the fabrik:locked:<user> label on this issue.

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -529,6 +529,11 @@ type InvocationRecorded struct {
 	// Duration is the wall-clock time from invocation start to completion.
 	// Zero when not set (e.g., comment-processing paths that don't track start time).
 	Duration time.Duration
+	// AfterCappedRun is true when this invocation was dispatched immediately after a
+	// turn-capped predecessor for the same stage (StageState.LastRunCapped[stage] was
+	// true at dispatch time). Stored in ItemState.LastInvocationAfterCappedRun so the
+	// InvocationObserver can forward it to the TUI/history.json.
+	AfterCappedRun bool
 }
 
 func (InvocationRecorded) isMutation()       {}
@@ -710,6 +715,21 @@ type LinkageHealAttempted struct {
 
 func (LinkageHealAttempted) isMutation()       {}
 func (m LinkageHealAttempted) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// StageCappedRunRecorded records whether the most recently finalized invocation of
+// a stage was turn-capped (hit its turn limit without completing). Applied
+// unconditionally on every finalized invocation of the stage (not just when true),
+// so the flag correctly clears after a normal completion and correctly persists
+// across a chain of consecutive capped runs.
+type StageCappedRunRecorded struct {
+	Repo      string
+	Number    int
+	StageName string
+	Capped    bool
+}
+
+func (StageCappedRunRecorded) isMutation()       {}
+func (m StageCappedRunRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
 // itemKeyFor constructs the canonical "owner/repo#N" item key used throughout the Store.
 // Returns "" when repo is empty (indicating an invalid or unroutable mutation).

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -527,6 +527,83 @@ func TestApplyWorkerExited(t *testing.T) {
 	}
 }
 
+// ---- StageCappedRunRecorded ----
+
+func TestApplyStageCappedRunRecorded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Review", Capped: true}, StageStateChanged)
+	if !getItem(t, s, testRepo, 1).StageState.LastRunCapped["Review"] {
+		t.Error("LastRunCapped[Review] not set")
+	}
+	snap, _ := s.Get(testRepo, 1)
+	if !snap.StageCapped("Review") {
+		t.Error("Snapshot.StageCapped(Review) = false, want true")
+	}
+}
+
+// TestApplyStageCappedRunRecordedOverwrites verifies the flag is unconditionally
+// overwritten on every finalize — a normal completion after a capped run clears it,
+// which is what makes the "immediately preceding run" framing correct rather than
+// sticky forever once set.
+func TestApplyStageCappedRunRecordedOverwrites(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Review", Capped: true})
+	if !getItem(t, s, testRepo, 1).StageState.LastRunCapped["Review"] {
+		t.Fatal("precondition: LastRunCapped[Review] not set")
+	}
+	applyExpect(t, s, StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Review", Capped: false}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.LastRunCapped["Review"] {
+		t.Error("LastRunCapped[Review] should be cleared after Capped=false overwrite")
+	}
+}
+
+// TestApplyStageCappedRunRecordedIsStageScoped verifies that a capped record for one
+// stage is unaffected by a mutation (of any kind, including comment-processing state
+// or a different stage) for a different stage name — the exact mis-scoping risk
+// Research flagged for ItemState.LastInvocationCompleted/LastTokenUsage.
+func TestApplyStageCappedRunRecordedIsStageScoped(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	s.Apply(StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Review", Capped: true})
+
+	// An intervening comment-processing invocation for the same issue...
+	s.Apply(InvocationRecorded{Repo: testRepo, Number: 1, Completed: true, IsComment: true})
+	// ...and a different stage's own capped-run record...
+	s.Apply(StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Implement", Capped: false})
+
+	st := getItem(t, s, testRepo, 1)
+	if !st.StageState.LastRunCapped["Review"] {
+		t.Error("LastRunCapped[Review] was clobbered by an intervening comment invocation or a different stage's record")
+	}
+	if st.StageState.LastRunCapped["Implement"] {
+		t.Error("LastRunCapped[Implement] should be false, unaffected by Review's true record")
+	}
+}
+
+func TestSnapshot_StageCapped_FalseWhenNeverRecorded(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	snap, _ := s.Get(testRepo, 1)
+	if snap.StageCapped("Review") {
+		t.Error("StageCapped(Review) = true, want false when never recorded")
+	}
+}
+
+// TestLastRunCappedSnapshotIsDeepCopy verifies that a Snapshot taken before a later
+// StageCappedRunRecorded retains its original value — confirming copyStageState
+// deep-copies the LastRunCapped map (no shared backing map), mirroring the existing
+// EnqueueCycles deep-copy test.
+func TestLastRunCappedSnapshotIsDeepCopy(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	held := applyExpect(t, s, StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Review", Capped: true}, StageStateChanged)
+	if !held.StageCapped("Review") {
+		t.Fatal("precondition: held snapshot StageCapped(Review) = false, want true")
+	}
+	// Mutate the store further.
+	s.Apply(StageCappedRunRecorded{Repo: testRepo, Number: 1, StageName: "Review", Capped: false})
+	if !held.StageCapped("Review") {
+		t.Error("held snapshot mutated by later overwrite: StageCapped(Review) = false, want true")
+	}
+}
+
 // ---- InvocationRecorded ----
 
 func TestApplyInvocationRecorded(t *testing.T) {
@@ -545,6 +622,32 @@ func TestApplyInvocationRecorded(t *testing.T) {
 	}
 	if st.LastTokenUsage.InputTokens != 100 {
 		t.Errorf("LastTokenUsage.InputTokens = %d; want 100", st.LastTokenUsage.InputTokens)
+	}
+}
+
+// TestApplyInvocationRecordedAfterCappedRun verifies AfterCappedRun mirrors into
+// ItemState.LastInvocationAfterCappedRun, and that a subsequent invocation without
+// the flag clears it (mirrors the existing IsComment clear-on-next-invocation test).
+func TestApplyInvocationRecordedAfterCappedRun(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, InvocationRecorded{
+		Repo:           testRepo,
+		Number:         1,
+		Completed:      true,
+		AfterCappedRun: true,
+	}, InvocationChanged)
+	if !getItem(t, s, testRepo, 1).LastInvocationAfterCappedRun {
+		t.Error("LastInvocationAfterCappedRun not set when AfterCappedRun=true")
+	}
+
+	applyExpect(t, s, InvocationRecorded{
+		Repo:           testRepo,
+		Number:         1,
+		Completed:      true,
+		AfterCappedRun: false,
+	}, InvocationChanged)
+	if getItem(t, s, testRepo, 1).LastInvocationAfterCappedRun {
+		t.Error("LastInvocationAfterCappedRun should be false after AfterCappedRun=false invocation")
 	}
 }
 

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -244,6 +244,14 @@ func (s Snapshot) LinkageHealAttempted(stageName, prSHA string) bool {
 	return recorded != "" && recorded == prSHA
 }
 
+// StageCapped reports whether the most recently finalized invocation of the given
+// stage was turn-capped (hit its turn limit without completing). Stage-scoped: an
+// intervening comment-processing invocation or a different stage's run does not
+// affect this value. Returns false if the stage has never run.
+func (s Snapshot) StageCapped(stageName string) bool {
+	return s.state.StageState.LastRunCapped[stageName]
+}
+
 // ---- deep-copy helpers ----
 
 func copyStrings(src []string) []string {
@@ -330,5 +338,6 @@ func copyStageState(s StageState) StageState {
 		EnqueueCycles:        copyMap(s.EnqueueCycles),
 		ProcessedComments:    copyMap(s.ProcessedComments),
 		LinkageHealAttempted: copyMap(s.LinkageHealAttempted),
+		LastRunCapped:        copyMap(s.LastRunCapped),
 	}
 }

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -444,6 +444,11 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.StageState.LinkageHealAttempted[v.StageName] = v.PRSHA
 		return StageStateChanged
 
+	case StageCappedRunRecorded:
+		ensureStageStateMaps(item)
+		item.StageState.LastRunCapped[v.StageName] = v.Capped
+		return StageStateChanged
+
 	case StageLastAttemptCleared:
 		ensureStageStateMaps(item)
 		delete(item.StageState.LastAttemptAt, v.StageName)
@@ -493,6 +498,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.LastInvocationIsComment = v.IsComment
 		item.LastInvocationDuration = v.Duration
 		item.LastTokenUsage = v.Usage
+		item.LastInvocationAfterCappedRun = v.AfterCappedRun
 		return InvocationChanged
 
 	case DeepFetchFailed:
@@ -1038,6 +1044,9 @@ func ensureStageStateMaps(item *ItemState) {
 	}
 	if ss.LinkageHealAttempted == nil {
 		ss.LinkageHealAttempted = make(map[string]string)
+	}
+	if ss.LastRunCapped == nil {
+		ss.LastRunCapped = make(map[string]bool)
 	}
 }
 

--- a/tui/events.go
+++ b/tui/events.go
@@ -71,6 +71,12 @@ type JobCompletedEvent struct {
 	MaxTurns       int
 	CostUSD        float64
 	Skipped        bool // synthetic fallback emit (deferred at emission site); InvocationObserver is authoritative (Skipped:false)
+	// AfterCappedRun is true when the immediately preceding invocation of this
+	// stage was turn-capped (hit max_turns without completing) — see issue #1081.
+	// A human reading a comment with this set should treat claims about
+	// freshly-run commands or verification with caution: the model may be
+	// reporting on inherited work from the capped predecessor as first-hand.
+	AfterCappedRun bool
 }
 
 func (JobCompletedEvent) tuiEvent() {}

--- a/tui/history.go
+++ b/tui/history.go
@@ -113,6 +113,7 @@ func (h HistoryPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 			TurnsUsed:      ev.TurnsUsed,
 			MaxTurns:       ev.MaxTurns,
 			CostUSD:        ev.CostUSD,
+			AfterCappedRun: ev.AfterCappedRun,
 		}
 		h.history = append(h.history, entry)
 		SaveHistory(h.history)
@@ -250,6 +251,14 @@ func (h *HistoryPaneComponent) rebuildViewportContent(innerWidth int) {
 			result = dimStyle.Render("  (retry)")
 		} else {
 			status = successStyle.Render("✓")
+		}
+		if he.AfterCappedRun {
+			// The immediately preceding invocation of this stage was turn-capped —
+			// this row's own claims about freshly-run commands or verification may
+			// be reporting on inherited work (issue #1081). Shown alongside — not
+			// instead of — the retry indicator above, since a row can be both a
+			// retry AND itself resuming a capped predecessor (a capped chain).
+			result += dimStyle.Render("  ⚠cap")
 		}
 		ts := dimStyle.Render(he.CompletedAt.Format("2006-01-02 15:04"))
 		dur := fmtDuration(he.Duration)

--- a/tui/history_test.go
+++ b/tui/history_test.go
@@ -502,3 +502,77 @@ func TestHistory_TurnCappedRetries(t *testing.T) {
 		t.Errorf("round-trip total cost = %.2f, want %.2f", loadedTotal, wantTotal)
 	}
 }
+
+// TestAfterCappedRun_RoundTripsAndRenders verifies AfterCappedRun (issue #1081)
+// round-trips through HistoryPaneComponent.Update into HistoryEntry, survives a
+// SaveHistory/LoadHistory cycle, and renders a distinct dim indicator in the
+// viewport alongside — not instead of — the existing retry indicator.
+func TestAfterCappedRun_RoundTripsAndRenders(t *testing.T) {
+	redirectHistory(t)
+
+	h := NewHistoryPaneComponent("")
+
+	comp, _ := h.Update(JobCompletedEvent{
+		IssueNumber:    2200,
+		StageName:      "Implement",
+		Success:        true,
+		Completed:      true,
+		AfterCappedRun: true,
+		CompletedAt:    time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC),
+	})
+	h = comp.(HistoryPaneComponent)
+
+	entries := h.History()
+	if len(entries) != 1 {
+		t.Fatalf("history has %d entries, want 1", len(entries))
+	}
+	if !entries[0].AfterCappedRun {
+		t.Error("AfterCappedRun not carried through Update into HistoryEntry")
+	}
+
+	// SaveHistory/LoadHistory round-trip must preserve the flag.
+	SaveHistory(entries)
+	loaded := LoadHistory()
+	if len(loaded) != 1 || !loaded[0].AfterCappedRun {
+		t.Errorf("AfterCappedRun not preserved across SaveHistory/LoadHistory round-trip: %+v", loaded)
+	}
+
+	// Rendering: the indicator must appear in the viewport.
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	m.width = 80
+	m.height = 24
+	m.history.history = entries
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = next.(Model)
+	view := m.history.View(m.width)
+	if !strings.Contains(view, "⚠cap") {
+		t.Errorf("expected ⚠cap indicator in viewHistory for AfterCappedRun entry, got: %q", view)
+	}
+}
+
+// TestAfterCappedRun_CoexistsWithRetryIndicator verifies a row that is itself both
+// incomplete (retry) AND resuming a capped predecessor shows both indicators —
+// the two facts are independent (a capped chain re-caps on every successor).
+func TestAfterCappedRun_CoexistsWithRetryIndicator(t *testing.T) {
+	redirectHistory(t)
+
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	m.width = 80
+	m.height = 24
+	m.history.history = []HistoryEntry{{
+		IssueNumber:    2201,
+		StageName:      "Implement",
+		Success:        true,
+		Completed:      false,
+		AfterCappedRun: true,
+	}}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = next.(Model)
+	view := m.history.View(m.width)
+	if !strings.Contains(view, "↻") {
+		t.Errorf("expected retry indicator ↻ for incomplete entry, got: %q", view)
+	}
+	if !strings.Contains(view, "⚠cap") {
+		t.Errorf("expected ⚠cap indicator alongside retry indicator, got: %q", view)
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -27,6 +27,9 @@ type HistoryEntry struct {
 	TurnsUsed      int
 	MaxTurns       int
 	CostUSD        float64
+	// AfterCappedRun mirrors JobCompletedEvent.AfterCappedRun — true when the
+	// immediately preceding invocation of this stage was turn-capped (see issue #1081).
+	AfterCappedRun bool
 }
 
 // activeJob tracks an in-flight worker.


### PR DESCRIPTION
Closes #1081

## What this does

When a stage hits `max_turns`, Fabrik SIGKILLs it and retries on a later poll — resuming the same Claude session against a worktree that already has the killed run's partial work. Today the retry's posted comment is indistinguishable from a normal, from-scratch completion: nothing signals that the predecessor died mid-stage, so a reviewer (or `cruise` auto-advancing) can't tell whether reported verification (test runs, lint, etc.) was actually performed in this invocation or just echoed from the truncated prior session.

This PR makes that discontinuity visible without judging the retry's content:

- **`StageState.LastRunCapped map[string]bool`** (new, stage-scoped) records whether the most recently finalized invocation of a given stage was turn-capped: `usage.MaxTurns > 0 && usage.TurnsUsed >= usage.MaxTurns && !completed` — deliberately independent of `err`, since the real-world turn-cap kill exits non-zero and would be missed by the existing `err == nil`-gated extension-loop check. Stage-scoped so an intervening comment-processing invocation (or a different stage's own run) can't clobber the signal.
- **Comment annotation.** When the immediately preceding invocation of a stage was capped, the successor's posted comment (issue and PR paths both) is prefixed with a one-line provenance notice. No turn numbers, no judgment of the retry's findings — just a heads-up that verification claims may be inherited.
- **`history.json` field.** `InvocationRecorded.AfterCappedRun` mirrors the same flag through to `tui.JobCompletedEvent`/`tui.HistoryEntry`, rendered as a dim `⚠cap` marker in the History pane (and picked up for free by `fabrik watch`).
- **Two log-only heuristics** (exploratory, never gate behavior): a successor that completed in under a quarter of the stage's turn budget immediately after a capped predecessor, and stage output that names the "inherited a prior session" situation in its own language.

Scoped to full-stage invocations only — the structurally identical comment-processing retry path (`comment_max_turns`) is a deliberate, separate follow-up (a human is already reading the thread live there).

## Key files

- `internal/itemstate/{itemstate,mutation,store,snapshot}.go` — new mutation, storage, and reader
- `engine/item.go` — read-before-dispatch / write-after-finalize wiring, annotation prepend, log heuristics
- `engine/claude.go` — annotation text and self-admission-language detector
- `engine/observers.go`, `tui/{events,history,model}.go` — TUI/history plumbing
- `docs/state-machine.md` (new "Turn-Cap Retry Provenance" subsection), `docs/USER_GUIDE.md` (History icon table), `docs/llms-full.txt` (regenerated)
- `adrs/071-turn-cap-retry-provenance.md`

## How to test

- `go test -race ./internal/itemstate/... ./engine/... ./tui/...` — all new/updated tests pass, including multi-run capped-chain and intervening-comment-invocation scenarios (`engine/capped_run_test.go`).
- Manually: configure a stage with a low `max_turns`, let an invocation hit the cap, then let the cooldown retry fire — the retry's posted comment should carry the provenance notice, and the History pane should show `⚠cap` on that row.