### PR TITLE
docs(stage-lifecycle): explain turn-cap retry session resumption

### DIFF
--- a/adrs/002-github-as-state-store.md
+++ b/adrs/002-github-as-state-store.md
@@ -46,4 +46,9 @@ Fabrik maintains local ephemeral state only:
 - Session files (`~/.fabrik/sessions/`): Claude Code session IDs for resumption.
 - Worktrees (`.fabrik/worktrees/`): Git worktrees for issue isolation.
 
+> **Superseded in part by [ADR-023](023-cwd-relative-runtime-state.md)**: session files and
+> logs moved from `~/.fabrik/` to `<cwd>/.fabrik/` in v0.0.32. The paths above describe the
+> layout at the time of this decision, not current behaviour. The decision this ADR records —
+> GitHub as the sole authoritative state store — is unaffected.
+
 None of this is authoritative — it's a cache that can be safely deleted.

--- a/adrs/014-stream-json-output-format.md
+++ b/adrs/014-stream-json-output-format.md
@@ -61,6 +61,7 @@ NDJSON) so no parsing changes are required.
   text. Users who open a `.log` file directly (e.g., `cat ~/.fabrik/logs/.../*.log`)
   will see raw JSON lines rather than human-readable text. Piping through
   `fabrik stream-filter` renders them readably.
+  (Path since changed to `<cwd>/.fabrik/logs/` — see [ADR-023](023-cwd-relative-runtime-state.md).)
 - `.log` file size increases because stdout (which can be many MB for long sessions)
   is now written to disk; previously only stderr diagnostics were written.
 - The `-output-*.json` file now contains NDJSON rather than a single JSON object.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1049,9 +1049,9 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 >   following a turn-capped attempt is a resume working correctly.
 >
 > The one case where a retry genuinely cannot know what its predecessor did is when the
-> session file is missing or unreadable, so `--resume` is skipped and a fresh session starts
-> against the existing worktree. See *Session Resume* in
-> [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
+> session file is missing, unreadable, or zero-length, so `--resume` is skipped and a fresh
+> session starts against the existing worktree. This is not currently detected or logged
+> (#1117). See *Session Resume* in [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1035,6 +1035,23 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 2. **Resume**: On retry, Claude resumes the existing conversation session with full context.
    The worktree is left as-is (no rebase) to preserve Claude's context.
 3. **WIP commit**: Partial work is committed and pushed to preserve progress.
+
+> **Reading the output of a resumed stage.** Because the retry continues the *same* session
+> rather than starting a new one, its posted comment can legitimately describe work the
+> earlier attempt performed — a test suite run before a turn-cap kill, for example, is
+> reported by the retry without being re-run. Two consequences routinely look like defects
+> but are not:
+>
+> - **A retry may report commands it did not run in that invocation.** The same session ran
+>   them earlier and still has the results in context. This is continuation, not fabrication.
+> - **A retry that completes in very few turns is the expected shape.** The work is already
+>   done; the continuation only needs enough turns to write it up. A two-turn completion
+>   following a turn-capped attempt is a resume working correctly.
+>
+> The one case where a retry genuinely cannot know what its predecessor did is when the
+> session file is missing or unreadable, so `--resume` is skipped and a fresh session starts
+> against the existing worktree. See *Session Resume* in
+> [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5875,6 +5875,33 @@ Before each Claude invocation, the engine writes context documents to `.fabrik-c
 
 Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, loaded via `--resume` to restore conversation context.
 
+The session ID is captured even when the invocation ends by hitting `max_turns` — `parseClaudeJSON` accepts a response whose `result` is empty as long as `session_id` is present (`engine/claude.go:1163-1166`), because a turn-cap kill produces exactly that shape. This is deliberate: it is what allows a turn-capped stage to be resumed rather than restarted.
+
+#### Retry after a turn-cap kill
+
+When a stage exceeds `max_turns`, the Claude CLI self-terminates with a non-zero exit, so `completed = false` and `err != nil`. The progress-based extension loop requires `err == nil`, so this falls through to the cooldown/retry path. A later poll re-invokes the same stage with `resume = true` (`engine/item.go:682` — `resume := !lastAttempt.IsZero()`).
+
+**The retry continues the same Claude session.** It is not a fresh agent inheriting a dirty worktree — it retains the killed run's conversation context, including the output of every command that run executed before the cap.
+
+Two consequences follow, and both routinely look like defects to someone reading only the posted comment:
+
+1. **A retry may legitimately report on work performed before the kill.** If the predecessor ran a test suite at turn 12 and was killed at turn 51, the successor can summarise those results without re-running anything. The work was genuinely performed, by the same session — this is continuation, not fabrication.
+2. **A retry completing in very few turns is the expected shape, not a warning sign.** The work is already done; the continuation only needs enough turns to write it up. A two-turn completion following a capped predecessor is a resume working correctly.
+
+Conversely, a successor that *announces* the situation (e.g. "found the implementation already complete from a prior interrupted session") is accurately describing its own resumed state.
+
+**Failure mode — silent fallback to a fresh session.** `--resume` is only appended when the session file exists and is non-empty (`engine/claude.go:480-484`):
+
+```go
+if resume {
+    if sessionID, err := os.ReadFile(sessFilePath); err == nil && len(sessionID) > 0 {
+        args = append(args, "--resume", strings.TrimSpace(string(sessionID)))
+    }
+}
+```
+
+If that read fails, the flag is dropped and the retry starts a **fresh session against a worktree that already contains the predecessor's changes**. Nothing currently detects or logs this, and it is the one case where a retry genuinely cannot know what its predecessor did. When diagnosing a suspect retry, confirm the session file was present before concluding the output was unreliable.
+
 ### Model Override
 
 Labels matching `model:<name>` on the issue override the stage's configured model.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1033,6 +1033,23 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 2. **Resume**: On retry, Claude resumes the existing conversation session with full context.
    The worktree is left as-is (no rebase) to preserve Claude's context.
 3. **WIP commit**: Partial work is committed and pushed to preserve progress.
+
+> **Reading the output of a resumed stage.** Because the retry continues the *same* session
+> rather than starting a new one, its posted comment can legitimately describe work the
+> earlier attempt performed — a test suite run before a turn-cap kill, for example, is
+> reported by the retry without being re-run. Two consequences routinely look like defects
+> but are not:
+>
+> - **A retry may report commands it did not run in that invocation.** The same session ran
+>   them earlier and still has the results in context. This is continuation, not fabrication.
+> - **A retry that completes in very few turns is the expected shape.** The work is already
+>   done; the continuation only needs enough turns to write it up. A two-turn completion
+>   following a turn-capped attempt is a resume working correctly.
+>
+> The one case where a retry genuinely cannot know what its predecessor did is when the
+> session file is missing or unreadable, so `--resume` is skipped and a fresh session starts
+> against the existing worktree. See *Session Resume* in
+> [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1047,9 +1047,9 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 >   following a turn-capped attempt is a resume working correctly.
 >
 > The one case where a retry genuinely cannot know what its predecessor did is when the
-> session file is missing or unreadable, so `--resume` is skipped and a fresh session starts
-> against the existing worktree. See *Session Resume* in
-> [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
+> session file is missing, unreadable, or zero-length, so `--resume` is skipped and a fresh
+> session starts against the existing worktree. This is not currently detected or logged
+> (#1117). See *Session Resume* in [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue
@@ -5890,7 +5890,7 @@ Before each Claude invocation, the engine writes context documents to `.fabrik-c
 
 ### Session Resume
 
-Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, loaded via `--resume` to restore conversation context.
+Session file: `.fabrik/sessions/issue-<N>/<stageName>.session`, relative to the process working directory — or `.fabrik/sessions/<owner>-<repo>/issue-<N>/<stageName>.session` on multi-repo projects (`engine/claude.go:227-242`). On retry, loaded via `--resume` to restore conversation context.
 
 The session ID is captured even when the invocation ends by hitting `max_turns` — `parseClaudeJSON` accepts a response whose `result` is empty as long as `session_id` is present (`engine/claude.go:1163-1166`), because a turn-cap kill produces exactly that shape. This is deliberate: it is what allows a turn-capped stage to be resumed rather than restarted.
 
@@ -5907,7 +5907,7 @@ Two consequences follow, and both routinely look like defects to someone reading
 
 Conversely, a successor that *announces* the situation (e.g. "found the implementation already complete from a prior interrupted session") is accurately describing its own resumed state.
 
-**Failure mode — silent fallback to a fresh session.** `--resume` is only appended when the session file exists and is non-empty (`engine/claude.go:480-484`):
+**Failure modes — the session ID is not always honoured.** `buildClaudeArgs` reads the session file inline (`engine/claude.go:480-484`):
 
 ```go
 if resume {
@@ -5917,7 +5917,17 @@ if resume {
 }
 ```
 
-If that read fails, the flag is dropped and the retry starts a **fresh session against a worktree that already contains the predecessor's changes**. Nothing currently detects or logs this, and it is the one case where a retry genuinely cannot know what its predecessor did. When diagnosing a suspect retry, confirm the session file was present before concluding the output was unreliable.
+Note the length check runs on the **untrimmed** bytes, which produces three distinct outcomes:
+
+| Session file | Behaviour |
+|---|---|
+| Missing or unreadable | `--resume` omitted → **fresh session** against the predecessor's worktree |
+| Zero bytes | `--resume` omitted → **fresh session** |
+| Whitespace only (e.g. a stray newline) | `len > 0` passes, then `TrimSpace` yields `""` → **`--resume` appended with an empty value** |
+
+None of these are detected or logged. The first two are the only cases where a retry genuinely cannot know what its predecessor did — so when diagnosing a suspect retry, confirm the session file was present and non-empty before concluding the output was unreliable.
+
+This inline read is also **not** the same as `engine.ReadSessionID` (`engine/claude.go:286-302`), which trims before returning and so treats a whitespace-only file as absent. `cmd/resume.go` uses `ReadSessionID`; the invocation path does not. Tracked in #1117.
 
 ### Model Override
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -87,7 +87,7 @@ Before each Claude invocation, the engine writes context documents to `.fabrik-c
 
 ### Session Resume
 
-Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, loaded via `--resume` to restore conversation context.
+Session file: `.fabrik/sessions/issue-<N>/<stageName>.session`, relative to the process working directory — or `.fabrik/sessions/<owner>-<repo>/issue-<N>/<stageName>.session` on multi-repo projects (`engine/claude.go:227-242`). On retry, loaded via `--resume` to restore conversation context.
 
 The session ID is captured even when the invocation ends by hitting `max_turns` — `parseClaudeJSON` accepts a response whose `result` is empty as long as `session_id` is present (`engine/claude.go:1163-1166`), because a turn-cap kill produces exactly that shape. This is deliberate: it is what allows a turn-capped stage to be resumed rather than restarted.
 
@@ -104,7 +104,7 @@ Two consequences follow, and both routinely look like defects to someone reading
 
 Conversely, a successor that *announces* the situation (e.g. "found the implementation already complete from a prior interrupted session") is accurately describing its own resumed state.
 
-**Failure mode — silent fallback to a fresh session.** `--resume` is only appended when the session file exists and is non-empty (`engine/claude.go:480-484`):
+**Failure modes — the session ID is not always honoured.** `buildClaudeArgs` reads the session file inline (`engine/claude.go:480-484`):
 
 ```go
 if resume {
@@ -114,7 +114,17 @@ if resume {
 }
 ```
 
-If that read fails, the flag is dropped and the retry starts a **fresh session against a worktree that already contains the predecessor's changes**. Nothing currently detects or logs this, and it is the one case where a retry genuinely cannot know what its predecessor did. When diagnosing a suspect retry, confirm the session file was present before concluding the output was unreliable.
+Note the length check runs on the **untrimmed** bytes, which produces three distinct outcomes:
+
+| Session file | Behaviour |
+|---|---|
+| Missing or unreadable | `--resume` omitted → **fresh session** against the predecessor's worktree |
+| Zero bytes | `--resume` omitted → **fresh session** |
+| Whitespace only (e.g. a stray newline) | `len > 0` passes, then `TrimSpace` yields `""` → **`--resume` appended with an empty value** |
+
+None of these are detected or logged. The first two are the only cases where a retry genuinely cannot know what its predecessor did — so when diagnosing a suspect retry, confirm the session file was present and non-empty before concluding the output was unreliable.
+
+This inline read is also **not** the same as `engine.ReadSessionID` (`engine/claude.go:286-302`), which trims before returning and so treats a whitespace-only file as absent. `cmd/resume.go` uses `ReadSessionID`; the invocation path does not. Tracked in #1117.
 
 ### Model Override
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -89,6 +89,33 @@ Before each Claude invocation, the engine writes context documents to `.fabrik-c
 
 Session file: `~/.fabrik/sessions/issue-<N>/<stageName>.session`. On retry, loaded via `--resume` to restore conversation context.
 
+The session ID is captured even when the invocation ends by hitting `max_turns` — `parseClaudeJSON` accepts a response whose `result` is empty as long as `session_id` is present (`engine/claude.go:1163-1166`), because a turn-cap kill produces exactly that shape. This is deliberate: it is what allows a turn-capped stage to be resumed rather than restarted.
+
+#### Retry after a turn-cap kill
+
+When a stage exceeds `max_turns`, the Claude CLI self-terminates with a non-zero exit, so `completed = false` and `err != nil`. The progress-based extension loop requires `err == nil`, so this falls through to the cooldown/retry path. A later poll re-invokes the same stage with `resume = true` (`engine/item.go:682` — `resume := !lastAttempt.IsZero()`).
+
+**The retry continues the same Claude session.** It is not a fresh agent inheriting a dirty worktree — it retains the killed run's conversation context, including the output of every command that run executed before the cap.
+
+Two consequences follow, and both routinely look like defects to someone reading only the posted comment:
+
+1. **A retry may legitimately report on work performed before the kill.** If the predecessor ran a test suite at turn 12 and was killed at turn 51, the successor can summarise those results without re-running anything. The work was genuinely performed, by the same session — this is continuation, not fabrication.
+2. **A retry completing in very few turns is the expected shape, not a warning sign.** The work is already done; the continuation only needs enough turns to write it up. A two-turn completion following a capped predecessor is a resume working correctly.
+
+Conversely, a successor that *announces* the situation (e.g. "found the implementation already complete from a prior interrupted session") is accurately describing its own resumed state.
+
+**Failure mode — silent fallback to a fresh session.** `--resume` is only appended when the session file exists and is non-empty (`engine/claude.go:480-484`):
+
+```go
+if resume {
+    if sessionID, err := os.ReadFile(sessFilePath); err == nil && len(sessionID) > 0 {
+        args = append(args, "--resume", strings.TrimSpace(string(sessionID)))
+    }
+}
+```
+
+If that read fails, the flag is dropped and the retry starts a **fresh session against a worktree that already contains the predecessor's changes**. Nothing currently detects or logs this, and it is the one case where a retry genuinely cannot know what its predecessor did. When diagnosing a suspect retry, confirm the session file was present before concluding the output was unreliable.
+
 ### Model Override
 
 Labels matching `model:<name>` on the issue override the stage's configured model.


### PR DESCRIPTION
Documents what happens when a turn-capped stage is retried — the gap that led to #1081 being filed as a bug.

`docs/stage-lifecycle.md` previously mentioned `--resume` in a single line and never explained the implication: the retry **continues the same Claude session**, so it can legitimately summarise commands its predecessor ran before the cap, and a very short retry is the expected shape of a resume working rather than evidence of fabricated output. Both of those read as defects from the posted comment alone.

Also documents the one real failure mode: `--resume` is silently dropped when the session file is missing or empty (`engine/claude.go:480-484`), leaving a fresh session on a worktree full of a predecessor's changes with nothing logged.

Docs-only. `docs/llms-full.txt` regenerated in the same commit per CLAUDE.md.

Related: #1081 (closed as not-a-bug), PR #1115 (closed unmerged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4L5oQDHChWDF3c6oj1haw