### PR TITLE
fix(engine): pause all work when REST rate limit is exhausted

### DIFF
--- a/engine/backoff.go
+++ b/engine/backoff.go
@@ -27,6 +27,24 @@ const rateLimitNearZeroPercent = 1
 // regardless of the configured poll interval.
 const maxIdleBackoff = 5 * time.Minute
 
+// rateLimitResetBuffer is added to the wait when pausing for a REST rate-limit
+// reset, so GitHub has actually rolled the hourly window before we resume (the
+// reset timestamp is second-granular and clocks may differ slightly).
+const rateLimitResetBuffer = 5 * time.Second
+
+// shouldPauseForRESTRateLimit reports whether the engine should skip the entire
+// poll work phase because the REST/core budget is exhausted and has not yet
+// reset. Unlike GraphQL — which the poll read consumes and which the interval
+// backoff (computeEffectiveInterval) throttles organically — the REST/core
+// budget is spent by per-item mutations (reactions, labels, comments, merges)
+// and janitor fetches. Stretching the poll interval does not conserve it, so
+// exhaustion requires a hard pause until the hourly reset rather than a retry
+// storm of 403s. Returns false when limit is unknown (limit == 0, e.g. before
+// the first REST call) or when the reset time has already passed.
+func shouldPauseForRESTRateLimit(remaining, limit int, reset, now time.Time) bool {
+	return isRateLimitNearZero(remaining, limit) && reset.After(now)
+}
+
 // idleBackoffMultiplier returns the backoff multiplier for the given idle duration.
 // Schedule: 0–5min → 1x, 5–10min → 2x, 10–20min → 4x, 20+ min → 0 (use maxIdleBackoff).
 func idleBackoffMultiplier(idleDuration time.Duration) int {

--- a/engine/backoff_test.go
+++ b/engine/backoff_test.go
@@ -236,3 +236,33 @@ func TestIsRateLimitNearZero_ZeroLimit(t *testing.T) {
 		t.Error("expected false: limit=0 must always return false")
 	}
 }
+
+// TestShouldPauseForRESTRateLimit covers the REST/core hard-gate decision: pause
+// only when the budget is near zero AND the reset is still in the future.
+func TestShouldPauseForRESTRateLimit(t *testing.T) {
+	now := time.Date(2026, 7, 26, 20, 20, 0, 0, time.UTC)
+	future := now.Add(10 * time.Minute)
+	past := now.Add(-1 * time.Minute)
+
+	cases := []struct {
+		name             string
+		remaining, limit int
+		reset            time.Time
+		want             bool
+	}{
+		{"exhausted, reset in future -> pause", 0, 5000, future, true},
+		{"near-zero (1%) boundary, future reset -> pause", 50, 5000, future, true},
+		{"just above near-zero, future reset -> no pause", 51, 5000, future, false},
+		{"healthy quota, future reset -> no pause", 4000, 5000, future, false},
+		{"exhausted but reset already passed -> no pause (resume)", 0, 5000, past, false},
+		{"exhausted, reset exactly now -> no pause (After is strict)", 0, 5000, now, false},
+		{"unknown limit (0) -> no pause", 0, 0, future, false},
+		{"zero-value reset (pre-first-call) -> no pause", 0, 5000, time.Time{}, false},
+	}
+	for _, c := range cases {
+		if got := shouldPauseForRESTRateLimit(c.remaining, c.limit, c.reset, now); got != c.want {
+			t.Errorf("%s: shouldPauseForRESTRateLimit(%d,%d,reset,now)=%v, want %v",
+				c.name, c.remaining, c.limit, got, c.want)
+		}
+	}
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -388,10 +388,37 @@ func (e *Engine) Run() error {
 	rateLimitLow := false
 	rateLimitRatio := 1.0
 	lastRemainingCount := 0
+	restRateLimitPaused := false
 
 	// doPollCycle runs poll(), updates idle/backoff state, emits PollCompletedEvent,
 	// and resets the ticker to the effective interval. Returns the error from poll().
 	doPollCycle := func() error {
+		// REST/core rate-limit hard gate. The GraphQL-driven interval backoff below
+		// conserves the GraphQL budget (spent by the poll read) but does nothing for
+		// the REST/core budget, which is spent by per-item mutations (reactions,
+		// labels, comments, merges) and janitor fetches. When REST is exhausted,
+		// skip the ENTIRE work phase — fetch, dispatch, and mutations — until
+		// GitHub's hourly reset, rather than hammering 403s in a retry storm.
+		// restStats are refreshed from the headers of every REST response (including
+		// 403s), so Reset is authoritative even once the budget is at zero.
+		restStats, _ := e.client.RateLimitStats()
+		if shouldPauseForRESTRateLimit(restStats.Remaining, restStats.Limit, restStats.Reset, time.Now()) {
+			if !restRateLimitPaused {
+				e.logf(0, "warn", "REST rate limit exhausted (%d/%d remaining) — pausing all work until reset at %s\n",
+					restStats.Remaining, restStats.Limit, restStats.Reset.Format(time.RFC3339))
+				e.emitStructural(tui.RateLimitAlertEvent{Exhausted: true, Reset: restStats.Reset})
+				restRateLimitPaused = true
+			}
+			ticker.Reset(time.Until(restStats.Reset) + rateLimitResetBuffer)
+			return nil
+		}
+		if restRateLimitPaused {
+			e.logf(0, "info", "REST rate limit reset (%d/%d remaining) — resuming work\n",
+				restStats.Remaining, restStats.Limit)
+			e.emitStructural(tui.RateLimitAlertEvent{Exhausted: false})
+			restRateLimitPaused = false
+		}
+
 		result, err := e.poll(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Problem

The poll-loop rate-limit backoff was driven **solely by the GraphQL budget** — `engine/poll.go` discarded the REST value from `RateLimitStats()` and fed only the GraphQL ratio into the hysteresis / interval backoff. The REST/core budget is spent by **per-item mutations** (reactions, labels, comments, merges) and janitor fetches, not by the poll read, so stretching the poll interval does nothing to conserve it.

When REST hit 0 (observed today on the dev instance: arbeithand's 5000/hr REST pool drained), the engine kept fetching, dispatching, and mutating, and every write returned `403 API rate limit exceeded` in a tight retry storm across reactions, label ops, and the janitor.

## Fix

Hard gate at the top of `doPollCycle`: when REST is near zero **and** the reset is still in the future, skip the entire work phase (fetch + dispatch + mutations) and sleep until GitHub's hourly reset, emitting the existing `RateLimitAlertEvent{Exhausted:true}` banner. Resume automatically once the window rolls.

REST stats are refreshed from the headers of **every** REST response (including 403s), so the reset timestamp is authoritative even at zero budget.

Gate logic is extracted to `shouldPauseForRESTRateLimit` for unit testing (8-case table test).

## Scope

- `engine/poll.go` — REST hard gate in `doPollCycle`.
- `engine/backoff.go` — `shouldPauseForRESTRateLimit` helper + `rateLimitResetBuffer`.
- `engine/backoff_test.go` — table test.

GraphQL backoff behavior is unchanged. No public API or doc-canonical behavior change.

## Test

`go build ./...`, `go vet ./engine/`, `go test -race ./engine/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)