### PR TITLE
fix(engine): honor REST rate-limit pause in janitor + buffer the pause predicate

### DIFF
--- a/engine/backoff.go
+++ b/engine/backoff.go
@@ -40,9 +40,15 @@ const rateLimitResetBuffer = 5 * time.Second
 // and janitor fetches. Stretching the poll interval does not conserve it, so
 // exhaustion requires a hard pause until the hourly reset rather than a retry
 // storm of 403s. Returns false when limit is unknown (limit == 0, e.g. before
-// the first REST call) or when the reset time has already passed.
+// the first REST call) or once reset+rateLimitResetBuffer has passed.
+//
+// The buffer is applied to the predicate itself, not just to the ticker reset in
+// doPollCycle: because doPollCycle can also be invoked directly from the wakeCh
+// branch (which bypasses the ticker), a wake in the (reset, reset+buffer) window
+// must still pause — otherwise work would resume before GitHub has surely rolled
+// the hourly window, risking a fresh burst of 403s.
 func shouldPauseForRESTRateLimit(remaining, limit int, reset, now time.Time) bool {
-	return isRateLimitNearZero(remaining, limit) && reset.After(now)
+	return isRateLimitNearZero(remaining, limit) && reset.Add(rateLimitResetBuffer).After(now)
 }
 
 // idleBackoffMultiplier returns the backoff multiplier for the given idle duration.

--- a/engine/backoff_test.go
+++ b/engine/backoff_test.go
@@ -254,8 +254,10 @@ func TestShouldPauseForRESTRateLimit(t *testing.T) {
 		{"near-zero (1%) boundary, future reset -> pause", 50, 5000, future, true},
 		{"just above near-zero, future reset -> no pause", 51, 5000, future, false},
 		{"healthy quota, future reset -> no pause", 4000, 5000, future, false},
-		{"exhausted but reset already passed -> no pause (resume)", 0, 5000, past, false},
-		{"exhausted, reset exactly now -> no pause (After is strict)", 0, 5000, now, false},
+		{"exhausted, reset long past (beyond buffer) -> no pause (resume)", 0, 5000, past, false},
+		{"exhausted, reset exactly now (within buffer) -> pause", 0, 5000, now, true},
+		{"exhausted, reset just passed but within buffer (wakeCh early) -> pause", 0, 5000, now.Add(-2 * time.Second), true},
+		{"exhausted, reset passed beyond buffer -> no pause (resume)", 0, 5000, now.Add(-1 * rateLimitResetBuffer).Add(-time.Second), false},
 		{"unknown limit (0) -> no pause", 0, 0, future, false},
 		{"zero-value reset (pre-first-call) -> no pause", 0, 5000, time.Time{}, false},
 	}

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -35,6 +35,18 @@ type janitorWMEntry struct {
 //	(c) worktree is clean (git status --porcelain returns no non-engine-managed paths)
 //	(d) no in-flight dispatch is registered for (repo, number) in the store
 func (e *Engine) runWorktreeJanitor(ctx context.Context) {
+	// Honor the REST rate-limit pause. The janitor runs on its own goroutine and
+	// makes REST closed-state fetches per off-board worktree, independently of the
+	// poll loop — so the doPollCycle gate alone does not stop it from burning the
+	// REST/core budget (or 403-ing) while the engine is paused for exhaustion.
+	// Skip the whole cycle until reset; the next scheduled tick retries.
+	restStats, _ := e.client.RateLimitStats()
+	if shouldPauseForRESTRateLimit(restStats.Remaining, restStats.Limit, restStats.Reset, time.Now()) {
+		e.logf(0, "janitor", "REST rate limit exhausted (%d/%d remaining) — skipping janitor cycle until reset at %s\n",
+			restStats.Remaining, restStats.Limit, restStats.Reset.Format(time.RFC3339))
+		return
+	}
+
 	worktreesRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
 
 	// Build reverse map: "owner-repo" dir name → ownerRepo string + WorktreeManager.


### PR DESCRIPTION
Follow-up to #1118 addressing CodeRabbit's two actionable findings on that PR (which auto-merged before the review landed).

## 1. Buffer the pause predicate (`backoff.go`) — `Major`

`shouldPauseForRESTRateLimit` used bare `reset.After(now)`. But `doPollCycle` is invoked from **both** the ticker *and* the `wakeCh` branch (poll.go), and only the ticker path adds `+ rateLimitResetBuffer`. A `wakeCh` wake in the `(reset, reset+buffer)` window would resume REST work before GitHub has surely rolled the hourly window. Fix: apply the buffer inside the predicate so every entry point honors it.

## 2. Janitor honors the pause (`janitor.go`) — `Major`

The worktree janitor runs on its **own goroutine** and makes REST closed-state fetches independently of the poll loop, so the `doPollCycle` gate did **not** stop it burning REST / 403-ing during exhaustion — exactly what was seen in the incident log (`[janitor] warn: cannot determine closed state … 403`). Gate `runWorktreeJanitor` on the same REST check (fresh `RateLimitStats()`, no shared mutable state) so *pause all work* is actually honored.

## 3. Full-suite validation (CodeRabbit process note)

CodeRabbit's sandbox reported unrelated `go test ./...` failures; they did **not** reproduce here. Full `go test -race ./...` passes clean.

## Tests

Added boundary cases for the `(reset, reset+buffer)` wake-early window in `TestShouldPauseForRESTRateLimit`. `go build ./...`, `go vet ./engine/`, `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)