### PR TITLE
fix(ci): pin Claude PR review to claude-sonnet-5 + honest failure fallback

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,21 +44,32 @@ jobs:
             Then submit a FORMAL pull-request review (not an issue comment) with:
               gh pr review ${{ github.event.pull_request.number }} --comment --body-file <your-findings-file>
             Add inline comments for specific line-level issues where useful.
-          claude_args: "--allowedTools Bash(git:*),Bash(gh:*),Read,Grep"
+          # Pin the model explicitly. Without --model, claude-code-action@v1
+          # picks its own default, which drifted to an unusable id
+          # (claude-opus-5[1m]) and made every review run fail with
+          # is_error:true after 1 turn — the safety-net step below then posted a
+          # useless "no blocking issues" stub. Sonnet is the intended reviewer
+          # (capable for diff review, far cheaper than Opus per-PR).
+          claude_args: "--model claude-sonnet-5 --allowedTools Bash(git:*),Bash(gh:*),Read,Grep"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Safety net: guarantee the review gate always clears even if the agent
-      # posted only a comment. A no-op if a formal review already exists.
-      - name: Ensure a formal review exists
+      # Fallback: if the agent produced no formal review (it errored, was
+      # skipped, or didn't post), surface that HONESTLY — never claim "no
+      # issues", since a false all-clear is worse than a visible failure (a
+      # failed review previously masqueraded as a clean one). Still posts a
+      # formal review so Fabrik's review gate (engine/reviews.go) clears rather
+      # than hanging.
+      - name: Report if no review was posted
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -m
           count=$(gh pr view "$PR" --json reviews \
             --jq '[.reviews[] | select(.author.login=="github-actions" or (.author.login|startswith("claude")))] | length')
           if [ "${count:-0}" -eq 0 ]; then
-            gh pr review "$PR" --comment --body "🤖 Automated test-repo review (Claude). No blocking issues surfaced by the agent step."
+            gh pr review "$PR" --comment --body "⚠️ **Claude review did not post a formal review.** The review step errored or was skipped (note: PRs that modify this workflow file are skipped by \`claude-code-action\`'s security guard — this resolves once merged). **This is NOT a clean bill of health.** Logs: ${RUN_URL}"
           fi


### PR DESCRIPTION
## Problem

The Claude PR reviewer regressed to posting a useless stub (`🤖 Automated test-repo review (Claude). No blocking issues surfaced by the agent step.`) on every PR. Two independent causes:

1. **Bad model default.** The workflow didn't pin a model, so `anthropics/claude-code-action@v1` picked its own default — which drifted to **`claude-opus-5[1m]`**, an id this key can't use. Every review run failed with `is_error:true` after 1 turn (confirmed in run logs), so no formal review was posted. Claude *did* post real reviews here before the drift (e.g. #1078), and `verveguy/liminis-context-graph` still works today with the exact config this PR adopts.

2. **Dishonest fallback.** The safety-net posted *"No blocking issues surfaced"* whenever no formal review existed — reporting a **failed or skipped** review as a clean one. That false all-clear is what masked the outage.

## Fix

1. Pin `--model claude-sonnet-5` (matches the known-good liminis-context-graph config; Sonnet is capable for diff review and far cheaper per-PR than Opus).
2. Replace the fallback message with an honest **"Claude review did not post — this is NOT a clean bill of health"** that links the run logs. It still posts a formal review so Fabrik's review gate (`engine/reviews.go`) clears rather than hangs.

## Cannot self-test — validate after merge

`claude-code-action` **skips any PR that modifies its own workflow file** (a security guard against secret exfiltration): *"your workflow will begin working once you merge your PR."* So this PR's own review run is skipped by design. Validation is: **merge, then confirm the next normal PR gets a real Sonnet review.**

## Follow-ups

- `shadoworg/fantasy`'s `claude-review.yml` has **no** model pin either — same one-line fix needed there.
- Open PRs branched before this merges (e.g. #1121) need a rebase to pick up the fixed workflow, else the validation guard skips their review too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)