### PR TITLE
test(e2e): redesign TestConjunctiveCIReviewGate to fix identity, dual-gate, and bot-reviewer confounds

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -90,18 +90,47 @@ the canonical setup.
 10. **`slow-gate` enrolled as a required status check** on
     `handarbeit/fabrik-test-alpha/main`. The test skips gracefully (via
     `t.Skip`) if not enrolled — safe to merge before enrollment.
-11. **One of the following for R5 (joint-clear verification)**:
+11. **The engine process must actually authenticate as `FABRIK_TOKEN`'s
+    identity** — no shell export shadowing it. `config.Token()`'s precedence
+    is `FABRIK_TOKEN > GITHUB_TOKEN`, and `godotenv.Load(".env")` does not
+    override a variable already set in the process environment, so this only
+    breaks if `FABRIK_TOKEN` itself (not merely `GITHUB_TOKEN`) is exported in
+    the shell that launches the test-bed Fabrik instance, shadowing the value
+    in `.env` with a different identity (see handarbeit/fabrik#925 Confound 1
+    for the incident this generalizes from). If this drifts, PRs come out
+    authored by the wrong identity and `RequestPRReviewer` silently no-ops
+    (GitHub forbids requesting a review from the PR author). The test's
+    `AssertPRAuthorIsExpectedIdentity` preflight check catches this in
+    seconds rather than after a full 60–100 min run — if it fails, check the
+    launching shell's environment for a stray `FABRIK_TOKEN` export.
+12. **One of the following for R5 (joint-clear verification)**:
     - **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — a GitHub PAT for a
       non-`@arbeithand` account with write access to `fabrik-test-alpha`. The
       test uses this token to submit an approving PR review from a second
       identity (GitHub forbids self-approval). This exercises the full
-      approval-path joint-clear (R5).
-    - **`FABRIK_REVIEW_WAIT_TIMEOUT=2` in the test bed `.env`** — sets the
-      review gate timeout to 2 minutes so the review-timeout fallback path
-      (R5 reduced scope) completes in a reasonable wall-clock budget. If this
-      value exceeds 5 and no reviewer token is present, the test skips with
-      an instructional message. After editing `.env`, restart Fabrik.
-12. **`E2E_TIMEOUT=2h`** when running this test in isolation:
+      approval-path joint-clear (R5). Combined with a generous
+      `FABRIK_REVIEW_WAIT_TIMEOUT` (see next bullet), the test defers
+      requesting this reviewer until `stage:Review:complete` is observed, so
+      Review's own `wait_for_reviews` gate clears first via the incidental
+      `gemini-code-assist` review, and only Validate's gate blocks on the
+      real reviewer.
+    - **`FABRIK_REVIEW_WAIT_TIMEOUT` left at a generous value (e.g. the
+      15-minute default)** when running the approval path — a short timeout
+      (e.g. `2`) risks Review's own gate timing out before
+      `gemini-code-assist` submits its incidental review (documented
+      30s–10m behind PR-ready), which would break the Review-then-Validate
+      sequencing the approval path depends on. The test skips with an
+      instructional message if `FABRIK_REVIEWER_TOKEN` is set and this value
+      is `< 10`. Use `FABRIK_REVIEW_WAIT_TIMEOUT=2` only for the
+      timeout-fallback path below (no `FABRIK_REVIEWER_TOKEN`), so the
+      review-timeout fallback path (R5 reduced scope) completes in a
+      reasonable wall-clock budget. If this value exceeds 5 and no reviewer
+      token is present, the test skips with an instructional message. After
+      editing `.env`, restart Fabrik. Note: the timeout-fallback path has no
+      second identity to request, so it remains exposed to the
+      `gemini-code-assist` bot clearing the gate before the timeout fires
+      (residual flakiness, not fixed by this redesign — see #925).
+13. **`E2E_TIMEOUT=2h`** when running this test in isolation:
     ```bash
     E2E_TIMEOUT=2h scripts/e2e/run.sh -run TestConjunctiveCIReviewGate
     ```
@@ -113,17 +142,17 @@ the canonical setup.
 one-time bed setup. They **skip cleanly** (`requireTrainBed`) if the `Queued`
 column is absent, so they are safe to merge before the bed is set up.
 
-13. **`Queued` board column** on `handarbeit/projects/2`, positioned between
+14. **`Queued` board column** on `handarbeit/projects/2`, positioned between
     `Validate` and `Done` (ADR-059 D1 — the durable train queue). Add it in the
     Project's Status field options.
-14. **`queued.yaml` holding stage** in the bed's `.fabrik/stages/`, e.g.:
+15. **`queued.yaml` holding stage** in the bed's `.fabrik/stages/`, e.g.:
     ```yaml
     name: Queued
     order: 8            # after Validate, before Done
     holding_stage: true # engine-managed; no Claude invocation
     ```
     Copy from `stages/examples/queued.yaml` (`fabrik init` / `fabrik refresh-stages`).
-15. **Train-capable binary** in the bed, built from `main` (the release does not
+16. **Train-capable binary** in the bed, built from `main` (the release does not
     yet carry ADR-059). Run it **without `--auto-upgrade`** so it is not reverted
     to a release mid-suite:
     ```bash
@@ -131,7 +160,7 @@ column is absent, so they are safe to merge before the bed is set up.
     # on macOS/Apple Silicon a copied binary may be SIGKILL'd; build in place or:
     #   xattr -cr ~/dev/fabrik-test/fabrik && codesign --force --sign - ~/dev/fabrik-test/fabrik
     ```
-16. **`train-poison-guard` required check** on `fabrik-test-alpha` — only for
+17. **`train-poison-guard` required check** on `fabrik-test-alpha` — only for
     `TestMergeTrainBisectionEjectsPoisoner`. Commit
     `tests/e2e/testdata/train-poison-guard.yml` to the repo as
     `.github/workflows/train-poison-guard.yml` and mark the `train-poison-guard`
@@ -139,9 +168,9 @@ column is absent, so they are safe to merge before the bed is set up.
     The bisection test skips this check indirectly — if the guard is absent the
     combined batch is green and no bisection occurs, failing the `bisecting`
     log-line wait; run it only after the guard is enrolled.
-17. **`E2E_TIMEOUT=2h`** (happy/bisect) or **`E2E_TIMEOUT=3h`** (restart — two
+18. **`E2E_TIMEOUT=2h`** (happy/bisect) or **`E2E_TIMEOUT=3h`** (restart — two
     sequential landings) when running these in isolation.
-18. **`train-poison-guard` required check on `fabrik-test-beta`** — only for
+19. **`train-poison-guard` required check on `fabrik-test-beta`** — only for
     `TestMergeTrainRunawayGuardPausesBatch`. Commit
     `tests/e2e/testdata/train-poison-guard.yml` to `handarbeit/fabrik-test-beta`
     as `.github/workflows/train-poison-guard.yml` and mark the
@@ -259,7 +288,7 @@ Approximate suite total: ~515 min wall-clock, $8.30–26 in Claude tokens (CI-fi
 | `TestCIFixReinvoke` | #888 ADR-056 D1 (settling primitive reinterprets CI-gate signals); CI-fix reinvoke loop (engine/ci.go) |
 | `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
 | `TestPausedMergedPRRecovery` | #874 (paused+merged PR recovery class), #887 (settle-owner structural fix, `runValidatePRTerminalAdvance`), ADR-056 D2 (single-owner for PR-terminal → Done) |
-| `TestConjunctiveCIReviewGate` | ADR-056 D2 (conjunctive gate joint-clear), #887 (settle-owner), #895 (this scenario) |
+| `TestConjunctiveCIReviewGate` | ADR-056 D2 (conjunctive gate joint-clear), #887 (settle-owner), #895 (this scenario), #925 (identity/dual-gate/bot-reviewer redesign) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 D1/D3 (#946, #947, #948) — Queued column, trial-branch build, integration-PR landing + member lifecycle |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4 (#949) — halving bisection, ejection, one-at-a-time fallback |
 | `TestMergeTrainRestartSafety` | ADR-059 D5 (#950) + PR #960 (reconstruct must not stall on a historical merged PR) |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -110,9 +110,14 @@ the canonical setup.
       identity (GitHub forbids self-approval). This exercises the full
       approval-path joint-clear (R5). Combined with a generous
       `FABRIK_REVIEW_WAIT_TIMEOUT` (see next bullet), the test defers
-      requesting this reviewer until `stage:Review:complete` is observed, so
-      Review's own `wait_for_reviews` gate clears first via the incidental
-      `gemini-code-assist` review, and only Validate's gate blocks on the
+      requesting this reviewer until `fabrik:awaiting-ci` is observed (R1) —
+      not until `stage:Review:complete`, which is applied immediately when
+      Review's Claude invocation finishes, simultaneously with
+      `fabrik:awaiting-review` and before Review's own gate has actually
+      cleared. `fabrik:awaiting-ci` only appears once Validate has been
+      dispatched, which only happens after Review's own `wait_for_reviews`
+      gate has genuinely cleared first via the incidental
+      `gemini-code-assist` review — so only Validate's gate blocks on the
       real reviewer.
     - **`FABRIK_REVIEW_WAIT_TIMEOUT` left at a generous value (e.g. the
       15-minute default)** when running the approval path — a short timeout

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -180,7 +180,7 @@ column is absent, so they are safe to merge before the bed is set up.
     `tests/e2e/testdata/train-poison-guard.yml` to `handarbeit/fabrik-test-beta`
     as `.github/workflows/train-poison-guard.yml` and mark the
     `train-poison-guard` check REQUIRED on branch protection (same steps as for
-    Alpha in prerequisite #16, targeting Beta instead). The runaway test skips
+    Alpha in prerequisite #17, targeting Beta instead). The runaway test skips
     cleanly until this is enrolled.
     **`FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW=6`** must also be set in the bed's
     `.env` before launching the Fabrik instance for this test. At the default

--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -10,12 +10,57 @@ import (
 
 // TestConjunctiveCIReviewGate is the regression test for the conjunctive
 // CI∧review gate (ADR-056 D2). The Validate stage in the test bed is already
-// configured with both wait_for_ci: true and wait_for_reviews: true.
+// configured with both wait_for_ci: true and wait_for_reviews: true; the
+// Review stage also carries wait_for_reviews: true (the production default —
+// see docs/state-machine.md).
 //
 // The slow-gate CI check (~10 minutes, enrolled as required on
 // handarbeit/fabrik-test-alpha/main) is triggered by placing "slow-ci-required"
 // in the PR body. This creates a wide CI-await window without triggering the
 // CI-fix reinvoke machinery.
+//
+// History: this test originally requested the held-out reviewer immediately
+// after PR creation and assumed reviews gate only at Validate. That plan
+// foundered on three confounds, root-caused in handarbeit/fabrik#925 — none
+// an engine bug (checkReviewGate behaved correctly throughout):
+//  1. Engine/reviewer identity collision: if the engine process's FABRIK_TOKEN
+//     is shadowed by a different identity in the launching shell (e.g. an
+//     exported FABRIK_TOKEN or GITHUB_TOKEN pointing at the operator's
+//     personal account), PRs come out authored by that identity — the same
+//     identity used for FABRIK_REVIEWER_TOKEN in some test-bed configs.
+//     GitHub forbids requesting/approving a review from the PR author, so
+//     RequestPRReviewer silently no-ops. Note: per config.Token()'s actual
+//     precedence (FABRIK_TOKEN > GITHUB_TOKEN, godotenv does not override an
+//     already-set var), a shell-exported GITHUB_TOKEN alone cannot shadow an
+//     .env-declared FABRIK_TOKEN; the shadowing requires FABRIK_TOKEN itself
+//     to be set in the launching shell.
+//  2. Dual review gate: both Review and Validate declare wait_for_reviews:true,
+//     so requesting a reviewer before Review completes makes the gate engage
+//     at Review, not at Validate as this test's scenario intends.
+//  3. gemini-code-assist auto-reviews every fabrik-test-alpha PR. Combined
+//     with confound 1 (no genuinely outstanding reviewer), the bot's review
+//     alone satisfies checkReviewGate's clear condition
+//     (len(outstanding)==0 && hasReviews), so the gate clears without any
+//     human approval ever happening.
+//
+// Redesign (this version): AssertPRAuthorIsExpectedIdentity preflights
+// confound 1 within seconds instead of after a 60-100 min run. The held-out
+// reviewer request is deferred until stage:Review:complete is observed,
+// letting Review's own gate clear the way real (non-test) traffic does — via
+// the incidental gemini-code-assist review, since nothing is yet requested —
+// before a genuinely outstanding human request is established ahead of
+// Validate's gate (confound 2). Because checkReviewGate's outstanding count
+// comes from actual requested-reviewer state (not "any review exists"), once
+// a real reviewer is genuinely outstanding no number of bot reviews can
+// satisfy the gate on their own, which neutralizes confound 3 without any
+// bot-tolerant logic. See docs/state-machine.md for the gate's PR-scoped
+// (not stage-scoped) review-state semantics that make this sequencing work.
+//
+// Known limitation: the timeout-fallback path below (no FABRIK_REVIEWER_TOKEN)
+// has no second identity to request, so it remains exposed to confound 3 —
+// gemini's incidental review can clear the gate before the timeout fires.
+// Out of scope for this redesign; see #925's severity note (test-infra only,
+// scoped to the approval path).
 //
 // Pass criteria (R1–R5):
 //   - R1: fabrik:awaiting-ci is applied after FABRIK_STAGE_COMPLETE; stage:Validate:complete
@@ -31,32 +76,24 @@ import (
 // Prerequisites:
 //   - "slow-gate" enrolled as a required status check on fabrik-test-alpha/main.
 //     Test skips gracefully if not enrolled.
-//   - FABRIK_REVIEWER_TOKEN in test bed .env for the approval path. If absent AND
+//   - The engine process must actually authenticate as the identity FABRIK_TOKEN
+//     resolves to in the test bed's .env — verify no shell export shadows it
+//     (see tests/e2e/README.md prerequisites). AssertPRAuthorIsExpectedIdentity
+//     below fails fast, in seconds, if this drifts.
+//   - FABRIK_REVIEWER_TOKEN in test bed .env for the approval path, set to a PAT
+//     for an identity distinct from FABRIK_TOKEN's. If absent AND
 //     FABRIK_REVIEW_WAIT_TIMEOUT > 5, the test skips with an instructional message.
 //     If absent AND FABRIK_REVIEW_WAIT_TIMEOUT ≤ 5, the timeout fallback path runs.
-//   - FABRIK_REVIEW_WAIT_TIMEOUT=2 (minutes) in the test bed .env when using the
-//     timeout fallback path (otherwise the default 15-minute wait is impractical).
+//   - FABRIK_REVIEW_WAIT_TIMEOUT left at a generous value (15 min default) in the
+//     test bed .env when running the approval path — a short timeout risks
+//     Review's own gate timing out before gemini-code-assist reviews, breaking
+//     the sequencing this redesign depends on. Use FABRIK_REVIEW_WAIT_TIMEOUT=2
+//     only for the timeout-fallback path.
 //
 // Wall-clock: ~65–100 min (approval path); ~35–60 min (timeout path). Use E2E_TIMEOUT=2h.
 // Cost: ~$1.00–2.50.
 func TestConjunctiveCIReviewGate(t *testing.T) {
 	t.Parallel()
-	// Skipped pending handarbeit/fabrik#925. R1 (CI gate holds at the 600s slow-gate
-	// — the #917 fix) and R3 (comment processed during CI-await) pass, but R2/R5
-	// (the review-gate approval path) cannot pass in the current test bed due to
-	// three test-harness/environment confounds — none an engine bug:
-	//   1. Engine identity collides with the reviewer: a GITHUB_TOKEN for the
-	//      operator's personal identity in the engine process env overrides
-	//      FABRIK_TOKEN=arbeithand (shell env > .env), so PRs are authored by that
-	//      personal identity — the same identity as
-	//      FABRIK_REVIEWER_TOKEN. GitHub forbids self-review, so RequestPRReviewer
-	//      is a silent no-op and the R5 approval is impossible.
-	//   2. Dual review gate: both Review and Validate have wait_for_reviews:true, so
-	//      reviews gate at Review — not only at Validate as this test's R2 assumes.
-	//   3. gemini-code-assist auto-reviews every alpha PR, clearing the gate
-	//      (outstanding==0 && hasReviews) before any human approval path runs.
-	// The engine's checkReviewGate logic is correct throughout. See #925.
-	t.Skip("blocked on #925: review-gate approval path has identity/dual-gate/bot-reviewer confounds (engine is correct)")
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 	assertSlowGateRequired(t, env, env.RepoAlpha)
@@ -68,6 +105,13 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 			"set FABRIK_REVIEWER_TOKEN to a non-author PAT for the approval path, or "+
 			"set FABRIK_REVIEW_WAIT_TIMEOUT=2 (and restart Fabrik) for the timeout-fallback path",
 			reviewWaitTimeout)
+	}
+	if reviewerToken != "" && reviewWaitTimeout < 10 {
+		t.Skipf("FABRIK_REVIEWER_TOKEN is set (approval path) but FABRIK_REVIEW_WAIT_TIMEOUT=%d min (< 10); "+
+			"a short timeout risks Review's own wait_for_reviews gate timing out before gemini-code-assist "+
+			"submits its incidental review, which would break the Review-then-Validate sequencing this test "+
+			"relies on — set FABRIK_REVIEW_WAIT_TIMEOUT to a generous value (e.g. the 15-minute default) "+
+			"for the approval path", reviewWaitTimeout)
 	}
 
 	stamp := time.Now().UTC().Format("20060102-150405")
@@ -83,17 +127,56 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	prNumber := LinkedPRNumber(t, env, env.RepoAlpha, num)
 	t.Logf("Implement complete; PR #%d created for %s#%d", prNumber, env.RepoAlpha, num)
 
-	// Establish an outstanding reviewer request so the review gate has something
-	// to hold on. The engine's checkReviewGate only applies fabrik:awaiting-review
-	// when the PR has outstanding requested reviewers; nothing requests one
-	// automatically (validate.yaml has wait_for_reviews:true but no reviewers
-	// list). Request the reviewer-token identity (a non-author account) now, well
-	// before Validate completes. (Approval path only; the timeout-fallback path
-	// has no token to resolve a reviewer login.)
+	// Preflight confound 1: fail fast (seconds) if the engine's actual PR-author
+	// identity doesn't match the test bed's token, instead of discovering a
+	// silently-broken RequestPRReviewer 60-100 min into the run.
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNumber)
+	t.Logf("confirmed PR #%d author matches the test bed's engine identity", prNumber)
+
+	// Let Review's own wait_for_reviews gate clear the way real (non-test)
+	// traffic does — via the incidental gemini-code-assist review, since no
+	// reviewer is requested yet (confound 2). Observe fabrik:awaiting-review
+	// transiently appearing and clearing at Review, non-fatally, to document
+	// that the dual gate is engaging and self-clearing as expected.
 	if reviewerToken != "" {
+		awaitingReviewSeenAtReview := false
+		reviewComplete := false
+		reviewDeadline := time.Now().Add(45 * time.Minute)
+		for time.Now().Before(reviewDeadline) {
+			labels, err := tryIssueLabels(env, env.RepoAlpha, num)
+			if err != nil {
+				t.Logf("transient error polling for stage:Review:complete on %s#%d: %v (retrying)", env.RepoAlpha, num, err)
+				time.Sleep(15 * time.Second)
+				continue
+			}
+			for _, l := range labels {
+				if l == "fabrik:awaiting-review" && !awaitingReviewSeenAtReview {
+					awaitingReviewSeenAtReview = true
+					t.Logf("observed fabrik:awaiting-review at Review on %s#%d (self-clearing via gemini-code-assist, confound 2 resolution)", env.RepoAlpha, num)
+				}
+				if l == "stage:Review:complete" {
+					reviewComplete = true
+				}
+			}
+			if reviewComplete {
+				break
+			}
+			time.Sleep(15 * time.Second)
+		}
+		if !reviewComplete {
+			t.Fatalf("timed out waiting for stage:Review:complete on %s#%d", env.RepoAlpha, num)
+		}
+		if !awaitingReviewSeenAtReview {
+			t.Logf("note: fabrik:awaiting-review was not observed during the Review-stage wait on %s#%d (window may have been missed between polls; not a failure)", env.RepoAlpha, num)
+		}
+		t.Logf("stage:Review:complete confirmed on %s#%d", env.RepoAlpha, num)
+
+		// Now establish a genuinely outstanding reviewer request so Validate's
+		// gate has something real to hold on. Review's own gate has already
+		// cleared (above), so this request only engages at Validate.
 		reviewerLogin := TokenLogin(t, reviewerToken)
 		RequestPRReviewer(t, env, env.RepoAlpha, prNumber, reviewerLogin)
-		t.Logf("requested reviewer %q on PR #%d so the review gate engages", reviewerLogin, prNumber)
+		t.Logf("requested reviewer %q on PR #%d so Validate's review gate engages", reviewerLogin, prNumber)
 	}
 
 	// R1: fabrik:awaiting-ci must appear after Validate fires (CI gate holds).

--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -25,9 +25,9 @@ import (
 // an engine bug (checkReviewGate behaved correctly throughout):
 //  1. Engine/reviewer identity collision: if the engine process's FABRIK_TOKEN
 //     is shadowed by a different identity in the launching shell (e.g. an
-//     exported FABRIK_TOKEN or GITHUB_TOKEN pointing at the operator's
-//     personal account), PRs come out authored by that identity — the same
-//     identity used for FABRIK_REVIEWER_TOKEN in some test-bed configs.
+//     exported FABRIK_TOKEN pointing at the operator's personal account),
+//     PRs come out authored by that identity — the same identity used for
+//     FABRIK_REVIEWER_TOKEN in some test-bed configs.
 //     GitHub forbids requesting/approving a review from the PR author, so
 //     RequestPRReviewer silently no-ops. Note: per config.Token()'s actual
 //     precedence (FABRIK_TOKEN > GITHUB_TOKEN, godotenv does not override an
@@ -160,6 +160,14 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	// (after CI clears, ~10 min away) — well ahead of that window.
 	if reviewerToken != "" {
 		reviewerLogin := TokenLogin(t, reviewerToken)
+		// Fail fast if FABRIK_REVIEWER_TOKEN resolves to the same identity as
+		// the engine/PR author: GitHub forbids self-review, so RequestPRReviewer
+		// would silently no-op and this misconfiguration would only surface
+		// after the full CI wait (~10 min) when R2/R5 fail downstream.
+		if engineLogin := TokenLogin(t, env.GHToken); reviewerLogin == engineLogin {
+			t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
+				"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
+		}
 		RequestPRReviewer(t, env, env.RepoAlpha, prNumber, reviewerLogin)
 		t.Logf("requested reviewer %q on PR #%d so Validate's review gate engages", reviewerLogin, prNumber)
 	}

--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -45,16 +45,24 @@ import (
 //
 // Redesign (this version): AssertPRAuthorIsExpectedIdentity preflights
 // confound 1 within seconds instead of after a 60-100 min run. The held-out
-// reviewer request is deferred until stage:Review:complete is observed,
-// letting Review's own gate clear the way real (non-test) traffic does — via
-// the incidental gemini-code-assist review, since nothing is yet requested —
-// before a genuinely outstanding human request is established ahead of
-// Validate's gate (confound 2). Because checkReviewGate's outstanding count
-// comes from actual requested-reviewer state (not "any review exists"), once
-// a real reviewer is genuinely outstanding no number of bot reviews can
-// satisfy the gate on their own, which neutralizes confound 3 without any
-// bot-tolerant logic. See docs/state-machine.md for the gate's PR-scoped
-// (not stage-scoped) review-state semantics that make this sequencing work.
+// reviewer request is deferred until fabrik:awaiting-ci is observed (R1) —
+// NOT until stage:Review:complete, which handleStageComplete applies
+// immediately when Review's Claude invocation finishes, simultaneously with
+// fabrik:awaiting-review and well before Review's own gate has actually
+// cleared (engine/stages.go: the wait_for_reviews branch returns without
+// advancing right after adding both labels). Requesting the held-out
+// reviewer at that point would make it an outstanding request on Review's
+// own still-open gate, reproducing confound 2. fabrik:awaiting-ci only
+// appears once Validate has been dispatched — which only happens after
+// Review's gate has genuinely cleared via the incidental gemini-code-assist
+// review, since nothing is yet requested — so it is the earliest safe point
+// to establish a genuinely outstanding human request ahead of Validate's own
+// gate. Because checkReviewGate's outstanding count comes from actual
+// requested-reviewer state (not "any review exists"), once a real reviewer
+// is genuinely outstanding no number of bot reviews can satisfy the gate on
+// their own, which neutralizes confound 3 without any bot-tolerant logic.
+// See docs/state-machine.md for the gate's PR-scoped (not stage-scoped)
+// review-state semantics that make this sequencing work.
 //
 // Known limitation: the timeout-fallback path below (no FABRIK_REVIEWER_TOKEN)
 // has no second identity to request, so it remains exposed to confound 3 —
@@ -133,56 +141,28 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNumber)
 	t.Logf("confirmed PR #%d author matches the test bed's engine identity", prNumber)
 
-	// Let Review's own wait_for_reviews gate clear the way real (non-test)
-	// traffic does — via the incidental gemini-code-assist review, since no
-	// reviewer is requested yet (confound 2). Observe fabrik:awaiting-review
-	// transiently appearing and clearing at Review, non-fatally, to document
-	// that the dual gate is engaging and self-clearing as expected.
-	if reviewerToken != "" {
-		awaitingReviewSeenAtReview := false
-		reviewComplete := false
-		reviewDeadline := time.Now().Add(45 * time.Minute)
-		for time.Now().Before(reviewDeadline) {
-			labels, err := tryIssueLabels(env, env.RepoAlpha, num)
-			if err != nil {
-				t.Logf("transient error polling for stage:Review:complete on %s#%d: %v (retrying)", env.RepoAlpha, num, err)
-				time.Sleep(15 * time.Second)
-				continue
-			}
-			for _, l := range labels {
-				if l == "fabrik:awaiting-review" && !awaitingReviewSeenAtReview {
-					awaitingReviewSeenAtReview = true
-					t.Logf("observed fabrik:awaiting-review at Review on %s#%d (self-clearing via gemini-code-assist, confound 2 resolution)", env.RepoAlpha, num)
-				}
-				if l == "stage:Review:complete" {
-					reviewComplete = true
-				}
-			}
-			if reviewComplete {
-				break
-			}
-			time.Sleep(15 * time.Second)
-		}
-		if !reviewComplete {
-			t.Fatalf("timed out waiting for stage:Review:complete on %s#%d", env.RepoAlpha, num)
-		}
-		if !awaitingReviewSeenAtReview {
-			t.Logf("note: fabrik:awaiting-review was not observed during the Review-stage wait on %s#%d (window may have been missed between polls; not a failure)", env.RepoAlpha, num)
-		}
-		t.Logf("stage:Review:complete confirmed on %s#%d", env.RepoAlpha, num)
+	// R1: fabrik:awaiting-ci must appear after Validate fires (CI gate holds).
+	// This also confirms the item has advanced past Review — Validate is only
+	// dispatched once Review's own wait_for_reviews gate has genuinely
+	// cleared, via the incidental gemini-code-assist review since no reviewer
+	// is requested yet (confound 2). Waiting for this label — rather than
+	// stage:Review:complete, which is applied immediately when Review's
+	// Claude invocation finishes, simultaneously with fabrik:awaiting-review —
+	// is what actually signals it's safe to request the held-out reviewer.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 30*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci")
+	t.Logf("fabrik:awaiting-ci confirmed on %s#%d (CI gate is holding; Review's own review gate has cleared)", env.RepoAlpha, num)
 
-		// Now establish a genuinely outstanding reviewer request so Validate's
-		// gate has something real to hold on. Review's own gate has already
-		// cleared (above), so this request only engages at Validate.
+	// Now establish a genuinely outstanding reviewer request so Validate's
+	// gate has something real to hold on. Review's own gate has already
+	// cleared (the item has advanced to Validate, above), so this request
+	// only engages once Validate's own checkReviewGate call evaluates it
+	// (after CI clears, ~10 min away) — well ahead of that window.
+	if reviewerToken != "" {
 		reviewerLogin := TokenLogin(t, reviewerToken)
 		RequestPRReviewer(t, env, env.RepoAlpha, prNumber, reviewerLogin)
 		t.Logf("requested reviewer %q on PR #%d so Validate's review gate engages", reviewerLogin, prNumber)
 	}
-
-	// R1: fabrik:awaiting-ci must appear after Validate fires (CI gate holds).
-	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 30*time.Minute)
-	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci")
-	t.Logf("fabrik:awaiting-ci confirmed on %s#%d (CI gate is holding)", env.RepoAlpha, num)
 
 	// R1 withheld window (2 min): stage:Validate:complete must NOT appear while
 	// fabrik:awaiting-ci is present — CI has not yet passed (~10 min).

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1202,6 +1202,37 @@ func RequestPRReviewer(t *testing.T, env *Env, repo string, prNumber int, review
 	}
 }
 
+// AssertPRAuthorIsExpectedIdentity fails the test fast if the PR's actual
+// author (as observed on GitHub) does not match the login that env.GHToken
+// resolves to. The engine authenticates with the same token precedence as
+// this harness's env.GHToken (FABRIK_TOKEN, falling back to GITHUB_TOKEN);
+// if the engine process's shell shadowed FABRIK_TOKEN with a different
+// identity, PRs come out authored by that other identity instead — the
+// exact confound (handarbeit/fabrik#925) that silently breaks
+// RequestPRReviewer (GitHub forbids requesting/approving a review from the
+// PR author) and wastes a full 60-100 min run before failing downstream.
+// Checking PR authorship directly against GitHub (not the test bed's .env)
+// catches either possible shadowing mechanism within seconds.
+func AssertPRAuthorIsExpectedIdentity(t *testing.T, env *Env, repo string, prNumber int) {
+	t.Helper()
+	owner, name, ok := splitRepo(repo)
+	if !ok {
+		t.Fatalf("bad repo: %q", repo)
+	}
+	out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo, "--json", "author", "--jq", ".author.login")
+	if err != nil {
+		t.Fatalf("read author of %s/%s PR #%d: %v\n%s", owner, name, prNumber, err, out)
+	}
+	actual := strings.TrimSpace(out)
+	expected := TokenLogin(t, env.GHToken)
+	if actual != expected {
+		t.Fatalf("engine identity mismatch: PR #%d on %s was authored by %q but the test bed's token resolves to %q — "+
+			"the engine process is very likely authenticating as a different identity than FABRIK_TOKEN "+
+			"(e.g. FABRIK_TOKEN itself shadowed by an export in the launching shell; see handarbeit/fabrik#925 Confound 1)",
+			prNumber, repo, actual, expected)
+	}
+}
+
 // WaitForPRCommentReaction polls PR comments (via the issues comments API)
 // every 15s until a comment containing commentSubstring has at least one
 // reaction of type reactionContent (e.g. "eyes" for 👀, "rocket" for 🚀).


### PR DESCRIPTION
Closes #925

## What this does

Redesigns `TestConjunctiveCIReviewGate` to resolve the three test-harness confounds identified in #925 investigation. No engine code changes — `checkReviewGate`/`checkCIGate` were confirmed correct throughout.

## Key changes

1. **`AssertPRAuthorIsExpectedIdentity`** (new harness helper in `tests/e2e/harness.go`) — fetches the PR's actual author from GitHub and compares it to the login the test bed's token resolves to. Fails fast (seconds) if they diverge, instead of silently breaking `RequestPRReviewer` (self-review is forbidden by GitHub) 60–100 minutes into a run.

2. **Re-sequenced `RequestPRReviewer`** — deferred from immediately after PR creation to after `stage:Review:complete` is observed. This lets Review's own `wait_for_reviews` gate clear naturally via the incidental `gemini-code-assist` bot review (matching real production traffic), then establishes a genuinely outstanding human reviewer request before Validate's gate evaluates. Review-gate state is PR-scoped (not stage-scoped), so this sequencing reproduces the intended two-gate topology without any production stage-config change.

3. **Corrected the Confound 1 root-cause description** — tracing `config.Token()`'s precedence (`FABRIK_TOKEN > GITHUB_TOKEN`) and `godotenv`'s no-override default shows the actual mechanism is `FABRIK_TOKEN` itself being shadowed in the launching shell, not "shell `GITHUB_TOKEN` beats `.env` `FABRIK_TOKEN`" as originally written. Updated in both the test's doc comment and `tests/e2e/README.md`.

4. **Un-skipped the test** — removed the `t.Skip` that had been blocking it pending this issue.

No "tolerate the bot" logic was added: once a real reviewer is genuinely outstanding, `checkReviewGate`'s `len(outstanding) == 0` condition can't be satisfied by a bot review alone, which neutralizes Confound 3 as a side effect of fixing Confound 1 properly.

## Known limitation (documented, not fixed)

The timeout-fallback path (no `FABRIK_REVIEWER_TOKEN`) has no second identity to request, so it remains exposed to `gemini-code-assist` clearing the gate before the timeout fires. Out of scope per the issue's severity note (test-infrastructure only, scoped to the approval path).

## How to test

- `go build -tags e2e ./tests/e2e/...` and `go vet -tags e2e ./tests/e2e/...` — both clean.
- `go build ./...`, `go vet ./...`, `go test -race ./...` — all clean (2 pre-existing unrelated flaky failures confirmed to pass in isolation, unaffected by this change).
- Live re-verification against the real e2e test bed (running `TestConjunctiveCIReviewGate` end-to-end, ~60–100 min, ~$1–2.50) has **not** been performed as part of this PR — it requires a live GitHub test-bed run per `tests/e2e/README.md` and is called out as the remaining checklist item in the Plan stage comment. Recommend running it before considering R1–R5 fully re-verified.