### PR TITLE
fix(claude): stop the immortal-session-pointer loop on a reaped Claude session

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1052,6 +1052,20 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 > session file is missing, unreadable, or zero-length, so `--resume` is skipped and a fresh
 > session starts against the existing worktree. This is not currently detected or logged
 > (#1117). See *Session Resume* in [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
+
+> **Troubleshooting: repeated near-instant `$0.00`, 0-turn failures on a comment.** If an
+> issue's comment is never processed and the stage logs show the same tiny failure over
+> and over — `subtype: "error_during_execution"`, an `errors[]` entry reading
+> `No conversation found with session ID: ...`, `num_turns: 0`, `total_cost_usd: 0` — the
+> session Claude Code was asked to resume has been reaped from its own history (its
+> `cleanupPeriodDays` retention, default 30 days), typically because the issue's last
+> stage invocation was over a month ago. From this fix onward, Fabrik detects this
+> structurally, deletes the stale session file, and starts a fresh session automatically
+> on the next poll — no operator action needed. On an older build without this fix, the
+> only way to unblock the issue is to manually delete the stale
+> `.fabrik/sessions/[<owner>-<repo>/]issue-<N>/<Stage>.session` file; moving the item out
+> of its board column and back does **not** work as a workaround, since an unresolved
+> comment always routes to comment processing regardless of board state.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1050,6 +1050,20 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 > session file is missing, unreadable, or zero-length, so `--resume` is skipped and a fresh
 > session starts against the existing worktree. This is not currently detected or logged
 > (#1117). See *Session Resume* in [`stage-lifecycle.md`](stage-lifecycle.md) for detail.
+
+> **Troubleshooting: repeated near-instant `$0.00`, 0-turn failures on a comment.** If an
+> issue's comment is never processed and the stage logs show the same tiny failure over
+> and over — `subtype: "error_during_execution"`, an `errors[]` entry reading
+> `No conversation found with session ID: ...`, `num_turns: 0`, `total_cost_usd: 0` — the
+> session Claude Code was asked to resume has been reaped from its own history (its
+> `cleanupPeriodDays` retention, default 30 days), typically because the issue's last
+> stage invocation was over a month ago. From this fix onward, Fabrik detects this
+> structurally, deletes the stale session file, and starts a fresh session automatically
+> on the next poll — no operator action needed. On an older build without this fix, the
+> only way to unblock the issue is to manually delete the stale
+> `.fabrik/sessions/[<owner>-<repo>/]issue-<N>/<Stage>.session` file; moving the item out
+> of its board column and back does **not** work as a workaround, since an unresolved
+> comment always routes to comment processing regardless of board state.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue
@@ -5928,6 +5942,19 @@ Note the length check runs on the **untrimmed** bytes, which produces three dist
 None of these are detected or logged. The first two are the only cases where a retry genuinely cannot know what its predecessor did — so when diagnosing a suspect retry, confirm the session file was present and non-empty before concluding the output was unreliable.
 
 This inline read is also **not** the same as `engine.ReadSessionID` (`engine/claude.go:286-302`), which trims before returning and so treats a whitespace-only file as absent. `cmd/resume.go` uses `ReadSessionID`; the invocation path does not. Tracked in #1117.
+
+#### Dead-session detection and self-heal
+
+A session file can point at a conversation Claude Code itself has since reaped (the CLI's own `cleanupPeriodDays` retention, default 30 days) — distinct from #1117's load failures above: the file is present and well-formed, but the ID no longer resolves to anything. `--resume <dead-id>` then fails structurally, and the CLI **echoes the requested `session_id` back unchanged** in its error response, so a naive unconditional resave would rewrite the exact same dead pointer every retry, making the failure self-renewing rather than merely stale.
+
+`interpretClaudeResult` (`engine/claude.go`) detects this from the parsed response, requiring both signals together:
+
+- `resp.Subtype == "error_during_execution"` (structural)
+- an entry in `resp.Errors` containing `"No conversation found with session ID"` (substring)
+
+On detection, it removes the session file immediately and skips the resave of `resp.SessionID` for that invocation — the one place `saveSessionIDDirect` would otherwise persist the dead ID right back to disk. The next invocation reads no session file, `buildClaudeArgs` omits `--resume`, and a fresh session starts and is saved normally. No retry counter or label is involved: because the specific dead ID is never rewritten, the identical failure cannot recur for that pointer, which bounds the loop without any additional machinery.
+
+This applies uniformly to both the stage-invocation and comment-processing call paths, since both flow through `interpretClaudeResult`.
 
 ### Model Override
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -126,6 +126,19 @@ None of these are detected or logged. The first two are the only cases where a r
 
 This inline read is also **not** the same as `engine.ReadSessionID` (`engine/claude.go:286-302`), which trims before returning and so treats a whitespace-only file as absent. `cmd/resume.go` uses `ReadSessionID`; the invocation path does not. Tracked in #1117.
 
+#### Dead-session detection and self-heal
+
+A session file can point at a conversation Claude Code itself has since reaped (the CLI's own `cleanupPeriodDays` retention, default 30 days) — distinct from #1117's load failures above: the file is present and well-formed, but the ID no longer resolves to anything. `--resume <dead-id>` then fails structurally, and the CLI **echoes the requested `session_id` back unchanged** in its error response, so a naive unconditional resave would rewrite the exact same dead pointer every retry, making the failure self-renewing rather than merely stale.
+
+`interpretClaudeResult` (`engine/claude.go`) detects this from the parsed response, requiring both signals together:
+
+- `resp.Subtype == "error_during_execution"` (structural)
+- an entry in `resp.Errors` containing `"No conversation found with session ID"` (substring)
+
+On detection, it removes the session file immediately and skips the resave of `resp.SessionID` for that invocation — the one place `saveSessionIDDirect` would otherwise persist the dead ID right back to disk. The next invocation reads no session file, `buildClaudeArgs` omits `--resume`, and a fresh session starts and is saved normally. No retry counter or label is involved: because the specific dead ID is never rewritten, the identical failure cannot recur for that pointer, which bounds the loop without any additional machinery.
+
+This applies uniformly to both the stage-invocation and comment-processing call paths, since both flow through `interpretClaudeResult`.
+
 ### Model Override
 
 Labels matching `model:<name>` on the issue override the stage's configured model.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -516,6 +516,7 @@ type claudeResponse struct {
 	CostUSD   float64  `json:"total_cost_usd"`
 	IsError   bool     `json:"is_error"`
 	Errors    []string `json:"errors"`
+	Subtype   string   `json:"subtype"`
 	// ModelUsage contains per-model accumulated token counts for the full session.
 	// These are more accurate than the top-level "usage" field, which reflects only
 	// the last API call rather than the entire multi-turn session.
@@ -712,13 +713,19 @@ func interpretClaudeResult(ctx context.Context, issueNumber int, rawOutput []byt
 	resp, ok := parseClaudeJSON(bytes.TrimSpace(rawOutput))
 	var text string
 	var usage TokenUsage
+	staleSessionDetected := false
 	if ok {
 		// Check for stale session ID error — delete the session file so the
 		// next retry starts fresh instead of looping on the same expired ID.
-		if resp.IsError && len(resp.Errors) > 0 {
+		// Both the structural subtype and the errors[] substring are required:
+		// the CLI echoes the dead session_id back on this response, so without
+		// this detection saveSessionIDDirect below would immediately rewrite
+		// the same dead pointer, making it self-renewing rather than merely stale.
+		if resp.IsError && resp.Subtype == "error_during_execution" && len(resp.Errors) > 0 {
 			for _, errMsg := range resp.Errors {
 				if strings.Contains(errMsg, "No conversation found with session ID") {
-					claudeLog(issueNumber, "warn", "session expired — deleting stale session file for retry\n")
+					staleSessionDetected = true
+					claudeLog(issueNumber, "warn", "session expired (stale session ID %q) — removing %s so the next invocation starts a fresh session\n", resp.SessionID, sessFilePath)
 					os.Remove(sessFilePath)
 					break
 				}
@@ -740,7 +747,9 @@ func interpretClaudeResult(ctx context.Context, issueNumber int, rawOutput []byt
 		} else {
 			claudeLog(issueNumber, "claude", "completed in %d turns, $%.4f\n", resp.NumTurns, resp.CostUSD)
 		}
-		saveSessionIDDirect(issueNumber, sessFilePath, resp.SessionID)
+		if !staleSessionDetected {
+			saveSessionIDDirect(issueNumber, sessFilePath, resp.SessionID)
+		}
 	} else if wasTimedOut {
 		// Process was killed before emitting a result JSON line. Extract text from
 		// intermediate assistant turns collected before the kill so we can detect

--- a/engine/interpret_claude_result_test.go
+++ b/engine/interpret_claude_result_test.go
@@ -3,7 +3,9 @@ package engine
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -99,5 +101,87 @@ func TestInterpretClaudeResult_WaitDelayOverride_TreatedAsCleanExit(t *testing.T
 	}
 	if !completed {
 		t.Errorf("expected completed=true")
+	}
+}
+
+// TestInterpretClaudeResult_StaleSession_DeletesFileAndDoesNotResave uses the
+// exact production payload shape from #1128: error_during_execution subtype,
+// an errors[] entry naming the dead session ID, that same ID echoed back in
+// session_id, and zero turns/cost. Before the fix, saveSessionIDDirect would
+// unconditionally rewrite the just-deleted file with this echoed dead ID,
+// making the stale pointer self-renewing instead of merely stale.
+func TestInterpretClaudeResult_StaleSession_DeletesFileAndDoesNotResave(t *testing.T) {
+	sessPath := filepath.Join(t.TempDir(), "issue-815", "Specify.session")
+	if err := os.MkdirAll(filepath.Dir(sessPath), 0700); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(sessPath, []byte("3fefda47-9ea5-422a-9cdb-33da6e13244d"), 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	raw := []byte(`{"subtype":"error_during_execution","duration_ms":0,"num_turns":0,"total_cost_usd":0,` +
+		`"session_id":"3fefda47-9ea5-422a-9cdb-33da6e13244d","is_error":true,` +
+		`"errors":["No conversation found with session ID: 3fefda47-9ea5-422a-9cdb-33da6e13244d"]}`)
+
+	text, completed, _, err := interpretClaudeResult(context.Background(), 815, raw, nil, false, sessPath, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if completed {
+		t.Errorf("expected completed=false (no FABRIK_STAGE_COMPLETE marker in this error response)")
+	}
+	if text != "" {
+		t.Errorf("text = %q, want empty result text", text)
+	}
+	if _, statErr := os.Stat(sessPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected stale session file to be deleted and NOT recreated, stat err = %v", statErr)
+	}
+}
+
+// TestInterpretClaudeResult_NonStaleError_StillSavesSession guards the
+// narrow-scoping decision: an IsError response that does not match both the
+// error_during_execution subtype and the dead-session errors[] substring
+// must still persist its session ID exactly as before (e.g. transient
+// errors like rate limits, where the session remains valid and resumable).
+func TestInterpretClaudeResult_NonStaleError_StillSavesSession(t *testing.T) {
+	sessPath := filepath.Join(t.TempDir(), "Specify.session")
+
+	raw := []byte(`{"subtype":"error_during_execution","is_error":true,"session_id":"sid-live",` +
+		`"errors":["rate limit exceeded"]}`)
+
+	_, _, _, err := interpretClaudeResult(context.Background(), 1, raw, nil, false, sessPath, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, statErr := os.ReadFile(sessPath)
+	if statErr != nil {
+		t.Fatalf("expected session file to be saved, stat err = %v", statErr)
+	}
+	if string(got) != "sid-live" {
+		t.Errorf("session file content = %q, want %q", got, "sid-live")
+	}
+}
+
+// TestInterpretClaudeResult_HealthyResume_SessionIDSaved confirms the
+// ordinary success path (no IsError) still persists the session ID —
+// the resave guard must not regress normal resume behavior.
+func TestInterpretClaudeResult_HealthyResume_SessionIDSaved(t *testing.T) {
+	sessPath := filepath.Join(t.TempDir(), "Specify.session")
+
+	raw := []byte(`{"result":"work done\nFABRIK_STAGE_COMPLETE","session_id":"sid-healthy","num_turns":3,"total_cost_usd":0.5}`)
+
+	_, completed, _, err := interpretClaudeResult(context.Background(), 1, raw, nil, false, sessPath, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !completed {
+		t.Errorf("expected completed=true")
+	}
+	got, statErr := os.ReadFile(sessPath)
+	if statErr != nil {
+		t.Fatalf("expected session file to be saved, stat err = %v", statErr)
+	}
+	if string(got) != "sid-healthy" {
+		t.Errorf("session file content = %q, want %q", got, "sid-healthy")
 	}
 }


### PR DESCRIPTION
Closes #1128

## What this does

Fixes an unbounded fast-fail retry loop that occurs when Fabrik tries to resume a Claude Code session whose transcript has been reaped by Claude Code's own retention policy (default 30 days). Once an issue's last invocation is older than that window, comment processing (which hardcodes `resume=true`) would fail identically forever, at $0.00 / 0 turns per attempt, with no cost signal to surface it.

## Root cause

`interpretClaudeResult` already detected this exact failure (`is_error` + an `errors[]` entry naming the dead session ID) and deleted the stale `.session` file — but 17 lines later, `saveSessionIDDirect` unconditionally rewrote `resp.SessionID` back to disk. On this specific error, the Claude CLI echoes the *same dead ID* it was asked to resume, so the delete and the resave happened in the same invocation, back to back. The self-heal logic existed but had never actually fired in the ~4 months since it was added.

## Fix

- Added `Subtype` to `claudeResponse` so detection requires the structural `subtype == "error_during_execution"` signal alongside the existing `errors[]` substring match (tightens detection, avoids misclassifying other error shapes).
- Captured the detection outcome in a local `staleSessionDetected` bool and skip the `saveSessionIDDirect` call when it's true — the deleted file simply stays gone.
- The next invocation reads no session file, `buildClaudeArgs` silently omits `--resume`, and a fresh session starts and gets saved normally. No retry counter, label, or `MaxRetries` wiring needed: once the specific dead ID is never rewritten, the identical failure structurally cannot recur.
- Expanded the log line to name the stale session ID and the file removed (fires once per occurrence, not once per poll).

This applies uniformly to both the stage-invocation and comment-processing paths, since both flow through `interpretClaudeResult` — no change needed at the hardcoded `resume=true` call site itself.

## Docs

- `docs/stage-lifecycle.md` § Session Resume: new subsection documenting the detection signal and delete-without-resave mechanism.
- `docs/USER_GUIDE.md` § Retry and Escalation: troubleshooting note for the symptom, plus a correction that the previously-suspected board-move workaround does **not** work (confirmed by production testing in the issue discussion) — the only exit on older builds is manually deleting the `.session` file.
- `docs/llms-full.txt` regenerated per the doc-bundle requirement.

## How to test

- `go test -race ./engine/...` — see the new fixtures in `engine/interpret_claude_result_test.go`, which use the exact production payload shape (`subtype: "error_during_execution"`, echoed dead `session_id`, `num_turns: 0`, `total_cost_usd: 0`): assert the stale file is deleted and not recreated, a non-matching `IsError` response still saves normally, and the healthy resume path is unaffected.
- `go build ./...` and `go vet ./...` are clean.