### PR TITLE
fix(claude): drop enabledPlugins from committed settings (restores Claude PR reviewer)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,9 +11,5 @@
       "Bash(git *)",
       "Bash(gh *)"
     ]
-  },
-  "enabledPlugins": {
-    "plugin-dev@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Problem

Even after pinning the model (#1123), the Claude PR reviewer still fails — the agent step errors in ~264ms with `is_error:true`, `total_cost_usd:0` (before any API call), and posts the honest fallback instead of a review.

Root cause: the committed `.claude/settings.json` has `enabledPlugins` (`plugin-dev`, `skill-creator` from `claude-plugins-official`). `claude-code-action` loads project settings (`settingSources: [user, project, local]`) and tries to enable those plugins, but that marketplace isn't installed in the CI runner — so headless `claude` dies on startup. `verveguy/liminis-context-graph` works precisely because it has no `enabledPlugins`.

This also breaks `claude` for any external contributor who clones fabrik without that marketplace.

## Fix (option A)

Plugin enablement is **environment-specific** and doesn't belong in committed settings. Remove `enabledPlugins` from the committed `.claude/settings.json` (keeping the benign permission allowlist); each environment enables plugins via its own gitignored `.claude/settings.local.json`.

Deliberately **not** disabling repo-level settings for CI in general (rejected option B) — repo settings applying is a feature, and the reviewer's untrusted-PR isolation is already handled by the action restoring `.claude` from `main`.

## Validation is post-merge

This PR can't self-test: `claude-code-action` restores `.claude` from **`main`** (untrusted-PR hardening), which still has `enabledPlugins` until this merges. After merge, the next normal PR (or a re-triggered #1125) should get a real Sonnet review.

## Follow-up
- `shadoworg/fantasy` still needs the Sonnet model pin (no `--model` today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)