### PR TITLE
docs(adrs): number new ADRs by issue number, not sequentially

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,14 @@ These files are the authoritative as-built specifications for Fabrik's engine be
 
 These are **as-built docs** — they describe what the engine currently does. They are distinct from `adrs/*.md`, which record architectural decisions and design rationale, not current state. Do not put state-machine content into ADRs or vice versa.
 
+### ADR numbering
+
+**New ADRs are numbered after the issue they come from**, not sequentially: an ADR for issue #1089 is `adrs/1089-kebab-title.md` with the heading `# ADR 1089: Title`. This matches `specs/` (`specs/895-conjunctive-ci-review-gate/`).
+
+Do **not** pick "the next free number." Several issues are normally in flight at once and whichever merges first takes the number, so a sequential choice collides with a sibling branch — and git merges it cleanly, because the filenames differ. Nothing catches it. The number can also go stale while the PR waits in Review or Validate, after it was verified as free. Four such collisions occurred in a single day on 2026-07-26 before this convention was adopted.
+
+`001`–`073` are legacy sequential numbers: leave them as they are, and never reuse or renumber them. Issue numbers are far above that range, so new ADRs cannot collide with legacy ones. If a single issue needs two ADRs, suffix them (`1089-a-...`, `1089-b-...`).
+
 PRs introducing new as-built behavioral docs should also add an entry here.
 
 ## Handling Community Bug Reports

--- a/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
@@ -66,9 +66,11 @@ For each significant decision:
 For each significant decision you make, ask: would a new contributor need to discover this without reading the code? Does it constrain future contributors in a non-obvious way? If yes, the decision warrants an ADR.
 
 When an ADR is warranted:
-- Add `- [ ] Create ADR NNN: Title` to the task checklist (ADR drafting is Implement's job, not Plan's).
-- To pick the right number, check the current highest-numbered file in `adrs/` at implementation time — don't hardcode a number in the plan, as parallel issues may create ADRs concurrently.
-- ADR files follow the format `adrs/NNN-kebab-title.md` with sequential 3-digit zero-padded numbers (e.g., `011-my-decision.md`).
+- Add `- [ ] Create ADR <issue-number>: Title` to the task checklist (ADR drafting is Implement's job, not Plan's).
+- **Number the ADR after the issue number it comes from** — an ADR for issue #1089 is `adrs/1089-kebab-title.md` with the heading `# ADR 1089: Title`. This mirrors how `specs/` is numbered (`specs/895-conjunctive-ci-review-gate/`).
+- **Never pick "the next sequential number."** Issue numbers are unique and stable; sequential numbers are not. Several issues are typically in flight at once, and whichever merges first takes the number — so a sequentially-chosen number silently collides with a sibling branch, and git merges it cleanly because the filenames differ. A number chosen this way can also go stale while the PR waits in Review or Validate, long after it was verified as free.
+- If one issue genuinely needs two ADRs, suffix them: `1089-a-...`, `1089-b-...`.
+- ADRs numbered `001`–`073` are legacy sequential numbers. Leave them alone; never reuse or renumber them.
 
 If no decisions meet this threshold, note that explicitly so Implement doesn't wonder whether you forgot.
 


### PR DESCRIPTION
Four ADR-number collisions occurred today across concurrently in-flight PRs — #1096, #957, #933, #1089. Git merges each cleanly because the filenames differ, so nothing catches the duplicate and the repo silently ends up with two ADRs sharing a number.

**The existing guidance already anticipated this and can't work.** `fabrik-plan/SKILL.md` said:

> check the current highest-numbered file in `adrs/` at implementation time — don't hardcode a number in the plan, as parallel issues may create ADRs concurrently

Implementation time is still *before* merge, so two branches routinely resolve to the same next-free number. And a number verified as free can go **stale in the queue**: #1096's ADR-073 was confirmed correct earlier today, then #1141 merged 073 first while #1096 sat in Validate.

**Fix: number ADRs after their issue** — `adrs/1089-comment-processing-circuit-breaker.md`, heading `# ADR 1089:`. Issue numbers are unique and stable regardless of merge order, need no cross-branch coordination, and make the ADR→issue link obvious from the filename. `specs/` already works this way (`specs/895-conjunctive-ci-review-gate/`).

Legacy `001`–`073` stay frozen and are never reused or renumbered. Current issue numbers are ~1140, so overlap with the legacy range is impossible. Two ADRs from one issue get `-a`/`-b` suffixes.

**Why not a CI duplicate-number check:** a failing check costs a full re-invocation cycle for the worker to notice and fix, whereas the convention prevents the mistake at authoring time. A CI guard is still reasonable belt-and-braces later, but it shouldn't be the primary mechanism.

Docs/skill only — no engine changes. Edits `plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md` (the embedded source, per CLAUDE.md) rather than the deployed `.fabrik/plugin/` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4L5oQDHChWDF3c6oj1haw