### PR TITLE
config: enable the merge train and add the Queued holding stage

### DIFF
--- a/.fabrik/config.yaml
+++ b/.fabrik/config.yaml
@@ -29,6 +29,19 @@ webhooks: true
 board_cache_mode: in-memory
 tui: true
 terminal: ghostty
+
+# Merge train (ADR-059): yolo items completing Validate advance to the Queued
+# holding stage instead of auto-merging individually, then land as one batched
+# integration PR. Requires a "Queued" column on the board matching
+# .fabrik/stages/queued.yaml.
+#
+# MUST be quoted: unquoted `on` is parsed as YAML boolean true, which fails to
+# unmarshal into the string field and silently leaves the train off.
+#
+# Note: fabrik:cruise items never enter the train — cruise short-circuits ahead
+# of the merge-train gate (engine/stages.go:246), leaving the PR for a human.
+# Only fabrik:yolo items are batched.
+merge_train: "on"
 # debug_output: false
 # symlink_env: false    # When true, creates a relative symlink at <worktree>/.env pointing to the fabrikDir .env.
 #                       # Enables worktree-based stages to pick up credentials (e.g. ANTHROPIC_API_KEY) from .env.

--- a/.fabrik/stages/queued.yaml
+++ b/.fabrik/stages/queued.yaml
@@ -1,0 +1,3 @@
+name: Queued
+order: 6
+holding_stage: true


### PR DESCRIPTION
Enables ADR-059 merge-train batching for this project, so a batch of ready `fabrik:yolo` issues lands as **one integration PR** rather than N sequential merges.

All three required pieces are in place:

| Piece | State |
|---|---|
| `Queued` column on project board #1, between Validate and Done | added |
| `.fabrik/stages/queued.yaml` — `order: 6`, `holding_stage: true` | this PR |
| `merge_train: "on"` in `.fabrik/config.yaml` | this PR |

Stage order is `Validate` (5) → `Queued` (6) → `Done` (99), and the board column names match the stage names exactly, so startup validation passes.

**`merge_train` is quoted deliberately.** Unquoted `on` is parsed by YAML 1.1 as boolean `true`, which fails to unmarshal into the `string` field and silently leaves the train **off** — the engine compares against the literal string `"on"`. Verified it round-trips as a string.

**Operator note, also in the config comment:** `fabrik:cruise` items never enter the train. Cruise short-circuits ahead of the merge-train gate (`engine/stages.go:246`), leaving the PR for a human to merge at Validate. Only `fabrik:yolo` items are batched — so enabling this does not change the behaviour of anything currently on cruise.

Config only; no engine changes. Takes effect on the next restart (a dev build rebuilds from `origin/main` when idle, per `cmd/root.go:143`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4L5oQDHChWDF3c6oj1haw