### PR TITLE
feat(pruefer): V1 core — self-hosted PR review daemon driving the claude CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@
 .env
 /fabrik
 /print-plugin-hash
+/pruefer
+.pruefer/pruefer.lock
+.pruefer/pruefer.log
+.pruefer/logs/
+.pruefer/*.pem
 # goreleaser build output — must be ignored or Go's buildvcs stamps release
 # artifacts +dirty (untracked dist/ makes the tree "modified" at build time).
 /dist/

--- a/adrs/1113-pruefer-v1-architecture.md
+++ b/adrs/1113-pruefer-v1-architecture.md
@@ -1,0 +1,100 @@
+# ADR 074: Pruefer V1 Architecture
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #1113 — V1 core: self-hosted PR review daemon driving the `claude` CLI
+
+## Context
+
+Fabrik's `wait_for_reviews: true` gate needs a reviewer that submits a formal `pull_request_review`. Depending on a hosted bot (Gemini) took the pipeline down on 2026-07-25 when its daily quota exhausted (#1058/#1059/#1065, analysed in #1071). The interim mitigation, `claude-review.yml` (a per-repo GitHub Actions workflow using `anthropics/claude-code-action`), works but bills per-token against an API key and multiplies badly under Fabrik's auto-fix-and-push review cycles (18 reviews on PR #1078, 19 on #1091), and is duplicated across eight repos.
+
+Pruefer is a small, self-hosted Go daemon — architecturally a sibling of Fabrik's engine, not a subordinate — that watches configured repositories, reviews pull requests by invoking the `claude` CLI (subscription-backed, not API-metered), and submits a formal comment-only review. This ADR records the structural decisions made to satisfy the issue's requirements, most of which were pinned down during Research/Plan and are recorded here as-built.
+
+## Decisions
+
+### 1. GitHub App identity, not a distinct PAT
+
+Pruefer authenticates as a GitHub App rather than a second personal-access-token account. Reviews and comments are attributed to `<app-slug>[bot]` — a genuine GitHub Bot identity. This makes the "review identity distinct from PR author" requirement **structural**: a GitHub App can never literally be a PR's human or bot author, eliminating the "misconfigured PAT accidentally equals PR author" failure mode that a token-based design leaves to operator discipline.
+
+Mechanics (`github/app.go`, `pruefer/auth.go`):
+- `BuildAppJWT` hand-rolls a short-lived (9-minute) RS256 JWT (`iss=<app_id>`), signed with the App's RSA private key. No JWT library — GitHub's App-auth flow needs exactly one fixed-shape token, which stdlib `crypto/rsa` + `encoding/json` + `encoding/base64` covers directly, consistent with this module's "minimize external dependencies" convention (`.claude/rules/golang.md`).
+- `FetchAppInstallations` (`GET /app/installations`, JWT-authenticated) discovers every installation of the App. If `github_app_installation_id` is unset in config and exactly one installation exists, it's used automatically; zero or multiple installations is a hard bootstrap error requiring explicit configuration — silently picking one among several could watch/act on the wrong org. Auto-discovery still removes per-repo config churn within a single installation's repo set, directly serving the issue's "adding a repo shouldn't mean N PRs" motivation.
+- `MintInstallationToken` exchanges the JWT for a ~1-hour installation access token, used as an ordinary Bearer token for all subsequent REST calls.
+- `FetchAppSlug` (`GET /app`) resolves the App's own login (`<slug>[bot]`) once at bootstrap, used for self-review skip and GitHub-derived review-state checks.
+- `github.Client.SetToken` (mutex-guarded, mirroring the existing `SetMergeStrategy` pattern) lets `pruefer.Auth.RunRefreshLoop` swap the token in place before expiry (5-minute margin) without reconstructing the client. A failed refresh is logged and retried after a fixed delay rather than crashing the daemon — the current token stays valid until its actual (not margin-adjusted) expiry, so a transient GitHub outage doesn't take Pruefer down.
+
+The App's private key never goes in `.env`: config takes a file path (`github_app_private_key_path`, default `.pruefer/app-private-key.pem`, gitignored) rather than an embedded PEM blob, sidestepping the multi-line-env-value encoding question entirely.
+
+### 2. Review-state mechanism: GitHub-derived, not on-disk
+
+"Already reviewed at SHA X" is derived by querying `FetchPRReviews` (extended with a `CommitID` field, populated from GitHub's REST `commit_id`) filtered to Pruefer's own App login, rather than a local database or file.
+
+This is self-healing and restart-safe by construction — the acceptance criterion "review state survives a restart" is satisfied with zero persistence code, and there is no local-state-vs-GitHub-truth divergence to reconcile. The incremental cost is one `FetchPRReviews` call per PR per poll cycle, which the daemon already pays regardless (it needs the PR's review list for the eligibility check itself).
+
+### 3. Ephemeral shallow clone, not zero-clone diff-only
+
+Each review does a single-use `git init` + `git fetch --depth 1 <url> refs/pull/<N>/head` + `git checkout FETCH_HEAD` into a fresh temp directory (`pruefer/worktree.go`), deleted after the review completes. The clone URL embeds the installation token as HTTP basic auth (`x-access-token:<token>@github.com/...`, GitHub's documented convention for App tokens); `runGit` redacts the token from any error text before it can reach logs.
+
+The issue's own example allowlist (`Read`, `Grep`, `Glob`, `Bash(git:*)`) presumes a checkout, and real review quality benefits from surrounding-code context, not just an isolated diff hunk. No bare-clone cache: Fabrik's worktrees persist for days across many stage runs on the same issue, but Pruefer's reviews are single-shot, so a cache would add lifecycle-management complexity for comparatively little benefit at V1 scale — flagged as a future optimization if watched-repo PR volume grows.
+
+`FetchPRDiff` (`GET /pulls/{n}` with `Accept: application/vnd.github.v3.diff`) is used separately, purely to measure diff size and parse changed paths cheaply before paying for a clone — see Decision 4.
+
+### 4. Diff-size guard runs before cloning, and skips rather than truncates
+
+`ReviewPR` (`pruefer/review.go`) fetches the diff via `FetchPRDiff` and compares its byte length against `Config.MaxDiffBytes` (default 500 KB) before doing any clone or Claude invocation. An oversized diff is **skipped**, not truncated — the PR stays outstanding for `wait_for_reviews` and the skip is logged, rather than silently feeding a partial diff into the prompt and producing a review that looks complete but wasn't. The same diff fetch is reused to parse changed paths (`ParseChangedPaths`, from `diff --git a/... b/...` headers) for path-exclusion matching, so the size guard and path-exclusion check share one network call.
+
+Cheap checks (draft, self-authored, excluded author/label, already-reviewed-at-SHA) run in `select.go`'s `Eligible` *before* the diff fetch, so a PR skipped on those grounds never costs the extra round-trip.
+
+### 5. Claude never calls `gh` or submits the review itself
+
+Despite the issue's illustrative allowlist example including `Bash(gh:*)`, the `gh` CLI is not read-only — `gh pr review --approve`, `gh pr merge`, `gh pr edit` are all reachable through an unscoped grant. Allowing it would make the "never `APPROVE`/`REQUEST_CHANGES`" and "never mutate the repo" guarantees prompt-level policy only — the same structural weakness `claude-review.yml` already has.
+
+Instead: Pruefer's Go code (`github.Client.SubmitPRReview`, `pruefer/review.go`) submits the review directly, with `event: "COMMENT"` hardcoded and never a caller-supplied parameter. Claude's tool allowlist (`pruefer/claude.go`'s `reviewAllowedTools`) is narrowed to `Read`, `Grep`, `Glob`, and specific read-only git subcommands (`Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git show:*)`, `Bash(git blame:*)`, `Bash(git grep:*)`, `Bash(git status:*)`) rather than blanket `Bash(git:*)` or any `gh` access at all. The App installation token is never placed in the Claude subprocess's environment — Claude has no GitHub-calling capability, so there is nothing to leak even if the allowlist were somehow bypassed. This makes "never approve" a code-level invariant, not a prompt-level one.
+
+### 6. Process-group kill escalation is duplicated, not extracted
+
+`engine/procattr_unix.go` / `_windows.go` implement `setCmdProcAttr` (start the process in its own process group) and `killProcGroupGraceful` (SIGINT→SIGTERM→SIGKILL escalation) — exactly what Pruefer's own Claude invocation needs, but both are unexported `package engine` functions, and the issue explicitly forbids importing `engine`.
+
+`pruefer/procattr_unix.go` / `_windows.go` duplicate this logic (~80 lines) rather than extracting it into a new shared `internal/` package. These are small, stable OS primitives; extracting them would touch `engine`'s existing call sites for a security-relevant piece of code for the sake of a one-time copy. Duplication is the lower-risk choice for V1.
+
+### 7. Defaults
+
+| Setting | Default | Rationale |
+|---|---|---|
+| Concurrency cap | 3 | Fabrik's default is 5, scoped to one board's throughput. Pruefer's reviews are lower-urgency and share one subscription-backed `claude` capacity across N watched repos, not one board — a lower cap leaves headroom. |
+| Diff-size guard | 500 KB | Large enough for real PRs, small enough to bound prompt size and review latency. Skip, not truncate (Decision 4). |
+| Poll interval | 120s | No webhook integration in V1; REST cost scales with watched-repo count. 120s balances on-demand `/pruefer review` responsiveness against API budget (vs. Fabrik's 30s, which assumes webhook-backed idle detection). |
+| Effort | medium | The issue explicitly frames max-effort-by-default as a cost decision, not a default. Medium is a defensible middle ground for routine review, raisable per-repo via config. |
+| Default exclusions | empty | Reviewing everything by default is safer than silently skipping dependency-bot PRs, which can carry real risk. Operators opt in per-repo to excluded authors/paths/labels. |
+
+### 8. Why V1 never approves or requests changes
+
+`SubmitPRReview` hardcodes `event: "COMMENT"`; there is no code path that can produce `APPROVE` or `REQUEST_CHANGES`. An automated approval is a policy decision this issue does not make, and `REQUEST_CHANGES` blocks merges and would need an explicit unblock path that doesn't exist yet. A comment-only review is sufficient to satisfy Fabrik's `hasReviews` gate predicate (`engine/reviews.go:271-275`) without taking on either of those additional product decisions.
+
+### 9. On invocation failure, post nothing
+
+If the `claude` invocation fails (process error, timeout, unparseable output, or an `is_error` result), `ReviewPR` returns a non-nil `Err` and submits no review (`pruefer/review.go`). No review-state is written on failure — since review state is GitHub-derived (Decision 2), the PR is naturally retried on the next poll cycle with no stale-state cleanup required. This is the opposite of `claude-review.yml`'s safety-net stub pattern (posting a placeholder comment when the review step fails): Pruefer owns its own retry loop, so a stalled gate is no longer a risk that a stub comment needs to hedge against, and a stub would misrepresent "no review happened" as "a review happened."
+
+## Consequences
+
+**Positive:**
+- The distinct-identity requirement is structural (App auth), not operator-discipline-dependent.
+- Zero persistence code for review state — restart-safety comes for free from deriving state off GitHub.
+- The never-approve guarantee is enforced in Go, not by prompt instruction — a compromised or confused Claude invocation cannot escalate to `APPROVE`/`REQUEST_CHANGES` or call `gh` at all.
+- No shared Go imports with `engine` — Pruefer can evolve independently and carries no risk of accidentally coupling to board/stage state.
+
+**Negative / Trade-offs:**
+- Installation-token refresh is a new liveness dependency absent from a plain-PAT design: an unrefreshed token silently starts failing every call ~1 hour after mint if the refresh loop breaks. Mitigated by a dedicated refresh-loop test asserting refresh fires before expiry, but this is a genuinely new failure class worth operator awareness (see README).
+- Duplicated process-group kill logic (`engine/procattr_*.go` vs. `pruefer/procattr_*.go`) is two copies of security-relevant code to keep in sync if either changes.
+- No bare-clone cache means every review re-fetches repo data from scratch; acceptable at V1 scale, a candidate optimization if watched-repo PR volume grows materially.
+- Empty default exclusions could produce noisy reviews on high-volume dependency-bot repos until an operator configures exclusions.
+
+## Related Work
+
+- `adrs/005-claude-cli-invocation.md` — original rationale for shelling out to `claude` via `os/exec`; Pruefer's invocation approach is fully consistent, no conflict.
+- `adrs/066-consolidated-github-request-helpers.md` — the `github/` package's REST core (`do()`/`doWithAccept()`, `restPostWithResponse`) that every new Pruefer-driven `github/` method routes through rather than hand-rolling HTTP.
+- `adrs/032-webhook-event-delivery.md` — ruled out GitHub Apps for webhook *delivery* on a local-CLI/no-public-URL basis. Does not conflict with this ADR: Pruefer uses a GitHub App purely for API authentication/identity, and polls (mirroring `engine/poll.go`'s shape) rather than receiving webhooks, so ADR-032's objection doesn't apply here.
+- `engine/reviews.go:271-275` (`hasReviews`) — the gate predicate a Pruefer-submitted `COMMENT` review satisfies.
+- `.github/workflows/claude-review.yml` — the existing per-repo mitigation Pruefer is not replacing in V1 (removal is explicitly out of scope for this issue); both the pattern to mirror (formal-review submission) and the pattern to avoid (safety-net stub, `synchronize`-triggered re-review loops) it demonstrates.
+
+**References:** [cmd/pruefer/README.md](../cmd/pruefer/README.md)

--- a/adrs/1113-pruefer-v1-architecture.md
+++ b/adrs/1113-pruefer-v1-architecture.md
@@ -1,4 +1,4 @@
-# ADR 074: Pruefer V1 Architecture
+# ADR 1113: Pruefer V1 Architecture
 
 **Date**: 2026-07-27
 **Status**: Accepted

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -32,3 +32,4 @@ contributors and future maintainers.
 | [067](067-merge-train-centralized-inflight-cleanup.md) | Centralized Merge-Train In-Flight Marker Cleanup | Accepted |
 | [073](073-outbound-bot-mention-neutralization.md) | Outbound Bot-Mention Neutralization | Accepted |
 | [1089](1089-comment-processing-circuit-breaker.md) | Comment-Processing Circuit Breaker | Accepted |
+| [1113](1113-pruefer-v1-architecture.md) | Pruefer V1 architecture (GitHub App identity, review-state, defaults) | Accepted |

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -1,0 +1,116 @@
+# Pruefer
+
+Pruefer is a self-hosted PR review daemon. It watches configured GitHub repositories, reviews open pull requests by invoking the `claude` CLI (subscription-backed, not API-metered), and submits a formal comment-only `pull_request_review`.
+
+It exists to satisfy Fabrik's `wait_for_reviews: true` gate (and any repo that wants a review bot) without depending on a hosted third-party reviewer's quota, and without per-token API billing. See [adrs/074-pruefer-v1-architecture.md](../../adrs/074-pruefer-v1-architecture.md) for the full architectural rationale.
+
+**V1 scope**: comment-only reviews (`event: COMMENT`). Pruefer never approves a PR and never requests changes — see the ADR for why.
+
+## How it works
+
+Every `poll_interval_seconds`, Pruefer lists open, non-draft PRs on each watched repo and, for each one, checks:
+
+- Is the PR authored by Pruefer's own bot identity? Skip (GitHub rejects self-review anyway).
+- Does an excluded author/label/path match? Skip.
+- Has Pruefer already reviewed this exact head SHA? Skip — **unless** an unprocessed `/pruefer review` comment is on the PR, which forces a fresh review of the current head.
+- Is the diff larger than `max_diff_bytes`? Skip (logged, not truncated).
+
+Otherwise, Pruefer clones the PR's head commit into a temporary directory, invokes `claude` with a read-only tool allowlist to produce review text, and submits it as a formal `pull_request_review` (event `COMMENT`) pinned to that head SHA. On any failure — clone, invocation, or submission — Pruefer posts nothing and logs the failure; the PR is naturally retried on the next poll.
+
+Review state ("already reviewed at SHA X") is derived from GitHub itself (existing reviews authored by Pruefer's bot identity), not stored locally — a restart never causes a review storm.
+
+## Setup
+
+### 1. Create a GitHub App
+
+Pruefer authenticates as a GitHub App so its reviews are attributed to a genuine bot identity (`<app-slug>[bot]`) — this is what makes "review identity distinct from PR author" structural rather than a setup mistake waiting to happen.
+
+1. Go to your org or personal account's **Settings → Developer settings → GitHub Apps → New GitHub App**.
+2. Fill in:
+   - **GitHub App name**: anything unique (e.g. `your-org-pruefer`). This becomes the `<slug>` in the App's `<slug>[bot]` identity.
+   - **Homepage URL**: any placeholder URL — not used.
+   - **Webhook**: **uncheck "Active"**. Pruefer polls; it does not receive webhooks (see ADR-074 for why this doesn't conflict with ADR-032's webhook-delivery ruling).
+3. **Repository permissions**, minimum required:
+   - **Pull requests**: Read and write (review submission, reading PR metadata/diff)
+   - **Contents**: Read (cloning the PR head commit)
+   - **Metadata**: Read (mandatory baseline for every App)
+   - **Issues**: Read (reading `/pruefer review` comments and their reactions — GitHub's Issue Comments API also covers PR-conversation comments)
+4. **Where can this GitHub App be installed?**: your choice — "Only on this account" is simplest for a single org.
+5. Click **Create GitHub App**. Note the **App ID** shown on the app's settings page.
+6. Scroll to **Private keys** and click **Generate a private key**. This downloads a `.pem` file — save it somewhere outside version control (Pruefer's default config gitignores `.pruefer/*.pem`).
+7. Click **Install App** (left sidebar) and install it on every repository you want Pruefer to watch.
+
+### 2. Place the private key
+
+Put the downloaded `.pem` file at `.pruefer/app-private-key.pem` (the default `github_app_private_key_path`), or point `github_app_private_key_path` at a different location. **Never** put the key's contents directly in `.env` or the YAML config — Pruefer only ever takes a file path.
+
+### 3. Configure Pruefer
+
+Create `.pruefer/config.yaml` (or use flags/env vars — see Configuration below):
+
+```yaml
+watched_repos:
+  - your-org/repo-one
+  - your-org/repo-two
+
+github_app_id: 123456
+# github_app_private_key_path: .pruefer/app-private-key.pem  # default shown
+# github_app_installation_id: 0  # 0 = auto-discover (requires exactly one installation)
+
+poll_interval_seconds: 120
+model: sonnet
+effort: medium
+concurrency_cap: 3
+max_diff_bytes: 500000
+
+# excluded_authors: [dependabot]
+# excluded_labels: [skip-review]
+# excluded_paths: ["vendor/**", "*.generated.go"]
+```
+
+If the App is installed on more than one org/account, set `github_app_installation_id` explicitly — Pruefer refuses to guess among multiple installations.
+
+### 4. Run it
+
+```bash
+go build -o pruefer ./cmd/pruefer
+./pruefer
+```
+
+Pruefer loads `.env` (via the same `godotenv`-based loader Fabrik uses), reads `.pruefer/config.yaml`, bootstraps GitHub App auth, and polls until interrupted (SIGINT/SIGTERM). Pruefer also needs a working `claude` CLI installation with a valid Claude Code subscription on the host it runs on — a separate credential from the GitHub App.
+
+A lock file at `.pruefer/pruefer.lock` prevents two instances from polling the same working directory concurrently.
+
+## On-demand re-review
+
+Comment `/pruefer review` on any watched PR to force a fresh review of the current head, even if that SHA was already reviewed. Pruefer acknowledges the command with a 👀 reaction when it picks it up and a 🚀 reaction once the review has been submitted — the same idempotency convention Fabrik uses for its own comment processing.
+
+## Configuration reference
+
+Precedence, highest to lowest: **flag > environment variable > YAML config file > default.**
+
+| Flag | Env var | YAML key | Default | Notes |
+|---|---|---|---|---|
+| `--repos` | `PRUEFER_REPOS` | `watched_repos` | (none — required) | Comma-separated `owner/repo` list |
+| `--poll-interval` | `PRUEFER_POLL_INTERVAL` | `poll_interval_seconds` | `120` | Seconds |
+| `--model` | `PRUEFER_MODEL` | `model` | `sonnet` | Claude model |
+| `--effort` | `PRUEFER_EFFORT` | `effort` | `medium` | `low`, `medium`, `high`, or `max` |
+| `--concurrency` | `PRUEFER_CONCURRENCY` | `concurrency_cap` | `3` | Max simultaneous `claude` invocations |
+| `--max-diff-bytes` | `PRUEFER_MAX_DIFF_BYTES` | `max_diff_bytes` | `500000` | PRs with a larger diff are skipped, not truncated |
+| `--excluded-authors` | `PRUEFER_EXCLUDED_AUTHORS` | `excluded_authors` | (none) | Comma-separated logins |
+| `--excluded-labels` | `PRUEFER_EXCLUDED_LABELS` | `excluded_labels` | (none) | Skip if any label matches |
+| `--excluded-paths` | `PRUEFER_EXCLUDED_PATHS` | `excluded_paths` | (none) | Glob patterns; skip only if **every** touched path matches |
+| `--github-app-id` | `PRUEFER_GITHUB_APP_ID` | `github_app_id` | (none — required) | |
+| `--github-app-private-key-path` | `PRUEFER_GITHUB_APP_PRIVATE_KEY_PATH` | `github_app_private_key_path` | `.pruefer/app-private-key.pem` | |
+| `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (auto-discover) | Required if the App has more than one installation |
+| `--config` | `PRUEFER_CONFIG` | — | `.pruefer/config.yaml` | Path to the YAML config file itself |
+
+Draft PRs are always skipped — there is no configuration flag to include them in V1.
+
+## Out of scope for V1
+
+- A TUI (follow-up issue).
+- `APPROVE` / `REQUEST_CHANGES` verdicts.
+- Inline line-level review comments (top-level comment body only).
+- Non-GitHub forges.
+- Removing `.github/workflows/claude-review.yml` from any repo — that stays until Pruefer is proven in practice.

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -97,6 +97,7 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 | `--effort` | `PRUEFER_EFFORT` | `effort` | `medium` | `low`, `medium`, `high`, or `max` |
 | `--concurrency` | `PRUEFER_CONCURRENCY` | `concurrency_cap` | `3` | Max simultaneous `claude` invocations |
 | `--max-diff-bytes` | `PRUEFER_MAX_DIFF_BYTES` | `max_diff_bytes` | `500000` | PRs with a larger diff are skipped, not truncated |
+| `--max-wall-time` | `PRUEFER_MAX_WALL_TIME` | `max_wall_time_seconds` | `0` (no cap) | Seconds; caps a single `claude` review invocation's wall-clock duration on top of the fixed 15-minute inactivity watchdog |
 | `--excluded-authors` | `PRUEFER_EXCLUDED_AUTHORS` | `excluded_authors` | (none) | Comma-separated logins |
 | `--excluded-labels` | `PRUEFER_EXCLUDED_LABELS` | `excluded_labels` | (none) | Skip if any label matches |
 | `--excluded-paths` | `PRUEFER_EXCLUDED_PATHS` | `excluded_paths` | (none) | Glob patterns; skip only if **every** touched path matches |

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -2,7 +2,7 @@
 
 Pruefer is a self-hosted PR review daemon. It watches configured GitHub repositories, reviews open pull requests by invoking the `claude` CLI (subscription-backed, not API-metered), and submits a formal comment-only `pull_request_review`.
 
-It exists to satisfy Fabrik's `wait_for_reviews: true` gate (and any repo that wants a review bot) without depending on a hosted third-party reviewer's quota, and without per-token API billing. See [adrs/074-pruefer-v1-architecture.md](../../adrs/074-pruefer-v1-architecture.md) for the full architectural rationale.
+It exists to satisfy Fabrik's `wait_for_reviews: true` gate (and any repo that wants a review bot) without depending on a hosted third-party reviewer's quota, and without per-token API billing. See [adrs/1113-pruefer-v1-architecture.md](../../adrs/1113-pruefer-v1-architecture.md) for the full architectural rationale.
 
 **V1 scope**: comment-only reviews (`event: COMMENT`). Pruefer never approves a PR and never requests changes — see the ADR for why.
 
@@ -29,7 +29,7 @@ Pruefer authenticates as a GitHub App so its reviews are attributed to a genuine
 2. Fill in:
    - **GitHub App name**: anything unique (e.g. `your-org-pruefer`). This becomes the `<slug>` in the App's `<slug>[bot]` identity.
    - **Homepage URL**: any placeholder URL — not used.
-   - **Webhook**: **uncheck "Active"**. Pruefer polls; it does not receive webhooks (see ADR-074 for why this doesn't conflict with ADR-032's webhook-delivery ruling).
+   - **Webhook**: **uncheck "Active"**. Pruefer polls; it does not receive webhooks (see ADR-1113 for why this doesn't conflict with ADR-032's webhook-delivery ruling).
 3. **Repository permissions**, minimum required:
    - **Pull requests**: Read and write (review submission, reading PR metadata/diff)
    - **Contents**: Read (cloning the PR head commit)

--- a/cmd/pruefer/main.go
+++ b/cmd/pruefer/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/handarbeit/fabrik/pruefer"
+)
+
+func main() {
+	if err := pruefer.Execute(); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/github/app.go
+++ b/github/app.go
@@ -22,7 +22,7 @@ const appHTTPTimeout = 30 * time.Second
 
 // appHTTPClient is package-level so tests can point it at an httptest server
 // without needing a constructed *Client (these are free functions — see
-// ADR-073's rationale for why App-auth bootstrap does not live on *Client).
+// ADR-074's rationale for why App-auth bootstrap does not live on *Client).
 var appHTTPClient = &http.Client{Timeout: appHTTPTimeout}
 
 // jwtClockSkew is subtracted from "issued at" to tolerate minor clock drift
@@ -145,7 +145,7 @@ func appRequest(method, baseURL, path, jwt string, result interface{}) error {
 // authenticated by jwt via GET /app/installations. Used for dynamic
 // installation discovery: Pruefer watches whatever repos the App is
 // installed on, so adding a repo requires only a GitHub-side installation
-// change, not a Pruefer config or code change (see ADR-073).
+// change, not a Pruefer config or code change (see ADR-074).
 func FetchAppInstallations(baseURL, jwt string) ([]AppInstallation, error) {
 	var raw []struct {
 		ID      int64 `json:"id"`

--- a/github/app.go
+++ b/github/app.go
@@ -22,7 +22,7 @@ const appHTTPTimeout = 30 * time.Second
 
 // appHTTPClient is package-level so tests can point it at an httptest server
 // without needing a constructed *Client (these are free functions — see
-// ADR-074's rationale for why App-auth bootstrap does not live on *Client).
+// ADR-1113's rationale for why App-auth bootstrap does not live on *Client).
 var appHTTPClient = &http.Client{Timeout: appHTTPTimeout}
 
 // jwtClockSkew is subtracted from "issued at" to tolerate minor clock drift
@@ -110,8 +110,13 @@ type AppInstallation struct {
 
 // appRequest performs a JWT-authenticated GitHub App API request (installation
 // discovery, token minting, or self-identity lookup) and decodes the JSON
-// response into result. baseURL allows tests to target an httptest server.
+// response into result. baseURL allows tests to target an httptest server;
+// an empty baseURL (the production case) falls back to defaultBaseURL, the
+// same convention github.Client uses.
 func appRequest(method, baseURL, path, jwt string, result interface{}) error {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
 	req, err := http.NewRequest(method, baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
@@ -145,7 +150,7 @@ func appRequest(method, baseURL, path, jwt string, result interface{}) error {
 // authenticated by jwt via GET /app/installations. Used for dynamic
 // installation discovery: Pruefer watches whatever repos the App is
 // installed on, so adding a repo requires only a GitHub-side installation
-// change, not a Pruefer config or code change (see ADR-074).
+// change, not a Pruefer config or code change (see ADR-1113).
 func FetchAppInstallations(baseURL, jwt string) ([]AppInstallation, error) {
 	var raw []struct {
 		ID      int64 `json:"id"`

--- a/github/app.go
+++ b/github/app.go
@@ -1,0 +1,199 @@
+package github
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// appHTTPTimeout bounds every GitHub App auth-bootstrap HTTP call (JWT-based
+// installation discovery and token minting). These are small, infrequent
+// calls — the same 30s budget used elsewhere in this package is generous.
+const appHTTPTimeout = 30 * time.Second
+
+// appHTTPClient is package-level so tests can point it at an httptest server
+// without needing a constructed *Client (these are free functions — see
+// ADR-073's rationale for why App-auth bootstrap does not live on *Client).
+var appHTTPClient = &http.Client{Timeout: appHTTPTimeout}
+
+// jwtClockSkew is subtracted from "issued at" to tolerate minor clock drift
+// between this host and GitHub's servers, per GitHub's own App-auth guidance.
+const jwtClockSkew = 60 * time.Second
+
+// jwtValidity is how long the minted JWT is valid for. GitHub caps this at 10
+// minutes; the JWT is only used to mint an installation token, so a short
+// lifetime is sufficient and safer.
+const jwtValidity = 9 * time.Minute
+
+// ParseAppPrivateKey parses a PEM-encoded RSA private key as used by a GitHub
+// App (downloaded from the App's settings page). Both PKCS#1 ("BEGIN RSA
+// PRIVATE KEY") and PKCS#8 ("BEGIN PRIVATE KEY") encodings are accepted,
+// since GitHub's own download and common conversions (e.g. via openssl)
+// produce either depending on tooling.
+func ParseAppPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in private key")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key (tried PKCS1 and PKCS8): %w", err)
+	}
+	rsaKey, ok := keyAny.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not an RSA key (got %T)", keyAny)
+	}
+	return rsaKey, nil
+}
+
+// base64URLEncode encodes data using unpadded base64url, as required by the
+// JWT spec (RFC 7519).
+func base64URLEncode(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+// BuildAppJWT constructs and signs a short-lived (9 minute) RS256 JWT
+// asserting the given GitHub App ID, per GitHub's App-authentication flow
+// (https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app).
+// This JWT authenticates as the App itself — it is exchanged for a
+// per-installation access token via MintInstallationToken, never used
+// directly against ordinary REST/GraphQL endpoints.
+//
+// Hand-rolled rather than via a JWT library: GitHub's App-auth flow needs
+// exactly one fixed-shape token (header.payload signed with RS256), which
+// stdlib crypto/rsa + encoding/json + encoding/base64 covers directly,
+// consistent with this module's "minimize external dependencies" convention.
+func BuildAppJWT(appID int64, privateKey *rsa.PrivateKey) (string, error) {
+	now := time.Now()
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	claims := map[string]int64{
+		"iat": now.Add(-jwtClockSkew).Unix(),
+		"exp": now.Add(jwtValidity).Unix(),
+		"iss": appID,
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("marshaling JWT header: %w", err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshaling JWT claims: %w", err)
+	}
+	signingInput := base64URLEncode(headerJSON) + "." + base64URLEncode(claimsJSON)
+
+	hashed := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("signing JWT: %w", err)
+	}
+	return signingInput + "." + base64URLEncode(sig), nil
+}
+
+// AppInstallation represents a single installation of a GitHub App, as
+// returned by GET /app/installations.
+type AppInstallation struct {
+	ID      int64  // Installation ID, needed to mint an installation access token.
+	Account string // Login of the org/user the App is installed on.
+}
+
+// appRequest performs a JWT-authenticated GitHub App API request (installation
+// discovery, token minting, or self-identity lookup) and decodes the JSON
+// response into result. baseURL allows tests to target an httptest server.
+func appRequest(method, baseURL, path, jwt string, result interface{}) error {
+	req, err := http.NewRequest(method, baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := appHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("GitHub App API returned %d: %s%s", resp.StatusCode, string(body), authErrorHint(resp.StatusCode))
+	}
+	if result == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+// FetchAppInstallations lists every installation of the GitHub App
+// authenticated by jwt via GET /app/installations. Used for dynamic
+// installation discovery: Pruefer watches whatever repos the App is
+// installed on, so adding a repo requires only a GitHub-side installation
+// change, not a Pruefer config or code change (see ADR-073).
+func FetchAppInstallations(baseURL, jwt string) ([]AppInstallation, error) {
+	var raw []struct {
+		ID      int64 `json:"id"`
+		Account struct {
+			Login string `json:"login"`
+		} `json:"account"`
+	}
+	if err := appRequest("GET", baseURL, "/app/installations", jwt, &raw); err != nil {
+		return nil, fmt.Errorf("fetching app installations: %w", err)
+	}
+	out := make([]AppInstallation, len(raw))
+	for i, inst := range raw {
+		out[i] = AppInstallation{ID: inst.ID, Account: inst.Account.Login}
+	}
+	return out, nil
+}
+
+// MintInstallationToken exchanges a JWT for a short-lived (~1 hour)
+// installation access token via POST
+// /app/installations/{installation_id}/access_tokens. The returned token is
+// used as an ordinary Bearer token for REST/GraphQL calls scoped to that
+// installation's repos and permissions; callers must refresh it before
+// expiresAt (see Pruefer's auth.go refresh loop).
+func MintInstallationToken(baseURL, jwt string, installationID int64) (token string, expiresAt time.Time, err error) {
+	var result struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	path := fmt.Sprintf("/app/installations/%d/access_tokens", installationID)
+	if err := appRequest("POST", baseURL, path, jwt, &result); err != nil {
+		return "", time.Time{}, fmt.Errorf("minting installation token for installation %d: %w", installationID, err)
+	}
+	return result.Token, result.ExpiresAt, nil
+}
+
+// FetchAppSlug returns the App's own slug (e.g. "my-reviewer") via GET /app,
+// JWT-authenticated. The App's bot identity login on issues/PRs/reviews is
+// always "<slug>[bot]" — used by Pruefer to recognize its own comments and
+// reviews (self-review skip, already-reviewed-at-SHA state).
+func FetchAppSlug(baseURL, jwt string) (string, error) {
+	var result struct {
+		Slug string `json:"slug"`
+	}
+	if err := appRequest("GET", baseURL, "/app", jwt, &result); err != nil {
+		return "", fmt.Errorf("fetching app identity: %w", err)
+	}
+	if result.Slug == "" {
+		return "", fmt.Errorf("github: /app response missing slug")
+	}
+	return result.Slug, nil
+}

--- a/github/app_test.go
+++ b/github/app_test.go
@@ -7,12 +7,19 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 )
+
+// roundTripFunc adapts a function to http.RoundTripper, letting tests
+// intercept appHTTPClient's requests without going over the network.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 // testAppPrivateKey generates a small (1024-bit — fast, test-only) RSA key
 // and returns it both as *rsa.PrivateKey and PKCS1-PEM-encoded bytes.
@@ -194,6 +201,36 @@ func TestFetchAppSlug_MissingSlug(t *testing.T) {
 
 	if _, err := FetchAppSlug(srv.URL, "test-jwt"); err == nil {
 		t.Fatal("expected error when slug is missing, got nil")
+	}
+}
+
+// TestAppRequest_EmptyBaseURLFallsBackToDefaultBaseURL guards the production
+// code path specifically: every other Bootstrap/appRequest test in this file
+// supplies an explicit httptest URL, so none of them would have caught
+// appRequest building a request against a bare relative path (and failing
+// with "unsupported protocol scheme \"\"") when baseURL == "" — which is
+// exactly what every real (non-test) caller passes. This intercepts
+// appHTTPClient's transport instead of using httptest, so the assertion is
+// "the request targets defaultBaseURL" without actually hitting the network.
+func TestAppRequest_EmptyBaseURLFallsBackToDefaultBaseURL(t *testing.T) {
+	var capturedURL string
+	origTransport := appHTTPClient.Transport
+	appHTTPClient.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedURL = req.URL.String()
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	defer func() { appHTTPClient.Transport = origTransport }()
+
+	if _, err := FetchAppInstallations("", "test-jwt"); err != nil {
+		t.Fatalf("FetchAppInstallations: %v", err)
+	}
+	want := defaultBaseURL + "/app/installations"
+	if capturedURL != want {
+		t.Errorf("request URL = %q, want %q (empty baseURL must fall back to defaultBaseURL)", capturedURL, want)
 	}
 }
 

--- a/github/app_test.go
+++ b/github/app_test.go
@@ -1,0 +1,210 @@
+package github
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testAppPrivateKey generates a small (1024-bit — fast, test-only) RSA key
+// and returns it both as *rsa.PrivateKey and PKCS1-PEM-encoded bytes.
+func testAppPrivateKey(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generating test RSA key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return key, pemBytes
+}
+
+func TestParseAppPrivateKey_PKCS1(t *testing.T) {
+	key, pemBytes := testAppPrivateKey(t)
+	parsed, err := ParseAppPrivateKey(pemBytes)
+	if err != nil {
+		t.Fatalf("ParseAppPrivateKey: %v", err)
+	}
+	if parsed.N.Cmp(key.N) != 0 {
+		t.Error("parsed key modulus does not match original")
+	}
+}
+
+func TestParseAppPrivateKey_PKCS8(t *testing.T) {
+	key, _ := testAppPrivateKey(t)
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshaling PKCS8: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
+
+	parsed, err := ParseAppPrivateKey(pemBytes)
+	if err != nil {
+		t.Fatalf("ParseAppPrivateKey (PKCS8): %v", err)
+	}
+	if parsed.N.Cmp(key.N) != 0 {
+		t.Error("parsed key modulus does not match original")
+	}
+}
+
+func TestParseAppPrivateKey_InvalidPEM(t *testing.T) {
+	if _, err := ParseAppPrivateKey([]byte("not a pem block")); err == nil {
+		t.Fatal("expected error for invalid PEM, got nil")
+	}
+}
+
+func TestBuildAppJWT_WellFormed(t *testing.T) {
+	key, _ := testAppPrivateKey(t)
+	tok, err := BuildAppJWT(12345, key)
+	if err != nil {
+		t.Fatalf("BuildAppJWT: %v", err)
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT segments, got %d: %q", len(parts), tok)
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decoding header: %v", err)
+	}
+	var header struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("unmarshaling header: %v", err)
+	}
+	if header.Alg != "RS256" || header.Typ != "JWT" {
+		t.Errorf("header = %+v, want alg=RS256 typ=JWT", header)
+	}
+
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decoding claims: %v", err)
+	}
+	var claims struct {
+		Iat int64 `json:"iat"`
+		Exp int64 `json:"exp"`
+		Iss int64 `json:"iss"`
+	}
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		t.Fatalf("unmarshaling claims: %v", err)
+	}
+	if claims.Iss != 12345 {
+		t.Errorf("iss = %d, want 12345", claims.Iss)
+	}
+	if claims.Exp <= claims.Iat {
+		t.Errorf("exp (%d) must be after iat (%d)", claims.Exp, claims.Iat)
+	}
+	now := time.Now().Unix()
+	if claims.Iat > now || claims.Iat < now-120 {
+		t.Errorf("iat = %d, want within [now-120, now] (now=%d)", claims.Iat, now)
+	}
+}
+
+func TestFetchAppInstallations(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-jwt" {
+			t.Errorf("Authorization = %q, want Bearer test-jwt", got)
+		}
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 111, "account": map[string]string{"login": "handarbeit"}},
+			{"id": 222, "account": map[string]string{"login": "someorg"}},
+		})
+	}))
+	defer srv.Close()
+
+	installs, err := FetchAppInstallations(srv.URL, "test-jwt")
+	if err != nil {
+		t.Fatalf("FetchAppInstallations: %v", err)
+	}
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installations, got %d", len(installs))
+	}
+	if installs[0].ID != 111 || installs[0].Account != "handarbeit" {
+		t.Errorf("installs[0] = %+v", installs[0])
+	}
+}
+
+func TestMintInstallationToken(t *testing.T) {
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/app/installations/999/access_tokens" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      "ghs_minted",
+			"expires_at": expiry.Format(time.RFC3339),
+		})
+	}))
+	defer srv.Close()
+
+	token, expiresAt, err := MintInstallationToken(srv.URL, "test-jwt", 999)
+	if err != nil {
+		t.Fatalf("MintInstallationToken: %v", err)
+	}
+	if token != "ghs_minted" {
+		t.Errorf("token = %q", token)
+	}
+	if !expiresAt.Equal(expiry) {
+		t.Errorf("expiresAt = %v, want %v", expiresAt, expiry)
+	}
+}
+
+func TestFetchAppSlug(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"slug": "pruefer-bot", "id": 42})
+	}))
+	defer srv.Close()
+
+	slug, err := FetchAppSlug(srv.URL, "test-jwt")
+	if err != nil {
+		t.Fatalf("FetchAppSlug: %v", err)
+	}
+	if slug != "pruefer-bot" {
+		t.Errorf("slug = %q, want pruefer-bot", slug)
+	}
+}
+
+func TestFetchAppSlug_MissingSlug(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 42})
+	}))
+	defer srv.Close()
+
+	if _, err := FetchAppSlug(srv.URL, "test-jwt"); err == nil {
+		t.Fatal("expected error when slug is missing, got nil")
+	}
+}
+
+func TestAppRequest_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`{"message":"Forbidden"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := FetchAppInstallations(srv.URL, "test-jwt"); err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+}

--- a/github/client.go
+++ b/github/client.go
@@ -60,7 +60,7 @@ func (c *Client) MergeStrategy() string {
 // SetToken replaces the client's bearer token. Safe to call concurrently
 // with in-flight requests. Needed by Pruefer's GitHub App installation-token
 // refresh loop, where the token expires roughly hourly and must be swapped
-// in place without reconstructing the client (see ADR-073).
+// in place without reconstructing the client (see ADR-074).
 func (c *Client) SetToken(token string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/github/client.go
+++ b/github/client.go
@@ -60,7 +60,7 @@ func (c *Client) MergeStrategy() string {
 // SetToken replaces the client's bearer token. Safe to call concurrently
 // with in-flight requests. Needed by Pruefer's GitHub App installation-token
 // refresh loop, where the token expires roughly hourly and must be swapped
-// in place without reconstructing the client (see ADR-074).
+// in place without reconstructing the client (see ADR-1113).
 func (c *Client) SetToken(token string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/github/client.go
+++ b/github/client.go
@@ -57,6 +57,24 @@ func (c *Client) MergeStrategy() string {
 	return c.mergeStrategy
 }
 
+// SetToken replaces the client's bearer token. Safe to call concurrently
+// with in-flight requests. Needed by Pruefer's GitHub App installation-token
+// refresh loop, where the token expires roughly hourly and must be swapped
+// in place without reconstructing the client (see ADR-073).
+func (c *Client) SetToken(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.token = token
+}
+
+// Token returns the client's current bearer token, safe for concurrent use
+// alongside SetToken.
+func (c *Client) Token() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.token
+}
+
 func NewClient(token string) *Client {
 	return &Client{
 		token:   token,
@@ -120,7 +138,7 @@ func (c *Client) graphqlRequest(query string, variables map[string]interface{}, 
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Authorization", "Bearer "+c.Token())
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)

--- a/github/comments.go
+++ b/github/comments.go
@@ -1,6 +1,10 @@
 package github
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 // AddComment posts a comment on an issue and returns the comment's database ID.
 func (c *Client) AddComment(owner, repo string, issueNumber int, body string) (int, error) {
@@ -98,6 +102,64 @@ func (c *Client) UpdateIssueBody(owner, repo string, issueNumber int, body strin
 		return fmt.Errorf("updating body of %s/%s#%d: %w", owner, repo, issueNumber, err)
 	}
 	return nil
+}
+
+// FetchIssueComments fetches the comments on an issue (or PR, since PRs are
+// issues on the REST API) via GET /issues/{n}/comments, including each
+// comment's reaction summary. Used by Pruefer to detect on-demand
+// "/pruefer review" comment commands and apply 👀/🚀 reaction idempotency.
+// Returns nil, nil on 404.
+func (c *Client) FetchIssueComments(owner, repo string, issueNumber int) ([]Comment, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100", c.baseURL, owner, repo, issueNumber)
+	var raw []struct {
+		ID        int       `json:"id"`
+		Body      string    `json:"body"`
+		CreatedAt time.Time `json:"created_at"`
+		User      struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Reactions struct {
+			PlusOne  int `json:"+1"`
+			MinusOne int `json:"-1"`
+			Laugh    int `json:"laugh"`
+			Hooray   int `json:"hooray"`
+			Confused int `json:"confused"`
+			Heart    int `json:"heart"`
+			Rocket   int `json:"rocket"`
+			Eyes     int `json:"eyes"`
+		} `json:"reactions"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fetching comments for %s/%s#%d: %w", owner, repo, issueNumber, err)
+	}
+	out := make([]Comment, len(raw))
+	for i, rc := range raw {
+		var reactions []ReactionGroup
+		add := func(content string, count int) {
+			if count > 0 {
+				reactions = append(reactions, ReactionGroup{Content: content, Count: count})
+			}
+		}
+		add("THUMBS_UP", rc.Reactions.PlusOne)
+		add("THUMBS_DOWN", rc.Reactions.MinusOne)
+		add("LAUGH", rc.Reactions.Laugh)
+		add("HOORAY", rc.Reactions.Hooray)
+		add("CONFUSED", rc.Reactions.Confused)
+		add("HEART", rc.Reactions.Heart)
+		add("ROCKET", rc.Reactions.Rocket)
+		add("EYES", rc.Reactions.Eyes)
+		out[i] = Comment{
+			DatabaseID: rc.ID,
+			Author:     rc.User.Login,
+			Body:       rc.Body,
+			CreatedAt:  rc.CreatedAt,
+			Reactions:  reactions,
+		}
+	}
+	return out, nil
 }
 
 // GetIssueBody fetches the body of an issue (or PR, since PRs are issues on the REST API).

--- a/github/prs.go
+++ b/github/prs.go
@@ -64,8 +64,9 @@ func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, e
 		User *struct {
 			Login string `json:"login"`
 		} `json:"user"`
-		State string `json:"state"`
-		Body  string `json:"body"`
+		State    string `json:"state"`
+		Body     string `json:"body"`
+		CommitID string `json:"commit_id"`
 	}
 	if err := c.restGetJSON(apiURL, &raw); err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -87,6 +88,7 @@ func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, e
 			State:      r.State,
 			Body:       r.Body,
 			DatabaseID: r.ID,
+			CommitID:   r.CommitID,
 		}
 	}
 	out := make([]PRReview, 0, len(order))
@@ -187,6 +189,13 @@ type PRDetails struct {
 	// Nil when not in queue or populated via REST. Pointer because GitHub returns
 	// null after dequeueing and Go's json decoder maps null to nil only on pointers.
 	MergeQueueEntry *MergeQueueEntry
+
+	// Author is the GitHub login of the PR's author. Populated by ListPRs and
+	// ListOpenPRs; other constructors may leave it empty.
+	Author string
+	// Labels is the list of label names applied to the PR. Populated by ListPRs
+	// and ListOpenPRs; other constructors may leave it empty.
+	Labels []string
 }
 
 // FetchPRMergeableFields fetches both the mergeable flag and mergeable_state for
@@ -444,7 +453,11 @@ func (c *Client) ListPRs(owner, repo string) ([]PRDetails, error) {
 		MergedAt string `json:"merged_at"` // non-null when merged; list endpoint omits the boolean "merged" field
 		Draft    bool   `json:"draft"`
 		Body     string `json:"body"`
-		Head     struct {
+		User     struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Labels []rawLabel `json:"labels"`
+		Head   struct {
 			SHA string `json:"sha"`
 			Ref string `json:"ref"`
 		} `json:"head"`
@@ -463,9 +476,106 @@ func (c *Client) ListPRs(owner, repo string) ([]PRDetails, error) {
 			HeadSHA:     pr.Head.SHA,
 			HeadRefName: pr.Head.Ref,
 			Body:        pr.Body,
+			Author:      pr.User.Login,
+			Labels:      labelNames(pr.Labels),
 		}
 	}
 	return out, nil
+}
+
+// rawLabel is the shared REST label shape ({"name": "..."}) used by both
+// ListPRs and ListOpenPRs.
+type rawLabel struct {
+	Name string `json:"name"`
+}
+
+// labelNames extracts label name strings from a slice of rawLabel.
+func labelNames(labels []rawLabel) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, len(labels))
+	for i, l := range labels {
+		out[i] = l.Name
+	}
+	return out
+}
+
+// ListOpenPRs returns all open pull requests for a repository (draft and
+// non-draft), including author and label metadata needed for Pruefer's PR
+// selection logic. Capped at 100 results (GitHub's max per_page); a warning
+// is logged (not silently truncated) when exactly 100 are returned, since
+// more open PRs may exist.
+func (c *Client) ListOpenPRs(owner, repo string) ([]PRDetails, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls?state=open&per_page=100", c.baseURL, owner, repo)
+	var raw []struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		State  string `json:"state"`
+		Draft  bool   `json:"draft"`
+		Body   string `json:"body"`
+		User   struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Labels []rawLabel `json:"labels"`
+		Head   struct {
+			SHA string `json:"sha"`
+			Ref string `json:"ref"`
+		} `json:"head"`
+	}
+	if err := c.restGetJSON(apiURL, &raw); err != nil {
+		return nil, fmt.Errorf("listing open PRs for %s/%s: %w", owner, repo, err)
+	}
+	if len(raw) == 100 {
+		logf(0, "prs", "ListOpenPRs %s/%s: received exactly 100 results — more open PRs may exist (pagination not implemented)\n", owner, repo)
+	}
+	out := make([]PRDetails, len(raw))
+	for i, pr := range raw {
+		out[i] = PRDetails{
+			Number:      pr.Number,
+			Title:       pr.Title,
+			State:       pr.State,
+			Draft:       pr.Draft,
+			Body:        pr.Body,
+			HeadSHA:     pr.Head.SHA,
+			HeadRefName: pr.Head.Ref,
+			Author:      pr.User.Login,
+			Labels:      labelNames(pr.Labels),
+		}
+	}
+	return out, nil
+}
+
+// FetchPRDiff fetches the raw unified diff for a pull request via GitHub's
+// diff media type, avoiding a local clone just to measure or inspect diff
+// size. Returns the diff as plain text.
+func (c *Client) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.baseURL, owner, repo, prNumber)
+	_, respBody, err := c.doWithAccept("GET", apiURL, "application/vnd.github.v3.diff", nil)
+	if err != nil {
+		return "", fmt.Errorf("fetching diff for PR #%d: %w", prNumber, err)
+	}
+	return string(respBody), nil
+}
+
+// SubmitPRReview submits a formal pull_request_review comment (event=COMMENT)
+// against the given commit SHA. The event type is hardcoded and never
+// caller-controlled — Pruefer V1 never submits APPROVE or REQUEST_CHANGES
+// verdicts (see ADR-073). Returns the numeric review ID.
+func (c *Client) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.baseURL, owner, repo, prNumber)
+	reqBody := map[string]interface{}{
+		"commit_id": commitSHA,
+		"body":      body,
+		"event":     "COMMENT",
+	}
+	var result struct {
+		ID int `json:"id"`
+	}
+	if err := c.restPostWithResponse(apiURL, reqBody, &result); err != nil {
+		return 0, fmt.Errorf("submitting review on PR #%d: %w", prNumber, err)
+	}
+	return result.ID, nil
 }
 
 // prNodeID fetches the GraphQL node ID of a pull request by its REST number.

--- a/github/prs.go
+++ b/github/prs.go
@@ -561,7 +561,7 @@ func (c *Client) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
 // SubmitPRReview submits a formal pull_request_review comment (event=COMMENT)
 // against the given commit SHA. The event type is hardcoded and never
 // caller-controlled — Pruefer V1 never submits APPROVE or REQUEST_CHANGES
-// verdicts (see ADR-073). Returns the numeric review ID.
+// verdicts (see ADR-074). Returns the numeric review ID.
 func (c *Client) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.baseURL, owner, repo, prNumber)
 	reqBody := map[string]interface{}{

--- a/github/prs.go
+++ b/github/prs.go
@@ -561,7 +561,7 @@ func (c *Client) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
 // SubmitPRReview submits a formal pull_request_review comment (event=COMMENT)
 // against the given commit SHA. The event type is hardcoded and never
 // caller-controlled — Pruefer V1 never submits APPROVE or REQUEST_CHANGES
-// verdicts (see ADR-074). Returns the numeric review ID.
+// verdicts (see ADR-1113). Returns the numeric review ID.
 func (c *Client) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.baseURL, owner, repo, prNumber)
 	reqBody := map[string]interface{}{

--- a/github/prs.go
+++ b/github/prs.go
@@ -196,6 +196,9 @@ type PRDetails struct {
 	// Labels is the list of label names applied to the PR. Populated by ListPRs
 	// and ListOpenPRs; other constructors may leave it empty.
 	Labels []string
+	// BaseRef is the PR's base branch name (e.g. "main"). Populated by
+	// ListOpenPRs; other constructors may leave it empty.
+	BaseRef string
 }
 
 // FetchPRMergeableFields fetches both the mergeable flag and mergeable_state for
@@ -522,6 +525,9 @@ func (c *Client) ListOpenPRs(owner, repo string) ([]PRDetails, error) {
 			SHA string `json:"sha"`
 			Ref string `json:"ref"`
 		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
 	}
 	if err := c.restGetJSON(apiURL, &raw); err != nil {
 		return nil, fmt.Errorf("listing open PRs for %s/%s: %w", owner, repo, err)
@@ -541,6 +547,7 @@ func (c *Client) ListOpenPRs(owner, repo string) ([]PRDetails, error) {
 			HeadRefName: pr.Head.Ref,
 			Author:      pr.User.Login,
 			Labels:      labelNames(pr.Labels),
+			BaseRef:     pr.Base.Ref,
 		}
 	}
 	return out, nil

--- a/github/pruefer_extensions_test.go
+++ b/github/pruefer_extensions_test.go
@@ -1,0 +1,310 @@
+package github
+
+// Tests for the github/ extensions added for Pruefer (issue #1113): token
+// refresh, diff fetch, review submission, open-PR listing, and issue-comment
+// fetch. Named separately from the feature files they cover since they group
+// by "what Pruefer needed", not by pre-existing file boundaries.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestSetToken_UpdatesSubsequentRequests(t *testing.T) {
+	var mu sync.Mutex
+	var seenTokens []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenTokens = append(seenTokens, r.Header.Get("Authorization"))
+		mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]interface{}{"allow_auto_merge": true})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token-v1", srv.URL)
+	if _, err := c.FetchAllowAutoMerge("owner", "repo"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	c.SetToken("token-v2")
+	if _, err := c.FetchAllowAutoMerge("owner", "repo"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seenTokens) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(seenTokens))
+	}
+	if seenTokens[0] != "Bearer token-v1" {
+		t.Errorf("first request token = %q", seenTokens[0])
+	}
+	if seenTokens[1] != "Bearer token-v2" {
+		t.Errorf("second request token = %q, want refreshed token", seenTokens[1])
+	}
+}
+
+func TestToken_ReturnsCurrentValue(t *testing.T) {
+	c := NewClient("initial")
+	if got := c.Token(); got != "initial" {
+		t.Errorf("Token() = %q, want initial", got)
+	}
+	c.SetToken("updated")
+	if got := c.Token(); got != "updated" {
+		t.Errorf("Token() = %q, want updated", got)
+	}
+}
+
+func TestFetchPRDiff(t *testing.T) {
+	const diffText = "diff --git a/foo.go b/foo.go\n+added line\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/pulls/42" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github.v3.diff" {
+			t.Errorf("Accept header = %q, want application/vnd.github.v3.diff", got)
+		}
+		w.Write([]byte(diffText))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	diff, err := c.FetchPRDiff("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("FetchPRDiff: %v", err)
+	}
+	if diff != diffText {
+		t.Errorf("diff = %q, want %q", diff, diffText)
+	}
+}
+
+func TestSubmitPRReview_HardcodesCommentEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/pulls/42/reviews" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if body["event"] != "COMMENT" {
+			t.Errorf("event = %v, want COMMENT (must never be caller-controlled)", body["event"])
+		}
+		if body["commit_id"] != "abc123" {
+			t.Errorf("commit_id = %v, want abc123", body["commit_id"])
+		}
+		if body["body"] != "review text" {
+			t.Errorf("body = %v, want %q", body["body"], "review text")
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 555})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	id, err := c.SubmitPRReview("owner", "repo", 42, "abc123", "review text")
+	if err != nil {
+		t.Fatalf("SubmitPRReview: %v", err)
+	}
+	if id != 555 {
+		t.Errorf("id = %d, want 555", id)
+	}
+}
+
+// SubmitPRReview's signature has no event parameter at all — verified at
+// compile time by the call above passing exactly (owner, repo, prNumber,
+// commitSHA, body). This test additionally guards the wire format so a
+// future refactor can't reintroduce a caller-supplied event without failing
+// TestSubmitPRReview_HardcodesCommentEvent above.
+
+func TestListOpenPRs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/pulls" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("state"); got != "open" {
+			t.Errorf("state query param = %q, want open", got)
+		}
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"number": 1, "title": "Fix bug", "state": "open", "draft": false,
+				"body": "body text",
+				"user": map[string]string{"login": "alice"},
+				"labels": []map[string]string{
+					{"name": "bug"}, {"name": "priority:high"},
+				},
+				"head": map[string]string{"sha": "sha1", "ref": "fix-branch"},
+			},
+			{
+				"number": 2, "title": "Draft work", "state": "open", "draft": true,
+				"user": map[string]string{"login": "dependabot[bot]"},
+				"head": map[string]string{"sha": "sha2", "ref": "draft-branch"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	prs, err := c.ListOpenPRs("owner", "repo")
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(prs))
+	}
+	if prs[0].Author != "alice" {
+		t.Errorf("prs[0].Author = %q, want alice", prs[0].Author)
+	}
+	if len(prs[0].Labels) != 2 || prs[0].Labels[0] != "bug" || prs[0].Labels[1] != "priority:high" {
+		t.Errorf("prs[0].Labels = %v", prs[0].Labels)
+	}
+	if !prs[1].Draft {
+		t.Error("prs[1].Draft = false, want true")
+	}
+	if prs[1].Author != "dependabot[bot]" {
+		t.Errorf("prs[1].Author = %q", prs[1].Author)
+	}
+}
+
+func TestListOpenPRs_WarnsAtCap(t *testing.T) {
+	var warned bool
+	Logf = func(issueNumber int, tag, format string, args ...any) {
+		if tag == "prs" {
+			warned = true
+		}
+	}
+	defer func() { Logf = nil }()
+
+	entries := make([]map[string]interface{}, 100)
+	for i := range entries {
+		entries[i] = map[string]interface{}{
+			"number": i + 1, "state": "open",
+			"user": map[string]string{"login": "someone"},
+			"head": map[string]string{"sha": "sha", "ref": "ref"},
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(entries)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	prs, err := c.ListOpenPRs("owner", "repo")
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(prs) != 100 {
+		t.Fatalf("expected 100 PRs, got %d", len(prs))
+	}
+	if !warned {
+		t.Error("expected a warning to be logged when exactly 100 PRs are returned")
+	}
+}
+
+func TestListPRs_PopulatesAuthorAndLabels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"number": 7, "state": "open",
+				"user":   map[string]string{"login": "bob"},
+				"labels": []map[string]string{{"name": "needs-review"}},
+				"head":   map[string]string{"sha": "sha7", "ref": "branch7"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	prs, err := c.ListPRs("owner", "repo")
+	if err != nil {
+		t.Fatalf("ListPRs: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR, got %d", len(prs))
+	}
+	if prs[0].Author != "bob" {
+		t.Errorf("Author = %q, want bob", prs[0].Author)
+	}
+	if len(prs[0].Labels) != 1 || prs[0].Labels[0] != "needs-review" {
+		t.Errorf("Labels = %v", prs[0].Labels)
+	}
+}
+
+func TestFetchPRReviews_PopulatesCommitID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 1, "user": map[string]string{"login": "pruefer-bot[bot]"}, "state": "COMMENTED", "commit_id": "deadbeef"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	reviews, err := c.FetchPRReviews("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 review, got %d", len(reviews))
+	}
+	if reviews[0].CommitID != "deadbeef" {
+		t.Errorf("CommitID = %q, want deadbeef", reviews[0].CommitID)
+	}
+}
+
+func TestFetchIssueComments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/issues/9/comments" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"id": 100, "body": "/pruefer review", "created_at": "2026-01-01T00:00:00Z",
+				"user":      map[string]string{"login": "maintainer"},
+				"reactions": map[string]interface{}{"+1": 0, "eyes": 1, "rocket": 0},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	comments, err := c.FetchIssueComments("owner", "repo", 9)
+	if err != nil {
+		t.Fatalf("FetchIssueComments: %v", err)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].Body != "/pruefer review" {
+		t.Errorf("Body = %q", comments[0].Body)
+	}
+	if comments[0].Author != "maintainer" {
+		t.Errorf("Author = %q", comments[0].Author)
+	}
+	if !comments[0].HasReaction("EYES") {
+		t.Error("expected HasReaction(EYES) = true")
+	}
+	if comments[0].HasReaction("ROCKET") {
+		t.Error("expected HasReaction(ROCKET) = false (count 0)")
+	}
+}
+
+func TestFetchIssueComments_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	comments, err := c.FetchIssueComments("owner", "repo", 999)
+	if err != nil {
+		t.Fatalf("expected nil error on 404, got %v", err)
+	}
+	if comments != nil {
+		t.Errorf("expected nil comments on 404, got %+v", comments)
+	}
+}

--- a/github/pruefer_extensions_test.go
+++ b/github/pruefer_extensions_test.go
@@ -138,6 +138,7 @@ func TestListOpenPRs(t *testing.T) {
 					{"name": "bug"}, {"name": "priority:high"},
 				},
 				"head": map[string]string{"sha": "sha1", "ref": "fix-branch"},
+				"base": map[string]string{"ref": "main"},
 			},
 			{
 				"number": 2, "title": "Draft work", "state": "open", "draft": true,
@@ -158,6 +159,9 @@ func TestListOpenPRs(t *testing.T) {
 	}
 	if prs[0].Author != "alice" {
 		t.Errorf("prs[0].Author = %q, want alice", prs[0].Author)
+	}
+	if prs[0].BaseRef != "main" {
+		t.Errorf("prs[0].BaseRef = %q, want main", prs[0].BaseRef)
 	}
 	if len(prs[0].Labels) != 2 || prs[0].Labels[0] != "bug" || prs[0].Labels[1] != "priority:high" {
 		t.Errorf("prs[0].Labels = %v", prs[0].Labels)

--- a/github/rest.go
+++ b/github/rest.go
@@ -44,14 +44,23 @@ func authErrorHint(statusCode int) string {
 	return ""
 }
 
-// do is the shared REST request core. It marshals body (when non-nil), sets
-// auth/content-type/accept headers, executes the request, records rate-limit
-// stats, and maps 404/405/422 responses to their sentinel errors uniformly
-// across every REST verb. body may be nil for GET/DELETE-without-body calls;
-// Content-Type is only set when body is non-nil, matching what each verb sent
-// before this helper existed. The full response body is always read and
-// returned so typed callers can decode it themselves.
+// do is the shared REST request core, using GitHub's standard JSON media
+// type. See doWithAccept for the full behavior description.
 func (c *Client) do(method, url string, body interface{}) (*http.Response, []byte, error) {
+	return c.doWithAccept(method, url, "application/vnd.github+json", body)
+}
+
+// doWithAccept is the shared REST request core. It marshals body (when
+// non-nil), sets auth/content-type/accept headers, executes the request,
+// records rate-limit stats, and maps 404/405/422 responses to their sentinel
+// errors uniformly across every REST verb. body may be nil for
+// GET/DELETE-without-body calls; Content-Type is only set when body is
+// non-nil, matching what each verb sent before this helper existed. The full
+// response body is always read and returned so typed callers can decode it
+// themselves. accept lets callers request a non-default media type (e.g.
+// GitHub's diff format) while sharing the rest of the request/error-handling
+// pipeline.
+func (c *Client) doWithAccept(method, url, accept string, body interface{}) (*http.Response, []byte, error) {
 	var reader io.Reader
 	if body != nil {
 		jsonBody, err := json.Marshal(body)
@@ -65,11 +74,11 @@ func (c *Client) do(method, url string, body interface{}) (*http.Response, []byt
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Authorization", "Bearer "+c.Token())
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Accept", accept)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/github/types.go
+++ b/github/types.go
@@ -81,6 +81,11 @@ type PRReview struct {
 	State      string // "APPROVED", "CHANGES_REQUESTED", or "COMMENTED"
 	Body       string // Review summary body (may be empty for comment-only reviews)
 	DatabaseID int    // Numeric PR review ID (0 if not fetched or unavailable)
+	// CommitID is the SHA the review was submitted against (GitHub's REST
+	// "commit_id" field). Needed to determine whether a review targets the
+	// PR's current head SHA or a stale one (Pruefer's GitHub-derived
+	// review-state mechanism; see ADR-073).
+	CommitID string
 }
 
 // MergeQueueEntry holds the merge-queue position and state for a pull request.

--- a/github/types.go
+++ b/github/types.go
@@ -84,7 +84,7 @@ type PRReview struct {
 	// CommitID is the SHA the review was submitted against (GitHub's REST
 	// "commit_id" field). Needed to determine whether a review targets the
 	// PR's current head SHA or a stale one (Pruefer's GitHub-derived
-	// review-state mechanism; see ADR-074).
+	// review-state mechanism; see ADR-1113).
 	CommitID string
 }
 

--- a/github/types.go
+++ b/github/types.go
@@ -84,7 +84,7 @@ type PRReview struct {
 	// CommitID is the SHA the review was submitted against (GitHub's REST
 	// "commit_id" field). Needed to determine whether a review targets the
 	// PR's current head SHA or a stale one (Pruefer's GitHub-derived
-	// review-state mechanism; see ADR-073).
+	// review-state mechanism; see ADR-074).
 	CommitID string
 }
 

--- a/pruefer/auth.go
+++ b/pruefer/auth.go
@@ -1,0 +1,163 @@
+package pruefer
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// tokenRefreshMargin is how long before an installation token's actual
+// expiry the refresh loop mints a replacement. Installation tokens are valid
+// ~1h; refreshing 5 minutes early tolerates clock drift and refresh-call
+// latency without ever operating on an expired token. Var (not const) so
+// tests can shrink it to exercise the refresh loop without waiting an hour.
+var tokenRefreshMargin = 5 * time.Minute
+
+// tokenRefreshRetryDelay is how long RunRefreshLoop waits before retrying a
+// failed refresh. Var so tests aren't forced to wait a full minute.
+var tokenRefreshRetryDelay = time.Minute
+
+// Auth holds the bootstrapped GitHub App identity Pruefer needs: the App's
+// own bot login (for self-review skip and GitHub-derived review-state
+// checks) and the machinery to keep the installation token on the wrapped
+// *github.Client fresh for the lifetime of the daemon.
+type Auth struct {
+	AppID          int64
+	InstallationID int64
+	// BotLogin is the App's own identity as it appears as a PR/review
+	// author, e.g. "pruefer-bot[bot]". Always slug + "[bot]" for a GitHub
+	// App — this is what makes the "review identity != PR author" guarantee
+	// structural rather than operator-discipline-dependent (see ADR-073).
+	BotLogin string
+
+	privateKey *rsa.PrivateKey
+	baseURL    string
+	client     *gh.Client
+
+	mu        sync.Mutex
+	expiresAt time.Time
+}
+
+// Bootstrap performs the full GitHub App auth flow: parses the private key,
+// builds a JWT, resolves the App's own bot login, resolves (or validates)
+// the installation to act as, and mints the first installation token onto
+// client. baseURL selects GitHub's API host; pass "" for production or an
+// httptest server URL in tests.
+func Bootstrap(cfg Config, client *gh.Client, baseURL string) (*Auth, error) {
+	keyPEM, err := os.ReadFile(cfg.AppPrivateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading GitHub App private key %s: %w", cfg.AppPrivateKeyPath, err)
+	}
+	privateKey, err := gh.ParseAppPrivateKey(keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parsing GitHub App private key %s: %w", cfg.AppPrivateKeyPath, err)
+	}
+
+	a := &Auth{
+		AppID:          cfg.AppID,
+		InstallationID: cfg.AppInstallationID,
+		privateKey:     privateKey,
+		baseURL:        baseURL,
+		client:         client,
+	}
+
+	jwt, err := gh.BuildAppJWT(a.AppID, a.privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("building app JWT: %w", err)
+	}
+
+	slug, err := gh.FetchAppSlug(baseURL, jwt)
+	if err != nil {
+		return nil, fmt.Errorf("resolving app identity: %w", err)
+	}
+	a.BotLogin = slug + "[bot]"
+
+	if a.InstallationID == 0 {
+		installations, err := gh.FetchAppInstallations(baseURL, jwt)
+		if err != nil {
+			return nil, fmt.Errorf("discovering app installations: %w", err)
+		}
+		switch len(installations) {
+		case 0:
+			return nil, fmt.Errorf("github app has no installations — install it on at least one account/repo first")
+		case 1:
+			a.InstallationID = installations[0].ID
+		default:
+			// V1 requires an explicit installation ID once more than one
+			// exists — silently picking one could watch/act on the wrong
+			// org. Auto-discovery still removes per-repo config churn
+			// within a single installation's repo set.
+			return nil, fmt.Errorf("github app has %d installations; set github_app_installation_id to select one", len(installations))
+		}
+	}
+
+	if err := a.refresh(); err != nil {
+		return nil, fmt.Errorf("minting initial installation token: %w", err)
+	}
+	return a, nil
+}
+
+// refresh mints a new installation token, applies it to the client, and
+// records its expiry.
+func (a *Auth) refresh() error {
+	jwt, err := gh.BuildAppJWT(a.AppID, a.privateKey)
+	if err != nil {
+		return fmt.Errorf("building app JWT: %w", err)
+	}
+	token, expiresAt, err := gh.MintInstallationToken(a.baseURL, jwt, a.InstallationID)
+	if err != nil {
+		return fmt.Errorf("minting installation token: %w", err)
+	}
+	a.client.SetToken(token)
+	a.mu.Lock()
+	a.expiresAt = expiresAt
+	a.mu.Unlock()
+	return nil
+}
+
+// ExpiresAt returns the current installation token's expiry, safe for
+// concurrent use alongside RunRefreshLoop.
+func (a *Auth) ExpiresAt() time.Time {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.expiresAt
+}
+
+// RunRefreshLoop refreshes the installation token proactively before it
+// expires, until ctx is cancelled. Meant to run in its own goroutine for the
+// daemon's lifetime. A failed refresh is logged and retried after
+// tokenRefreshRetryDelay rather than crashing the daemon — a transient
+// GitHub outage shouldn't take Pruefer down, since the *current* token
+// stays valid until its actual (not margin-adjusted) expiry.
+func (a *Auth) RunRefreshLoop(ctx context.Context, logf func(format string, args ...any)) {
+	for {
+		wait := time.Until(a.ExpiresAt()) - tokenRefreshMargin
+		if wait < 0 {
+			wait = 0
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(wait):
+		}
+		if err := a.refresh(); err != nil {
+			if logf != nil {
+				logf("auth: installation token refresh failed, retrying in %s: %v", tokenRefreshRetryDelay, err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(tokenRefreshRetryDelay):
+			}
+			continue
+		}
+		if logf != nil {
+			logf("auth: installation token refreshed, expires %s", a.ExpiresAt().Format(time.RFC3339))
+		}
+	}
+}

--- a/pruefer/auth.go
+++ b/pruefer/auth.go
@@ -32,7 +32,7 @@ type Auth struct {
 	// BotLogin is the App's own identity as it appears as a PR/review
 	// author, e.g. "pruefer-bot[bot]". Always slug + "[bot]" for a GitHub
 	// App — this is what makes the "review identity != PR author" guarantee
-	// structural rather than operator-discipline-dependent (see ADR-073).
+	// structural rather than operator-discipline-dependent (see ADR-074).
 	BotLogin string
 
 	privateKey *rsa.PrivateKey

--- a/pruefer/auth.go
+++ b/pruefer/auth.go
@@ -32,7 +32,7 @@ type Auth struct {
 	// BotLogin is the App's own identity as it appears as a PR/review
 	// author, e.g. "pruefer-bot[bot]". Always slug + "[bot]" for a GitHub
 	// App — this is what makes the "review identity != PR author" guarantee
-	// structural rather than operator-discipline-dependent (see ADR-074).
+	// structural rather than operator-discipline-dependent (see ADR-1113).
 	BotLogin string
 
 	privateKey *rsa.PrivateKey

--- a/pruefer/auth_test.go
+++ b/pruefer/auth_test.go
@@ -1,0 +1,237 @@
+package pruefer
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// writeTestPrivateKey generates a small (test-only) RSA key, writes it as a
+// PEM file under dir, and returns the file path.
+func writeTestPrivateKey(t *testing.T, dir string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generating test RSA key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	path := filepath.Join(dir, "app-private-key.pem")
+	if err := os.WriteFile(path, pemBytes, 0600); err != nil {
+		t.Fatalf("writing private key file: %v", err)
+	}
+	return path
+}
+
+// fakeAppServer serves the three GitHub App endpoints Bootstrap/refresh use.
+// mintCount is incremented on every access_tokens call so tests can assert
+// refresh behavior.
+type fakeAppServer struct {
+	installations []gh.AppInstallation
+	slug          string
+	tokenExpiry   func() time.Time
+	mintCount     atomic.Int32
+
+	mu          sync.Mutex
+	lastMintedAt time.Time
+}
+
+func newFakeAppServer(slug string, installations []gh.AppInstallation, tokenExpiry func() time.Time) (*httptest.Server, *fakeAppServer) {
+	f := &fakeAppServer{slug: slug, installations: installations, tokenExpiry: tokenExpiry}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{"slug": f.slug, "id": 1})
+	})
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		raw := make([]map[string]interface{}, len(f.installations))
+		for i, inst := range f.installations {
+			raw[i] = map[string]interface{}{"id": inst.ID, "account": map[string]string{"login": inst.Account}}
+		}
+		json.NewEncoder(w).Encode(raw)
+	})
+	mux.HandleFunc("/app/installations/", func(w http.ResponseWriter, r *http.Request) {
+		f.mintCount.Add(1)
+		f.mu.Lock()
+		f.lastMintedAt = time.Now()
+		f.mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      fmt.Sprintf("ghs_token_%d", f.mintCount.Load()),
+			"expires_at": f.tokenExpiry().UTC().Format(time.RFC3339),
+		})
+	})
+	return httptest.NewServer(mux), f
+}
+
+func TestBootstrap_SingleInstallationAutoDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, _ := newFakeAppServer("pruefer-bot", []gh.AppInstallation{{ID: 111, Account: "handarbeit"}}, func() time.Time {
+		return time.Now().Add(time.Hour)
+	})
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
+	client := gh.NewClientWithBaseURL("", srv.URL)
+	auth, err := Bootstrap(cfg, client, srv.URL)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if auth.InstallationID != 111 {
+		t.Errorf("InstallationID = %d, want 111", auth.InstallationID)
+	}
+	if auth.BotLogin != "pruefer-bot[bot]" {
+		t.Errorf("BotLogin = %q, want pruefer-bot[bot]", auth.BotLogin)
+	}
+	if client.Token() == "" {
+		t.Error("expected client token to be set after Bootstrap")
+	}
+	if auth.ExpiresAt().IsZero() {
+		t.Error("expected ExpiresAt to be set after Bootstrap")
+	}
+}
+
+func TestBootstrap_ExplicitInstallationIDSkipsDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	discoveryCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{"slug": "pruefer-bot"})
+	})
+	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
+		discoveryCalled = true
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	})
+	mux.HandleFunc("/app/installations/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token": "ghs_x", "expires_at": time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, AppInstallationID: 999}
+	client := gh.NewClientWithBaseURL("", srv.URL)
+	auth, err := Bootstrap(cfg, client, srv.URL)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if auth.InstallationID != 999 {
+		t.Errorf("InstallationID = %d, want 999 (explicit config value)", auth.InstallationID)
+	}
+	if discoveryCalled {
+		t.Error("expected /app/installations to be skipped when AppInstallationID is explicitly configured")
+	}
+}
+
+func TestBootstrap_MultipleInstallationsRequiresExplicitID(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, _ := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit"},
+		{ID: 222, Account: "someorg"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
+	client := gh.NewClientWithBaseURL("", srv.URL)
+	if _, err := Bootstrap(cfg, client, srv.URL); err == nil {
+		t.Fatal("expected an error when multiple installations exist and none is configured")
+	}
+}
+
+func TestBootstrap_NoInstallations(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, _ := newFakeAppServer("pruefer-bot", nil, func() time.Time { return time.Now().Add(time.Hour) })
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
+	client := gh.NewClientWithBaseURL("", srv.URL)
+	if _, err := Bootstrap(cfg, client, srv.URL); err == nil {
+		t.Fatal("expected an error when the app has no installations")
+	}
+}
+
+func TestBootstrap_MissingPrivateKeyFile(t *testing.T) {
+	cfg := Config{AppID: 42, AppPrivateKeyPath: "/nonexistent/key.pem"}
+	client := gh.NewClient("")
+	if _, err := Bootstrap(cfg, client, ""); err == nil {
+		t.Fatal("expected an error when the private key file is missing")
+	}
+}
+
+func TestRunRefreshLoop_RefreshesBeforeExpiry(t *testing.T) {
+	oldMargin, oldRetry := tokenRefreshMargin, tokenRefreshRetryDelay
+	tokenRefreshMargin = 50 * time.Millisecond
+	tokenRefreshRetryDelay = 20 * time.Millisecond
+	defer func() { tokenRefreshMargin, tokenRefreshRetryDelay = oldMargin, oldRetry }()
+
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	// Token expires 100ms after each mint — with a 50ms margin, the refresh
+	// loop must mint again ~50ms after the previous mint.
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{{ID: 111, Account: "handarbeit"}}, func() time.Time {
+		return time.Now().Add(100 * time.Millisecond)
+	})
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
+	client := gh.NewClientWithBaseURL("", srv.URL)
+	auth, err := Bootstrap(cfg, client, srv.URL)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	// Bootstrap itself mints once.
+	if got := fake.mintCount.Load(); got != 1 {
+		t.Fatalf("mintCount after Bootstrap = %d, want 1", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	var logLines []string
+	var mu sync.Mutex
+	done := make(chan struct{})
+	go func() {
+		auth.RunRefreshLoop(ctx, func(format string, args ...any) {
+			mu.Lock()
+			logLines = append(logLines, fmt.Sprintf(format, args...))
+			mu.Unlock()
+		})
+		close(done)
+	}()
+	<-done
+
+	// The refresh loop must have minted at least once more within the
+	// context window — proving refresh-before-expiry actually fires, not
+	// just the initial Bootstrap mint.
+	if got := fake.mintCount.Load(); got < 2 {
+		t.Errorf("mintCount after refresh loop = %d, want >= 2 (refresh loop must fire before token expiry)", got)
+	}
+	if got := client.Token(); got == "" {
+		t.Fatal("expected a token to be set")
+	}
+}
+
+func TestAuth_ExpiresAt_ZeroBeforeBootstrap(t *testing.T) {
+	a := &Auth{}
+	if !a.ExpiresAt().IsZero() {
+		t.Error("expected ExpiresAt to be zero before any refresh")
+	}
+}

--- a/pruefer/auth_test.go
+++ b/pruefer/auth_test.go
@@ -48,7 +48,7 @@ type fakeAppServer struct {
 	tokenExpiry   func() time.Time
 	mintCount     atomic.Int32
 
-	mu          sync.Mutex
+	mu           sync.Mutex
 	lastMintedAt time.Time
 }
 

--- a/pruefer/claude.go
+++ b/pruefer/claude.go
@@ -1,0 +1,305 @@
+package pruefer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// reviewAllowedTools is the fixed, read-only tool allowlist for every review
+// invocation. Unlike a Fabrik stage's configurable allowed_tools, this list
+// is hardcoded and non-configurable: the reviewer must never mutate the
+// working tree or the repo, and Claude never submits the review itself —
+// Pruefer's Go code calls github.Client.SubmitPRReview directly once Claude
+// has produced review text. Bash(gh:*) is deliberately excluded even though
+// the issue's own illustrative example includes it: gh pr review --approve
+// / gh pr merge are reachable through an unscoped grant, which would make
+// "never approve" a prompt-level policy rather than a code-level guarantee
+// (see adrs/073-pruefer-v1-architecture.md).
+var reviewAllowedTools = []string{
+	"Read", "Grep", "Glob",
+	"Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)",
+	"Bash(git blame:*)", "Bash(git grep:*)", "Bash(git status:*)",
+}
+
+// reviewInactivityTimeout mirrors engine/claude.go's hardcoded 15-minute
+// inactivity watchdog: if claude produces no stdout for this long, the
+// process is presumed stuck and killed so it doesn't hold a concurrency
+// slot forever. Var (not const) so tests can shrink it.
+var reviewInactivityTimeout = 15 * time.Minute
+
+// reviewWaitDelay mirrors engine/claude.go's claudeWaitDelay: how long to
+// wait for stdout pipe drain after the process exits before giving up on
+// recovering output held open by a grandchild process.
+var reviewWaitDelay = 30 * time.Second
+
+// reviewKillGrace is the SIGINT/SIGTERM grace window used by Review's kill
+// escalation. Fixed (unlike Fabrik's per-stage configurable kill_grace)
+// since Pruefer has no stage YAML to source an override from.
+var reviewKillGrace = 10 * time.Second
+
+// ReviewRequest bundles the inputs for a single Claude review invocation.
+// The PR's head commit is expected to already be checked out at WorkDir
+// (see worktree.go) — Claude inspects it directly rather than receiving the
+// diff purely as prompt text, so it can use git/Read/Grep/Glob for
+// surrounding-code context.
+type ReviewRequest struct {
+	Owner       string
+	Repo        string
+	PRNumber    int
+	Title       string
+	Body        string
+	HeadSHA     string
+	BaseBranch  string
+	Model       string
+	Effort      string
+	WorkDir     string        // ephemeral clone directory; claude's cwd
+	MaxWallTime time.Duration // 0 = no wall-time cap
+}
+
+// ClaudeInvoker defines the interface for invoking Claude Code to produce
+// review text for a single PR. Deliberately narrower than
+// engine.ClaudeInvoker — no stages.Stage, no gh.ProjectItem — since Pruefer
+// has no board/stage concept.
+type ClaudeInvoker interface {
+	Review(ctx context.Context, req ReviewRequest) (reviewText string, err error)
+}
+
+// RealClaudeInvoker invokes the real claude CLI via exec.CommandContext,
+// mirroring engine/claude.go's runClaude: non-interactive permission mode,
+// a fixed read-only tool allowlist, an inactivity watchdog, an optional
+// wall-time deadline, WaitDelay for buffered-stdout recovery, and graceful
+// SIGINT→SIGTERM→SIGKILL process-group kill on cancellation.
+type RealClaudeInvoker struct{}
+
+// buildReviewPrompt constructs the prompt sent to claude via stdin.
+func buildReviewPrompt(req ReviewRequest) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are Pruefer, an automated code reviewer for pull request %s/%s#%d: %q.\n\n", req.Owner, req.Repo, req.PRNumber, req.Title)
+	b.WriteString("The PR's head commit is already checked out in your working directory. Use git (diff, log, show, blame, grep, status), Read, Grep, and Glob to inspect the change and any surrounding code you need for context — you have no write access and no other tools.\n\n")
+	if req.BaseBranch != "" {
+		fmt.Fprintf(&b, "The PR's base branch is %q; compare against it (e.g. `git diff %s...HEAD`) to see only this PR's changes.\n\n", req.BaseBranch, req.BaseBranch)
+	}
+	if req.Body != "" {
+		b.WriteString("## PR description\n\n")
+		b.WriteString(req.Body)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Write a code review as you would comment on the pull request: call out bugs, correctness issues, security concerns, and significant design problems. Skip nitpicks and style preferences unless they matter.\n\n")
+	b.WriteString("You are NOT approving or requesting changes — this is a comment-only review. Do not use approval/rejection language such as \"LGTM\" or \"requesting changes\".\n\n")
+	b.WriteString("Output ONLY the review text itself: no preamble, no meta-commentary about what you are about to do.\n")
+	return b.String()
+}
+
+// buildReviewArgs constructs the claude CLI argument list for a review
+// invocation. Always non-interactive (--permission-mode dontAsk) and always
+// the fixed read-only allowlist — there is no unrestricted/label-driven
+// escape hatch, unlike Fabrik stages.
+func buildReviewArgs(req ReviewRequest) []string {
+	args := []string{
+		"--output-format", "stream-json",
+		"--verbose",
+		"--permission-mode", "dontAsk",
+	}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	for _, tool := range reviewAllowedTools {
+		args = append(args, "--allowedTools", tool)
+	}
+	return args
+}
+
+// buildReviewEnv returns the environment variable overrides applied on top
+// of os.Environ() for a review invocation.
+func buildReviewEnv(req ReviewRequest) []string {
+	effort := req.Effort
+	if effort == "" {
+		effort = DefaultEffort
+	}
+	return []string{
+		"CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1",
+		"CLAUDE_CODE_EFFORT_LEVEL=" + effort,
+	}
+}
+
+// mergeEnv builds a subprocess environment from base (typically
+// os.Environ()), with overrides applied on top. Keys present in overrides
+// are removed from base first so overrides take effect even when base
+// already contains the same key — mirrors engine/claude.go's mergeEnv.
+func mergeEnv(base, overrides []string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	keys := make(map[string]bool, len(overrides))
+	for _, kv := range overrides {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			keys[kv[:i]] = true
+		}
+	}
+	result := make([]string, 0, len(base)+len(overrides))
+	for _, kv := range base {
+		if i := strings.IndexByte(kv, '='); i > 0 && keys[kv[:i]] {
+			continue
+		}
+		result = append(result, kv)
+	}
+	return append(result, overrides...)
+}
+
+// activityWriter wraps an io.Writer and updates a shared atomic timestamp on
+// every Write call. Used by the inactivity watchdog — mirrors
+// engine/claude.go's activityWriter.
+type activityWriter struct {
+	inner        io.Writer
+	lastActivity *atomic.Int64
+}
+
+func (w *activityWriter) Write(p []byte) (int, error) {
+	w.lastActivity.Store(time.Now().UnixNano())
+	return w.inner.Write(p)
+}
+
+// claudeReviewResponse mirrors the subset of claude --output-format
+// stream-json's final result object that Pruefer needs.
+type claudeReviewResponse struct {
+	Result  string `json:"result"`
+	IsError bool   `json:"is_error"`
+}
+
+// parseClaudeReviewJSON parses claude's NDJSON stream output, handling both
+// a single result object and a conversation array (only the last
+// {"type":"result",...} line matters in the array case).
+func parseClaudeReviewJSON(output []byte) (claudeReviewResponse, bool) {
+	var resp claudeReviewResponse
+	if err := json.Unmarshal(output, &resp); err == nil && resp.Result != "" {
+		return resp, true
+	}
+	var lastResult *claudeReviewResponse
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var envelope struct {
+			Type    string `json:"type"`
+			Result  string `json:"result"`
+			IsError bool   `json:"is_error"`
+		}
+		if err := json.Unmarshal(line, &envelope); err != nil || envelope.Type != "result" {
+			continue
+		}
+		r := claudeReviewResponse{Result: envelope.Result, IsError: envelope.IsError}
+		lastResult = &r
+	}
+	if lastResult != nil {
+		return *lastResult, true
+	}
+	return claudeReviewResponse{}, false
+}
+
+// Review invokes the claude CLI once, in req.WorkDir, and returns its review
+// text. On any failure — process error, timeout, unparseable output, or an
+// is_error response — it returns a non-nil error and an empty string.
+// Per the issue's "on invocation failure, post nothing" requirement,
+// callers must not submit a review when err != nil.
+func (r *RealClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (string, error) {
+	logf(req.PRNumber, "claude", "reviewing %s/%s#%d (head %s) in %s\n", req.Owner, req.Repo, req.PRNumber, req.HeadSHA, req.WorkDir)
+
+	stageCtx := ctx
+	cancel := context.CancelFunc(func() {})
+	if req.MaxWallTime > 0 {
+		stageCtx, cancel = context.WithTimeout(ctx, req.MaxWallTime)
+	}
+	defer cancel()
+
+	var stdout bytes.Buffer
+	var lastActivity atomic.Int64
+	lastActivity.Store(time.Now().UnixNano())
+	var stdoutWriter io.Writer = &activityWriter{inner: &stdout, lastActivity: &lastActivity}
+
+	cmd := exec.CommandContext(stageCtx, "claude", buildReviewArgs(req)...)
+	cmd.Dir = req.WorkDir
+	cmd.Env = mergeEnv(os.Environ(), buildReviewEnv(req))
+	cmd.Stdin = strings.NewReader(buildReviewPrompt(req))
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = stdoutWriter
+	waitDelay := reviewWaitDelay
+	if waitDelay <= 0 {
+		waitDelay = 30 * time.Second
+	}
+	cmd.WaitDelay = waitDelay
+	setCmdProcAttr(cmd)
+
+	watchdogCtx, watchdogCancel := context.WithCancel(context.Background())
+	defer watchdogCancel()
+
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			reason := "context_cancel"
+			if req.MaxWallTime > 0 && stageCtx.Err() == context.DeadlineExceeded {
+				reason = "max_wall_time"
+			}
+			killProcGroupGraceful(cmd.Process.Pid, req.PRNumber, "review", reason, reviewKillGrace, reviewKillGrace)
+		}
+		return nil
+	}
+
+	if err := cmd.Start(); err != nil {
+		watchdogCancel()
+		return "", fmt.Errorf("starting claude: %w", err)
+	}
+	pid := cmd.Process.Pid
+
+	go func(pid int) {
+		timer := time.NewTimer(reviewInactivityTimeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				since := time.Since(time.Unix(0, lastActivity.Load()))
+				if since >= reviewInactivityTimeout {
+					logf(req.PRNumber, "warn", "review invocation idle for %s with no output — killing\n", reviewInactivityTimeout)
+					killProcGroupGraceful(pid, req.PRNumber, "review", "inactivity_timeout", reviewKillGrace, reviewKillGrace)
+					return
+				}
+				timer.Reset(reviewInactivityTimeout - since)
+			case <-watchdogCtx.Done():
+				return
+			}
+		}
+	}(pid)
+
+	runErr := cmd.Wait()
+	watchdogCancel()
+	killProcGroup(cmd, req.PRNumber, "review")
+
+	if errors.Is(runErr, exec.ErrWaitDelay) && ctx.Err() == nil {
+		logf(req.PRNumber, "warn", "WaitDelay fired: claude exited but grandchild processes held stdout pipe open; processing buffered output (%d bytes)\n", stdout.Len())
+		runErr = nil
+	}
+
+	if runErr != nil {
+		return "", fmt.Errorf("claude exited with error: %w", runErr)
+	}
+
+	resp, ok := parseClaudeReviewJSON(bytes.TrimSpace(stdout.Bytes()))
+	if !ok {
+		return "", fmt.Errorf("could not parse claude output (%d bytes)", stdout.Len())
+	}
+	if resp.IsError {
+		return "", fmt.Errorf("claude reported an error: %s", resp.Result)
+	}
+	if strings.TrimSpace(resp.Result) == "" {
+		return "", fmt.Errorf("claude produced an empty review")
+	}
+	return resp.Result, nil
+}

--- a/pruefer/claude.go
+++ b/pruefer/claude.go
@@ -23,7 +23,7 @@ import (
 // the issue's own illustrative example includes it: gh pr review --approve
 // / gh pr merge are reachable through an unscoped grant, which would make
 // "never approve" a prompt-level policy rather than a code-level guarantee
-// (see adrs/074-pruefer-v1-architecture.md).
+// (see adrs/1113-pruefer-v1-architecture.md).
 var reviewAllowedTools = []string{
 	"Read", "Grep", "Glob",
 	"Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)",

--- a/pruefer/claude.go
+++ b/pruefer/claude.go
@@ -23,7 +23,7 @@ import (
 // the issue's own illustrative example includes it: gh pr review --approve
 // / gh pr merge are reachable through an unscoped grant, which would make
 // "never approve" a prompt-level policy rather than a code-level guarantee
-// (see adrs/073-pruefer-v1-architecture.md).
+// (see adrs/074-pruefer-v1-architecture.md).
 var reviewAllowedTools = []string{
 	"Read", "Grep", "Glob",
 	"Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)",

--- a/pruefer/claude_test.go
+++ b/pruefer/claude_test.go
@@ -1,0 +1,252 @@
+package pruefer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildReviewArgs_ReadOnlyAllowlist(t *testing.T) {
+	args := buildReviewArgs(ReviewRequest{Model: "sonnet"})
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--permission-mode dontAsk") {
+		t.Errorf("args = %v, want --permission-mode dontAsk", args)
+	}
+	if strings.Contains(joined, "--dangerously-skip-permissions") {
+		t.Errorf("args = %v, must never contain --dangerously-skip-permissions (Pruefer has no unrestricted opt-out)", args)
+	}
+	if strings.Contains(joined, "Bash(gh:*)") {
+		t.Error("allowlist must not contain Bash(gh:*) — gh is not read-only (gh pr review --approve, gh pr merge)")
+	}
+	if strings.Contains(joined, "Edit") || strings.Contains(joined, "Write") {
+		t.Error("allowlist must not contain Edit or Write — the reviewer must never mutate the working tree")
+	}
+	for _, want := range []string{"Read", "Grep", "Glob", "Bash(git diff:*)", "Bash(git log:*)", "Bash(git show:*)", "Bash(git blame:*)", "Bash(git grep:*)", "Bash(git status:*)"} {
+		found := false
+		for i, a := range args {
+			if a == "--allowedTools" && i+1 < len(args) && args[i+1] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected allowedTools to include %q, args = %v", want, args)
+		}
+	}
+	if !slices.Contains(args, "--model") {
+		t.Errorf("expected --model to be passed when Model is set, args = %v", args)
+	}
+}
+
+func TestBuildReviewArgs_NoModelWhenUnset(t *testing.T) {
+	args := buildReviewArgs(ReviewRequest{})
+	if slices.Contains(args, "--model") {
+		t.Errorf("expected no --model flag when Model is empty, args = %v", args)
+	}
+}
+
+func TestBuildReviewEnv_DefaultsEffort(t *testing.T) {
+	env := buildReviewEnv(ReviewRequest{})
+	joined := strings.Join(env, " ")
+	if !strings.Contains(joined, "CLAUDE_CODE_EFFORT_LEVEL="+DefaultEffort) {
+		t.Errorf("env = %v, want default effort %q", env, DefaultEffort)
+	}
+	if !strings.Contains(joined, "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1") {
+		t.Errorf("env = %v, want adaptive thinking disabled", env)
+	}
+}
+
+func TestBuildReviewEnv_HonorsExplicitEffort(t *testing.T) {
+	env := buildReviewEnv(ReviewRequest{Effort: "max"})
+	if !slices.Contains(env, "CLAUDE_CODE_EFFORT_LEVEL=max") {
+		t.Errorf("env = %v, want CLAUDE_CODE_EFFORT_LEVEL=max", env)
+	}
+}
+
+func TestMergeEnv_OverridesTakePrecedence(t *testing.T) {
+	base := []string{"FOO=old", "BAR=keep"}
+	overrides := []string{"FOO=new"}
+	got := mergeEnv(base, overrides)
+	want := map[string]string{"FOO": "new", "BAR": "keep"}
+	seen := map[string]string{}
+	for _, kv := range got {
+		parts := strings.SplitN(kv, "=", 2)
+		seen[parts[0]] = parts[1]
+	}
+	for k, v := range want {
+		if seen[k] != v {
+			t.Errorf("seen[%q] = %q, want %q (full env: %v)", k, seen[k], v, got)
+		}
+	}
+}
+
+func TestParseClaudeReviewJSON_SingleObject(t *testing.T) {
+	resp, ok := parseClaudeReviewJSON([]byte(`{"result":"looks good, minor nit on line 4","is_error":false}`))
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if resp.Result != "looks good, minor nit on line 4" {
+		t.Errorf("Result = %q", resp.Result)
+	}
+	if resp.IsError {
+		t.Error("IsError = true, want false")
+	}
+}
+
+func TestParseClaudeReviewJSON_ConversationArray(t *testing.T) {
+	stream := `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"thinking..."}]}}
+{"type":"result","result":"final review text","is_error":false}`
+	resp, ok := parseClaudeReviewJSON([]byte(stream))
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if resp.Result != "final review text" {
+		t.Errorf("Result = %q", resp.Result)
+	}
+}
+
+func TestParseClaudeReviewJSON_Unparseable(t *testing.T) {
+	_, ok := parseClaudeReviewJSON([]byte("not json at all"))
+	if ok {
+		t.Error("expected ok=false for unparseable output")
+	}
+}
+
+// writeFakeClaude installs a fake "claude" binary on a temp bin dir added to
+// PATH, mirroring engine/grandchild_test.go's pattern. The script reads and
+// discards stdin (the prompt), then emits the given stdout.
+func writeFakeClaude(t *testing.T, script string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake claude script uses #!/bin/sh")
+	}
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(fakeClaude, []byte("#!/bin/sh\ncat >/dev/null\n"+script), 0755); err != nil {
+		t.Fatalf("writing fake claude script: %v", err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+}
+
+func TestRealClaudeInvoker_Review_Success(t *testing.T) {
+	writeFakeClaude(t, `printf '%s\n' '{"type":"result","result":"Found one bug: nil check missing on line 12.","is_error":false}'`+"\n")
+
+	r := &RealClaudeInvoker{}
+	workDir := t.TempDir()
+	text, err := r.Review(context.Background(), ReviewRequest{
+		Owner: "handarbeit", Repo: "fabrik", PRNumber: 1, Title: "Fix bug",
+		HeadSHA: "abc123", WorkDir: workDir,
+	})
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	if text != "Found one bug: nil check missing on line 12." {
+		t.Errorf("text = %q", text)
+	}
+}
+
+func TestRealClaudeInvoker_Review_ProcessError(t *testing.T) {
+	writeFakeClaude(t, "exit 1\n")
+
+	r := &RealClaudeInvoker{}
+	_, err := r.Review(context.Background(), ReviewRequest{PRNumber: 1, WorkDir: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected an error when claude exits non-zero")
+	}
+}
+
+func TestRealClaudeInvoker_Review_IsErrorResponse(t *testing.T) {
+	writeFakeClaude(t, `printf '%s\n' '{"type":"result","result":"something went wrong internally","is_error":true}'`+"\n")
+
+	r := &RealClaudeInvoker{}
+	_, err := r.Review(context.Background(), ReviewRequest{PRNumber: 1, WorkDir: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected an error when claude reports is_error=true")
+	}
+}
+
+func TestRealClaudeInvoker_Review_UnparseableOutput(t *testing.T) {
+	writeFakeClaude(t, `printf 'not json\n'`+"\n")
+
+	r := &RealClaudeInvoker{}
+	_, err := r.Review(context.Background(), ReviewRequest{PRNumber: 1, WorkDir: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected an error when claude's output cannot be parsed")
+	}
+}
+
+func TestRealClaudeInvoker_Review_InactivityTimeout(t *testing.T) {
+	orig := reviewInactivityTimeout
+	reviewInactivityTimeout = 100 * time.Millisecond
+	defer func() { reviewInactivityTimeout = orig }()
+
+	// The fake claude script hangs (sleeps) without producing any stdout —
+	// the inactivity watchdog must kill it well before the test timeout.
+	writeFakeClaude(t, "sleep 30\n")
+
+	r := &RealClaudeInvoker{}
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.Review(context.Background(), ReviewRequest{PRNumber: 1, WorkDir: t.TempDir()})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected an error when claude is killed for inactivity")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Review did not return within 10s — inactivity watchdog did not fire")
+	}
+}
+
+func TestRealClaudeInvoker_Review_ContextCancelKillsProcess(t *testing.T) {
+	origGrace := reviewKillGrace
+	reviewKillGrace = 200 * time.Millisecond
+	defer func() { reviewKillGrace = origGrace }()
+
+	writeFakeClaude(t, "trap '' INT TERM\nsleep 30\n") // ignores SIGINT/SIGTERM so the test also exercises the SIGKILL escalation step
+
+	r := &RealClaudeInvoker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.Review(ctx, ReviewRequest{PRNumber: 1, WorkDir: t.TempDir()})
+		done <- err
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected an error when the context is cancelled mid-invocation")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Review did not return within 10s of context cancellation")
+	}
+}
+
+func TestMockClaudeInvoker_RecordsCalls(t *testing.T) {
+	m := &mockClaudeInvoker{}
+	req := ReviewRequest{PRNumber: 7}
+	text, err := m.Review(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	if text != "mock review" {
+		t.Errorf("text = %q, want default mock review text", text)
+	}
+	if m.callCount() != 1 {
+		t.Errorf("callCount = %d, want 1", m.callCount())
+	}
+	if got := m.callsSnapshot()[0].PRNumber; got != 7 {
+		t.Errorf("recorded PRNumber = %d, want 7", got)
+	}
+}

--- a/pruefer/comment.go
+++ b/pruefer/comment.go
@@ -1,0 +1,93 @@
+package pruefer
+
+import (
+	"strings"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// reviewCommand is the PR comment command that forces a fresh review of the
+// current head, bypassing only the already-reviewed-at-this-SHA check (not
+// draft/self-authored/exclusion checks — see select.go's Eligible).
+const reviewCommand = "/pruefer review"
+
+// GitHubCommenter is the subset of *github.Client's comment/reaction methods
+// this file needs. A narrow interface — rather than depending on the full
+// client — keeps these functions testable without HTTP mocking.
+type GitHubCommenter interface {
+	FetchIssueComments(owner, repo string, issueNumber int) ([]gh.Comment, error)
+	AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error
+}
+
+// isReviewCommand reports whether body contains the /pruefer review
+// command, matched case-insensitively — consistent with how Fabrik
+// recognizes its own comment commands.
+func isReviewCommand(body string) bool {
+	return strings.Contains(strings.ToLower(body), reviewCommand)
+}
+
+// unprocessedReviewCommands returns the "/pruefer review" comments on
+// owner/repo#prNumber that have not yet been marked processed (no ROCKET
+// reaction) — the same 👀/🚀 reaction-based idempotency convention Fabrik
+// uses for its own comment processing (see engine/comments.go).
+func unprocessedReviewCommands(client GitHubCommenter, owner, repo string, prNumber int) ([]gh.Comment, error) {
+	comments, err := client.FetchIssueComments(owner, repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+	var out []gh.Comment
+	for _, c := range comments {
+		if isReviewCommand(c.Body) && !c.HasReaction("ROCKET") {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+// PendingForceReview reports whether owner/repo#prNumber has an unprocessed
+// "/pruefer review" comment.
+func PendingForceReview(client GitHubCommenter, owner, repo string, prNumber int) (bool, error) {
+	pending, err := unprocessedReviewCommands(client, owner, repo, prNumber)
+	if err != nil {
+		return false, err
+	}
+	return len(pending) > 0, nil
+}
+
+// AcknowledgeForceReview adds the 👀 (eyes) reaction to every unprocessed
+// "/pruefer review" comment, signaling that Pruefer has picked it up and is
+// acting on it. Call before invoking Claude; a failure here is non-fatal to
+// the review itself (the caller should log and continue).
+func AcknowledgeForceReview(client GitHubCommenter, owner, repo string, prNumber int) error {
+	pending, err := unprocessedReviewCommands(client, owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	for _, c := range pending {
+		if c.HasReaction("EYES") {
+			continue
+		}
+		if err := client.AddCommentReaction(owner, repo, c.DatabaseID, "eyes"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MarkForceReviewsProcessed adds the 🚀 (rocket) reaction to every
+// unprocessed "/pruefer review" comment on owner/repo#prNumber, so a
+// subsequent poll does not treat them as still-pending. Call only after a
+// review has actually been submitted for the forced request (see review.go)
+// — this is the durable "don't reprocess this comment" marker.
+func MarkForceReviewsProcessed(client GitHubCommenter, owner, repo string, prNumber int) error {
+	pending, err := unprocessedReviewCommands(client, owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	for _, c := range pending {
+		if err := client.AddCommentReaction(owner, repo, c.DatabaseID, "rocket"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pruefer/comment_test.go
+++ b/pruefer/comment_test.go
@@ -1,0 +1,182 @@
+package pruefer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// fakeCommenter implements GitHubCommenter in-memory for tests.
+type fakeCommenter struct {
+	mu       sync.Mutex
+	comments []gh.Comment
+	fetchErr error
+	reactErr error
+}
+
+func (f *fakeCommenter) FetchIssueComments(owner, repo string, issueNumber int) ([]gh.Comment, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fetchErr != nil {
+		return nil, f.fetchErr
+	}
+	out := make([]gh.Comment, len(f.comments))
+	copy(out, f.comments)
+	return out, nil
+}
+
+func (f *fakeCommenter) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.reactErr != nil {
+		return f.reactErr
+	}
+	contentName := map[string]string{"eyes": "EYES", "rocket": "ROCKET"}[content]
+	for i := range f.comments {
+		if f.comments[i].DatabaseID == commentDatabaseID {
+			f.comments[i].Reactions = append(f.comments[i].Reactions, gh.ReactionGroup{Content: contentName, Count: 1})
+		}
+	}
+	return nil
+}
+
+func TestIsReviewCommand(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{"/pruefer review", true},
+		{"/PRUEFER REVIEW", true},
+		{"  /pruefer review please", true},
+		{"can someone run /pruefer review on this?", true},
+		{"looks good to me", false},
+		{"/pruefer reviews", true}, // substring match is intentional (prefix of a longer word is fine here)
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isReviewCommand(tc.body); got != tc.want {
+			t.Errorf("isReviewCommand(%q) = %v, want %v", tc.body, got, tc.want)
+		}
+	}
+}
+
+func TestPendingForceReview_NoComments(t *testing.T) {
+	f := &fakeCommenter{}
+	pending, err := PendingForceReview(f, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("PendingForceReview: %v", err)
+	}
+	if pending {
+		t.Error("expected no pending force review")
+	}
+}
+
+func TestPendingForceReview_UnprocessedCommand(t *testing.T) {
+	f := &fakeCommenter{comments: []gh.Comment{
+		{DatabaseID: 1, Body: "/pruefer review"},
+	}}
+	pending, err := PendingForceReview(f, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("PendingForceReview: %v", err)
+	}
+	if !pending {
+		t.Error("expected a pending force review")
+	}
+}
+
+func TestPendingForceReview_AlreadyProcessed(t *testing.T) {
+	f := &fakeCommenter{comments: []gh.Comment{
+		{DatabaseID: 1, Body: "/pruefer review", Reactions: []gh.ReactionGroup{{Content: "ROCKET", Count: 1}}},
+	}}
+	pending, err := PendingForceReview(f, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("PendingForceReview: %v", err)
+	}
+	if pending {
+		t.Error("expected no pending force review — comment already has a ROCKET reaction")
+	}
+}
+
+func TestPendingForceReview_PropagatesFetchError(t *testing.T) {
+	f := &fakeCommenter{fetchErr: fmt.Errorf("boom")}
+	if _, err := PendingForceReview(f, "owner", "repo", 1); err == nil {
+		t.Fatal("expected fetch error to propagate")
+	}
+}
+
+func TestAcknowledgeForceReview_AddsEyesReaction(t *testing.T) {
+	f := &fakeCommenter{comments: []gh.Comment{
+		{DatabaseID: 1, Body: "/pruefer review"},
+	}}
+	if err := AcknowledgeForceReview(f, "owner", "repo", 1); err != nil {
+		t.Fatalf("AcknowledgeForceReview: %v", err)
+	}
+	if !f.comments[0].HasReaction("EYES") {
+		t.Error("expected EYES reaction to be recorded")
+	}
+}
+
+func TestAcknowledgeForceReview_SkipsAlreadyAcknowledged(t *testing.T) {
+	f := &fakeCommenter{comments: []gh.Comment{
+		{DatabaseID: 1, Body: "/pruefer review", Reactions: []gh.ReactionGroup{{Content: "EYES", Count: 1}}},
+	}}
+	callCount := 0
+	origReact := f.reactErr
+	_ = origReact
+	// Wrap to count calls via a small shim.
+	wrapped := &countingCommenter{fakeCommenter: f, onReact: func() { callCount++ }}
+	if err := AcknowledgeForceReview(wrapped, "owner", "repo", 1); err != nil {
+		t.Fatalf("AcknowledgeForceReview: %v", err)
+	}
+	if callCount != 0 {
+		t.Errorf("expected no AddCommentReaction calls when already acknowledged, got %d", callCount)
+	}
+}
+
+// countingCommenter wraps *fakeCommenter and counts AddCommentReaction calls.
+type countingCommenter struct {
+	*fakeCommenter
+	onReact func()
+}
+
+func (c *countingCommenter) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	c.onReact()
+	return c.fakeCommenter.AddCommentReaction(owner, repo, commentDatabaseID, content)
+}
+
+func TestMarkForceReviewsProcessed_AddsRocketToAllUnprocessed(t *testing.T) {
+	f := &fakeCommenter{comments: []gh.Comment{
+		{DatabaseID: 1, Body: "/pruefer review"},
+		{DatabaseID: 2, Body: "unrelated comment"},
+		{DatabaseID: 3, Body: "/pruefer review", Reactions: []gh.ReactionGroup{{Content: "ROCKET", Count: 1}}},
+	}}
+	if err := MarkForceReviewsProcessed(f, "owner", "repo", 1); err != nil {
+		t.Fatalf("MarkForceReviewsProcessed: %v", err)
+	}
+	if !f.comments[0].HasReaction("ROCKET") {
+		t.Error("expected comment 1 (unprocessed /pruefer review) to gain a ROCKET reaction")
+	}
+	if f.comments[1].HasReaction("ROCKET") {
+		t.Error("comment 2 (unrelated) must not gain a ROCKET reaction")
+	}
+
+	pending, err := PendingForceReview(f, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("PendingForceReview: %v", err)
+	}
+	if pending {
+		t.Error("expected no pending force review after MarkForceReviewsProcessed")
+	}
+}
+
+func TestMarkForceReviewsProcessed_PropagatesReactionError(t *testing.T) {
+	f := &fakeCommenter{
+		comments: []gh.Comment{{DatabaseID: 1, Body: "/pruefer review"}},
+		reactErr: fmt.Errorf("rate limited"),
+	}
+	if err := MarkForceReviewsProcessed(f, "owner", "repo", 1); err == nil {
+		t.Fatal("expected reaction error to propagate")
+	}
+}

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -1,0 +1,290 @@
+// Package pruefer implements the Pruefer V1 daemon: a self-hosted PR review
+// bot that watches configured GitHub repositories, reviews pull requests by
+// invoking the claude CLI, and submits formal pull_request_review comments.
+// It mirrors the architectural shape of Fabrik's engine (poll loop, claude
+// CLI invocation, GitHub REST client) but shares no Go imports with engine —
+// see adrs/073-pruefer-v1-architecture.md.
+package pruefer
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Defaults, justified in adrs/073-pruefer-v1-architecture.md.
+const (
+	DefaultPollInterval   = 120 * time.Second
+	DefaultModel          = "sonnet"
+	DefaultEffort         = "medium"
+	DefaultConcurrencyCap = 3
+	DefaultMaxDiffBytes   = 500_000 // 500 KB
+	DefaultConfigPath     = ".pruefer/config.yaml"
+	DefaultPrivateKeyPath = ".pruefer/app-private-key.pem"
+)
+
+// Config holds Pruefer's fully-resolved runtime configuration, after
+// applying the flag > env > YAML file > default precedence chain in
+// LoadConfig.
+type Config struct {
+	WatchedRepos    []string // "owner/repo"
+	PollInterval    time.Duration
+	Model           string
+	Effort          string
+	ConcurrencyCap  int
+	MaxDiffBytes    int64
+	ExcludedAuthors []string
+	ExcludedPaths   []string // glob patterns; a PR is skipped only if ALL touched paths match
+	ExcludedLabels  []string // a PR is skipped if ANY label matches
+
+	AppID             int64
+	AppPrivateKeyPath string
+	// AppInstallationID pins Pruefer to a single installation. Zero means
+	// auto-discover every installation of the App (see pruefer/auth.go).
+	AppInstallationID int64
+}
+
+// yamlConfig is the shape of Pruefer's YAML config file. All fields are
+// optional; pointer types distinguish "absent" from "explicit zero" for
+// numeric fields, mirroring config.ProjectConfig's convention.
+type yamlConfig struct {
+	WatchedRepos      []string `yaml:"watched_repos"`
+	PollIntervalSec   *int     `yaml:"poll_interval_seconds"`
+	Model             string   `yaml:"model"`
+	Effort            string   `yaml:"effort"`
+	ConcurrencyCap    *int     `yaml:"concurrency_cap"`
+	MaxDiffBytes      *int64   `yaml:"max_diff_bytes"`
+	ExcludedAuthors   []string `yaml:"excluded_authors"`
+	ExcludedPaths     []string `yaml:"excluded_paths"`
+	ExcludedLabels    []string `yaml:"excluded_labels"`
+	AppID             *int64   `yaml:"github_app_id"`
+	AppPrivateKeyPath string   `yaml:"github_app_private_key_path"`
+	AppInstallationID *int64   `yaml:"github_app_installation_id"`
+}
+
+// loadYAMLConfig reads path, returning a zero-value yamlConfig (no error) if
+// the file does not exist.
+func loadYAMLConfig(path string) (yamlConfig, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return yamlConfig{}, nil
+	}
+	if err != nil {
+		return yamlConfig{}, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var yc yamlConfig
+	if err := yaml.Unmarshal(data, &yc); err != nil {
+		return yamlConfig{}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return yc, nil
+}
+
+// flagValues holds the raw values parsed by LoadConfig's flag.FlagSet.
+type flagValues struct {
+	repos             string
+	pollIntervalSec   int
+	model             string
+	effort            string
+	concurrencyCap    int
+	maxDiffBytes      int64
+	excludedAuthors   string
+	excludedPaths     string
+	excludedLabels    string
+	appID             int64
+	appPrivateKeyPath string
+	appInstallationID int64
+	configPath        string
+}
+
+// LoadConfig resolves Pruefer's configuration from, in increasing priority:
+// defaults, the YAML config file (PRUEFER_CONFIG env var or --config flag,
+// default .pruefer/config.yaml), PRUEFER_* environment variables, then
+// command-line flags — mirroring cmd/root.go's flag > env > config file >
+// default precedence convention. args is the program's argument list
+// excluding argv[0] (os.Args[1:] in production; injectable for tests).
+func LoadConfig(args []string) (Config, error) {
+	fs := flag.NewFlagSet("pruefer", flag.ContinueOnError)
+	var fv flagValues
+	fs.StringVar(&fv.repos, "repos", "", "Comma-separated list of owner/repo to watch")
+	fs.IntVar(&fv.pollIntervalSec, "poll-interval", 0, "Poll interval in seconds")
+	fs.StringVar(&fv.model, "model", "", "Claude model to use for reviews")
+	fs.StringVar(&fv.effort, "effort", "", "Claude thinking effort level (low, medium, high, max)")
+	fs.IntVar(&fv.concurrencyCap, "concurrency", 0, "Max concurrent claude invocations")
+	fs.Int64Var(&fv.maxDiffBytes, "max-diff-bytes", 0, "Skip PRs whose diff exceeds this many bytes")
+	fs.StringVar(&fv.excludedAuthors, "excluded-authors", "", "Comma-separated PR authors to skip")
+	fs.StringVar(&fv.excludedPaths, "excluded-paths", "", "Comma-separated path globs to skip (all touched paths must match)")
+	fs.StringVar(&fv.excludedLabels, "excluded-labels", "", "Comma-separated labels to skip (any match)")
+	fs.Int64Var(&fv.appID, "github-app-id", 0, "GitHub App ID")
+	fs.StringVar(&fv.appPrivateKeyPath, "github-app-private-key-path", "", "Path to the GitHub App's PEM private key")
+	fs.Int64Var(&fv.appInstallationID, "github-app-installation-id", 0, "GitHub App installation ID (0 = auto-discover)")
+	fs.StringVar(&fv.configPath, "config", DefaultConfigPath, "Path to Pruefer's YAML config file")
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+
+	explicit := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
+
+	configPath := fv.configPath
+	if !explicit["config"] {
+		if v := os.Getenv("PRUEFER_CONFIG"); v != "" {
+			configPath = v
+		}
+	}
+
+	yc, err := loadYAMLConfig(configPath)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg := Config{
+		WatchedRepos:      yc.WatchedRepos,
+		PollInterval:      DefaultPollInterval,
+		Model:             DefaultModel,
+		Effort:            DefaultEffort,
+		ConcurrencyCap:    DefaultConcurrencyCap,
+		MaxDiffBytes:      DefaultMaxDiffBytes,
+		ExcludedAuthors:   yc.ExcludedAuthors,
+		ExcludedPaths:     yc.ExcludedPaths,
+		ExcludedLabels:    yc.ExcludedLabels,
+		AppPrivateKeyPath: DefaultPrivateKeyPath,
+	}
+	if yc.PollIntervalSec != nil {
+		cfg.PollInterval = time.Duration(*yc.PollIntervalSec) * time.Second
+	}
+	if yc.Model != "" {
+		cfg.Model = yc.Model
+	}
+	if yc.Effort != "" {
+		cfg.Effort = yc.Effort
+	}
+	if yc.ConcurrencyCap != nil {
+		cfg.ConcurrencyCap = *yc.ConcurrencyCap
+	}
+	if yc.MaxDiffBytes != nil {
+		cfg.MaxDiffBytes = *yc.MaxDiffBytes
+	}
+	if yc.AppID != nil {
+		cfg.AppID = *yc.AppID
+	}
+	if yc.AppPrivateKeyPath != "" {
+		cfg.AppPrivateKeyPath = yc.AppPrivateKeyPath
+	}
+	if yc.AppInstallationID != nil {
+		cfg.AppInstallationID = *yc.AppInstallationID
+	}
+
+	applyEnv(&cfg)
+
+	if explicit["repos"] {
+		cfg.WatchedRepos = splitCSV(fv.repos)
+	}
+	if explicit["poll-interval"] {
+		cfg.PollInterval = time.Duration(fv.pollIntervalSec) * time.Second
+	}
+	if explicit["model"] {
+		cfg.Model = fv.model
+	}
+	if explicit["effort"] {
+		cfg.Effort = fv.effort
+	}
+	if explicit["concurrency"] {
+		cfg.ConcurrencyCap = fv.concurrencyCap
+	}
+	if explicit["max-diff-bytes"] {
+		cfg.MaxDiffBytes = fv.maxDiffBytes
+	}
+	if explicit["excluded-authors"] {
+		cfg.ExcludedAuthors = splitCSV(fv.excludedAuthors)
+	}
+	if explicit["excluded-paths"] {
+		cfg.ExcludedPaths = splitCSV(fv.excludedPaths)
+	}
+	if explicit["excluded-labels"] {
+		cfg.ExcludedLabels = splitCSV(fv.excludedLabels)
+	}
+	if explicit["github-app-id"] {
+		cfg.AppID = fv.appID
+	}
+	if explicit["github-app-private-key-path"] {
+		cfg.AppPrivateKeyPath = fv.appPrivateKeyPath
+	}
+	if explicit["github-app-installation-id"] {
+		cfg.AppInstallationID = fv.appInstallationID
+	}
+
+	return cfg, nil
+}
+
+// applyEnv overlays PRUEFER_* environment variables onto cfg, between the
+// YAML file and flag layers of the precedence chain.
+func applyEnv(cfg *Config) {
+	if v := os.Getenv("PRUEFER_REPOS"); v != "" {
+		cfg.WatchedRepos = splitCSV(v)
+	}
+	if v := os.Getenv("PRUEFER_POLL_INTERVAL"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.PollInterval = time.Duration(n) * time.Second
+		}
+	}
+	if v := os.Getenv("PRUEFER_MODEL"); v != "" {
+		cfg.Model = v
+	}
+	if v := os.Getenv("PRUEFER_EFFORT"); v != "" {
+		cfg.Effort = v
+	}
+	if v := os.Getenv("PRUEFER_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.ConcurrencyCap = n
+		}
+	}
+	if v := os.Getenv("PRUEFER_MAX_DIFF_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			cfg.MaxDiffBytes = n
+		}
+	}
+	if v := os.Getenv("PRUEFER_EXCLUDED_AUTHORS"); v != "" {
+		cfg.ExcludedAuthors = splitCSV(v)
+	}
+	if v := os.Getenv("PRUEFER_EXCLUDED_PATHS"); v != "" {
+		cfg.ExcludedPaths = splitCSV(v)
+	}
+	if v := os.Getenv("PRUEFER_EXCLUDED_LABELS"); v != "" {
+		cfg.ExcludedLabels = splitCSV(v)
+	}
+	if v := os.Getenv("PRUEFER_GITHUB_APP_ID"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			cfg.AppID = n
+		}
+	}
+	if v := os.Getenv("PRUEFER_GITHUB_APP_PRIVATE_KEY_PATH"); v != "" {
+		cfg.AppPrivateKeyPath = v
+	}
+	if v := os.Getenv("PRUEFER_GITHUB_APP_INSTALLATION_ID"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			cfg.AppInstallationID = n
+		}
+	}
+}
+
+// splitCSV splits a comma-separated string into a trimmed, non-empty slice.
+// Returns nil for an empty input.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -3,7 +3,7 @@
 // invoking the claude CLI, and submits formal pull_request_review comments.
 // It mirrors the architectural shape of Fabrik's engine (poll loop, claude
 // CLI invocation, GitHub REST client) but shares no Go imports with engine —
-// see adrs/074-pruefer-v1-architecture.md.
+// see adrs/1113-pruefer-v1-architecture.md.
 package pruefer
 
 import (
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Defaults, justified in adrs/074-pruefer-v1-architecture.md.
+// Defaults, justified in adrs/1113-pruefer-v1-architecture.md.
 const (
 	DefaultPollInterval   = 120 * time.Second
 	DefaultModel          = "sonnet"

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -38,6 +38,11 @@ type Config struct {
 	Effort          string
 	ConcurrencyCap  int
 	MaxDiffBytes    int64
+	// MaxWallTime caps a single claude review invocation's wall-clock
+	// duration. Zero means no cap (only the fixed 15-minute inactivity
+	// watchdog applies), matching Fabrik's own stage `max_wall_time`
+	// convention: absent/zero = uncapped.
+	MaxWallTime     time.Duration
 	ExcludedAuthors []string
 	ExcludedPaths   []string // glob patterns; a PR is skipped only if ALL touched paths match
 	ExcludedLabels  []string // a PR is skipped if ANY label matches
@@ -59,6 +64,7 @@ type yamlConfig struct {
 	Effort            string   `yaml:"effort"`
 	ConcurrencyCap    *int     `yaml:"concurrency_cap"`
 	MaxDiffBytes      *int64   `yaml:"max_diff_bytes"`
+	MaxWallTimeSec    *int     `yaml:"max_wall_time_seconds"`
 	ExcludedAuthors   []string `yaml:"excluded_authors"`
 	ExcludedPaths     []string `yaml:"excluded_paths"`
 	ExcludedLabels    []string `yaml:"excluded_labels"`
@@ -92,6 +98,7 @@ type flagValues struct {
 	effort            string
 	concurrencyCap    int
 	maxDiffBytes      int64
+	maxWallTimeSec    int
 	excludedAuthors   string
 	excludedPaths     string
 	excludedLabels    string
@@ -116,6 +123,7 @@ func LoadConfig(args []string) (Config, error) {
 	fs.StringVar(&fv.effort, "effort", "", "Claude thinking effort level (low, medium, high, max)")
 	fs.IntVar(&fv.concurrencyCap, "concurrency", 0, "Max concurrent claude invocations")
 	fs.Int64Var(&fv.maxDiffBytes, "max-diff-bytes", 0, "Skip PRs whose diff exceeds this many bytes")
+	fs.IntVar(&fv.maxWallTimeSec, "max-wall-time", 0, "Wall-clock cap in seconds for a single claude review invocation (0 = no cap)")
 	fs.StringVar(&fv.excludedAuthors, "excluded-authors", "", "Comma-separated PR authors to skip")
 	fs.StringVar(&fv.excludedPaths, "excluded-paths", "", "Comma-separated path globs to skip (all touched paths must match)")
 	fs.StringVar(&fv.excludedLabels, "excluded-labels", "", "Comma-separated labels to skip (any match)")
@@ -169,6 +177,9 @@ func LoadConfig(args []string) (Config, error) {
 	if yc.MaxDiffBytes != nil {
 		cfg.MaxDiffBytes = *yc.MaxDiffBytes
 	}
+	if yc.MaxWallTimeSec != nil {
+		cfg.MaxWallTime = time.Duration(*yc.MaxWallTimeSec) * time.Second
+	}
 	if yc.AppID != nil {
 		cfg.AppID = *yc.AppID
 	}
@@ -198,6 +209,9 @@ func LoadConfig(args []string) (Config, error) {
 	}
 	if explicit["max-diff-bytes"] {
 		cfg.MaxDiffBytes = fv.maxDiffBytes
+	}
+	if explicit["max-wall-time"] {
+		cfg.MaxWallTime = time.Duration(fv.maxWallTimeSec) * time.Second
 	}
 	if explicit["excluded-authors"] {
 		cfg.ExcludedAuthors = splitCSV(fv.excludedAuthors)
@@ -246,6 +260,11 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("PRUEFER_MAX_DIFF_BYTES"); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
 			cfg.MaxDiffBytes = n
+		}
+	}
+	if v := os.Getenv("PRUEFER_MAX_WALL_TIME"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxWallTime = time.Duration(n) * time.Second
 		}
 	}
 	if v := os.Getenv("PRUEFER_EXCLUDED_AUTHORS"); v != "" {

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -3,7 +3,7 @@
 // invoking the claude CLI, and submits formal pull_request_review comments.
 // It mirrors the architectural shape of Fabrik's engine (poll loop, claude
 // CLI invocation, GitHub REST client) but shares no Go imports with engine —
-// see adrs/073-pruefer-v1-architecture.md.
+// see adrs/074-pruefer-v1-architecture.md.
 package pruefer
 
 import (
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Defaults, justified in adrs/073-pruefer-v1-architecture.md.
+// Defaults, justified in adrs/074-pruefer-v1-architecture.md.
 const (
 	DefaultPollInterval   = 120 * time.Second
 	DefaultModel          = "sonnet"

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -1,0 +1,184 @@
+package pruefer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeYAMLConfig(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfig_DefaultsWhenNothingSet(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig([]string{"-config", filepath.Join(dir, "missing.yaml")})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.PollInterval != DefaultPollInterval {
+		t.Errorf("PollInterval = %v, want %v", cfg.PollInterval, DefaultPollInterval)
+	}
+	if cfg.Model != DefaultModel {
+		t.Errorf("Model = %q, want %q", cfg.Model, DefaultModel)
+	}
+	if cfg.Effort != DefaultEffort {
+		t.Errorf("Effort = %q, want %q", cfg.Effort, DefaultEffort)
+	}
+	if cfg.ConcurrencyCap != DefaultConcurrencyCap {
+		t.Errorf("ConcurrencyCap = %d, want %d", cfg.ConcurrencyCap, DefaultConcurrencyCap)
+	}
+	if cfg.MaxDiffBytes != DefaultMaxDiffBytes {
+		t.Errorf("MaxDiffBytes = %d, want %d", cfg.MaxDiffBytes, DefaultMaxDiffBytes)
+	}
+	if cfg.AppPrivateKeyPath != DefaultPrivateKeyPath {
+		t.Errorf("AppPrivateKeyPath = %q, want %q", cfg.AppPrivateKeyPath, DefaultPrivateKeyPath)
+	}
+	if len(cfg.WatchedRepos) != 0 {
+		t.Errorf("WatchedRepos = %v, want empty", cfg.WatchedRepos)
+	}
+}
+
+func TestLoadConfig_YAMLOverridesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `
+watched_repos:
+  - handarbeit/fabrik
+  - handarbeit/other
+poll_interval_seconds: 60
+model: opus
+effort: high
+concurrency_cap: 5
+max_diff_bytes: 100000
+excluded_authors:
+  - dependabot[bot]
+excluded_labels:
+  - skip-review
+`)
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.PollInterval != 60*time.Second {
+		t.Errorf("PollInterval = %v, want 60s", cfg.PollInterval)
+	}
+	if cfg.Model != "opus" {
+		t.Errorf("Model = %q, want opus", cfg.Model)
+	}
+	if cfg.Effort != "high" {
+		t.Errorf("Effort = %q, want high", cfg.Effort)
+	}
+	if cfg.ConcurrencyCap != 5 {
+		t.Errorf("ConcurrencyCap = %d, want 5", cfg.ConcurrencyCap)
+	}
+	if cfg.MaxDiffBytes != 100000 {
+		t.Errorf("MaxDiffBytes = %d, want 100000", cfg.MaxDiffBytes)
+	}
+	if len(cfg.WatchedRepos) != 2 || cfg.WatchedRepos[0] != "handarbeit/fabrik" {
+		t.Errorf("WatchedRepos = %v", cfg.WatchedRepos)
+	}
+	if len(cfg.ExcludedAuthors) != 1 || cfg.ExcludedAuthors[0] != "dependabot[bot]" {
+		t.Errorf("ExcludedAuthors = %v", cfg.ExcludedAuthors)
+	}
+	if len(cfg.ExcludedLabels) != 1 || cfg.ExcludedLabels[0] != "skip-review" {
+		t.Errorf("ExcludedLabels = %v", cfg.ExcludedLabels)
+	}
+}
+
+func TestLoadConfig_EnvOverridesYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `
+model: opus
+concurrency_cap: 5
+`)
+	t.Setenv("PRUEFER_MODEL", "haiku")
+	t.Setenv("PRUEFER_CONCURRENCY", "7")
+
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Model != "haiku" {
+		t.Errorf("Model = %q, want haiku (env should override YAML)", cfg.Model)
+	}
+	if cfg.ConcurrencyCap != 7 {
+		t.Errorf("ConcurrencyCap = %d, want 7 (env should override YAML)", cfg.ConcurrencyCap)
+	}
+}
+
+func TestLoadConfig_FlagOverridesEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `model: opus`)
+	t.Setenv("PRUEFER_MODEL", "haiku")
+
+	cfg, err := LoadConfig([]string{"-config", path, "-model", "sonnet"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Model != "sonnet" {
+		t.Errorf("Model = %q, want sonnet (flag should override env)", cfg.Model)
+	}
+}
+
+func TestLoadConfig_PrueferConfigEnvSelectsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `model: opus`)
+	t.Setenv("PRUEFER_CONFIG", path)
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Model != "opus" {
+		t.Errorf("Model = %q, want opus (PRUEFER_CONFIG should select the file)", cfg.Model)
+	}
+}
+
+func TestLoadConfig_ExplicitFlagBeatsPrueferConfigEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := writeYAMLConfig(t, dir, `model: opus`)
+	flagPath := filepath.Join(dir, "flag-config.yaml")
+	if err := os.WriteFile(flagPath, []byte(`model: haiku`), 0600); err != nil {
+		t.Fatalf("writing flag config: %v", err)
+	}
+	t.Setenv("PRUEFER_CONFIG", envPath)
+
+	cfg, err := LoadConfig([]string{"-config", flagPath})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Model != "haiku" {
+		t.Errorf("Model = %q, want haiku (-config flag should win over PRUEFER_CONFIG)", cfg.Model)
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"a", []string{"a"}},
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a , b ,c ", []string{"a", "b", "c"}},
+		{"a,,b", []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		got := splitCSV(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("splitCSV(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("splitCSV(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -37,6 +37,9 @@ func TestLoadConfig_DefaultsWhenNothingSet(t *testing.T) {
 	if cfg.MaxDiffBytes != DefaultMaxDiffBytes {
 		t.Errorf("MaxDiffBytes = %d, want %d", cfg.MaxDiffBytes, DefaultMaxDiffBytes)
 	}
+	if cfg.MaxWallTime != 0 {
+		t.Errorf("MaxWallTime = %v, want 0 (uncapped by default)", cfg.MaxWallTime)
+	}
 	if cfg.AppPrivateKeyPath != DefaultPrivateKeyPath {
 		t.Errorf("AppPrivateKeyPath = %q, want %q", cfg.AppPrivateKeyPath, DefaultPrivateKeyPath)
 	}
@@ -88,6 +91,36 @@ excluded_labels:
 	}
 	if len(cfg.ExcludedLabels) != 1 || cfg.ExcludedLabels[0] != "skip-review" {
 		t.Errorf("ExcludedLabels = %v", cfg.ExcludedLabels)
+	}
+}
+
+func TestLoadConfig_MaxWallTimePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `max_wall_time_seconds: 600`)
+
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxWallTime != 600*time.Second {
+		t.Errorf("MaxWallTime = %v, want 600s (from YAML)", cfg.MaxWallTime)
+	}
+
+	t.Setenv("PRUEFER_MAX_WALL_TIME", "900")
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxWallTime != 900*time.Second {
+		t.Errorf("MaxWallTime = %v, want 900s (env should override YAML)", cfg.MaxWallTime)
+	}
+
+	cfg, err = LoadConfig([]string{"-config", path, "-max-wall-time", "1200"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.MaxWallTime != 1200*time.Second {
+		t.Errorf("MaxWallTime = %v, want 1200s (flag should override env)", cfg.MaxWallTime)
 	}
 }
 

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -47,7 +47,7 @@ func (d *Daemon) lockPath() string {
 // Run acquires an exclusive file lock (preventing two Pruefer instances from
 // double-polling the same watched repos, mirroring engine/poll.go's
 // Engine.Run) and polls on Config.PollInterval until ctx is cancelled.
-func (d *Daemon) Run(ctx context.Context) error {
+func (d *Daemon) Run(ctx context.Context) (err error) {
 	lockPath := d.lockPath()
 	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
 		return fmt.Errorf("creating lock dir: %w", err)
@@ -56,7 +56,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("opening lock file %s: %w", lockPath, err)
 	}
-	defer lockFile.Close()
+	// A failed Close on a writable handle can mean a lost write (though the
+	// lock file's own contents are never written to — this guards against
+	// the general case). Surface it as the function's error when nothing
+	// else already failed; otherwise log it so it isn't silently dropped.
+	defer func() {
+		if cerr := lockFile.Close(); cerr != nil {
+			if err == nil {
+				err = fmt.Errorf("closing lock file %s: %w", lockPath, cerr)
+			} else {
+				logf(0, "poll", "closing lock file %s after prior error: %v\n", lockPath, cerr)
+			}
+		}
+	}()
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		return fmt.Errorf("another pruefer instance is already running (lock file: %s)", lockPath)
 	}

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -1,0 +1,138 @@
+package pruefer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// GitHubLister is the subset of *github.Client's methods Daemon needs
+// beyond GitHubReviewer: listing open PRs per watched repo.
+type GitHubLister interface {
+	GitHubReviewer
+	ListOpenPRs(owner, repo string) ([]gh.PRDetails, error)
+}
+
+// Daemon polls Pruefer's configured repos and dispatches eligible PRs to
+// ReviewPR, mirroring engine/poll.go's Run()→poll(ctx) shape but with no
+// board/stage concept: each cycle just lists open PRs per watched repo and
+// hands them to ReviewPR, which does its own eligibility filtering.
+type Daemon struct {
+	Client   GitHubLister
+	Claude   ClaudeInvoker
+	Clone    CloneFunc
+	Config   Config
+	BotLogin string
+
+	// FabrikDir is the directory containing .pruefer/pruefer.lock. Defaults
+	// to "." (cwd) when empty.
+	FabrikDir string
+}
+
+func (d *Daemon) lockPath() string {
+	dir := d.FabrikDir
+	if dir == "" {
+		dir = "."
+	}
+	return filepath.Join(dir, ".pruefer", "pruefer.lock")
+}
+
+// Run acquires an exclusive file lock (preventing two Pruefer instances from
+// double-polling the same watched repos, mirroring engine/poll.go's
+// Engine.Run) and polls on Config.PollInterval until ctx is cancelled.
+func (d *Daemon) Run(ctx context.Context) error {
+	lockPath := d.lockPath()
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
+		return fmt.Errorf("creating lock dir: %w", err)
+	}
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("opening lock file %s: %w", lockPath, err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return fmt.Errorf("another pruefer instance is already running (lock file: %s)", lockPath)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+
+	interval := d.Config.PollInterval
+	if interval <= 0 {
+		interval = DefaultPollInterval
+	}
+	logf(0, "poll", "pruefer starting: watching %d repo(s), poll interval %s, concurrency %d\n",
+		len(d.Config.WatchedRepos), interval, d.effectiveConcurrency())
+
+	for {
+		d.poll(ctx)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(interval):
+		}
+	}
+}
+
+func (d *Daemon) effectiveConcurrency() int {
+	if d.Config.ConcurrencyCap > 0 {
+		return d.Config.ConcurrencyCap
+	}
+	return DefaultConcurrencyCap
+}
+
+// poll runs one polling cycle across every watched repo, dispatching
+// eligible PRs to ReviewPR through a concurrency-capped semaphore shared
+// across the whole cycle (not per-repo) — Pruefer's claude capacity is one
+// subscription shared across every watched repo, not one per repo.
+func (d *Daemon) poll(ctx context.Context) {
+	sem := make(chan struct{}, d.effectiveConcurrency())
+	var wg sync.WaitGroup
+
+	for _, repoSpec := range d.Config.WatchedRepos {
+		owner, repo, ok := splitOwnerRepo(repoSpec)
+		if !ok {
+			logf(0, "warn", "skipping malformed watched repo %q (want owner/repo)\n", repoSpec)
+			continue
+		}
+		prs, err := d.Client.ListOpenPRs(owner, repo)
+		if err != nil {
+			logf(0, "warn", "listing open PRs for %s/%s: %v — skipping this repo this cycle\n", owner, repo, err)
+			continue
+		}
+		for _, pr := range prs {
+			pr := pr
+			wg.Add(1)
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				wg.Done()
+				continue
+			}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				outcome := ReviewPR(ctx, d.Client, d.Claude, d.Clone, d.Config, d.BotLogin, owner, repo, pr)
+				if outcome.Err != nil {
+					logf(pr.Number, "warn", "reviewing %s/%s#%d: %v\n", owner, repo, pr.Number, outcome.Err)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+// splitOwnerRepo splits "owner/repo" into its two parts. Returns ok=false
+// for anything else (missing/extra slash, empty parts).
+func splitOwnerRepo(spec string) (owner, repo string, ok bool) {
+	parts := strings.Split(spec, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -3,7 +3,9 @@ package pruefer
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -238,8 +240,9 @@ func TestDaemonRun_LockPreventsSecondInstance(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- d1.Run(ctx1) }()
 
-	// Give d1 a moment to acquire the lock.
-	time.Sleep(100 * time.Millisecond)
+	// Wait until d1 actually holds the lock, rather than assuming a fixed
+	// sleep is long enough — probe the same lock file ourselves.
+	waitUntil(t, 2*time.Second, func() bool { return lockHeld(t, d1.lockPath()) })
 
 	d2 := &Daemon{Client: client, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
 	if err := d2.Run(context.Background()); err == nil {
@@ -252,4 +255,21 @@ func TestDaemonRun_LockPreventsSecondInstance(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("first Daemon.Run did not exit after context cancellation")
 	}
+}
+
+// lockHeld reports whether some other process/goroutine currently holds an
+// exclusive flock on path, by attempting (and immediately releasing) a
+// non-blocking flock of our own.
+func lockHeld(t *testing.T, path string) bool {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return false // lock file/dir may not exist yet
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return true
+	}
+	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return false
 }

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -1,0 +1,255 @@
+package pruefer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// fakeLister extends fakeReviewer with ListOpenPRs, keyed by "owner/repo".
+type fakeLister struct {
+	*fakeReviewer
+	mu            sync.Mutex
+	prsByRepo     map[string][]gh.PRDetails
+	listErrByRepo map[string]error
+}
+
+func newFakeLister() *fakeLister {
+	return &fakeLister{
+		fakeReviewer:  newFakeReviewer(),
+		prsByRepo:     map[string][]gh.PRDetails{},
+		listErrByRepo: map[string]error{},
+	}
+}
+
+func (f *fakeLister) ListOpenPRs(owner, repo string) ([]gh.PRDetails, error) {
+	key := owner + "/" + repo
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.listErrByRepo[key]; err != nil {
+		return nil, err
+	}
+	return f.prsByRepo[key], nil
+}
+
+// concurrencyTrackingInvoker blocks each Review call on a shared gate until
+// released, tracking the maximum number of concurrent in-flight calls.
+type concurrencyTrackingInvoker struct {
+	mu      sync.Mutex
+	current int
+	maxSeen int
+	release chan struct{}
+}
+
+func newConcurrencyTrackingInvoker() *concurrencyTrackingInvoker {
+	return &concurrencyTrackingInvoker{release: make(chan struct{})}
+}
+
+func (c *concurrencyTrackingInvoker) Review(ctx context.Context, req ReviewRequest) (string, error) {
+	c.mu.Lock()
+	c.current++
+	if c.current > c.maxSeen {
+		c.maxSeen = c.current
+	}
+	c.mu.Unlock()
+
+	<-c.release
+
+	c.mu.Lock()
+	c.current--
+	c.mu.Unlock()
+	return "reviewed", nil
+}
+
+func (c *concurrencyTrackingInvoker) currentCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.current
+}
+
+func (c *concurrencyTrackingInvoker) maxSeenCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.maxSeen
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}
+
+func TestDaemonPoll_EnforcesConcurrencyCap(t *testing.T) {
+	client := newFakeLister()
+	var prs []gh.PRDetails
+	for i := 1; i <= 6; i++ {
+		prs = append(prs, gh.PRDetails{Number: i, Author: "alice", HeadSHA: fmt.Sprintf("sha%d", i)})
+	}
+	client.prsByRepo["owner/repo"] = prs
+
+	claude := newConcurrencyTrackingInvoker()
+	clone, _ := fakeClone(t, nil)
+
+	d := &Daemon{
+		Client:   client,
+		Claude:   claude,
+		Clone:    clone,
+		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 2},
+		BotLogin: "pruefer-bot[bot]",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		d.poll(context.Background())
+		close(done)
+	}()
+
+	// Wait until the cap is actually saturated before asserting on it —
+	// otherwise we might sample before all cap-many goroutines have started.
+	waitUntil(t, 2*time.Second, func() bool { return claude.currentCount() == 2 })
+	if got := claude.currentCount(); got > 2 {
+		t.Errorf("concurrent claude invocations = %d, want <= 2 (ConcurrencyCap)", got)
+	}
+	// Give any over-eager dispatch a moment to (wrongly) exceed the cap.
+	time.Sleep(50 * time.Millisecond)
+	if got := claude.currentCount(); got > 2 {
+		t.Errorf("concurrent claude invocations = %d, want <= 2 (ConcurrencyCap)", got)
+	}
+
+	close(claude.release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("poll did not complete within 5s after releasing all invocations")
+	}
+
+	if claude.maxSeenCount() > 2 {
+		t.Errorf("max concurrent claude invocations observed = %d, want <= 2", claude.maxSeenCount())
+	}
+	if client.submitCallCount() != 6 {
+		t.Errorf("expected all 6 eligible PRs to be reviewed, got %d submissions", client.submitCallCount())
+	}
+}
+
+func TestDaemonPoll_DiffSizeGuardAppliesAcrossRepos(t *testing.T) {
+	client := newFakeLister()
+	client.prsByRepo["owner/repo"] = []gh.PRDetails{{Number: 1, Author: "alice", HeadSHA: "sha1"}}
+	client.diff = "this diff is way over the tiny cap configured below"
+	claude := &mockClaudeInvoker{}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	d := &Daemon{
+		Client:   client,
+		Claude:   claude,
+		Clone:    clone,
+		Config:   Config{WatchedRepos: []string{"owner/repo"}, MaxDiffBytes: 5, ConcurrencyCap: 3},
+		BotLogin: "pruefer-bot[bot]",
+	}
+	d.poll(context.Background())
+
+	if cloneCalls.Load() != 0 {
+		t.Error("expected the oversized-diff PR to skip before cloning")
+	}
+	if claude.callCount() != 0 {
+		t.Error("expected the oversized-diff PR to skip before invoking claude")
+	}
+	if client.submitCallCount() != 0 {
+		t.Error("expected no review submitted for the oversized-diff PR")
+	}
+}
+
+func TestDaemonPoll_SkipsMalformedWatchedRepo(t *testing.T) {
+	client := newFakeLister()
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	d := &Daemon{
+		Client:   client,
+		Claude:   claude,
+		Clone:    clone,
+		Config:   Config{WatchedRepos: []string{"not-a-valid-repo-spec"}},
+		BotLogin: "pruefer-bot[bot]",
+	}
+	d.poll(context.Background()) // must not panic
+}
+
+func TestDaemonPoll_ContinuesAfterOneRepoListFails(t *testing.T) {
+	client := newFakeLister()
+	client.listErrByRepo["owner/broken"] = fmt.Errorf("500 internal server error")
+	client.prsByRepo["owner/good"] = []gh.PRDetails{{Number: 1, Author: "alice", HeadSHA: "sha1"}}
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	d := &Daemon{
+		Client:   client,
+		Claude:   claude,
+		Clone:    clone,
+		Config:   Config{WatchedRepos: []string{"owner/broken", "owner/good"}, ConcurrencyCap: 3},
+		BotLogin: "pruefer-bot[bot]",
+	}
+	d.poll(context.Background())
+
+	if client.submitCallCount() != 1 {
+		t.Errorf("expected the good repo's PR to still be reviewed despite the broken repo failing, got %d submissions", client.submitCallCount())
+	}
+}
+
+func TestSplitOwnerRepo(t *testing.T) {
+	cases := []struct {
+		spec      string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{"handarbeit/fabrik", "handarbeit", "fabrik", true},
+		{"handarbeit", "", "", false},
+		{"handarbeit/fabrik/extra", "", "", false},
+		{"/fabrik", "", "", false},
+		{"handarbeit/", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tc := range cases {
+		owner, repo, ok := splitOwnerRepo(tc.spec)
+		if ok != tc.wantOK || owner != tc.wantOwner || repo != tc.wantRepo {
+			t.Errorf("splitOwnerRepo(%q) = (%q, %q, %v), want (%q, %q, %v)", tc.spec, owner, repo, ok, tc.wantOwner, tc.wantRepo, tc.wantOK)
+		}
+	}
+}
+
+func TestDaemonRun_LockPreventsSecondInstance(t *testing.T) {
+	dir := t.TempDir()
+	client := newFakeLister()
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	d1 := &Daemon{Client: client, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	errCh := make(chan error, 1)
+	go func() { errCh <- d1.Run(ctx1) }()
+
+	// Give d1 a moment to acquire the lock.
+	time.Sleep(100 * time.Millisecond)
+
+	d2 := &Daemon{Client: client, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
+	if err := d2.Run(context.Background()); err == nil {
+		t.Fatal("expected the second Daemon.Run to fail while the first holds the lock")
+	}
+
+	cancel1()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first Daemon.Run did not exit after context cancellation")
+	}
+}

--- a/pruefer/execute.go
+++ b/pruefer/execute.go
@@ -1,0 +1,57 @@
+package pruefer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/handarbeit/fabrik/config"
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// Execute is Pruefer's entry point: loads .env, resolves configuration,
+// bootstraps GitHub App auth, constructs the GitHub client and Daemon, and
+// runs until interrupted (SIGINT/SIGTERM). Mirrors cmd.Execute()'s shape
+// for the main fabrik binary (see cmd/root.go), scaled down to Pruefer's
+// needs — no board/stage machinery, no TUI.
+func Execute() error {
+	if err := config.LoadDotenv(); err != nil {
+		return fmt.Errorf("loading .env: %w", err)
+	}
+
+	cfg, err := LoadConfig(os.Args[1:])
+	if err != nil {
+		return err
+	}
+	if cfg.AppID == 0 {
+		return fmt.Errorf("github_app_id is required (set via config file, PRUEFER_GITHUB_APP_ID, or --github-app-id)")
+	}
+	if len(cfg.WatchedRepos) == 0 {
+		return fmt.Errorf("no watched repos configured (set watched_repos, PRUEFER_REPOS, or --repos)")
+	}
+
+	client := gh.NewClient("")
+	auth, err := Bootstrap(cfg, client, "")
+	if err != nil {
+		return fmt.Errorf("bootstrapping GitHub App auth: %w", err)
+	}
+	logf(0, "auth", "authenticated as %s (installation %d)\n", auth.BotLogin, auth.InstallationID)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go auth.RunRefreshLoop(ctx, func(format string, args ...any) {
+		logf(0, "auth", format, args...)
+	})
+
+	daemon := &Daemon{
+		Client:   client,
+		Claude:   &RealClaudeInvoker{},
+		Clone:    CloneForReview,
+		Config:   cfg,
+		BotLogin: auth.BotLogin,
+	}
+	return daemon.Run(ctx)
+}

--- a/pruefer/log.go
+++ b/pruefer/log.go
@@ -1,0 +1,23 @@
+package pruefer
+
+import (
+	"fmt"
+	"os"
+)
+
+// Logf is an optional package-level logger hook, mirroring github.Logf and
+// engine's claudeLogf. When set (by Daemon during construction), Pruefer's
+// internal log lines are routed here instead of stderr, so they can land in
+// a structured log file in Fabrik's style. nil falls back to stderr (e.g. in
+// tests).
+var Logf func(prNumber int, tag, format string, args ...any)
+
+// logf is the package-internal logging helper that fans out to Logf if set,
+// otherwise stderr. prNumber == 0 for messages not scoped to a specific PR.
+func logf(prNumber int, tag, format string, args ...any) {
+	if Logf != nil {
+		Logf(prNumber, tag, format, args...)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[pr#%d %s] "+format, append([]any{prNumber, tag}, args...)...)
+}

--- a/pruefer/mocks_test.go
+++ b/pruefer/mocks_test.go
@@ -1,0 +1,40 @@
+package pruefer
+
+import (
+	"context"
+	"sync"
+)
+
+// mockClaudeInvoker implements ClaudeInvoker for testing, mirroring
+// engine/mocks_test.go's mockClaudeInvoker shape: an injectable fn plus a
+// mutex-protected call log, safe for use from concurrent tests.
+type mockClaudeInvoker struct {
+	mu    sync.Mutex
+	fn    func(req ReviewRequest) (string, error)
+	calls []ReviewRequest
+}
+
+func (m *mockClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (string, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, req)
+	fn := m.fn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(req)
+	}
+	return "mock review", nil
+}
+
+func (m *mockClaudeInvoker) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *mockClaudeInvoker) callsSnapshot() []ReviewRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]ReviewRequest, len(m.calls))
+	copy(out, m.calls)
+	return out
+}

--- a/pruefer/procattr_unix.go
+++ b/pruefer/procattr_unix.go
@@ -1,0 +1,94 @@
+//go:build !windows
+
+package pruefer
+
+// Duplicated from engine/procattr_unix.go rather than extracted into a
+// shared internal package: these are small, stable OS primitives, and
+// extracting them would touch engine's existing call sites for a
+// security-relevant piece of code for the sake of a one-time ~80-line copy
+// (see adrs/073-pruefer-v1-architecture.md).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// setCmdProcAttr starts cmd in its own process group so grandchild processes
+// can be cleaned up after cmd exits.
+func setCmdProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcGroup sends SIGKILL to cmd's entire process group, cleaning up any
+// grandchild processes that outlived the claude process. ESRCH (no such
+// process) is silently ignored — the group may already be gone. Unexpected
+// errors are logged so cleanup failures are diagnosable.
+func killProcGroup(cmd *exec.Cmd, prNumber int, label string) {
+	if cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	if pid <= 0 {
+		return
+	}
+	logf(prNumber, "kill", "sending SIGKILL to PGID %d (grandchild cleanup)\n", pid)
+	// Negative PID targets the process group (PGID == claude's PID when Setpgid is set).
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		fmt.Fprintf(os.Stderr, "[pr#%d pruefer] killProcGroup %q: unexpected error killing process group %d: %v\n", prNumber, label, pid, err)
+	}
+}
+
+// isProcessAlive returns true if the process with the given PID is alive.
+// Uses signal 0 (does not kill the process; only probes existence/permissions).
+// EPERM means the process exists but we lack permission — treat as alive.
+// ESRCH means no such process — treat as dead.
+func isProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+// killProcGroupGraceful sends signals in escalating order to the process
+// group: SIGINT → (sigintGrace) → SIGTERM → (sigtermGrace) → SIGKILL. A zero
+// sigintGrace skips the SIGINT step entirely; a zero sigtermGrace skips the
+// SIGTERM step (falls straight to SIGKILL). Liveness is re-probed before
+// each subsequent signal; ESRCH stops escalation early.
+func killProcGroupGraceful(pid, prNumber int, label, reason string, sigintGrace, sigtermGrace time.Duration) {
+	if pid <= 0 {
+		return
+	}
+	if sigintGrace > 0 {
+		logf(prNumber, "kill", "sending SIGINT to PGID %d (reason=%s)\n", pid, reason)
+		if err := syscall.Kill(-pid, syscall.SIGINT); err != nil {
+			if err == syscall.ESRCH {
+				return // group already gone
+			}
+			fmt.Fprintf(os.Stderr, "[pr#%d pruefer] killProcGroupGraceful %q: SIGINT error on pgid %d: %v\n", prNumber, label, pid, err)
+		}
+		time.Sleep(sigintGrace)
+		if err := syscall.Kill(-pid, 0); err == syscall.ESRCH {
+			return // group exited during SIGINT grace window
+		}
+	}
+
+	if sigtermGrace > 0 {
+		logf(prNumber, "kill", "sending SIGTERM to PGID %d (reason=%s)\n", pid, reason)
+		if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil {
+			if err == syscall.ESRCH {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "[pr#%d pruefer] killProcGroupGraceful %q: SIGTERM error on pgid %d: %v\n", prNumber, label, pid, err)
+		}
+		time.Sleep(sigtermGrace)
+		if err := syscall.Kill(-pid, 0); err == syscall.ESRCH {
+			return // group exited during SIGTERM grace window
+		}
+	}
+
+	logf(prNumber, "kill", "sending SIGKILL to PGID %d (reason=%s)\n", pid, reason)
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		fmt.Fprintf(os.Stderr, "[pr#%d pruefer] killProcGroupGraceful %q: SIGKILL error on pgid %d: %v\n", prNumber, label, pid, err)
+	}
+}

--- a/pruefer/procattr_unix.go
+++ b/pruefer/procattr_unix.go
@@ -6,7 +6,7 @@ package pruefer
 // shared internal package: these are small, stable OS primitives, and
 // extracting them would touch engine's existing call sites for a
 // security-relevant piece of code for the sake of a one-time ~80-line copy
-// (see adrs/074-pruefer-v1-architecture.md).
+// (see adrs/1113-pruefer-v1-architecture.md).
 
 import (
 	"fmt"

--- a/pruefer/procattr_unix.go
+++ b/pruefer/procattr_unix.go
@@ -6,7 +6,7 @@ package pruefer
 // shared internal package: these are small, stable OS primitives, and
 // extracting them would touch engine's existing call sites for a
 // security-relevant piece of code for the sake of a one-time ~80-line copy
-// (see adrs/073-pruefer-v1-architecture.md).
+// (see adrs/074-pruefer-v1-architecture.md).
 
 import (
 	"fmt"

--- a/pruefer/procattr_unix_test.go
+++ b/pruefer/procattr_unix_test.go
@@ -1,0 +1,98 @@
+//go:build !windows
+
+package pruefer
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// startSleeper starts a detached "sleep" process in its own process group
+// and returns the *exec.Cmd (already started). Callers must ensure the
+// process is reaped (it will be, once killed, since no one calls Wait —
+// tests only assert liveness via signal 0, which does not require reaping
+// for the ESRCH check to eventually succeed on most platforms; to keep
+// this simple and avoid zombies, tests call cmd.Wait() in a goroutine).
+func startSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group signaling is unix-only")
+	}
+	cmd := exec.Command("sleep", "30")
+	setCmdProcAttr(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting sleep process: %v", err)
+	}
+	go cmd.Wait() // reap to avoid a zombie once killed
+	return cmd
+}
+
+func TestIsProcessAlive(t *testing.T) {
+	cmd := startSleeper(t)
+	pid := cmd.Process.Pid
+	if !isProcessAlive(pid) {
+		t.Fatal("expected process to be alive immediately after start")
+	}
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("killing process: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for isProcessAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if isProcessAlive(pid) {
+		t.Error("expected process to be dead after Kill")
+	}
+}
+
+func TestKillProcGroup_SendsSIGKILL(t *testing.T) {
+	cmd := startSleeper(t)
+	pid := cmd.Process.Pid
+	killProcGroup(cmd, 42, "test")
+	deadline := time.Now().Add(2 * time.Second)
+	for isProcessAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if isProcessAlive(pid) {
+		t.Error("expected process to be dead after killProcGroup")
+	}
+}
+
+func TestKillProcGroupGraceful_EscalatesToSIGKILL(t *testing.T) {
+	cmd := startSleeper(t)
+	pid := cmd.Process.Pid
+	// Zero grace windows collapse straight to SIGKILL — this exercises the
+	// full escalation call path without a real multi-second test.
+	killProcGroupGraceful(pid, 42, "test", "unit_test", 0, 0)
+	deadline := time.Now().Add(2 * time.Second)
+	for isProcessAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if isProcessAlive(pid) {
+		t.Error("expected process to be dead after killProcGroupGraceful")
+	}
+}
+
+func TestKillProcGroupGraceful_SigIntSufficient(t *testing.T) {
+	// A process that exits cleanly on SIGINT (the default disposition for a
+	// plain "sleep") should be gone before the SIGTERM/SIGKILL steps ever run.
+	cmd := startSleeper(t)
+	pid := cmd.Process.Pid
+	killProcGroupGraceful(pid, 42, "test", "unit_test", 50*time.Millisecond, 2*time.Second)
+	if isProcessAlive(pid) {
+		t.Error("expected process to be dead after SIGINT grace window (sleep exits on SIGINT)")
+	}
+}
+
+func TestKillProcGroupGraceful_ZeroPID_NoOp(t *testing.T) {
+	// Must not panic or signal PID 0 (which would hit the caller's own
+	// process group) when passed a zero/negative PID.
+	killProcGroupGraceful(0, 42, "test", "unit_test", 0, 0)
+}
+
+func TestKillProcGroup_NilProcess_NoOp(t *testing.T) {
+	cmd := &exec.Cmd{}
+	killProcGroup(cmd, 42, "test") // must not panic
+}

--- a/pruefer/procattr_windows.go
+++ b/pruefer/procattr_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package pruefer
+
+import (
+	"os/exec"
+	"time"
+)
+
+// setCmdProcAttr is a no-op on Windows: process groups work differently and
+// the Setpgid/SIGKILL approach is Unix-specific.
+func setCmdProcAttr(cmd *exec.Cmd) {}
+
+// killProcGroup is a no-op on Windows.
+func killProcGroup(cmd *exec.Cmd, prNumber int, label string) {}
+
+// killProcGroupGraceful is a no-op on Windows.
+func killProcGroupGraceful(pid, prNumber int, label, reason string, sigintGrace, sigtermGrace time.Duration) {
+}
+
+// isProcessAlive returns true on Windows — process liveness via signal 0 is
+// Unix-specific. Conservative default.
+func isProcessAlive(pid int) bool { return true }

--- a/pruefer/review.go
+++ b/pruefer/review.go
@@ -102,7 +102,8 @@ func ReviewPR(ctx context.Context, client GitHubReviewer, claude ClaudeInvoker, 
 
 	reviewText, err := claude.Review(ctx, ReviewRequest{
 		Owner: owner, Repo: repo, PRNumber: pr.Number, Title: pr.Title, Body: pr.Body,
-		HeadSHA: pr.HeadSHA, Model: cfg.Model, Effort: cfg.Effort, WorkDir: dir,
+		HeadSHA: pr.HeadSHA, BaseBranch: pr.BaseRef, Model: cfg.Model, Effort: cfg.Effort,
+		WorkDir: dir, MaxWallTime: cfg.MaxWallTime,
 	})
 	if err != nil {
 		logf(pr.Number, "claude", "review invocation failed for %s/%s#%d: %v — posting nothing\n", owner, repo, pr.Number, err)

--- a/pruefer/review.go
+++ b/pruefer/review.go
@@ -1,0 +1,124 @@
+package pruefer
+
+import (
+	"context"
+	"fmt"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// GitHubReviewer is the subset of *github.Client's methods review.go needs:
+// diff fetch (for the size guard and path exclusion), existing-review
+// lookup (for GitHub-derived review state), review submission, and — via
+// GitHubCommenter — the /pruefer review comment lifecycle. Token exposes
+// the current installation token for CloneForReview's HTTPS auth. A narrow
+// interface keeps tests independent of HTTP mocking.
+type GitHubReviewer interface {
+	GitHubCommenter
+	FetchPRDiff(owner, repo string, prNumber int) (string, error)
+	FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, error)
+	SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error)
+	Token() string
+}
+
+// CloneFunc creates an ephemeral clone of a PR's head commit and returns its
+// directory plus a cleanup function. Matches CloneForReview's signature;
+// injectable so tests can substitute a local git repo instead of hitting
+// github.com.
+type CloneFunc func(ctx context.Context, owner, repo, token string, prNumber int) (dir string, cleanup func(), err error)
+
+// ReviewOutcome records what happened when ReviewPR was asked to review a
+// PR, so callers (daemon.go, tests) can observe results without parsing logs.
+type ReviewOutcome struct {
+	Reviewed bool       // true iff a formal review was submitted
+	Skipped  bool       // true iff the PR was ineligible
+	Reason   SkipReason // set iff Skipped
+	Err      error      // non-nil on a genuine failure (clone, claude invocation, API call)
+}
+
+// ReviewPR runs the full per-PR pipeline: on-demand-comment detection,
+// eligibility check, diff-size guard, ephemeral clone, Claude invocation,
+// and — on success — formal review submission pinned to the PR's current
+// head SHA.
+//
+// On any failure it posts nothing (per the issue's explicit "on invocation
+// failure, post nothing rather than a stub" requirement) and returns a
+// non-nil Err; the PR is naturally retried on the next poll since review
+// state is derived from GitHub itself, not persisted locally.
+//
+// Cheap checks (draft, self-authored, excluded author/label, already-
+// reviewed-at-SHA) run before any diff fetch; only a PR that passes those
+// triggers the FetchPRDiff call used for the size guard and path exclusion,
+// so a skip never costs an extra network round-trip.
+func ReviewPR(ctx context.Context, client GitHubReviewer, claude ClaudeInvoker, clone CloneFunc, cfg Config, botLogin, owner, repo string, pr gh.PRDetails) ReviewOutcome {
+	forceReview, err := PendingForceReview(client, owner, repo, pr.Number)
+	if err != nil {
+		logf(pr.Number, "warn", "checking for /pruefer review command on %s/%s#%d: %v\n", owner, repo, pr.Number, err)
+		forceReview = false // not fatal to the poll cycle — treat as no forced review this round
+	}
+
+	reviews, err := client.FetchPRReviews(owner, repo, pr.Number)
+	if err != nil {
+		return ReviewOutcome{Err: fmt.Errorf("fetching existing reviews: %w", err)}
+	}
+
+	cheapCheck := EligibilityInput{
+		PR:              pr,
+		BotLogin:        botLogin,
+		ExcludedAuthors: cfg.ExcludedAuthors,
+		ExcludedLabels:  cfg.ExcludedLabels,
+		ExistingReviews: reviews,
+		ForceReview:     forceReview,
+	}
+	if ok, reason := Eligible(cheapCheck); !ok {
+		logf(pr.Number, "select", "skipping %s/%s#%d: %s\n", owner, repo, pr.Number, reason)
+		return ReviewOutcome{Skipped: true, Reason: reason}
+	}
+
+	diff, err := client.FetchPRDiff(owner, repo, pr.Number)
+	if err != nil {
+		return ReviewOutcome{Err: fmt.Errorf("fetching diff: %w", err)}
+	}
+	if cfg.MaxDiffBytes > 0 && int64(len(diff)) > cfg.MaxDiffBytes {
+		logf(pr.Number, "select", "skipping %s/%s#%d: diff is %d bytes, exceeds max_diff_bytes=%d\n", owner, repo, pr.Number, len(diff), cfg.MaxDiffBytes)
+		return ReviewOutcome{Skipped: true, Reason: SkipDiffTooLarge}
+	}
+	if len(cfg.ExcludedPaths) > 0 && allPathsExcluded(ParseChangedPaths(diff), cfg.ExcludedPaths) {
+		logf(pr.Number, "select", "skipping %s/%s#%d: %s\n", owner, repo, pr.Number, SkipExcludedPath)
+		return ReviewOutcome{Skipped: true, Reason: SkipExcludedPath}
+	}
+
+	if forceReview {
+		if err := AcknowledgeForceReview(client, owner, repo, pr.Number); err != nil {
+			logf(pr.Number, "warn", "acknowledging /pruefer review comment on %s/%s#%d: %v\n", owner, repo, pr.Number, err)
+		}
+	}
+
+	dir, cleanup, err := clone(ctx, owner, repo, client.Token(), pr.Number)
+	if err != nil {
+		return ReviewOutcome{Err: fmt.Errorf("cloning PR head: %w", err)}
+	}
+	defer cleanup()
+
+	reviewText, err := claude.Review(ctx, ReviewRequest{
+		Owner: owner, Repo: repo, PRNumber: pr.Number, Title: pr.Title, Body: pr.Body,
+		HeadSHA: pr.HeadSHA, Model: cfg.Model, Effort: cfg.Effort, WorkDir: dir,
+	})
+	if err != nil {
+		logf(pr.Number, "claude", "review invocation failed for %s/%s#%d: %v — posting nothing\n", owner, repo, pr.Number, err)
+		return ReviewOutcome{Err: fmt.Errorf("claude review invocation: %w", err)}
+	}
+
+	if _, err := client.SubmitPRReview(owner, repo, pr.Number, pr.HeadSHA, reviewText); err != nil {
+		return ReviewOutcome{Err: fmt.Errorf("submitting review: %w", err)}
+	}
+
+	if forceReview {
+		if err := MarkForceReviewsProcessed(client, owner, repo, pr.Number); err != nil {
+			logf(pr.Number, "warn", "marking /pruefer review comment processed on %s/%s#%d: %v\n", owner, repo, pr.Number, err)
+		}
+	}
+
+	logf(pr.Number, "review", "submitted review for %s/%s#%d at %s\n", owner, repo, pr.Number, pr.HeadSHA)
+	return ReviewOutcome{Reviewed: true}
+}

--- a/pruefer/review_test.go
+++ b/pruefer/review_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	gh "github.com/handarbeit/fabrik/github"
@@ -67,13 +68,20 @@ func (f *fakeReviewer) submitCallCount() int {
 	return len(f.submitCalls)
 }
 
+func (f *fakeReviewer) diffCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.diffCalls
+}
+
 // fakeClone returns a CloneFunc that records calls and returns a fresh temp
-// dir without touching the network or git at all.
-func fakeClone(t *testing.T, err error) (CloneFunc, *int) {
+// dir without touching the network or git at all. Safe for concurrent use
+// (daemon_test.go dispatches ReviewPR from multiple goroutines).
+func fakeClone(t *testing.T, err error) (CloneFunc, *atomic.Int32) {
 	t.Helper()
-	calls := 0
+	var calls atomic.Int32
 	fn := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
-		calls++
+		calls.Add(1)
 		if err != nil {
 			return "", func() {}, err
 		}
@@ -102,8 +110,8 @@ func TestReviewPR_EligiblePR_SubmitsExactlyOneReview(t *testing.T) {
 	if outcome.Err != nil {
 		t.Fatalf("outcome.Err = %v, want nil", outcome.Err)
 	}
-	if *cloneCalls != 1 {
-		t.Errorf("clone called %d times, want 1", *cloneCalls)
+	if cloneCalls.Load() != 1 {
+		t.Errorf("clone called %d times, want 1", cloneCalls.Load())
 	}
 	if claude.callCount() != 1 {
 		t.Errorf("claude called %d times, want 1", claude.callCount())
@@ -129,7 +137,7 @@ func TestReviewPR_RepollSameSHA_DoesNotReReview(t *testing.T) {
 	if !outcome.Skipped || outcome.Reason != SkipAlreadyReviewed {
 		t.Fatalf("outcome = %+v, want Skipped with SkipAlreadyReviewed", outcome)
 	}
-	if *cloneCalls != 0 {
+	if cloneCalls.Load() != 0 {
 		t.Error("expected no clone when the PR was already reviewed at this SHA")
 	}
 	if claude.callCount() != 0 {
@@ -151,7 +159,7 @@ func TestReviewPR_DraftPR_Skipped(t *testing.T) {
 	if !outcome.Skipped || outcome.Reason != SkipDraft {
 		t.Fatalf("outcome = %+v, want Skipped with SkipDraft", outcome)
 	}
-	if *cloneCalls != 0 || claude.callCount() != 0 || client.submitCallCount() != 0 {
+	if cloneCalls.Load() != 0 || claude.callCount() != 0 || client.submitCallCount() != 0 {
 		t.Error("draft PR must not clone, invoke claude, or submit a review")
 	}
 	if client.diffCalls != 0 {
@@ -188,7 +196,7 @@ func TestReviewPR_ForceReview_BypassesAlreadyReviewed(t *testing.T) {
 	if !outcome.Reviewed {
 		t.Fatalf("outcome = %+v, want Reviewed=true (forced re-review)", outcome)
 	}
-	if *cloneCalls != 1 || claude.callCount() != 1 || client.submitCallCount() != 1 {
+	if cloneCalls.Load() != 1 || claude.callCount() != 1 || client.submitCallCount() != 1 {
 		t.Error("forced re-review must clone, invoke claude, and submit exactly one review")
 	}
 	if !client.comments[0].HasReaction("ROCKET") {
@@ -209,7 +217,7 @@ func TestReviewPR_DiffTooLarge_Skipped(t *testing.T) {
 	if !outcome.Skipped || outcome.Reason != SkipDiffTooLarge {
 		t.Fatalf("outcome = %+v, want Skipped with SkipDiffTooLarge", outcome)
 	}
-	if *cloneCalls != 0 || claude.callCount() != 0 {
+	if cloneCalls.Load() != 0 || claude.callCount() != 0 {
 		t.Error("oversized diff must skip before cloning or invoking claude")
 	}
 }
@@ -227,7 +235,7 @@ func TestReviewPR_ExcludedPath_Skipped(t *testing.T) {
 	if !outcome.Skipped || outcome.Reason != SkipExcludedPath {
 		t.Fatalf("outcome = %+v, want Skipped with SkipExcludedPath", outcome)
 	}
-	if *cloneCalls != 0 || claude.callCount() != 0 {
+	if cloneCalls.Load() != 0 || claude.callCount() != 0 {
 		t.Error("excluded-path PR must skip before cloning or invoking claude")
 	}
 }
@@ -245,8 +253,8 @@ func TestReviewPR_ClaudeFailure_PostsNothing(t *testing.T) {
 	if outcome.Err == nil {
 		t.Fatal("expected a non-nil error when claude invocation fails")
 	}
-	if *cloneCalls != 1 {
-		t.Errorf("expected exactly one clone attempt, got %d", *cloneCalls)
+	if cloneCalls.Load() != 1 {
+		t.Errorf("expected exactly one clone attempt, got %d", cloneCalls.Load())
 	}
 	if client.submitCallCount() != 0 {
 		t.Error("expected no review submission when claude invocation fails — post nothing, not a stub")

--- a/pruefer/review_test.go
+++ b/pruefer/review_test.go
@@ -1,0 +1,304 @@
+package pruefer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// fakeReviewer implements GitHubReviewer in-memory for review.go's tests.
+type fakeReviewer struct {
+	*fakeCommenter
+
+	diff       string
+	diffErr    error
+	reviews    []gh.PRReview
+	reviewsErr error
+	submitErr  error
+	token      string
+
+	mu          sync.Mutex
+	submitCalls []submitCall
+	diffCalls   int
+}
+
+type submitCall struct {
+	owner, repo string
+	prNumber    int
+	commitSHA   string
+	body        string
+}
+
+func (f *fakeReviewer) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
+	f.mu.Lock()
+	f.diffCalls++
+	f.mu.Unlock()
+	if f.diffErr != nil {
+		return "", f.diffErr
+	}
+	return f.diff, nil
+}
+
+func (f *fakeReviewer) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, error) {
+	if f.reviewsErr != nil {
+		return nil, f.reviewsErr
+	}
+	return f.reviews, nil
+}
+
+func (f *fakeReviewer) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.submitErr != nil {
+		return 0, f.submitErr
+	}
+	f.submitCalls = append(f.submitCalls, submitCall{owner, repo, prNumber, commitSHA, body})
+	return len(f.submitCalls), nil
+}
+
+func (f *fakeReviewer) Token() string { return f.token }
+
+func (f *fakeReviewer) submitCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.submitCalls)
+}
+
+// fakeClone returns a CloneFunc that records calls and returns a fresh temp
+// dir without touching the network or git at all.
+func fakeClone(t *testing.T, err error) (CloneFunc, *int) {
+	t.Helper()
+	calls := 0
+	fn := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
+		calls++
+		if err != nil {
+			return "", func() {}, err
+		}
+		return t.TempDir(), func() {}, nil
+	}
+	return fn, &calls
+}
+
+func newFakeReviewer() *fakeReviewer {
+	return &fakeReviewer{fakeCommenter: &fakeCommenter{}, token: "tok"}
+}
+
+func TestReviewPR_EligiblePR_SubmitsExactlyOneReview(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (string, error) {
+		return "Looks fine, one nit.", nil
+	}}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1", Title: "Add feature"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed {
+		t.Fatalf("outcome = %+v, want Reviewed=true", outcome)
+	}
+	if outcome.Err != nil {
+		t.Fatalf("outcome.Err = %v, want nil", outcome.Err)
+	}
+	if *cloneCalls != 1 {
+		t.Errorf("clone called %d times, want 1", *cloneCalls)
+	}
+	if claude.callCount() != 1 {
+		t.Errorf("claude called %d times, want 1", claude.callCount())
+	}
+	if client.submitCallCount() != 1 {
+		t.Fatalf("SubmitPRReview called %d times, want exactly 1", client.submitCallCount())
+	}
+	call := client.submitCalls[0]
+	if call.commitSHA != "sha1" || call.body != "Looks fine, one nit." {
+		t.Errorf("submitCall = %+v", call)
+	}
+}
+
+func TestReviewPR_RepollSameSHA_DoesNotReReview(t *testing.T) {
+	client := newFakeReviewer()
+	client.reviews = []gh.PRReview{{Author: "pruefer-bot[bot]", CommitID: "sha1"}}
+	claude := &mockClaudeInvoker{}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Skipped || outcome.Reason != SkipAlreadyReviewed {
+		t.Fatalf("outcome = %+v, want Skipped with SkipAlreadyReviewed", outcome)
+	}
+	if *cloneCalls != 0 {
+		t.Error("expected no clone when the PR was already reviewed at this SHA")
+	}
+	if claude.callCount() != 0 {
+		t.Error("expected no claude invocation when the PR was already reviewed at this SHA")
+	}
+	if client.submitCallCount() != 0 {
+		t.Error("expected no review submission when the PR was already reviewed at this SHA")
+	}
+}
+
+func TestReviewPR_DraftPR_Skipped(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1", Draft: true}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Skipped || outcome.Reason != SkipDraft {
+		t.Fatalf("outcome = %+v, want Skipped with SkipDraft", outcome)
+	}
+	if *cloneCalls != 0 || claude.callCount() != 0 || client.submitCallCount() != 0 {
+		t.Error("draft PR must not clone, invoke claude, or submit a review")
+	}
+	if client.diffCalls != 0 {
+		t.Error("draft PR must not even fetch the diff (cheap checks run first)")
+	}
+}
+
+func TestReviewPR_SelfAuthored_Skipped(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "pruefer-bot[bot]", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Skipped || outcome.Reason != SkipSelfAuthored {
+		t.Fatalf("outcome = %+v, want Skipped with SkipSelfAuthored", outcome)
+	}
+	if claude.callCount() != 0 || client.submitCallCount() != 0 {
+		t.Error("self-authored PR must not invoke claude or submit a review")
+	}
+}
+
+func TestReviewPR_ForceReview_BypassesAlreadyReviewed(t *testing.T) {
+	client := newFakeReviewer()
+	client.reviews = []gh.PRReview{{Author: "pruefer-bot[bot]", CommitID: "sha1"}}
+	client.comments = []gh.Comment{{DatabaseID: 42, Body: "/pruefer review"}}
+	claude := &mockClaudeInvoker{}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed {
+		t.Fatalf("outcome = %+v, want Reviewed=true (forced re-review)", outcome)
+	}
+	if *cloneCalls != 1 || claude.callCount() != 1 || client.submitCallCount() != 1 {
+		t.Error("forced re-review must clone, invoke claude, and submit exactly one review")
+	}
+	if !client.comments[0].HasReaction("ROCKET") {
+		t.Error("expected the /pruefer review comment to be marked processed (ROCKET reaction)")
+	}
+}
+
+func TestReviewPR_DiffTooLarge_Skipped(t *testing.T) {
+	client := newFakeReviewer()
+	client.diff = "x diff content"
+	claude := &mockClaudeInvoker{}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	cfg := Config{MaxDiffBytes: 5} // "x diff content" is well over 5 bytes
+	outcome := ReviewPR(context.Background(), client, claude, clone, cfg, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Skipped || outcome.Reason != SkipDiffTooLarge {
+		t.Fatalf("outcome = %+v, want Skipped with SkipDiffTooLarge", outcome)
+	}
+	if *cloneCalls != 0 || claude.callCount() != 0 {
+		t.Error("oversized diff must skip before cloning or invoking claude")
+	}
+}
+
+func TestReviewPR_ExcludedPath_Skipped(t *testing.T) {
+	client := newFakeReviewer()
+	client.diff = "diff --git a/docs/readme.md b/docs/readme.md\n+change\n"
+	claude := &mockClaudeInvoker{}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	cfg := Config{ExcludedPaths: []string{"docs/*"}}
+	outcome := ReviewPR(context.Background(), client, claude, clone, cfg, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Skipped || outcome.Reason != SkipExcludedPath {
+		t.Fatalf("outcome = %+v, want Skipped with SkipExcludedPath", outcome)
+	}
+	if *cloneCalls != 0 || claude.callCount() != 0 {
+		t.Error("excluded-path PR must skip before cloning or invoking claude")
+	}
+}
+
+func TestReviewPR_ClaudeFailure_PostsNothing(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (string, error) {
+		return "", fmt.Errorf("claude crashed")
+	}}
+	clone, cloneCalls := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if outcome.Err == nil {
+		t.Fatal("expected a non-nil error when claude invocation fails")
+	}
+	if *cloneCalls != 1 {
+		t.Errorf("expected exactly one clone attempt, got %d", *cloneCalls)
+	}
+	if client.submitCallCount() != 0 {
+		t.Error("expected no review submission when claude invocation fails — post nothing, not a stub")
+	}
+}
+
+func TestReviewPR_CloneFailure_PostsNothing(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, fmt.Errorf("clone failed"))
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if outcome.Err == nil {
+		t.Fatal("expected a non-nil error when cloning fails")
+	}
+	if claude.callCount() != 0 {
+		t.Error("expected no claude invocation when cloning fails")
+	}
+	if client.submitCallCount() != 0 {
+		t.Error("expected no review submission when cloning fails")
+	}
+}
+
+func TestReviewPR_SubmitFailure_ReturnsError(t *testing.T) {
+	client := newFakeReviewer()
+	client.submitErr = fmt.Errorf("422 already reviewed")
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if outcome.Err == nil {
+		t.Fatal("expected a non-nil error when SubmitPRReview fails")
+	}
+	if outcome.Reviewed {
+		t.Error("Reviewed must be false when submission failed")
+	}
+}
+
+func TestReviewPR_ExcludedAuthor_Skipped(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "dependabot[bot]", HeadSHA: "sha1"}
+	cfg := Config{ExcludedAuthors: []string{"dependabot[bot]"}}
+	outcome := ReviewPR(context.Background(), client, claude, clone, cfg, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Skipped || outcome.Reason != SkipExcludedAuthor {
+		t.Fatalf("outcome = %+v, want Skipped with SkipExcludedAuthor", outcome)
+	}
+}

--- a/pruefer/review_test.go
+++ b/pruefer/review_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
 )
@@ -122,6 +123,30 @@ func TestReviewPR_EligiblePR_SubmitsExactlyOneReview(t *testing.T) {
 	call := client.submitCalls[0]
 	if call.commitSHA != "sha1" || call.body != "Looks fine, one nit." {
 		t.Errorf("submitCall = %+v", call)
+	}
+}
+
+func TestReviewPR_PopulatesBaseBranchAndMaxWallTime(t *testing.T) {
+	client := newFakeReviewer()
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1", BaseRef: "main"}
+	cfg := Config{MaxWallTime: 10 * time.Minute}
+	outcome := ReviewPR(context.Background(), client, claude, clone, cfg, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed {
+		t.Fatalf("outcome = %+v, want Reviewed=true", outcome)
+	}
+	calls := claude.callsSnapshot()
+	if len(calls) != 1 {
+		t.Fatalf("claude called %d times, want 1", len(calls))
+	}
+	if calls[0].BaseBranch != "main" {
+		t.Errorf("ReviewRequest.BaseBranch = %q, want %q", calls[0].BaseBranch, "main")
+	}
+	if calls[0].MaxWallTime != 10*time.Minute {
+		t.Errorf("ReviewRequest.MaxWallTime = %v, want %v", calls[0].MaxWallTime, 10*time.Minute)
 	}
 }
 

--- a/pruefer/select.go
+++ b/pruefer/select.go
@@ -21,6 +21,7 @@ const (
 	SkipExcludedLabel   SkipReason = "excluded label"
 	SkipExcludedPath    SkipReason = "excluded path: every touched file matches an exclusion glob"
 	SkipAlreadyReviewed SkipReason = "already reviewed at this head SHA"
+	SkipDiffTooLarge    SkipReason = "diff exceeds max_diff_bytes"
 )
 
 // EligibilityInput bundles everything Eligible needs to decide whether a PR

--- a/pruefer/select.go
+++ b/pruefer/select.go
@@ -50,7 +50,7 @@ type EligibilityInput struct {
 // ForceReview overrides only the already-reviewed-at-this-SHA check — draft,
 // self-authored, and excluded-author/label/path checks always apply, since
 // "/pruefer review" forces a *fresh* review, not a bypass of every safety
-// check (see adrs/073-pruefer-v1-architecture.md).
+// check (see adrs/074-pruefer-v1-architecture.md).
 func Eligible(in EligibilityInput) (bool, SkipReason) {
 	if in.PR.Draft {
 		return false, SkipDraft

--- a/pruefer/select.go
+++ b/pruefer/select.go
@@ -50,7 +50,7 @@ type EligibilityInput struct {
 // ForceReview overrides only the already-reviewed-at-this-SHA check — draft,
 // self-authored, and excluded-author/label/path checks always apply, since
 // "/pruefer review" forces a *fresh* review, not a bypass of every safety
-// check (see adrs/074-pruefer-v1-architecture.md).
+// check (see adrs/1113-pruefer-v1-architecture.md).
 func Eligible(in EligibilityInput) (bool, SkipReason) {
 	if in.PR.Draft {
 		return false, SkipDraft
@@ -97,11 +97,40 @@ func allPathsExcluded(changed, patterns []string) bool {
 
 func matchesAny(path string, patterns []string) bool {
 	for _, pat := range patterns {
-		if ok, err := filepath.Match(pat, path); err == nil && ok {
+		if matchGlob(pat, path) {
 			return true
 		}
 	}
 	return false
+}
+
+// matchGlob matches path against pattern using filepath.Match semantics per
+// path segment, plus "**" as a segment that matches zero or more path
+// segments (so "vendor/**" excludes everything under vendor/, matching the
+// documented behavior in cmd/pruefer/README.md — plain filepath.Match alone
+// never lets "*" cross a "/" and so cannot express that).
+func matchGlob(pattern, path string) bool {
+	return matchGlobParts(strings.Split(pattern, "/"), strings.Split(path, "/"))
+}
+
+func matchGlobParts(pat, name []string) bool {
+	if len(pat) == 0 {
+		return len(name) == 0
+	}
+	if pat[0] == "**" {
+		if matchGlobParts(pat[1:], name) {
+			return true
+		}
+		return len(name) > 0 && matchGlobParts(pat, name[1:])
+	}
+	if len(name) == 0 {
+		return false
+	}
+	ok, err := filepath.Match(pat[0], name[0])
+	if err != nil || !ok {
+		return false
+	}
+	return matchGlobParts(pat[1:], name[1:])
 }
 
 // alreadyReviewedAtHead reports whether reviews contains a review authored

--- a/pruefer/select.go
+++ b/pruefer/select.go
@@ -1,0 +1,139 @@
+package pruefer
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// SkipReason names why a PR was not selected for review. Used both for
+// structured logging and by callers that want to explain a skip decision to
+// a human. The zero value (empty string) is never returned by Eligible when
+// it reports true.
+type SkipReason string
+
+const (
+	SkipDraft           SkipReason = "draft"
+	SkipSelfAuthored    SkipReason = "self-authored: PR author is the review identity"
+	SkipExcludedAuthor  SkipReason = "excluded author"
+	SkipExcludedLabel   SkipReason = "excluded label"
+	SkipExcludedPath    SkipReason = "excluded path: every touched file matches an exclusion glob"
+	SkipAlreadyReviewed SkipReason = "already reviewed at this head SHA"
+)
+
+// EligibilityInput bundles everything Eligible needs to decide whether a PR
+// should be reviewed.
+type EligibilityInput struct {
+	PR              gh.PRDetails
+	BotLogin        string // Pruefer's own review identity, e.g. "pruefer-bot[bot]"
+	ExcludedAuthors []string
+	ExcludedLabels  []string
+	ExcludedPaths   []string // glob patterns (filepath.Match syntax), matched against every changed path
+	// ExistingReviews are the PR's current reviews (any author); Eligible
+	// looks specifically for one authored by BotLogin at PR.HeadSHA.
+	ExistingReviews []gh.PRReview
+	// ChangedPaths is the list of file paths touched by the PR, typically
+	// parsed from its diff via ParseChangedPaths. Empty/nil means "unknown"
+	// — path exclusion never fires when paths aren't available, since
+	// exclusion requires ALL paths to match.
+	ChangedPaths []string
+	// ForceReview is true when an unprocessed "/pruefer review" comment
+	// requests a fresh review of the current head regardless of prior
+	// review state.
+	ForceReview bool
+}
+
+// Eligible reports whether a PR should be reviewed, and if not, why.
+// ForceReview overrides only the already-reviewed-at-this-SHA check — draft,
+// self-authored, and excluded-author/label/path checks always apply, since
+// "/pruefer review" forces a *fresh* review, not a bypass of every safety
+// check (see adrs/073-pruefer-v1-architecture.md).
+func Eligible(in EligibilityInput) (bool, SkipReason) {
+	if in.PR.Draft {
+		return false, SkipDraft
+	}
+	if in.BotLogin != "" && strings.EqualFold(in.PR.Author, in.BotLogin) {
+		return false, SkipSelfAuthored
+	}
+	for _, a := range in.ExcludedAuthors {
+		if strings.EqualFold(a, in.PR.Author) {
+			return false, SkipExcludedAuthor
+		}
+	}
+	for _, l := range in.ExcludedLabels {
+		for _, prLabel := range in.PR.Labels {
+			if strings.EqualFold(l, prLabel) {
+				return false, SkipExcludedLabel
+			}
+		}
+	}
+	if len(in.ExcludedPaths) > 0 && allPathsExcluded(in.ChangedPaths, in.ExcludedPaths) {
+		return false, SkipExcludedPath
+	}
+	if !in.ForceReview && alreadyReviewedAtHead(in.ExistingReviews, in.BotLogin, in.PR.HeadSHA) {
+		return false, SkipAlreadyReviewed
+	}
+	return true, ""
+}
+
+// allPathsExcluded reports whether every path in changed matches at least
+// one glob in patterns. Returns false (not excluded) when changed is empty
+// — an unknown diff must never be silently skipped just because path
+// exclusions are configured.
+func allPathsExcluded(changed, patterns []string) bool {
+	if len(changed) == 0 {
+		return false
+	}
+	for _, path := range changed {
+		if !matchesAny(path, patterns) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesAny(path string, patterns []string) bool {
+	for _, pat := range patterns {
+		if ok, err := filepath.Match(pat, path); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// alreadyReviewedAtHead reports whether reviews contains a review authored
+// by botLogin whose CommitID matches headSHA exactly.
+func alreadyReviewedAtHead(reviews []gh.PRReview, botLogin, headSHA string) bool {
+	if botLogin == "" || headSHA == "" {
+		return false
+	}
+	for _, r := range reviews {
+		if strings.EqualFold(r.Author, botLogin) && r.CommitID == headSHA {
+			return true
+		}
+	}
+	return false
+}
+
+// diffGitHeaderRE matches a unified diff's per-file header line:
+// "diff --git a/<path> b/<path>".
+var diffGitHeaderRE = regexp.MustCompile(`(?m)^diff --git a/(.+) b/(.+)$`)
+
+// ParseChangedPaths extracts the set of file paths touched by a unified
+// diff, from its "diff --git a/... b/..." header lines. Uses the b/
+// (post-change) path; for renames this differs from the a/ path, but which
+// side of a rename is reported doesn't matter for glob-based path exclusion.
+// Returns nil if the diff contains no recognizable file headers.
+func ParseChangedPaths(diff string) []string {
+	matches := diffGitHeaderRE.FindAllStringSubmatch(diff, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[2])
+	}
+	return out
+}

--- a/pruefer/select_test.go
+++ b/pruefer/select_test.go
@@ -1,0 +1,236 @@
+package pruefer
+
+import (
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+func TestEligible(t *testing.T) {
+	baseReviews := []gh.PRReview{
+		{Author: "pruefer-bot[bot]", CommitID: "old-sha"},
+	}
+
+	tests := []struct {
+		name       string
+		in         EligibilityInput
+		wantOK     bool
+		wantReason SkipReason
+	}{
+		{
+			name: "eligible: no exclusions, never reviewed",
+			in: EligibilityInput{
+				PR: gh.PRDetails{Author: "alice", HeadSHA: "sha1", Draft: false},
+			},
+			wantOK: true,
+		},
+		{
+			name: "draft PR is skipped",
+			in: EligibilityInput{
+				PR: gh.PRDetails{Author: "alice", HeadSHA: "sha1", Draft: true},
+			},
+			wantOK:     false,
+			wantReason: SkipDraft,
+		},
+		{
+			name: "self-authored PR is skipped",
+			in: EligibilityInput{
+				PR:       gh.PRDetails{Author: "pruefer-bot[bot]", HeadSHA: "sha1"},
+				BotLogin: "pruefer-bot[bot]",
+			},
+			wantOK:     false,
+			wantReason: SkipSelfAuthored,
+		},
+		{
+			name: "self-authored check is case-insensitive",
+			in: EligibilityInput{
+				PR:       gh.PRDetails{Author: "Pruefer-Bot[bot]", HeadSHA: "sha1"},
+				BotLogin: "pruefer-bot[bot]",
+			},
+			wantOK:     false,
+			wantReason: SkipSelfAuthored,
+		},
+		{
+			name: "excluded author is skipped",
+			in: EligibilityInput{
+				PR:              gh.PRDetails{Author: "dependabot[bot]", HeadSHA: "sha1"},
+				ExcludedAuthors: []string{"dependabot[bot]"},
+			},
+			wantOK:     false,
+			wantReason: SkipExcludedAuthor,
+		},
+		{
+			name: "non-excluded author is not skipped",
+			in: EligibilityInput{
+				PR:              gh.PRDetails{Author: "alice", HeadSHA: "sha1"},
+				ExcludedAuthors: []string{"dependabot[bot]"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "excluded label (any match) is skipped",
+			in: EligibilityInput{
+				PR:             gh.PRDetails{Author: "alice", HeadSHA: "sha1", Labels: []string{"docs", "skip-review"}},
+				ExcludedLabels: []string{"skip-review"},
+			},
+			wantOK:     false,
+			wantReason: SkipExcludedLabel,
+		},
+		{
+			name: "non-matching labels are not skipped",
+			in: EligibilityInput{
+				PR:             gh.PRDetails{Author: "alice", HeadSHA: "sha1", Labels: []string{"docs"}},
+				ExcludedLabels: []string{"skip-review"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "excluded path: all touched paths match is skipped",
+			in: EligibilityInput{
+				PR:            gh.PRDetails{Author: "alice", HeadSHA: "sha1"},
+				ExcludedPaths: []string{"docs/*"},
+				ChangedPaths:  []string{"docs/a.md", "docs/b.md"},
+			},
+			wantOK:     false,
+			wantReason: SkipExcludedPath,
+		},
+		{
+			name: "excluded path: partial match is NOT skipped",
+			in: EligibilityInput{
+				PR:            gh.PRDetails{Author: "alice", HeadSHA: "sha1"},
+				ExcludedPaths: []string{"docs/*"},
+				ChangedPaths:  []string{"docs/a.md", "engine/claude.go"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "excluded path: unknown changed paths never trigger exclusion",
+			in: EligibilityInput{
+				PR:            gh.PRDetails{Author: "alice", HeadSHA: "sha1"},
+				ExcludedPaths: []string{"docs/*"},
+				ChangedPaths:  nil,
+			},
+			wantOK: true,
+		},
+		{
+			name: "already reviewed at this head SHA is skipped",
+			in: EligibilityInput{
+				PR:              gh.PRDetails{Author: "alice", HeadSHA: "old-sha"},
+				BotLogin:        "pruefer-bot[bot]",
+				ExistingReviews: baseReviews,
+			},
+			wantOK:     false,
+			wantReason: SkipAlreadyReviewed,
+		},
+		{
+			name: "new commit (different head SHA) is eligible again",
+			in: EligibilityInput{
+				PR:              gh.PRDetails{Author: "alice", HeadSHA: "new-sha"},
+				BotLogin:        "pruefer-bot[bot]",
+				ExistingReviews: baseReviews,
+			},
+			wantOK: true,
+		},
+		{
+			name: "forced re-review bypasses already-reviewed-at-SHA",
+			in: EligibilityInput{
+				PR:              gh.PRDetails{Author: "alice", HeadSHA: "old-sha"},
+				BotLogin:        "pruefer-bot[bot]",
+				ExistingReviews: baseReviews,
+				ForceReview:     true,
+			},
+			wantOK: true,
+		},
+		{
+			name: "forced re-review does NOT bypass draft skip",
+			in: EligibilityInput{
+				PR:          gh.PRDetails{Author: "alice", HeadSHA: "sha1", Draft: true},
+				ForceReview: true,
+			},
+			wantOK:     false,
+			wantReason: SkipDraft,
+		},
+		{
+			name: "forced re-review does NOT bypass self-authored skip",
+			in: EligibilityInput{
+				PR:          gh.PRDetails{Author: "pruefer-bot[bot]", HeadSHA: "sha1"},
+				BotLogin:    "pruefer-bot[bot]",
+				ForceReview: true,
+			},
+			wantOK:     false,
+			wantReason: SkipSelfAuthored,
+		},
+		{
+			name: "review by a different author at the same SHA does not count",
+			in: EligibilityInput{
+				PR:       gh.PRDetails{Author: "alice", HeadSHA: "old-sha"},
+				BotLogin: "pruefer-bot[bot]",
+				ExistingReviews: []gh.PRReview{
+					{Author: "some-human", CommitID: "old-sha"},
+				},
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, reason := Eligible(tt.in)
+			if ok != tt.wantOK {
+				t.Errorf("Eligible() ok = %v, want %v (reason=%q)", ok, tt.wantOK, reason)
+			}
+			if !ok && reason != tt.wantReason {
+				t.Errorf("Eligible() reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestParseChangedPaths(t *testing.T) {
+	diff := `diff --git a/engine/claude.go b/engine/claude.go
+index abc..def 100644
+--- a/engine/claude.go
++++ b/engine/claude.go
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/docs/README.md b/docs/README.md
+index 111..222 100644
+--- a/docs/README.md
++++ b/docs/README.md
+@@ -1,1 +1,1 @@
+-old doc
++new doc
+`
+	got := ParseChangedPaths(diff)
+	want := []string{"engine/claude.go", "docs/README.md"}
+	if len(got) != len(want) {
+		t.Fatalf("ParseChangedPaths() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ParseChangedPaths()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseChangedPaths_Empty(t *testing.T) {
+	if got := ParseChangedPaths(""); got != nil {
+		t.Errorf("ParseChangedPaths(\"\") = %v, want nil", got)
+	}
+	if got := ParseChangedPaths("not a diff"); got != nil {
+		t.Errorf("ParseChangedPaths(garbage) = %v, want nil", got)
+	}
+}
+
+func TestParseChangedPaths_Rename(t *testing.T) {
+	diff := `diff --git a/old_name.go b/new_name.go
+similarity index 100%
+rename from old_name.go
+rename to new_name.go
+`
+	got := ParseChangedPaths(diff)
+	if len(got) != 1 || got[0] != "new_name.go" {
+		t.Errorf("ParseChangedPaths(rename) = %v, want [new_name.go]", got)
+	}
+}

--- a/pruefer/select_test.go
+++ b/pruefer/select_test.go
@@ -113,6 +113,25 @@ func TestEligible(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name: "excluded path: ** matches nested paths (README's documented vendor/** example)",
+			in: EligibilityInput{
+				PR:            gh.PRDetails{Author: "alice", HeadSHA: "sha1"},
+				ExcludedPaths: []string{"vendor/**"},
+				ChangedPaths:  []string{"vendor/pkg/foo/bar.go"},
+			},
+			wantOK:     false,
+			wantReason: SkipExcludedPath,
+		},
+		{
+			name: "excluded path: ** does not match outside the prefixed dir",
+			in: EligibilityInput{
+				PR:            gh.PRDetails{Author: "alice", HeadSHA: "sha1"},
+				ExcludedPaths: []string{"vendor/**"},
+				ChangedPaths:  []string{"engine/claude.go"},
+			},
+			wantOK: true,
+		},
+		{
 			name: "already reviewed at this head SHA is skipped",
 			in: EligibilityInput{
 				PR:              gh.PRDetails{Author: "alice", HeadSHA: "old-sha"},

--- a/pruefer/worktree.go
+++ b/pruefer/worktree.go
@@ -29,7 +29,7 @@ func cloneURL(owner, repo, token string) string {
 // fresh temp dir. Fabrik's worktrees persist for days across many stage
 // runs on the same issue; Pruefer's reviews are single-shot, so a cache
 // would add lifecycle-management complexity for comparatively little
-// benefit at V1 scale (see adrs/073-pruefer-v1-architecture.md).
+// benefit at V1 scale (see adrs/074-pruefer-v1-architecture.md).
 func CloneForReview(ctx context.Context, owner, repo, token string, prNumber int) (dir string, cleanup func(), err error) {
 	return cloneRef(ctx, cloneURL(owner, repo, token), token, fmt.Sprintf("refs/pull/%d/head", prNumber), prNumber)
 }

--- a/pruefer/worktree.go
+++ b/pruefer/worktree.go
@@ -1,0 +1,96 @@
+package pruefer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// cloneURL returns the HTTPS clone URL Pruefer uses to fetch a PR's head
+// commit, with the installation token embedded as HTTP basic auth.
+// "x-access-token" is GitHub's documented username convention for App
+// installation tokens. Safe here because each clone is single-use and
+// discarded (see CloneForReview) — there is no persisted git config for the
+// token to leak from afterward, and runGit redacts the token from any
+// returned error text.
+func cloneURL(owner, repo, token string) string {
+	return fmt.Sprintf("https://x-access-token:%s@github.com/%s/%s.git", token, owner, repo)
+}
+
+// CloneForReview creates an ephemeral shallow clone of owner/repo at the
+// given PR's head commit (refs/pull/<N>/head), for Claude to inspect during
+// review. Returns the clone directory; callers must call the returned
+// cleanup function when done (safe to call multiple times, including on
+// error paths).
+//
+// No bare-clone cache: each review does a single-use, depth-1 fetch into a
+// fresh temp dir. Fabrik's worktrees persist for days across many stage
+// runs on the same issue; Pruefer's reviews are single-shot, so a cache
+// would add lifecycle-management complexity for comparatively little
+// benefit at V1 scale (see adrs/073-pruefer-v1-architecture.md).
+func CloneForReview(ctx context.Context, owner, repo, token string, prNumber int) (dir string, cleanup func(), err error) {
+	return cloneRef(ctx, cloneURL(owner, repo, token), token, fmt.Sprintf("refs/pull/%d/head", prNumber), prNumber)
+}
+
+// cloneRef does the actual init/fetch/checkout sequence against an explicit
+// remoteURL and ref. Split out from CloneForReview so tests can exercise it
+// against a local file-based git repo instead of github.com.
+func cloneRef(ctx context.Context, remoteURL, token, ref string, prNumber int) (dir string, cleanup func(), err error) {
+	dir, err = os.MkdirTemp("", fmt.Sprintf("pruefer-pr-%d-*", prNumber))
+	if err != nil {
+		return "", func() {}, fmt.Errorf("creating temp clone dir: %w", err)
+	}
+	cleanup = func() { os.RemoveAll(dir) }
+
+	if err := runGit(ctx, dir, token, "init", "-q"); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if err := runGit(ctx, dir, token, "fetch", "--depth", "1", "-q", remoteURL, ref); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("fetching %s: %w", ref, err)
+	}
+	if err := runGit(ctx, dir, token, "checkout", "-q", "FETCH_HEAD"); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("checking out FETCH_HEAD: %w", err)
+	}
+	return dir, cleanup, nil
+}
+
+// runGit runs git in dir with a clean, non-interactive environment
+// (GIT_TERMINAL_PROMPT=0, so a misconfigured/expired token fails fast
+// instead of hanging on a credential prompt), redacting token from any
+// error output so it never reaches logs.
+func runGit(ctx context.Context, dir, token string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		displayArgs := args
+		if token != "" {
+			msg = strings.ReplaceAll(msg, token, "***")
+			displayArgs = redactArgs(args, token)
+		}
+		return fmt.Errorf("git %s: %w: %s", strings.Join(displayArgs, " "), err, strings.TrimSpace(msg))
+	}
+	return nil
+}
+
+// redactArgs returns a copy of args with any argument containing token
+// replaced by a masked version, so an error message built from the argv
+// never echoes the installation token.
+func redactArgs(args []string, token string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if token != "" && strings.Contains(a, token) {
+			out[i] = strings.ReplaceAll(a, token, "***")
+		} else {
+			out[i] = a
+		}
+	}
+	return out
+}

--- a/pruefer/worktree.go
+++ b/pruefer/worktree.go
@@ -29,7 +29,7 @@ func cloneURL(owner, repo, token string) string {
 // fresh temp dir. Fabrik's worktrees persist for days across many stage
 // runs on the same issue; Pruefer's reviews are single-shot, so a cache
 // would add lifecycle-management complexity for comparatively little
-// benefit at V1 scale (see adrs/074-pruefer-v1-architecture.md).
+// benefit at V1 scale (see adrs/1113-pruefer-v1-architecture.md).
 func CloneForReview(ctx context.Context, owner, repo, token string, prNumber int) (dir string, cleanup func(), err error) {
 	return cloneRef(ctx, cloneURL(owner, repo, token), token, fmt.Sprintf("refs/pull/%d/head", prNumber), prNumber)
 }

--- a/pruefer/worktree_test.go
+++ b/pruefer/worktree_test.go
@@ -1,0 +1,144 @@
+package pruefer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func skipIfNoGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+}
+
+// initSourceRepoWithPullRef creates a local git repo with one commit on
+// main, and a second commit reachable only via refs/pull/<prNumber>/head
+// (simulating a GitHub PR head ref that isn't on any branch). Returns the
+// repo's path and the SHA of the PR-head commit.
+func initSourceRepoWithPullRef(t *testing.T, prNumber int) (repoPath, headSHA string) {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	run("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-q", "-m", "initial commit")
+
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("pr change\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "feature.txt")
+	run("commit", "-q", "-m", "pr commit")
+	sha := run("rev-parse", "HEAD")
+
+	// Detach the PR commit from main and expose it only as refs/pull/N/head,
+	// mirroring how GitHub exposes PR heads that aren't on a real branch.
+	run("update-ref", "refs/pull/"+strconv.Itoa(prNumber)+"/head", sha)
+	run("reset", "-q", "--hard", "HEAD~1")
+
+	return dir, sha
+}
+
+func TestCloneRef_ChecksOutPRHead(t *testing.T) {
+	skipIfNoGit(t)
+	repoPath, headSHA := initSourceRepoWithPullRef(t, 42)
+
+	dir, cleanup, err := cloneRef(context.Background(), repoPath, "", "refs/pull/42/head", 42)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("cloneRef: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "feature.txt")); err != nil {
+		t.Errorf("expected feature.txt (only present at the PR head) to exist in clone: %v", err)
+	}
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != headSHA {
+		t.Errorf("checked-out HEAD = %s, want %s", got, headSHA)
+	}
+}
+
+func TestCloneRef_CleanupRemovesDir(t *testing.T) {
+	skipIfNoGit(t)
+	repoPath, _ := initSourceRepoWithPullRef(t, 7)
+
+	dir, cleanup, err := cloneRef(context.Background(), repoPath, "", "refs/pull/7/head", 7)
+	if err != nil {
+		t.Fatalf("cloneRef: %v", err)
+	}
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("expected clone dir to be removed after cleanup(), stat err = %v", err)
+	}
+}
+
+func TestCloneRef_MissingRefFails(t *testing.T) {
+	skipIfNoGit(t)
+	repoPath, _ := initSourceRepoWithPullRef(t, 7)
+
+	_, cleanup, err := cloneRef(context.Background(), repoPath, "", "refs/pull/999/head", 999)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("expected an error when the ref does not exist")
+	}
+}
+
+func TestRunGit_RedactsTokenFromErrorOutput(t *testing.T) {
+	skipIfNoGit(t)
+	dir := t.TempDir()
+	const secretToken = "ghs_super_secret_token_value"
+	err := runGit(context.Background(), dir, secretToken, "fetch", "--depth", "1", "https://x-access-token:"+secretToken+"@example.invalid/owner/repo.git", "refs/pull/1/head")
+	if err == nil {
+		t.Fatal("expected an error fetching from a nonexistent host")
+	}
+	if strings.Contains(err.Error(), secretToken) {
+		t.Errorf("error message leaked the token: %v", err)
+	}
+}
+
+func TestRedactArgs(t *testing.T) {
+	args := []string{"fetch", "https://x-access-token:secret123@github.com/o/r.git", "refs/pull/1/head"}
+	got := redactArgs(args, "secret123")
+	for _, a := range got {
+		if strings.Contains(a, "secret123") {
+			t.Errorf("redactArgs left the token in place: %v", got)
+		}
+	}
+	if got[0] != "fetch" || got[2] != "refs/pull/1/head" {
+		t.Errorf("redactArgs modified non-token args: %v", got)
+	}
+}
+
+func TestCloneURL_EmbedsCredentials(t *testing.T) {
+	url := cloneURL("owner", "repo", "tok123")
+	want := "https://x-access-token:tok123@github.com/owner/repo.git"
+	if url != want {
+		t.Errorf("cloneURL = %q, want %q", url, want)
+	}
+}


### PR DESCRIPTION
Closes #1113

## Summary

Adds Pruefer, a new self-hosted Go daemon at `cmd/pruefer/` that watches configured GitHub repositories, reviews open non-draft pull requests by invoking the `claude` CLI (subscription-backed, not API-metered), and submits a formal comment-only `pull_request_review`. This replaces the need to depend on a hosted third-party reviewer's quota (the 2026-07-25 Gemini outage that stalled the pipeline, #1058/#1059/#1065/#1071) without the per-token billing and per-repo YAML duplication of the interim `claude-review.yml` mitigation.

## Key changes

- **`pruefer/`** (new package): config loading (flag > env > YAML > default precedence), GitHub App JWT/installation-token auth bootstrap with a background refresh loop, a narrow `ClaudeInvoker` interface + real `exec.CommandContext`-based implementation (read-only tool allowlist, inactivity/wall-time watchdog, graceful process-group kill), ephemeral shallow-clone PR checkout, PR eligibility selection (draft/self-authored/excluded-author-label-path/already-reviewed-at-SHA), `/pruefer review` on-demand re-review via reaction idempotency, per-PR review orchestration, and the poll-loop daemon with a concurrency-capped dispatch semaphore and file-lock single-instance guard.
- **`github/`** additive extensions (no existing behavior changed): GitHub App JWT construction and installation-token minting (`app.go`), `Client.SetToken` mutex-guarded mutator, `FetchPRDiff`, `SubmitPRReview` (hardcoded `event: COMMENT` — never caller-controlled), `ListOpenPRs`, `FetchIssueComments`, and additive `PRReview.CommitID` / `PRDetails.Author`/`Labels` fields.
- **`cmd/pruefer/main.go`**: thin entry point, `go build ./...` now also produces a `pruefer` binary.
- **`adrs/074-pruefer-v1-architecture.md`**: records the GitHub App identity decision, GitHub-derived review-state mechanism, ephemeral-clone diff acquisition, the code-level (not prompt-level) never-approve guarantee, procattr duplication-vs-extraction, and the concurrency/diff-size/poll/effort defaults.
- **`cmd/pruefer/README.md`**: GitHub App setup walkthrough (permissions, private key, installation), config reference, and the on-demand `/pruefer review` command.
- **`.gitignore`**: ignores the built `pruefer` binary and local `.pruefer/` operational artifacts (lock file, logs, private key).

Identity is a GitHub App (`<slug>[bot]`) rather than a distinct PAT, per the operator's directive during Research — this makes the "review identity ≠ PR author" requirement structural rather than an operator-discipline-dependent setup mistake. Review state ("already reviewed at this head SHA") is derived from GitHub's own review list, not persisted locally, so a restart never causes a re-review storm. Claude never calls `gh` or submits the review itself — Go code submits the formal review with `event: COMMENT` hardcoded, so "never approve" is a code-level invariant.

## Testing

- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass (2720 tests across 17 packages; the one pre-existing failure, `TestExecute_ConfigYAMLApplied`, is on `main` too and untouched by this branch — it depends on network access unavailable in this sandbox).
- `pruefer/` and `github/` alone: 355 tests, all passing, including table tests for every PR-selection case (already-reviewed-at-SHA, draft, self-authored, excluded author/path/label, new commit, forced re-review), concurrency-cap and diff-size-guard enforcement, and a token-refresh-before-expiry test.
- Claude invocation is mocked behind `ClaudeInvoker` in all tests — no real `claude` binary is shelled out to.
- Manually verified `go build -o pruefer ./cmd/pruefer && ./pruefer --help` produces a working binary with the documented flag set.

## How to test

```bash
go build ./...
go test -race ./pruefer/... ./github/...
go build -o pruefer ./cmd/pruefer && ./pruefer --help
```

Setting up a live GitHub App and running the daemon against a real repo is documented in `cmd/pruefer/README.md`.