### PR TITLE
test(e2e): jitter harness poll intervals to desynchronise concurrent scenarios

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -209,6 +209,11 @@ overall test timeout with `E2E_TIMEOUT` (default `90m`).
 
 The `e2e` build tag keeps all of this out of the default `go test ./...` run.
 
+Set **`E2E_JITTER_SEED`** (a `uint64`) to make the harness's poll-interval
+jitter (see below) reproducible — useful for locally reproducing a
+flaky-looking failure. Leave it unset for normal runs; the jitter self-seeds
+randomly by default.
+
 #### Parallelism cap — the shared bed oversubscribes easily
 
 15 of the 16 scenarios are `t.Parallel()`, but they **all drive one shared
@@ -230,6 +235,11 @@ Lower values reduce oversubscription at the cost of wall-clock. The long
 merge-train and CI-fix scenarios (see their notes above) are still best run in
 isolation. **Do not** run the full suite unbounded expecting a clean pass — the
 failure will be timeouts, not real regressions.
+
+On top of the `-parallel` cap, every GitHub-polling wait helper's retry
+interval is jittered ±20% (see `pollSleep` in `harness.go`) so concurrent
+scenarios' polls desynchronize instead of converging into lockstep bursts
+against the shared API budget (see #1104).
 
 ### Reset between runs
 

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -162,6 +164,55 @@ func SetIssueStatus(t *testing.T, env *Env, itemID, columnName string) {
 	}
 }
 
+// pollRandMu guards pollRand, since ~15 of the 16 e2e test functions run
+// under t.Parallel() and several call multiple wait-helpers concurrently.
+var pollRandMu sync.Mutex
+var pollRand = newPollRand()
+
+// newPollRand builds the package-scoped RNG source used by pollSleep. It
+// self-seeds randomly unless E2E_JITTER_SEED is set to a valid uint64, in
+// which case both PCG seed halves derive from it, making the jitter sequence
+// reproducible for harness unit tests and for local repro of flaky-looking
+// failures. A malformed E2E_JITTER_SEED falls back to auto-seeding rather
+// than failing — a bad env var shouldn't break every e2e test.
+func newPollRand() *rand.Rand {
+	if s := os.Getenv("E2E_JITTER_SEED"); s != "" {
+		if seed, err := strconv.ParseUint(s, 10, 64); err == nil {
+			return rand.New(rand.NewPCG(seed, seed))
+		}
+	}
+	return rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+}
+
+// jitterWithRand returns a duration uniformly distributed over
+// [base*0.8, base*1.2) using the supplied RNG. It is pure (no global state)
+// so unit tests can exercise it with their own seeded generator.
+func jitterWithRand(r *rand.Rand, base time.Duration) time.Duration {
+	f := r.Float64() // [0, 1)
+	return base + time.Duration(float64(base)*0.20*(2*f-1))
+}
+
+// pollSleep sleeps for base, jittered ±20% (uniform, the "equal jitter"
+// family). This is deliberately not full jitter (rand in [0, base]), whose
+// mean of base/2 would roughly double the harness's steady-state request
+// rate against the exact shared GitHub API/GraphQL budget this jitter is
+// meant to protect. It's also deliberately not decorrelated jitter, which
+// grows a retry sequence from the previous sleep — these wait-helpers are
+// steady-state condition polls, not retry-after-failure backoff, so there's
+// no "previous sleep" to grow from. Fixed base ± 20% preserves the mean
+// interval (so total request volume and suite wall-clock stay essentially
+// unchanged) while still desynchronizing concurrent scenarios, since each
+// poller's phase drifts every iteration and lockstep breaks within a few
+// cycles. This does widen a wait-helper's existing tail-sleep deadline
+// overshoot from at most one base to at most base*1.2 (e.g. 15s to 18s) —
+// negligible against per-scenario timeouts measured in minutes to hours.
+func pollSleep(base time.Duration) {
+	pollRandMu.Lock()
+	d := jitterWithRand(pollRand, base)
+	pollRandMu.Unlock()
+	time.Sleep(d)
+}
+
 // WaitForProjectStatus polls the project board until the item for issueNumber
 // reports Status == columnName, or fails after timeout. Use this after
 // SetIssueStatus when a subsequent action (e.g. an external PR merge that
@@ -195,7 +246,7 @@ func WaitForProjectStatus(t *testing.T, env *Env, repo string, issueNumber int, 
 				}
 			}
 		}
-		time.Sleep(10 * time.Second)
+		pollSleep(10 * time.Second)
 	}
 	t.Fatalf("timed out waiting for project status %q on %s#%d (last observed %q)",
 		columnName, repo, issueNumber, last)
@@ -210,7 +261,7 @@ func WaitForIssueLabel(t *testing.T, env *Env, repo string, issueNumber int, lab
 		labels, err := tryIssueLabels(env, repo, issueNumber)
 		if err != nil {
 			t.Logf("WaitForIssueLabel: transient gh error on %s#%d: %v (will retry)", repo, issueNumber, err)
-			time.Sleep(15 * time.Second)
+			pollSleep(15 * time.Second)
 			continue
 		}
 		for _, l := range labels {
@@ -218,7 +269,7 @@ func WaitForIssueLabel(t *testing.T, env *Env, repo string, issueNumber int, lab
 				return
 			}
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	last, _ := tryIssueLabels(env, repo, issueNumber)
 	t.Fatalf("timed out waiting for label %q on %s#%d (had: %v)", label, repo, issueNumber, last)
@@ -276,7 +327,7 @@ func WaitForIssueClosed(t *testing.T, env *Env, repo string, issueNumber int, ti
 		} else if state == "CLOSED" {
 			return
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	state, _ := tryIssueState(env, repo, issueNumber)
 	t.Fatalf("timed out waiting for %s#%d to close (last observed: %q)", repo, issueNumber, state)
@@ -291,7 +342,7 @@ func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, la
 		labels, err := tryIssueLabels(env, repo, issueNumber)
 		if err != nil {
 			t.Logf("WaitForLabelAbsent: transient gh error on %s#%d: %v (will retry)", repo, issueNumber, err)
-			time.Sleep(15 * time.Second)
+			pollSleep(15 * time.Second)
 			continue
 		}
 		present := false
@@ -304,7 +355,7 @@ func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, la
 		if !present {
 			return
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for label %q to disappear from %s#%d", label, repo, issueNumber)
 }
@@ -431,7 +482,7 @@ func WaitForLinkedPR(t *testing.T, env *Env, repo string, issueNum int, timeout 
 				}
 			}
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for an open PR with head=%s in %s", branch, repo)
 	return 0
@@ -524,7 +575,7 @@ func WaitForChildIssueInRepo(t *testing.T, env *Env, childRepo string, since tim
 				return nums[0]
 			}
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for a child sub-issue in %s (since %s)", childRepo, sinceStr)
 	return 0
@@ -848,7 +899,7 @@ func LinkedPRNumber(t *testing.T, env *Env, repo string, issueNumber int) int {
 		if err == nil && n > 0 {
 			return n
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for linked PR on %s#%d", repo, issueNumber)
 	return 0
@@ -883,7 +934,7 @@ func WaitForPRCommentContaining(t *testing.T, env *Env, repo string, prNumber in
 		bodies, err := tryPRComments(env, repo, prNumber)
 		if err != nil {
 			t.Logf("WaitForPRCommentContaining: transient error on %s#%d: %v (will retry)", repo, prNumber, err)
-			time.Sleep(15 * time.Second)
+			pollSleep(15 * time.Second)
 			continue
 		}
 		for _, b := range bodies {
@@ -891,7 +942,7 @@ func WaitForPRCommentContaining(t *testing.T, env *Env, repo string, prNumber in
 				return
 			}
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for PR comment containing %q on %s#%d", substring, repo, prNumber)
 }
@@ -982,7 +1033,7 @@ func WaitForCheckConclusion(t *testing.T, env *Env, repo string, prNumber int, c
 				return
 			}
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for check %q to reach conclusion %q on %s#%d (last observed %q)",
 		checkName, want, repo, prNumber, last)
@@ -1278,14 +1329,14 @@ func WaitForPRCommentReaction(t *testing.T, env *Env, repo string, prNumber int,
 			"--jq", filter)
 		if err != nil {
 			t.Logf("WaitForPRCommentReaction: transient error on %s PR #%d: %v (will retry)", repo, prNumber, err)
-			time.Sleep(15 * time.Second)
+			pollSleep(15 * time.Second)
 			continue
 		}
 		count, parseErr := strconv.Atoi(strings.TrimSpace(out))
 		if parseErr == nil && count > 0 {
 			return
 		}
-		time.Sleep(15 * time.Second)
+		pollSleep(15 * time.Second)
 	}
 	t.Fatalf("timed out waiting for %q reaction on comment containing %q on %s PR #%d",
 		reactionContent, commentSubstring, repo, prNumber)

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -178,6 +178,9 @@ var pollRand = newPollRand()
 func newPollRand() *rand.Rand {
 	if s := os.Getenv("E2E_JITTER_SEED"); s != "" {
 		if seed, err := strconv.ParseUint(s, 10, 64); err == nil {
+			// Reusing seed for both PCG state and sequence is intentional:
+			// we only need a reproducible sequence from a single uint64 for
+			// test determinism, not two independent streams.
 			return rand.New(rand.NewPCG(seed, seed))
 		}
 	}
@@ -192,8 +195,10 @@ func jitterWithRand(r *rand.Rand, base time.Duration) time.Duration {
 	return base + time.Duration(float64(base)*0.20*(2*f-1))
 }
 
-// pollSleep sleeps for base, jittered ±20% (uniform, the "equal jitter"
-// family). This is deliberately not full jitter (rand in [0, base]), whose
+// pollSleep sleeps for base, jittered ±20% (uniform, a fixed proportional-
+// jitter band centered on base — not AWS's "equal jitter", which is
+// asymmetric and floored at base/2). This is deliberately not full jitter
+// (rand in [0, base]), whose
 // mean of base/2 would roughly double the harness's steady-state request
 // rate against the exact shared GitHub API/GraphQL budget this jitter is
 // meant to protect. It's also deliberately not decorrelated jitter, which

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"math/rand/v2"
+	"sync"
 	"testing"
 	"time"
 )
@@ -107,4 +108,32 @@ func TestNewPollRandMalformedSeedFallsBack(t *testing.T) {
 	if d < 12*time.Second || d >= 18*time.Second {
 		t.Fatalf("jitter from fallback-seeded generator out of bounds: %v", d)
 	}
+}
+
+// TestPollSleepBoundsAndConcurrency exercises pollSleep itself (not just the
+// pure jitterWithRand helper), verifying the observed sleep duration is
+// consistent with the documented ±20% band and that the shared, mutex-guarded
+// pollRand survives concurrent callers under -race.
+func TestPollSleepBoundsAndConcurrency(t *testing.T) {
+	const base = 20 * time.Millisecond
+	// time.Sleep only guarantees "at least" the requested duration, so bounds
+	// are checked loosely (half the lower bound, 3x the upper bound) to avoid
+	// flaking under scheduler slack on a loaded CI machine.
+	lo := time.Duration(float64(base)*0.8) / 2
+	hi := time.Duration(float64(base)*1.2) * 3
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			pollSleep(base)
+			elapsed := time.Since(start)
+			if elapsed < lo || elapsed > hi {
+				t.Errorf("pollSleep(%v) returned after %v, outside sanity bounds [%v, %v]", base, elapsed, lo, hi)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"math/rand/v2"
+	"testing"
+	"time"
+)
+
+// TestJitterWithRandBounds verifies jitterWithRand never returns a negative
+// duration and always stays within the documented [base*0.8, base*1.2) range.
+func TestJitterWithRandBounds(t *testing.T) {
+	r := rand.New(rand.NewPCG(1, 2))
+	base := 15 * time.Second
+	lo := time.Duration(float64(base) * 0.8)
+	hi := time.Duration(float64(base) * 1.2)
+
+	for i := 0; i < 10000; i++ {
+		d := jitterWithRand(r, base)
+		if d < 0 {
+			t.Fatalf("sample %d: got negative duration %v", i, d)
+		}
+		if d < lo || d >= hi {
+			t.Fatalf("sample %d: %v outside documented bounds [%v, %v)", i, d, lo, hi)
+		}
+	}
+}
+
+// TestJitterWithRandDistribution checks the sample mean stays close to base
+// and that values actually vary (i.e. jitter isn't a no-op).
+func TestJitterWithRandDistribution(t *testing.T) {
+	r := rand.New(rand.NewPCG(3, 4))
+	base := 15 * time.Second
+
+	const n = 10000
+	var sum time.Duration
+	min, max := base, base
+	for i := 0; i < n; i++ {
+		d := jitterWithRand(r, base)
+		sum += d
+		if d < min {
+			min = d
+		}
+		if d > max {
+			max = d
+		}
+	}
+	mean := sum / n
+
+	// Mean should land close to base — within 5% of it, well inside the ±20%
+	// jitter band, since deviations should average out over n=10000 samples.
+	tolerance := time.Duration(float64(base) * 0.05)
+	if diff := mean - base; diff < -tolerance || diff > tolerance {
+		t.Fatalf("sample mean %v too far from base %v (tolerance %v)", mean, base, tolerance)
+	}
+	if min == max {
+		t.Fatalf("all %d samples identical (%v) — jitter is not varying", n, min)
+	}
+}
+
+// TestJitterWithRandDeterministic confirms two generators seeded identically
+// produce identical output sequences, satisfying the "deterministic under
+// test" requirement.
+func TestJitterWithRandDeterministic(t *testing.T) {
+	base := 15 * time.Second
+	r1 := rand.New(rand.NewPCG(42, 42))
+	r2 := rand.New(rand.NewPCG(42, 42))
+
+	for i := 0; i < 100; i++ {
+		d1 := jitterWithRand(r1, base)
+		d2 := jitterWithRand(r2, base)
+		if d1 != d2 {
+			t.Fatalf("sample %d: identically-seeded generators diverged: %v != %v", i, d1, d2)
+		}
+	}
+}
+
+// TestNewPollRandSeeded verifies that setting E2E_JITTER_SEED produces a
+// reproducible RNG: two calls to newPollRand with the same seed value yield
+// generators that produce identical jitter sequences.
+func TestNewPollRandSeeded(t *testing.T) {
+	t.Setenv("E2E_JITTER_SEED", "12345")
+	r1 := newPollRand()
+	r2 := newPollRand()
+
+	base := 15 * time.Second
+	for i := 0; i < 100; i++ {
+		d1 := jitterWithRand(r1, base)
+		d2 := jitterWithRand(r2, base)
+		if d1 != d2 {
+			t.Fatalf("sample %d: newPollRand with same E2E_JITTER_SEED diverged: %v != %v", i, d1, d2)
+		}
+	}
+}
+
+// TestNewPollRandMalformedSeedFallsBack verifies an invalid E2E_JITTER_SEED
+// falls back to auto-seeding rather than panicking or erroring.
+func TestNewPollRandMalformedSeedFallsBack(t *testing.T) {
+	t.Setenv("E2E_JITTER_SEED", "not-a-number")
+	r := newPollRand()
+	if r == nil {
+		t.Fatal("newPollRand returned nil for malformed E2E_JITTER_SEED")
+	}
+	// Should still produce a value in bounds.
+	d := jitterWithRand(r, 15*time.Second)
+	if d < 12*time.Second || d >= 18*time.Second {
+		t.Fatalf("jitter from fallback-seeded generator out of bounds: %v", d)
+	}
+}


### PR DESCRIPTION
Closes #1104

## What this does

Adds a shared `pollSleep(base time.Duration)` helper to `tests/e2e/harness.go` and wires it into all 14 fixed-interval `time.Sleep(N * time.Second)` call sites across the 10 GitHub-polling wait helpers (`WaitForProjectStatus`, `WaitForIssueLabel`, `WaitForIssueClosed`, `WaitForLabelAbsent`, `WaitForLinkedPR`, `WaitForChildIssueInRepo`, `LinkedPRNumber`, `WaitForPRCommentContaining`, `WaitForCheckConclusion`, `WaitForPRCommentReaction`). `WaitForLogLine`'s unrelated 500ms local-file-tail sleep is untouched, per the issue's explicit scope.

## Jitter model

Fixed base ± 20% (uniform, "equal jitter" family) — chosen over full jitter (mean `base/2`, would roughly double steady-state request rate against the shared API budget) and decorrelated jitter (needs a growing retry sequence; these are steady-state condition polls, not retry-after-failure backoff). The rationale is documented in `pollSleep`'s doc comment.

## Determinism

The RNG is a package-scoped, mutex-guarded `*rand.Rand` (`math/rand/v2`, `rand.NewPCG`), since ~15 of 16 e2e test functions run under `t.Parallel()`. Seeding is controlled by a new `E2E_JITTER_SEED` env var (uint64): set it for a reproducible jitter sequence (e.g. to locally reproduce a flaky-looking failure); leave it unset for normal runs, where it self-seeds randomly. A malformed value falls back to auto-seeding rather than failing.

## Testing

- New `tests/e2e/harness_test.go` (`//go:build e2e`) unit-tests the jitter helper: bounds (`[base*0.8, base*1.2)`, never negative), distribution sanity (mean close to base, values vary), determinism under matching seeds, and the `E2E_JITTER_SEED` plumbing including its malformed-value fallback.
- `go vet -tags e2e ./tests/e2e/` passes.
- `go test -tags e2e -race -run 'TestJitter|TestNewPollRand' ./tests/e2e/` — all 5 new tests pass.
- `go test -race ./...` — full suite passes except one pre-existing, unrelated, timing-sensitive flaky test (`TestKillProcGroupGraceful_StructuredLog` in `engine`, about SIGTERM/SIGKILL wall-time kills), which passes cleanly when run in isolation and is untouched by this change.
- Full-suite validation of the desynchronization effect against the real bed is human-driven and out of scope for this PR (per the issue and #971).

## Docs

`tests/e2e/README.md` documents `E2E_JITTER_SEED` alongside `E2E_PARALLEL`/`E2E_TIMEOUT`, and notes the ±20% poll-interval jitter in the "Parallelism cap" section.