### PR TITLE
Confirm org membership before routing NONE-association issues to community board

### DIFF
--- a/.github/workflows/route-community-issues.yml
+++ b/.github/workflows/route-community-issues.yml
@@ -54,20 +54,26 @@ jobs:
           AUTHOR: ${{ github.event.issue.user.login }}
         run: |
           set +e
-          RESPONSE=$(gh api "orgs/${ORG}/memberships/${AUTHOR}" 2>/tmp/membership-err.log)
-          STATUS=$?
+          RAW=$(gh api -i "orgs/${ORG}/memberships/${AUTHOR}" 2>/tmp/membership-err.log)
           set -e
+          # Strip CR so header/body parsing below isn't tripped up by CRLF.
+          RAW=$(printf '%s\n' "$RAW" | tr -d '\r')
+          # Read the numeric status straight from the HTTP status line — not
+          # from gh's human-readable error text, which is message-format text
+          # that can drift between gh CLI versions (#1137 review feedback).
+          HTTP_CODE=$(printf '%s\n' "$RAW" | awk 'NR==1 && /^HTTP\// {print $2; exit}')
+          BODY=$(printf '%s\n' "$RAW" | awk 'f{print} !NF{f=1}')
 
-          if [ "$STATUS" -eq 0 ]; then
-            STATE=$(echo "$RESPONSE" | jq -r '.state // "unknown"')
-            ROLE=$(echo "$RESPONSE" | jq -r '.role // "unknown"')
-            echo "Membership check: ${AUTHOR} IS a member of ${ORG} (state=${STATE}, role=${ROLE}) despite author_association=NONE (private membership). Basis: 200 from /orgs/${ORG}/memberships/${AUTHOR}. Skipping community routing."
+          if [ "$HTTP_CODE" = "200" ]; then
+            STATE=$(echo "$BODY" | jq -r '.state // "unknown"')
+            ROLE=$(echo "$BODY" | jq -r '.role // "unknown"')
+            echo "Membership check: ${AUTHOR} IS a member of ${ORG} (state=${STATE}, role=${ROLE}) despite author_association=NONE (private membership). Basis: HTTP 200 from /orgs/${ORG}/memberships/${AUTHOR}. Skipping community routing."
             echo "route=false" >> "$GITHUB_OUTPUT"
-          elif grep -q "HTTP 404" /tmp/membership-err.log; then
-            echo "Membership check: ${AUTHOR} is NOT a member of ${ORG}. Basis: 404 from /orgs/${ORG}/memberships/${AUTHOR}. Routing as community issue."
+          elif [ "$HTTP_CODE" = "404" ]; then
+            echo "Membership check: ${AUTHOR} is NOT a member of ${ORG}. Basis: HTTP 404 from /orgs/${ORG}/memberships/${AUTHOR}. Routing as community issue."
             echo "route=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Error: membership check for ${AUTHOR} in ${ORG} returned an ambiguous result (neither a clean 200 nor 404) — failing closed and skipping routing rather than guessing. Raw output:"
+            echo "Error: membership check for ${AUTHOR} in ${ORG} returned an ambiguous result (HTTP status: ${HTTP_CODE:-none}) — failing closed and skipping routing rather than guessing. Raw output:"
             cat /tmp/membership-err.log
             echo "route=false" >> "$GITHUB_OUTPUT"
             exit 1

--- a/.github/workflows/route-community-issues.yml
+++ b/.github/workflows/route-community-issues.yml
@@ -12,6 +12,16 @@ name: Route community issues to triage board
 # Requires a repo secret ADD_TO_PROJECT_PAT: a PAT with `project` (write) scope
 # for the handarbeit org — the default GITHUB_TOKEN cannot write org-level
 # Projects. Without the secret the job fails loudly (it never silently no-ops).
+#
+# author_association alone is NOT sufficient to detect maintainers (#1137).
+# It reflects visible affiliation only: a maintainer whose org membership is
+# set to private reports NONE, identical to a genuine stranger. This bit us
+# on 2026-07-26 — an org admin with private membership had seven of their own
+# issues misrouted onto this public board before anyone noticed. Do not
+# "simplify" this workflow back to the association check alone; for a NONE
+# association we make one confirming call to the org-membership API before
+# deciding. OWNER/MEMBER/COLLABORATOR stay a free, correct fast path — the
+# extra call only fires for the ambiguous NONE case, so it stays rare.
 
 on:
   issues:
@@ -26,14 +36,50 @@ jobs:
     if: ${{ !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) }}
     runs-on: ubuntu-latest
     steps:
+      # NONE is ambiguous: it covers both genuine non-members and maintainers
+      # with private org membership (#1137). Confirm via the authoritative
+      # membership API rather than trusting the visible-affiliation proxy.
+      # This step is skipped (not run) for any other association value, in
+      # which case its outputs are empty and the routing steps below proceed
+      # unaffected.
+      - name: Confirm org membership for NONE-association authors
+        id: membership
+        if: github.event.issue.author_association == 'NONE'
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          ORG: handarbeit
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set +e
+          RESPONSE=$(gh api "orgs/${ORG}/memberships/${AUTHOR}" 2>/tmp/membership-err.log)
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -eq 0 ]; then
+            STATE=$(echo "$RESPONSE" | jq -r '.state // "unknown"')
+            ROLE=$(echo "$RESPONSE" | jq -r '.role // "unknown"')
+            echo "Membership check: ${AUTHOR} IS a member of ${ORG} (state=${STATE}, role=${ROLE}) despite author_association=NONE (private membership). Basis: 200 from /orgs/${ORG}/memberships/${AUTHOR}. Skipping community routing."
+            echo "route=false" >> "$GITHUB_OUTPUT"
+          elif grep -q "HTTP 404" /tmp/membership-err.log; then
+            echo "Membership check: ${AUTHOR} is NOT a member of ${ORG}. Basis: 404 from /orgs/${ORG}/memberships/${AUTHOR}. Routing as community issue."
+            echo "route=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Error: membership check for ${AUTHOR} in ${ORG} returned an ambiguous result (neither a clean 200 nor 404) — failing closed and skipping routing rather than guessing. Raw output:"
+            cat /tmp/membership-err.log
+            echo "route=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
       - name: Add issue to Triage & Roadmap board (project #3)
         id: add
+        if: success() && steps.membership.outputs.route != 'false'
         uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/handarbeit/projects/3
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
       - name: Set Status = Triage
+        if: success() && steps.membership.outputs.route != 'false'
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
           ITEM_ID: ${{ steps.add.outputs.itemId }}

--- a/.github/workflows/route-community-issues.yml
+++ b/.github/workflows/route-community-issues.yml
@@ -12,6 +12,9 @@ name: Route community issues to triage board
 # Requires a repo secret ADD_TO_PROJECT_PAT: a PAT with `project` (write) scope
 # for the handarbeit org — the default GITHUB_TOKEN cannot write org-level
 # Projects. Without the secret the job fails loudly (it never silently no-ops).
+# It also needs `read:org` scope for the membership-confirmation step below
+# (#1137), and its owning account must itself be a member of the org — without
+# either, that step fails closed on every NONE-association author.
 #
 # author_association alone is NOT sufficient to detect maintainers (#1137).
 # It reflects visible affiliation only: a maintainer whose org membership is


### PR DESCRIPTION
Closes #1137

## What this does

Hardens `.github/workflows/route-community-issues.yml` so maintainer status is determined by actual GitHub org membership, not by `author_association`, which only reflects *visible* affiliation. A maintainer with private org membership reports `author_association: NONE`, identical to a genuine stranger — this misrouted seven maintainer issues (#1104, #1113, #1114, #1117, #1119, #1120, #1128) onto the public triage board before it was caught.

## Key changes

- `author_association` remains a free, correct fast path for `OWNER`/`MEMBER`/`COLLABORATOR` (job-level `if:`, unchanged).
- A new `Confirm org membership for NONE-association authors` step runs only when `author_association == 'NONE'`, calling `GET /orgs/{org}/memberships/{username}` with the PAT (`ADD_TO_PROJECT_PAT`). Three outcomes, each logged with its basis:
  - **200** → confirmed member (private membership) → skip routing.
  - **404** → confirmed non-member → route as community, as before.
  - **anything else** (403/302/5xx/network) → ambiguous → **fail closed**: skip routing and fail the workflow run (`exit 1`), so the run shows red rather than silently succeeding.
- The two existing routing steps are gated on `success() && steps.membership.outputs.route != 'false'`, which correctly treats a *skipped* membership step (association wasn't `NONE`) as "proceed" (empty output `!= 'false'`) while a *failed* membership step is blocked via `success()`.
- The workflow's header comment now explains why `author_association` alone is insufficient, referencing this issue, so a future reader doesn't "simplify" the guard back to the association check alone.

## Two facts this depends on that can't be verified from the repo

Please confirm these on GitHub before/after merging — if either is false, the workflow degrades safely (fails closed on every `NONE`-association issue, red X on every run) but silently routes zero community issues until fixed:

1. **`ADD_TO_PROJECT_PAT` carries `read:org` scope** (org → PAT settings).
2. **The PAT's owning account is itself a member of `handarbeit`** — required for `/orgs/{org}/memberships/{username}` to return a decisive 200/404 rather than a 403.

`ADD_TO_PROJECT_PAT` also expires ~2027-07-26 — out of scope to renew here, flagging per the issue.

## How to test

No CI lints GitHub Actions workflow YAML in this repo, so this was verified manually:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/route-community-issues.yml'))"` — parses cleanly.
- Traced all four branches by hand: `OWNER`/`MEMBER`/`COLLABORATOR` (job skipped, unchanged), `NONE` + confirmed member (routing steps skipped, job green), `NONE` + confirmed non-member (routing steps run, job green), `NONE` + ambiguous/error (routing steps skipped, job red).
- To exercise it live post-merge: open a test issue from an account with `NONE` association and watch the Actions run log for the "Membership check: ..." line stating the basis for the decision.