### PR TITLE
Broaden startup cleanup to sweep orphaned stage:*:in_progress labels

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5076,6 +5076,22 @@ When a Fabrik process crashes, deferred cleanup never runs. On the next startup,
 3. `store.Apply(WorkerExited{})` — no-op since `Worker` is already nil; applied for idempotency.
 4. Log the cleanup at `"startup"` tag.
 
+#### Startup Orphaned in_progress Scan (Broader Sweep)
+
+The lock-gated pass above only reaches items that *still hold* a stale lock label. An `in_progress` label orphaned after its paired lock was already cleanly released — the normal outcome when `release()` (`engine/item.go`) succeeds at removing the lock but the paired `removeInProgressLabel` call fails transiently, since that call has no retry — is invisible to it and survives every restart. `runStartupOrphanedInProgressScan()` closes this gap with a second, broader sweep.
+
+**Trigger:** Same call site as the lock-gated pass — runs immediately after `runStartupCleanup()`, inside the same `if firstPollErr == nil` block in `poll.go`.
+
+**Detection:** Scan `store.All()` — every managed item in the store, not filtered by lock label. For each item, build the set of stage names carrying `stage:<Name>:complete` or `stage:<Name>:failed`. Then, for each `stage:<Name>:in_progress` label on the same item whose `<Name>` is in that set, the label is stale by definition — a stage cannot be both finished and in progress — and is removed.
+
+**No `Worker()` or lock-label filter.** This is a deliberate divergence from the lock-gated pass, not an oversight: dispatch ordering already guarantees `complete`/`failed` and `in_progress` never legitimately co-occur for the same stage — `removeFailedLabel` runs before `in_progress` is re-added on retry, and `complete` blocks further dispatch of that stage entirely. Any occurrence of the co-occurrence is therefore stale regardless of whether a worker or lock is present, making the predicate self-justifying and safe to run unconditionally at startup.
+
+**Cleanup per item:** for each stale `in_progress` label found, `RemoveLabel(label)` from GitHub (with write-through to cache on success), logged as `[startup] removed stale label %q` — the same format as the lock-gated pass. Errors are logged as warnings and not retried, matching the lock-gated pass's behavior.
+
+**Additive, not a replacement:** this pass runs alongside, not instead of, the lock-gated sweep — the two predicates (stale lock label vs. `complete`/`failed` co-occurrence) are independent and both run every startup.
+
+**Scope:** startup-only. A periodic (mid-run) version of this sweep would additionally need to exclude items with a live in-process worker for that stage — the startup case is safe without that check only because no workers exist yet in a freshly-started process. Running this sweep periodically is not implemented (see issue #1135).
+
 #### Updated `fabrik:locked:<user>` Label Lifecycle
 
 The lock label is now removed by four paths (previously two):

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2283,6 +2283,22 @@ When a Fabrik process crashes, deferred cleanup never runs. On the next startup,
 3. `store.Apply(WorkerExited{})` — no-op since `Worker` is already nil; applied for idempotency.
 4. Log the cleanup at `"startup"` tag.
 
+#### Startup Orphaned in_progress Scan (Broader Sweep)
+
+The lock-gated pass above only reaches items that *still hold* a stale lock label. An `in_progress` label orphaned after its paired lock was already cleanly released — the normal outcome when `release()` (`engine/item.go`) succeeds at removing the lock but the paired `removeInProgressLabel` call fails transiently, since that call has no retry — is invisible to it and survives every restart. `runStartupOrphanedInProgressScan()` closes this gap with a second, broader sweep.
+
+**Trigger:** Same call site as the lock-gated pass — runs immediately after `runStartupCleanup()`, inside the same `if firstPollErr == nil` block in `poll.go`.
+
+**Detection:** Scan `store.All()` — every managed item in the store, not filtered by lock label. For each item, build the set of stage names carrying `stage:<Name>:complete` or `stage:<Name>:failed`. Then, for each `stage:<Name>:in_progress` label on the same item whose `<Name>` is in that set, the label is stale by definition — a stage cannot be both finished and in progress — and is removed.
+
+**No `Worker()` or lock-label filter.** This is a deliberate divergence from the lock-gated pass, not an oversight: dispatch ordering already guarantees `complete`/`failed` and `in_progress` never legitimately co-occur for the same stage — `removeFailedLabel` runs before `in_progress` is re-added on retry, and `complete` blocks further dispatch of that stage entirely. Any occurrence of the co-occurrence is therefore stale regardless of whether a worker or lock is present, making the predicate self-justifying and safe to run unconditionally at startup.
+
+**Cleanup per item:** for each stale `in_progress` label found, `RemoveLabel(label)` from GitHub (with write-through to cache on success), logged as `[startup] removed stale label %q` — the same format as the lock-gated pass. Errors are logged as warnings and not retried, matching the lock-gated pass's behavior.
+
+**Additive, not a replacement:** this pass runs alongside, not instead of, the lock-gated sweep — the two predicates (stale lock label vs. `complete`/`failed` co-occurrence) are independent and both run every startup.
+
+**Scope:** startup-only. A periodic (mid-run) version of this sweep would additionally need to exclude items with a live in-process worker for that stage — the startup case is safe without that check only because no workers exist yet in a freshly-started process. Running this sweep periodically is not implemented (see issue #1135).
+
 #### Updated `fabrik:locked:<user>` Label Lifecycle
 
 The lock label is now removed by four paths (previously two):

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -534,6 +534,7 @@ func (e *Engine) Run() error {
 	// Skipped on poll failure to avoid scanning an empty/partial store.
 	if firstPollErr == nil {
 		e.runStartupCleanup()
+		e.runStartupOrphanedInProgressScan()
 		e.runStartupTransientLabelScan()
 		e.runStartupTerminalScan()
 		if e.cfg.JanitorIntervalHours > 0 {

--- a/engine/worker_liveness.go
+++ b/engine/worker_liveness.go
@@ -196,3 +196,69 @@ func (e *Engine) runStartupCleanup() {
 		e.logf(0, "startup", "startup cleanup: attempted stale editing label removal on %d issue(s)\n", cleanedEditing)
 	}
 }
+
+// runStartupOrphanedInProgressScan scans every item in the store (not just
+// items with a stale lock label) for stage:<Name>:in_progress labels whose
+// stage <Name> also carries stage:<Name>:complete or stage:<Name>:failed on
+// the same item. That co-occurrence is stale by definition — a stage cannot
+// be both finished and in progress — so the in_progress label is removed.
+//
+// Unlike runStartupCleanup's lock-gated sweep, this pass does NOT check
+// Worker() or any lock label. This is deliberate, not an oversight: dispatch
+// ordering guarantees complete/failed and in_progress never legitimately
+// co-occur for the same stage during normal operation (removeFailedLabel
+// runs before in_progress is re-added on retry, and complete blocks further
+// dispatch entirely), so any occurrence found here is stale regardless of
+// whether a worker or lock is present. This makes the predicate self-
+// justifying and safe to run unconditionally at startup — see issue #1135.
+//
+// This sweep is startup-only. Running it mid-poll would additionally need to
+// exclude items with a live in-process worker for that stage, which this
+// issue's scope does not require (see docs/state-machine.md).
+//
+// Must be called after the store is populated by the first poll cycle.
+func (e *Engine) runStartupOrphanedInProgressScan() {
+	var cleaned int
+	for _, snap := range e.store.All() {
+		labels := snap.Labels()
+
+		terminalStages := make(map[string]bool)
+		for _, label := range labels {
+			if !strings.HasPrefix(label, "stage:") {
+				continue
+			}
+			if strings.HasSuffix(label, ":complete") {
+				terminalStages[strings.TrimSuffix(strings.TrimPrefix(label, "stage:"), ":complete")] = true
+			} else if strings.HasSuffix(label, ":failed") {
+				terminalStages[strings.TrimSuffix(strings.TrimPrefix(label, "stage:"), ":failed")] = true
+			}
+		}
+		if len(terminalStages) == 0 {
+			continue
+		}
+
+		owner, repoName := parseOwnerRepo(snap.Repo())
+		number := snap.Number()
+		for _, label := range labels {
+			if !strings.HasPrefix(label, "stage:") || !strings.HasSuffix(label, ":in_progress") {
+				continue
+			}
+			stageName := strings.TrimSuffix(strings.TrimPrefix(label, "stage:"), ":in_progress")
+			if !terminalStages[stageName] {
+				continue
+			}
+			if err := e.client.RemoveLabelFromIssue(owner, repoName, number, label); err != nil {
+				e.logf(number, "warn", "could not remove orphaned in_progress label %q: %v\n", label, err)
+				continue
+			}
+			e.logf(number, "startup", "removed stale label %q\n", label)
+			if c := e.cache(); c != nil {
+				c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repoName, number), label)
+			}
+			cleaned++
+		}
+	}
+	if cleaned > 0 {
+		e.logf(0, "startup", "orphaned in_progress scan: removed %d stale label(s)\n", cleaned)
+	}
+}

--- a/engine/worker_liveness_test.go
+++ b/engine/worker_liveness_test.go
@@ -574,6 +574,114 @@ func TestDetectorSkipsFreshWorker(t *testing.T) {
 	}
 }
 
+// TestRunStartupOrphanedInProgressScan_RemovesStaleLabel verifies that the
+// broadened startup sweep removes a stage:in_progress label that co-occurs
+// with stage:complete for the same stage, even with no lock label present.
+func TestRunStartupOrphanedInProgressScan_RemovesStaleLabel(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(t, client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 30, []string{
+		"stage:Implement:complete",
+		"stage:Implement:in_progress",
+	})
+
+	e.runStartupOrphanedInProgressScan()
+
+	removed := removeLabelsCalled(client, 30)
+	if !hasRemovedLabel(removed, "stage:Implement:in_progress") {
+		t.Errorf("expected stage:Implement:in_progress to be removed; got: %v", removed)
+	}
+	if hasRemovedLabel(removed, "stage:Implement:complete") {
+		t.Errorf("stage:Implement:complete should not be removed; got: %v", removed)
+	}
+}
+
+// TestRunStartupOrphanedInProgressScan_FailedCoOccurrence verifies that
+// stage:<Name>:failed also triggers the staleness predicate, not just
+// stage:<Name>:complete.
+func TestRunStartupOrphanedInProgressScan_FailedCoOccurrence(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(t, client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 31, []string{
+		"stage:Review:failed",
+		"stage:Review:in_progress",
+	})
+
+	e.runStartupOrphanedInProgressScan()
+
+	removed := removeLabelsCalled(client, 31)
+	if !hasRemovedLabel(removed, "stage:Review:in_progress") {
+		t.Errorf("expected stage:Review:in_progress to be removed; got: %v", removed)
+	}
+}
+
+// TestRunStartupOrphanedInProgressScan_LeavesGenuineInFlightUntouched verifies
+// that an item whose in_progress stage has no complete/failed counterpart is
+// left untouched — even when a Worker is active, proving the predicate itself
+// (not worker-liveness) is what protects genuinely in-flight stages.
+func TestRunStartupOrphanedInProgressScan_LeavesGenuineInFlightUntouched(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(t, client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 32, []string{"stage:Implement:in_progress"})
+	setWorker(e, 32, os.Getpid(), "Implement", time.Now())
+
+	e.runStartupOrphanedInProgressScan()
+
+	removed := removeLabelsCalled(client, 32)
+	if len(removed) > 0 {
+		t.Errorf("expected no labels removed for genuinely in-flight stage; got: %v", removed)
+	}
+}
+
+// TestRunStartupOrphanedInProgressScan_DifferentStageUnaffected verifies that
+// the predicate is scoped per stage name: a complete label for one stage must
+// not trigger removal of an in_progress label for a different stage.
+func TestRunStartupOrphanedInProgressScan_DifferentStageUnaffected(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(t, client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 33, []string{
+		"stage:Implement:complete",
+		"stage:Review:in_progress",
+	})
+
+	e.runStartupOrphanedInProgressScan()
+
+	removed := removeLabelsCalled(client, 33)
+	if len(removed) > 0 {
+		t.Errorf("expected no labels removed for different-stage in_progress; got: %v", removed)
+	}
+}
+
+// TestRunStartupOrphanedInProgressScan_PreservesLockGatedSweep verifies that
+// the new broader pass composes correctly with the existing lock-gated sweep
+// when both run in sequence (as poll.go does): the stale lock label and the
+// orphaned in_progress label are both removed, without double-counting or panics.
+func TestRunStartupOrphanedInProgressScan_PreservesLockGatedSweep(t *testing.T) {
+	client := &mockGitHubClient{}
+	e := testEngine(t, client, &mockClaudeInvoker{})
+
+	bootstrapItem(t, e, 34, []string{
+		"fabrik:locked:testuser",
+		"stage:Implement:complete",
+		"stage:Implement:in_progress",
+	})
+
+	e.runStartupCleanup()
+	e.runStartupOrphanedInProgressScan()
+
+	removed := removeLabelsCalled(client, 34)
+	if !hasRemovedLabel(removed, "fabrik:locked:testuser") {
+		t.Errorf("expected lock label to be removed; got: %v", removed)
+	}
+	if !hasRemovedLabel(removed, "stage:Implement:in_progress") {
+		t.Errorf("expected in_progress label to be removed; got: %v", removed)
+	}
+}
+
 // TestWorkerStaleTimeoutDefault verifies that workerStaleTimeout() returns 5 minutes
 // when Config.WorkerStaleTimeout is zero, and the configured value otherwise.
 func TestWorkerStaleTimeoutDefault(t *testing.T) {


### PR DESCRIPTION
Closes #1135

## What this does

Adds a second, broader startup sweep — `runStartupOrphanedInProgressScan()` — that removes stale `stage:<Name>:in_progress` labels from *any* managed item, not only those still holding a stale `fabrik:locked:<user>` label.

Today's lock-gated sweep (`runStartupCleanup` / `forEachStaleUnworkedItem`) only reaches items where the lock label survived a crash alongside `in_progress`. But the common failure mode is the lock being cleanly released while the paired `removeInProgressLabel` call fails transiently (it has no retry) — leaving `in_progress` orphaned with no lock to key off of. That label then survives every restart forever, eroding operator trust in the board (see #980 for a live example).

## Key changes

- **`engine/worker_liveness.go`** — new `runStartupOrphanedInProgressScan()`. For every item in the store, builds the set of stage names carrying `stage:<Name>:complete` or `stage:<Name>:failed`, then removes any `stage:<Name>:in_progress` label whose `<Name>` is in that set. Deliberately does **not** filter on `Worker()` or lock state — dispatch ordering already guarantees `complete`/`failed` and `in_progress` can't legitimately co-occur for the same stage, so the co-occurrence alone is proof of staleness.
- **`engine/poll.go`** — wires the new pass into the existing startup sequence, right after `runStartupCleanup()`.
- **`engine/worker_liveness_test.go`** — 5 new tests: stale-label removal via `complete`, via `failed`, genuine in-flight stages left untouched (even with an active Worker), per-stage-name scoping, and composition with the existing lock-gated sweep.
- **`docs/state-machine.md`** / **`docs/llms-full.txt`** — documents the new sweep's detection predicate, its deliberate lack of a `Worker()`/lock filter, and its startup-only scope, per repo convention.

## Out of scope (per issue)

- No retry added to the original `removeInProgressLabel` call in `release()`.
- This sweep is startup-only; running it periodically mid-run is a separate follow-up (would need to additionally exclude items with a live in-process worker).
- No change to lock-label semantics.

## How to test

- `go build ./...`, `go vet ./...` — clean.
- `go test -race ./engine/...` — 1646 tests pass, including the 5 new ones.
- Full `go test -race ./...` passes except one pre-existing, unrelated failure in `cmd` (`TestExecute_ConfigYAMLApplied`) that requires live network access to GitHub's GraphQL API, unavailable in this sandbox.