### PR TITLE
feat(janitor): prune stale session files on the existing janitor cadence

### DIFF
--- a/adrs/1136-session-janitor.md
+++ b/adrs/1136-session-janitor.md
@@ -1,0 +1,154 @@
+# ADR 1136: Age-Based Session-File Pruning
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #1136 — Session files are never pruned: 83% of stored session IDs point at reaped conversations
+
+## Context
+
+`.fabrik/sessions/` stores one `.session` file per (issue, stage) pair — a pointer to the Claude Code
+conversation Fabrik resumes from on the next invocation (`engine/claude.go`'s `sessionFile`/
+`saveSessionIDDirect`). Nothing in Fabrik ever deletes one. Claude Code itself reaps conversation
+transcripts after `cleanupPeriodDays` (default 30, user-configurable), so the pointer's lifetime is
+unbounded while the thing it points at has a 30-day expiry. Measured on a working install on
+2026-07-26: 1,998 `.session` files on disk, only 338 pointing at a conversation that still exists —
+83% pointing at nothing, spread across 293 issues, most long closed. Every other category of Fabrik
+runtime state has a bound: stage logs are pruned by `LogRetentionDays` (`runLogJanitor`/`pruneLogs`,
+`engine/janitor.go`), and worktrees are swept hourly by the worktree janitor. Sessions had neither.
+
+This is the substrate that made #1128 possible: #1128 fixes the *symptom* (detect a dead session at
+invocation time, clear the entry, start fresh); this issue removes the substrate so that recovery path
+stays a rare event instead of the 83%-of-the-time steady state.
+
+Two decisions were explicitly left to Research rather than picked silently by the original issue:
+which pruning mechanism to use, and whether a new config key is needed.
+
+## Decision
+
+### Mechanism: age-based only, not liveness-checking
+
+Prune `.session` files whose mtime exceeds a configurable retention window (`session_retention_days`,
+new config key, default **14 days**, `0` disables), mirroring `pruneLogs`'s existing shape exactly:
+scope-guarded directory walk, `now.AddDate(0, 0, -retentionDays)` cutoff, `now` injected for
+deterministic tests, followed by best-effort empty-directory cleanup.
+
+The alternative considered — **liveness-checking**, listing
+`~/.claude/projects/<sanitized-cwd>/*.jsonl` and intersecting against stored session IDs — was
+rejected. It would be Fabrik's first code path that reads Claude Code's internal on-disk transcript
+layout. Nothing else in the codebase depends on that path today, not even #1128's own dead-session
+recovery, which detects staleness structurally from the Claude CLI's own error response
+(`"No conversation found with session ID"`) rather than by inspecting Claude Code's on-disk state.
+Coupling to an internal, unversioned storage convention means an unannounced Claude Code layout change
+would silently stop all session pruning fleet-wide, with no test able to catch it before it ships. A
+hybrid (age-based plus liveness-checking as a second, tighter mechanism) was also rejected: liveness
+checking only earns its complexity if it lets the retention window be safely *shorter* than a pure
+age-based cutoff, and the coupling risk above outweighs that marginal benefit — age-based alone already
+satisfies every line of the issue's Definition of Done.
+
+A `.session` file's mtime already means the right thing with zero new bookkeeping:
+`saveSessionIDDirect` rewrites the file on every stage invocation that produces a session ID, so mtime
+is exactly "last time this (issue, stage) pair was invoked" — the correct staleness proxy.
+
+**Default of 14 days** matches `LogRetentionDays`'s own precedent (no comparable upstream constraint
+either) and sits comfortably under Claude Code's 30-day `cleanupPeriodDays` default, so Fabrik's own
+prune generally lands ahead of — or not far behind — Claude's reap, keeping the rotten-pointer
+population near zero in steady state rather than accumulating toward the 83% this issue measured.
+
+### Scheduling: new pass on the existing janitor, no new scheduler
+
+`runSessionJanitor(ctx)` is a third periodic pass in `engine/janitor.go`, invoked from the same two
+`engine/poll.go` call sites as `runWorktreeJanitor`/`runLogJanitor` (the post-first-poll startup pass
+and the hourly ticker goroutine), gated by the same `JanitorIntervalHours > 0` condition. No new
+goroutine, ticker, or config surface for cadence — `session_retention_days` only controls the age
+cutoff, exactly as `log_retention_days` does for the log janitor.
+
+### In-flight guard: directory-wide, not stage-specific
+
+The spec requires never deleting a session file for a stage currently in flight. The existing
+worktree-janitor check — `snap.Worker() != nil && !isWorkerStale(snap.Worker(), e.workerStaleTimeout())`
+(`engine/janitor.go`) — is reused, but widened: once an issue has *any* live worker registered, **every**
+`.session` file under that issue's session directory is skipped for the cycle, not only the file
+matching the worker's current `StageName`. This is a deliberate conservative widening: it costs one
+`store.Get(ownerRepo, issueNumber)` call per issue directory — already the same cost the worktree
+janitor pays per issue — and it avoids a race where the active stage transitions mid-cycle, between
+the age check and the delete, in a way that a stage-specific check could miss.
+
+### Unresolved multi-repo directories: skip entirely, never delete
+
+Sessions dirs use the same `<owner>-<repo>` naming convention as worktree dirs
+(`sessionDirForItem`/`strings.ReplaceAll(issue.Repo, "/", "-")`), so a multi-repo session directory
+name is resolved back to `"owner/repo"` via the same reverse map the worktree janitor builds from
+`e.worktreeManagers` (factored out as the shared `buildWMByDirName()` helper so both janitors stay in
+sync). Unlike the worktree janitor, there is **no git-remote fallback** available for an unresolvable
+directory (`janitorResolveOwnerRepo`'s `git remote get-url origin` requires an actual git checkout to
+run inside, and a sessions-only directory has none). When a directory's name isn't found in the
+reverse map, the entire directory is skipped for the cycle — counted, never deleted from — consistent
+with this codebase's established "ambiguity → don't touch, log and move on" convention (the same
+philosophy behind the worktree janitor's own conservative gate).
+
+### Logging: one summary line per cycle
+
+`session-janitor` tag, same shape as `runLogJanitor`'s summary line:
+
+```
+cycle complete: scanned N session files, removed M, skipped K (in-flight=I, unresolved-repo=U)
+```
+
+Never one line per file — a first run against an install like the one measured in the issue
+(1,660 dead pointers) would otherwise flood the log.
+
+## Rationale
+
+### Why no REST calls or closed-state gate, unlike the worktree janitor?
+
+The worktree janitor's four-condition gate exists because a worktree holds uncommitted work that must
+never be destroyed while an issue could still be worked — that requires knowing whether the issue is
+closed, which requires a REST fallback (plus a rate-limit pre-check) for off-board issues. A session
+file carries no work-in-progress state; it is a resume pointer, and #1128 already makes losing one
+gracefully recoverable — the next invocation just starts a fresh session. The spec's Definition of
+Done reflects this asymmetry: it gates only on in-flight status and age, never on issue-closed state.
+The session janitor is therefore pure store-lookup plus filesystem walk — no `FetchIssue` fallback, no
+rate-limit gate, no closed-state cache — simpler than the worktree janitor and closer in shape to the
+log janitor.
+
+### Why factor out `buildWMByDirName()`?
+
+Both the worktree and session janitors need the identical `e.worktreeManagers` → `"owner-repo"`
+reverse map. Duplicating the ~8-line construction risks silent drift if the mapping logic ever
+changes (e.g. how `owner-repo` names are derived); a single shared helper makes that structurally
+impossible.
+
+### Why is empty-directory cleanup included, given it was explicitly optional in scope?
+
+It was called out as a nice-to-have, not a requirement, specifically to avoid blocking on it. In
+practice it is a small bottom-up `os.Remove` pass over directories already collected during the main
+walk (mirroring `pruneLogs`'s own Phase 3), so it was cheap enough to include rather than leave as a
+coin flip.
+
+## Consequences
+
+**Positive:**
+- The rotten-pointer population (measured at 83% of 1,998 files) is bounded by `session_retention_days`
+  instead of growing forever; #1128's dead-session recovery path becomes a rare event rather than the
+  steady state.
+- No new coupling to Claude Code's internal on-disk layout — the janitor's correctness does not depend
+  on an unversioned convention Fabrik doesn't own.
+- Both session directory layouts (single-repo `issue-N/`, multi-repo `<owner>-<repo>/issue-N/`) are
+  scanned unconditionally, so a project that switches between single- and multi-repo mode doesn't leave
+  the old layout's directories to accumulate with nothing to clean them up.
+
+**Negative / Trade-offs:**
+- Age is a *proxy* for liveness, not exact. An issue that sits `fabrik:paused` (e.g. awaiting human
+  input) for longer than `session_retention_days` has no in-flight worker, so it does not qualify for
+  the in-flight guard — its session file can be pruned mid-pause even though the underlying Claude Code
+  conversation may still be resumable for up to 30 days. This is spec-compliant (only "in flight" is
+  protected, not "paused-but-will-resume") and the consequence is bounded — the next invocation just
+  starts a fresh session, the same fallback used whenever a session pointer goes dead for any other
+  reason — but it is a real, if minor, behavior change, documented in `docs/USER_GUIDE.md`'s Session
+  Janitor section.
+- An unresolvable multi-repo session directory (a permanently deregistered repo whose
+  `WorktreeManager` is never re-created) is skipped every cycle and could accumulate indefinitely.
+  This mirrors an existing, already-accepted risk in the worktree janitor's own unregistered-repo
+  fallback chain — not a new class of problem introduced here.
+
+**References:** [ADR-055: Worktree Janitor](055-worktree-janitor.md)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,7 @@ type Config struct {
 	JanitorIntervalHours      int    // hours; 1 = default; 0 disables the janitor
 	LogRetentionDays          int    // days; 14 = default; 0 disables age-based log pruning
 	LogMaxBytes               int64  // bytes; 2147483648 = default; 0 disables size-cap pruning
+	SessionRetentionDays      int    // days; 14 = default; 0 disables age-based session pruning
 	ArchiveAfter              string // Go duration string; "" means use default (168h = 1 week); also FABRIK_ARCHIVE_AFTER
 	ArchiveDone               string // on or off; "" means use default (on); also FABRIK_ARCHIVE_DONE
 }
@@ -180,6 +181,7 @@ func Execute() error {
 	flag.IntVar(&cfg.JanitorIntervalHours, "janitor-interval", 1, "Worktree janitor scan interval in hours; 0 disables the janitor (also FABRIK_JANITOR_INTERVAL)")
 	flag.IntVar(&cfg.LogRetentionDays, "log-retention-days", 14, "Delete log files older than this many days; 0 disables age-based pruning (also FABRIK_LOG_RETENTION_DAYS)")
 	flag.Int64Var(&cfg.LogMaxBytes, "log-max-bytes", 2147483648, "Total size cap for .fabrik/logs/ in bytes; oldest files deleted first after age prune; 0 disables size cap (also FABRIK_LOG_MAX_BYTES)")
+	flag.IntVar(&cfg.SessionRetentionDays, "session-retention-days", 14, "Delete .session files older than this many days; 0 disables age-based pruning (also FABRIK_SESSION_RETENTION_DAYS)")
 	flag.StringVar(&cfg.KillGraceSigInt, "kill-grace-sigint", "", "Grace window after SIGINT before SIGTERM in the kill escalation sequence (Go duration: 10s, 0s to skip SIGINT entirely; also FABRIK_KILL_GRACE_SIGINT; default 10s)")
 	flag.StringVar(&cfg.KillGraceSigTerm, "kill-grace-sigterm", "", "Grace window after SIGTERM before SIGKILL in the kill escalation sequence (Go duration: 10s; also FABRIK_KILL_GRACE_SIGTERM; default 10s)")
 	flag.StringVar(&cfg.ArchiveAfter, "archive-after", "", "Grace period since an item settled into Done before it is auto-archived off the project board (Go duration: 168h, 24h; also FABRIK_ARCHIVE_AFTER; default 168h = 1 week)")
@@ -547,6 +549,21 @@ func Execute() error {
 			}
 		}
 	}
+	if !explicitFlags["session-retention-days"] {
+		if v := os.Getenv("FABRIK_SESSION_RETENTION_DAYS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				cfg.SessionRetentionDays = n
+			} else {
+				fmt.Fprintf(os.Stderr, "[warn] FABRIK_SESSION_RETENTION_DAYS=%q is invalid (must be a non-negative integer of days; 0 = disable); using default 14\n", v)
+			}
+		} else if pc.SessionRetentionDays != nil {
+			if *pc.SessionRetentionDays < 0 {
+				fmt.Fprintf(os.Stderr, "[warn] config.yaml session_retention_days=%d is invalid (must be a non-negative integer; 0 = disable); using default 14\n", *pc.SessionRetentionDays)
+			} else {
+				cfg.SessionRetentionDays = *pc.SessionRetentionDays
+			}
+		}
+	}
 	if !explicitFlags["kill-grace-sigint"] {
 		cfg.KillGraceSigInt = resolveDuration(cfg.KillGraceSigInt, "FABRIK_KILL_GRACE_SIGINT") // validated in killGraceSigInt() helper
 	}
@@ -758,6 +775,7 @@ func Execute() error {
 		JanitorIntervalHours:      cfg.JanitorIntervalHours,
 		LogRetentionDays:          cfg.LogRetentionDays,
 		LogMaxBytes:               cfg.LogMaxBytes,
+		SessionRetentionDays:      cfg.SessionRetentionDays,
 		ArchiveAfter:              archiveAfter(cfg.ArchiveAfter),
 		ArchiveDone:               archiveDoneMode(cfg.ArchiveDone),
 		ReadyCh:                   testReadyCh,

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ type ProjectConfig struct {
 	JanitorIntervalHours      *int     `yaml:"janitor_interval_hours"`
 	LogRetentionDays          *int     `yaml:"log_retention_days"`
 	LogMaxBytes               *int64   `yaml:"log_max_bytes"`
+	SessionRetentionDays      *int     `yaml:"session_retention_days"`
 	MergeTrain                string   `yaml:"merge_train"`
 	AutoMergeStrategy         string   `yaml:"auto_merge_strategy"`
 	MaxBatchSize              *int     `yaml:"max_batch_size"`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -432,7 +432,7 @@ Pruning runs in three phases per cycle:
 2. **Size-cap backstop**: after age-pruning, if the total size of `.fabrik/logs/` still exceeds `log_max_bytes`, delete the oldest files (by mtime) until the tree is under the cap. Default **2 GiB**. `0` disables the size cap.
 3. **Empty-dir cleanup**: remove any now-empty `issue-N/` and `<owner>-<repo>/` directories.
 
-The janitor only ever touches `.fabrik/logs/`. It never modifies `sessions/`, `worktrees/`, `repos/`, or `debug/`.
+The janitor only ever touches `.fabrik/logs/`. It never modifies `worktrees/`, `repos/`, or `debug/`. (`sessions/` has its own janitor — see [Session Janitor](#session-janitor) below.)
 
 At the end of each scan Fabrik logs:
 
@@ -451,6 +451,36 @@ log_max_bytes: 2147483648   # default (2 GiB) — set to 0 to disable size-cap p
 Also controllable via `--log-retention-days` / `--log-max-bytes` flags or `FABRIK_LOG_RETENTION_DAYS` / `FABRIK_LOG_MAX_BYTES` environment variables.
 
 > **Note:** Because the prune runs on every tick (not only at startup), the size-cap backstop only has to absorb at most one tick-interval of log growth. An instance producing more than `log_max_bytes` within a single `janitor_interval_hours` window can transiently exceed the cap until the next tick — the hourly default makes this a non-issue in practice.
+
+### Session Janitor
+
+`.fabrik/sessions/` stores one `.session` file per (issue, stage) pair — a pointer to the Claude Code conversation Fabrik resumes from on the next invocation. Nothing else in Fabrik ever deletes these files, so on a long-running instance the vast majority end up pointing at conversations Claude Code has already reaped on its own `cleanupPeriodDays` schedule (default 30 days) — dead pointers that just accumulate.
+
+The **session janitor** prunes `.fabrik/sessions/` by age. It runs on the **same cadence as the worktree and log janitors** (disabled when `janitor_interval_hours: 0`):
+
+1. **Once at startup**, after the first successful poll.
+2. **Hourly** thereafter (same `janitor_interval_hours` cadence).
+
+Each cycle deletes any `.session` file whose mtime is older than `session_retention_days` × 24 h (default **14 days**; `0` disables age-based pruning), for both directory layouts Fabrik produces (`.fabrik/sessions/issue-N/` for single-repo projects, `.fabrik/sessions/<owner>-<repo>/issue-N/` for multi-repo). Now-empty `issue-N/` and `<owner>-<repo>/` directories left behind are removed as well.
+
+**A session file for a stage currently in flight is never deleted**, regardless of age: if an issue has a live worker registered, every `.session` file under that issue's session directory is skipped for the cycle — not just the file for the worker's current stage. This is deliberately conservative: it avoids a race where the active stage changes mid-cycle between the age check and the delete.
+
+Pruning is **age-based only**, not liveness-checking against Claude Code's own transcript store — see [ADR 1136](../adrs/1136-session-janitor.md) for the tradeoff. One consequence worth knowing: an issue that sits `fabrik:paused` (e.g. awaiting human input) for longer than `session_retention_days` has no in-flight worker, so its session file can be pruned mid-pause even though the underlying Claude Code conversation may still be resumable for up to 30 days. This is by design — the janitor only protects "in flight," not "paused-but-will-resume" — and the consequence is bounded: the next invocation just starts a fresh Claude session instead of resuming, the same graceful fallback used when a session pointer goes dead for any other reason.
+
+At the end of each scan Fabrik logs:
+
+```
+[session-janitor] cycle complete: scanned N session files, removed M, skipped K (in-flight=I, unresolved-repo=U)
+```
+
+**Configuration:**
+
+```yaml
+# .fabrik/config.yaml
+session_retention_days: 14   # default — set to 0 to disable age-based pruning
+```
+
+Also controllable via `--session-retention-days` flag or `FABRIK_SESSION_RETENTION_DAYS` environment variable.
 
 ---
 
@@ -547,6 +577,12 @@ user: your-github-username
 # oldest files are deleted first until total size is under this cap. Set to 0
 # to disable size-cap pruning.
 # log_max_bytes: 2147483648
+
+# Session janitor: delete .fabrik/sessions/ .session files older than this many
+# days (default 14). Runs on the same janitor_interval_hours cadence. Never
+# deletes a session file for a stage currently in flight. Set to 0 to disable
+# age-based pruning.
+# session_retention_days: 14
 
 # Required status/check-run context names the ci-gate must see confirmed
 # `success` for, on the PR's exact head SHA, before it will clear (ADR-933).
@@ -657,6 +693,7 @@ FABRIK_USER=my-personal-username
 | `--janitor-interval` | Hours between janitor runs (closed-issue cleanup, stale-label eviction); 0 disables the janitor; also `FABRIK_JANITOR_INTERVAL` | `1` |
 | `--log-retention-days` | Delete `.fabrik/logs/` files older than this many days; 0 disables age-based pruning; also `FABRIK_LOG_RETENTION_DAYS` | `14` |
 | `--log-max-bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune; 0 disables size-cap pruning; also `FABRIK_LOG_MAX_BYTES` | `2147483648` (2 GiB) |
+| `--session-retention-days` | Delete `.fabrik/sessions/` `.session` files older than this many days; 0 disables age-based pruning; never deletes a session file for a stage currently in flight; also `FABRIK_SESSION_RETENTION_DAYS` | `14` |
 | `--kill-grace-sigint` | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGINT entirely; also `FABRIK_KILL_GRACE_SIGINT`) | `""` (10s) |
 | `--kill-grace-sigterm` | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGTERM entirely; also `FABRIK_KILL_GRACE_SIGTERM`) | `""` (10s) |
 | `--archive-after` | Grace period since an item settled into Done (its `stage:<Done>:complete` label was applied) before it is auto-archived off the project board (Go duration: `168h`, `24h`; `"0s"` archives immediately once eligible; also `FABRIK_ARCHIVE_AFTER`) | `""` (168h = 1 week) |
@@ -707,6 +744,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_JANITOR_INTERVAL` | `janitor_interval_hours` | Hours between janitor runs (non-negative integer; `0` disables the janitor) | `1` |
 | `FABRIK_LOG_RETENTION_DAYS` | `log_retention_days` | Delete log files older than this many days (non-negative integer; `0` disables age-based pruning) | `14` |
 | `FABRIK_LOG_MAX_BYTES` | `log_max_bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune (`0` disables size-cap pruning) | `2147483648` (2 GiB) |
+| `FABRIK_SESSION_RETENTION_DAYS` | `session_retention_days` | Delete `.fabrik/sessions/` `.session` files older than this many days (non-negative integer; `0` disables age-based pruning; never deletes a session file for a stage currently in flight) | `14` |
 | `FABRIK_KILL_GRACE_SIGINT` | *(no config.yaml key)* | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGINT step entirely) | `""` (10s) |
 | `FABRIK_KILL_GRACE_SIGTERM` | *(no config.yaml key)* | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGTERM step, SIGKILL fires immediately after SIGINT) | `""` (10s) |
 | `FABRIK_ARCHIVE_AFTER` | *(no config.yaml key)* | Grace period since an item settled into Done before it is auto-archived off the project board (Go duration string: `"168h"`, `"24h"`; empty or unset = use default of 168h/1 week; `"0s"` archives immediately once eligible; invalid or negative values fall back to the default) | `""` (168h = 1 week) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -430,7 +430,7 @@ Pruning runs in three phases per cycle:
 2. **Size-cap backstop**: after age-pruning, if the total size of `.fabrik/logs/` still exceeds `log_max_bytes`, delete the oldest files (by mtime) until the tree is under the cap. Default **2 GiB**. `0` disables the size cap.
 3. **Empty-dir cleanup**: remove any now-empty `issue-N/` and `<owner>-<repo>/` directories.
 
-The janitor only ever touches `.fabrik/logs/`. It never modifies `sessions/`, `worktrees/`, `repos/`, or `debug/`.
+The janitor only ever touches `.fabrik/logs/`. It never modifies `worktrees/`, `repos/`, or `debug/`. (`sessions/` has its own janitor — see [Session Janitor](#session-janitor) below.)
 
 At the end of each scan Fabrik logs:
 
@@ -449,6 +449,36 @@ log_max_bytes: 2147483648   # default (2 GiB) — set to 0 to disable size-cap p
 Also controllable via `--log-retention-days` / `--log-max-bytes` flags or `FABRIK_LOG_RETENTION_DAYS` / `FABRIK_LOG_MAX_BYTES` environment variables.
 
 > **Note:** Because the prune runs on every tick (not only at startup), the size-cap backstop only has to absorb at most one tick-interval of log growth. An instance producing more than `log_max_bytes` within a single `janitor_interval_hours` window can transiently exceed the cap until the next tick — the hourly default makes this a non-issue in practice.
+
+### Session Janitor
+
+`.fabrik/sessions/` stores one `.session` file per (issue, stage) pair — a pointer to the Claude Code conversation Fabrik resumes from on the next invocation. Nothing else in Fabrik ever deletes these files, so on a long-running instance the vast majority end up pointing at conversations Claude Code has already reaped on its own `cleanupPeriodDays` schedule (default 30 days) — dead pointers that just accumulate.
+
+The **session janitor** prunes `.fabrik/sessions/` by age. It runs on the **same cadence as the worktree and log janitors** (disabled when `janitor_interval_hours: 0`):
+
+1. **Once at startup**, after the first successful poll.
+2. **Hourly** thereafter (same `janitor_interval_hours` cadence).
+
+Each cycle deletes any `.session` file whose mtime is older than `session_retention_days` × 24 h (default **14 days**; `0` disables age-based pruning), for both directory layouts Fabrik produces (`.fabrik/sessions/issue-N/` for single-repo projects, `.fabrik/sessions/<owner>-<repo>/issue-N/` for multi-repo). Now-empty `issue-N/` and `<owner>-<repo>/` directories left behind are removed as well.
+
+**A session file for a stage currently in flight is never deleted**, regardless of age: if an issue has a live worker registered, every `.session` file under that issue's session directory is skipped for the cycle — not just the file for the worker's current stage. This is deliberately conservative: it avoids a race where the active stage changes mid-cycle between the age check and the delete.
+
+Pruning is **age-based only**, not liveness-checking against Claude Code's own transcript store — see [ADR 1136](../adrs/1136-session-janitor.md) for the tradeoff. One consequence worth knowing: an issue that sits `fabrik:paused` (e.g. awaiting human input) for longer than `session_retention_days` has no in-flight worker, so its session file can be pruned mid-pause even though the underlying Claude Code conversation may still be resumable for up to 30 days. This is by design — the janitor only protects "in flight," not "paused-but-will-resume" — and the consequence is bounded: the next invocation just starts a fresh Claude session instead of resuming, the same graceful fallback used when a session pointer goes dead for any other reason.
+
+At the end of each scan Fabrik logs:
+
+```
+[session-janitor] cycle complete: scanned N session files, removed M, skipped K (in-flight=I, unresolved-repo=U)
+```
+
+**Configuration:**
+
+```yaml
+# .fabrik/config.yaml
+session_retention_days: 14   # default — set to 0 to disable age-based pruning
+```
+
+Also controllable via `--session-retention-days` flag or `FABRIK_SESSION_RETENTION_DAYS` environment variable.
 
 ---
 
@@ -545,6 +575,12 @@ user: your-github-username
 # oldest files are deleted first until total size is under this cap. Set to 0
 # to disable size-cap pruning.
 # log_max_bytes: 2147483648
+
+# Session janitor: delete .fabrik/sessions/ .session files older than this many
+# days (default 14). Runs on the same janitor_interval_hours cadence. Never
+# deletes a session file for a stage currently in flight. Set to 0 to disable
+# age-based pruning.
+# session_retention_days: 14
 
 # Required status/check-run context names the ci-gate must see confirmed
 # `success` for, on the PR's exact head SHA, before it will clear (ADR-933).
@@ -655,6 +691,7 @@ FABRIK_USER=my-personal-username
 | `--janitor-interval` | Hours between janitor runs (closed-issue cleanup, stale-label eviction); 0 disables the janitor; also `FABRIK_JANITOR_INTERVAL` | `1` |
 | `--log-retention-days` | Delete `.fabrik/logs/` files older than this many days; 0 disables age-based pruning; also `FABRIK_LOG_RETENTION_DAYS` | `14` |
 | `--log-max-bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune; 0 disables size-cap pruning; also `FABRIK_LOG_MAX_BYTES` | `2147483648` (2 GiB) |
+| `--session-retention-days` | Delete `.fabrik/sessions/` `.session` files older than this many days; 0 disables age-based pruning; never deletes a session file for a stage currently in flight; also `FABRIK_SESSION_RETENTION_DAYS` | `14` |
 | `--kill-grace-sigint` | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGINT entirely; also `FABRIK_KILL_GRACE_SIGINT`) | `""` (10s) |
 | `--kill-grace-sigterm` | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration: `5s`, `10s`; empty string = use default of 10s; `"0s"` = skip SIGTERM entirely; also `FABRIK_KILL_GRACE_SIGTERM`) | `""` (10s) |
 | `--archive-after` | Grace period since an item settled into Done (its `stage:<Done>:complete` label was applied) before it is auto-archived off the project board (Go duration: `168h`, `24h`; `"0s"` archives immediately once eligible; also `FABRIK_ARCHIVE_AFTER`) | `""` (168h = 1 week) |
@@ -705,6 +742,7 @@ FABRIK_USER=my-personal-username
 | `FABRIK_JANITOR_INTERVAL` | `janitor_interval_hours` | Hours between janitor runs (non-negative integer; `0` disables the janitor) | `1` |
 | `FABRIK_LOG_RETENTION_DAYS` | `log_retention_days` | Delete log files older than this many days (non-negative integer; `0` disables age-based pruning) | `14` |
 | `FABRIK_LOG_MAX_BYTES` | `log_max_bytes` | Total size cap for `.fabrik/logs/` in bytes; oldest files deleted first after age prune (`0` disables size-cap pruning) | `2147483648` (2 GiB) |
+| `FABRIK_SESSION_RETENTION_DAYS` | `session_retention_days` | Delete `.fabrik/sessions/` `.session` files older than this many days (non-negative integer; `0` disables age-based pruning; never deletes a session file for a stage currently in flight) | `14` |
 | `FABRIK_KILL_GRACE_SIGINT` | *(no config.yaml key)* | Grace window between SIGINT and SIGTERM when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGINT step entirely) | `""` (10s) |
 | `FABRIK_KILL_GRACE_SIGTERM` | *(no config.yaml key)* | Grace window between SIGTERM and SIGKILL when killing the Claude process group (Go duration string: `"5s"`, `"10s"`; empty or unset = use default of 10s; `"0s"` = skip SIGTERM step, SIGKILL fires immediately after SIGINT) | `""` (10s) |
 | `FABRIK_ARCHIVE_AFTER` | *(no config.yaml key)* | Grace period since an item settled into Done before it is auto-archived off the project board (Go duration string: `"168h"`, `"24h"`; empty or unset = use default of 168h/1 week; `"0s"` archives immediately once eligible; invalid or negative values fall back to the default) | `""` (168h = 1 week) |

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -68,6 +68,7 @@ type Config struct {
 	JanitorIntervalHours      int           // Periodic worktree janitor cadence in hours; 0 disables the janitor (default 1)
 	LogRetentionDays          int           // Log files older than this many days are pruned; 0 disables age-based pruning (default 14)
 	LogMaxBytes               int64         // Total size cap for .fabrik/logs/; oldest files deleted first after age prune; 0 disables (default 2 GiB)
+	SessionRetentionDays      int           // .session files older than this many days are pruned; 0 disables age-based pruning (default 14)
 	ArchiveAfter              time.Duration // Grace period since stage:<Done>:complete was applied before a Done item is archived (default 168h = 1 week; ADR-068)
 	ArchiveDone               string        // "on" (default) or "off" to fully disable Done-item auto-archival (also FABRIK_ARCHIVE_DONE; ADR-068)
 	// ReadyCh is closed once Run() has registered signal handlers. Tests use

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -22,6 +22,22 @@ type janitorWMEntry struct {
 	wm        *WorktreeManager
 }
 
+// buildWMByDirName builds a reverse map from "owner-repo" directory name to
+// ownerRepo string + WorktreeManager, derived from e.worktreeManagers. Used by
+// both the worktree and session janitors to resolve multi-repo directory names.
+// The engine mutex is held only long enough to copy; callers get a snapshot.
+func (e *Engine) buildWMByDirName() map[string]janitorWMEntry {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	wmByDirName := make(map[string]janitorWMEntry, len(e.worktreeManagers))
+	for ownerRepo, wm := range e.worktreeManagers {
+		owner, repo := parseOwnerRepo(ownerRepo)
+		dirName := owner + "-" + repo
+		wmByDirName[dirName] = janitorWMEntry{ownerRepo: ownerRepo, wm: wm}
+	}
+	return wmByDirName
+}
+
 // runWorktreeJanitor scans .fabrik/worktrees/<owner-repo>/issue-N/ directories
 // and reaps worktrees whose issues are provably terminal and whose directories
 // are clean. Conservative: when in doubt, leaves the worktree and logs the reason.
@@ -49,16 +65,7 @@ func (e *Engine) runWorktreeJanitor(ctx context.Context) {
 
 	worktreesRoot := filepath.Join(e.fabrikDir, ".fabrik", "worktrees")
 
-	// Build reverse map: "owner-repo" dir name → ownerRepo string + WorktreeManager.
-	// Held only long enough to copy; the rest of the cycle is lock-free.
-	e.mu.Lock()
-	wmByDirName := make(map[string]janitorWMEntry, len(e.worktreeManagers))
-	for ownerRepo, wm := range e.worktreeManagers {
-		owner, repo := parseOwnerRepo(ownerRepo)
-		dirName := owner + "-" + repo
-		wmByDirName[dirName] = janitorWMEntry{ownerRepo: ownerRepo, wm: wm}
-	}
-	e.mu.Unlock()
+	wmByDirName := e.buildWMByDirName()
 
 	closedCache := make(map[string]bool) // "owner/repo#N" → isClosed; reset each cycle
 	var scanned, reaped int

--- a/engine/janitor.go
+++ b/engine/janitor.go
@@ -318,6 +318,189 @@ func (e *Engine) runLogJanitor(ctx context.Context) {
 	)
 }
 
+// runSessionJanitor prunes .fabrik/sessions/ of .session files whose age
+// exceeds SessionRetentionDays (age-based expiry — see adrs/1136-session-janitor.md
+// for why liveness-checking against Claude Code's internal transcript layout was
+// rejected). Disabled when SessionRetentionDays == 0. Never deletes a session file
+// for a stage currently in flight: once any live (non-stale) worker is found for
+// an issue, the entire issue's session directory is skipped that cycle, not just
+// the file matching the worker's current stage (avoids a race where the active
+// stage transitions mid-cycle between the age check and the delete). Called from
+// poll.go at startup and on every periodic janitor tick, alongside the worktree
+// and log janitors — same cadence, no new scheduler.
+func (e *Engine) runSessionJanitor(ctx context.Context) {
+	_ = ctx // reserved for future use; the walk below performs no cancellable I/O
+	sessionsRoot := filepath.Join(e.fabrikDir, ".fabrik", "sessions")
+	wmByDirName := e.buildWMByDirName()
+
+	resolveOwnerRepo := func(dirName string) (string, bool) {
+		entry, ok := wmByDirName[dirName]
+		if !ok {
+			return "", false
+		}
+		return entry.ownerRepo, true
+	}
+	isInFlight := func(ownerRepo string, issueNumber int) bool {
+		snap, snapErr := e.store.Get(ownerRepo, issueNumber)
+		return snapErr == nil && snap.Worker() != nil && !isWorkerStale(snap.Worker(), e.workerStaleTimeout())
+	}
+
+	scanned, removed, skippedInFlight, skippedUnresolved, err := pruneSessions(
+		sessionsRoot, e.cfg.SessionRetentionDays, time.Now(), e.defaultRepo(), resolveOwnerRepo, isInFlight,
+	)
+	if err != nil {
+		e.logf(0, "session-janitor", "warn: prune error: %v\n", err)
+		return
+	}
+	skipped := scanned - removed
+	e.logf(0, "session-janitor",
+		"cycle complete: scanned %d session files, removed %d, skipped %d (in-flight=%d, unresolved-repo=%d)\n",
+		scanned, removed, skipped, skippedInFlight, skippedUnresolved,
+	)
+}
+
+// pruneSessions walks root (.fabrik/sessions/) and removes ".session" files
+// whose mtime is older than retentionDays. Handles both directory layouts
+// produced by engine/claude.go:
+//   - single-repo: root/issue-N/<Stage>.session (ownerRepo = singleRepoOwnerRepo)
+//   - multi-repo:  root/<owner>-<repo>/issue-N/<Stage>.session
+//
+// resolveOwnerRepo maps a multi-repo "<owner>-<repo>" directory name to an
+// "owner/repo" string; when it returns ok=false (unregistered/deregistered repo,
+// no git checkout to fall back on), the entire directory is skipped — counted
+// in skippedUnresolved, never deleted from — consistent with this codebase's
+// "ambiguity → don't touch, log and move on" convention.
+//
+// isInFlight reports whether an issue has a live (non-stale) worker registered;
+// when true, every ".session" file under that issue's directory is skipped that
+// cycle regardless of age (skippedInFlight), per the spec's conservative,
+// directory-wide in-flight guard.
+//
+// now is injected for deterministic testing (mirrors pruneLogs). Returns zero
+// counts without error when root does not exist (normal first-run case) or when
+// retentionDays <= 0 (age-based pruning disabled).
+func pruneSessions(
+	root string,
+	retentionDays int,
+	now time.Time,
+	singleRepoOwnerRepo string,
+	resolveOwnerRepo func(dirName string) (ownerRepo string, ok bool),
+	isInFlight func(ownerRepo string, issueNumber int) bool,
+) (scanned, removed, skippedInFlight, skippedUnresolved int, err error) {
+	if retentionDays <= 0 {
+		return 0, 0, 0, 0, nil
+	}
+
+	absRoot, resolveErr := filepath.Abs(root)
+	if resolveErr != nil {
+		absRoot = filepath.Clean(root)
+	}
+	topEntries, readErr := os.ReadDir(absRoot)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return 0, 0, 0, 0, nil
+		}
+		return 0, 0, 0, 0, fmt.Errorf("reading sessions root %s: %w", absRoot, readErr)
+	}
+
+	cutoff := now.AddDate(0, 0, -retentionDays)
+	var issueDirs []string // candidates for empty-dir cleanup (bottom level)
+	var repoDirs []string  // candidates for empty-dir cleanup (multi-repo top level)
+
+	pruneIssueDir := func(issueDirPath, ownerRepo string, issueNumber int) {
+		issueDirs = append(issueDirs, issueDirPath)
+		fileEntries, rdErr := os.ReadDir(issueDirPath)
+		if rdErr != nil {
+			return
+		}
+		inFlight := isInFlight(ownerRepo, issueNumber)
+		for _, fe := range fileEntries {
+			if fe.IsDir() || !strings.HasSuffix(fe.Name(), ".session") {
+				continue
+			}
+			scanned++
+			if inFlight {
+				skippedInFlight++
+				continue
+			}
+			info, infoErr := fe.Info()
+			if infoErr != nil {
+				continue // skip unreadable file metadata; treat as still present
+			}
+			if info.ModTime().Before(cutoff) {
+				if rmErr := os.Remove(filepath.Join(issueDirPath, fe.Name())); rmErr == nil {
+					removed++
+				}
+			}
+		}
+	}
+
+	countUnresolved := func(repoDirPath string) {
+		issueEntries, rdErr := os.ReadDir(repoDirPath)
+		if rdErr != nil {
+			return
+		}
+		for _, ie := range issueEntries {
+			if !ie.IsDir() {
+				continue
+			}
+			files, _ := os.ReadDir(filepath.Join(repoDirPath, ie.Name()))
+			for _, fe := range files {
+				if !fe.IsDir() && strings.HasSuffix(fe.Name(), ".session") {
+					scanned++
+					skippedUnresolved++
+				}
+			}
+		}
+	}
+
+	for _, entry := range topEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if n := janitorParseIssueN(name); n > 0 {
+			// Single-repo layout: root/issue-N/*.session
+			pruneIssueDir(filepath.Join(absRoot, name), singleRepoOwnerRepo, n)
+			continue
+		}
+		// Multi-repo layout: root/<owner>-<repo>/issue-N/*.session
+		repoDirPath := filepath.Join(absRoot, name)
+		ownerRepo, ok := resolveOwnerRepo(name)
+		if !ok {
+			countUnresolved(repoDirPath)
+			continue
+		}
+		repoDirs = append(repoDirs, repoDirPath)
+		issueEntries, rdErr := os.ReadDir(repoDirPath)
+		if rdErr != nil {
+			continue
+		}
+		for _, ie := range issueEntries {
+			if !ie.IsDir() {
+				continue
+			}
+			n := janitorParseIssueN(ie.Name())
+			if n == 0 {
+				continue
+			}
+			pruneIssueDir(filepath.Join(repoDirPath, ie.Name()), ownerRepo, n)
+		}
+	}
+
+	// Empty-dir cleanup: bottom-up — issue-N dirs first, then their parent
+	// owner-repo dirs. os.Remove fails (silently, here) on a non-empty directory,
+	// so this only ever removes directories left fully empty by the prune above.
+	for _, d := range issueDirs {
+		_ = os.Remove(d)
+	}
+	for _, d := range repoDirs {
+		_ = os.Remove(d)
+	}
+
+	return
+}
+
 // logFileEntry holds metadata for a single file under .fabrik/logs/.
 type logFileEntry struct {
 	path  string

--- a/engine/janitor_test.go
+++ b/engine/janitor_test.go
@@ -558,3 +558,324 @@ func TestLogJanitorPeriodicPath(t *testing.T) {
 		t.Errorf("periodic path: recent file should be kept: %v", err)
 	}
 }
+
+// ── Session janitor tests ───────────────────────────────────────────────────
+
+// seedSessionFile writes a fake session-ID file to dir/name and sets its mtime.
+// Returns the full path.
+func seedSessionFile(t *testing.T, dir, name string, mtime time.Time) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("seedSessionFile mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("test-session-id"), 0644); err != nil {
+		t.Fatalf("seedSessionFile WriteFile %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("seedSessionFile Chtimes %s: %v", path, err)
+	}
+	return path
+}
+
+// TestPruneSessionsAgePrune_SingleRepoLayout verifies age-based pruning on the
+// single-repo layout: root/issue-N/<Stage>.session.
+func TestPruneSessionsAgePrune_SingleRepoLayout(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	old := now.Add(-15 * 24 * time.Hour)   // older than 14-day default
+	recent := now.Add(-1 * 24 * time.Hour) // within retention window
+
+	issueDir := filepath.Join(root, "issue-1")
+	oldFile := seedSessionFile(t, issueDir, "Implement.session", old)
+	newFile := seedSessionFile(t, issueDir, "Review.session", recent)
+
+	noResolve := func(string) (string, bool) { return "", false }
+	notInFlight := func(string, int) bool { return false }
+
+	scanned, removed, skippedInFlight, skippedUnresolved, err := pruneSessions(root, 14, now, "owner/repo", noResolve, notInFlight)
+	if err != nil {
+		t.Fatalf("pruneSessions: %v", err)
+	}
+	if scanned != 2 {
+		t.Errorf("scanned=%d, want 2", scanned)
+	}
+	if removed != 1 {
+		t.Errorf("removed=%d, want 1", removed)
+	}
+	if skippedInFlight != 0 || skippedUnresolved != 0 {
+		t.Errorf("skippedInFlight=%d skippedUnresolved=%d, want 0 0", skippedInFlight, skippedUnresolved)
+	}
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("old session file should be deleted")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("new session file should be kept: %v", err)
+	}
+}
+
+// TestPruneSessionsAgePrune_MultiRepoLayout verifies age-based pruning on the
+// multi-repo layout: root/<owner>-<repo>/issue-N/<Stage>.session.
+func TestPruneSessionsAgePrune_MultiRepoLayout(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	old := now.Add(-15 * 24 * time.Hour)
+	recent := now.Add(-1 * 24 * time.Hour)
+
+	issueDir := filepath.Join(root, "owner-repo", "issue-1")
+	oldFile := seedSessionFile(t, issueDir, "Implement.session", old)
+	newFile := seedSessionFile(t, issueDir, "Review.session", recent)
+
+	resolve := func(dirName string) (string, bool) {
+		if dirName == "owner-repo" {
+			return "owner/repo", true
+		}
+		return "", false
+	}
+	notInFlight := func(string, int) bool { return false }
+
+	scanned, removed, skippedInFlight, skippedUnresolved, err := pruneSessions(root, 14, now, "", resolve, notInFlight)
+	if err != nil {
+		t.Fatalf("pruneSessions: %v", err)
+	}
+	if scanned != 2 || removed != 1 {
+		t.Errorf("scanned=%d removed=%d, want 2 1", scanned, removed)
+	}
+	if skippedInFlight != 0 || skippedUnresolved != 0 {
+		t.Errorf("skippedInFlight=%d skippedUnresolved=%d, want 0 0", skippedInFlight, skippedUnresolved)
+	}
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("old session file should be deleted")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("new session file should be kept: %v", err)
+	}
+}
+
+// TestPruneSessionsInFlightGuard_SkipsWholeDirectory verifies that once an
+// issue has a live in-flight worker, every ".session" file under that issue's
+// directory is retained regardless of age — not just the file matching the
+// worker's current stage.
+func TestPruneSessionsInFlightGuard_SkipsWholeDirectory(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	old := now.Add(-30 * 24 * time.Hour)
+
+	// Issue 5 is in flight; both its (unrelated-stage) files must survive.
+	inFlightIssueDir := filepath.Join(root, "issue-5")
+	oldImplementFile := seedSessionFile(t, inFlightIssueDir, "Implement.session", old)
+	oldReviewFile := seedSessionFile(t, inFlightIssueDir, "Review.session", old)
+
+	// Issue 6 is not in flight; its stale file must be removed.
+	notInFlightIssueDir := filepath.Join(root, "issue-6")
+	oldFile6 := seedSessionFile(t, notInFlightIssueDir, "Implement.session", old)
+
+	isInFlight := func(ownerRepo string, issueNumber int) bool {
+		return issueNumber == 5
+	}
+	noResolve := func(string) (string, bool) { return "", false }
+
+	scanned, removed, skippedInFlight, skippedUnresolved, err := pruneSessions(root, 14, now, "owner/repo", noResolve, isInFlight)
+	if err != nil {
+		t.Fatalf("pruneSessions: %v", err)
+	}
+	if scanned != 3 {
+		t.Errorf("scanned=%d, want 3", scanned)
+	}
+	if removed != 1 {
+		t.Errorf("removed=%d, want 1 (only issue-6's file)", removed)
+	}
+	if skippedInFlight != 2 {
+		t.Errorf("skippedInFlight=%d, want 2 (both issue-5 files)", skippedInFlight)
+	}
+	if skippedUnresolved != 0 {
+		t.Errorf("skippedUnresolved=%d, want 0", skippedUnresolved)
+	}
+	for _, f := range []string{oldImplementFile, oldReviewFile} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("in-flight issue's session file %s should be retained: %v", f, err)
+		}
+	}
+	if _, err := os.Stat(oldFile6); !os.IsNotExist(err) {
+		t.Errorf("issue-6's stale file should be deleted")
+	}
+}
+
+// TestPruneSessionsUnresolvedMultiRepoDir_SkippedEntirely verifies that a
+// multi-repo directory whose name cannot be resolved to an owner/repo is
+// skipped in its entirety — nothing under it is deleted, regardless of age.
+func TestPruneSessionsUnresolvedMultiRepoDir_SkippedEntirely(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	old := now.Add(-30 * 24 * time.Hour)
+
+	issueDir := filepath.Join(root, "unknown-owner-unknown-repo", "issue-1")
+	oldFile := seedSessionFile(t, issueDir, "Implement.session", old)
+
+	noResolve := func(string) (string, bool) { return "", false }
+	notInFlight := func(string, int) bool { return false }
+
+	scanned, removed, skippedInFlight, skippedUnresolved, err := pruneSessions(root, 14, now, "", noResolve, notInFlight)
+	if err != nil {
+		t.Fatalf("pruneSessions: %v", err)
+	}
+	if scanned != 1 || removed != 0 {
+		t.Errorf("scanned=%d removed=%d, want 1 0", scanned, removed)
+	}
+	if skippedUnresolved != 1 {
+		t.Errorf("skippedUnresolved=%d, want 1", skippedUnresolved)
+	}
+	if skippedInFlight != 0 {
+		t.Errorf("skippedInFlight=%d, want 0", skippedInFlight)
+	}
+	if _, err := os.Stat(oldFile); err != nil {
+		t.Errorf("session file under unresolved repo dir should be retained: %v", err)
+	}
+}
+
+// TestPruneSessionsNonExistentRoot verifies that pruneSessions returns clean
+// zero counts (not an error) when the sessions directory doesn't exist yet.
+func TestPruneSessionsNonExistentRoot(t *testing.T) {
+	nonExistentRoot := filepath.Join(t.TempDir(), "no-such-dir")
+	scanned, removed, skippedInFlight, skippedUnresolved, err := pruneSessions(
+		nonExistentRoot, 14, time.Now(), "owner/repo",
+		func(string) (string, bool) { return "", false },
+		func(string, int) bool { return false },
+	)
+	if err != nil {
+		t.Errorf("expected nil error for non-existent root, got: %v", err)
+	}
+	if scanned != 0 || removed != 0 || skippedInFlight != 0 || skippedUnresolved != 0 {
+		t.Errorf("expected zero counts for non-existent root, got scanned=%d removed=%d", scanned, removed)
+	}
+}
+
+// TestPruneSessionsDisabled verifies that retentionDays=0 disables age-based
+// pruning entirely — no files are scanned or removed.
+func TestPruneSessionsDisabled(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	ancient := now.Add(-365 * 24 * time.Hour)
+	issueDir := filepath.Join(root, "issue-1")
+	f := seedSessionFile(t, issueDir, "Implement.session", ancient)
+
+	scanned, removed, _, _, err := pruneSessions(root, 0, now, "owner/repo",
+		func(string) (string, bool) { return "", false },
+		func(string, int) bool { return false },
+	)
+	if err != nil {
+		t.Fatalf("pruneSessions: %v", err)
+	}
+	if scanned != 0 || removed != 0 {
+		t.Errorf("retentionDays=0: scanned=%d removed=%d, want 0 0", scanned, removed)
+	}
+	if _, err := os.Stat(f); err != nil {
+		t.Errorf("file should not be deleted when retentionDays=0: %v", err)
+	}
+}
+
+// TestPruneSessionsEmptyDirCleanup verifies that empty issue-N/ and
+// owner-repo/ directories are removed after pruning, while non-empty
+// directories are kept (parity with pruneLogs Phase 3; not required by the
+// Definition of Done but included since it's cheap given the directories
+// already collected during the walk).
+func TestPruneSessionsEmptyDirCleanup(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	ancient := now.Add(-30 * 24 * time.Hour)
+
+	// Single-repo layout: issue-1 becomes fully empty after pruning.
+	emptyIssueDir := filepath.Join(root, "issue-1")
+	seedSessionFile(t, emptyIssueDir, "Implement.session", ancient)
+
+	// Multi-repo layout: owner-repo/issue-2 becomes fully empty, and owner-repo/
+	// itself has no other children so it should be removed too.
+	repoDir := filepath.Join(root, "owner-repo")
+	emptyMultiIssueDir := filepath.Join(repoDir, "issue-2")
+	seedSessionFile(t, emptyMultiIssueDir, "Implement.session", ancient)
+
+	// Multi-repo layout: owner-repo2/issue-3 has one old + one new file, so it survives.
+	repoDir2 := filepath.Join(root, "owner-repo2")
+	nonEmptyIssueDir := filepath.Join(repoDir2, "issue-3")
+	seedSessionFile(t, nonEmptyIssueDir, "old.session", ancient)
+	seedSessionFile(t, nonEmptyIssueDir, "new.session", now)
+
+	resolve := func(dirName string) (string, bool) {
+		switch dirName {
+		case "owner-repo":
+			return "owner/repo", true
+		case "owner-repo2":
+			return "owner/repo2", true
+		default:
+			return "", false
+		}
+	}
+	notInFlight := func(string, int) bool { return false }
+
+	_, _, _, _, err := pruneSessions(root, 14, now, "owner/repo0", resolve, notInFlight)
+	if err != nil {
+		t.Fatalf("pruneSessions: %v", err)
+	}
+
+	if _, err := os.Stat(emptyIssueDir); !os.IsNotExist(err) {
+		t.Errorf("emptied issue-1/ dir should be removed")
+	}
+	if _, err := os.Stat(emptyMultiIssueDir); !os.IsNotExist(err) {
+		t.Errorf("emptied owner-repo/issue-2/ dir should be removed")
+	}
+	if _, err := os.Stat(repoDir); !os.IsNotExist(err) {
+		t.Errorf("emptied owner-repo/ dir should be removed")
+	}
+	if _, err := os.Stat(nonEmptyIssueDir); err != nil {
+		t.Errorf("non-empty owner-repo2/issue-3/ dir should be kept: %v", err)
+	}
+}
+
+// TestSessionJanitorIntegration verifies the periodic path (runSessionJanitor,
+// the function the janitor ticker calls every cycle): a stale session file for
+// a closed issue with no in-flight worker is removed, while a session file for
+// an issue with a live WorkerEntered worker is retained regardless of age.
+func TestSessionJanitorIntegration(t *testing.T) {
+	fabrikDir := t.TempDir()
+	sessionsRoot := filepath.Join(fabrikDir, ".fabrik", "sessions")
+
+	now := time.Now()
+	ancient := now.Add(-20 * 24 * time.Hour) // exceeds 14-day default
+
+	const repo = "owner/repo"
+
+	// Issue 20: closed, no worker — stale session file should be removed.
+	staleIssueDir := filepath.Join(sessionsRoot, "issue-20")
+	staleFile := seedSessionFile(t, staleIssueDir, "Implement.session", ancient)
+
+	// Issue 21: has a live in-flight worker — stale session file should be retained.
+	inFlightIssueDir := filepath.Join(sessionsRoot, "issue-21")
+	inFlightFile := seedSessionFile(t, inFlightIssueDir, "Review.session", ancient)
+
+	eng := NewWithDeps(Config{
+		Owner:                "owner",
+		Repo:                 "repo",
+		MaxConcurrent:        1,
+		JanitorIntervalHours: 1,
+		SessionRetentionDays: 14,
+	}, &mockGitHubClient{}, &mockClaudeInvoker{}, nil)
+	eng.fabrikDir = fabrikDir
+
+	seedClosed(eng, repo, 20)
+	seedOpenOnStage(eng, repo, 21, "Implement")
+	eng.store.Apply(itemstate.WorkerEntered{
+		Repo:      repo,
+		Number:    21,
+		StageName: "Implement",
+		StartedAt: time.Now(),
+	})
+
+	eng.runSessionJanitor(context.Background())
+
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Errorf("stale session file for closed/no-worker issue should be removed, but still exists")
+	}
+	if _, err := os.Stat(inFlightFile); err != nil {
+		t.Errorf("session file for in-flight issue should be retained: %v", err)
+	}
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -540,6 +540,7 @@ func (e *Engine) Run() error {
 		if e.cfg.JanitorIntervalHours > 0 {
 			e.runWorktreeJanitor(ctx)
 			e.runLogJanitor(ctx)
+			e.runSessionJanitor(ctx)
 		}
 	}
 
@@ -548,8 +549,8 @@ func (e *Engine) Run() error {
 	e.startWorkerDetector(ctx)
 
 	// Start periodic janitor goroutine. On each tick: reaps orphaned worktrees for
-	// closed, off-board issues and prunes .fabrik/logs/ by age and total size.
-	// Disabled when JanitorIntervalHours == 0.
+	// closed, off-board issues, prunes .fabrik/logs/ by age and total size, and
+	// prunes .fabrik/sessions/ by age. Disabled when JanitorIntervalHours == 0.
 	if e.cfg.JanitorIntervalHours > 0 {
 		go func() {
 			ticker := time.NewTicker(time.Duration(e.cfg.JanitorIntervalHours) * time.Hour)
@@ -561,6 +562,7 @@ func (e *Engine) Run() error {
 				case <-ticker.C:
 					e.runWorktreeJanitor(ctx)
 					e.runLogJanitor(ctx)
+					e.runSessionJanitor(ctx)
 				}
 			}
 		}()


### PR DESCRIPTION
Closes #1136

## What

`.fabrik/sessions/` grows without bound today — nothing ever deletes a `.session` file, and a measured install had 83% of them pointing at Claude Code conversations already reaped by Claude's own 30-day `cleanupPeriodDays`. This adds a third periodic pass, `runSessionJanitor`, to the existing janitor (`engine/janitor.go`), riding the same `JanitorIntervalHours` cadence as the worktree and log janitors — no new scheduler or goroutine.

## Key changes

- **New config key `session_retention_days`** (CLI flag, env var, `config.yaml` key; default 14, mirrors `log_retention_days` exactly, including the `explicitFlags` guard so an explicit `0` isn't clobbered by env/yaml).
- **`pruneSessions`**: age-based pruning (mtime cutoff, `now` injected for deterministic tests), handling both directory layouts (`issue-N/` single-repo, `<owner>-<repo>/issue-N/` multi-repo) in one pass, plus opportunistic empty-directory cleanup.
- **In-flight guard, directory-wide**: reuses the worktree janitor's `snap.Worker()`/`isWorkerStale` check, but widened so that *any* live worker on an issue protects its *entire* session directory that cycle — not just the file for the worker's current stage. Avoids a race where the active stage changes mid-cycle between the age check and the delete.
- **Unresolvable multi-repo directories are skipped entirely**, never deleted from — there's no git checkout to fall back on for owner/repo resolution the way the worktree janitor has.
- **`buildWMByDirName()`** extracted as a shared helper so the worktree and session janitors can't drift on the `<owner>-<repo>` reverse-map logic.
- Age-based expiry was chosen over liveness-checking against Claude Code's internal transcript store (`~/.claude/projects/...`) — see `adrs/1136-session-janitor.md` for the full tradeoff.
- Docs: new "Session Janitor" section in `docs/USER_GUIDE.md` (corrects a now-stale claim that the log janitor never touches `sessions/`), CLI-flag/env-var table rows, config.yaml example, and the regenerated `docs/llms-full.txt` bundle.

## How to test

- `go test -race ./engine/... -run 'TestPruneSessions|TestSessionJanitor' -v` — unit tests cover both layouts, age cutoff, the directory-wide in-flight guard, unresolved multi-repo dirs, a missing root, `retentionDays=0`, and empty-dir cleanup; an integration test drives `runSessionJanitor` end-to-end against a real store and filesystem.
- `go test -race ./...` passes in full (2727 tests).
- Manually: set `--session-retention-days 0` to confirm pruning is disabled, or seed `.fabrik/sessions/issue-N/Stage.session` with an old mtime and watch it disappear on the next janitor tick with a single `[session-janitor] cycle complete: ...` log line.