### PR TITLE
Decouple self-writes from probe staleness detection (runaway-loop fix 4/4)

### DIFF
--- a/adrs/044-probe-driven-poll-loop.md
+++ b/adrs/044-probe-driven-poll-loop.md
@@ -170,3 +170,33 @@ The single production call to the old `isProbeOnlyTerminal` in `runProbeAndDeepF
 ### Consequence
 
 Items that are closed and in a Done/cleanup stage but whose worktrees still exist on disk proceed through the normal dispatch path: deep-fetch → `processItem` → `cleanup_worktree` → worktree removed → `isTerminalPredicate` (label-aware) confirms terminal on the next poll. The existing cost-saving short-circuit is preserved for items whose worktrees have already been cleaned up.
+
+## Addendum 4 — Self-write staleness baseline (issue #1090, 2026-07-27)
+
+### Problem
+
+The staleness check in step 7 of the probe loop compares `effectiveUpdatedAt` (GitHub-derived: `max(issue.updatedAt, projectItem.updatedAt, linkedPR.updatedAt)`) against `LastSeenSourceUpdatedAt`, a per-item baseline written only by `ItemDeepFetched` on a full deep-fetch. Fabrik's own board mutations — posting a comment, adding/removing a label, editing the issue body, moving the board status column — bump the real GitHub `updatedAt` exactly like an external change, but none of Fabrik's write paths touched `LastSeenSourceUpdatedAt` to match. The very next probe cycle therefore always saw the item as stale and forced an immediate `FetchItemDetails`, even though nothing actionable had changed.
+
+During the #1083 incident this is why the ping-pong comment loop ran as fast as polling allowed rather than backing off: every Fabrik reply forced its own immediate re-fetch on the next cycle. An echo-suppression mechanism already existed for the **webhook** delivery path (`webhookMgr.RegisterEcho`/`RegisterEchoIfSubscribed`, ADR-042), but nothing analogous existed for the **probe/poll staleness** comparison, which runs unconditionally every cycle regardless of webhook mode.
+
+### Fix
+
+A new, single-purpose mutation, `itemstate.SelfWriteObserved{Repo, Number}`, advances `LastSeenSourceUpdatedAt` to the local wall-clock time (`time.Now()`) at the moment of a self-write — no deep-fetch, no other field touched. `store.go`'s `applyToItem` guards the advance with `if now.After(item.LastSeenSourceUpdatedAt)`, making it monotonic: it can never regress a value a concurrent `ItemDeepFetched` already recorded, and a `DeepFetchInvalidated` reset (zero value) always wins against a stale `SelfWriteObserved` racing behind it. A local wall-clock timestamp was chosen over a GitHub-returned one because only `UpdateIssueBody`'s REST response would cheaply carry the issue's own `updated_at` — the other four categories' responses don't surface it, and fetching it separately would defeat the "no new deep-fetch" goal. This mirrors the existing `ItemDeepFetched`/`RegisterEcho` precedent of using `time.Now()` for comparable bookkeeping, accepting the same coarse-grained clock-skew characteristic `cacheIsStale` already has.
+
+The mutation is applied via `e.store.Apply(...)` directly, bypassing `boardcache.CacheImpl` — mirroring the existing `engine/comment_breaker.go` precedent of engine code writing straight to the shared `Store`. Since `Engine.store` is always non-nil regardless of cache/webhook wiring, this needs no `e.cache() != nil` guard and is not gated on `e.webhookMgr`, satisfying the requirement that polling-only mode (`webhookMgr == nil`) behave identically to webhook mode.
+
+It is wired into exactly five call sites, each gated on the same success signal that already gates the adjacent `RegisterEcho`/`RegisterEchoIfSubscribed` call:
+
+- Label add — `engine/mutate.go` `syncLabelAdd` (unconditional; reaching the call site already implies `AddLabelToIssue` succeeded).
+- Label remove — `engine/mutate.go` `syncLabelRemoval` (gated on `echo`, the same signal that suppresses the webhook echo on a `gh.ErrNotFound` no-op removal).
+- Comment post — `engine/mutate.go` `postComment` (unconditional; `AddComment` failure returns before this point).
+- Issue body edit — `engine/comments.go` `publishCommentOutput` (inside `UpdateIssueBody`'s success branch).
+- Project board status move — `engine/stages.go`'s `advanceToQueued` and `advanceToNextStage`, `engine/no_work_needed_settle.go`, and `engine/closed_item_advance_settle.go` (inside each site's `UpdateProjectItemStatus` success branch).
+
+This was deliberately **not** baked into the shared `LocalStatusUpdated`/`LocalLabelAdded`/`LocalLabelRemoved`/`LocalCommentAdded` self-mutation cases in `store.go`: `LocalStatusUpdated` has a genuine non-self-write caller (`engine/reconcile.go`'s Layer-1 webhook fallback, syncing the cache after an *externally observed* status change), and the `Local*` label/comment mutations have call sites well beyond the five named here. Baking the advance into those shared cases would have silently suppressed detection of external changes at those other sites — a direct violation of the "must not mask a genuine external change" requirement. A dedicated mutation, applied only at the five scoped sites, avoids that trap.
+
+### Consequence
+
+A Fabrik self-comment, self-label-add/remove, self-body-edit, or self-status-move no longer causes the very next probe cycle to treat the item as stale — the resulting `updatedAt` bump is already accounted for. A genuine external change (human/bot comment, label, or status change) landing with a later `effectiveUpdatedAt` still compares as stale and triggers a real deep-fetch on the next probe, since the baseline only ever advances to the self-write's own timestamp, never further.
+
+**Known scope boundary, left deliberately unaddressed**: PR-body self-writes (`engine/pr.go`'s `updatePRVerification`/`ensurePRLinksIssue`, `engine/prcreate.go`'s linkage-heal edit) and a second issue-body-edit site (`engine/item.go`'s stage-output publishing path) bump a component of `effectiveUpdatedAt` the same way but are outside the five call sites this issue scoped in. These will still reproduce the spurious-staleness pattern; a candidate follow-up issue if it proves to matter in practice, not a silent gap — documented here and in the PR description.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6053,6 +6053,24 @@ The probe loop:
 
 `FetchItemDetails` writes `ItemDeepFetched` to the Store, updating `LastSeenSourceUpdatedAt` to the new `effectiveUpdatedAt`. The candidates loop that runs later in the same poll cycle sees these items as fresh (via `IsItemCacheFresh`) and skips duplicate fetches.
 
+**Self-write staleness baseline (`SelfWriteObserved`)**
+
+The staleness check in step 7 compares `effectiveUpdatedAt` against `LastSeenSourceUpdatedAt`, which is otherwise written only by a full deep-fetch (`ItemDeepFetched`). Without a second writer, every one of Fabrik's own board mutations — which bump the real GitHub `updatedAt` just like an external edit — would make the very next probe cycle see the item as stale and force an immediate `FetchItemDetails`, even though nothing actionable changed (the #1083 incident: a self-posted reply forced its own re-fetch on the next poll, running the ping-pong loop as fast as polling allowed instead of backing off).
+
+`itemstate.SelfWriteObserved{Repo, Number}` closes this gap: applied via `e.store.Apply(...)` directly (bypassing `boardcache.CacheImpl`, so it needs no cache-wired guard and is not gated on `e.webhookMgr`), it advances `LastSeenSourceUpdatedAt` to the local wall-clock time at the moment of the self-write — no deep-fetch, no other field touched. The advance is monotonic (`store.go`'s `applyToItem` only updates when `time.Now()` is after the current baseline), so it can never regress a value a concurrent `ItemDeepFetched` or an earlier `SelfWriteObserved` already recorded, and a `DeepFetchInvalidated` reset (zero value) always "wins" against a stale `SelfWriteObserved` racing behind it.
+
+It is wired into exactly five call sites, mirroring the existing webhook `RegisterEcho`/`RegisterEchoIfSubscribed` success-gating at each:
+
+- Label add (`engine/mutate.go` `syncLabelAdd`) — unconditional; reaching the call site already implies `AddLabelToIssue` succeeded.
+- Label remove (`engine/mutate.go` `syncLabelRemoval`) — gated on `echo`, the same signal that suppresses the webhook echo on a `gh.ErrNotFound` no-op removal.
+- Comment post (`engine/mutate.go` `postComment`) — unconditional; `AddComment` failure returns before this point.
+- Issue body edit (`engine/comments.go` `publishCommentOutput`) — inside `UpdateIssueBody`'s success branch.
+- Project board status move (`engine/stages.go` `advanceToQueued` and `advanceToNextStage`, `engine/no_work_needed_settle.go`, `engine/closed_item_advance_settle.go`) — inside each site's `UpdateProjectItemStatus` success branch.
+
+A failed mutation at any of these sites never advances the baseline, so the next probe still correctly treats the item as stale. And because the mechanism only ever *advances* the baseline to the current wall clock, a genuine external change that lands with a later `effectiveUpdatedAt` (a human/bot comment, label, or status change arriving after our self-write) still compares as stale and triggers a real deep-fetch — the suppression only ever applies to the self-write's own `updatedAt` bump, never to activity after it.
+
+**Known scope boundary**: this covers only the five call sites above. PR-body self-writes (`engine/pr.go`'s `updatePRVerification`/`ensurePRLinksIssue`, `engine/prcreate.go`'s linkage-heal edit) and a second issue-body-edit site (`engine/item.go`'s stage-output publishing path) bump a component of `effectiveUpdatedAt` the same way but are not wired to `SelfWriteObserved` — a deliberate, documented gap (see ADR-044 Addendum 4), not an oversight, left as a candidate follow-up if it proves to matter in practice.
+
 **Terminal-item skip**
 
 An item is **terminal** once Fabrik has confirmed it has nothing left to do: its status is a cleanup stage (e.g. `Done`), its labels include `stage:<StageName>:complete`, and no transient lifecycle label (`fabrik:awaiting-review`, `fabrik:awaiting-ci`, `fabrik:awaiting-input`, `fabrik:rebase-needed`, `fabrik:bot-reprompted`, `fabrik:claude-limit`) or lock label (`fabrik:locked:*`) is present.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -3175,6 +3175,24 @@ The probe loop:
 
 `FetchItemDetails` writes `ItemDeepFetched` to the Store, updating `LastSeenSourceUpdatedAt` to the new `effectiveUpdatedAt`. The candidates loop that runs later in the same poll cycle sees these items as fresh (via `IsItemCacheFresh`) and skips duplicate fetches.
 
+**Self-write staleness baseline (`SelfWriteObserved`)**
+
+The staleness check in step 7 compares `effectiveUpdatedAt` against `LastSeenSourceUpdatedAt`, which is otherwise written only by a full deep-fetch (`ItemDeepFetched`). Without a second writer, every one of Fabrik's own board mutations — which bump the real GitHub `updatedAt` just like an external edit — would make the very next probe cycle see the item as stale and force an immediate `FetchItemDetails`, even though nothing actionable changed (the #1083 incident: a self-posted reply forced its own re-fetch on the next poll, running the ping-pong loop as fast as polling allowed instead of backing off).
+
+`itemstate.SelfWriteObserved{Repo, Number}` closes this gap: applied via `e.store.Apply(...)` directly (bypassing `boardcache.CacheImpl`, so it needs no cache-wired guard and is not gated on `e.webhookMgr`), it advances `LastSeenSourceUpdatedAt` to the local wall-clock time at the moment of the self-write — no deep-fetch, no other field touched. The advance is monotonic (`store.go`'s `applyToItem` only updates when `time.Now()` is after the current baseline), so it can never regress a value a concurrent `ItemDeepFetched` or an earlier `SelfWriteObserved` already recorded, and a `DeepFetchInvalidated` reset (zero value) always "wins" against a stale `SelfWriteObserved` racing behind it.
+
+It is wired into exactly five call sites, mirroring the existing webhook `RegisterEcho`/`RegisterEchoIfSubscribed` success-gating at each:
+
+- Label add (`engine/mutate.go` `syncLabelAdd`) — unconditional; reaching the call site already implies `AddLabelToIssue` succeeded.
+- Label remove (`engine/mutate.go` `syncLabelRemoval`) — gated on `echo`, the same signal that suppresses the webhook echo on a `gh.ErrNotFound` no-op removal.
+- Comment post (`engine/mutate.go` `postComment`) — unconditional; `AddComment` failure returns before this point.
+- Issue body edit (`engine/comments.go` `publishCommentOutput`) — inside `UpdateIssueBody`'s success branch.
+- Project board status move (`engine/stages.go` `advanceToQueued` and `advanceToNextStage`, `engine/no_work_needed_settle.go`, `engine/closed_item_advance_settle.go`) — inside each site's `UpdateProjectItemStatus` success branch.
+
+A failed mutation at any of these sites never advances the baseline, so the next probe still correctly treats the item as stale. And because the mechanism only ever *advances* the baseline to the current wall clock, a genuine external change that lands with a later `effectiveUpdatedAt` (a human/bot comment, label, or status change arriving after our self-write) still compares as stale and triggers a real deep-fetch — the suppression only ever applies to the self-write's own `updatedAt` bump, never to activity after it.
+
+**Known scope boundary**: this covers only the five call sites above. PR-body self-writes (`engine/pr.go`'s `updatePRVerification`/`ensurePRLinksIssue`, `engine/prcreate.go`'s linkage-heal edit) and a second issue-body-edit site (`engine/item.go`'s stage-output publishing path) bump a component of `effectiveUpdatedAt` the same way but are not wired to `SelfWriteObserved` — a deliberate, documented gap (see ADR-044 Addendum 4), not an oversight, left as a candidate follow-up if it proves to matter in practice.
+
 **Terminal-item skip**
 
 An item is **terminal** once Fabrik has confirmed it has nothing left to do: its status is a cleanup stage (e.g. `Done`), its labels include `stage:<StageName>:complete`, and no transient lifecycle label (`fabrik:awaiting-review`, `fabrik:awaiting-ci`, `fabrik:awaiting-input`, `fabrik:rebase-needed`, `fabrik:bot-reprompted`, `fabrik:claude-limit`) or lock label (`fabrik:locked:*`) is present.

--- a/engine/closed_item_advance_settle.go
+++ b/engine/closed_item_advance_settle.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
 
@@ -97,10 +98,13 @@ func (e *Engine) advanceClosedItemToDone(board *gh.ProjectBoard, item gh.Project
 		e.logf(item.Number, "warn", "closed-item advance: could not move to %s: %v — will retry next poll\n", cleanupName, err)
 		return
 	}
+	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	if c := e.cache(); c != nil {
-		owner, repo := itemOwnerRepo(item, e.defaultRepo())
 		c.UpdateItemStatus(boardcache.ItemKey(owner+"/"+repo, item.Number), cleanupName)
 	}
+	// Advances the probe staleness baseline (#1090) — the status move above just
+	// bumped the item's real GitHub updatedAt via the project-item mutation.
+	e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 	}

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -462,8 +462,14 @@ func (e *Engine) publishCommentOutput(owner, repo string, item gh.ProjectItem, s
 		// no write-through: excluded — issue body is not read from cache for dispatch decisions
 		if err := e.client.UpdateIssueBody(owner, repo, item.Number, updatedBody); err != nil {
 			e.logf(item.Number, "warn", "could not update issue body: %v\n", err)
-		} else if e.webhookMgr != nil {
-			e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, item.Number))
+		} else {
+			// Advances the probe staleness baseline (#1090) — the edit above just
+			// bumped the issue's real GitHub updatedAt, so the next probe cycle
+			// must not treat that bump as a stale signal.
+			e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
+			if e.webhookMgr != nil {
+				e.webhookMgr.RegisterEcho("issues", "edited", boardcache.ItemKey(owner+"/"+repo, item.Number))
+			}
 		}
 		output = stripMarkers(output, "FABRIK_ISSUE_UPDATE_BEGIN", "FABRIK_ISSUE_UPDATE_END")
 		// Circuit breaker (#1089): a FABRIK_ISSUE_UPDATE is the only forward-progress

--- a/engine/comments_selfwrite_test.go
+++ b/engine/comments_selfwrite_test.go
@@ -1,0 +1,54 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// Covers the fifth self-write category (#1090): issue body edit via
+// publishCommentOutput's FABRIK_ISSUE_UPDATE handling. Unlike the mutate.go
+// call sites, this one has no cache write-through to piggyback on, so the
+// SelfWriteObserved call is standalone — these tests verify it fires only on
+// a successful UpdateIssueBody call.
+
+// bodyOnlyOutput contains nothing but a FABRIK_ISSUE_UPDATE block: after
+// publishCommentOutput strips it, the remaining output is empty, so the
+// function's later stage-comment posting (which would independently advance
+// the staleness baseline via postComment — see mutate_test.go) is skipped.
+// This isolates the assertions below to the issue-body-edit call site only.
+const bodyOnlyOutput = "FABRIK_ISSUE_UPDATE_BEGIN\nupdated spec body\nFABRIK_ISSUE_UPDATE_END\n"
+
+func TestPublishCommentOutput_BodyEditAdvancesStaleness(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{Number: 50, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Specify"}
+	before := time.Now()
+
+	eng.publishCommentOutput("owner", "repo", item, stage, nil, bodyOnlyOutput, "", "main")
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 50); got.Before(before) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want advanced to >= %v after a successful issue body edit", got, before)
+	}
+}
+
+func TestPublishCommentOutput_BodyEditErrorDoesNotAdvanceStaleness(t *testing.T) {
+	client := &mockGitHubClient{
+		updateIssueBodyFn: func(owner, repo string, issueNumber int, body string) error {
+			return errors.New("api error")
+		},
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+	item := gh.ProjectItem{Number: 51, Repo: "owner/repo"}
+	stage := &stages.Stage{Name: "Specify"}
+
+	eng.publishCommentOutput("owner", "repo", item, stage, nil, bodyOnlyOutput, "", "main")
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 51); !got.IsZero() {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want unchanged (zero) when UpdateIssueBody fails", got)
+	}
+}

--- a/engine/mutate.go
+++ b/engine/mutate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
 )
 
 // cache returns e.readClient cast to *boardcache.CacheImpl, or nil when the
@@ -31,6 +32,11 @@ func (e *Engine) syncLabelAdd(item gh.ProjectItem, label string, echo bool) {
 	if c := e.cache(); c != nil {
 		c.ApplyLabelAdded(boardcache.ItemKey(owner+"/"+repo, item.Number), label)
 	}
+	// Reaching this point means the caller's GitHub label-add mutation already
+	// succeeded — this is the only real "did GitHub's own updatedAt just bump"
+	// signal available here, so the probe staleness baseline advances
+	// unconditionally (#1090).
+	e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 	if echo && e.webhookMgr != nil {
 		e.webhookMgr.RegisterEcho("issues", "labeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+label)
 	}
@@ -66,6 +72,13 @@ func (e *Engine) syncLabelRemoval(item gh.ProjectItem, label string, echo bool) 
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
 	if c := e.cache(); c != nil {
 		c.ApplyLabelRemoved(boardcache.ItemKey(owner+"/"+repo, item.Number), label)
+	}
+	// echo is only true when the underlying RemoveLabelFromIssue call actually
+	// removed something on GitHub (not gh.ErrNotFound) — the same "real mutation
+	// happened" signal RegisterEcho below relies on, so the staleness baseline
+	// advances under the identical condition (#1090).
+	if echo {
+		e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 	}
 	if echo && e.webhookMgr != nil {
 		e.webhookMgr.RegisterEcho("issues", "unlabeled", boardcache.ItemKey(owner+"/"+repo, item.Number)+"+"+label)
@@ -111,6 +124,10 @@ func (e *Engine) postComment(item gh.ProjectItem, body string, react, echo bool)
 			DatabaseID: dbID, Body: body, Author: e.cfg.User, CreatedAt: time.Now(),
 		})
 	}
+	// AddComment already succeeded (the error path returned above), so the
+	// staleness baseline advances unconditionally, same as the cache
+	// write-through above (#1090).
+	e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 	if echo && e.webhookMgr != nil {
 		e.webhookMgr.RegisterEcho("issue_comment", "created", boardcache.ItemKey(owner+"/"+repo, item.Number))
 	}

--- a/engine/mutate_test.go
+++ b/engine/mutate_test.go
@@ -3,10 +3,22 @@ package engine
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 )
+
+// lastSeenSourceUpdatedAt returns the current probe staleness baseline for
+// owner/repo#number, failing the test if the item isn't in the store.
+func lastSeenSourceUpdatedAt(t *testing.T, eng *Engine, repo string, number int) time.Time {
+	t.Helper()
+	snap, err := eng.store.Get(repo, number)
+	if err != nil {
+		t.Fatalf("store.Get(%q, %d): %v", repo, number, err)
+	}
+	return snap.State().LastSeenSourceUpdatedAt
+}
 
 // ── cache() ──────────────────────────────────────────────────────────────
 
@@ -511,5 +523,133 @@ func TestPauseIssue_RemoveAutoMerge(t *testing.T) {
 	}
 	if !containsLabel(labels, "fabrik:paused") || !containsLabel(labels, "fabrik:awaiting-input") {
 		t.Errorf("expected pause labels present, got %v", labels)
+	}
+}
+
+// ── SelfWriteObserved probe-staleness baseline (#1090) ───────────────────────
+//
+// These tests exercise the same three engine/mutate.go call sites as above,
+// but assert against the itemstate.Store's LastSeenSourceUpdatedAt baseline
+// rather than the boardcache write-through — the two are deliberately
+// independent mechanisms (see engine/mutate.go comments), so a passing
+// write-through test above does not imply the baseline advanced correctly.
+
+func TestApplyLabelAdd_AdvancesStaleness(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	before := time.Now()
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelAdd(item, "fabrik:paused", true)
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); got.Before(before) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want advanced to >= %v after a successful label add", got, before)
+	}
+}
+
+func TestApplyLabelAdd_ErrorDoesNotAdvanceStaleness(t *testing.T) {
+	client := &mockGitHubClient{
+		addLabelToIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			return errors.New("api error")
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelAdd(item, "fabrik:paused", true)
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); !got.IsZero() {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want unchanged (zero) on a failed label add", got)
+	}
+}
+
+// TestApplyLabelRemove_SuccessAdvancesStaleness covers the genuine-removal
+// path (echo=true), where syncLabelRemoval must advance the baseline.
+func TestApplyLabelRemove_SuccessAdvancesStaleness(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:blocked")
+	before := time.Now()
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelRemove(item, "fabrik:blocked", true)
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); got.Before(before) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want advanced to >= %v after a successful label removal", got, before)
+	}
+}
+
+// TestApplyLabelRemove_ErrNotFoundDoesNotAdvanceStaleness covers the
+// idempotent-no-op path (echo=false on gh.ErrNotFound): no real GitHub change
+// occurred, so the staleness baseline must not advance, mirroring the
+// adjacent RegisterEcho suppression.
+func TestApplyLabelRemove_ErrNotFoundDoesNotAdvanceStaleness(t *testing.T) {
+	client := &mockGitHubClient{
+		removeLabelFromIssueFn: func(owner, repo string, issueNumber int, labelName string) error {
+			return gh.ErrNotFound
+		},
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:editing")
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelRemove(item, "fabrik:editing", true)
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); !got.IsZero() {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want unchanged (zero) on an ErrNotFound no-op removal", got)
+	}
+}
+
+func TestPostComment_SuccessAdvancesStaleness(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 42, nil
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	before := time.Now()
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if _, err := eng.postComment(item, "hello", false, true); err != nil {
+		t.Fatalf("postComment: %v", err)
+	}
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); got.Before(before) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want advanced to >= %v after a successful comment post", got, before)
+	}
+}
+
+func TestPostComment_ErrorDoesNotAdvanceStaleness(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			return 0, errors.New("rate limited")
+		},
+	}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	if _, err := eng.postComment(item, "hello", false, true); err == nil {
+		t.Fatal("expected an error from postComment")
+	}
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); !got.IsZero() {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want unchanged (zero) on a failed comment post", got)
+	}
+}
+
+// TestApplyLabelAdd_AdvancesStalenessWithoutWebhookMgr verifies the "must work
+// identically in polling-only mode" requirement (#1090): the baseline advance
+// must not be gated on e.webhookMgr, unlike the adjacent RegisterEcho call.
+func TestApplyLabelAdd_AdvancesStalenessWithoutWebhookMgr(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng, _ := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	eng.webhookMgr = nil // polling-only mode
+	before := time.Now()
+
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo"}
+	eng.applyLabelAdd(item, "fabrik:paused", true)
+
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); got.Before(before) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want advanced to >= %v in polling-only mode (webhookMgr == nil)", got, before)
 	}
 }

--- a/engine/no_work_needed_settle.go
+++ b/engine/no_work_needed_settle.go
@@ -189,6 +189,9 @@ func (e *Engine) settleNoWorkNeeded(board *gh.ProjectBoard, item gh.ProjectItem,
 		if c := e.cache(); c != nil {
 			c.UpdateItemStatus(boardcache.ItemKey(owner+"/"+repo, item.Number), "Done")
 		}
+		// Advances the probe staleness baseline (#1090) — the status move above
+		// just bumped the item's real GitHub updatedAt via the project-item mutation.
+		e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 		}

--- a/engine/stages.go
+++ b/engine/stages.go
@@ -456,6 +456,9 @@ func (e *Engine) advanceToQueued(_ context.Context, board *gh.ProjectBoard, item
 	if c := e.cache(); c != nil {
 		c.UpdateItemStatus(boardcache.ItemKey(owner+"/"+repo, item.Number), hs.Name)
 	}
+	// Advances the probe staleness baseline (#1090) — the status move above just
+	// bumped the item's real GitHub updatedAt via the project-item mutation.
+	e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 	if e.webhookMgr != nil {
 		e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 	}
@@ -503,6 +506,9 @@ func (e *Engine) advanceToNextStage(board *gh.ProjectBoard, item gh.ProjectItem,
 		if c := e.cache(); c != nil {
 			c.UpdateItemStatus(boardcache.ItemKey(owner+"/"+repo, item.Number), next.Name)
 		}
+		// Advances the probe staleness baseline (#1090) — the status move above
+		// just bumped the item's real GitHub updatedAt via the project-item mutation.
+		e.store.Apply(itemstate.SelfWriteObserved{Repo: owner + "/" + repo, Number: item.Number})
 		if e.webhookMgr != nil {
 			e.webhookMgr.RegisterEchoIfSubscribed("projects_v2_item", "edited", item.ItemID)
 		}

--- a/engine/terminal_selfwrite_test.go
+++ b/engine/terminal_selfwrite_test.go
@@ -1,0 +1,294 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/boardcache"
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+var errTestAPIFailure = errors.New("api error")
+
+// Acceptance-level tests for the SelfWriteObserved probe staleness baseline
+// (#1090), exercised through the full runProbeAndDeepFetch path rather than
+// against the Store directly (see mutate_test.go / comments_selfwrite_test.go
+// for the lower-level unit tests). Each test warms a deep-fetch cache entry
+// at baseTime, performs one self-write category, then runs a probe cycle and
+// asserts whether a further deep-fetch occurs.
+
+// warmDeepFetchAt seeds owner/repo#1 with a deep fetch that reports UpdatedAt
+// = baseTime, populating both LastDeepFetchAt and LastSeenSourceUpdatedAt so
+// the subsequent staleness comparison is meaningful (a never-deep-fetched
+// item is always treated as stale, which would make every test trivially
+// pass regardless of SelfWriteObserved).
+func warmDeepFetchAt(t *testing.T, cache *boardcache.CacheImpl, baseTime time.Time) gh.ProjectItem {
+	t.Helper()
+	item := gh.ProjectItem{Number: 1, Repo: "owner/repo", ItemID: "PVTI_001"}
+	if err := cache.FetchItemDetails(&item); err != nil {
+		t.Fatalf("warm-up FetchItemDetails: %v", err)
+	}
+	if item.UpdatedAt.IsZero() || !item.UpdatedAt.Equal(baseTime) {
+		t.Fatalf("warm-up did not record baseTime: got %v, want %v", item.UpdatedAt, baseTime)
+	}
+	return item
+}
+
+// newWarmableClient returns a client whose FetchItemDetails always reports
+// baseTime, and a pointer to the call counter so tests can assert whether the
+// probe cycle triggered an additional deep-fetch beyond the warm-up call.
+func newWarmableClient(baseTime time.Time) (*mockGitHubClient, *int) {
+	calls := 0
+	client := &mockGitHubClient{
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			calls++
+			item.UpdatedAt = baseTime
+			return nil
+		},
+	}
+	return client, &calls
+}
+
+func TestRunProbeAndDeepFetch_SelfWriteLabelAdd_SuppressesRefetch(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	item := warmDeepFetchAt(t, cache, baseTime)
+	if *calls != 1 {
+		t.Fatalf("expected 1 warm-up deep-fetch, got %d", *calls)
+	}
+
+	eng.addLabel(item, "fabrik:awaiting-input")
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+	if !afterSelfWrite.After(baseTime) {
+		t.Fatalf("expected baseline to advance past baseTime after label add, got %v", afterSelfWrite)
+	}
+
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: afterSelfWrite},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 1 {
+		t.Errorf("expected no additional deep-fetch after a self-write with unchanged external state; total calls = %d", *calls)
+	}
+}
+
+func TestRunProbeAndDeepFetch_SelfWriteLabelRemove_SuppressesRefetch(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	item := warmDeepFetchAt(t, cache, baseTime)
+	cache.ApplyLabelAdded(boardcache.ItemKey("owner/repo", 1), "fabrik:blocked")
+
+	eng.removeLabel(item, "fabrik:blocked")
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+	if !afterSelfWrite.After(baseTime) {
+		t.Fatalf("expected baseline to advance past baseTime after label removal, got %v", afterSelfWrite)
+	}
+
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: afterSelfWrite},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 1 {
+		t.Errorf("expected no additional deep-fetch after a self-write with unchanged external state; total calls = %d", *calls)
+	}
+}
+
+func TestRunProbeAndDeepFetch_SelfWriteCommentPost_SuppressesRefetch(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	client.addCommentFn = func(owner, repo string, issueNumber int, body string) (int, error) {
+		return 99, nil
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	item := warmDeepFetchAt(t, cache, baseTime)
+
+	eng.postItemComment(item, "hello", false)
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+	if !afterSelfWrite.After(baseTime) {
+		t.Fatalf("expected baseline to advance past baseTime after comment post, got %v", afterSelfWrite)
+	}
+
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: afterSelfWrite},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 1 {
+		t.Errorf("expected no additional deep-fetch after a self-write with unchanged external state; total calls = %d", *calls)
+	}
+}
+
+func TestRunProbeAndDeepFetch_SelfWriteBodyEdit_SuppressesRefetch(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	item := warmDeepFetchAt(t, cache, baseTime)
+	stage := &stages.Stage{Name: "Research"}
+
+	eng.publishCommentOutput("owner", "repo", item, stage, nil, bodyOnlyOutput, "", "main")
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+	if !afterSelfWrite.After(baseTime) {
+		t.Fatalf("expected baseline to advance past baseTime after issue body edit, got %v", afterSelfWrite)
+	}
+
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: afterSelfWrite},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 1 {
+		t.Errorf("expected no additional deep-fetch after a self-write with unchanged external state; total calls = %d", *calls)
+	}
+}
+
+func TestRunProbeAndDeepFetch_SelfWriteStatusMove_SuppressesRefetch(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	client.updateProjectItemStatusFn = func(projectID, itemID, fieldID, optionID string) error {
+		return nil
+	}
+	stgs := testStagesWithValidate()
+	eng := testEngineWithStages(t, client, stgs)
+
+	cache := boardcache.NewCacheImpl(client, eng.store, func(string, ...any) {})
+	testBootstrapFromBoard(cache, &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{ID: "I_001", ItemID: "PVTI_001", Number: 1, Repo: "owner/repo", Status: "Research"},
+		},
+	})
+	eng.readClient = cache
+	item := warmDeepFetchAt(t, cache, baseTime)
+	item.Status = "Research"
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	if err := eng.advanceToNextStage(board, item, stgs[0]); err != nil {
+		t.Fatalf("advanceToNextStage: %v", err)
+	}
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+	if !afterSelfWrite.After(baseTime) {
+		t.Fatalf("expected baseline to advance past baseTime after status move, got %v", afterSelfWrite)
+	}
+
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Plan", EffectiveUpdatedAt: afterSelfWrite},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 1 {
+		t.Errorf("expected no additional deep-fetch after a self-write with unchanged external state; total calls = %d", *calls)
+	}
+}
+
+// TestRunProbeAndDeepFetch_SelfWrite_ExternalChangeAfter_StillRefetches
+// verifies the "must not mask a genuine external change" requirement: a
+// probe reporting an EffectiveUpdatedAt strictly later than the self-write's
+// recorded baseline (e.g. a human comment landing right after our reply)
+// must still trigger a deep-fetch.
+func TestRunProbeAndDeepFetch_SelfWrite_ExternalChangeAfter_StillRefetches(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	item := warmDeepFetchAt(t, cache, baseTime)
+
+	eng.addLabel(item, "fabrik:awaiting-input")
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+
+	externalChange := afterSelfWrite.Add(time.Minute)
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: externalChange},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 2 {
+		t.Errorf("expected a deep-fetch for the genuine external change after our self-write; total calls = %d, want 2", *calls)
+	}
+}
+
+// TestRunProbeAndDeepFetch_SelfWrite_FailedMutation_StillTreatedStale verifies
+// that a failed self-write (the GitHub call itself errors) does not advance
+// the baseline — so a subsequent probe reporting the timestamp a successful
+// mutation *would* have produced is still correctly treated as stale.
+func TestRunProbeAndDeepFetch_SelfWrite_FailedMutation_StillTreatedStale(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	client.addLabelToIssueFn = func(owner, repo string, issueNumber int, labelName string) error {
+		return errTestAPIFailure
+	}
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	item := warmDeepFetchAt(t, cache, baseTime)
+
+	eng.addLabel(item, "fabrik:awaiting-input")
+	if got := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1); !got.Equal(baseTime) {
+		t.Fatalf("expected baseline unchanged (still baseTime) after failed label add, got %v", got)
+	}
+
+	// Simulate what GitHub's real updatedAt would be if the label add had
+	// actually succeeded (i.e. what an external observer — or a retried,
+	// successful mutation — would report).
+	simulatedRealUpdate := baseTime.Add(time.Minute)
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: simulatedRealUpdate},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 2 {
+		t.Errorf("expected the probe to still treat the item as stale after a failed self-write; total calls = %d, want 2", *calls)
+	}
+}
+
+// TestRunProbeAndDeepFetch_SelfWrite_SuppressesRefetch_PollingOnlyMode
+// verifies the "must work identically in polling-only mode" requirement: the
+// baseline advance must not be gated on e.webhookMgr.
+func TestRunProbeAndDeepFetch_SelfWrite_SuppressesRefetch_PollingOnlyMode(t *testing.T) {
+	baseTime := time.Now().Add(-time.Hour)
+	client, calls := newWarmableClient(baseTime)
+	eng, cache := testEngineWithCache(t, client, &mockClaudeInvoker{})
+	eng.webhookMgr = nil // polling-only mode
+	item := warmDeepFetchAt(t, cache, baseTime)
+
+	eng.addLabel(item, "fabrik:awaiting-input")
+	afterSelfWrite := lastSeenSourceUpdatedAt(t, eng, "owner/repo", 1)
+	if !afterSelfWrite.After(baseTime) {
+		t.Fatalf("expected baseline to advance past baseTime in polling-only mode, got %v", afterSelfWrite)
+	}
+
+	client.probeProjectBoardFn = func(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+		return []gh.BoardProbeItem{
+			{ItemID: "PVTI_001", ContentID: "I_001", Number: 1, Repo: "owner/repo",
+				Status: "Research", EffectiveUpdatedAt: afterSelfWrite},
+		}, "PVT_1", nil
+	}
+	eng.runProbeAndDeepFetch(cache)
+
+	if *calls != 1 {
+		t.Errorf("expected no additional deep-fetch in polling-only mode after a self-write with unchanged external state; total calls = %d", *calls)
+	}
+}

--- a/internal/itemstate/change.go
+++ b/internal/itemstate/change.go
@@ -66,6 +66,12 @@ const (
 	// review activity, check runs, or thread comments, which also set
 	// LinkedPRChanged) can filter precisely.
 	PRStateChanged
+	// SelfWriteBaselineChanged indicates LastSeenSourceUpdatedAt was advanced by
+	// a SelfWriteObserved mutation (#1090). Pure bookkeeping for the probe
+	// staleness check — intentionally excluded from wakeChFlags/cycleSetFlags
+	// (engine/observers.go) so it never wakes the poll loop or bypasses the
+	// dispatch cooldown.
+	SelfWriteBaselineChanged
 )
 
 // Change describes what fields a mutation altered. Delivered to every Observer

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -83,6 +83,14 @@ type ItemState struct {
 	// This is the "GraphQL fetching is primary; updatedAt makes the staleness check
 	// cheap" contract — webhooks remain an optimization that keeps the cache fresh
 	// between polls but never replace the polling refresh path.
+	//
+	// Has a second writer besides ItemDeepFetched: SelfWriteObserved (#1090)
+	// advances it to time.Now() at each of Fabrik's own self-write call sites
+	// (label add/remove, comment post, issue body edit, board status move) so a
+	// self-caused GitHub updatedAt bump isn't mistaken for external staleness on
+	// the next probe cycle. Both writers share the same monotonic guard in
+	// applyToItem, and DeepFetchInvalidated's zero-reset always wins against a
+	// stale SelfWriteObserved racing behind it.
 	LastSeenSourceUpdatedAt time.Time
 
 	// LastDeepFetchFailureAt is the time the most recent deep fetch attempt failed.

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -251,6 +251,24 @@ type LocalLockReleased struct {
 func (LocalLockReleased) isMutation()       {}
 func (m LocalLockReleased) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
+// SelfWriteObserved advances an item's probe staleness baseline
+// (LastSeenSourceUpdatedAt) to the current wall-clock time, without performing
+// a deep fetch and without touching any other field. Applied at every call
+// site where Fabrik performs a self-write (label add/remove, comment post,
+// issue body edit, board status move) that is known to bump the item's real
+// GitHub updatedAt but whose cache write-through already reflects the
+// resulting state (#1090). Store.applyToItem enforces monotonicity: the
+// baseline only ever advances, never moves backward relative to a prior
+// deep-fetch or self-write, so a concurrent DeepFetchInvalidated (which
+// zeroes the baseline) can never be "un-done" by a stale SelfWriteObserved.
+type SelfWriteObserved struct {
+	Repo   string
+	Number int
+}
+
+func (SelfWriteObserved) isMutation()       {}
+func (m SelfWriteObserved) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
 // ---- Periodic reconciliation ----
 
 // BoardReconciled is submitted by the periodic poll loop after a full board fetch.

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -1,6 +1,7 @@
 package itemstate
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -302,6 +303,59 @@ func TestApplyItemDeepFetched(t *testing.T) {
 	}
 	if st.LastDeepFetchAt.IsZero() {
 		t.Error("LastDeepFetchAt not set")
+	}
+}
+
+// ---- SelfWriteObserved ----
+
+func TestApplySelfWriteObserved(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	before := time.Now()
+	applyExpect(t, s, SelfWriteObserved{Repo: testRepo, Number: 1}, SelfWriteBaselineChanged)
+	st := getItem(t, s, testRepo, 1)
+	if st.LastSeenSourceUpdatedAt.Before(before) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want >= %v", st.LastSeenSourceUpdatedAt, before)
+	}
+}
+
+// TestApplySelfWriteObservedMonotonic verifies the "never move the baseline
+// backward" requirement (#1090): a SelfWriteObserved applied after a deep
+// fetch that already recorded a later source updatedAt (e.g. clock skew, or a
+// deep fetch racing ahead of the self-write's cache write-through) must not
+// regress LastSeenSourceUpdatedAt to the earlier local wall-clock value.
+func TestApplySelfWriteObservedMonotonic(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	future := time.Now().Add(time.Hour)
+	fresh := testProjectItem(testRepo, 1)
+	fresh.UpdatedAt = future
+	if _, _, err := s.Apply(ItemDeepFetched{Repo: testRepo, Number: 1, FreshState: fresh}); err != nil {
+		t.Fatalf("seed ItemDeepFetched: %v", err)
+	}
+
+	snap, changes, err := s.Apply(SelfWriteObserved{Repo: testRepo, Number: 1})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(changes) != 0 && changes[0].Fields&SelfWriteBaselineChanged != 0 {
+		t.Error("SelfWriteObserved advanced the baseline backward past a later recorded value")
+	}
+	if st := snap.State(); !st.LastSeenSourceUpdatedAt.Equal(future) {
+		t.Errorf("LastSeenSourceUpdatedAt = %v; want unchanged %v", st.LastSeenSourceUpdatedAt, future)
+	}
+}
+
+// TestApplySelfWriteObservedTouchesOnlyBaseline verifies the requirement that
+// SelfWriteObserved touch no field other than LastSeenSourceUpdatedAt (#1090).
+func TestApplySelfWriteObservedTouchesOnlyBaseline(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	before := getItem(t, s, testRepo, 1)
+	if _, _, err := s.Apply(SelfWriteObserved{Repo: testRepo, Number: 1}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	after := getItem(t, s, testRepo, 1)
+	before.LastSeenSourceUpdatedAt = after.LastSeenSourceUpdatedAt
+	if !reflect.DeepEqual(before, after) {
+		t.Errorf("SelfWriteObserved touched a field other than LastSeenSourceUpdatedAt:\nbefore=%+v\nafter=%+v", before, after)
 	}
 }
 

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -574,6 +574,14 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.LastSeenSourceUpdatedAt = time.Time{}
 		return DeepFetchChanged
 
+	case SelfWriteObserved:
+		now := time.Now()
+		if now.After(item.LastSeenSourceUpdatedAt) {
+			item.LastSeenSourceUpdatedAt = now
+			return SelfWriteBaselineChanged
+		}
+		return 0
+
 	case PRHeadSHAUpdated:
 		ensureLinkedPR(item, v.LinkedPRNum)
 		if v.LinkedPRNum != 0 {


### PR DESCRIPTION
Closes #1090

## Summary

Adds a probe-side self-write baseline so Fabrik's own board mutations (label add/remove, comment post, issue body edit, board status move) no longer cause the very next poll cycle to treat the item as stale and force an unnecessary deep-fetch. This is fix 4 of 4 in the #1083 incident-response series — a politeness/GraphQL-budget improvement (fixes 1–3 already stop the runaway-loop behavior itself).

## Mechanism

- New `itemstate.SelfWriteObserved{Repo, Number}` mutation advances `ItemState.LastSeenSourceUpdatedAt` to a local wall-clock timestamp at mutation time, monotonically (never regresses a value set by a concurrent `ItemDeepFetched`/`DeepFetchInvalidated`).
- Wired directly via `e.store.Apply(...)` at exactly the five self-write call sites named in the spec: `syncLabelAdd`/`syncLabelRemoval`/`postComment` (`engine/mutate.go`), the issue-body-edit site (`engine/comments.go`), and all four board-status-move sites (`engine/stages.go` ×2, `engine/no_work_needed_settle.go`, `engine/closed_item_advance_settle.go`).
- Gated identically to each site's adjacent `RegisterEcho`/`RegisterEchoIfSubscribed` call — only advances on a successful, real GitHub-side mutation (e.g. `syncLabelRemoval` only advances when `echo=true`, i.e. not on an `ErrNotFound` no-op).
- Works identically in polling-only and webhook mode, since it bypasses `boardcache.CacheImpl` entirely and writes straight to the always-present `Engine.store`.
- Deliberately scoped to the five named call sites only — PR-body self-writes (`engine/pr.go`, `engine/prcreate.go`) and a second issue-body-edit site (`engine/item.go`) reproduce the same pattern but are out of scope per the spec; documented as a known follow-up gap in the ADR-044 addendum.

## Testing

- New unit tests in `internal/itemstate` cover the mutation's monotonicity and that it touches no other field.
- New tests in `engine/mutate_test.go` and `engine/comments_selfwrite_test.go` cover baseline-advance-on-success / no-advance-on-failure for each of the five categories.
- New acceptance-level tests in `engine/terminal_selfwrite_test.go` exercise `runProbeAndDeepFetch` end-to-end: self-write + unchanged external state ⇒ no deep-fetch; self-write + genuine external change arriving after ⇒ deep-fetch still occurs; failed self-write ⇒ baseline not advanced; polling-only mode (`webhookMgr == nil`) exhibits the same suppression as webhook mode.
- `go build ./...`, `go vet ./...`, and `go test -race ./...` all pass (2740 tests, 15 packages).

## Docs

- `docs/state-machine.md`'s per-poll probe section updated to describe the new self-write/staleness interaction.
- `docs/llms-full.txt` regenerated (verified no drift).
- Documented as Addendum 4 to `adrs/044-probe-driven-poll-loop.md`.

## How to test

- `go test -race ./engine/... ./internal/itemstate/... ./boardcache/...`