### PR TITLE
Back off to the usage-limit reset time and suspend Claude dispatch account-wide

### DIFF
--- a/adrs/1120-claude-usage-limit-backoff-and-suspension.md
+++ b/adrs/1120-claude-usage-limit-backoff-and-suspension.md
@@ -1,0 +1,182 @@
+# ADR 1120: Account-Wide Claude Usage-Limit Backoff and Suspension
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #1120 — Back off to the usage-limit reset time and suspend Claude dispatch account-wide
+
+## Context
+
+ADR-1119 gave Fabrik detection for a Claude account usage-limit exit (`claudeUsageLimitError{Message,
+ResetTime}`), excluded it from `max_retries`, and applied a `fabrik:claude-limit` label. It deliberately
+left two costs unaddressed:
+
+1. `handleUsageLimitExit` applies `itemstate.StageAttempted`, so the affected issue retries on the
+   normal dispatch cooldown (`PollSeconds * 10`, 5 minutes by default) — against a limit that resets in
+   hours. Every one of those retries is guaranteed to fail.
+2. The limit is account-wide, not per-issue. With `max_concurrent > 1`, every in-flight item
+   independently rediscovers the same limit inside the same window and waits out its own cooldown —
+   reported by @bdueck in #1084 across two issues simultaneously.
+
+`claudeUsageLimitError.ResetTime` already carries the CLI's own reset-time fragment (e.g. `"10:20pm
+(America/Edmonton)"`) — a 12-hour clock time plus an IANA zone, no date. Fabrik already solves an
+analogous problem for the unrelated GitHub GraphQL/REST budget (`engine/backoff.go`,
+`engine/terminal.go`, `tui.RateLimitAlertEvent`); this issue borrows that shape but not its
+implementation, because the two conditions differ in what they gate: the GraphQL budget is spent by the
+entire poll cycle, so its pause sits at the top of `doPollCycle`, whereas the Claude usage limit is spent
+only by Claude invocations, and unrelated engine work (board polling, settle scans, label
+reconciliation) must keep running while Claude dispatch is suspended.
+
+## Decision
+
+1. **Reset-time parsing** (`engine/usage_limit_backoff.go`): `parseUsageLimitResetTime(resetTime string,
+   now time.Time) (time.Time, bool)` splits the `"<clock> (<zone>)"` fragment, resolves the zone via
+   `time.LoadLocation`, parses the clock via the `"3:04pm"` reference layout, and rolls the result to the
+   next day if it isn't after `now` in that zone (the fragment carries no date, so "already past" only
+   ever means "meant tomorrow"). `computeUsageLimitResetDeadline` wraps this and falls back to
+   `now.Add(claudeUsageLimitFallbackBackoff)` — a fixed **1 hour** — when `resetTime` is empty or doesn't
+   parse, reporting which path was taken so callers can log it.
+
+2. **Account-wide suspension state**: a single `claudeSuspendedUntil time.Time` field on `Engine`,
+   guarded by its own `claudeSuspendMu` (not the general-purpose `e.mu`, to keep the critical section
+   independent of unrelated engine state). A zero value unambiguously means "not suspended"; the entire
+   check is `now.Before(claudeSuspendedUntil)`. `activateClaudeSuspension(issueNumber, resetTimeRaw,
+   now)` computes the deadline and only updates the field if no suspension is active or the new deadline
+   is later — concurrent workers reporting the same or different reset times converge on the latest one,
+   never shortening an active window. `clearClaudeSuspension(reason)` clears it. Both log and emit
+   `tui.ClaudeUsageLimitAlertEvent` only on an actual state change, the same non-spamming idiom already
+   used for `fabrik:claude-limit`/`fabrik:awaiting-ci`.
+
+3. **Checked lazily at invocation time, not polled by a ticker.** `claudeSuspendedUntilTime(now)` is a
+   cheap read evaluated at each of the three places a Claude invocation can actually be attempted:
+   `runInvocationWithExtension` (`engine/item.go`, stage runs), `processComments`/
+   `runCommentExtensionLoop` (`engine/comments.go`, comment review), and `resolveConflictWithClaude`
+   (`engine/merge_train.go`, inline merge-train conflict resolution). Once `now` reaches the deadline,
+   the very next dispatch attempt — which was going to happen anyway on the normal poll cadence —
+   proceeds normally. There is no second wake mechanism.
+
+4. **Gate + detect inline at each of the three call sites, not a shared `ClaudeInvoker` wrapper.** A
+   uniform wrapper returning one sentinel for "just detected" and "already suspended" would still leave
+   each caller needing bespoke handling of *what happens when Claude doesn't run* — skip the comment
+   circuit-breaker count, don't eject a merge-train member — so the wrapper would just relay those
+   concerns back out anyway. Handling each site explicitly keeps the blast radius of each change small
+   and independently reviewable, and reuses the existing `claudeUsageLimitError` sentinel for both the
+   fresh-detection and gated-already-suspended cases, so `finalizeStageOutcome`'s existing
+   `errors.As` → `handleUsageLimitExit` routing from #1119 needed no changes beyond the comment-copy fix
+   below.
+
+5. **`comments.go` and `merge_train.go` now detect the sentinel, not just gate on it.** Before this
+   issue, neither path unwrapped `claudeUsageLimitError` — a hit there was indistinguishable from an
+   ordinary error to its caller. `processComments` now returns immediately (before any reaction, label,
+   or worktree side effect) when the gate reports suspended, and skips `checkCommentBreaker` when the
+   error it got back from `runCommentExtensionLoop` is a usage-limit hit — an account-wide condition is
+   not evidence this issue's comment thread made no progress.
+
+6. **Merge-train: a usage-limit hit is a fatal `assembleTrialBranch` error, not a per-member ejection.**
+   `resolveConflictWithClaude`'s signature changed from `bool` to `(bool, error)`. Previously, returning
+   `false` for *any* reason — including a real API error — caused `git merge --abort` + `ejectMember`.
+   That's correct for a genuinely unresolvable conflict but was a real correctness bug for an
+   account-wide usage limit: ejecting a healthy member because the account ran dry. `assembleTrialBranch`
+   now distinguishes the two: `(false, nil)` still ejects; `(false, non-nil)` aborts the merge and
+   propagates the error, which `assembleAndValidate`'s existing fatal-error path already handles (log,
+   clean up trial artifacts, return — retried on the train's next natural cycle, no member punished).
+
+7. **TUI**: a new `ClaudeUsageLimitAlertEvent{Suspended bool, Reset time.Time}` (`tui/events.go`) drives a
+   new, fully independent `ClaudeUsageLimitBannerComponent` (`tui/usage_limit_banner.go`) mirroring
+   `AlertBannerComponent`'s `Update`/`Height`/`View` shape. It is a second component, not an extension of
+   `AlertBannerComponent`, because the GitHub rate-limit and Claude usage-limit conditions are unrelated
+   and can be active simultaneously — a single component would need internal priority/stacking logic for
+   two independent triggers, whereas two components each independently contributing to the layout height
+   budget (exactly like `alert` already does) is simpler and matches the existing composition pattern in
+   `model.go`. The banner self-clears on a `TickEvent` once `now` passes the reset, rather than requiring
+   the engine to emit an explicit "resumed" event at exactly that moment — driving the visual expiry off
+   the already-existing per-second tick fan-out is simpler than adding a timer goroutine purely for TUI
+   cosmetics.
+
+8. **Comment-copy fix**: `handleUsageLimitExit`'s explanatory comment no longer says "Fabrik will keep
+   retrying on the normal poll cooldown" — it now names the account-wide suspension and describes
+   automatic resume at the reset time or on the next successful invocation, whichever comes first.
+
+## Rationale
+
+### Why a single `time.Time` deadline rather than a boolean + reset pair?
+
+A zero value is an unambiguous "not suspended" sentinel, so the entire visibility check is one
+comparison. Extending an active suspension when a second worker reports a later reset is `if
+new.After(current) { current = new }` — there is no separate "active" flag that could drift out of sync
+with the deadline it's supposed to describe.
+
+### Why not gate at the `doPollCycle` layer, mirroring the GitHub rate-limit pause exactly?
+
+The GraphQL/REST budget is spent by the poll cycle itself (fetch + dispatch + mutations), so pausing the
+whole work phase is the correct unit of suspension for that condition. The Claude usage limit is spent
+only by Claude invocations; gating the whole poll cycle would also stop settle scans, label
+reconciliation, and board polling for no reason — explicitly out of scope per the issue. The gate
+therefore has to sit at (or near) the three actual invocation call sites instead.
+
+### Why is the fixed fallback exactly 1 hour?
+
+An order of magnitude longer than the existing 5-minute dispatch cooldown, so a hit still meaningfully
+reduces hammering even with no parseable reset time, without over-committing to a duration that would
+strand the engine long after a real (shorter) limit already cleared. Weekly-limit hits — which likely
+don't carry a same-day `HH:MMam/pm` reset fragment at all — simply re-arm this same 1-hour fallback
+repeatedly until the account recovers. That's a guess for the weekly case (it may not resolve for days),
+but it's still strictly better than the current 5-minute-cooldown hammering, and a fixed conservative
+backoff (not perfect knowledge of weekly-reset timing) is what the issue asked for.
+
+### Why does the banner self-clear on a tick instead of waiting for the engine to say so?
+
+If literally no item is ever up for dispatch during the suspension window, the engine's own
+`claudeSuspendedUntilTime` check never runs, so it never proactively emits a "resumed" event either — it
+only resolves the next time something asks. Driving the banner's own expiry off the already-existing
+per-second `TickEvent` (which every component already receives) means the TUI can accurately reflect
+"the reset time has passed" even in that scenario, without adding a dedicated wake-up mechanism to the
+engine purely to keep a status line honest. This can make the banner clear visually slightly ahead of the
+engine's own internal state changing — harmless, since the engine always compares
+`claudeSuspendedUntil` against live `time.Now()` rather than trusting any cached "is it active" flag.
+
+### Why fatal-error-not-ejection for merge-train, rather than leaving the existing eject-on-false behavior?
+
+The existing behavior conflated "Claude couldn't resolve this conflict" with "Claude couldn't be invoked
+at all" — both returned `false`. An account-wide usage limit says nothing about whether the *specific*
+member's conflict is resolvable; ejecting it anyway would punish an innocent member for an unrelated
+outage and could dissolve a batch that would have landed cleanly once the limit cleared. Propagating a
+fatal error instead reuses the trial-assembly retry path that already exists for other setup failures
+(`EnsureTrainWorktreeAt`, `PushTrainBranch`), so no new recovery mechanism was needed.
+
+## Consequences
+
+**Positive:**
+- A usage-limit window now costs one detection and one automatic resume, not `max_concurrent`
+  independent discoveries each waiting out its own 5-minute cooldown.
+- The account-wide suspension is checked lazily with no additional goroutine, ticker, or polling loop —
+  it piggybacks entirely on invocation attempts and dispatch cadence that already exist.
+- Merge-train no longer ejects healthy members during an account-wide outage.
+- The GitHub rate-limit and Claude usage-limit conditions remain visibly and operationally distinct in
+  logs, labels, and the TUI, per the naming caution in the issue.
+
+**Negative / Trade-offs:**
+- The suspension is per-process (`Engine`-scoped state) — a fleet of Fabrik instances sharing one Claude
+  account will each independently discover and suspend on the limit. Cross-process coordination is an
+  explicit non-goal of this issue.
+- The 1-hour fallback is a guess for the weekly-limit case, which may run considerably longer; the engine
+  will simply re-arm the fallback repeatedly rather than ever waiting the correct, longer duration.
+- No ceiling was added on repeated usage-limit hits (unchanged from ADR-1119) — a persistently
+  misdetected condition still retries indefinitely rather than escalating for human review, now spaced
+  out by the suspension window rather than the 5-minute cooldown.
+- The TUI banner's self-clear-on-tick can run slightly ahead of the engine's own suspension state when no
+  item is dispatched during the window — a cosmetic-only lag, not a correctness issue (see Rationale
+  above). A future contributor might be tempted to "fix" this with a ticker; it is intentional.
+
+## Explicitly Out of Scope
+
+A dedicated escalation/safety-net path for persistent or repeated misdetection remains deferred, per
+ADR-1119's own explicit deferral — this issue adds the backoff/suspension half of that ADR's follow-up
+list but not the escalation half. Cross-process coordination between multiple Fabrik instances sharing
+one account is a known, accepted gap (see Consequences). `max_retries` semantics for genuine failures and
+GitHub's own (unrelated) rate-limit handling are untouched.
+
+**References:** ADR-1119 (`1119-claude-usage-limit-detection.md`) — the detection and retry-exemption
+work this ADR builds on. `engine/backoff.go` (`shouldPauseForRESTRateLimit`, `nextRateLimitLow`),
+`engine/terminal.go` (`runProbeAndDeepFetch`) — the GitHub rate-limit suspension pattern this ADR mirrors
+in shape, deliberately not merges with. `docs/state-machine.md` §7.3 — the as-built description of both
+the per-issue exemption (ADR-1119) and this account-wide suspension.

--- a/adrs/1120-claude-usage-limit-backoff-and-suspension.md
+++ b/adrs/1120-claude-usage-limit-backoff-and-suspension.md
@@ -42,9 +42,16 @@ reconciliation) must keep running while Claude dispatch is suspended.
    check is `now.Before(claudeSuspendedUntil)`. `activateClaudeSuspension(issueNumber, resetTimeRaw,
    now)` computes the deadline and only updates the field if no suspension is active or the new deadline
    is later — concurrent workers reporting the same or different reset times converge on the latest one,
-   never shortening an active window. `clearClaudeSuspension(reason)` clears it. Both log and emit
-   `tui.ClaudeUsageLimitAlertEvent` only on an actual state change, the same non-spamming idiom already
-   used for `fabrik:claude-limit`/`fabrik:awaiting-ci`.
+   never shortening an active window. `clearClaudeSuspension(reason)` clears it, called only when an
+   invocation actually *succeeds* (`err == nil`) — not merely when it returns something other than a
+   `claudeUsageLimitError`. A generic, unrelated error is not evidence the account-wide limit has
+   cleared, and clearing on it unconditionally would race with a concurrently-running worker: worker A
+   can start an invocation before any suspension is active, worker B can detect the limit and activate
+   the suspension while A's invocation is still in flight, and A's invocation can then return an
+   unrelated error moments later — clearing on any-non-limit-error would wipe out B's just-activated
+   suspension before it ever gated anything. Both `activateClaudeSuspension` and `clearClaudeSuspension`
+   log and emit `tui.ClaudeUsageLimitAlertEvent` only on an actual state change, the same non-spamming
+   idiom already used for `fabrik:claude-limit`/`fabrik:awaiting-ci`.
 
 3. **Checked lazily at invocation time, not polled by a ticker.** `claudeSuspendedUntilTime(now)` is a
    cheap read evaluated at each of the three places a Claude invocation can actually be attempted:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1133,19 +1133,25 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 > of its board column and back does **not** work as a workaround, since an unresolved
 > comment always routes to comment processing regardless of board state.
 
-> **Troubleshooting: a stage keeps retrying with a `fabrik:claude-limit` label and no
-> progress.** If the issue carries `fabrik:claude-limit` and a comment naming a Claude
-> account usage limit (e.g. `You've hit your session limit · resets 10:20pm
-> (America/Edmonton)`), the underlying Claude account has run out of usage — this is
-> not a stage failure, and it is not GitHub's own rate limiting (a separate, unrelated
-> mechanism). Fabrik detected the CLI's usage-limit exit message, so it does **not**
-> count this attempt against `--max-retries`: no `stage:<name>:failed`, no
-> `fabrik:paused`, no escalation comment. The stage will keep retrying on the normal
-> poll cooldown (`poll_interval x 10`) until an invocation succeeds, at which point
-> `fabrik:claude-limit` clears automatically. No operator action is required beyond
-> waiting for the account's usage limit to reset — backing off until the stated reset
-> time and pausing dispatch account-wide are tracked as a follow-up; until then, expect
-> one wasted invocation per cooldown window for each affected issue during an outage.
+> **Troubleshooting: a stage carries `fabrik:claude-limit` and dispatch looks idle.** If
+> the issue carries `fabrik:claude-limit` and a comment naming a Claude account usage
+> limit (e.g. `You've hit your session limit · resets 10:20pm (America/Edmonton)`), the
+> underlying Claude account has run out of usage — this is not a stage failure, and it
+> is not GitHub's own rate limiting (a separate, unrelated mechanism; see *Rate Limit
+> Monitoring* below). Fabrik detected the CLI's usage-limit exit message, so it does
+> **not** count this attempt against `--max-retries`: no `stage:<name>:failed`, no
+> `fabrik:paused`, no escalation comment. As soon as one worker observes the limit,
+> Fabrik parses the reset time from the CLI's own message and suspends *all* new Claude
+> dispatch account-wide — not just for this issue — until that time, so a usage-limit
+> window costs one detection and one automatic resume rather than every concurrent item
+> independently rediscovering and waiting out the same limit. If the reset time can't be
+> parsed (unexpected wording, missing zone), Fabrik falls back to a fixed one-hour
+> suspension instead of hammering on the normal 5-minute cooldown. The suspension and
+> its expected end are visible in the log (tag `claude-limit`) and, in the TUI, as a
+> dedicated banner distinct from the GitHub rate-limit banner (see *Claude Usage-Limit
+> Suspension* below). It clears automatically — either at the computed reset time or as
+> soon as any invocation succeeds, whichever comes first — at which point
+> `fabrik:claude-limit` also clears on this issue. No operator action is required.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue
@@ -2390,6 +2396,30 @@ polling resumes. You do not need to restart Fabrik — it recovers on its own. O
 recovery from near-zero exhaustion, Fabrik fires an immediate probe rather than
 waiting for the next scheduled poll tick, so processing resumes as soon as the
 budget is restored.
+
+### Claude Usage-Limit Suspension
+
+This is a separate mechanism from GitHub rate-limit monitoring above — it tracks the
+Claude account's own usage limit (session or weekly), not GitHub's API budget. Board
+polling, settle scans, and label reconciliation are unaffected; only the *start* of new
+Claude invocations is gated.
+
+When any worker's Claude invocation exits because the account's usage limit was hit,
+Fabrik suspends the start of every new Claude invocation — across all issues, not just
+the one that hit the limit — until the reset time named in the CLI's own error message,
+and displays a banner distinct from the GraphQL one:
+
+```
+⚠ Claude usage limit hit — dispatch suspended. Resumes in 47m (22:20 local time).
+```
+
+If the reset time can't be parsed, Fabrik falls back to a fixed one-hour suspension
+instead of retrying on the normal cooldown. The suspension clears automatically —
+either once the reset time passes or as soon as any invocation succeeds, whichever
+comes first — and dispatch resumes with no operator action required. Already-running
+Claude invocations are never interrupted by this; the suspension only prevents new ones
+from starting. See the `fabrik:claude-limit` troubleshooting note above for the
+per-issue label/comment behavior layered on top of this account-wide gate.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1131,19 +1131,25 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
 > of its board column and back does **not** work as a workaround, since an unresolved
 > comment always routes to comment processing regardless of board state.
 
-> **Troubleshooting: a stage keeps retrying with a `fabrik:claude-limit` label and no
-> progress.** If the issue carries `fabrik:claude-limit` and a comment naming a Claude
-> account usage limit (e.g. `You've hit your session limit · resets 10:20pm
-> (America/Edmonton)`), the underlying Claude account has run out of usage — this is
-> not a stage failure, and it is not GitHub's own rate limiting (a separate, unrelated
-> mechanism). Fabrik detected the CLI's usage-limit exit message, so it does **not**
-> count this attempt against `--max-retries`: no `stage:<name>:failed`, no
-> `fabrik:paused`, no escalation comment. The stage will keep retrying on the normal
-> poll cooldown (`poll_interval x 10`) until an invocation succeeds, at which point
-> `fabrik:claude-limit` clears automatically. No operator action is required beyond
-> waiting for the account's usage limit to reset — backing off until the stated reset
-> time and pausing dispatch account-wide are tracked as a follow-up; until then, expect
-> one wasted invocation per cooldown window for each affected issue during an outage.
+> **Troubleshooting: a stage carries `fabrik:claude-limit` and dispatch looks idle.** If
+> the issue carries `fabrik:claude-limit` and a comment naming a Claude account usage
+> limit (e.g. `You've hit your session limit · resets 10:20pm (America/Edmonton)`), the
+> underlying Claude account has run out of usage — this is not a stage failure, and it
+> is not GitHub's own rate limiting (a separate, unrelated mechanism; see *Rate Limit
+> Monitoring* below). Fabrik detected the CLI's usage-limit exit message, so it does
+> **not** count this attempt against `--max-retries`: no `stage:<name>:failed`, no
+> `fabrik:paused`, no escalation comment. As soon as one worker observes the limit,
+> Fabrik parses the reset time from the CLI's own message and suspends *all* new Claude
+> dispatch account-wide — not just for this issue — until that time, so a usage-limit
+> window costs one detection and one automatic resume rather than every concurrent item
+> independently rediscovering and waiting out the same limit. If the reset time can't be
+> parsed (unexpected wording, missing zone), Fabrik falls back to a fixed one-hour
+> suspension instead of hammering on the normal 5-minute cooldown. The suspension and
+> its expected end are visible in the log (tag `claude-limit`) and, in the TUI, as a
+> dedicated banner distinct from the GitHub rate-limit banner (see *Claude Usage-Limit
+> Suspension* below). It clears automatically — either at the computed reset time or as
+> soon as any invocation succeeds, whichever comes first — at which point
+> `fabrik:claude-limit` also clears on this issue. No operator action is required.
 4. **Max retries**: After `--max-retries` failures (default 3):
    - `fabrik:paused` and `stage:<name>:failed` labels are added
    - An explanatory comment is posted on the issue
@@ -2388,6 +2394,30 @@ polling resumes. You do not need to restart Fabrik — it recovers on its own. O
 recovery from near-zero exhaustion, Fabrik fires an immediate probe rather than
 waiting for the next scheduled poll tick, so processing resumes as soon as the
 budget is restored.
+
+### Claude Usage-Limit Suspension
+
+This is a separate mechanism from GitHub rate-limit monitoring above — it tracks the
+Claude account's own usage limit (session or weekly), not GitHub's API budget. Board
+polling, settle scans, and label reconciliation are unaffected; only the *start* of new
+Claude invocations is gated.
+
+When any worker's Claude invocation exits because the account's usage limit was hit,
+Fabrik suspends the start of every new Claude invocation — across all issues, not just
+the one that hit the limit — until the reset time named in the CLI's own error message,
+and displays a banner distinct from the GraphQL one:
+
+```
+⚠ Claude usage limit hit — dispatch suspended. Resumes in 47m (22:20 local time).
+```
+
+If the reset time can't be parsed, Fabrik falls back to a fixed one-hour suspension
+instead of retrying on the normal cooldown. The suspension clears automatically —
+either once the reset time passes or as soon as any invocation succeeds, whichever
+comes first — and dispatch resumes with no operator action required. Already-running
+Claude invocations are never interrupted by this; the suspension only prevents new ones
+from starting. See the `fabrik:claude-limit` troubleshooting note above for the
+per-issue label/comment behavior layered on top of this account-wide gate.
 
 ---
 
@@ -4815,11 +4845,76 @@ failure.
 **Regression guard:** a usage-limit hit followed by a genuine failure leaves the full `MaxRetries`
 budget available for the genuine failure — the limit hit consumes zero attempts.
 
-**Out of scope (follow-up issue):** backing off until the stated reset time, suspending dispatch
-account-wide when one worker observes the limit, and a dedicated escalation/safety-net path for
-persistent misdetection. Without `MaxRetries` counting against it, a misdetected or unusually
-long-lived condition retries indefinitely rather than ever escalating for human review — an accepted,
-explicit limitation until the backoff-to-reset follow-up lands.
+**Account-wide suspension and backoff-to-reset (ADR-1120):** the per-issue handling above is layered
+under an account-wide gate, because the usage limit applies to the account, not the issue — without it,
+every concurrently-dispatched item independently rediscovers the same limit and each waits out its own
+per-issue cooldown. `Engine` carries a single suspension deadline (`claudeSuspendedUntil time.Time`,
+guarded by a dedicated `claudeSuspendMu`, distinct from the general-purpose `e.mu`) that is checked
+lazily — a cheap read — at each of the three places a Claude invocation can actually be attempted:
+the stage-invocation loop (`runInvocationWithExtension`, `engine/item.go`), the comment-review loop
+(`processComments`/`runCommentExtensionLoop`, `engine/comments.go`), and merge-train inline conflict
+resolution (`resolveConflictWithClaude`, `engine/merge_train.go`).
+
+- **Parsing the reset time:** `parseUsageLimitResetTime` (`engine/usage_limit_backoff.go`) parses the
+  raw `"3:04pm (Zone/City)"`-shaped fragment carried in `claudeUsageLimitError.ResetTime` via
+  `time.LoadLocation` (zone) and the `"3:04pm"` reference layout (clock), resolves it against the
+  current date in that zone, and rolls to the next day if the resulting wall-clock time is not after
+  now (the fragment carries no date). `computeUsageLimitResetDeadline` wraps this and falls back to a
+  fixed `claudeUsageLimitFallbackBackoff` (1 hour) — a full order of magnitude longer than the
+  ordinary 5-minute dispatch cooldown — whenever `ResetTime` is empty or the fragment doesn't parse
+  (unknown zone, malformed clock, missing parentheses), logging which path was taken.
+- **Activating and extending:** `activateClaudeSuspension(issueNumber, resetTimeRaw, now)` computes the
+  deadline and, under `claudeSuspendMu`, only updates `claudeSuspendedUntil` if no suspension is
+  currently active or the newly computed deadline is later than the one already recorded — so
+  concurrent workers racing to report the same or different reset times converge on the latest deadline
+  seen, never shortening an active window. It logs (tag `"claude-limit"`, naming the reset time and
+  whether it was parsed or a fallback) and emits `tui.ClaudeUsageLimitAlertEvent{Suspended: true, Reset:
+  deadline}` only on an actual change — the same non-spamming idiom as the per-issue label.
+- **Gating:** each of the three call sites checks `claudeSuspendedUntilTime(time.Now())` before
+  attempting an invocation. If suspended, the stage-invocation and merge-train paths short-circuit by
+  returning/propagating a `*claudeUsageLimitError` without calling Claude at all (routed through the
+  same per-issue handling described above); `processComments` returns `nil` immediately, before any
+  reaction, label, or worktree side effect, so the comment remains "new" and is retried on a later poll
+  once dispatch resumes. Already-running invocations are unaffected — the gate only blocks the *start*
+  of a new one.
+- **Detecting at all three sites:** `comments.go` and `merge_train.go` did not unwrap
+  `claudeUsageLimitError` before this issue landed, so a hit there was misattributed as ordinary
+  failure — a comment-review usage-limit hit counted toward the comment circuit breaker, and a
+  merge-train conflict-resolution usage-limit hit was indistinguishable from a genuinely unresolvable
+  conflict and ejected a healthy member. Both paths now detect the sentinel via `errors.As` after their
+  `InvokeForComments` call: `runCommentExtensionLoop` activates/clears the suspension and
+  `processComments` skips `checkCommentBreaker` on a usage-limit outcome; `resolveConflictWithClaude`
+  returns `(bool, error)` instead of a bare `bool`, and `assembleTrialBranch` treats a non-nil error as
+  a fatal assembly failure (cleanup, retry next cycle) rather than running `git merge --abort` +
+  `ejectMember` — an account-wide condition says nothing about whether that member's conflict is
+  resolvable.
+- **Auto-resume:** there is no ticker or wake mechanism for the suspension — `claudeSuspendedUntilTime`
+  simply returns "not suspended" once `now` reaches the deadline, so the very next dispatch attempt
+  (which was going to happen anyway on the normal poll cadence) proceeds normally. Non-Claude engine
+  work (board polling, settle scans, label reconciliation) is never gated by this mechanism.
+- **Early clear:** any of the three call sites that reaches Claude without a usage-limit error calls
+  `clearClaudeSuspension(reason)`, which clears `claudeSuspendedUntil` (logging + emitting
+  `tui.ClaudeUsageLimitAlertEvent{Suspended: false}`) if a suspension was active — the parsed/fallback
+  deadline is a hint, not a contract, so a successful invocation ahead of it lifts the suspension
+  immediately rather than waiting it out.
+- **TUI surfacing:** `ClaudeUsageLimitAlertEvent` (`tui/events.go`) drives a dedicated
+  `ClaudeUsageLimitBannerComponent` (`tui/usage_limit_banner.go`), independent of the GitHub
+  rate-limit `AlertBannerComponent` per the naming distinction above — both can be visible at once. The
+  banner also self-clears on a `TickEvent` whose time has passed the reset, a cosmetic-only convenience
+  that can run slightly ahead of the engine's own lazy check (harmless, since the engine never trusts
+  the banner's state).
+- **Updated comment copy:** the per-issue explanatory comment posted by `handleUsageLimitExit` no
+  longer says "Fabrik will keep retrying on the normal poll cooldown" — it now describes the
+  account-wide suspension and automatic resume at the reset time (or as soon as any invocation
+  succeeds).
+
+**Out of scope (still deferred):** a dedicated escalation/safety-net path for persistent or repeated
+misdetection. Without `MaxRetries` counting against a usage-limit exit, a misdetected or unusually
+long-lived condition still retries indefinitely (now spaced out by the account-wide suspension window
+rather than the 5-minute cooldown) instead of ever escalating for human review — an accepted, explicit
+limitation per ADR-1119 and ADR-1120. Cross-process coordination between multiple Fabrik instances
+sharing one account is also out of scope: the suspension is per-process, so a fleet of instances will
+each discover the limit once.
 
 ### 7.4 Multi-Instance Lock Protocol
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4892,11 +4892,14 @@ resolution (`resolveConflictWithClaude`, `engine/merge_train.go`).
   simply returns "not suspended" once `now` reaches the deadline, so the very next dispatch attempt
   (which was going to happen anyway on the normal poll cadence) proceeds normally. Non-Claude engine
   work (board polling, settle scans, label reconciliation) is never gated by this mechanism.
-- **Early clear:** any of the three call sites that reaches Claude without a usage-limit error calls
+- **Early clear:** any of the three call sites whose invocation succeeds (`err == nil`) calls
   `clearClaudeSuspension(reason)`, which clears `claudeSuspendedUntil` (logging + emitting
   `tui.ClaudeUsageLimitAlertEvent{Suspended: false}`) if a suspension was active — the parsed/fallback
   deadline is a hint, not a contract, so a successful invocation ahead of it lifts the suspension
-  immediately rather than waiting it out.
+  immediately rather than waiting it out. A generic, unrelated error is deliberately *not* treated as
+  evidence the limit has cleared: it proves nothing about account-wide state, and clearing on it would
+  race with a concurrently-running worker that just activated the suspension, undoing the detection
+  moments after it happened.
 - **TUI surfacing:** `ClaudeUsageLimitAlertEvent` (`tui/events.go`) drives a dedicated
   `ClaudeUsageLimitBannerComponent` (`tui/usage_limit_banner.go`), independent of the GitHub
   rate-limit `AlertBannerComponent` per the naming distinction above — both can be visible at once. The

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1967,11 +1967,76 @@ failure.
 **Regression guard:** a usage-limit hit followed by a genuine failure leaves the full `MaxRetries`
 budget available for the genuine failure — the limit hit consumes zero attempts.
 
-**Out of scope (follow-up issue):** backing off until the stated reset time, suspending dispatch
-account-wide when one worker observes the limit, and a dedicated escalation/safety-net path for
-persistent misdetection. Without `MaxRetries` counting against it, a misdetected or unusually
-long-lived condition retries indefinitely rather than ever escalating for human review — an accepted,
-explicit limitation until the backoff-to-reset follow-up lands.
+**Account-wide suspension and backoff-to-reset (ADR-1120):** the per-issue handling above is layered
+under an account-wide gate, because the usage limit applies to the account, not the issue — without it,
+every concurrently-dispatched item independently rediscovers the same limit and each waits out its own
+per-issue cooldown. `Engine` carries a single suspension deadline (`claudeSuspendedUntil time.Time`,
+guarded by a dedicated `claudeSuspendMu`, distinct from the general-purpose `e.mu`) that is checked
+lazily — a cheap read — at each of the three places a Claude invocation can actually be attempted:
+the stage-invocation loop (`runInvocationWithExtension`, `engine/item.go`), the comment-review loop
+(`processComments`/`runCommentExtensionLoop`, `engine/comments.go`), and merge-train inline conflict
+resolution (`resolveConflictWithClaude`, `engine/merge_train.go`).
+
+- **Parsing the reset time:** `parseUsageLimitResetTime` (`engine/usage_limit_backoff.go`) parses the
+  raw `"3:04pm (Zone/City)"`-shaped fragment carried in `claudeUsageLimitError.ResetTime` via
+  `time.LoadLocation` (zone) and the `"3:04pm"` reference layout (clock), resolves it against the
+  current date in that zone, and rolls to the next day if the resulting wall-clock time is not after
+  now (the fragment carries no date). `computeUsageLimitResetDeadline` wraps this and falls back to a
+  fixed `claudeUsageLimitFallbackBackoff` (1 hour) — a full order of magnitude longer than the
+  ordinary 5-minute dispatch cooldown — whenever `ResetTime` is empty or the fragment doesn't parse
+  (unknown zone, malformed clock, missing parentheses), logging which path was taken.
+- **Activating and extending:** `activateClaudeSuspension(issueNumber, resetTimeRaw, now)` computes the
+  deadline and, under `claudeSuspendMu`, only updates `claudeSuspendedUntil` if no suspension is
+  currently active or the newly computed deadline is later than the one already recorded — so
+  concurrent workers racing to report the same or different reset times converge on the latest deadline
+  seen, never shortening an active window. It logs (tag `"claude-limit"`, naming the reset time and
+  whether it was parsed or a fallback) and emits `tui.ClaudeUsageLimitAlertEvent{Suspended: true, Reset:
+  deadline}` only on an actual change — the same non-spamming idiom as the per-issue label.
+- **Gating:** each of the three call sites checks `claudeSuspendedUntilTime(time.Now())` before
+  attempting an invocation. If suspended, the stage-invocation and merge-train paths short-circuit by
+  returning/propagating a `*claudeUsageLimitError` without calling Claude at all (routed through the
+  same per-issue handling described above); `processComments` returns `nil` immediately, before any
+  reaction, label, or worktree side effect, so the comment remains "new" and is retried on a later poll
+  once dispatch resumes. Already-running invocations are unaffected — the gate only blocks the *start*
+  of a new one.
+- **Detecting at all three sites:** `comments.go` and `merge_train.go` did not unwrap
+  `claudeUsageLimitError` before this issue landed, so a hit there was misattributed as ordinary
+  failure — a comment-review usage-limit hit counted toward the comment circuit breaker, and a
+  merge-train conflict-resolution usage-limit hit was indistinguishable from a genuinely unresolvable
+  conflict and ejected a healthy member. Both paths now detect the sentinel via `errors.As` after their
+  `InvokeForComments` call: `runCommentExtensionLoop` activates/clears the suspension and
+  `processComments` skips `checkCommentBreaker` on a usage-limit outcome; `resolveConflictWithClaude`
+  returns `(bool, error)` instead of a bare `bool`, and `assembleTrialBranch` treats a non-nil error as
+  a fatal assembly failure (cleanup, retry next cycle) rather than running `git merge --abort` +
+  `ejectMember` — an account-wide condition says nothing about whether that member's conflict is
+  resolvable.
+- **Auto-resume:** there is no ticker or wake mechanism for the suspension — `claudeSuspendedUntilTime`
+  simply returns "not suspended" once `now` reaches the deadline, so the very next dispatch attempt
+  (which was going to happen anyway on the normal poll cadence) proceeds normally. Non-Claude engine
+  work (board polling, settle scans, label reconciliation) is never gated by this mechanism.
+- **Early clear:** any of the three call sites that reaches Claude without a usage-limit error calls
+  `clearClaudeSuspension(reason)`, which clears `claudeSuspendedUntil` (logging + emitting
+  `tui.ClaudeUsageLimitAlertEvent{Suspended: false}`) if a suspension was active — the parsed/fallback
+  deadline is a hint, not a contract, so a successful invocation ahead of it lifts the suspension
+  immediately rather than waiting it out.
+- **TUI surfacing:** `ClaudeUsageLimitAlertEvent` (`tui/events.go`) drives a dedicated
+  `ClaudeUsageLimitBannerComponent` (`tui/usage_limit_banner.go`), independent of the GitHub
+  rate-limit `AlertBannerComponent` per the naming distinction above — both can be visible at once. The
+  banner also self-clears on a `TickEvent` whose time has passed the reset, a cosmetic-only convenience
+  that can run slightly ahead of the engine's own lazy check (harmless, since the engine never trusts
+  the banner's state).
+- **Updated comment copy:** the per-issue explanatory comment posted by `handleUsageLimitExit` no
+  longer says "Fabrik will keep retrying on the normal poll cooldown" — it now describes the
+  account-wide suspension and automatic resume at the reset time (or as soon as any invocation
+  succeeds).
+
+**Out of scope (still deferred):** a dedicated escalation/safety-net path for persistent or repeated
+misdetection. Without `MaxRetries` counting against a usage-limit exit, a misdetected or unusually
+long-lived condition still retries indefinitely (now spaced out by the account-wide suspension window
+rather than the 5-minute cooldown) instead of ever escalating for human review — an accepted, explicit
+limitation per ADR-1119 and ADR-1120. Cross-process coordination between multiple Fabrik instances
+sharing one account is also out of scope: the suspension is per-process, so a fleet of instances will
+each discover the limit once.
 
 ### 7.4 Multi-Instance Lock Protocol
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2014,11 +2014,14 @@ resolution (`resolveConflictWithClaude`, `engine/merge_train.go`).
   simply returns "not suspended" once `now` reaches the deadline, so the very next dispatch attempt
   (which was going to happen anyway on the normal poll cadence) proceeds normally. Non-Claude engine
   work (board polling, settle scans, label reconciliation) is never gated by this mechanism.
-- **Early clear:** any of the three call sites that reaches Claude without a usage-limit error calls
+- **Early clear:** any of the three call sites whose invocation succeeds (`err == nil`) calls
   `clearClaudeSuspension(reason)`, which clears `claudeSuspendedUntil` (logging + emitting
   `tui.ClaudeUsageLimitAlertEvent{Suspended: false}`) if a suspension was active — the parsed/fallback
   deadline is a hint, not a contract, so a successful invocation ahead of it lifts the suspension
-  immediately rather than waiting it out.
+  immediately rather than waiting it out. A generic, unrelated error is deliberately *not* treated as
+  evidence the limit has cleared: it proves nothing about account-wide state, and clearing on it would
+  race with a concurrently-running worker that just activated the suspension, undoing the detection
+  moments after it happened.
 - **TUI surfacing:** `ClaudeUsageLimitAlertEvent` (`tui/events.go`) drives a dedicated
   `ClaudeUsageLimitBannerComponent` (`tui/usage_limit_banner.go`), independent of the GitHub
   rate-limit `AlertBannerComponent` per the naming distinction above — both can be visible at once. The

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -140,6 +141,15 @@ func (e *Engine) humanNewComments(item gh.ProjectItem) []gh.Comment {
 // Flow: 👀 reactions → editing label → invoke Claude → perform actions / update issue body → remove editing label → 🚀 reactions
 func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, comments []gh.Comment, onPIDReady ...func(int)) error {
 	owner, repo := itemOwnerRepo(item, e.defaultRepo())
+
+	// Account-wide Claude usage-limit suspension gate (ADR-1120): checked before
+	// any side effect (reactions, labels, worktree setup) so a suspended cycle is
+	// a full no-op — the comment remains "new" and is retried on the next poll
+	// once dispatch resumes, rather than being consumed by a doomed invocation.
+	if _, suspended := e.claudeSuspendedUntilTime(time.Now()); suspended {
+		e.logf(item.Number, "claude-limit", "Claude dispatch suspended account-wide; skipping comment review\n")
+		return nil
+	}
 
 	// Merge any unresolved PR review thread comments into the working slice.
 	// This ensures that when a user nudge arrives (e.g. "please address Copilot
@@ -300,6 +310,16 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 			e.logf(item.Number, "skip", "cancelled during claude comment review\n")
 			return nil
 		}
+		// A Claude usage-limit hit is not "no forward progress" — it's an
+		// account-wide condition unrelated to this issue's comment thread, already
+		// handled by activateClaudeSuspension above. Counting it toward the
+		// circuit breaker would risk tripping the breaker purely because the
+		// account ran dry, not because this issue is stuck.
+		var limitErr *claudeUsageLimitError
+		if errors.As(err, &limitErr) {
+			e.logf(item.Number, "claude-limit", "claude comment review hit the account usage limit; not counted toward the comment circuit breaker\n")
+			return nil
+		}
 		e.logf(item.Number, "warn", "claude comment review issue: %v\n", err)
 		// A non-completing, erroring invocation is exactly the "no forward progress"
 		// case the circuit breaker exists to catch — check it here too, not only
@@ -383,6 +403,13 @@ func (e *Engine) runCommentExtensionLoop(ctx context.Context, stage *stages.Stag
 		invOutput, completed, invUsage, err = e.claude.InvokeForComments(ctx, stage, *item, comments, workDir, invokeOpts)
 		output += invOutput
 		usage = addTokenUsage(usage, invUsage)
+
+		var limitErr *claudeUsageLimitError
+		if errors.As(err, &limitErr) {
+			e.activateClaudeSuspension(item.Number, limitErr.ResetTime, time.Now())
+		} else {
+			e.clearClaudeSuspension("comment review invocation reached Claude")
+		}
 
 		// hitLimit uses currentBudget > 0 (not base > 0) so that extension only fires
 		// when fabrik:extend-turns is present.

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -407,7 +407,10 @@ func (e *Engine) runCommentExtensionLoop(ctx context.Context, stage *stages.Stag
 		var limitErr *claudeUsageLimitError
 		if errors.As(err, &limitErr) {
 			e.activateClaudeSuspension(item.Number, limitErr.ResetTime, time.Now())
-		} else {
+		} else if err == nil {
+			// Only a successful invocation is evidence the limit has cleared — a generic,
+			// unrelated error proves nothing about account-wide usage-limit state and must
+			// not clear it (see the matching comment in item.go's runInvocationWithExtension).
 			e.clearClaudeSuspension("comment review invocation reached Claude")
 		}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -116,6 +116,8 @@ type Engine struct {
 	mergeTrainTrials         map[string][]time.Time // key: "owner/repo", trial timestamps for runaway guard (ADR-059 D8)
 	issueCtxs                sync.Map               // key: issueKey string, value: issueCtxEntry; per-issue context for kill-reason propagation
 	baseBranchWarnedSet      sync.Map               // key: "owner/repo#N:branch"; prevents repeated fallback comments for bad base: labels
+	claudeSuspendMu          sync.Mutex             // guards claudeSuspendedUntil
+	claudeSuspendedUntil     time.Time              // zero = not suspended; account-wide Claude dispatch suspension deadline (see usage_limit_backoff.go)
 	events                   chan tui.Event         // nil in tests / plain-text mode; TUI goroutine consumes
 	logFile                  *os.File               // persistent log file at .fabrik/fabrik.log; nil if not opened
 	logMu                    sync.Mutex             // serializes concurrent writes to logFile

--- a/engine/item.go
+++ b/engine/item.go
@@ -970,6 +970,12 @@ func (e *Engine) runInvocationWithExtension(ctx context.Context, item gh.Project
 	}
 	baseline := snapshotBaseline(stage, item, workDir)
 
+	if _, suspended := e.claudeSuspendedUntilTime(time.Now()); suspended {
+		e.logf(item.Number, "claude-limit", "Claude dispatch suspended account-wide; skipping invocation")
+		err = &claudeUsageLimitError{Message: "account usage-limit suspension active"}
+		return output, completed, usage, totalMultiple, err
+	}
+
 	currentBudget := firstBudget
 	for {
 		opts.MaxTurnsOverride = currentBudget
@@ -978,6 +984,13 @@ func (e *Engine) runInvocationWithExtension(ctx context.Context, item gh.Project
 		invOutput, completed, invUsage, err = e.claude.Invoke(ctx, stage, item, nil, resume, workDir, opts)
 		output += invOutput
 		usage = addTokenUsage(usage, invUsage)
+
+		var limitErr *claudeUsageLimitError
+		if errors.As(err, &limitErr) {
+			e.activateClaudeSuspension(item.Number, limitErr.ResetTime, time.Now())
+		} else {
+			e.clearClaudeSuspension("stage invocation reached Claude")
+		}
 
 		hitLimit := !completed && err == nil && stage.MaxTurns > 0 && invUsage.TurnsUsed >= currentBudget
 		if !hitLimit || totalMultiple >= 3 {
@@ -2084,15 +2097,17 @@ func (e *Engine) handleBoundaryViolation(owner, repo string, repoStr string, ite
 // claudeUsageLimitError in claude.go), not because the stage genuinely
 // failed. It mirrors handleBoundaryViolation's "StageAttempted without
 // StageRetryIncremented" split (ADR-1119): the invocation is recorded so the
-// normal dispatch cooldown applies (which is what prevents hammering the
-// limit in a tight retry loop), but nothing that implies a genuine failed
-// run happens — no commitWIP/push (nothing was produced), no
+// normal per-issue dispatch cooldown applies, but nothing that implies a
+// genuine failed run happens — no commitWIP/push (nothing was produced), no
 // markCommentsSeenByStage, no StageRetryIncremented, no stage:<name>:failed,
-// no fabrik:paused. The explanatory comment and fabrik:claude-limit label
-// are applied only on the transition into the condition (label absent ->
-// applied); while the label remains set across repeated poll cycles, this
-// is a no-op, matching the non-spamming behavior of other gate labels such
-// as fabrik:awaiting-ci.
+// no fabrik:paused. The actual hammering prevention is the account-wide
+// Claude dispatch suspension activated by runInvocationWithExtension (see
+// activateClaudeSuspension in usage_limit_backoff.go, ADR-1120) before this
+// is even called — the per-issue cooldown here is a secondary guard. The
+// explanatory comment and fabrik:claude-limit label are applied only on the
+// transition into the condition (label absent -> applied); while the label
+// remains set across repeated poll cycles, this is a no-op, matching the
+// non-spamming behavior of other gate labels such as fabrik:awaiting-ci.
 func (e *Engine) handleUsageLimitExit(p stageOutcomeParams, limitErr *claudeUsageLimitError) {
 	item := p.item
 	stage := p.stage
@@ -2117,7 +2132,7 @@ func (e *Engine) handleUsageLimitExit(p stageOutcomeParams, limitErr *claudeUsag
 
 	if !hasLabel(item.Labels, "fabrik:claude-limit") {
 		comment := fmt.Sprintf(
-			"🏭 **Fabrik — Claude usage limit hit**\n\nStage **%s** did not run because the Claude account usage limit was reached%s. This is not a stage failure — it does not count against `max_retries`. Fabrik will keep retrying on the normal poll cooldown; the `fabrik:claude-limit` label clears automatically once an invocation succeeds.",
+			"🏭 **Fabrik — Claude usage limit hit**\n\nStage **%s** did not run because the Claude account usage limit was reached%s. This is not a stage failure — it does not count against `max_retries`. Fabrik has suspended Claude dispatch account-wide (not just for this issue) until the reset time and will resume automatically once it passes, or as soon as any invocation succeeds — no operator action is required. The `fabrik:claude-limit` label clears automatically once an invocation for this issue succeeds.",
 			stage.Name, resetSuffix,
 		)
 		e.postItemComment(item, comment, false)

--- a/engine/item.go
+++ b/engine/item.go
@@ -988,7 +988,12 @@ func (e *Engine) runInvocationWithExtension(ctx context.Context, item gh.Project
 		var limitErr *claudeUsageLimitError
 		if errors.As(err, &limitErr) {
 			e.activateClaudeSuspension(item.Number, limitErr.ResetTime, time.Now())
-		} else {
+		} else if err == nil {
+			// Only a successful invocation is evidence the limit has cleared (ADR-1120's
+			// "early clear on success"). A generic, unrelated error proves nothing about
+			// account-wide usage-limit state and must not clear it — doing so unconditionally
+			// would race with a concurrently-running worker that just activated the
+			// suspension, undoing it moments after detection.
 			e.clearClaudeSuspension("stage invocation reached Claude")
 		}
 

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -840,11 +840,14 @@ func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.Pr
 		e.activateClaudeSuspension(memberItem.Number, limitErr.ResetTime, time.Now())
 		return false, err
 	}
-	e.clearClaudeSuspension("merge-train conflict resolution reached Claude")
 	if err != nil {
+		// A generic, unrelated error proves nothing about account-wide usage-limit state
+		// and must not clear an active suspension (see the matching comment in item.go's
+		// runInvocationWithExtension) — only fall through to clear below on success.
 		e.logf(memberItem.Number, "merge-train", "Claude conflict resolution failed: %v\n", err)
 		return false, nil
 	}
+	e.clearClaudeSuspension("merge-train conflict resolution reached Claude")
 
 	// Check whether conflicts remain after Claude's work.
 	// Parse line-by-line to avoid false positives from file paths containing

--- a/engine/merge_train.go
+++ b/engine/merge_train.go
@@ -469,10 +469,23 @@ func (e *Engine) assembleTrialBranch(ctx context.Context, p trialParams, members
 		// Conflict — attempt Claude resolution.
 		e.logf(member.item.Number, "merge-train", "merge conflict for #%d: %s — attempting Claude resolution\n", member.item.Number, strings.TrimSpace(string(mergeOut)))
 		opts := InvokeOptions{BaseBranch: p.baseBranch, MaxTurnsOverride: p.maxTurnsOverride}
-		if e.resolveConflictWithClaude(ctx, member.item, wtDir, p.holdingStg, member.headSHA, opts) {
+		resolved, resolveErr := e.resolveConflictWithClaude(ctx, member.item, wtDir, p.holdingStg, member.headSHA, opts)
+		if resolved {
 			survivors = append(survivors, member)
 			e.logf(member.item.Number, "merge-train", "conflict for #%d resolved by Claude\n", member.item.Number)
 			continue
+		}
+		if resolveErr != nil {
+			// Resolution could not even be attempted (account-wide Claude usage-limit
+			// suspension, ADR-1120) — this says nothing about whether #%d's conflict is
+			// resolvable, so ejecting the member here would be a correctness bug. Abort
+			// the in-progress merge and propagate as a fatal assembly error instead; the
+			// caller's fatal-error path cleans up trial artifacts and retries on the
+			// train's next natural cycle, with no member punished.
+			abortCmd := exec.Command("git", "merge", "--abort")
+			abortCmd.Dir = wtDir
+			abortCmd.CombinedOutput() // best-effort
+			return nil, "", fmt.Errorf("resolving conflict for #%d: %w", member.item.Number, resolveErr)
 		}
 
 		// Unresolvable — abort merge and eject.
@@ -807,15 +820,30 @@ func buildTrainConflictComment(memberItem gh.ProjectItem, prSHA string) gh.Comme
 }
 
 // resolveConflictWithClaude invokes Claude inline to resolve merge conflicts in the
-// trial branch worktree. Returns true if resolution succeeded (no conflict markers remain
-// and the resolution is committed).
-func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.ProjectItem, trainWorkDir string, holdingStg *stages.Stage, prSHA string, opts InvokeOptions) bool {
+// trial branch worktree. Returns (true, nil) if resolution succeeded (no conflict markers
+// remain and the resolution is committed), (false, nil) if the conflict is genuinely
+// unresolvable (the caller ejects the member), or (false, non-nil) if resolution could not
+// even be attempted — currently only a claudeUsageLimitError (ADR-1120). Callers must treat
+// the two false cases differently: an account-wide usage-limit hit is not evidence this
+// member's conflict is unresolvable, so it must not be ejected.
+func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.ProjectItem, trainWorkDir string, holdingStg *stages.Stage, prSHA string, opts InvokeOptions) (bool, error) {
+	if _, suspended := e.claudeSuspendedUntilTime(time.Now()); suspended {
+		e.logf(memberItem.Number, "claude-limit", "Claude dispatch suspended account-wide; skipping conflict resolution for #%d\n", memberItem.Number)
+		return false, &claudeUsageLimitError{Message: "account usage-limit suspension active"}
+	}
+
 	comment := buildTrainConflictComment(memberItem, prSHA)
 
 	_, _, _, err := e.claude.InvokeForComments(ctx, holdingStg, memberItem, []gh.Comment{comment}, trainWorkDir, opts)
+	var limitErr *claudeUsageLimitError
+	if errors.As(err, &limitErr) {
+		e.activateClaudeSuspension(memberItem.Number, limitErr.ResetTime, time.Now())
+		return false, err
+	}
+	e.clearClaudeSuspension("merge-train conflict resolution reached Claude")
 	if err != nil {
 		e.logf(memberItem.Number, "merge-train", "Claude conflict resolution failed: %v\n", err)
-		return false
+		return false, nil
 	}
 
 	// Check whether conflicts remain after Claude's work.
@@ -830,7 +858,7 @@ func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.Pr
 			if code == "UU" || code == "AA" || code == "DD" ||
 				code == "AU" || code == "UD" || code == "UA" || code == "DU" {
 				e.logf(memberItem.Number, "merge-train", "conflict markers remain after Claude resolution\n")
-				return false
+				return false, nil
 			}
 		}
 	}
@@ -840,7 +868,7 @@ func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.Pr
 	diffCmd.Dir = trainWorkDir
 	if out, diffErr := diffCmd.CombinedOutput(); diffErr != nil {
 		e.logf(memberItem.Number, "merge-train", "git diff --check reports conflicts: %s\n", strings.TrimSpace(string(out)))
-		return false
+		return false, nil
 	}
 
 	// Verify git considers merge done (index clean or committed).
@@ -857,11 +885,11 @@ func (e *Engine) resolveConflictWithClaude(ctx context.Context, memberItem gh.Pr
 		commitCmd.Dir = trainWorkDir
 		if out, commitErr := commitCmd.CombinedOutput(); commitErr != nil {
 			e.logf(memberItem.Number, "merge-train", "could not commit resolution: %s\n", strings.TrimSpace(string(out)))
-			return false
+			return false, nil
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // ejectMember posts an ejection comment on the member issue, increments the ejection

--- a/engine/merge_train_test.go
+++ b/engine/merge_train_test.go
@@ -1022,6 +1022,93 @@ func TestMergeTrainWorker_UnresolvableConflict(t *testing.T) {
 	}
 }
 
+// TestMergeTrainWorker_UsageLimitDuringConflictResolution verifies ADR-1120: a Claude
+// usage-limit hit during inline conflict resolution must NOT eject the member (unlike a
+// genuine unresolvable conflict, exercised by TestMergeTrainWorker_UnresolvableConflict
+// above) — it's an account-wide condition unrelated to whether #2's conflict is
+// resolvable. assembleTrialBranch should instead propagate a fatal error, aborting the
+// whole trial assembly so no draft PR is created and no ejection comment is posted.
+func TestMergeTrainWorker_UsageLimitDuringConflictResolution(t *testing.T) {
+	skipIfNoGit(t)
+	_, srcDir, _, wm := setupTrainRepo(t)
+
+	// Both branches modify the same line — guaranteed conflict.
+	sha1 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-1", "counter.txt", "branch1-value\n")
+	sha2 := pushBranchToBare(t, srcDir, wm.baseDir, "fabrik/issue-2", "counter.txt", "branch2-value\n")
+
+	var addCommentIssues []int
+	var createdPRs int
+	var mu sync.Mutex
+
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			switch issueNumber {
+			case 1:
+				return &gh.PRDetails{Number: 10, HeadSHA: sha1, State: "open"}, nil
+			case 2:
+				return &gh.PRDetails{Number: 11, HeadSHA: sha2, State: "open"}, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+		addCommentFn: func(owner, repo string, issueNumber int, body string) (int, error) {
+			mu.Lock()
+			addCommentIssues = append(addCommentIssues, issueNumber)
+			mu.Unlock()
+			return 1, nil
+		},
+		createDraftPRFn: func(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+			mu.Lock()
+			createdPRs++
+			mu.Unlock()
+			return 99, nil
+		},
+	}
+	// Claude conflict resolution hits the account usage limit instead of resolving.
+	claude := &mockClaudeInvoker{
+		invokeForCommentsFn: func(stage *stages.Stage, issue gh.ProjectItem, comments []gh.Comment, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "", false, TokenUsage{}, &claudeUsageLimitError{Message: "usage limit reached", ResetTime: "10:20pm (America/Edmonton)"}
+		},
+	}
+	eng := trainTestEngine(t, client, claude, wm)
+	eng.mu.Lock()
+	eng.worktreeManagers["owner/repo"] = wm
+	eng.mu.Unlock()
+
+	batch := []gh.ProjectItem{makeTrainItem(1, "Issue 1"), makeTrainItem(2, "Issue 2")}
+	state := &mergeTrainWorkerState{assembling: true, trialName: fmt.Sprintf("merge-train-repo-%d", time.Now().Unix())}
+	eng.mergeTrainInFlight.Store("owner/repo", state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	eng.runMergeTrainWorker(ctx, state, "owner", "repo", batch)
+
+	mu.Lock()
+	prs := createdPRs
+	comments := append([]int(nil), addCommentIssues...)
+	mu.Unlock()
+
+	// No draft PR — the whole trial assembly must abort as a fatal error, not land
+	// a partial survivor set.
+	if prs != 0 {
+		t.Errorf("expected 0 draft PRs (fatal assembly error), got %d", prs)
+	}
+	// Issue #2 must NOT receive an ejection comment — the usage limit says nothing
+	// about whether its conflict is resolvable.
+	for _, n := range comments {
+		if n == 2 {
+			t.Error("issue #2 must not be ejected on a Claude usage-limit hit")
+		}
+	}
+	// The account-wide suspension must have been activated by the detection.
+	if _, suspended := eng.claudeSuspendedUntilTime(time.Now()); !suspended {
+		t.Error("expected account-wide Claude suspension to be active after the usage-limit hit")
+	}
+	// In-flight entry must still be cleared despite the fatal error (ADR-067).
+	if _, ok := eng.mergeTrainInFlight.Load("owner/repo"); ok {
+		t.Error("expected mergeTrainInFlight to be cleared after fatal assembly error")
+	}
+}
+
 // TestMergeTrainWorker_ZeroSurvivors verifies FR-6: when FetchLinkedPR fails for
 // all members (ejecting each one), no draft PR is created and the in-flight entry
 // is cleared (Task 11e).

--- a/engine/usage_limit_backoff.go
+++ b/engine/usage_limit_backoff.go
@@ -1,0 +1,145 @@
+package engine
+
+import (
+	"strings"
+	"time"
+
+	"github.com/handarbeit/fabrik/tui"
+)
+
+// claudeUsageLimitFallbackBackoff is the fixed conservative backoff applied
+// when a usage-limit reset time can't be parsed (empty ResetTime, malformed
+// fragment, or unknown IANA zone). An order of magnitude longer than the
+// normal 5-minute dispatch cooldown so a hit still meaningfully reduces
+// hammering even without a known reset, without over-committing to a
+// duration that might strand the engine long after the real limit clears.
+const claudeUsageLimitFallbackBackoff = 1 * time.Hour
+
+// usageLimitResetTimeLayout is the Go reference-time layout matching the
+// 12-hour clock fragment Anthropic's CLI emits (e.g. "10:20pm").
+const usageLimitResetTimeLayout = "3:04pm"
+
+// parseUsageLimitResetTime parses a reset-time fragment of the form
+// "3:04pm (Zone/City)" — a 12-hour wall-clock time plus an IANA zone name,
+// with no date — into a concrete time.Time. The wall-clock time is resolved
+// against now's date in the parsed zone; if the resulting time is not after
+// now, it is rolled forward one day (the CLI always reports a future reset,
+// so "already past" only happens because the fragment carries no date).
+//
+// Returns ok=false for any fragment that doesn't match the expected shape or
+// whose zone doesn't load — callers fall back to a fixed backoff in that case.
+func parseUsageLimitResetTime(resetTime string, now time.Time) (time.Time, bool) {
+	clockStr, zoneStr, ok := splitUsageLimitResetFragment(resetTime)
+	if !ok {
+		return time.Time{}, false
+	}
+	loc, err := time.LoadLocation(zoneStr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	clock, err := time.ParseInLocation(usageLimitResetTimeLayout, clockStr, loc)
+	if err != nil {
+		return time.Time{}, false
+	}
+	nowInLoc := now.In(loc)
+	deadline := time.Date(
+		nowInLoc.Year(), nowInLoc.Month(), nowInLoc.Day(),
+		clock.Hour(), clock.Minute(), 0, 0, loc,
+	)
+	if !deadline.After(nowInLoc) {
+		deadline = deadline.AddDate(0, 0, 1)
+	}
+	return deadline, true
+}
+
+// splitUsageLimitResetFragment splits "3:04pm (Zone/City)" into its clock and
+// zone parts. Returns ok=false if the fragment doesn't have the expected
+// "<clock> (<zone>)" shape.
+func splitUsageLimitResetFragment(resetTime string) (clockStr, zoneStr string, ok bool) {
+	open := strings.IndexByte(resetTime, '(')
+	closeIdx := strings.IndexByte(resetTime, ')')
+	if open < 0 || closeIdx < 0 || closeIdx < open {
+		return "", "", false
+	}
+	clockStr = strings.TrimSpace(resetTime[:open])
+	zoneStr = strings.TrimSpace(resetTime[open+1 : closeIdx])
+	if clockStr == "" || zoneStr == "" {
+		return "", "", false
+	}
+	return clockStr, zoneStr, true
+}
+
+// computeUsageLimitResetDeadline computes the deadline a usage-limit
+// suspension should run until. It wraps parseUsageLimitResetTime, falling
+// back to a fixed conservative backoff (claudeUsageLimitFallbackBackoff) when
+// resetTime is empty or doesn't parse. The second return value reports
+// whether the deadline came from a successfully parsed reset time (true) or
+// the fallback (false), so callers can log which path was taken.
+func computeUsageLimitResetDeadline(resetTime string, now time.Time) (deadline time.Time, parsed bool) {
+	if deadline, ok := parseUsageLimitResetTime(resetTime, now); ok {
+		return deadline, true
+	}
+	return now.Add(claudeUsageLimitFallbackBackoff), false
+}
+
+// claudeSuspendedUntilTime reports whether Claude dispatch is currently
+// suspended account-wide, and the deadline if so. Returns ok=false once now
+// has reached the deadline, at which point the very next dispatch attempt
+// proceeds normally — there is no separate "resume" step to run.
+func (e *Engine) claudeSuspendedUntilTime(now time.Time) (deadline time.Time, ok bool) {
+	e.claudeSuspendMu.Lock()
+	deadline = e.claudeSuspendedUntil
+	e.claudeSuspendMu.Unlock()
+	if deadline.IsZero() || !now.Before(deadline) {
+		return time.Time{}, false
+	}
+	return deadline, true
+}
+
+// activateClaudeSuspension records that a worker observed the account usage
+// limit and suspends new Claude dispatch account-wide until the computed
+// deadline. If a suspension is already active, the deadline is only extended
+// (never shortened) — concurrent workers racing to report the same or
+// different reset times converge on the latest one seen. Logs and emits
+// tui.ClaudeUsageLimitAlertEvent only when the suspension actually changes
+// (activates or extends), mirroring the non-spamming idiom used for
+// fabrik:claude-limit/fabrik:awaiting-ci.
+func (e *Engine) activateClaudeSuspension(issueNumber int, resetTimeRaw string, now time.Time) {
+	deadline, parsed := computeUsageLimitResetDeadline(resetTimeRaw, now)
+
+	e.claudeSuspendMu.Lock()
+	changed := e.claudeSuspendedUntil.IsZero() || deadline.After(e.claudeSuspendedUntil)
+	if changed {
+		e.claudeSuspendedUntil = deadline
+	}
+	e.claudeSuspendMu.Unlock()
+
+	if !changed {
+		return
+	}
+
+	if parsed {
+		e.logf(issueNumber, "claude-limit", "account usage-limit hit; suspending Claude dispatch account-wide until %s (parsed from CLI reset time)", deadline.Format(time.RFC3339))
+	} else {
+		e.logf(issueNumber, "claude-limit", "account usage-limit hit; reset time unparseable, falling back to a %s suspension of Claude dispatch account-wide until %s", claudeUsageLimitFallbackBackoff, deadline.Format(time.RFC3339))
+	}
+	e.emitStructural(tui.ClaudeUsageLimitAlertEvent{Suspended: true, Reset: deadline})
+}
+
+// clearClaudeSuspension clears an active account-wide Claude suspension, if
+// one is set. Called both when a successful invocation proves the limit has
+// already cleared (early clear, ahead of the computed deadline) and lazily
+// once now passes the deadline. Logs and emits
+// tui.ClaudeUsageLimitAlertEvent only when a suspension was actually active.
+func (e *Engine) clearClaudeSuspension(reason string) {
+	e.claudeSuspendMu.Lock()
+	wasActive := !e.claudeSuspendedUntil.IsZero()
+	e.claudeSuspendedUntil = time.Time{}
+	e.claudeSuspendMu.Unlock()
+
+	if !wasActive {
+		return
+	}
+	e.logf(0, "claude-limit", "clearing account-wide Claude dispatch suspension: %s", reason)
+	e.emitStructural(tui.ClaudeUsageLimitAlertEvent{Suspended: false})
+}

--- a/engine/usage_limit_backoff_test.go
+++ b/engine/usage_limit_backoff_test.go
@@ -61,9 +61,9 @@ func TestParseUsageLimitResetTime(t *testing.T) {
 			name:      "now in a different zone than the fragment",
 			resetTime: "10:20pm (America/Edmonton)",
 			// 2026-07-27 20:00 America/Edmonton == 2026-07-28 04:00 UTC.
-			now:       time.Date(2026, 7, 28, 4, 0, 0, 0, time.UTC),
-			wantOK:    true,
-			want:      time.Date(2026, 7, 27, 22, 20, 0, 0, loc),
+			now:    time.Date(2026, 7, 28, 4, 0, 0, 0, time.UTC),
+			wantOK: true,
+			want:   time.Date(2026, 7, 27, 22, 20, 0, 0, loc),
 		},
 	}
 

--- a/engine/usage_limit_backoff_test.go
+++ b/engine/usage_limit_backoff_test.go
@@ -1,0 +1,217 @@
+package engine
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseUsageLimitResetTime(t *testing.T) {
+	loc, err := time.LoadLocation("America/Edmonton")
+	if err != nil {
+		t.Fatalf("loading America/Edmonton: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		resetTime string
+		now       time.Time
+		wantOK    bool
+		want      time.Time
+	}{
+		{
+			name:      "same day, reset later today",
+			resetTime: "10:20pm (America/Edmonton)",
+			now:       time.Date(2026, 7, 27, 20, 0, 0, 0, loc),
+			wantOK:    true,
+			want:      time.Date(2026, 7, 27, 22, 20, 0, 0, loc),
+		},
+		{
+			name:      "already past, rolls to next day",
+			resetTime: "10:20pm (America/Edmonton)",
+			now:       time.Date(2026, 7, 27, 23, 0, 0, 0, loc),
+			wantOK:    true,
+			want:      time.Date(2026, 7, 28, 22, 20, 0, 0, loc),
+		},
+		{
+			name:      "unknown zone",
+			resetTime: "10:20pm (Nowhere/Fakezone)",
+			now:       time.Date(2026, 7, 27, 20, 0, 0, 0, loc),
+			wantOK:    false,
+		},
+		{
+			name:      "malformed, no parens",
+			resetTime: "10:20pm America/Edmonton",
+			now:       time.Date(2026, 7, 27, 20, 0, 0, 0, loc),
+			wantOK:    false,
+		},
+		{
+			name:      "malformed clock",
+			resetTime: "not-a-time (America/Edmonton)",
+			now:       time.Date(2026, 7, 27, 20, 0, 0, 0, loc),
+			wantOK:    false,
+		},
+		{
+			name:      "empty",
+			resetTime: "",
+			now:       time.Date(2026, 7, 27, 20, 0, 0, 0, loc),
+			wantOK:    false,
+		},
+		{
+			name:      "now in a different zone than the fragment",
+			resetTime: "10:20pm (America/Edmonton)",
+			// 2026-07-27 20:00 America/Edmonton == 2026-07-28 04:00 UTC.
+			now:       time.Date(2026, 7, 28, 4, 0, 0, 0, time.UTC),
+			wantOK:    true,
+			want:      time.Date(2026, 7, 27, 22, 20, 0, 0, loc),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseUsageLimitResetTime(tt.resetTime, tt.now)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got=%v)", ok, tt.wantOK, got)
+			}
+			if !ok {
+				return
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("deadline = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeUsageLimitResetDeadline(t *testing.T) {
+	loc, err := time.LoadLocation("America/Edmonton")
+	if err != nil {
+		t.Fatalf("loading America/Edmonton: %v", err)
+	}
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, loc)
+
+	t.Run("parseable reset time", func(t *testing.T) {
+		deadline, parsed := computeUsageLimitResetDeadline("10:20pm (America/Edmonton)", now)
+		if !parsed {
+			t.Fatal("expected parsed=true")
+		}
+		want := time.Date(2026, 7, 27, 22, 20, 0, 0, loc)
+		if !deadline.Equal(want) {
+			t.Errorf("deadline = %v, want %v", deadline, want)
+		}
+	})
+
+	t.Run("empty reset time falls back", func(t *testing.T) {
+		deadline, parsed := computeUsageLimitResetDeadline("", now)
+		if parsed {
+			t.Fatal("expected parsed=false")
+		}
+		want := now.Add(claudeUsageLimitFallbackBackoff)
+		if !deadline.Equal(want) {
+			t.Errorf("deadline = %v, want %v", deadline, want)
+		}
+	})
+
+	t.Run("malformed reset time falls back", func(t *testing.T) {
+		deadline, parsed := computeUsageLimitResetDeadline("garbage", now)
+		if parsed {
+			t.Fatal("expected parsed=false")
+		}
+		want := now.Add(claudeUsageLimitFallbackBackoff)
+		if !deadline.Equal(want) {
+			t.Errorf("deadline = %v, want %v", deadline, want)
+		}
+	})
+}
+
+func TestClaudeSuspendedUntilTime(t *testing.T) {
+	e := testEngine(t, nil, nil)
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
+
+	if _, ok := e.claudeSuspendedUntilTime(now); ok {
+		t.Fatal("expected not suspended before any activation")
+	}
+
+	e.activateClaudeSuspension(1, "", now)
+	deadline := now.Add(claudeUsageLimitFallbackBackoff)
+
+	if got, ok := e.claudeSuspendedUntilTime(now); !ok || !got.Equal(deadline) {
+		t.Fatalf("claudeSuspendedUntilTime = (%v, %v), want (%v, true)", got, ok, deadline)
+	}
+
+	// Once now reaches the deadline, suspension has lazily cleared.
+	if _, ok := e.claudeSuspendedUntilTime(deadline); ok {
+		t.Fatal("expected suspension to have lazily expired at the deadline")
+	}
+}
+
+func TestActivateClaudeSuspension_ExtendsNotShortens(t *testing.T) {
+	e := testEngine(t, nil, nil)
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
+
+	// First activation: fallback deadline (now + 1h).
+	e.activateClaudeSuspension(1, "", now)
+	first := now.Add(claudeUsageLimitFallbackBackoff)
+
+	// Second activation with an earlier fallback base — should NOT shorten.
+	e.activateClaudeSuspension(2, "", now.Add(-30*time.Minute))
+	if got, ok := e.claudeSuspendedUntilTime(now); !ok || !got.Equal(first) {
+		t.Fatalf("expected deadline to remain %v, got (%v, %v)", first, got, ok)
+	}
+
+	// Third activation with a later base — should extend.
+	later := now.Add(2 * time.Hour)
+	e.activateClaudeSuspension(3, "", later)
+	want := later.Add(claudeUsageLimitFallbackBackoff)
+	if got, ok := e.claudeSuspendedUntilTime(now); !ok || !got.Equal(want) {
+		t.Fatalf("expected deadline to extend to %v, got (%v, %v)", want, got, ok)
+	}
+}
+
+func TestClearClaudeSuspension(t *testing.T) {
+	e := testEngine(t, nil, nil)
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
+
+	e.activateClaudeSuspension(1, "", now)
+	if _, ok := e.claudeSuspendedUntilTime(now); !ok {
+		t.Fatal("expected suspension to be active")
+	}
+
+	e.clearClaudeSuspension("test clear")
+	if _, ok := e.claudeSuspendedUntilTime(now); ok {
+		t.Fatal("expected suspension to be cleared")
+	}
+
+	// Clearing again is a harmless no-op.
+	e.clearClaudeSuspension("test clear again")
+}
+
+// TestActivateClaudeSuspension_Concurrent drives N goroutines racing to
+// activate the suspension with different reset times; the final deadline
+// must be the max deadline any goroutine computed, and go test -race must be
+// clean (validates claudeSuspendMu actually guards the field).
+func TestActivateClaudeSuspension_Concurrent(t *testing.T) {
+	e := testEngine(t, nil, nil)
+	now := time.Date(2026, 7, 27, 20, 0, 0, 0, time.UTC)
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			// Vary the "now" base per goroutine so deadlines differ.
+			e.activateClaudeSuspension(i, "", now.Add(time.Duration(i)*time.Minute))
+		}(i)
+	}
+	wg.Wait()
+
+	want := now.Add(time.Duration(n-1) * time.Minute).Add(claudeUsageLimitFallbackBackoff)
+	got, ok := e.claudeSuspendedUntilTime(now)
+	if !ok {
+		t.Fatal("expected suspension to be active")
+	}
+	if !got.Equal(want) {
+		t.Errorf("final deadline = %v, want max deadline %v", got, want)
+	}
+}

--- a/engine/usage_limit_test.go
+++ b/engine/usage_limit_test.go
@@ -467,3 +467,44 @@ func TestUsageLimitSuspension_UnrelatedErrorDoesNotClearConcurrentlyActivatedSus
 		t.Error("expected the concurrently-activated suspension to survive this invocation's unrelated error, but it was cleared")
 	}
 }
+
+// TestProcessComments_SuspendedGate_IsFullNoOp verifies the ADR-1120 claim in
+// processComments' own gate comment: while the account-wide Claude suspension
+// is active, the function must return immediately with zero side effects — no
+// 👀 reaction, no fabrik:editing label, no Claude invocation — so the comment
+// remains "new" and is retried on a later poll once dispatch resumes, rather
+// than being partially consumed by a doomed cycle.
+func TestProcessComments_SuspendedGate_IsFullNoOp(t *testing.T) {
+	skipIfNoGit(t)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{}
+	eng := testEngineWithRepo(t, client, claude)
+	eng.activateClaudeSuspension(0, "10:20pm (America/Edmonton)", time.Now())
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	stage := &stages.Stage{Name: "Research", Order: 1, Completion: stages.CompletionCriteria{Type: "claude"}}
+	item := gh.ProjectItem{Number: 11, Body: "spec"}
+	userComments := []gh.Comment{
+		{ID: "C_1", DatabaseID: 111, Author: "testuser", Body: "please continue"},
+	}
+
+	if err := eng.processComments(context.Background(), board, item, stage, userComments); err != nil {
+		t.Fatalf("processComments returned error while suspended: %v", err)
+	}
+
+	if len(claude.forCommentsCalls) != 0 {
+		t.Errorf("expected 0 Claude invocations while suspended, got %d", len(claude.forCommentsCalls))
+	}
+	if len(client.addCommentReactionCalls) != 0 {
+		t.Errorf("expected 0 👀 reactions while suspended, got %d: %v", len(client.addCommentReactionCalls), client.addCommentReactionCalls)
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:editing" {
+			t.Error("expected fabrik:editing to NOT be added while suspended (gate must fire before any side effect)")
+		}
+	}
+	if len(client.addLabelCalls) != 0 {
+		t.Errorf("expected 0 label mutations while suspended, got %d: %v", len(client.addLabelCalls), client.addLabelCalls)
+	}
+}

--- a/engine/usage_limit_test.go
+++ b/engine/usage_limit_test.go
@@ -423,3 +423,47 @@ func TestUsageLimitSuspension_ConcurrentDispatchShortCircuitsAfterDetection(t *t
 		t.Errorf("expected Claude invocation count to stay at %d while suspended, got %d — concurrent dispatch bypassed the gate", callsAfterDetection, finalCalls)
 	}
 }
+
+// TestUsageLimitSuspension_UnrelatedErrorDoesNotClearConcurrentlyActivatedSuspension
+// is a regression guard for a race in the "clear on non-limit error" path: an
+// invocation that started before any suspension was active can still be
+// in-flight when another worker detects the limit and activates the
+// suspension. If the in-flight invocation then returns a generic, unrelated
+// error (not a claudeUsageLimitError, and not a success), that must NOT clear
+// the suspension the other worker just activated — a generic error is not
+// evidence the account-wide limit has cleared. Only a successful invocation
+// (err == nil) may clear it (ADR-1120's "early clear on success").
+func TestUsageLimitSuspension_UnrelatedErrorDoesNotClearConcurrentlyActivatedSuspension(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	var eng *Engine
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			// Simulate a concurrent worker detecting the limit and activating the
+			// account-wide suspension while THIS invocation is still in flight.
+			eng.activateClaudeSuspension(999, "10:20pm (America/Edmonton)", time.Now())
+			// This invocation's own outcome is unrelated to the usage limit.
+			return "partial output", false, TokenUsage{}, errors.New("some genuine transient failure")
+		},
+	}
+
+	eng = NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 106, Title: "Race regression", Status: "Research", ItemID: "PVTI_106"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	if _, suspended := eng.claudeSuspendedUntilTime(time.Now()); !suspended {
+		t.Error("expected the concurrently-activated suspension to survive this invocation's unrelated error, but it was cleared")
+	}
+}

--- a/engine/usage_limit_test.go
+++ b/engine/usage_limit_test.go
@@ -3,9 +3,12 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/stages"
@@ -273,6 +276,14 @@ func TestUsageLimitThenGenuineFailure_LeavesFullRetryBudget(t *testing.T) {
 	if err := eng.processItem(context.Background(), board, item); err != nil {
 		t.Fatalf("processItem (first call): %v", err)
 	}
+	// The first hit activated the account-wide Claude suspension (ADR-1120,
+	// exercised separately by TestUsageLimitSuspension_ConcurrentDispatchShortCircuitsAfterDetection).
+	// This test is about per-issue retry-budget semantics, not the suspension
+	// window, so clear it here to simulate the second poll happening after the
+	// suspension has lifted — otherwise the second call would be gated before
+	// ever reaching Claude and callCount would never advance to the genuine
+	// failure branch.
+	eng.clearClaudeSuspension("test: simulate suspension window elapsed before second poll")
 	// Second poll: item now carries fabrik:claude-limit, as it would after a
 	// real board re-fetch following the first call's label add.
 	item.Labels = []string{"fabrik:claude-limit"}
@@ -342,5 +353,73 @@ func TestUsageLimitExit_SecondConsecutiveHit_DoesNotRepostComment(t *testing.T) 
 	}
 	if got := snap.Attempts("Research"); got != 0 {
 		t.Errorf("Attempts(\"Research\") = %d, want 0 after two usage-limit hits", got)
+	}
+}
+
+// TestUsageLimitSuspension_ConcurrentDispatchShortCircuitsAfterDetection is the
+// account-wide suspension acceptance-criteria test (ADR-1120): once one worker
+// has detected the usage limit and activated the suspension, every other
+// concurrently-dispatched item must short-circuit via the gate in
+// runInvocationWithExtension without reaching e.claude.Invoke — "a single
+// detection suspends all workers; subsequent items do not each invoke and
+// fail."
+func TestUsageLimitSuspension_ConcurrentDispatchShortCircuitsAfterDetection(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "", false, TokenUsage{}, &claudeUsageLimitError{Message: "hit your session limit", ResetTime: "10:20pm (America/Edmonton)"}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxConcurrent: 5, Stages: testStages()},
+		client, claude, wm,
+	)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+
+	// First dispatch: no suspension active yet, so this one actually reaches
+	// Claude, detects the limit, and activates the account-wide suspension.
+	detector := gh.ProjectItem{Number: 200, Title: "Detector", Status: "Research", ItemID: "PVTI_200"}
+	if err := eng.processItem(context.Background(), board, detector); err != nil {
+		t.Fatalf("processItem (detector): %v", err)
+	}
+	claude.mu.Lock()
+	callsAfterDetection := len(claude.calls)
+	claude.mu.Unlock()
+	if callsAfterDetection != 1 {
+		t.Fatalf("expected exactly 1 Claude invocation from the detecting call, got %d", callsAfterDetection)
+	}
+	if _, suspended := eng.claudeSuspendedUntilTime(time.Now()); !suspended {
+		t.Fatal("expected account-wide Claude suspension to be active after detection")
+	}
+
+	// N concurrent dispatches for other items — the suspension is already
+	// active, so every one of them must be gated in runInvocationWithExtension
+	// before e.claude.Invoke is ever called.
+	const n = 10
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			num := 201 + i
+			item := gh.ProjectItem{Number: num, Title: fmt.Sprintf("Concurrent %d", num), Status: "Research", ItemID: fmt.Sprintf("PVTI_%d", num)}
+			if err := eng.processItem(context.Background(), board, item); err != nil {
+				t.Errorf("processItem (concurrent #%d): %v", num, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	claude.mu.Lock()
+	finalCalls := len(claude.calls)
+	claude.mu.Unlock()
+	if finalCalls != callsAfterDetection {
+		t.Errorf("expected Claude invocation count to stay at %d while suspended, got %d — concurrent dispatch bypassed the gate", callsAfterDetection, finalCalls)
 	}
 }

--- a/tui/events.go
+++ b/tui/events.go
@@ -164,6 +164,25 @@ type RateLimitAlertEvent struct {
 
 func (RateLimitAlertEvent) tuiEvent() {}
 
+// ClaudeUsageLimitAlertEvent is emitted by the engine when the account-wide
+// Claude usage-limit suspension state changes: Suspended=true when a worker
+// observes the account's usage limit (session or weekly) and suspends new
+// Claude dispatch account-wide; Suspended=false when the suspension clears,
+// either because the computed reset time passed or because an invocation
+// succeeded ahead of it. Reset is the time dispatch is expected to resume
+// (zero if unknown).
+//
+// Deliberately distinct from RateLimitAlertEvent: that event tracks GitHub's
+// GraphQL/REST rate-limit budget, an unrelated condition that can be active
+// at the same time. Conflating the two under one name would make it
+// impossible to tell which budget is exhausted from the log/TUI alone.
+type ClaudeUsageLimitAlertEvent struct {
+	Suspended bool
+	Reset     time.Time
+}
+
+func (ClaudeUsageLimitAlertEvent) tuiEvent() {}
+
 // CommentBreakerTrippedEvent is emitted when the comment-processing circuit
 // breaker trips: the same issue underwent InvocationCount comment-processing
 // invocations within Window with no forward progress (#1089). This is a

--- a/tui/model.go
+++ b/tui/model.go
@@ -117,14 +117,15 @@ type Model struct {
 	stopCh chan<- StopRequest
 
 	// components
-	header   HeaderComponent
-	alert    AlertBannerComponent
-	active   ActivePaneComponent
-	history  HistoryPaneComponent
-	warnings WarningsPaneComponent
-	detail   DetailPanelComponent
-	help     HelpPanelComponent
-	footer   FooterComponent
+	header     HeaderComponent
+	alert      AlertBannerComponent
+	usageLimit ClaudeUsageLimitBannerComponent
+	active     ActivePaneComponent
+	history    HistoryPaneComponent
+	warnings   WarningsPaneComponent
+	detail     DetailPanelComponent
+	help       HelpPanelComponent
+	footer     FooterComponent
 }
 
 // minHistoryRows is the minimum number of rows reserved for the history pane
@@ -173,10 +174,11 @@ func New(pollSeconds int, info ProjectInfo, pluginDir string, wakeCh chan struct
 			skillsStaleCount: skillsStaleCount,
 			customWorkflow:   customWorkflow,
 		},
-		alert:    AlertBannerComponent{now: now},
-		active:   active,
-		history:  NewHistoryPaneComponent(info.Repo),
-		warnings: NewWarningsPaneComponent(),
+		alert:      AlertBannerComponent{now: now},
+		usageLimit: ClaudeUsageLimitBannerComponent{now: now},
+		active:     active,
+		history:    NewHistoryPaneComponent(info.Repo),
+		warnings:   NewWarningsPaneComponent(),
 		footer: FooterComponent{
 			projectInfo: info,
 			now:         now,
@@ -629,6 +631,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.active = comp.(ActivePaneComponent)
 		comp, _ = m.alert.Update(msg)
 		m.alert = comp.(AlertBannerComponent)
+		comp, _ = m.usageLimit.Update(msg)
+		m.usageLimit = comp.(ClaudeUsageLimitBannerComponent)
 		comp, _ = m.footer.Update(msg)
 		m.footer = comp.(FooterComponent)
 		wcomp, _ := m.warnings.Update(msg)
@@ -664,6 +668,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case RateLimitAlertEvent:
 		comp, _ := m.alert.Update(msg)
 		m.alert = comp.(AlertBannerComponent)
+		m.updateLayout(false)
+		return m, nil
+
+	case ClaudeUsageLimitAlertEvent:
+		comp, _ := m.usageLimit.Update(msg)
+		m.usageLimit = comp.(ClaudeUsageLimitBannerComponent)
 		m.updateLayout(false)
 		return m, nil
 
@@ -779,7 +789,7 @@ func (m *Model) updateLayout(scrollToTop bool) {
 		m.prepareDetailItem()
 		detailH = m.detail.Height()
 	}
-	totalAvail := m.height - m.header.Height() - m.alert.Height() - activeH - detailH - m.footer.Height()
+	totalAvail := m.height - m.header.Height() - m.alert.Height() - m.usageLimit.Height() - activeH - detailH - m.footer.Height()
 
 	helpH := 0
 	if m.helpPanel {
@@ -852,6 +862,9 @@ func (m Model) View() string {
 	sections = append(sections, m.header.View(m.width))
 	if alertView := m.alert.View(m.width); alertView != "" {
 		sections = append(sections, alertView)
+	}
+	if usageLimitView := m.usageLimit.View(m.width); usageLimitView != "" {
+		sections = append(sections, usageLimitView)
 	}
 	sections = append(sections, m.active.View(m.width))
 

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -494,6 +494,7 @@ func TestTuiEventMethods(t *testing.T) {
 	TickEvent{}.tuiEvent()
 	SkillsStaleEvent{}.tuiEvent()
 	RateLimitAlertEvent{}.tuiEvent()
+	ClaudeUsageLimitAlertEvent{}.tuiEvent()
 }
 
 // TestUpdate_RateLimitAlertEvent_Exhausted verifies that after receiving a
@@ -563,6 +564,113 @@ func TestUpdateLayout_AlertBannerHeightBudget(t *testing.T) {
 	got := lipgloss.Height(m.View())
 	if got != termHeight {
 		t.Errorf("with banner visible: View() height = %d, want %d (height budget not accounting for banner)", got, termHeight)
+	}
+}
+
+// TestUpdate_ClaudeUsageLimitAlertEvent_Suspended verifies that after
+// receiving a ClaudeUsageLimitAlertEvent{Suspended: true}, the usage-limit
+// banner becomes active and visible — mirrors
+// TestUpdate_RateLimitAlertEvent_Exhausted, but for the distinct
+// account-wide Claude suspension condition (ADR-1120).
+func TestUpdate_ClaudeUsageLimitAlertEvent_Suspended(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	reset := time.Now().Add(time.Hour)
+
+	next, _ := m.Update(ClaudeUsageLimitAlertEvent{Suspended: true, Reset: reset})
+	m = next.(Model)
+
+	if !m.usageLimit.active {
+		t.Error("expected usageLimit.active=true after ClaudeUsageLimitAlertEvent{Suspended: true}")
+	}
+	if !m.usageLimit.reset.Equal(reset) {
+		t.Errorf("expected usageLimit.reset=%v, got %v", reset, m.usageLimit.reset)
+	}
+	if !m.usageLimit.isVisible() {
+		t.Error("expected usage-limit banner to be visible after Suspended=true event")
+	}
+}
+
+// TestUpdate_ClaudeUsageLimitAlertEvent_Cleared verifies that after receiving
+// a ClaudeUsageLimitAlertEvent{Suspended: false}, the banner's active flag is
+// cleared and it stops being visible — mirrors
+// TestUpdate_RateLimitAlertEvent_Recovered.
+func TestUpdate_ClaudeUsageLimitAlertEvent_Cleared(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	m.usageLimit.active = true
+	m.usageLimit.reset = time.Now().Add(time.Hour)
+
+	next, _ := m.Update(ClaudeUsageLimitAlertEvent{Suspended: false})
+	m = next.(Model)
+
+	if m.usageLimit.active {
+		t.Error("expected usageLimit.active=false after ClaudeUsageLimitAlertEvent{Suspended: false}")
+	}
+	if m.usageLimit.isVisible() {
+		t.Error("expected usage-limit banner to be hidden after Suspended=false event")
+	}
+}
+
+// TestClaudeUsageLimitBanner_SelfClearsOnTickPastReset verifies that the
+// banner stops rendering once a TickEvent's At time reaches or passes the
+// computed reset, even with no explicit Suspended=false event — the
+// cosmetic self-clear behavior documented on
+// ClaudeUsageLimitBannerComponent.isVisible.
+func TestClaudeUsageLimitBanner_SelfClearsOnTickPastReset(t *testing.T) {
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	reset := time.Now().Add(time.Hour)
+
+	next, _ := m.Update(ClaudeUsageLimitAlertEvent{Suspended: true, Reset: reset})
+	m = next.(Model)
+	if !m.usageLimit.isVisible() {
+		t.Fatal("precondition: banner should be visible right after activation")
+	}
+
+	// Tick to a time before the reset — still visible.
+	next, _ = m.Update(TickEvent{At: reset.Add(-time.Minute)})
+	m = next.(Model)
+	if !m.usageLimit.isVisible() {
+		t.Error("expected banner to remain visible before reset")
+	}
+
+	// Tick past the reset — banner self-clears.
+	next, _ = m.Update(TickEvent{At: reset.Add(time.Minute)})
+	m = next.(Model)
+	if m.usageLimit.isVisible() {
+		t.Error("expected banner to self-clear once now passes reset")
+	}
+	if m.usageLimit.Height() != 0 {
+		t.Errorf("expected usageLimit.Height()=0 after self-clear, got %d", m.usageLimit.Height())
+	}
+}
+
+// TestUpdateLayout_ClaudeUsageLimitBannerHeightBudget verifies that the
+// layout height invariant holds when the usage-limit banner is visible
+// (banner takes 1 row) — mirrors TestUpdateLayout_AlertBannerHeightBudget.
+func TestUpdateLayout_ClaudeUsageLimitBannerHeightBudget(t *testing.T) {
+	redirectHistory(t)
+
+	const termWidth = 80
+	const termHeight = 24
+
+	m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+	m.usageLimit.active = true
+	m.usageLimit.reset = time.Now().Add(time.Hour)
+	m.usageLimit.now = time.Now()
+
+	if !m.usageLimit.isVisible() {
+		t.Fatal("precondition: usage-limit banner should be visible")
+	}
+	if m.usageLimit.Height() != 1 {
+		t.Fatalf("precondition: usageLimit Height() = %d, want 1", m.usageLimit.Height())
+	}
+
+	// Apply window size — triggers updateLayout.
+	next, _ := m.Update(tea.WindowSizeMsg{Width: termWidth, Height: termHeight})
+	m = next.(Model)
+
+	got := lipgloss.Height(m.View())
+	if got != termHeight {
+		t.Errorf("with usage-limit banner visible: View() height = %d, want %d (height budget not accounting for banner)", got, termHeight)
 	}
 }
 

--- a/tui/usage_limit_banner.go
+++ b/tui/usage_limit_banner.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ClaudeUsageLimitBannerComponent renders a single high-visibility row while
+// Claude dispatch is suspended account-wide after a usage-limit hit
+// (ADR-1120). It implements the Component interface and mirrors
+// AlertBannerComponent's shape, but is fully independent — the GitHub
+// rate-limit banner and this one track unrelated conditions and can both be
+// visible at once. Height() returns 1 when the banner is visible and 0
+// otherwise, so the layout budget in model.go is correct.
+type ClaudeUsageLimitBannerComponent struct {
+	active bool
+	reset  time.Time
+	now    time.Time
+}
+
+// isVisible returns true when the banner should be shown: a suspension is
+// active and (when a reset time is known) now hasn't reached it yet. This
+// lets the banner self-clear off the per-second TickEvent fan-out even if no
+// explicit ClaudeUsageLimitAlertEvent{Suspended: false} ever arrives (e.g. no
+// item was up for dispatch during the window) — see ADR-1120 on why this is
+// a harmless cosmetic-only lag relative to the engine's own lazy check.
+func (c ClaudeUsageLimitBannerComponent) isVisible() bool {
+	if !c.active {
+		return false
+	}
+	if !c.reset.IsZero() && !c.now.Before(c.reset) {
+		return false
+	}
+	return true
+}
+
+// Update handles events relevant to the usage-limit banner.
+func (c ClaudeUsageLimitBannerComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case ClaudeUsageLimitAlertEvent:
+		if ev.Suspended {
+			c.active = true
+			c.reset = ev.Reset
+		} else {
+			c.active = false
+			c.reset = time.Time{}
+		}
+	case TickEvent:
+		c.now = ev.At
+	}
+	return c, nil
+}
+
+// Height returns 1 when the banner is visible, 0 otherwise.
+func (c ClaudeUsageLimitBannerComponent) Height() int {
+	if c.isVisible() {
+		return 1
+	}
+	return 0
+}
+
+// View renders the usage-limit banner at the given width.
+func (c ClaudeUsageLimitBannerComponent) View(width int) string {
+	if !c.isVisible() {
+		return ""
+	}
+	text := "⚠ Claude usage limit hit — dispatch suspended."
+	countdown := fmtBannerCountdown(c.reset, c.now)
+	if countdown != "" {
+		text += " " + countdown
+	}
+	// Truncate to a single line so Height() == 1 is always accurate on
+	// narrow terminals where the text would otherwise wrap.
+	if width > 0 && lipgloss.Width(text) > width {
+		runes := []rune(text)
+		for len(runes) > 0 && lipgloss.Width(string(runes)+"…") > width {
+			runes = runes[:len(runes)-1]
+		}
+		text = string(runes) + "…"
+	}
+	return failStyle.Bold(true).Width(width).Render(text)
+}


### PR DESCRIPTION
Closes #1120

## Summary

Once one worker detects a Claude account usage-limit exit, Fabrik now suspends the start of all new Claude invocations account-wide until the parsed (or, if unparseable, a fixed 1-hour fallback) reset time, instead of letting every concurrent worker independently rediscover the same limit and burn its own 5-minute dispatch cooldown. Builds directly on #1119's detection/exemption work.

## Key changes

- **`engine/usage_limit_backoff.go`** (new): `parseUsageLimitResetTime`/`computeUsageLimitResetDeadline` parse the CLI's `"10:20pm (America/Edmonton)"`-shaped reset fragment (rolling to the next day when already past), falling back to a 1-hour suspension when unparseable. `Engine.claudeSuspendedUntil` (a single `time.Time`, guarded by a dedicated mutex) is the account-wide suspension state, checked lazily — no ticker — at each Claude invocation site.
- **Three gated/detecting call sites**: `runInvocationWithExtension` (stage runs), `processComments`/`runCommentExtensionLoop` (comment review — also skips the comment circuit breaker on a usage-limit outcome), and `resolveConflictWithClaude` (merge-train inline conflict resolution).
- **Merge-train correctness fix**: `resolveConflictWithClaude` now returns `(bool, error)` instead of a bare `bool`. A usage-limit hit is propagated as a fatal `assembleTrialBranch` error (cleanup + retry next cycle) rather than ejecting the member — previously this would have incorrectly ejected a healthy member just because the account ran dry.
- **TUI**: new `ClaudeUsageLimitAlertEvent` + `ClaudeUsageLimitBannerComponent`, fully independent of the existing GitHub rate-limit banner so both can be visible simultaneously without either clobbering the other's state. Self-clears on tick once the reset time passes.
- **Updated comment copy**: `handleUsageLimitExit`'s explanatory comment no longer says "Fabrik will keep retrying on the normal poll cooldown" — it now describes the account-wide suspension and automatic resume.
- **Docs**: extended `docs/state-machine.md` §7.3, added a "Claude Usage-Limit Suspension" subsection to `docs/USER_GUIDE.md`, regenerated `llms-full.txt`, and added ADR-1120 documenting the design decisions (why gate+detect inline rather than a shared wrapper, the merge-train fatal-error-not-ejection call, the 1-hour fallback choice, the lazy resume-check).

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./engine/... ./tui/...` — 1883 tests pass, including new coverage: reset-time parsing table tests, suspension activate/extend/clear concurrency test, a concurrent-dispatch test asserting exactly one Claude invocation occurs across N concurrent items after suspension activates, a merge-train test asserting a usage-limit hit doesn't eject a member, and TUI banner activation/clear/self-clear-on-tick/layout-height tests
- [ ] Reviewer: confirm the merge-train signature change (`resolveConflictWithClaude` → `(bool, error)`) reads cleanly at its single call site in `assembleTrialBranch`