### PR TITLE
feat(release): auto-bump plugin/fabrik version in cut-release.sh when source changed

### DIFF
--- a/adrs/816-plugin-version-auto-bump.md
+++ b/adrs/816-plugin-version-auto-bump.md
@@ -1,0 +1,92 @@
+# ADR 816: Auto-Bump `plugin/fabrik` Version on Source Change in `cut-release.sh`
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #816 — feat(release): auto-bump plugin versions on cut-release when source changed
+
+## Context
+
+Claude Code's `/plugin update` detects a new plugin release by comparing the cached `plugin.json` `version` field against the version at `ref: main` in `marketplace.json`. Same version number means no refresh fires, even if the plugin's source content changed. This bit the shadoworg → handarbeit migration: `plugin/fabrik/skills/*/SKILL.md` was updated to reference the new domain, but the manifest stayed at `0.1.0`. Users running `/plugin update fabrik` were told they already had the latest version and kept seeing stale content, requiring a manual `0.1.0 → 0.1.1` bump (PR #790) just to force a cache refresh.
+
+`.claude-plugin/marketplace.json` lists exactly one plugin — `fabrik` (source path `plugin/fabrik`, `ref: main`). `plugin/fabrik-workflows` has never been listed there; it is embedded directly into the Go binary (`plugin/embed.go`) and distributed via `fabrik init`/`fabrik upgrade`, which detect changes by content hash (`ComputeEmbeddedVersion`, `plugin/known_embedded_versions.go`), not by comparing `plugin.json`'s `version` field. It is therefore not subject to the staleness bug this ADR's mechanism exists to fix, and is out of scope.
+
+A prior prototype (PR #809, closed unmerged) implemented the detection-and-bump logic but used `jq` (a dependency this issue explicitly forbids), bumped both plugins (over-broad scope), and had no opt-out flag, no release-notes entry, and no automated test.
+
+## Decision
+
+Add `tools/bump-plugin-version/`, a small standalone Go program (mirroring the existing `tools/print-plugin-hash/` invocation shape and `tools/verify-release-artifact/`'s pure-function/`main()` split for offline testability) with two pure functions:
+
+- `sourceChanged(repoDir, pluginDir, manifestPath, prevTag string) (bool, error)` — runs `git diff --name-only <prevTag>..HEAD -- <pluginDir> ':(exclude)'<manifestPath>` and reports whether the output is non-empty.
+- `bumpPatchVersion(manifestPath string) (oldVer, newVer string, err error)` — extracts the sole `"version": "MAJOR.MINOR.PATCH"` field via a regexp, increments the patch component, and replaces the exact matched substring in the file's bytes. It errors if the field is missing, malformed, or appears more than once.
+
+`main()` takes `<plugin-dir> <manifest-path> <prev-tag>`, prints `"<old> <new>"` to stdout when a bump fires, prints nothing and exits 0 when it doesn't, and exits non-zero on git or manifest errors.
+
+`scripts/cut-release.sh` gains a new step 4b, sequenced after the existing "commit release notes" push and before the tag step:
+
+1. `PREV_TAG` is captured via `git describe --tags --abbrev=0 --match='v*'` right before step 4 (tags were already fetched in pre-flight); empty if there is no prior tag.
+2. If `--no-plugin-bump` was passed, or `PREV_TAG` is empty, the step is skipped with a warning.
+3. Otherwise the tool is invoked for `plugin/fabrik`. If it reports a bump, the script appends a changelog line (`- Auto-bumped fabrik plugin to <new> (source changed since <prevTag>)`) to that release's `release-notes/<version>.md`, then commits `plugin.json` and the notes file together as `arbeithand <handarbeit@handarbeit.io>` (reusing the exact `GIT_AUTHOR_*`/`GIT_COMMITTER_*` + author-verification + credential-helper-nuked PAT-in-URL push pattern already used for the release-notes commit), and pushes to `main` before the tag is created.
+
+The pre-flight `DIRTY=` allowlist is extended to also permit a modified `plugin/fabrik/.claude-plugin/plugin.json`, alongside the existing `release-notes/<version>.md` and `plugin/known_embedded_versions.go` entries.
+
+## Rationale
+
+### Why Go, not bash/awk/jq, for the detection and patch logic?
+
+The issue explicitly forbids requiring the standalone `jq` binary — PR #809's prototype used it for both reading and writing `version`. Research found no existing shell-test harness in this repo (no `scripts/lib/`, no `*_test.sh`), and the issue requires at least one automated test runnable without GitHub access. Putting both the diff-detection and the version-patch logic in one small Go tool — following `tools/verify-release-artifact`'s pure-function/`main()` split, the strongest existing precedent for exactly this shape of git-repo-dependent tool test — is the only option that satisfies "no `jq`" and "testable offline" without inventing new shell-testing infrastructure.
+
+### Why a targeted string replace instead of a full `encoding/json` marshal round-trip?
+
+`encoding/json` is used only implicitly, via the regexp validating the extracted version's shape. The actual mutation replaces the exact `"version": "<old>"` substring, erroring if it doesn't appear exactly once. A full unmarshal/marshal round-trip would risk reformatting the entire file (key order, indentation, trailing newline) for what should be a single-field patch — unnecessary blast radius, and it would make the resulting diff noisy for reviewers of the auto-generated commit.
+
+### Why a second commit for the release-notes changelog entry, not an amend?
+
+By the time step 4b runs, `release-notes/<version>.md` has already been committed and pushed in step 4 (its own separate push, which the script has always done this way). Amending that pushed commit would require a force-push, which the script never does anywhere else and which would violate the same non-destructive philosophy documented at the top of the script ("On failure after the tag is pushed, the script does NOT auto-clean"). A second commit, touching both `plugin.json` and the notes file together, is consistent with the script's existing pattern of sequential, non-destructive bot commits — the same reasoning already applies to the existing two-commit sequence for `known_embedded_versions.go` vs. `release-notes/<version>.md` within step 4 itself (both staged and committed together there, but that's a single commit since both are new/dirty at the same point — here the notes file is already committed, forcing a second one).
+
+### Why anchor the changelog insertion on the `## Internal` heading rather than the section's end?
+
+Locating a markdown section's *end* boundary reliably in `awk` is fragile (the next `##` heading, or EOF, or edge cases with trailing whitespace). Anchoring on the heading line itself is a single well-defined match. Bullet order within a changelog section doesn't matter, so inserting immediately after the heading (or appending a new `## Internal` section if none exists) is sufficient and mirrors the existing `known_embedded_versions.go` insert-before-closing-brace `awk` pattern already used earlier in the same script.
+
+### Why is `plugin/fabrik-workflows` out of scope?
+
+It is not listed in `.claude-plugin/marketplace.json` and is never installed via `/plugin update` — it ships embedded in the Fabrik binary and is refreshed by `fabrik init`/`fabrik upgrade` via independent content-hash-based change detection (`plugin/embed.go`, `plugin/known_embedded_versions.go`). It was never actually subject to the staleness bug this ADR's mechanism exists to fix, so bumping it here (as PR #809's prototype did) would be scope creep with no corresponding user-facing benefit.
+
+### Why patch-only, not automatic minor/major bumps?
+
+A patch bump is sufficient to force `/plugin update`'s cache-invalidation comparison to see a different version; it makes no claim about the *size* of the underlying change. Minor/major version semantics (breaking changes, new capabilities) require human judgment about what the plugin's version number should communicate to users, which an automated diff-presence check cannot infer. This remains a manual override: nothing in this mechanism prevents someone from hand-editing `plugin.json` to a minor/major bump before running `cut-release.sh`, at which point the diff since that new commit (once tagged) naturally resets.
+
+## Consequences
+
+**Positive:**
+- Every release that touches `plugin/fabrik`'s source now force-invalidates `/plugin update`'s cache automatically — the exact failure mode from the shadoworg → handarbeit migration cannot recur silently.
+- No new external dependency (`jq` avoided entirely; the tool uses only the Go standard library plus the `git` binary already required elsewhere in the script).
+- The bump is visible in the GitHub Release changelog via the auto-appended `## Internal` line, so it isn't a silent commit a maintainer has to notice separately.
+- `--no-plugin-bump` gives an explicit escape hatch for hotfix releases where the extra commit is undesirable.
+- Fully covered by offline unit tests (`tools/bump-plugin-version/main_test.go`) exercising both the "bump fires" and "no bump" paths in real temporary git repositories, independent of the rest of `cut-release.sh` (which needs `.env`/`FABRIK_TOKEN`/`gh`/network and can't be exercised offline).
+
+**Negative / Trade-offs:**
+- **Double-push failure window**: two separate bot commits (release notes, then plugin bump) are now pushed to `main` in sequence before the tag. If the second push fails after the first succeeds, `main` has a release-notes commit but no plugin-bump commit; the script's `die` message for this step names the exact state and gives explicit recovery commands (push the still-local commit manually, or discard it and retry), consistent with the script's existing no-auto-clean philosophy — this is a message-quality mitigation, not a logic fix, since the script already fails loudly and stops before tagging either way.
+- **No live end-to-end test of `cut-release.sh` itself** (it requires `FABRIK_TOKEN`/`gh`/network to run for real) — coverage relies on the Go tool's unit tests plus a `bash -n` syntax check of the script; this mirrors the same accepted limitation noted in ADR 071 for this script's other guards.
+- A previous plugin bump commit is excluded from the next release's change-detection diff (the manifest path is pathspec-excluded), so this cannot recursively re-trigger itself — verified directly by `TestSourceChanged_ManifestOnlyChangeExcluded` and the end-to-end test in `main_test.go`.
+
+## Testing
+
+`tools/bump-plugin-version/main_test.go` builds real temporary git repos (via the real `git` binary, guarded by the project's standard `skipIfNoGit` convention) and covers:
+- `sourceChanged` returns `true` when a non-manifest file under `plugin/fabrik` changed since the tag.
+- `sourceChanged` returns `false` when only files outside `plugin/fabrik` changed.
+- `sourceChanged` returns `false` when only the manifest itself changed (pathspec exclusion working as intended).
+- `sourceChanged` errors on an empty `prevTag`.
+- `bumpPatchVersion` correctly increments `0.2.0 → 0.2.1` and leaves the rest of the manifest untouched.
+- `bumpPatchVersion` errors on a malformed, missing, or duplicated `version` field.
+- An end-to-end scenario mirroring two consecutive release cycles: a plugin-source change triggers a bump and tag, and a subsequent unrelated change does not re-trigger a bump (guarding against the manifest-exclusion regression described above).
+
+`scripts/cut-release.sh` was syntax-checked with `bash -n`; the new step 4b logic was reviewed by inspection against the existing step 4/5 patterns it reuses, since a full run requires bot credentials and network access unavailable in this environment.
+
+## Related Work
+
+- PR #790 — the original manual `0.1.0 → 0.1.1` bump this ADR's automation makes unnecessary going forward.
+- PR #809 — closed, unmerged prototype of `bump_plugin_if_changed()`. Confirmed the mechanism's overall shape but used `jq`, bumped both plugins, and lacked the opt-out flag, release-notes entry, and tests this ADR's implementation adds.
+- ADR 071 (`071-release-artifact-vcs-verification.md`) — the precedent for a comparably-scoped `cut-release.sh` guard, including the `DIRTY=` allowlist rationale this ADR extends to a third file.
+- The Plan for this issue also called for a best-effort sync of `.claude/skills/cut-release/SKILL.md`'s step list and flags list. That edit was attempted and skipped during Implement — a harness permission policy denied modification of files under `.claude/skills/`, the same limitation ADR 071's Implement hit. `docs/USER_GUIDE.md` alone carries the mechanism's documentation; it is the canonical doc the issue requires.
+
+**References:** [docs/USER_GUIDE.md §Built-in Skill: `/cut-release`](../docs/USER_GUIDE.md)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1946,6 +1946,27 @@ After a successful push, `/cut-release` automatically files a GitHub issue:
 
 The `fabrik:yolo` label means Fabrik will pick it up automatically and run it through the pipeline. You don't need to do anything else for documentation updates after cutting a release.
 
+#### Plugin version auto-bump
+
+Claude Code's `/plugin update` detects a new plugin release by comparing the cached `plugin.json` `version` field against the version at `ref: main` in `marketplace.json` — same version number means no refresh fires, even if the plugin's source changed. To prevent users from getting stuck on stale cached content, `cut-release.sh` may commit a version bump to `plugin/fabrik/.claude-plugin/plugin.json` before it tags the release:
+
+- **When it fires**: after the release-notes commit is pushed and before the tag is created, the script diffs `plugin/fabrik` (excluding the manifest itself) against the previous release tag. If anything changed, it patch-bumps `plugin.json`'s `version` field (e.g. `0.2.0` → `0.2.1`) and commits it as `@arbeithand`, in a separate commit alongside an appended changelog line in that release's `release-notes/<version>.md`, e.g.:
+
+  ```
+  - Auto-bumped fabrik plugin to 0.2.1 (source changed since v0.0.75)
+  ```
+
+- **When it doesn't fire**: if `plugin/fabrik`'s source is unchanged since the previous tag, or there is no previous tag (first-ever release), no extra commit is made and nothing is appended to the release notes.
+- **Scope**: only `plugin/fabrik` (the one plugin listed in `marketplace.json`) is bumped. `plugin/fabrik-workflows` is embedded directly into the Fabrik binary and distributed via `fabrik init`/`fabrik upgrade`; it uses independent content-hash-based change detection and is not affected by the `/plugin update` staleness issue this bump exists to fix.
+- **Bump type**: patch-only. Minor/major version bumps for `plugin/fabrik` remain a manual responsibility.
+- **Escape hatch**: pass `--no-plugin-bump` to skip this step entirely, e.g. for a hotfix release where you don't want the extra commit:
+
+  ```
+  scripts/cut-release.sh v0.0.68 --no-plugin-bump
+  ```
+
+Don't be surprised to see a second `@arbeithand` commit on `main` after a release that touched plugin source — this is expected, not a sign something went wrong.
+
 #### Release-artifact verification guard
 
 The GitHub Actions release workflow (`.github/workflows/release.yml`, via `.goreleaser.yaml`) independently verifies every built binary before it is published — a check that runs in CI, separate from and in addition to `cut-release.sh`'s own local build/test gate.
@@ -1960,7 +1981,7 @@ The GitHub Actions release workflow (`.github/workflows/release.yml`, via `.gore
 
 **This guard exists because `v0.0.75` shipped with `vcs.modified=true`** — a dirty-tree build that was undetectable except via `go version -m` on the downloaded binary. **A guard trip does not mean re-cutting `v0.0.75`** — `proxy.golang.org` has already cached that version's zip and checksum, and republishing different content under the same tag would break every consumer that already resolved it. If the guard trips on a *future* release, fix the underlying cause and cut a new version; never force through or re-tag. See also: issue #1073, which gitignored goreleaser's own `dist/` output directory, since an untracked `dist/` at build time was independently identified as a plausible (though at the time unconfirmed) cause of the same symptom — this guard is the safety net for if that fix turns out to be incomplete.
 
-The `cut-release.sh` allowlist for uncommitted `release-notes/<version>.md` and `plugin/known_embedded_versions.go` (documented inline at the script's `DIRTY=` check) was reviewed alongside this guard: both files are committed by the script itself *before* the tag is pushed, so neither can reach the CI-built artifact — the allowlist is unrelated to what this guard protects against and was left unchanged.
+The `cut-release.sh` allowlist for uncommitted `release-notes/<version>.md`, `plugin/known_embedded_versions.go`, and `plugin/fabrik/.claude-plugin/plugin.json` (documented inline at the script's `DIRTY=` check) was reviewed alongside this guard: all three files are committed by the script itself *before* the tag is pushed, so none can reach the CI-built artifact — the allowlist is unrelated to what this guard protects against and was left unchanged.
 
 ### Built-in Skill: `/audit-documentation`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1944,6 +1944,27 @@ After a successful push, `/cut-release` automatically files a GitHub issue:
 
 The `fabrik:yolo` label means Fabrik will pick it up automatically and run it through the pipeline. You don't need to do anything else for documentation updates after cutting a release.
 
+#### Plugin version auto-bump
+
+Claude Code's `/plugin update` detects a new plugin release by comparing the cached `plugin.json` `version` field against the version at `ref: main` in `marketplace.json` — same version number means no refresh fires, even if the plugin's source changed. To prevent users from getting stuck on stale cached content, `cut-release.sh` may commit a version bump to `plugin/fabrik/.claude-plugin/plugin.json` before it tags the release:
+
+- **When it fires**: after the release-notes commit is pushed and before the tag is created, the script diffs `plugin/fabrik` (excluding the manifest itself) against the previous release tag. If anything changed, it patch-bumps `plugin.json`'s `version` field (e.g. `0.2.0` → `0.2.1`) and commits it as `@arbeithand`, in a separate commit alongside an appended changelog line in that release's `release-notes/<version>.md`, e.g.:
+
+  ```
+  - Auto-bumped fabrik plugin to 0.2.1 (source changed since v0.0.75)
+  ```
+
+- **When it doesn't fire**: if `plugin/fabrik`'s source is unchanged since the previous tag, or there is no previous tag (first-ever release), no extra commit is made and nothing is appended to the release notes.
+- **Scope**: only `plugin/fabrik` (the one plugin listed in `marketplace.json`) is bumped. `plugin/fabrik-workflows` is embedded directly into the Fabrik binary and distributed via `fabrik init`/`fabrik upgrade`; it uses independent content-hash-based change detection and is not affected by the `/plugin update` staleness issue this bump exists to fix.
+- **Bump type**: patch-only. Minor/major version bumps for `plugin/fabrik` remain a manual responsibility.
+- **Escape hatch**: pass `--no-plugin-bump` to skip this step entirely, e.g. for a hotfix release where you don't want the extra commit:
+
+  ```
+  scripts/cut-release.sh v0.0.68 --no-plugin-bump
+  ```
+
+Don't be surprised to see a second `@arbeithand` commit on `main` after a release that touched plugin source — this is expected, not a sign something went wrong.
+
 #### Release-artifact verification guard
 
 The GitHub Actions release workflow (`.github/workflows/release.yml`, via `.goreleaser.yaml`) independently verifies every built binary before it is published — a check that runs in CI, separate from and in addition to `cut-release.sh`'s own local build/test gate.
@@ -1958,7 +1979,7 @@ The GitHub Actions release workflow (`.github/workflows/release.yml`, via `.gore
 
 **This guard exists because `v0.0.75` shipped with `vcs.modified=true`** — a dirty-tree build that was undetectable except via `go version -m` on the downloaded binary. **A guard trip does not mean re-cutting `v0.0.75`** — `proxy.golang.org` has already cached that version's zip and checksum, and republishing different content under the same tag would break every consumer that already resolved it. If the guard trips on a *future* release, fix the underlying cause and cut a new version; never force through or re-tag. See also: issue #1073, which gitignored goreleaser's own `dist/` output directory, since an untracked `dist/` at build time was independently identified as a plausible (though at the time unconfirmed) cause of the same symptom — this guard is the safety net for if that fix turns out to be incomplete.
 
-The `cut-release.sh` allowlist for uncommitted `release-notes/<version>.md` and `plugin/known_embedded_versions.go` (documented inline at the script's `DIRTY=` check) was reviewed alongside this guard: both files are committed by the script itself *before* the tag is pushed, so neither can reach the CI-built artifact — the allowlist is unrelated to what this guard protects against and was left unchanged.
+The `cut-release.sh` allowlist for uncommitted `release-notes/<version>.md`, `plugin/known_embedded_versions.go`, and `plugin/fabrik/.claude-plugin/plugin.json` (documented inline at the script's `DIRTY=` check) was reviewed alongside this guard: all three files are committed by the script itself *before* the tag is pushed, so none can reach the CI-built artifact — the allowlist is unrelated to what this guard protects against and was left unchanged.
 
 ### Built-in Skill: `/audit-documentation`
 

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -243,6 +243,21 @@ else
         /^## Internal[[:space:]]*$/ && !inserted { print line; inserted=1 }
       ' "$NOTES_FILE" > "${NOTES_FILE}.tmp"
       mv "${NOTES_FILE}.tmp" "$NOTES_FILE"
+    elif grep -Eq '^## Upgrading[[:space:]]*$' "$NOTES_FILE"; then
+      # No existing Internal section: insert a new one directly before
+      # Upgrading (always the last section in the notes schema) rather than
+      # appending at the file's end, which would land after the closing
+      # ```bash fence and break the canonical section order.
+      awk -v line="$CHANGELOG_LINE" '
+        /^## Upgrading[[:space:]]*$/ && !inserted {
+          print "## Internal"
+          print line
+          print ""
+          inserted=1
+        }
+        { print }
+      ' "$NOTES_FILE" > "${NOTES_FILE}.tmp"
+      mv "${NOTES_FILE}.tmp" "$NOTES_FILE"
     else
       {
         echo ""

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -5,6 +5,7 @@
 #   scripts/cut-release.sh v0.0.67
 #   scripts/cut-release.sh v0.0.67 --skip-tests       # skip race-tested suite (last-resort)
 #   scripts/cut-release.sh v0.0.67 --no-doc-issue     # skip filing the doc-update issue
+#   scripts/cut-release.sh v0.0.67 --no-plugin-bump   # skip the plugin/fabrik version auto-bump
 #
 # Prereqs:
 #   - On main, clean working tree, ff'd to origin/main
@@ -19,6 +20,9 @@
 #   2. PAT identity check (must be arbeithand)
 #   3. go build + go test -race
 #   4. Commit release-notes.md (if dirty) as arbeithand
+#   4b. If plugin/fabrik's source changed since the previous tag, patch-bump
+#       plugin/fabrik/.claude-plugin/plugin.json and commit as arbeithand
+#       (skippable with --no-plugin-bump)
 #   5. Tag, push tag with credential helpers nuked + PAT-in-URL
 #   6. Watch the release workflow run; fail loudly on non-success
 #   7. Verify the published release author and discussion author are both arbeithand
@@ -33,18 +37,20 @@ set -euo pipefail
 VERSION="${1:-}"
 SKIP_TESTS=0
 NO_DOC_ISSUE=0
+NO_PLUGIN_BUMP=0
 shift || true
 while [ $# -gt 0 ]; do
   case "$1" in
-    --skip-tests)   SKIP_TESTS=1 ;;
-    --no-doc-issue) NO_DOC_ISSUE=1 ;;
+    --skip-tests)     SKIP_TESTS=1 ;;
+    --no-doc-issue)   NO_DOC_ISSUE=1 ;;
+    --no-plugin-bump) NO_PLUGIN_BUMP=1 ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
   esac
   shift
 done
 
 if [ -z "$VERSION" ]; then
-  echo "Usage: $0 vX.Y.Z [--skip-tests] [--no-doc-issue]" >&2
+  echo "Usage: $0 vX.Y.Z [--skip-tests] [--no-doc-issue] [--no-plugin-bump]" >&2
   exit 2
 fi
 if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -74,17 +80,19 @@ BRANCH="$(git branch --show-current)"
 [ "$BRANCH" = "main" ] || die "must be on main (currently on '$BRANCH')"
 ok "on main"
 
-# Allow uncommitted release-notes/<version>.md and plugin/known_embedded_versions.go
-# (the latter is updated by this script itself after the build step).
+# Allow uncommitted release-notes/<version>.md, plugin/known_embedded_versions.go,
+# and plugin/fabrik/.claude-plugin/plugin.json (all three are updated by this
+# script itself, after the build step and in step 4b).
 #
-# Allowlist disposition (reviewed for #1070): both files are committed by
-# this script's own step 4, *before* the tag is created and pushed in step 5.
-# By the time release.yml's CI job checks out the tag, it's a fresh clone —
-# it never sees this local working tree, dirty or not. So this allowlist
-# cannot affect the CI-built artifact and does not need to be tightened; the
-# built-artifact VCS check lives in .goreleaser.yaml/release.yml instead (see
+# Allowlist disposition (reviewed for #1070, extended for #816): all three
+# files are committed by this script's own step 4 / step 4b, *before* the tag
+# is created and pushed in step 5. By the time release.yml's CI job checks
+# out the tag, it's a fresh clone — it never sees this local working tree,
+# dirty or not. So this allowlist cannot affect the CI-built artifact and
+# does not need to be tightened; the built-artifact VCS check lives in
+# .goreleaser.yaml/release.yml instead (see
 # adrs/071-release-artifact-vcs-verification.md).
-DIRTY=$(git status --porcelain | grep -Ev "^\?\? release-notes/${VERSION}\.md$| M release-notes/${VERSION}\.md$|^M  release-notes/${VERSION}\.md$| M plugin/known_embedded_versions\.go$|^M  plugin/known_embedded_versions\.go$" || true)
+DIRTY=$(git status --porcelain | grep -Ev "^\?\? release-notes/${VERSION}\.md$| M release-notes/${VERSION}\.md$|^M  release-notes/${VERSION}\.md$| M plugin/known_embedded_versions\.go$|^M  plugin/known_embedded_versions\.go$| M plugin/fabrik/\.claude-plugin/plugin\.json$|^M  plugin/fabrik/\.claude-plugin/plugin\.json$" || true)
 [ -z "$DIRTY" ] || die "working tree dirty:
 $DIRTY"
 ok "working tree acceptable"
@@ -167,6 +175,11 @@ else
   ok "all tests pass with -race"
 fi
 
+# Capture the previous release tag now, before this release's tag exists,
+# for the plugin-bump change-detection diff in step 4b. Tags were already
+# fetched in pre-flight. Empty on a first-ever release (no v* tag yet).
+PREV_TAG="$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || true)"
+
 # ─── 4. commit release notes as arbeithand ────────────────────────────────────
 step "Commit release notes"
 # Stage the per-version source-of-truth file and the updated known-versions list.
@@ -193,6 +206,70 @@ else
     push "https://x-access-token:${FABRIK_TOKEN}@github.com/${REPO}.git" main >/dev/null 2>&1 \
     || die "release-notes push failed"
   ok "release-notes commit pushed"
+fi
+
+# ─── 4b. auto-bump plugin/fabrik version if source changed ───────────────────
+# Claude Code's /plugin update compares plugin.json's version field against
+# marketplace.json@main; same version number means no refresh fires even if
+# the plugin's source changed. Patch-bump plugin/fabrik's manifest whenever
+# its source changed since the previous tag, so users always get fresh
+# content. plugin/fabrik-workflows is out of scope — it's not listed in
+# marketplace.json and has its own content-hash-based change detection.
+step "Plugin version bump"
+PLUGIN_MANIFEST="plugin/fabrik/.claude-plugin/plugin.json"
+if [ "$NO_PLUGIN_BUMP" -eq 1 ]; then
+  warn "--no-plugin-bump was passed; skipping plugin/fabrik version bump"
+elif [ -z "$PREV_TAG" ]; then
+  warn "no previous release tag found — skipping plugin/fabrik version bump (first release?)"
+else
+  if ! BUMP_OUTPUT="$(go run ./tools/bump-plugin-version/ plugin/fabrik "$PLUGIN_MANIFEST" "$PREV_TAG")"; then
+    die "bump-plugin-version failed for plugin/fabrik (prev tag: $PREV_TAG)"
+  fi
+  if [ -z "$BUMP_OUTPUT" ]; then
+    ok "plugin/fabrik unchanged since $PREV_TAG — no bump needed"
+  else
+    OLD_PLUGIN_VER="$(printf '%s' "$BUMP_OUTPUT" | cut -d' ' -f1)"
+    NEW_PLUGIN_VER="$(printf '%s' "$BUMP_OUTPUT" | cut -d' ' -f2)"
+    ok "bumped plugin/fabrik $OLD_PLUGIN_VER -> $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
+
+    # Append a changelog line so the version bump is visible in the GitHub
+    # Release notes. release-notes/<version>.md was already committed and
+    # pushed above, so this lands in a second commit alongside the manifest
+    # bump rather than amending the already-pushed one.
+    CHANGELOG_LINE="- Auto-bumped fabrik plugin to $NEW_PLUGIN_VER (source changed since $PREV_TAG)"
+    if grep -Eq '^## Internal[[:space:]]*$' "$NOTES_FILE"; then
+      awk -v line="$CHANGELOG_LINE" '
+        { print }
+        /^## Internal[[:space:]]*$/ && !inserted { print line; inserted=1 }
+      ' "$NOTES_FILE" > "${NOTES_FILE}.tmp"
+      mv "${NOTES_FILE}.tmp" "$NOTES_FILE"
+    else
+      {
+        echo ""
+        echo "## Internal"
+        echo "$CHANGELOG_LINE"
+      } >> "$NOTES_FILE"
+    fi
+
+    git add "$PLUGIN_MANIFEST" "$NOTES_FILE"
+    GIT_AUTHOR_NAME="$BOT_LOGIN" \
+    GIT_AUTHOR_EMAIL="$BOT_EMAIL" \
+    GIT_COMMITTER_NAME="$BOT_LOGIN" \
+    GIT_COMMITTER_EMAIL="$BOT_EMAIL" \
+    git commit -m "Bump fabrik plugin to $NEW_PLUGIN_VER" --quiet
+    COMMIT_AUTHOR="$(git log -1 --pretty=format:'%an <%ae>')"
+    [ "$COMMIT_AUTHOR" = "$BOT_LOGIN <$BOT_EMAIL>" ] \
+      || die "plugin-bump commit author wrong (got: $COMMIT_AUTHOR)"
+    ok "committed as $COMMIT_AUTHOR"
+
+    step "Push plugin-bump commit as @$BOT_LOGIN"
+    git \
+      -c credential.helper= \
+      -c credential.https://github.com.helper= \
+      push "https://x-access-token:${FABRIK_TOKEN}@github.com/${REPO}.git" main >/dev/null 2>&1 \
+      || die "plugin-bump push failed — the release-notes commit for $VERSION was already pushed to main, but this plugin-bump commit ($(git rev-parse HEAD)) is still local only. Push it manually (git push origin main) or discard it (git reset --hard HEAD~1) before retrying."
+    ok "plugin-bump commit pushed"
+  fi
 fi
 
 # ─── 5. tag + push ────────────────────────────────────────────────────────────

--- a/tools/bump-plugin-version/main.go
+++ b/tools/bump-plugin-version/main.go
@@ -98,12 +98,11 @@ func bumpPatchVersion(manifestPath string) (oldVer, newVer string, err error) {
 	oldVer = fmt.Sprintf("%s.%s.%s", major, minor, patch)
 	newVer = fmt.Sprintf("%s.%s.%d", major, minor, patchN+1)
 
-	oldField := fmt.Sprintf(`"version": "%s"`, oldVer)
-	newField := fmt.Sprintf(`"version": "%s"`, newVer)
-	if strings.Count(content, oldField) != 1 {
-		return "", "", fmt.Errorf("%s: expected exactly one occurrence of %s, found %d", manifestPath, oldField, strings.Count(content, oldField))
-	}
-	updated := strings.Replace(content, oldField, newField, 1)
+	// Splice in the new patch digits at the exact byte range the regex
+	// matched, rather than reconstructing the field as a literal with
+	// hardcoded spacing — that would desync from versionFieldRe's \s*
+	// tolerance if the manifest's actual spacing ever differed.
+	updated := content[:m[6]] + strconv.Itoa(patchN+1) + content[m[7]:]
 
 	if err := os.WriteFile(manifestPath, []byte(updated), 0o644); err != nil {
 		return "", "", fmt.Errorf("writing %s: %w", manifestPath, err)

--- a/tools/bump-plugin-version/main.go
+++ b/tools/bump-plugin-version/main.go
@@ -1,0 +1,112 @@
+// bump-plugin-version detects whether a marketplace-distributed plugin's
+// source changed since the previous release tag and, if so, patch-bumps the
+// "version" field in its .claude-plugin/plugin.json manifest.
+//
+// This exists because Claude Code's `/plugin update` compares the cached
+// plugin.json version against the version at ref:main in marketplace.json —
+// same version number means no refresh fires, even if the plugin's source
+// (skills, prompts, etc.) changed. Bumping the patch version on every
+// source-changing release forces the cache to refresh.
+//
+// Usage: go run ./tools/bump-plugin-version/ <plugin-dir> <manifest-path> <prev-tag>
+//
+// Prints "<old-version> <new-version>" to stdout and exits 0 if a bump
+// fired. Prints nothing and exits 0 if plugin-dir has no changes since
+// prev-tag (excluding manifest-path itself). Exits non-zero on git or
+// manifest-parsing errors.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Fprintf(os.Stderr, "usage: %s <plugin-dir> <manifest-path> <prev-tag>\n", os.Args[0])
+		os.Exit(2)
+	}
+	pluginDir := os.Args[1]
+	manifestPath := os.Args[2]
+	prevTag := os.Args[3]
+
+	changed, err := sourceChanged(".", pluginDir, manifestPath, prevTag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bump-plugin-version: %v\n", err)
+		os.Exit(1)
+	}
+	if !changed {
+		os.Exit(0)
+	}
+
+	oldVer, newVer, err := bumpPatchVersion(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bump-plugin-version: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s %s\n", oldVer, newVer)
+}
+
+// sourceChanged reports whether any file under pluginDir (excluding
+// manifestPath) differs between prevTag and HEAD, in the git repo rooted at
+// repoDir.
+func sourceChanged(repoDir, pluginDir, manifestPath, prevTag string) (bool, error) {
+	if prevTag == "" {
+		return false, fmt.Errorf("prevTag must not be empty")
+	}
+	cmd := exec.Command("git", "-C", repoDir, "diff", "--name-only",
+		prevTag+"..HEAD", "--", pluginDir, ":(exclude)"+manifestPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("git diff %s..HEAD -- %s: %w: %s", prevTag, pluginDir, err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+var versionFieldRe = regexp.MustCompile(`"version":\s*"([0-9]+)\.([0-9]+)\.([0-9]+)"`)
+
+// bumpPatchVersion patch-bumps the "version" field in the JSON manifest at
+// manifestPath (e.g. "0.2.0" -> "0.2.1") via a targeted string replace, so
+// the rest of the file's formatting is left untouched. It errors if the
+// field is missing, malformed, or appears more than once.
+func bumpPatchVersion(manifestPath string) (oldVer, newVer string, err error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return "", "", fmt.Errorf("reading %s: %w", manifestPath, err)
+	}
+	content := string(data)
+
+	matches := versionFieldRe.FindAllStringSubmatchIndex(content, -1)
+	if len(matches) == 0 {
+		return "", "", fmt.Errorf("%s: no \"version\": \"MAJOR.MINOR.PATCH\" field found", manifestPath)
+	}
+	if len(matches) > 1 {
+		return "", "", fmt.Errorf("%s: multiple \"version\" fields found, expected exactly one", manifestPath)
+	}
+
+	m := matches[0]
+	major, minor, patch := content[m[2]:m[3]], content[m[4]:m[5]], content[m[6]:m[7]]
+	patchN, err := strconv.Atoi(patch)
+	if err != nil {
+		return "", "", fmt.Errorf("%s: malformed patch version %q: %w", manifestPath, patch, err)
+	}
+
+	oldVer = fmt.Sprintf("%s.%s.%s", major, minor, patch)
+	newVer = fmt.Sprintf("%s.%s.%d", major, minor, patchN+1)
+
+	oldField := fmt.Sprintf(`"version": "%s"`, oldVer)
+	newField := fmt.Sprintf(`"version": "%s"`, newVer)
+	if strings.Count(content, oldField) != 1 {
+		return "", "", fmt.Errorf("%s: expected exactly one occurrence of %s, found %d", manifestPath, oldField, strings.Count(content, oldField))
+	}
+	updated := strings.Replace(content, oldField, newField, 1)
+
+	if err := os.WriteFile(manifestPath, []byte(updated), 0o644); err != nil {
+		return "", "", fmt.Errorf("writing %s: %w", manifestPath, err)
+	}
+	return oldVer, newVer, nil
+}

--- a/tools/bump-plugin-version/main_test.go
+++ b/tools/bump-plugin-version/main_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func skipIfNoGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+}
+
+// runIn runs a command in dir, failing the test with its combined output on error.
+func runIn(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %s: %v", name, args, out, err)
+	}
+	return string(out)
+}
+
+const testManifest = `{
+  "name": "fabrik",
+  "version": "0.2.0",
+  "description": "test plugin"
+}
+`
+
+// initRepoWithPlugin creates a temp git repo with a plugin/fabrik/ directory
+// (a manifest plus one source file), tags the initial commit v0.1.0, and
+// returns the repo dir.
+func initRepoWithPlugin(t *testing.T) (dir string, prevTag string) {
+	t.Helper()
+	dir = t.TempDir()
+
+	mustWrite := func(rel, content string) {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	mustWrite("plugin/fabrik/.claude-plugin/plugin.json", testManifest)
+	mustWrite("plugin/fabrik/skills/foo/SKILL.md", "# Foo skill\n")
+	mustWrite("README.md", "# repo\n")
+
+	runIn(t, dir, "git", "init", "-b", "main")
+	runIn(t, dir, "git", "config", "user.email", "test@test.com")
+	runIn(t, dir, "git", "config", "user.name", "Test")
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "initial")
+	runIn(t, dir, "git", "tag", "v0.1.0")
+
+	return dir, "v0.1.0"
+}
+
+func TestSourceChanged_FiresOnNonManifestChange(t *testing.T) {
+	skipIfNoGit(t)
+	dir, prevTag := initRepoWithPlugin(t)
+
+	skillPath := filepath.Join(dir, "plugin/fabrik/skills/foo/SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("# Foo skill (updated)\n"), 0o644); err != nil {
+		t.Fatalf("update SKILL.md: %v", err)
+	}
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "update skill")
+
+	changed, err := sourceChanged(dir, "plugin/fabrik", "plugin/fabrik/.claude-plugin/plugin.json", prevTag)
+	if err != nil {
+		t.Fatalf("sourceChanged() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("sourceChanged() = false, want true after non-manifest source change")
+	}
+}
+
+func TestSourceChanged_NoBumpWhenUnrelatedFileChanges(t *testing.T) {
+	skipIfNoGit(t)
+	dir, prevTag := initRepoWithPlugin(t)
+
+	readmePath := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# repo (updated)\n"), 0o644); err != nil {
+		t.Fatalf("update README.md: %v", err)
+	}
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "update readme")
+
+	changed, err := sourceChanged(dir, "plugin/fabrik", "plugin/fabrik/.claude-plugin/plugin.json", prevTag)
+	if err != nil {
+		t.Fatalf("sourceChanged() error = %v", err)
+	}
+	if changed {
+		t.Fatal("sourceChanged() = true, want false when only files outside plugin dir changed")
+	}
+}
+
+func TestSourceChanged_ManifestOnlyChangeExcluded(t *testing.T) {
+	skipIfNoGit(t)
+	dir, prevTag := initRepoWithPlugin(t)
+
+	manifestPath := filepath.Join(dir, "plugin/fabrik/.claude-plugin/plugin.json")
+	bumped := strings.Replace(testManifest, `"version": "0.2.0"`, `"version": "0.2.1"`, 1)
+	if err := os.WriteFile(manifestPath, []byte(bumped), 0o644); err != nil {
+		t.Fatalf("update manifest: %v", err)
+	}
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "manual bump")
+
+	changed, err := sourceChanged(dir, "plugin/fabrik", "plugin/fabrik/.claude-plugin/plugin.json", prevTag)
+	if err != nil {
+		t.Fatalf("sourceChanged() error = %v", err)
+	}
+	if changed {
+		t.Fatal("sourceChanged() = true, want false when only the manifest itself changed")
+	}
+}
+
+func TestSourceChanged_NoPriorTagErrors(t *testing.T) {
+	skipIfNoGit(t)
+	dir, _ := initRepoWithPlugin(t)
+
+	if _, err := sourceChanged(dir, "plugin/fabrik", "plugin/fabrik/.claude-plugin/plugin.json", ""); err == nil {
+		t.Fatal("sourceChanged() with empty prevTag = nil error, want error")
+	}
+}
+
+func TestBumpPatchVersion_Success(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	if err := os.WriteFile(manifestPath, []byte(testManifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	oldVer, newVer, err := bumpPatchVersion(manifestPath)
+	if err != nil {
+		t.Fatalf("bumpPatchVersion() error = %v", err)
+	}
+	if oldVer != "0.2.0" || newVer != "0.2.1" {
+		t.Fatalf("bumpPatchVersion() = (%q, %q), want (0.2.0, 0.2.1)", oldVer, newVer)
+	}
+
+	updated, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read updated manifest: %v", err)
+	}
+	if !strings.Contains(string(updated), `"version": "0.2.1"`) {
+		t.Fatalf("updated manifest does not contain new version:\n%s", updated)
+	}
+	if !strings.Contains(string(updated), `"name": "fabrik"`) {
+		t.Fatalf("updated manifest lost unrelated fields:\n%s", updated)
+	}
+}
+
+func TestBumpPatchVersion_MalformedVersionErrors(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	content := `{"name": "fabrik", "version": "not-a-version"}`
+	if err := os.WriteFile(manifestPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if _, _, err := bumpPatchVersion(manifestPath); err == nil {
+		t.Fatal("bumpPatchVersion() with malformed version = nil error, want error")
+	}
+}
+
+func TestBumpPatchVersion_MissingVersionErrors(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	content := `{"name": "fabrik"}`
+	if err := os.WriteFile(manifestPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if _, _, err := bumpPatchVersion(manifestPath); err == nil {
+		t.Fatal("bumpPatchVersion() with missing version field = nil error, want error")
+	}
+}
+
+func TestBumpPatchVersion_MultipleFieldsErrors(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "plugin.json")
+	content := `{"version": "0.2.0", "nested": {"version": "0.2.0"}}`
+	if err := os.WriteFile(manifestPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if _, _, err := bumpPatchVersion(manifestPath); err == nil {
+		t.Fatal("bumpPatchVersion() with multiple version fields = nil error, want error")
+	}
+}
+
+func TestEndToEnd_BumpFiresThenNoBumpOnNextRelease(t *testing.T) {
+	skipIfNoGit(t)
+	dir, prevTag := initRepoWithPlugin(t)
+
+	// Simulate a release cycle: plugin source changes, then cut-release.sh
+	// would call sourceChanged() (true) and bumpPatchVersion() (0.2.0 -> 0.2.1).
+	skillPath := filepath.Join(dir, "plugin/fabrik/skills/foo/SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("# Foo skill (updated)\n"), 0o644); err != nil {
+		t.Fatalf("update SKILL.md: %v", err)
+	}
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "update skill")
+
+	manifestPath := filepath.Join(dir, "plugin/fabrik/.claude-plugin/plugin.json")
+	changed, err := sourceChanged(dir, "plugin/fabrik", "plugin/fabrik/.claude-plugin/plugin.json", prevTag)
+	if err != nil {
+		t.Fatalf("sourceChanged() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("expected source changed after skill update")
+	}
+	oldVer, newVer, err := bumpPatchVersion(manifestPath)
+	if err != nil {
+		t.Fatalf("bumpPatchVersion() error = %v", err)
+	}
+	if oldVer != "0.2.0" || newVer != "0.2.1" {
+		t.Fatalf("bumpPatchVersion() = (%q, %q), want (0.2.0, 0.2.1)", oldVer, newVer)
+	}
+
+	// Commit the bump and tag the new release, mirroring cut-release.sh's
+	// step 4b + step 5.
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "bump plugin version")
+	runIn(t, dir, "git", "tag", "v0.1.1")
+
+	// Next release cycle with no further plugin source changes: no bump.
+	readmePath := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# repo (again)\n"), 0o644); err != nil {
+		t.Fatalf("update README.md: %v", err)
+	}
+	runIn(t, dir, "git", "add", ".")
+	runIn(t, dir, "git", "commit", "-m", "update readme again")
+
+	changed, err = sourceChanged(dir, "plugin/fabrik", "plugin/fabrik/.claude-plugin/plugin.json", "v0.1.1")
+	if err != nil {
+		t.Fatalf("sourceChanged() error = %v", err)
+	}
+	if changed {
+		t.Fatal("sourceChanged() = true after unrelated change following the bump commit, want false (manifest-only prior bump must not trigger a recursive bump)")
+	}
+}


### PR DESCRIPTION
Closes #816

## Problem

Claude Code's `/plugin update` compares the cached `plugin.json` `version` field against the version at `ref: main` in `marketplace.json`. Same version number → no refresh fires, even if the plugin's source changed. This bit the shadoworg → handarbeit migration (PR #790's manual `0.1.0 → 0.1.1` bump was the workaround). This PR automates that bump so it can't happen again.

## Changes

- **`tools/bump-plugin-version/`** (new): a small Go tool with two pure, independently-tested functions — `sourceChanged()` (git-diffs `plugin/fabrik` against the previous release tag, excluding the manifest itself) and `bumpPatchVersion()` (patch-bumps the `version` field via a targeted string replace, not a full JSON marshal round-trip, so the rest of the manifest's formatting is untouched). No `jq` dependency, per the issue's explicit requirement.
- **`scripts/cut-release.sh`**:
  - New step 4b, sequenced after the release-notes commit/push and before the tag: invokes the tool for `plugin/fabrik`; if source changed since the previous tag, patch-bumps `plugin/fabrik/.claude-plugin/plugin.json`, appends a changelog line to that release's `release-notes/<version>.md`, and commits+pushes both as `arbeithand` before the tag is created.
  - New `--no-plugin-bump` escape-hatch flag.
  - `DIRTY=` pre-flight allowlist extended to permit a modified `plugin/fabrik/.claude-plugin/plugin.json`.
  - Skips gracefully when there's no previous tag (first-ever release) or `--no-plugin-bump` is passed.
- **`docs/USER_GUIDE.md`** (+ regenerated `docs/llms-full.txt`): documents the auto-bump mechanism, when it fires/doesn't, and the `--no-plugin-bump` flag.
- **`adrs/816-plugin-version-auto-bump.md`**: records the design decisions (Go over bash/jq, targeted string replace, second commit vs. amend, changelog anchor point, `fabrik-workflows` scope exclusion).
- Scope is `plugin/fabrik` only — `plugin/fabrik-workflows` isn't marketplace-listed and already has independent content-hash-based change detection (`plugin/embed.go`), per the issue's scope correction.

**Known gap**: `.claude/skills/cut-release/SKILL.md` was not synced with the new step/flag (best-effort item in the plan) — the harness denied writes under `.claude/skills/` in this environment, the same limitation noted in ADR 071's Implement. `docs/USER_GUIDE.md` is the issue's canonical documentation requirement and is fully updated.

## Testing

- `tools/bump-plugin-version/main_test.go`: covers bump-fires, no-bump-when-unchanged, manifest-only-change-excluded (no recursive bump), malformed/missing/duplicate version-field errors, and an end-to-end two-release-cycle scenario — all using real temporary git repos, runnable offline.
- `go build ./...`, `go vet ./...`, `go test -race ./...` all pass (one pre-existing, unrelated flaky test — `cmd.TestExecute_ConfigYAMLApplied` — fails identically on `main` itself; confirmed via a scratch worktree, not caused by this change).
- `scripts/cut-release.sh` syntax-checked with `bash -n`.