### PR TITLE
feat(pruefer): add terminal UI (bubbletea), modelled on Fabrik's tui package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /fabrik
 /print-plugin-hash
 /pruefer
+!/pruefer/
 .pruefer/pruefer.lock
 .pruefer/pruefer.log
 .pruefer/logs/

--- a/adrs/1114-pruefer-tui-architecture.md
+++ b/adrs/1114-pruefer-tui-architecture.md
@@ -1,0 +1,70 @@
+# ADR 1114: Pruefer Terminal UI Architecture
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #1114 — terminal UI (bubbletea), modelled on Fabrik's `tui/` package
+
+## Context
+
+Pruefer's V1 core (#1113) runs headless: it polls watched repos, invokes `claude`, and submits comment-only PR reviews, emitting structured log lines. That's enough to be useful but opaque while running — no at-a-glance view of which repos are being watched, which PRs are in flight, what a review cost, or why a PR was skipped. The V1 ADR explicitly scoped a TUI out as a follow-up; this ADR records that follow-up's structural decisions.
+
+The requirement is to feel like the same family of tool as Fabrik's own engine TUI (`tui/`) — same stack (`bubbletea`/`bubbles`/`lipgloss`), same model/update/view split — while keeping headless operation fully supported and behaviorally identical to TUI-on, and without introducing a Go import from `pruefer/` into `engine/`/`itemstate`/`boardcache` (the constraint ADR-1113 already established).
+
+## Decisions
+
+### 1. New `pruefer/tui` package, not a shared import of Fabrik's `tui/`
+
+Fabrik's `tui/` styles and helpers (`dimStyle`, `borderStyle`, `fmtDuration`, …) are unexported package-level values — "reuse the pattern" necessarily means duplicating a small set of lipgloss styles and format helpers, not importing them. `pruefer/tui/styles.go` and the per-pane components (`header.go`, `repos.go`, `active.go`, `history.go`, `detail.go`, `footer.go`, `model.go`) mirror Fabrik's `tui/` structure file-for-file where a direct analogue exists. This follows the same precedent as `pruefer/procattr_unix.go` duplicating `engine/procattr_unix.go` (ADR-1113 Decision 6): small, stable code is cheaper to duplicate than to extract into a shared package for one caller. Extracting genuinely shared code, if it emerges, is an explicit follow-up per the issue — not part of this change.
+
+### 2. Event emission wraps `ReviewPR` from `poll()`, not inside it
+
+`Daemon.poll`'s dispatch goroutine already has everything an observer needs — the review's start time and the full `ReviewOutcome` returned by `ReviewPR` — so `ReviewStartedEvent`/`ReviewCompletedEvent` are emitted immediately before and after the existing `ReviewPR` call, entirely from `poll()` (`pruefer/daemon.go`). **`ReviewPR`'s signature, control flow, and return shape are untouched.** This was chosen deliberately over emitting from inside `ReviewPR` (or wrapping/altering its decision branches) because it makes the issue's "no behaviour coupling" requirement close to structurally guaranteed rather than a matter of careful discipline: there is no code path inside `ReviewPR` that can observe, and therefore no code path that can accidentally depend on, whether a TUI is attached.
+
+### 3. `Daemon.Emit func(ptui.Event)`, nil-checked at every call site
+
+Pruefer has no access to Fabrik's `itemstate.Store` pub/sub observer machinery (ADR-1113's "no shared Go imports with `engine`" constraint rules it out), so the daemon-side hook is a single field — `Daemon.Emit func(ptui.Event)` — checked through a private `d.emit(ev)` helper that is a true no-op when `Emit == nil`. This is the direct analogue of `engine.Engine`'s `e.events == nil` sentinel (`engine/engine.go`), reused here without the observer-store machinery, since `poll()` is the sole place events originate and Fabrik's dual-store fan-out has no counterpart to build. `-notui` operation therefore costs one nil check per event site — the same "zero-cost/no-op-safe when disabled" property the issue requires.
+
+### 4. Per-repo poll status: one `RepoPollEvent` per repo per cycle, combining timestamp + count + error
+
+The spec's first open question — what "poll status" means per watched repo — is resolved as: last-poll timestamp, PR count found, and last error, combined into a single event emitted at the existing `ListOpenPRs` call site inside `poll()`'s per-repo loop (`pruefer/daemon.go`). No new API calls: all three fields are already locally available at that call site (the timestamp is taken immediately before the call; the count and error come from its return value).
+
+### 5. Completed-review retention: bounded in-memory ring buffer (last 200), not persisted
+
+The spec's second open question — retention window for "recently completed reviews" — is resolved as an in-memory ring buffer capped at 200 entries (`pruefer/tui/history.go`), evicting oldest-first. This is a **deliberate divergence** from Fabrik's own `tui/history.go`, which is unbounded and persists to `.fabrik/history.json`. Rationale: Pruefer is a long-running daemon (weeks/months between restarts), not an interactively-restarted CLI — unbounded+persisted history would grow without limit and requires new disk I/O this issue doesn't otherwise need. A capped in-memory buffer keeps the "recently completed" view useful (last ~200 reviews is ample for a live dashboard) without either concern. Restarting Pruefer clears history, matching the session-scoped nature of Decision 6 below.
+
+### 6. Session-total cost/turns: in-memory, reset on restart, accumulated in the footer
+
+The spec's third open question — whether the session aggregate persists across restarts — is resolved as in-memory-only, reset on every daemon restart, matching Fabrik's own session-scoped TUI state. Fabrik's TUI has no existing footer/header precedent for this (confirmed in Research: only a per-entry `HistoryEntry.CostUSD`, summed ad hoc in one test), so `pruefer/tui/footer.go`'s running total was designed fresh — accumulated from each `ReviewCompletedEvent` and displayed alongside the rate-limit gauge, consistent with where Fabrik places session-adjacent gauges without copying a component that doesn't exist.
+
+### 7. Rate-limit surfacing via an optional interface, not a required one
+
+Adding `RateLimitStats() (rest, graphql gh.RateLimitStats)` directly to `GitHubLister`/`GitHubReviewer` would force every existing test fake to implement a method it has no use for. Instead, `pruefer/daemon.go` defines a narrow `RateLimitReporter` interface and type-asserts `d.Client.(RateLimitReporter)` once per poll cycle; `*github.Client` satisfies it in production, and test fakes are unaffected unless they choose to implement it (in which case they simply emit no `RateLimitSnapshotEvent` — correct behavior, not a gap). The event carries the `rest` return value only, never `graphql` — Pruefer issues only REST calls (`ListOpenPRs`, `FetchPRDiff`, `FetchPRReviews`, `SubmitPRReview`), so surfacing `graphql` (Fabrik's own footer convention, since the engine is GraphQL-heavy) would always render a zero/empty gauge for Pruefer.
+
+### 8. Turn/cost capture: `ClaudeInvoker.Review` returns `ReviewResult`, not a bare string
+
+`pruefer/claude.go`'s `claudeReviewResponse` previously carried only `Result`/`IsError`. This issue adds `NumTurns`/`CostUSD` (JSON keys `num_turns`/`total_cost_usd`, matching `engine/claude.go`'s equivalent parsing), and both of `parseClaudeReviewJSON`'s parse paths — the single-JSON-object case and the NDJSON-envelope-loop case — copy them through explicitly (the two-path parser is exactly where Fabrik's own equivalent function has had to get this right before; both paths are covered by tests to guard against one path regressing silently). `ClaudeInvoker.Review`'s signature changes from `(string, error)` to `(ReviewResult, error)`, where `ReviewResult{Text, NumTurns, CostUSD}` — an additive, mechanical change: `ReviewPR` swaps `reviewText` for `result.Text` and copies the two new fields into `ReviewOutcome`, which itself gains `NumTurns`/`CostUSD` fields (zero value = "no data", consistent with `ReviewOutcome`'s existing zero-value conventions).
+
+### 9. No TUI-driven review trigger
+
+Confirms the spec's default assumption: the existing `/pruefer review` GitHub-comment path (`pruefer/comment.go`) already covers on-demand review. The TUI is observe-only; it has no keybinding or code path that can initiate, retry, or cancel a review.
+
+## Consequences
+
+**Positive:**
+- `ReviewPR`'s decision logic is provably untouched by TUI wiring — event emission is bolted on from the outside in `poll()`, not threaded through the function whose behavior "no behaviour coupling" protects.
+- `-notui` is a true zero-cost path: every event site is a single nil-check away from being a no-op, mirroring `engine.Engine`'s own sentinel idiom.
+- Rate-limit and turn/cost surfacing required no new instrumentation beyond what the issue explicitly asked for (`github.Client.RateLimitStats()` already existed; `claude.go` parsing was the one genuinely new piece).
+
+**Negative / Trade-offs:**
+- `pruefer/tui` duplicates a non-trivial amount of structure from Fabrik's `tui/` (styles, `Component` interface, header/detail/footer shapes). Two copies to keep conceptually in sync if either evolves, accepted per Decision 1's rationale and the issue's explicit "extraction is a follow-up" scoping.
+- Completed-review history and the session-total cost/turn count are both lost on every daemon restart (Decisions 5 and 6) — a deliberate trade against unbounded growth and new disk I/O, but it means a long-running daemon's "session total" resets more often than an operator might expect from the name.
+- `ClaudeInvoker.Review`'s signature change is a breaking change to the interface, requiring every caller and test mock in `pruefer/` to update in the same change set (compile-time enforced, not a runtime risk, but a wider diff than a purely additive change would have been).
+
+## Related Work
+
+- `adrs/1113-pruefer-v1-architecture.md` — establishes the "no shared Go imports with `engine`" constraint this ADR's Decisions 2, 3, and 7 all work within, and the duplication-over-extraction precedent Decision 1 follows.
+- `tui/` (`model.go`, `header.go`, `active.go`, `history.go`, `detail.go`, `footer.go`, `component.go`, `events.go`) — the structural pattern `pruefer/tui` mirrors.
+- `engine/engine.go`'s `Engine.SetEvents`/`e.events == nil` — the nil-channel-as-no-op idiom `Daemon.Emit`/`d.emit` reuses.
+- `engine/claude.go`'s `claudeResponse`/`tokenUsageFromResponse` — the turn/cost parsing shape `pruefer/claude.go`'s `claudeReviewResponse`/`ReviewResult` mirrors.
+
+**References:** [cmd/pruefer/README.md](../cmd/pruefer/README.md)

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -33,3 +33,4 @@ contributors and future maintainers.
 | [073](073-outbound-bot-mention-neutralization.md) | Outbound Bot-Mention Neutralization | Accepted |
 | [1089](1089-comment-processing-circuit-breaker.md) | Comment-Processing Circuit Breaker | Accepted |
 | [1113](1113-pruefer-v1-architecture.md) | Pruefer V1 architecture (GitHub App identity, review-state, defaults) | Accepted |
+| [1114](1114-pruefer-tui-architecture.md) | Pruefer terminal UI architecture (event plumbing, retention, rate-limit surfacing) | Accepted |

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -81,6 +81,20 @@ Pruefer loads `.env` (via the same `godotenv`-based loader Fabrik uses), reads `
 
 A lock file at `.pruefer/pruefer.lock` prevents two instances from polling the same working directory concurrently.
 
+## Terminal UI
+
+When run with a real terminal attached (both stdin and stdout), Pruefer launches an interactive TUI by default — the same `bubbletea`/`bubbles`/`lipgloss` stack and model/update/view structure as Fabrik's own `tui/` package, so the two feel like the same family of tool. It shows:
+
+- Watched repositories, each with its last poll time, PR count found, and last error (if any).
+- PRs currently under review, with elapsed time since the review started.
+- Recently completed reviews (last 200, in-memory — not persisted across restarts): repo, PR, outcome (reviewed / skipped / errored), turns, cost, and duration.
+- Skipped PRs with their reason, covering every skip category Pruefer tracks (draft, self-authored, excluded author/label/path, already reviewed at this head SHA, diff too large).
+- Errors, plus GitHub REST API rate-limit state and a running session-total cost/turn count.
+
+Keyboard: `q` or `ctrl+c` to quit, `tab` to switch panes, `↑`/`↓` or `j`/`k` to scroll and select an entry, `enter` to view its detail.
+
+The TUI is purely observational — it never changes which PRs get reviewed, when, or how. Running with `-notui` disables it entirely and falls back to Pruefer's existing structured `logf`-based console output, with **identical review behavior** either way. Use `-notui` (or `PRUEFER_TUI=0` / `tui: false` in the YAML config) when running under systemd, tmux with no attached TTY, or any other non-interactive environment.
+
 ## On-demand re-review
 
 Comment `/pruefer review` on any watched PR to force a fresh review of the current head, even if that SHA was already reviewed. Pruefer acknowledges the command with a 👀 reaction when it picks it up and a 🚀 reaction once the review has been submitted — the same idempotency convention Fabrik uses for its own comment processing.
@@ -105,12 +119,12 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 | `--github-app-private-key-path` | `PRUEFER_GITHUB_APP_PRIVATE_KEY_PATH` | `github_app_private_key_path` | `.pruefer/app-private-key.pem` | |
 | `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (auto-discover) | Required if the App has more than one installation |
 | `--config` | `PRUEFER_CONFIG` | — | `.pruefer/config.yaml` | Path to the YAML config file itself |
+| `-notui` | `PRUEFER_TUI` | `tui` | `true` | Set `-notui` / `PRUEFER_TUI=0` / `tui: false` to disable the interactive TUI and fall back to console logging. The TUI is further gated on a real terminal being detected on both stdin and stdout, regardless of this setting. |
 
 Draft PRs are always skipped — there is no configuration flag to include them in V1.
 
 ## Out of scope for V1
 
-- A TUI (follow-up issue).
 - `APPROVE` / `REQUEST_CHANGES` verdicts.
 - Inline line-level review comments (top-level comment body only).
 - Non-GitHub forges.

--- a/pruefer/claude.go
+++ b/pruefer/claude.go
@@ -70,7 +70,17 @@ type ReviewRequest struct {
 // engine.ClaudeInvoker — no stages.Stage, no gh.ProjectItem — since Pruefer
 // has no board/stage concept.
 type ClaudeInvoker interface {
-	Review(ctx context.Context, req ReviewRequest) (reviewText string, err error)
+	Review(ctx context.Context, req ReviewRequest) (ReviewResult, error)
+}
+
+// ReviewResult carries a completed review invocation's output text plus the
+// turn/cost instrumentation the TUI's cost-visibility requirement depends
+// on, mirroring engine/claude.go's TokenUsage capture (NumTurns/CostUSD
+// parsed from claude's stream-json "result" envelope).
+type ReviewResult struct {
+	Text     string
+	NumTurns int
+	CostUSD  float64
 }
 
 // RealClaudeInvoker invokes the real claude CLI via exec.CommandContext,
@@ -169,10 +179,13 @@ func (w *activityWriter) Write(p []byte) (int, error) {
 }
 
 // claudeReviewResponse mirrors the subset of claude --output-format
-// stream-json's final result object that Pruefer needs.
+// stream-json's final result object that Pruefer needs. NumTurns/CostUSD
+// mirror engine/claude.go's claudeResponse fields of the same JSON keys.
 type claudeReviewResponse struct {
-	Result  string `json:"result"`
-	IsError bool   `json:"is_error"`
+	Result   string  `json:"result"`
+	IsError  bool    `json:"is_error"`
+	NumTurns int     `json:"num_turns"`
+	CostUSD  float64 `json:"total_cost_usd"`
 }
 
 // parseClaudeReviewJSON parses claude's NDJSON stream output, handling both
@@ -190,14 +203,16 @@ func parseClaudeReviewJSON(output []byte) (claudeReviewResponse, bool) {
 			continue
 		}
 		var envelope struct {
-			Type    string `json:"type"`
-			Result  string `json:"result"`
-			IsError bool   `json:"is_error"`
+			Type     string  `json:"type"`
+			Result   string  `json:"result"`
+			IsError  bool    `json:"is_error"`
+			NumTurns int     `json:"num_turns"`
+			CostUSD  float64 `json:"total_cost_usd"`
 		}
 		if err := json.Unmarshal(line, &envelope); err != nil || envelope.Type != "result" {
 			continue
 		}
-		r := claudeReviewResponse{Result: envelope.Result, IsError: envelope.IsError}
+		r := claudeReviewResponse{Result: envelope.Result, IsError: envelope.IsError, NumTurns: envelope.NumTurns, CostUSD: envelope.CostUSD}
 		lastResult = &r
 	}
 	if lastResult != nil {
@@ -207,11 +222,12 @@ func parseClaudeReviewJSON(output []byte) (claudeReviewResponse, bool) {
 }
 
 // Review invokes the claude CLI once, in req.WorkDir, and returns its review
-// text. On any failure — process error, timeout, unparseable output, or an
-// is_error response — it returns a non-nil error and an empty string.
-// Per the issue's "on invocation failure, post nothing" requirement,
-// callers must not submit a review when err != nil.
-func (r *RealClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (string, error) {
+// text plus turn/cost instrumentation. On any failure — process error,
+// timeout, unparseable output, or an is_error response — it returns a
+// non-nil error and a zero-value ReviewResult. Per the issue's "on
+// invocation failure, post nothing" requirement, callers must not submit a
+// review when err != nil.
+func (r *RealClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (ReviewResult, error) {
 	logf(req.PRNumber, "claude", "reviewing %s/%s#%d (head %s) in %s\n", req.Owner, req.Repo, req.PRNumber, req.HeadSHA, req.WorkDir)
 
 	stageCtx := ctx
@@ -255,7 +271,7 @@ func (r *RealClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (stri
 
 	if err := cmd.Start(); err != nil {
 		watchdogCancel()
-		return "", fmt.Errorf("starting claude: %w", err)
+		return ReviewResult{}, fmt.Errorf("starting claude: %w", err)
 	}
 	pid := cmd.Process.Pid
 
@@ -288,18 +304,18 @@ func (r *RealClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (stri
 	}
 
 	if runErr != nil {
-		return "", fmt.Errorf("claude exited with error: %w", runErr)
+		return ReviewResult{}, fmt.Errorf("claude exited with error: %w", runErr)
 	}
 
 	resp, ok := parseClaudeReviewJSON(bytes.TrimSpace(stdout.Bytes()))
 	if !ok {
-		return "", fmt.Errorf("could not parse claude output (%d bytes)", stdout.Len())
+		return ReviewResult{}, fmt.Errorf("could not parse claude output (%d bytes)", stdout.Len())
 	}
 	if resp.IsError {
-		return "", fmt.Errorf("claude reported an error: %s", resp.Result)
+		return ReviewResult{}, fmt.Errorf("claude reported an error: %s", resp.Result)
 	}
 	if strings.TrimSpace(resp.Result) == "" {
-		return "", fmt.Errorf("claude produced an empty review")
+		return ReviewResult{}, fmt.Errorf("claude produced an empty review")
 	}
-	return resp.Result, nil
+	return ReviewResult{Text: resp.Result, NumTurns: resp.NumTurns, CostUSD: resp.CostUSD}, nil
 }

--- a/pruefer/claude_test.go
+++ b/pruefer/claude_test.go
@@ -136,19 +136,25 @@ func writeFakeClaude(t *testing.T, script string) {
 }
 
 func TestRealClaudeInvoker_Review_Success(t *testing.T) {
-	writeFakeClaude(t, `printf '%s\n' '{"type":"result","result":"Found one bug: nil check missing on line 12.","is_error":false}'`+"\n")
+	writeFakeClaude(t, `printf '%s\n' '{"type":"result","result":"Found one bug: nil check missing on line 12.","is_error":false,"num_turns":7,"total_cost_usd":0.1234}'`+"\n")
 
 	r := &RealClaudeInvoker{}
 	workDir := t.TempDir()
-	text, err := r.Review(context.Background(), ReviewRequest{
+	result, err := r.Review(context.Background(), ReviewRequest{
 		Owner: "handarbeit", Repo: "fabrik", PRNumber: 1, Title: "Fix bug",
 		HeadSHA: "abc123", WorkDir: workDir,
 	})
 	if err != nil {
 		t.Fatalf("Review: %v", err)
 	}
-	if text != "Found one bug: nil check missing on line 12." {
-		t.Errorf("text = %q", text)
+	if result.Text != "Found one bug: nil check missing on line 12." {
+		t.Errorf("Text = %q", result.Text)
+	}
+	if result.NumTurns != 7 {
+		t.Errorf("NumTurns = %d, want 7", result.NumTurns)
+	}
+	if result.CostUSD != 0.1234 {
+		t.Errorf("CostUSD = %v, want 0.1234", result.CostUSD)
 	}
 }
 
@@ -236,12 +242,12 @@ func TestRealClaudeInvoker_Review_ContextCancelKillsProcess(t *testing.T) {
 func TestMockClaudeInvoker_RecordsCalls(t *testing.T) {
 	m := &mockClaudeInvoker{}
 	req := ReviewRequest{PRNumber: 7}
-	text, err := m.Review(context.Background(), req)
+	result, err := m.Review(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Review: %v", err)
 	}
-	if text != "mock review" {
-		t.Errorf("text = %q, want default mock review text", text)
+	if result.Text != "mock review" {
+		t.Errorf("Text = %q, want default mock review text", result.Text)
 	}
 	if m.callCount() != 1 {
 		t.Errorf("callCount = %d, want 1", m.callCount())

--- a/pruefer/claude_test.go
+++ b/pruefer/claude_test.go
@@ -102,13 +102,19 @@ func TestParseClaudeReviewJSON_SingleObject(t *testing.T) {
 func TestParseClaudeReviewJSON_ConversationArray(t *testing.T) {
 	stream := `{"type":"system","subtype":"init"}
 {"type":"assistant","message":{"content":[{"type":"text","text":"thinking..."}]}}
-{"type":"result","result":"final review text","is_error":false}`
+{"type":"result","result":"final review text","is_error":false,"num_turns":4,"total_cost_usd":0.0567}`
 	resp, ok := parseClaudeReviewJSON([]byte(stream))
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
 	if resp.Result != "final review text" {
 		t.Errorf("Result = %q", resp.Result)
+	}
+	if resp.NumTurns != 4 {
+		t.Errorf("NumTurns = %d, want 4 (NDJSON envelope path must carry turns through)", resp.NumTurns)
+	}
+	if resp.CostUSD != 0.0567 {
+		t.Errorf("CostUSD = %v, want 0.0567 (NDJSON envelope path must carry cost through)", resp.CostUSD)
 	}
 }
 

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -47,6 +47,12 @@ type Config struct {
 	ExcludedPaths   []string // glob patterns; a PR is skipped only if ALL touched paths match
 	ExcludedLabels  []string // a PR is skipped if ANY label matches
 
+	// TUI controls whether Execute launches the bubbletea dashboard. Default
+	// true; -notui / PRUEFER_TUI=0 / config.yaml's `tui: false` disable it,
+	// mirroring cmd/root.go's --notui/FABRIK_TUI convention. Execute further
+	// gates this on a real terminal being detected (see tui_run.go's useTUI).
+	TUI bool
+
 	AppID             int64
 	AppPrivateKeyPath string
 	// AppInstallationID pins Pruefer to a single installation. Zero means
@@ -71,6 +77,7 @@ type yamlConfig struct {
 	AppID             *int64   `yaml:"github_app_id"`
 	AppPrivateKeyPath string   `yaml:"github_app_private_key_path"`
 	AppInstallationID *int64   `yaml:"github_app_installation_id"`
+	TUI               *bool    `yaml:"tui"`
 }
 
 // loadYAMLConfig reads path, returning a zero-value yamlConfig (no error) if
@@ -106,6 +113,7 @@ type flagValues struct {
 	appPrivateKeyPath string
 	appInstallationID int64
 	configPath        string
+	noTUI             bool
 }
 
 // LoadConfig resolves Pruefer's configuration from, in increasing priority:
@@ -131,6 +139,7 @@ func LoadConfig(args []string) (Config, error) {
 	fs.StringVar(&fv.appPrivateKeyPath, "github-app-private-key-path", "", "Path to the GitHub App's PEM private key")
 	fs.Int64Var(&fv.appInstallationID, "github-app-installation-id", 0, "GitHub App installation ID (0 = auto-discover)")
 	fs.StringVar(&fv.configPath, "config", DefaultConfigPath, "Path to Pruefer's YAML config file")
+	fs.BoolVar(&fv.noTUI, "notui", false, "Disable the interactive TUI dashboard (default: enabled when a real terminal is detected)")
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
 	}
@@ -161,6 +170,10 @@ func LoadConfig(args []string) (Config, error) {
 		ExcludedPaths:     yc.ExcludedPaths,
 		ExcludedLabels:    yc.ExcludedLabels,
 		AppPrivateKeyPath: DefaultPrivateKeyPath,
+		TUI:               true,
+	}
+	if yc.TUI != nil {
+		cfg.TUI = *yc.TUI
 	}
 	if yc.PollIntervalSec != nil {
 		cfg.PollInterval = time.Duration(*yc.PollIntervalSec) * time.Second
@@ -231,6 +244,9 @@ func LoadConfig(args []string) (Config, error) {
 	if explicit["github-app-installation-id"] {
 		cfg.AppInstallationID = fv.appInstallationID
 	}
+	if explicit["notui"] {
+		cfg.TUI = !fv.noTUI
+	}
 
 	return cfg, nil
 }
@@ -287,6 +303,11 @@ func applyEnv(cfg *Config) {
 	if v := os.Getenv("PRUEFER_GITHUB_APP_INSTALLATION_ID"); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
 			cfg.AppInstallationID = n
+		}
+	}
+	if v := os.Getenv("PRUEFER_TUI"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.TUI = b
 		}
 	}
 }

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -32,12 +32,12 @@ const (
 // applying the flag > env > YAML file > default precedence chain in
 // LoadConfig.
 type Config struct {
-	WatchedRepos    []string // "owner/repo"
-	PollInterval    time.Duration
-	Model           string
-	Effort          string
-	ConcurrencyCap  int
-	MaxDiffBytes    int64
+	WatchedRepos   []string // "owner/repo"
+	PollInterval   time.Duration
+	Model          string
+	Effort         string
+	ConcurrencyCap int
+	MaxDiffBytes   int64
 	// MaxWallTime caps a single claude review invocation's wall-clock
 	// duration. Zero means no cap (only the fixed 15-minute inactivity
 	// watchdog applies), matching Fabrik's own stage `max_wall_time`

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -46,6 +46,42 @@ func TestLoadConfig_DefaultsWhenNothingSet(t *testing.T) {
 	if len(cfg.WatchedRepos) != 0 {
 		t.Errorf("WatchedRepos = %v, want empty", cfg.WatchedRepos)
 	}
+	if !cfg.TUI {
+		t.Errorf("TUI = false, want true (default on)")
+	}
+}
+
+func TestLoadConfig_TUIPrecedence(t *testing.T) {
+	dir := t.TempDir()
+
+	// YAML can disable it.
+	path := writeYAMLConfig(t, dir, `tui: false`)
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.TUI {
+		t.Errorf("TUI = true, want false (from YAML)")
+	}
+
+	// Env overrides YAML.
+	t.Setenv("PRUEFER_TUI", "true")
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.TUI {
+		t.Errorf("TUI = false, want true (env should override YAML)")
+	}
+
+	// -notui flag overrides env.
+	cfg, err = LoadConfig([]string{"-config", path, "-notui"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.TUI {
+		t.Errorf("TUI = true, want false (-notui flag should override env)")
+	}
 }
 
 func TestLoadConfig_YAMLOverridesDefaults(t *testing.T) {

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
+	ptui "github.com/handarbeit/fabrik/pruefer/tui"
 )
 
 // GitHubLister is the subset of *github.Client's methods Daemon needs
@@ -18,6 +19,17 @@ import (
 type GitHubLister interface {
 	GitHubReviewer
 	ListOpenPRs(owner, repo string) ([]gh.PRDetails, error)
+}
+
+// RateLimitReporter is an optional interface implemented by *github.Client:
+// type-asserted against Daemon.Client once per poll cycle so the TUI can
+// surface REST API rate-limit state. Deliberately separate from
+// GitHubLister/GitHubReviewer — adding this method there would force every
+// test fake to implement it; fakes that don't simply emit no
+// RateLimitSnapshotEvent, which is correct (there is no rate-limit data to
+// show).
+type RateLimitReporter interface {
+	RateLimitStats() (rest, graphql gh.RateLimitStats)
 }
 
 // Daemon polls Pruefer's configured repos and dispatches eligible PRs to
@@ -34,6 +46,21 @@ type Daemon struct {
 	// FabrikDir is the directory containing .pruefer/pruefer.lock. Defaults
 	// to "." (cwd) when empty.
 	FabrikDir string
+
+	// Emit, when non-nil, receives TUI observability events for poll cycles,
+	// in-flight reviews, and outcomes. nil (the default) is a true no-op —
+	// mirroring engine.Engine's events-channel-nil idiom — so headless
+	// (-notui) operation incurs zero overhead and is never coupled to
+	// ReviewPR's decision logic: every emit call here wraps ReviewPR from
+	// the outside, never alters its inputs, return value, or control flow.
+	Emit func(ptui.Event)
+}
+
+// emit is a nil-checked convenience wrapper around d.Emit.
+func (d *Daemon) emit(ev ptui.Event) {
+	if d.Emit != nil {
+		d.Emit(ev)
+	}
 }
 
 func (d *Daemon) lockPath() string {
@@ -112,11 +139,15 @@ func (d *Daemon) poll(ctx context.Context) {
 			logf(0, "warn", "skipping malformed watched repo %q (want owner/repo)\n", repoSpec)
 			continue
 		}
+		repoName := owner + "/" + repo
+		pollAt := time.Now()
 		prs, err := d.Client.ListOpenPRs(owner, repo)
 		if err != nil {
 			logf(0, "warn", "listing open PRs for %s/%s: %v — skipping this repo this cycle\n", owner, repo, err)
+			d.emit(ptui.RepoPollEvent{Repo: repoName, At: pollAt, Err: err.Error()})
 			continue
 		}
+		d.emit(ptui.RepoPollEvent{Repo: repoName, At: pollAt, PRCount: len(prs)})
 		for _, pr := range prs {
 			pr := pr
 			wg.Add(1)
@@ -129,14 +160,31 @@ func (d *Daemon) poll(ctx context.Context) {
 			go func() {
 				defer wg.Done()
 				defer func() { <-sem }()
+				startedAt := time.Now()
+				d.emit(ptui.ReviewStartedEvent{Repo: repoName, PRNumber: pr.Number, Title: pr.Title, StartedAt: startedAt})
 				outcome := ReviewPR(ctx, d.Client, d.Claude, d.Clone, d.Config, d.BotLogin, owner, repo, pr)
 				if outcome.Err != nil {
 					logf(pr.Number, "warn", "reviewing %s/%s#%d: %v\n", owner, repo, pr.Number, outcome.Err)
 				}
+				errText := ""
+				if outcome.Err != nil {
+					errText = outcome.Err.Error()
+				}
+				d.emit(ptui.ReviewCompletedEvent{
+					Repo: repoName, PRNumber: pr.Number, Title: pr.Title,
+					Reviewed: outcome.Reviewed, Skipped: outcome.Skipped, Reason: string(outcome.Reason),
+					Err: errText, NumTurns: outcome.NumTurns, CostUSD: outcome.CostUSD,
+					Duration: time.Since(startedAt), CompletedAt: time.Now(),
+				})
 			}()
 		}
 	}
 	wg.Wait()
+
+	if reporter, ok := d.Client.(RateLimitReporter); ok {
+		rest, _ := reporter.RateLimitStats()
+		d.emit(ptui.RateLimitSnapshotEvent{Stats: rest})
+	}
 }
 
 // splitOwnerRepo splits "owner/repo" into its two parts. Returns ok=false

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
+	ptui "github.com/handarbeit/fabrik/pruefer/tui"
 )
 
 // fakeLister extends fakeReviewer with ListOpenPRs, keyed by "owner/repo".
@@ -203,6 +204,69 @@ func TestDaemonPoll_ContinuesAfterOneRepoListFails(t *testing.T) {
 
 	if client.submitCallCount() != 1 {
 		t.Errorf("expected the good repo's PR to still be reviewed despite the broken repo failing, got %d submissions", client.submitCallCount())
+	}
+}
+
+// buildParityFixture returns a fresh Daemon (with the given Emit hook) plus
+// its client/claude fakes, seeded with a fixed mix of PRs: one eligible for
+// review, one skipped as draft, and one that fails to clone (a genuine
+// error). Used by TestDaemonPoll_TUIOffAndOnProduceIdenticalDecisions to
+// build two independent runs from an identical starting fixture.
+func buildParityFixture(t *testing.T, emit func(ptui.Event)) (*Daemon, *fakeLister, *mockClaudeInvoker) {
+	t.Helper()
+	client := newFakeLister()
+	client.prsByRepo["owner/repo"] = []gh.PRDetails{
+		{Number: 1, Author: "alice", HeadSHA: "sha1"},
+		{Number: 2, Author: "alice", HeadSHA: "sha2", Draft: true},
+	}
+	claude := &mockClaudeInvoker{}
+	clone, _ := fakeClone(t, nil)
+	d := &Daemon{
+		Client:   client,
+		Claude:   claude,
+		Clone:    clone,
+		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 3},
+		BotLogin: "pruefer-bot[bot]",
+		Emit:     emit,
+	}
+	return d, client, claude
+}
+
+// TestDaemonPoll_TUIOffAndOnProduceIdenticalDecisions asserts the issue's
+// core "no behaviour coupling" requirement: running poll() with Daemon.Emit
+// nil (TUI-off/headless) versus set to a recorder (TUI-on) must produce
+// identical review decisions — same submit count, same claude invocation
+// count — for the same inputs. The TUI-on run must also actually observe
+// events, proving the wiring is exercised rather than trivially satisfied by
+// both runs doing nothing.
+func TestDaemonPoll_TUIOffAndOnProduceIdenticalDecisions(t *testing.T) {
+	dOff, clientOff, claudeOff := buildParityFixture(t, nil)
+	dOff.poll(context.Background())
+
+	var mu sync.Mutex
+	var events []ptui.Event
+	dOn, clientOn, claudeOn := buildParityFixture(t, func(ev ptui.Event) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	})
+	dOn.poll(context.Background())
+
+	if clientOff.submitCallCount() != 1 {
+		t.Fatalf("TUI-off: submitCallCount() = %d, want 1 (only the non-draft PR reviewed)", clientOff.submitCallCount())
+	}
+	if clientOn.submitCallCount() != clientOff.submitCallCount() {
+		t.Errorf("submitCallCount mismatch: TUI-off=%d, TUI-on=%d, want equal", clientOff.submitCallCount(), clientOn.submitCallCount())
+	}
+	if claudeOn.callCount() != claudeOff.callCount() {
+		t.Errorf("claude callCount mismatch: TUI-off=%d, TUI-on=%d, want equal", claudeOff.callCount(), claudeOn.callCount())
+	}
+
+	mu.Lock()
+	n := len(events)
+	mu.Unlock()
+	if n == 0 {
+		t.Error("TUI-on run emitted no events — Emit wiring is not actually exercised by this test")
 	}
 }
 

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -51,7 +51,7 @@ func newConcurrencyTrackingInvoker() *concurrencyTrackingInvoker {
 	return &concurrencyTrackingInvoker{release: make(chan struct{})}
 }
 
-func (c *concurrencyTrackingInvoker) Review(ctx context.Context, req ReviewRequest) (string, error) {
+func (c *concurrencyTrackingInvoker) Review(ctx context.Context, req ReviewRequest) (ReviewResult, error) {
 	c.mu.Lock()
 	c.current++
 	if c.current > c.maxSeen {
@@ -64,7 +64,7 @@ func (c *concurrencyTrackingInvoker) Review(ctx context.Context, req ReviewReque
 	c.mu.Lock()
 	c.current--
 	c.mu.Unlock()
-	return "reviewed", nil
+	return ReviewResult{Text: "reviewed"}, nil
 }
 
 func (c *concurrencyTrackingInvoker) currentCount() int {

--- a/pruefer/execute.go
+++ b/pruefer/execute.go
@@ -15,7 +15,11 @@ import (
 // bootstraps GitHub App auth, constructs the GitHub client and Daemon, and
 // runs until interrupted (SIGINT/SIGTERM). Mirrors cmd.Execute()'s shape
 // for the main fabrik binary (see cmd/root.go), scaled down to Pruefer's
-// needs — no board/stage machinery, no TUI.
+// needs — no board/stage machinery. The interactive TUI is enabled by
+// default when a real terminal is detected (see useTUI); -notui or a
+// non-interactive environment (systemd/tmux with no TTY) falls back to
+// Pruefer's existing logf-based structured logging with identical review
+// behavior.
 func Execute() error {
 	if err := config.LoadDotenv(); err != nil {
 		return fmt.Errorf("loading .env: %w", err)
@@ -52,6 +56,10 @@ func Execute() error {
 		Clone:    CloneForReview,
 		Config:   cfg,
 		BotLogin: auth.BotLogin,
+	}
+
+	if useTUI(cfg) {
+		return runTUI(ctx, daemon)
 	}
 	return daemon.Run(ctx)
 }

--- a/pruefer/mocks_test.go
+++ b/pruefer/mocks_test.go
@@ -10,11 +10,11 @@ import (
 // mutex-protected call log, safe for use from concurrent tests.
 type mockClaudeInvoker struct {
 	mu    sync.Mutex
-	fn    func(req ReviewRequest) (string, error)
+	fn    func(req ReviewRequest) (ReviewResult, error)
 	calls []ReviewRequest
 }
 
-func (m *mockClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (string, error) {
+func (m *mockClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (ReviewResult, error) {
 	m.mu.Lock()
 	m.calls = append(m.calls, req)
 	fn := m.fn
@@ -22,7 +22,7 @@ func (m *mockClaudeInvoker) Review(ctx context.Context, req ReviewRequest) (stri
 	if fn != nil {
 		return fn(req)
 	}
-	return "mock review", nil
+	return ReviewResult{Text: "mock review"}, nil
 }
 
 func (m *mockClaudeInvoker) callCount() int {

--- a/pruefer/review.go
+++ b/pruefer/review.go
@@ -34,6 +34,8 @@ type ReviewOutcome struct {
 	Skipped  bool       // true iff the PR was ineligible
 	Reason   SkipReason // set iff Skipped
 	Err      error      // non-nil on a genuine failure (clone, claude invocation, API call)
+	NumTurns int        // set iff Reviewed; turns used by the claude invocation
+	CostUSD  float64    // set iff Reviewed; cost of the claude invocation
 }
 
 // ReviewPR runs the full per-PR pipeline: on-demand-comment detection,
@@ -100,7 +102,7 @@ func ReviewPR(ctx context.Context, client GitHubReviewer, claude ClaudeInvoker, 
 	}
 	defer cleanup()
 
-	reviewText, err := claude.Review(ctx, ReviewRequest{
+	result, err := claude.Review(ctx, ReviewRequest{
 		Owner: owner, Repo: repo, PRNumber: pr.Number, Title: pr.Title, Body: pr.Body,
 		HeadSHA: pr.HeadSHA, BaseBranch: pr.BaseRef, Model: cfg.Model, Effort: cfg.Effort,
 		WorkDir: dir, MaxWallTime: cfg.MaxWallTime,
@@ -110,7 +112,7 @@ func ReviewPR(ctx context.Context, client GitHubReviewer, claude ClaudeInvoker, 
 		return ReviewOutcome{Err: fmt.Errorf("claude review invocation: %w", err)}
 	}
 
-	if _, err := client.SubmitPRReview(owner, repo, pr.Number, pr.HeadSHA, reviewText); err != nil {
+	if _, err := client.SubmitPRReview(owner, repo, pr.Number, pr.HeadSHA, result.Text); err != nil {
 		return ReviewOutcome{Err: fmt.Errorf("submitting review: %w", err)}
 	}
 
@@ -121,5 +123,5 @@ func ReviewPR(ctx context.Context, client GitHubReviewer, claude ClaudeInvoker, 
 	}
 
 	logf(pr.Number, "review", "submitted review for %s/%s#%d at %s\n", owner, repo, pr.Number, pr.HeadSHA)
-	return ReviewOutcome{Reviewed: true}
+	return ReviewOutcome{Reviewed: true, NumTurns: result.NumTurns, CostUSD: result.CostUSD}
 }

--- a/pruefer/review_test.go
+++ b/pruefer/review_test.go
@@ -97,8 +97,8 @@ func newFakeReviewer() *fakeReviewer {
 
 func TestReviewPR_EligiblePR_SubmitsExactlyOneReview(t *testing.T) {
 	client := newFakeReviewer()
-	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (string, error) {
-		return "Looks fine, one nit.", nil
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (ReviewResult, error) {
+		return ReviewResult{Text: "Looks fine, one nit.", NumTurns: 3, CostUSD: 0.05}, nil
 	}}
 	clone, cloneCalls := fakeClone(t, nil)
 
@@ -123,6 +123,9 @@ func TestReviewPR_EligiblePR_SubmitsExactlyOneReview(t *testing.T) {
 	call := client.submitCalls[0]
 	if call.commitSHA != "sha1" || call.body != "Looks fine, one nit." {
 		t.Errorf("submitCall = %+v", call)
+	}
+	if outcome.NumTurns != 3 || outcome.CostUSD != 0.05 {
+		t.Errorf("outcome NumTurns/CostUSD = %d/%v, want 3/0.05", outcome.NumTurns, outcome.CostUSD)
 	}
 }
 
@@ -267,8 +270,8 @@ func TestReviewPR_ExcludedPath_Skipped(t *testing.T) {
 
 func TestReviewPR_ClaudeFailure_PostsNothing(t *testing.T) {
 	client := newFakeReviewer()
-	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (string, error) {
-		return "", fmt.Errorf("claude crashed")
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (ReviewResult, error) {
+		return ReviewResult{}, fmt.Errorf("claude crashed")
 	}}
 	clone, cloneCalls := fakeClone(t, nil)
 

--- a/pruefer/tui/active.go
+++ b/pruefer/tui/active.go
@@ -1,0 +1,162 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// activeReview tracks one in-flight review, mirroring tui/active.go's
+// activeJob shape (StartedAt for elapsed-time display).
+type activeReview struct {
+	Repo      string
+	PRNumber  int
+	Title     string
+	StartedAt time.Time
+}
+
+// activeReviewKey mirrors tui/active.go's activeJobKey pattern: reviews are
+// keyed "owner/repo#N" rather than by repo alone, since Pruefer's single
+// shared concurrency semaphore can run reviews from multiple watched repos
+// at once.
+func activeReviewKey(repo string, prNumber int) string {
+	return fmt.Sprintf("%s#%d", repo, prNumber)
+}
+
+// ActivePaneComponent manages the in-flight-reviews pane.
+type ActivePaneComponent struct {
+	active        map[string]*activeReview
+	idx           int
+	focused       bool
+	spinnerFrames []string
+	spinnerIdx    int
+	now           time.Time
+}
+
+// newActivePaneComponent returns an ActivePaneComponent ready to receive
+// events (its map and spinner frames initialized).
+func newActivePaneComponent() ActivePaneComponent {
+	return ActivePaneComponent{
+		active:        make(map[string]*activeReview),
+		spinnerFrames: []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},
+	}
+}
+
+func (a ActivePaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case TickEvent:
+		a.now = ev.At
+		if len(a.spinnerFrames) > 0 {
+			a.spinnerIdx = (a.spinnerIdx + 1) % len(a.spinnerFrames)
+		}
+
+	case ReviewStartedEvent:
+		if a.active == nil {
+			a.active = make(map[string]*activeReview)
+		}
+		a.active[activeReviewKey(ev.Repo, ev.PRNumber)] = &activeReview{
+			Repo: ev.Repo, PRNumber: ev.PRNumber, Title: ev.Title, StartedAt: ev.StartedAt,
+		}
+
+	case ReviewCompletedEvent:
+		delete(a.active, activeReviewKey(ev.Repo, ev.PRNumber))
+		if keys := a.sortedKeys(); a.idx >= len(keys) && a.idx > 0 {
+			a.idx = len(keys) - 1
+		}
+
+	case tea.KeyMsg:
+		if !a.focused {
+			return a, nil
+		}
+		switch ev.String() {
+		case "up", "k":
+			if a.idx > 0 {
+				a.idx--
+			}
+		case "down", "j":
+			if a.idx < len(a.sortedKeys())-1 {
+				a.idx++
+			}
+		}
+	}
+	return a, nil
+}
+
+func (a ActivePaneComponent) sortedKeys() []string {
+	keys := make([]string, 0, len(a.active))
+	for k := range a.active {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (a ActivePaneComponent) View(width int) string {
+	focusIndicator := " "
+	if a.focused {
+		focusIndicator = "▸"
+	}
+	title := activeStyle.Render(fmt.Sprintf("%s In-Flight Reviews (%d)", focusIndicator, len(a.active)))
+
+	maxWidth := width - 6
+	if maxWidth < 20 {
+		maxWidth = 20
+	}
+	keys := a.sortedKeys()
+	spinner := ""
+	if len(a.spinnerFrames) > 0 {
+		spinner = a.spinnerFrames[a.spinnerIdx]
+	}
+	var lines []string
+	for idx, key := range keys {
+		job := a.active[key]
+		elapsed := fmtDuration(a.now.Sub(job.StartedAt))
+		titleStr := ""
+		if job.Title != "" {
+			titleStr = " " + dimStyle.Render(job.Title)
+		}
+		line := fmt.Sprintf("%s %-30s %s%s", spinner, key, elapsed, titleStr)
+		if runes := []rune(line); len(runes) > maxWidth {
+			line = string(runes[:maxWidth-1]) + "…"
+		}
+		if a.focused && idx == a.idx {
+			line = selectedStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		lines = append(lines, dimStyle.Render("no reviews in flight"))
+	}
+	content := title + "\n" + strings.Join(lines, "\n")
+	return borderStyle.Width(width - 4).Render(content)
+}
+
+func (a ActivePaneComponent) Height() int {
+	n := len(a.active)
+	if n == 0 {
+		n = 1
+	}
+	return n + 3
+}
+
+// SetFocused updates the focused state.
+func (a *ActivePaneComponent) SetFocused(f bool) {
+	a.focused = f
+}
+
+// Selected returns the currently selected in-flight review, or nil if none.
+func (a ActivePaneComponent) Selected() *activeReview {
+	keys := a.sortedKeys()
+	if a.idx < len(keys) {
+		return a.active[keys[a.idx]]
+	}
+	return nil
+}
+
+// Count returns the number of in-flight reviews.
+func (a ActivePaneComponent) Count() int {
+	return len(a.active)
+}

--- a/pruefer/tui/active_test.go
+++ b/pruefer/tui/active_test.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestActivePane_ReviewStartedAddsEntry(t *testing.T) {
+	a := newActivePaneComponent()
+	start := time.Now()
+	comp, _ := a.Update(ReviewStartedEvent{Repo: "handarbeit/fabrik", PRNumber: 5, Title: "fix bug", StartedAt: start})
+	a = comp.(ActivePaneComponent)
+
+	if a.Count() != 1 {
+		t.Fatalf("Count() = %d, want 1", a.Count())
+	}
+	got := a.Selected()
+	if got == nil || got.PRNumber != 5 || got.Repo != "handarbeit/fabrik" {
+		t.Fatalf("Selected() = %+v, want PR #5 on handarbeit/fabrik", got)
+	}
+}
+
+func TestActivePane_ElapsedTimeAdvancesWithTick(t *testing.T) {
+	a := newActivePaneComponent()
+	start := time.Now()
+	comp, _ := a.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 1, StartedAt: start})
+	a = comp.(ActivePaneComponent)
+
+	comp, _ = a.Update(TickEvent{At: start.Add(90 * time.Second)})
+	a = comp.(ActivePaneComponent)
+
+	view := a.View(120)
+	if !strings.Contains(view, "01:30") {
+		t.Errorf("View() does not show elapsed 01:30:\n%s", view)
+	}
+}
+
+func TestActivePane_ReviewCompletedRemovesEntry(t *testing.T) {
+	a := newActivePaneComponent()
+	comp, _ := a.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 1, StartedAt: time.Now()})
+	a = comp.(ActivePaneComponent)
+	comp, _ = a.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 2, StartedAt: time.Now()})
+	a = comp.(ActivePaneComponent)
+	if a.Count() != 2 {
+		t.Fatalf("Count() = %d, want 2", a.Count())
+	}
+
+	comp, _ = a.Update(ReviewCompletedEvent{Repo: "o/r", PRNumber: 1})
+	a = comp.(ActivePaneComponent)
+	if a.Count() != 1 {
+		t.Fatalf("after completion, Count() = %d, want 1", a.Count())
+	}
+	if got := a.Selected(); got == nil || got.PRNumber != 2 {
+		t.Fatalf("remaining entry = %+v, want PR #2", got)
+	}
+}
+
+func TestActivePane_KeyedByRepoAndPRNumber(t *testing.T) {
+	a := newActivePaneComponent()
+	// Same PR number, different repos — must not collide.
+	comp, _ := a.Update(ReviewStartedEvent{Repo: "handarbeit/fabrik", PRNumber: 1, StartedAt: time.Now()})
+	a = comp.(ActivePaneComponent)
+	comp, _ = a.Update(ReviewStartedEvent{Repo: "handarbeit/other", PRNumber: 1, StartedAt: time.Now()})
+	a = comp.(ActivePaneComponent)
+	if a.Count() != 2 {
+		t.Fatalf("Count() = %d, want 2 (distinct repos, same PR number)", a.Count())
+	}
+}
+
+func TestActivePane_UnfocusedIgnoresKeys(t *testing.T) {
+	a := newActivePaneComponent()
+	a.focused = false
+	comp, _ := a.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 1, StartedAt: time.Now()})
+	a = comp.(ActivePaneComponent)
+	comp, _ = a.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 2, StartedAt: time.Now()})
+	a = comp.(ActivePaneComponent)
+
+	comp, _ = a.Update(keyMsg("down"))
+	a = comp.(ActivePaneComponent)
+	if a.idx != 0 {
+		t.Errorf("idx = %d, want 0 (unfocused pane must ignore key events)", a.idx)
+	}
+}
+
+func TestActivePane_EmptyView(t *testing.T) {
+	a := newActivePaneComponent()
+	if !strings.Contains(a.View(80), "no reviews in flight") {
+		t.Errorf("View() = %q, want placeholder text", a.View(80))
+	}
+}

--- a/pruefer/tui/component.go
+++ b/pruefer/tui/component.go
@@ -1,0 +1,12 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Component is the interface implemented by each TUI pane/section. The root
+// Model orchestrates layout and focus; each Component owns its own state
+// and rendering. Mirrors Fabrik's tui/component.go.
+type Component interface {
+	Update(msg tea.Msg) (Component, tea.Cmd)
+	View(width int) string
+	Height() int
+}

--- a/pruefer/tui/detail.go
+++ b/pruefer/tui/detail.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// DetailItem is a union type holding fields needed for detail panel
+// rendering, constructed by the root model from whichever pane is focused —
+// mirrors tui/detail.go's DetailItem.
+type DetailItem struct {
+	Repo        string
+	PRNumber    int
+	Title       string
+	IsActive    bool // true for an in-flight review, false for a completed one
+	Elapsed     time.Duration
+	Duration    time.Duration
+	Reviewed    bool
+	Skipped     bool
+	Reason      string
+	Err         string
+	NumTurns    int
+	CostUSD     float64
+	CompletedAt time.Time
+}
+
+// DetailPanelComponent renders metadata for a selected review. It is a pure
+// view component — Update is a no-op, mirroring tui/detail.go.
+type DetailPanelComponent struct {
+	item      *DetailItem
+	visible   bool
+	lastWidth int
+}
+
+func (d DetailPanelComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	return d, nil
+}
+
+func (d DetailPanelComponent) View(width int) string {
+	if !d.visible || d.item == nil {
+		return ""
+	}
+
+	item := d.item
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Review:  %s", activeReviewKey(item.Repo, item.PRNumber)))
+	if item.Title != "" {
+		lines = append(lines, fmt.Sprintf("Title:   %s", item.Title))
+	}
+
+	if item.IsActive {
+		lines = append(lines, fmt.Sprintf("Elapsed: %s", fmtDuration(item.Elapsed)))
+	} else {
+		status := "reviewed"
+		switch {
+		case item.Err != "":
+			status = "error: " + item.Err
+		case item.Skipped:
+			status = "skipped: " + item.Reason
+		}
+		lines = append(lines, fmt.Sprintf("Status:   %s", status))
+		lines = append(lines, fmt.Sprintf("Duration: %s", fmtDuration(item.Duration)))
+		if item.NumTurns > 0 {
+			lines = append(lines, fmt.Sprintf("Turns:    %d", item.NumTurns))
+		}
+		if item.CostUSD > 0 {
+			lines = append(lines, fmt.Sprintf("Cost:     $%.4f", item.CostUSD))
+		}
+		if !item.CompletedAt.IsZero() {
+			lines = append(lines, fmt.Sprintf("At:       %s", item.CompletedAt.Format("2006-01-02 15:04:05")))
+		}
+	}
+
+	titleLine := dimStyle.Render("Detail") + "  " + dimStyle.Render("[enter] close")
+	content := titleLine + "\n" + strings.Join(lines, "\n")
+	return borderStyle.Width(width - 4).Render(content)
+}
+
+func (d DetailPanelComponent) Height() int {
+	if !d.visible || d.item == nil {
+		return 0
+	}
+	w := d.lastWidth
+	if w == 0 {
+		w = 80
+	}
+	view := d.View(w)
+	if view == "" {
+		return 0
+	}
+	return strings.Count(view, "\n") + 1
+}
+
+// SetItem updates the item displayed in the detail panel.
+func (d *DetailPanelComponent) SetItem(item *DetailItem) {
+	d.item = item
+}
+
+// SetWidth records the terminal width for use in Height() calculations.
+func (d *DetailPanelComponent) SetWidth(w int) {
+	d.lastWidth = w
+}
+
+// SetVisible controls whether the detail panel is shown.
+func (d *DetailPanelComponent) SetVisible(v bool) {
+	d.visible = v
+}
+
+// IsVisible returns whether the detail panel is shown.
+func (d DetailPanelComponent) IsVisible() bool {
+	return d.visible
+}

--- a/pruefer/tui/detail_test.go
+++ b/pruefer/tui/detail_test.go
@@ -1,0 +1,104 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetailPanel_HiddenByDefault(t *testing.T) {
+	var d DetailPanelComponent
+	if d.View(80) != "" {
+		t.Errorf("View() = %q, want empty when not visible", d.View(80))
+	}
+	if d.Height() != 0 {
+		t.Errorf("Height() = %d, want 0 when not visible", d.Height())
+	}
+}
+
+func TestDetailPanel_ActiveReviewShowsElapsed(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetItem(&DetailItem{
+		Repo: "handarbeit/fabrik", PRNumber: 5, Title: "fix bug",
+		IsActive: true, Elapsed: 90 * time.Second,
+	})
+	d.SetVisible(true)
+	d.SetWidth(100)
+
+	view := d.View(100)
+	if !strings.Contains(view, "handarbeit/fabrik#5") {
+		t.Errorf("View() missing review key:\n%s", view)
+	}
+	if !strings.Contains(view, "fix bug") {
+		t.Errorf("View() missing title:\n%s", view)
+	}
+	if !strings.Contains(view, "01:30") {
+		t.Errorf("View() missing elapsed time:\n%s", view)
+	}
+	if d.Height() == 0 {
+		t.Error("Height() = 0, want > 0 when visible with an item")
+	}
+}
+
+func TestDetailPanel_CompletedReviewShowsTurnsCostDuration(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetItem(&DetailItem{
+		Repo: "o/r", PRNumber: 9, Reviewed: true,
+		NumTurns: 8, CostUSD: 1.2345, Duration: 45 * time.Second,
+		CompletedAt: time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC),
+	})
+	d.SetVisible(true)
+	d.SetWidth(100)
+
+	view := d.View(100)
+	for _, want := range []string{"Turns:    8", "$1.2345", "00:45", "2026-07-27"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("View() missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestDetailPanel_SkippedReviewShowsReason(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetItem(&DetailItem{Repo: "o/r", PRNumber: 3, Skipped: true, Reason: "draft"})
+	d.SetVisible(true)
+	d.SetWidth(100)
+
+	if !strings.Contains(d.View(100), "skipped: draft") {
+		t.Errorf("View() missing skip reason:\n%s", d.View(100))
+	}
+}
+
+func TestDetailPanel_ErroredReviewShowsError(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetItem(&DetailItem{Repo: "o/r", PRNumber: 3, Err: "claude review invocation: boom"})
+	d.SetVisible(true)
+	d.SetWidth(100)
+
+	if !strings.Contains(d.View(100), "error: claude review invocation: boom") {
+		t.Errorf("View() missing error text:\n%s", d.View(100))
+	}
+}
+
+func TestDetailPanel_NilItemHidesEvenWhenVisible(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetVisible(true)
+	d.SetItem(nil)
+	if d.View(100) != "" {
+		t.Errorf("View() = %q, want empty when item is nil", d.View(100))
+	}
+}
+
+func TestDetailPanel_UpdateIsNoOp(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetItem(&DetailItem{Repo: "o/r", PRNumber: 1})
+	d.SetVisible(true)
+	comp, cmd := d.Update(TickEvent{At: time.Now()})
+	if cmd != nil {
+		t.Error("Update() returned a non-nil cmd, want nil (pure view component)")
+	}
+	after := comp.(DetailPanelComponent)
+	if after.item.PRNumber != 1 {
+		t.Error("Update() mutated state, want no-op")
+	}
+}

--- a/pruefer/tui/events.go
+++ b/pruefer/tui/events.go
@@ -1,0 +1,79 @@
+// Package tui implements Pruefer's terminal UI, structurally mirroring
+// Fabrik's own tui/ package (event types -> Component tree -> thin wiring
+// layer) without importing it — see adrs/1114-pruefer-tui-architecture.md
+// and adrs/1113-pruefer-v1-architecture.md's "no shared Go imports with
+// engine" constraint, which this package also honors.
+package tui
+
+import (
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// Event is the interface implemented by all typed daemon events.
+type Event interface {
+	tuiEvent()
+}
+
+// RepoPollEvent is emitted once per watched repo per poll cycle, at the
+// existing ListOpenPRs call site — combining last-poll timestamp, PR count
+// found, and last error into one event (Pruefer's "poll status" per repo).
+type RepoPollEvent struct {
+	Repo    string // "owner/repo"
+	At      time.Time
+	PRCount int
+	Err     string // empty means no error
+}
+
+func (RepoPollEvent) tuiEvent() {}
+
+// ReviewStartedEvent is emitted by poll()'s dispatch goroutine just before
+// calling ReviewPR, not from inside ReviewPR itself — ReviewPR's control
+// flow is untouched by TUI wiring.
+type ReviewStartedEvent struct {
+	Repo      string // "owner/repo"
+	PRNumber  int
+	Title     string
+	StartedAt time.Time
+}
+
+func (ReviewStartedEvent) tuiEvent() {}
+
+// ReviewCompletedEvent is emitted by poll()'s dispatch goroutine after
+// ReviewPR returns, carrying the full outcome. Reason is the SkipReason
+// rendered as a string (not the pruefer.SkipReason type) to keep this
+// package free of a dependency on the pruefer package it is imported by.
+type ReviewCompletedEvent struct {
+	Repo        string
+	PRNumber    int
+	Title       string
+	Reviewed    bool
+	Skipped     bool
+	Reason      string // set iff Skipped
+	Err         string // set iff a genuine failure occurred; empty otherwise
+	NumTurns    int
+	CostUSD     float64
+	Duration    time.Duration
+	CompletedAt time.Time
+}
+
+func (ReviewCompletedEvent) tuiEvent() {}
+
+// RateLimitSnapshotEvent is emitted once per poll cycle with the daemon's
+// current REST API rate-limit stats. Pruefer only issues REST calls
+// (ListOpenPRs, FetchPRDiff, FetchPRReviews, SubmitPRReview), so this always
+// carries github.Client.RateLimitStats()'s rest return value, never graphql.
+type RateLimitSnapshotEvent struct {
+	Stats gh.RateLimitStats
+}
+
+func (RateLimitSnapshotEvent) tuiEvent() {}
+
+// TickEvent is emitted once per second by the TUI loop to drive
+// elapsed-time and countdown updates.
+type TickEvent struct {
+	At time.Time
+}
+
+func (TickEvent) tuiEvent() {}

--- a/pruefer/tui/footer.go
+++ b/pruefer/tui/footer.go
@@ -1,0 +1,129 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// FooterComponent renders the bottom status bar: the running session-total
+// cost/turns (accumulated in-memory across every reviewed PR, reset on
+// daemon restart — matching Fabrik's own session-scoped TUI totals, see
+// adrs/1114-pruefer-tui-architecture.md) and the GitHub REST API rate-limit
+// gauge (github.Client.RateLimitStats()'s "rest" return value — Pruefer
+// issues no GraphQL requests, so "graphql" would always read zero).
+type FooterComponent struct {
+	reviewedCount int
+	totalTurns    int
+	totalCostUSD  float64
+	restStats     rateLimitStats
+	now           time.Time
+}
+
+// rateLimitStats mirrors github.RateLimitStats's fields needed for display,
+// avoiding importing the whole github package into this file (events.go
+// already does, for RateLimitSnapshotEvent — this local type just narrows
+// what footer.go itself reads from it).
+type rateLimitStats struct {
+	Limit     int
+	Remaining int
+	Reset     time.Time
+}
+
+func (f FooterComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case TickEvent:
+		f.now = ev.At
+	case ReviewCompletedEvent:
+		if ev.Reviewed {
+			f.reviewedCount++
+			f.totalTurns += ev.NumTurns
+			f.totalCostUSD += ev.CostUSD
+		}
+	case RateLimitSnapshotEvent:
+		f.restStats = rateLimitStats{Limit: ev.Stats.Limit, Remaining: ev.Stats.Remaining, Reset: ev.Stats.Reset}
+	}
+	return f, nil
+}
+
+func (f FooterComponent) View(width int) string {
+	leftPlain := fmt.Sprintf("session: %d reviewed  ·  %d turns  ·  $%.4f", f.reviewedCount, f.totalTurns, f.totalCostUSD)
+	left := dimStyle.Render(leftPlain)
+
+	var right string
+	if f.restStats.Limit > 0 {
+		countdown := fmtRateLimitCountdown(f.restStats.Reset, f.now)
+		plain := fmt.Sprintf("rest %d/%d  %s", f.restStats.Remaining, f.restStats.Limit, countdown)
+		pct := float64(f.restStats.Remaining) / float64(f.restStats.Limit)
+		var style lipgloss.Style
+		switch {
+		case pct > 0.5:
+			style = successStyle
+		case pct > 0.2:
+			style = activeStyle
+		default:
+			style = failStyle
+		}
+		right = style.Render(plain)
+	}
+
+	maxWidth := width - 2
+	if maxWidth < 1 {
+		maxWidth = 1
+	}
+	if right == "" {
+		if lipgloss.Width(left) > maxWidth {
+			runes := []rune(leftPlain)
+			for len(runes) > 0 && lipgloss.Width(dimStyle.Render(string(runes)+"…")) > maxWidth {
+				runes = runes[:len(runes)-1]
+			}
+			left = dimStyle.Render(string(runes) + "…")
+		}
+		return left
+	}
+
+	rightWidth := lipgloss.Width(right)
+	gap := maxWidth - lipgloss.Width(left) - rightWidth
+	if gap < 1 {
+		availLeft := maxWidth - rightWidth - 1
+		if availLeft < 0 {
+			availLeft = 0
+		}
+		runes := []rune(leftPlain)
+		for len(runes) > 0 && lipgloss.Width(dimStyle.Render(string(runes)+"…")) > availLeft {
+			runes = runes[:len(runes)-1]
+		}
+		if len(runes) == 0 {
+			left = ""
+		} else {
+			left = dimStyle.Render(string(runes) + "…")
+		}
+		gap = maxWidth - lipgloss.Width(left) - rightWidth
+		if gap < 0 {
+			gap = 0
+		}
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+func (f FooterComponent) Height() int {
+	return 1
+}
+
+// TotalCostUSD returns the accumulated session-total review cost.
+func (f FooterComponent) TotalCostUSD() float64 {
+	return f.totalCostUSD
+}
+
+// TotalTurns returns the accumulated session-total review turns.
+func (f FooterComponent) TotalTurns() int {
+	return f.totalTurns
+}
+
+// ReviewedCount returns the accumulated session-total number of reviewed PRs.
+func (f FooterComponent) ReviewedCount() int {
+	return f.reviewedCount
+}

--- a/pruefer/tui/footer_test.go
+++ b/pruefer/tui/footer_test.go
@@ -1,0 +1,71 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+func TestFooter_SessionTotalsAccumulateFromReviewedOnly(t *testing.T) {
+	var f FooterComponent
+	comp, _ := f.Update(ReviewCompletedEvent{Reviewed: true, NumTurns: 5, CostUSD: 0.10})
+	f = comp.(FooterComponent)
+	comp, _ = f.Update(ReviewCompletedEvent{Reviewed: true, NumTurns: 3, CostUSD: 0.05})
+	f = comp.(FooterComponent)
+	// Skipped and errored completions must not contribute to the session total.
+	comp, _ = f.Update(ReviewCompletedEvent{Skipped: true, Reason: "draft"})
+	f = comp.(FooterComponent)
+	comp, _ = f.Update(ReviewCompletedEvent{Err: "boom"})
+	f = comp.(FooterComponent)
+
+	if f.ReviewedCount() != 2 {
+		t.Errorf("ReviewedCount() = %d, want 2", f.ReviewedCount())
+	}
+	if f.TotalTurns() != 8 {
+		t.Errorf("TotalTurns() = %d, want 8", f.TotalTurns())
+	}
+	if got, want := f.TotalCostUSD(), 0.15; got < want-1e-9 || got > want+1e-9 {
+		t.Errorf("TotalCostUSD() = %v, want %v", got, want)
+	}
+
+	view := f.View(120)
+	if !strings.Contains(view, "2 reviewed") || !strings.Contains(view, "8 turns") {
+		t.Errorf("View() does not show session totals:\n%s", view)
+	}
+}
+
+func TestFooter_RateLimitGaugeColoring(t *testing.T) {
+	cases := []struct {
+		name             string
+		remaining, limit int
+	}{
+		{"healthy", 800, 1000},
+		{"warning", 300, 1000},
+		{"critical", 50, 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f FooterComponent
+			comp, _ := f.Update(RateLimitSnapshotEvent{Stats: gh.RateLimitStats{
+				Limit: tc.limit, Remaining: tc.remaining, Reset: time.Now().Add(10 * time.Minute),
+			}})
+			f = comp.(FooterComponent)
+			comp, _ = f.Update(TickEvent{At: time.Now()})
+			f = comp.(FooterComponent)
+
+			view := f.View(120)
+			if !strings.Contains(view, "rest") {
+				t.Errorf("View() does not show rest rate-limit gauge:\n%s", view)
+			}
+		})
+	}
+}
+
+func TestFooter_NoRateLimitDataOmitsGauge(t *testing.T) {
+	var f FooterComponent
+	if strings.Contains(f.View(120), "rest") {
+		t.Errorf("View() shows rate-limit gauge before any RateLimitSnapshotEvent:\n%s", f.View(120))
+	}
+}

--- a/pruefer/tui/header.go
+++ b/pruefer/tui/header.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// HeaderComponent renders the top title bar: program name, watched-repo
+// count, and elapsed session time.
+type HeaderComponent struct {
+	repoCount int
+	startedAt time.Time
+	now       time.Time
+}
+
+func (h HeaderComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	if ev, ok := msg.(TickEvent); ok {
+		h.now = ev.At
+	}
+	return h, nil
+}
+
+func (h HeaderComponent) View(width int) string {
+	title := titleStyle.Render("Pruefer")
+	elapsed := fmtDuration(h.now.Sub(h.startedAt))
+	info := dimStyle.Render(fmt.Sprintf("watching %d repo(s)  ·  up %s", h.repoCount, elapsed))
+	return title + "  " + info
+}
+
+func (h HeaderComponent) Height() int {
+	return 1
+}
+
+// SetRepoCount records the number of watched repos, shown in the header.
+func (h *HeaderComponent) SetRepoCount(n int) {
+	h.repoCount = n
+}
+
+// SetStartedAt records the daemon's session start time, used to compute the
+// elapsed-uptime display.
+func (h *HeaderComponent) SetStartedAt(t time.Time) {
+	h.startedAt = t
+	h.now = t
+}

--- a/pruefer/tui/history.go
+++ b/pruefer/tui/history.go
@@ -1,0 +1,209 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// maxHistoryEntries bounds HistoryPaneComponent's in-memory ring buffer.
+// Deliberate divergence from Fabrik's tui/history.go (unbounded, persisted
+// to .fabrik/history.json): Pruefer is a long-running daemon (weeks/months
+// uptime), not an interactively-restarted CLI, so unbounded+persisted
+// history would grow without limit and add disk I/O this package doesn't
+// need — see adrs/1114-pruefer-tui-architecture.md.
+const maxHistoryEntries = 200
+
+// HistoryEntry records one completed ReviewPR outcome — reviewed, skipped,
+// or errored, unified into a single shape (mirroring how Fabrik's own
+// HistoryEntry unifies success/error/blocked-on-input) rather than a
+// separate skip-only pane.
+type HistoryEntry struct {
+	Repo        string
+	PRNumber    int
+	Title       string
+	Reviewed    bool
+	Skipped     bool
+	Reason      string // set iff Skipped; one of pruefer.SkipReason's values
+	Err         string // set iff a genuine failure occurred; empty otherwise
+	NumTurns    int
+	CostUSD     float64
+	Duration    time.Duration
+	CompletedAt time.Time
+}
+
+// HistoryPaneComponent manages the completed-reviews pane: a bounded,
+// in-memory-only ring buffer of the most recent maxHistoryEntries entries.
+type HistoryPaneComponent struct {
+	entries []HistoryEntry // oldest first
+	idx     int             // selection index; 0 = most recent
+	focused bool
+}
+
+func (h HistoryPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case ReviewCompletedEvent:
+		entry := HistoryEntry{
+			Repo:        ev.Repo,
+			PRNumber:    ev.PRNumber,
+			Title:       ev.Title,
+			Reviewed:    ev.Reviewed,
+			Skipped:     ev.Skipped,
+			Reason:      ev.Reason,
+			Err:         ev.Err,
+			NumTurns:    ev.NumTurns,
+			CostUSD:     ev.CostUSD,
+			Duration:    ev.Duration,
+			CompletedAt: ev.CompletedAt,
+		}
+		h.entries = append(h.entries, entry)
+		if len(h.entries) > maxHistoryEntries {
+			h.entries = h.entries[len(h.entries)-maxHistoryEntries:]
+		}
+
+	case tea.KeyMsg:
+		if !h.focused {
+			return h, nil
+		}
+		switch ev.String() {
+		case "up", "k":
+			if h.idx > 0 {
+				h.idx--
+			}
+		case "down", "j":
+			if h.idx < len(h.entries)-1 {
+				h.idx++
+			}
+		}
+	}
+	return h, nil
+}
+
+func (h HistoryPaneComponent) View(width int) string {
+	focusIndicator := " "
+	if h.focused {
+		focusIndicator = "▸"
+	}
+	title := dimStyle.Render(fmt.Sprintf("%s Completed Reviews (%d)", focusIndicator, len(h.entries)))
+
+	maxWidth := width - 6
+	if maxWidth < 20 {
+		maxWidth = 20
+	}
+	var lines []string
+	for i := len(h.entries) - 1; i >= 0; i-- {
+		e := h.entries[i]
+		var status, extra string
+		switch {
+		case e.Err != "":
+			status = failStyle.Render("✗")
+			extra = dimStyle.Render("  " + e.Err)
+		case e.Skipped:
+			status = activeStyle.Render("○")
+			extra = dimStyle.Render("  skipped: " + e.Reason)
+		default:
+			status = successStyle.Render("✓")
+			parts := []string{}
+			if e.NumTurns > 0 {
+				parts = append(parts, fmt.Sprintf("%d turns", e.NumTurns))
+			}
+			if e.CostUSD > 0 {
+				parts = append(parts, fmt.Sprintf("$%.4f", e.CostUSD))
+			}
+			if len(parts) > 0 {
+				extra = dimStyle.Render("  " + strings.Join(parts, " "))
+			}
+		}
+		ts := dimStyle.Render(e.CompletedAt.Format("15:04:05"))
+		dur := fmtDuration(e.Duration)
+		key := activeReviewKey(e.Repo, e.PRNumber)
+		titleStr := ""
+		if e.Title != "" {
+			titleStr = "  " + dimStyle.Render(e.Title)
+		}
+		line := fmt.Sprintf("%s %-24s %s %s%s%s", status, key, ts, dur, extra, titleStr)
+		displayIdx := len(h.entries) - 1 - i
+		if h.focused && displayIdx == h.idx {
+			line = selectedStyle.Render(line)
+		}
+		if runes := []rune(line); len(runes) > maxWidth {
+			line = string(runes[:maxWidth-1]) + "…"
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		lines = append(lines, dimStyle.Render("no completed reviews yet"))
+	}
+
+	// Window the display around the selection so Height() (which caps at
+	// maxDisplayedHistoryRows) always matches what View() actually renders —
+	// mirrors tui/active.go's windowing-with-"… N more" fallback.
+	total := len(lines)
+	if total > maxDisplayedHistoryRows {
+		maxRows := maxDisplayedHistoryRows
+		start := h.idx - maxRows/2
+		if start < 0 {
+			start = 0
+		}
+		if start+maxRows > total {
+			start = total - maxRows
+		}
+		if start > 0 || start+maxRows < total {
+			maxRows--
+		}
+		windowed := lines[start : start+maxRows]
+		if start > 0 || start+maxRows < total {
+			windowed = append(windowed, dimStyle.Render(fmt.Sprintf("  … %d more", total-maxRows)))
+		}
+		lines = windowed
+	}
+
+	content := title + "\n" + strings.Join(lines, "\n")
+	return borderStyle.Width(width - 4).Render(content)
+}
+
+// maxDisplayedHistoryRows caps the number of history rows rendered at once;
+// older entries remain retained (up to maxHistoryEntries) and selectable,
+// just scrolled out of view.
+const maxDisplayedHistoryRows = 10
+
+func (h HistoryPaneComponent) Height() int {
+	n := len(h.entries)
+	if n == 0 {
+		n = 1
+	}
+	if n > maxDisplayedHistoryRows {
+		n = maxDisplayedHistoryRows
+	}
+	return n + 3
+}
+
+// SetFocused updates the focused state.
+func (h *HistoryPaneComponent) SetFocused(f bool) {
+	h.focused = f
+}
+
+// Selected returns the currently selected history entry, or nil if none.
+// Index 0 is the most recently completed review.
+func (h HistoryPaneComponent) Selected() *HistoryEntry {
+	if len(h.entries) == 0 {
+		return nil
+	}
+	realIdx := len(h.entries) - 1 - h.idx
+	if realIdx >= 0 && realIdx < len(h.entries) {
+		return &h.entries[realIdx]
+	}
+	return nil
+}
+
+// Count returns the number of completed-review entries currently retained.
+func (h HistoryPaneComponent) Count() int {
+	return len(h.entries)
+}
+
+// Entries returns the retained history entries, oldest first.
+func (h HistoryPaneComponent) Entries() []HistoryEntry {
+	return h.entries
+}

--- a/pruefer/tui/history.go
+++ b/pruefer/tui/history.go
@@ -38,7 +38,7 @@ type HistoryEntry struct {
 // in-memory-only ring buffer of the most recent maxHistoryEntries entries.
 type HistoryPaneComponent struct {
 	entries []HistoryEntry // oldest first
-	idx     int             // selection index; 0 = most recent
+	idx     int            // selection index; 0 = most recent
 	focused bool
 }
 

--- a/pruefer/tui/history_test.go
+++ b/pruefer/tui/history_test.go
@@ -1,0 +1,158 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// allSkipReasons mirrors pruefer.SkipReason's seven values (as plain
+// strings, since this package cannot import pruefer without creating an
+// import cycle — pruefer imports pruefer/tui).
+var allSkipReasons = []string{
+	"draft",
+	"self-authored: PR author is the review identity",
+	"excluded author",
+	"excluded label",
+	"excluded path: every touched file matches an exclusion glob",
+	"already reviewed at this head SHA",
+	"diff exceeds max_diff_bytes",
+}
+
+func TestHistoryPane_AllSkipReasonsRenderInHistory(t *testing.T) {
+	var h HistoryPaneComponent
+	for i, reason := range allSkipReasons {
+		comp, _ := h.Update(ReviewCompletedEvent{
+			Repo: "handarbeit/fabrik", PRNumber: 100 + i, Skipped: true, Reason: reason,
+			CompletedAt: time.Now(),
+		})
+		h = comp.(HistoryPaneComponent)
+	}
+	if h.Count() != len(allSkipReasons) {
+		t.Fatalf("Count() = %d, want %d", h.Count(), len(allSkipReasons))
+	}
+	view := h.View(120)
+	for _, reason := range allSkipReasons {
+		if !strings.Contains(view, reason) {
+			t.Errorf("View() does not contain skip reason %q:\n%s", reason, view)
+		}
+	}
+}
+
+func TestHistoryPane_ErroredEntryRendersError(t *testing.T) {
+	var h HistoryPaneComponent
+	comp, _ := h.Update(ReviewCompletedEvent{
+		Repo: "handarbeit/fabrik", PRNumber: 42, Err: "cloning PR head: boom",
+		CompletedAt: time.Now(),
+	})
+	h = comp.(HistoryPaneComponent)
+
+	entry := h.Selected()
+	if entry == nil {
+		t.Fatal("Selected() = nil, want the errored entry")
+	}
+	if entry.Err != "cloning PR head: boom" {
+		t.Errorf("Selected().Err = %q, want %q", entry.Err, "cloning PR head: boom")
+	}
+	if !strings.Contains(h.View(120), "boom") {
+		t.Errorf("View() does not render the error text:\n%s", h.View(120))
+	}
+}
+
+func TestHistoryPane_ReviewedEntryRendersTurnsAndCost(t *testing.T) {
+	var h HistoryPaneComponent
+	comp, _ := h.Update(ReviewCompletedEvent{
+		Repo: "handarbeit/fabrik", PRNumber: 7, Reviewed: true,
+		NumTurns: 12, CostUSD: 0.4321, Duration: 90 * time.Second,
+		CompletedAt: time.Now(),
+	})
+	h = comp.(HistoryPaneComponent)
+
+	view := h.View(120)
+	if !strings.Contains(view, "12 turns") {
+		t.Errorf("View() does not render turn count:\n%s", view)
+	}
+	if !strings.Contains(view, "$0.4321") {
+		t.Errorf("View() does not render cost:\n%s", view)
+	}
+}
+
+func TestHistoryPane_RingBufferEvictsOldestAtCapacity(t *testing.T) {
+	var h HistoryPaneComponent
+	for i := 0; i < maxHistoryEntries; i++ {
+		comp, _ := h.Update(ReviewCompletedEvent{
+			Repo: "o/r", PRNumber: i, Reviewed: true, CompletedAt: time.Now(),
+		})
+		h = comp.(HistoryPaneComponent)
+	}
+	if h.Count() != maxHistoryEntries {
+		t.Fatalf("Count() = %d, want %d", h.Count(), maxHistoryEntries)
+	}
+	entries := h.Entries()
+	if entries[0].PRNumber != 0 {
+		t.Fatalf("oldest entry PRNumber = %d, want 0", entries[0].PRNumber)
+	}
+
+	// One more entry pushes total to maxHistoryEntries+1 — the oldest (PR #0)
+	// must be evicted, and the buffer must stay at exactly maxHistoryEntries.
+	comp, _ := h.Update(ReviewCompletedEvent{
+		Repo: "o/r", PRNumber: maxHistoryEntries, Reviewed: true, CompletedAt: time.Now(),
+	})
+	h = comp.(HistoryPaneComponent)
+
+	if h.Count() != maxHistoryEntries {
+		t.Fatalf("after overflow, Count() = %d, want %d", h.Count(), maxHistoryEntries)
+	}
+	entries = h.Entries()
+	if entries[0].PRNumber != 1 {
+		t.Errorf("after overflow, oldest entry PRNumber = %d, want 1 (PR #0 evicted)", entries[0].PRNumber)
+	}
+	if entries[len(entries)-1].PRNumber != maxHistoryEntries {
+		t.Errorf("after overflow, newest entry PRNumber = %d, want %d", entries[len(entries)-1].PRNumber, maxHistoryEntries)
+	}
+}
+
+func TestHistoryPane_SelectedNavigatesWithKeys(t *testing.T) {
+	h := HistoryPaneComponent{focused: true}
+	for i := 0; i < 3; i++ {
+		comp, _ := h.Update(ReviewCompletedEvent{Repo: "o/r", PRNumber: i, Reviewed: true, CompletedAt: time.Now()})
+		h = comp.(HistoryPaneComponent)
+	}
+	// idx 0 = most recently completed (PR #2).
+	if got := h.Selected(); got == nil || got.PRNumber != 2 {
+		t.Fatalf("initial Selected() = %+v, want PR #2", got)
+	}
+	comp, _ := h.Update(keyMsg("down"))
+	h = comp.(HistoryPaneComponent)
+	if got := h.Selected(); got == nil || got.PRNumber != 1 {
+		t.Fatalf("after down, Selected() = %+v, want PR #1", got)
+	}
+	comp, _ = h.Update(keyMsg("up"))
+	h = comp.(HistoryPaneComponent)
+	if got := h.Selected(); got == nil || got.PRNumber != 2 {
+		t.Fatalf("after up, Selected() = %+v, want PR #2", got)
+	}
+}
+
+func TestHistoryPane_UnfocusedIgnoresKeys(t *testing.T) {
+	h := HistoryPaneComponent{focused: false}
+	for i := 0; i < 2; i++ {
+		comp, _ := h.Update(ReviewCompletedEvent{Repo: "o/r", PRNumber: i, Reviewed: true, CompletedAt: time.Now()})
+		h = comp.(HistoryPaneComponent)
+	}
+	comp, _ := h.Update(keyMsg("down"))
+	h = comp.(HistoryPaneComponent)
+	if h.idx != 0 {
+		t.Errorf("idx = %d, want 0 (unfocused pane must ignore key events)", h.idx)
+	}
+}
+
+func TestHistoryPane_EmptyView(t *testing.T) {
+	var h HistoryPaneComponent
+	if !strings.Contains(h.View(80), "no completed reviews yet") {
+		t.Errorf("View() = %q, want placeholder text", h.View(80))
+	}
+	if h.Height() != 4 { // 1 placeholder line + 3
+		t.Errorf("Height() = %d, want 4", h.Height())
+	}
+}

--- a/pruefer/tui/model.go
+++ b/pruefer/tui/model.go
@@ -1,0 +1,246 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// pane identifies which TUI section has focus.
+type pane int
+
+const (
+	paneRepos pane = iota
+	paneActive
+	paneHistory
+)
+
+// Model is the bubbletea TUI model for Pruefer, structurally mirroring
+// Fabrik's tui.Model (model/update/view split, header, detail pane) —
+// see adrs/1114-pruefer-tui-architecture.md.
+type Model struct {
+	width  int
+	height int
+
+	focusPane   pane
+	detailPanel bool
+
+	header  HeaderComponent
+	repos   RepoPaneComponent
+	active  ActivePaneComponent
+	history HistoryPaneComponent
+	detail  DetailPanelComponent
+	footer  FooterComponent
+}
+
+// New creates an initial TUI model. watchedRepos seeds the repos pane so
+// every configured repo is visible ("never polled") before its first
+// RepoPollEvent arrives. startedAt is the daemon's session start time, used
+// for the header's elapsed-uptime display.
+func New(watchedRepos []string, startedAt time.Time) Model {
+	repos := RepoPaneComponent{focused: true}
+	repos.SetWatchedRepos(watchedRepos)
+
+	header := HeaderComponent{}
+	header.SetRepoCount(len(watchedRepos))
+	header.SetStartedAt(startedAt)
+
+	return Model{
+		focusPane: paneRepos,
+		header:    header,
+		repos:     repos,
+		active:    newActivePaneComponent(),
+	}
+}
+
+// Init starts the 1-second tick.
+func (m Model) Init() tea.Cmd {
+	return tickCmd()
+}
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
+		return TickEvent{At: t}
+	})
+}
+
+// Update handles all messages (events and tea messages).
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch ev := msg.(type) {
+	case tea.KeyMsg:
+		switch ev.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+
+		case "tab":
+			switch m.focusPane {
+			case paneRepos:
+				m.focusPane = paneActive
+			case paneActive:
+				m.focusPane = paneHistory
+			default:
+				m.focusPane = paneRepos
+			}
+			m.syncFocus()
+			return m, nil
+
+		case "enter":
+			m.detailPanel = !m.detailPanel
+			m.prepareDetailItem()
+			return m, nil
+		}
+
+		var cmd tea.Cmd
+		switch m.focusPane {
+		case paneRepos:
+			var comp Component
+			comp, cmd = m.repos.Update(msg)
+			m.repos = comp.(RepoPaneComponent)
+		case paneActive:
+			var comp Component
+			comp, cmd = m.active.Update(msg)
+			m.active = comp.(ActivePaneComponent)
+		case paneHistory:
+			var comp Component
+			comp, cmd = m.history.Update(msg)
+			m.history = comp.(HistoryPaneComponent)
+		}
+		if m.detailPanel {
+			m.prepareDetailItem()
+		}
+		return m, cmd
+
+	case tea.WindowSizeMsg:
+		m.width = ev.Width
+		m.height = ev.Height
+		return m, nil
+
+	case TickEvent:
+		comp, _ := m.header.Update(msg)
+		m.header = comp.(HeaderComponent)
+		comp, _ = m.repos.Update(msg)
+		m.repos = comp.(RepoPaneComponent)
+		comp, _ = m.active.Update(msg)
+		m.active = comp.(ActivePaneComponent)
+		comp, _ = m.footer.Update(msg)
+		m.footer = comp.(FooterComponent)
+		if m.detailPanel {
+			m.prepareDetailItem()
+		}
+		return m, tickCmd()
+
+	case RepoPollEvent:
+		comp, _ := m.repos.Update(msg)
+		m.repos = comp.(RepoPaneComponent)
+		return m, nil
+
+	case ReviewStartedEvent:
+		comp, _ := m.active.Update(msg)
+		m.active = comp.(ActivePaneComponent)
+		return m, nil
+
+	case ReviewCompletedEvent:
+		comp, _ := m.active.Update(msg)
+		m.active = comp.(ActivePaneComponent)
+		hcomp, _ := m.history.Update(msg)
+		m.history = hcomp.(HistoryPaneComponent)
+		fcomp, _ := m.footer.Update(msg)
+		m.footer = fcomp.(FooterComponent)
+		if m.detailPanel {
+			m.prepareDetailItem()
+		}
+		return m, nil
+
+	case RateLimitSnapshotEvent:
+		comp, _ := m.footer.Update(msg)
+		m.footer = comp.(FooterComponent)
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// syncFocus updates focused state on pane components to match m.focusPane.
+func (m *Model) syncFocus() {
+	m.repos.SetFocused(m.focusPane == paneRepos)
+	m.active.SetFocused(m.focusPane == paneActive)
+	m.history.SetFocused(m.focusPane == paneHistory)
+}
+
+// prepareDetailItem constructs the DetailItem from the focused pane's
+// current selection.
+func (m *Model) prepareDetailItem() {
+	if m.focusPane == paneActive {
+		if job := m.active.Selected(); job != nil {
+			m.detail.SetItem(&DetailItem{
+				Repo:     job.Repo,
+				PRNumber: job.PRNumber,
+				Title:    job.Title,
+				IsActive: true,
+				Elapsed:  m.header.now.Sub(job.StartedAt),
+			})
+		} else {
+			m.detail.SetItem(nil)
+		}
+	} else if entry := m.history.Selected(); entry != nil {
+		m.detail.SetItem(&DetailItem{
+			Repo:        entry.Repo,
+			PRNumber:    entry.PRNumber,
+			Title:       entry.Title,
+			Reviewed:    entry.Reviewed,
+			Skipped:     entry.Skipped,
+			Reason:      entry.Reason,
+			Err:         entry.Err,
+			NumTurns:    entry.NumTurns,
+			CostUSD:     entry.CostUSD,
+			Duration:    entry.Duration,
+			CompletedAt: entry.CompletedAt,
+		})
+	} else {
+		m.detail.SetItem(nil)
+	}
+	m.detail.SetWidth(m.width)
+	m.detail.SetVisible(m.detailPanel)
+}
+
+// View renders the full TUI.
+func (m Model) View() string {
+	if m.width == 0 {
+		return "Loading..."
+	}
+
+	var sections []string
+	sections = append(sections, m.header.View(m.width))
+	sections = append(sections, m.repos.View(m.width))
+	sections = append(sections, m.active.View(m.width))
+
+	if m.detailPanel {
+		if detail := m.detail.View(m.width); detail != "" {
+			sections = append(sections, detail)
+		}
+	}
+
+	sections = append(sections, m.history.View(m.width))
+	sections = append(sections, m.footer.View(m.width))
+
+	return strings.Join(sections, "\n")
+}
+
+// FocusedPaneName returns the name of the currently focused pane, for tests.
+func (m Model) FocusedPaneName() string {
+	switch m.focusPane {
+	case paneRepos:
+		return "repos"
+	case paneActive:
+		return "active"
+	case paneHistory:
+		return "history"
+	}
+	return ""
+}
+
+// DetailVisible reports whether the detail panel is currently shown.
+func (m Model) DetailVisible() bool {
+	return m.detailPanel
+}

--- a/pruefer/tui/model_test.go
+++ b/pruefer/tui/model_test.go
@@ -1,0 +1,137 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestModel_QuitOnQAndCtrlC(t *testing.T) {
+	m := New([]string{"handarbeit/fabrik"}, time.Now())
+	for _, key := range []string{"q", "ctrl+c"} {
+		_, cmd := m.Update(keyMsg(key))
+		if cmd == nil {
+			t.Errorf("Update(%q) returned nil cmd, want tea.Quit", key)
+		}
+	}
+}
+
+func TestModel_TabCyclesFocus(t *testing.T) {
+	m := New(nil, time.Now())
+	if got := m.FocusedPaneName(); got != "repos" {
+		t.Fatalf("initial focus = %q, want repos", got)
+	}
+	next, _ := m.Update(keyMsg("tab"))
+	m = next.(Model)
+	if got := m.FocusedPaneName(); got != "active" {
+		t.Fatalf("after 1 tab, focus = %q, want active", got)
+	}
+	next, _ = m.Update(keyMsg("tab"))
+	m = next.(Model)
+	if got := m.FocusedPaneName(); got != "history" {
+		t.Fatalf("after 2 tabs, focus = %q, want history", got)
+	}
+	next, _ = m.Update(keyMsg("tab"))
+	m = next.(Model)
+	if got := m.FocusedPaneName(); got != "repos" {
+		t.Fatalf("after 3 tabs, focus = %q, want repos (wrapped)", got)
+	}
+}
+
+func TestModel_EnterTogglesDetailPanel(t *testing.T) {
+	m := New(nil, time.Now())
+	if m.DetailVisible() {
+		t.Fatal("detail panel visible before any enter press")
+	}
+	next, _ := m.Update(keyMsg("enter"))
+	m = next.(Model)
+	if !m.DetailVisible() {
+		t.Fatal("detail panel not visible after enter")
+	}
+	next, _ = m.Update(keyMsg("enter"))
+	m = next.(Model)
+	if m.DetailVisible() {
+		t.Fatal("detail panel still visible after second enter")
+	}
+}
+
+func TestModel_DetailPanelShowsSelectedActiveReview(t *testing.T) {
+	m := New(nil, time.Now())
+	start := time.Now()
+	next, _ := m.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 1, Title: "fix bug", StartedAt: start})
+	m = next.(Model)
+	// Focus the active pane, then open detail.
+	next, _ = m.Update(keyMsg("tab"))
+	m = next.(Model)
+	next, _ = m.Update(keyMsg("enter"))
+	m = next.(Model)
+
+	if m.detail.item == nil {
+		t.Fatal("detail.item is nil, want the selected active review")
+	}
+	if m.detail.item.PRNumber != 1 || !m.detail.item.IsActive {
+		t.Errorf("detail.item = %+v, want active PR #1", m.detail.item)
+	}
+}
+
+func TestModel_RepoPollEventRoutesToRepoPane(t *testing.T) {
+	m := New([]string{"handarbeit/fabrik"}, time.Now())
+	next, _ := m.Update(RepoPollEvent{Repo: "handarbeit/fabrik", At: time.Now(), PRCount: 3})
+	m = next.(Model)
+	if m.repos.repos["handarbeit/fabrik"].PRCount != 3 {
+		t.Errorf("repos pane PRCount = %d, want 3", m.repos.repos["handarbeit/fabrik"].PRCount)
+	}
+}
+
+func TestModel_ReviewLifecycleRoutesToActiveHistoryAndFooter(t *testing.T) {
+	m := New(nil, time.Now())
+	start := time.Now()
+	next, _ := m.Update(ReviewStartedEvent{Repo: "o/r", PRNumber: 9, StartedAt: start})
+	m = next.(Model)
+	if m.active.Count() != 1 {
+		t.Fatalf("active.Count() = %d, want 1 after ReviewStartedEvent", m.active.Count())
+	}
+
+	next, _ = m.Update(ReviewCompletedEvent{
+		Repo: "o/r", PRNumber: 9, Reviewed: true, NumTurns: 4, CostUSD: 0.02,
+		Duration: 30 * time.Second, CompletedAt: time.Now(),
+	})
+	m = next.(Model)
+	if m.active.Count() != 0 {
+		t.Errorf("active.Count() = %d, want 0 after ReviewCompletedEvent", m.active.Count())
+	}
+	if m.history.Count() != 1 {
+		t.Errorf("history.Count() = %d, want 1 after ReviewCompletedEvent", m.history.Count())
+	}
+	if m.footer.ReviewedCount() != 1 {
+		t.Errorf("footer.ReviewedCount() = %d, want 1", m.footer.ReviewedCount())
+	}
+}
+
+func TestModel_RateLimitSnapshotRoutesToFooter(t *testing.T) {
+	m := New(nil, time.Now())
+	next, _ := m.Update(RateLimitSnapshotEvent{})
+	m = next.(Model)
+	_ = m.footer.View(100) // no panic; wiring reaches the footer component
+}
+
+func TestModel_TickAdvancesHeaderClock(t *testing.T) {
+	start := time.Now()
+	m := New(nil, start)
+	next, _ := m.Update(TickEvent{At: start.Add(5 * time.Minute)})
+	m = next.(Model)
+	if m.header.now.Before(start.Add(4 * time.Minute)) {
+		t.Errorf("header.now did not advance with TickEvent")
+	}
+}
+
+func TestModel_ViewDoesNotPanicBeforeWindowSize(t *testing.T) {
+	m := New([]string{"handarbeit/fabrik"}, time.Now())
+	if got := m.View(); got != "Loading..." {
+		t.Errorf("View() before WindowSizeMsg = %q, want %q", got, "Loading...")
+	}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = next.(Model)
+	_ = m.View() // no panic
+}

--- a/pruefer/tui/repos.go
+++ b/pruefer/tui/repos.go
@@ -1,0 +1,110 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// repoStatus is the per-watched-repo poll status tracked by
+// RepoPaneComponent — last poll time, PR count found, and last error,
+// combined per the spec's "poll status" open question.
+type repoStatus struct {
+	Repo       string
+	LastPollAt time.Time
+	PRCount    int
+	LastErr    string
+}
+
+// RepoPaneComponent renders the watched-repositories pane.
+type RepoPaneComponent struct {
+	repos   map[string]*repoStatus
+	order   []string // insertion order, seeded from Config.WatchedRepos
+	now     time.Time
+	focused bool
+}
+
+func (r RepoPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
+	switch ev := msg.(type) {
+	case TickEvent:
+		r.now = ev.At
+	case RepoPollEvent:
+		if r.repos == nil {
+			r.repos = make(map[string]*repoStatus)
+		}
+		st, ok := r.repos[ev.Repo]
+		if !ok {
+			st = &repoStatus{Repo: ev.Repo}
+			r.repos[ev.Repo] = st
+			r.order = append(r.order, ev.Repo)
+		}
+		st.LastPollAt = ev.At
+		st.PRCount = ev.PRCount
+		st.LastErr = ev.Err
+	}
+	return r, nil
+}
+
+func (r RepoPaneComponent) View(width int) string {
+	focusIndicator := " "
+	if r.focused {
+		focusIndicator = "▸"
+	}
+	title := activeStyle.Render(fmt.Sprintf("%s Watched Repos (%d)", focusIndicator, len(r.order)))
+
+	maxWidth := width - 6
+	if maxWidth < 20 {
+		maxWidth = 20
+	}
+	var lines []string
+	for _, repo := range r.order {
+		st := r.repos[repo]
+		age := "never polled"
+		if !st.LastPollAt.IsZero() {
+			age = fmtDuration(r.now.Sub(st.LastPollAt)) + " ago"
+		}
+		line := fmt.Sprintf("%-30s %2d PR(s)  polled %s", repo, st.PRCount, age)
+		if st.LastErr != "" {
+			line += "  " + failStyle.Render("error: "+st.LastErr)
+		}
+		if runes := []rune(line); len(runes) > maxWidth {
+			line = string(runes[:maxWidth-1]) + "…"
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) == 0 {
+		lines = append(lines, dimStyle.Render("no repos configured"))
+	}
+	content := title + "\n" + strings.Join(lines, "\n")
+	return borderStyle.Width(width - 4).Render(content)
+}
+
+func (r RepoPaneComponent) Height() int {
+	n := len(r.order)
+	if n == 0 {
+		n = 1
+	}
+	return n + 3
+}
+
+// SetFocused updates the focused state.
+func (r *RepoPaneComponent) SetFocused(f bool) {
+	r.focused = f
+}
+
+// SetWatchedRepos seeds the pane with the configured repo list in order, so
+// every watched repo is visible ("never polled") before its first
+// RepoPollEvent arrives.
+func (r *RepoPaneComponent) SetWatchedRepos(repos []string) {
+	if r.repos == nil {
+		r.repos = make(map[string]*repoStatus)
+	}
+	for _, repo := range repos {
+		if _, ok := r.repos[repo]; !ok {
+			r.repos[repo] = &repoStatus{Repo: repo}
+			r.order = append(r.order, repo)
+		}
+	}
+}

--- a/pruefer/tui/repos_test.go
+++ b/pruefer/tui/repos_test.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepoPane_SeedsWatchedReposAsNeverPolled(t *testing.T) {
+	var r RepoPaneComponent
+	r.SetWatchedRepos([]string{"handarbeit/fabrik", "handarbeit/other"})
+
+	view := r.View(120)
+	if !strings.Contains(view, "handarbeit/fabrik") || !strings.Contains(view, "handarbeit/other") {
+		t.Fatalf("View() missing seeded repos:\n%s", view)
+	}
+	if !strings.Contains(view, "never polled") {
+		t.Errorf("View() does not show 'never polled' before first poll:\n%s", view)
+	}
+}
+
+func TestRepoPane_PollEventUpdatesStatus(t *testing.T) {
+	var r RepoPaneComponent
+	r.SetWatchedRepos([]string{"handarbeit/fabrik"})
+	now := time.Now()
+
+	comp, _ := r.Update(RepoPollEvent{Repo: "handarbeit/fabrik", At: now, PRCount: 4})
+	r = comp.(RepoPaneComponent)
+	comp, _ = r.Update(TickEvent{At: now})
+	r = comp.(RepoPaneComponent)
+
+	view := r.View(120)
+	if !strings.Contains(view, "4 PR(s)") {
+		t.Errorf("View() does not show PR count:\n%s", view)
+	}
+	if strings.Contains(view, "never polled") {
+		t.Errorf("View() still shows 'never polled' after a poll:\n%s", view)
+	}
+}
+
+func TestRepoPane_PollErrorRenders(t *testing.T) {
+	var r RepoPaneComponent
+	r.SetWatchedRepos([]string{"handarbeit/fabrik"})
+
+	comp, _ := r.Update(RepoPollEvent{Repo: "handarbeit/fabrik", At: time.Now(), Err: "listing PRs: 500"})
+	r = comp.(RepoPaneComponent)
+
+	if !strings.Contains(r.View(120), "error: listing PRs: 500") {
+		t.Errorf("View() does not show poll error:\n%s", r.View(120))
+	}
+}
+
+func TestRepoPane_UnseenRepoFromPollEventIsAdded(t *testing.T) {
+	// A RepoPollEvent for a repo not seeded via SetWatchedRepos (e.g. daemon
+	// wired without seeding) must still be tracked, not dropped.
+	var r RepoPaneComponent
+	comp, _ := r.Update(RepoPollEvent{Repo: "handarbeit/fabrik", At: time.Now(), PRCount: 1})
+	r = comp.(RepoPaneComponent)
+	if len(r.order) != 1 {
+		t.Fatalf("order = %v, want 1 entry", r.order)
+	}
+}

--- a/pruefer/tui/styles.go
+++ b/pruefer/tui/styles.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Styles duplicated from Fabrik's tui/styles.go — unexported there, so
+// structural mirroring means duplicating this small set rather than
+// importing it (see adrs/1114-pruefer-tui-architecture.md).
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("205"))
+
+	borderStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			Padding(0, 1)
+
+	successStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	failStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	dimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	activeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	selectedStyle = lipgloss.NewStyle().Background(lipgloss.Color("238"))
+)
+
+// fmtDuration formats a duration as MM:SS, mirroring tui/commands.go.
+func fmtDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	d = d.Round(time.Second)
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%02d:%02d", m, s)
+}
+
+// fmtRateLimitCountdown returns a human-readable string describing how long
+// until the rate limit resets relative to now, mirroring tui/commands.go.
+func fmtRateLimitCountdown(reset time.Time, now time.Time) string {
+	remaining := reset.Sub(now)
+	if remaining <= 0 {
+		return "soon"
+	}
+	secs := int(remaining.Seconds())
+	if secs >= 3600 {
+		return fmt.Sprintf("%dh", secs/3600)
+	}
+	if secs >= 60 {
+		return fmt.Sprintf("%dm", secs/60)
+	}
+	return fmt.Sprintf("%ds", secs)
+}

--- a/pruefer/tui/testutil_test.go
+++ b/pruefer/tui/testutil_test.go
@@ -1,0 +1,22 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// keyMsg builds a tea.KeyMsg whose String() matches s, covering the named
+// keys used by this package's keybindings plus arbitrary single-rune keys.
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}

--- a/pruefer/tui_run.go
+++ b/pruefer/tui_run.go
@@ -1,0 +1,75 @@
+package pruefer
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
+
+	ptui "github.com/handarbeit/fabrik/pruefer/tui"
+)
+
+// useTUI reports whether Execute should launch the interactive TUI: enabled
+// when cfg.TUI is true (the default; -notui/PRUEFER_TUI/config.yaml's
+// `tui: false` can disable it) AND a real terminal is detected on both
+// stdin and stdout — mirrors cmd/root.go's identical useTUI computation.
+func useTUI(cfg Config) bool {
+	return cfg.TUI &&
+		(isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) &&
+		(isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))
+}
+
+// runTUI wires the event channel, starts the bubbletea program, and runs the
+// daemon — mirrors cmd/root.go's runTUI. The daemon handles SIGINT/SIGTERM
+// itself via the context Execute constructed; bubbletea uses
+// WithoutSignalHandler so it doesn't interfere. When the daemon exits, the
+// TUI is quit; when the user quits the TUI first (q/ctrl+c), a SIGTERM is
+// sent to the process so the daemon's own signal handling shuts it down
+// gracefully — identical coordination to cmd/root.go's runTUI.
+func runTUI(ctx context.Context, d *Daemon) error {
+	events := make(chan ptui.Event, 256)
+	d.Emit = func(ev ptui.Event) {
+		// Drop rather than block the daemon if the TUI falls behind —
+		// observability must never apply backpressure to review work.
+		select {
+		case events <- ev:
+		default:
+		}
+	}
+
+	tuiModel := ptui.New(d.Config.WatchedRepos, time.Now())
+	p := tea.NewProgram(tuiModel, tea.WithAltScreen(), tea.WithoutSignalHandler())
+
+	go func() {
+		for ev := range events {
+			p.Send(ev)
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := d.Run(ctx)
+		close(events)
+		errCh <- err
+		p.Quit()
+	}()
+
+	if _, err := p.Run(); err != nil {
+		p.ReleaseTerminal()
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		<-errCh
+		return err
+	}
+	p.ReleaseTerminal()
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		return <-errCh
+	}
+}


### PR DESCRIPTION
Closes #1114

## Summary

Adds an interactive terminal UI to Pruefer, structurally mirroring Fabrik's own `tui/` package (event types → `Component` tree → thin wiring layer), while keeping headless operation first-class and behaviorally identical.

## What's included

- **`pruefer/tui`** — new package: `events.go` (`RepoPollEvent`, `ReviewStartedEvent`, `ReviewCompletedEvent`, `RateLimitSnapshotEvent`, `TickEvent`), `component.go`, `styles.go`, and panes for header, watched repos (with poll status), in-flight reviews (elapsed time), history (bounded 200-entry in-memory ring buffer covering reviewed/skipped/errored outcomes and all seven `SkipReason` values), a detail panel, and a footer (REST rate-limit gauge + running session cost/turn total). Fully unit-tested with synthetic events, no terminal required.
- **`pruefer/tui_run.go`** — `useTUI`/`runTUI`, mirroring `cmd/root.go`'s wiring: builds the event channel, starts the `tea.Program`, forwards events, coordinates shutdown with the daemon's own signal handling.
- **`pruefer/daemon.go`** — a nil-checked `Emit func(tui.Event)` field (the same no-op idiom as `engine.Engine`'s events channel). Events are emitted from `poll()`'s dispatch goroutine wrapping each `ReviewPR` call — `ReviewPR`'s own control flow and return shape are untouched. A `RateLimitReporter` optional interface surfaces `github.Client.RateLimitStats()`'s REST stats once per cycle without forcing every test fake to implement it.
- **`pruefer/claude.go` / `pruefer/review.go`** — new per-review turn/cost capture: `ClaudeInvoker.Review` now returns `ReviewResult{Text, NumTurns, CostUSD}`, parsed from `claude`'s `stream-json` output (`num_turns`/`total_cost_usd`) across both of `parseClaudeReviewJSON`'s parse paths. `ReviewOutcome` gains matching `NumTurns`/`CostUSD` fields.
- **`pruefer/config.go`** — `-notui` flag / `PRUEFER_TUI` env var / `tui:` YAML key (default on, gated further on a real terminal being detected on stdin+stdout).
- **`cmd/pruefer/README.md`** — new "Terminal UI" section and config table row; removes the stale "TUI (follow-up issue)" out-of-scope bullet.
- **`adrs/1114-pruefer-tui-architecture.md`** — records the design decisions: event plumbing (no `engine`/`itemstate` imports), the bounded/in-memory retention choice (deliberate divergence from Fabrik's unbounded+persisted history), session-total scope, and the REST-vs-GraphQL rate-limit surfacing choice.

## Behavioral guarantee

A dedicated test asserts TUI-off and TUI-on produce identical `ReviewOutcome`/submission behavior for the same inputs — event emission is additive instrumentation around `ReviewPR`, never inside it.

## How to test

```bash
go build ./... && go vet ./... && go test -race ./...
```

`pruefer/` and `pruefer/tui/` tests cover the model/update logic (synthetic events, no terminal) and the TUI-off/TUI-on parity assertion. One pre-existing, environment-dependent failure (`cmd.TestExecute_ConfigYAMLApplied`, a network-dependent SIGINT-timing test) is unrelated to this change — it fails identically on an unrelated worktree with no pruefer changes.