### PR TITLE
fix(engine): don't classify a turn-capped run as a usage-limit exit

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4880,9 +4880,25 @@ parsed `claudeResponse.Result` field, since it is unconfirmed whether a real occ
 in `claudeResponse.Errors[]`, or in non-JSON plain text — for Anthropic's usage-limit exit message via
 `detectUsageLimitExit()`. When Claude exits non-zero without a `FABRIK_STAGE_COMPLETE` marker and the
 message matches, `interpretClaudeResult` returns a `*claudeUsageLimitError{Message, ResetTime}`
-sentinel instead of the generic error wrapper. The turn-count/cost shape (`~1 turn, $0.00`) is logged
-alongside purely for diagnostic corroboration and never gates detection — a genuine immediate stage
-failure can share the same shape.
+sentinel instead of the generic error wrapper.
+
+The turn-count/cost shape gates detection in one direction only. It is **never** used to *confirm* a
+usage limit — a genuine immediate stage failure shares the `~1 turn, $0.00` shape, so treating that
+shape as positive evidence would produce false negatives on real failures. It **is** used to *exclude*
+one: `detectUsageLimitExit` returns `detected = false` when `usage.TurnsUsed > 0 && usage.CostUSD > 0`,
+because a real usage-limit exit terminates the invocation immediately, before any work is billed, so an
+invocation that consumed turns *and* incurred cost cannot have hit one. Ruling in and ruling out are
+different inferences; only the former is unsound here.
+
+The exclusion is conjunctive (turns **and** cost) so a partially-recorded usage struct cannot suppress
+a genuine detection.
+
+This guard exists because the message is matched against **raw invocation output**, which necessarily
+includes text the assistant itself wrote. Without it, any stage whose output merely discusses usage
+limits self-triggers an account-wide suspension — on 2026-07-27 a turn-capped run on #1178 that quoted
+#1084's example message suspended dispatch for ~11 hours (#1183). Matching prose remains the underlying
+weakness; classifying from the CLI's structured result (`subtype` / `terminal_reason`) is the durable
+fix and is not yet implemented.
 
 **Handling:** `finalizeStageOutcome()` (`engine/item.go`) detects the sentinel via `errors.As`,
 immediately after the existing engine-shutdown guard, and routes to `handleUsageLimitExit()`, which:

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1981,9 +1981,25 @@ parsed `claudeResponse.Result` field, since it is unconfirmed whether a real occ
 in `claudeResponse.Errors[]`, or in non-JSON plain text — for Anthropic's usage-limit exit message via
 `detectUsageLimitExit()`. When Claude exits non-zero without a `FABRIK_STAGE_COMPLETE` marker and the
 message matches, `interpretClaudeResult` returns a `*claudeUsageLimitError{Message, ResetTime}`
-sentinel instead of the generic error wrapper. The turn-count/cost shape (`~1 turn, $0.00`) is logged
-alongside purely for diagnostic corroboration and never gates detection — a genuine immediate stage
-failure can share the same shape.
+sentinel instead of the generic error wrapper.
+
+The turn-count/cost shape gates detection in one direction only. It is **never** used to *confirm* a
+usage limit — a genuine immediate stage failure shares the `~1 turn, $0.00` shape, so treating that
+shape as positive evidence would produce false negatives on real failures. It **is** used to *exclude*
+one: `detectUsageLimitExit` returns `detected = false` when `usage.TurnsUsed > 0 && usage.CostUSD > 0`,
+because a real usage-limit exit terminates the invocation immediately, before any work is billed, so an
+invocation that consumed turns *and* incurred cost cannot have hit one. Ruling in and ruling out are
+different inferences; only the former is unsound here.
+
+The exclusion is conjunctive (turns **and** cost) so a partially-recorded usage struct cannot suppress
+a genuine detection.
+
+This guard exists because the message is matched against **raw invocation output**, which necessarily
+includes text the assistant itself wrote. Without it, any stage whose output merely discusses usage
+limits self-triggers an account-wide suspension — on 2026-07-27 a turn-capped run on #1178 that quoted
+#1084's example message suspended dispatch for ~11 hours (#1183). Matching prose remains the underlying
+weakness; classifying from the CLI's structured result (`subtype` / `terminal_reason`) is the durable
+fix and is not yet implemented.
 
 **Handling:** `finalizeStageOutcome()` (`engine/item.go`) detects the sentinel via `errors.As`,
 immediately after the existing engine-shutdown guard, and routes to `handleUsageLimitExit()`, which:

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -67,9 +67,31 @@ func (e *claudeUsageLimitError) Error() string {
 // in resp.Result, only in resp.Errors[] (never copied into text today), or in
 // non-JSON plain stdout; scanning raw bytes is correct under all three shapes
 // without needing to know which is real.
-func detectUsageLimitExit(rawOutput []byte) (msg, resetTime string, detected bool) {
+// The usage-limit message is matched against raw output, which necessarily
+// includes text the assistant itself wrote. usage is therefore used as an
+// exclusion gate: an invocation that consumed turns and incurred cost cannot
+// have exited on an account usage limit, because such an exit terminates the
+// invocation immediately (0 turns, $0.00) before any work is billed.
+//
+// Note the asymmetry, which is deliberate and is the whole point of this guard.
+// #1119's spec correctly forbids using the "~1 turn, $0.00" shape to *confirm*
+// a usage limit, since a genuine immediate stage failure shares that shape —
+// that would risk false negatives. Using the inverse shape to *rule one out* is
+// sound: no real usage-limit exit does 51 turns of work first. Ruling in and
+// ruling out are not the same inference.
+//
+// Without this, any stage whose output merely discusses usage limits
+// self-triggers a suspension. That is not hypothetical in this repository: on
+// 2026-07-27 issue #1178's Implement stage, which was writing tests about
+// usage-limit detection, quoted #1084's example message and suspended Claude
+// dispatch account-wide for ~11 hours after a plain turn-cap exit (51 turns,
+// $2.28). See #1183.
+func detectUsageLimitExit(rawOutput []byte, usage TokenUsage) (msg, resetTime string, detected bool) {
 	match := usageLimitHitRE.Find(rawOutput)
 	if match == nil {
+		return "", "", false
+	}
+	if usage.TurnsUsed > 0 && usage.CostUSD > 0 {
 		return "", "", false
 	}
 	if m := usageLimitResetRE.FindSubmatch(rawOutput); m != nil {
@@ -907,10 +929,10 @@ func interpretClaudeResult(ctx context.Context, issueNumber int, rawOutput []byt
 			claudeLog(issueNumber, "warn", "stage completed (marker found) but Claude exited with error: %v\n", runErr)
 			return text, true, usage, fmt.Errorf("claude exited with error: %w", runErr)
 		}
-		// Corroborating shape (~1 turn, $0.00) is logged only for diagnostics —
-		// per the issue spec it must never gate detection, since a genuine
-		// immediate stage failure can share the same shape.
-		if msg, resetTime, detected := detectUsageLimitExit(rawOutput); detected {
+		// usage is passed as an exclusion gate only: it can rule a usage-limit
+		// exit *out* (turns consumed and cost incurred means the invocation ran,
+		// so no limit was hit), but never rules one in — see detectUsageLimitExit.
+		if msg, resetTime, detected := detectUsageLimitExit(rawOutput, usage); detected {
 			claudeLog(issueNumber, "claude-limit", "usage-limit exit detected (resetTime=%q, turns=%d, cost=$%.4f): %s\n", resetTime, usage.TurnsUsed, usage.CostUSD, msg)
 			return text, false, usage, &claudeUsageLimitError{Message: msg, ResetTime: resetTime}
 		}

--- a/engine/claude_usage_limit_test.go
+++ b/engine/claude_usage_limit_test.go
@@ -16,6 +16,7 @@ func TestDetectUsageLimitExit(t *testing.T) {
 	tests := []struct {
 		name          string
 		raw           string
+		usage         TokenUsage
 		wantDetected  bool
 		wantMsg       string
 		wantResetTime string
@@ -74,11 +75,43 @@ func TestDetectUsageLimitExit(t *testing.T) {
 			raw:          ``,
 			wantDetected: false,
 		},
+		{
+			// Regression for #1183. A turn-capped run whose own output quotes the
+			// usage-limit message — which happens routinely in this repository,
+			// where issues, specs and tests discuss these exact strings — must not
+			// be classified as a usage-limit exit. On 2026-07-27 this suspended
+			// Claude dispatch account-wide for ~11 hours after a plain turn cap.
+			name: "negative: turn-capped run quoting the message in its own output",
+			raw: `{"subtype":"error_max_turns","terminal_reason":"max_turns","is_error":true,` +
+				`"num_turns":51,"result":"added a test fixture: You've hit your session limit ` +
+				`· resets 10:20pm (America/Edmonton)","errors":["Reached maximum number of turns (50)"]}`,
+			usage:        TokenUsage{TurnsUsed: 51, CostUSD: 2.2766},
+			wantDetected: false,
+		},
+		{
+			// The exclusion must be conjunctive: cost without turns (or vice versa)
+			// is not evidence the invocation ran, so detection still stands.
+			name:          "cost recorded but zero turns still detects",
+			raw:           `{"result":"You've hit your session limit · resets 6:05am (UTC)","is_error":true}`,
+			usage:         TokenUsage{TurnsUsed: 0, CostUSD: 0.01},
+			wantDetected:  true,
+			wantMsg:       "hit your session limit",
+			wantResetTime: "6:05am (UTC)",
+		},
+		{
+			// The canonical real shape: immediate exit, nothing consumed.
+			name:          "genuine limit exit with zero turns and zero cost detects",
+			raw:           `{"result":"You've hit your weekly limit · resets 6:05am (UTC)","is_error":true}`,
+			usage:         TokenUsage{},
+			wantDetected:  true,
+			wantMsg:       "hit your weekly limit",
+			wantResetTime: "6:05am (UTC)",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			msg, resetTime, detected := detectUsageLimitExit([]byte(tt.raw))
+			msg, resetTime, detected := detectUsageLimitExit([]byte(tt.raw), tt.usage)
 			if detected != tt.wantDetected {
 				t.Fatalf("detected = %v, want %v (msg=%q, resetTime=%q)", detected, tt.wantDetected, msg, resetTime)
 			}

--- a/engine/claude_usage_limit_test.go
+++ b/engine/claude_usage_limit_test.go
@@ -156,6 +156,42 @@ func TestInterpretClaudeResult_UsageLimitExit_ReturnsSentinelError(t *testing.T)
 	}
 }
 
+// TestInterpretClaudeResult_TurnCappedQuotingMessage_NotUsageLimit is the
+// full-pipeline regression for #1183. The unit-level table test hand-supplies a
+// TokenUsage, so it cannot catch the field wiring silently breaking: the raw
+// payload here carries both num_turns and a nonzero total_cost_usd, so the
+// exclusion gate only fires if tokenUsageFromResponse/parseClaudeJSON actually
+// populate TurnsUsed and CostUSD from the JSON.
+//
+// The shape reproduces the incident: a turn-capped run whose own output quotes
+// the usage-limit message (routine in this repository, where issues, specs and
+// tests discuss these exact strings). It must NOT return the sentinel.
+func TestInterpretClaudeResult_TurnCappedQuotingMessage_NotUsageLimit(t *testing.T) {
+	raw := []byte(`{"subtype":"error_max_turns","terminal_reason":"max_turns","is_error":true,` +
+		`"num_turns":51,"total_cost_usd":2.2766,` +
+		`"result":"added a test fixture: You've hit your session limit · resets 10:20pm (America/Edmonton)",` +
+		`"errors":["Reached maximum number of turns (50)"]}`)
+
+	_, completed, usage, err := interpretClaudeResult(context.Background(), 1, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+
+	// Guard the wiring the exclusion depends on: if these are zero, the gate is
+	// inert and the assertion below would pass for the wrong reason.
+	if usage.TurnsUsed == 0 || usage.CostUSD == 0 {
+		t.Fatalf("usage not parsed from raw payload: TurnsUsed=%d CostUSD=%v — exclusion gate would be inert", usage.TurnsUsed, usage.CostUSD)
+	}
+
+	var limitErr *claudeUsageLimitError
+	if errors.As(err, &limitErr) {
+		t.Fatalf("turn-capped run quoting the usage-limit message was classified as a usage-limit exit (ResetTime=%q); #1183 regression", limitErr.ResetTime)
+	}
+	if err == nil {
+		t.Errorf("expected a generic error for a non-zero exit, got nil")
+	}
+	if completed {
+		t.Errorf("expected completed=false for a turn-capped run")
+	}
+}
+
 // TestInterpretClaudeResult_UsageLimitExit_MarkerTakesPrecedence verifies that
 // a genuine stage completion (FABRIK_STAGE_COMPLETE present) is never
 // misclassified as a usage-limit exit, even if the output happens to also


### PR DESCRIPTION
Refs #1183 — this is a targeted stop-gap; the issue stays open for the remaining Definition of Done items (structural detection, reset-time trust, restart-free suspension clearing).

## The bug

`detectUsageLimitExit` matches a regex against **raw invocation output**, which necessarily includes text the assistant itself wrote. So any stage whose output merely *discusses* usage limits self-triggers an account-wide Claude dispatch suspension.

That is not hypothetical in this repository. On 2026-07-27, #1178's Implement stage — writing tests *about* usage-limit detection, quoting #1084's example message as a fixture — exited on a plain turn cap:

```json
"subtype": "error_max_turns", "terminal_reason": "max_turns", "num_turns": 51
```

Fabrik classified it as a usage-limit hit and suspended dispatch **for every repo and issue** until the reset time it parsed out of that quoted fixture — `10:20pm (America/Edmonton)`, a timezone the operator isn't in. Roughly **11 hours** of pipeline downtime, caused by a turn cap.

Three facts made it unambiguous: 51 turns and $2.28 consumed (a real limit exit does 0 turns, $0.00), the invocation's own terminal state was `max_turns`, and the "parsed" reset time was verbatim from an issue body.

## The fix

Pass `TokenUsage` as an **exclusion gate**. An invocation that consumed turns *and* incurred cost cannot have exited on a usage limit, because such an exit terminates immediately, before any work is billed.

**The asymmetry is the point.** #1119's spec explicitly forbids using the "~1 turn, $0.00" shape to *confirm* a usage limit — a genuine immediate stage failure shares that shape, so that would risk false negatives. Using the *inverse* shape to *rule one out* is sound: no real usage-limit exit does 51 turns of work first. Ruling in and ruling out are different inferences, and only the former was prohibited. The existing call-site comment is updated to say so, since the distinction is easy to "correct" back.

The exclusion is conjunctive (turns **and** cost) so a partially-recorded usage struct can't suppress a genuine detection.

## Tests

Three cases added to the existing table, plus threading `usage` through it:

- **Regression:** turn-capped run quoting the message in its own output → not detected
- **Conjunctivity:** cost recorded but zero turns → still detected
- **Canonical:** zero turns, zero cost → still detected

`go build`, `go vet` clean; `go test -race ./engine/ ./internal/...` — **1,856 tests pass**.

## Scope

Deliberately a targeted stop-gap, to unblock the pipeline. The durable fix is to classify from the CLI's structured result (`subtype` / `terminal_reason`, neither of which `claudeResponse` captures today) rather than from output prose — tracked in #1178 and in #1183's requirements.

Note the suspension is in-memory (`engine/engine.go:119-120`), so restarting the engine clears a false positive; #1183 also asks for a way to clear it without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4L5oQDHChWDF3c6oj1haw
