### PR TITLE
Render turn-budget exhaustion as incomplete/resumable, not as an error

### DIFF
--- a/adrs/1178-turn-limit-classification.md
+++ b/adrs/1178-turn-limit-classification.md
@@ -1,0 +1,139 @@
+# ADR 1178: Turn-Limit Classification via CLI Subtype, Not Exit Code
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #1178 — TUI renders turn-budget exhaustion as "(error)" when it is an incomplete, resumable run
+
+## Context
+
+A stage invocation that exhausts its `max_turns` budget causes the `claude` CLI to self-terminate
+with a non-zero exit. Before this change, `finalizeStageOutcome`/`processComments` collapsed every
+non-nil invocation error — a genuine fault (bad prompt, dead session, permission error) and a
+turn-cap exit alike — into `InvocationRecorded{Errored: true}`. That fed `ItemState.LastInvocationErrored`,
+then `tui.JobCompletedEvent{Success: false}`, and `tui/history.go`'s `!he.Success` branch rendered it
+as `✗ (error)` — indistinguishable from a real failure. A turn-cap exit is not a fault: it is an
+incomplete run that made real progress and resumes in the same Claude session on the next attempt
+(session-ID capture already survives a max-turns kill specifically to enable this — see #1081).
+Reading several capped runs as red errors drives the wrong diagnosis (investigate a fault) instead of
+the right one (raise the budget). #1114 was the concrete trigger: five capped Implement runs all
+rendered as errors, totalling $21.77 in the History pane.
+
+The CLI's own result JSON already discriminates the two cases structurally, via `subtype`:
+
+```json
+{"subtype": "error_max_turns", "terminal_reason": "max_turns", "num_turns": 51, "is_error": true}
+```
+
+versus a genuine fault (the #1128 stale-session case):
+
+```json
+{"subtype": "error_during_execution", "num_turns": 0, "is_error": true}
+```
+
+`claudeResponse.Subtype` was already captured on the struct (added for #1128's stale-session check),
+but discarded for every other classification purpose — the generic non-zero-exit path never
+consulted it. A turn-count heuristic (`MaxTurns > 0 && TurnsUsed >= MaxTurns && !Completed`) was
+considered and rejected: the CLI's own turn accounting can report a count past the configured cap
+(observed `num_turns: 51` against `max_turns: 50`), so a `>=` comparison rides on slightly odd
+arithmetic and can't cleanly distinguish "hit the cap" from "legitimately used the last turn and
+finished."
+
+## Decision
+
+Detection and threading mirror ADR-1119's `claudeUsageLimitError` pattern structurally, with one
+deliberate control-flow divergence:
+
+1. **`engine/claude.go`** — `claudeResponse` gains `TerminalReason string`. A new
+   `claudeTurnLimitError{TerminalReason, NumTurns}` sentinel is returned from `interpretClaudeResult`
+   when `runErr != nil`, the result JSON parsed (`ok`), and `resp.Subtype == "error_max_turns"`. This
+   check sits immediately before the existing `detectUsageLimitExit` check — after the
+   engine-shutdown guard and the `stageCompleteRE` completed-despite-error carve-out, so neither
+   existing carve-out is disturbed.
+2. **`engine/item.go` (`finalizeStageOutcome`) and `engine/comments.go` (comment-processing path)** —
+   both detect the sentinel via `errors.As(err, &turnLimitErr)`, **without an early return**. The
+   local `err` is left untouched for every other purpose (retry/escalation control flow,
+   `StageRetryIncremented`, `MaxRetries`, `commitWIP`, branch push) — only the `InvocationRecorded`
+   write changes: `Errored: err != nil && !turnLimited`, `TurnLimited: turnLimited`.
+3. **`internal/itemstate`** — `InvocationRecorded.TurnLimited` / `ItemState.LastInvocationTurnLimited`
+   thread the classification through the store, applied in `store.go` identically to the other
+   `InvocationRecorded` fields.
+4. **`engine/observers.go` → `tui`** — `InvocationObserver.OnChange` passes `TurnLimited` into
+   `tui.JobCompletedEvent`; `HistoryEntry` and `DetailItem` carry it through to render. Because
+   `Errored` (hence `Success`) is now `false` for a turn-cap exit, the existing `!he.Completed`
+   branch is reached instead of `!he.Success` — no branch reordering was needed, only a sub-branch
+   within `!he.Completed` choosing `(turn limit)` (when `TurnLimited`) vs. `(retry)` (otherwise),
+   reusing the same `↻` icon. `tui/detail.go`'s `statusStr` gets the analogous
+   `"incomplete (turn limit)"` vs. `"incomplete"` distinction, since it renders the same
+   `HistoryEntry` data one keystroke away and would otherwise still show "error" for a capped run.
+
+## Rationale
+
+### Why a sentinel error, not a widened `ClaudeInvoker` return signature?
+
+Both call sites already propagate the raw `error` from `interpretClaudeResult` unchanged; a sentinel
+costs zero interface or mock changes across the test suite, and `errors.As` at the call site is the
+same idiom `claudeUsageLimitError` already established.
+
+### Why does `claudeTurnLimitError` *not* early-return, unlike `claudeUsageLimitError`?
+
+`claudeUsageLimitError` represents a stage that never ran — the account was locked out before Claude
+did any work, so skipping `StageAttempted`'s cooldown-only path is correct and nothing else should
+happen. A turn-cap exit is the opposite: real work happened, the process actually ran to its budget
+limit, and the *existing* retry/escalation pipeline (outer cooldown-retry via `resume=true`,
+consuming `MaxRetries` budget across separate `processItem` dispatches) is how a genuine turn-cap
+already recovers today — confirmed pre-existing and deliberate via #1081's closing comment ("the
+retry is the same Claude session... someone deliberately made session-ID capture survive a turn-cap
+kill specifically so the retry could resume") and #448's reflog evidence. This ADR does not touch
+that pipeline. `claudeTurnLimitError` therefore only ever changes what feeds the `InvocationRecorded`
+write; every other consequence of `err != nil` is left exactly as it was before this change.
+
+### Why `Subtype` alone gates the branch, with `TerminalReason` captured but not required
+
+`Subtype` already has a proven parse path (used for #1128's `error_during_execution` check);
+`terminal_reason` is captured at negligible cost per the issue's own note that it's wanted for future
+consumers, but adding a second condition to this one decision point buys nothing for #1178's scope.
+
+### `Success`/`Errored` vs. `Completed`: now two independent axes
+
+Before this change, a turn-cap exit made `Success == false` imply "something went wrong." After this
+change, `Success`/`Errored` mean "genuine fault" and `Completed` independently means "no
+`FABRIK_STAGE_COMPLETE` marker was seen." A turn-cap exit is `Errored: false, Completed: false,
+TurnLimited: true` — incomplete but not a fault. A future reader of `finalizeStageOutcome` should not
+assume these two fields still move together the way they did before #1178.
+
+## Consequences
+
+**Positive:**
+- The TUI History pane and detail panel render a turn-cap exit as `↻ (turn limit)` /
+  `incomplete (turn limit)` instead of `✗ (error)`, matching what actually happened.
+- The distinction is available to any future consumer of `ItemState`/`history.json`, not just
+  re-derived locally in the TUI (the issue's explicit requirement).
+- No change to retry/escalation semantics for a turn-cap exit — `MaxRetries`, cooldown, and the
+  outer resume path behave exactly as before.
+
+**Negative / Trade-offs:**
+- The in-process progress-based turn-extension loop (`item.go`'s `hitLimit` check, ADR-030) still
+  requires `err == nil` to engage, and a genuine CLI-classified `error_max_turns` exit always has
+  `err != nil` — so that faster in-process extension mechanism structurally never fires for the
+  exact condition this ADR makes visible. Recovery still happens only via the slower outer
+  cooldown/retry path. This is a pre-existing gap, not introduced or worsened by this change, and is
+  explicitly left unaddressed here — see Explicitly Out of Scope.
+- `history.json` entries written before this change default `TurnLimited` to `false` on load (zero
+  value) — old capped runs remain displayed as errors retroactively; no migration was attempted since
+  they were, in fact, indistinguishable at write time.
+
+## Explicitly Out of Scope (deferred)
+
+- Revisiting the `err == nil` gate on the in-process turn-extension loop so a genuine turn-cap could
+  extend in-process instead of via the outer retry path — flagged during Research/Plan as a natural
+  follow-up, but a distinct behavioral change from this issue's rendering-only scope.
+- Generalizing `subtype`/`terminal_reason` capture into a first-class, general-purpose
+  invocation-failure-classification mechanism for other consumers (e.g. replacing #1122's `errors[]`
+  string-matching, or formalizing #1128's `error_during_execution` detection as a named condition
+  rather than an inline check). `claudeTurnLimitError` is now a second bespoke sentinel following the
+  same shape as `claudeUsageLimitError`; a third such condition would be a good trigger to extract the
+  shared pattern, but this ADR does not do so.
+
+**References:** ADR-1119 (`claudeUsageLimitError`) is the direct structural precedent for the
+sentinel-error idiom this ADR reuses; ADR-030 documents the progress-based turn-extension loop whose
+`err == nil` gate this ADR's Negative section flags but does not change.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2252,8 +2252,15 @@ cost, and issue title. Status icons:
 | `✓` | Stage completed successfully |
 | `✗` | Stage failed (hit max retries) |
 | `?` | Stage blocked / awaiting user input |
-| `↻` | Stage retrying |
+| `↻` (retry) | Stage retrying after a genuine incomplete attempt |
+| `↻` (turn limit) | Invocation exhausted its turn budget — not a failure; the same Claude session resumes and picks up where it left off |
 | `💬` | Issue has unprocessed comments |
+
+A turn-capped invocation is distinguished from a genuine error using the Claude CLI's
+own result classification (`subtype: "error_max_turns"`), not by inferring it from turn
+counts. It renders with the same `↻` icon as a retry, since it is incomplete and
+resumable rather than a fault — `✗ (error)` is reserved for invocations that did not
+complete for some other reason.
 
 **Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. The panel's appearance when there are no active warnings depends on whether there are dismissed warnings:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2250,8 +2250,15 @@ cost, and issue title. Status icons:
 | `✓` | Stage completed successfully |
 | `✗` | Stage failed (hit max retries) |
 | `?` | Stage blocked / awaiting user input |
-| `↻` | Stage retrying |
+| `↻` (retry) | Stage retrying after a genuine incomplete attempt |
+| `↻` (turn limit) | Invocation exhausted its turn budget — not a failure; the same Claude session resumes and picks up where it left off |
 | `💬` | Issue has unprocessed comments |
+
+A turn-capped invocation is distinguished from a genuine error using the Claude CLI's
+own result classification (`subtype: "error_max_turns"`), not by inferring it from turn
+counts. It renders with the same `↻` icon as a retry, since it is incomplete and
+resumable rather than a fault — `✗ (error)` is reserved for invocations that did not
+complete for some other reason.
 
 **Warnings panel**: Sits below History and surfaces actionable pre-flight issues that Fabrik detected at startup (e.g. `allow_auto_merge` disabled on a managed repo, stage-config drift). The panel header is colour-coded: dim grey for zero outstanding warnings, yellow for 1–2, red for 3+. The panel's appearance when there are no active warnings depends on whether there are dismissed warnings:
 
@@ -5249,6 +5256,7 @@ The following fields are stored in `ItemState` / `LinkedPRState` and accessed ex
 | `LastTokenUsage` | `InvocationRecorded{Usage: ...}` | `snap.State().LastTokenUsage` | `e.lastUsage[iKey]` |
 | `LastInvocationCompleted` | `InvocationRecorded{Completed: ...}` | `snap.State().LastInvocationCompleted` | `e.lastCompleted[iKey]` |
 | `LastInvocationBlocked` | `InvocationRecorded{Blocked: ...}` | `snap.State().LastInvocationBlocked` | `e.lastBlocked[iKey]` |
+| `LastInvocationTurnLimited` | `InvocationRecorded{TurnLimited: ...}` | `snap.State().LastInvocationTurnLimited` | N/A (new in #1178) |
 | `LastDeepFetchFailureAt` | `DeepFetchFailed{At: ...}` (set); `ItemDeepFetched` (clears) | `snap.State().LastDeepFetchFailureAt` | `e.deepFetchFailureTime[iKey]` |
 | `LinkedPR.CheckRuns` | `CheckRunCompleted` (when SHA is already in `shaToKey`); `PRHeadSHAUpdated` drain (flushes `pendingCheckRuns[sha]`); **`PRHeadSHAUpdated` prune** (clears the slice when the head SHA genuinely changes, not on first linkage — #958 leg 3); fallback populate in `FetchCheckRuns` | `snap.LinkedPR().CheckRuns` | CacheImpl: `c.checkRuns[sha]` (Phase 5 F4: migrated to Store in #563) |
 | `LinkedPR.LastCIFixNoOpSHA` | `CIFixNoOpRecorded{SHA}` (#958 leg 2) | `snap.LastCIFixNoOpSHA()` | N/A (new in #958) |
@@ -5429,7 +5437,7 @@ All ChangeFlags are produced by the single shared store. Field ownership is by m
 | `PRStateChanged` | Webhook/reconcile | `PRDetailsUpdated` only — a narrower sub-flag of `LinkedPRChanged` for genuine PR-level state transitions (merged, closed, draft↔ready). Emitted alongside `LinkedPRChanged`, never alone. **Not** set by `PRReviewSubmitted`/`PRReviewCommentCreated`/`ReviewThreadCommentAdded` — see `CommentBreakerObserver` (§4.6) for why that distinction is load-bearing. |
 | `CommentsChanged` | Webhook/reconcile | `IssueCommentCreated`, `LocalCommentAdded` |
 | `AssigneesChanged` | Webhook/reconcile | `IssueAssigneesUpdated` (via `applyIssuesDelta` on `issues.assigned`/`issues.unassigned` events) |
-| `InvocationChanged` | Engine-side | `InvocationRecorded` (token usage, completed, blocked, IsComment) |
+| `InvocationChanged` | Engine-side | `InvocationRecorded` (token usage, completed, blocked, turn-limited, IsComment) |
 | `StageStateChanged` | Engine-side | `StageAttempted`, `StageRetryIncremented`, `ReviewCycleIncremented`, etc. |
 | `WorkerChanged` | Engine-side | `WorkerEntered`, `LocalLockAcquired` (with Worker), `WorkerPIDSet`, `WorkerHeartbeat`, `WorkerExited` — all worker-handle mutations |
 | `WorkerLifecycleChanged` | Engine-side | `WorkerEntered`, `WorkerExited` only — lifecycle transitions that change dispatch eligibility; emitted alongside `WorkerChanged`; this is the wake-relevant sub-flag |
@@ -5460,7 +5468,7 @@ The unconditional `wakeCh <- struct{}{}` send that previously lived in the webho
 |----------|--------------|-----------|-------|
 | `wakeChObserver` | shared store (once) | `Change.Fields & wakeChFlags != 0` | `wakeCh <- struct{}{}` (non-blocking) |
 | `mayNeedWorkObserver` | shared store (once) | `Change.Fields & cycleSetFlags != 0` (excludes `WorkerLifecycleChanged` — see §9.9) | adds `repo#number` to `e.mayNeedWork` |
-| `InvocationObserver` | shared store | `Change.Fields & InvocationChanged != 0` | `tui.JobCompletedEvent` |
+| `InvocationObserver` | shared store | `Change.Fields & InvocationChanged != 0` | `tui.JobCompletedEvent` (`Success`/`Errored` are `false`/`true` respectively only for a genuine fault as of #1178 — a turn-cap exit (CLI `subtype: "error_max_turns"`) sets `TurnLimited: true` instead and no longer counts as an error for rendering purposes, even though the underlying Claude process still exited non-zero and the existing retry/cooldown mechanics are unaffected; `Completed` remains a separate axis meaning "no `FABRIK_STAGE_COMPLETE` marker was seen") |
 | `StageChangeObserver` | shared store | `Change.Fields & StatusChanged != 0` | `tui.StageChangedEvent` |
 | Pause observer (closure) | `CacheImpl.SubscribePause` | `Pause()` / `Resume()` | `tui.WebhookStatusEvent` |
 
@@ -6366,6 +6374,8 @@ The session ID is captured even when the invocation ends by hitting `max_turns` 
 #### Retry after a turn-cap kill
 
 When a stage exceeds `max_turns`, the Claude CLI self-terminates with a non-zero exit, so `completed = false` and `err != nil`. The progress-based extension loop requires `err == nil`, so this falls through to the cooldown/retry path. A later poll re-invokes the same stage with `resume = true` (`engine/item.go:682` — `resume := !lastAttempt.IsZero()`).
+
+As of #1178, the CLI's own result classification (`subtype: "error_max_turns"`) is captured alongside this exit and threaded into `InvocationRecorded.TurnLimited`, so `history.json`/the TUI can render this case as incomplete-and-resumable rather than as a generic failure. This changes only the classification/rendering surfaced from the invocation — the retry/cooldown mechanics described above are unchanged.
 
 **The retry continues the same Claude session.** It is not a fresh agent inheriting a dirty worktree — it retains the killed run's conversation context, including the output of every command that run executed before the cap.
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -95,6 +95,8 @@ The session ID is captured even when the invocation ends by hitting `max_turns` 
 
 When a stage exceeds `max_turns`, the Claude CLI self-terminates with a non-zero exit, so `completed = false` and `err != nil`. The progress-based extension loop requires `err == nil`, so this falls through to the cooldown/retry path. A later poll re-invokes the same stage with `resume = true` (`engine/item.go:682` — `resume := !lastAttempt.IsZero()`).
 
+As of #1178, the CLI's own result classification (`subtype: "error_max_turns"`) is captured alongside this exit and threaded into `InvocationRecorded.TurnLimited`, so `history.json`/the TUI can render this case as incomplete-and-resumable rather than as a generic failure. This changes only the classification/rendering surfaced from the invocation — the retry/cooldown mechanics described above are unchanged.
+
 **The retry continues the same Claude session.** It is not a fresh agent inheriting a dirty worktree — it retains the killed run's conversation context, including the output of every command that run executed before the cap.
 
 Two consequences follow, and both routinely look like defects to someone reading only the posted comment:

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2350,6 +2350,7 @@ The following fields are stored in `ItemState` / `LinkedPRState` and accessed ex
 | `LastTokenUsage` | `InvocationRecorded{Usage: ...}` | `snap.State().LastTokenUsage` | `e.lastUsage[iKey]` |
 | `LastInvocationCompleted` | `InvocationRecorded{Completed: ...}` | `snap.State().LastInvocationCompleted` | `e.lastCompleted[iKey]` |
 | `LastInvocationBlocked` | `InvocationRecorded{Blocked: ...}` | `snap.State().LastInvocationBlocked` | `e.lastBlocked[iKey]` |
+| `LastInvocationTurnLimited` | `InvocationRecorded{TurnLimited: ...}` | `snap.State().LastInvocationTurnLimited` | N/A (new in #1178) |
 | `LastDeepFetchFailureAt` | `DeepFetchFailed{At: ...}` (set); `ItemDeepFetched` (clears) | `snap.State().LastDeepFetchFailureAt` | `e.deepFetchFailureTime[iKey]` |
 | `LinkedPR.CheckRuns` | `CheckRunCompleted` (when SHA is already in `shaToKey`); `PRHeadSHAUpdated` drain (flushes `pendingCheckRuns[sha]`); **`PRHeadSHAUpdated` prune** (clears the slice when the head SHA genuinely changes, not on first linkage — #958 leg 3); fallback populate in `FetchCheckRuns` | `snap.LinkedPR().CheckRuns` | CacheImpl: `c.checkRuns[sha]` (Phase 5 F4: migrated to Store in #563) |
 | `LinkedPR.LastCIFixNoOpSHA` | `CIFixNoOpRecorded{SHA}` (#958 leg 2) | `snap.LastCIFixNoOpSHA()` | N/A (new in #958) |
@@ -2530,7 +2531,7 @@ All ChangeFlags are produced by the single shared store. Field ownership is by m
 | `PRStateChanged` | Webhook/reconcile | `PRDetailsUpdated` only — a narrower sub-flag of `LinkedPRChanged` for genuine PR-level state transitions (merged, closed, draft↔ready). Emitted alongside `LinkedPRChanged`, never alone. **Not** set by `PRReviewSubmitted`/`PRReviewCommentCreated`/`ReviewThreadCommentAdded` — see `CommentBreakerObserver` (§4.6) for why that distinction is load-bearing. |
 | `CommentsChanged` | Webhook/reconcile | `IssueCommentCreated`, `LocalCommentAdded` |
 | `AssigneesChanged` | Webhook/reconcile | `IssueAssigneesUpdated` (via `applyIssuesDelta` on `issues.assigned`/`issues.unassigned` events) |
-| `InvocationChanged` | Engine-side | `InvocationRecorded` (token usage, completed, blocked, IsComment) |
+| `InvocationChanged` | Engine-side | `InvocationRecorded` (token usage, completed, blocked, turn-limited, IsComment) |
 | `StageStateChanged` | Engine-side | `StageAttempted`, `StageRetryIncremented`, `ReviewCycleIncremented`, etc. |
 | `WorkerChanged` | Engine-side | `WorkerEntered`, `LocalLockAcquired` (with Worker), `WorkerPIDSet`, `WorkerHeartbeat`, `WorkerExited` — all worker-handle mutations |
 | `WorkerLifecycleChanged` | Engine-side | `WorkerEntered`, `WorkerExited` only — lifecycle transitions that change dispatch eligibility; emitted alongside `WorkerChanged`; this is the wake-relevant sub-flag |
@@ -2561,7 +2562,7 @@ The unconditional `wakeCh <- struct{}{}` send that previously lived in the webho
 |----------|--------------|-----------|-------|
 | `wakeChObserver` | shared store (once) | `Change.Fields & wakeChFlags != 0` | `wakeCh <- struct{}{}` (non-blocking) |
 | `mayNeedWorkObserver` | shared store (once) | `Change.Fields & cycleSetFlags != 0` (excludes `WorkerLifecycleChanged` — see §9.9) | adds `repo#number` to `e.mayNeedWork` |
-| `InvocationObserver` | shared store | `Change.Fields & InvocationChanged != 0` | `tui.JobCompletedEvent` |
+| `InvocationObserver` | shared store | `Change.Fields & InvocationChanged != 0` | `tui.JobCompletedEvent` (`Success`/`Errored` are `false`/`true` respectively only for a genuine fault as of #1178 — a turn-cap exit (CLI `subtype: "error_max_turns"`) sets `TurnLimited: true` instead and no longer counts as an error for rendering purposes, even though the underlying Claude process still exited non-zero and the existing retry/cooldown mechanics are unaffected; `Completed` remains a separate axis meaning "no `FABRIK_STAGE_COMPLETE` marker was seen") |
 | `StageChangeObserver` | shared store | `Change.Fields & StatusChanged != 0` | `tui.StageChangedEvent` |
 | Pause observer (closure) | `CacheImpl.SubscribePause` | `Pause()` / `Resume()` | `tui.WebhookStatusEvent` |
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -60,6 +60,28 @@ func (e *claudeUsageLimitError) Error() string {
 	return fmt.Sprintf("claude usage limit hit: %s", e.Message)
 }
 
+// claudeTurnLimitError signals that a Claude invocation exited because it
+// exhausted its configured turn budget (CLI-reported subtype
+// "error_max_turns"), not because the stage genuinely failed. Unlike
+// claudeUsageLimitError, this does NOT short-circuit finalizeStageOutcome /
+// processComments with an early return: the existing retry/escalation
+// machinery (StageAttempted, commitWIP, StageRetryIncremented, MaxRetries)
+// must still run exactly as it does today for a turn-cap exit — that
+// behavior is pre-existing and deliberate (see #1081/#448), and out of scope
+// for #1178. This sentinel only changes what feeds the InvocationRecorded
+// write, so history/TUI can render the run as incomplete-but-resumable
+// rather than as a genuine fault.
+type claudeTurnLimitError struct {
+	// TerminalReason is the CLI's own terminal_reason field, if present, for logging.
+	TerminalReason string
+	// NumTurns is the CLI-reported turn count at exit, for logging.
+	NumTurns int
+}
+
+func (e *claudeTurnLimitError) Error() string {
+	return fmt.Sprintf("claude exited: turn limit reached (num_turns=%d)", e.NumTurns)
+}
+
 // detectUsageLimitExit scans raw invocation output — the full NDJSON stdout
 // stream, not the parsed claudeResponse.Result or the already-collapsed text
 // variable — for Anthropic's account usage-limit exit message. Raw bytes are
@@ -671,6 +693,10 @@ type claudeResponse struct {
 	IsError   bool     `json:"is_error"`
 	Errors    []string `json:"errors"`
 	Subtype   string   `json:"subtype"`
+	// TerminalReason is the CLI's more explicit structural classification
+	// (e.g. "max_turns"), captured for logging/future use alongside Subtype.
+	// Only Subtype is consulted for the error_max_turns branch condition below.
+	TerminalReason string `json:"terminal_reason"`
 	// ModelUsage contains per-model accumulated token counts for the full session.
 	// These are more accurate than the top-level "usage" field, which reflects only
 	// the last API call rather than the entire multi-turn session.
@@ -928,6 +954,18 @@ func interpretClaudeResult(ctx context.Context, issueNumber int, rawOutput []byt
 		if stageCompleteRE.MatchString(text) {
 			claudeLog(issueNumber, "warn", "stage completed (marker found) but Claude exited with error: %v\n", runErr)
 			return text, true, usage, fmt.Errorf("claude exited with error: %w", runErr)
+		}
+		// Structural turn-cap classification from the CLI's own result object,
+		// not inferred from turn counts (the CLI's own accounting can report a
+		// turn count past the configured cap, e.g. num_turns: 51 against
+		// max_turns: 50, so an inference built on >= would be fragile). This
+		// check runs before detectUsageLimitExit precisely because relying on
+		// output-prose matching there caused this exact condition to
+		// misclassify as a usage-limit exit — see detectUsageLimitExit's doc
+		// comment and #1183.
+		if ok && resp.Subtype == "error_max_turns" {
+			claudeLog(issueNumber, "claude", "turn limit reached (subtype=error_max_turns, terminal_reason=%q, num_turns=%d)\n", resp.TerminalReason, resp.NumTurns)
+			return text, false, usage, &claudeTurnLimitError{TerminalReason: resp.TerminalReason, NumTurns: resp.NumTurns}
 		}
 		// usage is passed as an exclusion gate only: it can rule a usage-limit
 		// exit *out* (turns consumed and cost incurred means the invocation ran,

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -289,14 +289,22 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 	// non-zero exit does NOT veto completion; it is recorded separately via Errored so
 	// the error is still visible in history (JobCompletedEvent.Success=false).
 	completed := invCompleted
+	// A turn-limit exit (CLI subtype error_max_turns) is not a genuine fault —
+	// see the identical wiring in finalizeStageOutcome (engine/item.go) and
+	// claudeTurnLimitError in engine/claude.go. Only what feeds the
+	// InvocationRecorded write changes; err itself is left untouched for the
+	// retry/circuit-breaker logic below.
+	var turnLimitErr *claudeTurnLimitError
+	turnLimited := errors.As(err, &turnLimitErr)
 	e.store.Apply(itemstate.InvocationRecorded{
-		Repo:      itemOwnerRepoString(item, e.defaultRepo()),
-		Number:    item.Number,
-		Completed: completed,
-		Errored:   err != nil,
-		Usage:     usage,
-		IsComment: true,
-		Duration:  time.Since(startedAt),
+		Repo:        itemOwnerRepoString(item, e.defaultRepo()),
+		Number:      item.Number,
+		Completed:   completed,
+		Errored:     err != nil && !turnLimited,
+		TurnLimited: turnLimited,
+		Usage:       usage,
+		IsComment:   true,
+		Duration:    time.Since(startedAt),
 	})
 	// Bail early ONLY if the stage did not complete. If FABRIK_STAGE_COMPLETE was
 	// emitted before the process exited non-zero (e.g. a timeout kill after the stage

--- a/engine/interpret_claude_result_test.go
+++ b/engine/interpret_claude_result_test.go
@@ -162,6 +162,79 @@ func TestInterpretClaudeResult_NonStaleError_StillSavesSession(t *testing.T) {
 	}
 }
 
+// TestInterpretClaudeResult_TurnCapExit_ClassifiedAsTurnLimitError uses the
+// exact production payload shape from #1114 (Implement,
+// Implement-20260727-125747-*.log): subtype error_max_turns, terminal_reason
+// max_turns, is_error true, and a CLI-reported num_turns (51) past the
+// configured cap (50) — confirming the classification is read directly from
+// subtype rather than inferred from a turn-count comparison. session_id is
+// included per the confirmed carve-out (#1081): the CLI still reports
+// session_id on a max_turns hit even though result text is empty, which is
+// what parseClaudeJSON's ok-gate requires to accept the payload.
+func TestInterpretClaudeResult_TurnCapExit_ClassifiedAsTurnLimitError(t *testing.T) {
+	raw := []byte(`{"type":"result","subtype":"error_max_turns","terminal_reason":"max_turns",` +
+		`"session_id":"sid-1114","errors":["Reached maximum number of turns (50)"],"is_error":true,"num_turns":51}`)
+
+	_, completed, _, err := interpretClaudeResult(context.Background(), 1114, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error to be returned")
+	}
+	if completed {
+		t.Errorf("expected completed=false (no FABRIK_STAGE_COMPLETE marker)")
+	}
+	var turnLimitErr *claudeTurnLimitError
+	if !errors.As(err, &turnLimitErr) {
+		t.Fatalf("expected *claudeTurnLimitError, got %T: %v", err, err)
+	}
+	if turnLimitErr.TerminalReason != "max_turns" {
+		t.Errorf("TerminalReason = %q, want %q", turnLimitErr.TerminalReason, "max_turns")
+	}
+	if turnLimitErr.NumTurns != 51 {
+		t.Errorf("NumTurns = %d, want 51", turnLimitErr.NumTurns)
+	}
+}
+
+// TestInterpretClaudeResult_GenuineError_NotClassifiedAsTurnLimit uses the
+// exact production payload shape from #1128 (reaped session): subtype
+// error_during_execution, distinct from error_max_turns. It must classify as
+// a generic error, never as *claudeTurnLimitError.
+func TestInterpretClaudeResult_GenuineError_NotClassifiedAsTurnLimit(t *testing.T) {
+	raw := []byte(`{"type":"result","subtype":"error_during_execution","session_id":"3fefda47-9ea5-422a-9cdb-33da6e13244d",` +
+		`"errors":["No conversation found with session ID: 3fefda47-…"],"is_error":true,"num_turns":0}`)
+
+	_, completed, _, err := interpretClaudeResult(context.Background(), 1128, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error to be returned")
+	}
+	if completed {
+		t.Errorf("expected completed=false")
+	}
+	var turnLimitErr *claudeTurnLimitError
+	if errors.As(err, &turnLimitErr) {
+		t.Errorf("expected genuine error NOT to be classified as *claudeTurnLimitError, got %v", turnLimitErr)
+	}
+}
+
+// TestInterpretClaudeResult_IncompleteWithoutCap_NotClassifiedAsTurnLimit
+// covers a non-zero exit with neither a completion marker nor any recognized
+// subtype (e.g. a crash or unrecognized failure) — must fall through to the
+// generic error path, not be misclassified as a turn cap.
+func TestInterpretClaudeResult_IncompleteWithoutCap_NotClassifiedAsTurnLimit(t *testing.T) {
+	raw := []byte(`{"result":"partial work, no marker","session_id":"sid-6"}`)
+
+	_, completed, _, err := interpretClaudeResult(context.Background(), 1, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error to be returned")
+	}
+	if completed {
+		t.Errorf("expected completed=false")
+	}
+	var turnLimitErr *claudeTurnLimitError
+	if errors.As(err, &turnLimitErr) {
+		t.Errorf("expected incomplete-without-cap NOT to be classified as *claudeTurnLimitError, got %v", turnLimitErr)
+	}
+}
+
 // TestInterpretClaudeResult_HealthyResume_SessionIDSaved confirms the
 // ordinary success path (no IsError) still persists the session ID —
 // the resave guard must not regress normal resume behavior.

--- a/engine/item.go
+++ b/engine/item.go
@@ -1105,6 +1105,19 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 		}
 	}
 
+	// A Claude turn-limit exit (CLI subtype error_max_turns) is not a genuine
+	// fault — it is an incomplete, resumable run that made real progress and
+	// will continue via the existing retry/cooldown path. Unlike the
+	// usage-limit case above, this does NOT short-circuit: StageAttempted,
+	// commitWIP, the branch push, and StageRetryIncremented/MaxRetries
+	// escalation all still run exactly as they do today for any other
+	// incomplete run. turnLimited only changes what feeds the
+	// InvocationRecorded write below, so history/TUI can render this as
+	// incomplete-but-resumable rather than as an error. See claudeTurnLimitError
+	// in claude.go and ADR-1178.
+	var turnLimitErr *claudeTurnLimitError
+	turnLimited := errors.As(err, &turnLimitErr)
+
 	// Any invocation reaching this point actually ran Claude and was not itself
 	// classified as a usage-limit exit (success, blocked-on-input, no-work-needed,
 	// genuine failure/retry, and PR-creation failure alike) — clear the gate label
@@ -1308,13 +1321,14 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 
 	// Store completion/blocked/usage state for TUI event emission in poll.go.
 	e.store.Apply(itemstate.InvocationRecorded{
-		Repo:      itemOwnerRepoString(item, e.defaultRepo()),
-		Number:    item.Number,
-		Completed: completed,
-		Blocked:   blockedOnInput,
-		Errored:   err != nil,
-		Usage:     usage,
-		Duration:  time.Since(p.workerStartedAt),
+		Repo:        itemOwnerRepoString(item, e.defaultRepo()),
+		Number:      item.Number,
+		Completed:   completed,
+		Blocked:     blockedOnInput,
+		Errored:     err != nil && !turnLimited,
+		TurnLimited: turnLimited,
+		Usage:       usage,
+		Duration:    time.Since(p.workerStartedAt),
 	})
 
 	if completed && noWorkNeeded {

--- a/engine/observers.go
+++ b/engine/observers.go
@@ -103,7 +103,8 @@ func (o *InvocationObserver) OnChange(change itemstate.Change, snap itemstate.Sn
 		StageName:      st.Status,
 		StageModel:     model,
 		IsComment:      st.LastInvocationIsComment,
-		Success:        !st.LastInvocationErrored, // false when the Claude process exited non-zero
+		Success:        !st.LastInvocationErrored, // false when the Claude process exited non-zero for a genuine fault
+		TurnLimited:    st.LastInvocationTurnLimited,
 		Completed:      st.LastInvocationCompleted,
 		BlockedOnInput: st.LastInvocationBlocked,
 		Duration:       st.LastInvocationDuration,

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -120,6 +120,13 @@ type ItemState struct {
 	// finished. The error is surfaced as JobCompletedEvent.Success=false in history.
 	LastInvocationErrored bool
 
+	// LastInvocationTurnLimited records whether the most recent Claude invocation
+	// exited because it exhausted its configured turn budget (CLI subtype
+	// error_max_turns), as opposed to a genuine failure. A turn-limited invocation
+	// is incomplete but resumable — surfaced as JobCompletedEvent.TurnLimited in
+	// history, rendered distinctly from a genuine error. See ADR-1178.
+	LastInvocationTurnLimited bool
+
 	// LastTokenUsage holds token consumption from the most recent Claude invocation.
 	// Replaces engine.lastUsage[iKey].
 	LastTokenUsage TokenUsage

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -114,10 +114,12 @@ type ItemState struct {
 	LastInvocationDuration time.Duration
 
 	// LastInvocationErrored records whether the most recent Claude invocation exited
-	// with a non-zero status (process error, timeout kill, etc.). This is recorded
-	// independently of LastInvocationCompleted: a stage can complete (FABRIK_STAGE_COMPLETE
-	// emitted) even when the process exits non-zero — e.g. a timeout kill after the stage
-	// finished. The error is surfaced as JobCompletedEvent.Success=false in history.
+	// with a non-zero status (process error, timeout kill, etc.) AND was not classified
+	// as a turn-limit exit (see LastInvocationTurnLimited) — i.e. a genuine fault. This
+	// is recorded independently of LastInvocationCompleted: a stage can complete
+	// (FABRIK_STAGE_COMPLETE emitted) even when the process exits non-zero — e.g. a
+	// timeout kill after the stage finished. The error is surfaced as
+	// JobCompletedEvent.Success=false in history.
 	LastInvocationErrored bool
 
 	// LastInvocationTurnLimited records whether the most recent Claude invocation

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -535,11 +535,18 @@ type InvocationRecorded struct {
 	Number    int
 	Completed bool
 	Blocked   bool
-	// Errored is true when the Claude process exited non-zero. Recorded independently
-	// of Completed — the completion marker is authoritative for whether the stage
-	// completed; Errored only records that the process didn't exit cleanly.
+	// Errored is true when the Claude process exited non-zero AND the exit was not
+	// classified as a turn-limit hit (see TurnLimited). Recorded independently of
+	// Completed — the completion marker is authoritative for whether the stage
+	// completed; Errored only records that the process didn't exit cleanly for a
+	// genuine fault.
 	Errored bool
-	Usage   TokenUsage
+	// TurnLimited is true when the Claude invocation exited because it exhausted
+	// its configured turn budget (CLI subtype error_max_turns), as opposed to a
+	// genuine failure. A turn-limited run is incomplete but resumable, not an
+	// error — see claudeTurnLimitError in engine/claude.go and ADR-1178.
+	TurnLimited bool
+	Usage       TokenUsage
 	// IsComment is true when the invocation processed a user comment rather than
 	// running a stage. Stored in ItemState.LastInvocationIsComment so that the
 	// InvocationObserver can forward the correct flag to the TUI.

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -490,6 +490,7 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 		item.LastInvocationCompleted = v.Completed
 		item.LastInvocationBlocked = v.Blocked
 		item.LastInvocationErrored = v.Errored
+		item.LastInvocationTurnLimited = v.TurnLimited
 		item.LastInvocationIsComment = v.IsComment
 		item.LastInvocationDuration = v.Duration
 		item.LastTokenUsage = v.Usage

--- a/tui/detail.go
+++ b/tui/detail.go
@@ -19,6 +19,7 @@ type DetailItem struct {
 	Elapsed        time.Duration
 	Duration       time.Duration
 	Success        bool
+	TurnLimited    bool
 	Completed      bool
 	BlockedOnInput bool
 	TurnsUsed      int
@@ -68,7 +69,11 @@ func (d DetailPanelComponent) View(width int) string {
 		} else if item.BlockedOnInput {
 			statusStr = "awaiting input"
 		} else if !item.Completed {
-			statusStr = "incomplete"
+			if item.TurnLimited {
+				statusStr = "incomplete (turn limit)"
+			} else {
+				statusStr = "incomplete"
+			}
 		}
 		lines = append(lines, fmt.Sprintf("Issue:    #%d", item.IssueNumber))
 		if item.Title != "" {

--- a/tui/detail_test.go
+++ b/tui/detail_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +41,27 @@ func TestUpdate_EscapeKey_ClosesDetailPanel(t *testing.T) {
 	nm := next.(Model)
 	if nm.detailPanel {
 		t.Error("expected detailPanel=false after escape key")
+	}
+}
+
+// TestDetailPanel_TurnLimitStatus verifies the detail panel's "Status" line renders
+// "incomplete (turn limit)" for a turn-capped entry, distinct from a plain "incomplete"
+// retry — part of the issue #1178 rendering fix (also applied in tui/history.go).
+func TestDetailPanel_TurnLimitStatus(t *testing.T) {
+	var d DetailPanelComponent
+	d.SetVisible(true)
+	d.SetWidth(80)
+
+	d.SetItem(&DetailItem{IssueNumber: 1, StageName: "Implement", Success: true, TurnLimited: true, Completed: false})
+	view := d.View(80)
+	if !strings.Contains(view, "incomplete (turn limit)") {
+		t.Errorf("expected %q in detail panel view for turn-capped entry, got: %q", "incomplete (turn limit)", view)
+	}
+
+	d.SetItem(&DetailItem{IssueNumber: 2, StageName: "Implement", Success: true, TurnLimited: false, Completed: false})
+	view = d.View(80)
+	if !strings.Contains(view, "Status:   incomplete") || strings.Contains(view, "turn limit") {
+		t.Errorf("expected plain %q (no turn limit) in detail panel view for retry entry, got: %q", "incomplete", view)
 	}
 }
 

--- a/tui/events.go
+++ b/tui/events.go
@@ -63,6 +63,7 @@ type JobCompletedEvent struct {
 	StageModel     string // model configured for the stage (e.g. "sonnet")
 	IsComment      bool   // true when processing a user comment, not a stage run
 	Success        bool   // no error from processItem
+	TurnLimited    bool   // invocation exited due to turn-budget exhaustion (CLI subtype error_max_turns), not a genuine fault
 	Completed      bool   // stage actually completed (FABRIK_STAGE_COMPLETE detected)
 	BlockedOnInput bool   // stage needs user input (FABRIK_BLOCKED_ON_INPUT detected)
 	Duration       time.Duration

--- a/tui/history.go
+++ b/tui/history.go
@@ -106,6 +106,7 @@ func (h HistoryPaneComponent) Update(msg tea.Msg) (Component, tea.Cmd) {
 			StageModel:     ev.StageModel,
 			IsComment:      ev.IsComment,
 			Success:        ev.Success,
+			TurnLimited:    ev.TurnLimited,
 			Completed:      ev.Completed,
 			BlockedOnInput: ev.BlockedOnInput,
 			Duration:       ev.Duration,
@@ -247,7 +248,11 @@ func (h *HistoryPaneComponent) rebuildViewportContent(innerWidth int) {
 			result = dimStyle.Render("  (input needed)")
 		} else if !he.Completed {
 			status = dimStyle.Render("↻")
-			result = dimStyle.Render("  (retry)")
+			if he.TurnLimited {
+				result = dimStyle.Render("  (turn limit)")
+			} else {
+				result = dimStyle.Render("  (retry)")
+			}
 		} else {
 			status = successStyle.Render("✓")
 		}

--- a/tui/history_test.go
+++ b/tui/history_test.go
@@ -494,7 +494,10 @@ func TestJobCompletedEvent_MultiAttempt(t *testing.T) {
 // TestHistory_TurnCappedRetries is the regression test for issue #847. It simulates
 // a stage that hits max_turns twice (capped, Completed: false) and then completes on
 // the third attempt, asserting all three invocations appear in history with distinct
-// costs and that only the final entry is marked Completed: true.
+// costs and that only the final entry is marked Completed: true. Per #1178, a capped
+// attempt is no longer a genuine fault: production now reports it as
+// Success: true, TurnLimited: true (not Success: false), so the two capped events here
+// are constructed the way finalizeStageOutcome actually emits them post-#1178.
 func TestHistory_TurnCappedRetries(t *testing.T) {
 	redirectHistory(t)
 
@@ -504,12 +507,13 @@ func TestHistory_TurnCappedRetries(t *testing.T) {
 	t2 := t1.Add(95 * time.Minute)
 	t3 := t2.Add(30 * time.Minute)
 
-	sendEvent := func(cost float64, completed bool, ts time.Time) {
+	sendEvent := func(cost float64, completed, turnLimited bool, ts time.Time) {
 		comp, _ := h.Update(JobCompletedEvent{
 			IssueNumber: 1128,
 			Repo:        "example-org/example-repo",
 			StageName:   "Implement",
-			Success:     completed,
+			Success:     completed || turnLimited,
+			TurnLimited: turnLimited,
 			Completed:   completed,
 			CostUSD:     cost,
 			TurnsUsed:   101,
@@ -521,9 +525,9 @@ func TestHistory_TurnCappedRetries(t *testing.T) {
 	}
 
 	// Two capped attempts followed by a completing attempt.
-	sendEvent(14.11, false, t1)
-	sendEvent(9.17, false, t2)
-	sendEvent(44.10, true, t3)
+	sendEvent(14.11, false, true, t1)
+	sendEvent(9.17, false, true, t2)
+	sendEvent(44.10, true, false, t3)
 
 	entries := h.History()
 
@@ -551,6 +555,18 @@ func TestHistory_TurnCappedRetries(t *testing.T) {
 	}
 	if !entries[2].Completed {
 		t.Errorf("entries[2].Completed = false, want true (completing attempt)")
+	}
+
+	// (c2) First two entries must be TurnLimited: true (not rendered as errors); last
+	// must be TurnLimited: false.
+	if !entries[0].TurnLimited {
+		t.Errorf("entries[0].TurnLimited = false, want true (capped attempt)")
+	}
+	if !entries[1].TurnLimited {
+		t.Errorf("entries[1].TurnLimited = false, want true (capped attempt)")
+	}
+	if entries[2].TurnLimited {
+		t.Errorf("entries[2].TurnLimited = true, want false (completing attempt)")
 	}
 
 	// (d) SaveHistory/LoadHistory round-trip must preserve all three entries.

--- a/tui/history_test.go
+++ b/tui/history_test.go
@@ -267,6 +267,71 @@ func TestViewHistory_IsComment(t *testing.T) {
 	}
 }
 
+// TestViewHistory_TurnLimitClassification is the regression test for issue #1178. It
+// covers the full rendering matrix required by the issue's Definition of Done: a
+// turn-capped invocation must render as "↻  (turn limit)" (not an error), a genuine
+// error must still render as "✗  (error)", and the existing blocked-on-input,
+// incomplete-without-cap, and success renderings must be unchanged.
+func TestViewHistory_TurnLimitClassification(t *testing.T) {
+	redirectHistory(t)
+
+	cases := []struct {
+		name  string
+		entry HistoryEntry
+		want  string
+		unwnt []string
+	}{
+		{
+			name:  "turn-capped",
+			entry: HistoryEntry{IssueNumber: 1, StageName: "Implement", Success: true, TurnLimited: true, Completed: false},
+			want:  "(turn limit)",
+			unwnt: []string{"(error)", "(retry)"},
+		},
+		{
+			name:  "genuine error",
+			entry: HistoryEntry{IssueNumber: 2, StageName: "Implement", Success: false, TurnLimited: false, Completed: false},
+			want:  "(error)",
+			unwnt: []string{"(turn limit)", "(retry)"},
+		},
+		{
+			name:  "blocked on input",
+			entry: HistoryEntry{IssueNumber: 3, StageName: "Implement", Success: true, Completed: false, BlockedOnInput: true},
+			want:  "(input needed)",
+			unwnt: []string{"(error)", "(turn limit)", "(retry)"},
+		},
+		{
+			name:  "incomplete without cap",
+			entry: HistoryEntry{IssueNumber: 4, StageName: "Implement", Success: true, TurnLimited: false, Completed: false},
+			want:  "(retry)",
+			unwnt: []string{"(error)", "(turn limit)"},
+		},
+		{
+			name:  "success",
+			entry: HistoryEntry{IssueNumber: 5, StageName: "Implement", Success: true, Completed: true},
+			want:  "✓",
+			unwnt: []string{"(error)", "(turn limit)", "(retry)", "(input needed)"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New(30, ProjectInfo{}, "", nil, nil, 0, false)
+			m.history.history = []HistoryEntry{tc.entry}
+			next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+			m = next.(Model)
+			view := m.history.View(m.width)
+			if !strings.Contains(view, tc.want) {
+				t.Errorf("%s: expected %q in view, got: %q", tc.name, tc.want, view)
+			}
+			for _, u := range tc.unwnt {
+				if strings.Contains(view, u) {
+					t.Errorf("%s: unexpected %q in view, got: %q", tc.name, u, view)
+				}
+			}
+		})
+	}
+}
+
 // TestViewHistory_ConfirmQuit verifies the quit confirmation prompt is shown in viewHistory.
 func TestViewHistory_ConfirmQuit(t *testing.T) {
 	redirectHistory(t)

--- a/tui/model.go
+++ b/tui/model.go
@@ -20,6 +20,7 @@ type HistoryEntry struct {
 	StageModel     string // model configured for the stage; empty means use claude default
 	IsComment      bool
 	Success        bool
+	TurnLimited    bool
 	Completed      bool
 	BlockedOnInput bool
 	Duration       time.Duration
@@ -836,6 +837,7 @@ func (m *Model) prepareDetailItem() {
 			StageName:      entry.StageName,
 			StageModel:     entry.StageModel,
 			Success:        entry.Success,
+			TurnLimited:    entry.TurnLimited,
 			Completed:      entry.Completed,
 			BlockedOnInput: entry.BlockedOnInput,
 			Duration:       entry.Duration,


### PR DESCRIPTION
Closes #1178

## What this does

A turn-cap exit (Claude CLI `subtype: "error_max_turns"`) was rendered identically to a genuine invocation failure — a red `✗ (error)` — in the TUI History pane and detail panel. It isn't a fault: it's an incomplete, resumable run that made real progress and continues in the same Claude session on the next attempt. This PR distinguishes the two cases using the CLI's own structural result classification instead of inferring the condition from turn counts.

## Key changes

- **`engine/claude.go`** — captures `TerminalReason` on `claudeResponse`; adds a `claudeTurnLimitError` sentinel returned from `interpretClaudeResult` when `resp.Subtype == "error_max_turns"`.
- **`engine/item.go` / `engine/comments.go`** — both `InvocationRecorded` write sites detect the sentinel via `errors.As` (no early return — retry/escalation semantics for a genuine turn-cap are unchanged) and compute `Errored: err != nil && !turnLimited`, `TurnLimited: turnLimited`.
- **`internal/itemstate`** — new `TurnLimited` field threaded through `InvocationRecorded` → `ItemState.LastInvocationTurnLimited` → the store.
- **`engine/observers.go` → `tui`** — threaded through `JobCompletedEvent`, `HistoryEntry`, and `DetailItem`. Because `Errored` is now `false` for a turn-cap, the existing `!he.Completed` branch is reached naturally; a sub-branch renders `↻ (turn limit)` (History pane) / `"incomplete (turn limit)"` (detail panel) instead of `(retry)` — same icon, no new color, no branch reordering.
- **Docs** — `docs/USER_GUIDE.md` icon legend, `docs/state-machine.md` field mapping, `docs/stage-lifecycle.md` cross-reference, `docs/llms-full.txt` regenerated.
- **`adrs/1178-turn-limit-classification.md`** — new ADR documenting the sentinel-error approach (mirroring ADR-1119) and its one deliberate divergence: no early return, since a genuine turn-cap's existing retry/escalation pipeline is pre-existing, deliberate behavior and out of scope here.

## Test plan

- `engine/interpret_claude_result_test.go`: turn-capped exit (using #1114's literal `error_max_turns` payload), genuine error (#1128's `error_during_execution` payload) confirmed *not* classified as turn-limited, incomplete-without-cap unaffected.
- `tui/history_test.go` (`TestViewHistory_TurnLimitClassification`): the full DoD matrix — turn-capped, genuine error, blocked-on-input, incomplete-without-cap, success — each asserting the expected text and absence of the others.
- `tui/detail_test.go`: detail-panel status string for a turn-capped entry.
- `go build ./...`, `go vet ./...` clean; `go test -race ./...` passes (2936 passed) except `TestExecute_ConfigYAMLApplied`, a pre-existing network-dependent flake reproduced identically on the pre-issue merge-base commit (296f7e7) — unrelated to this change.