### PR TITLE
feat(pruefer): pass --setting-sources user so the reviewed PR's .claude settings are never loaded

### DIFF
--- a/pruefer/claude.go
+++ b/pruefer/claude.go
@@ -113,11 +113,25 @@ func buildReviewPrompt(req ReviewRequest) string {
 // invocation. Always non-interactive (--permission-mode dontAsk) and always
 // the fixed read-only allowlist — there is no unrestricted/label-driven
 // escape hatch, unlike Fabrik stages.
+//
+// Together with reviewAllowedTools above and --permission-mode dontAsk
+// below, --setting-sources user is the third piece of Pruefer's security
+// posture: it requests only the operator's own ~/.claude/settings.json,
+// never the reviewed PR's .claude/settings.json or .claude/settings.local.json.
+// Those files come from code that has not been reviewed yet, so a
+// malicious or careless PR could otherwise widen the reviewer's own tool
+// grants via permissions.allow entries. This is additive, not a substitute
+// for the untrusted-workspace default that already blocks loading them —
+// the clone is never marked trusted (no hasTrustDialogAccepted) — it just
+// makes the restriction explicit instead of incidental, and stops Claude
+// Code from emitting an "Ignoring N permissions.allow entries" warning for
+// settings files it was never asked to load in the first place.
 func buildReviewArgs(req ReviewRequest) []string {
 	args := []string{
 		"--output-format", "stream-json",
 		"--verbose",
 		"--permission-mode", "dontAsk",
+		"--setting-sources", "user",
 	}
 	if req.Model != "" {
 		args = append(args, "--model", req.Model)

--- a/pruefer/claude_test.go
+++ b/pruefer/claude_test.go
@@ -44,6 +44,21 @@ func TestBuildReviewArgs_ReadOnlyAllowlist(t *testing.T) {
 	}
 }
 
+func TestBuildReviewArgs_UserSettingsOnly(t *testing.T) {
+	args := buildReviewArgs(ReviewRequest{})
+
+	found := false
+	for i, a := range args {
+		if a == "--setting-sources" && i+1 < len(args) && args[i+1] == "user" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --setting-sources user, args = %v", args)
+	}
+}
+
 func TestBuildReviewArgs_NoModelWhenUnset(t *testing.T) {
 	args := buildReviewArgs(ReviewRequest{})
 	if slices.Contains(args, "--model") {


### PR DESCRIPTION
Closes #1190

## What

Adds `--setting-sources user` to the `claude` CLI invocation in `pruefer/claude.go`'s `buildReviewArgs`, so every Pruefer review requests only the operator's own `~/.claude/settings.json` — never the reviewed PR's `.claude/settings.json` or `.claude/settings.local.json`.

## Why

Those files come from the PR under review — code that hasn't been reviewed yet. In `handarbeit/fabrik` they currently include `Edit`, `Write`, and `Bash(go build*)` under `permissions.allow`. Until now, those grants were blocked only incidentally by Claude Code's untrusted-workspace default (which also emits a noisy, unsuppressible "Ignoring N permissions.allow entries..." warning with a different temp path on every single review). This change makes the restriction explicit and intentional instead of incidental, and eliminates the warning by never requesting those files in the first place — it does not touch or weaken the untrusted-workspace default, which remains in force as a backstop.

## Changes

- `pruefer/claude.go`: added `--setting-sources user` to `buildReviewArgs`'s returned args; extended the doc comment above the function to document this as the third piece of Pruefer's security posture, alongside `reviewAllowedTools` and `--permission-mode dontAsk`.
- `pruefer/claude_test.go`: added `TestBuildReviewArgs_UserSettingsOnly`, asserting `--setting-sources user` is present in the built args (flag/value adjacency check, mirroring the existing `--allowedTools` test pattern).

No changes to `cmd.Stderr` forwarding, trust handling, `hasTrustDialogAccepted`, or the ephemeral clone logic — all confirmed unaffected/unnecessary by Research.

## Manual verification (required by the issue)

Constructed an untrusted local git workspace (`/tmp/pruefer-verify`, not in `~/.claude.json`'s trusted projects) with `.claude/settings.json` containing 3 `permissions.allow` entries (`Edit`, `Write`, `Bash(go build*)`), then ran the real `claude` CLI (v2.1.220) non-interactively:

- **Baseline** (`--permission-mode dontAsk --allowedTools Read`, no `--setting-sources`): stderr showed `Ignoring 3 permissions.allow entries from .claude/settings.json: this workspace has not been trusted...` — reproducing the reported noise.
- **With the fix** (same command + `--setting-sources user`): stderr was empty — no warning.

This confirms `--setting-sources user` is sufficient on its own; no suppression or string-matching was needed or added.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./pruefer/...` (134 passed)
- [x] Manual verification against the real `claude` CLI (see above)
- [x] `go test ./...` — one pre-existing, unrelated failure in `cmd.TestExecute_ConfigYAMLApplied` (network-dependent GraphQL board fetch + SIGINT timing, fails in isolation regardless of this change, untouched package)