### PR TITLE
feat(pruefer): post findings as inline review thread comments

### DIFF
--- a/adrs/1189-pruefer-inline-review-comments.md
+++ b/adrs/1189-pruefer-inline-review-comments.md
@@ -1,0 +1,70 @@
+# ADR 1189: Pruefer Inline Review Comments
+
+**Date**: 2026-07-27
+**Status**: Accepted
+**Issue**: #1189 — post findings as inline review thread comments so Fabrik's review-reinvoke can consume them
+
+## Context
+
+Pruefer V1 (ADR-1113) submitted its entire review as a single top-level `body` on the `pull_request_review`, deliberately scoping inline comments as "desirable but optional" to ship. That left a gap: Fabrik's review-reinvoke path (`buildReviewThreadComments`, `engine/reviews.go`) reads only line-anchored review comments, never the top-level body. A Pruefer review satisfied `wait_for_reviews: true` but produced zero auto-fix work — findings existed only as prose a human had to relay by hand (observed live on PR #1185).
+
+This issue closes that gap: `SubmitPRReview` now accepts an optional `comments[]` array alongside `body` in the same request, the review prompt emits structured findings instead of free prose, and findings are mapped onto diff-validated anchors before submission.
+
+## Decisions
+
+### 1. Two-part output contract: prose summary, then a fenced ```json findings array
+
+`buildReviewPrompt` (`pruefer/claude.go`) instructs Claude to produce free-form prose first (the only text GitHub surfaces outside inline comments — it must stand on its own as an overall assessment), followed by exactly one fenced ` ```json ` code block containing a JSON array of `{"path", "line", "body"}` objects, one per finding. `path` must match the diff exactly; `line` must be a line visible in the new (post-change) file version.
+
+A fenced JSON block was chosen over markdown headings or another prose convention because it parses reliably with a single non-greedy regex plus `encoding/json` — no heuristic section-splitting, no ambiguity about where one finding ends and the next begins. This is new territory for the codebase (no prior structured-output contract exists for a Claude invocation anywhere in Fabrik or Pruefer), so the format was picked for parse reliability over prompt elegance.
+
+### 2. No fenced block, or malformed JSON inside it, degrades to whole-text-as-summary — never an error
+
+`parseReviewFindings` (`pruefer/findings.go`) is intentionally forgiving: if the fence is absent or its content doesn't unmarshal as `[]ReviewFinding`, the entire input becomes the summary and zero findings are extracted. This is not a parse-failure error path — it is the same body-only review Pruefer already submitted before this issue, so it costs nothing beyond "no inline comments this round."
+
+This also settles a question ADR-1113's Decision 9 ("on invocation failure, post nothing") left open: a *successful* Claude invocation that didn't follow the new contract is not treated the same as an invocation failure. Decision 9 is reserved for genuine invocation failures (process crash, empty/error output) — a review that came back but wasn't structured the way the prompt asked still gets posted, just without inline comments. Never let an imperfect (or absent) findings block sink the review.
+
+### 3. Anchor validation runs client-side, before submission — never after a 422
+
+GitHub's `POST /pulls/{n}/reviews` rejects the **entire review** if any single entry in `comments[]` has a `path`/`line` that isn't a valid position in the diff. There is no partial-success response and no structured error type in `github/client.go` that would let a caller distinguish a 422 from any other 4xx after the fact (`restPostWithResponse` surfaces every non-2xx as the same formatted error string). Retrying-after-422 was never a viable design — the only way to guarantee "the review submits" is to never send an invalid anchor in the first place.
+
+`validRightAnchors` (`pruefer/diffanchor.go`) parses the PR's unified diff (already fetched by `ReviewPR` for the size guard — no second `FetchPRDiff` call) into the set of valid RIGHT-side `(path, line)` positions: every context or added line inside a hunk, keyed off each hunk's `+++ b/<path>` header so renamed files resolve to their destination path. Deletion-only lines, lines outside any hunk, and deleted files (`+++ /dev/null`) produce no anchors.
+
+### 4. Unanchorable findings demote into the body, under an explicit heading — never dropped, never silent
+
+`partitionFindings` splits findings into `comments` (valid anchor → `gh.ReviewComment`) and `demoted` (everything else). `buildReviewBody` appends demoted findings to the prose summary under a `## Additional findings (could not anchor to diff)` heading, each rendered as `**path:line**: body`.
+
+The heading matters: a demoted finding that read identically to ambient summary prose would be just as opaque to `buildReviewThreadComments` as today's all-prose reviews, defeating the point of distinguishing it at all. It's still unconsumable by the auto-fix loop either way — that's inherent to demotion, not a bug — but a human reading the review body should be able to tell "this was a specific finding Pruefer couldn't place" from "this is the overall verdict."
+
+### 5. `side` is hardcoded to `"RIGHT"` in `SubmitPRReview`, mirroring the existing hardcoded `event`
+
+`ReviewComment` (`github/types.go`) has no `Side` field. `SubmitPRReview` (`github/prs.go`) sets `"side": "RIGHT"` on every wire-level comment entry unconditionally — single-line, post-change-side anchors are the only shape V1 supports (`start_line` ranges and `LEFT`-side/base-diff anchors are out of scope). This is the same structural-invariant pattern ADR-1113 Decision 8 used for `event: "COMMENT"`: not caller-controllable, and locked down by a dedicated test (`TestSubmitPRReview_HardcodesRightSide`) the same way `TestSubmitPRReview_HardcodesCommentEvent` locks down `event`.
+
+### 6. `comments` is omitted from the request body when empty, not sent as `[]`
+
+When there are no anchorable findings — including today's plain-prose case — `SubmitPRReview`'s request body has no `comments` key at all, preserving the exact wire shape callers relied on before this parameter existed. `TestSubmitPRReview_HardcodesCommentEvent`'s assertions needed no changes beyond its call site's new (nil-comments) argument.
+
+### 7. Anchor validation lives in `pruefer`, not `github`
+
+`validRightAnchors` and `partitionFindings` are Pruefer-specific diff-domain logic, not generic REST client behavior — `github` stays a thin client with no knowledge of diff formats. This mirrors `ParseChangedPaths` (`pruefer/select.go`, file-level diff parsing already living in `pruefer`) and keeps consistent with ADR-1113 Decision 6's "no shared imports between `pruefer` and `engine`" boundary, extended here to keep `github` free of diff-domain logic too.
+
+## Consequences
+
+**Positive:**
+- Pruefer's findings are now consumable by Fabrik's existing review-reinvoke path with zero changes to the consumer side (`buildReviewThreadComments` already reads `gh.Comment.Path`/`.Line`) — the circuit Pruefer → Fabrik auto-fix → Pruefer re-review closes.
+- The 422-all-or-nothing risk is structurally eliminated, not mitigated: an unanchorable finding can never reach the wire, so it can never take down the rest of the review.
+- Backward compatible by construction: a plain-prose Claude response (today's behavior, or the fallback when Claude doesn't follow the new contract) produces zero findings and an unmodified body-only review — no special-case branch needed.
+
+**Negative / Trade-offs:**
+- The `path`/`line` findings contract is a new prompt-engineering surface with no runtime guarantee Claude follows it — degrades gracefully to zero inline comments, but under-delivers silently rather than erroring. Not fully verifiable by unit tests; the issue's own "Verification worth doing by hand" (a live Pruefer review on a `fabrik:yolo` PR) is the real check.
+- Off-by-one errors in hunk-line-counting are the sharpest correctness risk: a bug here produces a *wrong* anchor (attaches to the wrong line) rather than a missing one, which "does it 422" tests alone wouldn't catch — mitigated by dedicated line-number-correctness tests against hand-authored synthetic diffs.
+- Multi-line (`start_line`) ranges remain unsupported; a finding that genuinely spans several lines is still reported as a single-line anchor or demoted.
+
+## Related Work
+
+- ADR-1113 (`adrs/1113-pruefer-v1-architecture.md`) — Decision 8 scoped inline comments as "desirable but optional" for V1; this issue is the explicitly anticipated follow-up. Decision 9 ("on invocation failure, post nothing") is extended here to distinguish invocation failure from successful-but-unstructured output (Decision 2 above).
+- `engine/reviews.go` (`buildReviewThreadComments`) — the consumer this issue feeds; explicitly out of scope to change, since it already reads the `gh.Comment.Path`/`.Line` shape this issue's `comments[]` produces.
+- `github/pruefer_extensions_test.go` (`TestSubmitPRReview_HardcodesCommentEvent`) — the pre-existing invariant this issue's signature change had to preserve unmodified.
+- PR #1185 — the live review that demonstrated the gap this issue closes.
+
+**References:** [cmd/pruefer/README.md](../cmd/pruefer/README.md)

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -34,3 +34,4 @@ contributors and future maintainers.
 | [1089](1089-comment-processing-circuit-breaker.md) | Comment-Processing Circuit Breaker | Accepted |
 | [1113](1113-pruefer-v1-architecture.md) | Pruefer V1 architecture (GitHub App identity, review-state, defaults) | Accepted |
 | [1114](1114-pruefer-tui-architecture.md) | Pruefer terminal UI architecture (event plumbing, retention, rate-limit surfacing) | Accepted |
+| [1189](1189-pruefer-inline-review-comments.md) | Pruefer inline review comments (structured findings, client-side anchor validation, body-demotion) | Accepted |

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -15,7 +15,7 @@ Every `poll_interval_seconds`, Pruefer lists open, non-draft PRs on each watched
 - Has Pruefer already reviewed this exact head SHA? Skip — **unless** an unprocessed `/pruefer review` comment is on the PR, which forces a fresh review of the current head.
 - Is the diff larger than `max_diff_bytes`? Skip (logged, not truncated).
 
-Otherwise, Pruefer clones the PR's head commit into a temporary directory, invokes `claude` with a read-only tool allowlist to produce review text, and submits it as a formal `pull_request_review` (event `COMMENT`) pinned to that head SHA. On any failure — clone, invocation, or submission — Pruefer posts nothing and logs the failure; the PR is naturally retried on the next poll.
+Otherwise, Pruefer clones the PR's head commit into a temporary directory, invokes `claude` with a read-only tool allowlist to produce a prose summary plus structured findings, and submits it as a formal `pull_request_review` (event `COMMENT`) pinned to that head SHA. Findings that map to a changed line in the diff are posted as line-anchored inline comments in the same request; any finding that can't be anchored (a line the diff doesn't touch) is demoted into the summary body instead of dropping it or failing the whole review. Inline comments are what let Fabrik's review-reinvoke path pick up Pruefer's findings and act on them automatically — see [adrs/1189-pruefer-inline-review-comments.md](../../adrs/1189-pruefer-inline-review-comments.md). On any failure — clone, invocation, or submission — Pruefer posts nothing and logs the failure; the PR is naturally retried on the next poll.
 
 Review state ("already reviewed at SHA X") is derived from GitHub itself (existing reviews authored by Pruefer's bot identity), not stored locally — a restart never causes a review storm.
 
@@ -126,6 +126,6 @@ Draft PRs are always skipped — there is no configuration flag to include them 
 ## Out of scope for V1
 
 - `APPROVE` / `REQUEST_CHANGES` verdicts.
-- Inline line-level review comments (top-level comment body only).
+- Multi-line (`start_line`) inline comment ranges — single-line anchors only.
 - Non-GitHub forges.
 - Removing `.github/workflows/claude-review.yml` from any repo — that stays until Pruefer is proven in practice.

--- a/github/prs.go
+++ b/github/prs.go
@@ -566,15 +566,33 @@ func (c *Client) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
 }
 
 // SubmitPRReview submits a formal pull_request_review comment (event=COMMENT)
-// against the given commit SHA. The event type is hardcoded and never
+// against the given commit SHA, optionally with line-anchored inline
+// comments posted in the same request. The event type is hardcoded and never
 // caller-controlled — Pruefer V1 never submits APPROVE or REQUEST_CHANGES
-// verdicts (see ADR-1113). Returns the numeric review ID.
-func (c *Client) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error) {
+// verdicts (see ADR-1113). Each comment's side is likewise hardcoded to
+// "RIGHT" — V1 supports only single-line, post-change-side anchors (see
+// adrs/1189-pruefer-inline-review-comments.md). The "comments" key is
+// omitted entirely when comments is empty, preserving the exact body-only
+// wire shape callers relied on before this parameter existed. Returns the
+// numeric review ID.
+func (c *Client) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string, comments []ReviewComment) (int, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.baseURL, owner, repo, prNumber)
 	reqBody := map[string]interface{}{
 		"commit_id": commitSHA,
 		"body":      body,
 		"event":     "COMMENT",
+	}
+	if len(comments) > 0 {
+		wireComments := make([]map[string]interface{}, len(comments))
+		for i, cm := range comments {
+			wireComments[i] = map[string]interface{}{
+				"path": cm.Path,
+				"line": cm.Line,
+				"side": "RIGHT",
+				"body": cm.Body,
+			}
+		}
+		reqBody["comments"] = wireComments
 	}
 	var result struct {
 		ID int `json:"id"`

--- a/github/pruefer_extensions_test.go
+++ b/github/pruefer_extensions_test.go
@@ -106,7 +106,7 @@ func TestSubmitPRReview_HardcodesCommentEvent(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token", srv.URL)
-	id, err := c.SubmitPRReview("owner", "repo", 42, "abc123", "review text")
+	id, err := c.SubmitPRReview("owner", "repo", 42, "abc123", "review text", nil)
 	if err != nil {
 		t.Fatalf("SubmitPRReview: %v", err)
 	}
@@ -117,9 +117,93 @@ func TestSubmitPRReview_HardcodesCommentEvent(t *testing.T) {
 
 // SubmitPRReview's signature has no event parameter at all — verified at
 // compile time by the call above passing exactly (owner, repo, prNumber,
-// commitSHA, body). This test additionally guards the wire format so a
-// future refactor can't reintroduce a caller-supplied event without failing
-// TestSubmitPRReview_HardcodesCommentEvent above.
+// commitSHA, body, comments). This test additionally guards the wire format
+// so a future refactor can't reintroduce a caller-supplied event without
+// failing TestSubmitPRReview_HardcodesCommentEvent above.
+
+func TestSubmitPRReview_NoComments_OmitsCommentsField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if _, ok := body["comments"]; ok {
+			t.Errorf("expected no \"comments\" key when comments is empty, got %v", body["comments"])
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	if _, err := c.SubmitPRReview("owner", "repo", 42, "abc123", "review text", nil); err != nil {
+		t.Fatalf("SubmitPRReview: %v", err)
+	}
+}
+
+func TestSubmitPRReview_WithComments_PostsCommentsArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		comments, ok := body["comments"].([]interface{})
+		if !ok || len(comments) != 2 {
+			t.Fatalf("comments = %v, want a 2-element array", body["comments"])
+		}
+		first, ok := comments[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("comments[0] = %v, want an object", comments[0])
+		}
+		if first["path"] != "engine/claude.go" {
+			t.Errorf("comments[0].path = %v, want engine/claude.go", first["path"])
+		}
+		if first["line"] != float64(954) {
+			t.Errorf("comments[0].line = %v, want 954", first["line"])
+		}
+		if first["body"] != "finding 1" {
+			t.Errorf("comments[0].body = %v, want %q", first["body"], "finding 1")
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	comments := []ReviewComment{
+		{Path: "engine/claude.go", Line: 954, Body: "finding 1"},
+		{Path: "engine/claude.go", Line: 960, Body: "finding 2"},
+	}
+	if _, err := c.SubmitPRReview("owner", "repo", 42, "abc123", "review text", comments); err != nil {
+		t.Fatalf("SubmitPRReview: %v", err)
+	}
+}
+
+func TestSubmitPRReview_HardcodesRightSide(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		comments, ok := body["comments"].([]interface{})
+		if !ok || len(comments) != 1 {
+			t.Fatalf("comments = %v, want a 1-element array", body["comments"])
+		}
+		entry, ok := comments[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("comments[0] = %v, want an object", comments[0])
+		}
+		if entry["side"] != "RIGHT" {
+			t.Errorf("comments[0].side = %v, want RIGHT (must never be caller-controlled)", entry["side"])
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	comments := []ReviewComment{{Path: "foo.go", Line: 1, Body: "x"}}
+	if _, err := c.SubmitPRReview("owner", "repo", 42, "abc123", "review text", comments); err != nil {
+		t.Fatalf("SubmitPRReview: %v", err)
+	}
+}
 
 func TestListOpenPRs(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/github/types.go
+++ b/github/types.go
@@ -169,6 +169,18 @@ type Comment struct {
 	DiffHunk string
 }
 
+// ReviewComment is a single line-anchored inline comment to submit as part of
+// a pull_request_review's comments[] array (outbound request shape only —
+// narrower than Comment, which carries response-only fields like ID/Author/
+// ReviewThreadID that don't apply to a submission). Line anchors the RIGHT
+// (post-change) side only; SubmitPRReview hardcodes "side": "RIGHT" — see
+// adrs/1189-pruefer-inline-review-comments.md.
+type ReviewComment struct {
+	Path string
+	Line int
+	Body string
+}
+
 // ReactionGroup represents a reaction type and its count on a comment.
 type ReactionGroup struct {
 	Content string // e.g. "THUMBS_UP", "EYES", etc.

--- a/pruefer/claude.go
+++ b/pruefer/claude.go
@@ -105,6 +105,11 @@ func buildReviewPrompt(req ReviewRequest) string {
 	}
 	b.WriteString("Write a code review as you would comment on the pull request: call out bugs, correctness issues, security concerns, and significant design problems. Skip nitpicks and style preferences unless they matter.\n\n")
 	b.WriteString("You are NOT approving or requesting changes — this is a comment-only review. Do not use approval/rejection language such as \"LGTM\" or \"requesting changes\".\n\n")
+	b.WriteString("Output has two parts, in this exact order:\n\n")
+	b.WriteString("1. A short prose summary: what you reviewed and your overall assessment. This is the only text GitHub shows outside of inline comments, so it must stand on its own.\n\n")
+	b.WriteString("2. A single fenced ```json code block containing a JSON array of your findings, each anchored to the exact file and line it concerns:\n\n")
+	b.WriteString("```json\n[{\"path\": \"engine/claude.go\", \"line\": 954, \"body\": \"...\"}]\n```\n\n")
+	b.WriteString("Each entry's \"path\" must be a file path exactly as it appears in the diff, and \"line\" must be a line number in the new (post-change) version of that file — i.e. a line you can see in `git diff` output prefixed with `+` or unprefixed (context), never a line that only existed in the old version. If you have no findings, emit an empty array `[]`. Do not put findings only in the prose — every specific, actionable finding belongs in the JSON array so it can be attached to its exact line; use the prose summary for overall assessment only.\n\n")
 	b.WriteString("Output ONLY the review text itself: no preamble, no meta-commentary about what you are about to do.\n")
 	return b.String()
 }

--- a/pruefer/diffanchor.go
+++ b/pruefer/diffanchor.go
@@ -46,10 +46,13 @@ func validRightAnchors(diff string) map[anchorKey]bool {
 			currentPath = ""
 			inHunk = false
 			continue
-		case strings.HasPrefix(line, "+++ "):
+		case !inHunk && strings.HasPrefix(line, "+++ "):
 			// "+++ b/<path>" gives the post-change path; "+++ /dev/null"
 			// (deleted file) or any other form leaves currentPath empty, so
-			// this file contributes no RIGHT-side anchors.
+			// this file contributes no RIGHT-side anchors. Gated on !inHunk
+			// so an added content line that itself happens to start with
+			// "+++ " (e.g. a diff fixture embedded as test data) is never
+			// misread as a new file header mid-hunk.
 			if m := diffNewFileHeaderRE.FindStringSubmatch(line); m != nil {
 				currentPath = m[1]
 			} else {

--- a/pruefer/diffanchor.go
+++ b/pruefer/diffanchor.go
@@ -1,0 +1,109 @@
+package pruefer
+
+import (
+	"bufio"
+	"regexp"
+	"strconv"
+	"strings"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// anchorKey identifies a single valid RIGHT-side (post-change) comment
+// position in a diff.
+type anchorKey struct {
+	Path string
+	Line int
+}
+
+var (
+	diffFileHeaderRE    = regexp.MustCompile(`^diff --git `)
+	diffNewFileHeaderRE = regexp.MustCompile(`^\+\+\+ b/(.+)$`)
+	diffHunkHeaderRE    = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@`)
+)
+
+// validRightAnchors parses a unified diff (as returned by FetchPRDiff) and
+// returns the set of (path, line) positions that are valid RIGHT-side
+// GitHub review-comment anchors: every context or added line within a hunk,
+// keyed by the hunk's "+++ b/<path>" header so renamed files resolve to
+// their destination path. Deletion-only lines, lines outside any hunk, and
+// files with no post-change path (deletions, "+++ /dev/null") produce no
+// anchors — GitHub's line+side=RIGHT comment API only accepts a line number
+// that exists in the new file version.
+func validRightAnchors(diff string) map[anchorKey]bool {
+	anchors := make(map[anchorKey]bool)
+	var currentPath string
+	var rightLine int
+	inHunk := false
+
+	scanner := bufio.NewScanner(strings.NewReader(diff))
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case diffFileHeaderRE.MatchString(line):
+			currentPath = ""
+			inHunk = false
+			continue
+		case strings.HasPrefix(line, "+++ "):
+			// "+++ b/<path>" gives the post-change path; "+++ /dev/null"
+			// (deleted file) or any other form leaves currentPath empty, so
+			// this file contributes no RIGHT-side anchors.
+			if m := diffNewFileHeaderRE.FindStringSubmatch(line); m != nil {
+				currentPath = m[1]
+			} else {
+				currentPath = ""
+			}
+			inHunk = false
+			continue
+		}
+
+		if m := diffHunkHeaderRE.FindStringSubmatch(line); m != nil {
+			start, err := strconv.Atoi(m[1])
+			if err != nil {
+				inHunk = false
+				continue
+			}
+			rightLine = start
+			inHunk = true
+			continue
+		}
+
+		if !inHunk || currentPath == "" {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "+"):
+			anchors[anchorKey{Path: currentPath, Line: rightLine}] = true
+			rightLine++
+		case strings.HasPrefix(line, "-"):
+			// Removed line: exists only on the left (base) side; the
+			// right-side line counter does not advance.
+		case strings.HasPrefix(line, "\\"):
+			// "\ No newline at end of file" — not a content line.
+		default:
+			// Context line (unchanged, present on both sides).
+			anchors[anchorKey{Path: currentPath, Line: rightLine}] = true
+			rightLine++
+		}
+	}
+	return anchors
+}
+
+// partitionFindings splits findings into those whose (Path, Line) is a
+// valid RIGHT-side anchor per anchors — mapped to gh.ReviewComment, ready
+// for SubmitPRReview's comments[] — and those that are not, returned
+// unchanged so the caller can demote them into the review body rather than
+// dropping them or risking a 422 on the whole submission.
+func partitionFindings(findings []ReviewFinding, anchors map[anchorKey]bool) (comments []gh.ReviewComment, demoted []ReviewFinding) {
+	for _, f := range findings {
+		if anchors[anchorKey{Path: f.Path, Line: f.Line}] {
+			comments = append(comments, gh.ReviewComment{Path: f.Path, Line: f.Line, Body: f.Body})
+		} else {
+			demoted = append(demoted, f)
+		}
+	}
+	return comments, demoted
+}

--- a/pruefer/diffanchor_test.go
+++ b/pruefer/diffanchor_test.go
@@ -97,6 +97,34 @@ index 1111111..2222222 100644
 	}
 }
 
+func TestValidRightAnchors_ContentLineResemblingFileHeader_NotMisreadMidHunk(t *testing.T) {
+	// An added content line that itself starts with "+++ " (e.g. a fixture
+	// file embedding diff text as test data) must not be mistaken for a new
+	// file header — that would reset currentPath/inHunk mid-hunk and
+	// truncate the anchor set for the rest of the file.
+	diff := "diff --git a/fixture.go b/fixture.go\n" +
+		"--- a/fixture.go\n" +
+		"+++ b/fixture.go\n" +
+		"@@ -1,1 +1,3 @@\n" +
+		" ctx\n" +
+		"+++ b/embedded.go\n" +
+		"+after\n"
+	anchors := validRightAnchors(diff)
+	want := map[anchorKey]bool{
+		{Path: "fixture.go", Line: 1}: true, // ctx
+		{Path: "fixture.go", Line: 2}: true, // "+++ b/embedded.go" content line
+		{Path: "fixture.go", Line: 3}: true, // after
+	}
+	if len(anchors) != len(want) {
+		t.Fatalf("anchors = %v, want %v", anchors, want)
+	}
+	for k := range want {
+		if !anchors[k] {
+			t.Errorf("missing expected anchor %+v", k)
+		}
+	}
+}
+
 func TestValidRightAnchors_MultipleFilesAndHunks(t *testing.T) {
 	diff := `diff --git a/a.go b/a.go
 --- a/a.go

--- a/pruefer/diffanchor_test.go
+++ b/pruefer/diffanchor_test.go
@@ -1,0 +1,176 @@
+package pruefer
+
+import "testing"
+
+const simpleDiff = `diff --git a/foo.go b/foo.go
+index 1111111..2222222 100644
+--- a/foo.go
++++ b/foo.go
+@@ -10,5 +10,6 @@ func Foo() {
+ 	unchanged1
+ 	unchanged2
+-	removed
++	added1
++	added2
+ 	unchanged3
+`
+
+func TestValidRightAnchors_OffByOneLineCorrectness(t *testing.T) {
+	anchors := validRightAnchors(simpleDiff)
+
+	// Hunk header "@@ -10,5 +10,6 @@" means the new file's first printed
+	// line (the first context line "unchanged1") is line 10.
+	want := map[anchorKey]bool{
+		{Path: "foo.go", Line: 10}: true, // unchanged1 (context)
+		{Path: "foo.go", Line: 11}: true, // unchanged2 (context)
+		{Path: "foo.go", Line: 12}: true, // added1
+		{Path: "foo.go", Line: 13}: true, // added2
+		{Path: "foo.go", Line: 14}: true, // unchanged3 (context)
+	}
+	if len(anchors) != len(want) {
+		t.Fatalf("anchors = %v, want %v", anchors, want)
+	}
+	for k := range want {
+		if !anchors[k] {
+			t.Errorf("missing expected anchor %+v", k)
+		}
+	}
+}
+
+func TestValidRightAnchors_DeletionOnlyLineRejected(t *testing.T) {
+	// The hunk has 3 context lines + 1 removed + 2 added = 6 diff lines, but
+	// only 5 of them exist on the right side: the removed line consumes no
+	// right-side line number at all, so it can never itself be a valid
+	// anchor and must not inflate the anchor count.
+	anchors := validRightAnchors(simpleDiff)
+	if len(anchors) != 5 {
+		t.Fatalf("expected exactly 5 anchors (deletion contributes none), got %d: %v", len(anchors), anchors)
+	}
+}
+
+func TestValidRightAnchors_PathNotInDiff_NoAnchors(t *testing.T) {
+	anchors := validRightAnchors(simpleDiff)
+	if anchors[anchorKey{Path: "unrelated.go", Line: 10}] {
+		t.Error("expected no anchor for a path never touched by the diff")
+	}
+}
+
+func TestValidRightAnchors_DeletedFile_NoAnchors(t *testing.T) {
+	diff := `diff --git a/gone.go b/gone.go
+deleted file mode 100644
+index 1111111..0000000
+--- a/gone.go
++++ /dev/null
+@@ -1,3 +0,0 @@
+-line1
+-line2
+-line3
+`
+	anchors := validRightAnchors(diff)
+	if len(anchors) != 0 {
+		t.Errorf("expected no anchors for a deleted file, got %v", anchors)
+	}
+}
+
+func TestValidRightAnchors_RenamedFile_UsesDestinationPath(t *testing.T) {
+	diff := `diff --git a/old_name.go b/new_name.go
+similarity index 95%
+rename from old_name.go
+rename to new_name.go
+index 1111111..2222222 100644
+--- a/old_name.go
++++ b/new_name.go
+@@ -1,2 +1,3 @@
+ unchanged
++added
+ tail
+`
+	anchors := validRightAnchors(diff)
+	if !anchors[anchorKey{Path: "new_name.go", Line: 1}] {
+		t.Error("expected anchor at new_name.go:1 (unchanged context line)")
+	}
+	if !anchors[anchorKey{Path: "new_name.go", Line: 2}] {
+		t.Error("expected anchor at new_name.go:2 (added line)")
+	}
+	if anchors[anchorKey{Path: "old_name.go", Line: 1}] {
+		t.Error("expected no anchors under the old (source) path")
+	}
+}
+
+func TestValidRightAnchors_MultipleFilesAndHunks(t *testing.T) {
+	diff := `diff --git a/a.go b/a.go
+--- a/a.go
++++ b/a.go
+@@ -1,2 +1,2 @@
+ ctx
+-old
++new
+diff --git a/b.go b/b.go
+--- a/b.go
++++ b/b.go
+@@ -5,1 +5,2 @@
+ ctx5
++added6
+`
+	anchors := validRightAnchors(diff)
+	want := []anchorKey{
+		{Path: "a.go", Line: 1},
+		{Path: "a.go", Line: 2},
+		{Path: "b.go", Line: 5},
+		{Path: "b.go", Line: 6},
+	}
+	if len(anchors) != len(want) {
+		t.Fatalf("anchors = %v, want %d entries", anchors, len(want))
+	}
+	for _, k := range want {
+		if !anchors[k] {
+			t.Errorf("missing expected anchor %+v", k)
+		}
+	}
+}
+
+func TestPartitionFindings_AllAnchorable(t *testing.T) {
+	anchors := map[anchorKey]bool{
+		{Path: "foo.go", Line: 10}: true,
+		{Path: "foo.go", Line: 12}: true,
+	}
+	findings := []ReviewFinding{
+		{Path: "foo.go", Line: 10, Body: "finding A"},
+		{Path: "foo.go", Line: 12, Body: "finding B"},
+	}
+	comments, demoted := partitionFindings(findings, anchors)
+	if len(comments) != 2 || len(demoted) != 0 {
+		t.Fatalf("comments=%v demoted=%v, want 2 comments, 0 demoted", comments, demoted)
+	}
+}
+
+func TestPartitionFindings_SomeUnanchorable(t *testing.T) {
+	anchors := map[anchorKey]bool{
+		{Path: "foo.go", Line: 10}: true,
+	}
+	findings := []ReviewFinding{
+		{Path: "foo.go", Line: 10, Body: "anchorable"},
+		{Path: "foo.go", Line: 999, Body: "unanchorable"},
+	}
+	comments, demoted := partitionFindings(findings, anchors)
+	if len(comments) != 1 || comments[0].Body != "anchorable" {
+		t.Fatalf("comments = %+v, want 1 entry with body 'anchorable'", comments)
+	}
+	if len(demoted) != 1 || demoted[0].Body != "unanchorable" {
+		t.Fatalf("demoted = %+v, want 1 entry with body 'unanchorable'", demoted)
+	}
+}
+
+func TestPartitionFindings_NoneAnchorable(t *testing.T) {
+	anchors := map[anchorKey]bool{}
+	findings := []ReviewFinding{
+		{Path: "foo.go", Line: 10, Body: "finding A"},
+	}
+	comments, demoted := partitionFindings(findings, anchors)
+	if len(comments) != 0 {
+		t.Fatalf("comments = %v, want none", comments)
+	}
+	if len(demoted) != 1 {
+		t.Fatalf("demoted = %v, want 1", demoted)
+	}
+}

--- a/pruefer/findings.go
+++ b/pruefer/findings.go
@@ -1,0 +1,76 @@
+package pruefer
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ReviewFinding is a single structured finding Claude reports against a
+// specific file/line, extracted from the review's fenced JSON block. Line
+// numbers are always interpreted against the PR's post-change (RIGHT side)
+// file version — see diffanchor.go for anchor validation.
+type ReviewFinding struct {
+	Path string `json:"path"`
+	Line int    `json:"line"`
+	Body string `json:"body"`
+}
+
+// findingsFenceRE matches a fenced ```json ... ``` code block, non-greedy so
+// it stops at the first closing fence. The "json" language tag is required —
+// buildReviewPrompt instructs Claude to always include it, so requiring it
+// here avoids false-matching an unrelated fenced code snippet quoted inside
+// the summary prose (e.g. Claude illustrating a fix with a ```go block).
+var findingsFenceRE = regexp.MustCompile("(?s)```json\\s*(.*?)```")
+
+// parseReviewFindings splits Claude's review output into its two-part
+// contract: free-form summary prose, followed by a single fenced ```json
+// array of {"path","line","body"} findings. Everything before the fence is
+// the summary; the fence's content is unmarshaled into findings.
+//
+// This is a graceful-degrade parser, not a strict one: when no fenced JSON
+// block is present, or its content doesn't unmarshal as a findings array,
+// the entire input is returned as the summary with zero findings. That
+// covers both today's plain-prose reviews and Claude failing to follow the
+// new contract — in neither case should the review fail to submit; it just
+// posts without inline comments, exactly as it does today.
+func parseReviewFindings(text string) (summary string, findings []ReviewFinding) {
+	loc := findingsFenceRE.FindStringSubmatchIndex(text)
+	if loc == nil {
+		return strings.TrimSpace(text), nil
+	}
+
+	fenceContent := text[loc[2]:loc[3]]
+	var parsed []ReviewFinding
+	if err := json.Unmarshal([]byte(fenceContent), &parsed); err != nil {
+		return strings.TrimSpace(text), nil
+	}
+
+	summary = strings.TrimSpace(text[:loc[0]])
+	return summary, parsed
+}
+
+// buildReviewBody assembles the final review body from the prose summary
+// plus any findings that could not be anchored to the diff. Demoted
+// findings are appended under an explicit heading, each rendered as
+// "**path:line**: body" — kept visually distinct from the summary so they
+// read as identifiable findings rather than blending into ambient prose,
+// even though (like all body text) they remain unconsumable by Fabrik's
+// inline-comment-only review-reinvoke path.
+func buildReviewBody(summary string, demoted []ReviewFinding) string {
+	if len(demoted) == 0 {
+		return summary
+	}
+
+	var findingsBlock strings.Builder
+	findingsBlock.WriteString("## Additional findings (could not anchor to diff)")
+	for _, f := range demoted {
+		fmt.Fprintf(&findingsBlock, "\n\n**%s:%d**: %s", f.Path, f.Line, f.Body)
+	}
+
+	if summary == "" {
+		return findingsBlock.String()
+	}
+	return summary + "\n\n" + findingsBlock.String()
+}

--- a/pruefer/findings_test.go
+++ b/pruefer/findings_test.go
@@ -1,0 +1,120 @@
+package pruefer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseReviewFindings_WellFormedFence(t *testing.T) {
+	text := "Overall looks good, one nit below.\n\n```json\n" +
+		`[{"path":"engine/claude.go","line":954,"body":"missing edge case"}]` +
+		"\n```\n"
+
+	summary, findings := parseReviewFindings(text)
+	if summary != "Overall looks good, one nit below." {
+		t.Errorf("summary = %q", summary)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %+v, want 1 entry", findings)
+	}
+	if findings[0].Path != "engine/claude.go" || findings[0].Line != 954 || findings[0].Body != "missing edge case" {
+		t.Errorf("findings[0] = %+v", findings[0])
+	}
+}
+
+func TestParseReviewFindings_MultipleFindings(t *testing.T) {
+	text := "Summary text.\n\n```json\n" +
+		`[{"path":"a.go","line":1,"body":"finding a"},{"path":"b.go","line":2,"body":"finding b"}]` +
+		"\n```\n"
+
+	summary, findings := parseReviewFindings(text)
+	if summary != "Summary text." {
+		t.Errorf("summary = %q", summary)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("findings = %+v, want 2 entries", findings)
+	}
+}
+
+func TestParseReviewFindings_NoFence_WholeTextAsSummary(t *testing.T) {
+	text := "Looks fine, one nit."
+	summary, findings := parseReviewFindings(text)
+	if summary != text {
+		t.Errorf("summary = %q, want %q", summary, text)
+	}
+	if findings != nil {
+		t.Errorf("findings = %+v, want nil", findings)
+	}
+}
+
+func TestParseReviewFindings_MalformedJSONInFence_FallsBack(t *testing.T) {
+	text := "Some review text.\n\n```json\nnot valid json at all\n```\n"
+	summary, findings := parseReviewFindings(text)
+	if want := strings.TrimSpace(text); summary != want {
+		t.Errorf("summary = %q, want the whole original text (trimmed) as fallback: %q", summary, want)
+	}
+	if findings != nil {
+		t.Errorf("findings = %+v, want nil on malformed JSON", findings)
+	}
+}
+
+func TestParseReviewFindings_EmptyFindingsArray(t *testing.T) {
+	text := "Nothing to flag.\n\n```json\n[]\n```\n"
+	summary, findings := parseReviewFindings(text)
+	if summary != "Nothing to flag." {
+		t.Errorf("summary = %q", summary)
+	}
+	if len(findings) != 0 {
+		t.Errorf("findings = %+v, want empty", findings)
+	}
+}
+
+func TestParseReviewFindings_IgnoresNonJSONFence(t *testing.T) {
+	text := "Consider this fix:\n\n```go\nfunc foo() {}\n```\n\nOtherwise fine."
+	summary, findings := parseReviewFindings(text)
+	if summary != text {
+		t.Errorf("summary = %q, want whole text (no ```json fence present)", summary)
+	}
+	if findings != nil {
+		t.Errorf("findings = %+v, want nil", findings)
+	}
+}
+
+func TestBuildReviewBody_NoDemoted_ReturnsSummaryUnchanged(t *testing.T) {
+	got := buildReviewBody("All good, minor nit inline.", nil)
+	if got != "All good, minor nit inline." {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBuildReviewBody_DemotedFindings_AppendedUnderHeading(t *testing.T) {
+	demoted := []ReviewFinding{
+		{Path: "vendor/lib.go", Line: 12, Body: "not part of this PR's diff"},
+	}
+	got := buildReviewBody("Reviewed the change.", demoted)
+	want := "Reviewed the change.\n\n## Additional findings (could not anchor to diff)\n\n**vendor/lib.go:12**: not part of this PR's diff"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildReviewBody_EmptySummary_DemotedFindings_NoLeadingBlankLines(t *testing.T) {
+	demoted := []ReviewFinding{{Path: "a.go", Line: 1, Body: "finding"}}
+	got := buildReviewBody("", demoted)
+	want := "## Additional findings (could not anchor to diff)\n\n**a.go:1**: finding"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildReviewBody_MultipleDemotedFindings(t *testing.T) {
+	demoted := []ReviewFinding{
+		{Path: "a.go", Line: 1, Body: "finding A"},
+		{Path: "b.go", Line: 2, Body: "finding B"},
+	}
+	got := buildReviewBody("Summary.", demoted)
+	want := "Summary.\n\n## Additional findings (could not anchor to diff)\n\n**a.go:1**: finding A\n\n**b.go:2**: finding B"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pruefer/review.go
+++ b/pruefer/review.go
@@ -17,7 +17,7 @@ type GitHubReviewer interface {
 	GitHubCommenter
 	FetchPRDiff(owner, repo string, prNumber int) (string, error)
 	FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, error)
-	SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error)
+	SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string, comments []gh.ReviewComment) (int, error)
 	Token() string
 }
 
@@ -112,7 +112,11 @@ func ReviewPR(ctx context.Context, client GitHubReviewer, claude ClaudeInvoker, 
 		return ReviewOutcome{Err: fmt.Errorf("claude review invocation: %w", err)}
 	}
 
-	if _, err := client.SubmitPRReview(owner, repo, pr.Number, pr.HeadSHA, result.Text); err != nil {
+	summary, findings := parseReviewFindings(result.Text)
+	comments, demoted := partitionFindings(findings, validRightAnchors(diff))
+	body := buildReviewBody(summary, demoted)
+
+	if _, err := client.SubmitPRReview(owner, repo, pr.Number, pr.HeadSHA, body, comments); err != nil {
 		return ReviewOutcome{Err: fmt.Errorf("submitting review: %w", err)}
 	}
 

--- a/pruefer/review_test.go
+++ b/pruefer/review_test.go
@@ -32,6 +32,7 @@ type submitCall struct {
 	prNumber    int
 	commitSHA   string
 	body        string
+	comments    []gh.ReviewComment
 }
 
 func (f *fakeReviewer) FetchPRDiff(owner, repo string, prNumber int) (string, error) {
@@ -51,13 +52,13 @@ func (f *fakeReviewer) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PR
 	return f.reviews, nil
 }
 
-func (f *fakeReviewer) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string) (int, error) {
+func (f *fakeReviewer) SubmitPRReview(owner, repo string, prNumber int, commitSHA, body string, comments []gh.ReviewComment) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.submitErr != nil {
 		return 0, f.submitErr
 	}
-	f.submitCalls = append(f.submitCalls, submitCall{owner, repo, prNumber, commitSHA, body})
+	f.submitCalls = append(f.submitCalls, submitCall{owner, repo, prNumber, commitSHA, body, comments})
 	return len(f.submitCalls), nil
 }
 

--- a/pruefer/review_test.go
+++ b/pruefer/review_test.go
@@ -3,6 +3,7 @@ package pruefer
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -337,5 +338,140 @@ func TestReviewPR_ExcludedAuthor_Skipped(t *testing.T) {
 
 	if !outcome.Skipped || outcome.Reason != SkipExcludedAuthor {
 		t.Fatalf("outcome = %+v, want Skipped with SkipExcludedAuthor", outcome)
+	}
+}
+
+// reviewTestDiff is a small synthetic unified diff with two hunks: one
+// adding a line at engine/claude.go:954 (a valid RIGHT-side anchor) and one
+// touching only context around line 10 of docs/readme.md (so line 999 in
+// that file is never a valid anchor).
+const reviewTestDiff = `diff --git a/engine/claude.go b/engine/claude.go
+index 1111111..2222222 100644
+--- a/engine/claude.go
++++ b/engine/claude.go
+@@ -952,2 +952,3 @@ func classify() {
+ line952
+ line953
++line954
+diff --git a/docs/readme.md b/docs/readme.md
+index 3333333..4444444 100644
+--- a/docs/readme.md
++++ b/docs/readme.md
+@@ -9,2 +9,2 @@
+ line9
+ line10
+`
+
+func TestReviewPR_FindingsMappedToChangedLines_PostsInlineComments(t *testing.T) {
+	client := newFakeReviewer()
+	client.diff = reviewTestDiff
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (ReviewResult, error) {
+		return ReviewResult{Text: "Reviewed the change. Looks solid.\n\n```json\n" +
+			`[{"path": "engine/claude.go", "line": 954, "body": "consider a comment here"}]` +
+			"\n```\n"}, nil
+	}}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed || outcome.Err != nil {
+		t.Fatalf("outcome = %+v, want Reviewed=true, Err=nil", outcome)
+	}
+	if client.submitCallCount() != 1 {
+		t.Fatalf("SubmitPRReview called %d times, want exactly 1", client.submitCallCount())
+	}
+	call := client.submitCalls[0]
+	if len(call.comments) != 1 {
+		t.Fatalf("submitted %d comments, want exactly 1", len(call.comments))
+	}
+	if call.comments[0].Path != "engine/claude.go" || call.comments[0].Line != 954 {
+		t.Errorf("comment = %+v, want Path=engine/claude.go Line=954", call.comments[0])
+	}
+	if call.body != "Reviewed the change. Looks solid." {
+		t.Errorf("body = %q, want the prose summary only (no demoted-findings section)", call.body)
+	}
+}
+
+func TestReviewPR_UnanchorableFinding_DemotedToBody(t *testing.T) {
+	client := newFakeReviewer()
+	client.diff = reviewTestDiff
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (ReviewResult, error) {
+		return ReviewResult{Text: "Mixed bag.\n\n```json\n" +
+			`[{"path": "engine/claude.go", "line": 954, "body": "anchorable"},` +
+			`{"path": "docs/readme.md", "line": 999, "body": "not in the diff at all"}]` +
+			"\n```\n"}, nil
+	}}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed || outcome.Err != nil {
+		t.Fatalf("outcome = %+v, want Reviewed=true, Err=nil", outcome)
+	}
+	call := client.submitCalls[0]
+	if len(call.comments) != 1 || call.comments[0].Line != 954 {
+		t.Fatalf("comments = %+v, want exactly the anchorable finding at line 954", call.comments)
+	}
+	if !strings.Contains(call.body, "Additional findings") || !strings.Contains(call.body, "not in the diff at all") {
+		t.Errorf("body = %q, want the unanchorable finding demoted into it under an explicit heading", call.body)
+	}
+}
+
+func TestReviewPR_NoAnchorableFindings_BodyOnly(t *testing.T) {
+	client := newFakeReviewer()
+	client.diff = reviewTestDiff
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (ReviewResult, error) {
+		return ReviewResult{Text: "Looks fine, one nit."}, nil
+	}}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed || outcome.Err != nil {
+		t.Fatalf("outcome = %+v, want Reviewed=true, Err=nil", outcome)
+	}
+	call := client.submitCalls[0]
+	if len(call.comments) != 0 {
+		t.Errorf("comments = %+v, want none (plain-prose review, no fenced findings)", call.comments)
+	}
+	if call.body != "Looks fine, one nit." {
+		t.Errorf("body = %q, want the unmodified prose", call.body)
+	}
+}
+
+func TestReviewPR_UnanchorableFinding_NeverPassedToSubmit(t *testing.T) {
+	// Guards the 422 risk at the unit level: a finding whose (path, line) is
+	// not a valid RIGHT-side anchor in the PR's diff must never reach
+	// SubmitPRReview's comments argument, since GitHub rejects the entire
+	// review if any one comment's anchor is invalid.
+	client := newFakeReviewer()
+	client.diff = reviewTestDiff
+	claude := &mockClaudeInvoker{fn: func(req ReviewRequest) (ReviewResult, error) {
+		return ReviewResult{Text: "Findings below.\n\n```json\n" +
+			`[{"path": "engine/claude.go", "line": 12345, "body": "line does not exist in this diff"}]` +
+			"\n```\n"}, nil
+	}}
+	clone, _ := fakeClone(t, nil)
+
+	pr := gh.PRDetails{Number: 1, Author: "alice", HeadSHA: "sha1"}
+	outcome := ReviewPR(context.Background(), client, claude, clone, Config{}, "pruefer-bot[bot]", "owner", "repo", pr)
+
+	if !outcome.Reviewed || outcome.Err != nil {
+		t.Fatalf("outcome = %+v, want Reviewed=true, Err=nil (unanchorable finding must not fail the review)", outcome)
+	}
+	call := client.submitCalls[0]
+	for _, c := range call.comments {
+		if c.Line == 12345 {
+			t.Fatalf("unanchorable finding at line 12345 was passed to SubmitPRReview's comments: %+v", call.comments)
+		}
+	}
+	if len(call.comments) != 0 {
+		t.Errorf("comments = %+v, want none", call.comments)
+	}
+	if !strings.Contains(call.body, "line does not exist in this diff") {
+		t.Errorf("body = %q, want the unanchorable finding demoted into it", call.body)
 	}
 }


### PR DESCRIPTION
Closes #1189

Extends Pruefer's review submission so findings land as line-anchored inline PR comments instead of all being flattened into one prose body — this is what lets Fabrik's review-reinvoke path (`buildReviewThreadComments`) actually consume Pruefer's findings and drive auto-fix work.

## What changed

- **`github` package**: `SubmitPRReview` gains an optional `comments []ReviewComment` parameter, posted in the same `pull_request_review` request. `event` stays hardcoded to `"COMMENT"` (unchanged invariant, still covered by `TestSubmitPRReview_HardcodesCommentEvent`); each comment's `side` is hardcoded to `"RIGHT"` for the same reason. The `comments` key is omitted from the wire payload entirely when there are none, so body-only submissions are byte-for-byte identical to before.
- **`pruefer/claude.go`**: `buildReviewPrompt` now asks for a two-part output — free-form prose summary first, then a single fenced ` ```json ` array of `{"path","line","body"}` findings.
- **`pruefer/findings.go`** (new): `parseReviewFindings` extracts the fenced block; if it's absent or malformed, the whole text becomes the summary and zero findings are returned — a graceful degrade, not an error, so a plain-prose response (today's behavior, or Claude not following the contract) still submits normally.
- **`pruefer/diffanchor.go`** (new): parses the PR's unified diff into the set of valid RIGHT-side `(path, line)` anchors (context/added lines inside a hunk; deletion-only lines and untouched files produce none), and partitions findings into anchorable (→ inline comments) vs. unanchorable (→ demoted into the body under an explicit `## Additional findings` heading).
- **`pruefer/review.go`**: `ReviewPR` wires it together, reusing the diff already fetched for the size guard — no second `FetchPRDiff` call.
- **`cmd/pruefer/README.md`** and **`adrs/1189-pruefer-inline-review-comments.md`**: updated flow description and out-of-scope list; new ADR records why anchor validation runs client-side before submission (GitHub 422s the *entire* review on one bad anchor, with no partial-success response to recover from) and why unanchorable findings demote rather than drop.

## Why client-side validation, not retry-after-422

`restPostWithResponse` has no structured error type carrying the HTTP status, and GitHub's all-or-nothing rejection means there's nothing to salvage after the fact anyway. Validating every anchor against the diff before the request is the only way to guarantee a review with N-1 good findings still posts when the Nth doesn't anchor.

## Testing

- `github/pruefer_extensions_test.go`: `TestSubmitPRReview_WithComments_PostsCommentsArray`, `TestSubmitPRReview_HardcodesRightSide`, `TestSubmitPRReview_NoComments_OmitsCommentsField`, plus the pre-existing `TestSubmitPRReview_HardcodesCommentEvent` (call site updated, assertions unchanged).
- `pruefer/findings_test.go`: well-formed fence, no-fence fallback, malformed-JSON fallback, empty array, non-JSON fence ignored, body-assembly with/without demoted findings.
- `pruefer/diffanchor_test.go`: off-by-one line correctness against a known hunk, deletion-only rejection, path-not-in-diff, deleted-file, renamed-file (destination path), multi-file/multi-hunk, and partition classification (all/some/none anchorable).
- `pruefer/review_test.go`: four new end-to-end `ReviewPR` tests against a synthetic diff — findings mapped to changed lines post as inline comments, an unanchorable finding demotes into the body, no-findings still submits body-only, and (the core 422 guard) an unanchorable finding is asserted to never reach `SubmitPRReview`'s `comments` argument.
- `go build ./...`, `go vet ./...`, and `go test -race ./...` all pass. One unrelated test (`TestExecute_ConfigYAMLApplied` in `cmd/`) fails identically on a clean `main` checkout in this sandbox — a pre-existing network-timing flake, not touched by this change.

## How to test

```
go test -race ./github/... ./pruefer/...
```