### PR TITLE
fix(gitignore): pruefer binary rule could never match; ignore .pruefer/ runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,12 +23,16 @@
 .env
 /fabrik
 /print-plugin-hash
-/pruefer
-!/pruefer/
-.pruefer/pruefer.lock
-.pruefer/pruefer.log
-.pruefer/logs/
-.pruefer/*.pem
+# NOTE: `go build -o pruefer` cannot place a binary at the repo root — the
+# pruefer/ package directory already exists, so Go writes pruefer/pruefer
+# instead (polluting the source tree). Build to bin/ instead:
+#   go build -o bin/pruefer ./cmd/pruefer
+/bin/
+# Operator-local Pruefer runtime state: App private key, live config, lock, logs.
+# Ignored wholesale — unlike .fabrik/config.yaml this is per-operator (App ID,
+# watched repos) and must not be committed to a public repo. See cmd/pruefer/README.md
+# for the config format.
+.pruefer/
 # goreleaser build output — must be ignored or Go's buildvcs stamps release
 # artifacts +dirty (untracked dist/ makes the tree "modified" at build time).
 /dist/


### PR DESCRIPTION
Two fixes found while setting Pruefer up to run from the Fabrik checkout.

**1. `/pruefer` was a dead rule.** It paired with `!/pruefer/` to ignore a root binary while keeping the source package tracked — but `go build -o pruefer` can't produce that binary. The `pruefer/` package directory already exists, so Go writes `pruefer/pruefer` *inside the source tree* instead, and `codesign` then leaves `pruefer/_CodeSignature/` beside it. Both land untracked and un-ignored in the package.

Replaced with `/bin/` and a comment recording why, so the rule isn't "restored" later:

```bash
go build -o bin/pruefer ./cmd/pruefer
```

**2. `.pruefer/config.yaml` wasn't ignored.** The App private key, lock and log were covered; the config wasn't. A `git add -A` would have committed an operator's **GitHub App ID and watched-repo list into a public repo**.

This differs deliberately from `.fabrik/config.yaml`, which *is* committed so project settings travel with the repo. Pruefer's config is per-operator — App ID, key path, which repos that operator watches — so it's ignored wholesale, with a pointer to `cmd/pruefer/README.md` for the format.

Verified after the change: 44 `pruefer/` source files still tracked, `bin/pruefer` ignored, `.pruefer/config.yaml` ignored, and `git status` clean apart from this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4L5oQDHChWDF3c6oj1haw