### PR TITLE
docs: correct stale reconcile-loop webhook-gating claims

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -177,7 +177,7 @@ func Execute() error {
 	flag.IntVar(&cfg.WebhookPort, "webhook-port", 0, "Local port for the webhook HTTP listener (0 = OS-assigned; also FABRIK_WEBHOOK_PORT)")
 	flag.StringVar(&cfg.WebhookEvents, "webhook-events", "", "Comma-separated list of GitHub event types to subscribe to (default: all supported events; also FABRIK_WEBHOOK_EVENTS)")
 	flag.IntVar(&cfg.StatusPollSeconds, "status-poll", 0, "Retained for config compatibility; the Layer 2 updatedAt gate now runs every poll cycle (~15 s) regardless of this value. Also FABRIK_STATUS_POLL.")
-	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile webhook-stream-health checks when --webhooks is enabled (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL). Inactive without --webhooks — the per-poll Reconcile is the only freshener in that mode.")
+	flag.IntVar(&cfg.ReconcileInterval, "reconcile-interval", 0, "Seconds between periodic light-reconcile drift checks (0 = use default of 180; also FABRIK_RECONCILE_INTERVAL). Always active — this is the sole correctness backstop in poll-only mode; when --webhooks is enabled it also drives webhook stream-health transitions.")
 	flag.IntVar(&cfg.JanitorIntervalHours, "janitor-interval", 1, "Worktree janitor scan interval in hours; 0 disables the janitor (also FABRIK_JANITOR_INTERVAL)")
 	flag.IntVar(&cfg.LogRetentionDays, "log-retention-days", 14, "Delete log files older than this many days; 0 disables age-based pruning (also FABRIK_LOG_RETENTION_DAYS)")
 	flag.Int64Var(&cfg.LogMaxBytes, "log-max-bytes", 2147483648, "Total size cap for .fabrik/logs/ in bytes; oldest files deleted first after age prune; 0 disables size cap (also FABRIK_LOG_MAX_BYTES)")

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6225,9 +6225,9 @@ Terminal state is stored as a `Terminal bool` field in `ItemState` and set/clear
 
 **Cold-start (startup scan)**: after `runStartupTransientLabelScan` removes stale transient labels, `runStartupTerminalScan` iterates all items in the Store and applies `TerminalFlagSet{Terminal: true}` to any that pass the terminal predicate. This uses bootstrap label data already present in the Store — no GitHub API call is needed. On a 362-item board with 340 terminal Done items, this eliminates ~340 deep-fetches on the first poll cycle.
 
-**`Reconcile` is drift-recovery only**: `cacheImpl.Reconcile(board)` is called only during drift-recovery in webhook mode (see below). It is no longer called on every poll cycle, and it is not called during cold-start bootstrap — that path uses `BootstrapFromProbe` instead.
+**`Reconcile` is drift-recovery only**: `cacheImpl.Reconcile(board)` is called only during drift-recovery, independent of webhook mode (see below). It is no longer called on every poll cycle, and it is not called during cold-start bootstrap — that path uses `BootstrapFromProbe` instead.
 
-**Full reconcile — drift-recovery (webhook mode)**
+**Full reconcile — drift-recovery (runs independent of webhook mode)**
 
 `LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. The older full-fetch-and-reconcile helper (`reconcileCache`) has been removed; `reconcileLoop`'s `LightReconcile` path is the sole reconciliation mechanism.
 
@@ -6264,7 +6264,7 @@ The `--board-cache` flag has been removed. `CacheImpl` is now wired unconditiona
 1. **Per-poll probe (`runProbeAndDeepFetch`)** (always active on bootstrapped cache) — see D.4
 2. **Layer 2 status sweep** (always active) — see D.4 and D.7
 3. **Webhook deltas** (when `--webhooks` is enabled) — see D.2
-4. **Light-reconcile drift recovery** (when `--webhooks` is enabled) — see D.5
+4. **Light-reconcile drift recovery** (always active, independent of `--webhooks`) — see D.5
 
 Tests that need to bypass the cache use `engine.NewWithDeps`, which wires `boardcache.GitHubAdapter` directly. This bypasses the Store-mutation pipeline and silently disables observers, so it is intended only for unit tests that don't exercise Store-driven behavior.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -3299,9 +3299,9 @@ Terminal state is stored as a `Terminal bool` field in `ItemState` and set/clear
 
 **Cold-start (startup scan)**: after `runStartupTransientLabelScan` removes stale transient labels, `runStartupTerminalScan` iterates all items in the Store and applies `TerminalFlagSet{Terminal: true}` to any that pass the terminal predicate. This uses bootstrap label data already present in the Store — no GitHub API call is needed. On a 362-item board with 340 terminal Done items, this eliminates ~340 deep-fetches on the first poll cycle.
 
-**`Reconcile` is drift-recovery only**: `cacheImpl.Reconcile(board)` is called only during drift-recovery in webhook mode (see below). It is no longer called on every poll cycle, and it is not called during cold-start bootstrap — that path uses `BootstrapFromProbe` instead.
+**`Reconcile` is drift-recovery only**: `cacheImpl.Reconcile(board)` is called only during drift-recovery, independent of webhook mode (see below). It is no longer called on every poll cycle, and it is not called during cold-start bootstrap — that path uses `BootstrapFromProbe` instead.
 
-**Full reconcile — drift-recovery (webhook mode)**
+**Full reconcile — drift-recovery (runs independent of webhook mode)**
 
 `LightReconcile` returns the fresh board snapshot when drift is detected, which the `reconcileTicker` goroutine passes directly to `cacheImpl.Reconcile(board)` — avoiding a second API call. The older full-fetch-and-reconcile helper (`reconcileCache`) has been removed; `reconcileLoop`'s `LightReconcile` path is the sole reconciliation mechanism.
 
@@ -3338,7 +3338,7 @@ The `--board-cache` flag has been removed. `CacheImpl` is now wired unconditiona
 1. **Per-poll probe (`runProbeAndDeepFetch`)** (always active on bootstrapped cache) — see D.4
 2. **Layer 2 status sweep** (always active) — see D.4 and D.7
 3. **Webhook deltas** (when `--webhooks` is enabled) — see D.2
-4. **Light-reconcile drift recovery** (when `--webhooks` is enabled) — see D.5
+4. **Light-reconcile drift recovery** (always active, independent of `--webhooks`) — see D.5
 
 Tests that need to bypass the cache use `engine.NewWithDeps`, which wires `boardcache.GitHubAdapter` directly. This bypasses the Store-mutation pipeline and silently disables observers, so it is intended only for unit tests that don't exercise Store-driven behavior.
 


### PR DESCRIPTION
Closes #1226

## What this does

Corrects documentation that incorrectly described the `reconcileLoop` (`engine/reconcile.go`) as gated on `--webhooks`, when it actually runs unconditionally whenever the cache is active (see `engine/poll.go:373-383`, and the code comments referencing #955). It is the sole correctness backstop in poll-only mode, and additionally drives webhook stream-health transitions when webhooks are enabled.

## Changes

- **`cmd/root.go`**: Rewrote the `--reconcile-interval` flag help text — removed "when --webhooks is enabled" and the trailing "Inactive without --webhooks" claim; now describes the loop as always active.
- **`docs/state-machine.md`**: Fixed three stale "webhook mode" / "when `--webhooks` is enabled" mentions describing the reconcile drift-recovery path (one of which — the D.4 `Reconcile is drift-recovery only` line — wasn't explicitly cited in the issue but sits immediately beside the corrected section header and needed to match for internal consistency). All three now agree with the already-correct statement at line ~2258 ("The reconcile ticker runs independent of webhooks (poll-only correctness backstop)").
- **`docs/llms-full.txt`**: Regenerated via `bash scripts/generate-llms-full.sh` per repo convention (CI's `docs-drift` workflow enforces this).

No runtime behavior changes — this is a documentation/help-text-only fix.

## How to test

- `go build -o fabrik .` and `go vet ./...` — both pass.
- `./fabrik --help` (or inspect `cmd/root.go:180`) to confirm the corrected `--reconcile-interval` description.
- Diff `docs/state-machine.md` around lines ~3302, ~3304, ~3341 against the reference statement at ~2258 to confirm they now agree.
- `bash scripts/generate-llms-full.sh` produces no further diff against the committed `docs/llms-full.txt`.