### PR TITLE
e2e: exercise both merge_train modes; default (off) path is uncovered

### DIFF
--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -2,14 +2,35 @@
 # scripts/e2e/run.sh — runner for the Fabrik end-to-end integration suite.
 #
 # Usage:
-#   scripts/e2e/run.sh                       # full suite
-#   scripts/e2e/run.sh --clean               # reset boards/PRs/branches first, then full suite
-#   scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch    # one test
-#   scripts/e2e/run.sh -run 'Smoke|NoWork'                 # subset
+#   scripts/e2e/run.sh                       # full two-mode validation gate (off, then on)
+#   scripts/e2e/run.sh --clean               # reset boards/PRs/branches first, then the gate
+#   scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch    # one test, both modes
+#   scripts/e2e/run.sh -run 'Smoke|NoWork'                 # subset, both modes
+#   E2E_TRAIN_MODE=off scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch  # single mode only
 #   E2E_PARALLEL=2 scripts/e2e/run.sh        # tighten the parallelism cap for a heavy run
 #
 # --clean (if given, must be the first argument) runs scripts/e2e/reset.sh for a
-# clean-slate bed before the suite. Anything else is passed to `go test`.
+# clean-slate bed before the run. Anything else is passed to `go test`.
+#
+# Two-mode validation gate (E2E_TRAIN_MODE, default: both "off" and "on"):
+#   FABRIK_MERGE_TRAIN is read at Fabrik startup, so exercising both landing
+#   paths requires a bed restart between them — never an in-run flip while
+#   t.Parallel() scenarios might be in flight (FR-5 of issue #1217). By
+#   default this script drives that restart itself: for each of "off" then
+#   "on", it runs a narrow go test invocation of TestSwitchTrainMode (which
+#   stops the bed, edits FABRIK_MERGE_TRAIN in its .env, and restarts it),
+#   THEN the normal suite invocation with E2E_TRAIN_MODE exported so
+#   scenarios resolve mode explicitly (resolveTrainMode) instead of
+#   re-reading the bed's .env themselves. "off" runs first because it's the
+#   path nearly all real usage takes (see #1217) — a regression there
+#   surfaces before spending time on the less-common train-on run.
+#
+#   Set E2E_TRAIN_MODE=on or E2E_TRAIN_MODE=off to force a single mode
+#   (one switch + one suite invocation) instead of the two-mode default —
+#   useful for iteration, a single -run scenario, or a future CI matrix leg.
+#   A two-mode run is roughly double the single-mode GitHub API cost — see
+#   #1219 for the budget headroom this assumes; merge it before attempting
+#   a full two-mode run.
 #
 # Parallelism cap (E2E_PARALLEL, default 4): 15 of the 16 e2e tests are
 # t.Parallel(), but they all drive ONE shared Fabrik bed (5 workers by default)
@@ -30,12 +51,12 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-# Optional clean-slate reset before the suite (must be the first argument).
+# Optional clean-slate reset before the run (must be the first argument).
 if [ "${1:-}" = "--clean" ]; then
   shift
   echo "== --clean: resetting the test bed via scripts/e2e/reset.sh =="
   "$REPO_ROOT/scripts/e2e/reset.sh"
-  echo "== reset complete; starting suite =="
+  echo "== reset complete; starting run =="
 fi
 
 # Default timeout — generous because scenarios can wait on Claude for minutes.
@@ -45,6 +66,28 @@ TIMEOUT="${E2E_TIMEOUT:-90m}"
 # shared bed (see header + issue #971). Default 4; override with E2E_PARALLEL.
 PARALLEL="${E2E_PARALLEL:-4}"
 
-# Default to verbose because these tests are long-running and the operator
-# wants progress.
-exec go test -tags=e2e -v -timeout "$TIMEOUT" -parallel "$PARALLEL" ./tests/e2e/... "$@"
+# switch_and_run stops the bed, flips FABRIK_MERGE_TRAIN to $1 in its .env,
+# restarts it (via the dedicated TestSwitchTrainMode invocation — a separate
+# `go test` process so the restart completes, bed fully back up, before the
+# suite invocation that follows even starts), then runs the suite with
+# E2E_TRAIN_MODE=$1 exported.
+switch_and_run() {
+  local mode="$1"
+  shift
+  echo "== switching test bed to FABRIK_MERGE_TRAIN=${mode} =="
+  E2E_TRAIN_SWITCH=1 E2E_TRAIN_MODE="$mode" go test -tags=e2e -v -timeout 3m \
+    -run '^TestSwitchTrainMode$' ./tests/e2e/...
+  echo "== running suite with E2E_TRAIN_MODE=${mode} =="
+  E2E_TRAIN_MODE="$mode" go test -tags=e2e -v -timeout "$TIMEOUT" -parallel "$PARALLEL" \
+    ./tests/e2e/... "$@"
+}
+
+if [ -n "${E2E_TRAIN_MODE:-}" ]; then
+  # Single mode forced by the caller — one switch + one suite invocation.
+  switch_and_run "$E2E_TRAIN_MODE" "$@"
+else
+  # Default: the full two-mode validation gate. "off" first — see header
+  # comment for why.
+  switch_and_run off "$@"
+  switch_and_run on "$@"
+fi

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -32,7 +32,7 @@
 #   #1219 for the budget headroom this assumes; merge it before attempting
 #   a full two-mode run.
 #
-# Parallelism cap (E2E_PARALLEL, default 4): 15 of the 16 e2e tests are
+# Parallelism cap (E2E_PARALLEL, default 4): 16 of the 17 e2e tests are
 # t.Parallel(), but they all drive ONE shared Fabrik bed (5 workers by default)
 # against ONE shared board + API budget. Go's default -parallel is GOMAXPROCS
 # (~8-12 cores), which oversubscribes the bed and produces cascading timeouts

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -32,6 +32,13 @@
 #   #1219 for the budget headroom this assumes; merge it before attempting
 #   a full two-mode run.
 #
+#   Failure mode: this script runs under set -e, so if the "off" leg fails
+#   (switch step or suite), the script aborts immediately and the "on" leg
+#   never runs — the shared bed is left running in FABRIK_MERGE_TRAIN=off,
+#   NOT restored to whatever mode it was in before this invocation started.
+#   If you hit a failure here, check/reset the bed's .env mode before
+#   assuming it's still in its prior state.
+#
 # Parallelism cap (E2E_PARALLEL, default 4): 16 of the 17 e2e tests are
 # t.Parallel(), but they all drive ONE shared Fabrik bed (5 workers by default)
 # against ONE shared board + API budget. Go's default -parallel is GOMAXPROCS

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -145,7 +145,12 @@ the canonical setup.
 `TestMergeTrainHappyPathLanding`, `TestMergeTrainBisectionEjectsPoisoner`,
 `TestMergeTrainRestartSafety`, and `TestMergeTrainRunawayGuardPausesBatch` need
 one-time bed setup. They **skip cleanly** (`requireTrainBed`) if the `Queued`
-column is absent, so they are safe to merge before the bed is set up.
+column is absent, so they are safe to merge before the bed is set up. They
+also skip cleanly under train mode `"off"` — these scenarios place issues
+directly in `Queued` via the GitHub API, which succeeds regardless of mode,
+but nothing drains `Queued` when `merge_train: off` (no per-item dispatch,
+no batch handler), so without this check they'd hang to their full 10–50 min
+timeout instead of skipping. Only run in the `on` leg of the two-mode gate.
 
 14. **`Queued` board column** on `handarbeit/projects/2`, positioned between
     `Validate` and `Done` (ADR-059 D1 — the durable train queue). Add it in the
@@ -194,13 +199,13 @@ column is absent, so they are safe to merge before the bed is set up.
 The recommended entrypoint is the runner script, which sets sensible defaults:
 
 ```bash
-# Full suite (slow — multiple scenarios × minutes each)
+# Full two-mode validation gate — off, then on (slow: two full runs)
 scripts/e2e/run.sh
 
-# Single scenario
+# Single scenario, both modes
 scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch
 
-# Subset by name pattern
+# Subset by name pattern, both modes
 scripts/e2e/run.sh -run 'Smoke|NoWork'
 ```
 
@@ -214,12 +219,42 @@ jitter (see below) reproducible — useful for locally reproducing a
 flaky-looking failure. Leave it unset for normal runs; the jitter self-seeds
 randomly by default.
 
+#### Two-mode validation gate — `merge_train: off` and `merge_train: on`
+
+`FABRIK_MERGE_TRAIN` is read once, at Fabrik startup, so exercising both
+landing paths requires restarting the bed between them — it cannot be flipped
+mid-run while `t.Parallel()` scenarios are in flight. By default `run.sh`
+drives this itself: for `off` then `on`, it runs a narrow `go test` invocation
+of `TestSwitchTrainMode` (stops the bed, edits `FABRIK_MERGE_TRAIN` in its
+`.env`, restarts it — a wholly separate process from the suite invocation
+that follows, so the restart is always complete before any scenario starts),
+then the full suite with `E2E_TRAIN_MODE` exported. `off` runs first because
+it's the path nearly all real usage takes; a regression there surfaces before
+spending time on the less-common train-on run.
+
+Force a single mode instead of the two-mode default with `E2E_TRAIN_MODE`:
+
+```bash
+E2E_TRAIN_MODE=off scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch
+E2E_TRAIN_MODE=on  scripts/e2e/run.sh
+```
+
+A two-mode run is roughly double the single-mode GitHub API cost — see #1219
+for the budget headroom this assumes, and merge it before attempting a full
+two-mode run.
+
+Scenarios resolve mode via `resolveTrainMode` (`harness.go`): `E2E_TRAIN_MODE`
+takes precedence when set (an invalid value is a hard test failure), falling
+back to a lenient read of the bed's own `.env` for ad-hoc/manual runs where
+the switch step never ran. The "Mode" column in the Scenarios table below
+records which scenarios assert a mode-specific contract.
+
 #### Parallelism cap — the shared bed oversubscribes easily
 
-15 of the 16 scenarios are `t.Parallel()`, but they **all drive one shared
+16 of the 17 scenarios are `t.Parallel()`, but they **all drive one shared
 Fabrik bed** (5 workers by default) against **one shared board and one shared
 GitHub API budget**. Go's default `-parallel` is `GOMAXPROCS` (~8–12 cores), so
-an unbounded full run fires ~15 scenarios at once, floods the 5-worker bed, and
+an unbounded full run fires ~16 scenarios at once, floods the 5-worker bed, and
 saturates the API — producing cascading `transient gh error … (will retry)`
 timeouts **even though every scenario passes standalone** (see issue #971).
 
@@ -267,26 +302,39 @@ it will refuse otherwise.
 
 ## Scenarios
 
-| Test | What it verifies | Approx wall-clock | Cost |
-|---|---|---|---|
-| `TestSmokeSingleRepoDispatch` | Worker dispatches on a trivial issue; Specify completes | 3–5 min | $0.10–0.20 |
-| `TestSmokeSingleRepoFullPipeline` | Full single-repo pipeline (Specify → … → Done with merged PR) | 20–40 min | $0.50–1.50 |
-| `TestNoWorkNeeded` | `FABRIK_NO_WORK_NEEDED` short-circuit closes issue without PR | 10–15 min | $0.30–0.50 |
-| `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` pause + comment-driven resume | 10–15 min | $0.30–0.50 |
-| `TestCrossRepoSpawn` | Cross-repo decomposition (spawn child in beta, gate parent, resume on close) | 45–60 min | $1.00–2.00 |
-| `TestYoloAutoMergeLabel` | `fabrik:yolo` auto-advance to Done via GitHub native auto-merge; timeline-verifies `fabrik:auto-merge-enabled` was applied | 20–40 min | $0.50–1.50 |
-| `TestCruiseFullPipeline` | `fabrik:cruise` auto-advances to Validate-complete without auto-merge; PR merged by human closes issue | 30–50 min | $0.80–2.00 |
-| `TestBaseBranchPipeline` | `base:<branch>` non-default base branch: throwaway branch created off main, PR targets it (not main), pipeline does not falsely pause at end of Implement, review gate clears via the base-independent REST feed | 35–55 min | $0.80–2.00 |
-| `TestCIFixReinvoke` | CI-fix reinvoke positive path: sentinel fails on first push, Claude fixes, CI passes, issue closes | 75–90 min | $1.00–3.00 |
-| `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | 30–60 min | $0.50–1.50 |
-| `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
-| `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
-| `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | 10–25 min | low (no Claude) |
-| `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | 20–40 min | low–moderate |
-| `TestMergeTrainRestartSafety` | ADR-059 D5 / #960: after a landing, a restart with the historical merged integration PR present does NOT stall the next batch (reconstruct proceeds fresh). **Not parallel** — restarts the bed | 25–50 min | low |
-| `TestMergeTrainRunawayGuardPausesBatch` | ADR-059 D8 (#964/#965): persistently-red 4-member batch trips the runaway guard at cap=6, pauses all Queued members, no member reaches Done. Runs on RepoBeta for counter isolation | 10–20 min | low (no Claude) |
+"Mode" records each scenario's classification from the #1217 mode audit (FR-2/FR-3/FR-4):
+**Both** — mode-invariant, single assertion set, passes under both `merge_train`
+settings unmodified. **Both (mode-aware)** — genuinely differs by mode; the
+scenario branches internally (via `resolveTrainMode`) and asserts the
+mode-appropriate contract in each. **Train-only (on)** — exercises the merge
+train directly; skips cleanly (`requireTrainBed`) under mode `"off"` or when
+the `Queued` column is absent, so it only runs in the gate's `on` leg.
 
-Approximate suite total: ~515 min wall-clock, $8.30–26 in Claude tokens (CI-fix, `TestPausedMergedPRRecovery`, and conjunctive-gate tests should be run separately with `E2E_TIMEOUT=3h` or `E2E_TIMEOUT=2h` as noted above).
+| Test | What it verifies | Mode | Approx wall-clock | Cost |
+|---|---|---|---|---|
+| `TestSmokeSingleRepoDispatch` | Worker dispatches on a trivial issue; Specify completes | Both | 3–5 min | $0.10–0.20 |
+| `TestSmokeSingleRepoFullPipeline` | Full single-repo pipeline (Specify → … → Done with merged PR) | Both | 20–40 min | $0.50–1.50 |
+| `TestNoWorkNeeded` | `FABRIK_NO_WORK_NEEDED` short-circuit closes issue without PR | Both | 10–15 min | $0.30–0.50 |
+| `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` pause + comment-driven resume | Both | 10–15 min | $0.30–0.50 |
+| `TestCrossRepoSpawn` | Cross-repo decomposition (spawn child in beta, gate parent, resume on close) | Both | 45–60 min | $1.00–2.00 |
+| `TestYoloAutoMergeLabel` | `fabrik:yolo` auto-advance to Done; mode-appropriate landing contract (native auto-merge + `fabrik:auto-merge-enabled` under "off"; train close-not-merge + label never applied under "on") | Both (mode-aware) | 20–40 min | $0.50–1.50 |
+| `TestConvergenceRace` | Deterministic post-Validate auto-merge race (#829): two conflicting yolo PRs; mode-appropriate `fabrik:auto-merge-enabled` contract, both land within budget, neither ends `fabrik:paused` | Both (mode-aware) | 80–100 min | $2–4 |
+| `TestCruiseFullPipeline` | `fabrik:cruise` auto-advances to Validate-complete without auto-merge; PR merged by human closes issue | Both | 30–50 min | $0.80–2.00 |
+| `TestBaseBranchPipeline` | `base:<branch>` non-default base branch: throwaway branch created off main, PR targets it (not main), pipeline does not falsely pause at end of Implement, review gate clears via the base-independent REST feed | Both | 35–55 min | $0.80–2.00 |
+| `TestCIFixReinvoke` | CI-fix reinvoke positive path: sentinel fails on first push, Claude fixes, CI passes, issue closes | Both | 75–90 min | $1.00–3.00 |
+| `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | Both | 30–60 min | $0.50–1.50 |
+| `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | Both | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
+| `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | Both | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
+| `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | Train-only (on) | 10–25 min | low (no Claude) |
+| `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | Train-only (on) | 20–40 min | low–moderate |
+| `TestMergeTrainRestartSafety` | ADR-059 D5 / #960: after a landing, a restart with the historical merged integration PR present does NOT stall the next batch (reconstruct proceeds fresh). **Not parallel** — restarts the bed | Train-only (on) | 25–50 min | low |
+| `TestMergeTrainRunawayGuardPausesBatch` | ADR-059 D8 (#964/#965): persistently-red 4-member batch trips the runaway guard at cap=6, pauses all Queued members, no member reaches Done. Runs on RepoBeta for counter isolation | Train-only (on) | 10–20 min | low (no Claude) |
+
+Approximate single-mode suite total: ~615 min wall-clock, $10.30–30 in Claude
+tokens (CI-fix, `TestPausedMergedPRRecovery`, and conjunctive-gate tests
+should be run separately with `E2E_TIMEOUT=3h` or `E2E_TIMEOUT=2h` as noted
+above). A full two-mode gate run is roughly double this, minus the near-instant
+skip of the four Train-only scenarios in the `off` leg.
 
 ### Regression coverage map
 
@@ -298,6 +346,7 @@ Approximate suite total: ~515 min wall-clock, $8.30–26 in Claude tokens (CI-fi
 | `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` marker, ed46b7fc (awaiting-input label clear) |
 | `TestCrossRepoSpawn` | #797 / #803 (on-demand spawn-target init), v0.0.66 spawn machinery, #800 (addBlockedBy mutation name) |
 | `TestYoloAutoMergeLabel` | #829 (GitHub native auto-merge for yolo), #831/#835/#871 (convergence regression cascade) |
+| `TestConvergenceRace` | #829 (post-Validate auto-merge race, Story 2/SC-002); regression guard for the production failure on example-org/example-repo#82 (spurious CI-fix-cycle-limit pause); #1217 (mode-aware `fabrik:auto-merge-enabled` assertion) |
 | `TestCruiseFullPipeline` | #898 (cruise/yolo gate at Validate, `engine/poll.go`); ensures cruise never triggers `checkAutoMergeConvergence` |
 | `TestBaseBranchPipeline` | #1046 (report: base:<branch> GraphQL data gap), #1047 (`verifyAndHealLinkageByBody` linkage fix), #1050 (base-independent review-gate REST data feed) |
 | `TestCIFixReinvoke` | #888 ADR-056 D1 (settling primitive reinterprets CI-gate signals); CI-fix reinvoke loop (engine/ci.go) |
@@ -324,9 +373,14 @@ Every escape-from-release regression earns a new scenario in this table.
 
 ## Design notes
 
-- Tests do **not** start or stop the Fabrik instance. The instance is expected
-  to be already running. (Future enhancement: a `harness.StartFabrik(t)` that
-  spawns/stops it per test session.)
+- Scenarios do **not** start or stop the Fabrik instance — the instance is
+  expected to be already running. Two exceptions, both using the
+  `StopFabrikTestBed`/`StartFabrikTestBed` helpers in `lifecycle.go`:
+  `TestMergeTrainRestartSafety` (restarts mid-scenario to exercise
+  restart-safety) and `TestSwitchTrainMode` (restarts to flip
+  `FABRIK_MERGE_TRAIN` for the two-mode gate — not itself a scenario, run
+  only via `run.sh`'s mode-switch step). Both are deliberately **not**
+  `t.Parallel()`.
 - Assertions are on **observable outcomes**, not internal state. We check
   GitHub for label changes, comments, PR creation, etc. — not the engine's
   internal `worktreeManagers` map.

--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -12,9 +12,10 @@ import (
 // poll-merge loop with GitHub's native auto-merge for yolo issues — and, per
 // #980, for the ADR-059 merge-train's own yolo landing contract.
 //
-// The test auto-detects the bed's configured FABRIK_MERGE_TRAIN mode (via the
-// bed's .env file) and asserts whichever contract that mode implies, since
-// the two are mutually exclusive at the engine level (attemptMergeOnValidate
+// The test resolves the suite's merge-train mode (resolveTrainMode —
+// E2E_TRAIN_MODE if set, else the bed's .env file) and asserts whichever
+// contract that mode implies, since the two are mutually exclusive at the
+// engine level (attemptMergeOnValidate
 // diverts every yolo Validate completion straight to advanceToQueued before
 // the fabrik:auto-merge-enabled label site is ever reached when the train is
 // on):

--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -52,7 +52,7 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 
-	trainMode := readEnvFileMergeTrainMode(t, env)
+	trainMode := resolveTrainMode(t, env)
 	t.Logf("bed train mode: %s", trainMode)
 
 	stamp := time.Now().UTC().Format("20060102-150405")

--- a/tests/e2e/convergence_race_test.go
+++ b/tests/e2e/convergence_race_test.go
@@ -34,11 +34,27 @@ import (
 //     re-enables; the slow-gate runs again; the second PR merges; the issue
 //     closes.
 //
+// The above (steps 3-7) is the train mode "off" contract. Under train mode
+// "on" (ADR-059), Validate completion for a yolo item diverts to
+// advanceToQueued before the fabrik:auto-merge-enabled label site is ever
+// reached (engine/merge_gate.go:230 — by design, non-queue repos never get
+// that label under the train), so the two conflicting PRs never race a
+// native GitHub auto-merge. Instead both members land via the train's own
+// batch/singleton landing path, and any textual conflict between them is
+// resolved inline while assembling the trial branch (ADR-059 D3) rather
+// than via a rebase-reinvoke. The pass criteria under "on" is therefore
+// evidence that the train's own contention path doesn't stall — both
+// issues still land within budget, neither ends fabrik:paused, and
+// fabrik:auto-merge-enabled is never applied — not a literal rebase-
+// reinvoke assertion.
+//
 // Pass criteria:
 //   - Both issues close within the wall-clock budget.
-//   - Both had fabrik:auto-merge-enabled applied (FR-004).
+//   - Train mode "off": both had fabrik:auto-merge-enabled applied (FR-004).
+//     Train mode "on": fabrik:auto-merge-enabled is never applied to either
+//     (merge_gate.go:230).
 //   - Neither ends in fabrik:paused (FR-013 was NOT triggered — convergence
-//     succeeded within budget).
+//     succeeded within budget). True in both modes.
 //
 // This is the regression test for the production failure on
 // example-org/example-repo#82 (spurious "CI fix cycle limit reached" on a
@@ -51,6 +67,9 @@ func TestConvergenceRace(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
+
+	trainMode := resolveTrainMode(t, env)
+	t.Logf("bed train mode: %s", trainMode)
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 
@@ -100,11 +119,28 @@ func TestConvergenceRace(t *testing.T) {
 	}
 	closeWg.Wait()
 
-	// Both PRs must have gone through the GitHub native auto-merge path.
-	for _, num := range nums {
-		AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
-	}
-	t.Logf("both issues had fabrik:auto-merge-enabled applied — FR-004 verified for both")
+	// The fabrik:auto-merge-enabled contract diverges by mode: under "off",
+	// attemptMergeOnValidate enables GitHub's native auto-merge and applies
+	// the label to both PRs (FR-004). Under "on", the same Validate
+	// completion diverts to advanceToQueued before that label site is ever
+	// reached, and the non-queue-repo path in merge_gate.go never applies it,
+	// by design (engine/merge_gate.go:230) — see TestYoloAutoMergeLabel for
+	// the reference pattern this mirrors.
+	t.Run(fmt.Sprintf("train-mode=%s", trainMode), func(t *testing.T) {
+		if trainMode == "on" {
+			for _, num := range nums {
+				AssertLabelWasNeverApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
+			}
+			t.Logf("fabrik:auto-merge-enabled was never applied to either issue — train-on contract verified " +
+				"(the conflicting pair resolved via the train's own inline trial-branch conflict resolution, " +
+				"ADR-059 D3, rather than a native auto-merge rebase-reinvoke)")
+			return
+		}
+		for _, num := range nums {
+			AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:auto-merge-enabled")
+		}
+		t.Logf("both issues had fabrik:auto-merge-enabled applied — FR-004 verified for both")
+	})
 
 	// Neither issue should have ended in fabrik:paused — that would mean
 	// either the convergence budget exhausted (FR-013) OR a legacy cycle

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1115,10 +1115,97 @@ func readEnvFileMaxCiFixCycles(t *testing.T, env *Env) int {
 	return n
 }
 
+// writeEnvFileValue replaces (or appends) a KEY=value line in a .env-style
+// file, preserving unrelated lines, blank lines, and comments as-is. Creates
+// the file if it doesn't exist yet. Unlike readEnvFileValue, this does a
+// literal "key=" line match rather than trimming/quote-stripping the value —
+// it owns line construction on the write side, so there's nothing to strip.
+func writeEnvFileValue(path, key, value string) error {
+	var lines []string
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		lines = strings.Split(string(data), "\n")
+		// strings.Split on a trailing newline yields a spurious final empty
+		// element; drop it so re-joining doesn't accumulate blank lines.
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+	case os.IsNotExist(err):
+		// No file yet — start from an empty line set.
+	default:
+		return err
+	}
+
+	newLine := key + "=" + value
+	replaced := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) == 2 && strings.TrimSpace(parts[0]) == key {
+			lines[i] = newLine
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		lines = append(lines, newLine)
+	}
+
+	// 0o600: .env files carry secrets (FABRIK_TOKEN). Only applies if the file
+	// doesn't already exist — os.WriteFile does not chmod an existing file.
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
+}
+
+// normalizeTrainMode validates and lowercases a mode string, accepting only
+// an exact case-insensitive "on" or "off" (surrounding whitespace tolerated).
+// Pulled out of resolveTrainMode as a pure function so its validation logic
+// is unit-testable without a *testing.T (a t.Fatalf-driven parent test
+// can't distinguish "the fatal path fired as designed" from "the test
+// itself failed" — Go propagates a failed subtest's failure to its parent).
+func normalizeTrainMode(v string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "on":
+		return "on", nil
+	case "off":
+		return "off", nil
+	default:
+		return "", fmt.Errorf("invalid mode %q (must be on or off)", v)
+	}
+}
+
+// resolveTrainMode determines the e2e suite's merge-train mode for the
+// current process. E2E_TRAIN_MODE (set by scripts/e2e/run.sh's two-mode
+// validation gate — see TestSwitchTrainMode) takes precedence when set,
+// satisfying FR-2: mode must be explicit and legible at the suite level, not
+// an ambient property of the bed's .env that a reader has to go look up. An
+// explicit-but-invalid E2E_TRAIN_MODE is a hard t.Fatalf — unlike the lenient
+// .env fallback below, a wrong explicit signal should be loud, not silently
+// defaulted.
+//
+// When E2E_TRAIN_MODE is unset (ad-hoc/manual bed usage — running go test
+// directly against a bed someone configured by hand), falls back to
+// readEnvFileMergeTrainMode's lenient read of the bed's own .env file.
+func resolveTrainMode(t *testing.T, env *Env) string {
+	t.Helper()
+	if v := os.Getenv("E2E_TRAIN_MODE"); v != "" {
+		mode, err := normalizeTrainMode(v)
+		if err != nil {
+			t.Fatalf("E2E_TRAIN_MODE=%q is invalid (must be on or off)", v)
+		}
+		return mode
+	}
+	return readEnvFileMergeTrainMode(t, env)
+}
+
 // readEnvFileMergeTrainMode reads FABRIK_MERGE_TRAIN from the test bed's .env
 // file, normalizing exactly like cmd/root.go's mergeTrainMode: missing/empty
 // or unrecognized values default to "off" (logged via t.Logf, not stderr),
-// and only an exact case-insensitive "on" returns "on".
+// and only an exact case-insensitive "on" returns "on". This is the fallback
+// path behind resolveTrainMode, used when E2E_TRAIN_MODE is unset.
 func readEnvFileMergeTrainMode(t *testing.T, env *Env) string {
 	t.Helper()
 	envFile := filepath.Join(env.FabrikTestDir, ".env")

--- a/tests/e2e/harness_test.go
+++ b/tests/e2e/harness_test.go
@@ -4,6 +4,8 @@ package e2e
 
 import (
 	"math/rand/v2"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -136,4 +138,155 @@ func TestPollSleepBoundsAndConcurrency(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestWriteEnvFileValueReplacesExistingKey verifies an existing KEY=value
+// line is replaced in place, and unrelated lines (including comments and
+// blanks) are preserved verbatim.
+func TestWriteEnvFileValueReplacesExistingKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	original := "# a comment\nFABRIK_TOKEN=abc123\n\nFABRIK_MERGE_TRAIN=on\nOTHER=1\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	if err := writeEnvFileValue(path, "FABRIK_MERGE_TRAIN", "off"); err != nil {
+		t.Fatalf("writeEnvFileValue: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back .env: %v", err)
+	}
+	want := "# a comment\nFABRIK_TOKEN=abc123\n\nFABRIK_MERGE_TRAIN=off\nOTHER=1\n"
+	if string(got) != want {
+		t.Fatalf("writeEnvFileValue replace mismatch:\ngot:  %q\nwant: %q", string(got), want)
+	}
+}
+
+// TestWriteEnvFileValueAppendsMissingKey verifies a key not already present
+// is appended as a new line, and that a brand-new (nonexistent) file is
+// created cleanly.
+func TestWriteEnvFileValueAppendsMissingKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	original := "FABRIK_TOKEN=abc123\n"
+	if err := os.WriteFile(path, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+
+	if err := writeEnvFileValue(path, "FABRIK_MERGE_TRAIN", "on"); err != nil {
+		t.Fatalf("writeEnvFileValue: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back .env: %v", err)
+	}
+	want := "FABRIK_TOKEN=abc123\nFABRIK_MERGE_TRAIN=on\n"
+	if string(got) != want {
+		t.Fatalf("writeEnvFileValue append mismatch:\ngot:  %q\nwant: %q", string(got), want)
+	}
+
+	// Nonexistent file: should be created from scratch with just the new line.
+	freshPath := filepath.Join(t.TempDir(), "fresh.env")
+	if err := writeEnvFileValue(freshPath, "FABRIK_MERGE_TRAIN", "off"); err != nil {
+		t.Fatalf("writeEnvFileValue on nonexistent file: %v", err)
+	}
+	got, err = os.ReadFile(freshPath)
+	if err != nil {
+		t.Fatalf("read back fresh .env: %v", err)
+	}
+	if string(got) != "FABRIK_MERGE_TRAIN=off\n" {
+		t.Fatalf("writeEnvFileValue on fresh file mismatch: got %q", string(got))
+	}
+}
+
+// TestResolveTrainModePrecedence verifies E2E_TRAIN_MODE takes precedence
+// over the bed's .env file, that unset E2E_TRAIN_MODE falls back to reading
+// .env, and that an invalid E2E_TRAIN_MODE value fails the test rather than
+// silently defaulting (unlike the lenient .env fallback).
+func TestResolveTrainModePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("FABRIK_MERGE_TRAIN=on\n"), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+	env := &Env{FabrikTestDir: dir}
+
+	t.Run("E2E_TRAIN_MODE takes precedence over .env", func(t *testing.T) {
+		t.Setenv("E2E_TRAIN_MODE", "off")
+		if got := resolveTrainMode(t, env); got != "off" {
+			t.Fatalf("resolveTrainMode() = %q, want %q (E2E_TRAIN_MODE should override .env's \"on\")", got, "off")
+		}
+	})
+
+	t.Run("falls back to .env when E2E_TRAIN_MODE unset", func(t *testing.T) {
+		t.Setenv("E2E_TRAIN_MODE", "")
+		if got := resolveTrainMode(t, env); got != "on" {
+			t.Fatalf("resolveTrainMode() = %q, want %q (fallback to .env's FABRIK_MERGE_TRAIN=on)", got, "on")
+		}
+	})
+
+	t.Run("case-insensitive E2E_TRAIN_MODE", func(t *testing.T) {
+		t.Setenv("E2E_TRAIN_MODE", "ON")
+		if got := resolveTrainMode(t, env); got != "on" {
+			t.Fatalf("resolveTrainMode() = %q, want %q", got, "on")
+		}
+	})
+}
+
+// TestResolveTrainModeUnrecognizedEnvFallsBackToOff verifies a malformed
+// .env value (not a resolveTrainMode concern directly, but exercises the
+// fallback path resolveTrainMode delegates to when E2E_TRAIN_MODE is unset)
+// still normalizes to "off" per readEnvFileMergeTrainMode's documented
+// lenient behavior.
+func TestResolveTrainModeUnrecognizedEnvFallsBackToOff(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("FABRIK_MERGE_TRAIN=garbage\n"), 0o600); err != nil {
+		t.Fatalf("seed .env: %v", err)
+	}
+	env := &Env{FabrikTestDir: dir}
+	t.Setenv("E2E_TRAIN_MODE", "")
+
+	if got := resolveTrainMode(t, env); got != "off" {
+		t.Fatalf("resolveTrainMode() = %q, want %q (lenient .env fallback on garbage value)", got, "off")
+	}
+}
+
+// TestNormalizeTrainMode exercises the pure validation logic resolveTrainMode
+// delegates to for E2E_TRAIN_MODE — including the "invalid value" case,
+// which can't be tested through resolveTrainMode itself: resolveTrainMode
+// calls t.Fatalf on invalid input, and a failing t.Run subtest propagates
+// its failure to the parent test, so there is no way to observe "the fatal
+// path fired as designed" without also failing the overall test run.
+func TestNormalizeTrainMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"on", "on", false},
+		{"ON", "on", false},
+		{" on ", "on", false},
+		{"off", "off", false},
+		{"OFF", "off", false},
+		{"sideways", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		got, err := normalizeTrainMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("normalizeTrainMode(%q) = %q, nil; want error", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeTrainMode(%q) unexpected error: %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("normalizeTrainMode(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
 }

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -17,11 +17,24 @@ import (
 // every item in Queued"), so an externally-placed Queued item with a linked PR is
 // a valid member — which is exactly what these helpers construct.
 
-// requireTrainBed skips the test unless the test board has a "Queued" column —
-// the one-time operator setup the merge train needs (ADR-059 D1). Keeps train
-// scenarios from failing on a bed that predates the train rollout.
+// requireTrainBed skips the test unless (a) the suite is running in train
+// mode "on" and (b) the test board has a "Queued" column — the one-time
+// operator setup the merge train needs (ADR-059 D1).
+//
+// The mode check comes first and matters on its own: these scenarios place
+// issues directly in Queued (QueueMember), a pure GitHub/board operation
+// that succeeds regardless of mode. But under merge_train: off, nothing
+// ever drains Queued — HoldingStage items are never individually dispatched,
+// and handleMergeTrainBatch (the batch drain) only runs when
+// e.cfg.MergeTrain == "on" (engine/poll.go). Without this check, running
+// these scenarios during an off-mode run would place members that are never
+// landed, and every wait helper below would burn its full 10-50 min timeout
+// as a false failure instead of skipping cleanly.
 func requireTrainBed(t *testing.T, env *Env) {
 	t.Helper()
+	if resolveTrainMode(t, env) != "on" {
+		t.Skip("merge-train scenario requires train mode \"on\" — skipping under train mode \"off\"")
+	}
 	// Retry on transient errors (e.g. GraphQL rate-limit exhaustion — gh project runs
 	// on GraphQL). A persistent read failure FAILS the test rather than silently
 	// skipping, so a rate-limited run does not masquerade as "bed not set up".

--- a/tests/e2e/train_mode_switch_test.go
+++ b/tests/e2e/train_mode_switch_test.go
@@ -40,6 +40,13 @@ func TestSwitchTrainMode(t *testing.T) {
 
 	env := LoadEnv(t)
 
+	// Mirrors RestartFabrikTestBed (lifecycle.go): register the bring-back-up
+	// before stopping, so a failure between Stop and Start (e.g. writeEnvFileValue
+	// erroring, or StartFabrikTestBed itself failing) still leaves the bed running
+	// instead of down for whoever/whatever uses it next. StartFabrikTestBed is a
+	// no-op if the bed is already up, so this is harmless on the successful path.
+	t.Cleanup(func() { StartFabrikTestBed(t, env) })
+
 	t.Logf("switching test bed to FABRIK_MERGE_TRAIN=%s", mode)
 	StopFabrikTestBed(t, env)
 

--- a/tests/e2e/train_mode_switch_test.go
+++ b/tests/e2e/train_mode_switch_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSwitchTrainMode restarts the shared test bed with FABRIK_MERGE_TRAIN
+// set to the mode named by E2E_TRAIN_MODE, satisfying FR-5: mode is read at
+// Fabrik startup, so switching it requires a restart — never an in-run flip
+// while other scenarios' t.Parallel() invocations might be in flight.
+//
+// This is deliberately its own `go test` invocation (see scripts/e2e/run.sh),
+// not folded into the main suite run: a dedicated invocation whose only test
+// is this one completes — bed fully back up in the new mode — before the
+// suite invocation that follows it even starts. That makes "the restart
+// completes before any scenario starts" structural rather than dependent on
+// Go's "non-parallel tests run before parallel ones" ordering interacting
+// correctly with whatever -run pattern the caller passed to a combined
+// invocation.
+//
+// Gated on E2E_TRAIN_SWITCH=1 in addition to requiring E2E_TRAIN_MODE, so a
+// broad -run pattern (or a plain full-suite invocation with E2E_TRAIN_MODE
+// set) doesn't accidentally sweep this test into the main suite run and
+// restart the bed a second, redundant time. scripts/e2e/run.sh's dedicated
+// switch step is the only caller that sets it.
+func TestSwitchTrainMode(t *testing.T) {
+	if os.Getenv("E2E_TRAIN_SWITCH") != "1" {
+		t.Skip("only runs when E2E_TRAIN_SWITCH=1 (set by scripts/e2e/run.sh's mode-switch step)")
+	}
+
+	rawMode := os.Getenv("E2E_TRAIN_MODE")
+	mode, err := normalizeTrainMode(rawMode)
+	if err != nil {
+		t.Fatalf("E2E_TRAIN_MODE=%q is invalid (must be on or off)", rawMode)
+	}
+
+	env := LoadEnv(t)
+
+	t.Logf("switching test bed to FABRIK_MERGE_TRAIN=%s", mode)
+	StopFabrikTestBed(t, env)
+
+	envFile := filepath.Join(env.FabrikTestDir, ".env")
+	if err := writeEnvFileValue(envFile, "FABRIK_MERGE_TRAIN", mode); err != nil {
+		t.Fatalf("write FABRIK_MERGE_TRAIN=%s to %s: %v", mode, envFile, err)
+	}
+
+	StartFabrikTestBed(t, env)
+	t.Logf("test bed restarted with FABRIK_MERGE_TRAIN=%s", mode)
+}


### PR DESCRIPTION
Closes #1217

## Summary

The e2e suite previously only ever exercised whichever `merge_train` mode the shared test bed happened to be configured with (currently `on`), leaving the `merge_train: off` path — the one nearly all real users are on — completely uncovered end-to-end. Two scenarios also encoded `off`-only assumptions and produced false failures against a train-on bed.

This PR makes the suite runnable in both modes via an explicit, restart-based fixture, generalizes the existing single-scenario mode-detection pattern, fixes the two known mode-divergent assertions, and documents the two-mode gate as the pre-release validation run.

## Key changes

- **`resolveTrainMode` / `writeEnvFileValue`** (`tests/e2e/harness.go`): generalizes the existing `readEnvFileMergeTrainMode` pattern. `resolveTrainMode` reads `E2E_TRAIN_MODE` first (hard failure on garbage input) and falls back to the bed's `.env` for ad-hoc runs. `writeEnvFileValue` is the new `.env` writer the mode-switch fixture needs.
- **`TestSwitchTrainMode`** (`tests/e2e/train_mode_switch_test.go`): a dedicated, gated (`E2E_TRAIN_SWITCH=1`), non-parallel test that stops the bed, flips `FABRIK_MERGE_TRAIN` in its `.env`, and restarts it — run as its own `go test` invocation so the restart always completes before any scenario starts (structurally satisfies FR-5, no mid-run flip).
- **`requireTrainBed`** (`tests/e2e/mergetrain_helpers.go`): now also skips under train mode `"off"`, since the four merge-train scenarios would otherwise place members in `Queued` that nothing ever drains, burning full 10-50 min timeouts as false failures.
- **`TestYoloAutoMergeLabel`**: now calls `resolveTrainMode` instead of the single-scenario helper it originated.
- **`TestConvergenceRace`**: the `fabrik:auto-merge-enabled` assertion now branches on mode — applied under `off`, never applied under `on` (`engine/merge_gate.go:230`, by design), matching the reference pattern `TestYoloAutoMergeLabel` already used.
- **`scripts/e2e/run.sh`**: the default (no `E2E_TRAIN_MODE`) invocation now runs the full suite twice — `off` then `on` — each preceded by the switch step. `E2E_TRAIN_MODE=on|off` forces a single mode for iteration.
- **`tests/e2e/README.md`**: new two-mode gate section, a `Mode` column on the Scenarios table classifying all 17 scenarios (mode-invariant / mode-aware / train-only), an updated merge-train prerequisites note, and a previously-undocumented `TestConvergenceRace` row added to the Scenarios and Regression-coverage tables (a pre-existing gap surfaced while auditing).

## Out of scope (unchanged)

No engine behavior was changed — this is test-infrastructure-only, matching the issue's explicit scope. A two-mode run is roughly double the single-mode API cost; per the issue, #1219 (GraphQL cost reduction) should land before a two-mode run is actually attempted against the shared bed.

## Test plan

- [x] `go build -tags=e2e ./tests/e2e/...` and `go vet -tags=e2e ./tests/e2e/...` — clean
- [x] `go test -tags=e2e ./tests/e2e/...` (no live bed) — all harness unit tests pass, including new coverage for `writeEnvFileValue`, `resolveTrainMode`, and `normalizeTrainMode`
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — clean except one pre-existing, environment-dependent failure (`TestExecute_ConfigYAMLApplied`, needs live GitHub GraphQL access unavailable in this sandbox; unrelated to this change — confirmed it fails identically on an unmodified tree)
- [x] `shellcheck scripts/e2e/run.sh` — clean
- [ ] **Manual live-bed verification** (from the Plan's task checklist) — running `E2E_TRAIN_MODE=off scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch` against the real shared bed to confirm the restart-and-flip actually works end-to-end. This wasn't done here: it requires operating on `~/dev/fabrik-test/`, outside this worktree's boundary, and would restart shared infrastructure other people may be using. Recommend running this once before merging, when the bed is free.