### PR TITLE
feat(pruefer): derive App installations from watched_repos (multi-org, one daemon)

### DIFF
--- a/adrs/1233-pruefer-multi-installation-auth.md
+++ b/adrs/1233-pruefer-multi-installation-auth.md
@@ -1,0 +1,78 @@
+# ADR 1233: Pruefer Multi-Installation Auth Derived from `watched_repos`
+
+**Date**: 2026-07-28
+**Status**: Accepted
+**Issue**: #1233 — derive App installations from `watched_repos` (multi-org, one daemon)
+
+## Context
+
+ADR-1113 Decision 1 authenticates Pruefer to **one** GitHub App installation per daemon: `github_app_installation_id` if set, or auto-discovery when the App has exactly one installation — zero or multiple installations was a hard bootstrap error. That was correct for a single-org deployment, but the App (`handarbeit-pruefer`) is now installed on four accounts (`handarbeit`, `verveguy`, `shadoworg`, `liminisapp`). Two consequences followed directly from the single-installation design:
+
+1. Auto-discovery now hard-errors on every fresh start, since more than one installation exists.
+2. Covering all four orgs required four separate daemons, one per installation, because an installation token is strictly scoped to that account's repos — `handarbeit`'s token cannot read a `verveguy` repo. A single `watched_repos` list spanning owners could never work against one token.
+
+The operator wants one daemon, driven by the `watched_repos` list they already maintain, covering repos across every org the App is installed on.
+
+This ADR amends/supersedes ADR-1113 Decision 1's single-installation resolution: installation resolution is now **derived from `watched_repos`** rather than pinned or auto-selected once per daemon.
+
+## Decisions
+
+### 1. Installations are resolved per distinct owner in `watched_repos`, not once per daemon
+
+`BootstrapMulti` (`pruefer/auth.go`, replacing `Bootstrap`) groups `Config.WatchedRepos` by owner (`distinctOwners`) and, for each distinct owner, resolves that owner's installation by matching `AppInstallation.Account == owner` against `FetchAppInstallations`'s result. One token is minted per distinct owner required, not per repo and not for every installation of the App.
+
+**This is also the whole security control.** The set of installations Pruefer ever mints a token for, or contacts, equals exactly the set of owners appearing in `watched_repos` — nothing more. Pruefer never enumerates "every installation of the App" and acts on all of them. An account that installs the (public) App but is never named in any operator's `watched_repos` is never tokenized and never contacted — structurally, not by a separate allowlist check that could drift out of sync with config. This is what makes registering the App as installable-by-anyone safe: "only act on my own accounts" falls directly out of what's listed in `watched_repos`, with no additional mechanism to keep correct. `TestBootstrapMulti_MultiOwnerMintsPerOwnerAndNeverTouchesStranger` asserts this directly — a "stranger" installation present in the mocked `FetchAppInstallations` response but absent from `watched_repos` receives zero requests.
+
+An owner with **no** matching installation is a hard bootstrap error naming the owner and how to fix it (`"no GitHub App installation found for owner %q ... install the app on %q"`) — consistent with ADR-1113's existing bootstrap-error style, just re-scoped from "the daemon's one installation" to "this one owner's installation."
+
+### 2. One `*github.Client` per owner, not a token-provider inside `github/client.go`
+
+Two mechanisms were available: (a) one `*github.Client` (and its own `*Auth`) per owner, reusing `SetToken`/`RunRefreshLoop` unchanged, or (b) threading an owner/request context through `github.Client`'s request core (`do`/`doWithAccept`/`graphqlRequest`) so a single client selects the right token per call.
+
+(a) was chosen. It confines the change to `pruefer/`: `AuthSet.Clients map[string]*gh.Client` holds one client per owner, and `Daemon.Clients map[string]GitHubLister` (replacing the single `Daemon.Client`) looks up the right client by owner in the poll loop (`daemon.go`'s `poll()`). (b) would have reached into `github/client.go`'s and `github/rest.go`'s shared request plumbing — used by Fabrik's own engine (board/PR/label calls) well beyond Pruefer — coupling a Pruefer-specific multi-tenancy concern onto code with a much broader blast radius, for no offsetting benefit: every method Pruefer calls (`ListOpenPRs`, `FetchPRDiff`, `FetchPRReviews`, `SubmitPRReview`, plus the clone token via `client.Token()`) already takes `owner, repo` explicitly, so the owner is known at every call site regardless of which mechanism routes the token.
+
+`ReviewPR`'s signature is unchanged — it already accepted one client per call; routing means only "which client `daemon.go` passes in," not a change to `ReviewPR` itself.
+
+### 3. Per-installation token refresh stays exactly `Auth.RunRefreshLoop`, dispatched once per distinct `*Auth`
+
+`AuthSet.RunRefreshLoops` starts one `RunRefreshLoop` goroutine per distinct `*Auth` in `AuthSet.auths`, deduplicated by pointer identity. `RunRefreshLoop` itself is untouched: each loop's failure handling (log + retry after `tokenRefreshRetryDelay`, current token stays valid until real expiry) was already fully self-contained per `*Auth` instance before this issue — becoming a multi-installation daemon only required running N independent instances of that already-independent loop instead of one, not redesigning its resilience contract. `TestAuthSet_RunRefreshLoops_IndependentPerInstallation` asserts a forced refresh failure on one installation has zero effect on another's continuing to refresh successfully.
+
+Deduping by `*Auth` pointer (not by owner) matters for the pinned path below: several owners sharing one pinned installation must get exactly one refresh goroutine, not one redundant goroutine per owner independently re-minting the same token.
+
+### 4. `github_app_installation_id` becomes a legacy pin/escape hatch, not a requirement
+
+When set (non-zero), `BootstrapMulti` skips owner-derived discovery entirely: it mints one token onto one client and maps every distinct watched owner to that same client, byte-for-byte reproducing pre-issue single-installation behavior (including skipping the `repository_selection` check in Decision 5 below — that check only applies on the discovery path). This preserves existing single-org deployments and the documented escape hatch unchanged; a genuinely wrong owner behind a pin still fails loudly (403) at review time, the same as it always has.
+
+When unset (the default, `0`), resolution is fully repo-derived per Decision 1. Zero watched repos plus no pin mints zero tokens and contacts zero installations — the security property in Decision 1 applied to its own degenerate case.
+
+`TestBootstrapMulti_ExplicitInstallationIDSkipsDiscovery` and `TestBootstrapMulti_SingleOwnerAutoDiscovered` cover both paths; existing single-owner/pinned-config test assertions from before this issue continue to hold under the new construction API.
+
+### 5. `repository_selection: selected` exclusion is a hard bootstrap error, checked eagerly, discovery-path-only
+
+`AppInstallation` gained a `RepositorySelection` field (`"all"` or `"selected"`, decoded from `GET /app/installations`'s existing response — previously discarded). For an owner resolved via discovery whose installation is `selected`-mode, `BootstrapMulti` eagerly calls the new `FetchInstallationRepositories` (`GET /installation/repositories`, authenticated with that installation's own token — not the App JWT, since this endpoint is scoped to installation identity) and hard-errors naming the specific watched repo if it isn't in the accessible set. Eager-at-bootstrap was chosen over lazy/on-first-403 to produce a clear, actionable startup error consistent with the issue's "actionable bootstrap errors" requirement, rather than surfacing the same problem only after a live review-time 403. This check is skipped on the pinned-legacy path (Decision 4) — the pin's contract is byte-for-byte pre-issue behavior, which never performed this check.
+
+### 6. Pagination gap in `FetchAppInstallations`/`FetchInstallationRepositories` is a known, deferred limitation
+
+Neither `GET /app/installations` nor `GET /installation/repositories` is paginated by this change — both default to GitHub's standard page size (~30). At today's install count (4) and typical `selected`-mode repo counts this is not a live bug, but it is a latent gap: an owner resolvable via a page GitHub doesn't return in the first response would produce the same "no installation found" error as a genuinely missing installation. Explicitly out of scope for this issue (per its own scope section); noted here rather than silently punted so a future installation-count increase past a page boundary has a paper trail.
+
+## Consequences
+
+**Positive:**
+- One daemon now covers every org/account the App is installed on, driven entirely by the `watched_repos` operators already maintain — no more one-daemon-per-installation, no more `github_app_installation_id` becoming mandatory the moment a second installation exists.
+- The public-App safety property is structural and testable (`TestBootstrapMulti_MultiOwnerMintsPerOwnerAndNeverTouchesStranger`), not a convention operators must remember to uphold separately.
+- Change is confined to `pruefer/` plus two additive fields/functions in `github/app.go`; `github/client.go`'s shared request core — used by Fabrik's engine — is untouched.
+- Single-owner and pinned configurations behave exactly as before; the escape hatch for forcing one installation regardless of owner still exists.
+
+**Negative / Trade-offs:**
+- `AuthSet.Clients` holds N `*github.Client` instances instead of one; `Daemon.Clients` is now a map keyed by owner instead of a single field — every call site that used to reach `d.Client` directly (the poll loop, the `RateLimitReporter` type assertion) had to become owner-aware.
+- `RateLimitSnapshotEvent`'s single `Stats` field became `{Owner, Stats}`; the TUI footer shows whichever owner's snapshot arrived most recently rather than an aggregate — a minor, cosmetic-only behavior change with no test/behavior contract depending on cross-owner aggregation.
+- A `selected`-mode installation now costs one extra API round-trip at bootstrap (only when that mode is actually encountered, and only on the discovery path).
+- Pagination remains unaddressed (Decision 6) — a real but currently inert gap.
+
+## Related Work
+
+- ADR-1113 (`adrs/1113-pruefer-v1-architecture.md`) Decision 1 — the single-installation design this ADR amends/supersedes. Decisions 2–9 of that ADR (review-state mechanism, ephemeral clone, diff-size guard, etc.) are unaffected; this ADR only revises how installation tokens are resolved and routed.
+- ADR-1189 (`adrs/1189-pruefer-inline-review-comments.md`) — orthogonal; inline comment anchoring has no interaction with which token submitted the review.
+- `cmd/pruefer/README.md` — Setup step 7, the config example, and the configuration reference table's `github_app_installation_id` row were updated in the same change to describe owner-derived resolution and the public-App-safety property.
+
+**References:** [cmd/pruefer/README.md](../cmd/pruefer/README.md)

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -38,7 +38,7 @@ Pruefer authenticates as a GitHub App so its reviews are attributed to a genuine
 4. **Where can this GitHub App be installed?**: your choice — "Only on this account" is simplest for a single org.
 5. Click **Create GitHub App**. Note the **App ID** shown on the app's settings page.
 6. Scroll to **Private keys** and click **Generate a private key**. This downloads a `.pem` file — save it somewhere outside version control (Pruefer's default config gitignores `.pruefer/*.pem`).
-7. Click **Install App** (left sidebar) and install it on every repository you want Pruefer to watch.
+7. Click **Install App** (left sidebar) and install it on every account whose repos you list in `watched_repos` — a single App installed on multiple orgs/accounts is exactly the multi-org setup this section leads into.
 
 ### 2. Place the private key
 
@@ -52,10 +52,11 @@ Create `.pruefer/config.yaml` (or use flags/env vars — see Configuration below
 watched_repos:
   - your-org/repo-one
   - your-org/repo-two
+  - another-org/repo-three   # a different owner works too — see below
 
 github_app_id: 123456
 # github_app_private_key_path: .pruefer/app-private-key.pem  # default shown
-# github_app_installation_id: 0  # 0 = auto-discover (requires exactly one installation)
+# github_app_installation_id: 0  # 0 = derive installations from watched_repos (see below)
 
 poll_interval_seconds: 120
 model: sonnet
@@ -68,7 +69,16 @@ max_diff_bytes: 500000
 # excluded_paths: ["vendor/**", "*.generated.go"]
 ```
 
-If the App is installed on more than one org/account, set `github_app_installation_id` explicitly — Pruefer refuses to guess among multiple installations.
+### Multi-org installations and the public-App safety property
+
+`watched_repos` may list repos across any number of distinct owners. Pruefer groups the list by owner and, for each distinct owner, resolves that owner's App installation and mints it its own token — refreshed independently on its own schedule. A single daemon can therefore cover every org/account the App is installed on, driven entirely by `watched_repos`.
+
+**The set of installations Pruefer ever tokenizes equals exactly the set of owners appearing in `watched_repos` — nothing more.** Pruefer never enumerates "every installation of the App" and acts on all of them; it only ever mints a token for, or contacts, an owner an operator explicitly listed. This is what makes it safe to register the App as installable by anyone: a stranger who installs it on their own account is structurally untouched, because no `watched_repos` entry names them. There's no separate allowlist to maintain — "only act on my own accounts" falls directly out of what's in the config.
+
+Two consequences:
+
+- If an owner in `watched_repos` has **no** matching App installation, Pruefer fails fast at startup with an error naming that owner (and how to fix it — install the App there).
+- `github_app_installation_id` is now a **legacy pin/escape hatch**, not a requirement. Leave it at `0` (or unset) to let Pruefer resolve one installation per watched owner automatically — this works cleanly even with several installations, as long as every owner you watch has one. Set it explicitly only to force every watched repo through one specific installation's token regardless of owner (the old single-installation behavior, preserved byte-for-byte for existing single-org deployments).
 
 ### 4. Run it
 
@@ -117,7 +127,7 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 | `--excluded-paths` | `PRUEFER_EXCLUDED_PATHS` | `excluded_paths` | (none) | Glob patterns; skip only if **every** touched path matches |
 | `--github-app-id` | `PRUEFER_GITHUB_APP_ID` | `github_app_id` | (none — required) | |
 | `--github-app-private-key-path` | `PRUEFER_GITHUB_APP_PRIVATE_KEY_PATH` | `github_app_private_key_path` | `.pruefer/app-private-key.pem` | |
-| `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (auto-discover) | Required if the App has more than one installation |
+| `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (derive from `watched_repos`) | Legacy pin: set to force every watched repo through one specific installation, regardless of owner |
 | `--config` | `PRUEFER_CONFIG` | — | `.pruefer/config.yaml` | Path to the YAML config file itself |
 | `-notui` | `PRUEFER_TUI` | `tui` | `true` | Set `-notui` / `PRUEFER_TUI=0` / `tui: false` to disable the interactive TUI and fall back to console logging. The TUI is further gated on a real terminal being detected on both stdin and stdout, regardless of this setting. |
 

--- a/github/app.go
+++ b/github/app.go
@@ -106,6 +106,11 @@ func BuildAppJWT(appID int64, privateKey *rsa.PrivateKey) (string, error) {
 type AppInstallation struct {
 	ID      int64  // Installation ID, needed to mint an installation access token.
 	Account string // Login of the org/user the App is installed on.
+	// RepositorySelection is "all" or "selected". "selected" means the
+	// installation only grants access to a subset of Account's repos — the
+	// actual subset is only discoverable via FetchInstallationRepositories,
+	// which requires an installation access token (not the App's JWT).
+	RepositorySelection string
 }
 
 // appRequest performs a JWT-authenticated GitHub App API request (installation
@@ -157,13 +162,38 @@ func FetchAppInstallations(baseURL, jwt string) ([]AppInstallation, error) {
 		Account struct {
 			Login string `json:"login"`
 		} `json:"account"`
+		RepositorySelection string `json:"repository_selection"`
 	}
 	if err := appRequest("GET", baseURL, "/app/installations", jwt, &raw); err != nil {
 		return nil, fmt.Errorf("fetching app installations: %w", err)
 	}
 	out := make([]AppInstallation, len(raw))
 	for i, inst := range raw {
-		out[i] = AppInstallation{ID: inst.ID, Account: inst.Account.Login}
+		out[i] = AppInstallation{ID: inst.ID, Account: inst.Account.Login, RepositorySelection: inst.RepositorySelection}
+	}
+	return out, nil
+}
+
+// FetchInstallationRepositories lists the repositories an installation
+// actually grants access to, via GET /installation/repositories. Only
+// meaningful (and only ever called) for an installation whose
+// RepositorySelection is "selected" — an "all" installation grants access to
+// every current and future repo on the account, so there is nothing to
+// enumerate. Unlike the App-JWT-authenticated calls above, this endpoint is
+// scoped to the installation's own identity: it must be authenticated with
+// that installation's access token, not the App's JWT.
+func FetchInstallationRepositories(baseURL, installationToken string) ([]string, error) {
+	var result struct {
+		Repositories []struct {
+			FullName string `json:"full_name"`
+		} `json:"repositories"`
+	}
+	if err := appRequest("GET", baseURL, "/installation/repositories", installationToken, &result); err != nil {
+		return nil, fmt.Errorf("fetching installation repositories: %w", err)
+	}
+	out := make([]string, len(result.Repositories))
+	for i, r := range result.Repositories {
+		out[i] = r.FullName
 	}
 	return out, nil
 }

--- a/github/app_test.go
+++ b/github/app_test.go
@@ -147,6 +147,74 @@ func TestFetchAppInstallations(t *testing.T) {
 	}
 }
 
+func TestFetchAppInstallations_DecodesRepositorySelection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 111, "account": map[string]string{"login": "handarbeit"}, "repository_selection": "all"},
+			{"id": 222, "account": map[string]string{"login": "someorg"}, "repository_selection": "selected"},
+		})
+	}))
+	defer srv.Close()
+
+	installs, err := FetchAppInstallations(srv.URL, "test-jwt")
+	if err != nil {
+		t.Fatalf("FetchAppInstallations: %v", err)
+	}
+	if len(installs) != 2 {
+		t.Fatalf("expected 2 installations, got %d", len(installs))
+	}
+	if installs[0].RepositorySelection != "all" {
+		t.Errorf("installs[0].RepositorySelection = %q, want %q", installs[0].RepositorySelection, "all")
+	}
+	if installs[1].RepositorySelection != "selected" {
+		t.Errorf("installs[1].RepositorySelection = %q, want %q", installs[1].RepositorySelection, "selected")
+	}
+}
+
+func TestFetchInstallationRepositories(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/installation/repositories" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ghs_installation_token" {
+			t.Errorf("Authorization = %q, want Bearer ghs_installation_token", got)
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"repositories": []map[string]interface{}{
+				{"full_name": "someorg/repo-one"},
+				{"full_name": "someorg/repo-two"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	repos, err := FetchInstallationRepositories(srv.URL, "ghs_installation_token")
+	if err != nil {
+		t.Fatalf("FetchInstallationRepositories: %v", err)
+	}
+	want := []string{"someorg/repo-one", "someorg/repo-two"}
+	if len(repos) != len(want) {
+		t.Fatalf("repos = %v, want %v", repos, want)
+	}
+	for i := range want {
+		if repos[i] != want[i] {
+			t.Errorf("repos[%d] = %q, want %q", i, repos[i], want[i])
+		}
+	}
+}
+
+func TestFetchInstallationRepositories_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`{"message":"Forbidden"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := FetchInstallationRepositories(srv.URL, "ghs_bad"); err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+}
+
 func TestMintInstallationToken(t *testing.T) {
 	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pruefer/auth.go
+++ b/pruefer/auth.go
@@ -22,10 +22,10 @@ var tokenRefreshMargin = 5 * time.Minute
 // failed refresh. Var so tests aren't forced to wait a full minute.
 var tokenRefreshRetryDelay = time.Minute
 
-// Auth holds the bootstrapped GitHub App identity Pruefer needs: the App's
-// own bot login (for self-review skip and GitHub-derived review-state
-// checks) and the machinery to keep the installation token on the wrapped
-// *github.Client fresh for the lifetime of the daemon.
+// Auth holds one bootstrapped GitHub App installation token and the
+// machinery to keep it fresh on the wrapped *github.Client for the lifetime
+// of the daemon. A multi-owner daemon holds one Auth per distinct
+// installation it needs — see AuthSet/BootstrapMulti.
 type Auth struct {
 	AppID          int64
 	InstallationID int64
@@ -33,6 +33,8 @@ type Auth struct {
 	// author, e.g. "pruefer-bot[bot]". Always slug + "[bot]" for a GitHub
 	// App — this is what makes the "review identity != PR author" guarantee
 	// structural rather than operator-discipline-dependent (see ADR-1113).
+	// Invariant across every installation of the same App, so every Auth in
+	// an AuthSet carries the same value.
 	BotLogin string
 
 	privateKey *rsa.PrivateKey
@@ -41,65 +43,6 @@ type Auth struct {
 
 	mu        sync.Mutex
 	expiresAt time.Time
-}
-
-// Bootstrap performs the full GitHub App auth flow: parses the private key,
-// builds a JWT, resolves the App's own bot login, resolves (or validates)
-// the installation to act as, and mints the first installation token onto
-// client. baseURL selects GitHub's API host; pass "" for production or an
-// httptest server URL in tests.
-func Bootstrap(cfg Config, client *gh.Client, baseURL string) (*Auth, error) {
-	keyPEM, err := os.ReadFile(cfg.AppPrivateKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading GitHub App private key %s: %w", cfg.AppPrivateKeyPath, err)
-	}
-	privateKey, err := gh.ParseAppPrivateKey(keyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("parsing GitHub App private key %s: %w", cfg.AppPrivateKeyPath, err)
-	}
-
-	a := &Auth{
-		AppID:          cfg.AppID,
-		InstallationID: cfg.AppInstallationID,
-		privateKey:     privateKey,
-		baseURL:        baseURL,
-		client:         client,
-	}
-
-	jwt, err := gh.BuildAppJWT(a.AppID, a.privateKey)
-	if err != nil {
-		return nil, fmt.Errorf("building app JWT: %w", err)
-	}
-
-	slug, err := gh.FetchAppSlug(baseURL, jwt)
-	if err != nil {
-		return nil, fmt.Errorf("resolving app identity: %w", err)
-	}
-	a.BotLogin = slug + "[bot]"
-
-	if a.InstallationID == 0 {
-		installations, err := gh.FetchAppInstallations(baseURL, jwt)
-		if err != nil {
-			return nil, fmt.Errorf("discovering app installations: %w", err)
-		}
-		switch len(installations) {
-		case 0:
-			return nil, fmt.Errorf("github app has no installations — install it on at least one account/repo first")
-		case 1:
-			a.InstallationID = installations[0].ID
-		default:
-			// V1 requires an explicit installation ID once more than one
-			// exists — silently picking one could watch/act on the wrong
-			// org. Auto-discovery still removes per-repo config churn
-			// within a single installation's repo set.
-			return nil, fmt.Errorf("github app has %d installations; set github_app_installation_id to select one", len(installations))
-		}
-	}
-
-	if err := a.refresh(); err != nil {
-		return nil, fmt.Errorf("minting initial installation token: %w", err)
-	}
-	return a, nil
 }
 
 // refresh mints a new installation token, applies it to the client, and
@@ -133,7 +76,9 @@ func (a *Auth) ExpiresAt() time.Time {
 // daemon's lifetime. A failed refresh is logged and retried after
 // tokenRefreshRetryDelay rather than crashing the daemon — a transient
 // GitHub outage shouldn't take Pruefer down, since the *current* token
-// stays valid until its actual (not margin-adjusted) expiry.
+// stays valid until its actual (not margin-adjusted) expiry. Each Auth's
+// loop is fully independent: a refresh failure on one installation has no
+// effect on any other Auth's loop or on the daemon as a whole.
 func (a *Auth) RunRefreshLoop(ctx context.Context, logf func(format string, args ...any)) {
 	for {
 		wait := time.Until(a.ExpiresAt()) - tokenRefreshMargin
@@ -160,4 +105,201 @@ func (a *Auth) RunRefreshLoop(ctx context.Context, logf func(format string, args
 			logf("auth: installation token refreshed, expires %s", a.ExpiresAt().Format(time.RFC3339))
 		}
 	}
+}
+
+// AuthSet holds the bootstrapped multi-installation auth state Pruefer needs
+// to review PRs across every distinct owner present in watched_repos: one
+// *github.Client (backed by its own *Auth) per distinct installation
+// actually required, plus the App's own bot identity (invariant across
+// installations — resolved once, not per owner).
+//
+// This is also the security boundary described in the issue: BootstrapMulti
+// only ever mints a token for an owner that appears in watched_repos. An
+// installation on an account nobody listed is never discovered into a
+// client, never minted a token, and never contacted — see BootstrapMulti's
+// doc comment for the mechanics.
+type AuthSet struct {
+	BotLogin string
+	// Clients maps each watched-repo owner to the *github.Client whose token
+	// is scoped to that owner's installation. Every owner present in
+	// WatchedRepos has an entry. When AppInstallationID pins a single
+	// installation, every owner maps to the same one client.
+	Clients map[string]*gh.Client
+
+	// auths holds the distinct underlying *Auth instances, deduplicated by
+	// pointer identity so a pinned installation shared by several owners
+	// gets exactly one refresh goroutine from RunRefreshLoops, not one per
+	// owner.
+	auths []*Auth
+}
+
+// BootstrapMulti performs the full GitHub App auth flow for every
+// installation Pruefer's configured watched_repos actually require:
+//   - parses the private key and resolves the App's own bot login once
+//     (both are properties of the App, not of any one installation)
+//   - if cfg.AppInstallationID is set, skips discovery entirely and mints
+//     one token onto one client shared by every watched owner — preserving
+//     pre-multi-installation behavior byte-for-byte for pinned/single-owner
+//     deployments
+//   - otherwise, derives the distinct owners from cfg.WatchedRepos, fetches
+//     the App's installations once, and mints+owns one token per owner by
+//     matching AppInstallation.Account == owner
+//
+// An owner with no matching installation is a hard bootstrap error naming
+// the owner. An owner whose installation has repository_selection ==
+// "selected" and excludes one of its listed repos is also a hard bootstrap
+// error naming the excluded repo. baseURL selects GitHub's API host; pass ""
+// for production or an httptest server URL in tests.
+func BootstrapMulti(cfg Config, baseURL string) (*AuthSet, error) {
+	keyPEM, err := os.ReadFile(cfg.AppPrivateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading GitHub App private key %s: %w", cfg.AppPrivateKeyPath, err)
+	}
+	privateKey, err := gh.ParseAppPrivateKey(keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parsing GitHub App private key %s: %w", cfg.AppPrivateKeyPath, err)
+	}
+
+	jwt, err := gh.BuildAppJWT(cfg.AppID, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("building app JWT: %w", err)
+	}
+	slug, err := gh.FetchAppSlug(baseURL, jwt)
+	if err != nil {
+		return nil, fmt.Errorf("resolving app identity: %w", err)
+	}
+	botLogin := slug + "[bot]"
+
+	as := &AuthSet{BotLogin: botLogin, Clients: map[string]*gh.Client{}}
+	owners := distinctOwners(cfg.WatchedRepos)
+
+	if cfg.AppInstallationID != 0 {
+		a, err := mintAuth(cfg.AppID, cfg.AppInstallationID, botLogin, privateKey, baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("minting initial installation token: %w", err)
+		}
+		for _, owner := range owners {
+			as.Clients[owner] = a.client
+		}
+		as.auths = []*Auth{a}
+		return as, nil
+	}
+
+	if len(owners) == 0 {
+		// No repos watched, nothing pinned: touch zero installations. This
+		// is the "installations touched = owners listed" property applied
+		// to its degenerate case.
+		return as, nil
+	}
+
+	installations, err := gh.FetchAppInstallations(baseURL, jwt)
+	if err != nil {
+		return nil, fmt.Errorf("discovering app installations: %w", err)
+	}
+	byAccount := make(map[string]gh.AppInstallation, len(installations))
+	for _, inst := range installations {
+		byAccount[inst.Account] = inst
+	}
+
+	for _, owner := range owners {
+		inst, ok := byAccount[owner]
+		if !ok {
+			return nil, fmt.Errorf("no GitHub App installation found for owner %q (watched in watched_repos) — install the app on %q", owner, owner)
+		}
+
+		a, err := mintAuth(cfg.AppID, inst.ID, botLogin, privateKey, baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("minting initial installation token for owner %q (installation %d): %w", owner, inst.ID, err)
+		}
+
+		if inst.RepositorySelection == "selected" {
+			if err := checkSelectedRepos(baseURL, a.client.Token(), owner, cfg.WatchedRepos); err != nil {
+				return nil, err
+			}
+		}
+
+		as.Clients[owner] = a.client
+		as.auths = append(as.auths, a)
+	}
+
+	return as, nil
+}
+
+// mintAuth builds a fresh *github.Client and *Auth for one installation and
+// mints its first token.
+func mintAuth(appID, installationID int64, botLogin string, privateKey *rsa.PrivateKey, baseURL string) (*Auth, error) {
+	client := gh.NewClientWithBaseURL("", baseURL)
+	a := &Auth{
+		AppID:          appID,
+		InstallationID: installationID,
+		BotLogin:       botLogin,
+		privateKey:     privateKey,
+		baseURL:        baseURL,
+		client:         client,
+	}
+	if err := a.refresh(); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// checkSelectedRepos verifies every watchedRepos entry owned by owner is
+// actually accessible to a repository_selection == "selected" installation,
+// returning a hard error naming the first excluded repo found. installToken
+// must be that installation's own access token — GET /installation/repositories
+// is scoped to the installation identity, not the App's JWT.
+func checkSelectedRepos(baseURL, installToken, owner string, watchedRepos []string) error {
+	accessible, err := gh.FetchInstallationRepositories(baseURL, installToken)
+	if err != nil {
+		return fmt.Errorf("listing accessible repositories for owner %q's installation: %w", owner, err)
+	}
+	accessibleSet := make(map[string]bool, len(accessible))
+	for _, r := range accessible {
+		accessibleSet[r] = true
+	}
+	for _, repoSpec := range watchedRepos {
+		o, _, ok := splitOwnerRepo(repoSpec)
+		if !ok || o != owner {
+			continue
+		}
+		if !accessibleSet[repoSpec] {
+			return fmt.Errorf("watched repo %q is not accessible to its App installation (repository_selection=selected excludes it) — grant %q access in the installation's repository settings for %q, or remove it from watched_repos", repoSpec, repoSpec, owner)
+		}
+	}
+	return nil
+}
+
+// distinctOwners returns the distinct owners of every well-formed
+// "owner/repo" entry in watchedRepos, in first-seen order. Malformed entries
+// are skipped here — poll() already logs and skips them independently.
+func distinctOwners(watchedRepos []string) []string {
+	seen := make(map[string]bool)
+	var owners []string
+	for _, spec := range watchedRepos {
+		owner, _, ok := splitOwnerRepo(spec)
+		if !ok || seen[owner] {
+			continue
+		}
+		seen[owner] = true
+		owners = append(owners, owner)
+	}
+	return owners
+}
+
+// RunRefreshLoops starts one RunRefreshLoop goroutine per distinct
+// installation in the set — deduplicated by *Auth pointer identity, so a
+// pinned installation shared by multiple owners gets exactly one goroutine,
+// not one per owner — and returns immediately. logf is called once per Auth
+// to build that installation's own log function, letting callers tag log
+// lines with the installation ID.
+func (as *AuthSet) RunRefreshLoops(ctx context.Context, logf func(installationID int64) func(format string, args ...any)) {
+	for _, a := range as.auths {
+		go a.RunRefreshLoop(ctx, logf(a.InstallationID))
+	}
+}
+
+// InstallationCount returns the number of distinct installations minted —
+// used for startup logging.
+func (as *AuthSet) InstallationCount() int {
+	return len(as.auths)
 }

--- a/pruefer/auth_test.go
+++ b/pruefer/auth_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -39,21 +40,42 @@ func writeTestPrivateKey(t *testing.T, dir string) string {
 	return path
 }
 
-// fakeAppServer serves the three GitHub App endpoints Bootstrap/refresh use.
-// mintCount is incremented on every access_tokens call so tests can assert
-// refresh behavior.
+// fakeAppServer serves the GitHub App endpoints BootstrapMulti/refresh use:
+// /app, /app/installations, /app/installations/{id}/access_tokens, and
+// (for repository_selection=="selected" installations)
+// /installation/repositories. mintCount is incremented on every
+// access_tokens call so tests can assert refresh behavior; mintCountByInst
+// breaks that down per installation ID for independent-refresh assertions.
+// installTokenToID lets the /installation/repositories handler figure out
+// which installation a request is authenticated as, from the Bearer token
+// minted for it.
 type fakeAppServer struct {
 	installations []gh.AppInstallation
 	slug          string
 	tokenExpiry   func() time.Time
-	mintCount     atomic.Int32
+	// failMint, if set, is consulted before every access_tokens mint for a
+	// given installation ID; returning true fails that mint (simulating a
+	// down/erroring installation) without affecting any other installation.
+	failMint func(installationID int64) bool
+	// selectedRepos maps an installation ID to the repos it actually grants
+	// access to, for installations with RepositorySelection == "selected".
+	selectedRepos map[int64][]string
 
-	mu           sync.Mutex
-	lastMintedAt time.Time
+	mintCount atomic.Int32
+
+	mu               sync.Mutex
+	mintCountByInst  map[int64]int
+	lastMintedAt     time.Time
+	installTokenToID map[string]int64
+	installationHits []int64 // access_tokens calls, in order, for assertion
 }
 
 func newFakeAppServer(slug string, installations []gh.AppInstallation, tokenExpiry func() time.Time) (*httptest.Server, *fakeAppServer) {
-	f := &fakeAppServer{slug: slug, installations: installations, tokenExpiry: tokenExpiry}
+	f := &fakeAppServer{
+		slug: slug, installations: installations, tokenExpiry: tokenExpiry,
+		mintCountByInst:  map[int64]int{},
+		installTokenToID: map[string]int64{},
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/app", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{"slug": f.slug, "id": 1})
@@ -61,24 +83,74 @@ func newFakeAppServer(slug string, installations []gh.AppInstallation, tokenExpi
 	mux.HandleFunc("/app/installations", func(w http.ResponseWriter, r *http.Request) {
 		raw := make([]map[string]interface{}, len(f.installations))
 		for i, inst := range f.installations {
-			raw[i] = map[string]interface{}{"id": inst.ID, "account": map[string]string{"login": inst.Account}}
+			raw[i] = map[string]interface{}{
+				"id": inst.ID, "account": map[string]string{"login": inst.Account},
+				"repository_selection": inst.RepositorySelection,
+			}
 		}
 		json.NewEncoder(w).Encode(raw)
 	})
 	mux.HandleFunc("/app/installations/", func(w http.ResponseWriter, r *http.Request) {
+		var instID int64
+		fmt.Sscanf(r.URL.Path, "/app/installations/%d/access_tokens", &instID)
+
+		f.mu.Lock()
+		f.installationHits = append(f.installationHits, instID)
+		f.mu.Unlock()
+
+		if f.failMint != nil && f.failMint(instID) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"message":"simulated mint failure"}`))
+			return
+		}
+
 		f.mintCount.Add(1)
 		f.mu.Lock()
+		f.mintCountByInst[instID]++
 		f.lastMintedAt = time.Now()
+		token := fmt.Sprintf("ghs_token_inst%d_%d", instID, f.mintCountByInst[instID])
+		f.installTokenToID[token] = instID
 		f.mu.Unlock()
+
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"token":      fmt.Sprintf("ghs_token_%d", f.mintCount.Load()),
+			"token":      token,
 			"expires_at": f.tokenExpiry().UTC().Format(time.RFC3339),
 		})
+	})
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		f.mu.Lock()
+		instID, ok := f.installTokenToID[auth]
+		f.mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		repos := f.selectedRepos[instID]
+		out := make([]map[string]interface{}, len(repos))
+		for i, r := range repos {
+			out[i] = map[string]interface{}{"full_name": r}
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"repositories": out})
 	})
 	return httptest.NewServer(mux), f
 }
 
-func TestBootstrap_SingleInstallationAutoDiscovered(t *testing.T) {
+func (f *fakeAppServer) mintCountFor(instID int64) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.mintCountByInst[instID]
+}
+
+func (f *fakeAppServer) hitInstallations() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]int64, len(f.installationHits))
+	copy(out, f.installationHits)
+	return out
+}
+
+func TestBootstrapMulti_SingleOwnerAutoDiscovered(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	srv, _ := newFakeAppServer("pruefer-bot", []gh.AppInstallation{{ID: 111, Account: "handarbeit"}}, func() time.Time {
@@ -86,27 +158,27 @@ func TestBootstrap_SingleInstallationAutoDiscovered(t *testing.T) {
 	})
 	defer srv.Close()
 
-	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
-	client := gh.NewClientWithBaseURL("", srv.URL)
-	auth, err := Bootstrap(cfg, client, srv.URL)
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, WatchedRepos: []string{"handarbeit/fabrik"}}
+	as, err := BootstrapMulti(cfg, srv.URL)
 	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
+		t.Fatalf("BootstrapMulti: %v", err)
 	}
-	if auth.InstallationID != 111 {
-		t.Errorf("InstallationID = %d, want 111", auth.InstallationID)
+	if as.BotLogin != "pruefer-bot[bot]" {
+		t.Errorf("BotLogin = %q, want pruefer-bot[bot]", as.BotLogin)
 	}
-	if auth.BotLogin != "pruefer-bot[bot]" {
-		t.Errorf("BotLogin = %q, want pruefer-bot[bot]", auth.BotLogin)
+	client, ok := as.Clients["handarbeit"]
+	if !ok {
+		t.Fatal("expected a client for owner handarbeit")
 	}
 	if client.Token() == "" {
-		t.Error("expected client token to be set after Bootstrap")
+		t.Error("expected client token to be set after BootstrapMulti")
 	}
-	if auth.ExpiresAt().IsZero() {
-		t.Error("expected ExpiresAt to be set after Bootstrap")
+	if as.InstallationCount() != 1 {
+		t.Errorf("InstallationCount() = %d, want 1", as.InstallationCount())
 	}
 }
 
-func TestBootstrap_ExplicitInstallationIDSkipsDiscovery(t *testing.T) {
+func TestBootstrapMulti_ExplicitInstallationIDSkipsDiscovery(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	discoveryCalled := false
@@ -126,112 +198,306 @@ func TestBootstrap_ExplicitInstallationIDSkipsDiscovery(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, AppInstallationID: 999}
-	client := gh.NewClientWithBaseURL("", srv.URL)
-	auth, err := Bootstrap(cfg, client, srv.URL)
+	// A pin combined with a multi-owner watched_repos: every owner must map
+	// to the one pinned client, and discovery must never be called.
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, AppInstallationID: 999,
+		WatchedRepos: []string{"handarbeit/fabrik", "verveguy/otherrepo"}}
+	as, err := BootstrapMulti(cfg, srv.URL)
 	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	if auth.InstallationID != 999 {
-		t.Errorf("InstallationID = %d, want 999 (explicit config value)", auth.InstallationID)
+		t.Fatalf("BootstrapMulti: %v", err)
 	}
 	if discoveryCalled {
 		t.Error("expected /app/installations to be skipped when AppInstallationID is explicitly configured")
 	}
+	if len(as.Clients) != 2 {
+		t.Fatalf("expected 2 owners mapped, got %d", len(as.Clients))
+	}
+	if as.Clients["handarbeit"] != as.Clients["verveguy"] {
+		t.Error("expected both owners to share the single pinned client")
+	}
+	if as.InstallationCount() != 1 {
+		t.Errorf("InstallationCount() = %d, want 1 (one goroutine for the shared pin)", as.InstallationCount())
+	}
 }
 
-func TestBootstrap_MultipleInstallationsRequiresExplicitID(t *testing.T) {
+func TestBootstrapMulti_MultiOwnerMintsPerOwnerAndNeverTouchesStranger(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit"},
+		{ID: 222, Account: "verveguy"},
+		{ID: 333, Account: "stranger"}, // installed on the App, never watched
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath,
+		WatchedRepos: []string{"handarbeit/fabrik", "verveguy/otherrepo"}}
+	as, err := BootstrapMulti(cfg, srv.URL)
+	if err != nil {
+		t.Fatalf("BootstrapMulti: %v", err)
+	}
+	if len(as.Clients) != 2 {
+		t.Fatalf("expected exactly 2 owners mapped, got %d: %v", len(as.Clients), as.Clients)
+	}
+	handarbeitClient, ok := as.Clients["handarbeit"]
+	if !ok || handarbeitClient.Token() == "" {
+		t.Fatal("expected a minted client for owner handarbeit")
+	}
+	verveguyClient, ok := as.Clients["verveguy"]
+	if !ok || verveguyClient.Token() == "" {
+		t.Fatal("expected a minted client for owner verveguy")
+	}
+	if handarbeitClient.Token() == verveguyClient.Token() {
+		t.Error("expected distinct tokens for distinct owners")
+	}
+	if _, ok := as.Clients["stranger"]; ok {
+		t.Fatal("expected no client for the unwatched stranger installation")
+	}
+
+	// The core public-app safety assertion: installation 333 (stranger) must
+	// never have had a token minted for it.
+	for _, instID := range fake.hitInstallations() {
+		if instID == 333 {
+			t.Fatal("expected installation 333 (stranger, unwatched) to never be minted a token")
+		}
+	}
+	if fake.mintCountFor(333) != 0 {
+		t.Errorf("mintCountFor(333) = %d, want 0 — stranger installation must never be tokenized", fake.mintCountFor(333))
+	}
+	if as.InstallationCount() != 2 {
+		t.Errorf("InstallationCount() = %d, want 2", as.InstallationCount())
+	}
+}
+
+func TestBootstrapMulti_MissingOwnerInstallationNamesOwner(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	srv, _ := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
 		{ID: 111, Account: "handarbeit"},
-		{ID: 222, Account: "someorg"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath,
+		WatchedRepos: []string{"handarbeit/fabrik", "notinstalled/otherrepo"}}
+	_, err := BootstrapMulti(cfg, srv.URL)
+	if err == nil {
+		t.Fatal("expected an error when an owner has no matching installation")
+	}
+	if !strings.Contains(err.Error(), "notinstalled") {
+		t.Errorf("error %q does not name the missing owner %q", err.Error(), "notinstalled")
+	}
+}
+
+func TestBootstrapMulti_SelectedModeExclusionNamesRepo(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "someorg", RepositorySelection: "selected"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{111: {"someorg/repo-one"}}
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath,
+		WatchedRepos: []string{"someorg/repo-one", "someorg/repo-excluded"}}
+	_, err := BootstrapMulti(cfg, srv.URL)
+	if err == nil {
+		t.Fatal("expected an error when a selected-mode installation excludes a watched repo")
+	}
+	if !strings.Contains(err.Error(), "someorg/repo-excluded") {
+		t.Errorf("error %q does not name the excluded repo %q", err.Error(), "someorg/repo-excluded")
+	}
+}
+
+func TestBootstrapMulti_SelectedModeSuccessWhenRepoIncluded(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "someorg", RepositorySelection: "selected"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	fake.selectedRepos = map[int64][]string{111: {"someorg/repo-one", "someorg/repo-two"}}
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath,
+		WatchedRepos: []string{"someorg/repo-one"}}
+	as, err := BootstrapMulti(cfg, srv.URL)
+	if err != nil {
+		t.Fatalf("BootstrapMulti: %v", err)
+	}
+	if _, ok := as.Clients["someorg"]; !ok {
+		t.Fatal("expected a client for owner someorg")
+	}
+}
+
+func TestBootstrapMulti_NoWatchedReposMintsNothing(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit"},
 	}, func() time.Time { return time.Now().Add(time.Hour) })
 	defer srv.Close()
 
 	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
-	client := gh.NewClientWithBaseURL("", srv.URL)
-	if _, err := Bootstrap(cfg, client, srv.URL); err == nil {
-		t.Fatal("expected an error when multiple installations exist and none is configured")
+	as, err := BootstrapMulti(cfg, srv.URL)
+	if err != nil {
+		t.Fatalf("BootstrapMulti: %v", err)
+	}
+	if len(as.Clients) != 0 {
+		t.Errorf("expected no clients when no repos are watched, got %d", len(as.Clients))
+	}
+	if fake.mintCount.Load() != 0 {
+		t.Errorf("mintCount = %d, want 0 (no installation calls with zero watched repos)", fake.mintCount.Load())
 	}
 }
 
-func TestBootstrap_NoInstallations(t *testing.T) {
+func TestBootstrapMulti_NoInstallations(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
 	srv, _ := newFakeAppServer("pruefer-bot", nil, func() time.Time { return time.Now().Add(time.Hour) })
 	defer srv.Close()
 
-	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
-	client := gh.NewClientWithBaseURL("", srv.URL)
-	if _, err := Bootstrap(cfg, client, srv.URL); err == nil {
-		t.Fatal("expected an error when the app has no installations")
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, WatchedRepos: []string{"handarbeit/fabrik"}}
+	if _, err := BootstrapMulti(cfg, srv.URL); err == nil {
+		t.Fatal("expected an error when the app has no installations and a repo is watched")
 	}
 }
 
-func TestBootstrap_MissingPrivateKeyFile(t *testing.T) {
-	cfg := Config{AppID: 42, AppPrivateKeyPath: "/nonexistent/key.pem"}
-	client := gh.NewClient("")
-	if _, err := Bootstrap(cfg, client, ""); err == nil {
+func TestBootstrapMulti_MissingPrivateKeyFile(t *testing.T) {
+	cfg := Config{AppID: 42, AppPrivateKeyPath: "/nonexistent/key.pem", WatchedRepos: []string{"handarbeit/fabrik"}}
+	if _, err := BootstrapMulti(cfg, ""); err == nil {
 		t.Fatal("expected an error when the private key file is missing")
 	}
 }
 
-func TestRunRefreshLoop_RefreshesBeforeExpiry(t *testing.T) {
+func TestAuthSet_RunRefreshLoops_IndependentPerInstallation(t *testing.T) {
 	oldMargin, oldRetry := tokenRefreshMargin, tokenRefreshRetryDelay
 	tokenRefreshMargin = 50 * time.Millisecond
 	tokenRefreshRetryDelay = 20 * time.Millisecond
-	defer func() { tokenRefreshMargin, tokenRefreshRetryDelay = oldMargin, oldRetry }()
 
 	dir := t.TempDir()
 	keyPath := writeTestPrivateKey(t, dir)
-	// Token expires 100ms after each mint — with a 50ms margin, the refresh
-	// loop must mint again ~50ms after the previous mint.
-	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{{ID: 111, Account: "handarbeit"}}, func() time.Time {
-		return time.Now().Add(100 * time.Millisecond)
-	})
+	// Token expires 100ms after each mint — with a 50ms margin, a healthy
+	// refresh loop must mint again ~50ms after the previous mint.
+	srv, fake := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit"},
+		{ID: 222, Account: "verveguy"},
+	}, func() time.Time { return time.Now().Add(100 * time.Millisecond) })
+	// Installation 222 mints fine once (for BootstrapMulti's initial token)
+	// but fails every subsequent refresh — must not stop 111's loop.
+	fake.failMint = func(instID int64) bool { return instID == 222 && fake.mintCountFor(222) >= 1 }
 	defer srv.Close()
 
-	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath}
-	client := gh.NewClientWithBaseURL("", srv.URL)
-	auth, err := Bootstrap(cfg, client, srv.URL)
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, WatchedRepos: []string{"handarbeit/fabrik", "verveguy/otherrepo"}}
+	as, err := BootstrapMulti(cfg, srv.URL)
 	if err != nil {
-		t.Fatalf("Bootstrap: %v", err)
-	}
-	// Bootstrap itself mints once.
-	if got := fake.mintCount.Load(); got != 1 {
-		t.Fatalf("mintCount after Bootstrap = %d, want 1", got)
+		t.Fatalf("BootstrapMulti: %v", err)
 	}
 
+	var mu sync.Mutex
+	var logLines []string
 	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
 	defer cancel()
-	var logLines []string
-	var mu sync.Mutex
-	done := make(chan struct{})
-	go func() {
-		auth.RunRefreshLoop(ctx, func(format string, args ...any) {
-			mu.Lock()
-			logLines = append(logLines, fmt.Sprintf(format, args...))
-			mu.Unlock()
-		})
-		close(done)
-	}()
-	<-done
 
-	// The refresh loop must have minted at least once more within the
-	// context window — proving refresh-before-expiry actually fires, not
-	// just the initial Bootstrap mint.
-	if got := fake.mintCount.Load(); got < 2 {
-		t.Errorf("mintCount after refresh loop = %d, want >= 2 (refresh loop must fire before token expiry)", got)
+	// RunRefreshLoops's own logic is just `go a.RunRefreshLoop(...)` fanned
+	// out per distinct installation in as.auths (same package, so visible
+	// here) — it gives no completion signal. Wrap each Auth's loop in a
+	// WaitGroup we own so the test can deterministically wait for every
+	// loop goroutine to actually return (not just for ctx to be Done, which
+	// only means they *may* be about to return) before restoring the
+	// shared tokenRefreshMargin/tokenRefreshRetryDelay package vars below;
+	// racing that restore against a still-running loop (which reads them)
+	// is exactly the kind of unsynchronized access `-race` exists to catch.
+	var wg sync.WaitGroup
+	for _, a := range as.auths {
+		a := a
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.RunRefreshLoop(ctx, func(format string, args ...any) {
+				mu.Lock()
+				logLines = append(logLines, fmt.Sprintf(format, args...))
+				mu.Unlock()
+			})
+		}()
 	}
-	if got := client.Token(); got == "" {
-		t.Fatal("expected a token to be set")
+	wg.Wait()
+	tokenRefreshMargin, tokenRefreshRetryDelay = oldMargin, oldRetry
+
+	if got := fake.mintCountFor(111); got < 2 {
+		t.Errorf("mintCountFor(111) = %d, want >= 2 (healthy installation's loop must keep refreshing)", got)
+	}
+	mu.Lock()
+	sawFailure := false
+	for _, line := range logLines {
+		if strings.Contains(line, "refresh failed") {
+			sawFailure = true
+		}
+	}
+	mu.Unlock()
+	if !sawFailure {
+		t.Error("expected at least one logged refresh failure for the always-failing installation")
 	}
 }
 
-func TestAuth_ExpiresAt_ZeroBeforeBootstrap(t *testing.T) {
+// TestAuthSet_RunRefreshLoops_DispatchesOneGoroutinePerAuth is a lightweight
+// smoke test for RunRefreshLoops itself (the independent-refresh mechanics
+// are covered in depth by TestAuthSet_RunRefreshLoops_IndependentPerInstallation
+// above): it uses the default (multi-minute) refresh margin so no actual
+// refresh fires during the test, avoiding any need to shrink the shared
+// tokenRefreshMargin/tokenRefreshRetryDelay package vars — the logf-builder
+// callback RunRefreshLoops invokes once per Auth, synchronously, before
+// spawning that Auth's goroutine gives a race-free dispatch signal.
+func TestAuthSet_RunRefreshLoops_DispatchesOneGoroutinePerAuth(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeTestPrivateKey(t, dir)
+	srv, _ := newFakeAppServer("pruefer-bot", []gh.AppInstallation{
+		{ID: 111, Account: "handarbeit"},
+		{ID: 222, Account: "verveguy"},
+	}, func() time.Time { return time.Now().Add(time.Hour) })
+	defer srv.Close()
+
+	cfg := Config{AppID: 42, AppPrivateKeyPath: keyPath, WatchedRepos: []string{"handarbeit/fabrik", "verveguy/otherrepo"}}
+	as, err := BootstrapMulti(cfg, srv.URL)
+	if err != nil {
+		t.Fatalf("BootstrapMulti: %v", err)
+	}
+
+	var mu sync.Mutex
+	seen := map[int64]bool{}
+	ctx, cancel := context.WithCancel(context.Background())
+	as.RunRefreshLoops(ctx, func(installationID int64) func(format string, args ...any) {
+		mu.Lock()
+		seen[installationID] = true
+		mu.Unlock()
+		return func(format string, args ...any) {}
+	})
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 2 {
+		t.Errorf("RunRefreshLoops built a logf for %d installation(s), want 2 (one per distinct Auth)", len(seen))
+	}
+	if !seen[111] || !seen[222] {
+		t.Errorf("seen = %v, want both installation 111 and 222", seen)
+	}
+}
+
+func TestAuth_ExpiresAt_ZeroBeforeAnyRefresh(t *testing.T) {
 	a := &Auth{}
 	if !a.ExpiresAt().IsZero() {
 		t.Error("expected ExpiresAt to be zero before any refresh")
+	}
+}
+
+func TestDistinctOwners(t *testing.T) {
+	got := distinctOwners([]string{"a/one", "b/two", "a/three", "malformed", "b/four"})
+	want := []string{"a", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("distinctOwners = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("distinctOwners[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -55,8 +55,12 @@ type Config struct {
 
 	AppID             int64
 	AppPrivateKeyPath string
-	// AppInstallationID pins Pruefer to a single installation. Zero means
-	// auto-discover every installation of the App (see pruefer/auth.go).
+	// AppInstallationID is a legacy pin/escape hatch: when set (non-zero),
+	// Pruefer skips owner-derived discovery entirely and routes every
+	// watched repo, regardless of owner, through this one installation's
+	// token — preserving pre-multi-installation behavior exactly. Zero (the
+	// default) means resolve one installation per distinct owner present in
+	// WatchedRepos instead (see BootstrapMulti in pruefer/auth.go).
 	AppInstallationID int64
 }
 

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -37,7 +37,12 @@ type RateLimitReporter interface {
 // board/stage concept: each cycle just lists open PRs per watched repo and
 // hands them to ReviewPR, which does its own eligibility filtering.
 type Daemon struct {
-	Client   GitHubLister
+	// Clients maps each watched-repo owner to the GitHubLister whose token
+	// is scoped to that owner's App installation — installation tokens are
+	// strictly owner-scoped, so using the wrong one is a 403, not a soft
+	// failure (see AuthSet/BootstrapMulti in auth.go). Every owner present
+	// in Config.WatchedRepos must have an entry.
+	Clients  map[string]GitHubLister
 	Claude   ClaudeInvoker
 	Clone    CloneFunc
 	Config   Config
@@ -139,9 +144,18 @@ func (d *Daemon) poll(ctx context.Context) {
 			logf(0, "warn", "skipping malformed watched repo %q (want owner/repo)\n", repoSpec)
 			continue
 		}
+		client, ok := d.Clients[owner]
+		if !ok {
+			// Should not happen: BootstrapMulti validates every watched
+			// owner has a resolved installation before the daemon starts.
+			// Defensive skip rather than a nil-pointer panic if it ever
+			// does (e.g. a hand-built Daemon in a future caller).
+			logf(0, "warn", "no client for owner %q (repo %s) — skipping this repo this cycle\n", owner, repoSpec)
+			continue
+		}
 		repoName := owner + "/" + repo
 		pollAt := time.Now()
-		prs, err := d.Client.ListOpenPRs(owner, repo)
+		prs, err := client.ListOpenPRs(owner, repo)
 		if err != nil {
 			logf(0, "warn", "listing open PRs for %s/%s: %v — skipping this repo this cycle\n", owner, repo, err)
 			d.emit(ptui.RepoPollEvent{Repo: repoName, At: pollAt, Err: err.Error()})
@@ -162,7 +176,7 @@ func (d *Daemon) poll(ctx context.Context) {
 				defer func() { <-sem }()
 				startedAt := time.Now()
 				d.emit(ptui.ReviewStartedEvent{Repo: repoName, PRNumber: pr.Number, Title: pr.Title, StartedAt: startedAt})
-				outcome := ReviewPR(ctx, d.Client, d.Claude, d.Clone, d.Config, d.BotLogin, owner, repo, pr)
+				outcome := ReviewPR(ctx, client, d.Claude, d.Clone, d.Config, d.BotLogin, owner, repo, pr)
 				if outcome.Err != nil {
 					logf(pr.Number, "warn", "reviewing %s/%s#%d: %v\n", owner, repo, pr.Number, outcome.Err)
 				}
@@ -181,9 +195,15 @@ func (d *Daemon) poll(ctx context.Context) {
 	}
 	wg.Wait()
 
-	if reporter, ok := d.Client.(RateLimitReporter); ok {
-		rest, _ := reporter.RateLimitStats()
-		d.emit(ptui.RateLimitSnapshotEvent{Stats: rest})
+	for _, owner := range distinctOwners(d.Config.WatchedRepos) {
+		client, ok := d.Clients[owner]
+		if !ok {
+			continue
+		}
+		if reporter, ok := client.(RateLimitReporter); ok {
+			rest, _ := reporter.RateLimitStats()
+			d.emit(ptui.RateLimitSnapshotEvent{Owner: owner, Stats: rest})
+		}
 	}
 }
 

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -104,7 +104,7 @@ func TestDaemonPoll_EnforcesConcurrencyCap(t *testing.T) {
 	clone, _ := fakeClone(t, nil)
 
 	d := &Daemon{
-		Client:   client,
+		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 2},
@@ -152,7 +152,7 @@ func TestDaemonPoll_DiffSizeGuardAppliesAcrossRepos(t *testing.T) {
 	clone, cloneCalls := fakeClone(t, nil)
 
 	d := &Daemon{
-		Client:   client,
+		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, MaxDiffBytes: 5, ConcurrencyCap: 3},
@@ -172,12 +172,11 @@ func TestDaemonPoll_DiffSizeGuardAppliesAcrossRepos(t *testing.T) {
 }
 
 func TestDaemonPoll_SkipsMalformedWatchedRepo(t *testing.T) {
-	client := newFakeLister()
 	claude := &mockClaudeInvoker{}
 	clone, _ := fakeClone(t, nil)
 
 	d := &Daemon{
-		Client:   client,
+		Clients:  map[string]GitHubLister{},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"not-a-valid-repo-spec"}},
@@ -194,7 +193,7 @@ func TestDaemonPoll_ContinuesAfterOneRepoListFails(t *testing.T) {
 	clone, _ := fakeClone(t, nil)
 
 	d := &Daemon{
-		Client:   client,
+		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/broken", "owner/good"}, ConcurrencyCap: 3},
@@ -204,6 +203,75 @@ func TestDaemonPoll_ContinuesAfterOneRepoListFails(t *testing.T) {
 
 	if client.submitCallCount() != 1 {
 		t.Errorf("expected the good repo's PR to still be reviewed despite the broken repo failing, got %d submissions", client.submitCallCount())
+	}
+}
+
+// TestDaemonPoll_RoutesEachRepoThroughOwnersToken is the multi-installation
+// routing test called for in the issue's Testing section: two owners, two
+// distinct fakeLister clients with distinct tokens, watched repos spanning
+// both — every repo's diff/submit/clone calls must only ever touch its own
+// owner's client/token, never the other's. A misrouted repo would either hit
+// the wrong fakeLister (asserted via per-client submitCallCount) or clone
+// with the wrong token (asserted via the clone spy).
+func TestDaemonPoll_RoutesEachRepoThroughOwnersToken(t *testing.T) {
+	clientA := newFakeLister()
+	clientA.token = "tok-ownerA"
+	clientA.prsByRepo["ownerA/repoA"] = []gh.PRDetails{{Number: 1, Author: "alice", HeadSHA: "shaA"}}
+
+	clientB := newFakeLister()
+	clientB.token = "tok-ownerB"
+	clientB.prsByRepo["ownerB/repoB"] = []gh.PRDetails{{Number: 2, Author: "bob", HeadSHA: "shaB"}}
+
+	claude := &mockClaudeInvoker{}
+
+	var cloneMu sync.Mutex
+	var cloneTokens []string
+	clone := func(ctx context.Context, owner, repo, token string, prNumber int) (string, func(), error) {
+		cloneMu.Lock()
+		cloneTokens = append(cloneTokens, owner+"/"+repo+"="+token)
+		cloneMu.Unlock()
+		return t.TempDir(), func() {}, nil
+	}
+
+	d := &Daemon{
+		Clients: map[string]GitHubLister{"ownerA": clientA, "ownerB": clientB},
+		Claude:  claude,
+		Clone:   clone,
+		Config: Config{
+			WatchedRepos:   []string{"ownerA/repoA", "ownerB/repoB"},
+			ConcurrencyCap: 3,
+		},
+		BotLogin: "pruefer-bot[bot]",
+	}
+	d.poll(context.Background())
+
+	if clientA.submitCallCount() != 1 {
+		t.Errorf("clientA (ownerA) submitCallCount = %d, want 1", clientA.submitCallCount())
+	}
+	if clientB.submitCallCount() != 1 {
+		t.Errorf("clientB (ownerB) submitCallCount = %d, want 1", clientB.submitCallCount())
+	}
+	for _, call := range clientA.submitCalls {
+		if call.owner != "ownerA" {
+			t.Errorf("clientA received a submit call for owner %q — should only ever see ownerA", call.owner)
+		}
+	}
+	for _, call := range clientB.submitCalls {
+		if call.owner != "ownerB" {
+			t.Errorf("clientB received a submit call for owner %q — should only ever see ownerB", call.owner)
+		}
+	}
+
+	cloneMu.Lock()
+	defer cloneMu.Unlock()
+	wantTokens := map[string]bool{"ownerA/repoA=tok-ownerA": true, "ownerB/repoB=tok-ownerB": true}
+	if len(cloneTokens) != 2 {
+		t.Fatalf("clone calls = %v, want exactly 2", cloneTokens)
+	}
+	for _, ct := range cloneTokens {
+		if !wantTokens[ct] {
+			t.Errorf("unexpected clone token pairing %q — each repo must clone with its own owner's token", ct)
+		}
 	}
 }
 
@@ -222,7 +290,7 @@ func buildParityFixture(t *testing.T, emit func(ptui.Event)) (*Daemon, *fakeList
 	claude := &mockClaudeInvoker{}
 	clone, _ := fakeClone(t, nil)
 	d := &Daemon{
-		Client:   client,
+		Clients:  map[string]GitHubLister{"owner": client},
 		Claude:   claude,
 		Clone:    clone,
 		Config:   Config{WatchedRepos: []string{"owner/repo"}, ConcurrencyCap: 3},
@@ -298,7 +366,7 @@ func TestDaemonRun_LockPreventsSecondInstance(t *testing.T) {
 	claude := &mockClaudeInvoker{}
 	clone, _ := fakeClone(t, nil)
 
-	d1 := &Daemon{Client: client, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
+	d1 := &Daemon{Clients: map[string]GitHubLister{"owner": client}, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
 	errCh := make(chan error, 1)
@@ -308,7 +376,7 @@ func TestDaemonRun_LockPreventsSecondInstance(t *testing.T) {
 	// sleep is long enough — probe the same lock file ourselves.
 	waitUntil(t, 2*time.Second, func() bool { return lockHeld(t, d1.lockPath()) })
 
-	d2 := &Daemon{Client: client, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
+	d2 := &Daemon{Clients: map[string]GitHubLister{"owner": client}, Claude: claude, Clone: clone, Config: Config{PollInterval: time.Hour}, FabrikDir: dir}
 	if err := d2.Run(context.Background()); err == nil {
 		t.Fatal("expected the second Daemon.Run to fail while the first holds the lock")
 	}

--- a/pruefer/execute.go
+++ b/pruefer/execute.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/handarbeit/fabrik/config"
-	gh "github.com/handarbeit/fabrik/github"
 )
 
 // Execute is Pruefer's entry point: loads .env, resolves configuration,
@@ -36,26 +36,37 @@ func Execute() error {
 		return fmt.Errorf("no watched repos configured (set watched_repos, PRUEFER_REPOS, or --repos)")
 	}
 
-	client := gh.NewClient("")
-	auth, err := Bootstrap(cfg, client, "")
+	authSet, err := BootstrapMulti(cfg, "")
 	if err != nil {
 		return fmt.Errorf("bootstrapping GitHub App auth: %w", err)
 	}
-	logf(0, "auth", "authenticated as %s (installation %d)\n", auth.BotLogin, auth.InstallationID)
+	owners := make([]string, 0, len(authSet.Clients))
+	for owner := range authSet.Clients {
+		owners = append(owners, owner)
+	}
+	logf(0, "auth", "authenticated as %s (%d installation(s), owners: %s)\n", authSet.BotLogin, authSet.InstallationCount(), strings.Join(owners, ", "))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	go auth.RunRefreshLoop(ctx, func(format string, args ...any) {
-		logf(0, "auth", format, args...)
+	authSet.RunRefreshLoops(ctx, func(installationID int64) func(format string, args ...any) {
+		prefix := fmt.Sprintf("installation %d: ", installationID)
+		return func(format string, args ...any) {
+			logf(0, "auth", prefix+format, args...)
+		}
 	})
 
+	clients := make(map[string]GitHubLister, len(authSet.Clients))
+	for owner, client := range authSet.Clients {
+		clients[owner] = client
+	}
+
 	daemon := &Daemon{
-		Client:   client,
+		Clients:  clients,
 		Claude:   &RealClaudeInvoker{},
 		Clone:    CloneForReview,
 		Config:   cfg,
-		BotLogin: auth.BotLogin,
+		BotLogin: authSet.BotLogin,
 	}
 
 	if useTUI(cfg) {

--- a/pruefer/tui/events.go
+++ b/pruefer/tui/events.go
@@ -60,11 +60,15 @@ type ReviewCompletedEvent struct {
 
 func (ReviewCompletedEvent) tuiEvent() {}
 
-// RateLimitSnapshotEvent is emitted once per poll cycle with the daemon's
-// current REST API rate-limit stats. Pruefer only issues REST calls
-// (ListOpenPRs, FetchPRDiff, FetchPRReviews, SubmitPRReview), so this always
-// carries github.Client.RateLimitStats()'s rest return value, never graphql.
+// RateLimitSnapshotEvent is emitted once per owner client per poll cycle
+// with that client's current REST API rate-limit stats. Pruefer only issues
+// REST calls (ListOpenPRs, FetchPRDiff, FetchPRReviews, SubmitPRReview), so
+// this always carries github.Client.RateLimitStats()'s rest return value,
+// never graphql. Owner identifies which owner's installation client the
+// snapshot came from; the footer displays whichever snapshot arrived most
+// recently rather than aggregating across owners.
 type RateLimitSnapshotEvent struct {
+	Owner string
 	Stats gh.RateLimitStats
 }
 


### PR DESCRIPTION
Closes #1233

## Summary

Pruefer previously authenticated to exactly one GitHub App installation per daemon, auto-discovering it only when the App had a single installation. With the App now installed on four accounts, that hard-errored on every fresh start and required one daemon per org. This PR replaces the single-installation model with owner-derived multi-installation auth: Pruefer groups `watched_repos` by owner, resolves and mints an independently-refreshed token per distinct owner, and routes each repo's review through its owner's token.

## Key changes

- **`github/app.go`**: `AppInstallation` gains `RepositorySelection`; new `FetchInstallationRepositories` (`GET /installation/repositories`) supports detecting `selected`-mode exclusions.
- **`pruefer/auth.go`**: `Bootstrap`/`Auth` replaced by `BootstrapMulti`/`AuthSet` — resolves one installation per distinct `watched_repos` owner (or, if `github_app_installation_id` is pinned, reproduces the old single-installation behavior byte-for-byte). Missing-owner and `selected`-mode-exclusion cases produce actionable bootstrap errors naming the owner/repo. Refresh loops run independently per installation, deduplicated by `*Auth` pointer.
- **`pruefer/daemon.go`**: `Daemon.Client` → `Daemon.Clients map[string]GitHubLister`; the poll loop routes each repo through its owner's client. `RateLimitReporter` snapshots become per-owner.
- **`pruefer/execute.go`**: wires `BootstrapMulti` + per-installation refresh loops + the owner-keyed client map.
- **`pruefer/tui/events.go`**: `RateLimitSnapshotEvent` gains an `Owner` field (additive).
- **Docs**: new ADR (`adrs/1233-pruefer-multi-installation-auth.md`) amending ADR-1113 Decision 1, plus a `cmd/pruefer/README.md` rewrite covering multi-org setup and the public-App-safety property — the set of installations Pruefer ever tokenizes equals exactly the owners listed in `watched_repos`, nothing more.

## Security property

Pruefer never enumerates or acts on "every installation of the App" — only on installations whose account appears as an owner in `watched_repos`. This is asserted directly in `TestBootstrapMulti_MultiOwnerMintsPerOwnerAndNeverTouchesStranger`, which includes an unlisted "stranger" installation in the mocked response and verifies it receives zero requests.

## Test plan

- `go build ./...`, `go vet ./...` clean.
- `go test -race ./pruefer/... ./github/...` — 454 tests passing, including:
  - Multi-owner routing through the correct per-owner token
  - Stranger installation never tokenized/contacted
  - Missing-owner-installation error names the owner
  - `selected`-mode exclusion error names the repo
  - Independent per-installation refresh (one forced failure doesn't affect others)
  - Existing single-owner/pinned-installation behavior unchanged
- Full-repo `go test -race ./...` passes except one pre-existing, unrelated flake in `cmd` (`TestExecute_ConfigYAMLApplied`, confirmed to fail identically on `main` without this branch's changes — a SIGINT-timing issue, not caused by this PR).