### PR TITLE
fix(github): default empty baseURL to production host (pruefer multi-install regression)

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -85,8 +85,17 @@ func NewClient(token string) *Client {
 	}
 }
 
-// NewClientWithBaseURL creates a client with a custom base URL (for testing).
+// NewClientWithBaseURL creates a client with a custom base URL. An empty
+// baseURL falls back to defaultBaseURL (the production API host), matching
+// NewClient and the appRequest convention — a caller passing "" means "the
+// real GitHub API", not a hostless client. Without this, production callers
+// (e.g. pruefer's mintAuth, which passes "" for the non-test case) built
+// clients whose requests hit "/repos/..." with no scheme/host ("unsupported
+// protocol scheme"). Tests always pass an httptest URL, so they never caught it.
 func NewClientWithBaseURL(token, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
 	return &Client{
 		token:   token,
 		baseURL: baseURL,

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -330,3 +330,18 @@ func TestRateLimitStats_Concurrent(t *testing.T) {
 		t.Errorf("graphql.Limit = %d, want 5000", graphql.Limit)
 	}
 }
+
+// TestNewClientWithBaseURL_EmptyDefaultsToProduction guards the production
+// path that pruefer's mintAuth exercises: passing "" must fall back to the
+// real API host, not leave a hostless client (which produced "unsupported
+// protocol scheme" on every request). Tests elsewhere always pass an httptest
+// URL, so this path was previously unexercised.
+func TestNewClientWithBaseURL_EmptyDefaultsToProduction(t *testing.T) {
+	if c := NewClientWithBaseURL("tok", ""); c.baseURL != defaultBaseURL {
+		t.Errorf("empty baseURL should default to %q, got %q", defaultBaseURL, c.baseURL)
+	}
+	const explicit = "https://example.test"
+	if c := NewClientWithBaseURL("tok", explicit); c.baseURL != explicit {
+		t.Errorf("explicit baseURL must be preserved: got %q, want %q", c.baseURL, explicit)
+	}
+}


### PR DESCRIPTION
## Regression from #1233

The pruefer multi-installation daemon authenticated fine (3 installations resolved from `watched_repos`) but **could not poll any repo** — every request failed with `unsupported protocol scheme ""` on `/repos/...`.

**Root cause:** `mintAuth` builds each installation's client via `NewClientWithBaseURL("", baseURL)` where `baseURL == ""` in production. Unlike `NewClient`, `NewClientWithBaseURL` set `baseURL` verbatim with no fallback → the client's baseURL stayed empty → hostless URLs. Every existing test passes an httptest URL, so this path was never exercised (that's how it cleared CI + the review gate).

**Fix:** default an empty `baseURL` to `defaultBaseURL`, matching `NewClient` and the `appRequest` convention. + a regression test.

**Verified live:** rebuilt + restarted the multi-org pruefer daemon — it now polls and reviews across handarbeit + verveguy + shadoworg cleanly (already skipping/reviewing real PRs, zero scheme errors). The running binary already carries this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)