### PR TITLE
ci: compile and vet the build-tagged e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # -tags e2e so the build-tagged e2e suite is vetted too. Without the tag
+      # `go vet ./...` matches no packages under tests/e2e, so that code is
+      # never vetted at all.
       - name: go vet
-        run: go vet ./...
+        run: go vet -tags e2e ./...
 
       - name: Test hygiene lint
         run: |
@@ -40,3 +43,15 @@ jobs:
         # TestExecute_ConfigYAMLApplied is a timing-sensitive SIGINT integration
         # test that fails intermittently on CI; it is tracked separately.
         run: go test -race -timeout 5m -skip TestExecute_ConfigYAMLApplied ./...
+
+      # Compile the e2e suite without running it. The scenarios are behind the
+      # `e2e` build tag and drive a real Fabrik bed against real repos, so they
+      # can't run in CI — but that also meant ~4k lines were never compiled
+      # here, and a signature change in engine/ or github/ could silently break
+      # the harness. The break would then only surface when someone runs the
+      # release gate, mid-release. `-run '^$'` matches no test, so this builds
+      # the test binary (catching errors inside Test functions, not just
+      # package code) and exits without executing a scenario or making any
+      # network call. There is no TestMain, so nothing runs. Takes <1s.
+      - name: compile e2e suite (not run)
+        run: go test -tags e2e -run '^$' ./tests/e2e/...


### PR DESCRIPTION
## Gap

CI runs `go vet ./...` and `go test ./...` with **no `-tags e2e`**, so the ~4k-line e2e suite is invisible to it — `go vet ./tests/e2e/...` reports *"matched no packages"*. A signature change in `engine/` or `github/` can silently break the harness while every check stays green; you'd discover it only when running the release gate, mid-release.

Today's #1251 is the live example: it changed `github.Client.SubmitPRReview`'s signature. It happens not to have broken e2e — but nothing in CI would have told us.

## Fix

- `go vet -tags e2e ./...` — so e2e files are vetted at all.
- New step: `go test -tags e2e -run '^$' ./tests/e2e/...` — compiles the **test binary** (catching errors inside `Test` functions, not just package code) and exits. `-run '^$'` matches no test; there is no `TestMain`; no scenario runs and no network call is made. **<0.3s.**

## Verification

Both steps pass on current main. To confirm the check has teeth, I injected a deliberate type error into `tests/e2e` — the step failed with `build failed` — then reverted and re-confirmed green.

## Why now

#1258 adds new e2e scenarios for review-authority. Landing this first means those scenarios get compile-checked by CI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)