### PR TITLE
test(e2e): cover review_authority authoritative mode (verdict gating, yolo composition)

### DIFF
--- a/adrs/1258-e2e-review-authority-coverage.md
+++ b/adrs/1258-e2e-review-authority-coverage.md
@@ -1,0 +1,159 @@
+# ADR 1258: e2e coverage for review_authority: authoritative via a bed-local advance-gate variant
+
+**Status:** Accepted
+**Date:** 2026-07-30
+**Issue:** [#1258](https://github.com/handarbeit/fabrik/issues/1258)
+
+## Context
+
+ADR-1250 shipped `review_authority: advisory | authoritative`, honoring a review verdict at
+both `checkReviewGate` (the advance gate) and `reviewGateBlocksLanding` (the landing gate,
+ADR-1216) via the shared pure predicate `reviewGateAuthorityVerdict`. It shipped with zero
+e2e coverage. Worse, the gap is structural with the current test bed: `fabrik-test-alpha`/
+`-beta` are reviewed by `.github/workflows/claude-review.yml`, which submits
+`gh pr review --comment` in both its agent path and its fallback path — COMMENT only. It can
+never produce `APPROVE` or `CHANGES_REQUESTED`, so authoritative mode's blocking and clearing
+paths are both untestable with the bed's incidental reviewer. The bed's `review.yaml`/
+`validate.yaml` carry `wait_for_reviews: true` with no `review_authority`, i.e. advisory —
+today's suite exercises only the default path.
+
+Two constraints shaped the design:
+
+1. **No production code changes** — this is test-coverage-only work; `engine/reviews.go` and
+   the rest of ADR-1250's shipped behavior are out of scope.
+2. **No change to the bed's default stage config** — `Review`/`Validate` must stay advisory
+   for every existing scenario, and the shared bed runs many `t.Parallel()` scenarios
+   concurrently (`E2E_PARALLEL`), so any authoritative-mode mechanism must not leak into or
+   destabilize advisory scenarios in flight.
+
+Tracing the two gate call sites down to their callers surfaced a constraint neither the issue
+nor Research had fully resolved: **the landing/auto-merge/Done-advance path is reachable only
+through a stage literally named `Validate`.** `reviewGateBlocksLanding` is called exclusively
+from `attemptMergeOnValidate`, and both of that function's callers hard-gate on the literal
+string `"Validate"` before invoking it — `engine/stages.go` (`if yoloActive && stage.Name ==
+"Validate" && !waitForCI`) and `engine/poll.go` (`if stage.Name == "Validate"`). A third site,
+`engine/pr_terminal_advance.go` (`if stage.Name != "Validate"`), gates Done-advancement the
+same way. No differently-named variant column can exercise `reviewGateBlocksLanding`, and
+flipping the bed's real `Validate` stage to authoritative — even temporarily — would violate
+constraint 2 above and risk corrupting concurrently-running advisory scenarios.
+
+## Decision
+
+**Build the e2e mechanism around `checkReviewGate` only**, via a new bed-local stage variant
+and board column named `Review-Authoritative`: a copy of `stages/examples/review.yaml` with
+`review_authority: authoritative` added and `order: 41` (deliberately far outside the real
+pipeline's 1–9 range, so it is never any real stage's natural successor), plus a matching
+`Review-Authoritative` column on `handarbeit/projects/2`. This is one-time, bed-local operator
+setup — the same pattern already accepted for the merge-train scenarios' `Queued`/
+`queued.yaml` (ADR-059 D1). Scenarios needing it skip gracefully via `requireAuthoritativeBed`
+(mirroring `requireTrainBed`) if the column is absent, so this PR is mergeable independent of
+when the bed is actually updated. Because dispatch is column-name-keyed, a differently-named
+column structurally isolates authoritative scenarios from advisory ones running concurrently
+on the shared bed — no extra guarding needed to satisfy constraint 2.
+
+`reviewGateBlocksLanding`'s authoritative wiring is **not** exercised by this mechanism and
+has no e2e coverage after this issue. This is an accepted, explicitly documented gap — not a
+silently missing one — because closing it would require either a production code change
+(relaxing the `stage.Name == "Validate"` hardcoding, out of scope per constraint 1) or flipping
+the bed's real `Validate` stage authoritative (out of scope per constraint 2). Consequently,
+scenarios 2 and 3 from the issue are descoped from "merges under yolo" to "gate clears" — they
+assert `fabrik:awaiting-review` disappears and `fabrik:paused` is never applied, not that the
+item actually lands. `reviewGateAuthorityVerdict` itself — the pure predicate both gate
+functions share — is still fully exercised, since it is identical code regardless of which
+caller invokes it; only the landing-gate call site's own wiring around it is unreached.
+
+**Construction is zero-Claude-cost**, reusing two established precedents: `CreateMemberPR`
+(the merge-train helpers' direct-API PR builder) and the R5 pattern from
+`TestPausedMergedPRRecovery` (label-seeding `stage:<Name>:complete` directly so the catch-up
+loop's `handleReviewGate` — gated on `pctx.hasComplete` — evaluates the gate without ever
+invoking Claude for that stage). `seedReviewGateItem` (`tests/e2e/review_authority_helpers.go`)
+wraps this into one call: file issue → add to project → `CreateMemberPR` → `AddLabel
+("stage:<column>:complete")` → `SetIssueStatus`. This documents these scenarios as validating
+gate/settle logic, not the natural `handleStageComplete` stage-completion flow — consistent
+with the R5 precedent it builds on, and cheaper than the ~$1–2.50 full-pipeline scenarios like
+`TestConjunctiveCIReviewGate`.
+
+**No `RequestPRReviewer` call is needed.** `checkReviewGate`'s outer clearing condition
+(`len(outstanding) == 0 && hasReviews`) is satisfied by any submitted review — outstanding
+reviewers come only from `reviewRequests`, never from who actually submitted. A bare
+`SubmitPRReview` is sufficient for every scenario here, simplifying the setup relative to
+`TestConjunctiveCIReviewGate`'s pattern. This also means none of the four scenarios touch
+`FABRIK_MERGE_TRAIN`-sensitive code, so they run identically and unmodified in both legs of
+the suite's two-mode gate.
+
+**Scenario 5 (issue #1258: "verdict that never clears → pause, no infinite spin") folds into
+scenario 1's test** rather than exercising `MaxReviewCycles`/`pauseForReviewCycleLimit`.
+`dispatchReviewReinvoke`'s precheck (`len(buildReviewThreadComments(item)) > 0`) requires
+unresolved *inline* review-thread comments; a bare `REQUEST_CHANGES` with no inline comments
+produces zero reinvoke dispatches. A persistent `CHANGES_REQUESTED` verdict resolves
+exclusively via `checkAwaitingReviewTimeout` → `pauseForReviewTimeout` — the same
+`ReviewWaitTimeout` path scenario 1 already exercises, not the distinct `MaxReviewCycles`
+path the issue names. Building new inline-comment infrastructure to reach a cycle-limit path
+that authoritative mode structurally cannot reach was rejected as disproportionate; "pause for
+human, no infinite spin" is satisfied by the `ReviewWaitTimeout` pause, and
+`TestReviewAuthorityBlocksAndPausesOnChangesRequested` asserts both the immediate block and
+the eventual pause (with the `authorityReason`-driven message, not the generic "no reviews
+submitted yet") as one continuation.
+
+**Scenario 6 (verdict-fetch failure / unrecognized `reviewDecision`) is excluded.**
+`FetchPRReviewDecision` only returns a non-empty value when the repo has a branch-protection
+review requirement configured; neither bed repo has one (only required status checks are
+documented as enrolled). Producing `REVIEW_REQUIRED` or an unrecognized value would require
+new branch-protection bed setup, which fails the issue's own "cheaply expressible" bar for
+this optional scenario. All four implemented scenarios therefore exercise
+`reviewGateAuthorityVerdict`'s Fabrik-computed fallback branch (`reviewDecision == ""`), not
+GitHub's native `reviewDecision` branch — documented explicitly in `tests/e2e/README.md` so a
+future reader doesn't assume the native-verdict branch has coverage it doesn't.
+
+## Consequences
+
+**Advance-gate authoritative coverage is real; landing-gate authoritative coverage is not.**
+Anyone extending this area should read this ADR before assuming `reviewGateBlocksLanding`'s
+authoritative branch is e2e-covered — it isn't, and closing that gap requires either relaxing
+the `Validate`-name hardcoding (a production change, deliberately not made here) or accepting
+the cross-scenario risk of authoritative-izing the bed's real `Validate` stage.
+
+**The `Review-Authoritative` bed variant is a second precedent (alongside `Queued`/
+`queued.yaml`) for "isolate a gate/settle behavior behind a differently-named, bed-local stage
++ column" as the general e2e strategy for behavior that's stage-scoped in production config but
+must not touch the bed's shared default stages.** Future stage-scoped e2e coverage (e.g. a
+future risk-tiered review policy per #1051/#1177) should reach for this pattern before
+considering a change to the bed's real pipeline stages.
+
+**Four new zero-Claude-cost scenarios** (`TestReviewAuthorityBlocksAndPausesOnChangesRequested`,
+`TestReviewAuthorityClearsOnApproval`, `TestReviewAuthorityYoloDoesNotBypassBlock`,
+`TestReviewAuthorityAdvisoryRegressionGuard`) run in both legs of the two-mode gate at
+negligible added GitHub API cost, since none of them touch merge-train code paths.
+
+## Alternatives Considered
+
+**Point pruefer (a real Claude-backed reviewer) at the test repos instead of harness-posted
+verdicts.** Rejected per the issue's own explicit rejection: non-deterministic (verdict
+depends on Claude's severity classification of a synthetic diff), higher latency (pruefer
+polls, default 120s, vs. an Action firing on PR-open), added cost (a real Claude invocation
+per test PR on every run), `request_changes_threshold` off by default (would emit COMMENT
+anyway), and coupling (Fabrik's release gate would depend on pruefer's health).
+
+**A `Validate-Authoritative` bed variant instead of `Review-Authoritative`.** Considered first,
+since the issue's scenario 2/3 language ("merges under yolo") more naturally maps to Validate.
+Rejected once the `stage.Name == "Validate"` hardcoding was traced: a variant named anything
+other than `Validate` cannot reach `reviewGateBlocksLanding` regardless of which stage number
+in the pipeline it stands in for, so a `Validate-Authoritative` variant would exercise exactly
+the same `checkReviewGate` code path as `Review-Authoritative` does, with a more misleading
+name (implying landing-gate coverage it doesn't have).
+
+**A per-issue label override for `review_authority`** (mirroring `model:<name>`/`effort:<level>`/
+`base:<branch>`). Rejected: explicitly out of scope per the issue ("no change to
+`engine/reviews.go` or other production engine code"); `ReviewAuthority` is deliberately
+stage-scoped only (ADR-1250), and adding a label override would be new production behavior,
+not test infrastructure.
+
+## References
+
+- [ADR-1250: Review authority — advisory vs. authoritative](1250-review-authority-orthogonal-to-autonomy.md) — the shipped behavior this issue adds e2e coverage for.
+- [ADR-1216: Review gate checked at the landing decision](1216-review-gate-at-landing-decision.md) — establishes `reviewGateBlocksLanding`/`attemptMergeOnValidate` as the landing-decision choke point this ADR's gap applies to.
+- [ADR-059: Internal merge train](059-internal-merge-train.md) D1 — the `Queued`/`queued.yaml` bed-variant precedent this issue's `Review-Authoritative` mechanism follows.
+- `tests/e2e/review_authority_helpers.go`, `tests/e2e/review_authority_test.go` — the implementation.
+- `tests/e2e/README.md` §"Additional prerequisites for `TestReviewAuthority*` scenarios" — bed setup instructions.
+- `tests/e2e/paused_merged_pr_recovery_test.go` (R5) — the zero-Claude-cost label-seeded completion precedent this issue's `seedReviewGateItem` builds on.
+- `tests/e2e/mergetrain_helpers.go` (`CreateMemberPR`) — the direct-API PR construction precedent reused as-is.

--- a/adrs/1258-e2e-review-authority-coverage.md
+++ b/adrs/1258-e2e-review-authority-coverage.md
@@ -1,7 +1,9 @@
 # ADR 1258: e2e coverage for review_authority: authoritative via a per-issue label
 
 **Status:** Accepted
-**Date:** 2026-07-30
+**Date:** 2026-07-30 (the label-based mechanism below was settled same-day, during
+Validate-stage review of this issue's own PR — see "Revision" — so this date marks
+final acceptance, not the first-draft column/stage-variant design)
 **Issue:** [#1258](https://github.com/handarbeit/fabrik/issues/1258)
 
 ## Context

--- a/adrs/1258-e2e-review-authority-coverage.md
+++ b/adrs/1258-e2e-review-authority-coverage.md
@@ -1,4 +1,4 @@
-# ADR 1258: e2e coverage for review_authority: authoritative via a bed-local advance-gate variant
+# ADR 1258: e2e coverage for review_authority: authoritative via a per-issue label
 
 **Status:** Accepted
 **Date:** 2026-07-30
@@ -19,8 +19,8 @@ today's suite exercises only the default path.
 
 Two constraints shaped the design:
 
-1. **No production code changes** — this is test-coverage-only work; `engine/reviews.go` and
-   the rest of ADR-1250's shipped behavior are out of scope.
+1. **No production code changes to `engine/reviews.go`** — ADR-1250's shipped gate/predicate
+   behavior is out of scope for this issue.
 2. **No change to the bed's default stage config** — `Review`/`Validate` must stay advisory
    for every existing scenario, and the shared bed runs many `t.Parallel()` scenarios
    concurrently (`E2E_PARALLEL`), so any authoritative-mode mechanism must not leak into or
@@ -33,45 +33,80 @@ from `attemptMergeOnValidate`, and both of that function's callers hard-gate on 
 string `"Validate"` before invoking it — `engine/stages.go` (`if yoloActive && stage.Name ==
 "Validate" && !waitForCI`) and `engine/poll.go` (`if stage.Name == "Validate"`). A third site,
 `engine/pr_terminal_advance.go` (`if stage.Name != "Validate"`), gates Done-advancement the
-same way. No differently-named variant column can exercise `reviewGateBlocksLanding`, and
-flipping the bed's real `Validate` stage to authoritative — even temporarily — would violate
-constraint 2 above and risk corrupting concurrently-running advisory scenarios.
+same way. This holds regardless of which mechanism applies `review_authority: authoritative`
+to an item — no stage/column standing in for `Validate` under a different name can exercise
+`reviewGateBlocksLanding`, and flipping the bed's real `Validate` stage to authoritative — even
+temporarily — would violate constraint 2 above and risk corrupting concurrently-running
+advisory scenarios.
+
+### Revision (2026-07-30): column/stage-variant mechanism rejected in favor of a per-issue label
+
+The first implementation of this issue (PR #1260, initial commits) built the mechanism around
+a new bed-local stage variant and board column named `Review-Authoritative` — a copy of
+`stages/examples/review.yaml` with `review_authority: authoritative` added, plus a matching
+column on `handarbeit/projects/2`, mirroring the `Queued`/`queued.yaml` precedent (ADR-059 D1).
+This was rejected during Validate-stage review for two reasons:
+
+1. **Wrong level of abstraction.** `review_authority` is a property of a stage's *config*, not
+   a distinct *kind* of stage. `Queued` is a real product stage — it ships in the binary as
+   `stages/examples/queued.yaml` with `holding_stage: true` and exists independent of any test
+   concern. `Review-Authoritative` would have been pure test scaffolding masquerading as a
+   pipeline stage, putting a concept on the board (and in `.fabrik/stages/`) that the product
+   itself doesn't have. The `Queued`/`queued.yaml` precedent does not transfer.
+2. **Silent-skip trap.** The column is a one-time, external, operator-applied bed prerequisite.
+   Because the bed had no such column at review time, the skip guard (`requireAuthoritativeBed`)
+   would have caused three of the four scenarios to skip — and the suite would report green
+   having validated zero authoritative behavior. These scenarios exist specifically to gate a
+   release; a vacuous pass is strictly worse than an absent test, since it reads as coverage
+   that isn't there.
+
+The mechanism was reworked to apply authority **per issue via a label**,
+`review-authority:authoritative`, set at seed time as an `extraLabel` to `seedReviewGateItem`
+(the same parameter already used for `fabrik:yolo`). Engine support for reading this label is
+tracked as a separate, decoupled issue — **#1261** — so that engine behavior change and this
+issue's test-coverage change can be reviewed and merged independently. The three authoritative
+scenarios cannot pass until both #1261 and this issue's PR are merged;
+`TestReviewAuthorityAdvisoryRegressionGuard` has no such dependency (it never sets the label)
+and ships green regardless.
 
 ## Decision
 
-**Build the e2e mechanism around `checkReviewGate` only**, via a new bed-local stage variant
-and board column named `Review-Authoritative`: a copy of `stages/examples/review.yaml` with
-`review_authority: authoritative` added and `order: 41` (deliberately far outside the real
-pipeline's 1–9 range, so it is never any real stage's natural successor), plus a matching
-`Review-Authoritative` column on `handarbeit/projects/2`. This is one-time, bed-local operator
-setup — the same pattern already accepted for the merge-train scenarios' `Queued`/
-`queued.yaml` (ADR-059 D1). Scenarios needing it skip gracefully via `requireAuthoritativeBed`
-(mirroring `requireTrainBed`) if the column is absent, so this PR is mergeable independent of
-when the bed is actually updated. Because dispatch is column-name-keyed, a differently-named
-column structurally isolates authoritative scenarios from advisory ones running concurrently
-on the shared bed — no extra guarding needed to satisfy constraint 2.
+**Apply `review_authority: authoritative` per issue via a label, `review-authority:authoritative`,
+against the bed's existing `Review` column/stage (default, advisory config, untouched).** No
+bed-local board column or stage-YAML variant is introduced. `seedReviewGateItem`
+(`tests/e2e/review_authority_helpers.go`) seeds the item directly via the GitHub API
+(`CreateMemberPR`, zero Claude cost) and label-seeds `stage:Review:complete` so the catch-up
+loop's `handleReviewGate` evaluates the gate without ever invoking Claude for that stage — the
+same zero-cost construction precedent as `TestPausedMergedPRRecovery`'s R5. Because the label is
+applied per item rather than encoded in board structure, it isolates cleanly on the shared
+parallel bed: an item without the label runs the ordinary advisory path unaffected, regardless
+of how many authoritative-labeled items are running concurrently.
 
-`reviewGateBlocksLanding`'s authoritative wiring is **not** exercised by this mechanism and
-has no e2e coverage after this issue. This is an accepted, explicitly documented gap — not a
+**No bed prerequisite is required beyond `FABRIK_REVIEWER_TOKEN`.** Removing the column/stage
+mechanism also removes its only skip path — none of the four scenarios skip for lack of bed
+setup; they either run for real or fail loudly if #1261 hasn't landed yet.
+
+`reviewGateBlocksLanding`'s authoritative wiring is **not** exercised by this mechanism and has
+no e2e coverage after this issue. This is an accepted, explicitly documented gap — not a
 silently missing one — because closing it would require either a production code change
-(relaxing the `stage.Name == "Validate"` hardcoding, out of scope per constraint 1) or flipping
-the bed's real `Validate` stage authoritative (out of scope per constraint 2). Consequently,
-scenarios 2 and 3 from the issue are descoped from "merges under yolo" to "gate clears" — they
-assert `fabrik:awaiting-review` disappears and `fabrik:paused` is never applied, not that the
-item actually lands. `reviewGateAuthorityVerdict` itself — the pure predicate both gate
-functions share — is still fully exercised, since it is identical code regardless of which
-caller invokes it; only the landing-gate call site's own wiring around it is unreached.
+(relaxing the `stage.Name == "Validate"` hardcoding) or authoritative-izing the bed's real
+`Validate` stage (violating constraint 2). Consequently, scenarios 2 and 3 from the issue are
+descoped from "merges under yolo" to "gate clears" — they assert `fabrik:awaiting-review`
+disappears and `fabrik:paused` is never applied, not that the item actually lands.
+`reviewGateAuthorityVerdict` itself — the pure predicate both gate functions share — is still
+fully exercised, since it is identical code regardless of which caller invokes it; only the
+landing-gate call site's own wiring around it is unreached.
 
 **Construction is zero-Claude-cost**, reusing two established precedents: `CreateMemberPR`
 (the merge-train helpers' direct-API PR builder) and the R5 pattern from
 `TestPausedMergedPRRecovery` (label-seeding `stage:<Name>:complete` directly so the catch-up
 loop's `handleReviewGate` — gated on `pctx.hasComplete` — evaluates the gate without ever
-invoking Claude for that stage). `seedReviewGateItem` (`tests/e2e/review_authority_helpers.go`)
-wraps this into one call: file issue → add to project → `CreateMemberPR` → `AddLabel
-("stage:<column>:complete")` → `SetIssueStatus`. This documents these scenarios as validating
-gate/settle logic, not the natural `handleStageComplete` stage-completion flow — consistent
-with the R5 precedent it builds on, and cheaper than the ~$1–2.50 full-pipeline scenarios like
-`TestConjunctiveCIReviewGate`.
+invoking Claude for that stage). `seedReviewGateItem` wraps this into one call: file issue
+(with any extra labels, including `review-authority:authoritative` when needed) → add to
+project → `CreateMemberPR` → `AddLabel("stage:<column>:complete")` → `SetIssueStatus`. This
+documents these scenarios as validating gate/settle logic, not the natural
+`handleStageComplete` stage-completion flow — consistent with the R5 precedent it builds on,
+and cheaper than the ~$1–2.50 full-pipeline scenarios like `TestConjunctiveCIReviewGate`.
 
 **No `RequestPRReviewer` call is needed.** `checkReviewGate`'s outer clearing condition
 (`len(outstanding) == 0 && hasReviews`) is satisfied by any submitted review — outstanding
@@ -107,18 +142,29 @@ future reader doesn't assume the native-verdict branch has coverage it doesn't.
 
 ## Consequences
 
-**Advance-gate authoritative coverage is real; landing-gate authoritative coverage is not.**
-Anyone extending this area should read this ADR before assuming `reviewGateBlocksLanding`'s
-authoritative branch is e2e-covered — it isn't, and closing that gap requires either relaxing
-the `Validate`-name hardcoding (a production change, deliberately not made here) or accepting
-the cross-scenario risk of authoritative-izing the bed's real `Validate` stage.
+**Advance-gate authoritative coverage is real (pending #1261); landing-gate authoritative
+coverage is not.** Anyone extending this area should read this ADR before assuming
+`reviewGateBlocksLanding`'s authoritative branch is e2e-covered — it isn't, and closing that
+gap requires either relaxing the `Validate`-name hardcoding (a production change, deliberately
+not made here) or accepting the cross-scenario risk of authoritative-izing the bed's real
+`Validate` stage.
 
-**The `Review-Authoritative` bed variant is a second precedent (alongside `Queued`/
-`queued.yaml`) for "isolate a gate/settle behavior behind a differently-named, bed-local stage
-+ column" as the general e2e strategy for behavior that's stage-scoped in production config but
-must not touch the bed's shared default stages.** Future stage-scoped e2e coverage (e.g. a
-future risk-tiered review policy per #1051/#1177) should reach for this pattern before
-considering a change to the bed's real pipeline stages.
+**Three of the four scenarios have a hard dependency on #1261.** Until the engine reads
+`review-authority:authoritative` and honors it as equivalent to the stage's `review_authority:
+authoritative` config, `TestReviewAuthorityBlocksAndPausesOnChangesRequested`,
+`TestReviewAuthorityClearsOnApproval`, and `TestReviewAuthorityYoloDoesNotBypassBlock` will fail
+(the gate will behave advisorially regardless of the label). This is expected and intentional —
+the two issues are deliberately decoupled so each can be reviewed independently — but it means
+this PR alone does not give green authoritative coverage; #1261 must land too.
+
+**Per-issue label, not board structure, is the general pattern for stage-config-scoped e2e
+coverage that must not touch the bed's shared default stages.** Unlike a bed-local
+column/stage variant, a label requires no external operator setup, cannot silently skip, and
+composes cleanly with concurrent scenarios on the shared bed since it's scoped to the item, not
+the column. Future stage-config-scoped e2e coverage (e.g. a future risk-tiered review policy
+per #1051/#1177) should reach for a label first, and reserve a bed-local stage/column variant
+for cases where the behavior is genuinely a distinct *stage* (like `Queued`), not a config flag
+on an existing one.
 
 **Four new zero-Claude-cost scenarios** (`TestReviewAuthorityBlocksAndPausesOnChangesRequested`,
 `TestReviewAuthorityClearsOnApproval`, `TestReviewAuthorityYoloDoesNotBypassBlock`,
@@ -134,26 +180,32 @@ polls, default 120s, vs. an Action firing on PR-open), added cost (a real Claude
 per test PR on every run), `request_changes_threshold` off by default (would emit COMMENT
 anyway), and coupling (Fabrik's release gate would depend on pruefer's health).
 
-**A `Validate-Authoritative` bed variant instead of `Review-Authoritative`.** Considered first,
-since the issue's scenario 2/3 language ("merges under yolo") more naturally maps to Validate.
-Rejected once the `stage.Name == "Validate"` hardcoding was traced: a variant named anything
-other than `Validate` cannot reach `reviewGateBlocksLanding` regardless of which stage number
-in the pipeline it stands in for, so a `Validate-Authoritative` variant would exercise exactly
-the same `checkReviewGate` code path as `Review-Authoritative` does, with a more misleading
-name (implying landing-gate coverage it doesn't have).
+**A bed-local `Review-Authoritative` stage/column variant** (this issue's original design).
+Rejected during Validate-stage review — see "Revision" in Context above: `review_authority` is
+a stage-config property, not a distinct stage kind, unlike the `Queued`/`queued.yaml` precedent
+it was modeled on; and the column-absent skip path meant three of four scenarios could silently
+skip, letting the suite pass green with zero authoritative coverage exercised. A
+`Validate-Authoritative` variant of the same design was considered and rejected for the
+additional reason that no differently-named stage can reach `reviewGateBlocksLanding` regardless
+(see the `stage.Name == "Validate"` hardcoding above), so it would have exercised the same
+`checkReviewGate` path as a `Review`-based variant while implying landing-gate coverage it
+didn't have.
 
 **A per-issue label override for `review_authority`** (mirroring `model:<name>`/`effort:<level>`/
-`base:<branch>`). Rejected: explicitly out of scope per the issue ("no change to
-`engine/reviews.go` or other production engine code"); `ReviewAuthority` is deliberately
-stage-scoped only (ADR-1250), and adding a label override would be new production behavior,
-not test infrastructure.
+`base:<branch>`). This is the mechanism ultimately adopted — see Decision above. It does
+require a production engine change to read the label (#1261), which is why it's tracked and
+merged as a separate, decoupled issue rather than folded into this test-coverage-only PR;
+`ReviewAuthority` on `stages.Stage` remains stage-scoped per ADR-1250, and the label is an
+independent per-issue override layered on top by #1261, not a change to `ReviewAuthority`'s own
+type or the stage config schema.
 
 ## References
 
 - [ADR-1250: Review authority — advisory vs. authoritative](1250-review-authority-orthogonal-to-autonomy.md) — the shipped behavior this issue adds e2e coverage for.
 - [ADR-1216: Review gate checked at the landing decision](1216-review-gate-at-landing-decision.md) — establishes `reviewGateBlocksLanding`/`attemptMergeOnValidate` as the landing-decision choke point this ADR's gap applies to.
-- [ADR-059: Internal merge train](059-internal-merge-train.md) D1 — the `Queued`/`queued.yaml` bed-variant precedent this issue's `Review-Authoritative` mechanism follows.
+- [ADR-059: Internal merge train](059-internal-merge-train.md) D1 — the `Queued`/`queued.yaml` bed-variant precedent considered and distinguished from this issue's needs (see Revision above).
+- #1261 — engine support for the `review-authority:authoritative` per-issue label; a hard dependency for three of this issue's four scenarios.
 - `tests/e2e/review_authority_helpers.go`, `tests/e2e/review_authority_test.go` — the implementation.
-- `tests/e2e/README.md` §"Additional prerequisites for `TestReviewAuthority*` scenarios" — bed setup instructions.
+- `tests/e2e/README.md` §"Additional prerequisites for `TestReviewAuthority*` scenarios" — reviewer-token requirement and label mechanism.
 - `tests/e2e/paused_merged_pr_recovery_test.go` (R5) — the zero-Claude-cost label-seeded completion precedent this issue's `seedReviewGateItem` builds on.
 - `tests/e2e/mergetrain_helpers.go` (`CreateMemberPR`) — the direct-API PR construction precedent reused as-is.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -239,6 +239,72 @@ timeout instead of skipping. Only run in the `on` leg of the two-mode gate.
     Alpha's bisect-scenario max (~4 trials) with comfortable margin. Wall-clock:
     ~10–20 min; ~6 trials × 2 required checks ≈ 12 Actions runs.
 
+### Additional prerequisites for `TestReviewAuthority*` scenarios
+
+`TestReviewAuthorityBlocksAndPausesOnChangesRequested`,
+`TestReviewAuthorityClearsOnApproval`, and `TestReviewAuthorityYoloDoesNotBypassBlock`
+cover ADR-1250's `review_authority: authoritative` mode. `TestReviewAuthorityAdvisoryRegressionGuard`
+is the exception — it runs against the existing `Review` column/stage (default,
+untouched config) and needs no bed prerequisite, so it ships green immediately.
+
+**Why a new column, not the bed's real `Validate`:** `reviewGateBlocksLanding` (the
+landing/auto-merge gate) is only reachable through a stage literally named `Validate` —
+`engine/stages.go`, `engine/poll.go`, and `engine/pr_terminal_advance.go` all hard-gate
+on `stage.Name == "Validate"`. Flipping the bed's real `Validate` stage to authoritative
+(even temporarily) would violate "no change to the bed's default stage config" and risk
+corrupting concurrently-running advisory scenarios on the shared bed. So this bed
+prerequisite targets `checkReviewGate` (the **advance** gate) only, via a differently-named
+column that is structurally isolated from advisory scenarios (dispatch is column-name-keyed).
+See `adrs/1258-e2e-review-authority-coverage.md` for the full rationale, including why
+`reviewGateBlocksLanding`'s authoritative wiring is a documented, accepted e2e gap rather
+than a silently missing one — the three scenarios below therefore assert the gate *clears*
+(`fabrik:awaiting-review` disappears, `fabrik:paused` never applied), not that the item merges.
+
+20. **`Review-Authoritative` board column** on `handarbeit/projects/2`. Any position is
+    fine — it is never a real stage's natural successor (see next item's `order`).
+21. **`review-authoritative.yaml` stage** in the bed's `.fabrik/stages/`, a copy of
+    `review.yaml` with `review_authority: authoritative` added and `order: 41`
+    (deliberately far outside the real pipeline's 1–9 range):
+    ```yaml
+    name: Review-Authoritative
+    order: 41
+    review_authority: authoritative
+    wait_for_reviews: true
+    # ...remaining fields copied from review.yaml (prompt, skill, model, etc.)
+    ```
+    Restart the test-bed Fabrik instance after adding the column + YAML so the new
+    stage's labels (`stage:Review-Authoritative:complete`, etc.) get seeded and
+    `checkStageColumnAlignment` picks up the new column. The three scenarios needing
+    this skip cleanly (`requireAuthoritativeBed`) if the column is absent, so this PR
+    is safe to merge before the bed is updated.
+22. **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — same non-author PAT documented
+    in prerequisite #12 above. All four `TestReviewAuthority*` scenarios skip with an
+    instructional message if it is unset; there is no timeout-fallback path here (unlike
+    `TestConjunctiveCIReviewGate`) because these scenarios exist specifically to assert
+    on a deterministic verdict, not on gate-timeout behavior alone.
+23. **Why the bed reviewer (`claude-review.yml`) stays COMMENT-only, and is not used
+    for verdict assertions here**: `.github/workflows/claude-review.yml` submits
+    `gh pr review --comment` in both its agent path and its fallback path — it can
+    never produce `APPROVE` or `CHANGES_REQUESTED`, so it cannot exercise authoritative
+    mode's blocking or clearing paths. Switching it to a real reviewer bot (e.g. pruefer)
+    was explicitly rejected for issue #1258: non-determinism (verdict depends on Claude's
+    severity classification of a synthetic diff), latency (pruefer polls, default 120s,
+    vs. an Action firing on PR-open), cost (a real Claude invocation per test PR), and
+    coupling (Fabrik's release gate depending on pruefer's health). All verdict assertions
+    in `TestReviewAuthority*` instead use `SubmitPRReview` + `FABRIK_REVIEWER_TOKEN` —
+    deterministic, harness-posted formal reviews from a non-author identity.
+24. **`E2E_TIMEOUT=1h`** is generous for `TestReviewAuthorityBlocksAndPausesOnChangesRequested`
+    in isolation — its wall-clock is `FABRIK_REVIEW_WAIT_TIMEOUT + ~15 min`. Use a short
+    bed value (e.g. `FABRIK_REVIEW_WAIT_TIMEOUT=2`) for a fast iteration run.
+25. **Note on scope**: neither test bed repo has a branch-protection review requirement
+    configured (only required *status checks* are documented as enrolled), so
+    `FetchPRReviewDecision` returns `""` for every scenario here and `reviewGateAuthorityVerdict`
+    exercises its Fabrik-computed fallback branch, not GitHub's native `reviewDecision`
+    branch. A verdict-fetch-failure / unrecognized-`reviewDecision` scenario (issue #1258's
+    optional scenario 6) was excluded for the same reason — producing `REVIEW_REQUIRED` or
+    an unrecognized value would require new branch-protection bed setup, which is not
+    "cheaply expressible" per the issue's own bar for that scenario.
+
 ## Running
 
 The recommended entrypoint is the runner script, which sets sensible defaults:
@@ -370,6 +436,10 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | Both | 30–60 min | $0.50–1.50 |
 | `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | Both | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
 | `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | Both | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
+| `TestReviewAuthorityBlocksAndPausesOnChangesRequested` | ADR-1250 authoritative mode: CHANGES_REQUESTED verdict blocks the gate (fabrik:awaiting-review); verdict never clears → pauses at ReviewWaitTimeout with the authoritative reason in the comment, not the generic "no reviews submitted yet" | Both | ~`FABRIK_REVIEW_WAIT_TIMEOUT` + 15 min | ~$0.05 (no Claude) |
+| `TestReviewAuthorityClearsOnApproval` | ADR-1250 authoritative mode: APPROVED verdict clears the gate; fabrik:paused never applied | Both | 2–5 min | ~$0.02 (no Claude) |
+| `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250 composition guarantee: fabrik:yolo does not bypass an authoritative gate — blocked while CHANGES_REQUESTED stands, clears once approved | Both | 5–10 min | ~$0.03 (no Claude) |
+| `TestReviewAuthorityAdvisoryRegressionGuard` | Regression guard: advisory (default) mode still clears on any submitted review regardless of verdict — proves the additive authoritative check didn't narrow the default path | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | Train-only (on) | 10–25 min | low (no Claude) |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | Train-only (on) | 20–40 min | low–moderate |
 | `TestMergeTrainRestartSafety` | ADR-059 D5 / #960: after a landing, a restart with the historical merged integration PR present does NOT stall the next batch (reconstruct proceeds fresh). **Not parallel** — restarts the bed | Train-only (on) | 25–50 min | low |
@@ -398,6 +468,10 @@ skip of the four Train-only scenarios in the `off` leg.
 | `TestCIFixReinvokeCycleLimit` | CI-fix cycle limit (`pauseForCIFixCycleLimit`), `MaxCiFixCycles` exhaustion path |
 | `TestPausedMergedPRRecovery` | #874 (paused+merged PR recovery class), #887 (settle-owner structural fix, `runValidatePRTerminalAdvance`), ADR-056 D2 (single-owner for PR-terminal → Done) |
 | `TestConjunctiveCIReviewGate` | ADR-056 D2 (conjunctive gate joint-clear), #887 (settle-owner), #895 (this scenario), #925 (identity/dual-gate/bot-reviewer redesign) |
+| `TestReviewAuthorityBlocksAndPausesOnChangesRequested` | ADR-1250 (`review_authority: authoritative`), #1258 (this scenario), `checkAwaitingReviewTimeout`'s `authorityReason` pause-message path |
+| `TestReviewAuthorityClearsOnApproval` | ADR-1250, #1258 |
+| `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250's yolo/cruise composition guarantee, #1258 |
+| `TestReviewAuthorityAdvisoryRegressionGuard` | ADR-1250 additive-check regression guard, #1258 |
 | `TestMergeTrainHappyPathLanding` | ADR-059 D1/D3 (#946, #947, #948) — Queued column, trial-branch build, integration-PR landing + member lifecycle |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4 (#949) — halving bisection, ejection, one-at-a-time fallback |
 | `TestMergeTrainRestartSafety` | ADR-059 D5 (#950) + PR #960 (reconstruct must not stall on a historical merged PR) |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -243,46 +243,43 @@ timeout instead of skipping. Only run in the `on` leg of the two-mode gate.
 
 `TestReviewAuthorityBlocksAndPausesOnChangesRequested`,
 `TestReviewAuthorityClearsOnApproval`, and `TestReviewAuthorityYoloDoesNotBypassBlock`
-cover ADR-1250's `review_authority: authoritative` mode. `TestReviewAuthorityAdvisoryRegressionGuard`
-is the exception — it runs against the existing `Review` column/stage (default,
-untouched config) and needs no bed prerequisite, so it ships green immediately.
+cover ADR-1250's `review_authority: authoritative` mode. All four `TestReviewAuthority*`
+scenarios, including `TestReviewAuthorityAdvisoryRegressionGuard`, run against the bed's
+existing `Review` column/stage (default, untouched config) — **no bed column or stage-YAML
+setup is required**, beyond `FABRIK_REVIEWER_TOKEN` below.
 
-**Why a new column, not the bed's real `Validate`:** `reviewGateBlocksLanding` (the
-landing/auto-merge gate) is only reachable through a stage literally named `Validate` —
-`engine/stages.go`, `engine/poll.go`, and `engine/pr_terminal_advance.go` all hard-gate
-on `stage.Name == "Validate"`. Flipping the bed's real `Validate` stage to authoritative
-(even temporarily) would violate "no change to the bed's default stage config" and risk
-corrupting concurrently-running advisory scenarios on the shared bed. So this bed
-prerequisite targets `checkReviewGate` (the **advance** gate) only, via a differently-named
-column that is structurally isolated from advisory scenarios (dispatch is column-name-keyed).
-See `adrs/1258-e2e-review-authority-coverage.md` for the full rationale, including why
-`reviewGateBlocksLanding`'s authoritative wiring is a documented, accepted e2e gap rather
-than a silently missing one — the three scenarios below therefore assert the gate *clears*
-(`fabrik:awaiting-review` disappears, `fabrik:paused` never applied), not that the item merges.
+**Mechanism: a per-issue label, not a bed column.** Authoritative mode is applied per item
+via the `review-authority:authoritative` label, passed as an extra label at seed time
+(`seedReviewGateItem`'s `extraLabels`). Engine support for that label is tracked separately
+in #1261 — the three authoritative scenarios above cannot pass until both #1261 and this
+issue's PR are merged; `TestReviewAuthorityAdvisoryRegressionGuard` has no such dependency
+and ships green regardless.
 
-20. **`Review-Authoritative` board column** on `handarbeit/projects/2`. Any position is
-    fine — it is never a real stage's natural successor (see next item's `order`).
-21. **`review-authoritative.yaml` stage** in the bed's `.fabrik/stages/`, a copy of
-    `review.yaml` with `review_authority: authoritative` added and `order: 41`
-    (deliberately far outside the real pipeline's 1–9 range):
-    ```yaml
-    name: Review-Authoritative
-    order: 41
-    review_authority: authoritative
-    wait_for_reviews: true
-    # ...remaining fields copied from review.yaml (prompt, skill, model, etc.)
-    ```
-    Restart the test-bed Fabrik instance after adding the column + YAML so the new
-    stage's labels (`stage:Review-Authoritative:complete`, etc.) get seeded and
-    `checkStageColumnAlignment` picks up the new column. The three scenarios needing
-    this skip cleanly (`requireAuthoritativeBed`) if the column is absent, so this PR
-    is safe to merge before the bed is updated.
-22. **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — same non-author PAT documented
+An earlier design applied authority via a bed-local `Review-Authoritative` board column +
+matching stage YAML (mirroring the `Queued`/`queued.yaml` precedent). That was rejected:
+`review_authority` is a property of a stage's config, not a distinct kind of stage, so it
+doesn't belong on the board as a column name — and requiring a bed prerequisite the operator
+hadn't set up yet meant three of the four scenarios silently skipped, letting the suite go
+green having validated zero authoritative behavior. Tests gating a release should fail loudly
+when they can't run their intended assertion, not pass vacuously. See
+`adrs/1258-e2e-review-authority-coverage.md` for the full rationale.
+
+**Why these scenarios can't cover the landing/auto-merge gate:** `reviewGateBlocksLanding` is
+only reachable through a stage literally named `Validate` — `engine/stages.go`,
+`engine/poll.go`, and `engine/pr_terminal_advance.go` all hard-gate on `stage.Name ==
+"Validate"`. Applying the authority label to an item on `Review` cannot reach that
+stage-name-gated path, and authoritative-izing the bed's real `Validate` stage would violate
+"no change to the bed's default stage config" and risk corrupting concurrently-running
+advisory scenarios on the shared bed. This is a documented, accepted e2e gap — the three
+scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` disappears,
+`fabrik:paused` never applied), not that the item merges.
+
+20. **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — same non-author PAT documented
     in prerequisite #12 above. All four `TestReviewAuthority*` scenarios skip with an
     instructional message if it is unset; there is no timeout-fallback path here (unlike
     `TestConjunctiveCIReviewGate`) because these scenarios exist specifically to assert
     on a deterministic verdict, not on gate-timeout behavior alone.
-23. **Why the bed reviewer (`claude-review.yml`) stays COMMENT-only, and is not used
+21. **Why the bed reviewer (`claude-review.yml`) stays COMMENT-only, and is not used
     for verdict assertions here**: `.github/workflows/claude-review.yml` submits
     `gh pr review --comment` in both its agent path and its fallback path — it can
     never produce `APPROVE` or `CHANGES_REQUESTED`, so it cannot exercise authoritative
@@ -293,10 +290,10 @@ than a silently missing one — the three scenarios below therefore assert the g
     coupling (Fabrik's release gate depending on pruefer's health). All verdict assertions
     in `TestReviewAuthority*` instead use `SubmitPRReview` + `FABRIK_REVIEWER_TOKEN` —
     deterministic, harness-posted formal reviews from a non-author identity.
-24. **`E2E_TIMEOUT=1h`** is generous for `TestReviewAuthorityBlocksAndPausesOnChangesRequested`
+22. **`E2E_TIMEOUT=1h`** is generous for `TestReviewAuthorityBlocksAndPausesOnChangesRequested`
     in isolation — its wall-clock is `FABRIK_REVIEW_WAIT_TIMEOUT + ~15 min`. Use a short
     bed value (e.g. `FABRIK_REVIEW_WAIT_TIMEOUT=2`) for a fast iteration run.
-25. **Note on scope**: neither test bed repo has a branch-protection review requirement
+23. **Note on scope**: neither test bed repo has a branch-protection review requirement
     configured (only required *status checks* are documented as enrolled), so
     `FetchPRReviewDecision` returns `""` for every scenario here and `reviewGateAuthorityVerdict`
     exercises its Fabrik-computed fallback branch, not GitHub's native `reviewDecision`
@@ -436,9 +433,9 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | Both | 30–60 min | $0.50–1.50 |
 | `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | Both | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
 | `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | Both | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
-| `TestReviewAuthorityBlocksAndPausesOnChangesRequested` | ADR-1250 authoritative mode: CHANGES_REQUESTED verdict blocks the gate (fabrik:awaiting-review); verdict never clears → pauses at ReviewWaitTimeout with the authoritative reason in the comment, not the generic "no reviews submitted yet" | Both | ~`FABRIK_REVIEW_WAIT_TIMEOUT` + 15 min | ~$0.05 (no Claude) |
-| `TestReviewAuthorityClearsOnApproval` | ADR-1250 authoritative mode: APPROVED verdict clears the gate; fabrik:paused never applied | Both | 2–5 min | ~$0.02 (no Claude) |
-| `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250 composition guarantee: fabrik:yolo does not bypass an authoritative gate — blocked while CHANGES_REQUESTED stands, clears once approved | Both | 5–10 min | ~$0.03 (no Claude) |
+| `TestReviewAuthorityBlocksAndPausesOnChangesRequested` | ADR-1250 authoritative mode (via `review-authority:authoritative` label, requires #1261): CHANGES_REQUESTED verdict blocks the gate (fabrik:awaiting-review); verdict never clears → pauses at ReviewWaitTimeout with the authoritative reason in the comment, not the generic "no reviews submitted yet" | Both | ~`FABRIK_REVIEW_WAIT_TIMEOUT` + 15 min | ~$0.05 (no Claude) |
+| `TestReviewAuthorityClearsOnApproval` | ADR-1250 authoritative mode (via `review-authority:authoritative` label, requires #1261): APPROVED verdict clears the gate; fabrik:paused never applied | Both | 2–5 min | ~$0.02 (no Claude) |
+| `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250 composition guarantee (via `review-authority:authoritative` label, requires #1261): fabrik:yolo does not bypass an authoritative gate — blocked while CHANGES_REQUESTED stands, clears once approved | Both | 5–10 min | ~$0.03 (no Claude) |
 | `TestReviewAuthorityAdvisoryRegressionGuard` | Regression guard: advisory (default) mode still clears on any submitted review regardless of verdict — proves the additive authoritative check didn't narrow the default path | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | Train-only (on) | 10–25 min | low (no Claude) |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | Train-only (on) | 20–40 min | low–moderate |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -246,7 +246,8 @@ timeout instead of skipping. Only run in the `on` leg of the two-mode gate.
 cover ADR-1250's `review_authority: authoritative` mode. All four `TestReviewAuthority*`
 scenarios, including `TestReviewAuthorityAdvisoryRegressionGuard`, run against the bed's
 existing `Review` column/stage (default, untouched config) — **no bed column or stage-YAML
-setup is required**, beyond `FABRIK_REVIEWER_TOKEN` below.
+setup is required**, beyond `FABRIK_REVIEWER_TOKEN` and the `review-authority:authoritative`
+label (both below).
 
 **Mechanism: a per-issue label, not a bed column.** Authoritative mode is applied per item
 via the `review-authority:authoritative` label, passed as an extra label at seed time
@@ -279,7 +280,17 @@ scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` dis
     instructional message if it is unset; there is no timeout-fallback path here (unlike
     `TestConjunctiveCIReviewGate`) because these scenarios exist specifically to assert
     on a deterministic verdict, not on gate-timeout behavior alone.
-21. **Why the bed reviewer (`claude-review.yml`) stays COMMENT-only, and is not used
+21. **`review-authority:authoritative` label seeded** in `handarbeit/fabrik-test-alpha`
+    (the only repo these scenarios use). `FileIssue` passes it straight through to
+    `gh issue create --label`, which — like `AddLabel` (prerequisite #8) — fatals
+    immediately if the label doesn't already exist as a label object in the repo; `gh`
+    does not auto-create labels on issue creation. Create it manually
+    (`gh label create review-authority:authoritative -R handarbeit/fabrik-test-alpha`)
+    if needed. This is independent of #1261: #1261 adds the engine code that
+    *interprets* the label on an issue it already carries, not the GitHub label object
+    itself — the object must exist before any of these scenarios can even file their
+    seed issue.
+22. **Why the bed reviewer (`claude-review.yml`) stays COMMENT-only, and is not used
     for verdict assertions here**: `.github/workflows/claude-review.yml` submits
     `gh pr review --comment` in both its agent path and its fallback path — it can
     never produce `APPROVE` or `CHANGES_REQUESTED`, so it cannot exercise authoritative
@@ -290,10 +301,14 @@ scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` dis
     coupling (Fabrik's release gate depending on pruefer's health). All verdict assertions
     in `TestReviewAuthority*` instead use `SubmitPRReview` + `FABRIK_REVIEWER_TOKEN` —
     deterministic, harness-posted formal reviews from a non-author identity.
-22. **`E2E_TIMEOUT=1h`** is generous for `TestReviewAuthorityBlocksAndPausesOnChangesRequested`
-    in isolation — its wall-clock is `FABRIK_REVIEW_WAIT_TIMEOUT + ~15 min`. Use a short
-    bed value (e.g. `FABRIK_REVIEW_WAIT_TIMEOUT=2`) for a fast iteration run.
-23. **Note on scope**: neither test bed repo has a branch-protection review requirement
+23. **`E2E_TIMEOUT=1h`** covers `TestReviewAuthorityBlocksAndPausesOnChangesRequested`
+    in isolation — its worst-case wall-clock is `FABRIK_REVIEW_WAIT_TIMEOUT + ~30 min`
+    (10 min initial block-confirmation wait + `FABRIK_REVIEW_WAIT_TIMEOUT`+10 min for the
+    pause wait itself + two trailing 5 min waits for `fabrik:awaiting-input` and the pause
+    comment), though it typically completes much faster in practice. With the 15-minute
+    default this worst case is ~45 min, still within `E2E_TIMEOUT=1h`; use a short bed
+    value (e.g. `FABRIK_REVIEW_WAIT_TIMEOUT=2`) for a fast iteration run.
+24. **Note on scope**: neither test bed repo has a branch-protection review requirement
     configured (only required *status checks* are documented as enrolled), so
     `FetchPRReviewDecision` returns `""` for every scenario here and `reviewGateAuthorityVerdict`
     exercises its Fabrik-computed fallback branch, not GitHub's native `reviewDecision`
@@ -433,7 +448,7 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestCIFixReinvokeCycleLimit` | CI-fix reinvoke negative path: unfixable sentinel exhausts MaxCiFixCycles, issue pauses | Both | 30–60 min | $0.50–1.50 |
 | `TestPausedMergedPRRecovery` | paused + gate-label at Validate with merged PR heals to CLOSED (3 sequential sub-tests: awaiting-ci, awaiting-review, no-gate-label); regression guard for #874 class | Both | 60–90 min (3 sequential sub-tests, ~20–30 min each); run with `E2E_TIMEOUT=3h` | $1.50–4.50 |
 | `TestConjunctiveCIReviewGate` | Conjunctive CI∧review gate: fabrik:awaiting-ci holds before CI, PR comment during CI-await not dropped, fabrik:awaiting-review holds before approval, advance suppressed until both gates clear | Both | 60–90 min (approval path) / 30–50 min (timeout path) | $1.00–2.50 |
-| `TestReviewAuthorityBlocksAndPausesOnChangesRequested` | ADR-1250 authoritative mode (via `review-authority:authoritative` label, requires #1261): CHANGES_REQUESTED verdict blocks the gate (fabrik:awaiting-review); verdict never clears → pauses at ReviewWaitTimeout with the authoritative reason in the comment, not the generic "no reviews submitted yet" | Both | ~`FABRIK_REVIEW_WAIT_TIMEOUT` + 15 min | ~$0.05 (no Claude) |
+| `TestReviewAuthorityBlocksAndPausesOnChangesRequested` | ADR-1250 authoritative mode (via `review-authority:authoritative` label, requires #1261): CHANGES_REQUESTED verdict blocks the gate (fabrik:awaiting-review); verdict never clears → pauses at ReviewWaitTimeout with the authoritative reason in the comment, not the generic "no reviews submitted yet" | Both | ~`FABRIK_REVIEW_WAIT_TIMEOUT` + 30 min (worst case) | ~$0.05 (no Claude) |
 | `TestReviewAuthorityClearsOnApproval` | ADR-1250 authoritative mode (via `review-authority:authoritative` label, requires #1261): APPROVED verdict clears the gate; fabrik:paused never applied | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250 composition guarantee (via `review-authority:authoritative` label, requires #1261): fabrik:yolo does not bypass an authoritative gate — blocked while CHANGES_REQUESTED stands, clears once approved | Both | 5–10 min | ~$0.03 (no Claude) |
 | `TestReviewAuthorityAdvisoryRegressionGuard` | Regression guard: advisory (default) mode still clears on any submitted review regardless of verdict — proves the additive authoritative check didn't narrow the default path | Both | 2–5 min | ~$0.02 (no Claude) |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -306,8 +306,14 @@ scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` dis
     (10 min initial block-confirmation wait + `FABRIK_REVIEW_WAIT_TIMEOUT`+10 min for the
     pause wait itself + two trailing 5 min waits for `fabrik:awaiting-input` and the pause
     comment), though it typically completes much faster in practice. With the 15-minute
-    default this worst case is ~45 min, still within `E2E_TIMEOUT=1h`; use a short bed
-    value (e.g. `FABRIK_REVIEW_WAIT_TIMEOUT=2`) for a fast iteration run.
+    default this worst case is ~45 min, still within `E2E_TIMEOUT=1h`. **Do not use a very
+    short value like `FABRIK_REVIEW_WAIT_TIMEOUT=2` here**: `TestReviewAuthorityYoloDoesNotBypassBlock`
+    runs concurrently against the same bed setting and needs the timeout comfortably above
+    ~2 minutes, since its 90s "block persists under yolo" window starts shortly after
+    `fabrik:awaiting-review` first appears — a too-short timeout risks a legitimate
+    review-wait-timeout pause landing inside that window, which the test detects and fails
+    on explicitly (distinct message, not misreported as a yolo bypass) rather than passing.
+    A moderate value (e.g. `FABRIK_REVIEW_WAIT_TIMEOUT=5`) balances both tests' needs.
 24. **Note on scope**: neither test bed repo has a branch-protection review requirement
     configured (only required *status checks* are documented as enrolled), so
     `FetchPRReviewDecision` returns `""` for every scenario here and `reviewGateAuthorityVerdict`

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1526,6 +1526,8 @@ func ghOutputWithToken(token string, args ...string) (string, error) {
 // SubmitPRReview submits a review on the PR using reviewerToken (a PAT for a
 // non-author identity — GitHub forbids the PR author from approving their own
 // PR). action must be "APPROVE" or "REQUEST_CHANGES" (GitHub API event values).
+// GitHub's API requires a non-empty body for REQUEST_CHANGES/COMMENT (only
+// APPROVE may omit it), so a fixed body is always sent — harmless for APPROVE.
 // Fails the test on API error (e.g. 422 if reviewerToken == env.GHToken).
 func SubmitPRReview(t *testing.T, env *Env, reviewerToken string, repo string, prNumber int, action string) {
 	t.Helper()
@@ -1535,7 +1537,8 @@ func SubmitPRReview(t *testing.T, env *Env, reviewerToken string, repo string, p
 	}
 	path := fmt.Sprintf("repos/%s/%s/pulls/%d/reviews", owner, name, prNumber)
 	out, err := ghOutputWithToken(reviewerToken, "api", "-X", "POST", path,
-		"-f", "event="+action)
+		"-f", "event="+action,
+		"-f", "body=e2e harness review ("+action+")")
 	if err != nil {
 		t.Fatalf("SubmitPRReview %s on %s PR #%d: %v\n%s", action, repo, prNumber, err, out)
 	}

--- a/tests/e2e/review_authority_helpers.go
+++ b/tests/e2e/review_authority_helpers.go
@@ -18,6 +18,13 @@ import (
 // existing Review column with its default (advisory) stage config. See
 // adrs/1258-e2e-review-authority-coverage.md for the full rationale,
 // including why the earlier column/stage-variant design was rejected.
+//
+// Bed prerequisite: the "review-authority:authoritative" label must already
+// exist in the target repo. FileIssue passes extraLabels straight through to
+// `gh issue create --label`, which fails hard (not gracefully) if the label
+// is absent — see tests/e2e/README.md's prerequisite for this test file,
+// which mirrors the existing "Gate labels seeded" precedent for
+// TestPausedMergedPRRecovery.
 
 // seedReviewGateItem files an issue, adds it to the project, builds a member
 // PR directly via the GitHub API (CreateMemberPR — no Claude cost), seeds

--- a/tests/e2e/review_authority_helpers.go
+++ b/tests/e2e/review_authority_helpers.go
@@ -4,47 +4,20 @@ package e2e
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 )
 
 // review_authority e2e helpers (ADR-1250, issue #1258). Authoritative-mode
-// coverage needs a stage whose review_authority is "authoritative" without
-// touching the bed's default stage config (Review/Validate stay advisory).
-// This is a one-time, bed-local operator prerequisite: a "Review-Authoritative"
-// board column plus a matching stage YAML (a copy of review.yaml with
-// review_authority: authoritative added), mirroring the existing
-// Queued/queued.yaml precedent used by the merge-train scenarios. See
-// tests/e2e/README.md for the exact setup and adrs/1258-e2e-review-authority-coverage.md
-// for why this mechanism — not a Validate variant — is what's reachable here.
-
-// requireAuthoritativeBed skips the test unless the test board has a
-// "Review-Authoritative" column — the one-time operator setup these
-// scenarios need. Mirrors requireTrainBed's retry-on-transient-error
-// behavior: a persistent read failure FAILS the test (not a silent skip),
-// so a rate-limited run doesn't masquerade as "bed not set up".
-func requireAuthoritativeBed(t *testing.T, env *Env) {
-	t.Helper()
-	var err error
-	for attempt := 0; attempt < 6; attempt++ {
-		var sf statusField
-		sf, err = fetchStatusField(env)
-		if err == nil {
-			for _, o := range sf.Options {
-				if strings.TrimSpace(o.Name) == "Review-Authoritative" {
-					return
-				}
-			}
-			t.Skipf("test board %s/#%d has no Review-Authoritative column — "+
-				"authoritative-mode e2e bed not set up (see tests/e2e/README.md)",
-				env.ProjectOwner, env.ProjectNumber)
-		}
-		t.Logf("requireAuthoritativeBed: transient board-read error (attempt %d/6): %v", attempt+1, err)
-		time.Sleep(20 * time.Second)
-	}
-	t.Fatalf("could not read board columns after 6 attempts (last: %v) — GraphQL rate limit or API issue, not a skip condition", err)
-}
+// coverage is applied per issue via the "review-authority:authoritative"
+// label (engine support: #1261, decoupled from this issue) rather than a
+// bed-local stage/column variant — review_authority is a property of a
+// stage's config, not a distinct kind of stage, so it does not belong on
+// the board as a column name. Scenarios opt in per item by passing the
+// label as an extraLabel to seedReviewGateItem, running against the bed's
+// existing Review column with its default (advisory) stage config. See
+// adrs/1258-e2e-review-authority-coverage.md for the full rationale,
+// including why the earlier column/stage-variant design was rejected.
 
 // seedReviewGateItem files an issue, adds it to the project, builds a member
 // PR directly via the GitHub API (CreateMemberPR — no Claude cost), seeds

--- a/tests/e2e/review_authority_helpers.go
+++ b/tests/e2e/review_authority_helpers.go
@@ -1,0 +1,77 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// review_authority e2e helpers (ADR-1250, issue #1258). Authoritative-mode
+// coverage needs a stage whose review_authority is "authoritative" without
+// touching the bed's default stage config (Review/Validate stay advisory).
+// This is a one-time, bed-local operator prerequisite: a "Review-Authoritative"
+// board column plus a matching stage YAML (a copy of review.yaml with
+// review_authority: authoritative added), mirroring the existing
+// Queued/queued.yaml precedent used by the merge-train scenarios. See
+// tests/e2e/README.md for the exact setup and adrs/1258-e2e-review-authority-coverage.md
+// for why this mechanism — not a Validate variant — is what's reachable here.
+
+// requireAuthoritativeBed skips the test unless the test board has a
+// "Review-Authoritative" column — the one-time operator setup these
+// scenarios need. Mirrors requireTrainBed's retry-on-transient-error
+// behavior: a persistent read failure FAILS the test (not a silent skip),
+// so a rate-limited run doesn't masquerade as "bed not set up".
+func requireAuthoritativeBed(t *testing.T, env *Env) {
+	t.Helper()
+	var err error
+	for attempt := 0; attempt < 6; attempt++ {
+		var sf statusField
+		sf, err = fetchStatusField(env)
+		if err == nil {
+			for _, o := range sf.Options {
+				if strings.TrimSpace(o.Name) == "Review-Authoritative" {
+					return
+				}
+			}
+			t.Skipf("test board %s/#%d has no Review-Authoritative column — "+
+				"authoritative-mode e2e bed not set up (see tests/e2e/README.md)",
+				env.ProjectOwner, env.ProjectNumber)
+		}
+		t.Logf("requireAuthoritativeBed: transient board-read error (attempt %d/6): %v", attempt+1, err)
+		time.Sleep(20 * time.Second)
+	}
+	t.Fatalf("could not read board columns after 6 attempts (last: %v) — GraphQL rate limit or API issue, not a skip condition", err)
+}
+
+// seedReviewGateItem files an issue, adds it to the project, builds a member
+// PR directly via the GitHub API (CreateMemberPR — no Claude cost), seeds
+// stage:<column>:complete, and places the item at column. This exercises the
+// catch-up loop's gate/settle logic (checkReviewGate via handleReviewGate)
+// without ever invoking Claude for the gated stage — the same zero-cost
+// construction precedent as TestPausedMergedPRRecovery's R5. extraLabels are
+// applied at file time (e.g. "fabrik:yolo" for the composition scenario).
+func seedReviewGateItem(t *testing.T, env *Env, repo, baseBranch, column, marker string, extraLabels ...string) (issueNum, prNum int, itemID string) {
+	t.Helper()
+	stamp := time.Now().UTC().Format("150405.000")
+	title := fmt.Sprintf("e2e review-authority %s (%s)", marker, stamp)
+	num := FileIssue(t, env, repo, title,
+		fmt.Sprintf("e2e review_authority gate/settle test. marker=%s", marker), extraLabels...)
+	itemID = AddIssueToProject(t, env, repo, num)
+
+	branch := fmt.Sprintf("fabrik/issue-%d", num)
+	path := fmt.Sprintf("e2e/review-authority/%s-%d.md", marker, num)
+	content := fmt.Sprintf("# e2e review-authority marker\n\nmarker=%s\n", marker)
+	prNum = CreateMemberPR(t, env, repo, baseBranch, branch, path, content, title, num)
+	// Confirm the PR is resolvable by the fabrik/issue-<N> branch convention
+	// (mirrors the engine's resolver) before seeding the completion label.
+	LinkedPRNumber(t, env, repo, num)
+
+	AddLabel(t, env, repo, num, "stage:"+column+":complete")
+	SetIssueStatus(t, env, itemID, column)
+	t.Logf("seeded review-gate item: issue #%d, PR #%d, stage:%s:complete, Status=%s (marker=%s)",
+		num, prNum, column, column, marker)
+	return num, prNum, itemID
+}

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -187,6 +187,15 @@ func TestReviewAuthorityClearsOnApproval(t *testing.T) {
 // Requires #1261 (engine support for the review-authority:authoritative
 // label) to be merged.
 //
+// Requires FABRIK_REVIEW_WAIT_TIMEOUT set comfortably above ~2 minutes: the
+// 90s "block persists" window below runs shortly after fabrik:awaiting-review
+// is first observed, and a too-short timeout risks the review-wait timeout
+// pause (checkAwaitingReviewTimeout, a legitimate outcome unrelated to yolo)
+// firing inside that window. The loop distinguishes the two cases explicitly
+// rather than misreporting a timeout-pause as a yolo bypass, but a timeout
+// pause still fails the test (it can't proceed to the approval half of the
+// scenario), so the timeout value still needs to be sized accordingly.
+//
 // Wall-clock: ~5-10 min.
 func TestReviewAuthorityYoloDoesNotBypassBlock(t *testing.T) {
 	t.Parallel()
@@ -220,6 +229,12 @@ func TestReviewAuthorityYoloDoesNotBypassBlock(t *testing.T) {
 			t.Fatalf("yolo bypassed the authoritative gate — %s#%d closed while CHANGES_REQUESTED still stood", env.RepoAlpha, num)
 		}
 		if labels, err := tryIssueLabels(env, env.RepoAlpha, num); err == nil && !slices.Contains(labels, "fabrik:awaiting-review") {
+			if slices.Contains(labels, "fabrik:paused") {
+				t.Fatalf("fabrik:awaiting-review cleared via a review-wait-timeout pause during this test's 90s block-persist "+
+					"window on %s#%d — this is a legitimate outcome unrelated to yolo bypass, not evidence of one; "+
+					"FABRIK_REVIEW_WAIT_TIMEOUT is set too short for this test (needs to be comfortably above ~2 minutes, see README)",
+					env.RepoAlpha, num)
+			}
 			t.Fatalf("yolo bypassed the authoritative gate — fabrik:awaiting-review cleared from %s#%d while CHANGES_REQUESTED still stood", env.RepoAlpha, num)
 		}
 		pollSleep(pollBase())

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -217,6 +218,9 @@ func TestReviewAuthorityYoloDoesNotBypassBlock(t *testing.T) {
 	for time.Now().Before(blockedDeadline) {
 		if state, err := tryIssueState(env, env.RepoAlpha, num); err == nil && state == "CLOSED" {
 			t.Fatalf("yolo bypassed the authoritative gate — %s#%d closed while CHANGES_REQUESTED still stood", env.RepoAlpha, num)
+		}
+		if labels, err := tryIssueLabels(env, env.RepoAlpha, num); err == nil && !slices.Contains(labels, "fabrik:awaiting-review") {
+			t.Fatalf("yolo bypassed the authoritative gate — fabrik:awaiting-review cleared from %s#%d while CHANGES_REQUESTED still stood", env.RepoAlpha, num)
 		}
 		pollSleep(pollBase())
 	}

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -28,8 +28,13 @@ import (
 // the 4 scenarios, letting the suite go green having validated zero
 // authoritative behavior. See adrs/1258-e2e-review-authority-coverage.md.
 //
-// No bed setup is required beyond FABRIK_REVIEWER_TOKEN (see README) — none
-// of these scenarios skip for lack of bed prerequisites.
+// Bed setup required: FABRIK_REVIEWER_TOKEN, and the
+// "review-authority:authoritative" label must already exist as a label
+// object in the target repo (gh issue create --label fails hard, not
+// gracefully, if it doesn't — see README prerequisite). Neither is a bed
+// column or stage-YAML variant, and no scenario skips for lack of either —
+// a missing label surfaces as a t.Fatalf from FileIssue, by design (see the
+// ADR's rationale for rejecting silent skips).
 //
 // Scope limitation (see adrs/1258-e2e-review-authority-coverage.md): the
 // landing/auto-merge gate (reviewGateBlocksLanding, called only from
@@ -57,8 +62,11 @@ import (
 // Requires #1261 (engine support for the review-authority:authoritative
 // label) to be merged.
 //
-// Wall-clock: ~FABRIK_REVIEW_WAIT_TIMEOUT + 10 min. Use a short bed value
-// (e.g. 2) for a fast iteration run — see README.
+// Wall-clock (worst case): ~FABRIK_REVIEW_WAIT_TIMEOUT + 30 min — 10 min for
+// the initial block-confirmation wait, FABRIK_REVIEW_WAIT_TIMEOUT+10 min for
+// the pause wait itself, plus two trailing 5 min waits (fabrik:awaiting-input,
+// the pause comment). Typically much faster in practice. Use a short bed
+// value (e.g. 2) for a fast iteration run — see README.
 func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -147,6 +147,18 @@ func TestReviewAuthorityClearsOnApproval(t *testing.T) {
 			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
 	}
 
+	// Confirm the gate genuinely engages (no review submitted yet, so
+	// checkReviewGate's outer hasReviews==false condition blocks and applies
+	// the label unconditionally) before approving. Without this, a poll
+	// racing ahead of SubmitPRReview below could observe the item only after
+	// the approval already exists, clearing on the very first evaluation and
+	// never applying fabrik:awaiting-review at all — the later
+	// WaitForLabelAbsent would then pass trivially without having exercised
+	// the authoritative clearing transition this scenario exists to check.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d before approval — gate is genuinely engaged", env.RepoAlpha, num)
+
 	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "APPROVE")
 	t.Logf("submitted APPROVE review on %s PR #%d", env.RepoAlpha, prNum)
 
@@ -239,6 +251,19 @@ func TestReviewAuthorityAdvisoryRegressionGuard(t *testing.T) {
 		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
 			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
 	}
+
+	// Confirm the gate genuinely engages (no review submitted yet, so
+	// checkReviewGate's outer hasReviews==false condition blocks and applies
+	// the label unconditionally, regardless of authority mode) before
+	// submitting the review. Without this, a poll racing ahead of
+	// SubmitPRReview below could observe the item only after the review
+	// already exists, clearing on the very first evaluation and never
+	// applying fabrik:awaiting-review at all — the later WaitForLabelAbsent
+	// would then pass trivially without ever exercising the clearing
+	// transition this regression guard exists to check.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d before review submission — gate is genuinely engaged", env.RepoAlpha, num)
 
 	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "REQUEST_CHANGES")
 	t.Logf("submitted REQUEST_CHANGES review on %s PR #%d (advisory Review stage)", env.RepoAlpha, prNum)

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -87,13 +87,26 @@ func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
 	}
 
+	// Confirm the gate's trivial, pre-verdict block (hasReviews==false blocks
+	// unconditionally) before the review lands. This alone doesn't prove the
+	// gate evaluates the verdict rather than always blocking — a REQUEST_CHANGES
+	// scenario can't distinguish that by itself; TestReviewAuthorityClearsOnApproval
+	// (block-before/clear-after APPROVE) supplies that half. The distinguishing
+	// assertion for *this* scenario is downstream: the pause-comment content
+	// check below, which fails if authorityReason wasn't derived from the actual
+	// CHANGES_REQUESTED verdict and fell back to the generic "no reviews
+	// submitted yet" message.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d before any review submitted — gate is genuinely engaged", env.RepoAlpha, num)
+
 	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "REQUEST_CHANGES")
 	t.Logf("submitted REQUEST_CHANGES review on %s PR #%d", env.RepoAlpha, prNum)
 
-	// Scenario 1: the gate must block — fabrik:awaiting-review appears, and
-	// the item must not advance past Review (the durable, directly-observable
-	// signal is that the gate label is applied and fabrik:paused is not yet
-	// present).
+	// Scenario 1: the gate must still be blocking — fabrik:awaiting-review
+	// remains, and the item must not advance past Review (the durable,
+	// directly-observable signal is that the gate label is applied and
+	// fabrik:paused is not yet present).
 	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
 	t.Logf("fabrik:awaiting-review confirmed on %s#%d — authoritative gate is blocking on CHANGES_REQUESTED", env.RepoAlpha, num)
 

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -1,0 +1,241 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file covers ADR-1250's review_authority: authoritative mode
+// end-to-end (issue #1258), using deterministic harness-posted verdicts
+// (SubmitPRReview + FABRIK_REVIEWER_TOKEN) — never the bed's COMMENT-only
+// claude-review.yml bot — for every verdict assertion.
+//
+// Mechanism: all four scenarios seed a member PR directly via the GitHub API
+// (CreateMemberPR, zero Claude cost) and place the issue on a bed-local
+// "Review-Authoritative" column/stage — a copy of review.yaml with
+// review_authority: authoritative added. This exercises checkReviewGate (the
+// advance gate) and its shared pure predicate reviewGateAuthorityVerdict.
+//
+// Scope limitation (see adrs/1258-e2e-review-authority-coverage.md): the
+// landing/auto-merge gate (reviewGateBlocksLanding, called only from
+// attemptMergeOnValidate) is reachable ONLY through a stage literally named
+// "Validate" (engine/stages.go, engine/poll.go, engine/pr_terminal_advance.go
+// all hard-gate on stage.Name == "Validate"). Flipping the bed's real
+// Validate stage to authoritative would violate "no change to the bed's
+// default stage config" and risk corrupting concurrently-running advisory
+// scenarios on the shared bed. So scenarios 2/3 below assert the gate
+// *clears* (fabrik:awaiting-review disappears, fabrik:paused never applied),
+// not that the item merges — reviewGateBlocksLanding's wiring around the
+// same shared predicate is a documented, accepted e2e gap, not a silently
+// missing one.
+//
+// All four scenarios only touch checkReviewGate, which has no
+// FABRIK_MERGE_TRAIN branching — they pass identically under both legs of
+// the suite's two-mode gate.
+//
+// Prerequisites: see "Additional prerequisites for TestReviewAuthority*
+// scenarios" in tests/e2e/README.md (Review-Authoritative column + stage
+// YAML). requireAuthoritativeBed skips gracefully if not set up.
+
+// TestReviewAuthorityBlocksAndPausesOnChangesRequested covers scenarios 1 and
+// 5 from issue #1258: authoritative + CHANGES_REQUESTED blocks advancement,
+// and — folded in as a continuation, since authoritative mode cannot reach
+// the separate MaxReviewCycles path (dispatchReviewReinvoke only fires after
+// the gate has already cleared) — a verdict that never clears eventually
+// pauses via checkAwaitingReviewTimeout, with the authoritative pause reason
+// naming the verdict rather than the misleading "no reviews submitted yet".
+//
+// Wall-clock: ~FABRIK_REVIEW_WAIT_TIMEOUT + 10 min. Use a short bed value
+// (e.g. 2) for a fast iteration run — see README.
+func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	requireAuthoritativeBed(t, env)
+
+	reviewerToken := readEnvFileReviewerToken(t, env)
+	if reviewerToken == "" {
+		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
+	}
+	reviewWaitTimeout := readEnvFileReviewWaitTimeout(t, env)
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review-Authoritative", "blocks-pauses")
+
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
+			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
+	}
+
+	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "REQUEST_CHANGES")
+	t.Logf("submitted REQUEST_CHANGES review on %s PR #%d", env.RepoAlpha, prNum)
+
+	// Scenario 1: the gate must block — fabrik:awaiting-review appears, and
+	// the item must not advance past Review-Authoritative (stage:*:complete
+	// for whatever stage would come next is n/a here since Review-Authoritative
+	// has no configured successor; the durable, directly-observable signal is
+	// that the gate label is applied and fabrik:paused is not yet present).
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d — authoritative gate is blocking on CHANGES_REQUESTED", env.RepoAlpha, num)
+
+	// Scenario 5: wait out the review timeout and confirm the pause fires
+	// with the authoritative reason, not the generic "no reviews submitted
+	// yet" message — this is the distinguishing assertion for AC1 and AC5.
+	timeoutWait := time.Duration(reviewWaitTimeout+10) * time.Minute
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:paused", timeoutWait)
+	t.Logf("fabrik:paused appeared on %s#%d (authoritative review gate timed out)", env.RepoAlpha, num)
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 5*time.Minute)
+
+	if state := IssueState(t, env, env.RepoAlpha, num); state != "OPEN" {
+		t.Fatalf("expected issue OPEN after authoritative review timeout, got %s on %s#%d", state, env.RepoAlpha, num)
+	}
+
+	// WaitForPRCommentContaining queries the /issues/<n>/comments REST
+	// endpoint, which is identical for issue and PR numbers on GitHub — the
+	// pause comment is posted on the issue (postComment uses item.Number),
+	// not the PR, so passing the issue number here is correct.
+	WaitForPRCommentContaining(t, env, env.RepoAlpha, num, "requested changes", 5*time.Minute)
+	t.Logf("pause comment names the authoritative verdict (\"requested changes\") on %s#%d", env.RepoAlpha, num)
+
+	bodies, err := tryPRComments(env, env.RepoAlpha, num)
+	if err != nil {
+		t.Fatalf("read comments on %s#%d: %v", env.RepoAlpha, num, err)
+	}
+	for _, b := range bodies {
+		if strings.Contains(strings.ToLower(b), "no reviews submitted yet") {
+			t.Fatalf("pause comment on %s#%d used the generic \"no reviews submitted yet\" message "+
+				"instead of the authoritative verdict reason — authorityReason did not propagate: %q",
+				env.RepoAlpha, num, b)
+		}
+	}
+	t.Logf("R5 verified: pause reason reflects the CHANGES_REQUESTED verdict, not the generic message")
+}
+
+// TestReviewAuthorityClearsOnApproval covers scenario 2: authoritative +
+// APPROVED clears the gate. Descoped from "merges" to "gate clears" — see
+// the file-level doc comment on the landing-gate scope limitation.
+//
+// Wall-clock: ~2-5 min.
+func TestReviewAuthorityClearsOnApproval(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	requireAuthoritativeBed(t, env)
+
+	reviewerToken := readEnvFileReviewerToken(t, env)
+	if reviewerToken == "" {
+		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
+	}
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review-Authoritative", "clears-approval")
+
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
+			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
+	}
+
+	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "APPROVE")
+	t.Logf("submitted APPROVE review on %s PR #%d", env.RepoAlpha, prNum)
+
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	t.Logf("fabrik:awaiting-review cleared on %s#%d — authoritative gate cleared on APPROVED", env.RepoAlpha, num)
+
+	AssertLabelWasNeverApplied(t, env, env.RepoAlpha, num, "fabrik:paused")
+	t.Logf("R2 verified: %s#%d never paused; authoritative gate cleared on approval", env.RepoAlpha, num)
+}
+
+// TestReviewAuthorityYoloDoesNotBypassBlock covers scenario 3 — the core
+// composition guarantee from ADR-1250: fabrik:yolo does not bypass an
+// authoritative gate. The item stays blocked while CHANGES_REQUESTED stands,
+// and only clears once approved. Descoped from "merges under yolo" to "gate
+// clears" for the same reason as TestReviewAuthorityClearsOnApproval.
+//
+// Wall-clock: ~5-10 min.
+func TestReviewAuthorityYoloDoesNotBypassBlock(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+	requireAuthoritativeBed(t, env)
+
+	reviewerToken := readEnvFileReviewerToken(t, env)
+	if reviewerToken == "" {
+		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
+	}
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review-Authoritative", "yolo-no-bypass", "fabrik:yolo")
+
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
+			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
+	}
+
+	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "REQUEST_CHANGES")
+	t.Logf("submitted REQUEST_CHANGES review on %s PR #%d (fabrik:yolo present)", env.RepoAlpha, prNum)
+
+	// The gate must block even though yolo is set — a bounded withheld window
+	// is sufficient here (unlike the first test, we don't need to wait out
+	// the full timeout; we only need to confirm yolo doesn't short-circuit
+	// the block).
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	blockedDeadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(blockedDeadline) {
+		if state, err := tryIssueState(env, env.RepoAlpha, num); err == nil && state == "CLOSED" {
+			t.Fatalf("yolo bypassed the authoritative gate — %s#%d closed while CHANGES_REQUESTED still stood", env.RepoAlpha, num)
+		}
+		pollSleep(pollBase())
+	}
+	t.Logf("yolo did not bypass the block: %s#%d still OPEN with fabrik:awaiting-review after CHANGES_REQUESTED", env.RepoAlpha, num)
+
+	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "APPROVE")
+	t.Logf("submitted APPROVE review on %s PR #%d", env.RepoAlpha, prNum)
+
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	t.Logf("R3 verified: %s#%d — yolo composed correctly: blocked on CHANGES_REQUESTED, cleared on APPROVE", env.RepoAlpha, num)
+}
+
+// TestReviewAuthorityAdvisoryRegressionGuard covers scenario 4: the
+// regression guard proving the additive authoritative check inside
+// checkReviewGate does not leak into advisory (default) mode. Runs against
+// the existing "Review" column/stage (untouched default config), so it ships
+// green regardless of whether the Review-Authoritative bed prerequisite has
+// been set up yet — no requireAuthoritativeBed call.
+//
+// This test would fail today if the authoritative check were made
+// non-additive (e.g. if it replaced rather than extended the
+// len(outstanding)==0 && hasReviews condition): a CHANGES_REQUESTED review
+// on an advisory-mode stage must still clear the gate, exactly as it did
+// before ADR-1250.
+//
+// Wall-clock: ~2-5 min.
+func TestReviewAuthorityAdvisoryRegressionGuard(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	reviewerToken := readEnvFileReviewerToken(t, env)
+	if reviewerToken == "" {
+		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
+	}
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "advisory-regression")
+
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
+			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
+	}
+
+	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "REQUEST_CHANGES")
+	t.Logf("submitted REQUEST_CHANGES review on %s PR #%d (advisory Review stage)", env.RepoAlpha, prNum)
+
+	// Advisory mode: any submitted review (regardless of verdict) with no
+	// outstanding requested reviewers clears the gate — this is the
+	// pre-#1250 behavior and must be unchanged.
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	t.Logf("R4 verified: %s#%d — advisory gate cleared on CHANGES_REQUESTED (additive check did not narrow the default path)", env.RepoAlpha, num)
+}

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -14,31 +14,37 @@ import (
 // claude-review.yml bot — for every verdict assertion.
 //
 // Mechanism: all four scenarios seed a member PR directly via the GitHub API
-// (CreateMemberPR, zero Claude cost) and place the issue on a bed-local
-// "Review-Authoritative" column/stage — a copy of review.yaml with
-// review_authority: authoritative added. This exercises checkReviewGate (the
-// advance gate) and its shared pure predicate reviewGateAuthorityVerdict.
+// (CreateMemberPR, zero Claude cost) against the bed's existing Review
+// column/stage (default, advisory config — untouched). Authoritative mode is
+// applied per issue via the "review-authority:authoritative" label passed as
+// an extraLabel to seedReviewGateItem; engine support for that label is
+// #1261 (filed, decoupled from this issue — these scenarios cannot pass
+// until both #1261 and this issue are merged). This exercises checkReviewGate
+// (the advance gate) and its shared pure predicate reviewGateAuthorityVerdict
+// without introducing any bed-local board column or stage-YAML variant — an
+// earlier design that did so was rejected because review_authority is a
+// property of a stage's config, not a distinct kind of stage, and because a
+// bed prerequisite the operator hadn't yet set up would silently skip 3 of
+// the 4 scenarios, letting the suite go green having validated zero
+// authoritative behavior. See adrs/1258-e2e-review-authority-coverage.md.
+//
+// No bed setup is required beyond FABRIK_REVIEWER_TOKEN (see README) — none
+// of these scenarios skip for lack of bed prerequisites.
 //
 // Scope limitation (see adrs/1258-e2e-review-authority-coverage.md): the
 // landing/auto-merge gate (reviewGateBlocksLanding, called only from
 // attemptMergeOnValidate) is reachable ONLY through a stage literally named
 // "Validate" (engine/stages.go, engine/poll.go, engine/pr_terminal_advance.go
-// all hard-gate on stage.Name == "Validate"). Flipping the bed's real
-// Validate stage to authoritative would violate "no change to the bed's
-// default stage config" and risk corrupting concurrently-running advisory
-// scenarios on the shared bed. So scenarios 2/3 below assert the gate
-// *clears* (fabrik:awaiting-review disappears, fabrik:paused never applied),
-// not that the item merges — reviewGateBlocksLanding's wiring around the
-// same shared predicate is a documented, accepted e2e gap, not a silently
-// missing one.
+// all hard-gate on stage.Name == "Validate"). Applying the authority label to
+// an item sitting on Review cannot reach that stage-name-gated path, so
+// scenarios 2/3 below assert the gate *clears* (fabrik:awaiting-review
+// disappears, fabrik:paused never applied), not that the item merges —
+// reviewGateBlocksLanding's wiring around the same shared predicate is a
+// documented, accepted e2e gap, not a silently missing one.
 //
 // All four scenarios only touch checkReviewGate, which has no
 // FABRIK_MERGE_TRAIN branching — they pass identically under both legs of
 // the suite's two-mode gate.
-//
-// Prerequisites: see "Additional prerequisites for TestReviewAuthority*
-// scenarios" in tests/e2e/README.md (Review-Authoritative column + stage
-// YAML). requireAuthoritativeBed skips gracefully if not set up.
 
 // TestReviewAuthorityBlocksAndPausesOnChangesRequested covers scenarios 1 and
 // 5 from issue #1258: authoritative + CHANGES_REQUESTED blocks advancement,
@@ -48,13 +54,15 @@ import (
 // pauses via checkAwaitingReviewTimeout, with the authoritative pause reason
 // naming the verdict rather than the misleading "no reviews submitted yet".
 //
+// Requires #1261 (engine support for the review-authority:authoritative
+// label) to be merged.
+//
 // Wall-clock: ~FABRIK_REVIEW_WAIT_TIMEOUT + 10 min. Use a short bed value
 // (e.g. 2) for a fast iteration run — see README.
 func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
-	requireAuthoritativeBed(t, env)
 
 	reviewerToken := readEnvFileReviewerToken(t, env)
 	if reviewerToken == "" {
@@ -62,7 +70,7 @@ func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 	}
 	reviewWaitTimeout := readEnvFileReviewWaitTimeout(t, env)
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review-Authoritative", "blocks-pauses")
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "blocks-pauses", "review-authority:authoritative")
 
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
@@ -74,10 +82,9 @@ func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 	t.Logf("submitted REQUEST_CHANGES review on %s PR #%d", env.RepoAlpha, prNum)
 
 	// Scenario 1: the gate must block — fabrik:awaiting-review appears, and
-	// the item must not advance past Review-Authoritative (stage:*:complete
-	// for whatever stage would come next is n/a here since Review-Authoritative
-	// has no configured successor; the durable, directly-observable signal is
-	// that the gate label is applied and fabrik:paused is not yet present).
+	// the item must not advance past Review (the durable, directly-observable
+	// signal is that the gate label is applied and fabrik:paused is not yet
+	// present).
 	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
 	t.Logf("fabrik:awaiting-review confirmed on %s#%d — authoritative gate is blocking on CHANGES_REQUESTED", env.RepoAlpha, num)
 
@@ -118,19 +125,21 @@ func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 // APPROVED clears the gate. Descoped from "merges" to "gate clears" — see
 // the file-level doc comment on the landing-gate scope limitation.
 //
+// Requires #1261 (engine support for the review-authority:authoritative
+// label) to be merged.
+//
 // Wall-clock: ~2-5 min.
 func TestReviewAuthorityClearsOnApproval(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
-	requireAuthoritativeBed(t, env)
 
 	reviewerToken := readEnvFileReviewerToken(t, env)
 	if reviewerToken == "" {
 		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
 	}
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review-Authoritative", "clears-approval")
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "clears-approval", "review-authority:authoritative")
 
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
@@ -154,19 +163,21 @@ func TestReviewAuthorityClearsOnApproval(t *testing.T) {
 // and only clears once approved. Descoped from "merges under yolo" to "gate
 // clears" for the same reason as TestReviewAuthorityClearsOnApproval.
 //
+// Requires #1261 (engine support for the review-authority:authoritative
+// label) to be merged.
+//
 // Wall-clock: ~5-10 min.
 func TestReviewAuthorityYoloDoesNotBypassBlock(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
-	requireAuthoritativeBed(t, env)
 
 	reviewerToken := readEnvFileReviewerToken(t, env)
 	if reviewerToken == "" {
 		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
 	}
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review-Authoritative", "yolo-no-bypass", "fabrik:yolo")
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "yolo-no-bypass", "review-authority:authoritative", "fabrik:yolo")
 
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
@@ -201,9 +212,8 @@ func TestReviewAuthorityYoloDoesNotBypassBlock(t *testing.T) {
 // TestReviewAuthorityAdvisoryRegressionGuard covers scenario 4: the
 // regression guard proving the additive authoritative check inside
 // checkReviewGate does not leak into advisory (default) mode. Runs against
-// the existing "Review" column/stage (untouched default config), so it ships
-// green regardless of whether the Review-Authoritative bed prerequisite has
-// been set up yet — no requireAuthoritativeBed call.
+// the existing "Review" column/stage with no authority label at all
+// (untouched default config), so it ships green independent of #1261.
 //
 // This test would fail today if the authoritative check were made
 // non-additive (e.g. if it replaced rather than extended the


### PR DESCRIPTION
Closes #1258

> [!IMPORTANT]
> **Status update (post-review rework):** the mechanism described below (a bed-local `Review-Authoritative` board column + stage-YAML variant) was **rejected during Validate-stage review** and replaced with a per-issue label, `review-authority:authoritative`, applied at seed time (see the "Approach"/"Key Decisions" sections below being superseded, and `adrs/1258-e2e-review-authority-coverage.md`'s "Revision" section for the full rationale). No bed column or stage-YAML setup is required for this PR.
>
> **Hard dependency on #1261 (unmerged):** engine support for reading the `review-authority:authoritative` label does not exist yet — `engine/reviews.go` only reads `stage.ReviewAuthority` from stage config today. Of the four new scenarios, only `TestReviewAuthorityAdvisoryRegressionGuard` is independent and passes today. The other three (`TestReviewAuthorityBlocksAndPausesOnChangesRequested`, `TestReviewAuthorityClearsOnApproval`, `TestReviewAuthorityYoloDoesNotBypassBlock`) **will fail** if run against the live bed until #1261 merges — this is expected, by design (the two issues are deliberately decoupled), not a defect in this PR. This PR alone does not close out working authoritative-mode e2e coverage; #1261 must land too.
>
> This is test-infrastructure-only — no production code (`engine/reviews.go` or otherwise) is touched, and these e2e scenarios are not run by this repo's CI (only compiled/vetted via `ci/compile-e2e-suite`), so the above does not block CI or this PR's mergeability.


## Summary

Add e2e scenarios that drive Fabrik's `review_authority: authoritative` gate end-to-end using deterministic, harness-posted review verdicts (`SubmitPRReview` + `FABRIK_REVIEWER_TOKEN`) — never relying on the bed's COMMENT-only bot reviewer for verdict assertions, and without switching the bed to a real reviewer bot (pruefer) or changing the bed's default stage config.

## Problem

#1250 shipped `review_authority: advisory | authoritative` (ADR-1250) — the engine now can honor a review **verdict** (no outstanding `CHANGES_REQUESTED`, required approvals met) at both the advance gate (`checkReviewGate`) and the landing gate (`reviewGateBlocksLanding`). It shipped with **zero e2e coverage**: `grep -riE "review_authority|authoritative|CHANGES_REQUESTED" tests/e2e/*.go` matches nothing but a doc comment.

Worse, the coverage gap is **structural** with the current test-bed reviewer. `handarbeit/fabrik-test-alpha` / `-beta` are reviewed by `.github/workflows/claude-review.yml`, which submits `gh pr review --comment` in both its agent path and its fallback path — **COMMENT only**. It can never produce `APPROVE` or `CHANGES_REQUESTED`, so authoritative mode's blocking path and its clearing path are both untestable with the bed as configured. The bed's `review.yaml` / `validate.yaml` set `wait_for_reviews: true` with no `review_authority`, i.e. advisory — so today's suite exercises the default path only.

This matters beyond the new feature: #1250 modified the **shared** clear-predicate code both modes run through, so authoritative bugs and advisory regressions both live in code the suite currently can't fully reach.

## Approach

### Approach

The core design question is *where* to apply `review_authority: authoritative` without touching production code or the bed's default stage config. I traced the two gate call sites in `engine/reviews.go` down to their callers and found a constraint Research flagged as an open question but didn't fully resolve:

- `checkReviewGate` (the **advance** gate) is invoked generically by `handleReviewGate` (`engine/catch_up_handlers.go:64`) for *any* stage carrying `stage:<Name>:complete`, keyed purely off that stage's config. It is stage-name-agnostic.
- `reviewGateBlocksLanding` (the **landing/auto-merge** gate) is only ever called from `attemptMergeOnValidate`, and *both* of that function's callers hard-gate on the literal string `"Validate"` before invoking it: `engine/stages.go:132` (`if yoloActive && stage.Name == "Validate" && !waitForCI`) and `engine/poll.go:1054` (`if stage.Name == "Validate"`). A third site, `engine/pr_terminal_advance.go:33`, gates Done-advancement the same way (`stage.Name != "Validate"`).

That means the landing/auto-merge/Done-advance path is reachable **only** through a stage literally named `Validate` — no differently-named variant column can exercise it, and flipping the bed's real `Validate` stage to authoritative (even temporarily) would violate "no change to the bed's default stage config" and risk corrupting concurrently-running advisory scenarios on the shared bed (the exact risk the issue calls out). Changing that hardcoding is explicitly out of scope ("no change to `engine/reviews.go` or other production engine code").

**Decision: build the mechanism around `checkReviewGate` only, via a new bed-local stage variant + column named `Review-Authoritative`, and explicitly descope the merge-specific assertions in scenarios 2/3.** `reviewGateAuthorityVerdict` — the pure predicate both gates share — is fully exercised this way; `reviewGateBlocksLanding`'s wiring around it is architecturally unreachable in e2e without either a production code change or a rule violation, so it stays a documented, accepted gap rather than a silently missing one.

Construction cost stays low by reusing the merge-train helpers' precedent (`CreateMemberPR` — a direct-API PR builder, no Claude cost) plus the R5 precedent from `TestPausedMergedPRRecovery` (label-seeding `stage:X:complete` directly so the catch-up loop evaluates the gate without ever invoking Claude for that stage). No new pipeline runs are needed for any of the four new scenarios.

A second finding worth noting: `checkReviewGate`'s outer clearing condition (`len(outstanding) == 0 && hasReviews`) is satisfied by *any* submitted review, whether or not a formal review request preceded it — outstanding reviewers come only from `reviewRequests`, not from who submitted. So `RequestPRReviewer`/`TokenLogin` aren't needed at all here; a bare `SubmitPRReview` is sufficient. This also means these scenarios never touch `FABRIK_MERGE_TRAIN`-sensitive code, so they run identically in both legs of the two-mode gate with no branching logic.

Scenario 5 ("verdict that never clears → pause, no infinite spin") does not naturally reach `MaxReviewCycles`: `dispatchReviewReinvoke` only fires *after* the gate has already cleared (it addresses lingering inline comments on an otherwise-satisfied review), never while `CHANGES_REQUESTED` is blocking. A persistent `CHANGES_REQUESTED` verdict resolves exclusively via `checkAwaitingReviewTimeout` → `pauseForReviewTimeout` — the same path scenario 1 exercises. Per Research's option (b), I'm folding scenario 5 into scenario 1's test as a longer-running continuation (assert the block immediately, then wait out `FABRIK_REVIEW_WAIT_TIMEOUT` and assert the pause fires with the correct reason) rather than building new cycle-limit infrastructure for a path authoritative mode can't reach.

Scenario 6 (verdict-fetch failure / unrecognized `reviewDecision`) is excluded: `FetchPRReviewDecision` only returns a non-empty value when the repo has a branch-protection review requirement configured, which neither bed repo has (only required *status checks* are documented as configured). Producing `REVIEW_REQUIRED` or an unrecognized value would require new branch-protection bed setup — not "cheaply expressible" per the issue's own bar for this scenario.

### New/Modified Files

| File | Change |
|------|--------|
| `tests/e2e/review_authority_helpers.go` | New. `requireAuthoritativeBed` (skip guard mirroring `requireTrainBed`) and `seedReviewGateItem` (thin wrapper: `FileIssue` → `AddIssueToProject` → `CreateMemberPR` (reused as-is) → `AddLabel("stage:<column>:complete")` → `SetIssueStatus`). |
| `tests/e2e/review_authority_test.go` | New. Four `t.Parallel()` scenarios covering AC 1–5 (see below). |
| `tests/e2e/README.md` | New "Additional prerequisites for `TestReviewAuthority*`" section, new Scenarios table rows, new Regression coverage map rows, explicit scope-limitation note. |
| `adrs/1258-e2e-review-authority-coverage.md` | New ADR (see below). |

No changes to `docs/USER_GUIDE.md`, `docs/state-machine.md`, or `docs/llms-full.txt` — Research already confirmed these correctly describe the shipped (unmodified) behavior; this issue adds test coverage only.

### Key Decisions

- **Mechanism: `Review-Authoritative` bed-local stage + column, not `Validate-Authoritative`.** A copy of `stages/examples/review.yaml` with `review_authority: authoritative` added, `order: 41` (deliberately far outside the real pipeline's 1–9 range so it's never any real stage's natural successor), saved bed-locally as `review-authoritative.yaml`, plus a matching `Review-Authoritative` column on `handarbeit/projects/2`. One-time operator setup, exactly mirroring the existing `Queued`/`queued.yaml` precedent (README items #14-15). Scenarios needing it skip gracefully via `requireAuthoritativeBed` if the column is absent, so this PR is safe to merge before the bed is updated.
- **Scenario 2/3 are descoped from "merges under yolo" to "gate clears / stays blocked."** Justified above by the `stage.Name == "Validate"` hardcoding at three production call sites. This is called out explicitly in the README and the new ADR so a future reader doesn't assume more coverage than exists.
- **Scenario 5 folds into scenario 1's test** (same `ReviewWaitTimeout` pause path), rather than building new `MaxReviewCycles` test infrastructure that authoritative mode structurally can't reach.
- **Scenario 6 is excluded**, with a one-line README note explaining why (no branch-protection review requirement on either bed repo, and adding one is not "cheaply expressible").
- **No `RequestPRReviewer` call needed** — `SubmitPRReview` alone satisfies `checkReviewGate`'s outer clearing condition, simplifying every new scenario relative to `TestConjunctiveCIReviewGate`'s pattern.
- **Regression guard (scenario 4) needs no bed prerequisite** — it runs against the existing `Review` column/stage (default config, untouched), so it ships green immediately regardless of whether the operator has added `Review-Authoritative` yet.
- **Direct-API construction (`CreateMemberPR` reuse) + label-seeded completion, zero Claude cost** for all four scenarios — consistent with the R5 precedent and appropriate here since these scenarios validate gate/settle logic, not the natural stage-completion flow (documented explicitly in the README, per Research's suggested note).

### ADR

Warranted: this documents a non-obvious production constraint (stage-name hardcoding blocking a category of e2e coverage) that will otherwise get rediscovered — or missed — by the next person trying to extend authoritative-mode test coverage, plus a reusable mechanism precedent (bed-local stage variant + column) alongside `Queued`/`queued.yaml`.

- [ ] Create ADR `adrs/1258-e2e-review-authority-coverage.md` (`# ADR 1258: ...`) documenting: the `Review-Authoritative` bed-variant mechanism; the discovered `stage.Name == "Validate"` hardcoding at `engine/stages.go:132`, `engine/poll.go:1054`, `engine/pr_terminal_advance.go:33` and its consequence (landing-gate/auto-merge authoritative coverage is architecturally out of reach for e2e without a production code change); the scenario 1+5 folding rationale; the scenario 6 exclusion rationale.

### Task Checklist

- [ ] Add `tests/e2e/review_authority_helpers.go` (build tag `e2e`): `requireAuthoritativeBed(t, env)` (skip if `Review-Authoritative` is not a Status option, via `fetchStatusField` — mirror `requireTrainBed`'s retry-on-transient-error behavior) and `seedReviewGateItem(t, env, repo, baseBranch, column, marker string) (issueNum, prNum int, itemID string)` (file issue, add to project, build PR via `CreateMemberPR` on `fabrik/issue-<N>`, seed `stage:<column>:complete`, place at `column` via `SetIssueStatus`).
- [ ] Add `TestReviewAuthorityBlocksAndPausesOnChangesRequested` in `tests/e2e/review_authority_test.go`: `requireAuthoritativeBed`; seed on `Review-Authoritative`; preflight `AssertPRAuthorIsExpectedIdentity`; `SubmitPRReview(..., "REQUEST_CHANGES")` using `readEnvFileReviewerToken` (skip if empty, mirroring the conjunctive-gate test's handling); assert `fabrik:awaiting-review` applied; wait `readEnvFileReviewWaitTimeout(t, env)+5` minutes; assert `fabrik:paused` + `fabrik:awaiting-input` applied and `WaitForIssueComment` contains the authoritative reason (verify it names `"requested changes"` and does **not** contain the generic `"no reviews submitted yet"` string — covers both AC 1 and AC 5).
- [ ] Add `TestReviewAuthorityClearsOnApproval`: same setup, `SubmitPRReview(..., "APPROVE")`; assert `WaitForLabelAbsent("fabrik:awaiting-review")` and `AssertLabelWasNeverApplied("fabrik:paused")` (AC 2, descoped per the Key Decisions note above).
- [ ] Add `TestReviewAuthorityYoloDoesNotBypassBlock`: seed with `fabrik:yolo` label at file time; `SubmitPRReview(..., "REQUEST_CHANGES")`; assert block persists (same as the first test, shorter bounded wait is fine — no need to wait out the full pause here); then `SubmitPRReview(..., "APPROVE")`; assert `WaitForLabelAbsent("fabrik:awaiting-review")` (AC 3 — composition guarantee, descoped from "merges" to "gate clears").
- [ ] Add `TestReviewAuthorityAdvisoryRegressionGuard`: seed on the existing `Review` column (no `requireAuthoritativeBed` — always runs); `SubmitPRReview(..., "REQUEST_CHANGES")`; assert `WaitForLabelAbsent("fabrik:awaiting-review")` (AC 4 — proves the additive authoritative check doesn't leak into advisory mode; this test fails today if the additive check were made non-additive, satisfying the acceptance criterion literally).
- [ ] `go build -tags e2e ./tests/e2e/...` and `go vet -tags e2e ./...` clean (mirrors the `docs-drift`-style `ci/compile-e2e-suite` job added in the immediately-preceding merged PR #1259).
- [ ] Update `tests/e2e/README.md`: new "Additional prerequisites for `TestReviewAuthority*` scenarios" section (stage-variant YAML content, column setup, cross-reference to the existing `FABRIK_REVIEWER_TOKEN` documentation rather than duplicating it, explicit note on why `claude-review.yml` stays COMMENT-only and isn't used for verdict assertions here); new Scenarios table rows (Mode: Both, since these never touch merge-train code); new Regression coverage map rows referencing ADR-1250/#1250/#1258; explicit note on the landing-gate scope limitation and scenario 6 exclusion, both with rationale.
- [ ] Create ADR per above.

### Risks

- **Bed setup is external and blocking for 3 of 4 scenarios.** `requireAuthoritativeBed` makes this a clean skip, not a failure, so the PR is mergeable independent of operator timing — consistent with how the merge-train scenarios shipped.
- **`FABRIK_REVIEW_WAIT_TIMEOUT` sizing.** The first test's wall-clock is directly proportional to this bed setting (shared with `TestConjunctiveCIReviewGate`); document the same "use a short value for a fast iteration run" guidance already established for that test rather than introducing a second knob.
- **Descoped merge-path assertions may read as incomplete coverage** to a future reader who only skims the issue's scenario list. Mitigated by making the descope and its architectural cause explicit in both the README and the ADR, not just in this plan.
- **`CreateMemberPR`'s cleanup (`t.Cleanup` deleting the branch) is per-test** — confirm no collision between the four new scenarios' branch names (each uses a fresh issue number via `FileIssue`, so `fabrik/issue-<N>` is unique per scenario; no action needed, just confirmed during implementation).

---
Used 29/100 turns, 7k input / 38k output tokens.

## Verification

Added e2e coverage for `review_authority: authoritative` (ADR-1250): `tests/e2e/review_authority_helpers.go` and `review_authority_test.go` cover scenarios 1–5 (block/pause on CHANGES_REQUESTED, clear on APPROVE, yolo doesn't bypass, advisory regression guard, timeout pause with correct reason) via deterministic `SubmitPRReview` verdicts against a new bed-local `Review-Authoritative` column/stage — no production code or bed default config changed. Updated `tests/e2e/README.md` and added `adrs/1258-e2e-review-authority-coverage.md` documenting the mechanism and the scope limitation (landing-gate coverage is architecturally unreachable without a `Validate`-named stage). Build, vet, and `-tags e2e` build/vet all pass; branch is clean and pushed.

---

Closes #1258
