### PR TITLE
fix(spawn): require FABRIK_SPAWN_CHILD markers to stand on their own line

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4699,6 +4699,8 @@ FABRIK_SPAWN_CHILD_END
 
 These blocks persist in the Plan stage comment — they are data, not consumed-and-stripped signals. The `preImplement` engine step reads them from the most-recent Plan comment body at Implement dispatch time.
 
+**Own-line requirement (enforced by `ParseSpawnBlocks`):** Both markers must stand on their own line, the same convention `FABRIK_STAGE_COMPLETE` follows. On the BEGIN line the target repo must be the only trailing token and a well-formed `owner/repo`; the END line must carry nothing else. Leading whitespace is tolerated, so a block nested under a list item still parses — trailing prose after the repo is not. A marker occurring inside prose (for example a backticked mention in the Plan's own task checklist) is therefore ignored, and cannot consume, truncate, or suppress a genuine block later in the same comment. Until this was enforced, such a mention silently destroyed the real block and the spawn simply did not happen (#1263). When a BEGIN-looking line is present but no well-formed block parses, `preImplement` now logs that fact rather than returning the same silent "nothing to spawn" result as a Plan that declared no children.
+
 **Code path:** `processItem()` → Implement stage dispatch → `preImplement()` (in `engine/spawn.go`)
 
 **Idempotency guard:** If the parent issue has `fabrik:children-spawned`, `preImplement` returns immediately (no-op). Manual removal of this label (and closing of orphaned children) is required to trigger a fresh spawn. This guard runs before the recovery path below and must remain first — recovery must never bypass it, or repeated deferred-retry cycles risk double-spawning.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -1725,6 +1725,8 @@ FABRIK_SPAWN_CHILD_END
 
 These blocks persist in the Plan stage comment — they are data, not consumed-and-stripped signals. The `preImplement` engine step reads them from the most-recent Plan comment body at Implement dispatch time.
 
+**Own-line requirement (enforced by `ParseSpawnBlocks`):** Both markers must stand on their own line, the same convention `FABRIK_STAGE_COMPLETE` follows. On the BEGIN line the target repo must be the only trailing token and a well-formed `owner/repo`; the END line must carry nothing else. Leading whitespace is tolerated, so a block nested under a list item still parses — trailing prose after the repo is not. A marker occurring inside prose (for example a backticked mention in the Plan's own task checklist) is therefore ignored, and cannot consume, truncate, or suppress a genuine block later in the same comment. Until this was enforced, such a mention silently destroyed the real block and the spawn simply did not happen (#1263). When a BEGIN-looking line is present but no well-formed block parses, `preImplement` now logs that fact rather than returning the same silent "nothing to spawn" result as a Plan that declared no children.
+
 **Code path:** `processItem()` → Implement stage dispatch → `preImplement()` (in `engine/spawn.go`)
 
 **Idempotency guard:** If the parent issue has `fabrik:children-spawned`, `preImplement` returns immediately (no-op). Manual removal of this label (and closing of orphaned children) is required to trigger a fresh spawn. This guard runs before the recovery path below and must remain first — recovery must never bypass it, or repeated deferred-retry cycles risk double-spawning.

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -64,7 +64,17 @@ func spawnBeginRepo(line string) string {
 	if !strings.HasPrefix(trimmed, spawnBeginMarker) {
 		return ""
 	}
-	fields := strings.Fields(strings.TrimPrefix(trimmed, spawnBeginMarker))
+	rest := strings.TrimPrefix(trimmed, spawnBeginMarker)
+
+	// The marker must be a whole word. Without this, a repo glued directly to
+	// it — "FABRIK_SPAWN_CHILD_BEGINowner/repo" — satisfies HasPrefix, survives
+	// TrimPrefix as a lone repo-shaped field, and is accepted as a genuine
+	// marker line: the same boundary confusion this function exists to reject.
+	if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
+		return ""
+	}
+
+	fields := strings.Fields(rest)
 	if len(fields) != 1 || !spawnRepoRE.MatchString(fields[0]) {
 		return ""
 	}

--- a/engine/spawn.go
+++ b/engine/spawn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -11,6 +12,19 @@ import (
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
+
+const (
+	spawnBeginMarker = "FABRIK_SPAWN_CHILD_BEGIN"
+	spawnEndMarker   = "FABRIK_SPAWN_CHILD_END"
+)
+
+// spawnRepoRE matches a well-formed "owner/repo" spawn target.
+//
+// Deliberately stricter than the "contains a slash" check it replaces (#1263):
+// a Plan that mentions the marker inside markdown prose produces a token like
+// "handarbeit/fabrik-test-beta`" — trailing backtick included — which contains
+// a slash and so used to be accepted as a real spawn target.
+var spawnRepoRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 // errPreImplementDeferred signals that preImplement could not conclusively
 // resolve the stage:Plan:complete-but-no-Plan-comment inconsistency (#982) on
@@ -27,71 +41,100 @@ type SpawnBlock struct {
 	Body  string
 }
 
+// spawnBeginRepo returns the target repo declared by line when line is a
+// genuine FABRIK_SPAWN_CHILD_BEGIN marker line, or "" when it is not one.
+//
+// A marker line must consist of nothing but the marker and a well-formed
+// owner/repo. That strictness is the fix for #1263: before it, the marker was
+// located with a bare strings.Index anywhere in the body, so a Plan that
+// mentioned the marker in prose — e.g. a markdown checklist item
+//
+//	- [ ] Emit `FABRIK_SPAWN_CHILD_BEGIN owner/repo` block scoping the child work
+//
+// — was treated as a real block opener. The parser then ran forward to the
+// *real* END marker, swallowed the authentic block as that phantom block's
+// content, failed the TITLE: check, and discarded it. The genuine spawn was
+// destroyed by the sentence describing it, and preImplement reported "nothing
+// to spawn" with no error.
+//
+// Leading whitespace is tolerated so a block nested in a list still parses;
+// trailing content after the repo is not, since that is the shape prose takes.
+func spawnBeginRepo(line string) string {
+	trimmed := strings.TrimSpace(strings.TrimRight(line, "\r"))
+	if !strings.HasPrefix(trimmed, spawnBeginMarker) {
+		return ""
+	}
+	fields := strings.Fields(strings.TrimPrefix(trimmed, spawnBeginMarker))
+	if len(fields) != 1 || !spawnRepoRE.MatchString(fields[0]) {
+		return ""
+	}
+	return fields[0]
+}
+
+// isSpawnEndLine reports whether line is a standalone END marker, applying the
+// same own-line rule as spawnBeginRepo so a prose mention of the END marker
+// cannot truncate a real block early.
+func isSpawnEndLine(line string) bool {
+	return strings.TrimSpace(strings.TrimRight(line, "\r")) == spawnEndMarker
+}
+
+// logUnparsedSpawnMarkers reports the case where a Plan comment contains the
+// BEGIN marker text but no well-formed block parsed out of it. Both that case
+// and "the Plan declared no children" return (false, nil) from preImplement,
+// and before #1263 they were indistinguishable in the logs too — so a spawn
+// that silently failed to happen looked exactly like a spawn that was never
+// requested. Called from both the direct and the recovery path.
+func (e *Engine) logUnparsedSpawnMarkers(number int, planBody string) {
+	if !strings.Contains(planBody, spawnBeginMarker) {
+		return
+	}
+	e.logf(number, "spawn", "pre-Implement: Plan comment mentions %s but no well-formed block parsed — "+
+		"each marker must stand on its own line, as %q ... %q; not spawning children\n",
+		spawnBeginMarker, spawnBeginMarker+" owner/repo", spawnEndMarker)
+}
+
 // ParseSpawnBlocks scans body for all FABRIK_SPAWN_CHILD_BEGIN/END pairs and
 // returns the parsed spawn blocks in order. Malformed or incomplete pairs are
-// silently skipped. The BEGIN marker must be followed by the target repo on
-// the same line: "FABRIK_SPAWN_CHILD_BEGIN owner/repo". The first non-empty
-// line after BEGIN is the TITLE: line; the body starts after the blank line
-// following the title.
+// skipped.
+//
+// Both markers must stand on their own line — the same convention
+// FABRIK_STAGE_COMPLETE follows (stageCompleteRE in engine/claude.go) and that
+// CLAUDE.md states for markers generally. The BEGIN line carries the target
+// repo: "FABRIK_SPAWN_CHILD_BEGIN owner/repo". The first non-empty line inside
+// the block is the TITLE: line; the body is everything after it.
 func ParseSpawnBlocks(body string) []SpawnBlock {
-	const beginPrefix = "FABRIK_SPAWN_CHILD_BEGIN"
-	const endMarker = "FABRIK_SPAWN_CHILD_END"
-
 	var blocks []SpawnBlock
-	remaining := body
-	for {
-		beginIdx := strings.Index(remaining, beginPrefix)
-		if beginIdx == -1 {
-			break
-		}
+	lines := strings.Split(body, "\n")
 
-		// Extract the rest of the BEGIN line to get the repo argument.
-		lineEnd := strings.IndexByte(remaining[beginIdx:], '\n')
-		var beginLine, afterBegin string
-		if lineEnd == -1 {
-			beginLine = remaining[beginIdx:]
-			afterBegin = ""
-		} else {
-			beginLine = remaining[beginIdx : beginIdx+lineEnd]
-			afterBegin = remaining[beginIdx+lineEnd+1:]
-		}
-
-		// BEGIN line must be exactly "FABRIK_SPAWN_CHILD_BEGIN owner/repo".
-		// Strip trailing \r if present (CRLF files).
-		beginLine = strings.TrimRight(beginLine, "\r")
-		repo := ""
-		if parts := strings.Fields(strings.TrimPrefix(beginLine, beginPrefix)); len(parts) > 0 {
-			repo = parts[0]
-		}
-
-		if repo == "" || !strings.Contains(repo, "/") {
-			// Malformed — advance past this BEGIN and keep scanning.
-			remaining = remaining[beginIdx+len(beginPrefix):]
+	for i := 0; i < len(lines); i++ {
+		repo := spawnBeginRepo(lines[i])
+		if repo == "" {
 			continue
 		}
 
-		endIdx := strings.Index(afterBegin, endMarker)
-		if endIdx == -1 {
-			// No matching END — stop scanning.
+		end := -1
+		for j := i + 1; j < len(lines); j++ {
+			if isSpawnEndLine(lines[j]) {
+				end = j
+				break
+			}
+		}
+		if end == -1 {
+			// No matching END — nothing further can be well-formed.
 			break
 		}
 
-		blockContent := afterBegin[:endIdx]
-
-		// Advance remaining past this full block.
-		remaining = afterBegin[endIdx+len(endMarker):]
-
-		// Parse TITLE: from the first non-empty line.
-		title, blockBody := parseTitleAndBody(blockContent)
-		if title == "" {
-			continue // malformed block
+		if title, blockBody := parseTitleAndBody(strings.Join(lines[i+1:end], "\n")); title != "" {
+			blocks = append(blocks, SpawnBlock{
+				Repo:  repo,
+				Title: title,
+				Body:  blockBody,
+			})
 		}
 
-		blocks = append(blocks, SpawnBlock{
-			Repo:  repo,
-			Title: title,
-			Body:  blockBody,
-		})
+		// Resume after this block's END whether or not it was well-formed, so a
+		// malformed block cannot re-open scanning inside its own content.
+		i = end
 	}
 	return blocks
 }
@@ -207,6 +250,7 @@ func (e *Engine) preImplement(ctx context.Context, board *gh.ProjectBoard, item 
 
 	blocks := ParseSpawnBlocks(planComment.Body)
 	if len(blocks) == 0 {
+		e.logUnparsedSpawnMarkers(item.Number, planComment.Body)
 		return false, nil
 	}
 
@@ -259,6 +303,7 @@ func (e *Engine) recoverMissingPlanComment(ctx context.Context, board *gh.Projec
 	blocks := ParseSpawnBlocks(planComment.Body)
 	if len(blocks) == 0 {
 		e.logf(item.Number, "spawn", "pre-Implement: live re-read recovered Plan comment with no spawn blocks — nothing to spawn\n")
+		e.logUnparsedSpawnMarkers(item.Number, planComment.Body)
 		return false, nil
 	}
 

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -1026,3 +1026,115 @@ FABRIK_SPAWN_CHILD_END
 		}
 	}
 }
+
+// ---- #1263 regression: prose mentions must not destroy real blocks ----
+
+// TestParseSpawnBlocks_ProseMentionDoesNotConsumeRealBlock reproduces the
+// production failure from e2e TestCrossRepoSpawn (parent fabrik-test-alpha#3796).
+// The Plan both described the marker in a markdown checklist AND emitted a real
+// block. The backticked mention carried a slash-containing token
+// ("handarbeit/fabrik-test-beta`"), so the pre-fix "contains a slash" check
+// accepted it as a block opener; the parser then ran to the real END, consumed
+// the authentic block as the phantom's content, failed the TITLE: check, and
+// dropped it — yielding zero blocks and a silent no-op spawn.
+func TestParseSpawnBlocks_ProseMentionDoesNotConsumeRealBlock(t *testing.T) {
+	body := "## Approach\n" +
+		"\n" +
+		"1. Plan (this stage) emits a `FABRIK_SPAWN_CHILD_BEGIN` block scoped to the beta-side work.\n" +
+		"\n" +
+		"### Task checklist\n" +
+		"\n" +
+		"- [ ] Emit `FABRIK_SPAWN_CHILD_BEGIN handarbeit/fabrik-test-beta` block (this stage) scoping the function + test\n" +
+		"\n" +
+		"FABRIK_SPAWN_CHILD_BEGIN handarbeit/fabrik-test-beta\n" +
+		"TITLE: Add HelloIssue3796() greeting function\n" +
+		"\n" +
+		"## Problem\n" +
+		"\n" +
+		"Beta-side half of the cross-repo spawn regression test.\n" +
+		"FABRIK_SPAWN_CHILD_END\n"
+
+	blocks := ParseSpawnBlocks(body)
+	if len(blocks) != 1 {
+		t.Fatalf("expected exactly 1 block (the real one), got %d — a prose mention consumed it", len(blocks))
+	}
+	b := blocks[0]
+	if b.Repo != "handarbeit/fabrik-test-beta" {
+		t.Errorf("repo: got %q, want %q", b.Repo, "handarbeit/fabrik-test-beta")
+	}
+	if b.Title != "Add HelloIssue3796() greeting function" {
+		t.Errorf("title: got %q, want %q", b.Title, "Add HelloIssue3796() greeting function")
+	}
+	if !strings.Contains(b.Body, "Beta-side half") {
+		t.Errorf("body should carry the real block's content, got: %q", b.Body)
+	}
+}
+
+// TestParseSpawnBlocks_ProseMentionAtLineStartRejected covers the variant the
+// leading-whitespace tolerance could otherwise let through: the marker opens
+// the line, but trailing prose follows the repo token. Real blocks carry the
+// repo and nothing else.
+func TestParseSpawnBlocks_ProseMentionAtLineStartRejected(t *testing.T) {
+	body := `
+FABRIK_SPAWN_CHILD_BEGIN owner/repo is the marker you emit to spawn a child.
+TITLE: Not a real block
+FABRIK_SPAWN_CHILD_END
+`
+	if blocks := ParseSpawnBlocks(body); len(blocks) != 0 {
+		t.Fatalf("expected 0 blocks for a prose line with trailing text, got %d", len(blocks))
+	}
+}
+
+// TestParseSpawnBlocks_BacktickedRepoRejected pins the specific token shape that
+// defeated the old "contains a slash" validation.
+func TestParseSpawnBlocks_BacktickedRepoRejected(t *testing.T) {
+	body := "FABRIK_SPAWN_CHILD_BEGIN handarbeit/fabrik-test-beta`\nTITLE: Phantom\nFABRIK_SPAWN_CHILD_END\n"
+	if blocks := ParseSpawnBlocks(body); len(blocks) != 0 {
+		t.Fatalf("expected 0 blocks for a backtick-suffixed repo, got %d", len(blocks))
+	}
+}
+
+// TestParseSpawnBlocks_IndentedBlockParses documents the deliberate tolerance:
+// a real block nested under a list item still parses. Only trailing content
+// after the repo disqualifies a line, not leading whitespace.
+func TestParseSpawnBlocks_IndentedBlockParses(t *testing.T) {
+	body := `
+  FABRIK_SPAWN_CHILD_BEGIN owner/child
+  TITLE: Indented but genuine
+  Body text here.
+  FABRIK_SPAWN_CHILD_END
+`
+	blocks := ParseSpawnBlocks(body)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Repo != "owner/child" {
+		t.Errorf("repo: got %q, want %q", blocks[0].Repo, "owner/child")
+	}
+	if blocks[0].Title != "Indented but genuine" {
+		t.Errorf("title: got %q, want %q", blocks[0].Title, "Indented but genuine")
+	}
+}
+
+// TestParseSpawnBlocks_MalformedBlockDoesNotSwallowNext ensures a block that
+// fails the TITLE: check does not re-open scanning inside its own content and
+// consume the following well-formed block.
+func TestParseSpawnBlocks_MalformedBlockDoesNotSwallowNext(t *testing.T) {
+	body := `
+FABRIK_SPAWN_CHILD_BEGIN owner/first
+no title line here, so this block is malformed
+FABRIK_SPAWN_CHILD_END
+
+FABRIK_SPAWN_CHILD_BEGIN owner/second
+TITLE: Second child
+Second body.
+FABRIK_SPAWN_CHILD_END
+`
+	blocks := ParseSpawnBlocks(body)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block (the well-formed second), got %d", len(blocks))
+	}
+	if blocks[0].Repo != "owner/second" {
+		t.Errorf("repo: got %q, want %q", blocks[0].Repo, "owner/second")
+	}
+}

--- a/engine/spawn_test.go
+++ b/engine/spawn_test.go
@@ -1138,3 +1138,25 @@ FABRIK_SPAWN_CHILD_END
 		t.Errorf("repo: got %q, want %q", blocks[0].Repo, "owner/second")
 	}
 }
+
+// TestParseSpawnBlocks_MarkerRequiresWordBoundary pins the separator between the
+// marker and its repo argument. Without it, "FABRIK_SPAWN_CHILD_BEGINowner/repo"
+// satisfies HasPrefix and survives TrimPrefix as a lone repo-shaped field — the
+// same boundary confusion the own-line rule exists to reject. Raised in review
+// of #1263.
+func TestParseSpawnBlocks_MarkerRequiresWordBoundary(t *testing.T) {
+	body := "FABRIK_SPAWN_CHILD_BEGINowner/repo\nTITLE: Glued marker\nFABRIK_SPAWN_CHILD_END\n"
+	if blocks := ParseSpawnBlocks(body); len(blocks) != 0 {
+		t.Fatalf("expected 0 blocks when no separator follows the marker, got %d", len(blocks))
+	}
+
+	// A tab separator is legitimate and must still parse.
+	tabbed := "FABRIK_SPAWN_CHILD_BEGIN\towner/repo\nTITLE: Tab separated\nFABRIK_SPAWN_CHILD_END\n"
+	blocks := ParseSpawnBlocks(tabbed)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block for a tab-separated repo, got %d", len(blocks))
+	}
+	if blocks[0].Repo != "owner/repo" {
+		t.Errorf("repo: got %q, want %q", blocks[0].Repo, "owner/repo")
+	}
+}


### PR DESCRIPTION
## Problem

`ParseSpawnBlocks` located `FABRIK_SPAWN_CHILD_BEGIN` with a bare `strings.Index`, matching the marker **anywhere in a line**. When a Plan comment both *mentioned* the marker in prose and emitted a real block, the prose mention was accepted as the block opener — the parser then ran forward to the **real** END marker, consumed the authentic block as the phantom's content, failed the `TITLE:` check, discarded it, and had already advanced past the real END. **The genuine spawn block was destroyed by the sentence describing it.**

Found by the e2e release gate (`TestCrossRepoSpawn`, parent `handarbeit/fabrik-test-alpha#3796`). The Plan wrote:

```
- [ ] Emit `FABRIK_SPAWN_CHILD_BEGIN handarbeit/fabrik-test-beta` block (this stage) scoping the beta-side function + test
```

The token ``handarbeit/fabrik-test-beta` `` contains a slash, so it passed the old `strings.Contains(repo, "/")` check.

Reproduced offline against the real comment body:

```
FULL body              -> 0 blocks
prose mentions removed -> 1 blocks
```

**The failure was silent.** `preImplement` returned `(false, nil)` — no log, no label, no comment — so a cross-repo decomposition that never happened was indistinguishable from one never requested. It surfaced only because the Implement agent noticed the contradiction and emitted `FABRIK_BLOCKED_ON_INPUT` instead of fabricating progress. Pre-existing and nondeterministic: it depends on model-authored Plan prose, and five prior runs of this scenario passed.

## Why this is a conformance fix, not a spec change

The own-line rule was **already the documented contract** — `plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md:174` states both markers "must each be on their own line", and `FABRIK_STAGE_COMPLETE` has always been anchored (`stageCompleteRE`, `engine/claude.go:26`). `ParseSpawnBlocks` just never enforced it.

## Changes

- Recognize BEGIN/END only as own-line markers. Leading whitespace tolerated (a block nested under a list item still parses); trailing prose after the repo rejected, since that is the shape a mention takes.
- Validate the repo as a well-formed `owner/repo` rather than "contains a slash".
- Resume scanning after a malformed block's END, so it cannot re-open scanning inside its own content and swallow the next block.
- Log when a BEGIN-looking line is present but nothing well-formed parses — from both the direct and the recovery path. Ends the silent path.
- `docs/state-machine.md` records the enforced rule; `docs/llms-full.txt` regenerated.

## Verification

- 5 new regression tests, built on the real #3796 comment shape. **Three fail against the previous parser** (verified by reverting `spawn.go` and re-running) — they are not vacuous.
- The captured production comment now parses to exactly 1 correct block.
- All 9 pre-existing `ParseSpawnBlocks` tests pass unchanged; 35 spawn/preImplement tests green.
- `go test -race -timeout 8m ./...` exit 0; `go vet -tags e2e ./...` clean.

## Out of scope

`extractBetweenMarkers` (`engine/claude.go:1225`), used for `FABRIK_ISSUE_UPDATE_*` / `FABRIK_SUMMARY_*`, shares the same unanchored-`strings.Index` shape and has an analogous latent flaw. Different callers and blast radius — worth its own issue.

Closes #1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fNKqEYTMh9XWgfSCZq4vy