### PR TITLE
fix(e2e): accept either authoritative pause-reason wording

### DIFF
--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1136,22 +1136,40 @@ func tryPRComments(env *Env, repo string, prNumber int) ([]string, error) {
 // the given substring, or timeout expires.
 func WaitForPRCommentContaining(t *testing.T, env *Env, repo string, prNumber int, substring string, timeout time.Duration) {
 	t.Helper()
+	WaitForPRCommentContainingAny(t, env, repo, prNumber, []string{substring}, timeout)
+}
+
+// WaitForPRCommentContainingAny is WaitForPRCommentContaining for assertions
+// that have more than one legitimate wording. It returns as soon as some
+// comment contains ANY of substrings, so a caller can accept several equally
+// correct engine messages instead of pinning the test to whichever one the
+// current bed configuration happens to produce.
+//
+// Matching is case-sensitive, like WaitForPRCommentContaining. Callers wanting
+// case-insensitivity should pass the variants explicitly rather than have this
+// helper fold case silently — some engine messages embed deliberately
+// capitalized GitHub enums (e.g. CHANGES_REQUESTED), and folding would make an
+// assertion that means to pin the enum quietly stop doing so.
+func WaitForPRCommentContainingAny(t *testing.T, env *Env, repo string, prNumber int, substrings []string, timeout time.Duration) {
+	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		bodies, err := tryPRComments(env, repo, prNumber)
 		if err != nil {
-			t.Logf("WaitForPRCommentContaining: transient error on %s#%d: %v (will retry)", repo, prNumber, err)
+			t.Logf("WaitForPRCommentContainingAny: transient error on %s#%d: %v (will retry)", repo, prNumber, err)
 			pollSleep(pollBase())
 			continue
 		}
 		for _, b := range bodies {
-			if strings.Contains(b, substring) {
-				return
+			for _, substring := range substrings {
+				if strings.Contains(b, substring) {
+					return
+				}
 			}
 		}
 		pollSleep(pollBase())
 	}
-	t.Fatalf("timed out waiting for PR comment containing %q on %s#%d", substring, repo, prNumber)
+	t.Fatalf("timed out waiting for PR comment containing any of %q on %s#%d", substrings, repo, prNumber)
 }
 
 // tryPRCheckRunConclusions resolves the head SHA of the PR and returns the

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -122,12 +122,28 @@ func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 		t.Fatalf("expected issue OPEN after authoritative review timeout, got %s on %s#%d", state, env.RepoAlpha, num)
 	}
 
-	// WaitForPRCommentContaining queries the /issues/<n>/comments REST
+	// WaitForPRCommentContainingAny queries the /issues/<n>/comments REST
 	// endpoint, which is identical for issue and PR numbers on GitHub — the
 	// pause comment is posted on the issue (postComment uses item.Number),
 	// not the PR, so passing the issue number here is correct.
-	WaitForPRCommentContaining(t, env, env.RepoAlpha, num, "requested changes", 5*time.Minute)
-	t.Logf("pause comment names the authoritative verdict (\"requested changes\") on %s#%d", env.RepoAlpha, num)
+	//
+	// The authoritative reason has two equally correct forms, because
+	// reviewGateAuthorityVerdict prefers GitHub's reviewDecision where branch
+	// protection defines a review requirement and falls back to Fabrik's own
+	// computation otherwise (ADR-1250, engine/reviews.go):
+	//
+	//   reviewDecision path (branch protection configured): "reviewDecision=CHANGES_REQUESTED"
+	//   fallback path (no branch-protection review requirement): "<author> requested changes"
+	//
+	// The bed's repos currently DO have a branch-protection review requirement,
+	// so the reviewDecision form is what appears today — asserting only the
+	// fallback wording made this test fail against correct engine behavior.
+	// Accept either: what AC1/AC5 actually require is that the reason names the
+	// CHANGES_REQUESTED verdict at all, rather than falling back to the generic
+	// "no reviews submitted yet" message (asserted negatively just below).
+	WaitForPRCommentContainingAny(t, env, env.RepoAlpha, num,
+		[]string{"reviewDecision=CHANGES_REQUESTED", "requested changes"}, 5*time.Minute)
+	t.Logf("pause comment names the authoritative CHANGES_REQUESTED verdict on %s#%d", env.RepoAlpha, num)
 
 	bodies, err := tryPRComments(env, env.RepoAlpha, num)
 	if err != nil {


### PR DESCRIPTION
## Problem

`TestReviewAuthorityBlocksAndPausesOnChangesRequested` failed in the release gate against **correct** engine behavior.

`reviewGateAuthorityVerdict` (ADR-1250) produces two equally legitimate reason strings:

| path | condition | reason |
|---|---|---|
| reviewDecision (`reviews.go:416`) | branch protection defines a review requirement — the **preferred** source | `reviewDecision=CHANGES_REQUESTED` |
| fallback (`reviews.go:440`) | no branch-protection review requirement | `<author> requested changes` |

The test waited for the fallback wording only. The bed's repos **do** have a branch-protection review requirement, so the engine emitted the reviewDecision form and the assertion timed out after ~21 minutes.

What Fabrik actually posted on `fabrik-test-alpha#3783`:

> Review authority is `authoritative` for this stage — reviewDecision=CHANGES_REQUESTED, and the gate will not clear until that is resolved.

That is exactly the `authorityReason` propagation ADR-1250 specifies.

## Changes

- `WaitForPRCommentContainingAny` for assertions with more than one correct wording. `WaitForPRCommentContaining` delegates to it — existing callers unchanged.
- Accept either authoritative reason form, so the scenario is not pinned to the bed's current branch-protection configuration.

The **negative guard** against the generic `"no reviews submitted yet"` message is deliberately untouched — that is the assertion carrying the real regression value (it is what ADR-1250 exists to prevent), and it passed in the failing run.

## Why test-side

The engine's reason strings are shipped, documented ADR-1250 behavior. Changing product text to satisfy an assertion would be backwards.

## Verification

- `go vet -tags e2e ./...` clean; e2e compile check (#1259) clean.
- Scenario will be re-run as part of the full two-mode release gate.

Closes #1265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fNKqEYTMh9XWgfSCZq4vy