### PR TITLE
Review-gate timeout: honest no-reviewer messaging + self-review escape hatch docs

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -828,7 +828,10 @@ wait_for_reviews: false   # Optional. When true, Fabrik waits for all requested 
                           #   auto-advance to be active. This loop repeats until no reviewers are
                           #   pending (up to FABRIK_MAX_REVIEW_CYCLES cycles). On timeout or cycle
                           #   limit, Fabrik pauses with fabrik:awaiting-input instead of advancing.
-                          #   See §3 Pending Reviewer Gate for full details.
+                          #   If this repo has no reviewer to request (no CODEOWNERS, no review
+                          #   bot), set this to false — that is the supported setting rather than
+                          #   waiting on a gate that can never clear on its own. See §3 Pending
+                          #   Reviewer Gate for full details, including the self-review escape hatch.
 review_authority: advisory # Optional: advisory (default) | authoritative. Only meaningful alongside
                           #   wait_for_reviews: true. advisory clears the gate once reviewers have
                           #   responded, whatever they said. authoritative additionally requires no
@@ -1448,6 +1451,21 @@ fabrik --review-wait-timeout=30
 #### Restart Persistence
 
 The timeout is based on the timestamp of when the `fabrik:awaiting-review` label was added to the issue, which is stored in GitHub's event history. If Fabrik restarts while waiting, it recalculates the remaining wait time from the label timestamp rather than resetting the clock. The cycle count is in-memory and resets on restart.
+
+#### No Reviewer Ever Requested
+
+`wait_for_reviews: true` assumes something will eventually request or submit a review — a human collaborator, CODEOWNERS, or a review bot. On a repo with none of those (a solo maintainer with no CODEOWNERS and no review bot installed, for example), no reviewer is ever requested, so the gate's dual condition can never clear on its own. Since GitHub forbids a PR author from approving their own PR, the gate can look unsatisfiable from the operator's side too.
+
+It isn't: **the gate's actual test is "has a human looked at this?", not "has a reviewer approved this?"** A `COMMENTED` review submitted by the PR author itself satisfies the gate — GitHub permits a self-`COMMENT` even though it forbids self-approval. This is the supported manual way to clear the gate when no other reviewer can respond.
+
+When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists four ways to resume:
+
+1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate.
+2. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer. This is the supported setting for a reviewer-less repo going forward, rather than repeatedly hitting this timeout.
+3. Merge the PR manually.
+4. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).
+
+Fabrik deliberately does not try to detect "no reviewer will ever respond" automatically (e.g. by inspecting CODEOWNERS or requested-reviewer history) — that signal can't distinguish "no reviewer exists" from "the reviewer is just slow or down," and guessing wrong in the direction of auto-advancing would merge an unreviewed PR. The gate stays loud-and-conservative; only the messaging tells you honestly what it knows.
 
 #### Authoritative Mode
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1460,7 +1460,7 @@ It isn't: **the gate's actual test is "has a human looked at this?", not "has a 
 
 When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists four ways to resume:
 
-1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate.
+1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate — unless the stage is `authoritative` and the repo requires approving reviews (branch protection reports `REVIEW_REQUIRED`), in which case an approval from another account is needed; see [Authoritative Mode](#authoritative-mode) below.
 2. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer. This is the supported setting for a reviewer-less repo going forward, rather than repeatedly hitting this timeout.
 3. Merge the PR manually.
 4. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1458,7 +1458,7 @@ It isn't: **the gate's actual test is "has a human looked at this?", not "has a 
 
 When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists four ways to resume:
 
-1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate.
+1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate — unless the stage is `authoritative` and the repo requires approving reviews (branch protection reports `REVIEW_REQUIRED`), in which case an approval from another account is needed; see [Authoritative Mode](#authoritative-mode) below.
 2. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer. This is the supported setting for a reviewer-less repo going forward, rather than repeatedly hitting this timeout.
 3. Merge the PR manually.
 4. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -826,7 +826,10 @@ wait_for_reviews: false   # Optional. When true, Fabrik waits for all requested 
                           #   auto-advance to be active. This loop repeats until no reviewers are
                           #   pending (up to FABRIK_MAX_REVIEW_CYCLES cycles). On timeout or cycle
                           #   limit, Fabrik pauses with fabrik:awaiting-input instead of advancing.
-                          #   See §3 Pending Reviewer Gate for full details.
+                          #   If this repo has no reviewer to request (no CODEOWNERS, no review
+                          #   bot), set this to false — that is the supported setting rather than
+                          #   waiting on a gate that can never clear on its own. See §3 Pending
+                          #   Reviewer Gate for full details, including the self-review escape hatch.
 review_authority: advisory # Optional: advisory (default) | authoritative. Only meaningful alongside
                           #   wait_for_reviews: true. advisory clears the gate once reviewers have
                           #   responded, whatever they said. authoritative additionally requires no
@@ -1446,6 +1449,21 @@ fabrik --review-wait-timeout=30
 #### Restart Persistence
 
 The timeout is based on the timestamp of when the `fabrik:awaiting-review` label was added to the issue, which is stored in GitHub's event history. If Fabrik restarts while waiting, it recalculates the remaining wait time from the label timestamp rather than resetting the clock. The cycle count is in-memory and resets on restart.
+
+#### No Reviewer Ever Requested
+
+`wait_for_reviews: true` assumes something will eventually request or submit a review — a human collaborator, CODEOWNERS, or a review bot. On a repo with none of those (a solo maintainer with no CODEOWNERS and no review bot installed, for example), no reviewer is ever requested, so the gate's dual condition can never clear on its own. Since GitHub forbids a PR author from approving their own PR, the gate can look unsatisfiable from the operator's side too.
+
+It isn't: **the gate's actual test is "has a human looked at this?", not "has a reviewer approved this?"** A `COMMENTED` review submitted by the PR author itself satisfies the gate — GitHub permits a self-`COMMENT` even though it forbids self-approval. This is the supported manual way to clear the gate when no other reviewer can respond.
+
+When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists four ways to resume:
+
+1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate.
+2. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer. This is the supported setting for a reviewer-less repo going forward, rather than repeatedly hitting this timeout.
+3. Merge the PR manually.
+4. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).
+
+Fabrik deliberately does not try to detect "no reviewer will ever respond" automatically (e.g. by inspecting CODEOWNERS or requested-reviewer history) — that signal can't distinguish "no reviewer exists" from "the reviewer is just slow or down," and guessing wrong in the direction of auto-advancing would merge an unreviewed PR. The gate stays loud-and-conservative; only the messaging tells you honestly what it knows.
 
 #### Authoritative Mode
 
@@ -3320,6 +3338,8 @@ Thirteen distinct event types drive state transitions (§2.1–2.11, §2.13, §2
 
 **Effect:** Can clear the review gate when `len(outstanding) == 0` and at least one non-DISMISSED review exists. A DISMISSED review does not satisfy the `hasReviews` condition. Does not directly trigger a stage invocation.
 
+**The self-review escape hatch.** `hasReviews` does not check the review's author or state beyond "not DISMISSED" — a `COMMENTED` review submitted by the PR author itself satisfies it, even though GitHub forbids a PR author from *approving* their own PR. This is intentional, not an oversight: the advisory gate's real question is "has a human looked at this?", not "has a reviewer approved this?" (see §6.1.1 for the authoritative-mode distinction, which layers an approval requirement on top). On a repo with no reviewer ever requested — no CODEOWNERS, no review bot installed — a self-authored `COMMENTED` review is the supported manual way to clear an otherwise-unsatisfiable gate; `wait_for_reviews: false` is the supported stage-config setting for such a repo going forward. See `docs/USER_GUIDE.md`'s `wait_for_reviews` section for the operator-facing version of this note.
+
 ### 2.4 PR Review Threads with Feedback
 
 **Trigger:** Reviewers leave inline code comments on the linked PR in unresolved review threads. These are real GitHub comments with `DatabaseID`s.
@@ -4332,7 +4352,7 @@ When all outstanding requested reviewers are bots (detected via `ReviewRequest.I
 
 ### 6.1.1 `review_authority`: Verdict-Aware Clearing (Authoritative Mode)
 
-Everything in §6.1 describes **advisory** mode — the default, and the only mode that existed before ADR-1250. Advisory clears the gate on **existence**: `len(outstanding) == 0 && hasReviews`, regardless of what any review actually says. A `CHANGES_REQUESTED` review does not, by itself, block advancement; a required reviewer only needs to *submit*, not *approve*.
+Everything in §6.1 describes **advisory** mode — the default, and the only mode that existed before ADR-1250. Advisory clears the gate on **existence**: `len(outstanding) == 0 && hasReviews`, regardless of what any review actually says. A `CHANGES_REQUESTED` review does not, by itself, block advancement; a required reviewer only needs to *submit*, not *approve*. This is why advisory mode's self-review escape hatch (§2.3) works at all: a `COMMENTED` review from the PR author is existence, not approval, and GitHub permits self-`COMMENT` while forbidding self-approval. Authoritative mode (below) layers an approval requirement on top of existence — on a repo with no reviewer and no branch-protection review requirement, a self-review still clears authoritative mode's own-repo fallback verdict check (the "Fabrik's own fallback" bullet below), since that check only fails on an active `CHANGES_REQUESTED`, not on the reviewer's identity.
 
 `review_authority: authoritative` is a per-stage YAML opt-in (`stages.Stage.ReviewAuthority`, `{"", "advisory", "authoritative"}`, default `""`/advisory) that makes the same clearing branch additionally **verdict-aware**. It is orthogonal to Fabrik's autonomy controls (`yolo`/`cruise`/manual) — autonomy answers "does Fabrik proceed without a human clicking go?"; authority answers "what must be true before proceeding is allowed?" See [ADR-1250](../adrs/1250-review-authority-orthogonal-to-autonomy.md).
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -346,6 +346,8 @@ Thirteen distinct event types drive state transitions (§2.1–2.11, §2.13, §2
 
 **Effect:** Can clear the review gate when `len(outstanding) == 0` and at least one non-DISMISSED review exists. A DISMISSED review does not satisfy the `hasReviews` condition. Does not directly trigger a stage invocation.
 
+**The self-review escape hatch.** `hasReviews` does not check the review's author or state beyond "not DISMISSED" — a `COMMENTED` review submitted by the PR author itself satisfies it, even though GitHub forbids a PR author from *approving* their own PR. This is intentional, not an oversight: the advisory gate's real question is "has a human looked at this?", not "has a reviewer approved this?" (see §6.1.1 for the authoritative-mode distinction, which layers an approval requirement on top). On a repo with no reviewer ever requested — no CODEOWNERS, no review bot installed — a self-authored `COMMENTED` review is the supported manual way to clear an otherwise-unsatisfiable gate; `wait_for_reviews: false` is the supported stage-config setting for such a repo going forward. See `docs/USER_GUIDE.md`'s `wait_for_reviews` section for the operator-facing version of this note.
+
 ### 2.4 PR Review Threads with Feedback
 
 **Trigger:** Reviewers leave inline code comments on the linked PR in unresolved review threads. These are real GitHub comments with `DatabaseID`s.
@@ -1358,7 +1360,7 @@ When all outstanding requested reviewers are bots (detected via `ReviewRequest.I
 
 ### 6.1.1 `review_authority`: Verdict-Aware Clearing (Authoritative Mode)
 
-Everything in §6.1 describes **advisory** mode — the default, and the only mode that existed before ADR-1250. Advisory clears the gate on **existence**: `len(outstanding) == 0 && hasReviews`, regardless of what any review actually says. A `CHANGES_REQUESTED` review does not, by itself, block advancement; a required reviewer only needs to *submit*, not *approve*.
+Everything in §6.1 describes **advisory** mode — the default, and the only mode that existed before ADR-1250. Advisory clears the gate on **existence**: `len(outstanding) == 0 && hasReviews`, regardless of what any review actually says. A `CHANGES_REQUESTED` review does not, by itself, block advancement; a required reviewer only needs to *submit*, not *approve*. This is why advisory mode's self-review escape hatch (§2.3) works at all: a `COMMENTED` review from the PR author is existence, not approval, and GitHub permits self-`COMMENT` while forbidding self-approval. Authoritative mode (below) layers an approval requirement on top of existence — on a repo with no reviewer and no branch-protection review requirement, a self-review still clears authoritative mode's own-repo fallback verdict check (the "Fabrik's own fallback" bullet below), since that check only fails on an active `CHANGES_REQUESTED`, not on the reviewer's identity.
 
 `review_authority: authoritative` is a per-stage YAML opt-in (`stages.Stage.ReviewAuthority`, `{"", "advisory", "authoritative"}`, default `""`/advisory) that makes the same clearing branch additionally **verdict-aware**. It is orthogonal to Fabrik's autonomy controls (`yolo`/`cruise`/manual) — autonomy answers "does Fabrik proceed without a human clicking go?"; authority answers "what must be true before proceeding is allowed?" See [ADR-1250](../adrs/1250-review-authority-orthogonal-to-autonomy.md).
 

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -1017,6 +1017,34 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 					"- (d) remove `fabrik:paused` to let the engine wait again.",
 				stage.Name, prRef, authorityLine, prRef, selfReviewCaveat, stage.Name, prRef,
 			)
+		} else if pendingLine == "" && hasReviews && authorityLine != "" {
+			// No reviewer is currently outstanding, but a review does exist —
+			// either a formerly-requested reviewer already responded (and was
+			// dropped from the requested-reviewers list), or a self-review was
+			// submitted by the PR author. Either way, nobody is "outstanding"
+			// right now, so the standard message below (which literally says
+			// "waiting for outstanding reviewers") would be false. Requiring
+			// authorityLine != "" keeps this branch's "does not satisfy" claim
+			// something Fabrik can actually back up: hasReviews can also be
+			// true defensively (the FetchPRReviews-failure fallback above
+			// treats review state as unknown-but-possibly-present, not
+			// confirmed), in which case authorityLine may still be "" if the
+			// separate reviewDecision fetch succeeded against that same stale,
+			// empty review list — falling through to the standard branch below
+			// rather than asserting a submitted review this branch can't
+			// actually confirm (#1268 review thread).
+			prRef := "the linked PR"
+			if item.LinkedPRNumber > 0 {
+				prRef = fmt.Sprintf("PR #%d", item.LinkedPRNumber)
+			}
+			msg = fmt.Sprintf(
+				"🏭 **Fabrik — review wait timeout**\n\n"+
+					"The review gate for stage **%s** timed out. No reviewer is currently outstanding on %s — a review "+
+					"has already been submitted, but it does not satisfy this stage's authoritative requirement.%s\n\n"+
+					"Fabrik has paused this issue. Please check the review status on %s, address any outstanding "+
+					"feedback, and then remove the `fabrik:paused` label to resume.",
+				stage.Name, prRef, authorityLine, prRef,
+			)
 		} else {
 			// Standard timeout message with named reviewers — unchanged.
 			msg = fmt.Sprintf(

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -692,22 +692,6 @@ func (e *Engine) checkBotPhase2Timeout(owner, repo string, item gh.ProjectItem) 
 	return false, true, true
 }
 
-// checkAwaitingReviewTimeout implements the fabrik:awaiting-review timeout
-// check: once ReviewWaitTimeout has elapsed since the label was applied, it
-// either fires Phase 1 of the bot-reviewer escalation ladder (re-prompting
-// every outstanding bot reviewer), lets an already-fired Phase 1 continue
-// waiting for Phase 2, or pauses for a mixed/pure-human/no-PR-number gate.
-// done=true means the caller should return (blocked, timedOut) directly;
-// done=false means the label wasn't found, was found but the timeout hasn't
-// elapsed yet, or Phase 1 already fired and Phase 2 hasn't timed out yet —
-// the caller falls through to the "still waiting" logging/label-apply tail.
-//
-// authorityReason is non-empty only when the caller's authoritative-mode
-// verdict check blocked (see reviewGateAuthorityVerdict) — i.e. outstanding is
-// empty and reviews exist, but the verdict itself isn't satisfied. When set,
-// it is used verbatim as the pause reason instead of the generic
-// "pending reviewers"/"no reviews submitted yet" messages, which would
-// otherwise misleadingly suggest nobody has reviewed at all.
 // reviewTimeoutReason builds the log-only reason string for the pause
 // branch of checkAwaitingReviewTimeout. authorityReason, when non-empty,
 // takes precedence: the gate is blocking on an authoritative verdict, not a
@@ -726,6 +710,23 @@ func reviewTimeoutReason(outstanding []string, authorityReason string) string {
 	return "no reviewers were requested, no review has been received, and Fabrik cannot determine whether one is coming"
 }
 
+// checkAwaitingReviewTimeout implements the fabrik:awaiting-review timeout
+// check: once ReviewWaitTimeout has elapsed since the label was applied, it
+// either fires Phase 1 of the bot-reviewer escalation ladder (re-prompting
+// every outstanding bot reviewer), lets an already-fired Phase 1 continue
+// waiting for Phase 2, or pauses for a mixed/pure-human/no-PR-number gate.
+// done=true means the caller should return (blocked, timedOut) directly;
+// done=false means the label wasn't found, was found but the timeout hasn't
+// elapsed yet, or Phase 1 already fired and Phase 2 hasn't timed out yet —
+// the caller falls through to the "still waiting" logging/label-apply tail.
+//
+// authorityReason is non-empty only when the caller's authoritative-mode
+// verdict check blocked (see reviewGateAuthorityVerdict) — i.e. outstanding is
+// empty and reviews exist, but the verdict itself isn't satisfied. When set,
+// it is used verbatim as the pause reason instead of the generic
+// "pending reviewers"/"no reviewers were requested" messages built by
+// reviewTimeoutReason, which would otherwise misleadingly suggest nobody has
+// reviewed at all.
 func (e *Engine) checkAwaitingReviewTimeout(owner, repo string, item gh.ProjectItem, outstanding []string, allBots, reprompted bool, authorityReason string) (blocked, timedOut, done bool) {
 	timeout := e.cfg.ReviewWaitTimeout
 	if timeout <= 0 {

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -708,6 +708,24 @@ func (e *Engine) checkBotPhase2Timeout(owner, repo string, item gh.ProjectItem) 
 // it is used verbatim as the pause reason instead of the generic
 // "pending reviewers"/"no reviews submitted yet" messages, which would
 // otherwise misleadingly suggest nobody has reviewed at all.
+// reviewTimeoutReason builds the log-only reason string for the pause
+// branch of checkAwaitingReviewTimeout. authorityReason, when non-empty,
+// takes precedence: the gate is blocking on an authoritative verdict, not a
+// plain review count. Otherwise, when reviewers are still outstanding, name
+// them. When neither applies, no reviewer was ever requested — state the
+// three things the engine actually knows (no reviewer requested, no review
+// received, can't determine if one is coming) instead of speculating about
+// bots that may not exist on this repo.
+func reviewTimeoutReason(outstanding []string, authorityReason string) string {
+	if authorityReason != "" {
+		return "authoritative gate blocking: " + authorityReason
+	}
+	if len(outstanding) > 0 {
+		return "pending reviewers: " + strings.Join(outstanding, ", ")
+	}
+	return "no reviewers were requested, no review has been received, and Fabrik cannot determine whether one is coming"
+}
+
 func (e *Engine) checkAwaitingReviewTimeout(owner, repo string, item gh.ProjectItem, outstanding []string, allBots, reprompted bool, authorityReason string) (blocked, timedOut, done bool) {
 	timeout := e.cfg.ReviewWaitTimeout
 	if timeout <= 0 {
@@ -762,14 +780,7 @@ func (e *Engine) checkAwaitingReviewTimeout(owner, repo string, item gh.ProjectI
 		}
 
 		// Mixed/pure-human or no PR number: existing pause behavior.
-		var reason string
-		if authorityReason != "" {
-			reason = "authoritative gate blocking: " + authorityReason
-		} else if len(outstanding) > 0 {
-			reason = "pending reviewers: " + strings.Join(outstanding, ", ")
-		} else {
-			reason = "no reviews submitted yet (bots may not have responded)"
-		}
+		reason := reviewTimeoutReason(outstanding, authorityReason)
 		e.logf(item.Number, "warn", "review wait timeout elapsed; pausing issue — %s\n", reason)
 		e.removeAwaitingReviewLabel(owner, repo, item)
 		return false, true, true

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -989,18 +989,33 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 			if item.LinkedPRNumber > 0 {
 				prRef = fmt.Sprintf("PR #%d", item.LinkedPRNumber)
 			}
+			// The self-review caveat is only true when Fabrik actually knows
+			// (or can't rule out) that a self-COMMENT won't be enough: that's
+			// exactly when authorityLine is non-empty — authoritative mode is
+			// active and currently blocking, whether because branch
+			// protection requires an approval or because the verdict
+			// couldn't be read. When authorityLine is empty (advisory mode,
+			// or authoritative with a confirmed non-blocking verdict), a
+			// self-review is known to satisfy the gate outright, so stating
+			// the caveat would contradict the PR's own "say what Fabrik
+			// actually knows to be true right now" goal (#1268 review
+			// thread).
+			selfReviewCaveat := ""
+			if authorityLine != "" {
+				selfReviewCaveat = ", unless this stage is `authoritative` and the repo requires approving reviews, " +
+					"in which case an approval from another account is needed"
+			}
 			msg = fmt.Sprintf(
 				"🏭 **Fabrik — review wait timeout**\n\n"+
 					"The review gate for stage **%s** timed out. No reviewer was ever requested on %s, and no review "+
 					"has been submitted — Fabrik cannot determine whether one is ever coming.%s\n\n"+
 					"Fabrik has paused this issue. To resume, either:\n"+
 					"- (a) post a review on %s yourself — a `COMMENTED` self-review from the PR author satisfies "+
-					"the gate, even though GitHub forbids self-approval, unless this stage is `authoritative` and "+
-					"the repo requires approving reviews, in which case an approval from another account is needed,\n"+
+					"the gate, even though GitHub forbids self-approval%s,\n"+
 					"- (b) set `wait_for_reviews: false` in the %s stage YAML if this repo has no reviewer,\n"+
 					"- (c) merge %s manually, or\n"+
 					"- (d) remove `fabrik:paused` to let the engine wait again.",
-				stage.Name, prRef, authorityLine, prRef, stage.Name, prRef,
+				stage.Name, prRef, authorityLine, prRef, selfReviewCaveat, stage.Name, prRef,
 			)
 		} else {
 			// Standard timeout message with named reviewers — unchanged.

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -995,7 +995,8 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 					"has been submitted — Fabrik cannot determine whether one is ever coming.%s\n\n"+
 					"Fabrik has paused this issue. To resume, either:\n"+
 					"- (a) post a review on %s yourself — a `COMMENTED` self-review from the PR author satisfies "+
-					"the gate, even though GitHub forbids self-approval,\n"+
+					"the gate, even though GitHub forbids self-approval, unless this stage is `authoritative` and "+
+					"the repo requires approving reviews, in which case an approval from another account is needed,\n"+
 					"- (b) set `wait_for_reviews: false` in the %s stage YAML if this repo has no reviewer,\n"+
 					"- (c) merge %s manually, or\n"+
 					"- (d) remove `fabrik:paused` to let the engine wait again.",

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -911,11 +911,19 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 		)
 	} else {
 		// Standard timeout: branches below on whether any reviewer was ever
-		// requested (pendingLine == "" means none was).
+		// requested (pendingLine == "" means none was) AND whether any review
+		// has actually been submitted. pendingLine alone is not sufficient:
+		// once a requested reviewer submits a formal review (e.g.
+		// CHANGES_REQUESTED), GitHub drops them from the requested-reviewers
+		// list, so pendingLine goes back to "" even though a review exists.
+		// That combination is reachable in authoritative mode, where the gate
+		// can still be blocking on that review's verdict — see #1268 review
+		// thread.
 		pendingLine := ""
 		if len(reviewerParts) > 0 {
 			pendingLine = "\n\nPending reviewers: " + strings.Join(reviewerParts, ", ")
 		}
+		_, hasReviews := reviewGateOutstanding(item.LinkedPRReviewRequests, item.LinkedPRReviews)
 		// Authoritative-mode context: live-fetch the verdict and reuse the same
 		// reviewGateAuthorityVerdict pure function both gate sites consult, so
 		// this message can never disagree with why the gate is actually
@@ -937,6 +945,7 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 					prNumber = pr.Number
 					if restReviews, err := e.readClient.FetchPRReviews(owner, repo, prNumber); err == nil {
 						reviews = restReviews
+						_, hasReviews = reviewGateOutstanding(nil, reviews)
 					}
 				}
 			}
@@ -956,11 +965,16 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 				}
 			}
 		}
-		if pendingLine == "" {
-			// No reviewer was ever requested on this PR — waiting longer cannot
-			// satisfy the gate. Say so plainly instead of claiming a wait on
-			// "outstanding reviewers" that don't exist, and offer the same
-			// remedies as Phase 2.
+		if pendingLine == "" && !hasReviews {
+			// No reviewer was ever requested on this PR, and no review has
+			// been submitted either — waiting longer cannot satisfy the gate.
+			// Say so plainly instead of claiming a wait on "outstanding
+			// reviewers" that don't exist, and offer the same remedies as
+			// Phase 2. The !hasReviews check matters: in authoritative mode a
+			// reviewer who submitted a formal review is no longer "pending"
+			// (pendingLine goes back to ""), but a review did happen — that
+			// case must fall through to the other branch below instead of
+			// falsely claiming none was submitted.
 			prRef := "the linked PR"
 			if item.LinkedPRNumber > 0 {
 				prRef = fmt.Sprintf("PR #%d", item.LinkedPRNumber)

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -946,6 +946,16 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 					if restReviews, err := e.readClient.FetchPRReviews(owner, repo, prNumber); err == nil {
 						reviews = restReviews
 						_, hasReviews = reviewGateOutstanding(nil, reviews)
+					} else {
+						// Conservative, matching checkReviewGate's failure handling:
+						// a transient fetch failure must not leave hasReviews at its
+						// stale item.LinkedPRReviews reading (always empty on this
+						// base:<branch> path) and fall into the no-reviewer-requested
+						// branch below, which would assert "no review has been
+						// submitted" — a claim we can no longer support. Treat review
+						// state as unknown-but-possibly-present instead.
+						e.logf(item.Number, "warn", "pauseForReviewTimeout: FetchPRReviews failed: %v\n", err)
+						hasReviews = true
 					}
 				}
 			}

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -910,7 +910,8 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 			stage.Name, botList, prRef, stage.Name, prRef,
 		)
 	} else {
-		// Standard timeout message with named reviewers.
+		// Standard timeout: branches below on whether any reviewer was ever
+		// requested (pendingLine == "" means none was).
 		pendingLine := ""
 		if len(reviewerParts) > 0 {
 			pendingLine = "\n\nPending reviewers: " + strings.Join(reviewerParts, ", ")
@@ -955,11 +956,35 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 				}
 			}
 		}
-		msg = fmt.Sprintf(
-			"🏭 **Fabrik — review wait timeout**\n\nThe review gate for stage **%s** timed out waiting for outstanding reviewers.%s%s\n\n"+
-				"Fabrik has paused this issue. Please check the PR for pending reviews, address any issues, and then remove the `fabrik:paused` label to resume.",
-			stage.Name, pendingLine, authorityLine,
-		)
+		if pendingLine == "" {
+			// No reviewer was ever requested on this PR — waiting longer cannot
+			// satisfy the gate. Say so plainly instead of claiming a wait on
+			// "outstanding reviewers" that don't exist, and offer the same
+			// remedies as Phase 2.
+			prRef := "the linked PR"
+			if item.LinkedPRNumber > 0 {
+				prRef = fmt.Sprintf("PR #%d", item.LinkedPRNumber)
+			}
+			msg = fmt.Sprintf(
+				"🏭 **Fabrik — review wait timeout**\n\n"+
+					"The review gate for stage **%s** timed out. No reviewer was ever requested on %s, and no review "+
+					"has been submitted — Fabrik cannot determine whether one is ever coming.%s\n\n"+
+					"Fabrik has paused this issue. To resume, either:\n"+
+					"- (a) post a review on %s yourself — a `COMMENTED` self-review from the PR author satisfies "+
+					"the gate, even though GitHub forbids self-approval,\n"+
+					"- (b) set `wait_for_reviews: false` in the %s stage YAML if this repo has no reviewer,\n"+
+					"- (c) merge %s manually, or\n"+
+					"- (d) remove `fabrik:paused` to let the engine wait again.",
+				stage.Name, prRef, authorityLine, prRef, stage.Name, prRef,
+			)
+		} else {
+			// Standard timeout message with named reviewers — unchanged.
+			msg = fmt.Sprintf(
+				"🏭 **Fabrik — review wait timeout**\n\nThe review gate for stage **%s** timed out waiting for outstanding reviewers.%s%s\n\n"+
+					"Fabrik has paused this issue. Please check the PR for pending reviews, address any issues, and then remove the `fabrik:paused` label to resume.",
+				stage.Name, pendingLine, authorityLine,
+			)
+		}
 	}
 
 	e.pauseIssue(item, msg, pauseOpts{

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1642,6 +1642,51 @@ func TestPauseForReviewTimeout_Authoritative_ReviewerRespondedButNotPending_NoFa
 	}
 }
 
+// On a base:<branch> repo in authoritative mode, item.LinkedPRReviews is
+// structurally empty (see comment on the REST-fallback block in
+// pauseForReviewTimeout), so hasReviews must be resolved via a live
+// FetchPRReviews call. If that call fails, the failure must not be silently
+// swallowed into a stale hasReviews=false reading — that would trip the
+// no-reviewers-requested branch and falsely claim "no review has been
+// submitted" even though review state is actually unknown. The gate must
+// fail conservatively, exactly as checkReviewGate's own REST-fallback does
+// (#1268 review thread).
+func TestPauseForReviewTimeout_Authoritative_NonDefaultBase_ReviewFetchFails_NoFalseClaim(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 77, State: "open"}, nil
+		},
+		fetchPRReviewsFn: func(owner, repo string, prNumber int) ([]gh.PRReview, error) {
+			return nil, fmt.Errorf("simulated transient GitHub API failure")
+		},
+		fetchPRReviewDecisionFn: func(owner, repo string, prNumber int) (string, error) {
+			return "", nil // no branch protection configured — exercises Fabrik's own fallback
+		},
+	}
+	eng := reviewTestEngine(t, client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		Labels:         []string{"fabrik:awaiting-review", "base:develop"},
+		LinkedPRNumber: 0, // structurally empty on a base:<branch> item
+	}
+	stage := &stages.Stage{Name: "Review", WaitForReviews: boolPtr(true), ReviewAuthority: "authoritative"}
+
+	eng.pauseForReviewTimeout(board, item, stage)
+
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if strings.Contains(body, "No reviewer was ever requested") || strings.Contains(body, "no review has been submitted") {
+		t.Errorf("pause comment must not assert no review was submitted when the review fetch itself failed, got:\n%s", body)
+	}
+	if strings.Contains(body, "wait_for_reviews: false") {
+		t.Errorf("pause comment should not offer the no-reviewer remedies when review state could not be determined, got:\n%s", body)
+	}
+}
+
 // removeAwaitingReviewLabel also removes the fabrik:bot-reprompted label.
 func TestRemoveAwaitingReviewLabel_CleansRepromptedLabels(t *testing.T) {
 	client := &mockGitHubClient{}

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1516,6 +1516,13 @@ func TestPauseForReviewTimeout_Authoritative_ReviewRequired_MentionsVerdict(t *t
 	if !strings.Contains(body, "REVIEW_REQUIRED") {
 		t.Errorf("expected pause comment to mention the REVIEW_REQUIRED verdict, got:\n%s", body)
 	}
+	// This is the exact scenario where advice (a)'s unqualified "a COMMENTED
+	// self-review satisfies the gate" would be actively wrong: branch
+	// protection requires an approving review, and a self-COMMENT (GitHub
+	// forbids self-approval) can never produce one (#1268 review thread).
+	if !strings.Contains(body, "another account") {
+		t.Errorf("pause comment must qualify the self-review remedy when authoritative mode requires approving reviews, got:\n%s", body)
+	}
 }
 
 // A FetchPRReviewDecision fetch error in the pause path must be surfaced in

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1588,6 +1588,58 @@ func TestPauseForReviewTimeout_Authoritative_NonDefaultBase_MentionsVerdict(t *t
 	if !strings.Contains(body, "bob requested changes") {
 		t.Errorf("expected pause comment to mention the outstanding CHANGES_REQUESTED verdict resolved via the base:<branch> REST fallback, got:\n%s", body)
 	}
+	// Regression guard (#1268 review thread): bob submitted a review, so
+	// pendingLine is "" (he's no longer a requested reviewer) but a review
+	// did happen — the comment must not claim otherwise.
+	if strings.Contains(body, "no review has been submitted") || strings.Contains(body, "No reviewer was ever requested") {
+		t.Errorf("pause comment must not claim no review was submitted when bob's CHANGES_REQUESTED review exists, got:\n%s", body)
+	}
+}
+
+// A requested reviewer who submits a formal review (e.g. CHANGES_REQUESTED)
+// is dropped from GitHub's requested-reviewers list, so pendingLine goes back
+// to "" even though a review was submitted. This is the default-branch
+// GraphQL path (LinkedPRReviews populated directly, no REST fallback) — the
+// no-reviewers-requested branch must not fire here, since a review did
+// happen and the message would otherwise contradict the appended
+// authorityLine quoting that same review's verdict (#1268 review thread).
+func TestPauseForReviewTimeout_Authoritative_ReviewerRespondedButNotPending_NoFalseClaim(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchPRReviewDecisionFn: func(owner, repo string, prNumber int) (string, error) {
+			if prNumber != 77 {
+				t.Errorf("expected FetchPRReviewDecision called with PR #77, got #%d", prNumber)
+			}
+			return "", nil // no branch protection configured — exercises Fabrik's own fallback
+		},
+	}
+	eng := reviewTestEngine(t, client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		Labels:         []string{"fabrik:awaiting-review"},
+		LinkedPRNumber: 77,
+		// LinkedPRReviewRequests intentionally empty: bob already submitted
+		// and is no longer outstanding.
+		LinkedPRReviews: []gh.PRReview{{Author: "bob", State: "CHANGES_REQUESTED"}},
+	}
+	stage := &stages.Stage{Name: "Review", WaitForReviews: boolPtr(true), ReviewAuthority: "authoritative"}
+
+	eng.pauseForReviewTimeout(board, item, stage)
+
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if !strings.Contains(body, "bob requested changes") {
+		t.Errorf("expected pause comment to mention the outstanding CHANGES_REQUESTED verdict, got:\n%s", body)
+	}
+	if strings.Contains(body, "no review has been submitted") || strings.Contains(body, "No reviewer was ever requested") {
+		t.Errorf("pause comment must not claim no review was submitted when bob's CHANGES_REQUESTED review exists, got:\n%s", body)
+	}
+	if strings.Contains(body, "wait_for_reviews: false") {
+		t.Errorf("pause comment should not offer the no-reviewer remedies when a review was actually submitted, got:\n%s", body)
+	}
 }
 
 // removeAwaitingReviewLabel also removes the fabrik:bot-reprompted label.

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -97,6 +97,51 @@ func TestReviewGateAuthorityVerdict(t *testing.T) {
 	}
 }
 
+func TestReviewTimeoutReason(t *testing.T) {
+	tests := []struct {
+		name            string
+		outstanding     []string
+		authorityReason string
+		wantContains    []string
+		wantExcludes    []string
+	}{
+		{
+			name:            "authorityReason takes precedence over everything else",
+			outstanding:     []string{"alice"},
+			authorityReason: "review authority is authoritative and CHANGES_REQUESTED is outstanding",
+			wantContains:    []string{"authoritative gate blocking:", "CHANGES_REQUESTED"},
+		},
+		{
+			name:         "outstanding reviewers named when present",
+			outstanding:  []string{"alice", "bob"},
+			wantContains: []string{"pending reviewers:", "alice", "bob"},
+			wantExcludes: []string{"authoritative gate blocking:", "bots"},
+		},
+		{
+			name:         "no reviewers requested states the three known facts, no bot speculation",
+			outstanding:  nil,
+			wantContains: []string{"no reviewers were requested", "no review has been received", "cannot determine whether one is coming"},
+			wantExcludes: []string{"bot", "authoritative gate blocking:", "pending reviewers:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reviewTimeoutReason(tt.outstanding, tt.authorityReason)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("reviewTimeoutReason(%v, %q) = %q, want substring %q", tt.outstanding, tt.authorityReason, got, want)
+				}
+			}
+			for _, excl := range tt.wantExcludes {
+				if strings.Contains(strings.ToLower(got), strings.ToLower(excl)) {
+					t.Errorf("reviewTimeoutReason(%v, %q) = %q, must not contain %q", tt.outstanding, tt.authorityReason, got, excl)
+				}
+			}
+		})
+	}
+}
+
 // --- review-authority:<mode> label override (#1261) -----------------------
 
 func TestExtractReviewAuthorityOverride(t *testing.T) {

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1693,6 +1693,16 @@ func TestPauseForReviewTimeout_Authoritative_ReviewerRespondedButNotPending_NoFa
 	if strings.Contains(body, "wait_for_reviews: false") {
 		t.Errorf("pause comment should not offer the no-reviewer remedies when a review was actually submitted, got:\n%s", body)
 	}
+	// bob is no longer outstanding (he already responded), so the standard
+	// "waiting for outstanding reviewers" wording is also false here — a
+	// distinct claim from the two checked above (#1268 review thread,
+	// follow-up finding).
+	if strings.Contains(body, "outstanding reviewers") {
+		t.Errorf("pause comment must not claim to wait on outstanding reviewers when bob already responded and nobody is pending, got:\n%s", body)
+	}
+	if !strings.Contains(body, "No reviewer is currently outstanding") {
+		t.Errorf("pause comment should state plainly that nobody is currently outstanding, got:\n%s", body)
+	}
 }
 
 // On a base:<branch> repo in authoritative mode, item.LinkedPRReviews is
@@ -1737,6 +1747,18 @@ func TestPauseForReviewTimeout_Authoritative_NonDefaultBase_ReviewFetchFails_NoF
 	}
 	if strings.Contains(body, "wait_for_reviews: false") {
 		t.Errorf("pause comment should not offer the no-reviewer remedies when review state could not be determined, got:\n%s", body)
+	}
+	// Deliberate fallthrough: hasReviews is forced true defensively here (the
+	// fetch failed, so review state is unknown-but-possibly-present), but
+	// authorityLine is "" because the separate, successful reviewDecision
+	// fetch was evaluated against that same stale, empty review list and
+	// came back satisfied. The pendingLine=="" && hasReviews branch requires
+	// authorityLine != "" precisely so it never asserts a submitted review
+	// this ambiguous state can't actually confirm — it falls through to the
+	// standard message instead, an existing imprecision this change doesn't
+	// widen (#1268 review thread, follow-up finding).
+	if !strings.Contains(body, "outstanding reviewers") {
+		t.Errorf("expected the standard fallback wording when review state is ambiguous, got:\n%s", body)
 	}
 }
 

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1483,6 +1483,13 @@ func TestPauseForReviewTimeout_NoReviewersRequested_ListsRemedies(t *testing.T) 
 	if !containsAll(body, "COMMENTED", "self-review", "wait_for_reviews: false", "merge", "fabrik:paused") {
 		t.Errorf("pause comment should list the four remedies including the COMMENTED self-review hatch; got:\n%s", body)
 	}
+	// Advisory mode (no ReviewAuthority set): a self-COMMENT is known to
+	// satisfy the gate outright, so the authoritative-mode caveat on remedy
+	// (a) must not appear — stating it here would assert something Fabrik
+	// doesn't actually know to be relevant (#1268 review thread).
+	if strings.Contains(body, "another account") {
+		t.Errorf("pause comment must not qualify the self-review remedy in advisory mode; got:\n%s", body)
+	}
 }
 
 // Authoritative-mode pause messaging must cover REVIEW_REQUIRED, not just an
@@ -1552,6 +1559,45 @@ func TestPauseForReviewTimeout_Authoritative_FetchError_MentionsUnreadableVerdic
 	body := client.addCommentCalls[0].body
 	if !strings.Contains(body, "could not be") {
 		t.Errorf("expected pause comment to mention the unreadable verdict, got:\n%s", body)
+	}
+	// The verdict is unknown, not confirmed non-blocking — Fabrik can't rule
+	// out that an approval requirement exists, so the self-review caveat
+	// must still be shown (#1268 review thread).
+	if !strings.Contains(body, "another account") {
+		t.Errorf("pause comment must qualify the self-review remedy when the verdict is unreadable, got:\n%s", body)
+	}
+}
+
+// Authoritative mode with a confirmed non-blocking verdict (no branch
+// protection review requirement configured) is the one case where Fabrik
+// positively knows a self-review will satisfy the gate — the caveat on
+// remedy (a) must not appear here, otherwise the message asserts an
+// authoritative-approval requirement that doesn't exist (#1268 review
+// thread).
+func TestPauseForReviewTimeout_Authoritative_NoRequirement_NoUnqualifiedCaveat(t *testing.T) {
+	client := &mockGitHubClient{
+		fetchPRReviewDecisionFn: func(owner, repo string, prNumber int) (string, error) {
+			return "", nil // no branch-protection review requirement configured
+		},
+	}
+	eng := reviewTestEngine(t, client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		Labels:         []string{"fabrik:awaiting-review"},
+		LinkedPRNumber: 77,
+	}
+	stage := &stages.Stage{Name: "Review", WaitForReviews: boolPtr(true), ReviewAuthority: "authoritative"}
+
+	eng.pauseForReviewTimeout(board, item, stage)
+
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if strings.Contains(body, "another account") {
+		t.Errorf("pause comment must not qualify the self-review remedy when authoritative mode has no active review requirement, got:\n%s", body)
 	}
 }
 

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -1445,6 +1445,44 @@ func TestPauseForReviewTimeout_ListsReviewerTypes(t *testing.T) {
 	if !containsAll(body, "copilot-pull-request-reviewer", "bot", "alice", "human") {
 		t.Errorf("pause comment should list reviewers with bot/human tags; got:\n%s", body)
 	}
+	// Regression guard: when reviewers were requested, the message must keep
+	// its existing "outstanding reviewers" wording and must not bleed into
+	// the no-reviewers-requested remedies text (#1268).
+	if !strings.Contains(body, "outstanding reviewers") {
+		t.Errorf("pause comment should still say 'outstanding reviewers' when reviewers were requested; got:\n%s", body)
+	}
+	if strings.Contains(body, "wait_for_reviews: false") {
+		t.Errorf("pause comment should not include the no-reviewers-requested remedies when reviewers were requested; got:\n%s", body)
+	}
+}
+
+// On a timeout where no reviewer was ever requested, the pause comment must
+// not claim to have waited on "outstanding reviewers" and must list the four
+// remedies, including the COMMENTED self-review hatch (#1268).
+func TestPauseForReviewTimeout_NoReviewersRequested_ListsRemedies(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := reviewTestEngine(t, client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{
+		Number:         10,
+		Repo:           "owner/repo",
+		Labels:         []string{"fabrik:awaiting-review"},
+		LinkedPRNumber: 42,
+	}
+	stage := &stages.Stage{Name: "Review", WaitForReviews: boolPtr(true)}
+
+	eng.pauseForReviewTimeout(board, item, stage)
+
+	if len(client.addCommentCalls) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(client.addCommentCalls))
+	}
+	body := client.addCommentCalls[0].body
+	if strings.Contains(body, "outstanding reviewers") {
+		t.Errorf("pause comment must not claim to wait on outstanding reviewers when none were requested; got:\n%s", body)
+	}
+	if !containsAll(body, "COMMENTED", "self-review", "wait_for_reviews: false", "merge", "fabrik:paused") {
+		t.Errorf("pause comment should list the four remedies including the COMMENTED self-review hatch; got:\n%s", body)
+	}
 }
 
 // Authoritative-mode pause messaging must cover REVIEW_REQUIRED, not just an


### PR DESCRIPTION
Closes #1268

## Summary

When the review-gate timeout fires on a repo where **no reviewer was ever requested**, the log line and pause comment used to describe a situation that isn't happening ("bots may not have responded", "timed out waiting for outstanding reviewers") and offered no way to unstick the issue. This is message-text-and-docs-only — no change to the gate's clear predicate, timeout, pause/advance decision, or labels.

## Changes

- **`engine/reviews.go`**: extracted the log-line reason into a pure `reviewTimeoutReason(outstanding, authorityReason) string` helper. The no-reviewers-requested branch now states the three things Fabrik actually knows — no reviewer was requested, no review has been received, and Fabrik cannot determine whether one is coming — instead of speculating about bots.
- **`engine/reviews.go`** (`pauseForReviewTimeout`): split the standard-timeout branch on `pendingLine == ""` (no reviewers were ever requested). That case no longer claims to have waited on "outstanding reviewers" — it says so plainly and lists four remedies, mirroring the existing Phase-2 bot-reprompt message: post a review yourself (noting a `COMMENTED` self-review from the PR author satisfies the gate even though GitHub forbids self-approval), set `wait_for_reviews: false` if this repo has no reviewer, merge manually, or remove `fabrik:paused` to wait again. The reviewers-were-requested branch, `authorityLine`, and the Phase-2 message are all byte-identical to before.
- **`docs/state-machine.md`** / **`docs/USER_GUIDE.md`**: document the self-review escape hatch (any non-DISMISSED review, including a self-authored `COMMENTED` review, satisfies `hasReviews`), the gate's real intent ("a human has looked at this," not "a reviewer approved this"), and `wait_for_reviews: false` as the supported setting for a reviewer-less repo. `docs/llms-full.txt` regenerated in the same commit.
- **`engine/reviews_test.go`**: new `TestReviewTimeoutReason` table test (all three log-line branches) and `TestPauseForReviewTimeout_NoReviewersRequested_ListsRemedies`, plus a regression assertion added to `TestPauseForReviewTimeout_ListsReviewerTypes` confirming the reviewers-requested branch is unchanged and doesn't bleed into the new remedies text.

## Scope

No change to gate timing, the clear predicate (`len(outstanding) == 0 && hasReviews`), pause-vs-advance behavior, or label handling — verified by running the existing Phase-2 and `Authoritative_*` tests unmodified (all pass, confirming no drift).

Surfaced by community report #1080 (solo maintainer, no CODEOWNERS, no review bot — the gate was unsatisfiable and produced misleading messaging). This closes the messaging half only; the config-key half (`reviewer_expected:`-style detection) remains open on the triage board for separate follow-up, possibly under #1051/#1055.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass except a pre-existing, network/timing-dependent `TestExecute_ConfigYAMLApplied` failure in `cmd`, confirmed to fail identically on the pre-change base commit and unrelated to this change
- [x] New/extended tests assert on branch selection and content (not full-string equality), per the issue's testing requirement