### PR TITLE
chore(merge-train): trial integration for #1271

### DIFF
--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -31,13 +31,24 @@ import (
 //   - Train mode "on" (ADR-059 D6/D7) — the yolo item advances Validate →
 //     Queued and lands via the merge train's own batch (landGreenBatch →
 //     landMergeTrainBatch) or singleton (landSingleton) landing path, both of
-//     which close-not-merge the member's own PR and land the change via a
-//     separate integration/singleton PR. Verifies: the issue reaches Done
-//     (board Status "Done" or issue CLOSED, whichever is observed first —
-//     the same race-tolerant pattern WaitForMemberLanded uses elsewhere),
-//     the member's own linked PR ends CLOSED (not MERGED), a "landing
-//     complete" bed-log line appears after the issue was filed, and
-//     fabrik:auto-merge-enabled is never applied at any point.
+//     which land the change via a separate integration/singleton PR and then
+//     attempt to close the member's own PR. That close attempt only
+//     sometimes succeeds: when the member merged cleanly into the trial
+//     branch, its commits are already ancestors of the base branch by the
+//     time the integration/singleton PR lands, so GitHub has already flipped
+//     the member PR to MERGED on its own — the engine's own close call then
+//     404/422s harmlessly (see #1271). CLOSED only happens when the trial
+//     needed conflict resolution. Both are legitimate terminal states; the
+//     invariant this test actually verifies is that the member's own PR was
+//     never itself the merge vehicle — i.e. a distinct integration/singleton
+//     PR exists and is the one GitHub reports MERGED. Verifies: the issue
+//     reaches Done (board Status "Done" or issue CLOSED, whichever is
+//     observed first — the same race-tolerant pattern WaitForMemberLanded
+//     uses elsewhere), the member's own linked PR reaches a terminal state
+//     (CLOSED or MERGED) while a distinct integration/singleton PR is
+//     confirmed MERGED, a "landing complete" bed-log line appears after the
+//     issue was filed, and fabrik:auto-merge-enabled is never applied at any
+//     point.
 //
 // Out of scope here (better suited to unit/integration tests because
 // provoking them deterministically in e2e is hard):
@@ -78,8 +89,28 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 			WaitForMemberLanded(t, env, env.RepoAlpha, num, 45*time.Minute)
 			t.Logf("%s#%d landed (Done or closed) — checking the merge-train path was taken", env.RepoAlpha, num)
 
-			waitForPRClosedNotMerged(t, env, env.RepoAlpha, prNum, 5*time.Minute)
-			t.Logf("member PR #%d closed without being merged — train landing contract verified", prNum)
+			// GitHub auto-marks a PR MERGED the instant its head commits become
+			// reachable from the base branch — even if Fabrik never called the
+			// merge API on that PR. When the member merged cleanly into the
+			// trial branch, that already happened by the time the
+			// integration/singleton PR lands, so the member's own PR is MERGED
+			// here, not CLOSED — and the engine's own close-the-member-PR call
+			// harmlessly 404/422s (see #1271). CLOSED only happens when the
+			// trial needed conflict resolution. Do NOT "fix" this back to a
+			// CLOSED-only assertion: both are legitimate terminal states. The
+			// invariant that actually matters — that the member's own PR was
+			// never the merge vehicle — is verified below by confirming a
+			// DISTINCT integration/singleton PR is the one GitHub reports
+			// MERGED.
+			landingPRNum := waitForLandingPRNumber(t, env, env.RepoAlpha, prNum, 5*time.Minute)
+			if landingPRNum == prNum {
+				t.Fatalf("member PR #%d cites itself as the landing PR — the member's own PR was the merge vehicle, not a separate integration/singleton PR (this would indicate a direct-merge regression)", prNum)
+			}
+			assertPRMerged(t, env, env.RepoAlpha, landingPRNum)
+			t.Logf("distinct integration/singleton PR #%d confirmed MERGED — train landing contract verified", landingPRNum)
+
+			waitForPRClosed(t, env, env.RepoAlpha, prNum, 5*time.Minute)
+			t.Logf("member PR #%d reached a terminal state (closed or merged-by-ancestry)", prNum)
 
 			WaitForLogLine(t, env, "landing complete", logStart, 5*time.Minute)
 			t.Logf("bed log shows a completed train landing")

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -315,6 +315,17 @@ var landedPRPattern = regexp.MustCompile(`Landed (?:via batch|one-at-a-time via 
 // suite. On timeout, check the bed log around this member's landing for
 // "warn: could not post landed comment on PR #<memberPRNum>" — if present,
 // the failure is this known-benign comment-post gap, not a stuck landing.
+//
+// No test-only fallback covers both landing paths reliably, so none is
+// implemented here — see #1275 (engine-side retry of this AddComment call,
+// the actual fix) for why: closedByPullRequestsReferences on the member
+// issue can't substitute because landSingleton's own landing-PR body says
+// "Lands #%d", not "Closes #%d" (engine/merge_train.go:778), so it never
+// registers as a closing PR reference for that path; and bed-log scanning
+// isn't member-scoped for the batch path's "merged integration PR #%d for
+// %s" (engine/merge_train.go:1786, repo-only — ambiguous under concurrent
+// merge-train activity), even though landSingleton's own log line happens to
+// be ("merged singleton landing PR #%d for #%d", engine/merge_train.go:796).
 func waitForLandingPRNumber(t *testing.T, env *Env, repo string, memberPRNum int, timeout time.Duration) int {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -332,8 +343,8 @@ func waitForLandingPRNumber(t *testing.T, env *Env, repo string, memberPRNum int
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for a \"landed via ...\" comment on member PR #%d on %s (last err: %v) — "+
 				"if the bed log shows \"warn: could not post landed comment on PR #%d\" around this landing, "+
-				"the engine's best-effort comment post failed transiently (not retried); this is a known, "+
-				"non-regression false failure — re-run the test", memberPRNum, repo, err, memberPRNum)
+				"the engine's best-effort comment post failed transiently (not retried, tracked as #1275); this "+
+				"is a known, non-regression false failure — re-run the test", memberPRNum, repo, err, memberPRNum)
 		}
 		time.Sleep(10 * time.Second)
 	}

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -5,6 +5,8 @@ package e2e
 import (
 	"encoding/base64"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -289,28 +291,36 @@ func waitForPRClosed(t *testing.T, env *Env, repo string, prNumber int, timeout 
 	}
 }
 
-// waitForPRClosedNotMerged polls until the PR reaches a terminal state, up to
-// timeout. Fails immediately on MERGED — for callers that need the stricter
-// "landed via a separate PR, not by GitHub merging this one" contract (e.g.
-// the merge-train's close-not-merge landing of a member's own PR), where
-// waitForPRClosed's permissive CLOSED-or-MERGED semantics would silently
-// accept the wrong outcome.
-func waitForPRClosedNotMerged(t *testing.T, env *Env, repo string, prNumber int, timeout time.Duration) {
+// landedPRPattern matches the engine-posted "landed" comment both landing
+// paths post on the member's OWN PR (engine/merge_train.go: landSingleton's
+// "Landed one-at-a-time via singleton PR #%d." and landMergeTrainBatch's
+// "Landed via batch PR #%d."), capturing the distinct integration/singleton
+// PR number the change actually landed through.
+var landedPRPattern = regexp.MustCompile(`Landed (?:via batch|one-at-a-time via singleton) PR #(\d+)\.`)
+
+// waitForLandingPRNumber polls the member's own PR comments (memberPRNum) for
+// the engine's "landed via ..." comment and returns the distinct
+// integration/singleton PR number it cites. This is scoped to the specific
+// member PR, so — unlike log scanning or WaitForIntegrationPR's repo-wide
+// "most recently created" search — it stays correct under t.Parallel()
+// execution where sibling merge-train scenarios land unrelated batches
+// concurrently in the same repo.
+func waitForLandingPRNumber(t *testing.T, env *Env, repo string, memberPRNum int, timeout time.Duration) int {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for {
-		out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
-			"--json", "state", "--jq", ".state")
+		bodies, err := tryPRComments(env, repo, memberPRNum)
 		if err == nil {
-			switch strings.TrimSpace(out) {
-			case "CLOSED":
-				return
-			case "MERGED":
-				t.Fatalf("member PR #%d on %s was MERGED, want CLOSED (should land via a separate integration/singleton PR, not by merging the member's own PR)", prNumber, repo)
+			for _, b := range bodies {
+				if m := landedPRPattern.FindStringSubmatch(b); m != nil {
+					if n, aerr := strconv.Atoi(m[1]); aerr == nil && n > 0 {
+						return n
+					}
+				}
 			}
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("member PR #%d on %s not closed within %s (last state: %q, err: %v)", prNumber, repo, timeout, strings.TrimSpace(out), err)
+			t.Fatalf("timed out waiting for a \"landed via ...\" comment on member PR #%d on %s (last err: %v)", memberPRNum, repo, err)
 		}
 		time.Sleep(10 * time.Second)
 	}

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -335,7 +335,7 @@ func assertPRMerged(t *testing.T, env *Env, repo string, prNumber int) {
 		t.Fatalf("could not read state of integration PR #%d: %v\n%s", prNumber, err, out)
 	}
 	if got := strings.TrimSpace(out); got != "MERGED" {
-		t.Fatalf("integration PR #%d state = %q, want MERGED (batch did not land atomically)", prNumber, got)
+		t.Fatalf("integration/singleton PR #%d state = %q, want MERGED (did not land atomically)", prNumber, got)
 	}
 }
 

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -332,13 +332,24 @@ func waitForLandingPRNumber(t *testing.T, env *Env, repo string, memberPRNum int
 	for {
 		bodies, err := tryPRComments(env, repo, memberPRNum)
 		if err == nil {
+			// Comments come back oldest-first; take the LAST match rather than
+			// the first so a restart-driven repost of the landed comment (or
+			// any other duplicate) yields the most recent — and therefore
+			// authoritative — landing PR number, not a stale one from an
+			// earlier partial run.
+			found := 0
 			for _, b := range bodies {
 				if m := landedPRPattern.FindStringSubmatch(b); m != nil {
 					if n, aerr := strconv.Atoi(m[1]); aerr == nil && n > 0 {
-						return n
+						found = n
 					}
 				}
 			}
+			if found > 0 {
+				return found
+			}
+		} else {
+			t.Logf("waitForLandingPRNumber: transient error reading PR #%d comments on %s: %v (will retry)", memberPRNum, repo, err)
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("timed out waiting for a \"landed via ...\" comment on member PR #%d on %s (last err: %v) — "+

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -305,6 +305,16 @@ var landedPRPattern = regexp.MustCompile(`Landed (?:via batch|one-at-a-time via 
 // "most recently created" search — it stays correct under t.Parallel()
 // execution where sibling merge-train scenarios land unrelated batches
 // concurrently in the same repo.
+//
+// This does depend on the engine's landed-comment AddComment call succeeding
+// (engine/merge_train.go:1817/:812 log a warn and move on if it fails — it is
+// not retried). That is the same best-effort-comment dependency
+// WaitForIssueComment/WaitForPRCommentContaining already carry for other
+// merge-train e2e scenarios (e.g. the "merge-train — ejected" and "runaway
+// guard tripped" comments), so this is not a new class of flakiness for the
+// suite. On timeout, check the bed log around this member's landing for
+// "warn: could not post landed comment on PR #<memberPRNum>" — if present,
+// the failure is this known-benign comment-post gap, not a stuck landing.
 func waitForLandingPRNumber(t *testing.T, env *Env, repo string, memberPRNum int, timeout time.Duration) int {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
@@ -320,7 +330,10 @@ func waitForLandingPRNumber(t *testing.T, env *Env, repo string, memberPRNum int
 			}
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for a \"landed via ...\" comment on member PR #%d on %s (last err: %v)", memberPRNum, repo, err)
+			t.Fatalf("timed out waiting for a \"landed via ...\" comment on member PR #%d on %s (last err: %v) — "+
+				"if the bed log shows \"warn: could not post landed comment on PR #%d\" around this landing, "+
+				"the engine's best-effort comment post failed transiently (not retried); this is a known, "+
+				"non-regression false failure — re-run the test", memberPRNum, repo, err, memberPRNum)
 		}
 		time.Sleep(10 * time.Second)
 	}


### PR DESCRIPTION
🏭 **Fabrik merge-train integration PR** (trial → main)

This is a disposable trial branch combining the following Queued member PRs:
#1271

Do not merge this PR manually — Fabrik manages the landing step.
Orphaned integration PRs (if the train worker crashed) can be closed manually via the GitHub UI.

Closes #1271

<!-- fabrik-merge-train-batch -->