### PR TITLE
test(e2e): add expected_reviewers scenarios (#1283 coverage)

### DIFF
--- a/adrs/1298-e2e-expected-reviewers-coverage.md
+++ b/adrs/1298-e2e-expected-reviewers-coverage.md
@@ -1,0 +1,182 @@
+# ADR 1298: e2e coverage for expected_reviewers via a per-issue label pair
+
+**Status:** Accepted
+**Date:** 2026-08-01
+**Issue:** [#1298](https://github.com/handarbeit/fabrik/issues/1298)
+
+## Context
+
+#1283 shipped `expected_reviewers` (declared unrequested reviewers for the review
+gate) with zero e2e coverage. The e2e test bed's `review.yaml`/`validate.yaml` leave
+`expected_reviewers` undeclared (`nil`), which correctly preserves the pre-#1283
+default (FR-5) — so the existing suite exercises only the undeclared path.
+Additionally, every existing review-gate scenario requests a reviewer explicitly,
+making `outstanding` non-empty, which short-circuits `reviewGateFastAdvance` before
+the declaration is even consulted. Both the declared-empty and declared-non-empty
+paths were unreachable from the suite as configured — the exact gap #1258 closed
+for `review_authority: authoritative`, recurring for a second stage-config field.
+
+This is a direct sequel to #1258/ADR-1258: same class of gap (a stage-config-scoped
+review-gate feature shipped without e2e coverage), same two constraints (no
+production code changes to `engine/reviews.go`/`stages/stages.go`; no change to the
+bed's default stage config for existing scenarios), and the same "landing gate is
+reachable only through a stage literally named `Validate`" limitation traced in
+ADR-1258's Context section — unchanged here, since neither issue touches that
+hardcoding.
+
+The one material difference from #1258: `review_authority` is a 2-value enum
+(`advisory`/`authoritative`), which is what made it cleanly encodable as a single
+boolean-style label. `expected_reviewers` is list-valued — an arbitrary reviewer-name
+list — so the same 1:1 label-to-config-value mapping doesn't transfer directly.
+
+## Decision
+
+**Apply a declared `expected_reviewers` value per issue via one of two fixed labels,
+against the bed's existing `Review` column/stage (default, untouched config).** No bed-
+local board column or stage-YAML variant is introduced.
+
+- `expected-reviewers:none` → `expected_reviewers: []` (the fast-advance path)
+- `expected-reviewers:declared` → `expected_reviewers: [e2e-synthetic-declared-reviewer]`
+  (the waiting/re-prompt-ladder path)
+
+Two fixed canned values, not a parametric list-valued label. `expected_reviewers`'s
+value shape (an arbitrary string list) doesn't collapse to a single boolean-style
+label the way `review_authority`'s enum did, but the five scenarios this issue's
+requirements specify only ever need two concrete values: empty, and a single
+declared name. Inventing a general CSV-in-label-value scheme (e.g.
+`expected-reviewers:name1,name2`) to cover list shapes no test here exercises would
+be speculative generality with no consumer — the same "keep it minimal" judgment
+Research's own open question flagged, mirroring #1261's narrow two-value scope for
+`review_authority`.
+
+Both labels are passed as `extraLabels` to the existing `seedReviewGateItem` helper
+(`tests/e2e/review_authority_helpers.go`) — no changes needed to that helper, since
+it already accepts arbitrary extra labels generically. This reuses #1258's harness
+pattern verbatim rather than inventing a second one: `CreateMemberPR` (zero Claude
+cost), `stage:Review:complete` label-seeding so the catch-up loop's
+`handleReviewGate` evaluates the gate without ever invoking Claude, and
+`SubmitPRReview` + `FABRIK_REVIEWER_TOKEN` for deterministic non-author verdicts
+where a scenario needs one.
+
+**Engine support for reading these two labels is tracked as a separate, decoupled
+follow-up issue**, not filed as part of #1298 and not spawned via
+`FABRIK_SPAWN_CHILD` — spawning would make #1298 `blockedBy` the follow-up, stalling
+test-writing (which needs no engine change) on an unrelated engine PR, inverting the
+whole point of "decoupled." This exactly mirrors how #1261 was kept decoupled from
+#1258. `TestExpectedReviewersFastAdvance`,
+`TestExpectedReviewersDeclaredWaitsAndReprompts`, `TestExpectedReviewersPrecedenceGuard`,
+and `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cannot pass until that
+follow-up merges and both label objects exist on the bed repo — they fail loudly
+(`FileIssue` fatal if the label object is missing; gate-timeout failure if the label
+exists but the engine doesn't yet read it), never skip silently.
+`TestExpectedReviewersUndeclaredRegressionGuard` sets neither label, exercises the
+bed's untouched `nil` default, and has no such dependency — it ships green in this
+PR alone.
+
+### Why a bed-local stage/column variant was rejected again, more severely than for #1258
+
+The alternative — a bed-local stage YAML declaring `expected_reviewers` directly,
+with a matching board column, mirroring the `Queued`/`queued.yaml` precedent — was
+considered (it's the "scenario-local stage/column variant" the issue's own Scope
+section pre-approved as an option) and rejected, for both of #1258's original
+reasons plus a third, specific to this feature:
+
+1. **Wrong level of abstraction** (same as #1258): `expected_reviewers` is a
+   property of a stage's config, not a distinct kind of stage. A bed-only
+   `ExpectedReviewers`-named stage would be test scaffolding masquerading as a
+   pipeline stage — the product itself has no such stage.
+2. **Silent-skip trap** (same as #1258): a missing bed prerequisite would let some
+   scenarios skip cleanly, reporting green while validating nothing.
+3. **Startup blast radius is categorically worse than #1258's rejected design.**
+   Tracing `checkStageColumnAlignment` (`engine/startup.go`) shows the exemptions
+   that make `CleanupWorktree`/`Unmanaged`/`HoldingStage` stages safe to omit from
+   the board do not extend to an ordinary `wait_for_reviews: true` stage:
+   `CleanupWorktree` and `Unmanaged` stages are exempt from the column check but
+   also never dispatch or evaluate gates at all; `HoldingStage` is exempt from the
+   check only when `merge_train != "on"`, but `engine/poll.go`'s catch-up loop
+   unconditionally skips `HoldingStage` items regardless of mode, so the exemption
+   wouldn't even help reach the gate. A **normal** stage — what
+   `expected_reviewers` + `wait_for_reviews: true` actually requires — gets **no
+   exemption**: if its YAML exists in `.fabrik/stages/` but its board column is
+   missing, Fabrik refuses to start entirely (`fmt.Errorf`, not a per-scenario
+   skip). This is a materially larger failure mode than #1258's already-rejected
+   `Review-Authoritative` design (whose worst case was three scenarios silently
+   skipping, not the whole shared bed refusing to start) — reinforcing rather than
+   merely repeating #1258's rejection.
+
+## Consequences
+
+**Advance-gate `expected_reviewers` coverage is real (pending the follow-up engine
+issue); landing-gate coverage is not.** Same accepted, documented gap as ADR-1258
+left for `review_authority` — `reviewGateBlocksLanding` is reachable only through a
+stage literally named `Validate`, and neither this issue nor its follow-up changes
+that hardcoding.
+
+**Four of the five scenarios have a hard dependency on the follow-up engine issue.**
+Until the engine reads `expected-reviewers:none`/`expected-reviewers:declared` and
+honors them as equivalent to the stage's `expected_reviewers` config,
+`TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
+`TestExpectedReviewersPrecedenceGuard`, and
+`TestExpectedReviewersFastAdvanceComposesWithAuthoritative` will fail (the gate
+behaves as if `expected_reviewers` were undeclared regardless of the label). This is
+expected and intentional, mirroring #1258/#1261's shipped state — this PR alone does
+not give green `expected_reviewers` coverage; the follow-up issue must land too.
+
+**Per-issue label, not board structure, remains the general pattern for
+stage-config-scoped e2e coverage that must not touch the bed's shared default
+stages** — ADR-1258's conclusion holds, now confirmed across two different
+value-shaped config fields (a 2-value enum and a reviewer-name list). A future
+stage-config-scoped feature should default to a label-per-value (or a small fixed
+label set for a bounded value space) rather than a bed-local stage/column variant,
+which should be reserved for behavior that is genuinely a distinct *stage* (like
+`Queued`), not a config flag on an existing one.
+
+**Five new zero-Claude-cost scenarios**
+(`TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
+`TestExpectedReviewersPrecedenceGuard`, `TestExpectedReviewersUndeclaredRegressionGuard`,
+`TestExpectedReviewersFastAdvanceComposesWithAuthoritative`) run in both legs of the
+two-mode gate at negligible added GitHub API cost, since none of them touch
+merge-train code paths. `TestExpectedReviewersDeclaredWaitsAndReprompts` is the
+first e2e coverage of the bot re-prompt ladder (`fabrik:bot-reprompted`, Phase 1/2
+of `checkAwaitingReviewTimeout`) at all — that path was unconditionally unreachable
+from the suite before this issue, since `reviewGateAllBots`'s declared-reviewer
+branch (the only way to reach the ladder without a formally requested bot reviewer)
+had no scenario declaring `expected_reviewers` to activate it.
+
+## Alternatives Considered
+
+**A bed-local `ExpectedReviewers`-declaring stage/column variant.** Rejected — see
+"Why a bed-local stage/column variant was rejected again, more severely than for
+#1258" above. Materially worse blast radius than #1258's already-rejected
+`Review-Authoritative` design: a missing column doesn't skip scenarios, it stops the
+shared bed from starting.
+
+**A parametric, arbitrary-list-encoding label** (e.g.
+`expected-reviewers:name1,name2`, or a label whose suffix is parsed as a
+comma-separated list). Rejected as speculative generality: the five scenarios this
+issue's requirements specify only need two concrete values (empty, and one
+declared name), and a general encoding scheme has no test consumer today. Two fixed
+labels, mirroring `effort:<level>`'s discrete-label idiom, cover everything needed
+with less surface to validate and document.
+
+**A per-issue label override for `ExpectedReviewers`** (mirroring `model:<name>`/
+`effort:<level>`/`base:<branch>`, and directly reusing #1261's `review-authority:<mode>`
+pattern). This is the mechanism ultimately adopted for the *test* side — see Decision
+above. It does require a production engine change to read the labels, which is why
+that change is tracked and merged as a separate, decoupled follow-up issue rather
+than folded into this test-coverage-only PR, exactly as #1261 was kept decoupled
+from #1258. `ExpectedReviewers` on `stages.Stage` remains stage-scoped per ADR-1283;
+the labels are an independent per-issue override layered on top by the follow-up
+issue, not a change to `ExpectedReviewers`'s own type or the stage config schema.
+
+## References
+
+- [ADR-1283: Declared unrequested reviewers for the review gate](1283-declared-unrequested-reviewers.md) — the shipped behavior this issue adds e2e coverage for.
+- [ADR-1258: e2e coverage for `review_authority: authoritative` via a per-issue label](1258-e2e-review-authority-coverage.md) — the direct precedent this issue follows and extends to a list-shaped config field; its Context/Decision/Consequences structure and its column/stage-variant rejection rationale are reused and reinforced here.
+- [ADR-1261: per-issue `review-authority:<mode>` label override](1261-per-issue-review-authority-label-override.md) — the engine-side decoupled-follow-up template the (not-yet-filed) `expected_reviewers` label-override issue should mirror.
+- `engine/reviews.go:379` `reviewGateFastAdvance`, `:144`/`:654` call sites, `:151-152`/`:1060-1062` declared-reviewer consumption — the production code this issue's scenarios exercise without modifying.
+- `stages/stages.go:106-127` `Stage.ExpectedReviewers`, `:288-325` `validateExpectedReviewers`.
+- `engine/startup.go:28-177` `checkStageColumnAlignment` — traced to establish the startup blast-radius argument against a bed-local stage/column design.
+- `tests/e2e/expected_reviewers_test.go` — the implementation.
+- `tests/e2e/review_authority_helpers.go` (`seedReviewGateItem`) — reused as-is, no changes.
+- `tests/e2e/README.md` §"Additional prerequisites for `TestExpectedReviewers*` scenarios".

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -337,6 +337,88 @@ scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` dis
     an unrecognized value would require new branch-protection bed setup, which is not
     "cheaply expressible" per the issue's own bar for that scenario.
 
+### Additional prerequisites for `TestExpectedReviewers*` scenarios
+
+`TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
+`TestExpectedReviewersPrecedenceGuard`, and
+`TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cover ADR-1283's
+`expected_reviewers` (declared unrequested reviewers for the review gate).
+`TestExpectedReviewersUndeclaredRegressionGuard` is the fifth scenario and has no
+dependency described below. All five run against the bed's existing `Review`
+column/stage (default, untouched config) — **no bed column or stage-YAML setup is
+required**, beyond `FABRIK_REVIEW_WAIT_TIMEOUT`/`FABRIK_REVIEWER_TOKEN` (already
+documented above) and the two labels below.
+
+**Mechanism: two per-issue labels, not a bed column.** A declared `expected_reviewers`
+value is applied per item via one of two labels, passed as an extra label at seed
+time (`seedReviewGateItem`'s `extraLabels`):
+
+- `expected-reviewers:none` → `expected_reviewers: []` (fast-advance path)
+- `expected-reviewers:declared` → `expected_reviewers: [e2e-synthetic-declared-reviewer]`
+  (waiting/re-prompt-ladder path)
+
+This is the same mechanism `TestReviewAuthority*` uses for
+`review-authority:authoritative` (see above), applied to a second, list-shaped
+stage-config field. Engine support for reading these two labels is tracked as a
+separate, decoupled follow-up issue (not yet filed as of #1298's PR — see that
+PR's description for the exact spec: the four call sites to update, the
+`declared` > `none` precedence rule, and the `github/labels.go` pre-seeding step).
+`TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
+`TestExpectedReviewersPrecedenceGuard`, and
+`TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cannot pass until that
+follow-up merges and both labels exist on the bed repo — they either run for real
+or fail loudly (not skip) if the follow-up hasn't landed yet, mirroring #1258's
+rejection of silent skips. `TestExpectedReviewersUndeclaredRegressionGuard` sets
+neither label, exercises the bed's untouched default (`nil`) config, and ships
+green regardless.
+
+A bed-local `wait_for_reviews`-bearing stage/board-column variant (mirroring the
+`Queued`/`queued.yaml` precedent) was considered and rejected for this feature too
+— see `adrs/1298-e2e-expected-reviewers-coverage.md`. Its blast radius is worse
+than the `Review-Authoritative` design #1258 already rejected: a normal (non-
+`HoldingStage`, non-`Unmanaged`) stage gets no board-column-alignment exemption at
+startup (`engine/startup.go` `checkStageColumnAlignment`), so a missing column
+would stop the shared bed from starting entirely — not just skip a handful of
+scenarios — taking every other in-flight parallel scenario down with it.
+
+**Why these scenarios can't cover the landing/auto-merge gate:** same reason as
+`TestReviewAuthority*` above — `reviewGateBlocksLanding` is only reachable through
+a stage literally named `Validate`, and seeding on `Review` cannot reach it. This
+is a documented, accepted e2e gap.
+
+25. **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — same non-author PAT as
+    prerequisite #20, required only by `TestExpectedReviewersPrecedenceGuard`
+    (the others don't need a submitted review). Skips with an instructional
+    message if unset.
+26. **`expected-reviewers:none` and `expected-reviewers:declared` labels seeded**
+    in `handarbeit/fabrik-test-alpha` (the only repo these scenarios use).
+    `FileIssue` passes extra labels straight through to `gh issue create --label`,
+    which — like `AddLabel` (prerequisite #8) and prerequisite #21's
+    `review-authority:authoritative` label — fatals immediately if a label doesn't
+    already exist as a label object in the repo; `gh` does not auto-create labels
+    on issue creation. Create both manually if needed:
+    ```
+    gh label create expected-reviewers:none -R handarbeit/fabrik-test-alpha
+    gh label create expected-reviewers:declared -R handarbeit/fabrik-test-alpha
+    ```
+    This is independent of the follow-up engine issue: that issue adds the code
+    that *interprets* a label an issue already carries, not the GitHub label
+    object itself — the objects must exist before any of these scenarios can even
+    file their seed issue.
+27. **`TestExpectedReviewersDeclaredWaitsAndReprompts`'s wall-clock is long**
+    (~2×`FABRIK_REVIEW_WAIT_TIMEOUT` + buffer, similar to
+    `TestReviewAuthorityBlocksAndPausesOnChangesRequested`) — Phase 1 and Phase 2
+    of the bot re-prompt ladder are folded into one continuation. The same
+    moderate `FABRIK_REVIEW_WAIT_TIMEOUT` value recommended in prerequisite #23
+    (e.g. `5`) applies here too; a very short value risks a legitimate Phase 1/2
+    transition racing this test's own bounded-window assertions in
+    `TestExpectedReviewersFastAdvance`/`...ComposesWithAuthoritative`.
+28. **The synthetic declared-reviewer name (`e2e-synthetic-declared-reviewer`)
+    must never resolve to a real, active GitHub account** on the bed's org —
+    same rationale as prerequisite #22's warning against reusing a real installed
+    bot: an unrelated real actor submitting a review would race the deterministic
+    re-prompt-ladder assertions in `TestExpectedReviewersDeclaredWaitsAndReprompts`.
+
 ## Running
 
 The recommended entrypoint is the runner script, which sets sensible defaults:
@@ -589,12 +671,17 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestReviewAuthorityClearsOnApproval` | ADR-1250 authoritative mode (via `review-authority:authoritative` label, requires #1261): APPROVED verdict clears the gate; fabrik:paused never applied | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250 composition guarantee (via `review-authority:authoritative` label, requires #1261): fabrik:yolo does not bypass an authoritative gate — blocked while CHANGES_REQUESTED stands, clears once approved | Both | 5–10 min | ~$0.03 (no Claude) |
 | `TestReviewAuthorityAdvisoryRegressionGuard` | Regression guard: advisory (default) mode still clears on any submitted review regardless of verdict — proves the additive authoritative check didn't narrow the default path | Both | 2–5 min | ~$0.02 (no Claude) |
+| `TestExpectedReviewersFastAdvance` | ADR-1283 `expected_reviewers: []` (via `expected-reviewers:none` label, requires follow-up engine issue): nothing requested/reviewed → gate fast-advances instead of waiting out the review timeout (the #1080 stall this feature fixes) | Both | 2–5 min | ~$0.02 (no Claude) |
+| `TestExpectedReviewersDeclaredWaitsAndReprompts` | ADR-1283 `expected_reviewers: [<name>]` (via `expected-reviewers:declared` label, requires follow-up engine issue): declared-but-unrequested reviewer holds the gate open, Phase 1 re-prompt ladder fires with an @mention comment, Phase 2 pauses for human when no response arrives | Both | ~2×`FABRIK_REVIEW_WAIT_TIMEOUT` + buffer | ~$0.05 (no Claude) |
+| `TestExpectedReviewersPrecedenceGuard` | ADR-1283 precedence guard (via `expected-reviewers:none` label, requires follow-up engine issue): a genuinely requested reviewer holds the gate open despite `expected_reviewers: []` being declared | Both | 5–10 min | ~$0.03 (no Claude) |
+| `TestExpectedReviewersUndeclaredRegressionGuard` | Regression guard: undeclared (`nil`) `expected_reviewers` still never fast-advances — pins the `expected != nil` check and proves the shipped default (FR-5) is unchanged | Both | 2–5 min | ~$0.02 (no Claude) |
+| `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` | ADR-1283 composition guard (via `expected-reviewers:none` + `review-authority:authoritative` labels, requires follow-up engine issue + #1261): fast-advance still fires ahead of the authority-verdict branch, since it only activates once hasReviews is true | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | Train-only (on) | 10–25 min | low (no Claude) |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | Train-only (on) | 20–40 min | low–moderate |
 | `TestMergeTrainRestartSafety` | ADR-059 D5 / #960: after a landing, a restart with the historical merged integration PR present does NOT stall the next batch (reconstruct proceeds fresh). **Not parallel** — restarts the bed | Train-only (on) | 25–50 min | low |
 | `TestMergeTrainRunawayGuardPausesBatch` | ADR-059 D8 (#964/#965): persistently-red 4-member batch trips the runaway guard at cap=6, pauses all Queued members, no member reaches Done. Runs on RepoBeta for counter isolation | Train-only (on) | 10–20 min | low (no Claude) |
 
-Approximate single-mode suite total: ~615 min wall-clock, $10.30–30 in Claude
+Approximate single-mode suite total: ~685 min wall-clock, $10.30–30 in Claude
 tokens. A full two-mode gate run is roughly double this, minus the
 near-instant skip of the four Train-only scenarios in the `off` leg — the
 default `E2E_TIMEOUT=4h` and the contention data behind it (see "How the
@@ -622,6 +709,11 @@ shape, not just the single-mode total.
 | `TestReviewAuthorityClearsOnApproval` | ADR-1250, #1258 |
 | `TestReviewAuthorityYoloDoesNotBypassBlock` | ADR-1250's yolo/cruise composition guarantee, #1258 |
 | `TestReviewAuthorityAdvisoryRegressionGuard` | ADR-1250 additive-check regression guard, #1258 |
+| `TestExpectedReviewersFastAdvance` | ADR-1283 (`expected_reviewers`), #1298 (this scenario), the #1080 stall the feature exists to eliminate |
+| `TestExpectedReviewersDeclaredWaitsAndReprompts` | ADR-1283, #1298 — first e2e coverage of the bot re-prompt ladder (`fabrik:bot-reprompted`, Phase 1/2 of `checkAwaitingReviewTimeout`) |
+| `TestExpectedReviewersPrecedenceGuard` | ADR-1283, #1298 — declared reviewers narrow waiting for unrequested reviewers only, never bypass a genuinely requested one |
+| `TestExpectedReviewersUndeclaredRegressionGuard` | ADR-1283 FR-5 regression guard, #1298 — pins `reviewGateFastAdvance`'s `expected != nil` check |
+| `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` | ADR-1283, #1298 — fast-advance independence from `review_authority` (ADR-1250) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 D1/D3 (#946, #947, #948) — Queued column, trial-branch build, integration-PR landing + member lifecycle |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4 (#949) — halving bisection, ejection, one-at-a-time fallback |
 | `TestMergeTrainRestartSafety` | ADR-059 D5 (#950) + PR #960 (reconstruct must not stall on a historical merged PR) |

--- a/tests/e2e/expected_reviewers_test.go
+++ b/tests/e2e/expected_reviewers_test.go
@@ -1,0 +1,270 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+// This file covers ADR-1283's expected_reviewers (declared unrequested
+// reviewers for the review gate) end-to-end (issue #1298), using
+// deterministic harness-posted verdicts (SubmitPRReview +
+// FABRIK_REVIEWER_TOKEN) — never the bed's COMMENT-only claude-review.yml
+// bot — for every verdict assertion. This is the direct #1258 precedent
+// applied to a second, list-shaped stage-config field.
+//
+// Mechanism: all scenarios seed a member PR directly via the GitHub API
+// (seedReviewGateItem -> CreateMemberPR, zero Claude cost) against the bed's
+// existing Review column/stage (default config — untouched). A declared
+// expected_reviewers value is applied per issue via one of two labels passed
+// as an extraLabel to seedReviewGateItem:
+//
+//	expectedReviewersNoneLabel     = "expected-reviewers:none"     -> []string{}
+//	expectedReviewersDeclaredLabel = "expected-reviewers:declared" -> []string{expectedReviewersSyntheticName}
+//
+// Engine support for reading these labels is a separate, decoupled follow-up
+// issue (not yet filed as of this PR — see the Implement-stage PR
+// description for its exact spec), mirroring how #1261 was kept decoupled
+// from #1258. Scenarios that rely on a declared value (fast-advance,
+// declared-waits, precedence, composition) cannot pass until that follow-up
+// merges and the two label objects exist on the bed repo; the regression
+// guard (undeclared/nil) has no such dependency and ships green in this PR
+// alone. See adrs/1298-e2e-expected-reviewers-coverage.md.
+//
+// Bed setup required: FABRIK_REVIEWER_TOKEN (existing prerequisite, reused
+// from #1258), and the "expected-reviewers:none" / "expected-reviewers:declared"
+// labels must already exist as label objects in the target repo (gh issue
+// create --label fails hard, not gracefully, if either doesn't — see README
+// prerequisite). Neither is a bed column or stage-YAML variant, and no
+// scenario skips for lack of either — a missing label surfaces as a
+// t.Fatalf from FileIssue, by design (mirroring #1258's rejection of silent
+// skips).
+//
+// expectedReviewersSyntheticName is deliberately not a real GitHub account
+// or an installed bot (e.g. NOT handarbeit-pruefer) — reviewGateAllBots'
+// declared-reviewer branch doesn't check IsBot for declared names, so any
+// structurally-valid (validateExpectedReviewers-passing) string works, and a
+// synthetic name avoids racing a real actor's review against the
+// deterministic re-prompt-ladder assertions in
+// TestExpectedReviewersDeclaredWaitsAndReprompts.
+//
+// Scope limitation (see adrs/1298-e2e-expected-reviewers-coverage.md, and
+// its #1258 precedent): the landing/auto-merge gate (reviewGateBlocksLanding,
+// called only from attemptMergeOnValidate) is reachable ONLY through a stage
+// literally named "Validate" (engine/stages.go, engine/poll.go,
+// engine/pr_terminal_advance.go all hard-gate on stage.Name == "Validate").
+// Seeding an item on Review cannot reach that stage-name-gated path, so this
+// file only exercises checkReviewGate (the advance gate) — a documented,
+// accepted gap, not a silently missing one.
+//
+// All scenarios only touch checkReviewGate, which has no FABRIK_MERGE_TRAIN
+// branching — they pass identically under both legs of the suite's two-mode
+// gate.
+const (
+	expectedReviewersNoneLabel     = "expected-reviewers:none"
+	expectedReviewersDeclaredLabel = "expected-reviewers:declared"
+	expectedReviewersSyntheticName = "e2e-synthetic-declared-reviewer"
+)
+
+// TestExpectedReviewersFastAdvance covers requirements scenario 1: with
+// expected_reviewers: [] declared, no requested reviewer, and no submitted
+// review, the gate fast-advances instead of waiting out
+// FABRIK_REVIEW_WAIT_TIMEOUT — the #1080 stall this feature exists to
+// eliminate. Requires the follow-up engine-side label-read issue to be
+// merged; see the file-level doc comment.
+//
+// Wall-clock: ~2-5 min (a short window well under FABRIK_REVIEW_WAIT_TIMEOUT).
+func TestExpectedReviewersFastAdvance(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-none-fast-advance", expectedReviewersNoneLabel)
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+
+	// The gate must never apply fabrik:awaiting-review at all — a fast
+	// advance clears before the label-apply branch is ever reached. Poll for
+	// a bounded window comfortably shorter than FABRIK_REVIEW_WAIT_TIMEOUT so
+	// a regressed (non-fast-advancing) gate is distinguishable from a
+	// fast-advancing one within this test's own timeout, not just by the
+	// absence of the label at the very end.
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		if labels, err := tryIssueLabels(env, env.RepoAlpha, num); err == nil && slices.Contains(labels, "fabrik:awaiting-review") {
+			t.Fatalf("fabrik:awaiting-review applied to %s#%d despite expected_reviewers: [] and nothing requested/reviewed — "+
+				"gate did not fast-advance (reviewGateFastAdvance not firing, or the follow-up engine label-read issue not merged)",
+				env.RepoAlpha, num)
+		}
+		pollSleep(pollBase())
+	}
+	AssertLabelWasNeverApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("R1 verified: %s#%d fast-advanced — fabrik:awaiting-review never applied with expected_reviewers: [] declared", env.RepoAlpha, num)
+}
+
+// TestExpectedReviewersDeclaredWaitsAndReprompts covers requirements
+// scenario 2: with expected_reviewers: [<name>] declared and no requested
+// reviewer, the gate waits (does not fast-advance) and the bot re-prompt
+// ladder engages — behavior undeclared config cannot reach at all (this is
+// the first e2e coverage of the bot re-prompt ladder). Folds Phase 1 and
+// Phase 2 into one continuation, mirroring how #1258 folded its scenario 5
+// into scenario 1's test. Requires the follow-up engine-side label-read
+// issue to be merged; see the file-level doc comment.
+//
+// Wall-clock (worst case): ~2xFABRIK_REVIEW_WAIT_TIMEOUT + buffer — see
+// README for a recommended bed value.
+func TestExpectedReviewersDeclaredWaitsAndReprompts(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	reviewWaitTimeout := readEnvFileReviewWaitTimeout(t, env)
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-declared-reprompt", expectedReviewersDeclaredLabel)
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+
+	// Contrast with TestExpectedReviewersFastAdvance: a declared-but-unmatched
+	// reviewer must NOT fast-advance — fabrik:awaiting-review is applied
+	// immediately, same as the undeclared default.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d — declared reviewer holds the gate open", env.RepoAlpha, num)
+
+	// Phase 1: after one ReviewWaitTimeout window with no response, the
+	// engine re-prompts the declared identity via a direct @mention comment
+	// (no PR review-request mutation, since it was never formally requested)
+	// and applies fabrik:bot-reprompted.
+	phase1Wait := time.Duration(reviewWaitTimeout+10) * time.Minute
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:bot-reprompted", phase1Wait)
+	t.Logf("fabrik:bot-reprompted appeared on %s#%d — Phase 1 re-prompt fired", env.RepoAlpha, num)
+
+	WaitForPRCommentContainingAny(t, env, env.RepoAlpha, num,
+		[]string{"@" + expectedReviewersSyntheticName}, 5*time.Minute)
+	t.Logf("Phase 1 re-prompt comment on %s#%d mentions the declared reviewer %q", env.RepoAlpha, num, expectedReviewersSyntheticName)
+
+	// Phase 2: the synthetic name never actually reviews, so after a second
+	// full timeout window the engine gives up and pauses for a human,
+	// removing both fabrik:bot-reprompted and fabrik:awaiting-review.
+	phase2Wait := time.Duration(reviewWaitTimeout+10) * time.Minute
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:paused", phase2Wait)
+	t.Logf("fabrik:paused appeared on %s#%d — Phase 2 timed out with no response from the declared reviewer", env.RepoAlpha, num)
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-input", 5*time.Minute)
+
+	if state := IssueState(t, env, env.RepoAlpha, num); state != "OPEN" {
+		t.Fatalf("expected issue OPEN after declared-reviewer Phase 2 timeout, got %s on %s#%d", state, env.RepoAlpha, num)
+	}
+	t.Logf("R2 verified: %s#%d — declared reviewer held the gate open, Phase 1 re-prompted, Phase 2 paused for human", env.RepoAlpha, num)
+}
+
+// TestExpectedReviewersPrecedenceGuard covers requirements scenario 3: a
+// genuinely requested reviewer (non-empty outstanding) overrides
+// expected_reviewers: [] — the declaration narrows waiting for *unrequested*
+// reviewers only and must never bypass wait_for_reviews for a reviewer
+// GitHub is actually tracking. Requires the follow-up engine-side
+// label-read issue to be merged; see the file-level doc comment.
+//
+// (The other half of "precedence" — an already-submitted review overriding
+// expected_reviewers: [] — is definitionally the same pre-#1283
+// hasReviews-clearing path every existing review-gate scenario already
+// exercises, since reviewGateFastAdvance short-circuits on hasReviews before
+// the declaration is even consulted; it is not re-asserted here as it would
+// be redundant, not a new assertion. See adrs/1298-e2e-expected-reviewers-coverage.md.)
+//
+// Wall-clock: ~5-10 min.
+func TestExpectedReviewersPrecedenceGuard(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	reviewerToken := readEnvFileReviewerToken(t, env)
+	if reviewerToken == "" {
+		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
+	}
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-none-precedence", expectedReviewersNoneLabel)
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+
+	reviewerLogin := TokenLogin(t, reviewerToken)
+	if engineLogin := TokenLogin(t, env.GHToken); reviewerLogin == engineLogin {
+		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
+			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
+	}
+
+	RequestPRReviewer(t, env, env.RepoAlpha, prNum, reviewerLogin)
+	t.Logf("requested reviewer %q on %s PR #%d despite expected_reviewers: [] being declared", reviewerLogin, env.RepoAlpha, prNum)
+
+	// A genuinely outstanding requested reviewer must hold the gate open —
+	// the empty declaration must not fast-advance past it.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("fabrik:awaiting-review confirmed on %s#%d — requested reviewer overrides expected_reviewers: []", env.RepoAlpha, num)
+
+	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "APPROVE")
+	t.Logf("submitted APPROVE review on %s PR #%d", env.RepoAlpha, prNum)
+
+	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	t.Logf("R3 verified: %s#%d — gate held for the requested reviewer despite expected_reviewers: [], cleared once they reviewed", env.RepoAlpha, num)
+}
+
+// TestExpectedReviewersUndeclaredRegressionGuard covers requirements
+// scenario 4: undeclared (nil) expected_reviewers still never fast-advances
+// — proves the shipped default (FR-5) is unchanged. Seeds with no extra
+// label at all, against the bed's existing, untouched Review stage — this
+// pins the `expected != nil` half of reviewGateFastAdvance specifically:
+// it fails if fast-advance were ever changed to treat nil the same as an
+// empty slice. Zero dependency on the follow-up engine issue; ships green
+// in this PR alone.
+//
+// Wall-clock: ~2-5 min.
+func TestExpectedReviewersUndeclaredRegressionGuard(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-nil-regression")
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+
+	// Undeclared (nil) must behave exactly as it did before #1283: the gate
+	// blocks unconditionally on "nothing requested, nothing reviewed yet",
+	// applying fabrik:awaiting-review immediately rather than fast-advancing.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
+	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("R4 verified: %s#%d — undeclared (nil) expected_reviewers still applies fabrik:awaiting-review, never fast-advances", env.RepoAlpha, num)
+}
+
+// TestExpectedReviewersFastAdvanceComposesWithAuthoritative covers
+// requirements scenario 5: expected_reviewers: [] fast-advance composes with
+// review_authority: authoritative — per reviewGateFastAdvance's doc comment,
+// this path is deliberately independent of authority because it only fires
+// when hasReviews is false (before any verdict could be weighed). Worth
+// pinning so a future change can't couple them and recreate #1080 for
+// authoritative stages. Requires the follow-up engine-side label-read issue
+// (for expected-reviewers:none) AND #1261 (for review-authority:authoritative,
+// already merged) to be in effect; see the file-level doc comment.
+//
+// Wall-clock: ~2-5 min.
+func TestExpectedReviewersFastAdvanceComposesWithAuthoritative(t *testing.T) {
+	t.Parallel()
+	env := LoadEnv(t)
+	AssertFabrikRunning(t, env)
+
+	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-none-authoritative",
+		expectedReviewersNoneLabel, "review-authority:authoritative")
+	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
+
+	// Same bounded-window assertion as TestExpectedReviewersFastAdvance:
+	// fast-advance must fire before any authority-verdict branch is ever
+	// reached (that branch only activates once hasReviews is true, which
+	// never happens here — nothing is ever reviewed).
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		if labels, err := tryIssueLabels(env, env.RepoAlpha, num); err == nil && slices.Contains(labels, "fabrik:awaiting-review") {
+			t.Fatalf("fabrik:awaiting-review applied to %s#%d despite expected_reviewers: [] and review-authority:authoritative — "+
+				"fast-advance did not fire ahead of the authority-verdict branch", env.RepoAlpha, num)
+		}
+		pollSleep(pollBase())
+	}
+	AssertLabelWasNeverApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
+	t.Logf("R5 verified: %s#%d fast-advanced despite review-authority:authoritative — fast-advance composes independently of authority mode", env.RepoAlpha, num)
+}

--- a/tests/e2e/expected_reviewers_test.go
+++ b/tests/e2e/expected_reviewers_test.go
@@ -139,9 +139,9 @@ func TestExpectedReviewersDeclaredWaitsAndReprompts(t *testing.T) {
 	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:bot-reprompted", phase1Wait)
 	t.Logf("fabrik:bot-reprompted appeared on %s#%d — Phase 1 re-prompt fired", env.RepoAlpha, num)
 
-	WaitForPRCommentContainingAny(t, env, env.RepoAlpha, num,
+	WaitForPRCommentContainingAny(t, env, env.RepoAlpha, prNum,
 		[]string{"@" + expectedReviewersSyntheticName}, 5*time.Minute)
-	t.Logf("Phase 1 re-prompt comment on %s#%d mentions the declared reviewer %q", env.RepoAlpha, num, expectedReviewersSyntheticName)
+	t.Logf("Phase 1 re-prompt comment on %s PR #%d mentions the declared reviewer %q", env.RepoAlpha, prNum, expectedReviewersSyntheticName)
 
 	// Phase 2: the synthetic name never actually reviews, so after a second
 	// full timeout window the engine gives up and pauses for a human,


### PR DESCRIPTION
Closes #1298

## Summary

#1283 shipped `expected_reviewers` (declared unrequested reviewers for the review gate) with zero e2e coverage. This PR adds five new scenarios in `tests/e2e/expected_reviewers_test.go` covering the declared-empty fast-advance path, the declared-non-empty waiting/re-prompt-ladder path, a precedence guard, and a regression guard for the undeclared (`nil`) default — following the #1258 precedent for deterministic, harness-driven review-gate testing (`SubmitPRReview` + `FABRIK_REVIEWER_TOKEN`, zero-Claude-cost seeding via `seedReviewGateItem`).

## What changed

- **`tests/e2e/expected_reviewers_test.go`** (new): `TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`, `TestExpectedReviewersPrecedenceGuard`, `TestExpectedReviewersUndeclaredRegressionGuard`, `TestExpectedReviewersFastAdvanceComposesWithAuthoritative`. All seed against the bed's existing, untouched `Review` column/stage via `seedReviewGateItem` — no bed-local stage/column variant, no changes to `.fabrik/stages/review.yaml`/`validate.yaml`.
- **`tests/e2e/README.md`**: new prerequisites subsection, five new scenario-table rows, five new regression-coverage-map rows.
- **`adrs/1298-e2e-expected-reviewers-coverage.md`** (new): records the decision (per-issue label pair vs. a bed-local stage/column variant) and why the latter was rejected even more decisively than #1258's analogous rejection (an ordinary `wait_for_reviews` stage gets no board-column-alignment exemption at Fabrik startup — a missing column would stop the entire shared bed from starting, not just skip a few scenarios).

## Mechanism

Two new per-issue labels, passed as `extraLabels` to the existing `seedReviewGateItem` helper (no changes to that helper):

- `expected-reviewers:none` → `expected_reviewers: []` (fast-advance path)
- `expected-reviewers:declared` → `expected_reviewers: [e2e-synthetic-declared-reviewer]` (waiting/re-prompt-ladder path)

This mirrors #1258's `review-authority:authoritative` label precedent, extended to a list-shaped config field via two fixed canned values rather than a general list-encoding scheme (no test here needs more than two concrete values).

**Engine support for reading these labels does not exist yet** — this PR is test-coverage only, per the issue's explicit scope (no changes to `engine/reviews.go`/`stages/stages.go`). `TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`, `TestExpectedReviewersPrecedenceGuard`, and `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` will fail until a follow-up engine issue lands and both label objects are created on the bed repo. `TestExpectedReviewersUndeclaredRegressionGuard` has no such dependency and ships green in this PR alone.

### Follow-up issue to file (not spawned — deliberately decoupled, mirroring #1261/#1258)

A separate issue should be filed for the engine-side label read:

- **Title**: e.g. "Per-issue `expected-reviewers:<mode>` label override for `expected_reviewers`"
- **New labels to interpret**: `expected-reviewers:none` → `[]string{}`; `expected-reviewers:declared` → `[]string{"e2e-synthetic-declared-reviewer"}` (or, more generally, a small fixed canned-value mapping)
- **Call sites to update**: `engine/reviews.go:144` (`checkReviewGate`'s fast-advance call), `:151-152` (declared-reviewer computation), `:654` (`reviewGateBlocksLanding`'s fast-advance call), `:1060-1062` (declared-reviewer status messaging in `pauseForReviewTimeout`) — add an `extractExpectedReviewersOverride`/`effectiveExpectedReviewers` pair structurally identical to #1261's `extractReviewAuthorityOverride`/`effectiveReviewAuthority`, consulted at both gate call sites so they can't disagree.
- **Precedence rule**: if both labels are present on one issue, `declared` wins over `none` (the conservative choice — waiting is always safer than fast-advancing), mirroring `effort:<level>`'s "most restrictive wins" convention rather than `model:<name>`'s "first wins" convention.
- **Bed setup**: create both label objects in `handarbeit/fabrik-test-alpha` via `gh label create expected-reviewers:none -R handarbeit/fabrik-test-alpha` and the `:declared` equivalent (documented in `tests/e2e/README.md`, prerequisite #26 in this PR).

## Test plan

- [x] `go vet -tags e2e ./...` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `gofmt -l` clean on the new test file
- [ ] Full e2e run (`scripts/e2e/run.sh -run 'TestExpectedReviewers'`) — 4 of 5 scenarios will fail until the follow-up engine issue lands and the two labels are created on the bed; `TestExpectedReviewersUndeclaredRegressionGuard` should pass standalone