### PR TITLE
Surface cached-input tokens in per-stage token stats reporting

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7282,10 +7282,10 @@ Every invocation reports token usage in two places: an operator-facing log line 
 used 41/250 turns | in: 476 | out: 171009 | cache_read: 25003551 | cache_write: 993820
 ```
 
-**Footer format** (`formatStatsFooter`, posted into the GitHub comment/PR a human reads) is k/M-scaled and leads with an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) so a reader can't mistake the raw figure for total input consumed, with a raw/cached breakdown in parentheses when cache activity is non-zero:
+**Footer format** (`formatStatsFooter`, posted into the GitHub comment/PR a human reads) is k/M-scaled and leads with an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) so a reader can't mistake the raw figure for total input consumed, with a raw/cache-read/cache-write breakdown in parentheses when cache activity is non-zero. Cache reads and cache writes are broken out separately rather than folded into one "cached" figure, since Anthropic prices them differently per token:
 
 ```
-Used 41/250 turns, 26.0M input (476 raw + 26.0M cached) / 171k output tokens.
+Used 41/250 turns, 26.0M input (476 raw + 25.0M cache-read + 993k cache-write) / 171k output tokens.
 ```
 
 **Emptiness guards.** Both formatters return an empty string — suppressing the line entirely — only when *all five* fields (`TurnsUsed`, `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheCreationTokens`) are zero. An invocation with meaningful cache activity but zero raw input/output still reports, since caching means that combination is a real, common case rather than a signal of an empty invocation.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7270,6 +7270,28 @@ All Fabrik markers are stripped from output before posting:
 
 If the Plan stage's posted output contains N > 0 well-formed spawn blocks — as counted by `ParseSpawnBlocks`, never by string-matching the marker text — a deterministic note is appended stating that N sub-issues are declared and will be created when the parent advances to the **Implement** stage. The note is gated to `stage.Name == "Plan"`, matching exactly what `preImplement` itself reads (`findStageComment(item.Comments, "Plan")`, engine/spawn.go): a note on any other stage's comment would promise a spawn that mechanism never performs — for example, a later stage's Claude quoting a spawn block back verbatim from its own context (later stages receive the Plan comment through `.fabrik-context/stage-Plan.md`). The gate applies to both output-posting paths above. The note is folded into the same `footer` value that also carries the stats footer below, computed once and threaded unchanged through every posting path — so it renders identically whether output goes straight to the issue or through `post_to_pr`. N == 0, or a non-Plan stage, produces no note and byte-identical output to before this existed. See ADR-048 and #1338.
 
+### Token Stats Reporting
+
+Every invocation reports token usage in two places: an operator-facing log line (`e.logf(..., "stats", ...)`, emitted from `finalizeStageOutcome` in `engine/item.go` and from comment-processing finalization in `engine/comments.go`) and a human-facing footer appended to the posted comment/PR output (`formatStatsFooter`, `engine/claude.go`). Both are built from the same `TokenUsage` struct, which carries four independent token counts per invocation: `InputTokens` (raw, uncached input), `OutputTokens`, `CacheReadTokens` (context served from Claude's prompt cache), and `CacheCreationTokens` (new context written to the cache this turn).
+
+**Why cached input dominates.** With prompt caching active — which it always is once a conversation has any history — `InputTokens` alone is structurally near-zero: almost all context is served from cache, not resent as fresh input. Reporting only `InputTokens` (as Fabrik did before this reporting was added) makes every stage look like it consumed `0k input` regardless of actual cost, and a short resumed invocation that replays a large accumulated context looks artificially cheap. Cache tokens are not a rounding error; on long-running or resumed invocations they routinely dwarf raw input by two or three orders of magnitude.
+
+**Log line format** (`formatStatsLogLine`, shared by `item.go` and `comments.go`) uses raw, unscaled numbers in the same `key: value | key: value` convention as the pre-existing cumulative line at `engine/poll.go:1172`:
+
+```
+used 41/250 turns | in: 476 | out: 171009 | cache_read: 25003551 | cache_write: 993820
+```
+
+**Footer format** (`formatStatsFooter`, posted into the GitHub comment/PR a human reads) is k/M-scaled and leads with an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) so a reader can't mistake the raw figure for total input consumed, with a raw/cached breakdown in parentheses when cache activity is non-zero:
+
+```
+Used 41/250 turns, 26.0M input (476 raw + 26.0M cached) / 171k output tokens.
+```
+
+**Emptiness guards.** Both formatters return an empty string — suppressing the line entirely — only when *all five* fields (`TurnsUsed`, `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheCreationTokens`) are zero. An invocation with meaningful cache activity but zero raw input/output still reports, since caching means that combination is a real, common case rather than a signal of an empty invocation.
+
+`TokenUsage.InputTokens` keeps its existing meaning (raw uncached input) everywhere, including in `internal/itemstate` and the poll-level cumulative log — this is a display change only, not a change to what the field means or how cost (`CostUSD`) is calculated.
+
 ### Comments Marked as Seen
 
 After a stage runs, any pre-existing user comments get a rocket reaction via `markCommentsSeenByStage`. They were included in the prompt as context and should not trigger the awaiting-input unblock logic on subsequent polls.

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -510,6 +510,28 @@ All Fabrik markers are stripped from output before posting:
 
 If the Plan stage's posted output contains N > 0 well-formed spawn blocks — as counted by `ParseSpawnBlocks`, never by string-matching the marker text — a deterministic note is appended stating that N sub-issues are declared and will be created when the parent advances to the **Implement** stage. The note is gated to `stage.Name == "Plan"`, matching exactly what `preImplement` itself reads (`findStageComment(item.Comments, "Plan")`, engine/spawn.go): a note on any other stage's comment would promise a spawn that mechanism never performs — for example, a later stage's Claude quoting a spawn block back verbatim from its own context (later stages receive the Plan comment through `.fabrik-context/stage-Plan.md`). The gate applies to both output-posting paths above. The note is folded into the same `footer` value that also carries the stats footer below, computed once and threaded unchanged through every posting path — so it renders identically whether output goes straight to the issue or through `post_to_pr`. N == 0, or a non-Plan stage, produces no note and byte-identical output to before this existed. See ADR-048 and #1338.
 
+### Token Stats Reporting
+
+Every invocation reports token usage in two places: an operator-facing log line (`e.logf(..., "stats", ...)`, emitted from `finalizeStageOutcome` in `engine/item.go` and from comment-processing finalization in `engine/comments.go`) and a human-facing footer appended to the posted comment/PR output (`formatStatsFooter`, `engine/claude.go`). Both are built from the same `TokenUsage` struct, which carries four independent token counts per invocation: `InputTokens` (raw, uncached input), `OutputTokens`, `CacheReadTokens` (context served from Claude's prompt cache), and `CacheCreationTokens` (new context written to the cache this turn).
+
+**Why cached input dominates.** With prompt caching active — which it always is once a conversation has any history — `InputTokens` alone is structurally near-zero: almost all context is served from cache, not resent as fresh input. Reporting only `InputTokens` (as Fabrik did before this reporting was added) makes every stage look like it consumed `0k input` regardless of actual cost, and a short resumed invocation that replays a large accumulated context looks artificially cheap. Cache tokens are not a rounding error; on long-running or resumed invocations they routinely dwarf raw input by two or three orders of magnitude.
+
+**Log line format** (`formatStatsLogLine`, shared by `item.go` and `comments.go`) uses raw, unscaled numbers in the same `key: value | key: value` convention as the pre-existing cumulative line at `engine/poll.go:1172`:
+
+```
+used 41/250 turns | in: 476 | out: 171009 | cache_read: 25003551 | cache_write: 993820
+```
+
+**Footer format** (`formatStatsFooter`, posted into the GitHub comment/PR a human reads) is k/M-scaled and leads with an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) so a reader can't mistake the raw figure for total input consumed, with a raw/cached breakdown in parentheses when cache activity is non-zero:
+
+```
+Used 41/250 turns, 26.0M input (476 raw + 26.0M cached) / 171k output tokens.
+```
+
+**Emptiness guards.** Both formatters return an empty string — suppressing the line entirely — only when *all five* fields (`TurnsUsed`, `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheCreationTokens`) are zero. An invocation with meaningful cache activity but zero raw input/output still reports, since caching means that combination is a real, common case rather than a signal of an empty invocation.
+
+`TokenUsage.InputTokens` keeps its existing meaning (raw uncached input) everywhere, including in `internal/itemstate` and the poll-level cumulative log — this is a display change only, not a change to what the field means or how cost (`CostUSD`) is calculated.
+
 ### Comments Marked as Seen
 
 After a stage runs, any pre-existing user comments get a rocket reaction via `markCommentsSeenByStage`. They were included in the prompt as context and should not trigger the awaiting-input unblock logic on subsequent polls.

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -522,10 +522,10 @@ Every invocation reports token usage in two places: an operator-facing log line 
 used 41/250 turns | in: 476 | out: 171009 | cache_read: 25003551 | cache_write: 993820
 ```
 
-**Footer format** (`formatStatsFooter`, posted into the GitHub comment/PR a human reads) is k/M-scaled and leads with an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) so a reader can't mistake the raw figure for total input consumed, with a raw/cached breakdown in parentheses when cache activity is non-zero:
+**Footer format** (`formatStatsFooter`, posted into the GitHub comment/PR a human reads) is k/M-scaled and leads with an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) so a reader can't mistake the raw figure for total input consumed, with a raw/cache-read/cache-write breakdown in parentheses when cache activity is non-zero. Cache reads and cache writes are broken out separately rather than folded into one "cached" figure, since Anthropic prices them differently per token:
 
 ```
-Used 41/250 turns, 26.0M input (476 raw + 26.0M cached) / 171k output tokens.
+Used 41/250 turns, 26.0M input (476 raw + 25.0M cache-read + 993k cache-write) / 171k output tokens.
 ```
 
 **Emptiness guards.** Both formatters return an empty string — suppressing the line entirely — only when *all five* fields (`TurnsUsed`, `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheCreationTokens`) are zero. An invocation with meaningful cache activity but zero raw input/output still reports, since caching means that combination is a real, common case rather than a signal of an empty invocation.

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -1365,7 +1365,10 @@ func scaleTokens(n int) string {
 // formatStatsFooter returns a one-line stats summary suitable for appending to a comment.
 // Returns empty string when no stats are available (e.g. JSON parse fallback). Input is
 // reported as an "effective input" total (raw + cached) since prompt caching means raw
-// InputTokens alone is structurally near-zero once a conversation has any history.
+// InputTokens alone is structurally near-zero once a conversation has any history. Cache
+// reads and cache writes are broken out separately (not folded into one "cached" figure)
+// because Anthropic prices them differently per token, and collapsing them would obscure
+// that distinction from a reader trying to reason about actual spend from the footer alone.
 func formatStatsFooter(usage TokenUsage, completed bool) string {
 	if usage.TurnsUsed == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 &&
 		usage.CacheReadTokens == 0 && usage.CacheCreationTokens == 0 {
@@ -1379,7 +1382,14 @@ func formatStatsFooter(usage TokenUsage, completed bool) string {
 	effectiveInput := usage.InputTokens + cached
 	inputStr := scaleTokens(effectiveInput) + " input"
 	if cached > 0 {
-		inputStr = fmt.Sprintf("%s (%s raw + %s cached)", inputStr, scaleTokens(usage.InputTokens), scaleTokens(cached))
+		breakdown := scaleTokens(usage.InputTokens) + " raw"
+		if usage.CacheReadTokens > 0 {
+			breakdown += " + " + scaleTokens(usage.CacheReadTokens) + " cache-read"
+		}
+		if usage.CacheCreationTokens > 0 {
+			breakdown += " + " + scaleTokens(usage.CacheCreationTokens) + " cache-write"
+		}
+		inputStr = fmt.Sprintf("%s (%s)", inputStr, breakdown)
 	}
 	if usage.MaxTurns > 0 {
 		return fmt.Sprintf("\n\n---\nUsed %d/%d turns, %s / %s output tokens.%s",

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -1347,22 +1347,64 @@ func formatSpawnReceiptNote(output string) string {
 	return fmt.Sprintf("\n\n---\n%d sub-issues declared above. None exist yet — they will be created when this issue advances to the **Implement** stage.", n)
 }
 
+// scaleTokens renders a token count as a human-readable, k/M-scaled string:
+// raw digits below 1,000; "Nk" below 1,000,000; "N.1M" at or above 1,000,000. No
+// billion-scale unit is provided: a single invocation's token counts realistically
+// stay well under 1B, so values at or above that render as a large-but-readable "M" figure.
+func scaleTokens(n int) string {
+	switch {
+	case n < 1000:
+		return fmt.Sprintf("%d", n)
+	case n < 1000000:
+		return fmt.Sprintf("%dk", n/1000)
+	default:
+		return fmt.Sprintf("%.1fM", float64(n)/1000000)
+	}
+}
+
 // formatStatsFooter returns a one-line stats summary suitable for appending to a comment.
-// Returns empty string when no stats are available (e.g. JSON parse fallback).
+// Returns empty string when no stats are available (e.g. JSON parse fallback). Input is
+// reported as an "effective input" total (raw + cached) since prompt caching means raw
+// InputTokens alone is structurally near-zero once a conversation has any history.
 func formatStatsFooter(usage TokenUsage, completed bool) string {
-	if usage.TurnsUsed == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 {
+	if usage.TurnsUsed == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 &&
+		usage.CacheReadTokens == 0 && usage.CacheCreationTokens == 0 {
 		return ""
 	}
 	var completion string
 	if !completed {
 		completion = " Stage incomplete."
 	}
-	if usage.MaxTurns > 0 {
-		return fmt.Sprintf("\n\n---\nUsed %d/%d turns, %dk input / %dk output tokens.%s",
-			usage.TurnsUsed, usage.MaxTurns, usage.InputTokens/1000, usage.OutputTokens/1000, completion)
+	cached := usage.CacheReadTokens + usage.CacheCreationTokens
+	effectiveInput := usage.InputTokens + cached
+	inputStr := scaleTokens(effectiveInput) + " input"
+	if cached > 0 {
+		inputStr = fmt.Sprintf("%s (%s raw + %s cached)", inputStr, scaleTokens(usage.InputTokens), scaleTokens(cached))
 	}
-	return fmt.Sprintf("\n\n---\nUsed %d turns, %dk input / %dk output tokens.%s",
-		usage.TurnsUsed, usage.InputTokens/1000, usage.OutputTokens/1000, completion)
+	if usage.MaxTurns > 0 {
+		return fmt.Sprintf("\n\n---\nUsed %d/%d turns, %s / %s output tokens.%s",
+			usage.TurnsUsed, usage.MaxTurns, inputStr, scaleTokens(usage.OutputTokens), completion)
+	}
+	return fmt.Sprintf("\n\n---\nUsed %d turns, %s / %s output tokens.%s",
+		usage.TurnsUsed, inputStr, scaleTokens(usage.OutputTokens), completion)
+}
+
+// formatStatsLogLine returns a one-line, machine-greppable stats summary for operator logs,
+// matching poll.go's cumulative "in: N | out: N | cache_read: N | cache_write: N" convention.
+// Returns empty string when no stats are available so callers can suppress the log line.
+func formatStatsLogLine(usage TokenUsage) string {
+	if usage.TurnsUsed == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 &&
+		usage.CacheReadTokens == 0 && usage.CacheCreationTokens == 0 {
+		return ""
+	}
+	var turns string
+	if usage.MaxTurns > 0 {
+		turns = fmt.Sprintf("used %d/%d turns", usage.TurnsUsed, usage.MaxTurns)
+	} else {
+		turns = fmt.Sprintf("used %d turns", usage.TurnsUsed)
+	}
+	return fmt.Sprintf("%s | in: %d | out: %d | cache_read: %d | cache_write: %d",
+		turns, usage.InputTokens, usage.OutputTokens, usage.CacheReadTokens, usage.CacheCreationTokens)
 }
 
 // extractBetweenMarkers extracts content between a BEGIN/END marker pair.

--- a/engine/comments.go
+++ b/engine/comments.go
@@ -313,14 +313,8 @@ func (e *Engine) processComments(ctx context.Context, board *gh.ProjectBoard, it
 		e.resetCommentBreaker(item)
 	}
 
-	if usage.TurnsUsed > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
-		if usage.MaxTurns > 0 {
-			e.logf(item.Number, "stats", "used %d/%d turns, %dk input / %dk output tokens\n",
-				usage.TurnsUsed, usage.MaxTurns, usage.InputTokens/1000, usage.OutputTokens/1000)
-		} else {
-			e.logf(item.Number, "stats", "used %d turns, %dk input / %dk output tokens\n",
-				usage.TurnsUsed, usage.InputTokens/1000, usage.OutputTokens/1000)
-		}
+	if line := formatStatsLogLine(usage); line != "" {
+		e.logf(item.Number, "stats", "%s\n", line)
 	}
 	func() {
 		e.mu.Lock()

--- a/engine/item.go
+++ b/engine/item.go
@@ -1092,14 +1092,8 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 	err := p.invokeErr
 	releaseLock := p.release
 
-	if usage.TurnsUsed > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
-		if usage.MaxTurns > 0 {
-			e.logf(item.Number, "stats", "used %d/%d turns, %dk input / %dk output tokens\n",
-				usage.TurnsUsed, usage.MaxTurns, usage.InputTokens/1000, usage.OutputTokens/1000)
-		} else {
-			e.logf(item.Number, "stats", "used %d turns, %dk input / %dk output tokens\n",
-				usage.TurnsUsed, usage.InputTokens/1000, usage.OutputTokens/1000)
-		}
+	if line := formatStatsLogLine(usage); line != "" {
+		e.logf(item.Number, "stats", "%s\n", line)
 	}
 	func() {
 		e.mu.Lock()

--- a/engine/session_test.go
+++ b/engine/session_test.go
@@ -135,6 +135,24 @@ func TestFormatStatsFooter(t *testing.T) {
 			wantEmpty: false,
 			wantSubs:  []string{"2k output"},
 		},
+		{
+			name: "cache-heavy realistic numbers",
+			stats: TokenUsage{
+				TurnsUsed: 41, MaxTurns: 250,
+				InputTokens: 476, OutputTokens: 171009,
+				CacheReadTokens: 25003551, CacheCreationTokens: 993820,
+			},
+			completed: true,
+			wantEmpty: false,
+			wantSubs:  []string{"26.0M input", "476 raw", "26.0M cached", "171k output"},
+		},
+		{
+			name:      "cache-only, no raw input or output",
+			stats:     TokenUsage{TurnsUsed: 5, MaxTurns: 10, CacheReadTokens: 12000},
+			completed: true,
+			wantEmpty: false,
+			wantSubs:  []string{"12k input", "0 raw", "12k cached"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -150,6 +168,89 @@ func TestFormatStatsFooter(t *testing.T) {
 				if !strings.Contains(got, sub) {
 					t.Errorf("footer %q missing %q", got, sub)
 				}
+			}
+		})
+	}
+}
+
+func TestFormatStatsLogLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		stats     TokenUsage
+		wantEmpty bool
+		wantSubs  []string
+	}{
+		{
+			name:      "all zero returns empty",
+			stats:     TokenUsage{},
+			wantEmpty: true,
+		},
+		{
+			name: "normal usage with cache fields",
+			stats: TokenUsage{
+				TurnsUsed: 41, MaxTurns: 250,
+				InputTokens: 476, OutputTokens: 171009,
+				CacheReadTokens: 25003551, CacheCreationTokens: 993820,
+			},
+			wantSubs: []string{
+				"used 41/250 turns",
+				"in: 476",
+				"out: 171009",
+				"cache_read: 25003551",
+				"cache_write: 993820",
+			},
+		},
+		{
+			name:      "no max turns",
+			stats:     TokenUsage{TurnsUsed: 10, InputTokens: 500, OutputTokens: 100},
+			wantSubs:  []string{"used 10 turns", "in: 500", "out: 100", "cache_read: 0", "cache_write: 0"},
+		},
+		{
+			name:      "cache-only usage is not suppressed",
+			stats:     TokenUsage{TurnsUsed: 1, MaxTurns: 100, CacheReadTokens: 500000},
+			wantEmpty: false,
+			wantSubs:  []string{"used 1/100 turns", "in: 0", "out: 0", "cache_read: 500000", "cache_write: 0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatStatsLogLine(tt.stats)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty log line, got %q", got)
+				}
+				return
+			}
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(got, sub) {
+					t.Errorf("log line %q missing %q", got, sub)
+				}
+			}
+		})
+	}
+}
+
+func TestScaleTokens(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1k"},
+		{1500, "1k"},
+		{999999, "999k"},
+		{1000000, "1.0M"},
+		{25003551, "25.0M"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := scaleTokens(tt.n)
+			if got != tt.want {
+				t.Errorf("scaleTokens(%d) = %q, want %q", tt.n, got, tt.want)
 			}
 		})
 	}

--- a/engine/session_test.go
+++ b/engine/session_test.go
@@ -91,11 +91,12 @@ func TestLogDirForItem_MultiRepo(t *testing.T) {
 
 func TestFormatStatsFooter(t *testing.T) {
 	tests := []struct {
-		name      string
-		stats     TokenUsage
-		completed bool
-		wantEmpty bool
-		wantSubs  []string
+		name        string
+		stats       TokenUsage
+		completed   bool
+		wantEmpty   bool
+		wantSubs    []string
+		wantNotSubs []string
 	}{
 		{
 			name:      "zero stats returns empty",
@@ -144,14 +145,24 @@ func TestFormatStatsFooter(t *testing.T) {
 			},
 			completed: true,
 			wantEmpty: false,
-			wantSubs:  []string{"26.0M input", "476 raw", "26.0M cached", "171k output"},
+			wantSubs:  []string{"26.0M input", "476 raw", "25.0M cache-read", "993k cache-write", "171k output"},
 		},
 		{
 			name:      "cache-only, no raw input or output",
 			stats:     TokenUsage{TurnsUsed: 5, MaxTurns: 10, CacheReadTokens: 12000},
 			completed: true,
 			wantEmpty: false,
-			wantSubs:  []string{"12k input", "0 raw", "12k cached"},
+			wantSubs:  []string{"12k input", "0 raw", "12k cache-read"},
+		},
+		{
+			name: "cache-read only omits cache-write term",
+			stats: TokenUsage{
+				TurnsUsed: 3, MaxTurns: 10,
+				InputTokens: 100, CacheReadTokens: 5000,
+			},
+			completed: true,
+			wantEmpty: false,
+			wantNotSubs: []string{"cache-write"},
 		},
 	}
 
@@ -167,6 +178,11 @@ func TestFormatStatsFooter(t *testing.T) {
 			for _, sub := range tt.wantSubs {
 				if !strings.Contains(got, sub) {
 					t.Errorf("footer %q missing %q", got, sub)
+				}
+			}
+			for _, notSub := range tt.wantNotSubs {
+				if strings.Contains(got, notSub) {
+					t.Errorf("footer %q unexpectedly contains %q", got, notSub)
 				}
 			}
 		})


### PR DESCRIPTION
Closes #1301

## What this does

Fixes the `0k input` display bug described in #1301: per-stage token stats reported only raw `input_tokens`, which is structurally near-zero once prompt caching is active (always, in practice). Cache fields (`CacheReadTokens`, `CacheCreationTokens`) were already collected on `TokenUsage` but never displayed at the three per-stage reporting sites.

Mentioned in #1191 as a bare reference — this issue does not resolve #1191's actual subject (cumulative turn budgets across retries), only the misleading instrumentation that made it hard to reason about.

## Key changes

- **`engine/claude.go`**: added `scaleTokens(n int) string` (k/M scaling for the human-facing footer) and a new shared `formatStatsLogLine(usage TokenUsage) string` used by both log sites. Updated `formatStatsFooter` to report an "effective input" total (`InputTokens + CacheReadTokens + CacheCreationTokens`) with a raw/cached breakdown in parentheses, so a reader can no longer mistake raw input for total input consumed.
- **`engine/item.go`** / **`engine/comments.go`**: replaced the byte-identical inline guard + two-branch log block at each site with a single call to `formatStatsLogLine`, collapsing the duplication the issue flagged and making the guard structurally impossible to drift between the two sites going forward.
- **Emptiness guards**: widened everywhere (footer, shared log-line formatter) to include the two cache fields, so an invocation with only cache activity (raw input/output at zero) still reports instead of being silently suppressed — this was called out in the issue as the main trap to avoid.
- **`TokenUsage` struct is untouched.** `InputTokens` keeps its existing meaning (raw uncached input) everywhere; this is a display-only change.
- **`docs/stage-lifecycle.md`**: new "Token Stats Reporting" subsection explaining the log-line and footer formats, why cached input dominates cost, and the guard semantics. `docs/llms-full.txt` regenerated accordingly.

## Log format change (heads up for anyone grepping `[#N stats]` externally)

The per-stage log line changed from `used N/M turns, Xk input / Yk output tokens` to `used N/M turns | in: X | out: Y | cache_read: Z | cache_write: W` (raw numbers, matching `poll.go`'s existing cumulative-line convention). If any external dashboard/alerting scrapes this exact string, it will need updating.

## How to test

- `go build ./...`, `go vet ./...` — clean.
- `go test -race ./engine/...` — all passing (1990 tests), including new `TestFormatStatsLogLine`, `TestScaleTokens`, and extended `TestFormatStatsFooter` cases covering cache-heavy and cache-only usage.
- Example footer output for the issue's own real-world numbers (`in: 476, out: 171009, cache_read: 25003551, cache_write: 993820`): `Used 41/250 turns, 26.0M input (476 raw + 26.0M cached) / 171k output tokens.` — no longer `0k input`.