### PR TITLE
fix(e2e): make TestCrossRepoSpawn fixture per-run unique

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -658,7 +658,7 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestSmokeSingleRepoFullPipeline` | Full single-repo pipeline (Specify → … → Done with merged PR) | Both | 20–40 min | $0.50–1.50 |
 | `TestNoWorkNeeded` | `FABRIK_NO_WORK_NEEDED` short-circuit closes issue without PR | Both | 10–15 min | $0.30–0.50 |
 | `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` pause + comment-driven resume | Both | 10–15 min | $0.30–0.50 |
-| `TestCrossRepoSpawn` | Cross-repo decomposition (spawn child in beta, gate parent, resume on close) | Both | 45–60 min | $1.00–2.00 |
+| `TestCrossRepoSpawn` | Cross-repo decomposition (spawn child in beta, gate parent, resume on close); final assertion reads back a per-run-unique sentinel string from the merged beta-side file, not merely the `fabrik:children-spawned` label | Both | 45–60 min | $1.00–2.00 |
 | `TestYoloAutoMergeLabel` | `fabrik:yolo` auto-advance to Done; mode-appropriate landing contract (native auto-merge + `fabrik:auto-merge-enabled` under "off"; train close-not-merge + label never applied under "on") | Both (mode-aware) | 20–40 min | $0.50–1.50 |
 | `TestConvergenceRace` | Deterministic post-Validate auto-merge race (#829): two conflicting yolo PRs; mode-appropriate `fabrik:auto-merge-enabled` contract, both land within budget, neither ends `fabrik:paused` | Both (mode-aware) | 80–100 min | $2–4 |
 | `TestCruiseFullPipeline` | `fabrik:cruise` auto-advances to Validate-complete without auto-merge; PR merged by human closes issue | Both | 30–50 min | $0.80–2.00 |
@@ -696,7 +696,7 @@ shape, not just the single-mode total.
 | `TestSmokeSingleRepoFullPipeline` | Full pipeline regression |
 | `TestNoWorkNeeded` | #733 (marker), #742 (close-on-no-work) |
 | `TestBlockedOnInput` | `FABRIK_BLOCKED_ON_INPUT` marker, ed46b7fc (awaiting-input label clear) |
-| `TestCrossRepoSpawn` | #797 / #803 (on-demand spawn-target init), v0.0.66 spawn machinery, #800 (addBlockedBy mutation name) |
+| `TestCrossRepoSpawn` | #797 / #803 (on-demand spawn-target init), v0.0.66 spawn machinery, #800 (addBlockedBy mutation name), #1308 (per-run-unique fixture token; stronger final assertion) |
 | `TestYoloAutoMergeLabel` | #829 (GitHub native auto-merge for yolo), #831/#835/#871 (convergence regression cascade) |
 | `TestConvergenceRace` | #829 (post-Validate auto-merge race, Story 2/SC-002); regression guard for the production failure on example-org/example-repo#82 (spurious CI-fix-cycle-limit pause); #1217 (mode-aware `fabrik:auto-merge-enabled` assertion) |
 | `TestCruiseFullPipeline` | #898 (cruise/yolo gate at Validate, `engine/poll.go`); ensures cruise never triggers `checkAutoMergeConvergence` |

--- a/tests/e2e/cross_repo_spawn_test.go
+++ b/tests/e2e/cross_repo_spawn_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -28,7 +29,17 @@ func TestCrossRepoSpawn(t *testing.T) {
 	AssertFabrikRunning(t, env)
 
 	startedAt := time.Now()
-	body := fmt.Sprintf(crossRepoBodyTemplate, env.RepoBeta, env.RepoBeta, env.RepoAlpha)
+
+	// Per-run-unique token so the fixture isn't satisfied by a prior run's
+	// beta-side work (#1308). idSuffix is a legal Go exported-identifier
+	// suffix (digits only, from the punctuation-stripped stamp); sentinel is
+	// the human-readable variant used as the function's returned string.
+	stamp := time.Now().UTC().Format("20060102-150405")
+	idSuffix := strings.ReplaceAll(stamp, "-", "")
+	sentinel := fmt.Sprintf("e2e-cross-repo-spawn-%s", stamp)
+
+	body := fmt.Sprintf(crossRepoBodyTemplate,
+		env.RepoBeta, env.RepoBeta, idSuffix, sentinel, env.RepoAlpha, idSuffix)
 	parent := FileIssue(t, env, env.RepoAlpha,
 		fmt.Sprintf("e2e cross-repo spawn (%s)", startedAt.Format("15:04:05")),
 		body,
@@ -75,12 +86,28 @@ func TestCrossRepoSpawn(t *testing.T) {
 	// Parent unblocks, runs Implement → Review → Validate → closes.
 	WaitForIssueClosed(t, env, env.RepoAlpha, parent, 30*time.Minute)
 	t.Logf("parent closed — cross-repo flow complete")
+
+	// fabrik:children-spawned only proves Plan emitted a spawn block — it
+	// doesn't prove the beta-side change was implemented correctly. Read the
+	// merged beta content back and confirm the run-specific sentinel landed,
+	// so the scenario still fails if the cross-repo spawn mechanism itself
+	// regresses (#1308).
+	content := FetchRepoFileContent(t, env, env.RepoBeta, "pkg/greeting/greeting.go")
+	if !strings.Contains(content, sentinel) {
+		t.Fatalf("expected sentinel %q not found in %s/pkg/greeting/greeting.go; fetched content:\n%s",
+			sentinel, env.RepoBeta, content)
+	}
+	t.Logf("sentinel %q confirmed in %s/pkg/greeting/greeting.go — beta-side work verified", sentinel, env.RepoBeta)
 }
 
 // crossRepoBodyTemplate is the issue body for TestCrossRepoSpawn. Written
 // without raw-string backticks (Go raw strings can't contain them); markdown
-// code spans use *italics* style instead. The two %s placeholders are
-// (1) beta repo name, (2) alpha repo name.
+// code spans use *italics* style instead. The %s placeholders, in order, are
+// (1) beta repo name, (2) beta repo name, (3) idSuffix (the per-run
+// identifier-safe token, in the beta function name), (4) sentinel (the
+// per-run human-readable token, as the returned string literal), (5) alpha
+// repo name, (6) idSuffix again (the same token, in the alpha call site —
+// must match (3) exactly since it's the same function).
 const crossRepoBodyTemplate = `## Goal
 
 Verify cross-repo decomposition works end-to-end. Plan should spawn a sub-issue in %s because the work requires changes in both repos in strict order.
@@ -88,16 +115,16 @@ Verify cross-repo decomposition works end-to-end. Plan should spawn a sub-issue 
 ## What needs to change
 
 ### In %s (the beta repo)
-- Add an exported function HelloE2E() string to pkg/greeting/greeting.go returning the literal string "e2e-cross-repo-spawn".
+- Add an exported function HelloE2E%s() string to pkg/greeting/greeting.go returning the literal string "%s".
 - Add a test for it in pkg/greeting/greeting_test.go.
 
 ### In %s (this repo)
-- Update main.go to call greeting.HelloE2E() (in addition to whatever it already does) and print the result.
+- Update main.go to call greeting.HelloE2E%s() (in addition to whatever it already does) and print the result.
 - Run go mod tidy if needed.
 
 ## Constraint
 
-Beta must land first because alpha cannot import a function that does not yet exist. Plan should emit a FABRIK_SPAWN_CHILD_BEGIN block targeting the beta repo to decompose.
+Beta must land first because alpha cannot import a function that does not yet exist. Plan should emit a FABRIK_SPAWN_CHILD_BEGIN block targeting the beta repo to decompose. Use the exact function name and string literal given above verbatim — do not invent your own; a per-run-unique token is already baked into them, and this scenario's final assertion depends on that exact text landing in the beta repo.
 
-This is an e2e regression test for #803 (on-demand spawn-target repo init).
+This is an e2e regression test for #803 (on-demand spawn-target repo init) and #1308 (per-run-unique fixture token).
 `

--- a/tests/e2e/cross_repo_spawn_test.go
+++ b/tests/e2e/cross_repo_spawn_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
 	"testing"
 	"time"
@@ -31,12 +32,17 @@ func TestCrossRepoSpawn(t *testing.T) {
 	startedAt := time.Now()
 
 	// Per-run-unique token so the fixture isn't satisfied by a prior run's
-	// beta-side work (#1308). idSuffix is a legal Go exported-identifier
-	// suffix (digits only, from the punctuation-stripped stamp); sentinel is
-	// the human-readable variant used as the function's returned string.
+	// beta-side work (#1308). The stamp alone is only second-granularity, so
+	// two runs starting in the same UTC second (a manual re-run right after a
+	// failure, or racing CI shards) would collide; a random nonce is appended
+	// to rule that out. idSuffix is a legal Go exported-identifier suffix
+	// (digits only, from the punctuation-stripped token); sentinel is the
+	// human-readable variant used as the function's returned string.
 	stamp := time.Now().UTC().Format("20060102-150405")
-	idSuffix := strings.ReplaceAll(stamp, "-", "")
-	sentinel := fmt.Sprintf("e2e-cross-repo-spawn-%s", stamp)
+	nonce := fmt.Sprintf("%04d", rand.IntN(10000))
+	token := stamp + "-" + nonce
+	idSuffix := strings.ReplaceAll(token, "-", "")
+	sentinel := fmt.Sprintf("e2e-cross-repo-spawn-%s", token)
 
 	body := fmt.Sprintf(crossRepoBodyTemplate,
 		env.RepoBeta, env.RepoBeta, idSuffix, sentinel, env.RepoAlpha, idSuffix)

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
@@ -637,6 +638,29 @@ query {
 		}
 	}
 	t.Fatalf("%s#%d not blocked by %s#%d (blockedBy was: %+v)", issueRepo, issueNumber, blockerRepo, blockerNumber, nodes)
+}
+
+// FetchRepoFileContent reads a file's content from repo's default branch via
+// the GitHub Contents API and returns it decoded. Mirrors CreateMemberPR's
+// write shape (mergetrain_helpers.go) but as a read. Fails the test
+// immediately on a fetch/decode error (API or plumbing failure) — a
+// content-mismatch check is the caller's responsibility, kept separate so a
+// transient API hiccup here is never mistaken for "the expected content is
+// absent". GitHub wraps the base64 content with embedded newlines, which
+// must be stripped before decoding.
+func FetchRepoFileContent(t *testing.T, env *Env, repo, path string) string {
+	t.Helper()
+	out, err := ghOutput(env, "api", fmt.Sprintf("repos/%s/contents/%s", repo, path),
+		"--jq", ".content")
+	if err != nil {
+		t.Fatalf("fetch %s from %s: %v\n%s", path, repo, err, out)
+	}
+	encoded := strings.ReplaceAll(strings.TrimSpace(out), "\n", "")
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode content of %s from %s: %v", path, repo, err)
+	}
+	return string(decoded)
 }
 
 // CloseIssue best-effort closes the named issue (used in t.Cleanup).


### PR DESCRIPTION
Closes #1308

## What this does

`TestCrossRepoSpawn`'s issue-body template asked for a fixed symbol name and sentinel string (`HelloE2E()` / `"e2e-cross-repo-spawn"`). Once any run created that function in the beta fixture repo, every later run found the work already done and the scenario stalled — punishing an agent that correctly noticed the fixture was already satisfied and asked for clarification instead of fabricating work.

This PR makes the fixture per-run unique, following the existing `stamp`/`marker` convention used by sibling e2e scenarios (`basebranch_test.go`, `smoke_test.go`, `auto_merge_test.go`).

## Key changes

- **`tests/e2e/cross_repo_spawn_test.go`**: generates a `stamp` (`time.Now().UTC().Format("20060102-150405")`), derives `idSuffix` (punctuation stripped — a legal Go exported-identifier suffix) and `sentinel` (`"e2e-cross-repo-spawn-<stamp>"` — human-readable, used as the returned string). Both are threaded through `crossRepoBodyTemplate` so the beta-side function name and alpha-side call site agree on the same token. Adds a final assertion that reads `pkg/greeting/greeting.go` back from beta's merged default branch and checks it contains `sentinel` — so the scenario still fails on a real regression in the cross-repo spawn mechanism, not just on the absence of the `fabrik:children-spawned` label.
- **`tests/e2e/harness.go`**: adds `FetchRepoFileContent(t, env, repo, path) string`, a GitHub Contents API read helper (base64-decode, embedded-newline stripping), mirroring the existing write helper `CreateMemberPR` (`mergetrain_helpers.go`).
- **`tests/e2e/README.md`**: updates the `TestCrossRepoSpawn` scenario-table row and regression-coverage-map row to reflect the stronger final assertion and reference this issue.

## How to test

- `go vet -tags e2e ./...` — clean.
- `go build -tags e2e ./tests/e2e/...` — compiles clean.
- `gofmt -l tests/e2e/cross_repo_spawn_test.go tests/e2e/harness.go` — clean (the one pre-existing `gofmt -l` hit in `paused_merged_pr_recovery_test.go` predates this change and is untouched).
- `go test -race -timeout 300s ./engine/...` — all 1993 tests pass (unaffected; this change is confined to the e2e test package).
- Manually rendered `crossRepoBodyTemplate` with sample values to confirm each `%s` slot lands in the right spot (beta function definition and alpha call site use the identical `idSuffix`; sentinel is the hyphenated string literal).
- The actual `TestCrossRepoSpawn` e2e scenario itself requires the live two-repo test bed and ~45-60 min wall-clock; not runnable in this environment, but is the scenario this PR restores to determinism.

## Docs

`tests/e2e/README.md` updated per the issue's requirements. No changes to the four canonical `docs/*.md` pages, so no `docs/llms-full.txt` regeneration needed.