### PR TITLE
fix(e2e): remove transient fabrik:awaiting-review precondition races

### DIFF
--- a/adrs/1258-e2e-review-authority-coverage.md
+++ b/adrs/1258-e2e-review-authority-coverage.md
@@ -118,6 +118,10 @@ reviewers come only from `reviewRequests`, never from who actually submitted. A 
 `FABRIK_MERGE_TRAIN`-sensitive code, so they run identically and unmodified in both legs of
 the suite's two-mode gate.
 
+> **Correction (2026-08-01):** this paragraph reasoned about the outer clearing condition
+> correctly but is otherwise wrong in practice — see "Revision (2026-08-01)" below. Three of
+> the four scenarios now do call `RequestPRReviewer`.
+
 **Scenario 5 (issue #1258: "verdict that never clears → pause, no infinite spin") folds into
 scenario 1's test** rather than exercising `MaxReviewCycles`/`pauseForReviewCycleLimit`.
 `dispatchReviewReinvoke`'s precheck (`len(buildReviewThreadComments(item)) > 0`) requires
@@ -172,6 +176,43 @@ on an existing one.
 `TestReviewAuthorityClearsOnApproval`, `TestReviewAuthorityYoloDoesNotBypassBlock`,
 `TestReviewAuthorityAdvisoryRegressionGuard`) run in both legs of the two-mode gate at
 negligible added GitHub API cost, since none of them touch merge-train code paths.
+
+## Revision (2026-08-01): `RequestPRReviewer` needed after all, for pre-verdict engagement proof
+
+Issue [#1312](https://github.com/handarbeit/fabrik/issues/1312) found that the "No
+`RequestPRReviewer` call is needed" rationale above, while correct about
+`checkReviewGate`'s outer clearing condition in isolation, did not account for the bed's own
+`claude-review.yml` bot. That bot reviews these trivial, markdown-only member PRs too (not
+just full Implement-stage PRs) — the same `COMMENT`-only workflow whose *verdict* this ADR's
+Context section already excluded from use, but whose mere existence as *a* submitted review
+was overlooked. A `COMMENT` review satisfies `hasReviews` exactly as well as this test's own
+deliberate `SubmitPRReview` call does, and it typically lands within ~60-100s of PR creation —
+often faster than the engine's first `checkReviewGate` evaluation under suite load (observed
+as slow as ~3.5 minutes in incident evidence). Three scenarios
+(`TestReviewAuthorityBlocksAndPausesOnChangesRequested`, `TestReviewAuthorityClearsOnApproval`,
+`TestReviewAuthorityAdvisoryRegressionGuard`) waited for `fabrik:awaiting-review` as a
+*precondition* before submitting their own deliberate verdict, intending to prove "the gate
+engaged before we reviewed it, so the later transition is genuinely observed, not a trivial
+first-look pass." When the bot's incidental review landed first, the outer clearing branch
+cleared the gate on the very first evaluation and never applied the label at all — a scenario
+timeout against **correct** engine behavior, not a defect, and not a symptom `checkReviewGate`'s
+clearing semantics need to change for (out of scope for both this ADR and #1312's fix).
+
+**Fix:** the three affected scenarios now call `RequestPRReviewer` immediately after
+`seedReviewGateItem`, reusing the `FABRIK_REVIEWER_TOKEN` identity they already require for
+their own deliberate verdict. This makes `outstanding` genuinely non-empty by construction —
+the exact mechanism this ADR's Decision section (above) reasoned was unnecessary — so the
+gate's pre-verdict engagement no longer depends on out-running any incidental reviewer,
+bot or otherwise. `TestReviewAuthorityYoloDoesNotBypassBlock`'s two
+`fabrik:awaiting-review` waits needed no such fix: both occur *after* that test's own genuine
+`REQUEST_CHANGES` review is already submitted, and once a genuine `CHANGES_REQUESTED` verdict
+exists, an unrelated incidental bot `COMMENT` — landing before or after it — can never satisfy
+the outer clearing condition on its own; that wait was already deterministic.
+
+This does not change `checkReviewGate`'s wall-clock/API-cost profile materially (one extra
+`gh pr edit --add-reviewer` call per affected scenario) and does not reopen the "silent-skip
+trap" this ADR's first Revision rejected — `RequestPRReviewer` fails the test loudly
+(`t.Fatalf`) if it errors, it does not skip.
 
 ## Alternatives Considered
 

--- a/adrs/1298-e2e-expected-reviewers-coverage.md
+++ b/adrs/1298-e2e-expected-reviewers-coverage.md
@@ -143,6 +143,48 @@ from the suite before this issue, since `reviewGateAllBots`'s declared-reviewer
 branch (the only way to reach the ladder without a formally requested bot reviewer)
 had no scenario declaring `expected_reviewers` to activate it.
 
+## Revision (2026-08-01): draft-PR construction for the scenarios `RequestPRReviewer` can't fix
+
+Issue [#1312](https://github.com/handarbeit/fabrik/issues/1312), fixing the same
+incidental-bot-review race for ADR-1258's `TestReviewAuthority*` scenarios (see that ADR's own
+"Revision (2026-08-01)"), found it applies here too, to four scenarios:
+`TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
+`TestExpectedReviewersUndeclaredRegressionGuard`, and
+`TestExpectedReviewersFastAdvanceComposesWithAuthoritative`. The bed's `claude-review.yml` bot
+reviews these member PRs too, typically within ~60-100s, and `expected_reviewers` is not
+consulted by `checkReviewGate`'s outer `len(outstanding) == 0 && hasReviews` clearing branch at
+all — a declared-but-unrequested or undeclared-nothing-requested configuration offers that
+branch no protection whatsoever. An incidental bot `COMMENT` landing before the engine's first
+gate evaluation clears the gate in advisory mode (or, for the authoritative-composition
+scenario, can apply the label via the authoritative-verdict branch instead — the opposite-
+direction failure) before these scenarios' own assertions ever run.
+
+Unlike ADR-1258's fix, **`RequestPRReviewer` is not an option for these four scenarios**: their
+properties under test are specifically "nothing was requested" (`TestExpectedReviewersFastAdvance`,
+`TestExpectedReviewersFastAdvanceComposesWithAuthoritative`, `TestExpectedReviewersUndeclaredRegressionGuard`)
+or "declared but *unrequested*" (`TestExpectedReviewersDeclaredWaitsAndReprompts`). A genuinely
+outstanding requested reviewer would falsify the very condition the scenario exists to verify —
+worse, for the declared-waits-and-reprompts case specifically, a real requested reviewer routes
+to the mixed/human pause path instead of the bot re-prompt ladder (`reviewGateAllBots`), silently
+defeating the scenario's actual purpose (the first e2e coverage of that ladder) rather than just
+racing an assertion.
+
+**Fix:** these four scenarios now seed via `seedReviewGateItemDraft` (`CreateMemberPRDraft`)
+instead of `seedReviewGateItem`, opening the member PR as a draft. Direct inspection of the bed's
+actual `claude-review.yml` confirmed its review job is guarded by
+`if: github.event.pull_request.draft == false` and triggers only on `opened`/`ready_for_review` —
+a draft PR that is never marked ready is therefore permanently invisible to it, removing the
+incidental review entirely rather than racing it. `engine/reviews.go` and the rest of the
+gate/dispatch path never inspect `IsDraft`, so this is purely a bed-workflow-triggering property
+with zero engine-behavior impact. `TestExpectedReviewersPrecedenceGuard` needed no such
+treatment — like ADR-1258's fixed scenarios, it already calls `RequestPRReviewer` before its
+wait, which is unaffected by this gap.
+
+This technique is bed-workflow-dependent in one sense worth flagging for future readers: if a
+future change to `claude-review.yml` removes the `draft == false` guard, these scenarios would
+silently become racy again with no compile-time signal. `tests/e2e/README.md` prerequisite #29
+points at the guard's exact condition for this reason.
+
 ## Alternatives Considered
 
 **A bed-local `ExpectedReviewers`-declaring stage/column variant.** Rejected — see

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -418,6 +418,23 @@ is a documented, accepted e2e gap.
     same rationale as prerequisite #22's warning against reusing a real installed
     bot: an unrelated real actor submitting a review would race the deterministic
     re-prompt-ladder assertions in `TestExpectedReviewersDeclaredWaitsAndReprompts`.
+29. **Draft-PR determinism technique (#1312)**: `TestExpectedReviewersFastAdvance`,
+    `TestExpectedReviewersDeclaredWaitsAndReprompts`,
+    `TestExpectedReviewersUndeclaredRegressionGuard`, and
+    `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` seed via
+    `seedReviewGateItemDraft` (which calls `CreateMemberPRDraft`) instead of
+    `seedReviewGateItem`. Their properties under test — "nothing was requested",
+    "declared but unrequested" — would be falsified by requesting a reviewer via
+    `RequestPRReviewer`, so unlike `TestReviewAuthority*` these scenarios can't
+    win the race deterministically that way. Opening the member
+    PR as a draft instead removes the race altogether: `claude-review.yml`
+    guards its review job with `if: github.event.pull_request.draft == false`
+    and triggers only on `opened`/`ready_for_review`, so a draft PR that is
+    never marked ready is permanently invisible to it — there is no incidental
+    bot review to land before the engine's first gate evaluation, or before
+    these scenarios' own bounded-window assertions. This requires no additional
+    bed setup; it is purely a change in how the harness constructs the member
+    PR.
 
 ## Running
 

--- a/tests/e2e/expected_reviewers_test.go
+++ b/tests/e2e/expected_reviewers_test.go
@@ -62,6 +62,20 @@ import (
 // All scenarios only touch checkReviewGate, which has no FABRIK_MERGE_TRAIN
 // branching — they pass identically under both legs of the suite's two-mode
 // gate.
+//
+// Determinism (#1312): four scenarios below (FastAdvance,
+// DeclaredWaitsAndReprompts, UndeclaredRegressionGuard,
+// FastAdvanceComposesWithAuthoritative) seed via seedReviewGateItemDraft
+// instead of seedReviewGateItem — their properties under test ("nothing was
+// requested", "declared but unrequested") would be falsified by
+// RequestPRReviewer, so unlike the review_authority_test.go fix they can't
+// use a genuinely outstanding reviewer to make the wait deterministic.
+// Opening the member PR as a draft keeps the bed's claude-review.yml bot
+// from ever reviewing it (its job is guarded by
+// `if: github.event.pull_request.draft == false`, triggering only on
+// opened/ready_for_review), removing the incidental review entirely rather
+// than racing it. TestExpectedReviewersPrecedenceGuard needs no such
+// treatment — it already calls RequestPRReviewer before its wait.
 const (
 	expectedReviewersNoneLabel     = "expected-reviewers:none"
 	expectedReviewersDeclaredLabel = "expected-reviewers:declared"
@@ -75,13 +89,20 @@ const (
 // eliminate. Requires the follow-up engine-side label-read issue to be
 // merged; see the file-level doc comment.
 //
+// Uses seedReviewGateItemDraft (#1312): this assertion can't currently fail
+// against an incidental bot review (a race there falls through to the
+// ordinary outer clearing branch, which also never applies the label), but a
+// race would silently stop this test from exercising the FR-2 fast-advance
+// code path it's named for. The draft-PR construction is coverage integrity,
+// not a correctness fix.
+//
 // Wall-clock: ~2-5 min (a short window well under FABRIK_REVIEW_WAIT_TIMEOUT).
 func TestExpectedReviewersFastAdvance(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-none-fast-advance", expectedReviewersNoneLabel)
+	num, prNum, _ := seedReviewGateItemDraft(t, env, env.RepoAlpha, "main", "Review", "expected-none-fast-advance", expectedReviewersNoneLabel)
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 
 	// The gate must never apply fabrik:awaiting-review at all — a fast
@@ -112,6 +133,18 @@ func TestExpectedReviewersFastAdvance(t *testing.T) {
 // into scenario 1's test. Requires the follow-up engine-side label-read
 // issue to be merged; see the file-level doc comment.
 //
+// Uses seedReviewGateItemDraft (#1312): this scenario's entire mechanism
+// depends on nothing being reviewed until the Phase 1/2 timeouts fire, but
+// expected_reviewers is not consulted by checkReviewGate's outer clearing
+// branch — an incidental bot COMMENT review would clear the gate in advisory
+// mode before Phase 1 can ever be reached, silently preventing the
+// re-prompt ladder (this test's actual subject) from engaging at all.
+// RequestPRReviewer isn't an option here either: a genuinely outstanding
+// *requested* reviewer routes to the mixed/human pause path instead of the
+// bot ladder (reviewGateAllBots). The draft PR is never marked ready for
+// the duration of this test, so the bed's claude-review.yml never reviews
+// it and there is no incidental review to race.
+//
 // Wall-clock (worst case): ~2xFABRIK_REVIEW_WAIT_TIMEOUT + buffer — see
 // README for a recommended bed value.
 func TestExpectedReviewersDeclaredWaitsAndReprompts(t *testing.T) {
@@ -121,7 +154,7 @@ func TestExpectedReviewersDeclaredWaitsAndReprompts(t *testing.T) {
 
 	reviewWaitTimeout := readEnvFileReviewWaitTimeout(t, env)
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-declared-reprompt", expectedReviewersDeclaredLabel)
+	num, prNum, _ := seedReviewGateItemDraft(t, env, env.RepoAlpha, "main", "Review", "expected-declared-reprompt", expectedReviewersDeclaredLabel)
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 
 	// Contrast with TestExpectedReviewersFastAdvance: a declared-but-unmatched
@@ -216,13 +249,20 @@ func TestExpectedReviewersPrecedenceGuard(t *testing.T) {
 // empty slice. Zero dependency on the follow-up engine issue; ships green
 // in this PR alone.
 //
+// Uses seedReviewGateItemDraft (#1312): the property under test is "nothing
+// requested, nothing reviewed yet" — RequestPRReviewer would falsify that
+// premise, so it can't be used to make the wait deterministic the way the
+// TestReviewAuthority* scenarios do. A draft PR means the bed's
+// claude-review.yml bot never reviews it, so there is no incidental review
+// to race against the engine's first gate evaluation.
+//
 // Wall-clock: ~2-5 min.
 func TestExpectedReviewersUndeclaredRegressionGuard(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-nil-regression")
+	num, prNum, _ := seedReviewGateItemDraft(t, env, env.RepoAlpha, "main", "Review", "expected-nil-regression")
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 
 	// Undeclared (nil) must behave exactly as it did before #1283: the gate
@@ -243,13 +283,23 @@ func TestExpectedReviewersUndeclaredRegressionGuard(t *testing.T) {
 // (for expected-reviewers:none) AND #1261 (for review-authority:authoritative,
 // already merged) to be in effect; see the file-level doc comment.
 //
+// Uses seedReviewGateItemDraft (#1312): this is the opposite-direction risk
+// of the WaitForIssueLabel-precondition race — an incidental bot review
+// landing before fast-advance's own check would make hasReviews true, and in
+// authoritative mode with no branch-protection review requirement configured
+// that falls back to "satisfied unless CHANGES_REQUESTED", which a bare
+// COMMENT is not, so the gate would still apply fabrik:awaiting-review via
+// the authoritative-verdict branch rather than fast-advancing — failing this
+// bounded "must never appear" assertion in the opposite direction from a
+// timeout. A draft PR removes the incidental review entirely.
+//
 // Wall-clock: ~2-5 min.
 func TestExpectedReviewersFastAdvanceComposesWithAuthoritative(t *testing.T) {
 	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-none-authoritative",
+	num, prNum, _ := seedReviewGateItemDraft(t, env, env.RepoAlpha, "main", "Review", "expected-none-authoritative",
 		expectedReviewersNoneLabel, "review-authority:authoritative")
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
 

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -85,6 +85,25 @@ func defaultBranchSHA(t *testing.T, env *Env, repo, baseBranch string) string {
 // conflict-resolution scenarios.
 func CreateMemberPR(t *testing.T, env *Env, repo, baseBranch, branch, path, content, issueTitle string, issueNum int) int {
 	t.Helper()
+	return createMemberPR(t, env, repo, baseBranch, branch, path, content, issueTitle, issueNum, false)
+}
+
+// CreateMemberPRDraft is CreateMemberPR, but opens the PR as a draft. The bed's
+// claude-review.yml review workflow guards its job with
+// `if: github.event.pull_request.draft == false` and only triggers on
+// opened/ready_for_review — a draft PR that is never marked ready is therefore
+// permanently invisible to it. Scenarios whose property under test is "nothing
+// has reviewed this PR yet" (e.g. expected_reviewers's declared-but-unrequested
+// and undeclared-nothing-requested cases) use this instead of CreateMemberPR to
+// avoid racing that bot's incidental review against the engine's first gate
+// evaluation (see #1312).
+func CreateMemberPRDraft(t *testing.T, env *Env, repo, baseBranch, branch, path, content, issueTitle string, issueNum int) int {
+	t.Helper()
+	return createMemberPR(t, env, repo, baseBranch, branch, path, content, issueTitle, issueNum, true)
+}
+
+func createMemberPR(t *testing.T, env *Env, repo, baseBranch, branch, path, content, issueTitle string, issueNum int, draft bool) int {
+	t.Helper()
 	baseSHA := defaultBranchSHA(t, env, repo, baseBranch)
 
 	// Create the branch ref off the base head.
@@ -111,9 +130,13 @@ func CreateMemberPR(t *testing.T, env *Env, repo, baseBranch, branch, path, cont
 
 	// Open the PR with the Closes #N linkage.
 	body := fmt.Sprintf("e2e merge-train member.\n\nCloses #%d\n", issueNum)
-	out, err := ghOutput(env, "pr", "create", "-R", repo,
+	args := []string{"pr", "create", "-R", repo,
 		"--base", baseBranch, "--head", branch,
-		"--title", issueTitle, "--body", body)
+		"--title", issueTitle, "--body", body}
+	if draft {
+		args = append(args, "--draft")
+	}
+	out, err := ghOutput(env, args...)
 	if err != nil {
 		t.Fatalf("create member PR for #%d on %s: %v\n%s", issueNum, repo, err, out)
 	}
@@ -121,7 +144,7 @@ func CreateMemberPR(t *testing.T, env *Env, repo, baseBranch, branch, path, cont
 	if prNum == 0 {
 		t.Fatalf("could not parse member PR number from %q", out)
 	}
-	t.Logf("created member PR #%d (issue #%d, branch %s, path %s)", prNum, issueNum, branch, path)
+	t.Logf("created member PR #%d (issue #%d, branch %s, path %s, draft=%v)", prNum, issueNum, branch, path, draft)
 	return prNum
 }
 

--- a/tests/e2e/review_authority_helpers.go
+++ b/tests/e2e/review_authority_helpers.go
@@ -33,7 +33,34 @@ import (
 // without ever invoking Claude for the gated stage — the same zero-cost
 // construction precedent as TestPausedMergedPRRecovery's R5. extraLabels are
 // applied at file time (e.g. "fabrik:yolo" for the composition scenario).
+//
+// The member PR is opened ready (non-draft), so the bed's claude-review.yml
+// bot will typically review it within ~60-100s. Scenarios that submit their
+// own deliberate verdict must not treat the bot's incidental review as proof
+// the gate engaged — see the file-level "Determinism" note below and #1312.
 func seedReviewGateItem(t *testing.T, env *Env, repo, baseBranch, column, marker string, extraLabels ...string) (issueNum, prNum int, itemID string) {
+	t.Helper()
+	return seedReviewGateItemImpl(t, env, repo, baseBranch, column, marker, false, extraLabels...)
+}
+
+// seedReviewGateItemDraft is seedReviewGateItem, but opens the member PR as a
+// draft (via CreateMemberPRDraft) so the bed's claude-review.yml bot never
+// reviews it — its job is guarded by
+// `if: github.event.pull_request.draft == false` and only triggers on
+// opened/ready_for_review. Use this when the property under test is "nothing
+// has reviewed this PR" (e.g. expected_reviewers's declared-but-unrequested
+// and undeclared-nothing-requested scenarios): with a real (non-draft) PR, an
+// incidental bot review can satisfy checkReviewGate's
+// `len(outstanding) == 0 && hasReviews` clearing branch before the scenario's
+// own assertions run, independent of any reviewer the test explicitly
+// requested or declared. Never mark the returned PR ready during such a
+// scenario, or the bot becomes eligible to review it again. See #1312.
+func seedReviewGateItemDraft(t *testing.T, env *Env, repo, baseBranch, column, marker string, extraLabels ...string) (issueNum, prNum int, itemID string) {
+	t.Helper()
+	return seedReviewGateItemImpl(t, env, repo, baseBranch, column, marker, true, extraLabels...)
+}
+
+func seedReviewGateItemImpl(t *testing.T, env *Env, repo, baseBranch, column, marker string, draft bool, extraLabels ...string) (issueNum, prNum int, itemID string) {
 	t.Helper()
 	stamp := time.Now().UTC().Format("150405.000")
 	title := fmt.Sprintf("e2e review-authority %s (%s)", marker, stamp)
@@ -44,14 +71,18 @@ func seedReviewGateItem(t *testing.T, env *Env, repo, baseBranch, column, marker
 	branch := fmt.Sprintf("fabrik/issue-%d", num)
 	path := fmt.Sprintf("e2e/review-authority/%s-%d.md", marker, num)
 	content := fmt.Sprintf("# e2e review-authority marker\n\nmarker=%s\n", marker)
-	prNum = CreateMemberPR(t, env, repo, baseBranch, branch, path, content, title, num)
+	if draft {
+		prNum = CreateMemberPRDraft(t, env, repo, baseBranch, branch, path, content, title, num)
+	} else {
+		prNum = CreateMemberPR(t, env, repo, baseBranch, branch, path, content, title, num)
+	}
 	// Confirm the PR is resolvable by the fabrik/issue-<N> branch convention
 	// (mirrors the engine's resolver) before seeding the completion label.
 	LinkedPRNumber(t, env, repo, num)
 
 	AddLabel(t, env, repo, num, "stage:"+column+":complete")
 	SetIssueStatus(t, env, itemID, column)
-	t.Logf("seeded review-gate item: issue #%d, PR #%d, stage:%s:complete, Status=%s (marker=%s)",
-		num, prNum, column, column, marker)
+	t.Logf("seeded review-gate item: issue #%d, PR #%d, stage:%s:complete, Status=%s (marker=%s, draft=%v)",
+		num, prNum, column, column, marker, draft)
 	return num, prNum, itemID
 }

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -51,6 +51,24 @@ import (
 // All four scenarios only touch checkReviewGate, which has no
 // FABRIK_MERGE_TRAIN branching — they pass identically under both legs of
 // the suite's two-mode gate.
+//
+// Determinism (#1312): the three scenarios below that assert
+// fabrik:awaiting-review as a *precondition* before their own deliberate
+// verdict lands (BlocksAndPausesOnChangesRequested, ClearsOnApproval,
+// AdvisoryRegressionGuard) each call RequestPRReviewer right after seeding,
+// making outstanding genuinely non-empty by construction. This corrects
+// ADR-1258's original "no RequestPRReviewer call is needed" rationale — that
+// reasoning covered checkReviewGate's outer clearing condition
+// (len(outstanding)==0 && hasReviews) in isolation, but didn't account for
+// the bed's own claude-review.yml bot satisfying that same condition with an
+// incidental COMMENT review before the engine's first gate evaluation, which
+// is exactly what #1312 reports. YoloDoesNotBypassBlock's two
+// fabrik:awaiting-review waits need no such fix: both occur after this
+// test's own genuine REQUEST_CHANGES review is already submitted, and once a
+// genuine CHANGES_REQUESTED review exists, an unrelated incidental bot
+// COMMENT landing before or after it can never satisfy the outer clearing
+// condition on its own — the wait is already deterministic. See
+// adrs/1258-e2e-review-authority-coverage.md's Revision section.
 
 // TestReviewAuthorityBlocksAndPausesOnChangesRequested covers scenarios 1 and
 // 5 from issue #1258: authoritative + CHANGES_REQUESTED blocks advancement,
@@ -82,10 +100,22 @@ func TestReviewAuthorityBlocksAndPausesOnChangesRequested(t *testing.T) {
 	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "blocks-pauses", "review-authority:authoritative")
 
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
-	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+	reviewerLogin := TokenLogin(t, reviewerToken)
+	if engineLogin := TokenLogin(t, env.GHToken); engineLogin == reviewerLogin {
 		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
 			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
 	}
+
+	// Request the reviewer so outstanding is genuinely non-empty by
+	// construction, before confirming the gate's pre-verdict block. Without
+	// this, the bed's claude-review.yml bot can land its own incidental
+	// COMMENT review before the engine's first gate evaluation; that alone
+	// satisfies checkReviewGate's outer len(outstanding)==0 && hasReviews
+	// clearing branch, which never applies fabrik:awaiting-review — the wait
+	// below would then time out against genuinely correct engine behavior
+	// (#1312), rather than proving the gate engaged.
+	RequestPRReviewer(t, env, env.RepoAlpha, prNum, reviewerLogin)
+	t.Logf("requested reviewer %q on %s PR #%d — outstanding is non-empty by construction, gate engagement is deterministic", reviewerLogin, env.RepoAlpha, prNum)
 
 	// Confirm the gate's trivial, pre-verdict block (hasReviews==false blocks
 	// unconditionally) before the review lands. This alone doesn't prove the
@@ -180,10 +210,23 @@ func TestReviewAuthorityClearsOnApproval(t *testing.T) {
 	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "clears-approval", "review-authority:authoritative")
 
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
-	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+	reviewerLogin := TokenLogin(t, reviewerToken)
+	if engineLogin := TokenLogin(t, env.GHToken); engineLogin == reviewerLogin {
 		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
 			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
 	}
+
+	// Request the reviewer so outstanding is genuinely non-empty by
+	// construction, before confirming the gate engages. Without this, the
+	// bed's claude-review.yml bot can land its own incidental COMMENT review
+	// before the engine's first gate evaluation and before this test's own
+	// APPROVE — that alone satisfies checkReviewGate's outer
+	// len(outstanding)==0 && hasReviews clearing branch, which never applies
+	// fabrik:awaiting-review. The wait below would then time out against
+	// genuinely correct engine behavior (#1312) instead of proving the gate
+	// engaged before the deliberate approval.
+	RequestPRReviewer(t, env, env.RepoAlpha, prNum, reviewerLogin)
+	t.Logf("requested reviewer %q on %s PR #%d — outstanding is non-empty by construction, gate engagement is deterministic", reviewerLogin, env.RepoAlpha, prNum)
 
 	// Confirm the gate genuinely engages (no review submitted yet, so
 	// checkReviewGate's outer hasReviews==false condition blocks and applies
@@ -303,10 +346,23 @@ func TestReviewAuthorityAdvisoryRegressionGuard(t *testing.T) {
 	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "advisory-regression")
 
 	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
-	if engineLogin, reviewerLogin := TokenLogin(t, env.GHToken), TokenLogin(t, reviewerToken); engineLogin == reviewerLogin {
+	reviewerLogin := TokenLogin(t, reviewerToken)
+	if engineLogin := TokenLogin(t, env.GHToken); engineLogin == reviewerLogin {
 		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
 			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
 	}
+
+	// Request the reviewer so outstanding is genuinely non-empty by
+	// construction, before confirming the gate engages. Without this, the
+	// bed's claude-review.yml bot can land its own incidental COMMENT review
+	// before the engine's first gate evaluation and before this test's own
+	// REQUEST_CHANGES — that alone satisfies checkReviewGate's outer
+	// len(outstanding)==0 && hasReviews clearing branch, which never applies
+	// fabrik:awaiting-review. The wait below would then time out against
+	// genuinely correct engine behavior (#1312) instead of proving the gate
+	// engaged before the deliberate verdict.
+	RequestPRReviewer(t, env, env.RepoAlpha, prNum, reviewerLogin)
+	t.Logf("requested reviewer %q on %s PR #%d — outstanding is non-empty by construction, gate engagement is deterministic", reviewerLogin, env.RepoAlpha, prNum)
 
 	// Confirm the gate genuinely engages (no review submitted yet, so
 	// checkReviewGate's outer hasReviews==false condition blocks and applies


### PR DESCRIPTION
Closes #1312

Several review-gate e2e scenarios waited for the transient `fabrik:awaiting-review` label to appear as a precondition before submitting their own deliberate verdict. That label only exists if the engine's gate evaluation runs before any review lands on the PR — the bed's `claude-review.yml` bot typically reviews these member PRs within ~60-100s, while the engine's first gate evaluation can take several minutes under suite load. When the bot wins that race, `checkReviewGate`'s outer `len(outstanding) == 0 && hasReviews` clearing branch clears the gate on its very first evaluation without ever applying the label — correct engine behavior that the affected scenarios misread as a failure.

## Changes

- **`tests/e2e/mergetrain_helpers.go`** / **`tests/e2e/review_authority_helpers.go`**: refactored `CreateMemberPR`/`seedReviewGateItem` into shared implementations with a `draft bool` parameter, adding `CreateMemberPRDraft`/`seedReviewGateItemDraft` wrappers. Existing exported signatures are unchanged, so none of the ~9 other call sites are affected.
- **`tests/e2e/review_authority_test.go`**: `TestReviewAuthorityBlocksAndPausesOnChangesRequested`, `TestReviewAuthorityClearsOnApproval`, and `TestReviewAuthorityAdvisoryRegressionGuard` now call `RequestPRReviewer` right after seeding, making `outstanding` genuinely non-empty by construction — the same deterministic pattern `TestConjunctiveCIReviewGate` already uses. `TestReviewAuthorityYoloDoesNotBypassBlock`'s two waits needed no change: they occur after its own genuine `REQUEST_CHANGES` review already stands, which an incidental bot `COMMENT` can never satisfy regardless of timing.
- **`tests/e2e/expected_reviewers_test.go`**: `TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`, `TestExpectedReviewersUndeclaredRegressionGuard`, and `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` now seed via `seedReviewGateItemDraft` instead. `RequestPRReviewer` isn't usable for these — their whole premise is "nothing was requested" or "declared but unrequested," which a genuine reviewer request would falsify. Opening the member PR as a draft removes the bot review entirely: `claude-review.yml`'s job is guarded by `if: github.event.pull_request.draft == false` and only triggers on `opened`/`ready_for_review` (confirmed by direct inspection of the bed workflow), so a draft PR that's never marked ready is permanently invisible to it.
- **`tests/e2e/README.md`**: documents the draft-PR determinism technique as prerequisite #29.
- **`adrs/1258-e2e-review-authority-coverage.md`** / **`adrs/1298-e2e-expected-reviewers-coverage.md`**: Revision sections correcting the "no `RequestPRReviewer` call is needed" rationale both ADRs originally asserted — that reasoning was correct about the clearing condition in isolation but didn't account for the bed's own bot satisfying it first.

## Scope

Test-only change. Engine review-gate behavior (`engine/reviews.go`) is unmodified — it was already correct, per the issue's own analysis. No production code, label semantics, or docs bundle regeneration triggered.

## How to test

- `go build ./...`, `go vet -tags e2e ./...`, and `go test -tags e2e -run '^$' ./tests/e2e/...` (compile-only check) all pass.
- `go test ./...` passes except a pre-existing, unrelated flake (`TestExecute_ConfigYAMLApplied` in `cmd/`, a SIGINT-timing test) reproducible on a clean tree with none of this PR's files touched.
- The fixed scenarios themselves require a live e2e bed run to observe the race no longer occurring; that's outside the scope of this static verification.