### PR TITLE
fix(e2e): make CI-fix cycle-limit path reachable, drop timer-race workaround

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -124,48 +124,42 @@ gh api rate_limit --jq '.resources.graphql'
    ```bash
    E2E_TIMEOUT=1h scripts/e2e/run.sh -run TestCIFixReinvoke
    ```
-8. **`FABRIK_CI_WAIT_TIMEOUT=120` (minutes) in the test bed `.env`** — required
-   for `TestCIFixReinvokeCycleLimit` to deterministically exercise the
-   cycle-limit pause path instead of racing the fixed CI-wait-timeout timer
-   (handarbeit/fabrik#1320). Both `pauseForCITimeout` (`engine/ci.go`) and
-   `pauseForCIFixCycleLimit` are evaluated independently every poll once
-   `fabrik:awaiting-ci` is applied; whichever condition is observed first
-   wins, and the two are otherwise uncoordinated. The engine default
-   (`FABRIK_CI_WAIT_TIMEOUT` unset → 30 min, see `ciWaitTimeout()`) is too
-   short: a captured release-gate run showed two failed CI-fix cycles
-   (`FABRIK_MAX_CI_FIX_CYCLES=2`) still executing at 1h26m26s (~87 min) under
-   full-suite load — comfortably past the 30-minute default, so the
-   wait-timeout timer fired first and the scenario observed the wrong (but
-   still engine-correct) pause reason. **This is the same 87-minute data
-   point cited in "How the timeout/parallelism defaults are derived" below.**
+8. **`FABRIK_CI_WAIT_TIMEOUT` — no override needed; the engine default (30
+   min, see `ciWaitTimeout()`) applies.** #1320 had introduced a
+   `FABRIK_CI_WAIT_TIMEOUT=120` requirement here, reasoning that
+   `TestCIFixReinvokeCycleLimit` needed extra headroom for the cycle-limit
+   path (`pauseForCIFixCycleLimit`) to win its race against the fixed
+   CI-wait-timeout timer (`pauseForCITimeout`). **handarbeit/fabrik#1323
+   found that premise false**: the scenario's fixture never guaranteed a new
+   commit on each CI-fix reinvoke, so the `#958 leg 2` no-op guard
+   (`engine/catch_up_handlers.go`) latched permanently after the very first
+   reinvoke — `CIFixCycleIncremented` never advanced past 1, and
+   `pauseForCIFixCycleLimit` was structurally unreachable *at any*
+   `FABRIK_CI_WAIT_TIMEOUT`. Raising the timeout to 120 min therefore didn't
+   fix a race; it just quadrupled time-to-escalation for every `wait_for_ci`
+   item in the bed, with no compensating benefit.
 
-   The test derives its own minimum safe value at runtime
-   (`minSafeCIWaitTimeoutMinutes` in `ci_fix_reinvoke_test.go`):
-   `observedWorstCaseMinutesPerCIFixCycle (45, i.e. ceil(87/2)) * maxCycles +
-   cycleLimitTimerHeadroomMinutes (30)`. For the recommended
-   `FABRIK_MAX_CI_FIX_CYCLES=2` (prerequisite #6), that's `45*2 + 30 = 120`
-   minutes — hence the **120** recommendation. If `FABRIK_CI_WAIT_TIMEOUT` in
-   the bed `.env` is below this computed minimum for the bed's configured
-   `FABRIK_MAX_CI_FIX_CYCLES`, the test `t.Skip`s with an instructional
-   diagnostic rather than racing the two timers and risking a false
-   pass/fail — see the "Requirements" section of #1320 for why "accept
-   either pause reason" was rejected (the #1319 anti-pattern: a test that
-   passes regardless of which path actually ran).
+   The fixture (`ciFixCycleLimitBody`) now forces an unconditional
+   scratch-file commit+push on every single CI-fix reinvoke, independent of
+   the agent's belief about fixability — the no-op guard only checks head-SHA
+   equality, so this is sufficient to make `CIFixCycleIncremented` genuinely
+   advance to `MaxCiFixCycles` through real repeated dispatch. With the path
+   actually reachable, whether the CI-wait-timeout timer also fires is
+   ordinary e2e timing risk like any other scenario in the bed — not a
+   known-guaranteed structural loss requiring bespoke pre-flight timer math.
+   The test now also asserts the PR gained at least `maxCycles` commits
+   beyond baseline (see `TestCIFixReinvokeCycleLimit`'s doc comment), making
+   "the cycle-limit path was genuinely exercised" independently verifiable
+   rather than inferred from timer coordination.
 
-   Raising this bed-wide from 30→120 min is a deliberate tradeoff: it also
-   lengthens how long a genuinely CI-stuck *unrelated* issue sits before a
-   human is notified via `pauseForCITimeout`, on any issue in the bed, not
-   just this scenario's. After editing `.env`, restart the test-bed Fabrik
-   instance so the new value takes effect.
-
-   **`TestCIFixReinvoke` has the same timer-coupling risk, dormant.** It is
-   currently `t.Skip`'d pending #916 (see the doc comment above `TestCIFixReinvoke`),
-   so this hasn't yet caused a failure, but a single successful CI-fix cycle
-   could plausibly also exceed a too-low `FABRIK_CI_WAIT_TIMEOUT` under load
-   once un-skipped. Re-check this when #916 unblocks it — the derivation
-   formula above only accounts for `TestCIFixReinvokeCycleLimit`'s
-   `MaxCiFixCycles`-bounded cost, not `TestCIFixReinvoke`'s single-cycle
-   recovery cost, which may need its own (likely smaller) minimum.
+   The 87-minute data point that backed the old `120` recommendation (a
+   captured release-gate run "still executing" with `FABRIK_MAX_CI_FIX_CYCLES=2`)
+   is now understood to have likely been an artifact of the same no-op-latch
+   bug — a cycle count stuck at 1 while wall-clock kept advancing is
+   indistinguishable from this exact defect. It should not be treated as a
+   trustworthy per-cycle cost measurement; a future live run against the
+   fixed fixture is what should supply real numbers if the wait-timeout timer
+   does turn out to race in practice.
 
 ### Marker-substring assertion audit (#1320)
 

--- a/tests/e2e/ci_fix_reinvoke_marker_test.go
+++ b/tests/e2e/ci_fix_reinvoke_marker_test.go
@@ -116,24 +116,3 @@ func TestHasEngineCIWaitTimeoutComment(t *testing.T) {
 		})
 	}
 }
-
-// TestMinSafeCIWaitTimeoutMinutes locks in the derivation formula so a future
-// edit to the constants (or the formula itself) is a visible, deliberate
-// change rather than a silent drift back toward the timer race.
-func TestMinSafeCIWaitTimeoutMinutes(t *testing.T) {
-	tests := []struct {
-		maxCycles int
-		want      int
-	}{
-		{maxCycles: 2, want: 120}, // 45*2 + 30 — the documented bed recommendation
-		{maxCycles: 3, want: 165},
-		{maxCycles: 1, want: 75},
-	}
-
-	for _, tt := range tests {
-		got := minSafeCIWaitTimeoutMinutes(tt.maxCycles)
-		if got != tt.want {
-			t.Fatalf("minSafeCIWaitTimeoutMinutes(%d) = %d, want %d", tt.maxCycles, got, tt.want)
-		}
-	}
-}

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -191,36 +191,23 @@ func hasEngineCIWaitTimeoutComment(bodies []string) bool {
 	return false
 }
 
-// observedWorstCaseMinutesPerCIFixCycle and cycleLimitTimerHeadroomMinutes
-// back minSafeCIWaitTimeoutMinutes, which computes the smallest
-// FABRIK_CI_WAIT_TIMEOUT (minutes) at which TestCIFixReinvokeCycleLimit can
-// deterministically exercise the cycle-limit pause path instead of racing
-// the fixed CI-wait-timeout timer (handarbeit/fabrik#1320).
-//
-// observedWorstCaseMinutesPerCIFixCycle=45 is derived from the one real data
-// point available: a captured release-gate run where this scenario was
-// still executing at 1h26m26s (~87min) with FABRIK_MAX_CI_FIX_CYCLES=2 — see
-// "How the timeout/parallelism defaults are derived" in tests/e2e/README.md.
-// ceil(87/2) = 44, rounded up to 45 for a whole-minutes-per-cycle budget.
-const observedWorstCaseMinutesPerCIFixCycle = 45
-
-// cycleLimitTimerHeadroomMinutes is added on top of the raw per-cycle
-// worst-case cost as margin against load variance beyond the single
-// observed data point backing observedWorstCaseMinutesPerCIFixCycle.
-const cycleLimitTimerHeadroomMinutes = 30
-
-// minSafeCIWaitTimeoutMinutes returns the minimum FABRIK_CI_WAIT_TIMEOUT
-// (minutes) needed for the cycle-limit path to deterministically win the
-// race against the fixed CI-wait-timeout timer, for a given
-// FABRIK_MAX_CI_FIX_CYCLES.
-func minSafeCIWaitTimeoutMinutes(maxCycles int) int {
-	return observedWorstCaseMinutesPerCIFixCycle*maxCycles + cycleLimitTimerHeadroomMinutes
-}
-
 // TestCIFixReinvokeCycleLimit is the negative-path regression test for the
 // CI-fix reinvoke cycle limit (engine/ci.go: pauseForCIFixCycleLimit).
 // The sentinel CI job is permanently failing for this issue — Claude cannot fix
 // it — so the engine must exhaust MaxCiFixCycles and pause the issue.
+//
+// handarbeit/fabrik#1323 superseded #1320's timer-race diagnosis: the
+// previous fixture never guaranteed a new commit per CI-fix reinvoke, so the
+// `#958 leg 2` no-op guard (engine/catch_up_handlers.go) latched after the
+// first reinvoke and CIFixCycleIncremented never advanced — the cycle-limit
+// path was structurally unreachable, at any FABRIK_CI_WAIT_TIMEOUT. The
+// fixture below (ciFixCycleLimitBody) instead forces an unconditional
+// scratch-file commit+push on every single reinvoke, independent of any
+// belief about fixability, which is the only thing the no-op guard actually
+// checks (head SHA equality). With that fixed, the cycle-limit path is
+// reached through genuine repeated dispatch and no bespoke timer
+// coordination with FABRIK_CI_WAIT_TIMEOUT is needed — the engine default
+// applies.
 //
 // Pass criteria:
 //   - fabrik:awaiting-ci appears (CI gate fires).
@@ -229,14 +216,24 @@ func minSafeCIWaitTimeoutMinutes(maxCycles int) int {
 //   - A genuine engine-authored "🏭 **Fabrik — CI fix cycle limit reached**"
 //     comment appears on the issue (matched by prefix, not substring — see
 //     hasEngineCycleLimitComment).
+//   - The PR gained at least maxCycles commits beyond its pre-Validate
+//     baseline, proving the cycle-limit path was reached via genuine
+//     repeated dispatch rather than a single latched no-op (non-vacuous
+//     per #1323's Requirements — see PRCommitCount check below).
 //
-// Prerequisite: "ci-fix-sentinel" must be enrolled as a required status check,
-// FABRIK_MAX_CI_FIX_CYCLES must be ≤ 3 (ideally 2), AND FABRIK_CI_WAIT_TIMEOUT
-// must be large enough that the cycle-limit path deterministically wins the
-// race against the fixed CI-wait-timeout timer (see minSafeCIWaitTimeoutMinutes
-// and "Additional prerequisites for TestCIFixReinvoke and
-// TestCIFixReinvokeCycleLimit" in tests/e2e/README.md). The test skips with an
-// instructional message if any condition is not met — handarbeit/fabrik#1320.
+// Prerequisite: "ci-fix-sentinel" must be enrolled as a required status
+// check, and FABRIK_MAX_CI_FIX_CYCLES must be ≤ 3 (ideally 2) — see
+// "Additional prerequisites for TestCIFixReinvoke and
+// TestCIFixReinvokeCycleLimit" in tests/e2e/README.md. The test skips with
+// an instructional message if either condition is not met.
+//
+// Manual, one-off, non-vacuous verification (not run by this test): to
+// confirm the cycle-limit comment assertion above would actually fail if
+// pauseForCIFixCycleLimit were broken, temporarily neutralize it locally
+// (e.g. make it a no-op) and re-run this scenario against a live bed —
+// expect a timeout waiting for fabrik:paused instead of a pass. This is a
+// deliberate, costly (~$0.50–1.50, 30-90 min) live-bed run per #1323's Risks
+// section, not something to repeat routinely.
 //
 // Wall-clock: ~30–60 min. Cost: ~$0.50–1.50.
 func TestCIFixReinvokeCycleLimit(t *testing.T) {
@@ -251,28 +248,6 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 	}
 	t.Logf("FABRIK_MAX_CI_FIX_CYCLES=%d — cycle limit test will fire after %d failed attempts", maxCycles, maxCycles)
 
-	// Timer coordination guard (handarbeit/fabrik#1320): the cycle-limit path
-	// and the fixed CI-wait-timeout timer race independently every poll.
-	// Under suite load, two full fix cycles routinely exceed the 30-minute
-	// engine default, so the wait-timeout timer wins and this scenario
-	// observes the wrong (but still engine-correct) pause reason. Rather than
-	// accept either pause reason — which would stop validating the
-	// cycle-limit path at all (the #1319 anti-pattern) — fail loudly with a
-	// diagnostic if the bed isn't configured with enough headroom.
-	ciWaitTimeout := readEnvFileCIWaitTimeout(t, env)
-	minSafe := minSafeCIWaitTimeoutMinutes(maxCycles)
-	if ciWaitTimeout < minSafe {
-		t.Skipf("FABRIK_CI_WAIT_TIMEOUT=%d in test bed .env is too low for FABRIK_MAX_CI_FIX_CYCLES=%d — "+
-			"the fixed CI-wait-timeout timer would likely win the race before the cycle limit is reached, "+
-			"producing a false negative for this scenario. Need FABRIK_CI_WAIT_TIMEOUT >= %d "+
-			"(observedWorstCaseMinutesPerCIFixCycle=%d * maxCycles + cycleLimitTimerHeadroomMinutes=%d). "+
-			"Set FABRIK_CI_WAIT_TIMEOUT=%d in the test bed .env and restart Fabrik — see "+
-			"\"Additional prerequisites for TestCIFixReinvoke and TestCIFixReinvokeCycleLimit\" in tests/e2e/README.md.",
-			ciWaitTimeout, maxCycles, minSafe, observedWorstCaseMinutesPerCIFixCycle, cycleLimitTimerHeadroomMinutes, minSafe)
-	}
-	t.Logf("FABRIK_CI_WAIT_TIMEOUT=%d >= minSafeCIWaitTimeoutMinutes(%d)=%d — timers are coordinated, cycle-limit path should win",
-		ciWaitTimeout, maxCycles, minSafe)
-
 	stamp := time.Now().UTC().Format("20060102-150405")
 	title := fmt.Sprintf("e2e ci-fix-cycle-limit (%s)", stamp)
 
@@ -280,6 +255,17 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
 	SetIssueStatus(t, env, itemID, "Specify")
 	t.Logf("filed %s#%d", env.RepoAlpha, num)
+
+	// Wait for Implement to complete, then capture baseline commit count —
+	// mirrors TestCIFixReinvoke's pattern, needed here for the non-vacuous
+	// commit-count check below.
+	WaitForIssueLabel(t, env, env.RepoAlpha, num, "stage:Implement:complete", 60*time.Minute)
+	prNumber := LinkedPRNumber(t, env, env.RepoAlpha, num)
+	baseCommits := PRCommitCount(t, env, env.RepoAlpha, prNumber)
+	t.Logf("PR #%d has %d commits at baseline (before Validate)", prNumber, baseCommits)
+
+	// Guard: the agent must NOT have modified the CI workflow.
+	AssertPRDidNotTouchWorkflows(t, env, env.RepoAlpha, prNumber)
 
 	// CI gate fires, then engine exhausts reinvoke cycles and pauses.
 	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-ci", 90*time.Minute)
@@ -321,15 +307,30 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 		if hasEngineCIWaitTimeoutComment(lastBodies) {
 			t.Fatalf("cycle limit comment not found on %s#%d after 5 minutes — instead the engine posted a CI "+
 				"wait-timeout pause comment. This means the fixed CI-wait-timeout timer won the race against the "+
-				"cycle-limit path (handarbeit/fabrik#1320) despite the bed-config guard above — the bed's "+
-				"FABRIK_CI_WAIT_TIMEOUT may be misconfigured, or fix cycles are taking longer than the documented "+
-				"worst case. This is a test timer-coordination problem, not necessarily an engine regression.",
-				env.RepoAlpha, num)
+				"cycle-limit path — the bed's FABRIK_CI_WAIT_TIMEOUT may be misconfigured too low relative to how "+
+				"long %d genuine CI-fix cycles actually take, or fix cycles are taking longer than expected. This "+
+				"is a test timer-coordination problem, not necessarily an engine regression.",
+				env.RepoAlpha, num, maxCycles)
 		}
 		t.Fatalf("cycle limit comment not found on %s#%d after 5 minutes, and no CI wait-timeout comment either — "+
 			"the engine may not have paused at all", env.RepoAlpha, num)
 	}
 	t.Logf("cycle limit comment confirmed on %s#%d — CI-fix cycle limit regression guard passed", env.RepoAlpha, num)
+
+	// Non-vacuous check (#1323): the cycle-limit path must have been reached
+	// via genuine repeated dispatch, not a single no-op latch. Each CI-fix
+	// reinvoke that actually dispatched pushed exactly one scratch-file
+	// commit (see ciFixCycleLimitBody), so the PR must have gained at least
+	// maxCycles commits beyond baseline.
+	finalCommits := PRCommitCount(t, env, env.RepoAlpha, prNumber)
+	if finalCommits < baseCommits+maxCycles {
+		t.Fatalf("cycle-limit path was not genuinely exercised on PR #%d: expected at least %d commits "+
+			"(baseCommits=%d + maxCycles=%d), got %d — this is consistent with the #958 leg 2 no-op guard "+
+			"latching after a single reinvoke rather than the engine dispatching %d genuine CI-fix cycles "+
+			"(handarbeit/fabrik#1323)", prNumber, baseCommits+maxCycles, baseCommits, maxCycles, finalCommits, maxCycles)
+	}
+	t.Logf("commit count guard passed: %d commits (base=%d + >=%d CI-fix cycles) — cycle-limit path genuinely exercised",
+		finalCommits, baseCommits, maxCycles)
 }
 
 // ciFixReinvokeBody is the issue body for TestCIFixReinvoke. The PR body must
@@ -396,30 +397,66 @@ commit.
 // ciFixCycleLimitBody is the issue body for TestCIFixReinvokeCycleLimit. The
 // PR body must contain "ci-fix-sentinel-unfixable" so the test-alpha CI
 // workflow runs a permanently-failing sentinel check regardless of content.
-// Claude will attempt to fix CI on each reinvoke but cannot succeed.
+//
+// The sentinel cannot be satisfied by any commit content, so this fixture's
+// job is not to fix CI — it is to guarantee a NEW commit on every single
+// CI-fix reinvoke, unconditionally, independent of whatever the agent
+// believes about fixability. The `#958 leg 2` no-op guard
+// (engine/catch_up_handlers.go) latches whenever a CI-fix reinvoke completes
+// without changing the PR's head SHA — which is exactly what the previous
+// "make your best effort" wording invited (handarbeit/fabrik#1323: the
+// no-op guard latched after the first reinvoke and the cycle-limit path was
+// structurally unreachable). Appending a line to a scratch file and pushing
+// is a mechanically verifiable action, not a judgment call, so
+// headAfter != headBefore holds every round and CIFixCycleIncremented
+// genuinely advances to MaxCiFixCycles.
 const ciFixCycleLimitBody = `## Goal
 
 End-to-end regression test for the Fabrik CI-fix cycle limit
-(handarbeit/fabrik#900). This issue is designed to exhaust MaxCiFixCycles
-by running an unfixable CI check.
+(handarbeit/fabrik#900, handarbeit/fabrik#1323). This issue is designed to
+exhaust MaxCiFixCycles by running an unfixable CI check while forcing a new
+commit on every single CI-fix reinvoke.
 
 ## The change
 
-Add exactly one new HTML comment to README.md, on its own line, immediately
-after the line containing "# fabrik-test-alpha". The comment must be:
+On the initial commit, add exactly one new HTML comment to README.md, on its
+own line, immediately after the line containing "# fabrik-test-alpha":
 
     <!-- ci-fix-cycle-limit-test -->
 
-This is the only change needed. Do NOT attempt to remove or alter the CI
-sentinel marker in the PR body — the sentinel is intentionally unfixable
-at the code level. Make your best effort on each CI-fix reinvoke, but the
-test expects the cycle limit to be reached.
+Also create a new file named exactly ` + "`.ci-fix-attempts.log`" + ` at the
+repository root, containing exactly one line:
+
+    attempt-1
+
+## MANDATORY action on EVERY CI-fix reinvoke (no exceptions)
+
+The CI sentinel check on this PR is PERMANENTLY UNFIXABLE — no code change,
+file edit, or workaround can make it pass. Do NOT attempt to diagnose or fix
+it, and do NOT decide there is "nothing to do" and skip pushing.
+
+Instead, on EVERY CI-fix reinvoke, unconditionally:
+
+1. Append exactly one new line to ` + "`.ci-fix-attempts.log`" + ` at the
+   repository root, reading ` + "`attempt-N`" + ` where N is one greater than
+   the highest attempt number already in the file (e.g. if the file's last
+   line is ` + "`attempt-1`" + `, append ` + "`attempt-2`" + `).
+2. Commit that change and push it.
+
+This applies to the first CI-fix reinvoke and every reinvoke after it, with
+no exceptions and regardless of any belief about whether the check is
+fixable — the point of this test is that it is not. A reinvoke that pushes
+no commit defeats the test.
 
 ## Hard constraints (do NOT violate)
 
 - NEVER modify any file under ` + "`.github/`" + `. The CI workflow — including the
   ci-fix-sentinel job — is immutable test infrastructure. It is intentionally
   unfixable here; editing it invalidates the test.
+- NEVER remove or alter the CI sentinel marker in the PR body.
+- On every CI-fix reinvoke, ALWAYS append to ` + "`.ci-fix-attempts.log`" + ` and
+  push, even though the check cannot be fixed. Skipping the push is the one
+  way to invalidate this test.
 
 ## CI behaviour required
 
@@ -430,5 +467,6 @@ ci-fix-sentinel-unfixable
 
 ## Scope
 
-Single file (README.md). Minimal change. No decomposition.
+README.md and ` + "`.ci-fix-attempts.log`" + ` only. Minimal change per commit. No
+decomposition.
 `

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -235,6 +235,18 @@ func hasEngineCIWaitTimeoutComment(bodies []string) bool {
 // deliberate, costly (~$0.50–1.50, 30-90 min) live-bed run per #1323's Risks
 // section, not something to repeat routinely.
 //
+// A known fragility (PR handarbeit/fabrik#1324 review): this scenario's
+// non-vacuousness now depends on the CI-fix agent faithfully obeying the
+// "MANDATORY ... no exceptions" append-and-push instruction in
+// ciFixCycleLimitBody on every single reinvoke — there is no engine-side
+// enforcement that any given reinvoke actually pushed. A run that fails the
+// commit-count check at the end is therefore ambiguous between two distinct
+// causes: a genuine engine regression (the cycle-limit path failing to
+// dispatch/advance) vs. the agent skipping a push on some round despite the
+// instruction. The commit-count message below distinguishes these only
+// after the fact, once the full run has already completed — there is no
+// cheaper way to tell them apart mid-run.
+//
 // Wall-clock: ~30–60 min. Cost: ~$0.50–1.50.
 func TestCIFixReinvokeCycleLimit(t *testing.T) {
 	t.Parallel()

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -239,13 +239,18 @@ func hasEngineCIWaitTimeoutComment(bodies []string) bool {
 // non-vacuousness now depends on the CI-fix agent faithfully obeying the
 // "MANDATORY ... no exceptions" append-and-push instruction in
 // ciFixCycleLimitBody on every single reinvoke — there is no engine-side
-// enforcement that any given reinvoke actually pushed. A run that fails the
-// commit-count check at the end is therefore ambiguous between two distinct
-// causes: a genuine engine regression (the cycle-limit path failing to
-// dispatch/advance) vs. the agent skipping a push on some round despite the
-// instruction. The commit-count message below distinguishes these only
-// after the fact, once the full run has already completed — there is no
-// cheaper way to tell them apart mid-run.
+// enforcement that any given reinvoke actually pushed. If the agent skips a
+// push on some round (e.g. it misjudges the unfixable check as fixable and
+// attempts a "real" fix that doesn't touch the scratch file), LastCIFixNoOpSHA
+// latches on that head SHA and dispatchWithCycleLimit's no-op short-circuit
+// starts skipping dispatch WITHOUT incrementing the cycle counter — so the
+// cycle limit is never reached at all, and the test fails earlier, as a
+// timeout waiting for fabrik:paused, not as the commit-count t.Fatalf below.
+// Either failure mode is loud (the test does not silently pass), but a
+// timeout is ambiguous between a genuine engine regression (the cycle-limit
+// path failing to dispatch/advance for real) and this agent-compliance
+// fragility — there is no cheaper way to distinguish them than the manual
+// pauseForCIFixCycleLimit-neutralization check described above.
 //
 // Wall-clock: ~30–60 min. Cost: ~$0.50–1.50.
 func TestCIFixReinvokeCycleLimit(t *testing.T) {

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -252,6 +252,16 @@ func hasEngineCIWaitTimeoutComment(bodies []string) bool {
 // fragility — there is no cheaper way to distinguish them than the manual
 // pauseForCIFixCycleLimit-neutralization check described above.
 //
+// Why PRCommitCount rather than an engine-observable signal (PR #1324
+// review): asserting directly on the engine's own CIFixCycleIncremented
+// application (catch_up_handlers.go) would remove the one-layer-removed gap
+// above, but the e2e harness has no mechanism to read the live bed's engine
+// process logs or internal state — only GitHub-visible signals (labels,
+// comments, commits) are observable from here. Adding one would be new
+// engine-side observability infrastructure, which is outside this issue's
+// explicit scope ("No change to engine behavior is implied by this issue").
+// PRCommitCount is the strongest non-vacuous signal available without it.
+//
 // Wall-clock: ~30–60 min. Cost: ~$0.50–1.50.
 func TestCIFixReinvokeCycleLimit(t *testing.T) {
 	t.Parallel()

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -331,6 +331,14 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 	}
 	t.Logf("commit count guard passed: %d commits (base=%d + >=%d CI-fix cycles) — cycle-limit path genuinely exercised",
 		finalCommits, baseCommits, maxCycles)
+
+	// Re-check the workflow guard now that the CI-fix reinvoke commits exist.
+	// The pre-Validate check above only covers the initial Implement commit;
+	// this fixture's whole point is to force genuine repeated dispatch, so
+	// the commits actually at risk of violating the "never touch .github/"
+	// hard constraint are the ones produced during the cycle-limit loop, not
+	// the baseline one.
+	AssertPRDidNotTouchWorkflows(t, env, env.RepoAlpha, prNumber)
 }
 
 // ciFixReinvokeBody is the issue body for TestCIFixReinvoke. The PR body must

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -1555,24 +1555,6 @@ func readEnvFileReviewWaitTimeout(t *testing.T, env *Env) int {
 	return n
 }
 
-// readEnvFileCIWaitTimeout reads FABRIK_CI_WAIT_TIMEOUT (minutes) from the
-// test bed's .env file. Returns 30 (the engine default, see
-// engine/ci.go:ciWaitTimeout) if the key is absent. Fails the test if the key
-// is present but not a valid integer.
-func readEnvFileCIWaitTimeout(t *testing.T, env *Env) int {
-	t.Helper()
-	envFile := filepath.Join(env.FabrikTestDir, ".env")
-	val, err := readEnvFileValue(envFile, "FABRIK_CI_WAIT_TIMEOUT")
-	if err != nil {
-		return 30
-	}
-	n, err := strconv.Atoi(strings.TrimSpace(val))
-	if err != nil {
-		t.Fatalf("FABRIK_CI_WAIT_TIMEOUT in %s is not an integer: %q", envFile, val)
-	}
-	return n
-}
-
 // ghOutputWithToken runs gh with a caller-supplied token (overrides GH_TOKEN).
 // Used by SubmitPRReview where the reviewer identity differs from the bot's
 // main PAT stored in *Env.


### PR DESCRIPTION
Closes #1323

## Summary

`TestCIFixReinvokeCycleLimit`'s fixture never guaranteed a new commit on each CI-fix reinvoke, so the `#958 leg 2` no-op guard (`engine/catch_up_handlers.go`) latched after the very first reinvoke. `CIFixCycleIncremented` never advanced, and `pauseForCIFixCycleLimit` — the very behavior the test claims to cover — was structurally unreachable at any `FABRIK_CI_WAIT_TIMEOUT`. This supersedes #1320's timer-race diagnosis, which was based on the false premise that raising the timeout alone would let the cycle-limit path win.

## What changed

- **`ciFixCycleLimitBody`** (`tests/e2e/ci_fix_reinvoke_test.go`): redesigned so the agent appends a line to a scratch file (`.ci-fix-attempts.log`) and commits+pushes **unconditionally** on every single CI-fix reinvoke, independent of any belief about fixability. The no-op guard only checks head-SHA equality, so this is enough to make it advance genuinely to `MaxCiFixCycles`.
- **`TestCIFixReinvokeCycleLimit`**: now captures a baseline `PRCommitCount` after Implement (mirroring `TestCIFixReinvoke`), asserts the workflow file wasn't touched, and — after the cycle-limit comment is confirmed — asserts the PR gained at least `maxCycles` commits beyond baseline. This makes "the cycle-limit path was genuinely exercised" independently verifiable, not just inferred.
- **Removed** the now-moot `minSafeCIWaitTimeoutMinutes` timer-coordination machinery (`observedWorstCaseMinutesPerCIFixCycle`, `cycleLimitTimerHeadroomMinutes`, the bed-config skip guard, `TestMinSafeCIWaitTimeoutMinutes`, and the now-unused `readEnvFileCIWaitTimeout` helper in `harness.go`) — its only data point (an 87-minute capture) is now understood to likely have been an artifact of this same bug.
- **`tests/e2e/README.md`**: prerequisite #8 reverted — no `FABRIK_CI_WAIT_TIMEOUT` override needed, the engine default (30 min) applies. Explains why #1320's premise no longer holds.
- Added a documented manual verification procedure (in `TestCIFixReinvokeCycleLimit`'s doc comment): neutralize `pauseForCIFixCycleLimit` locally and re-run against a live bed to confirm the assertions would actually fail — a deliberate, costly, one-off step, not run by this PR.

## Out of scope / not changed

- **No engine behavior changes.** `engine/catch_up_handlers.go`'s no-op guard and `engine/ci.go`'s `pauseForCIFixCycleLimit`/`pauseForCITimeout` are confirmed correct as-is and untouched.
- **No `docs/state-machine.md` change** — the engine's documented behavior is unchanged, so Validate shouldn't expect a doc update here (per Plan's explicit decision).
- `TestCIFixReinvoke`/#916 is out of scope and remains skipped.

## How to test

- `go build ./...` and `go vet ./...` — clean.
- `go build -tags e2e ./...` and `go vet -tags e2e ./tests/e2e/...` — clean.
- `go test -tags e2e -run 'TestHasEngineCycleLimitComment|TestHasEngineCIWaitTimeoutComment' ./tests/e2e/...` — passes (fast, no live bed needed).
- `go test ./...` — full suite passes except a pre-existing, unrelated flake (`cmd.TestExecute_ConfigYAMLApplied`, a SIGINT-handling test failing identically on `main` before this change).
- The actual live-bed verification of `TestCIFixReinvokeCycleLimit` (and the manual `pauseForCIFixCycleLimit`-neutralization check) requires a real e2e run against `handarbeit/fabrik-test-alpha` (~$0.50–1.50, 30–90 min) and is documented as a deliberate follow-up, not performed here.