### PR TITLE
Update docs for v0.0.76

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,10 @@ CLI flag  >  shell env var  >  .env file  >  .fabrik/config.yaml  >  built-in de
 Run `fabrik init` to generate `.fabrik/config.yaml` in your project. This file holds
 all non-secret project settings and should be committed to git. See the
 [Configuration Reference](docs/USER_GUIDE.md#2-configuration-reference) in the User
-Guide for a full field-by-field description with examples and defaults.
+Guide for a full field-by-field description with examples and defaults, including
+`required_status_contexts` — per-repo required context names the CI gate must see
+confirmed `success` for, needed only when a repo's required CI signal is a classic
+commit status rather than a normal GitHub Actions check run.
 
 **Secrets** (GitHub tokens) belong in a gitignored `.env` file only:
 
@@ -396,8 +399,10 @@ Fabrik uses labels to track state:
 | `effort:<level>` | Override thinking effort for this issue only — valid values: `low`, `medium`, `high`, `max`; precedence: `max > high > medium > low`. Complements `model:` label. |
 | `fabrik:yolo` | Force auto-advance even when `auto_advance: false`; also triggers auto-merge of the linked PR when Validate completes |
 | `fabrik:auto-merge-enabled` | Applied when Fabrik enables GitHub's native auto-merge on a yolo PR after Validate completes; serves as the idempotency guard and convergence-budget start anchor; removed when the PR merges or is closed |
-| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, `fabrik:yolo` takes precedence. |
+| `fabrik:cruise` | Auto-advances through all stages like `fabrik:yolo` but stops at Validate — no auto-merge, no move to Done. If both `fabrik:cruise` and `fabrik:yolo` are present, cruise takes precedence. |
 | `fabrik:unrestricted` | Pass `--dangerously-skip-permissions` to Claude Code for this issue only, bypassing the default `--permission-mode dontAsk` posture and the entire tool allowlist. Use only when a stage needs tools outside the default set (e.g. `deno`, `bun`, or other non-standard toolchains). **Caution:** removes all tool restrictions. |
+| `review-authority:<mode>` | Override the stage's configured `review_authority` for this issue only (`advisory` or `authoritative`); only meaningful alongside `wait_for_reviews: true`. See [Authoritative Mode](docs/USER_GUIDE.md#authoritative-mode) in the User Guide. |
+| `expected-reviewers:<mode>` | Override the stage's configured `expected_reviewers` for this issue only (`none` or `declared`); only meaningful alongside `wait_for_reviews: true`. See [Declaring Expected Reviewers](docs/USER_GUIDE.md#declaring-expected-reviewers) in the User Guide. |
 | `fabrik:extend-turns` | Pre-grant 2× `max_turns` budget for the next invocation; auto-extends to 3× when stage progress is detected; auto-removed on successful stage completion. |
 | `fabrik:revalidate` | Force re-entry of the Validate stage — the engine clears `stage:Validate:complete`, `stage:Validate:failed`, `fabrik:paused`, `fabrik:awaiting-input`, `fabrik:awaiting-ci`, `fabrik:auto-merge-enabled`, and itself, then re-runs Validate on the current HEAD SHA. Use as a one-action recovery for stuck-Validate, or as the manual fallback for items that completed Validate before SHA-change auto-revalidation was deployed. |
 | `base:<branch>` | Override the base branch for this issue — Fabrik forks from, rebases onto, and targets PRs at `<branch>` instead of the repository default. Must be set before Research. If the branch does not exist on the remote, Fabrik falls back to the default branch and posts a comment. |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1611,6 +1611,8 @@ wait_for_ci: true
 
 CI checks are only evaluated on the **PR head SHA** — Fabrik makes two REST calls per poll: one to get the head SHA via the linked PR, and one to fetch the check runs. If no check runs exist **and** GitHub's `mergeable_state` is either empty or `"unknown"` (meaning no legacy Commit Status is blocking merge), the gate clears immediately. If `mergeable_state` is non-empty and not `"unknown"` (a legacy Commit Status or external status check is actively blocking merge), the gate holds even with no `check_runs` — Fabrik falls back to CIWaitTimeout escalation to avoid blocking forever.
 
+For a repo whose required CI signal is a classic commit status rather than a normal GitHub Actions check run, configure `required_status_contexts` (per-repo, in [`.fabrik/config.yaml`](#2-configuration-reference), ADR-933) so the gate can distinguish a required context that never ran from one that was correctly skipped.
+
 #### Label Lifecycle
 
 When a `wait_for_ci: true` stage emits `FABRIK_STAGE_COMPLETE`, Fabrik immediately adds the `fabrik:awaiting-ci` label to the issue — it means "CI gate active" and covers both pending and failed CI states. `stage:X:complete` is withheld until `checkCIGate` confirms all checks pass (conjunctive gate, ADR 032). This label:
@@ -2522,6 +2524,18 @@ from the parent process do not leak into Claude subprocesses. If you previously
 relied on ambient env vars being available inside Claude (e.g., API keys or tool
 paths set in your shell), pass them explicitly via your stage YAML or a shell
 wrapper script.
+
+### Worker Session Naming (`--name`)
+
+Every worker invocation carries a `--name fabrik:<owner>/<repo>#<issue>:<stage>`
+flag (e.g. `fabrik:handarbeit/fabrik#1284:Implement`), giving each Fabrik worker a
+self-describing identity in `ps` output — `ps aux | grep -- "--name fabrik:"` finds
+every worker on the host, and the sentinel itself names which repo, issue, and stage
+each one is serving. The flag is gated on a one-time startup probe of the installed
+`claude` binary's `--help` output; on older binaries that predate the flag, it's
+omitted and workers run exactly as before. It is observability-only — the engine
+never reads or branches on it. See [stage-lifecycle.md § Worker Session Naming](stage-lifecycle.md#worker-session-naming---name)
+for the full as-built mechanism.
 
 ### Rate Limit Monitoring
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -482,7 +482,7 @@ fabrik --auto-upgrade</pre>
         <span class="feature-icon">👁️</span>
         <div class="feature-title">Pending Reviewer Gate</div>
         <div class="feature-desc">
-          Waits for all requested PR reviewers then re-invokes the stage to address comments.
+          Waits for requested reviewers—including self-submitting bots—then re-invokes the stage, optionally enforcing an authoritative verdict before advancing.
         </div>
       </a>
       <a class="feature-card" href="{{ '/state-machine' | relative_url }}#65-ci-gate-and-ci-fix-reinvoke" aria-label="CI Gate — open documentation">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1609,6 +1609,8 @@ wait_for_ci: true
 
 CI checks are only evaluated on the **PR head SHA** — Fabrik makes two REST calls per poll: one to get the head SHA via the linked PR, and one to fetch the check runs. If no check runs exist **and** GitHub's `mergeable_state` is either empty or `"unknown"` (meaning no legacy Commit Status is blocking merge), the gate clears immediately. If `mergeable_state` is non-empty and not `"unknown"` (a legacy Commit Status or external status check is actively blocking merge), the gate holds even with no `check_runs` — Fabrik falls back to CIWaitTimeout escalation to avoid blocking forever.
 
+For a repo whose required CI signal is a classic commit status rather than a normal GitHub Actions check run, configure `required_status_contexts` (per-repo, in [`.fabrik/config.yaml`](#2-configuration-reference), ADR-933) so the gate can distinguish a required context that never ran from one that was correctly skipped.
+
 #### Label Lifecycle
 
 When a `wait_for_ci: true` stage emits `FABRIK_STAGE_COMPLETE`, Fabrik immediately adds the `fabrik:awaiting-ci` label to the issue — it means "CI gate active" and covers both pending and failed CI states. `stage:X:complete` is withheld until `checkCIGate` confirms all checks pass (conjunctive gate, ADR 032). This label:
@@ -2520,6 +2522,18 @@ from the parent process do not leak into Claude subprocesses. If you previously
 relied on ambient env vars being available inside Claude (e.g., API keys or tool
 paths set in your shell), pass them explicitly via your stage YAML or a shell
 wrapper script.
+
+### Worker Session Naming (`--name`)
+
+Every worker invocation carries a `--name fabrik:<owner>/<repo>#<issue>:<stage>`
+flag (e.g. `fabrik:handarbeit/fabrik#1284:Implement`), giving each Fabrik worker a
+self-describing identity in `ps` output — `ps aux | grep -- "--name fabrik:"` finds
+every worker on the host, and the sentinel itself names which repo, issue, and stage
+each one is serving. The flag is gated on a one-time startup probe of the installed
+`claude` binary's `--help` output; on older binaries that predate the flag, it's
+omitted and workers run exactly as before. It is observability-only — the engine
+never reads or branches on it. See [stage-lifecycle.md § Worker Session Naming](stage-lifecycle.md#worker-session-naming---name)
+for the full as-built mechanism.
 
 ### Rate Limit Monitoring
 


### PR DESCRIPTION
Closes #1331

## Summary

Audits `docs/USER_GUIDE.md`, `README.md`, and `docs/index.md` against `release-notes/v0.0.76.md` and fills in the user-facing gaps found:

- **README.md**
  - Added `review-authority:<mode>` and `expected-reviewers:<mode>` rows to the Labels table (previously absent entirely).
  - Fixed a factual bug in the adjacent `fabrik:cruise` row: it stated `fabrik:yolo` takes precedence when both are present — the actual (and documented-elsewhere) behavior is that **cruise** takes precedence.
  - Added a short pointer to `required_status_contexts` in the Configuration section, consistent with README's existing "point to the User Guide, don't duplicate field docs" style.

- **docs/USER_GUIDE.md**
  - Added a new "Worker Session Naming (`--name`)" subsection under Observability, summarizing the `ps`-discoverable session sentinel (`fabrik:<owner>/<repo>#<issue>:<stage>`) and linking to `stage-lifecycle.md` for the full as-built mechanism.
  - Added a one-line forward-reference from the CI Gate "Enabling the Gate" section to the existing `required_status_contexts` config example, so it's discoverable from prose rather than only from a commented-out YAML block.
  - Regenerated `docs/llms-full.txt` (required since `USER_GUIDE.md` is in the bundle's `ORDERED` list).

- **docs/index.md**
  - Refreshed the "Pending Reviewer Gate" feature-card blurb, which predated and didn't reflect the two headline v0.0.76 review-gate features (`expected_reviewers` bot-aware waiting, `review_authority` verdict enforcement).

Everything else audited (`review_authority`/`expected_reviewers` prose, the `FABRIK_ISSUE`/`FABRIK_REPO`/`FABRIK_WORKTREE`/`FABRIK_ROOT`/`FABRIK_PR` env var docs, plugin auto-bump docs, the USER_GUIDE.md Labels Reference rows) was already accurate and needed no changes — confirmed during research, not assumed.

Out of scope per the issue: backfilling README's other pre-existing missing labels (`fabrik:awaiting-done`, `fabrik:bot-reprompted`, `fabrik:claude-limit`, etc.) — candidate for a separate follow-up issue.

## Test plan

- [x] `bash scripts/generate-llms-full.sh` produces no further diff (bundle in sync with `USER_GUIDE.md`).
- [x] Verified all new/edited cross-reference anchors (`#authoritative-mode`, `#declaring-expected-reviewers`, `#2-configuration-reference`, `#pending-reviewer-gate`, `stage-lifecycle.md#worker-session-naming---name`) resolve to real headings.
- [x] Verified `required_status_contexts` prose against its actual `.fabrik/config.yaml` example and ADR-933.
- [x] Verified cruise/yolo precedence fix against `engine/stages.go` and existing correct wording in `docs/USER_GUIDE.md`.
- This is a documentation-only change — no code paths affected, no `go build`/`go test` impact.