### PR TITLE
chore(merge-train): trial integration for #1334

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1498,12 +1498,13 @@ The timeout is based on the timestamp of when the `fabrik:awaiting-review` label
 
 It isn't: **the gate's actual test is "has a human looked at this?", not "has a reviewer approved this?"** A `COMMENTED` review submitted by the PR author itself satisfies the gate — GitHub permits a self-`COMMENT` even though it forbids self-approval. This is the supported manual way to clear the gate when no other reviewer can respond.
 
-When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists four ways to resume:
+When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists five ways to resume:
 
 1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate — unless the stage is `authoritative` and the repo requires approving reviews (branch protection reports `REVIEW_REQUIRED`), in which case an approval from another account is needed; see [Authoritative Mode](#authoritative-mode) below.
-2. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer. This is the supported setting for a reviewer-less repo going forward, rather than repeatedly hitting this timeout.
-3. Merge the PR manually.
-4. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).
+2. Set `expected_reviewers: []` in the stage YAML to declare that no *unrequested* reviewer (e.g. a bot) is expected here — an explicitly requested reviewer is still honored. This is the narrower, purpose-built option: it stops the gate from waiting out unrequested reviewers that will never respond, without disabling the gate for a reviewer requested on a later PR. See [Declaring Expected Reviewers](#declaring-expected-reviewers) below.
+3. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer at all. This disables the review gate entirely, including for a reviewer requested on a later PR — the supported setting only when no review will ever be relevant on this repo.
+4. Merge the PR manually.
+5. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).
 
 Fabrik deliberately does not try to detect "no reviewer will ever respond" automatically (e.g. by inspecting CODEOWNERS or requested-reviewer history) — that signal can't distinguish "no reviewer exists" from "the reviewer is just slow or down," and guessing wrong in the direction of auto-advancing would merge an unreviewed PR. The gate stays loud-and-conservative; only the messaging tells you honestly what it knows.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1496,12 +1496,13 @@ The timeout is based on the timestamp of when the `fabrik:awaiting-review` label
 
 It isn't: **the gate's actual test is "has a human looked at this?", not "has a reviewer approved this?"** A `COMMENTED` review submitted by the PR author itself satisfies the gate — GitHub permits a self-`COMMENT` even though it forbids self-approval. This is the supported manual way to clear the gate when no other reviewer can respond.
 
-When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists four ways to resume:
+When the timeout elapses with no reviewer ever requested, Fabrik's pause comment says so plainly — it does not claim to have waited on "outstanding reviewers" that don't exist — and lists five ways to resume:
 
 1. Post a review on the PR yourself. A `COMMENTED` self-review satisfies the gate — unless the stage is `authoritative` and the repo requires approving reviews (branch protection reports `REVIEW_REQUIRED`), in which case an approval from another account is needed; see [Authoritative Mode](#authoritative-mode) below.
-2. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer. This is the supported setting for a reviewer-less repo going forward, rather than repeatedly hitting this timeout.
-3. Merge the PR manually.
-4. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).
+2. Set `expected_reviewers: []` in the stage YAML to declare that no *unrequested* reviewer (e.g. a bot) is expected here — an explicitly requested reviewer is still honored. This is the narrower, purpose-built option: it stops the gate from waiting out unrequested reviewers that will never respond, without disabling the gate for a reviewer requested on a later PR. See [Declaring Expected Reviewers](#declaring-expected-reviewers) below.
+3. Set `wait_for_reviews: false` in the stage YAML if this repo has no reviewer at all. This disables the review gate entirely, including for a reviewer requested on a later PR — the supported setting only when no review will ever be relevant on this repo.
+4. Merge the PR manually.
+5. Remove the `fabrik:paused` label to let the engine wait again (useful if a reviewer is actually expected and just hasn't gotten to it yet).
 
 Fabrik deliberately does not try to detect "no reviewer will ever respond" automatically (e.g. by inspecting CODEOWNERS or requested-reviewer history) — that signal can't distinguish "no reviewer exists" from "the reviewer is just slow or down," and guessing wrong in the direction of auto-advancing would merge an unreviewed PR. The gate stays loud-and-conservative; only the messaging tells you honestly what it knows.
 

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -234,7 +234,7 @@ func (e *Engine) checkReviewGate(board *gh.ProjectBoard, item gh.ProjectItem, st
 	} else if len(declaredOutstanding) > 0 {
 		e.logf(item.Number, "awaiting-review", "waiting for declared reviewer(s): %s\n", strings.Join(declaredOutstanding, ", "))
 	} else {
-		e.logf(item.Number, "awaiting-review", "waiting for initial review submission (no reviewers requested; bot reviewers may still be processing)\n")
+		e.logf(item.Number, "awaiting-review", "waiting for initial review submission (no reviewers requested, none declared via expected_reviewers)\n")
 	}
 
 	// Apply label on first block transition.
@@ -1308,9 +1308,9 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 			// check matters for the same reason: a declared-but-unrequested
 			// reviewer that hasn't responded yet is a case Fabrik *can* name
 			// (see the standard branch below, which surfaces it via
-			// expectedReviewersLine) — asserting here that "Fabrik cannot
-			// determine whether one is ever coming" would contradict the
-			// operator's own declaration.
+			// expectedReviewersLine) — framing this branch's "whether one is
+			// ever coming" as declarable rather than unknowable would
+			// contradict the operator's own declaration if it applied here.
 			prRef := "the linked PR"
 			if item.LinkedPRNumber > 0 {
 				prRef = fmt.Sprintf("PR #%d", item.LinkedPRNumber)
@@ -1334,14 +1334,17 @@ func (e *Engine) pauseForReviewTimeout(board *gh.ProjectBoard, item gh.ProjectIt
 			msg = fmt.Sprintf(
 				"🏭 **Fabrik — review wait timeout**\n\n"+
 					"The review gate for stage **%s** timed out. No reviewer was ever requested on %s, and no review "+
-					"has been submitted — Fabrik cannot determine whether one is ever coming.%s\n\n"+
+					"has been submitted. Whether one is ever coming is declarable rather than unknowable — see remedy (b) below.%s\n\n"+
 					"Fabrik has paused this issue. To resume, either:\n"+
 					"- (a) post a review on %s yourself — a `COMMENTED` self-review from the PR author satisfies "+
 					"the gate, even though GitHub forbids self-approval%s,\n"+
-					"- (b) set `wait_for_reviews: false` in the %s stage YAML if this repo has no reviewer,\n"+
-					"- (c) merge %s manually, or\n"+
-					"- (d) remove `fabrik:paused` to let the engine wait again.",
-				stage.Name, prRef, authorityLine, prRef, selfReviewCaveat, stage.Name, prRef,
+					"- (b) set `expected_reviewers: []` in the %s stage YAML to declare that no *unrequested* "+
+					"reviewer is expected here — an explicitly requested reviewer is still honored,\n"+
+					"- (c) set `wait_for_reviews: false` in the %s stage YAML to disable the review gate entirely "+
+					"if this repo has no reviewer,\n"+
+					"- (d) merge %s manually, or\n"+
+					"- (e) remove `fabrik:paused` to let the engine wait again.",
+				stage.Name, prRef, authorityLine, prRef, selfReviewCaveat, stage.Name, stage.Name, prRef,
 			)
 		} else if pendingLine == "" && hasReviews && authorityLine != "" {
 			// No reviewer is currently outstanding, but a review does exist —

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -11,6 +11,7 @@ import (
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
+	"github.com/handarbeit/fabrik/tui"
 )
 
 // reviewTestStages returns a two-stage pipeline for review gate tests.
@@ -623,6 +624,54 @@ func TestCheckReviewGate_NoReviewersNoReviews_Blocks(t *testing.T) {
 	}
 	if len(client.addLabelCalls) != 1 {
 		t.Errorf("expected 1 label add (fabrik:awaiting-review), got %d", len(client.addLabelCalls))
+	}
+}
+
+// FR-1 (#1334): when nothing is requested and nothing is declared via
+// expected_reviewers, the blocking log line must state what is known — that
+// nothing is requested and nothing is declared — and name expected_reviewers
+// as the way to change that. It must not speculate that bot reviewers may
+// still be processing (#1080).
+func TestCheckReviewGate_NoReviewersNoDeclaration_LogsExpectedReviewersRemedy(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := reviewTestEngine(t, client)
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	eventsCh := make(chan tui.Event, 32)
+	eng.events = eventsCh
+	item := gh.ProjectItem{
+		Number:                 10,
+		Repo:                   "owner/repo",
+		LinkedPRReviewRequests: nil, // no requested reviewers
+		LinkedPRReviews:        nil, // no reviews submitted yet
+	}
+	stage := &stages.Stage{Name: "Implement", WaitForReviews: boolPtr(true)} // no ExpectedReviewers declared
+
+	blocked, _, _ := eng.checkReviewGate(board, item, stage)
+	if !blocked {
+		t.Fatal("expected blocked when no reviews submitted yet")
+	}
+
+	close(eventsCh)
+	var msg string
+	var found bool
+	for ev := range eventsCh {
+		le, ok := ev.(tui.LogEvent)
+		if !ok || le.Tag != "awaiting-review" {
+			continue
+		}
+		if strings.Contains(le.Message, "waiting for initial review submission") {
+			msg = le.Message
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a log event for 'waiting for initial review submission'")
+	}
+	if !strings.Contains(msg, "no reviewers requested") || !strings.Contains(msg, "none declared via expected_reviewers") {
+		t.Errorf("expected log to state nothing requested and nothing declared via expected_reviewers, got: %s", msg)
+	}
+	if strings.Contains(msg, "bot reviewers may still be processing") {
+		t.Errorf("log must not speculate that bot reviewers may still be processing when nothing is requested or declared, got: %s", msg)
 	}
 }
 
@@ -1556,8 +1605,9 @@ func TestPauseForReviewTimeout_ListsReviewerTypes(t *testing.T) {
 }
 
 // On a timeout where no reviewer was ever requested, the pause comment must
-// not claim to have waited on "outstanding reviewers" and must list the four
-// remedies, including the COMMENTED self-review hatch (#1268).
+// not claim to have waited on "outstanding reviewers" and must list the five
+// remedies, including the COMMENTED self-review hatch (#1268) and the
+// expected_reviewers: [] declaration (#1283, #1334).
 func TestPauseForReviewTimeout_NoReviewersRequested_ListsRemedies(t *testing.T) {
 	client := &mockGitHubClient{}
 	eng := reviewTestEngine(t, client)
@@ -1579,8 +1629,24 @@ func TestPauseForReviewTimeout_NoReviewersRequested_ListsRemedies(t *testing.T) 
 	if strings.Contains(body, "outstanding reviewers") {
 		t.Errorf("pause comment must not claim to wait on outstanding reviewers when none were requested; got:\n%s", body)
 	}
-	if !containsAll(body, "COMMENTED", "self-review", "wait_for_reviews: false", "merge", "fabrik:paused") {
-		t.Errorf("pause comment should list the four remedies including the COMMENTED self-review hatch; got:\n%s", body)
+	if !containsAll(body, "COMMENTED", "self-review", "expected_reviewers: []", "wait_for_reviews: false", "merge", "fabrik:paused") {
+		t.Errorf("pause comment should list the five remedies including the COMMENTED self-review hatch and expected_reviewers: []; got:\n%s", body)
+	}
+	// FR-2: expected_reviewers: [] and wait_for_reviews: false must be
+	// distinguished, not merged into one recommendation — the former narrows
+	// waiting for unrequested reviewers while honoring an explicit request,
+	// the latter disables the gate entirely.
+	if !strings.Contains(body, "entirely") {
+		t.Errorf("pause comment should distinguish wait_for_reviews: false as disabling the gate entirely; got:\n%s", body)
+	}
+	// FR-3: the old "cannot determine whether one is ever coming" framing
+	// asserted an inherent limit that expected_reviewers (#1283) removed —
+	// it must be replaced with declarable-not-unknowable framing.
+	if strings.Contains(body, "cannot determine whether one is ever coming") {
+		t.Errorf("pause comment must not claim Fabrik cannot determine whether a reviewer is coming — this is now declarable via expected_reviewers; got:\n%s", body)
+	}
+	if !strings.Contains(body, "declarable") {
+		t.Errorf("pause comment should note that whether a reviewer is coming is declarable; got:\n%s", body)
 	}
 	// Advisory mode (no ReviewAuthority set): a self-COMMENT is known to
 	// satisfy the gate outright, so the authoritative-mode caveat on remedy


### PR DESCRIPTION
🏭 **Fabrik merge-train integration PR** (trial → main)

This is a disposable trial branch combining the following Queued member PRs:
#1334

Do not merge this PR manually — Fabrik manages the landing step.
Orphaned integration PRs (if the train worker crashed) can be closed manually via the GitHub UI.

Closes #1334

<!-- fabrik-merge-train-batch -->