### PR TITLE
Make CLAUDE_CONFIG_DIR passthrough observable, pinned by a test, and documented

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -116,6 +116,10 @@ GitHub token to a gitignored `.env` file:
 # Required scopes: repo, project, workflow
 # Create at: https://github.com/settings/tokens (select "Tokens (classic)")
 FABRIK_TOKEN=ghp_...
+
+# Optional: run this instance's Claude invocations against a different Claude
+# account/subscription. See "Alternate Claude Profile (CLAUDE_CONFIG_DIR)" below.
+# CLAUDE_CONFIG_DIR=/home/user/.claude-alt-profile
 ```
 
 > **Note:** When a `.git/` directory is present, Fabrik refuses to start if `.env` exists but is not listed in `.gitignore` (prevents accidental token leaks). In directories **without** `.git/` — containers, CI workspaces, or bare directories — this check is skipped and `.env` is loaded normally without requiring a `.gitignore` entry.
@@ -2524,7 +2528,43 @@ Claude Code is invoked with a clean, isolated environment — environment variab
 from the parent process do not leak into Claude subprocesses. If you previously
 relied on ambient env vars being available inside Claude (e.g., API keys or tool
 paths set in your shell), pass them explicitly via your stage YAML or a shell
-wrapper script.
+wrapper script. `CLAUDE_CONFIG_DIR` is the one deliberate exception to this rule —
+see the next section.
+
+### Alternate Claude Profile (`CLAUDE_CONFIG_DIR`)
+
+Setting `CLAUDE_CONFIG_DIR` in the engine's environment points every Claude Code
+invocation at an alternate credentials/config directory — a different account,
+subscription, and billing quota than the engine's own default profile. Fabrik
+does not set, read, or otherwise manage this variable; it simply never strips it,
+so an ambient value passes straight through into every worker subprocess.
+
+This is the pattern to use when you want one Fabrik instance's stage invocations
+to bill against a different Claude account than the one the engine itself runs
+as — for example, running several instances across several accounts to spread
+usage-limit exposure.
+
+Set it in `.env` (already `.gitignore`-enforced, per the note above):
+
+```
+CLAUDE_CONFIG_DIR=/home/user/.claude-alt-profile
+```
+
+It survives `--auto-upgrade` re-execs: a re-exec restarts the same binary from
+scratch, which re-runs `.env` loading at startup, so the value is picked up again
+exactly as on a fresh start.
+
+To confirm it took effect, check the startup output (stderr and `.fabrik/fabrik.log`)
+for a line naming the resolved directory:
+
+```
+[startup] notice: CLAUDE_CONFIG_DIR is set to "/home/user/.claude-alt-profile" — Claude invocations will use this profile directory instead of the default account. See docs/USER_GUIDE.md.
+```
+
+No line means `CLAUDE_CONFIG_DIR` was unset — every invocation runs against the
+default profile. Fabrik does not validate the directory's contents or credential
+state; a misconfigured or unauthenticated profile fails wherever Claude Code
+itself would fail, not at Fabrik startup.
 
 ### Worker Session Naming (`--name`)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2536,8 +2536,10 @@ see the next section.
 Setting `CLAUDE_CONFIG_DIR` in the engine's environment points every Claude Code
 invocation at an alternate credentials/config directory — a different account,
 subscription, and billing quota than the engine's own default profile. Fabrik
-does not set, read, or otherwise manage this variable; it simply never strips it,
-so an ambient value passes straight through into every worker subprocess.
+does not set or otherwise manage this variable; it only reads it once, at
+startup, to emit the notice below — it simply never strips it from the
+subprocess environment, so an ambient value passes straight through into every
+worker subprocess.
 
 This is the pattern to use when you want one Fabrik instance's stage invocations
 to bill against a different Claude account than the one the engine itself runs

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2524,22 +2524,27 @@ working directory. Useful for diagnosing prompt issues or unexpected behavior.
 
 ### Subprocess Environment
 
-Claude Code is invoked with a clean, isolated environment — environment variables
-from the parent process do not leak into Claude subprocesses. If you previously
-relied on ambient env vars being available inside Claude (e.g., API keys or tool
-paths set in your shell), pass them explicitly via your stage YAML or a shell
-wrapper script. `CLAUDE_CONFIG_DIR` is the one deliberate exception to this rule —
-see the next section.
+Claude Code is invoked with the engine's full parent-process environment as its
+base — every ambient variable in the engine's own environment is inherited by
+Claude subprocesses. Fabrik does not isolate or clear this environment; instead
+it shadows a small, explicit set of keys it cares about (`CLAUDE_CODE_EFFORT_LEVEL`,
+`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, the `FABRIK_*` invocation facts,
+`GH_TOKEN`/`GITHUB_TOKEN`) so that Fabrik's own value for those specific keys
+always wins over an ambient one, no matter which happened to be set first.
+Everything else — anything not on that list — passes through untouched. If you
+want a stage-specific variable to reach Claude reliably regardless of what's
+ambient, pass it explicitly via your stage YAML or a shell wrapper script rather
+than relying on shell export order.
 
 ### Alternate Claude Profile (`CLAUDE_CONFIG_DIR`)
 
-Setting `CLAUDE_CONFIG_DIR` in the engine's environment points every Claude Code
-invocation at an alternate credentials/config directory — a different account,
-subscription, and billing quota than the engine's own default profile. Fabrik
-does not set or otherwise manage this variable; it only reads it once, at
-startup, to emit the notice below — it simply never strips it from the
-subprocess environment, so an ambient value passes straight through into every
-worker subprocess.
+`CLAUDE_CONFIG_DIR` is not special-cased by Fabrik — it is simply one instance of
+the general passthrough rule above, which is what makes this pattern work at all.
+Setting it in the engine's environment points every Claude Code invocation at an
+alternate credentials/config directory — a different account, subscription, and
+billing quota than the engine's own default profile. Fabrik does not set or
+otherwise manage this variable; it only reads it once, at startup, to emit the
+notice below.
 
 This is the pattern to use when you want one Fabrik instance's stage invocations
 to bill against a different Claude account than the one the engine itself runs

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2534,8 +2534,10 @@ see the next section.
 Setting `CLAUDE_CONFIG_DIR` in the engine's environment points every Claude Code
 invocation at an alternate credentials/config directory — a different account,
 subscription, and billing quota than the engine's own default profile. Fabrik
-does not set, read, or otherwise manage this variable; it simply never strips it,
-so an ambient value passes straight through into every worker subprocess.
+does not set or otherwise manage this variable; it only reads it once, at
+startup, to emit the notice below — it simply never strips it from the
+subprocess environment, so an ambient value passes straight through into every
+worker subprocess.
 
 This is the pattern to use when you want one Fabrik instance's stage invocations
 to bill against a different Claude account than the one the engine itself runs

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2522,22 +2522,27 @@ working directory. Useful for diagnosing prompt issues or unexpected behavior.
 
 ### Subprocess Environment
 
-Claude Code is invoked with a clean, isolated environment — environment variables
-from the parent process do not leak into Claude subprocesses. If you previously
-relied on ambient env vars being available inside Claude (e.g., API keys or tool
-paths set in your shell), pass them explicitly via your stage YAML or a shell
-wrapper script. `CLAUDE_CONFIG_DIR` is the one deliberate exception to this rule —
-see the next section.
+Claude Code is invoked with the engine's full parent-process environment as its
+base — every ambient variable in the engine's own environment is inherited by
+Claude subprocesses. Fabrik does not isolate or clear this environment; instead
+it shadows a small, explicit set of keys it cares about (`CLAUDE_CODE_EFFORT_LEVEL`,
+`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, the `FABRIK_*` invocation facts,
+`GH_TOKEN`/`GITHUB_TOKEN`) so that Fabrik's own value for those specific keys
+always wins over an ambient one, no matter which happened to be set first.
+Everything else — anything not on that list — passes through untouched. If you
+want a stage-specific variable to reach Claude reliably regardless of what's
+ambient, pass it explicitly via your stage YAML or a shell wrapper script rather
+than relying on shell export order.
 
 ### Alternate Claude Profile (`CLAUDE_CONFIG_DIR`)
 
-Setting `CLAUDE_CONFIG_DIR` in the engine's environment points every Claude Code
-invocation at an alternate credentials/config directory — a different account,
-subscription, and billing quota than the engine's own default profile. Fabrik
-does not set or otherwise manage this variable; it only reads it once, at
-startup, to emit the notice below — it simply never strips it from the
-subprocess environment, so an ambient value passes straight through into every
-worker subprocess.
+`CLAUDE_CONFIG_DIR` is not special-cased by Fabrik — it is simply one instance of
+the general passthrough rule above, which is what makes this pattern work at all.
+Setting it in the engine's environment points every Claude Code invocation at an
+alternate credentials/config directory — a different account, subscription, and
+billing quota than the engine's own default profile. Fabrik does not set or
+otherwise manage this variable; it only reads it once, at startup, to emit the
+notice below.
 
 This is the pattern to use when you want one Fabrik instance's stage invocations
 to bill against a different Claude account than the one the engine itself runs

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -114,6 +114,10 @@ GitHub token to a gitignored `.env` file:
 # Required scopes: repo, project, workflow
 # Create at: https://github.com/settings/tokens (select "Tokens (classic)")
 FABRIK_TOKEN=ghp_...
+
+# Optional: run this instance's Claude invocations against a different Claude
+# account/subscription. See "Alternate Claude Profile (CLAUDE_CONFIG_DIR)" below.
+# CLAUDE_CONFIG_DIR=/home/user/.claude-alt-profile
 ```
 
 > **Note:** When a `.git/` directory is present, Fabrik refuses to start if `.env` exists but is not listed in `.gitignore` (prevents accidental token leaks). In directories **without** `.git/` — containers, CI workspaces, or bare directories — this check is skipped and `.env` is loaded normally without requiring a `.gitignore` entry.
@@ -2522,7 +2526,43 @@ Claude Code is invoked with a clean, isolated environment — environment variab
 from the parent process do not leak into Claude subprocesses. If you previously
 relied on ambient env vars being available inside Claude (e.g., API keys or tool
 paths set in your shell), pass them explicitly via your stage YAML or a shell
-wrapper script.
+wrapper script. `CLAUDE_CONFIG_DIR` is the one deliberate exception to this rule —
+see the next section.
+
+### Alternate Claude Profile (`CLAUDE_CONFIG_DIR`)
+
+Setting `CLAUDE_CONFIG_DIR` in the engine's environment points every Claude Code
+invocation at an alternate credentials/config directory — a different account,
+subscription, and billing quota than the engine's own default profile. Fabrik
+does not set, read, or otherwise manage this variable; it simply never strips it,
+so an ambient value passes straight through into every worker subprocess.
+
+This is the pattern to use when you want one Fabrik instance's stage invocations
+to bill against a different Claude account than the one the engine itself runs
+as — for example, running several instances across several accounts to spread
+usage-limit exposure.
+
+Set it in `.env` (already `.gitignore`-enforced, per the note above):
+
+```
+CLAUDE_CONFIG_DIR=/home/user/.claude-alt-profile
+```
+
+It survives `--auto-upgrade` re-execs: a re-exec restarts the same binary from
+scratch, which re-runs `.env` loading at startup, so the value is picked up again
+exactly as on a fresh start.
+
+To confirm it took effect, check the startup output (stderr and `.fabrik/fabrik.log`)
+for a line naming the resolved directory:
+
+```
+[startup] notice: CLAUDE_CONFIG_DIR is set to "/home/user/.claude-alt-profile" — Claude invocations will use this profile directory instead of the default account. See docs/USER_GUIDE.md.
+```
+
+No line means `CLAUDE_CONFIG_DIR` was unset — every invocation runs against the
+default profile. Fabrik does not validate the directory's contents or credential
+state; a misconfigured or unauthenticated profile fails wherever Claude Code
+itself would fail, not at Fabrik startup.
 
 ### Worker Session Naming (`--name`)
 

--- a/engine/claude_test.go
+++ b/engine/claude_test.go
@@ -1,6 +1,16 @@
 package engine
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
 
 func TestIsDegenerateOutput(t *testing.T) {
 	cases := []struct {
@@ -47,4 +57,76 @@ func TestIsDegenerateOutput_MultiLineNeverFlagged(t *testing.T) {
 	if isDegenerateOutput(in2) {
 		t.Errorf("isDegenerateOutput(%q) = true, want false (multi-line body must never be flagged)", in2)
 	}
+}
+
+// TestInvokeClaude_ClaudeConfigDirSurvives pins #1350's R4/R5: CLAUDE_CONFIG_DIR,
+// when present in the engine's own environment (typically via .env, per
+// config.LoadDotenv), must survive into the environment constructed for a real
+// Claude invocation. Neither buildClaudeEnv nor mergeEnv ever add an override
+// entry for this key, so it passes through from os.Environ() untouched — this
+// is the exact mechanism the issue describes as unpinned and at risk from #1346's
+// planned mergeEnv rewrite. The two subtests assert on the constructed
+// subprocess environment directly (not on invocation success), and the
+// present/absent pairing proves the assertion is non-vacuous: a broken
+// passthrough would make the "set" subtest fail while the "unset" subtest
+// would pass regardless, so only the pairing together confirms the test can
+// detect a regression.
+func TestInvokeClaude_ClaudeConfigDirSurvives(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	envFile := filepath.Join(binDir, "env.txt")
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := fmt.Sprintf(`#!/bin/sh
+cat >/dev/null
+env > %s
+printf '%%s\n' '{"result":"claude config dir test\nFABRIK_STAGE_COMPLETE\n","session_id":"sess_claudeconfigdir","num_turns":1,"total_cost_usd":0.0}'
+`, envFile)
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	workDir := t.TempDir()
+	stage := &stages.Stage{
+		Name:       "Implement",
+		Prompt:     "Implement it",
+		Completion: stages.CompletionCriteria{Type: "claude"},
+	}
+	issue := gh.ProjectItem{Number: 1350, Repo: "acme/widgets", Title: "CLAUDE_CONFIG_DIR passthrough test"}
+
+	t.Run("present in engine env survives into the constructed subprocess env", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "/home/user/.claude-alt-profile")
+		_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		if err != nil {
+			t.Fatalf("InvokeClaude: %v", err)
+		}
+		data, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("reading env file: %v", err)
+		}
+		env := string(data)
+		if !strings.Contains(env, "CLAUDE_CONFIG_DIR=/home/user/.claude-alt-profile") {
+			t.Errorf("expected CLAUDE_CONFIG_DIR to survive into the subprocess env, got:\n%s", env)
+		}
+	})
+
+	t.Run("absent from engine env stays absent from the constructed subprocess env", func(t *testing.T) {
+		if prev, ok := os.LookupEnv("CLAUDE_CONFIG_DIR"); ok {
+			os.Unsetenv("CLAUDE_CONFIG_DIR")
+			t.Cleanup(func() { os.Setenv("CLAUDE_CONFIG_DIR", prev) })
+		}
+		_, _, _, err := InvokeClaude(context.Background(), stage, issue, nil, false, workDir, InvokeOptions{})
+		if err != nil {
+			t.Fatalf("InvokeClaude: %v", err)
+		}
+		data, err := os.ReadFile(envFile)
+		if err != nil {
+			t.Fatalf("reading env file: %v", err)
+		}
+		env := string(data)
+		if strings.Contains(env, "CLAUDE_CONFIG_DIR") {
+			t.Errorf("expected CLAUDE_CONFIG_DIR to be entirely absent, got:\n%s", env)
+		}
+	})
 }

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -83,6 +83,20 @@ func pollStatusClear() {
 	}
 }
 
+// logClaudeConfigDir is the testable core of the R1/R3 startup notice: when
+// CLAUDE_CONFIG_DIR is set in the engine's environment, Claude Code invocations
+// use that directory's credentials/profile instead of the default account, and
+// this is otherwise unobservable (ps eww only shows exec-time env, not vars set
+// by godotenv during startup — see #1350). A no-op when configDir is empty, so
+// the unset case stays byte-for-byte silent (R2).
+func logClaudeConfigDir(configDir string, w io.Writer) {
+	if configDir == "" {
+		return
+	}
+	fmt.Fprintf(w, "[startup] notice: CLAUDE_CONFIG_DIR is set to %q — Claude invocations will use this profile "+
+		"directory instead of the default account. See docs/USER_GUIDE.md.\n", configDir)
+}
+
 func (e *Engine) Run() error {
 	// Acquire an exclusive file lock to prevent multiple Fabrik instances from
 	// processing the same project board concurrently. The lock file lives in
@@ -126,9 +140,11 @@ func (e *Engine) Run() error {
 		w := io.MultiWriter(os.Stderr, e.logFile)
 		stages.WarnStageDrift(e.cfg.Stages, e.cfg.Version, w)
 		stages.WarnUndeclaredReviewers(e.cfg.Stages, w)
+		logClaudeConfigDir(os.Getenv("CLAUDE_CONFIG_DIR"), w)
 	} else {
 		stages.WarnStageDrift(e.cfg.Stages, e.cfg.Version, os.Stderr)
 		stages.WarnUndeclaredReviewers(e.cfg.Stages, os.Stderr)
+		logClaudeConfigDir(os.Getenv("CLAUDE_CONFIG_DIR"), os.Stderr)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -88,7 +88,9 @@ func pollStatusClear() {
 // use that directory's credentials/profile instead of the default account, and
 // this is otherwise unobservable (ps eww only shows exec-time env, not vars set
 // by godotenv during startup — see #1350). A no-op when configDir is empty, so
-// the unset case stays byte-for-byte silent (R2).
+// the unset case stays byte-for-byte silent (R2). Emitted once, from the
+// environment snapshot at process start — if CLAUDE_CONFIG_DIR ever became
+// reloadable without a full re-exec, this notice would go stale.
 func logClaudeConfigDir(configDir string, w io.Writer) {
 	if configDir == "" {
 		return
@@ -136,15 +138,16 @@ func (e *Engine) Run() error {
 	// notice, to both stderr (visible at startup) and fabrik.log (durable for
 	// post-mortems). Without the log copy, recurrences of "same drift bit us
 	// again" are invisible from the persistent log alone.
+	configDir := os.Getenv("CLAUDE_CONFIG_DIR")
 	if e.logFile != nil {
 		w := io.MultiWriter(os.Stderr, e.logFile)
 		stages.WarnStageDrift(e.cfg.Stages, e.cfg.Version, w)
 		stages.WarnUndeclaredReviewers(e.cfg.Stages, w)
-		logClaudeConfigDir(os.Getenv("CLAUDE_CONFIG_DIR"), w)
+		logClaudeConfigDir(configDir, w)
 	} else {
 		stages.WarnStageDrift(e.cfg.Stages, e.cfg.Version, os.Stderr)
 		stages.WarnUndeclaredReviewers(e.cfg.Stages, os.Stderr)
-		logClaudeConfigDir(os.Getenv("CLAUDE_CONFIG_DIR"), os.Stderr)
+		logClaudeConfigDir(configDir, os.Stderr)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3217,3 +3217,25 @@ func hasAddLabelCallLocked(client *mockGitHubClient, label string) bool {
 	}
 	return false
 }
+
+func TestLogClaudeConfigDir_SetWritesOneLine(t *testing.T) {
+	var buf strings.Builder
+	logClaudeConfigDir("/home/user/.claude-alt", &buf)
+
+	out := buf.String()
+	if !strings.Contains(out, "/home/user/.claude-alt") {
+		t.Fatalf("expected output to name the directory, got: %q", out)
+	}
+	if strings.Count(out, "\n") != 1 {
+		t.Fatalf("expected exactly one line, got: %q", out)
+	}
+}
+
+func TestLogClaudeConfigDir_UnsetWritesNothing(t *testing.T) {
+	var buf strings.Builder
+	logClaudeConfigDir("", &buf)
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when configDir is empty, got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
Closes #1350

## What this does

`CLAUDE_CONFIG_DIR` already works today — Fabrik never touches it, so it passes straight from the engine's environment (typically via `.env`) into every Claude subprocess, letting an instance bill against a different Claude account/subscription. This PR doesn't change that behavior; it makes it observable, pins it with a regression test, and documents it.

## Changes

- **`engine/poll.go`**: adds `logClaudeConfigDir(configDir string, w io.Writer)`, a pure function that emits exactly one `[startup] notice: ...` line naming the resolved directory when `CLAUDE_CONFIG_DIR` is set, and is a strict no-op when it's unset. Wired into `Run()`'s existing drift/reviewer-warning block, so it reaches both `os.Stderr` and `fabrik.log` via the same `io.MultiWriter` pattern already used there, and runs before the poll loop starts.
- **`engine/claude_test.go`**: adds `TestInvokeClaude_ClaudeConfigDirSurvives`, a regression test at the same `InvokeClaude` integration altitude as the existing `TestInvokeClaude_FabrikEnvVarsInjected`. It asserts directly on the constructed subprocess environment (not on invocation success) via a present/absent subtest pair. I verified this test is non-vacuous by temporarily sabotaging `mergeEnv` to strip `CLAUDE_CONFIG_DIR` locally — the "present" subtest failed as expected — then reverted the sabotage before committing.
- **`engine/poll_test.go`**: adds `TestLogClaudeConfigDir` unit tests for the new pure function (set → one line naming the dir; unset → zero bytes written).
- **`docs/USER_GUIDE.md`**: adds `CLAUDE_CONFIG_DIR` to the `.env` example, a caveat on "Subprocess Environment" noting this is the one deliberate exception to the "clean, isolated environment" rule, and a new "Alternate Claude Profile (`CLAUDE_CONFIG_DIR`)" subsection covering what it does, that it survives `--auto-upgrade` re-execs, and how to confirm it took effect from the startup line.
- **`docs/llms-full.txt`**: regenerated per repo convention.

No changes to `mergeEnv` or `buildClaudeEnv` semantics — those are explicitly out of scope (that's issue #1346's business).

## Sequencing note

Per the issue's Risks section: **this should land before #1346**, which plans to rewrite `mergeEnv` to add key-removal/namespace-scrubbing — the exact code this passthrough depends on, and the exact regression `TestInvokeClaude_ClaudeConfigDirSurvives` exists to catch.

## Test plan

- `go build ./...`, `go vet ./...` clean
- `go test -race ./...` passes (one unrelated pre-existing flake in `cmd.TestExecute_ConfigYAMLApplied`, confirmed to fail identically on `main` without this branch's changes — a SIGINT-shutdown-timing test unrelated to this change)
- New tests: `TestLogClaudeConfigDir` (poll_test.go), `TestInvokeClaude_ClaudeConfigDirSurvives` (claude_test.go)