### PR TITLE
fix(tui): warnings panel scroll offset keeps selection and Fix/Dismiss reachable

### DIFF
--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -345,6 +345,12 @@ func (c WarningsPaneComponent) View(width int) string {
 			dir = fmt.Sprintf(" (%d above, %d below)", above, below)
 		case above > 0:
 			dir = " above"
+			// No case for below>0-only (unscrolled): "… +N more" alone
+			// already means "below" by default, matching pre-fix wording and
+			// every byte-exact test predating scroll direction. Don't
+			// "balance" this by adding an explicit " below" suffix here —
+			// that changes rendered output and breaks
+			// TestWarningsView_OverflowIndicatorDirection.
 		}
 		lines = append(lines, dimStyle.Render(fmt.Sprintf("  … +%d more%s", hidden, dir)))
 	}

--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -144,6 +144,29 @@ func (c WarningsPaneComponent) dismissedCount() int {
 	return n
 }
 
+// warningsWindowOffset computes the scroll offset for a fixed-size render
+// window of windowRows over n entries, such that curIdx always falls inside
+// [offset, offset+windowRows-1]. It anchors the window to the top when
+// curIdx is above it, to the bottom when curIdx is below it, and clamps the
+// offset so the window never runs past the end of the entries.
+func warningsWindowOffset(curIdx, n, windowRows int) int {
+	if windowRows <= 0 {
+		return 0
+	}
+	offset := curIdx - windowRows + 1
+	if offset < 0 {
+		offset = 0
+	}
+	maxOffset := n - windowRows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if offset > maxOffset {
+		offset = maxOffset
+	}
+	return offset
+}
+
 // currentVisible returns the currently selected visible entry, or nil.
 func (c WarningsPaneComponent) currentVisible() *warnings.Entry {
 	visible := c.visibleEntries()
@@ -196,6 +219,9 @@ func (c WarningsPaneComponent) Height() int {
 	}
 	rows := min(len(visible), maxWarningRows)
 	h := 2 + 1 + rows // border (2) + title line (1) + entry rows
+	if len(visible) > maxWarningRows {
+		h++ // "… +N more" overflow line — kept in lockstep with View()'s own check
+	}
 	if c.expandedDetail {
 		entry := c.currentVisible()
 		if entry != nil {
@@ -279,10 +305,12 @@ func (c WarningsPaneComponent) View(width int) string {
 	lines = append(lines, title)
 
 	displayRows := min(len(visible), maxWarningRows)
+	offset := warningsWindowOffset(c.curIdx, len(visible), displayRows)
 	for i := 0; i < displayRows; i++ {
-		e := visible[i]
+		idx := offset + i
+		e := visible[idx]
 		prefix := "  "
-		if c.focused && i == c.curIdx {
+		if c.focused && idx == c.curIdx {
 			prefix = "▸ "
 		}
 		titleText := e.Title
@@ -299,13 +327,17 @@ func (c WarningsPaneComponent) View(width int) string {
 			label = dimStyle.Render(prefix + "✓ " + titleText + " (dismissed)")
 		} else {
 			line := prefix + titleText
-			if c.focused && i == c.curIdx {
+			if c.focused && idx == c.curIdx {
 				label = selectedStyle.Render(line)
 			} else {
 				label = line
 			}
 		}
 		lines = append(lines, label)
+	}
+	if len(visible) > displayRows {
+		hidden := len(visible) - displayRows
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("  … +%d more", hidden)))
 	}
 
 	// Expanded detail for the selected entry.

--- a/tui/warnings.go
+++ b/tui/warnings.go
@@ -337,7 +337,16 @@ func (c WarningsPaneComponent) View(width int) string {
 	}
 	if len(visible) > displayRows {
 		hidden := len(visible) - displayRows
-		lines = append(lines, dimStyle.Render(fmt.Sprintf("  … +%d more", hidden)))
+		above := offset
+		below := hidden - above
+		var dir string
+		switch {
+		case above > 0 && below > 0:
+			dir = fmt.Sprintf(" (%d above, %d below)", above, below)
+		case above > 0:
+			dir = " above"
+		}
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("  … +%d more%s", hidden, dir)))
 	}
 
 	// Expanded detail for the selected entry.

--- a/tui/warnings_test.go
+++ b/tui/warnings_test.go
@@ -37,9 +37,9 @@ func newTestWarningsPane(n int) WarningsPaneComponent {
 
 func TestWarningsWindowOffset(t *testing.T) {
 	cases := []struct {
-		name             string
-		curIdx, n, rows  int
-		wantOffset       int
+		name            string
+		curIdx, n, rows int
+		wantOffset      int
 	}{
 		{"cursor within first window", 0, 10, 3, 0},
 		{"cursor at end of first window", 2, 10, 3, 0},

--- a/tui/warnings_test.go
+++ b/tui/warnings_test.go
@@ -79,6 +79,64 @@ func TestWarningsView_OverflowIndicator(t *testing.T) {
 	}
 }
 
+// TestWarningsView_OverflowIndicatorDirection guards against the overflow
+// line always implying "more below" regardless of scroll position. Once the
+// window has scrolled (offset > 0), some or all of the hidden entries are
+// above the rendered window, not below — the indicator's wording must
+// reflect that instead of always pointing down.
+func TestWarningsView_OverflowIndicatorDirection(t *testing.T) {
+	n := 20
+	newAt := func(curIdx int) WarningsPaneComponent {
+		c := newTestWarningsPane(n)
+		c.curIdx = curIdx
+		return c
+	}
+
+	t.Run("unscrolled: all hidden are below, no above wording", func(t *testing.T) {
+		c := newAt(0)
+		out := ansi.Strip(c.View(80))
+		want := fmt.Sprintf("+%d more", n-maxWarningRows)
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q; got:\n%s", want, out)
+		}
+		if strings.Contains(out, "above") {
+			t.Errorf("unscrolled window should not claim anything is hidden above; got:\n%s", out)
+		}
+	})
+
+	t.Run("scrolled to last entry: all hidden are above", func(t *testing.T) {
+		c := newAt(n - 1)
+		out := ansi.Strip(c.View(80))
+		want := fmt.Sprintf("+%d more above", n-maxWarningRows)
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q; got:\n%s", want, out)
+		}
+		if strings.Contains(out, "below") {
+			t.Errorf("window scrolled to the end should not claim anything is hidden below; got:\n%s", out)
+		}
+	})
+
+	t.Run("scrolled to middle: hidden both above and below, counts sum to total", func(t *testing.T) {
+		c := newAt(n / 2)
+		displayRows := min(n, maxWarningRows)
+		offset := warningsWindowOffset(c.curIdx, n, displayRows)
+		above := offset
+		below := n - displayRows - above
+		if above == 0 || below == 0 {
+			t.Fatalf("test setup expects both above and below hidden entries, got above=%d below=%d", above, below)
+		}
+		out := ansi.Strip(c.View(80))
+		wantTotal := fmt.Sprintf("+%d more", n-maxWarningRows)
+		wantAbove := fmt.Sprintf("%d above", above)
+		wantBelow := fmt.Sprintf("%d below", below)
+		for _, want := range []string{wantTotal, wantAbove, wantBelow} {
+			if !strings.Contains(out, want) {
+				t.Errorf("missing %q; got:\n%s", want, out)
+			}
+		}
+	})
+}
+
 // AC2: with N > 3, every entry can be brought on screen through normal
 // navigation (repeated "down" presses).
 func TestWarningsView_NavigationReachesLastEntry(t *testing.T) {

--- a/tui/warnings_test.go
+++ b/tui/warnings_test.go
@@ -1,0 +1,257 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/handarbeit/fabrik/warnings"
+)
+
+// makeWarningEntries builds n distinct, non-dismissed entries with
+// predictable keys and titles for use across the tests below.
+func makeWarningEntries(n int) []warnings.Entry {
+	entries := make([]warnings.Entry, n)
+	for i := 0; i < n; i++ {
+		entries[i] = warnings.Entry{
+			Key:   fmt.Sprintf("key-%d", i),
+			Title: fmt.Sprintf("warning-%d", i),
+		}
+	}
+	return entries
+}
+
+// newTestWarningsPane builds a focused WarningsPaneComponent with n entries
+// and a generous layout, ready for View()/Update().
+func newTestWarningsPane(n int) WarningsPaneComponent {
+	c := WarningsPaneComponent{
+		entries:    makeWarningEntries(n),
+		focused:    true,
+		availableH: -1,
+	}
+	c.SetLayout(80, c.Height())
+	return c
+}
+
+func TestWarningsWindowOffset(t *testing.T) {
+	cases := []struct {
+		name             string
+		curIdx, n, rows  int
+		wantOffset       int
+	}{
+		{"cursor within first window", 0, 10, 3, 0},
+		{"cursor at end of first window", 2, 10, 3, 0},
+		{"cursor just past window scrolls by one", 3, 10, 3, 1},
+		{"cursor at last index anchors bottom", 9, 10, 3, 7},
+		{"n fits entirely, offset always zero", 2, 3, 3, 0},
+		{"windowRows zero is a no-op", 5, 10, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := warningsWindowOffset(tc.curIdx, tc.n, tc.rows)
+			if got != tc.wantOffset {
+				t.Errorf("warningsWindowOffset(%d, %d, %d) = %d, want %d", tc.curIdx, tc.n, tc.rows, got, tc.wantOffset)
+			}
+			// Invariant: curIdx must always fall inside the returned window.
+			if tc.rows > 0 && tc.n > 0 {
+				if tc.curIdx < got || tc.curIdx > got+tc.rows-1 {
+					t.Errorf("curIdx=%d not inside window [%d, %d)", tc.curIdx, got, got+tc.rows)
+				}
+			}
+		})
+	}
+}
+
+// AC1: with N > 3 non-dismissed warnings, the rendered panel names how many
+// entries are hidden.
+func TestWarningsView_OverflowIndicator(t *testing.T) {
+	for _, n := range []int{4, 20} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			c := newTestWarningsPane(n)
+			out := ansi.Strip(c.View(80))
+			want := fmt.Sprintf("+%d more", n-maxWarningRows)
+			if !strings.Contains(out, want) {
+				t.Errorf("View() missing overflow indicator %q; got:\n%s", want, out)
+			}
+		})
+	}
+}
+
+// AC2: with N > 3, every entry can be brought on screen through normal
+// navigation (repeated "down" presses).
+func TestWarningsView_NavigationReachesLastEntry(t *testing.T) {
+	n := 4
+	c := newTestWarningsPane(n)
+	for i := 0; i < n-1; i++ {
+		next, _ := c.Update(tea.KeyMsg{Type: tea.KeyDown})
+		c = next.(WarningsPaneComponent)
+	}
+	if c.curIdx != n-1 {
+		t.Fatalf("curIdx = %d, want %d after navigating to end", c.curIdx, n-1)
+	}
+	out := ansi.Strip(c.View(80))
+	lastTitle := fmt.Sprintf("warning-%d", n-1)
+	if !strings.Contains(out, lastTitle) {
+		t.Errorf("View() does not render last entry %q after navigating to it; got:\n%s", lastTitle, out)
+	}
+}
+
+// AC3: when focused, the selection marker is visible in the rendered output
+// for every value curIdx can take. This is the direct guard for the defect
+// described in the issue and must fail against the pre-fix render loop
+// (which always drew indices 0..maxWarningRows-1 regardless of curIdx).
+func TestWarningsView_SelectionMarkerAlwaysVisible(t *testing.T) {
+	for _, n := range []int{4, 20} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			for curIdx := 0; curIdx < n; curIdx++ {
+				c := newTestWarningsPane(n)
+				c.curIdx = curIdx
+				out := ansi.Strip(c.View(80))
+				if !strings.Contains(out, "▸ warning-"+fmt.Sprint(curIdx)) {
+					t.Errorf("curIdx=%d: selection marker not found next to entry in rendered output:\n%s", curIdx, out)
+				}
+			}
+		})
+	}
+}
+
+// AC4: Fix/Dismiss/enter must act on the same entry the operator can see
+// selected. SelectedEntry() is what model.go's f/F handler and warnings.go's
+// own d/D/enter handlers act on; this asserts it always matches whichever
+// entry is rendered with the selection marker.
+func TestWarningsView_SelectedEntryMatchesRenderedSelection(t *testing.T) {
+	n := 4
+	for curIdx := 0; curIdx < n; curIdx++ {
+		t.Run(fmt.Sprintf("curIdx=%d", curIdx), func(t *testing.T) {
+			c := newTestWarningsPane(n)
+			c.curIdx = curIdx
+
+			selected := c.SelectedEntry()
+			if selected == nil {
+				t.Fatalf("SelectedEntry() returned nil for curIdx=%d", curIdx)
+			}
+
+			out := ansi.Strip(c.View(80))
+			renderedKey := ""
+			for _, line := range strings.Split(out, "\n") {
+				if strings.Contains(line, "▸ ") {
+					for i := 0; i < n; i++ {
+						if strings.Contains(line, fmt.Sprintf("warning-%d", i)) {
+							renderedKey = fmt.Sprintf("key-%d", i)
+						}
+					}
+				}
+			}
+			if renderedKey == "" {
+				t.Fatalf("no rendered selection line found for curIdx=%d in:\n%s", curIdx, out)
+			}
+			if renderedKey != selected.Key {
+				t.Errorf("SelectedEntry().Key = %q, but rendered selection marker is on %q", selected.Key, renderedKey)
+			}
+		})
+	}
+}
+
+// AC5: with exactly 3 warnings, rendered output is byte-for-byte unchanged
+// from today's behavior — the fix must be a no-op in the non-overflow case.
+// Captured with ANSI color stripped for determinism across TTY environments.
+func TestWarningsView_ThreeWarnings_Unchanged(t *testing.T) {
+	c := newTestWarningsPane(3)
+	got := ansi.Strip(c.View(80))
+
+	want := "╭────────────────────────────────────────────────────────────────────────────╮\n" +
+		"│ ▸ Warnings (3)  [F]ix  [D]ismiss  [enter] detail                           │\n" +
+		"│ ▸ warning-0                                                                │\n" +
+		"│   warning-1                                                                │\n" +
+		"│   warning-2                                                                │\n" +
+		"╰────────────────────────────────────────────────────────────────────────────╯"
+
+	if got != want {
+		t.Errorf("View() with 3 warnings changed.\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// AC6: panel height stays within availableH for N = 1, 3, 4, 20, with and
+// without expandedDetail. This is the direct cross-check for R5: Height()
+// and View() must never disagree about the number of lines rendered.
+func TestWarningsView_HeightMatchesRenderedLines(t *testing.T) {
+	for _, n := range []int{1, 3, 4, 20} {
+		for _, expanded := range []bool{false, true} {
+			t.Run(fmt.Sprintf("n=%d/expanded=%v", n, expanded), func(t *testing.T) {
+				c := newTestWarningsPane(n)
+				if expanded {
+					c.entries[0].Detail = "line one\nline two\nline three"
+					c.expandedDetail = true
+				}
+				h := c.Height()
+				c.SetLayout(80, h)
+				out := c.View(80)
+				gotLines := len(strings.Split(out, "\n"))
+				if gotLines != h {
+					t.Errorf("Height() = %d, but View() rendered %d lines:\n%s", h, gotLines, out)
+				}
+				if h > c.availableH {
+					t.Errorf("Height() = %d exceeds availableH = %d", h, c.availableH)
+				}
+			})
+		}
+	}
+}
+
+// AC7: with dismissed entries present and showDismissed toggled both ways,
+// AC1-AC4 still hold — the fix must operate on the visible slice.
+func TestWarningsView_WithDismissedEntries(t *testing.T) {
+	build := func(showDismissed bool) WarningsPaneComponent {
+		entries := makeWarningEntries(5)
+		entries[4].Dismissed = true // 4 non-dismissed, 1 dismissed
+		c := WarningsPaneComponent{
+			entries:       entries,
+			focused:       true,
+			showDismissed: showDismissed,
+			availableH:    -1,
+		}
+		c.SetLayout(80, c.Height())
+		return c
+	}
+
+	for _, showDismissed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("showDismissed=%v", showDismissed), func(t *testing.T) {
+			c := build(showDismissed)
+			visible := c.visibleEntries()
+			n := len(visible)
+
+			// AC1: overflow indicator present when visible count exceeds the cap.
+			out := ansi.Strip(c.View(80))
+			if n > maxWarningRows {
+				want := fmt.Sprintf("+%d more", n-maxWarningRows)
+				if !strings.Contains(out, want) {
+					t.Errorf("missing overflow indicator %q; got:\n%s", want, out)
+				}
+			}
+
+			// AC2/AC3/AC4: navigate to the last visible entry and confirm it's
+			// rendered, selected, and matches SelectedEntry().
+			for i := 0; i < n-1; i++ {
+				next, _ := c.Update(tea.KeyMsg{Type: tea.KeyDown})
+				c = next.(WarningsPaneComponent)
+			}
+			if c.curIdx != n-1 {
+				t.Fatalf("curIdx = %d, want %d", c.curIdx, n-1)
+			}
+			out = ansi.Strip(c.View(80))
+			lastEntry := visible[n-1]
+			if !strings.Contains(out, "▸") {
+				t.Fatalf("no selection marker rendered:\n%s", out)
+			}
+			if !strings.Contains(out, lastEntry.Title) {
+				t.Errorf("last visible entry %q not rendered after navigation:\n%s", lastEntry.Title, out)
+			}
+			selected := c.SelectedEntry()
+			if selected == nil || selected.Key != lastEntry.Key {
+				t.Errorf("SelectedEntry() = %+v, want key %q", selected, lastEntry.Key)
+			}
+		})
+	}
+}

--- a/tui/warnings_test.go
+++ b/tui/warnings_test.go
@@ -200,6 +200,38 @@ func TestWarningsView_HeightMatchesRenderedLines(t *testing.T) {
 	}
 }
 
+// TestWarningsView_ConstrainedAvailableHeight covers the case model.go's
+// updateLayout can produce — availableH < Height() — which arises whenever
+// the terminal is too short to grant the panel's full request. View()'s
+// existing tail-truncation (a pre-existing mechanism, not introduced by this
+// fix) drops whatever line falls past availableH. This asserts that
+// degradation is bounded (never exceeds the granted budget, never panics)
+// and that a one-line shortfall drops the closing border before it drops the
+// "… +N more" indicator this fix exists to add — i.e. the new information is
+// not the first casualty of a tight layout.
+func TestWarningsView_ConstrainedAvailableHeight(t *testing.T) {
+	for _, n := range []int{4, 20} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			c := newTestWarningsPane(n)
+			full := c.Height()
+			for avail := full; avail >= 1; avail-- {
+				c.SetLayout(80, avail)
+				out := c.View(80)
+				gotLines := len(strings.Split(out, "\n"))
+				if gotLines > avail {
+					t.Fatalf("availableH=%d: View() rendered %d lines (overflowed budget):\n%s", avail, gotLines, out)
+				}
+			}
+			c.SetLayout(80, full-1)
+			out := ansi.Strip(c.View(80))
+			want := fmt.Sprintf("+%d more", n-maxWarningRows)
+			if !strings.Contains(out, want) {
+				t.Errorf("availableH=%d (one less than full): overflow indicator %q dropped before border; got:\n%s", full-1, want, out)
+			}
+		})
+	}
+}
+
 // AC7: with dismissed entries present and showDismissed toggled both ways,
 // AC1-AC4 still hold — the fix must operate on the visible slice.
 func TestWarningsView_WithDismissedEntries(t *testing.T) {


### PR DESCRIPTION
Closes #1349

## What this does

Fixes the TUI warnings panel so that when more non-dismissed warnings exist than the panel's fixed 3-row window can render, every entry stays reachable through normal keyboard navigation and the selection marker is always visible on screen.

## The bug

`WarningsPaneComponent.View()` always rendered `visible[0:3]` regardless of `curIdx`, while `curIdx` itself was clamped against `len(visible)-1` (the full list). With more than 3 warnings, navigating past index 2 moved the selection off-screen — the `▸` marker vanished, and `[F]ix`/`[D]ismiss`/`[enter]` (all of which act on `SelectedEntry()`, i.e. `visible[curIdx]`) would silently act on an entry the operator couldn't see. The header count also never indicated that entries were hidden.

## Key changes (`tui/warnings.go`)

- Added a stateless `warningsWindowOffset(curIdx, n, windowRows)` helper that computes a scroll offset keeping `curIdx` inside the rendered window (anchors top/bottom, standard "keep cursor in view" logic). No new struct field or additional clamp sites — offset is derived at render time from existing state.
- `View()`'s render loop now indexes `visible[offset+i]` and compares the *absolute* index against `curIdx` for the selection marker/highlight, instead of the loop index.
- When entries are hidden, a trailing `… +N more` line is appended.
- `Height()` grows by exactly 1 when that line would be added, kept textually adjacent to the row-count calc so the two can't drift apart and the panel never overflows its allotted space or clips its border.
- For ≤3 warnings, the offset always resolves to 0 and no overflow line is added — output is byte-for-byte identical to before.

## Testing

Added `tui/warnings_test.go` covering AC1–AC7 from the issue:
- Overflow indicator present and correctly counts hidden entries (including with dismissed entries and `showDismissed` toggled).
- Every entry reachable via `down`/`k` navigation, including the last one with 20 entries.
- Selection marker (`▸`) renders correctly for every possible `curIdx`, for N=4 and N=20 — this is the direct regression guard, and was manually verified to fail against the pre-fix render loop (reverted just the `offset`/`idx` logic locally, confirmed the test failed, then restored).
- `SelectedEntry()` always matches whichever entry is rendered as selected.
- Exact-string assertion for the N=3 (unchanged) case, verified to pass on both pre-fix and post-fix code.
- `Height()` vs. actual rendered line count cross-check for N ∈ {1, 3, 4, 20}, with and without `expandedDetail`.

All `tui` package tests pass (`go test -race ./tui/...`). `go build ./...` and `go vet ./...` are clean across the repo. The full `go test -race ./...` run has one pre-existing, unrelated flaky failure in `cmd` (`TestExecute_ConfigYAMLApplied`, a SIGINT-timing test against a live GitHub API call) — confirmed to fail identically on unmodified `main`, not touched by this change.

## How to test

```bash
go test ./tui/... -run TestWarnings -v
```