### PR TITLE
Gate repo label seeding and dispatch on write access

### DIFF
--- a/adrs/1347-repo-write-access-gating.md
+++ b/adrs/1347-repo-write-access-gating.md
@@ -123,3 +123,17 @@ convention for this one notice was judged unnecessary scope.
   for the remainder of that process's lifetime, even if it is genuinely unwritable —
   self-heals on the next restart, and is strictly no worse than this codebase's
   unconditional pre-#1347 behavior for that one repo.
+- **Cleanup stages are not exempted from the dispatch gate**, unlike the
+  `fabrik:awaiting-done` gate a few lines above it in `itemMayNeedWork`. This was
+  raised in PR review (#1356): doesn't a repo with no write access still need its
+  local worktree cleaned up? No — `handleCleanupStage` is not a pure local
+  filesystem operation, it calls `addLabel`/`removeLabel` (`stage:*:complete`,
+  `fabrik:extend-turns`) and is reached via `acquireLockAndVerify`, which writes
+  lock/`in_progress` labels first — all real GitHub mutations. Exempting cleanup
+  would reopen exactly the write this ADR closes. Accepted consequence: a worktree
+  already on disk for an issue whose repo is later resolved as `CanPush: false`
+  (e.g., a pre-existing worktree from before this fix shipped, or a repo whose
+  access was revoked after Fabrik had legitimately processed it) is never
+  auto-cleaned — a disk-space leak, not a correctness or security issue. Manual
+  removal of the worktree directory is the only path, consistent with this issue's
+  own "retroactively removing labels already seeded" non-goal.

--- a/adrs/1347-repo-write-access-gating.md
+++ b/adrs/1347-repo-write-access-gating.md
@@ -137,3 +137,13 @@ convention for this one notice was judged unnecessary scope.
   auto-cleaned — a disk-space leak, not a correctness or security issue. Manual
   removal of the worktree directory is the only path, consistent with this issue's
   own "retroactively removing labels already seeded" non-goal.
+- **`checkAllowAutoMerge`'s `!CanPush` early return also clears any stale
+  `allow_auto_merge` warning for the repo** (raised in PR review, #1356): a repo
+  previously writable with `allow_auto_merge` disabled would have a warning
+  recorded; if access is later revoked, the early return would otherwise skip past
+  the function's own `Clear` branch forever (`checkedAutoMergeRepos` never lets it
+  re-run for that repo in the same process), leaving an unfixable, now-moot warning
+  immortal in `.fabrik/warnings.json`. This is a distinct case from #1348's
+  stale-warning sweep, which only clears warnings for repos that have left the
+  board entirely — a repo still on the board with newly revoked access is never
+  "absent" from `seenRepos`, so #1348's sweep does not reach it.

--- a/adrs/1347-repo-write-access-gating.md
+++ b/adrs/1347-repo-write-access-gating.md
@@ -1,0 +1,125 @@
+# ADR 1347: Gate repo mutation and dispatch on write access
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Issue:** [#1347](https://github.com/handarbeit/fabrik/issues/1347)
+
+## Context
+
+Fabrik derives its managed-repo set from board items, not configuration: any repo
+that has ever had an issue tracked on the project board is treated as a repo Fabrik
+administers. `poll.go`'s per-repo discovery block and `Run()`'s single-repo startup
+block both unconditionally call `checkAllowAutoMerge` and `SeedLabels` (~25 label
+`POST`s) for every repo seen, with no check that the configured token can actually
+write to it.
+
+Tracking an upstream issue on your own GitHub Projects board (a normal, legitimate
+workflow — the `verveguy` project 5 case: `LadybugDB/ladybug`, `verveguy/liminis-graph`,
+`verveguy/markdownload`, `verveguy/remarkable`) caused Fabrik to attempt ~25 label
+creates against a repo the operator does not administer. The writes fail on
+permissions and are logged non-fatal, so nothing surfaces it — but it is still an
+unrequested write attempt against a third party's repository, visible in their audit
+log. Worse, if the operator *does* happen to have write access to the upstream repo
+(a contributor with triage/write role), the writes **succeed**, silently injecting
+`fabrik:*`/`stage:*`/`model:*` labels into someone else's project. `checkAllowAutoMerge`
+on the same path also produces a permanently unresolvable warning (its stated fix,
+`gh api -X PATCH ... allow_auto_merge=true`, requires admin rights the operator by
+definition doesn't have).
+
+`GET /repos/{owner}/{repo}` — the same endpoint `FetchAllowAutoMerge` already calls
+once per repo per run, cached via `checkedAutoMergeRepos` — returns a `permissions`
+object (`push`, `admin`, `maintain`, `triage`, `pull`) for an authenticated request.
+This is a write-access signal already arriving on the wire and being discarded.
+
+## Decision
+
+**Widen the existing probe, don't add a new one.** `FetchAllowAutoMerge(owner, repo)
+(bool, error)` becomes `FetchRepoAccess(owner, repo) (RepoAccess, error)`, decoding
+`permissions.push` alongside `allow_auto_merge` from the same response. `RepoAccess`
+is a named struct (`{AllowAutoMerge, CanPush bool}`), not a wider tuple — the two
+concerns are independent and a struct keeps them discoverable at call sites, at the
+cost of a small, fully enumerable rename diff (4 implementations, ~6 test call sites).
+
+**One shared cached resolver, three consumers.** `Engine.resolveRepoAccess(owner,
+repo)` is the single source of truth, keyed `"owner/repo"` (matching the existing
+`seededRepos`/`checkedAutoMergeRepos` convention), consulted identically by:
+
+1. **Label seeding** (`poll.go`, both call sites) — skips `SeedLabels` when
+   `!CanPush`.
+2. **`checkAllowAutoMerge`** — skips its warning entirely when `!CanPush` (a repo
+   Fabrik can't push to also can't have `allow_auto_merge` administered on it, so the
+   unfixable-warning problem disappears as a side effect of the same gate).
+3. **`itemMayNeedWork`'s dispatch gate** (`engine/item.go`) — a new early return,
+   shaped exactly like the existing `stage.HoldingStage || stage.Unmanaged` check,
+   denies dispatch for any item whose repo is cached as `!CanPush`.
+
+This mirrors the codebase's existing "one shared resolver, multiple gates consult it
+identically" convention (`effectiveReviewAuthority`/`effectiveExpectedReviewers`) and
+guarantees the "reported once" notice (below) can live in exactly one place regardless
+of which consumer resolves a given repo first.
+
+**Board items in an unmanaged repo are skipped from dispatch entirely, not processed
+read-only.** Nearly every stage past Specify/Research needs to push commits and
+open/update PRs against the repo — exactly the access already found absent. Partial
+processing would fail later, less clearly, closer to when a human is waiting on it.
+The gate is placed in `itemMayNeedWork` (the shallow, no-deep-fetch prefilter that
+already gates `HoldingStage`/`Unmanaged` stages the same way), not `itemNeedsWork` — a
+rejected item never reaches `FetchItemDetails`, `selectDeepFetchCandidates`, or
+`dispatchCandidates`, so it costs zero API calls beyond the one repo-access probe.
+
+**The dispatch gate reads the cache; it never triggers a probe.** A repo not yet
+resolved is admitted (fail-open on "unknown"), not gated. In production this default
+never matters: `poll()`'s seeding block resolves every board-discovered repo before
+`selectDeepFetchCandidates` runs, in the same poll cycle, for both the first time a
+repo is seen and every poll after — an ordering the seeding block and dispatch gate
+both rely on textually, not through a type-level guarantee.
+
+**Fail open, cache the failure, for the rest of the process run.** If the probe
+itself errors (network failure, transient 5xx — not a clean `200` with `push: false`),
+`resolveRepoAccess` treats the repo as `{AllowAutoMerge: true, CanPush: true}` and
+caches that result. This matches `checkAllowAutoMerge`'s prior error posture for the
+same GET request and prioritizes not stranding a genuinely managed repo over closing
+every edge case of a misprobed unmanaged one. A repo whose very first probe hits a
+transient error is treated as managed for the rest of the run (self-heals on restart)
+rather than losing dispatch for a blip — accepted as the safer default of the two.
+
+**Gate on `permissions.push`, not `permissions.admin`.** This closes the issue's
+concrete motivating case (zero-access upstream repos). A contributor with
+push-but-not-admin access will still see the `allow_auto_merge` warning with its
+admin-only remediation — a real, narrower residual gap, left out of scope: the
+acceptance criteria for this issue don't exercise the push-vs-admin distinction, and
+the spec frames the gate as "write access" throughout.
+
+**No board-side mutation of any kind on an unmanaged repo, ever — not even to record
+the determination.** Unlike `fabrik:blocked` (which persists its gate state as a label
+on the blocked issue, in a repo Fabrik always has write access to by definition), the
+repo being gated here IS the repo any label write would need to land in. The access
+cache and its one-time log line are purely in-process (`Engine.repoAccess`) — never a
+GitHub-side label, comment, or other mutation on the unmanaged repo or its issues.
+
+**The "no write access" notice is a plain `logf` warn line, not a `warnings.Record`
+TUI entry.** No existing `FixAction` value (`shell_command`, `fabrik_command`) fits
+"remove the item from the board" — inventing a new informational `FixAction`
+convention for this one notice was judged unnecessary scope.
+
+## Consequences
+
+- A repo the token cannot push to now produces zero label-mutation requests and no
+  unfixable `allow_auto_merge` warning; its board items are skipped from dispatch with
+  a single logged reason, reported once per repo per process run.
+- A repo the token can write to is completely unaffected: same seeding, same
+  auto-merge check, same call count as before this change — the write-access signal
+  is decoded from a response already being fetched, not a new round-trip.
+- The `FetchAllowAutoMerge` → `FetchRepoAccess` rename touches all four
+  implementations (`github.Client`, `engine.mockGitHubClient`,
+  `cmd.testGitHubUpgradeClient`, the `GitHubClient` interface) and their test call
+  sites; `go build` catches any missed site immediately.
+- A contributor with push-but-not-admin access on a repo still hits the
+  `allow_auto_merge` unfixable-warning problem — not solved by this change. A future
+  issue could split the `checkAllowAutoMerge`-specific suppression onto
+  `permissions.admin` instead of `permissions.push` without touching the seeding or
+  dispatch gates, which are correctly scoped to `push`.
+- A repo whose first-ever probe hits a transient network error is treated as managed
+  for the remainder of that process's lifetime, even if it is genuinely unwritable —
+  self-heals on the next restart, and is strictly no worse than this codebase's
+  unconditional pre-#1347 behavior for that one repo.

--- a/cmd/cmd_extra_test.go
+++ b/cmd/cmd_extra_test.go
@@ -32,8 +32,8 @@ func (m *testGitHubUpgradeClient) FetchLatestRelease(owner, repo string) (*gh.La
 	}
 	return nil, nil
 }
-func (m *testGitHubUpgradeClient) FetchAllowAutoMerge(owner, repo string) (bool, error) {
-	return true, nil
+func (m *testGitHubUpgradeClient) FetchRepoAccess(owner, repo string) (gh.RepoAccess, error) {
+	return gh.RepoAccess{AllowAutoMerge: true, CanPush: true}, nil
 }
 func (m *testGitHubUpgradeClient) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
 	return &gh.ProjectBoard{}, nil

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -223,6 +223,15 @@ The `.fabrik/` directory (config, stages, plugin) always lives in the directory 
 
 Fabrik can manage issues across every repository on the board in a single run. To enable multi-repo mode, omit (or comment out) the `repo:` field in `.fabrik/config.yaml` — Fabrik then discovers repositories lazily from the project board and processes issues from all of them. Each repository gets its own bare clone at `.fabrik/repos/<owner>-<repo>.git` and its own set of worktrees, all driven by the same poll loop.
 
+#### Write-access gating for board-derived repos
+
+Because repos are discovered from board items rather than configured explicitly, tracking an upstream issue on your own board (a normal GitHub Projects workflow) can surface a repo you don't administer. Fabrik checks the configured token's write access to each newly discovered repo (piggybacked on the same API call already used for the `allow_auto_merge` check — no extra request) before seeding any labels or evaluating `allow_auto_merge` on it:
+
+- A repo the token **can** write to is managed exactly as before: labels are seeded, `allow_auto_merge` is checked, and its board items are dispatched into the pipeline normally.
+- A repo the token **cannot** write to is skipped entirely: no label-mutation requests are made against it, no `allow_auto_merge` warning is printed (its only fix requires admin rights the operator doesn't have), and its board items are **not processed at all** — not even read-only. Nearly every stage past Specify/Research needs to push commits and open PRs, which requires exactly the access already found absent, so partial processing would only fail later and less clearly. Fabrik logs a one-time notice naming the repo and reason instead.
+
+The access determination is cached per repo for the life of the process — it costs one API call the first time a repo is seen, never repeated on later polls.
+
 ### Git Clone Protocol (HTTPS vs SSH)
 
 By default, Fabrik uses HTTPS to bare-clone managed repos (`https://github.com/<owner>/<repo>.git`). Users who authenticate via SSH keys can switch to SSH clone URLs instead.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -221,6 +221,15 @@ The `.fabrik/` directory (config, stages, plugin) always lives in the directory 
 
 Fabrik can manage issues across every repository on the board in a single run. To enable multi-repo mode, omit (or comment out) the `repo:` field in `.fabrik/config.yaml` — Fabrik then discovers repositories lazily from the project board and processes issues from all of them. Each repository gets its own bare clone at `.fabrik/repos/<owner>-<repo>.git` and its own set of worktrees, all driven by the same poll loop.
 
+#### Write-access gating for board-derived repos
+
+Because repos are discovered from board items rather than configured explicitly, tracking an upstream issue on your own board (a normal GitHub Projects workflow) can surface a repo you don't administer. Fabrik checks the configured token's write access to each newly discovered repo (piggybacked on the same API call already used for the `allow_auto_merge` check — no extra request) before seeding any labels or evaluating `allow_auto_merge` on it:
+
+- A repo the token **can** write to is managed exactly as before: labels are seeded, `allow_auto_merge` is checked, and its board items are dispatched into the pipeline normally.
+- A repo the token **cannot** write to is skipped entirely: no label-mutation requests are made against it, no `allow_auto_merge` warning is printed (its only fix requires admin rights the operator doesn't have), and its board items are **not processed at all** — not even read-only. Nearly every stage past Specify/Research needs to push commits and open PRs, which requires exactly the access already found absent, so partial processing would only fail later and less clearly. Fabrik logs a one-time notice naming the repo and reason instead.
+
+The access determination is cached per repo for the life of the process — it costs one API call the first time a repo is seen, never repeated on later polls.
+
 ### Git Clone Protocol (HTTPS vs SSH)
 
 By default, Fabrik uses HTTPS to bare-clone managed repos (`https://github.com/<owner>/<repo>.git`). Users who authenticate via SSH keys can switch to SSH clone URLs instead.
@@ -6499,6 +6508,7 @@ Shallow pre-filtering is a two-pass process that avoids the expensive `FetchItem
 |-------|-----------|
 | Stage exists | `FindStage(stages, item.Status) != nil` |
 | Closed issue | Not closed, OR cleanup stage, OR has `stage:<X>:complete` label |
+| Repo write access | Repo not yet resolved by `resolveRepoAccess` (fail-open on "unknown"), OR resolved with `CanPush: true`. A repo cached with `CanPush: false` is never admitted, regardless of stage or status — see ADR-1347. Purely in-memory (no API call); the probe itself always runs earlier in the same poll cycle, in `poll()`'s seeding block. |
 | Cleanup stage | Worktree exists on disk (local filesystem check only) |
 | Deep-fetch failure cooldown | No recent `FetchItemDetails` failure, OR failure cooldown expired |
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -3356,6 +3356,7 @@ Shallow pre-filtering is a two-pass process that avoids the expensive `FetchItem
 |-------|-----------|
 | Stage exists | `FindStage(stages, item.Status) != nil` |
 | Closed issue | Not closed, OR cleanup stage, OR has `stage:<X>:complete` label |
+| Repo write access | Repo not yet resolved by `resolveRepoAccess` (fail-open on "unknown"), OR resolved with `CanPush: true`. A repo cached with `CanPush: false` is never admitted, regardless of stage or status — see ADR-1347. Purely in-memory (no API call); the probe itself always runs earlier in the same poll cycle, in `poll()`'s seeding block. |
 | Cleanup stage | Worktree exists on disk (local filesystem check only) |
 | Deep-fetch failure cooldown | No recent `FetchItemDetails` failure, OR failure cooldown expired |
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -94,35 +94,36 @@ type Engine struct {
 	worktreeManagers            map[string]*WorktreeManager // key: "owner/repo"; one WM per discovered repo
 	fabrikDir                   string                      // directory containing .fabrik/ (always os.Getwd() at startup)
 	mu                          sync.Mutex
-	store                       *itemstate.Store       // per-item engine state (locks, invocation outcomes, deep-fetch, CI-gate); see ADR-036
-	totalTokens                 TokenUsage             // accumulated token usage since process start
-	lastReportedCost            float64                // cost at last [stats] report; skip repeat prints when unchanged
-	mayNeedWork                 map[string]bool        // key: issueKey; items that have changed since the last poll cycle
-	mayNeedWorkMu               sync.Mutex             // guards mayNeedWork
-	seededRepos                 map[string]bool        // key: "owner/repo"; in-memory guard to avoid re-seeding on every poll
-	checkedAutoMergeRepos       map[string]bool        // key: "owner/repo"; guard to emit allow_auto_merge warning at most once per run
-	idleCount                   int                    // consecutive idle polls; triggers self-upgrade at threshold
-	idleStart                   time.Time              // when consecutive idle polls began; zero value = not idle
-	lastProjectUpdatedAt        time.Time              // last seen project.updatedAt from FetchProjectUpdatedAt gate; zero = not yet checked
-	wakeCh                      chan struct{}          // TUI sends on this to wake the poll loop immediately; nil if no TUI
-	stopCh                      chan tui.StopRequest   // TUI sends on this to stop a specific in-flight issue; nil if no TUI
-	sem                         chan struct{}          // semaphore bounding concurrent workers across poll cycles
-	wg                          sync.WaitGroup         // tracks in-flight workers for graceful shutdown
-	cloneInFlight               sync.Map               // key: "owner/repo" string, value: *cloneCall; per-repo bare-clone coordination
-	mergeTrainInFlight          sync.Map               // key: "owner/repo", value: *mergeTrainWorkerState; per-repo train dispatch guard
-	mergeTrainEjectionsMu       sync.Mutex             // guards mergeTrainEjectionCounts
-	mergeTrainEjectionCounts    map[string]int         // key: "owner/repo#N", ejection count per member
-	mergeTrainTrialsMu          sync.Mutex             // guards mergeTrainTrials
-	mergeTrainTrials            map[string][]time.Time // key: "owner/repo", trial timestamps for runaway guard (ADR-059 D8)
-	issueCtxs                   sync.Map               // key: issueKey string, value: issueCtxEntry; per-issue context for kill-reason propagation
-	baseBranchWarnedSet         sync.Map               // key: "owner/repo#N:branch"; prevents repeated fallback comments for bad base: labels
-	mergeTrainBatchSnapshotSeen sync.Map               // key: "owner/repo", value: string signature (sorted item numbers) of the last-logged Queued batch snapshot
-	claudeSuspendMu             sync.Mutex             // guards claudeSuspendedUntil
-	claudeSuspendedUntil        time.Time              // zero = not suspended; account-wide Claude dispatch suspension deadline (see usage_limit_backoff.go)
-	events                      chan tui.Event         // nil in tests / plain-text mode; TUI goroutine consumes
-	logFile                     *os.File               // persistent log file at .fabrik/fabrik.log; nil if not opened
-	logMu                       sync.Mutex             // serializes concurrent writes to logFile
-	webhookMgr                  *webhookManager        // nil when webhooks are disabled
+	store                       *itemstate.Store         // per-item engine state (locks, invocation outcomes, deep-fetch, CI-gate); see ADR-036
+	totalTokens                 TokenUsage               // accumulated token usage since process start
+	lastReportedCost            float64                  // cost at last [stats] report; skip repeat prints when unchanged
+	mayNeedWork                 map[string]bool          // key: issueKey; items that have changed since the last poll cycle
+	mayNeedWorkMu               sync.Mutex               // guards mayNeedWork
+	seededRepos                 map[string]bool          // key: "owner/repo"; in-memory guard to avoid re-seeding on every poll
+	checkedAutoMergeRepos       map[string]bool          // key: "owner/repo"; guard to emit allow_auto_merge warning at most once per run
+	repoAccess                  map[string]gh.RepoAccess // key: "owner/repo"; resolveRepoAccess's cache — single source of truth for seeding, the allow_auto_merge check, and itemMayNeedWork's dispatch gate (ADR-1347)
+	idleCount                   int                      // consecutive idle polls; triggers self-upgrade at threshold
+	idleStart                   time.Time                // when consecutive idle polls began; zero value = not idle
+	lastProjectUpdatedAt        time.Time                // last seen project.updatedAt from FetchProjectUpdatedAt gate; zero = not yet checked
+	wakeCh                      chan struct{}            // TUI sends on this to wake the poll loop immediately; nil if no TUI
+	stopCh                      chan tui.StopRequest     // TUI sends on this to stop a specific in-flight issue; nil if no TUI
+	sem                         chan struct{}            // semaphore bounding concurrent workers across poll cycles
+	wg                          sync.WaitGroup           // tracks in-flight workers for graceful shutdown
+	cloneInFlight               sync.Map                 // key: "owner/repo" string, value: *cloneCall; per-repo bare-clone coordination
+	mergeTrainInFlight          sync.Map                 // key: "owner/repo", value: *mergeTrainWorkerState; per-repo train dispatch guard
+	mergeTrainEjectionsMu       sync.Mutex               // guards mergeTrainEjectionCounts
+	mergeTrainEjectionCounts    map[string]int           // key: "owner/repo#N", ejection count per member
+	mergeTrainTrialsMu          sync.Mutex               // guards mergeTrainTrials
+	mergeTrainTrials            map[string][]time.Time   // key: "owner/repo", trial timestamps for runaway guard (ADR-059 D8)
+	issueCtxs                   sync.Map                 // key: issueKey string, value: issueCtxEntry; per-issue context for kill-reason propagation
+	baseBranchWarnedSet         sync.Map                 // key: "owner/repo#N:branch"; prevents repeated fallback comments for bad base: labels
+	mergeTrainBatchSnapshotSeen sync.Map                 // key: "owner/repo", value: string signature (sorted item numbers) of the last-logged Queued batch snapshot
+	claudeSuspendMu             sync.Mutex               // guards claudeSuspendedUntil
+	claudeSuspendedUntil        time.Time                // zero = not suspended; account-wide Claude dispatch suspension deadline (see usage_limit_backoff.go)
+	events                      chan tui.Event           // nil in tests / plain-text mode; TUI goroutine consumes
+	logFile                     *os.File                 // persistent log file at .fabrik/fabrik.log; nil if not opened
+	logMu                       sync.Mutex               // serializes concurrent writes to logFile
+	webhookMgr                  *webhookManager          // nil when webhooks are disabled
 	// heartbeatIntervalOverride overrides the package-level heartbeatInterval constant
 	// when non-zero. Used by tests to reduce the heartbeat period to sub-millisecond.
 	heartbeatIntervalOverride time.Duration
@@ -221,6 +222,7 @@ func New(cfg Config) (*Engine, error) {
 		mayNeedWork:              make(map[string]bool),
 		seededRepos:              make(map[string]bool),
 		checkedAutoMergeRepos:    make(map[string]bool),
+		repoAccess:               make(map[string]gh.RepoAccess),
 		sem:                      make(chan struct{}, cfg.MaxConcurrent),
 		mergeTrainEjectionCounts: make(map[string]int),
 		mergeTrainTrials:         make(map[string][]time.Time),
@@ -276,6 +278,7 @@ func NewWithDeps(cfg Config, client GitHubClient, claude ClaudeInvoker, worktree
 		mayNeedWork:              make(map[string]bool),
 		seededRepos:              make(map[string]bool),
 		checkedAutoMergeRepos:    make(map[string]bool),
+		repoAccess:               make(map[string]gh.RepoAccess),
 		sem:                      make(chan struct{}, maxConcurrent),
 		mergeTrainEjectionCounts: make(map[string]int),
 		mergeTrainTrials:         make(map[string][]time.Time),

--- a/engine/interfaces.go
+++ b/engine/interfaces.go
@@ -60,7 +60,7 @@ type GitHubClient interface {
 	EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error
 	DequeuePullRequest(owner, repo string, prNumber int) error
 	FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error)
-	FetchAllowAutoMerge(owner, repo string) (bool, error)
+	FetchRepoAccess(owner, repo string) (gh.RepoAccess, error)
 	FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error)
 	SeedLabels(owner, repo string, stageNames []string, lockedUser string) error
 	RateLimitStats() (rest, graphql gh.RateLimitStats)

--- a/engine/item.go
+++ b/engine/item.go
@@ -169,6 +169,18 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 	// resolveRepoAccess, always resolved earlier in poll() for every board-
 	// discovered repo before this function is reached; a repo not yet in the
 	// cache is admitted (fail-open on "unknown"), never gated on "unknown".
+	//
+	// Deliberately NOT exempted for stage.CleanupWorktree, unlike the
+	// fabrik:awaiting-done gate above: handleCleanupStage is not a pure local
+	// filesystem operation — it calls addLabel/removeLabel (stage:*:complete,
+	// fabrik:extend-turns) and acquireLockAndVerify writes lock/in_progress
+	// labels before that, all real GitHub mutations. Admitting cleanup here
+	// would reopen exactly the unwanted write against an unmanaged repo this
+	// gate exists to close. Accepted trade-off: a worktree that already exists
+	// on disk for an issue whose repo is later resolved as CanPush:false is
+	// never auto-cleaned (a disk-space leak, not a correctness issue); removing
+	// it is a manual, out-of-scope operation, same as this issue's other
+	// manual-cleanup carve-outs. See ADR-1347.
 	if access, ok := e.cachedRepoAccess(itemOwnerRepoString(item, e.defaultRepo())); ok && !access.CanPush {
 		return false
 	}

--- a/engine/item.go
+++ b/engine/item.go
@@ -161,6 +161,18 @@ func (e *Engine) itemMayNeedWork(item gh.ProjectItem) bool {
 		return false
 	}
 
+	// A repo the configured token has no write access to is never dispatched
+	// (R6): nearly every stage past Specify/Research needs to push commits and
+	// open/update PRs against this repo, which requires the very write access
+	// already determined to be absent — partial (read-only) processing would
+	// just fail later, less clearly. The access cache is populated by
+	// resolveRepoAccess, always resolved earlier in poll() for every board-
+	// discovered repo before this function is reached; a repo not yet in the
+	// cache is admitted (fail-open on "unknown"), never gated on "unknown".
+	if access, ok := e.cachedRepoAccess(itemOwnerRepoString(item, e.defaultRepo())); ok && !access.CanPush {
+		return false
+	}
+
 	// Cleanup stages bypass the updatedAt cache — their trigger is worktree
 	// existence (a local filesystem check), not issue/PR changes. Board column
 	// moves (Validate→Done by a human) don't always bump updatedAt, so cleanup

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -537,6 +537,50 @@ func TestItemNeedsWork_UnmanagedStage(t *testing.T) {
 	}
 }
 
+// TestItemMayNeedWork_NoWriteAccessSkipsDispatch verifies R6: an item whose
+// repo is cached as CanPush: false is never admitted for dispatch, regardless
+// of stage or status.
+func TestItemMayNeedWork_NoWriteAccessSkipsDispatch(t *testing.T) {
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.repoAccess["owner/repo"] = gh.RepoAccess{AllowAutoMerge: true, CanPush: false}
+	item := gh.ProjectItem{
+		Number: 1,
+		Status: "Research",
+	}
+	if eng.itemMayNeedWork(item) {
+		t.Error("item in a repo with no write access should not need work")
+	}
+}
+
+// TestItemMayNeedWork_UnresolvedRepoAccessAdmits verifies the fail-open default:
+// a repo not yet present in the repoAccess cache (resolveRepoAccess hasn't run
+// for it yet) is admitted, not gated — the gate only fires once the access
+// determination is actually known.
+func TestItemMayNeedWork_UnresolvedRepoAccessAdmits(t *testing.T) {
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	item := gh.ProjectItem{
+		Number: 1,
+		Status: "Research",
+	}
+	if !eng.itemMayNeedWork(item) {
+		t.Error("item in a repo with no cached access determination should be admitted (fail-open on unknown)")
+	}
+}
+
+// TestItemMayNeedWork_WriteAccessAdmits verifies a repo cached as CanPush: true
+// is unaffected by the new gate.
+func TestItemMayNeedWork_WriteAccessAdmits(t *testing.T) {
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.repoAccess["owner/repo"] = gh.RepoAccess{AllowAutoMerge: true, CanPush: true}
+	item := gh.ProjectItem{
+		Number: 1,
+		Status: "Research",
+	}
+	if !eng.itemMayNeedWork(item) {
+		t.Error("item in a writable repo should still need work")
+	}
+}
+
 // TestItemMayNeedWork_ClosedIssue_CleanupStage verifies that a closed issue in
 // a cleanup stage still passes itemMayNeedWork when the worktree directory exists.
 func TestItemMayNeedWork_ClosedIssue_CleanupStage(t *testing.T) {

--- a/engine/item_extra_test.go
+++ b/engine/item_extra_test.go
@@ -581,6 +581,46 @@ func TestItemMayNeedWork_WriteAccessAdmits(t *testing.T) {
 	}
 }
 
+// TestItemMayNeedWork_NoWriteAccessSkipsCleanupStage verifies that, unlike the
+// fabrik:awaiting-done gate, the repo-access gate is NOT exempted for
+// stage.CleanupWorktree: handleCleanupStage performs real GitHub label writes
+// (stage:*:complete, fabrik:extend-turns removal), so admitting a cleanup-stage
+// item for a repo with no write access would reopen exactly the unwanted write
+// this gate exists to prevent. A worktree that already exists on disk for such
+// an issue is left uncleaned (a disk-space leak, not a correctness issue) —
+// see the comment above the gate in item.go and ADR-1347.
+func TestItemMayNeedWork_NoWriteAccessSkipsCleanupStage(t *testing.T) {
+	rootDir := t.TempDir()
+	wm := NewWorktreeManager(rootDir)
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "repo",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStagesWithCleanup(),
+		},
+		&mockGitHubClient{},
+		&mockClaudeInvoker{},
+		wm,
+	)
+	eng.repoAccess["owner/repo"] = gh.RepoAccess{AllowAutoMerge: true, CanPush: false}
+	const issueNum = 99
+	if err := os.MkdirAll(wm.WorktreeDir(issueNum), 0755); err != nil {
+		t.Fatal(err)
+	}
+	item := gh.ProjectItem{
+		Number:   issueNum,
+		Status:   "Done",
+		IsClosed: true,
+	}
+	if eng.itemMayNeedWork(item) {
+		t.Error("cleanup-stage item in a repo with no write access should not need work — cleanup writes labels via GitHub")
+	}
+}
+
 // TestItemMayNeedWork_ClosedIssue_CleanupStage verifies that a closed issue in
 // a cleanup stage still passes itemMayNeedWork when the worktree directory exists.
 func TestItemMayNeedWork_ClosedIssue_CleanupStage(t *testing.T) {

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -66,7 +66,7 @@ type mockGitHubClient struct {
 	enqueuePullRequestFn          func(owner, repo string, prNumber int, expectedHeadOID string) error
 	dequeuePullRequestFn          func(owner, repo string, prNumber int) error
 	fetchCommitsBehindFn          func(owner, repo, base, head string) (int, error)
-	fetchAllowAutoMergeFn         func(owner, repo string) (bool, error)
+	fetchRepoAccessFn             func(owner, repo string) (gh.RepoAccess, error)
 	fetchIssueFn                  func(owner, repo string, issueNumber int) (*gh.IssueData, error)
 	createPRFn                    func(owner, repo, title, head, base, body string) (int, error)
 	listPRsFn                     func(owner, repo string) ([]gh.PRDetails, error)
@@ -514,14 +514,14 @@ func (m *mockGitHubClient) FetchLatestRelease(owner, repo string) (*gh.LatestRel
 	return nil, nil
 }
 
-func (m *mockGitHubClient) FetchAllowAutoMerge(owner, repo string) (bool, error) {
+func (m *mockGitHubClient) FetchRepoAccess(owner, repo string) (gh.RepoAccess, error) {
 	m.mu.Lock()
-	fn := m.fetchAllowAutoMergeFn
+	fn := m.fetchRepoAccessFn
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(owner, repo)
 	}
-	return true, nil
+	return gh.RepoAccess{AllowAutoMerge: true, CanPush: true}, nil
 }
 
 func (m *mockGitHubClient) FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error) {

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -246,8 +246,10 @@ func (e *Engine) Run() error {
 		stageNames = append(stageNames, s.Name)
 	}
 	if e.cfg.Repo != "" {
-		if err := e.client.SeedLabels(e.cfg.Owner, e.cfg.Repo, stageNames, e.cfg.User); err != nil {
-			e.logf(0, "warn", "label seeding failed (non-fatal): %v\n", err)
+		if e.resolveRepoAccess(e.cfg.Owner, e.cfg.Repo).CanPush {
+			if err := e.client.SeedLabels(e.cfg.Owner, e.cfg.Repo, stageNames, e.cfg.User); err != nil {
+				e.logf(0, "warn", "label seeding failed (non-fatal): %v\n", err)
+			}
 		}
 		e.mu.Lock()
 		e.seededRepos[e.cfg.Owner+"/"+e.cfg.Repo] = true
@@ -991,8 +993,10 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 				continue
 			}
 			e.checkAllowAutoMerge(owner, repo)
-			if err := e.client.SeedLabels(owner, repo, sn, e.cfg.User); err != nil {
-				e.logf(0, "warn", "label seeding for %s failed (non-fatal): %v\n", ownerRepo, err)
+			if e.resolveRepoAccess(owner, repo).CanPush {
+				if err := e.client.SeedLabels(owner, repo, sn, e.cfg.User); err != nil {
+					e.logf(0, "warn", "label seeding for %s failed (non-fatal): %v\n", ownerRepo, err)
+				}
 			}
 			e.mu.Lock()
 			e.seededRepos[ownerRepo] = true

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1681,6 +1682,191 @@ func TestSeedLabels_ExcludesUnmanagedStage(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected Done (cleanup stage) included in seeded stage names, got %v", calls[0].stageNames)
+	}
+}
+
+// TestSeedLabels_NoWriteAccessSkipsSeeding verifies AC1/R1: a repo whose
+// FetchRepoAccess reports CanPush: false receives zero SeedLabels calls, while
+// a sibling repo with write access is seeded exactly as before (AC3/R5).
+func TestSeedLabels_NoWriteAccessSkipsSeeding(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 1, Title: "Managed", Status: "Research", Repo: "owner/managed"},
+			{Number: 2, Title: "Unmanaged", Status: "Research", Repo: "owner/unmanaged"},
+		},
+	}
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return board, nil
+		},
+		fetchStatusFieldFn: func(projectID string) (*gh.StatusField, error) {
+			return &gh.StatusField{FieldID: "F1", Options: map[string]string{"Research": "OPT_1"}}, nil
+		},
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			if repo == "unmanaged" {
+				return gh.RepoAccess{AllowAutoMerge: true, CanPush: false}, nil
+			}
+			return gh.RepoAccess{AllowAutoMerge: true, CanPush: true}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		client,
+		&mockClaudeInvoker{},
+		nil,
+	)
+
+	if _, err := eng.poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	eng.wg.Wait()
+
+	client.mu.Lock()
+	calls := make([]seedLabelsCall, len(client.seedLabelsCalls))
+	copy(calls, client.seedLabelsCalls)
+	client.mu.Unlock()
+
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 SeedLabels call (managed repo only), got %d: %+v", len(calls), calls)
+	}
+	if calls[0].owner+"/"+calls[0].repo != "owner/managed" {
+		t.Errorf("expected SeedLabels called for owner/managed, got %s/%s", calls[0].owner, calls[0].repo)
+	}
+}
+
+// TestResolveRepoAccess_ProbedOncePerRepoAcrossConsumers verifies AC4/R3: the
+// underlying FetchRepoAccess probe fires at most once per repo per process
+// run, even though seeding, checkAllowAutoMerge, and the dispatch gate all
+// consult resolveRepoAccess for the same repo across multiple poll cycles.
+func TestResolveRepoAccess_ProbedOncePerRepoAcrossConsumers(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 1, Title: "Issue 1", Status: "Research", Repo: "owner/repo1"},
+		},
+	}
+	var probeCount int32
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return board, nil
+		},
+		fetchStatusFieldFn: func(projectID string) (*gh.StatusField, error) {
+			return &gh.StatusField{FieldID: "F1", Options: map[string]string{"Research": "OPT_1"}}, nil
+		},
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			atomic.AddInt32(&probeCount, 1)
+			return gh.RepoAccess{AllowAutoMerge: true, CanPush: true}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		client,
+		&mockClaudeInvoker{},
+		nil,
+	)
+
+	for i := 0; i < 3; i++ {
+		if _, err := eng.poll(context.Background()); err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+		eng.wg.Wait()
+	}
+
+	if got := atomic.LoadInt32(&probeCount); got != 1 {
+		t.Errorf("FetchRepoAccess called %d times across 3 polls; want exactly 1", got)
+	}
+}
+
+// TestPoll_UnmanagedRepoSkippedFromDispatch verifies AC5/AC6: an item whose
+// repo has no write access is never deep-fetched (and therefore never
+// stage-invoked), while a sibling item in a managed repo is processed
+// normally in the same poll cycle.
+func TestPoll_UnmanagedRepoSkippedFromDispatch(t *testing.T) {
+	board := &gh.ProjectBoard{
+		ProjectID: "PVT_1",
+		Items: []gh.ProjectItem{
+			{Number: 1, Title: "Managed", Status: "Research", Repo: "owner/managed"},
+			{Number: 2, Title: "Unmanaged", Status: "Research", Repo: "owner/unmanaged"},
+		},
+	}
+	var deepFetched []string
+	var mu sync.Mutex
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return board, nil
+		},
+		fetchStatusFieldFn: func(projectID string) (*gh.StatusField, error) {
+			return &gh.StatusField{FieldID: "F1", Options: map[string]string{"Research": "OPT_1"}}, nil
+		},
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			if repo == "unmanaged" {
+				return gh.RepoAccess{AllowAutoMerge: true, CanPush: false}, nil
+			}
+			return gh.RepoAccess{AllowAutoMerge: true, CanPush: true}, nil
+		},
+		fetchItemDetailsFn: func(item *gh.ProjectItem) error {
+			mu.Lock()
+			deepFetched = append(deepFetched, item.Repo)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{
+			Owner:         "owner",
+			Repo:          "",
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		client,
+		&mockClaudeInvoker{},
+		nil,
+	)
+
+	if _, err := eng.poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	eng.wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	sawManaged, sawUnmanaged := false, false
+	for _, r := range deepFetched {
+		if r == "owner/managed" {
+			sawManaged = true
+		}
+		if r == "owner/unmanaged" {
+			sawUnmanaged = true
+		}
+	}
+	if sawUnmanaged {
+		t.Error("item in an unmanaged (no write access) repo must not be deep-fetched")
+	}
+	if !sawManaged {
+		t.Error("item in a managed (write access) repo should still be deep-fetched and processed normally")
 	}
 }
 

--- a/engine/repo.go
+++ b/engine/repo.go
@@ -57,6 +57,20 @@ func itemOwnerRepo(item gh.ProjectItem, defaultRepo string) (owner, repo string)
 	return parseOwnerRepo(r)
 }
 
+// cachedRepoAccess returns the previously resolved write-access determination
+// for "owner/repo" key, without triggering a probe. Used by itemMayNeedWork's
+// dispatch gate, which must stay a pure in-memory check — the repo-access
+// probe itself always runs earlier in the same poll cycle, in poll()'s
+// seeding block (see resolveRepoAccess). Returns ok=false when the repo
+// hasn't been resolved yet, in which case the caller should admit rather
+// than gate (fail-open on "unknown", not "unwritable").
+func (e *Engine) cachedRepoAccess(key string) (access gh.RepoAccess, ok bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	access, ok = e.repoAccess[key]
+	return access, ok
+}
+
 // parseIssueKey reverses issueKey: parses "owner/repo#N" into (owner, repo, issueNumber).
 // Falls back to (defaultOwner, defaultRepo, 0) on malformed input.
 func parseIssueKey(key, defaultOwner, defaultRepo string) (owner, repo string, issueNumber int) {

--- a/engine/startup.go
+++ b/engine/startup.go
@@ -348,11 +348,16 @@ func (e *Engine) resolveRepoAccess(owner, repo string) gh.RepoAccess {
 // checkAllowAutoMerge queries the GitHub API for the allow_auto_merge setting on
 // owner/repo and prints a WARNING if it is disabled. Non-fatal: API errors are
 // logged at warn level and processing continues. The check fires at most once per
-// repo per process run (guarded by checkedAutoMergeRepos). Skips entirely — no
-// warning, no API call beyond the shared resolveRepoAccess probe — when the
+// repo per process run (guarded by checkedAutoMergeRepos). Skips the warning
+// entirely — no API call beyond the shared resolveRepoAccess probe — when the
 // token has no write access to the repo (R2): a repo Fabrik can't push to also
 // can't have allow_auto_merge administered on it, and resolveRepoAccess has
-// already logged the "no write access" notice once.
+// already logged the "no write access" notice once. Also clears any
+// allow_auto_merge warning already recorded for the repo from a prior run when
+// access was still present: a repo whose access is revoked between runs would
+// otherwise keep an unfixable, now-moot warning immortal in
+// .fabrik/warnings.json forever, since !CanPush never reaches this function's
+// own Clear branch below again.
 func (e *Engine) checkAllowAutoMerge(owner, repo string) {
 	key := owner + "/" + repo
 	e.mu.Lock()
@@ -364,6 +369,7 @@ func (e *Engine) checkAllowAutoMerge(owner, repo string) {
 	}
 	access := e.resolveRepoAccess(owner, repo)
 	if !access.CanPush {
+		_ = warnings.Clear("allow_auto_merge:" + key)
 		return
 	}
 	if !access.AllowAutoMerge {

--- a/engine/startup.go
+++ b/engine/startup.go
@@ -304,10 +304,55 @@ func (e *Engine) checkHTTPSCredentials(hasSSHRewrite bool) {
 	}
 }
 
+// resolveRepoAccess returns the cached write-access determination for
+// owner/repo, probing and caching it on first call (at most once per repo per
+// process run, per R3/AC4). It is the single shared resolver consulted by
+// label seeding, checkAllowAutoMerge, and itemMayNeedWork's dispatch gate
+// (ADR-1347) — whichever of those calls it first for a given repo is the one
+// that fetches and logs.
+//
+// Fails open (CanPush: true) on a probe error (network failure, transient
+// 5xx), matching this codebase's prior error posture for the same GET
+// request: a genuinely managed repo should not lose dispatch/seeding for the
+// rest of the process lifetime over a transient blip.
+func (e *Engine) resolveRepoAccess(owner, repo string) gh.RepoAccess {
+	key := owner + "/" + repo
+	e.mu.Lock()
+	access, cached := e.repoAccess[key]
+	e.mu.Unlock()
+	if cached {
+		return access
+	}
+
+	access, err := e.client.FetchRepoAccess(owner, repo)
+	if err != nil {
+		e.logf(0, "warn", "could not determine repo access for %s: %v (assuming writable)\n", key, err)
+		access = gh.RepoAccess{AllowAutoMerge: true, CanPush: true}
+	}
+
+	e.mu.Lock()
+	existing, already := e.repoAccess[key]
+	if already {
+		access = existing
+	} else {
+		e.repoAccess[key] = access
+	}
+	e.mu.Unlock()
+
+	if !already && !access.CanPush {
+		e.logf(0, "startup", "%s: no write access — skipping label seeding and allow_auto_merge check; items from this repo will not be processed\n", key)
+	}
+	return access
+}
+
 // checkAllowAutoMerge queries the GitHub API for the allow_auto_merge setting on
 // owner/repo and prints a WARNING if it is disabled. Non-fatal: API errors are
 // logged at warn level and processing continues. The check fires at most once per
-// repo per process run (guarded by checkedAutoMergeRepos).
+// repo per process run (guarded by checkedAutoMergeRepos). Skips entirely — no
+// warning, no API call beyond the shared resolveRepoAccess probe — when the
+// token has no write access to the repo (R2): a repo Fabrik can't push to also
+// can't have allow_auto_merge administered on it, and resolveRepoAccess has
+// already logged the "no write access" notice once.
 func (e *Engine) checkAllowAutoMerge(owner, repo string) {
 	key := owner + "/" + repo
 	e.mu.Lock()
@@ -317,12 +362,11 @@ func (e *Engine) checkAllowAutoMerge(owner, repo string) {
 	if already {
 		return
 	}
-	enabled, err := e.client.FetchAllowAutoMerge(owner, repo)
-	if err != nil {
-		e.logf(0, "warn", "could not check allow_auto_merge for %s: %v\n", key, err)
+	access := e.resolveRepoAccess(owner, repo)
+	if !access.CanPush {
 		return
 	}
-	if !enabled {
+	if !access.AllowAutoMerge {
 		e.logf(0, "startup", "WARNING: %s has allow_auto_merge disabled.\n", key)
 		e.logf(0, "startup", "WARNING: yolo issues on this repo will reach Validate complete but their PRs will not merge.\n")
 		e.logf(0, "startup", "WARNING: Fix: gh api -X PATCH repos/%s -f allow_auto_merge=true\n", key)

--- a/engine/startup_test.go
+++ b/engine/startup_test.go
@@ -763,6 +763,32 @@ func TestCheckAllowAutoMerge_EnabledIsSilent(t *testing.T) {
 	}
 }
 
+// TestCheckAllowAutoMerge_NoWriteAccessSkipsWarning verifies AC2/R2: a repo
+// with no write access produces no allow_auto_merge warning even when
+// AllowAutoMerge is false — the unfixable-without-admin-rights warning must
+// not fire for a repo the operator can't administer at all.
+func TestCheckAllowAutoMerge_NoWriteAccessSkipsWarning(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
+	client := &mockGitHubClient{
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			return gh.RepoAccess{AllowAutoMerge: false, CanPush: false}, nil
+		},
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+
+	out := captureStdout(func() {
+		eng.checkAllowAutoMerge("owner", "repo")
+	})
+
+	if strings.Contains(out, "WARNING") {
+		t.Errorf("expected no WARNING for a repo with no write access, even with allow_auto_merge disabled; got: %q", out)
+	}
+	if strings.Contains(out, "gh api -X PATCH") {
+		t.Errorf("expected no admin-only remediation for a repo with no write access; got: %q", out)
+	}
+}
+
 func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
 	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
 	t.Cleanup(func() { warnings.WarningsPathOverride = "" })

--- a/engine/startup_test.go
+++ b/engine/startup_test.go
@@ -723,8 +723,8 @@ func TestCheckAllowAutoMerge_DisabledEmitsWarning(t *testing.T) {
 	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
 	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	client := &mockGitHubClient{
-		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
-			return false, nil
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			return gh.RepoAccess{AllowAutoMerge: false, CanPush: true}, nil
 		},
 	}
 	eng := testEngine(t, client, &mockClaudeInvoker{})
@@ -748,8 +748,8 @@ func TestCheckAllowAutoMerge_EnabledIsSilent(t *testing.T) {
 	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
 	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	client := &mockGitHubClient{
-		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
-			return true, nil
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			return gh.RepoAccess{AllowAutoMerge: true, CanPush: true}, nil
 		},
 	}
 	eng := testEngine(t, client, &mockClaudeInvoker{})
@@ -767,8 +767,8 @@ func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
 	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
 	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	client := &mockGitHubClient{
-		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
-			return false, errors.New("network error")
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			return gh.RepoAccess{}, errors.New("network error")
 		},
 	}
 	eng := testEngine(t, client, &mockClaudeInvoker{})
@@ -778,7 +778,9 @@ func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
 		eng.checkAllowAutoMerge("owner", "repo")
 	})
 
-	// No WARNING block should be emitted for an API error.
+	// No WARNING block should be emitted for an API error. A probe error fails
+	// open (CanPush: true, AllowAutoMerge: true), so no allow_auto_merge
+	// warning fires either.
 	if strings.Contains(out, "WARNING") {
 		t.Errorf("should not print WARNING on API error; got: %q", out)
 	}
@@ -789,9 +791,9 @@ func TestCheckAllowAutoMerge_DedupSuppressesSecondCall(t *testing.T) {
 	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
 	var callCount int
 	client := &mockGitHubClient{
-		fetchAllowAutoMergeFn: func(owner, repo string) (bool, error) {
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
 			callCount++
-			return false, nil
+			return gh.RepoAccess{AllowAutoMerge: false, CanPush: true}, nil
 		},
 	}
 	eng := testEngine(t, client, &mockClaudeInvoker{})

--- a/engine/startup_test.go
+++ b/engine/startup_test.go
@@ -789,6 +789,46 @@ func TestCheckAllowAutoMerge_NoWriteAccessSkipsWarning(t *testing.T) {
 	}
 }
 
+// TestCheckAllowAutoMerge_NoWriteAccessClearsStaleWarning verifies that a
+// previously recorded allow_auto_merge warning is cleared, not left immortal,
+// when a later run finds the repo's write access has been revoked. Without
+// this, the !CanPush early return would skip past checkAllowAutoMerge's own
+// Clear branch forever, since checkedAutoMergeRepos never lets this function
+// re-run for the repo a second time in the same process (raised in PR review
+// on #1347).
+func TestCheckAllowAutoMerge_NoWriteAccessClearsStaleWarning(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
+
+	if err := warnings.Record(warnings.Entry{
+		Key:    "allow_auto_merge:owner/repo",
+		Type:   "allow_auto_merge",
+		Title:  "allow_auto_merge disabled on owner/repo",
+		Detail: "stale entry from a prior run when access was still present",
+	}); err != nil {
+		t.Fatalf("seeding stale warning: %v", err)
+	}
+
+	client := &mockGitHubClient{
+		fetchRepoAccessFn: func(owner, repo string) (gh.RepoAccess, error) {
+			return gh.RepoAccess{AllowAutoMerge: false, CanPush: false}, nil
+		},
+	}
+	eng := testEngine(t, client, &mockClaudeInvoker{})
+
+	eng.checkAllowAutoMerge("owner", "repo")
+
+	entries, err := warnings.Load()
+	if err != nil {
+		t.Fatalf("loading warnings: %v", err)
+	}
+	for _, e := range entries {
+		if e.Key == "allow_auto_merge:owner/repo" {
+			t.Errorf("expected stale allow_auto_merge warning to be cleared once access is revoked; still present: %+v", e)
+		}
+	}
+}
+
 func TestCheckAllowAutoMerge_APIErrorIsNonFatal(t *testing.T) {
 	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
 	t.Cleanup(func() { warnings.WarningsPathOverride = "" })

--- a/github/client.go
+++ b/github/client.go
@@ -198,15 +198,21 @@ func (c *Client) FetchLatestRelease(owner, repo string) (*LatestRelease, error) 
 	return &release, nil
 }
 
-// FetchAllowAutoMerge calls GET /repos/{owner}/{repo} and returns the value of
-// the allow_auto_merge field. Returns an error if the request fails.
-func (c *Client) FetchAllowAutoMerge(owner, repo string) (bool, error) {
+// FetchRepoAccess calls GET /repos/{owner}/{repo} and returns the allow_auto_merge
+// setting alongside the authenticated token's push access (permissions.push) —
+// both decoded from the same response, so this adds no extra API round-trip
+// beyond what the allow_auto_merge check already required. Returns an error if
+// the request fails.
+func (c *Client) FetchRepoAccess(owner, repo string) (RepoAccess, error) {
 	url := c.baseURL + "/repos/" + owner + "/" + repo
 	var result struct {
 		AllowAutoMerge bool `json:"allow_auto_merge"`
+		Permissions    struct {
+			Push bool `json:"push"`
+		} `json:"permissions"`
 	}
 	if err := c.restGetJSON(url, &result); err != nil {
-		return false, fmt.Errorf("fetching allow_auto_merge for %s/%s: %w", owner, repo, err)
+		return RepoAccess{}, fmt.Errorf("fetching repo access for %s/%s: %w", owner, repo, err)
 	}
-	return result.AllowAutoMerge, nil
+	return RepoAccess{AllowAutoMerge: result.AllowAutoMerge, CanPush: result.Permissions.Push}, nil
 }

--- a/github/pruefer_extensions_test.go
+++ b/github/pruefer_extensions_test.go
@@ -25,11 +25,11 @@ func TestSetToken_UpdatesSubsequentRequests(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithBaseURL("token-v1", srv.URL)
-	if _, err := c.FetchAllowAutoMerge("owner", "repo"); err != nil {
+	if _, err := c.FetchRepoAccess("owner", "repo"); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
 	c.SetToken("token-v2")
-	if _, err := c.FetchAllowAutoMerge("owner", "repo"); err != nil {
+	if _, err := c.FetchRepoAccess("owner", "repo"); err != nil {
 		t.Fatalf("second call: %v", err)
 	}
 

--- a/github/types.go
+++ b/github/types.go
@@ -29,6 +29,13 @@ type Dependency struct {
 	Repo   string // "owner/repo" of the blocking issue; empty if same repo
 }
 
+// RepoAccess captures the write-access-relevant fields from GET /repos/{owner}/{repo}
+// for the authenticated token. CanPush reflects permissions.push on that response.
+type RepoAccess struct {
+	AllowAutoMerge bool
+	CanPush        bool
+}
+
 // ReviewRequest represents a pending review request on a pull request.
 type ReviewRequest struct {
 	Login string // GitHub login of the requested reviewer (user or bot)


### PR DESCRIPTION
Closes #1347

## What this does

Fabrik discovers its managed-repo set from board items, not configuration — any repo that's ever had an issue tracked on the board gets ~25 label-creation attempts and an `allow_auto_merge` check, even when the configured token has no write access to it (e.g. tracking an upstream issue on your own board). This PR determines write access before mutating, instead of discovering it by failure.

## Key changes

- **`github`**: `FetchAllowAutoMerge` → `FetchRepoAccess`, decoding `permissions.push` alongside `allow_auto_merge` from the same `GET /repos/{owner}/{repo}` response — no new API round-trip.
- **`engine`**: new `resolveRepoAccess(owner, repo)` resolver, cached per repo per process run (`Engine.repoAccess`), consulted by three sites:
  - Label seeding (both the multi-repo per-poll block and the single-repo startup block) skips `SeedLabels` when the repo isn't writable.
  - `checkAllowAutoMerge` skips its warning entirely for an unwritable repo (its remediation requires admin rights the operator by definition doesn't have).
  - `itemMayNeedWork` gains a new early-return gate, shaped like the existing `HoldingStage`/`Unmanaged` check, so board items in an unwritable repo are never deep-fetched or dispatched — not even read-only, since downstream stages need to push/open PRs.
- A repo not yet resolved is admitted (fail-open on "unknown"), and a probe error fails open too (matches the prior `checkAllowAutoMerge` posture) — cached for the rest of the run either way.
- No GitHub-side mutation of any kind ever happens on an unmanaged repo, including to record the determination itself — the cache and its one-time log notice are purely in-process.

## Docs

- `adrs/1347-repo-write-access-gating.md` — records the fail-open-on-error, push-vs-admin, and single-resolver design decisions.
- `docs/state-machine.md` Appendix B gains a row for the new dispatch-gate check.
- `docs/USER_GUIDE.md`'s Multi-Repo Support section documents the gating behavior.
- `docs/llms-full.txt` regenerated.

## How to test

- `go test -race ./...` — full suite passes (one pre-existing, environment-dependent flake in `cmd.TestExecute_ConfigYAMLApplied` reproduces identically on the unmodified base commit, confirmed unrelated).
- New tests: `TestSeedLabels_NoWriteAccessSkipsSeeding` (AC1), `TestResolveRepoAccess_ProbedOncePerRepoAcrossConsumers` (AC4), `TestPoll_UnmanagedRepoSkippedFromDispatch` (AC5/AC6), plus `itemMayNeedWork` unit tests for gated/admitted-writable/admitted-unresolved cases, and an updated `TestCheckAllowAutoMerge_*` suite (AC2).