### PR TITLE
Sweep stale allow_auto_merge and stage-config warnings (#1348)

### DIFF
--- a/adrs/1348-stale-warning-sweep.md
+++ b/adrs/1348-stale-warning-sweep.md
@@ -1,0 +1,90 @@
+# ADR 1348: Stale Warning Sweep
+
+**Date**: 2026-08-02
+**Status**: Accepted
+**Issue**: #1348 — `allow_auto_merge` warnings are never cleared when the repo they refer to leaves the
+board (durable-state leak)
+
+## Context
+
+`.fabrik/warnings.json` (`warnings/warnings.go`, ADR-052) backs the TUI's Warnings panel. Several
+engine-side detectors follow the same idiom: record an entry (`warnings.Record`) when a condition is
+true, clear it (`warnings.Clear`) when the same subject is re-checked and the condition has resolved.
+That idiom has a gap — a subject that stops being checked *at all* never revisits the `Clear` branch, so
+any warning recorded for it is immortal.
+
+`checkAllowAutoMerge` (`engine/startup.go`) is called once per repo per process run, from the label-
+seeding path (`poll.go`) for repos discovered on the *current* board. A repo that leaves the board is
+never re-checked, so a warning recorded while it was still on the board can never be cleared. This was
+observed in production on the `verveguy` project: four `allow_auto_merge` warnings for repos absent from
+the current board persisted indefinitely, pushing the non-dismissed count past the TUI panel's row cap
+and hiding live warnings behind dead ones. This is the same shape as the orphaned `stage:*:in_progress`
+labels (#1135) and the `fabrik:claude-limit` account-wide label before its own sweep (ADR-1183).
+
+Research (R7) confirmed two further instances of the identical shape — `stage_drift` and
+`undeclared_reviewers` (`stages/drift.go`), both keyed by stage name and only re-visited for stage names
+present in the *current* `e.cfg.Stages` pass — and one warning type that is safe by construction:
+`version_skew` (`engine/upgrade.go`), whose key subject (the resolved on-disk executable path) is
+re-derived fresh on every check rather than looked up in a shrinking discovered set, so its `Clear`
+branch is always reachable.
+
+## Decision
+
+**Add `warnings.ClearMissing(warningType string, present map[string]bool) ([]string, error)`** as a
+shared bulk-predicate primitive, rather than having each sweep loop over per-key `warnings.Clear` calls.
+`Clear` unconditionally calls `save()` even when the key was never present in the file — a naive loop
+over N possibly-stale keys, run every poll, would write the file on every poll unless every caller
+independently got the pre-filtering exactly right. Putting "only write if something is actually stale"
+inside the package removes an entire class of regression (AC5: no writes when nothing needs clearing)
+rather than relying on caller discipline, and collapses what would otherwise be an O(N) sequence of
+independent load-filter-save round trips into a single pass — relevant once multiple entries are stale
+in the same poll, as the observed field case (four) was.
+
+**Two separate, type-specific call sites — not one generic sweep runner.** The repo-keyed and
+stage-name-keyed leaks have different known-good sets (`seenRepos` vs. `e.cfg.Stages` names), different
+owning packages (`engine` vs. `stages`), and different correct cadences (see below). Forcing both through
+one cross-package abstraction would buy nothing for two call sites total. `stage_drift` and
+`undeclared_reviewers`, which *do* share everything (same known-good set, same call site), are unified
+into one `stages.SweepStaleWarnings` call that invokes `ClearMissing` twice.
+
+**`allow_auto_merge` sweeps every poll; `stage_drift`/`undeclared_reviewers` sweep once at startup.** The
+repo sweep's known-good set (`seenRepos`) is itself rebuilt every poll from the live board, so running
+the sweep every poll makes a repo's departure (or return) visible immediately, at zero extra cost (no new
+fetch — R2/R4). The stage-name sweep's known-good set (`e.cfg.Stages`) is fixed for the life of the
+process and only changes across a restart (including the in-place SIGHUP restart, which re-execs and
+re-runs `Run()` from scratch) — running it every poll would be correct but pointless work, so it runs
+once, alongside the existing `WarnStageDrift`/`WarnUndeclaredReviewers` calls at startup.
+
+**The engine's own configured repo is exempted from the repo sweep (single-repo mode only).**
+`checkAllowAutoMerge(e.cfg.Owner, e.cfg.Repo)` fires unconditionally at `Run()` startup regardless of
+whether the board currently has any open items for that repo, but `seenRepos` is built purely from
+`board.Items`. Without an exemption, a transient zero-open-items poll for the operator's own configured
+repo (e.g. everything currently sitting in Done) would durably clear a legitimate warning — and because
+`checkedAutoMergeRepos` never re-fires for that repo after the first startup call, the warning would not
+reappear until a process restart, unlike every other cosmetic, self-healing settle scan in this codebase.
+`sweepStaleAllowAutoMergeWarnings` therefore unions `e.defaultRepo()` into the comparison set (copying
+`seenRepos` first — never mutating the caller's map) whenever it is non-empty. Multi-repo mode
+(`e.cfg.Repo == ""`) has no equivalent always-present repo, so `defaultRepo()` returning `""` is a
+correct no-op there.
+
+**`version_skew` gets a doc comment, not a sweep.** Its subject is re-derived fresh on every
+idle-upgrade check rather than looked up in a shrinking set, so its existing `Clear` branch is already
+reachable every evaluation — adding a sweep would be dead code. A comment on `checkVersionSkew`
+(`engine/upgrade.go`) records this reasoning explicitly per R7, rather than leaving it to silence.
+
+## Consequences
+
+- A warning whose subject has genuinely left the board (or the stage config) is cleared automatically,
+  without operator intervention or a restart, closing the gap that required a hand-edit of
+  `warnings.json` in the field incident.
+- `ClearMissing` is now the preferred idiom for any future "durable per-subject warning whose known-good
+  set is already computed elsewhere" case — the two sweeps here, plus `version_skew`'s existing
+  self-refreshing case, cover the full current warning surface (R7).
+- No change to which conditions produce a warning, no TUI rendering change, and this is not a general
+  expiry/TTL mechanism: only subjects provably absent from an already-known-good set are ever cleared.
+- Over-clearing risk (a sweep keying off the wrong field, or comparing against a filtered rather than the
+  full known-good set) is mitigated by scoping `ClearMissing` to one `Type` per call and by explicit test
+  coverage: a still-on-the-board repo's warning (regardless of its auto-merge state) and a still-
+  configured `Unmanaged` stage's warning must both survive their respective sweeps.
+
+See `docs/state-machine.md` §7.11 for the as-built behavior.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2438,7 +2438,7 @@ Tab into the Warnings panel to take action:
 - **S** — show/hide dismissed entries
 - **Enter** — expand/collapse the full detail text for the selected entry
 
-Warning entries persist to `.fabrik/warnings.json` and survive auto-upgrade restarts. Dismissed entries are preserved in the file until the underlying condition clears, at which point they are removed entirely.
+Warning entries persist to `.fabrik/warnings.json` and survive auto-upgrade restarts. Dismissed entries are preserved in the file until the underlying condition clears, at which point they are removed entirely. This includes the condition's *subject* going away entirely (e.g. a repo leaving the project board, or a stage being renamed) — a per-poll or startup sweep clears those automatically too, without requiring a restart (see `docs/state-machine.md` §7.11).
 
 ### History Persistence
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5665,6 +5665,68 @@ A detected stall still applies `StageRetryIncremented` and counts against `MaxRe
 
 **Scope note:** this implements only the "cheaper to detect" trend signal from issue #1146 — a turn-capped attempt followed by a declining, incomplete one. It does not add live NDJSON tool-use parsing to detect backgrounding-then-silence within a single invocation (the issue's other suggested signal); that remains a possible follow-up if the trend signal proves insufficient in practice.
 
+### 7.11 Stale Warning Sweep
+
+`.fabrik/warnings.json` (`warnings/warnings.go`, ADR-052) backs the TUI's Warnings panel. Several
+engine-side detectors record an entry when a condition is true and clear it via `warnings.Clear` when
+the *same* re-checked subject's condition resolves — but a subject that stops being checked at all (a
+repo leaves the board, a stage is renamed or its YAML deleted) never revisits the `Clear` branch, so its
+entry is immortal. This is the same durable-state-leak shape as the orphaned `stage:*:in_progress`
+labels (#1135) and the `fabrik:claude-limit` account-wide label before §7.3's sweep (ADR-1183). Observed
+in production on the `verveguy` project (#1348): four `allow_auto_merge` warnings for repos that had
+left the board persisted indefinitely, pushing live warnings past the panel's row cap.
+
+**`warnings.ClearMissing(warningType string, present map[string]bool) ([]string, error)`** is the shared
+bulk-predicate primitive both sweeps below use. `warnings.Clear(key)` always calls `save()` even when
+`key` was never present — a caller-side loop over N possibly-stale keys would therefore write the file
+on every poll unless every caller independently pre-filters correctly. `ClearMissing` removes that
+footgun structurally: it loads the file once, removes every entry whose `Type == warningType` and whose
+`Key` subject (the portion after `"<warningType>:"`) is absent from `present`, and only calls `save()`
+when at least one entry was actually removed. Entries of other `Type`s are never touched regardless of
+`Key`, and a present-subject entry is preserved whether or not it is `Dismissed` — the sweep is about
+*absent subjects*, not about un-dismissing anything still around. Returns the full `Key` of each cleared
+entry for the caller to log.
+
+**`allow_auto_merge` (repo-keyed, per-poll).** `sweepStaleAllowAutoMergeWarnings`
+(`engine/allow_auto_merge_settle.go`) is called from `poll()` immediately after `seenRepos` — the board
+repo set `poll()` already computes for the label-seeding path (`poll.go` ~line 925) — is built, before
+the label-seeding loop runs. It calls `warnings.ClearMissing("allow_auto_merge", present)` with `present`
+= `seenRepos` unioned with `e.defaultRepo()` (single-repo mode only). The union matters:
+`checkAllowAutoMerge(e.cfg.Owner, e.cfg.Repo)` fires unconditionally at `Run()` startup regardless of
+whether the board currently has any open items for that repo, but `seenRepos` is built purely from
+`board.Items` — without the union, a transient zero-open-items poll for the operator's own configured
+repo (e.g. everything currently in Done) would durably clear a legitimate warning for it, and because
+`checkedAutoMergeRepos` never re-fires for that repo after the first startup call, the warning would not
+reappear until a process restart. Multi-repo mode (`e.cfg.Repo == ""`) has no equivalent always-present
+repo, so `defaultRepo()` returning `""` is a correct no-op there. Runs every poll, because `seenRepos`
+itself is rebuilt every poll (a repo leaving/rejoining the board is visible immediately). No new API
+calls: everything consumed is already computed this poll cycle. Each clear logs one line (tag
+`"startup"`) naming the full key and the reason ("repo no longer on the board").
+
+**`stage_drift` / `undeclared_reviewers` (stage-name-keyed, startup-only).** `stages.SweepStaleWarnings`
+(`stages/drift.go`) is called once from `Run()`, immediately after the existing `WarnStageDrift`/
+`WarnUndeclaredReviewers` calls (both the `e.logFile != nil` and the plain-stderr branch), with the same
+unfiltered `e.cfg.Stages` those two functions themselves consume — using the `Unmanaged`-excluding
+`stageNames` list built later in `poll.go` for `SeedLabels` would wrongly sweep a still-valid `Unmanaged`
+stage's warning. It builds the current stage-name set and calls `warnings.ClearMissing` twice, once per
+`Type`. Startup-only (not per-poll) is correct here, unlike the repo sweep: `e.cfg.Stages` is fixed for
+the life of the process and only changes across a restart (including the in-place SIGHUP restart, which
+re-execs and re-runs `Run()` from scratch), so re-running the sweep every poll would be correct but
+pointless. Each clear logs one line naming the full key and the reason ("stage no longer configured"),
+written to the same `io.Writer` (`os.Stderr`, tee'd to `fabrik.log` when open) as the sibling drift/
+undeclared-reviewers warnings.
+
+**`version_skew`: no sweep needed, by construction.** `checkVersionSkew`'s (`engine/upgrade.go`) key
+subject is the resolved on-disk executable path, re-derived fresh via `filepath.EvalSymlinks` on *every*
+idle-upgrade check (`poll.go`), not looked up against a shrinking discovered set the way a board repo or
+a configured stage name is. Its `Clear` branch (`diskVersion == running`) is therefore reachable on every
+single evaluation, so the warning can never outlive the condition that produced it — see the doc comment
+on `checkVersionSkew` for the same reasoning in code.
+
+**Non-goals.** No change to which conditions *produce* a warning, no TUI rendering change, and this is
+not a general warning-expiry/TTL mechanism — only subjects that have provably gone away (absent from a
+known-good set already computed elsewhere) are ever cleared. See ADR-1348.
+
 ---
 
 ## 8. Invalid / Unexpected States

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2436,7 +2436,7 @@ Tab into the Warnings panel to take action:
 - **S** — show/hide dismissed entries
 - **Enter** — expand/collapse the full detail text for the selected entry
 
-Warning entries persist to `.fabrik/warnings.json` and survive auto-upgrade restarts. Dismissed entries are preserved in the file until the underlying condition clears, at which point they are removed entirely.
+Warning entries persist to `.fabrik/warnings.json` and survive auto-upgrade restarts. Dismissed entries are preserved in the file until the underlying condition clears, at which point they are removed entirely. This includes the condition's *subject* going away entirely (e.g. a repo leaving the project board, or a stage being renamed) — a per-poll or startup sweep clears those automatically too, without requiring a restart (see `docs/state-machine.md` §7.11).
 
 ### History Persistence
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5700,8 +5700,10 @@ repo (e.g. everything currently in Done) would durably clear a legitimate warnin
 reappear until a process restart. Multi-repo mode (`e.cfg.Repo == ""`) has no equivalent always-present
 repo, so `defaultRepo()` returning `""` is a correct no-op there. Runs every poll, because `seenRepos`
 itself is rebuilt every poll (a repo leaving/rejoining the board is visible immediately). No new API
-calls: everything consumed is already computed this poll cycle. Each clear logs one line (tag
-`"startup"`) naming the full key and the reason ("repo no longer on the board").
+calls: everything consumed is already computed this poll cycle. Each clear logs one line (tag `"poll"`,
+matching the cadence of the other per-poll log lines it sits next to — not `"startup"`, which the
+codebase reserves for once-per-process/once-per-repo events) naming the full key and the reason ("repo
+no longer on the board").
 
 **`stage_drift` / `undeclared_reviewers` (stage-name-keyed, startup-only).** `stages.SweepStaleWarnings`
 (`stages/drift.go`) is called once from `Run()`, immediately after the existing `WarnStageDrift`/

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2557,8 +2557,10 @@ repo (e.g. everything currently in Done) would durably clear a legitimate warnin
 reappear until a process restart. Multi-repo mode (`e.cfg.Repo == ""`) has no equivalent always-present
 repo, so `defaultRepo()` returning `""` is a correct no-op there. Runs every poll, because `seenRepos`
 itself is rebuilt every poll (a repo leaving/rejoining the board is visible immediately). No new API
-calls: everything consumed is already computed this poll cycle. Each clear logs one line (tag
-`"startup"`) naming the full key and the reason ("repo no longer on the board").
+calls: everything consumed is already computed this poll cycle. Each clear logs one line (tag `"poll"`,
+matching the cadence of the other per-poll log lines it sits next to — not `"startup"`, which the
+codebase reserves for once-per-process/once-per-repo events) naming the full key and the reason ("repo
+no longer on the board").
 
 **`stage_drift` / `undeclared_reviewers` (stage-name-keyed, startup-only).** `stages.SweepStaleWarnings`
 (`stages/drift.go`) is called once from `Run()`, immediately after the existing `WarnStageDrift`/

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2522,6 +2522,68 @@ A detected stall still applies `StageRetryIncremented` and counts against `MaxRe
 
 **Scope note:** this implements only the "cheaper to detect" trend signal from issue #1146 — a turn-capped attempt followed by a declining, incomplete one. It does not add live NDJSON tool-use parsing to detect backgrounding-then-silence within a single invocation (the issue's other suggested signal); that remains a possible follow-up if the trend signal proves insufficient in practice.
 
+### 7.11 Stale Warning Sweep
+
+`.fabrik/warnings.json` (`warnings/warnings.go`, ADR-052) backs the TUI's Warnings panel. Several
+engine-side detectors record an entry when a condition is true and clear it via `warnings.Clear` when
+the *same* re-checked subject's condition resolves — but a subject that stops being checked at all (a
+repo leaves the board, a stage is renamed or its YAML deleted) never revisits the `Clear` branch, so its
+entry is immortal. This is the same durable-state-leak shape as the orphaned `stage:*:in_progress`
+labels (#1135) and the `fabrik:claude-limit` account-wide label before §7.3's sweep (ADR-1183). Observed
+in production on the `verveguy` project (#1348): four `allow_auto_merge` warnings for repos that had
+left the board persisted indefinitely, pushing live warnings past the panel's row cap.
+
+**`warnings.ClearMissing(warningType string, present map[string]bool) ([]string, error)`** is the shared
+bulk-predicate primitive both sweeps below use. `warnings.Clear(key)` always calls `save()` even when
+`key` was never present — a caller-side loop over N possibly-stale keys would therefore write the file
+on every poll unless every caller independently pre-filters correctly. `ClearMissing` removes that
+footgun structurally: it loads the file once, removes every entry whose `Type == warningType` and whose
+`Key` subject (the portion after `"<warningType>:"`) is absent from `present`, and only calls `save()`
+when at least one entry was actually removed. Entries of other `Type`s are never touched regardless of
+`Key`, and a present-subject entry is preserved whether or not it is `Dismissed` — the sweep is about
+*absent subjects*, not about un-dismissing anything still around. Returns the full `Key` of each cleared
+entry for the caller to log.
+
+**`allow_auto_merge` (repo-keyed, per-poll).** `sweepStaleAllowAutoMergeWarnings`
+(`engine/allow_auto_merge_settle.go`) is called from `poll()` immediately after `seenRepos` — the board
+repo set `poll()` already computes for the label-seeding path (`poll.go` ~line 925) — is built, before
+the label-seeding loop runs. It calls `warnings.ClearMissing("allow_auto_merge", present)` with `present`
+= `seenRepos` unioned with `e.defaultRepo()` (single-repo mode only). The union matters:
+`checkAllowAutoMerge(e.cfg.Owner, e.cfg.Repo)` fires unconditionally at `Run()` startup regardless of
+whether the board currently has any open items for that repo, but `seenRepos` is built purely from
+`board.Items` — without the union, a transient zero-open-items poll for the operator's own configured
+repo (e.g. everything currently in Done) would durably clear a legitimate warning for it, and because
+`checkedAutoMergeRepos` never re-fires for that repo after the first startup call, the warning would not
+reappear until a process restart. Multi-repo mode (`e.cfg.Repo == ""`) has no equivalent always-present
+repo, so `defaultRepo()` returning `""` is a correct no-op there. Runs every poll, because `seenRepos`
+itself is rebuilt every poll (a repo leaving/rejoining the board is visible immediately). No new API
+calls: everything consumed is already computed this poll cycle. Each clear logs one line (tag
+`"startup"`) naming the full key and the reason ("repo no longer on the board").
+
+**`stage_drift` / `undeclared_reviewers` (stage-name-keyed, startup-only).** `stages.SweepStaleWarnings`
+(`stages/drift.go`) is called once from `Run()`, immediately after the existing `WarnStageDrift`/
+`WarnUndeclaredReviewers` calls (both the `e.logFile != nil` and the plain-stderr branch), with the same
+unfiltered `e.cfg.Stages` those two functions themselves consume — using the `Unmanaged`-excluding
+`stageNames` list built later in `poll.go` for `SeedLabels` would wrongly sweep a still-valid `Unmanaged`
+stage's warning. It builds the current stage-name set and calls `warnings.ClearMissing` twice, once per
+`Type`. Startup-only (not per-poll) is correct here, unlike the repo sweep: `e.cfg.Stages` is fixed for
+the life of the process and only changes across a restart (including the in-place SIGHUP restart, which
+re-execs and re-runs `Run()` from scratch), so re-running the sweep every poll would be correct but
+pointless. Each clear logs one line naming the full key and the reason ("stage no longer configured"),
+written to the same `io.Writer` (`os.Stderr`, tee'd to `fabrik.log` when open) as the sibling drift/
+undeclared-reviewers warnings.
+
+**`version_skew`: no sweep needed, by construction.** `checkVersionSkew`'s (`engine/upgrade.go`) key
+subject is the resolved on-disk executable path, re-derived fresh via `filepath.EvalSymlinks` on *every*
+idle-upgrade check (`poll.go`), not looked up against a shrinking discovered set the way a board repo or
+a configured stage name is. Its `Clear` branch (`diskVersion == running`) is therefore reachable on every
+single evaluation, so the warning can never outlive the condition that produced it — see the doc comment
+on `checkVersionSkew` for the same reasoning in code.
+
+**Non-goals.** No change to which conditions *produce* a warning, no TUI rendering change, and this is
+not a general warning-expiry/TTL mechanism — only subjects that have provably gone away (absent from a
+known-good set already computed elsewhere) are ever cleared. See ADR-1348.
+
 ---
 
 ## 8. Invalid / Unexpected States

--- a/engine/allow_auto_merge_settle.go
+++ b/engine/allow_auto_merge_settle.go
@@ -1,0 +1,49 @@
+package engine
+
+import "github.com/handarbeit/fabrik/warnings"
+
+// sweepStaleAllowAutoMergeWarnings clears any recorded allow_auto_merge
+// warning whose subject repo is no longer present on the current board
+// (#1348). checkAllowAutoMerge's own Clear call is only reachable when a
+// repo is re-checked AND auto-merge is now enabled — a repo that has left
+// the board entirely is never re-checked at all, so its warning is
+// otherwise immortal, the same durable-state-leak shape as the orphaned
+// stage:*:in_progress labels (#1135) and the fabrik:claude-limit sweep
+// (ADR-1183).
+//
+// seenRepos is the poll()-local set already computed from board.Items for
+// the label-seeding path (R2: no new fetch) — this sweep must be called
+// with that same set, not an independently recomputed one.
+//
+// The engine's own configured repo (single-repo mode only) is unioned in
+// before comparing: checkAllowAutoMerge(e.cfg.Owner, e.cfg.Repo) fires
+// unconditionally at Run() startup regardless of whether the board
+// currently has any open items for that repo, but seenRepos is built
+// purely from board.Items. Without this exemption, a transient
+// zero-open-items poll for the operator's own configured repo (e.g.
+// everything currently in Done) would durably clear a legitimate warning —
+// and because checkedAutoMergeRepos never re-fires for that repo after the
+// first startup call, the warning would not come back until a process
+// restart. Multi-repo mode (e.cfg.Repo == "") has no equivalent
+// always-present repo, so defaultRepo() returning "" is a correct no-op
+// here.
+//
+// Runs every poll (cheap: warnings.ClearMissing performs a single load, and
+// only saves when something was actually stale — R4/AC5). No API calls.
+func (e *Engine) sweepStaleAllowAutoMergeWarnings(seenRepos map[string]bool) {
+	present := make(map[string]bool, len(seenRepos)+1)
+	for r := range seenRepos {
+		present[r] = true
+	}
+	if dr := e.defaultRepo(); dr != "" {
+		present[dr] = true
+	}
+	cleared, err := warnings.ClearMissing("allow_auto_merge", present)
+	if err != nil {
+		e.logf(0, "warn", "stale allow_auto_merge warning sweep failed: %v\n", err)
+		return
+	}
+	for _, key := range cleared {
+		e.logf(0, "startup", "cleared stale warning %s: repo no longer on the board\n", key)
+	}
+}

--- a/engine/allow_auto_merge_settle.go
+++ b/engine/allow_auto_merge_settle.go
@@ -30,6 +30,17 @@ import "github.com/handarbeit/fabrik/warnings"
 //
 // Runs every poll (cheap: warnings.ClearMissing performs a single load, and
 // only saves when something was actually stale — R4/AC5). No API calls.
+//
+// present is required to be non-empty before any clearing is attempted: in
+// multi-repo mode, retryOnEmpty (github/project.go) can still exhaust its
+// retries and return a genuinely zero-item board (e.g. a persistent indexer
+// hiccup, or a project that's transiently empty of open items across every
+// configured repo). Unlike single-repo mode, multi-repo has no defaultRepo()
+// to fall back on, so an empty seenRepos would otherwise make every
+// allow_auto_merge warning for every repo look "absent" and wipe them all in
+// one pass. Skipping the sweep entirely when present is empty mirrors the
+// same "never destructively act on zero signal" reasoning behind the
+// single-repo defaultRepo() exemption above.
 func (e *Engine) sweepStaleAllowAutoMergeWarnings(seenRepos map[string]bool) {
 	present := make(map[string]bool, len(seenRepos)+1)
 	for r := range seenRepos {
@@ -37,6 +48,9 @@ func (e *Engine) sweepStaleAllowAutoMergeWarnings(seenRepos map[string]bool) {
 	}
 	if dr := e.defaultRepo(); dr != "" {
 		present[dr] = true
+	}
+	if len(present) == 0 {
+		return
 	}
 	cleared, err := warnings.ClearMissing("allow_auto_merge", present)
 	if err != nil {

--- a/engine/allow_auto_merge_settle.go
+++ b/engine/allow_auto_merge_settle.go
@@ -58,6 +58,6 @@ func (e *Engine) sweepStaleAllowAutoMergeWarnings(seenRepos map[string]bool) {
 		return
 	}
 	for _, key := range cleared {
-		e.logf(0, "startup", "cleared stale warning %s: repo no longer on the board\n", key)
+		e.logf(0, "poll", "cleared stale warning %s: repo no longer on the board\n", key)
 	}
 }

--- a/engine/allow_auto_merge_settle_test.go
+++ b/engine/allow_auto_merge_settle_test.go
@@ -200,3 +200,49 @@ func TestSweepStaleAllowAutoMergeWarnings_MultiRepoModeNoExemption(t *testing.T)
 		t.Fatalf("expected multi-repo mode to have no exemption, got %v", entries)
 	}
 }
+
+// TestSweepStaleAllowAutoMergeWarnings_MultiRepoModeEmptyBoardSkipsSweep
+// guards against the destructive-wipe shape flagged in review: in multi-repo
+// mode there is no defaultRepo() to fall back on, so a genuinely empty
+// seenRepos (e.g. retryOnEmpty in github/project.go exhausting retries on a
+// persistent indexer hiccup) would otherwise make every recorded
+// allow_auto_merge warning look "absent" and clear them all in one pass. The
+// sweep must skip entirely — not just skip clearing a specific repo — when
+// it has zero signal to compare against.
+func TestSweepStaleAllowAutoMergeWarnings_MultiRepoModeEmptyBoardSkipsSweep(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "allow_auto_merge:owner/repo", Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	eng := NewWithDeps(
+		Config{
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		&mockGitHubClient{},
+		&mockClaudeInvoker{},
+		NewWorktreeManager(t.TempDir()),
+	)
+
+	before, err := os.Stat(warnings.WarningsPathOverride)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 || entries[0].Key != "allow_auto_merge:owner/repo" {
+		t.Fatalf("expected warning preserved when the board is empty in multi-repo mode, got %v", entries)
+	}
+	after, err := os.Stat(warnings.WarningsPathOverride)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("expected no write when the sweep is skipped; mtime changed from %v to %v", before.ModTime(), after.ModTime())
+	}
+}

--- a/engine/allow_auto_merge_settle_test.go
+++ b/engine/allow_auto_merge_settle_test.go
@@ -1,0 +1,202 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/handarbeit/fabrik/warnings"
+)
+
+func setWarningsOverride(t *testing.T) {
+	t.Helper()
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	t.Cleanup(func() { warnings.WarningsPathOverride = "" })
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_ClearsAbsentRepo is AC1: a recorded
+// allow_auto_merge warning for a repo absent from the current board is
+// cleared by the sweep. Neutralizing the sweep call (removing it from
+// poll()) makes this fail, proving the test is non-vacuous per the issue's
+// Verification note.
+func TestSweepStaleAllowAutoMergeWarnings_ClearsAbsentRepo(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{
+		Key:  "allow_auto_merge:gone/repo",
+		Type: "allow_auto_merge",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{"owner/repo": true})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 0 {
+		t.Fatalf("expected absent-repo warning cleared, got %v", entries)
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_PreservesPresentRepo is AC2: a
+// warning for a repo still on the board is not cleared, regardless of its
+// auto-merge state. This is the guard against over-clearing.
+func TestSweepStaleAllowAutoMergeWarnings_PreservesPresentRepo(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{
+		Key:  "allow_auto_merge:owner/repo",
+		Type: "allow_auto_merge",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{"owner/repo": true})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 || entries[0].Key != "allow_auto_merge:owner/repo" {
+		t.Fatalf("expected present-repo warning preserved, got %v", entries)
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_IgnoresOtherTypes is AC3.
+func TestSweepStaleAllowAutoMergeWarnings_IgnoresOtherTypes(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{
+		Key:  "stage_drift:SomeStage",
+		Type: "stage_drift",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+
+	// Empty board — if the sweep mis-scoped by Type, this would clear the
+	// stage_drift entry too.
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 || entries[0].Key != "stage_drift:SomeStage" {
+		t.Fatalf("expected unrelated warning type untouched, got %v", entries)
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_PreservesDismissed is AC4: a
+// dismissed warning for a repo still on the board stays present and
+// dismissed.
+func TestSweepStaleAllowAutoMergeWarnings_PreservesDismissed(t *testing.T) {
+	setWarningsOverride(t)
+	key := "allow_auto_merge:owner/repo"
+	if err := warnings.Record(warnings.Entry{Key: key, Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := warnings.Dismiss(key); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{"owner/repo": true})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 || !entries[0].Dismissed {
+		t.Fatalf("expected dismissed entry preserved and still dismissed, got %v", entries)
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_NoWriteWhenNothingStale is AC5: no
+// API calls (mockGitHubClient with no fetchAllowAutoMergeFn would panic if
+// called) and no write when nothing needs clearing.
+func TestSweepStaleAllowAutoMergeWarnings_NoWriteWhenNothingStale(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "allow_auto_merge:owner/repo", Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+
+	before, err := os.Stat(warnings.WarningsPathOverride)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{"owner/repo": true})
+
+	after, err := os.Stat(warnings.WarningsPathOverride)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("expected no write when nothing stale; mtime changed from %v to %v", before.ModTime(), after.ModTime())
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_LogsOncePerClear is AC6: exactly one
+// log line per clear, naming the key and the reason.
+func TestSweepStaleAllowAutoMergeWarnings_LogsOncePerClear(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "allow_auto_merge:gone/repo", Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+
+	out := captureStdout(func() {
+		eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{"owner/repo": true})
+	})
+
+	if got := strings.Count(out, "allow_auto_merge:gone/repo"); got != 1 {
+		t.Fatalf("expected exactly one log line naming the key, got %d in: %q", got, out)
+	}
+	if !strings.Contains(out, "no longer on the board") {
+		t.Errorf("expected log line to name the reason, got: %q", out)
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_ExemptsConfiguredRepo covers the
+// single-repo-mode edge case surfaced in Research: checkAllowAutoMerge for
+// the engine's own configured repo fires unconditionally at startup, but a
+// transient poll with zero open items for that repo must not durably clear
+// a legitimate warning for it.
+func TestSweepStaleAllowAutoMergeWarnings_ExemptsConfiguredRepo(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "allow_auto_merge:owner/repo", Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{}) // Owner="owner", Repo="repo"
+
+	// seenRepos is empty — the board has no open items for the configured
+	// repo right now — but the warning must survive via the defaultRepo()
+	// union.
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 {
+		t.Fatalf("expected configured repo's warning exempted from sweep, got %v", entries)
+	}
+}
+
+// TestSweepStaleAllowAutoMergeWarnings_MultiRepoModeNoExemption confirms
+// multi-repo mode (Owner=="" && Repo=="") has no always-present repo:
+// defaultRepo() returns "" and is correctly a no-op union.
+func TestSweepStaleAllowAutoMergeWarnings_MultiRepoModeNoExemption(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "allow_auto_merge:gone/repo", Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+	eng := NewWithDeps(
+		Config{
+			ProjectNum:    1,
+			User:          "testuser",
+			Token:         "token",
+			MaxConcurrent: 5,
+			Stages:        testStages(),
+		},
+		&mockGitHubClient{},
+		&mockClaudeInvoker{},
+		NewWorktreeManager(t.TempDir()),
+	)
+
+	eng.sweepStaleAllowAutoMergeWarnings(map[string]bool{"other/repo": true})
+
+	entries, _ := warnings.Load()
+	if len(entries) != 0 {
+		t.Fatalf("expected multi-repo mode to have no exemption, got %v", entries)
+	}
+}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -143,10 +143,12 @@ func (e *Engine) Run() error {
 		w := io.MultiWriter(os.Stderr, e.logFile)
 		stages.WarnStageDrift(e.cfg.Stages, e.cfg.Version, w)
 		stages.WarnUndeclaredReviewers(e.cfg.Stages, w)
+		stages.SweepStaleWarnings(e.cfg.Stages, w)
 		logClaudeConfigDir(configDir, w)
 	} else {
 		stages.WarnStageDrift(e.cfg.Stages, e.cfg.Version, os.Stderr)
 		stages.WarnUndeclaredReviewers(e.cfg.Stages, os.Stderr)
+		stages.SweepStaleWarnings(e.cfg.Stages, os.Stderr)
 		logClaudeConfigDir(configDir, os.Stderr)
 	}
 
@@ -954,6 +956,11 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 		}
 		e.logf(0, "poll", "repos on board: %v\n", repos)
 	}
+
+	// Clear any allow_auto_merge warning whose subject repo has left the
+	// board entirely — see sweepStaleAllowAutoMergeWarnings for why this
+	// can't be reached by checkAllowAutoMerge's own Clear branch (#1348).
+	e.sweepStaleAllowAutoMergeWarnings(seenRepos)
 
 	// Seed labels on repos discovered for the first time this process run.
 	// seededRepos is guarded by e.mu; the poll loop is single-goroutine but

--- a/engine/upgrade.go
+++ b/engine/upgrade.go
@@ -103,6 +103,14 @@ var versionSkewExecCommandFn = exec.CommandContext
 // syscall.Exec re-exec, or a manual/external replacement (e.g. a fleet
 // sharing ~/go/bin/fabrik). Non-fatal: any error resolving the path or
 // running the subprocess is logged and the check is skipped for this poll.
+//
+// Unlike allow_auto_merge/stage_drift/undeclared_reviewers (#1348), this
+// warning needs no separate stale-sweep. Its key's subject — the resolved
+// on-disk executable path — is re-derived fresh on every idle-upgrade check
+// (poll.go), not looked up against a shrinking discovered set (board repos,
+// configured stages). The Clear branch below is therefore reachable on
+// every single evaluation, so the warning can never outlive the condition
+// that produced it.
 func (e *Engine) checkVersionSkew(ctx context.Context) {
 	exe, err := versionSkewExecutableFn()
 	if err != nil {

--- a/stages/drift.go
+++ b/stages/drift.go
@@ -181,7 +181,20 @@ func WarnUndeclaredReviewers(userStages []*Stage, w io.Writer) {
 // Startup-only, not per-poll: the known-good set (stage names) is fixed for
 // the life of the process and only changes across a restart, unlike
 // allow_auto_merge's per-poll-refreshed board repo set.
+//
+// Guards against an empty/nil userStages the same way WarnStageDrift does:
+// cmd/root.go already fails startup before Run() is ever reached if stage
+// loading produces zero configs, so this should be unreachable in practice —
+// but without the guard, an empty present set would make every currently
+// recorded stage_drift/undeclared_reviewers entry look "absent" and wipe
+// them all in one pass. Matching WarnStageDrift's own no-op keeps the two
+// functions consistent and removes that failure mode even if the invariant
+// is ever violated (e.g. a future caller that doesn't go through
+// cmd/root.go's validation).
 func SweepStaleWarnings(userStages []*Stage, w io.Writer) {
+	if len(userStages) == 0 {
+		return
+	}
 	present := make(map[string]bool, len(userStages))
 	for _, s := range userStages {
 		present[s.Name] = true

--- a/stages/drift.go
+++ b/stages/drift.go
@@ -165,6 +165,39 @@ func WarnUndeclaredReviewers(userStages []*Stage, w io.Writer) {
 	}
 }
 
+// SweepStaleWarnings clears stage_drift and undeclared_reviewers warnings
+// for stage names no longer present in userStages (#1348). Both
+// WarnStageDrift and WarnUndeclaredReviewers only reach their own
+// warnings.Clear branch for a name they actually visit this pass — a
+// renamed or deleted stage YAML is therefore never visited again, and its
+// warning is otherwise immortal, the same durable-state-leak shape as
+// allow_auto_merge (see sweepStaleAllowAutoMergeWarnings in engine/).
+//
+// userStages must be the same unfiltered set WarnStageDrift/
+// WarnUndeclaredReviewers themselves consume (including Unmanaged/cleanup
+// stages) — comparing against a filtered subset would wrongly sweep a
+// still-valid stage's warning.
+//
+// Startup-only, not per-poll: the known-good set (stage names) is fixed for
+// the life of the process and only changes across a restart, unlike
+// allow_auto_merge's per-poll-refreshed board repo set.
+func SweepStaleWarnings(userStages []*Stage, w io.Writer) {
+	present := make(map[string]bool, len(userStages))
+	for _, s := range userStages {
+		present[s.Name] = true
+	}
+	for _, warningType := range []string{"stage_drift", "undeclared_reviewers"} {
+		cleared, err := warnings.ClearMissing(warningType, present)
+		if err != nil {
+			fmt.Fprintf(w, "[startup] warning: stale %s warning sweep failed: %v\n", warningType, err)
+			continue
+		}
+		for _, key := range cleared {
+			fmt.Fprintf(w, "[startup] cleared stale warning %s: stage no longer configured\n", key)
+		}
+	}
+}
+
 // driftTitle builds the one-line warnings-panel title for a stage-drift entry.
 // It names the missing keys (not just their count) so the summary is actionable
 // without drilling into the detail view.

--- a/stages/drift_test.go
+++ b/stages/drift_test.go
@@ -439,6 +439,78 @@ func TestMissingTopLevelKeys_SortedOutput(t *testing.T) {
 	}
 }
 
+func TestSweepStaleWarnings_ClearsRenamedOrRemovedStage(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "stage_drift:OldName", Type: "stage_drift"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := warnings.Record(warnings.Entry{Key: "undeclared_reviewers:OldName", Type: "undeclared_reviewers"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	SweepStaleWarnings([]*Stage{{Name: "NewName"}}, &buf)
+
+	entries, _ := warnings.Load()
+	if len(entries) != 0 {
+		t.Fatalf("expected both stale entries cleared, got %v", entries)
+	}
+	if !strings.Contains(buf.String(), "stage_drift:OldName") || !strings.Contains(buf.String(), "undeclared_reviewers:OldName") {
+		t.Errorf("expected log to name both cleared keys, got: %q", buf.String())
+	}
+}
+
+func TestSweepStaleWarnings_PreservesConfiguredStage(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "stage_drift:Implement", Type: "stage_drift"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	SweepStaleWarnings([]*Stage{{Name: "Implement"}}, &buf)
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 || entries[0].Key != "stage_drift:Implement" {
+		t.Fatalf("expected still-configured stage's warning preserved, got %v", entries)
+	}
+	if buf.String() != "" {
+		t.Errorf("expected no log output when nothing stale, got: %q", buf.String())
+	}
+}
+
+func TestSweepStaleWarnings_IgnoresOtherTypes(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "allow_auto_merge:owner/repo", Type: "allow_auto_merge"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	SweepStaleWarnings(nil, &buf)
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 || entries[0].Key != "allow_auto_merge:owner/repo" {
+		t.Fatalf("expected unrelated warning type untouched, got %v", entries)
+	}
+}
+
+func TestSweepStaleWarnings_IncludesUnmanagedStages(t *testing.T) {
+	// The sweep must be called with the unfiltered stage set (including
+	// Unmanaged stages) — otherwise a currently-valid Unmanaged stage's
+	// warning would be wrongly swept.
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "stage_drift:Backlog", Type: "stage_drift"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	SweepStaleWarnings([]*Stage{{Name: "Backlog", Unmanaged: true}}, &buf)
+
+	entries, _ := warnings.Load()
+	if len(entries) != 1 {
+		t.Fatalf("expected Unmanaged stage's warning preserved, got %v", entries)
+	}
+}
+
 func TestDriftTitle_NamesMissingFields(t *testing.T) {
 	// The summary title must name the missing key(s), not just their count, so
 	// the warnings panel is actionable without opening the detail view.

--- a/stages/drift_test.go
+++ b/stages/drift_test.go
@@ -493,6 +493,35 @@ func TestSweepStaleWarnings_IgnoresOtherTypes(t *testing.T) {
 	}
 }
 
+// TestSweepStaleWarnings_EmptyUserStagesPreservesEntries guards against the
+// destructive-wipe shape flagged in review: without an early return for an
+// empty/nil userStages (matching WarnStageDrift's own guard), a present set
+// derived from zero stages would make every recorded stage_drift/
+// undeclared_reviewers entry look "absent" and clear them all in one pass.
+// cmd/root.go already fails startup before Run() is reached if stage loading
+// produces zero configs, so this is normally unreachable — the guard is
+// defense in depth for any future caller that bypasses that validation.
+func TestSweepStaleWarnings_EmptyUserStagesPreservesEntries(t *testing.T) {
+	setWarningsOverride(t)
+	if err := warnings.Record(warnings.Entry{Key: "stage_drift:Implement", Type: "stage_drift"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := warnings.Record(warnings.Entry{Key: "undeclared_reviewers:Implement", Type: "undeclared_reviewers"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	SweepStaleWarnings(nil, &buf)
+
+	entries, _ := warnings.Load()
+	if len(entries) != 2 {
+		t.Fatalf("expected both entries preserved when userStages is empty, got %v", entries)
+	}
+	if buf.String() != "" {
+		t.Errorf("expected no log output when the sweep is skipped, got: %q", buf.String())
+	}
+}
+
 func TestSweepStaleWarnings_IncludesUnmanagedStages(t *testing.T) {
 	// The sweep must be called with the unfiltered stage set (including
 	// Unmanaged stages) — otherwise a currently-valid Unmanaged stage's

--- a/warnings/warnings.go
+++ b/warnings/warnings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -153,6 +154,46 @@ func Clear(key string) error {
 	}
 	wf.Entries = filtered
 	return save(wf)
+}
+
+// ClearMissing removes every entry of the given warningType whose subject —
+// the portion of Key after the "<warningType>:" prefix — is not a key in
+// present. It is the bulk counterpart to Clear, built for settle scans that
+// compare a set of recorded warnings against an already-known-good set (e.g.
+// the current board repos, or the current stage names): rather than looping
+// per-key calls to Clear (which always calls save() even when the key was
+// never present), ClearMissing loads once, filters in memory, and only saves
+// when at least one entry was actually removed — so a poll with nothing
+// stale performs zero writes. Entries of other Types are never touched,
+// regardless of their Key. Dismissed is not special-cased: a stale entry is
+// removed whether or not it was dismissed, matching Clear's behavior; a
+// present-subject entry (dismissed or not) is always preserved. Returns the
+// full Key of each cleared entry, for caller-side logging.
+func ClearMissing(warningType string, present map[string]bool) ([]string, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	wf, err := load()
+	if err != nil {
+		return nil, err
+	}
+	prefix := warningType + ":"
+	var cleared []string
+	filtered := wf.Entries[:0]
+	for _, e := range wf.Entries {
+		if e.Type == warningType && !present[strings.TrimPrefix(e.Key, prefix)] {
+			cleared = append(cleared, e.Key)
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	if len(cleared) == 0 {
+		return nil, nil
+	}
+	wf.Entries = filtered
+	if err := save(wf); err != nil {
+		return nil, err
+	}
+	return cleared, nil
 }
 
 // Dismiss sets dismissed=true for the entry with the given key.

--- a/warnings/warnings_test.go
+++ b/warnings/warnings_test.go
@@ -207,6 +207,112 @@ func TestLoad_VersionMismatch(t *testing.T) {
 	}
 }
 
+func TestClearMissing_RemovesAbsentSubject(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "allow_auto_merge:owner/gone", Type: "allow_auto_merge", Title: "gone"}); err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := ClearMissing("allow_auto_merge", map[string]bool{"owner/present": true})
+	if err != nil {
+		t.Fatalf("ClearMissing: %v", err)
+	}
+	if len(cleared) != 1 || cleared[0] != "allow_auto_merge:owner/gone" {
+		t.Fatalf("expected [allow_auto_merge:owner/gone] cleared, got %v", cleared)
+	}
+	entries, _ := Load()
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries remaining, got %v", entries)
+	}
+}
+
+func TestClearMissing_PreservesPresentSubject(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "allow_auto_merge:owner/present", Type: "allow_auto_merge", Title: "present"}); err != nil {
+		t.Fatal(err)
+	}
+	cleared, err := ClearMissing("allow_auto_merge", map[string]bool{"owner/present": true})
+	if err != nil {
+		t.Fatalf("ClearMissing: %v", err)
+	}
+	if len(cleared) != 0 {
+		t.Fatalf("expected nothing cleared, got %v", cleared)
+	}
+	entries, _ := Load()
+	if len(entries) != 1 || entries[0].Key != "allow_auto_merge:owner/present" {
+		t.Fatalf("expected entry preserved, got %v", entries)
+	}
+}
+
+func TestClearMissing_PreservesDismissedPresentSubject(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "allow_auto_merge:owner/present", Type: "allow_auto_merge", Title: "present"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Dismiss("allow_auto_merge:owner/present"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ClearMissing("allow_auto_merge", map[string]bool{"owner/present": true}); err != nil {
+		t.Fatalf("ClearMissing: %v", err)
+	}
+	entries, _ := Load()
+	if len(entries) != 1 || !entries[0].Dismissed {
+		t.Fatalf("expected dismissed entry preserved and still dismissed, got %v", entries)
+	}
+}
+
+func TestClearMissing_IgnoresOtherTypes(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "stage_drift:SomeStage", Type: "stage_drift", Title: "drift"}); err != nil {
+		t.Fatal(err)
+	}
+	// Empty present set for allow_auto_merge — a stage_drift entry must never
+	// be swept by a call scoped to a different Type, regardless of subject.
+	cleared, err := ClearMissing("allow_auto_merge", map[string]bool{})
+	if err != nil {
+		t.Fatalf("ClearMissing: %v", err)
+	}
+	if len(cleared) != 0 {
+		t.Fatalf("expected nothing cleared, got %v", cleared)
+	}
+	entries, _ := Load()
+	if len(entries) != 1 || entries[0].Key != "stage_drift:SomeStage" {
+		t.Fatalf("expected stage_drift entry untouched, got %v", entries)
+	}
+}
+
+func TestClearMissing_NoWriteWhenNothingStale(t *testing.T) {
+	setOverride(t)
+	if err := Record(Entry{Key: "allow_auto_merge:owner/present", Type: "allow_auto_merge", Title: "present"}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(WarningsPathOverride)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if _, err := ClearMissing("allow_auto_merge", map[string]bool{"owner/present": true}); err != nil {
+		t.Fatalf("ClearMissing: %v", err)
+	}
+	after, err := os.Stat(WarningsPathOverride)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("expected no write (mtime unchanged), before=%v after=%v", before.ModTime(), after.ModTime())
+	}
+}
+
+func TestClearMissing_NoFileCreatedWhenMissing(t *testing.T) {
+	setOverride(t)
+	// No file exists yet — ClearMissing must not create one.
+	if _, err := ClearMissing("allow_auto_merge", map[string]bool{}); err != nil {
+		t.Fatalf("ClearMissing: %v", err)
+	}
+	if _, err := os.Stat(WarningsPathOverride); !os.IsNotExist(err) {
+		t.Errorf("expected no file created, stat err = %v", err)
+	}
+}
+
 func TestConcurrentRecord(t *testing.T) {
 	setOverride(t)
 	var wg sync.WaitGroup


### PR DESCRIPTION
Closes #1348

## Problem

`allow_auto_merge` warnings recorded by `checkAllowAutoMerge` were never cleared once the repo they referred to left the project board — the clearing branch only runs when the repo is *re-checked*, and a repo absent from the board is never re-checked. Entries in `.fabrik/warnings.json` became immortal, surfacing on every startup and pushing live warnings past the TUI panel's row cap. `stage_drift` and `undeclared_reviewers` (`stages/drift.go`) share the identical shape, keyed by stage name instead of repo.

## What this PR does

- Adds `warnings.ClearMissing(warningType, present)` — a bulk predicate clear that loads the warnings file once, removes every entry of a given `Type` whose subject isn't in `present`, and only writes when something was actually removed (avoids `Clear`'s per-call unconditional write).
- Adds `sweepStaleAllowAutoMergeWarnings` (`engine/allow_auto_merge_settle.go`), run every poll right after `seenRepos` is computed, using that same set (no new API calls). The engine's own configured repo is unioned in for single-repo mode so a transient zero-open-items poll can't durably clear a still-valid warning.
- Adds `stages.SweepStaleWarnings` (`stages/drift.go`), run once at startup alongside the existing `WarnStageDrift`/`WarnUndeclaredReviewers` calls, using the same unfiltered `e.cfg.Stages` set.
- Documents why `version_skew` needs no sweep (its subject is re-derived fresh every check, not looked up in a shrinking set) via a code comment on `checkVersionSkew`.
- Adds `docs/state-machine.md` §7.11, `adrs/1348-stale-warning-sweep.md`, a `docs/USER_GUIDE.md` addendum, and regenerates `docs/llms-full.txt`.

## How to test

- `go test ./warnings/... ./stages/... ./engine/... -race` — new tests cover AC1-AC6 plus the single-repo-mode exemption edge case, verifying: absent-subject warnings clear, present-subject warnings survive (including with auto-merge still disabled), unrelated warning types are untouched, dismissed state is preserved, no writes occur when nothing is stale, and exactly one log line is emitted per clear.
- `go build ./... && go vet ./...`