### PR TITLE
fix(plugin): dev-build fingerprint no longer permanently disables plugin skill auto-refresh

### DIFF
--- a/adrs/046-installed-version-tracking.md
+++ b/adrs/046-installed-version-tracking.md
@@ -36,7 +36,8 @@ sorted concatenation of all embedded file hashes.
 | absent | "" | any | Migration — no plugin files on disk | No-op; no seed |
 | present | == installedVer | == installedVer | Up to date | No-op |
 | present | == installedVer | != installedVer | installedVer in KnownEmbeddedVersions | Upgrade available — auto-refresh (non-TTY) or y/N prompt (TTY) |
-| present | == installedVer | != installedVer | installedVer NOT in KnownEmbeddedVersions | Corrupted migration — treat as custom workflow; warn operator |
+| present | == installedVer | != installedVer | installedVer NOT in KnownEmbeddedVersions, checking binary is a dev build | Upgrade available — auto-refresh, same as "in KnownEmbeddedVersions" (see ADR 1297) |
+| present | == installedVer | != installedVer | installedVer NOT in KnownEmbeddedVersions, checking binary is a release build | Corrupted migration — treat as custom workflow; warn operator |
 | present | != installedVer | any | Custom workflow | Block refresh; warn operator |
 
 ### Migration baseline
@@ -65,7 +66,13 @@ When `disk == installed != embedded`, before treating this as a safe auto-refres
 `checkPluginState` checks whether `installedVer` appears in `KnownEmbeddedVersions`.
 If it does not, the value was written by the buggy pre-fix migration (which
 recorded the customised disk hash, not an embedded hash) and the state is treated
-as a custom workflow instead of an upgrade.
+as a custom workflow instead of an upgrade — **unless the checking binary is
+itself a dev build** (see ADR 1297), in which case the unlisted fingerprint is
+trusted as a prior legitimate dev-build write instead. `KnownEmbeddedVersions`
+only ever grows from release-cut fingerprints, so a dev build's own embedded
+content can never appear in it by construction; without the ADR 1297 carve-out,
+every dev instance and test bed is permanently misclassified as customized after
+its first plugin refresh.
 
 The list grows by one entry when the embedded plugin fingerprint changes between
 releases, appended automatically by `scripts/cut-release.sh` after the build
@@ -93,7 +100,7 @@ New functions in `plugin/refresh.go`:
 - `WriteVersionHash(pluginDir, hash string) error` — writes hash to `.installed-version`
 - `WriteInstalledVersion(pluginDir string) error` — writes the current embedded hash (post-upgrade)
 - `ReadInstalledVersion(pluginDir string) (string, error)` — reads the file; returns `("", nil)` if absent
-- `CheckPluginState(pluginDir string) (customWorkflow, upgradeNeeded bool, err error)` — implements the four-state table above; runs migration as a side-effect when installed-version is absent
+- `CheckPluginState(pluginDir string, isDevBuild bool) (customWorkflow, upgradeNeeded bool, err error)` — implements the table above; runs migration as a side-effect when installed-version is absent; `isDevBuild` gates the corrupted-state guard's unlisted-fingerprint branch (see ADR 1297)
 
 All auto-refresh paths in `cmd/root.go` and `cmd/upgrade.go` are updated to call
 `CheckPluginState` before touching `.fabrik/plugin/`.

--- a/adrs/1297-dev-build-fingerprint-corrupted-state-guard.md
+++ b/adrs/1297-dev-build-fingerprint-corrupted-state-guard.md
@@ -1,0 +1,149 @@
+# ADR 1297: Dev-Build Gate for the Plugin Corrupted-State Guard
+
+**Date**: 2026-08-02
+**Status**: Accepted
+
+## Context
+
+ADR 046 introduced `plugin.KnownEmbeddedVersions`, a hardcoded list of every
+plugin fingerprint ever legitimately written to `.installed-version` by a
+**release** binary. `checkPluginState`'s corrupted-state guard uses list
+membership to decide, when `disk == installedVer` but `embeddedVer` differs,
+whether `installedVer` traces back to a legitimate release or to the buggy
+pre-v0.0.64 migration that recorded a customised disk hash as `installedVer`
+(the incident chain: #746 → #747 → #820 "EMERGENCY: customisation-protection
+migration silently 'forgets' pre-existing customisations" → #822, which
+introduced `KnownEmbeddedVersions` as the fix).
+
+That list is release-only by construction: it grows one entry per release
+whose embedded plugin content changed, appended automatically by
+`scripts/cut-release.sh`. A **dev build** — `fabrik` built from source, as
+every developer and every test bed runs — writes a fingerprint of its own
+embedded plugin content, which can never appear in a release-only list. The
+very first plugin refresh performed by a dev build therefore poisons
+`.installed-version` with a fingerprint the corrupted-state guard will never
+recognize, and every subsequent startup takes the "custom workflow" branch —
+indistinguishable from a real operator edit. This is worse than cosmetic: the
+project's own e2e release-gate test bed and primary dev instance were both
+found silently running stale agent skills as a result, meaning the release
+gate had been validating against instructions that differed from what ships.
+
+## Decision
+
+Gate the corrupted-state guard's "unlisted `installedVer`" branch on whether
+**the checking binary itself** is a dev build. `cmd.Version` already
+distinguishes dev builds from release builds cleanly (`strings.HasPrefix(Version,
+"dev")`, the same check `runUpgrade` already uses to skip the binary-download
+path). `checkPluginState` and `CheckPluginState` gain an `isDevBuild bool`
+parameter; when an unlisted `installedVer` is encountered:
+
+- **`isDevBuild == true`**: trust it — treat as a legitimate prior dev-build
+  write, return `(false, true)` (safe to auto-refresh), same as a
+  known-embedded hash.
+- **`isDevBuild == false`** (release binary): unchanged from pre-#1297
+  behavior — treat as the buggy migration's corrupted state, return
+  `(true, false)` (custom workflow, skip auto-refresh).
+
+`plugin` cannot import `cmd` (the dependency direction is `cmd → plugin`), so
+the dev/release signal is computed by `cmd` — which already has `Version` in
+scope at all four `CheckPluginState` call sites — and passed in as a bool.
+
+For the accompanying "name the differing files" requirement, `cmd/root.go`'s
+two "local customizations" warnings now call a new `pluginCustomizationWarning`
+helper, which reuses `diffingPluginFiles` (`cmd/upgrade.go`) — the same
+embedded-vs-disk comparison basis already used for stale-skill counting — to
+list which files differ, appended to the existing warning text.
+
+## Alternatives Considered
+
+**Provenance tagging.** Record `dev` vs `release` alongside the fingerprint
+(e.g. a second line in `.installed-version`, or a parallel metadata file).
+Rejected as the primary mechanism because it does not self-heal
+already-poisoned installs: an existing `.installed-version` written before
+this fix has no tag, so the classification logic still needs a fallback rule
+for "no tag present" — at which point the fallback rule *is* the actual fix,
+and the tag is redundant machinery on top of it. It would also require a
+`ReadInstalledVersion` format change, which the "no format/schema change"
+constraint (self-heal without migration, see Risks below) rules out for a
+targeted correction.
+
+**Dropping list-membership entirely for this branch.** Re-derive the
+"customized" signal purely from `disk == installedVer` (already computed
+earlier in the same function) rather than checking `installedVer` against
+`KnownEmbeddedVersions` at all. Self-heals instantly and needs no format
+change, but reopens exactly the #820 data-loss class for **release** builds:
+`KnownEmbeddedVersions` exists specifically because a real operator's
+customised disk hash, once corrupted into `installedVer` by the old buggy
+migration, is indistinguishable from a legitimate release fingerprint using
+`disk == installedVer` alone. Dropping the check would silently overwrite any
+release install still carrying a pre-v0.0.68 corrupted `installedVer` —
+precisely the case `TestCheckPluginState_CorruptedMigration` exists to
+prevent. Rejected: too broad given the explicit "must not weaken detection"
+requirement.
+
+**Local allowlist file, appended on write.** Have a build append its own
+embedded fingerprint to a local (gitignored) allowlist when it writes
+`.installed-version`, so a later startup recognizes it. Same self-heal gap as
+provenance tagging — an already-poisoned install's *classification* logic
+still needs to change for the current bad state to recover, since a
+`customWorkflow=true` verdict short-circuits every code path that would
+otherwise append to the allowlist. Also adds a new on-disk artifact and file
+I/O for a "targeted correction" scoped issue.
+
+## Rationale for the Chosen Approach
+
+- **Self-heals immediately, no migration step.** The gate depends only on the
+  checking binary's own runtime identity (`cmd.Version`), not on any
+  persisted tag or list. An already-poisoned `.installed-version` from a
+  prior dev-build refresh — including the project's own e2e bed and primary
+  dev instance, both found stuck in this state — is reclassified correctly
+  on the very next startup, satisfying the issue's explicit no-migration
+  constraint.
+- **Doesn't touch the population `KnownEmbeddedVersions` was built to
+  protect.** The #820 incident was a release-binary migration bug hitting
+  real operator installs. Gating on `isDevBuild` leaves a release build's
+  behavior for an unlisted `installedVer` completely unchanged — it still
+  treats it as a corrupted migration and still protects that population.
+  Only the population this fix is actually about (dev builds, whose
+  fingerprints structurally can never be listed) gets new behavior.
+- **No format change.** `.installed-version` remains a bare SHA256 string.
+  No `ReadInstalledVersion`/`WriteVersionHash` changes, no new on-disk
+  artifact.
+- **Minimal surface area for a targeted correction.** One new parameter
+  threaded through two functions, four call sites updated, one new warning
+  helper. The untouched migration branch (`installedVer` absent) and the
+  `diskVer != installedVer` branch (genuine operator edit — detected
+  regardless of build type) are unaffected, per the issue's explicit
+  "must not weaken/must not rewrite" constraints.
+
+### Acknowledged trade-off
+
+A developer who hand-edits `.fabrik/plugin/` on a dev-build machine, at the
+exact moment disk still equals a stale `installedVer` and embedded content has
+changed, is no longer flagged as customized — `isDevBuild` trusts the
+unlisted fingerprint outright in that branch. This narrows the corrupted-state
+guard's protection window, but does not eliminate it: the far more common real
+case — actively editing `.fabrik/plugin/` mid-session, where `diskVer !=
+installedVer` — hits the untouched branch at `checkPluginState`'s line 174 and
+is still protected identically to a release build. The #820 incident this
+guard exists to prevent happened on release-binary installs, which remain
+fully protected.
+
+## Risks / Dependencies
+
+- Whichever mechanism is chosen must not require a one-time migration step for
+  installations already stuck misclassified — satisfied, since the gate is
+  evaluated fresh on every startup from live binary identity, not from a
+  value that needs to have been written under the new logic to take effect.
+- `cmd/upgrade.go`'s own "local customizations" messages
+  (`checkPluginSkillsWithReader`'s TTY and non-TTY paths, and the
+  `upgrade --force`-required error) consume the same `CheckPluginState`
+  return values and so stop misfiring on dev builds as a side effect of this
+  fix, without their wording being touched (explicitly out of scope per the
+  originating issue).
+
+## See Also
+
+- ADR 046 — the original three-way comparison design and `KnownEmbeddedVersions`
+- #746, #747, #820, #822 — the incident lineage that produced `KnownEmbeddedVersions`
+- #1297 — this fix

--- a/adrs/1297-dev-build-fingerprint-corrupted-state-guard.md
+++ b/adrs/1297-dev-build-fingerprint-corrupted-state-guard.md
@@ -144,6 +144,14 @@ self-heal already-poisoned installs without a format change. The intersection
 this leaves exposed — an old pre-0bd2c57e-corrupted install, first inspected
 by a dev build instead of a release build — is judged narrow enough to accept
 given the alternative costs, but it is a real gap, not a hypothetical one.
+Since the guard re-evaluates from live binary state on every startup rather
+than latching a verdict, any release-binary check closes the window for that
+install permanently — the exposure is specifically "a pre-0bd2c57e-corrupted
+install whose very first post-fix startup happens to be a dev build." In
+practice that means building `fabrik` from source and pointing it at an
+already-`fabrik init`'d directory that has never itself been started with a
+release binary since — a real but uncommon operational sequence, not the
+typical `go install`/release-download path most operator installs take.
 
 ## Risks / Dependencies
 

--- a/adrs/1297-dev-build-fingerprint-corrupted-state-guard.md
+++ b/adrs/1297-dev-build-fingerprint-corrupted-state-guard.md
@@ -118,16 +118,32 @@ I/O for a "targeted correction" scoped issue.
 
 ### Acknowledged trade-off
 
-A developer who hand-edits `.fabrik/plugin/` on a dev-build machine, at the
-exact moment disk still equals a stale `installedVer` and embedded content has
-changed, is no longer flagged as customized — `isDevBuild` trusts the
-unlisted fingerprint outright in that branch. This narrows the corrupted-state
-guard's protection window, but does not eliminate it: the far more common real
-case — actively editing `.fabrik/plugin/` mid-session, where `diskVer !=
-installedVer` — hits the untouched branch at `checkPluginState`'s line 174 and
-is still protected identically to a release build. The #820 incident this
-guard exists to prevent happened on release-binary installs, which remain
-fully protected.
+`isDevBuild` trusts *any* unlisted-but-disk-matching `installedVer`, not just
+one this specific dev build actually wrote — there is no persisted signal
+distinguishing "an unlisted hash because it's a dev build's own fingerprint"
+from "an unlisted hash because it's a genuine pre-existing customization."
+Live edits are not at risk from this: editing a file changes `diskVer`, which
+diverges from `installedVer` and is caught unconditionally by the untouched
+`diskVer != installedVer` branch (`checkPluginState` line 191) regardless of
+build type — an operator actively customizing `.fabrik/plugin/` is protected
+identically to a release build.
+
+The actual residual risk is a **pre-existing** corrupted install: one where
+`disk == installedVer` already holds a genuine customization hash, written by
+the pre-0bd2c57e migration bug (#820) before `KnownEmbeddedVersions` existed,
+sitting untouched since. If such an install is later checked for the first
+time by a dev build rather than a release build, `isDevBuild` trusts the
+unlisted fingerprint and auto-refreshes over it, permanently erasing the
+customization the corrupted-state guard exists to protect. Per Research, no
+code path in the current codebase can *newly* write such a state — the bug
+that produced it was fixed in 0bd2c57e — so this only threatens installs that
+were already corrupted before that fix shipped and have not been re-checked
+since. Closing this gap fully would require persisting provenance (or an
+allowlist) at write time, both already rejected above for failing to
+self-heal already-poisoned installs without a format change. The intersection
+this leaves exposed — an old pre-0bd2c57e-corrupted install, first inspected
+by a dev build instead of a release build — is judged narrow enough to accept
+given the alternative costs, but it is a real gap, not a hypothetical one.
 
 ## Risks / Dependencies
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -791,7 +791,7 @@ func Execute() error {
 	var skillsStaleCount int
 	var customWorkflow bool
 	if _, statErr := os.Stat(".fabrik/plugin"); statErr == nil {
-		cw, upgradeNeeded, cwErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+		cw, upgradeNeeded, cwErr := fabrikplugin.CheckPluginState(".fabrik/plugin", strings.HasPrefix(Version, "dev"))
 		if cwErr != nil {
 			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed: %v\n", cwErr)
 		} else {
@@ -816,7 +816,7 @@ func Execute() error {
 		return runTUI(eng, cfg.PollSeconds, buildProjectInfo(cfg, pc), cfg.PluginDir, wakeCh, stopCh, skillsStaleCount, customWorkflow)
 	}
 	if customWorkflow {
-		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+		fmt.Fprintf(os.Stderr, "%s", pluginCustomizationWarning(".fabrik/plugin"))
 	} else if skillsStaleCount > 0 {
 		if refreshErr := checkPluginSkillsWithReader(".fabrik/plugin", false, nil); refreshErr != nil {
 			fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skill refresh failed: %v\n", refreshErr)
@@ -882,11 +882,11 @@ func handleReexecPluginRefresh(envVar, msgSuffix string) {
 		return
 	}
 	os.Unsetenv(envVar)
-	customWorkflow, upgradeNeeded, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+	customWorkflow, upgradeNeeded, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin", strings.HasPrefix(Version, "dev"))
 	if stateErr != nil {
 		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin state check failed%s: %v\n", msgSuffix, stateErr)
 	} else if customWorkflow {
-		fmt.Fprintf(os.Stderr, "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh; run 'fabrik upgrade --force' to overwrite\n")
+		fmt.Fprintf(os.Stderr, "%s", pluginCustomizationWarning(".fabrik/plugin"))
 	} else if upgradeNeeded {
 		if _, err := fabrikplugin.RefreshPlugin(); err != nil {
 			fmt.Fprintf(os.Stderr, "[upgrade] warning: RefreshPlugin failed%s: %v\n", msgSuffix, err)
@@ -896,6 +896,22 @@ func handleReexecPluginRefresh(envVar, msgSuffix string) {
 	} else {
 		fmt.Fprintf(os.Stderr, "[upgrade] info: plugin baseline seeded; skill refresh deferred to next startup\n")
 	}
+}
+
+// pluginCustomizationWarning builds the "local customizations" startup warning,
+// naming the specific files that differ between pluginDir and the currently
+// embedded plugin (the same comparison basis diffingPluginFiles uses for stale-
+// skill detection in cmd/upgrade.go), so the warning is directly actionable
+// rather than a bare assertion. Falls back to the assertion alone if the diff
+// itself fails or reports no differences (e.g. a race with a concurrent
+// refresh) rather than raising an error to the caller.
+func pluginCustomizationWarning(pluginDir string) string {
+	msg := "[upgrade] warning: plugin skills have local customizations — skipping auto-refresh"
+	if diffing, diffErr := diffingPluginFiles(pluginDir); diffErr == nil && len(diffing) > 0 {
+		msg += fmt.Sprintf(" (differing: %s)", strings.Join(diffing, ", "))
+	}
+	msg += "; run 'fabrik upgrade --force' to overwrite\n"
+	return msg
 }
 
 // reviewWaitTimeout converts a ReviewWaitTimeout config value (minutes) to a

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -100,7 +100,7 @@ func runUpgrade(args []string) error {
 	}
 
 	// Default path: check three-way state before refreshing.
-	customWorkflow, _, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin")
+	customWorkflow, _, stateErr := fabrikplugin.CheckPluginState(".fabrik/plugin", strings.HasPrefix(Version, "dev"))
 	if stateErr != nil {
 		return fmt.Errorf("checking plugin state: %w", stateErr)
 	}
@@ -145,7 +145,7 @@ func checkPluginSkillsWithReader(pluginDir string, isTTY bool, r io.Reader) erro
 	// Three-way check: detect operator customizations before refreshing.
 	// upgradeNeeded=true only when disk==installed and embedded differs (safe to refresh).
 	// Migration path (installedVer absent) returns (false,false): do nothing until next cycle.
-	customWorkflow, upgradeNeeded, stateErr := fabrikplugin.CheckPluginState(pluginDir)
+	customWorkflow, upgradeNeeded, stateErr := fabrikplugin.CheckPluginState(pluginDir, strings.HasPrefix(Version, "dev"))
 	if stateErr != nil {
 		return fmt.Errorf("checking plugin state: %w", stateErr)
 	}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -198,6 +198,77 @@ func TestCheckPluginSkillsWithReader_AutoRefresh_NonTTY(t *testing.T) {
 	}
 }
 
+// TestCheckPluginSkillsWithReader_DevBuildUnlistedFingerprint_AutoRefresh
+// verifies the issue #1297 fix: a fingerprint written by a dev build (disk ==
+// installedVer, but installedVer was never registered in
+// KnownEmbeddedVersions, since a dev build's own embedded content can never
+// appear in that release-only list) auto-refreshes normally instead of being
+// misclassified as an operator customization. Deliberately does NOT use
+// writeInstalledForDir, which registers the hash in KnownEmbeddedVersions —
+// that would test the already-covered known-embedded path, not this one. The
+// test process itself runs as a dev build (Version has no ldflags-injected
+// release tag), so checkPluginSkillsWithReader's internal CheckPluginState
+// call exercises the isDevBuild=true branch under test without any Version
+// mutation.
+func TestCheckPluginSkillsWithReader_DevBuildUnlistedFingerprint_AutoRefresh(t *testing.T) {
+	if !strings.HasPrefix(Version, "dev") {
+		t.Skipf("test process must run as a dev build for this test to exercise the intended branch; Version=%q", Version)
+	}
+	pluginDir := buildPluginDir(t)
+	// Simulate "old" installed state written by a prior dev-build refresh:
+	// old content on disk, installedVer seeded from it, but never added to
+	// KnownEmbeddedVersions (a dev fingerprint structurally never is).
+	entries, err := filepath.Glob(filepath.Join(pluginDir, "skills", "*", "SKILL.md"))
+	if err != nil || len(entries) == 0 {
+		t.Fatal("no SKILL.md files found in test plugin dir")
+	}
+	if err := os.WriteFile(entries[0], []byte("old dev-build content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	diskVer, err := fabrikplugin.ComputeDiskVersion(pluginDir)
+	if err != nil {
+		t.Fatalf("ComputeDiskVersion: %v", err)
+	}
+	for _, known := range fabrikplugin.KnownEmbeddedVersions {
+		if diskVer == known {
+			t.Skip("diskVer accidentally matches a known embedded version — cannot test unlisted-fingerprint path")
+		}
+	}
+	if err := fabrikplugin.WriteVersionHash(pluginDir, diskVer); err != nil {
+		t.Fatalf("WriteVersionHash: %v", err)
+	}
+	// disk == installedVer (both diskVer); embedded differs; installedVer unlisted.
+
+	r, w, _ := os.Pipe()
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	callErr := checkPluginSkillsWithReader(pluginDir, false, strings.NewReader(""))
+
+	w.Close()
+	os.Stderr = origStderr
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if callErr != nil {
+		t.Fatalf("expected nil error, got %v", callErr)
+	}
+	if strings.Contains(output, "local customizations") {
+		t.Fatalf("dev-build unlisted fingerprint must NOT be treated as a customization, got: %q", output)
+	}
+	if !strings.Contains(output, "auto-refreshed") {
+		t.Fatalf("expected auto-refresh message on stderr, got: %q", output)
+	}
+	// File must now match embedded content — proves auto-refresh actually ran.
+	rel, _ := filepath.Rel(pluginDir, entries[0])
+	embeddedData, _ := fabrikplugin.FabrikPlugin.ReadFile(filepath.Join("fabrik-workflows", rel))
+	diskData, _ := os.ReadFile(entries[0])
+	if !bytes.Equal(embeddedData, diskData) {
+		t.Fatal("dev-build unlisted-fingerprint path should auto-refresh disk with embedded content")
+	}
+}
+
 // TestCheckPluginSkillsWithReader_CustomWorkflow_TTYRedirects verifies that
 // when operator customizations are detected, the TTY path shows a redirect
 // message (--force / --reconcile) instead of the y/N prompt.

--- a/plugin/refresh.go
+++ b/plugin/refresh.go
@@ -203,6 +203,12 @@ func checkPluginState(pluginDir string, knownVersions []string, isDevBuild bool)
 		//   - or a release binary is looking at an installedVer it cannot vouch
 		//     for — the buggy v0.0.64 migration wrote a customized disk hash as
 		//     installedVer — treat as custom workflow.
+		// NOTE: isDevBuild trusts any unlisted match, not just a fingerprint this
+		// binary itself wrote — a pre-existing install already corrupted by the
+		// old pre-0bd2c57e bug (disk == installedVer holding a real customization)
+		// would also be trusted if first checked by a dev build. Closing that gap
+		// needs persisted provenance, rejected elsewhere for self-heal reasons —
+		// see ADR 1297's "Acknowledged trade-off".
 		if isKnownEmbedded(installedVer, knownVersions) || isDevBuild {
 			return false, true, nil
 		}

--- a/plugin/refresh.go
+++ b/plugin/refresh.go
@@ -115,14 +115,24 @@ func ReadInstalledVersion(pluginDir string) (string, error) {
 // CheckPluginState performs a three-way comparison (embedded vs installedVer vs
 // disk) and determines whether the operator has local customizations or whether
 // an auto-refresh is needed. It delegates to checkPluginState with the global
-// KnownEmbeddedVersions list.
-func CheckPluginState(pluginDir string) (customWorkflow, upgradeNeeded bool, err error) {
-	return checkPluginState(pluginDir, KnownEmbeddedVersions)
+// KnownEmbeddedVersions list. isDevBuild identifies whether the calling binary
+// is a dev build (see checkPluginState for why this matters).
+func CheckPluginState(pluginDir string, isDevBuild bool) (customWorkflow, upgradeNeeded bool, err error) {
+	return checkPluginState(pluginDir, KnownEmbeddedVersions, isDevBuild)
 }
 
 // checkPluginState is the testable implementation of CheckPluginState.
 // knownVersions is the list of all plugin fingerprints ever legitimately written
 // by a release binary; it is injected so tests can supply custom lists.
+// isDevBuild identifies whether the calling binary is a dev build (built from
+// source, as every developer and every test bed runs) rather than a release
+// binary. A dev build's own embedded content, by construction, can never be a
+// member of knownVersions — that list only ever grows from release-cut
+// fingerprints (scripts/cut-release.sh). Without this distinction, the very
+// first plugin refresh performed by a dev build poisons installedVer with a
+// fingerprint that no release build will ever recognize, permanently
+// misclassifying every subsequent startup as a genuine operator customization
+// (see issue #1297).
 //
 // Migration path (installedVer absent):
 //   - diskVer == ""            → no-op (empty dir is not a customization)
@@ -132,15 +142,22 @@ func CheckPluginState(pluginDir string) (customWorkflow, upgradeNeeded bool, err
 //
 // Corrupted-state guard (installedVer present, disk==installed, embedded differs):
 //   - installedVer in knownVersions → legitimate upgrade; return (false,true)
-//   - installedVer not in knownVersions → buggy v0.0.64 migration wrote a
-//     customized disk hash as installedVer; treat as custom workflow; return (true,false)
+//   - installedVer not in knownVersions and isDevBuild → this binary's own dev
+//     builds can never populate knownVersions, so an unlisted-but-disk-matching
+//     installedVer is trusted as a prior legitimate dev-build write, not
+//     mistaken for the pre-v0.0.64 corruption; return (false,true)
+//   - installedVer not in knownVersions and !isDevBuild → release binary sees
+//     an installedVer it cannot vouch for; buggy v0.0.64 migration wrote a
+//     customized disk hash as installedVer; treat as custom workflow;
+//     return (true,false) — unchanged from pre-#1297 behavior, preserving the
+//     protection that motivated KnownEmbeddedVersions in the first place (#820)
 //
 // Return values:
 //
 //	customWorkflow=true  — disk differs from installedVer; skip auto-refresh.
 //	upgradeNeeded=true   — disk matches installedVer but embedded differs; auto-refresh safe.
 //	both false           — no action needed.
-func checkPluginState(pluginDir string, knownVersions []string) (customWorkflow, upgradeNeeded bool, err error) {
+func checkPluginState(pluginDir string, knownVersions []string, isDevBuild bool) (customWorkflow, upgradeNeeded bool, err error) {
 	installedVer, err := ReadInstalledVersion(pluginDir)
 	if err != nil {
 		return false, false, err
@@ -180,9 +197,13 @@ func checkPluginState(pluginDir string, knownVersions []string) (customWorkflow,
 		// Disk matches installedVer but embedded has changed. Before treating this
 		// as a safe auto-refresh, verify that installedVer was written by a
 		// legitimate release binary (i.e., it is a known embedded hash).
-		// If it is not in the known list, the buggy v0.0.64 migration wrote a
-		// customized disk hash as installedVer — treat as custom workflow.
-		if isKnownEmbedded(installedVer, knownVersions) {
+		// If it is not in the known list, either:
+		//   - this binary is itself a dev build, which can never appear in the
+		//     release-only known list by construction — trust it (see doc comment)
+		//   - or a release binary is looking at an installedVer it cannot vouch
+		//     for — the buggy v0.0.64 migration wrote a customized disk hash as
+		//     installedVer — treat as custom workflow.
+		if isKnownEmbedded(installedVer, knownVersions) || isDevBuild {
 			return false, true, nil
 		}
 		return true, false, nil

--- a/plugin/refresh_test.go
+++ b/plugin/refresh_test.go
@@ -101,7 +101,7 @@ func TestCheckPluginState_Migration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cw, up, err := CheckPluginState(dir)
+	cw, up, err := CheckPluginState(dir, false)
 	if err != nil {
 		t.Fatalf("CheckPluginState error: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestCheckPluginState_NoOp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cw, up, err := CheckPluginState(dir)
+	cw, up, err := CheckPluginState(dir, false)
 	if err != nil {
 		t.Fatalf("CheckPluginState error: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestCheckPluginState_AutoRefresh(t *testing.T) {
 	}
 
 	// Inject diskVer2 as a "known" version so the corrupted-state guard passes.
-	cw, up, err := checkPluginState(dir2, []string{diskVer2})
+	cw, up, err := checkPluginState(dir2, []string{diskVer2}, false)
 	if err != nil {
 		t.Fatalf("checkPluginState error: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestCheckPluginState_CustomWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cw, up, err := CheckPluginState(dir)
+	cw, up, err := CheckPluginState(dir, false)
 	if err != nil {
 		t.Fatalf("CheckPluginState error: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestCheckPluginState_MigrationCustomised(t *testing.T) {
 	}
 	// No .installed-version file present (simulating pre-v0.0.64).
 
-	cw, up, err := CheckPluginState(dir)
+	cw, up, err := CheckPluginState(dir, false)
 	if err != nil {
 		t.Fatalf("CheckPluginState error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestCheckPluginState_CorruptedMigration(t *testing.T) {
 		t.Skip("embedded matches customized disk — cannot test corrupted-migration path")
 	}
 
-	cw, up, err := checkPluginState(dir, []string{})
+	cw, up, err := checkPluginState(dir, []string{}, false)
 	if err != nil {
 		t.Fatalf("checkPluginState error: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestCheckPluginState_KnownEmbeddedAutoRefresh(t *testing.T) {
 		t.Skip("embedded matches old hash — cannot test known-embedded auto-refresh")
 	}
 	// Inject oldHash into known list → should return upgradeNeeded=true.
-	cw, up, err := checkPluginState(dir, []string{oldHash})
+	cw, up, err := checkPluginState(dir, []string{oldHash}, false)
 	if err != nil {
 		t.Fatalf("checkPluginState error: %v", err)
 	}
@@ -331,6 +331,58 @@ func TestCheckPluginState_KnownEmbeddedAutoRefresh(t *testing.T) {
 	}
 	if !up {
 		t.Errorf("known-embedded-auto-refresh: upgradeNeeded should be true")
+	}
+}
+
+// TestCheckPluginState_DevBuildUnlistedFingerprint verifies that when
+// installedVer is present, disk==installed, embedded differs, and installedVer
+// is not in knownVersions, a dev build (isDevBuild=true) still auto-refreshes
+// (upgradeNeeded=true) rather than being misclassified as a custom workflow —
+// the fix for issue #1297. Mirrors TestCheckPluginState_CorruptedMigration's
+// setup exactly, differing only in isDevBuild and the expected outcome.
+func TestCheckPluginState_DevBuildUnlistedFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	if err := populatePluginDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Modify a skill to create a disk state distinct from the current embedded
+	// content — this simulates a dev build's own (unlisted) embedded fingerprint
+	// having previously been written as installedVer.
+	entries, _ := filepath.Glob(filepath.Join(dir, "skills", "*", "SKILL.md"))
+	if len(entries) == 0 {
+		t.Fatal("no SKILL.md files found")
+	}
+	if err := os.WriteFile(entries[0], []byte("dev build content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	diskVer, err := ComputeDiskVersion(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a prior dev-build refresh: installedVer = disk fingerprint, never
+	// registered in KnownEmbeddedVersions (dev fingerprints structurally can't be).
+	if err := WriteVersionHash(dir, diskVer); err != nil {
+		t.Fatal(err)
+	}
+	for _, known := range KnownEmbeddedVersions {
+		if diskVer == known {
+			t.Skip("diskVer accidentally matches a known embedded version — cannot test dev-build path")
+		}
+	}
+	embeddedVer := ComputeEmbeddedVersion()
+	if embeddedVer == diskVer {
+		t.Skip("embedded matches dev-build disk — cannot test dev-build path")
+	}
+
+	cw, up, err := checkPluginState(dir, []string{}, true)
+	if err != nil {
+		t.Fatalf("checkPluginState error: %v", err)
+	}
+	if cw {
+		t.Errorf("dev-build-unlisted-fingerprint: customWorkflow should be false, got true")
+	}
+	if !up {
+		t.Errorf("dev-build-unlisted-fingerprint: upgradeNeeded should be true, got false")
 	}
 }
 


### PR DESCRIPTION
Closes #1297

## What this does

Fixes the `checkPluginState` corrupted-state guard (`plugin/refresh.go`) so a fingerprint written by a dev build is no longer permanently misclassified as an operator customization.

## Root cause

`KnownEmbeddedVersions` is a release-only fingerprint list, appended to by `scripts/cut-release.sh`. When `disk == installedVer` but `embeddedVer` differs, the guard checked whether `installedVer` was in that list — treating "not found" as evidence of the buggy pre-v0.0.64 migration and permanently skipping auto-refresh. A dev build's own embedded content can never appear in a release-only list by construction, so the very first plugin refresh performed by a dev build (every developer, every test bed) poisoned `.installed-version` and every subsequent startup silently stopped receiving plugin skill updates.

## Fix

`checkPluginState`/`CheckPluginState` now take an `isDevBuild bool` (computed from `cmd.Version`'s existing dev/release distinction and passed in, since `plugin` cannot import `cmd`). When the checking binary is a dev build, an unlisted-but-disk-matching `installedVer` is trusted and treated as a safe auto-refresh, exactly like a known-embedded hash. Release-build behavior is completely unchanged — this preserves the exact protection `KnownEmbeddedVersions` was built for after the #820 data-loss incident.

Because the gate depends only on runtime binary identity, not persisted state, already-poisoned installs (including the project's own e2e test bed and primary dev instance) self-heal on their very next startup — no `.installed-version` surgery or `--force` needed.

Also reworded the two "local customizations" startup warnings in `cmd/root.go` (via a new `pluginCustomizationWarning` helper) to name the specific files that differ, computed against the currently-embedded plugin via the existing `diffingPluginFiles` helper — so the warning is directly actionable instead of a bare assertion.

## Key changes

- `plugin/refresh.go` — `isDevBuild` parameter gates the corrupted-state guard's unlisted-fingerprint branch
- `cmd/root.go` — both `CheckPluginState` call sites pass `strings.HasPrefix(Version, "dev")`; new `pluginCustomizationWarning` helper names differing files
- `cmd/upgrade.go` — both `CheckPluginState` call sites updated (no wording changes, out of scope per the issue)
- `adrs/1297-dev-build-fingerprint-corrupted-state-guard.md` — new ADR documenting the gating decision and rejected alternatives
- `adrs/046-installed-version-tracking.md` — amended three-way comparison table and signature

## Test plan

- New unit test `TestCheckPluginState_DevBuildUnlistedFingerprint` (`plugin/refresh_test.go`) covering the dev-build auto-refresh path
- New integration test `TestCheckPluginSkillsWithReader_DevBuildUnlistedFingerprint_AutoRefresh` (`cmd/upgrade_test.go`) covering the same path through the full non-TTY upgrade flow
- Existing regression coverage for genuine operator customization (`TestCheckPluginState_CorruptedMigration`, `TestCheckPluginSkillsWithReader_CustomWorkflow_NonTTYWarning`) verified unmodified in intent, still passing
- `go build ./...`, `go vet -tags e2e ./...` clean
- `go test -race ./...` clean (one pre-existing flaky failure, `TestExecute_ConfigYAMLApplied`, confirmed to fail identically on unmodified `main` — unrelated to this change, a SIGINT-timing/network issue)