### PR TITLE
feat(pruefer): ship as a released artifact with self-upgrade

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,10 +34,41 @@ builds:
       post:
         - cmd: ./.release-tools/verify-release-artifact {{ .Path }} {{ .Env.TAG_COMMIT }}
           output: true
+  # Pruefer ships from the same tag/release as fabrik — one shared release
+  # cadence, not an independent tag flow. See adrs/1197-pruefer-self-upgrade.md
+  # for the rationale (simplicity, matches the monorepo; accepted tradeoff is
+  # every fabrik-only release republishes an unchanged pruefer binary).
+  - id: pruefer
+    binary: pruefer
+    main: ./cmd/pruefer
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/handarbeit/fabrik/pruefer.Version={{.Version}}
+    hooks:
+      # Same VCS-cleanliness verification as the fabrik build above — goreleaser
+      # hooks are per-build-id, not global, so this must be repeated here.
+      post:
+        - cmd: ./.release-tools/verify-release-artifact {{ .Path }} {{ .Env.TAG_COMMIT }}
+          output: true
 
 archives:
   - id: fabrik
+    ids:
+      - fabrik
     name_template: "fabrik_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+  - id: pruefer
+    ids:
+      - pruefer
+    name_template: "pruefer_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz
 

--- a/adrs/1197-pruefer-self-upgrade.md
+++ b/adrs/1197-pruefer-self-upgrade.md
@@ -1,0 +1,72 @@
+# ADR 1197: Ship Pruefer as a released artifact with self-upgrade
+
+**Date**: 2026-08-02
+**Status**: Accepted
+**Issue**: #1197 — ship Pruefer as a released artifact and wire auto-upgrade
+
+## Context
+
+Pruefer had no auto-upgrade: it silently ran whatever binary was last built by hand. That is worse than it sounds for a daemon with no board and no issues — a stale Fabrik is *visible* (its behavior on issues looks wrong and someone investigates); a stale Pruefer just keeps reviewing with old logic with no signal. On 2026-07-27, both #1189 (inline review comments) and #1190 (`--setting-sources`) landed while a running Pruefer instance kept posting body-only reviews with trust warnings until someone noticed and rebuilt manually.
+
+`internal/selfupgrade` (ADR-1196) already extracted Fabrik's self-upgrade logic into an engine-free package specifically so Pruefer could consume it without violating ADR-1113's no-`engine`-import boundary. This issue is that follow-up: publish a `pruefer` binary from `.goreleaser.yaml` and wire `cmd/pruefer`/`pruefer/` to `internal/selfupgrade`.
+
+**This issue captures the work; it does not authorize shipping it in the imminent release.** Pruefer needs more bake time in the dev setup before it ships as a distributed artifact — see the issue's own top-of-body note. The `fabrik:cruise` label (not `fabrik:yolo`) was on this issue for that reason: cruise advances stages but does not auto-merge, leaving the actual merge timing to a human decision made separately from this ADR.
+
+## Decisions
+
+### 1. Version stamping is duplicated into `pruefer/version.go`, not shared
+
+`cmd/version.go`'s `Version` var and its `versionWithSHA`/`appendDirtyIfModified` helpers live in package `cmd`, which imports `engine` (`cmd/root.go`). Pruefer cannot import `cmd` without crossing the ADR-1113 boundary. The ~70 lines of version-stamping logic are duplicated into `pruefer/version.go` verbatim instead, following the precedent ADR-1113 Decision 6 already set for `pruefer/procattr_*.go` (small, stable OS-primitive code duplicated across a hard architectural boundary rather than adding a third shared package). Version-stamping logic changes rarely and has no daemon-specific behavior to diverge on, so the duplication-drift risk ADR-1196 weighed against for the self-upgrade logic itself doesn't apply here.
+
+### 2. `DevBuildConfig.Dir` points at `cmd/pruefer`, not the checkout root
+
+Fabrik's `main.go` lives at the repo root, so `engine/upgrade.go` passes `Dir: e.fabrikDir` (the checkout root) straight through, and `go build -o exe .` builds the right package. Pruefer's `main.go` lives at `cmd/pruefer/`. Pointing `Dir` at the checkout root would make `CheckAndRebuildDev`'s hardcoded `go build -o exe .` silently build a **fabrik** binary and write it to Pruefer's own executable path — a `go vet`/`go test` pass would not catch this.
+
+Instead, `pruefer/upgrade.go`'s `devBuildDir` helper resolves `Dir` to `<FabrikDir>/cmd/pruefer`. Every git subcommand `CheckAndRebuildDev` runs (`rev-parse`, `fetch`, `pull --ff-only`, `remote get-url`) resolves correctly from any subdirectory of the checkout — git walks up to find `.git` — so this requires zero changes to `internal/selfupgrade`, keeping that package's "no change beyond what's needed to call it from Pruefer" scope intact.
+
+### 3. The release-check client is a dedicated, unauthenticated `github.Client`
+
+Pruefer's only GitHub credentials are per-`watched_repos`-owner App installation tokens (`Daemon.Clients`, built by `BootstrapMulti`). There is no guarantee `handarbeit` is even a watched owner, and App installations can be scoped to "selected repositories," which may not include `fabrik` itself. Repurposing a review-owner's token for an unrelated cross-repo release check would also be a scope violation of that token's purpose.
+
+`checkReleaseUpgrade` constructs its own `github.NewClientWithBaseURL("", releaseAPIBaseURL)` (an unauthenticated client in production; `releaseAPIBaseURL` is a test-only seam pointing at an httptest server). `fabrik` is a public repo, so an unauthenticated client is sufficient for both the `FetchLatestRelease` call and the asset download. Accepted tradeoff: GitHub's lower unauthenticated rate limit. If `handarbeit/fabrik` ever goes private, this path breaks with no fallback credential — out of scope to solve here, but worth flagging for whoever hits it.
+
+### 4. `--auto-upgrade` defaults to off
+
+Mirrors `cmd/root.go`'s `-auto-upgrade` flag default, despite this issue's own framing that Pruefer's staleness is uniquely invisible (no board, no issues) compared to Fabrik's. This is a new, lightly-battle-tested code path in a daemon with no human-in-the-loop visibility of its own; an operator should opt in deliberately via `--auto-upgrade` / `PRUEFER_AUTO_UPGRADE` / `auto_upgrade: true`, rather than the daemon silently starting to replace its own binary the moment this ships. Consistency with Fabrik's existing convention also matters more than closing the visibility gap by default — the README documents the recommendation to enable it explicitly.
+
+### 5. The upgrade check runs at the poll boundary, throttled to 30 minutes
+
+`Daemon.poll(ctx)` already calls `wg.Wait()` before returning, so **every return from `poll()` guarantees zero in-flight reviews** — unlike Fabrik's engine, which spans async workers across multiple poll cycles and needs `HasInFlightWorker()`/idle-count machinery to establish the same guarantee. Placing the upgrade check in `Daemon.Run`'s loop, immediately after `d.poll(ctx)` returns, satisfies the "never swap mid-review" requirement by construction — re-exec'ing mid-review would orphan an ephemeral clone and a running `claude` subprocess with no review posted.
+
+The 30-minute throttle (`upgradeCheckInterval`, tracked via a local `time.Time` in `Run` — not a `Daemon` field, since `Run` is the sole sequential caller) is a rate/cost control, not a safety requirement: Pruefer's default poll interval is 120s, which would otherwise mean a `git fetch`/GitHub-Releases-API hit roughly every 2 minutes.
+
+### 6. Darwin codesign requires no new call site
+
+`resignDarwinBinary` (`internal/selfupgrade/release.go`) already runs unconditionally inside `PerformReleaseUpgrade` itself, generic since ADR-1196. Wiring Pruefer to `PerformReleaseUpgrade` automatically exercises it on darwin/arm64 — confirmed by reading the call graph; no separate call site or Pruefer-specific wiring was needed.
+
+### 7. Release cadence: one shared tag ships both `fabrik` and `pruefer`
+
+`.goreleaser.yaml` gains a second `builds`/`archives` pair (`id: pruefer`, `main: ./cmd/pruefer`, same darwin/linux × arm64/amd64 matrix and ldflags-version-stamp shape as `fabrik`, its own `hooks.post` block — goreleaser hooks are per-build-id, not global, so the `verify-release-artifact` VCS-cleanliness check had to be duplicated onto the new build entry). Both binaries publish from the same tag/release.
+
+This is the simplest option and matches the monorepo — no second release pipeline, no cross-repo tag coordination. Accepted tradeoff: every Fabrik-only release republishes an unchanged Pruefer binary (and vice versa). An independent tag/release flow per binary was considered and rejected: it would require a second `release.yml`-equivalent workflow and a second versioning scheme, for a cost (occasional redundant Pruefer republish) that's cheap compared to the coordination overhead of two release trains in one repo.
+
+## Consequences
+
+**Positive:**
+- A release now publishes a `pruefer` binary for the same platform matrix as `fabrik`, with `pruefer --version` reporting a stamped release tag or `dev(<sha>)` for a source build — closing the artifact gap that made auto-upgrade impossible before this issue.
+- The poll-boundary placement gives Pruefer a stronger "never mid-review" guarantee than Fabrik's own engine needs comparable machinery for — a structural property of Pruefer's simpler, fully-synchronous-per-cycle poll loop, not something this issue had to build.
+- `pruefer/` and `cmd/pruefer/` still import no `engine` symbols (`go list -deps ./pruefer/... ./cmd/pruefer/... | grep engine` is empty), preserving ADR-1113's boundary.
+
+**Negative / Trade-offs:**
+- Version-stamping logic now exists in two places (`cmd/version.go`, `pruefer/version.go`) that must be kept in sync by hand if the stamping scheme ever changes — an accepted, ADR-1113-precedented cost for a hard architectural boundary.
+- The unauthenticated release-check client has no fallback if `handarbeit/fabrik` ever goes private or unauthenticated rate limits prove too tight in practice.
+- Every Fabrik-only release republishes an unchanged Pruefer artifact (and vice versa) under the shared-tag decision.
+- `--auto-upgrade` defaulting off means an operator who doesn't read the README continues to run a Pruefer that never self-upgrades — the exact problem this issue exists to fix, until they opt in. Documented prominently in `cmd/pruefer/README.md` as a recommendation, not a default.
+
+## Related Work
+
+- `adrs/1113-pruefer-v1-architecture.md` — the no-`engine`-import boundary this issue respects, and Decision 6's duplication precedent for version stamping.
+- `adrs/1196-extract-self-upgrade-package.md` — the extraction this issue builds on; explicitly named "wiring Pruefer to `internal/selfupgrade` and adding Pruefer to the release matrix" as this issue's follow-up.
+- `engine/upgrade.go` — the wiring model `pruefer/upgrade.go` mirrors, adapted for Pruefer's simpler synchronous poll loop.
+- `cmd/pruefer/README.md` — documents both deployment modes (dev rebuild vs. release download) and the `--auto-upgrade` recommendation.
+- #1189, #1190 — the changes a stale, unupgraded Pruefer daemon silently missed in production, motivating this issue.

--- a/adrs/1197-pruefer-self-upgrade.md
+++ b/adrs/1197-pruefer-self-upgrade.md
@@ -42,7 +42,7 @@ The 30-minute throttle (`upgradeCheckInterval`, tracked via a local `time.Time` 
 
 ### 6. Darwin codesign requires no new call site
 
-`resignDarwinBinary` (`internal/selfupgrade/release.go`) already runs unconditionally inside `PerformReleaseUpgrade` itself, generic since ADR-1196. Wiring Pruefer to `PerformReleaseUpgrade` automatically exercises it on darwin/arm64 — confirmed by reading the call graph; no separate call site or Pruefer-specific wiring was needed.
+`resignDarwinBinary` (`internal/selfupgrade/release.go`) already runs unconditionally inside `PerformReleaseUpgrade` itself, generic since ADR-1196. Wiring Pruefer to `PerformReleaseUpgrade` automatically exercises it on darwin/arm64 — confirmed by reading the call graph; no separate call site or Pruefer-specific wiring was needed. The dev-rebuild path (`CheckAndRebuildDev`) never calls `resignDarwinBinary` — by design: it builds the binary locally with `go build`, which never hits the AMFI trust-cache issue that ad-hoc resigning a *downloaded* binary is there to work around.
 
 ### 7. Release cadence: one shared tag ships both `fabrik` and `pruefer`
 

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -94,6 +94,19 @@ Pruefer loads `.env` (via the same `godotenv`-based loader Fabrik uses), reads `
 
 A lock file at `.pruefer/pruefer.lock` prevents two instances from polling the same working directory concurrently.
 
+## Version & self-upgrade
+
+`pruefer --version` (or `-version`) prints the running build's version and exits: a stamped release tag (e.g. `v0.0.76`) for a binary downloaded from GitHub Releases, or `dev(<short-sha>)` for a binary built from source. This distinction is what the self-upgrade logic below uses to pick its upgrade path — Pruefer ships from the same `.goreleaser.yaml`/tag as Fabrik itself, not an independent release train (see [adrs/1197-pruefer-self-upgrade.md](../../adrs/1197-pruefer-self-upgrade.md) for the rationale).
+
+Self-upgrade is **off by default** (`--auto-upgrade` / `PRUEFER_AUTO_UPGRADE` / `auto_upgrade: true`) — an operator opts in deliberately, mirroring Fabrik's own `-auto-upgrade` default. Given that a stale Pruefer has no board or issues to make its staleness visible (see the top of this README's motivation), **enabling `--auto-upgrade` is recommended** for any long-running deployment. When enabled, Pruefer checks for an upgrade at the poll boundary — right after a poll cycle's reviews have all completed (`Daemon.poll` joins every in-flight review before returning) and before the next poll begins — so an upgrade never interrupts an in-flight review's ephemeral clone or `claude` subprocess. The check itself is throttled to roughly every 30 minutes, independent of `poll_interval_seconds`, to bound `git fetch`/GitHub Releases API chatter.
+
+Which upgrade path runs depends on how the binary was built:
+
+- **Dev mode** (running version is `dev(<sha>)`): Pruefer must be run from the Fabrik source checkout, invoked such that `.pruefer/pruefer.lock` (and thus Pruefer's working directory) sits at the checkout root — the same convention Fabrik's own dev-rebuild path uses. On finding new commits on `origin/main` (or unpushed local commits matching neither), Pruefer runs `git pull --ff-only` and rebuilds itself with `go build` from `cmd/pruefer` before re-exec'ing. This is the mode you get by building and running `pruefer` directly inside a Fabrik checkout — no extra configuration needed beyond `--auto-upgrade`.
+- **Release mode** (running version is a stamped tag): Pruefer checks `handarbeit/fabrik`'s GitHub Releases for a newer tag using a dedicated, unauthenticated GitHub API client (decoupled from the per-owner App installation tokens used for reviews — those aren't guaranteed to cover `handarbeit/fabrik`), downloads the matching platform archive, atomically replaces the running binary, and re-execs. This is the mode for a deployment running from a distinct directory (e.g. `~/dev/pruefer`) with a binary downloaded from a release — the actual "usage" deployment shape this feature targets.
+
+On macOS arm64, a release-mode upgrade re-signs the replacement binary ad-hoc after download (the same step Fabrik's own upgrade path uses) so the swapped-in binary isn't rejected by Gatekeeper/AMFI.
+
 ## Terminal UI
 
 When run with a real terminal attached (both stdin and stdout), Pruefer launches an interactive TUI by default — the same `bubbletea`/`bubbles`/`lipgloss` stack and model/update/view structure as Fabrik's own `tui/` package, so the two feel like the same family of tool. It shows:
@@ -177,6 +190,8 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 | `--config` | `PRUEFER_CONFIG` | — | `.pruefer/config.yaml` | Path to the YAML config file itself |
 | `-notui` | `PRUEFER_TUI` | `tui` | `true` | Set `-notui` / `PRUEFER_TUI=0` / `tui: false` to disable the interactive TUI and fall back to console logging. The TUI is further gated on a real terminal being detected on both stdin and stdout, regardless of this setting. |
 | `--log-file` | `PRUEFER_LOG_FILE` | `log_file` | `.pruefer/pruefer.log` | Path daemon log lines are written to, resolved against the process's working directory (same convention as `github_app_private_key_path`). An explicitly empty value (`--log-file ""`, `PRUEFER_LOG_FILE=`, or `log_file: ""`) disables file logging entirely. See [Logging](#logging). |
+| `--auto-upgrade` | `PRUEFER_AUTO_UPGRADE` | `auto_upgrade` | `false` | Check for a newer version at the poll boundary and self-upgrade (dev-rebuild or release-download, depending on the running build — see [Version & self-upgrade](#version--self-upgrade)). Recommended for long-running deployments. |
+| `--version` | — | — | — | Print the running version (a stamped release tag, or `dev(<sha>)`) and exit. |
 
 Draft PRs are always skipped — there is no configuration flag to include them in V1.
 

--- a/github/client.go
+++ b/github/client.go
@@ -178,7 +178,11 @@ func (c *Client) graphqlRequest(query string, variables map[string]interface{}, 
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.Token())
+	// See doWithAccept in rest.go for why an empty token omits the header
+	// rather than sending a blank bearer credential.
+	if token := c.Token(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -54,6 +54,37 @@ func TestGraphqlRequest_Success(t *testing.T) {
 	}
 }
 
+// TestGraphqlRequest_EmptyTokenOmitsAuthHeader is the GraphQL-path
+// counterpart to TestRestPost_EmptyTokenOmitsAuthHeader in rest_test.go —
+// graphqlRequest must omit the Authorization header entirely when the token
+// is empty, not send "Bearer " with nothing after it, which GitHub's API
+// treats as invalid credentials rather than as unauthenticated.
+func TestGraphqlRequest_EmptyTokenOmitsAuthHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, present := r.Header["Authorization"]; present {
+			t.Errorf("Authorization header present with value %q, want header entirely absent", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":{"viewer":{"login":"anon"}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("", srv.URL)
+
+	var result struct {
+		Data struct {
+			Viewer struct {
+				Login string `json:"login"`
+			} `json:"viewer"`
+		} `json:"data"`
+	}
+
+	err := c.graphqlRequest("{ viewer { login } }", nil, &result)
+	if err != nil {
+		t.Fatalf("graphqlRequest: %v", err)
+	}
+}
+
 func TestGraphqlRequest_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)

--- a/github/rest.go
+++ b/github/rest.go
@@ -110,7 +110,16 @@ func (c *Client) doWithAccept(method, url, accept string, body interface{}) (*ht
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.Token())
+	// An empty token means "deliberately unauthenticated" (e.g. pruefer's
+	// release-check client against the public fabrik repo) — omit the header
+	// rather than sending "Bearer " with nothing after it. GitHub's REST API
+	// treats a blank bearer token as invalid credentials (401 Bad
+	// credentials), not as equivalent to no Authorization header at all
+	// (verified against the real API), so setting it unconditionally would
+	// break every unauthenticated caller.
+	if token := c.Token(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/github/rest_test.go
+++ b/github/rest_test.go
@@ -33,6 +33,28 @@ func TestRestPost_Success(t *testing.T) {
 	}
 }
 
+// TestRestPost_EmptyTokenOmitsAuthHeader guards the fix for a production 401:
+// doWithAccept must omit the Authorization header entirely when the token is
+// empty ("deliberately unauthenticated", e.g. pruefer's release-check client
+// against the public fabrik repo), rather than sending "Bearer " with nothing
+// after it — GitHub's REST API treats a blank bearer token as invalid
+// credentials, not as equivalent to no Authorization header at all.
+func TestRestPost_EmptyTokenOmitsAuthHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, present := r.Header["Authorization"]; present {
+			t.Errorf("Authorization header present with value %q, want header entirely absent", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("", srv.URL)
+	err := c.restPost(srv.URL+"/test", map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatalf("restPost: %v", err)
+	}
+}
+
 func TestRestPost_4xxError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(422)

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -81,6 +81,18 @@ type Config struct {
 	// default) means resolve one installation per distinct owner present in
 	// WatchedRepos instead (see BootstrapMulti in pruefer/auth.go).
 	AppInstallationID int64
+
+	// AutoUpgrade enables self-upgrade checks at the poll boundary (see
+	// Daemon.checkAndUpgrade in pruefer/upgrade.go). Default false, mirroring
+	// cmd/root.go's -auto-upgrade default — an operator opts in deliberately
+	// rather than the daemon silently replacing its own binary. See
+	// ADR-1197.
+	AutoUpgrade bool
+
+	// VersionRequested is set when --version is passed. Execute checks this
+	// before validating required config (AppID/WatchedRepos) so `pruefer
+	// --version` works without a fully configured environment.
+	VersionRequested bool
 }
 
 // yamlConfig is the shape of Pruefer's YAML config file. All fields are
@@ -103,6 +115,7 @@ type yamlConfig struct {
 	AppInstallationID       *int64   `yaml:"github_app_installation_id"`
 	TUI                     *bool    `yaml:"tui"`
 	LogFile                 *string  `yaml:"log_file"`
+	AutoUpgrade             *bool    `yaml:"auto_upgrade"`
 }
 
 // loadYAMLConfig reads path, returning a zero-value yamlConfig (no error) if
@@ -141,6 +154,8 @@ type flagValues struct {
 	configPath              string
 	noTUI                   bool
 	logFile                 string
+	autoUpgrade             bool
+	versionRequested        bool
 }
 
 // LoadConfig resolves Pruefer's configuration from, in increasing priority:
@@ -169,8 +184,14 @@ func LoadConfig(args []string) (Config, error) {
 	fs.StringVar(&fv.configPath, "config", DefaultConfigPath, "Path to Pruefer's YAML config file")
 	fs.BoolVar(&fv.noTUI, "notui", false, "Disable the interactive TUI dashboard (default: enabled when a real terminal is detected)")
 	fs.StringVar(&fv.logFile, "log-file", "", "Path to write daemon log lines to (empty disables file logging; default .pruefer/pruefer.log)")
+	fs.BoolVar(&fv.autoUpgrade, "auto-upgrade", false, "At each poll boundary (never mid-review), check GitHub Releases for a newer version and self-upgrade; dev builds (built from the fabrik source checkout) rebuild from origin/main instead")
+	fs.BoolVar(&fv.versionRequested, "version", false, "Print the pruefer version and exit")
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
+	}
+
+	if fv.versionRequested {
+		return Config{VersionRequested: true}, nil
 	}
 
 	explicit := make(map[string]bool)
@@ -201,12 +222,16 @@ func LoadConfig(args []string) (Config, error) {
 		AppPrivateKeyPath: DefaultPrivateKeyPath,
 		TUI:               true,
 		LogFile:           DefaultLogPath,
+		AutoUpgrade:       false,
 	}
 	if yc.RequestChangesThreshold != "" {
 		cfg.RequestChangesThreshold = Severity(yc.RequestChangesThreshold)
 	}
 	if yc.TUI != nil {
 		cfg.TUI = *yc.TUI
+	}
+	if yc.AutoUpgrade != nil {
+		cfg.AutoUpgrade = *yc.AutoUpgrade
 	}
 	if yc.PollIntervalSec != nil {
 		cfg.PollInterval = time.Duration(*yc.PollIntervalSec) * time.Second
@@ -289,6 +314,9 @@ func LoadConfig(args []string) (Config, error) {
 	if explicit["log-file"] {
 		cfg.LogFile = fv.logFile
 	}
+	if explicit["auto-upgrade"] {
+		cfg.AutoUpgrade = fv.autoUpgrade
+	}
 
 	if cfg.RequestChangesThreshold != "" && !validSeverity(cfg.RequestChangesThreshold) {
 		return Config{}, fmt.Errorf("request_changes_threshold: %q is not a recognized severity tier (must be one of low, medium, high, critical, or empty to disable)", cfg.RequestChangesThreshold)
@@ -365,6 +393,11 @@ func applyEnv(cfg *Config) {
 	// used above, is what makes that distinction possible.
 	if v, ok := os.LookupEnv("PRUEFER_LOG_FILE"); ok {
 		cfg.LogFile = v
+	}
+	if v := os.Getenv("PRUEFER_AUTO_UPGRADE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.AutoUpgrade = b
+		}
 	}
 }
 

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -162,6 +162,66 @@ func TestLoadConfig_TUIPrecedence(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_AutoUpgradeDefaultsOff(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadConfig([]string{"-config", filepath.Join(dir, "missing.yaml")})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.AutoUpgrade {
+		t.Errorf("AutoUpgrade = true, want false by default")
+	}
+}
+
+func TestLoadConfig_AutoUpgradePrecedence(t *testing.T) {
+	dir := t.TempDir()
+
+	// YAML can enable it.
+	path := writeYAMLConfig(t, dir, `auto_upgrade: true`)
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.AutoUpgrade {
+		t.Errorf("AutoUpgrade = false, want true (from YAML)")
+	}
+
+	// Env overrides YAML.
+	t.Setenv("PRUEFER_AUTO_UPGRADE", "false")
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.AutoUpgrade {
+		t.Errorf("AutoUpgrade = true, want false (env should override YAML)")
+	}
+
+	// --auto-upgrade flag overrides env.
+	t.Setenv("PRUEFER_AUTO_UPGRADE", "false")
+	cfg, err = LoadConfig([]string{"-config", path, "-auto-upgrade"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.AutoUpgrade {
+		t.Errorf("AutoUpgrade = false, want true (--auto-upgrade flag should override env)")
+	}
+}
+
+func TestLoadConfig_VersionRequestedShortCircuits(t *testing.T) {
+	// --version must work even with no config file present and no other
+	// required flags set, so it short-circuits before YAML/env resolution.
+	cfg, err := LoadConfig([]string{"-version"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.VersionRequested {
+		t.Errorf("VersionRequested = false, want true")
+	}
+	if cfg.AppID != 0 || len(cfg.WatchedRepos) != 0 {
+		t.Errorf("expected short-circuited zero-value Config aside from VersionRequested, got %+v", cfg)
+	}
+}
+
 func TestLoadConfig_YAMLOverridesDefaults(t *testing.T) {
 	dir := t.TempDir()
 	path := writeYAMLConfig(t, dir, `

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -183,8 +183,30 @@ func (d *Daemon) Run(ctx context.Context) (err error) {
 	logf(0, "poll", "pruefer starting: watching %d repo(s), poll interval %s, concurrency %d\n",
 		len(d.Config.WatchedRepos), interval, d.effectiveConcurrency())
 
+	// lastUpgradeCheck is local to Run, not a Daemon field: Run is the sole
+	// sequential caller (both TUI and headless modes call d.Run), so there's
+	// no concurrent access to guard against. Zero value means the first
+	// iteration always checks.
+	var lastUpgradeCheck time.Time
+
 	for {
 		d.poll(ctx)
+
+		// The upgrade check runs after poll() returns — poll() already calls
+		// wg.Wait() before returning, so the in-flight review set is
+		// guaranteed empty here. This is the poll-boundary safety guarantee:
+		// re-exec'ing mid-review would orphan an ephemeral clone and a
+		// running claude subprocess with no review posted (see ADR-1197).
+		//
+		// The 30-minute throttle is a rate/cost control, not a safety
+		// requirement — it exists to bound git-fetch/GitHub-Releases-API
+		// chatter (Pruefer's own poll interval defaults to 120s, which would
+		// otherwise mean checking upstream roughly every 2 minutes).
+		if d.Config.AutoUpgrade && time.Since(lastUpgradeCheck) >= upgradeCheckInterval {
+			lastUpgradeCheck = time.Now()
+			d.checkAndUpgrade()
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -50,6 +50,15 @@ type Daemon struct {
 
 	// FabrikDir is the directory containing .pruefer/pruefer.lock. Defaults
 	// to "." (cwd) when empty.
+	//
+	// For the dev-build self-upgrade path (checkAndUpgrade → devBuildDir in
+	// upgrade.go) to work, FabrikDir must also be the root of the Fabrik
+	// source checkout — devBuildDir resolves <FabrikDir>/cmd/pruefer as the
+	// package to rebuild. This is not enforced: Execute() never sets this
+	// field explicitly, relying on the "" → cwd default, so it's on the
+	// operator to run Pruefer with its working directory at the checkout
+	// root for dev-mode auto-upgrade to work. A mismatch fails closed —
+	// selfupgrade.IsSourceCheckout simply returns false — rather than erroring.
 	FabrikDir string
 
 	// Emit, when non-nil, receives TUI observability events for poll cycles,
@@ -202,7 +211,18 @@ func (d *Daemon) Run(ctx context.Context) (err error) {
 		// requirement — it exists to bound git-fetch/GitHub-Releases-API
 		// chatter (Pruefer's own poll interval defaults to 120s, which would
 		// otherwise mean checking upstream roughly every 2 minutes).
-		if d.Config.AutoUpgrade && time.Since(lastUpgradeCheck) >= upgradeCheckInterval {
+		//
+		// ctx.Err() == nil guards against racing a shutdown signal: neither
+		// selfupgrade.CheckAndRebuildDev nor PerformReleaseUpgrade take a
+		// context, and a successful upgrade ends in syscall.Exec — once
+		// started, nothing can abort it. Without this guard, a SIGINT/SIGTERM
+		// arriving while d.poll(ctx) is still finishing could be immediately
+		// followed by a full git-fetch/build/re-exec or download/replace/
+		// re-exec cycle instead of the loop reaching the <-ctx.Done() case
+		// below, silently discarding the shutdown request. Mirrors
+		// engine/poll.go's equivalent guard on its own checkAndUpgrade call
+		// sites.
+		if d.Config.AutoUpgrade && ctx.Err() == nil && time.Since(lastUpgradeCheck) >= upgradeCheckInterval {
 			lastUpgradeCheck = time.Now()
 			d.checkAndUpgrade()
 		}

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -483,3 +483,35 @@ func TestDaemonRun_UpgradeCheckSkippedWhenDisabled(t *testing.T) {
 		t.Errorf("release-check hits = %d, want 0 (AutoUpgrade is false)", got)
 	}
 }
+
+// TestDaemonRun_UpgradeCheckSkippedWhenContextAlreadyCancelled guards the
+// ctx.Err() == nil guard in Run's loop: neither selfupgrade helper takes a
+// context and a successful upgrade ends in syscall.Exec, so once started
+// nothing can abort it. This reproduces the shutdown race the guard exists
+// for — a cancellation that has already landed by the time poll() returns —
+// and asserts the upgrade check is suppressed rather than firing and
+// silently discarding the pending shutdown.
+func TestDaemonRun_UpgradeCheckSkippedWhenContextAlreadyCancelled(t *testing.T) {
+	srv, hits := releaseCheckCounter(t)
+
+	origBase := releaseAPIBaseURL
+	releaseAPIBaseURL = srv.URL
+	t.Cleanup(func() { releaseAPIBaseURL = origBase })
+	setVersion(t, "v0.0.1")
+
+	d := &Daemon{
+		Config:    Config{PollInterval: 15 * time.Millisecond, AutoUpgrade: true},
+		FabrikDir: t.TempDir(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already done before Run's first poll() even starts
+
+	if err := d.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := hits(); got != 0 {
+		t.Errorf("release-check hits = %d, want 0 (ctx was already cancelled before the poll boundary)", got)
+	}
+}

--- a/pruefer/daemon_test.go
+++ b/pruefer/daemon_test.go
@@ -3,6 +3,8 @@ package pruefer
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"syscall"
@@ -404,4 +406,80 @@ func lockHeld(t *testing.T, path string) bool {
 	}
 	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 	return false
+}
+
+// releaseCheckCounter starts a test server standing in for GitHub's release
+// API, counting hits and always reporting "up to date" (same tag as the
+// running version) so no download/exec is ever attempted.
+func releaseCheckCounter(t *testing.T) (srv *httptest.Server, hits func() int) {
+	t.Helper()
+	var mu sync.Mutex
+	count := 0
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		fmt.Fprint(w, `{"tag_name": "v0.0.1", "assets": []}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return count
+	}
+}
+
+// TestDaemonRun_UpgradeCheckFiresAfterPollWhenEnabled verifies that Run
+// invokes the upgrade check at the poll boundary when Config.AutoUpgrade is
+// set, and that the 30-minute throttle suppresses repeat checks across
+// several fast poll cycles within the same Run call.
+func TestDaemonRun_UpgradeCheckFiresAfterPollWhenEnabled(t *testing.T) {
+	srv, hits := releaseCheckCounter(t)
+
+	origBase := releaseAPIBaseURL
+	releaseAPIBaseURL = srv.URL
+	t.Cleanup(func() { releaseAPIBaseURL = origBase })
+	setVersion(t, "v0.0.1")
+
+	d := &Daemon{
+		Config:    Config{PollInterval: 15 * time.Millisecond, AutoUpgrade: true},
+		FabrikDir: t.TempDir(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	if err := d.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := hits(); got != 1 {
+		t.Errorf("release-check hits = %d, want exactly 1 (throttle should suppress repeats across fast poll cycles)", got)
+	}
+}
+
+// TestDaemonRun_UpgradeCheckSkippedWhenDisabled verifies that Run never
+// invokes the upgrade check when Config.AutoUpgrade is false (the default) —
+// an operator must opt in.
+func TestDaemonRun_UpgradeCheckSkippedWhenDisabled(t *testing.T) {
+	srv, hits := releaseCheckCounter(t)
+
+	origBase := releaseAPIBaseURL
+	releaseAPIBaseURL = srv.URL
+	t.Cleanup(func() { releaseAPIBaseURL = origBase })
+	setVersion(t, "v0.0.1")
+
+	d := &Daemon{
+		Config:    Config{PollInterval: 15 * time.Millisecond, AutoUpgrade: false},
+		FabrikDir: t.TempDir(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	if err := d.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := hits(); got != 0 {
+		t.Errorf("release-check hits = %d, want 0 (AutoUpgrade is false)", got)
+	}
 }

--- a/pruefer/execute.go
+++ b/pruefer/execute.go
@@ -29,6 +29,10 @@ func Execute() error {
 	if err != nil {
 		return err
 	}
+	if cfg.VersionRequested {
+		fmt.Println(Version)
+		return nil
+	}
 	if cfg.AppID == 0 {
 		return fmt.Errorf("github_app_id is required (set via config file, PRUEFER_GITHUB_APP_ID, or --github-app-id)")
 	}

--- a/pruefer/upgrade.go
+++ b/pruefer/upgrade.go
@@ -3,6 +3,7 @@ package pruefer
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/selfupgrade"
@@ -15,6 +16,13 @@ const (
 	fabrikOwner = "handarbeit"
 	fabrikRepo  = "fabrik"
 )
+
+// upgradeCheckInterval throttles Daemon.Run's upgrade check, independent of
+// Config.PollInterval. Pruefer doesn't need this for safety (the
+// poll-boundary placement already guarantees no in-flight review) — it's
+// purely a rate/cost control on git-fetch and GitHub Releases API chatter.
+// See ADR-1197.
+const upgradeCheckInterval = 30 * time.Minute
 
 // releaseAPIBaseURL overrides the GitHub API host used by
 // checkReleaseUpgrade's dedicated release-check client. Empty (the

--- a/pruefer/upgrade.go
+++ b/pruefer/upgrade.go
@@ -1,0 +1,96 @@
+package pruefer
+
+import (
+	"path/filepath"
+	"strings"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/selfupgrade"
+)
+
+// fabrikOwner and fabrikRepo are the canonical owner/repo Pruefer's releases
+// come from — Pruefer ships from the fabrik monorepo's release, not a
+// separate repo (see ADR-1197).
+const (
+	fabrikOwner = "handarbeit"
+	fabrikRepo  = "fabrik"
+)
+
+// releaseAPIBaseURL overrides the GitHub API host used by
+// checkReleaseUpgrade's dedicated release-check client. Empty (the
+// production default) means the real GitHub API; tests point this at an
+// httptest server so no real network call is made.
+var releaseAPIBaseURL string
+
+// checkAndUpgrade selects the upgrade path based on the running version,
+// mirroring engine/upgrade.go's checkAndUpgrade:
+//   - dev builds (version starts with "dev"): git pull → go build → re-exec
+//   - release builds (all other versions): GitHub Releases API → download →
+//     atomic replace → re-exec
+//
+// The actual logic lives in internal/selfupgrade, which neither daemon owns
+// — see that package's doc comment and adrs/1196-extract-self-upgrade-package.md.
+//
+// Callers must only invoke this at a poll boundary when no review is in
+// flight (see Daemon.Run) — re-exec'ing mid-review orphans the in-flight
+// ephemeral clone and claude subprocess.
+func (d *Daemon) checkAndUpgrade() {
+	if !strings.HasPrefix(Version, "dev") {
+		d.checkReleaseUpgrade()
+		return
+	}
+
+	logfn := func(format string, args ...any) {
+		logf(0, "upgrade", format, args...)
+	}
+
+	selfupgrade.CheckAndRebuildDev(selfupgrade.DevBuildConfig{
+		Dir:            devBuildDir(d.FabrikDir),
+		Version:        Version,
+		BaseBranch:     "main",
+		ExpectedRemote: fabrikOwner + "/" + fabrikRepo,
+		Logf:           logfn,
+	})
+}
+
+// devBuildDir resolves the source-checkout subdirectory CheckAndRebuildDev
+// should operate in for Pruefer's dev-build path. Unlike fabrik, whose
+// main.go lives at the checkout root, Pruefer's main package lives at
+// cmd/pruefer — pointing Dir there makes both the git subcommands (which
+// resolve correctly from any subdirectory of the checkout) and
+// `go build -o exe .` (which builds whatever package "." resolves to
+// relative to Dir) operate on the right package, with no changes needed to
+// internal/selfupgrade itself. fabrikDir is d.FabrikDir; "" defaults to ".".
+func devBuildDir(fabrikDir string) string {
+	if fabrikDir == "" {
+		fabrikDir = "."
+	}
+	return filepath.Join(fabrikDir, "cmd", "pruefer")
+}
+
+// checkReleaseUpgrade is the release-based upgrade path. It checks the
+// GitHub Releases API for a version newer than the running binary, downloads
+// the matching platform asset, atomically replaces the running binary, and
+// re-execs. Unlike Pruefer's per-owner App installation tokens (scoped to
+// Config.WatchedRepos, not guaranteed to cover handarbeit/fabrik), this uses
+// a dedicated unauthenticated client — fabrik is a public repo, so this is
+// sufficient for both the releases-API lookup and the asset download (see
+// ADR-1197 for the tradeoff).
+//
+// All failures are non-fatal: a warning is logged and the poll loop continues.
+func (d *Daemon) checkReleaseUpgrade() {
+	logfn := func(format string, args ...any) {
+		logf(0, "upgrade", format, args...)
+	}
+	// Error discarded intentionally: failures are logged by
+	// selfupgrade.PerformReleaseUpgrade itself via logf, and this caller's
+	// contract is non-fatal — the poll loop continues regardless.
+	_ = selfupgrade.PerformReleaseUpgrade(selfupgrade.ReleaseConfig{
+		Client:     gh.NewClientWithBaseURL("", releaseAPIBaseURL),
+		Owner:      fabrikOwner,
+		Repo:       fabrikRepo,
+		BinaryName: "pruefer",
+		Version:    Version,
+		Logf:       logfn,
+	})
+}

--- a/pruefer/upgrade_test.go
+++ b/pruefer/upgrade_test.go
@@ -1,0 +1,112 @@
+package pruefer
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestDevBuildDir(t *testing.T) {
+	tests := []struct {
+		name      string
+		fabrikDir string
+		want      string
+	}{
+		{name: "empty defaults to cwd", fabrikDir: "", want: filepath.Join(".", "cmd", "pruefer")},
+		{name: "absolute checkout root", fabrikDir: "/home/user/dev/fabrik", want: filepath.Join("/home/user/dev/fabrik", "cmd", "pruefer")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := devBuildDir(tt.fabrikDir); got != tt.want {
+				t.Errorf("devBuildDir(%q) = %q, want %q", tt.fabrikDir, got, tt.want)
+			}
+		})
+	}
+}
+
+// setVersion sets the package-level Version var for the duration of the test
+// and restores it on cleanup — Version is a shared package global so tests
+// must not leave it mutated for later tests.
+func setVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := Version
+	Version = v
+	t.Cleanup(func() { Version = orig })
+}
+
+// TestCheckAndUpgrade_DevVersion_NotSourceCheckout_NoOp verifies the dev-build
+// branch is taken for a "dev"-prefixed version, and that it's a safe no-op
+// (no panic, no exec) when FabrikDir doesn't point at a real fabrik checkout
+// — exercising the wiring without needing a real git repo or a subprocess.
+func TestCheckAndUpgrade_DevVersion_NotSourceCheckout_NoOp(t *testing.T) {
+	setVersion(t, "dev(abc1234)")
+	d := &Daemon{FabrikDir: t.TempDir()}
+	d.checkAndUpgrade()
+}
+
+// TestCheckAndUpgrade_ReleaseVersion_UpToDate verifies that a non-"dev"
+// version takes the release-check branch, using a dedicated client pointed
+// at a local test server (never Pruefer's per-owner App installation
+// tokens). Returning the same tag as the running version means "up to
+// date" — no download is attempted.
+func TestCheckAndUpgrade_ReleaseVersion_UpToDate(t *testing.T) {
+	fetched := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+		wantPath := "/repos/" + fabrikOwner + "/" + fabrikRepo + "/releases/latest"
+		if r.URL.Path != wantPath {
+			t.Errorf("request path = %q, want %q", r.URL.Path, wantPath)
+		}
+		fmt.Fprintf(w, `{"tag_name": "v0.0.1", "assets": []}`)
+	}))
+	defer srv.Close()
+
+	orig := releaseAPIBaseURL
+	releaseAPIBaseURL = srv.URL
+	t.Cleanup(func() { releaseAPIBaseURL = orig })
+
+	setVersion(t, "v0.0.1")
+	d := &Daemon{}
+	d.checkAndUpgrade()
+
+	if !fetched {
+		t.Error("release-check server was not hit — release branch was not taken")
+	}
+}
+
+// TestCheckAndUpgrade_ReleaseVersion_DownloadAttempted verifies that when a
+// newer release with a matching platform asset is found, the binary name
+// used to construct the asset filename is "pruefer" — not "fabrik" — and
+// that the download is actually attempted (it then fails gracefully, since
+// the test server returns a 500, so no extraction or exec occurs).
+func TestCheckAndUpgrade_ReleaseVersion_DownloadAttempted(t *testing.T) {
+	downloaded := false
+	matchingAsset := fmt.Sprintf("pruefer_9.9.9_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/asset.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		downloaded = true
+		http.Error(w, "test server error", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"tag_name": "v9.9.9", "assets": [{"name": %q, "browser_download_url": %q}]}`,
+			matchingAsset, srv.URL+"/asset.tar.gz")
+	})
+
+	orig := releaseAPIBaseURL
+	releaseAPIBaseURL = srv.URL
+	t.Cleanup(func() { releaseAPIBaseURL = orig })
+
+	setVersion(t, "v0.0.1")
+	d := &Daemon{}
+	d.checkAndUpgrade()
+
+	if !downloaded {
+		t.Error("download server was not hit — asset name construction (BinaryName=pruefer) may be wrong")
+	}
+}

--- a/pruefer/version.go
+++ b/pruefer/version.go
@@ -1,0 +1,78 @@
+package pruefer
+
+import "runtime/debug"
+
+// Version is the pruefer binary version. For local/development builds this
+// defaults to "dev" and is enriched with the short VCS revision at startup.
+// Release builds inject the git tag via ldflags:
+//
+//	-X github.com/handarbeit/fabrik/pruefer.Version={{.Version}}
+//
+// This duplicates cmd/version.go's versionWithSHA/appendDirtyIfModified
+// rather than importing package cmd, which pulls in engine — pruefer must
+// never import engine (ADR-1113). See ADR-1197 for the duplication call.
+var Version = "dev"
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	Version = versionWithSHA(Version, info, ok)
+	Version = appendDirtyIfModified(Version, info, ok)
+}
+
+// versionWithSHA returns v unchanged if it is not "dev" (i.e. a real release
+// version was injected via ldflags). For "dev" builds it distinguishes a
+// working-tree build from an installed module:
+//
+//   - If vcs.revision is present, this binary was built by `go build`/`go run`
+//     in a source checkout — report "dev(<short-sha>)". This check comes FIRST
+//     because modern Go (1.24+) stamps a VCS-derived pseudo-version (e.g.
+//     "v0.0.74-0.20260716173320-6198e8102f90+dirty") into Main.Version for such
+//     builds, not the old "(devel)" sentinel. Keying on Main.Version would
+//     otherwise report that pseudo-version, which breaks the "dev"-prefixed
+//     auto-upgrade gate (pruefer/upgrade.go checkAndUpgrade) — the build would
+//     take the release-download path and never rebuild from origin/main.
+//   - Otherwise (no vcs.revision), a `go install pkg@vX.Y.Z` build carries the
+//     resolved module version in Main.Version — report it directly.
+//   - If neither is available, return "dev" unchanged.
+func versionWithSHA(v string, info *debug.BuildInfo, ok bool) string {
+	if v != "dev" {
+		return v
+	}
+	if !ok || info == nil {
+		return v
+	}
+	// Working-tree build: vcs.revision present → dev(<sha>), regardless of the
+	// (possibly pseudo-version) Main.Version that modern Go stamps.
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" && s.Value != "" {
+			short := s.Value
+			if len(short) > 7 {
+				short = short[:7]
+			}
+			return "dev(" + short + ")"
+		}
+	}
+	// No VCS info: an installed module (go install pkg@vX.Y.Z) carries its
+	// resolved version in Main.Version.
+	if mv := info.Main.Version; mv != "" && mv != "(devel)" {
+		return mv
+	}
+	return v
+}
+
+// appendDirtyIfModified appends "+dirty" to v when the running binary's own
+// embedded VCS build info reports vcs.modified=true — regardless of whether
+// v is a ldflags-injected release version or a dev build. This surfaces a
+// locally-built or improperly-released binary instead of it masquerading as
+// a clean release.
+func appendDirtyIfModified(v string, info *debug.BuildInfo, ok bool) string {
+	if !ok || info == nil {
+		return v
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.modified" && s.Value == "true" {
+			return v + "+dirty"
+		}
+	}
+	return v
+}

--- a/pruefer/version_test.go
+++ b/pruefer/version_test.go
@@ -1,0 +1,183 @@
+package pruefer
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func buildInfoWithRevision(rev string) *debug.BuildInfo {
+	return &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: rev},
+		},
+	}
+}
+
+func buildInfoWithMainVersion(mv string) *debug.BuildInfo {
+	return &debug.BuildInfo{
+		Main: debug.Module{Version: mv},
+	}
+}
+
+func TestVersionWithSHA(t *testing.T) {
+	tests := []struct {
+		name     string
+		v        string
+		info     *debug.BuildInfo
+		ok       bool
+		expected string
+	}{
+		{
+			name:     "injected release version passes through unchanged",
+			v:        "v1.2.3",
+			info:     buildInfoWithRevision("abc1234567890"),
+			ok:       true,
+			expected: "v1.2.3",
+		},
+		{
+			name:     "dev with no build info degrades to dev",
+			v:        "dev",
+			info:     nil,
+			ok:       false,
+			expected: "dev",
+		},
+		{
+			name:     "dev with empty VCS revision degrades to dev",
+			v:        "dev",
+			info:     buildInfoWithRevision(""),
+			ok:       true,
+			expected: "dev",
+		},
+		{
+			name:     "dev with 7+ char SHA produces dev(short-sha)",
+			v:        "dev",
+			info:     buildInfoWithRevision("abcdef1234567"),
+			ok:       true,
+			expected: "dev(abcdef1)",
+		},
+		{
+			name:     "dev with short SHA uses full value",
+			v:        "dev",
+			info:     buildInfoWithRevision("abc12"),
+			ok:       true,
+			expected: "dev(abc12)",
+		},
+		{
+			name:     "dev with exactly 7 char SHA",
+			v:        "dev",
+			info:     buildInfoWithRevision("abcdef1"),
+			ok:       true,
+			expected: "dev(abcdef1)",
+		},
+		{
+			name:     "go install pkg@vX.Y.Z reports Main.Version",
+			v:        "dev",
+			info:     buildInfoWithMainVersion("v0.0.71"),
+			ok:       true,
+			expected: "v0.0.71",
+		},
+		{
+			name: "local checkout with (devel) Main.Version falls through to VCS SHA",
+			v:    "dev",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "abcdef1234567"},
+				},
+			},
+			ok:       true,
+			expected: "dev(abcdef1)",
+		},
+		{
+			// Regression: modern Go (1.24+) stamps a VCS-derived pseudo-version
+			// into Main.Version for working-tree builds instead of "(devel)".
+			// vcs.revision is still present, so this must report dev(<sha>) — not
+			// the pseudo-version — or the "dev"-prefixed auto-upgrade gate breaks
+			// and the instance never rebuilds from origin/main.
+			name: "working-tree build with pseudo-version Main.Version still reports dev(sha)",
+			v:    "dev",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.0.74-0.20260716173320-6198e8102f90+dirty"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "6198e8102f90bc3757461fdfc50707d0a4767cc7"},
+					{Key: "vcs.modified", Value: "true"},
+				},
+			},
+			ok:       true,
+			expected: "dev(6198e81)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := versionWithSHA(tt.v, tt.info, tt.ok)
+			if got != tt.expected {
+				t.Errorf("versionWithSHA(%q, ...) = %q, want %q", tt.v, got, tt.expected)
+			}
+		})
+	}
+}
+
+func buildInfoWithModified(modified string) *debug.BuildInfo {
+	return &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "abcdef1234567"},
+			{Key: "vcs.modified", Value: modified},
+		},
+	}
+}
+
+func TestAppendDirtyIfModified(t *testing.T) {
+	tests := []struct {
+		name     string
+		v        string
+		info     *debug.BuildInfo
+		ok       bool
+		expected string
+	}{
+		{
+			name:     "release version with dirty build info gets +dirty appended",
+			v:        "v1.2.3",
+			info:     buildInfoWithModified("true"),
+			ok:       true,
+			expected: "v1.2.3+dirty",
+		},
+		{
+			name:     "release version with clean build info is unchanged",
+			v:        "v1.2.3",
+			info:     buildInfoWithModified("false"),
+			ok:       true,
+			expected: "v1.2.3",
+		},
+		{
+			name:     "dev build with dirty build info gets +dirty appended",
+			v:        "dev(abcdef1)",
+			info:     buildInfoWithModified("true"),
+			ok:       true,
+			expected: "dev(abcdef1)+dirty",
+		},
+		{
+			name:     "no build info leaves version unchanged",
+			v:        "v1.2.3",
+			info:     nil,
+			ok:       false,
+			expected: "v1.2.3",
+		},
+		{
+			name:     "missing vcs.modified setting leaves version unchanged",
+			v:        "v1.2.3",
+			info:     buildInfoWithRevision("abcdef1234567"),
+			ok:       true,
+			expected: "v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendDirtyIfModified(tt.v, tt.info, tt.ok)
+			if got != tt.expected {
+				t.Errorf("appendDirtyIfModified(%q, ...) = %q, want %q", tt.v, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1197

## Summary

Wires Pruefer to the same self-upgrade capability Fabrik already has (`internal/selfupgrade`, ADR-1196), and publishes a `pruefer` binary from `.goreleaser.yaml` alongside `fabrik` so the release-download upgrade path has an artifact to fetch. `pruefer/` still imports no `engine` symbols.

## Key changes

- **`.goreleaser.yaml`**: adds a `pruefer` builds/archives entry (`main: ./cmd/pruefer`, same darwin/linux × arm64/amd64 matrix, ldflags version stamp, its own `verify-release-artifact` post-hook). Both binaries ship from the same tag/release — see ADR-1197 for the rationale.
- **`pruefer/version.go`**: `Version` var + duplicated `versionWithSHA`/`appendDirtyIfModified` from `cmd/version.go` (duplicated rather than shared, since `package cmd` imports `engine` — ADR-1113 Decision 6 precedent).
- **`pruefer/upgrade.go`**: `Daemon.checkAndUpgrade()` mirrors `engine/upgrade.go`'s dev/release branch. Dev-build path points `DevBuildConfig.Dir` at `<checkout>/cmd/pruefer` (not the checkout root, since that's where Pruefer's `main` package actually lives). Release path uses a dedicated unauthenticated `github.Client` (Pruefer's only other GitHub credentials are per-owner App installation tokens with no guarantee they cover `handarbeit/fabrik`).
- **`pruefer/daemon.go`**: fires the upgrade check in `Run`'s loop right after `poll()` returns — `poll()` already `wg.Wait()`s on every in-flight review before returning, so this placement satisfies "never swap mid-review" by construction. Throttled to 30 minutes independent of `PollInterval`.
- **`pruefer/config.go` / `execute.go`**: adds `--auto-upgrade`/`PRUEFER_AUTO_UPGRADE`/`auto_upgrade` (default off, mirroring Fabrik's own default) and `--version` (short-circuits before required-config validation).
- **`adrs/1197-pruefer-self-upgrade.md`**: records the five non-obvious decisions above plus the release-cadence choice.
- **`cmd/pruefer/README.md`**: new "Version & self-upgrade" section covering both deployment modes, plus a `--auto-upgrade` config-reference row.

## Not for the imminent release

Per the issue body's own instruction, this is captured work, not something to ship immediately — Pruefer needs more bake time. The issue carries `fabrik:cruise` (not `fabrik:yolo`), so this PR will not auto-merge; the actual merge timing is a separate human decision.

## Test plan

- `go build ./...`, `go vet ./...` — clean.
- `go test -race ./...` — full suite passes except `TestExecute_ConfigYAMLApplied` (`cmd` package), which is a pre-existing environmental flake unrelated to this change — verified it fails identically on a clean `main` checkout with none of this PR's changes.
- `goreleaser check` validates the updated `.goreleaser.yaml`; a snapshot build of the `pruefer` build ID (`goreleaser build --snapshot --id pruefer`) successfully builds and runs the `verify-release-artifact` hook.
- `go list -deps ./pruefer/... ./cmd/pruefer/... | grep engine` returns nothing.