### PR TITLE
e2e: delete vacuous scenario, strengthen NoWorkNeeded, add per-test timings, document authoring rule

### DIFF
--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -149,6 +149,39 @@ report_test_outcomes() {
       '
 }
 
+# report_test_timings prints a ranked (slowest-first) per-test wall-clock
+# summary from a `go test -json` log, labeled with which leg (mode) it came
+# from. This is the evidence #1355's R3 exists to produce: "which scenarios
+# cost the most" should be a measured number from a real gate run, not a
+# guess, so future cost/value tradeoffs on expensive-and-thin scenarios are
+# evidence-based.
+#
+# Elapsed is only meaningful on a test's terminal event (Go's test2json emits
+# it on pass/fail/skip; run/cont/pause events carry no useful duration), so
+# the filter selects those three actions directly rather than reusing
+# report_test_outcomes's "last action, any type" grouping. Subtests (names
+# containing "/") are excluded — same per-test (not per-subtest) granularity
+# as report_test_outcomes. Called unconditionally (pass or fail) so a timing
+# table is always emitted for every leg that actually ran, not just failing
+# ones — see switch_and_run below for why this can't be a single combined
+# report across both legs.
+report_test_timings() {
+  local jsonlog="$1"
+  local mode="$2"
+  echo "== per-test wall-clock (leg: ${mode}), slowest first =="
+  jq -R 'fromjson? // empty' "$jsonlog" \
+    | jq -s -r '
+        [ .[] | select(.Test != null and (.Test | contains("/") | not)
+            and (.Action == "pass" or .Action == "fail" or .Action == "skip")) ]
+        | group_by(.Test)
+        | map({test: .[0].Test, result: .[-1].Action, elapsed: (.[-1].Elapsed // 0)})
+        | sort_by(-.elapsed)
+        | .[]
+        | [(.elapsed | tostring) + "s", .result, .test] | @tsv
+      ' \
+    | { column -t -s "$(printf '\t')" 2>/dev/null || cat; }
+}
+
 # switch_and_run stops the bed, flips FABRIK_MERGE_TRAIN to $1 in its .env,
 # restarts it (via the dedicated TestSwitchTrainMode invocation — a separate
 # `go test` process so the restart completes, bed fully back up, before the
@@ -195,6 +228,9 @@ switch_and_run() {
     | tee "$jsonlog" \
     | { jq -R -r 'fromjson? // empty | select(.Action=="output") | .Output' 2>/dev/null || true; } \
     || rc=$?
+
+  report_test_timings "$jsonlog" "$mode" \
+    || echo "warning: failed to compute test timings (jq error) — inspect the raw JSON log directly: $jsonlog" >&2
 
   if [ "$rc" -ne 0 ]; then
     echo "== suite FAILED (leg: ${mode}, exit ${rc}) — classifying test outcomes ==" >&2

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -428,14 +428,13 @@ scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` dis
 ### Additional prerequisites for `TestExpectedReviewers*` scenarios
 
 `TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
-`TestExpectedReviewersPrecedenceGuard`, and
-`TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cover ADR-1283's
+and `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cover ADR-1283's
 `expected_reviewers` (declared unrequested reviewers for the review gate).
-`TestExpectedReviewersUndeclaredRegressionGuard` is the fifth scenario and has no
-dependency described below. All five run against the bed's existing `Review`
+`TestExpectedReviewersUndeclaredRegressionGuard` is the fourth scenario and has no
+dependency described below. All four run against the bed's existing `Review`
 column/stage (default, untouched config) — **no bed column or stage-YAML setup is
-required**, beyond `FABRIK_REVIEW_WAIT_TIMEOUT`/`FABRIK_REVIEWER_TOKEN` (already
-documented above) and the two labels below.
+required**, beyond `FABRIK_REVIEW_WAIT_TIMEOUT` (already documented above) and the
+two labels below.
 
 **Mechanism: two per-issue labels, not a bed column.** A declared `expected_reviewers`
 value is applied per item via one of two labels, passed as an extra label at seed
@@ -452,8 +451,7 @@ separate, decoupled follow-up issue (not yet filed as of #1298's PR — see that
 PR's description for the exact spec: the four call sites to update, the
 `declared` > `none` precedence rule, and the `github/labels.go` pre-seeding step).
 `TestExpectedReviewersFastAdvance`, `TestExpectedReviewersDeclaredWaitsAndReprompts`,
-`TestExpectedReviewersPrecedenceGuard`, and
-`TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cannot pass until that
+and `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` cannot pass until that
 follow-up merges and both labels exist on the bed repo — they either run for real
 or fail loudly (not skip) if the follow-up hasn't landed yet, mirroring #1258's
 rejection of silent skips. `TestExpectedReviewersUndeclaredRegressionGuard` sets
@@ -474,11 +472,7 @@ scenarios — taking every other in-flight parallel scenario down with it.
 a stage literally named `Validate`, and seeding on `Review` cannot reach it. This
 is a documented, accepted e2e gap.
 
-26. **`FABRIK_REVIEWER_TOKEN` in the test bed `.env`** — same non-author PAT as
-    prerequisite #21, required only by `TestExpectedReviewersPrecedenceGuard`
-    (the others don't need a submitted review). Skips with an instructional
-    message if unset.
-27. **`expected-reviewers:none` and `expected-reviewers:declared` labels seeded**
+26. **`expected-reviewers:none` and `expected-reviewers:declared` labels seeded**
     in `handarbeit/fabrik-test-alpha` (the only repo these scenarios use).
     `FileIssue` passes extra labels straight through to `gh issue create --label`,
     which — like `AddLabel` (prerequisite #9) and prerequisite #22's
@@ -493,7 +487,7 @@ is a documented, accepted e2e gap.
     that *interprets* a label an issue already carries, not the GitHub label
     object itself — the objects must exist before any of these scenarios can even
     file their seed issue.
-28. **`TestExpectedReviewersDeclaredWaitsAndReprompts`'s wall-clock is long**
+27. **`TestExpectedReviewersDeclaredWaitsAndReprompts`'s wall-clock is long**
     (~2×`FABRIK_REVIEW_WAIT_TIMEOUT` + buffer, similar to
     `TestReviewAuthorityBlocksAndPausesOnChangesRequested`) — Phase 1 and Phase 2
     of the bot re-prompt ladder are folded into one continuation. The same
@@ -501,12 +495,12 @@ is a documented, accepted e2e gap.
     (e.g. `5`) applies here too; a very short value risks a legitimate Phase 1/2
     transition racing this test's own bounded-window assertions in
     `TestExpectedReviewersFastAdvance`/`...ComposesWithAuthoritative`.
-29. **The synthetic declared-reviewer name (`e2e-synthetic-declared-reviewer`)
+28. **The synthetic declared-reviewer name (`e2e-synthetic-declared-reviewer`)
     must never resolve to a real, active GitHub account** on the bed's org —
     same rationale as prerequisite #23's warning against reusing a real installed
     bot: an unrelated real actor submitting a review would race the deterministic
     re-prompt-ladder assertions in `TestExpectedReviewersDeclaredWaitsAndReprompts`.
-30. **Draft-PR determinism technique (#1312)**: `TestExpectedReviewersFastAdvance`,
+29. **Draft-PR determinism technique (#1312)**: `TestExpectedReviewersFastAdvance`,
     `TestExpectedReviewersDeclaredWaitsAndReprompts`,
     `TestExpectedReviewersUndeclaredRegressionGuard`, and
     `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` seed via
@@ -789,7 +783,6 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestReviewAuthorityAdvisoryRegressionGuard` | Regression guard: advisory (default) mode still clears on any submitted review regardless of verdict — proves the additive authoritative check didn't narrow the default path | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestExpectedReviewersFastAdvance` | ADR-1283 `expected_reviewers: []` (via `expected-reviewers:none` label, requires follow-up engine issue): nothing requested/reviewed → gate fast-advances instead of waiting out the review timeout (the #1080 stall this feature fixes) | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestExpectedReviewersDeclaredWaitsAndReprompts` | ADR-1283 `expected_reviewers: [<name>]` (via `expected-reviewers:declared` label, requires follow-up engine issue): declared-but-unrequested reviewer holds the gate open, Phase 1 re-prompt ladder fires with an @mention comment, Phase 2 pauses for human when no response arrives | Both | ~2×`FABRIK_REVIEW_WAIT_TIMEOUT` + buffer | ~$0.05 (no Claude) |
-| `TestExpectedReviewersPrecedenceGuard` | ADR-1283 precedence guard (via `expected-reviewers:none` label, requires follow-up engine issue): a genuinely requested reviewer holds the gate open despite `expected_reviewers: []` being declared | Both | 5–10 min | ~$0.03 (no Claude) |
 | `TestExpectedReviewersUndeclaredRegressionGuard` | Regression guard: undeclared (`nil`) `expected_reviewers` still never fast-advances — pins the `expected != nil` check and proves the shipped default (FR-5) is unchanged | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` | ADR-1283 composition guard (via `expected-reviewers:none` + `review-authority:authoritative` labels, requires follow-up engine issue + #1261): fast-advance still fires ahead of the authority-verdict branch, since it only activates once hasReviews is true | Both | 2–5 min | ~$0.02 (no Claude) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | Train-only (on) | 10–25 min | low (no Claude) |
@@ -827,7 +820,6 @@ shape, not just the single-mode total.
 | `TestReviewAuthorityAdvisoryRegressionGuard` | ADR-1250 additive-check regression guard, #1258 |
 | `TestExpectedReviewersFastAdvance` | ADR-1283 (`expected_reviewers`), #1298 (this scenario), the #1080 stall the feature exists to eliminate |
 | `TestExpectedReviewersDeclaredWaitsAndReprompts` | ADR-1283, #1298 — first e2e coverage of the bot re-prompt ladder (`fabrik:bot-reprompted`, Phase 1/2 of `checkAwaitingReviewTimeout`) |
-| `TestExpectedReviewersPrecedenceGuard` | ADR-1283, #1298 — declared reviewers narrow waiting for unrequested reviewers only, never bypass a genuinely requested one |
 | `TestExpectedReviewersUndeclaredRegressionGuard` | ADR-1283 FR-5 regression guard, #1298 — pins `reviewGateFastAdvance`'s `expected != nil` check |
 | `TestExpectedReviewersFastAdvanceComposesWithAuthoritative` | ADR-1283, #1298 — fast-advance independence from `review_authority` (ADR-1250) |
 | `TestMergeTrainHappyPathLanding` | ADR-059 D1/D3 (#946, #947, #948) — Queued column, trial-branch build, integration-PR landing + member lifecycle |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -736,6 +736,39 @@ reports), and **never started** (parked waiting for a free `-parallel` slot,
 which the built-in panic dump omits entirely). The full JSON log is kept for
 follow-up debugging at the path printed above.
 
+#### Per-test wall-clock summary (#1355)
+
+Unlike the failure classification above, `report_test_timings` runs
+unconditionally — pass or fail — right after each leg's suite invocation
+finishes, so "which scenarios cost the most" is a measured number from every
+gate run rather than a guess:
+
+```
+== per-test wall-clock (leg: off), slowest first ==
+2312.4s  pass  TestConvergenceRace
+1382.1s  pass  TestPausedMergedPRRecovery
+612.0s   pass  TestNoWorkNeeded
+58.3s    pass  TestSmokeSingleRepoDispatch
+0s       skip  TestMergeTrainHappyPathLanding
+```
+
+Elapsed is Go's own per-test `Elapsed` field from the `go test -json` stream
+(only meaningful on a test's terminal pass/fail/skip event), sorted
+descending; subtests are folded into their parent, same as the failure
+classification above. Printed once per leg — a combined cross-leg table
+isn't possible without changing `switch_and_run`'s per-leg `jsonlog` scoping
+(see the function's own doc comment for why).
+
+**Verification status:** the `jq` pipeline itself is proven against
+synthetic `go test -json` fixtures (multiple tests, a subtest, all three
+terminal actions, sorted correctly) — not by inspection. A full smoke test
+of the integrated `scripts/e2e/run.sh` output (AC4) against a live gate run
+was not performed for the same reason as `TestNoWorkNeeded`'s live-bed
+verification above: doing so touches `~/dev/fabrik-test`, outside any
+automated Fabrik stage's worktree sandbox. Run `scripts/e2e/run.sh -run
+TestSmokeSingleRepoDispatch` manually to confirm the table prints in
+context.
+
 #### Teardown on kill
 
 A run killed by `E2E_TIMEOUT` (or an external signal) skips every in-flight

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -927,6 +927,52 @@ Every escape-from-release regression earns a new scenario in this table.
    the test bed (`t.Cleanup` is your friend).
 4. Document what regression the scenario protects against. Reference the
    originating issue or PR.
+5. **Assert on something that can only be produced by the engine, on the
+   specific path under test** (handarbeit/fabrik#1355). A scenario that
+   passes just as easily against a broken engine as a working one is worse
+   than no scenario at all — it looks like coverage but proves nothing, and
+   the failure is invisible until someone happens to ask why the test
+   passed. Two incidents motivated this rule:
+   - **#1320**: `TestCIFixReinvokeCycleLimit` matched the engine's
+     `🏭 **Fabrik — CI fix cycle limit reached**` marker via
+     `strings.Contains` across *every* comment on the issue, including
+     stage-output comments the Claude agent itself wrote. On
+     `handarbeit/fabrik-test-alpha#4049` a Research-stage comment quoted the
+     marker text in prose while describing the feature — the engine never
+     posted the marker at all, but the substring scan matched the prose
+     instead and the test passed green.
+   - **#1319**: `TestExpectedReviewersPrecedenceGuard` passed identically
+     against an engine with zero `expected_reviewers` support and against
+     the fixed engine — its assertion (`fabrik:awaiting-review` held while a
+     reviewer is outstanding) was true under both, so it never actually
+     exercised the feature it was named for. It was deleted rather than
+     fixed (see handarbeit/fabrik#1355 R1) once shown the property it wanted
+     to prove is unreachable in e2e by construction: `reviewGateFastAdvance`
+     (`engine/reviews.go`) short-circuits on the outstanding-reviewer check
+     before the `expected_reviewers` branch is ever reached.
+
+   In practice:
+   - **Match engine-authored comments by body prefix, never by substring
+     anywhere in the body.** Mirror `findNewComments`
+     (`engine/comments.go:17`), which uses `strings.HasPrefix(c.Body, "🏭
+     **Fabrik")` to distinguish Fabrik's own output from anything an agent
+     wrote. See the "Marker-substring assertion audit (#1320)" section above
+     for the full audit of every `🏭`-marker call site in this package, and
+     `ci_fix_reinvoke_marker_test.go` / `no_work_needed_marker_test.go` for
+     the concrete pattern to copy: a literal prefix `const`, a
+     `strings.HasPrefix`-based helper, and a companion fast (no live bed)
+     unit test with fixtures proving the helper accepts genuine engine
+     output and rejects a fixture shaped like the #4049 false-pass (prose
+     that quotes the marker text).
+   - Before writing the assertion, ask what a *broken* version of the
+     feature under test would do differently. If the answer is "nothing
+     observable," the scenario doesn't yet discriminate — strengthen it
+     (per the `TestNoWorkNeeded`/#1355 R2 fix above) or don't add it.
+   - **Prefer a loud, diagnostic `t.Skip` over an assertion that can be
+     satisfied by accident.** A skip with a clear reason ("prerequisite X
+     not configured") is honest about missing coverage; a green check that
+     doesn't actually exercise the path under test is worse, because it
+     hides the gap.
 
 ## Design notes
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -213,6 +213,61 @@ A repo-wide search (`grep -rn "🏭" tests/e2e/*.go`) found every call site in
 No other `tests/e2e/*.go` file references the `🏭` emoji or a
 `"🏭 **Fabrik —"` literal.
 
+### `TestNoWorkNeeded` discriminator verification (#1355)
+
+`TestNoWorkNeeded` used to assert only `WaitForIssueClosed` (plus a
+best-effort "no open PR" spot-check) — insufficient by itself, since closing
+proves the pipeline finished, not that it took the no-work-needed path
+specifically (the same vacuity class as #1320/#1319). It now additionally
+asserts the engine's own no-work-needed skip comment
+(`noWorkNeededSkipComment`, `engine/no_work_needed_settle.go`) is present,
+matched by body prefix via `hasNoWorkNeededSkipComment`
+(`no_work_needed_marker_test.go`) — never by substring-anywhere, for the same
+reason `hasEngineCycleLimitComment` matches by prefix.
+
+**Verified so far:** `TestHasNoWorkNeededSkipComment` is a fast, no-live-bed
+unit test that proves the helper accepts both genuine comment variants
+`noWorkNeededSkipComment` can produce and rejects a fixture where an agent
+quotes the marker text in prose (the #4049/#1320 false-pass shape) — run it
+with `go test -tags e2e -run TestHasNoWorkNeededSkipComment ./tests/e2e/`.
+This establishes the matching logic itself discriminates correctly.
+
+**Not yet verified: a genuine red/green cycle against the live e2e bed**
+(the issue's own Verification Note calls this the load-bearing step). Doing
+so requires temporarily neutralizing `noWorkNeededSkipComment`'s posting in
+a locally-built engine binary, deploying that binary to the shared
+`~/dev/fabrik-test` bed, and restarting the bed's Fabrik instance — all
+outside the `tests/e2e/` worktree, and outside the sandbox boundary an
+automated Fabrik Implement/Review/Validate stage operates under (see
+CLAUDE.md's "Worktree Boundary"). No pipeline stage in this repo can safely
+perform that step; it requires a human operator with direct access to the
+bed. Steps to complete AC3 before merge:
+
+```bash
+cd ~/dev/fabrik-test
+# Stop the running instance (Ctrl-C in its session, or: kill $(cat .fabrik/fabrik.lock))
+
+# RED: neutralize the skip-comment posting, uncommitted
+#   in engine/no_work_needed_settle.go, make noWorkNeededSkipComment return ""
+go build -o fabrik .
+./fabrik -notui &   # do NOT pass --auto-upgrade, it would overwrite this build
+cd -   # back to this branch's checkout
+go test -tags e2e -run TestNoWorkNeeded ./tests/e2e/ -timeout 25m -v
+# Expect FAIL: "no engine-authored no-work-needed skip comment ... found"
+
+cd ~/dev/fabrik-test
+git diff --stat engine/   # confirm the neutralization is still the only engine change
+git checkout -- engine/no_work_needed_settle.go   # revert
+go build -o fabrik .
+# restart the instance (Ctrl-C the red one first): ./fabrik -notui --auto-upgrade &
+cd -
+go test -tags e2e -run TestNoWorkNeeded ./tests/e2e/ -timeout 25m -v
+# Expect PASS
+```
+
+Record both outcomes (pass/fail, timestamps, relevant log lines) in the PR
+or as a follow-up comment on handarbeit/fabrik#1355 once run.
+
 ### Additional prerequisites for `TestPausedMergedPRRecovery`
 
 9. **Gate labels seeded** in `handarbeit/fabrik-test-alpha`: `fabrik:awaiting-ci`,

--- a/tests/e2e/expected_reviewers_test.go
+++ b/tests/e2e/expected_reviewers_test.go
@@ -28,10 +28,10 @@ import (
 // issue (not yet filed as of this PR — see the Implement-stage PR
 // description for its exact spec), mirroring how #1261 was kept decoupled
 // from #1258. Scenarios that rely on a declared value (fast-advance,
-// declared-waits, precedence, composition) cannot pass until that follow-up
-// merges and the two label objects exist on the bed repo; the regression
-// guard (undeclared/nil) has no such dependency and ships green in this PR
-// alone. See adrs/1298-e2e-expected-reviewers-coverage.md.
+// declared-waits, composition) cannot pass until that follow-up merges and
+// the two label objects exist on the bed repo; the regression guard
+// (undeclared/nil) has no such dependency and ships green in this PR alone.
+// See adrs/1298-e2e-expected-reviewers-coverage.md.
 //
 // Bed setup required: FABRIK_REVIEWER_TOKEN (existing prerequisite, reused
 // from #1258), and the "expected-reviewers:none" / "expected-reviewers:declared"
@@ -74,8 +74,7 @@ import (
 // from ever reviewing it (its job is guarded by
 // `if: github.event.pull_request.draft == false`, triggering only on
 // opened/ready_for_review), removing the incidental review entirely rather
-// than racing it. TestExpectedReviewersPrecedenceGuard needs no such
-// treatment — it already calls RequestPRReviewer before its wait.
+// than racing it.
 const (
 	expectedReviewersNoneLabel     = "expected-reviewers:none"
 	expectedReviewersDeclaredLabel = "expected-reviewers:declared"
@@ -188,56 +187,6 @@ func TestExpectedReviewersDeclaredWaitsAndReprompts(t *testing.T) {
 		t.Fatalf("expected issue OPEN after declared-reviewer Phase 2 timeout, got %s on %s#%d", state, env.RepoAlpha, num)
 	}
 	t.Logf("R2 verified: %s#%d — declared reviewer held the gate open, Phase 1 re-prompted, Phase 2 paused for human", env.RepoAlpha, num)
-}
-
-// TestExpectedReviewersPrecedenceGuard covers requirements scenario 3: a
-// genuinely requested reviewer (non-empty outstanding) overrides
-// expected_reviewers: [] — the declaration narrows waiting for *unrequested*
-// reviewers only and must never bypass wait_for_reviews for a reviewer
-// GitHub is actually tracking. Requires the follow-up engine-side
-// label-read issue to be merged; see the file-level doc comment.
-//
-// (The other half of "precedence" — an already-submitted review overriding
-// expected_reviewers: [] — is definitionally the same pre-#1283
-// hasReviews-clearing path every existing review-gate scenario already
-// exercises, since reviewGateFastAdvance short-circuits on hasReviews before
-// the declaration is even consulted; it is not re-asserted here as it would
-// be redundant, not a new assertion. See adrs/1298-e2e-expected-reviewers-coverage.md.)
-//
-// Wall-clock: ~5-10 min.
-func TestExpectedReviewersPrecedenceGuard(t *testing.T) {
-	t.Parallel()
-	env := LoadEnv(t)
-	AssertFabrikRunning(t, env)
-
-	reviewerToken := readEnvFileReviewerToken(t, env)
-	if reviewerToken == "" {
-		t.Skip("FABRIK_REVIEWER_TOKEN not set in test bed .env — required for deterministic verdict scenarios")
-	}
-
-	num, prNum, _ := seedReviewGateItem(t, env, env.RepoAlpha, "main", "Review", "expected-none-precedence", expectedReviewersNoneLabel)
-	AssertPRAuthorIsExpectedIdentity(t, env, env.RepoAlpha, prNum)
-
-	reviewerLogin := TokenLogin(t, reviewerToken)
-	if engineLogin := TokenLogin(t, env.GHToken); reviewerLogin == engineLogin {
-		t.Fatalf("FABRIK_REVIEWER_TOKEN resolves to %q, the same identity as the engine/PR author — "+
-			"set FABRIK_REVIEWER_TOKEN to a distinct GitHub account's PAT", reviewerLogin)
-	}
-
-	RequestPRReviewer(t, env, env.RepoAlpha, prNum, reviewerLogin)
-	t.Logf("requested reviewer %q on %s PR #%d despite expected_reviewers: [] being declared", reviewerLogin, env.RepoAlpha, prNum)
-
-	// A genuinely outstanding requested reviewer must hold the gate open —
-	// the empty declaration must not fast-advance past it.
-	WaitForIssueLabel(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
-	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "fabrik:awaiting-review")
-	t.Logf("fabrik:awaiting-review confirmed on %s#%d — requested reviewer overrides expected_reviewers: []", env.RepoAlpha, num)
-
-	SubmitPRReview(t, env, reviewerToken, env.RepoAlpha, prNum, "APPROVE")
-	t.Logf("submitted APPROVE review on %s PR #%d", env.RepoAlpha, prNum)
-
-	WaitForLabelAbsent(t, env, env.RepoAlpha, num, "fabrik:awaiting-review", 10*time.Minute)
-	t.Logf("R3 verified: %s#%d — gate held for the requested reviewer despite expected_reviewers: [], cleared once they reviewed", env.RepoAlpha, num)
 }
 
 // TestExpectedReviewersUndeclaredRegressionGuard covers requirements

--- a/tests/e2e/no_work_needed_marker_test.go
+++ b/tests/e2e/no_work_needed_marker_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// noWorkNeededSkipCommentPrefix is the literal prefix shared by both
+// variants of the engine's own no-work-needed skip comment
+// (engine/no_work_needed_settle.go: noWorkNeededSkipComment). Matching on
+// HasPrefix rather than Contains ensures hasNoWorkNeededSkipComment can only
+// be satisfied by a genuine engine-authored comment, not by a stage-output
+// comment where an agent quotes the marker text in prose while reasoning
+// about the feature — the same body-prefix convention findNewComments
+// (engine/comments.go) uses to distinguish Fabrik's own output from prose,
+// and the same fix pattern already shipped for #1320's cycle-limit marker.
+const noWorkNeededSkipCommentPrefix = "🏭 **Fabrik — skipped: no work needed**"
+
+// hasNoWorkNeededSkipComment reports whether bodies contains a genuine
+// engine-authored no-work-needed skip comment. It matches on
+// strings.HasPrefix, mirroring hasEngineCycleLimitComment
+// (ci_fix_reinvoke_test.go).
+func hasNoWorkNeededSkipComment(bodies []string) bool {
+	for _, b := range bodies {
+		if strings.HasPrefix(b, noWorkNeededSkipCommentPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHasNoWorkNeededSkipComment proves hasNoWorkNeededSkipComment can only
+// be satisfied by a genuine engine-authored no-work-needed skip comment, not
+// by a stage-output comment where an agent quotes the marker text while
+// reasoning about the feature. This is a fast, directly-runnable check (no
+// live bed, no GitHub API, no Claude cost) — run it with:
+//
+//	go test -tags e2e -run TestHasNoWorkNeededSkipComment ./tests/e2e/
+//
+// It exists to satisfy handarbeit/fabrik#1355's R2, which strengthens
+// TestNoWorkNeeded to assert on this engine-unique observable rather than
+// WaitForIssueClosed alone (which cannot distinguish the no-work-needed path
+// from an ordinary close — the exact defect class #1320 and #1319 already
+// exposed elsewhere in this suite).
+func TestHasNoWorkNeededSkipComment(t *testing.T) {
+	genuineGeneral := "🏭 **Fabrik — skipped: no work needed**\n\n" +
+		"_Skipped: no work needed (FABRIK_NO_WORK_NEEDED emitted by Plan)._"
+
+	genuineChildrenSpawned := "🏭 **Fabrik — skipped: no work needed**\n\n" +
+		"_Skipped: no work needed — all work was delegated to spawned children " +
+		"and this issue has no commits of its own._"
+
+	// prose mirrors an agent quoting the marker text in prose while
+	// discussing the feature — the shape of the #4049/#1320 false-pass, but
+	// for this marker instead of the CI-fix cycle-limit one.
+	prose := "🏭 **Fabrik — stage: Research**\n" +
+		"*branch: fabrik/issue-1355 | commit: abc123*\n\n" +
+		"## Research Findings\n\n" +
+		"When Plan emits FABRIK_NO_WORK_NEEDED, the engine posts a comment " +
+		"beginning \"🏭 **Fabrik — skipped: no work needed**\" to record the " +
+		"decision. This is the observable TestNoWorkNeeded is designed to verify.\n"
+
+	unrelated := "Thanks for filing this — I'll take a look."
+
+	tests := []struct {
+		name   string
+		bodies []string
+		want   bool
+	}{
+		{
+			name:   "genuine general-path comment is accepted",
+			bodies: []string{unrelated, genuineGeneral},
+			want:   true,
+		},
+		{
+			name:   "genuine children-spawned-variant comment is accepted",
+			bodies: []string{genuineChildrenSpawned},
+			want:   true,
+		},
+		{
+			name:   "prose quoting the marker is rejected",
+			bodies: []string{prose, unrelated},
+			want:   false,
+		},
+		{
+			name:   "unrelated comment alone is rejected",
+			bodies: []string{unrelated},
+			want:   false,
+		},
+		{
+			name:   "no comments at all",
+			bodies: nil,
+			want:   false,
+		},
+		{
+			name:   "both genuine and prose present — still accepted on the genuine one",
+			bodies: []string{prose, genuineGeneral},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasNoWorkNeededSkipComment(tt.bodies)
+			if got != tt.want {
+				t.Fatalf("hasNoWorkNeededSkipComment(%q) = %v, want %v", tt.bodies, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/no_work_needed_test.go
+++ b/tests/e2e/no_work_needed_test.go
@@ -3,7 +3,9 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -17,6 +19,19 @@ import (
 //
 // This is the regression test for #733 (the marker itself) and #742 (the
 // close-on-no-work fix).
+//
+// handarbeit/fabrik#1355 (R2): WaitForIssueClosed alone cannot distinguish
+// the no-work-needed path from an ordinary close — a broken
+// settleNoWorkNeeded that somehow still closed the issue some other way
+// would pass this test just as easily as a correctly-working one. The
+// assertion below additionally requires the engine's own no-work-needed
+// skip comment (noWorkNeededSkipComment, engine/no_work_needed_settle.go),
+// matched by body prefix via hasNoWorkNeededSkipComment
+// (no_work_needed_marker_test.go) — an observable only settleNoWorkNeeded
+// produces — closing the vacuity gap. settleNoWorkNeeded posts this comment
+// before it moves the item to Done and closes the issue, so once
+// WaitForIssueClosed returns, the comment is guaranteed to already exist if
+// the no-work-needed path actually ran; no polling race is needed.
 //
 // Wall-clock: ~10-15 min. Cost: ~$0.30-0.50.
 func TestNoWorkNeeded(t *testing.T) {
@@ -50,8 +65,28 @@ This is an e2e regression test for #733 (the marker) and #742 (close-on-no-work)
 	WaitForIssueClosed(t, env, env.RepoAlpha, num, 20*time.Minute)
 	t.Logf("%s#%d closed without PR — short-circuit verified", env.RepoAlpha, num)
 
+	// The engine's own no-work-needed skip comment must be present, matched
+	// by body prefix — the discriminating assertion for R2 (see doc comment
+	// above). settleNoWorkNeeded posts it before closing, so it is already
+	// there by the time WaitForIssueClosed returns; a single fetch suffices.
+	out, err := ghOutput(env, "issue", "view", fmt.Sprint(num), "-R", env.RepoAlpha,
+		"--json", "comments", "--jq", "[.comments[].body]")
+	if err != nil {
+		t.Fatalf("could not fetch comments on %s#%d: %v", env.RepoAlpha, num, err)
+	}
+	var bodies []string
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(out)), &bodies); jsonErr != nil {
+		t.Fatalf("could not parse comments on %s#%d: %v (raw: %s)", env.RepoAlpha, num, jsonErr, out)
+	}
+	if !hasNoWorkNeededSkipComment(bodies) {
+		t.Fatalf("no engine-authored no-work-needed skip comment (prefix %q) found on %s#%d — "+
+			"the issue closed, but not provably via the no-work-needed path",
+			noWorkNeededSkipCommentPrefix, env.RepoAlpha, num)
+	}
+	t.Logf("no-work-needed skip comment confirmed on %s#%d — no-work-needed path genuinely exercised", env.RepoAlpha, num)
+
 	// Spot-check: should NOT have any open PR referencing this issue.
-	out, err := ghOutput(env, "pr", "list", "-R", env.RepoAlpha, "--state", "open",
+	out, err = ghOutput(env, "pr", "list", "-R", env.RepoAlpha, "--state", "open",
 		"--search", fmt.Sprintf("in:body \"Closes #%d\"", num),
 		"--json", "number", "--jq", "length")
 	if err != nil {

--- a/tests/e2e/no_work_needed_test.go
+++ b/tests/e2e/no_work_needed_test.go
@@ -33,6 +33,21 @@ import (
 // WaitForIssueClosed returns, the comment is guaranteed to already exist if
 // the no-work-needed path actually ran; no polling race is needed.
 //
+// The "guaranteed to already exist" guarantee is conditional, not absolute:
+// settleNoWorkNeeded only posts a skip comment for stages strictly between
+// the emitter and Done (engine/no_work_needed_settle.go's loop guard,
+// `s.Order <= stage.Order || s.Order >= doneOrder || s.Unmanaged`). The
+// invariant this assertion actually relies on is "at least one non-cleanup,
+// non-unmanaged stage exists strictly between the emitting stage and Done" —
+// true today because this scenario emits at Plan, leaving Implement, Review,
+// Queued, and Validate in range (four skip comments observed live against
+// handarbeit/fabrik-test-alpha#4162, matching exactly). If a future variant
+// of this scenario moved the emitting stage to the one immediately before
+// Done, the loop body would never execute, no skip comment would be posted,
+// and this assertion would fail against a correctly-working engine — not a
+// regression, but a discriminator that no longer applies to that shape.
+//
+
 // Wall-clock: ~10-15 min. Cost: ~$0.30-0.50.
 func TestNoWorkNeeded(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes #1355

## Summary

Implements #1355's four independent surfaces:

- **R1** — Deleted `TestExpectedReviewersPrecedenceGuard` (`tests/e2e/expected_reviewers_test.go`). `reviewGateFastAdvance` (`engine/reviews.go`) short-circuits on `len(outstanding) > 0` before ever reaching the `expected_reviewers: []` check, so the scenario could never fail differently for declared-`[]` vs. undeclared-`nil` — it was structurally unable to discriminate. Cleaned up the now-stale README rows (Scenarios table, Regression coverage map) and prose mentions, removed prerequisite #26 (`FABRIK_REVIEWER_TOKEN`, needed only by the deleted test), and renumbered #27–30 → #26–29.
- **R2** — Strengthened `TestNoWorkNeeded` to additionally assert the engine's own no-work-needed skip comment (`noWorkNeededSkipComment`, `engine/no_work_needed_settle.go`) is present, matched by **body prefix** via a new `hasNoWorkNeededSkipComment` helper (`tests/e2e/no_work_needed_marker_test.go`) — following the exact pattern already shipped for #1320's `hasEngineCycleLimitComment`. A companion fast unit test (`TestHasNoWorkNeededSkipComment`, no live bed) proves the helper accepts both comment variants `noWorkNeededSkipComment` can produce and rejects a fixture where an agent quotes the marker text in prose (the #4049/#1320 false-pass shape).
- **R3** — Added `report_test_timings` to `scripts/e2e/run.sh`: a ranked, slowest-first per-test wall-clock summary parsed from the existing `go test -json` log, printed unconditionally (pass or fail) once per leg, right alongside the existing failure-only `report_test_outcomes`.
- **R4** — Expanded the "Adding a scenario" checklist in `tests/e2e/README.md` with the authoring rule: assert only on something the specific path under test can produce; match engine-authored comments by body prefix (never substring-anywhere, per `findNewComments`'s convention); prefer a loud `t.Skip` over an assertion satisfiable by accident. Names both #1320 and #1319 as the worked examples and points at the two marker-test files as the pattern to copy.

No engine code was touched anywhere in this PR (diff is scoped to `tests/e2e/expected_reviewers_test.go`, `tests/e2e/no_work_needed_test.go`, `tests/e2e/no_work_needed_marker_test.go`, `scripts/e2e/run.sh`, `tests/e2e/README.md` only).

## Acceptance criteria status

- **AC1** ✅ `TestExpectedReviewersPrecedenceGuard` no longer exists. The four remaining `TestExpectedReviewers*` scenarios build, run, and skip cleanly (confirmed against the currently-down live bed — see verification below).
- **AC2** ✅ `go test ./engine/... -run TestReviewGateFastAdvance -v` passes all 5 subtests, including `"declared none but a reviewer is requested — still waits"` (`engine/reviews_test.go:2261`) — the property R1 removes from e2e remains covered.
- **AC3** ⚠️ **Partially verified — needs a manual step before merge.** The *matching logic* is proven by `TestHasNoWorkNeededSkipComment`'s fast unit test (accepts both genuine comment variants, rejects a prose-quoting fixture). The issue's own Verification Note calls for an actual **red/green cycle against the live e2e bed** (neutralize the comment-posting, confirm the strengthened assertion fails, revert, confirm it passes). **This could not be performed from within the sandboxed Implement worktree** — it requires rebuilding and restarting the shared `~/dev/fabrik-test` instance, which sits outside any automated Fabrik stage's worktree boundary (confirmed directly: the harness resets `cwd` on any attempt to leave the worktree, and file writes outside it are sandboxed). Exact manual steps are documented in `tests/e2e/README.md`'s new "`TestNoWorkNeeded` discriminator verification (#1355)" section — a human operator should run these against the live bed before this merges, per the issue's own warning that a false "already discriminates" conclusion would leave the exact defect this issue exists to close.
- **AC4** ⚠️ Same constraint as AC3. The `jq` pipeline itself is proven correct against synthetic `go test -json` fixtures (multiple tests, a subtest excluded, all three terminal actions, correct descending sort). A full `scripts/e2e/run.sh` smoke test against the live bed was not performed for the same sandbox-boundary reason; documented in the new "Per-test wall-clock summary (#1355)" README section with the manual command to run.
- **AC5** ✅ The authoring rule is documented in `tests/e2e/README.md`'s "Adding a scenario" section, naming both #1320 and #1319.

## Verification performed

```
go build ./... && go vet ./...                                    # clean
go build -tags=e2e ./... && go vet -tags=e2e ./...                # clean
go test -race -timeout 8m ./...                                   # all packages pass
go test ./engine/... -run TestReviewGateFastAdvance -v             # 5/5 subtests pass (AC2)
go test -tags e2e -run 'TestNoWorkNeeded|TestExpectedReviewers' ./tests/e2e/... -v
  # all 5 remaining scenarios build and SKIP cleanly (bed process confirmed dead —
  # no live-bed mutation occurred)
go test -tags e2e -run 'TestHasNoWorkNeededSkipComment|TestHasEngineCycleLimitComment|TestHasEngineCIWaitTimeoutComment' ./tests/e2e/... -v
  # all marker-discrimination unit tests pass
```

`report_test_timings`'s `jq` pipeline was tested in isolation against a synthetic `go test -json` log (multiple top-level tests, one with a subtest, one pass/one fail/one skip) and produces correctly ranked, subtest-excluded output.

## Manual follow-up required before merge

1. Run `TestNoWorkNeeded`'s red/green cycle against the live `~/dev/fabrik-test` bed per the steps in `tests/e2e/README.md`'s new discriminator-verification section (closes the AC3 gap).
2. Run `scripts/e2e/run.sh -run TestSmokeSingleRepoDispatch` (or similar) against the live bed to confirm the timing table renders in context (closes the AC4 gap).

## Test plan for reviewers

- Read `tests/e2e/no_work_needed_test.go` / `no_work_needed_marker_test.go` — confirm the new assertion matches `noWorkNeededSkipComment`'s actual output shape in `engine/no_work_needed_settle.go`.
- Read `scripts/e2e/run.sh`'s new `report_test_timings` — confirm the `jq` filter logic against `report_test_outcomes` right above it.
- Perform the two manual live-bed steps above before approving.