### PR TITLE
Ship label protocol knowledge to consumer projects via the plugin embed

### DIFF
--- a/adrs/1339-labels-md-drift-detection.md
+++ b/adrs/1339-labels-md-drift-detection.md
@@ -1,0 +1,74 @@
+# ADR 1339: LABELS.md Drift Detection
+
+**Date**: 2026-08-02
+**Status**: Accepted
+**Issue**: #1339 — Ship Fabrik label knowledge to the stage skills that reach consumer projects
+
+## Context
+
+`plugin/fabrik-workflows/LABELS.md` ships a ~12 KB, hand-curated condensation of `docs/state-machine.md`
+§1.4 ("Label Semantics Reference," a ~30-row table) to consumer projects via the plugin embed. Requirement
+6 of #1339 states that any divergence between `LABELS.md` and `docs/state-machine.md` is a bug — a
+hand-maintained derivative of a much larger source, with no check, will drift, and the failure mode
+(consumer projects reading confidently wrong label documentation) is worse than the pre-#1339 gap (no
+documentation at all).
+
+The obvious precedent is `.github/workflows/docs-drift.yml` and `scripts/generate-llms-full.sh`:
+regenerate `docs/llms-full.txt` deterministically from the four canonical doc pages, fail the PR if the
+committed file differs from the regen output. That pattern requires the derived artifact to be a
+byte-for-byte, deterministic function of its sources — `llms-full.txt` is a literal concatenation.
+
+`LABELS.md` is not that. It is condensed roughly 40:1 from `state-machine.md`, curated into prose grouped
+by lifecycle role (Pause & Block / Gates / Operator Overrides / Engine-Internal) rather than
+`state-machine.md`'s own Controlling/Modifier split. There is no function `f(state-machine.md) →
+LABELS.md` to write — regenerating it would mean either turning it into a mechanically-templated document
+(defeating the "reference sized for on-demand reading" framing that motivated writing curated prose in
+the first place) or comparing `LABELS.md` to itself (a no-op).
+
+## Decision
+
+**Drift detection is a name-presence check, not byte-exact regeneration.** A Go test
+(`plugin/labels_drift_test.go`) parses `docs/state-machine.md` §1.4's table, extracts each row's label
+identifier, strips `<placeholder>` suffixes to a literal prefix (e.g. `` `fabrik:locked:<user>` `` →
+`fabrik:locked:`), and asserts each prefix appears somewhere in the concatenation of `LABELS.md` plus all
+12 `SKILL.md` files. This catches the failure mode Requirement 6 is actually worried about — a label
+added, renamed, or removed in the canonical doc and never propagated to consumers — without requiring a
+regenerator that cannot exist.
+
+This is a **deliberately weaker guarantee** than `docs-drift.yml`'s byte-exact check: it verifies a
+label's *name* is mentioned, not that its *documented semantics* match. A label whose behavior changes in
+`state-machine.md` without a name change will not be caught. This gap is accepted and stated explicitly
+here, in the test's own doc comment, and in `LABELS.md`'s closing "Notes for skill authors" section — so
+it is never mistaken for a stronger guarantee than it provides. Requirement 6 asked Research/Plan to
+either implement a mechanical guard or record why one isn't feasible; the conclusion here is a middle
+ground — a real, if narrower, mechanical guard, with the narrowing made explicit rather than silently
+accepted.
+
+**The check reads `docs/state-machine.md` from the source tree, but `LABELS.md`/`SKILL.md` from
+`plugin.FabrikPlugin`** (the embed), not the source tree. `docs/` is never embedded — correctly, since
+it's fabrik source and never ships — so the canonical side has no choice but to be a source-tree read.
+Reading the consumer side from the embed rather than the source tree is a deliberate second win: the
+test also fails if the `//go:embed fabrik-workflows/LABELS.md` directive is ever accidentally dropped
+from `plugin/embed.go`, catching an embed-wiring regression in the same test that catches content drift.
+
+**The check is a Go test, not a dedicated CI workflow.** It rides the existing `go test ./...` job with
+no new required-status-check registration. The alternative — a `docs-drift.yml`-style dedicated workflow
+— was rejected on direct precedent: #1234/#1236 (both closed) document that a drift-check workflow
+existing in `.github/workflows/` is not sufficient by itself to block a non-compliant merge; it must also
+be explicitly added to `required_status_checks.contexts` on branch protection, a step that was missed
+once already in this repo. A Go test avoids that entire failure class — it is already a required check by
+virtue of being part of the existing test suite.
+
+## Consequences
+
+- A label added, renamed, or removed in `docs/state-machine.md` §1.4 without a corresponding update to
+  `LABELS.md` or the 12 skill files fails `go test ./...`, the same gate every other Go change in this
+  repo already passes through — no new CI surface, no new branch-protection configuration.
+- The guarantee is explicitly weaker than `docs-drift.yml`'s: a label whose *semantics* change without a
+  *name* change is not caught. This is stated in three places (this ADR, the test's doc comment,
+  `LABELS.md` itself) so a future reader does not mistake partial coverage for full coverage.
+- `LABELS.md`'s ~15 KB size budget remains unenforced mechanically (Research's Constraint 2) — this ADR
+  covers drift detection only, not size. That risk is accepted as noted in the issue's Risks section.
+- If `docs/state-machine.md` §1.4 is ever restructured (e.g. the table format changes, or labels move to
+  a different section), `plugin/labels_drift_test.go`'s parser will need a corresponding update — it is
+  coupled to the table's current Markdown shape, not just its content.

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -510,3 +510,53 @@ func TestRunUpgrade_CustomWorkflowError(t *testing.T) {
 		t.Fatalf("expected 'local customizations' in error, got: %v", callErr)
 	}
 }
+
+// TestRunUpgrade_DeliversLabelsMdToExistingInstall covers issue #1339 AC3: an
+// already-populated .fabrik/plugin/ (not a fresh init) that predates LABELS.md
+// must receive it via the default (non---force) `fabrik upgrade` path. A
+// fresh-init-only test would not catch a regression in this refresh path.
+//
+// The fixture is built from the current embedded FS (which now includes
+// LABELS.md) with LABELS.md then removed from disk, simulating a prior
+// install made before this file existed. installedVer is seeded from that
+// post-removal disk state via ComputeDiskVersion+WriteVersionHash — not
+// WriteInstalledVersion, which always writes ComputeEmbeddedVersion() (the
+// current, LABELS.md-inclusive fingerprint) and would desync disk vs.
+// installed, missing the "pristine but stale" state this test targets.
+func TestRunUpgrade_DeliversLabelsMdToExistingInstall(t *testing.T) {
+	dir := t.TempDir()
+	chdirTest(t, dir)
+	pluginDir := buildFabrikPluginDir(t)
+
+	labelsPath := filepath.Join(pluginDir, "LABELS.md")
+	if _, err := os.Stat(labelsPath); err != nil {
+		t.Fatalf("expected embedded LABELS.md fixture to exist before removal: %v", err)
+	}
+	if err := os.Remove(labelsPath); err != nil {
+		t.Fatalf("removing LABELS.md from fixture: %v", err)
+	}
+
+	diskVer, err := fabrikplugin.ComputeDiskVersion(pluginDir)
+	if err != nil {
+		t.Fatalf("ComputeDiskVersion: %v", err)
+	}
+	if err := fabrikplugin.WriteVersionHash(pluginDir, diskVer); err != nil {
+		t.Fatalf("WriteVersionHash: %v", err)
+	}
+
+	if err := runUpgrade([]string{}); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+
+	embeddedData, err := fabrikplugin.FabrikPlugin.ReadFile("fabrik-workflows/LABELS.md")
+	if err != nil {
+		t.Fatalf("reading embedded LABELS.md: %v", err)
+	}
+	diskData, err := os.ReadFile(labelsPath)
+	if err != nil {
+		t.Fatalf("LABELS.md missing after upgrade: %v", err)
+	}
+	if !bytes.Equal(embeddedData, diskData) {
+		t.Fatal("LABELS.md on disk does not match embedded content after upgrade")
+	}
+}

--- a/plugin/embed.go
+++ b/plugin/embed.go
@@ -14,5 +14,6 @@ import "embed"
 //
 //go:embed fabrik-workflows/.claude-plugin/plugin.json
 //go:embed fabrik-workflows/README.md
+//go:embed fabrik-workflows/LABELS.md
 //go:embed fabrik-workflows/skills/*/SKILL.md
 var FabrikPlugin embed.FS

--- a/plugin/fabrik-workflows/LABELS.md
+++ b/plugin/fabrik-workflows/LABELS.md
@@ -50,6 +50,14 @@ part of the normal happy path, not an error condition.
   Blocks auto-advance and PR landing until clear. See `review-authority:<mode>`
   and `expected-reviewers:<mode>` below for how the gate's strictness and
   reviewer expectations can be tuned per-issue.
+- **`fabrik:bot-reprompted`** — Idempotency guard for the review gate's
+  bot-reviewer escalation ladder: applied once `fabrik:awaiting-review` has
+  been active for a full `ReviewWaitTimeout` and every outstanding reviewer
+  is a bot (requested, declared via `expected_reviewers`, or both) — the
+  engine re-triggers each bot's webhook and posts a check-in comment.
+  Removed when a bot responds and the gate clears naturally, or when a
+  second full timeout elapses with still no response (the issue is then
+  paused). Never persists beyond one gate cycle.
 - **`fabrik:awaiting-ci`** — The `wait_for_ci: true` CI gate is active.
   Applied the instant a stage emits `FABRIK_STAGE_COMPLETE`; the stage's own
   `stage:<name>:complete` label is deliberately withheld until CI actually

--- a/plugin/fabrik-workflows/LABELS.md
+++ b/plugin/fabrik-workflows/LABELS.md
@@ -1,0 +1,200 @@
+# Fabrik Label Reference
+
+Fabrik uses GitHub issue labels as its state mechanism. Each stage skill's own
+"Labels You Interact With" section documents the *hot subset* — the labels
+that stage actually reads or writes on a normal run. This file is the
+long-tail reference: everything else, for when you need to reason about a
+label your stage doesn't touch directly (e.g. explaining engine behavior to
+a user, or understanding why an issue is stuck).
+
+**Canonical source**: `docs/state-machine.md` §1.4 "Label Semantics
+Reference" is the exhaustive, authoritative as-built spec (fabrik source,
+not shipped to consumers). This file is a condensed derivative, sized for
+on-demand reading rather than exhaustive reference. If something here
+seems to conflict with observed engine behavior, `docs/state-machine.md` —
+or the fabrik source itself — wins.
+
+## Pause & Block
+
+Labels that suspend processing entirely.
+
+- **`fabrik:paused`** — Processing stopped on active stages. Applied after
+  retry exhaustion, `FABRIK_BLOCKED_ON_INPUT`, a review/CI/rebase timeout or
+  cycle limit, a manual TUI stop, or the comment-processing circuit breaker
+  tripping (too many non-advancing comments in a row). Cleared by the user
+  removing it manually, or by a human (non-bot) comment arriving on the
+  issue — an implicit resume. Cleanup stages ignore comments entirely while
+  paused. A Validate-stage item whose PR was merged externally can still
+  advance regardless of this label.
+- **`fabrik:awaiting-input`** — Companion to `fabrik:paused` marking the
+  specific "blocked on user input" variant (as opposed to a retry-exhaustion
+  or timeout pause). Cleared the same way as `fabrik:paused`, plus
+  automatically on the next stage completion (removes any orphaned label
+  left over from a manual `fabrik:paused` removal).
+- **`fabrik:blocked`** — Set when the issue has open `blockedBy`
+  dependencies (via GitHub's Issue Dependencies feature). Cleared as soon as
+  all blockers close — either immediately (a push-based observer) or within
+  one dependency re-check cycle. Suspends all stage dispatch while present.
+
+## Gates
+
+Labels that hold an item at its current stage until an external condition
+(CI, review, mergeability) resolves. Distinct from Pause & Block: gates are
+part of the normal happy path, not an error condition.
+
+- **`fabrik:awaiting-review`** — The `wait_for_reviews: true` review gate is
+  active: outstanding PR reviewer requests remain, or a self-submitting bot
+  reviewer (Copilot/Gemini/CodeRabbit-style — never formally "requested")
+  hasn't yet posted a review. Cleared when every reviewer responds, or when
+  `FABRIK_REVIEW_WAIT_TIMEOUT` elapses (the issue is then paused instead).
+  Blocks auto-advance and PR landing until clear. See `review-authority:<mode>`
+  and `expected-reviewers:<mode>` below for how the gate's strictness and
+  reviewer expectations can be tuned per-issue.
+- **`fabrik:awaiting-ci`** — The `wait_for_ci: true` CI gate is active.
+  Applied the instant a stage emits `FABRIK_STAGE_COMPLETE`; the stage's own
+  `stage:<name>:complete` label is deliberately withheld until CI actually
+  passes (a conjunctive gate — completion and green CI both required).
+  Cleared when all CI checks pass, or when GitHub reports the PR as
+  mergeable via `mergeable_state`. Also (re-)applied on a confirmed CI
+  failure to drive the CI-fix reinvocation path (the engine re-prompts the
+  stage with failing-check details). Suppresses stage re-dispatch while
+  present — only the catch-up/settle loop evaluates CI during this window.
+- **`fabrik:rebase-needed`** — The linked PR no longer cleanly merges onto
+  its base branch (GitHub reports `mergeable == false`, a confirmed
+  conflict — not simply "still computing"). The engine re-dispatches the
+  stage to resolve the conflict. Cleared when the rebase succeeds and
+  GitHub reports mergeable again, or when the PR merges/closes. At
+  `MaxRebaseCycles`, the issue is paused for human intervention instead.
+- **`fabrik:awaiting-done`** — A `FABRIK_NO_WORK_NEEDED` decision has been
+  made; the board move to Done and/or issue close is still outstanding.
+  Retried every poll regardless of the item's current board column.
+  Suppresses dispatch of every non-cleanup stage while present. Cleared
+  once both the Done move and issue close succeed; escalates to
+  `fabrik:paused` after `MaxRetries` failed settle passes.
+- **`fabrik:awaiting-member-close`** / **`fabrik:awaiting-close`** — Same
+  shape as `fabrik:awaiting-done`, scoped to narrower failure paths: a
+  merge-train member issue whose close call failed after its PR already
+  merged (`awaiting-member-close`), or a `base:<branch>` issue whose
+  engine-initiated close failed after its Done-advance already happened
+  (`awaiting-close`). Both retried every poll until the issue is confirmed
+  closed, then escalate to `fabrik:paused` after `MaxRetries`.
+- **`fabrik:awaiting-placement`** — A spawned child issue's initial
+  project-board column placement failed at spawn time. Retried every poll
+  until placement succeeds or the child is observed closed; escalates to
+  `fabrik:paused` (on the child) after `MaxRetries`. Does not itself
+  suppress dispatch — a stranded child in an unrecognized column
+  (typically Backlog) never resolves to a stage there anyway.
+- **`fabrik:auto-merge-enabled`** — Engine-internal marker that GitHub's
+  native auto-merge has been enabled on the PR (yolo + non-cruise, at
+  Validate completion). Anchors the auto-merge convergence budget and
+  bypasses the legacy CI/review gates while present. Cleared when the PR
+  merges or closes, the user disables auto-merge in the GitHub UI, or the
+  convergence budget is exhausted (pauses the issue). Never applied when
+  `fabrik:cruise` is also present.
+
+## Operator Overrides
+
+User-applied labels that change engine behavior for one issue. All are
+applied and removed manually; the engine never adds or clears these itself
+except where noted.
+
+- **`fabrik:yolo`** — Forces auto-advance through stages even when a
+  stage's YAML sets `auto_advance: false`; also triggers GitHub-native
+  auto-merge of the linked PR once Validate completes.
+- **`fabrik:cruise`** — Forces auto-advance without auto-merge; the
+  pipeline stops (issue stays open, PR unmerged) once Validate completes.
+  When both `cruise` and `yolo` are present, **cruise wins** for both
+  end-of-Validate decisions.
+- **`fabrik:unrestricted`** — Passes `--dangerously-skip-permissions`
+  instead of `--permission-mode dontAsk`, bypassing the default tool
+  allowlist entirely. Use sparingly — it removes all tool restrictions.
+- **`fabrik:extend-turns`** — Pre-grants a 2× turn budget for every stage
+  and comment-processing invocation while present. Persists across stages;
+  removed only at the Done cleanup stage, or manually. No-op when a stage's
+  `max_turns == 0` (already unlimited).
+- **`model:<name>`** — Selects a specific Claude model for this issue
+  (e.g. `model:opus`). First label wins if more than one is present.
+- **`effort:<level>`** — Overrides the stage's configured thinking effort
+  (`low`/`medium`/`high`/`max`) for this issue only. Highest-ranked value
+  wins if more than one is present.
+- **`base:<branch>`** — Overrides the worktree base branch: Fabrik forks
+  from, rebases onto, and targets PRs at `<branch>` instead of the
+  repository default. Must be set before Research. Falls back to the
+  default branch (with an explanatory comment) if `<branch>` isn't found
+  on the remote.
+- **`review-authority:<mode>`** (`advisory`/`authoritative`) — Overrides a
+  `wait_for_reviews: true` stage's `review_authority` for this issue only.
+  `advisory` (the unset default) clears the gate once reviewers have
+  responded, whatever they said. `authoritative` additionally requires no
+  outstanding CHANGES_REQUESTED and satisfied required approvals. Both
+  labels present → resolves to `authoritative` (more restrictive), with a
+  logged warning. Unrecognized suffix → ignored, falls back to stage
+  config.
+- **`expected-reviewers:<mode>`** (`none`/`declared`) — Overrides a
+  `wait_for_reviews: true` stage's `expected_reviewers` for this issue
+  only. `none` enables an immediate fast-advance when nothing was actually
+  requested. `declared` resolves to a fixed synthetic test identity (never
+  posts a real review — expect the full wait-timeout ladder to run out).
+  Both present → resolves to `declared` (imposes waiting), with a logged
+  warning. Unrecognized suffix → ignored, falls back to stage config.
+- **`fabrik:revalidate`** — Forces re-entry into the Validate stage: the
+  engine strips `stage:Validate:{complete,failed}`, `fabrik:paused`,
+  `fabrik:awaiting-input`, `fabrik:awaiting-ci`, `fabrik:auto-merge-enabled`,
+  and the trigger label itself, then Validate dispatches on the next poll.
+  Applied to a non-Validate issue: only the trigger label is removed, with
+  a warning. Safe to apply mid-flight — held until the active worker exits.
+- **`fabrik:clear-claude-limit`** — One-shot operator command: clears an
+  active account-wide Claude usage-limit suspension without an engine
+  restart. Consumed and removed from every carrying item in the same poll
+  pass. Not scoped to the issue it's applied to — the suspension it clears
+  is account-wide.
+
+## Engine-Internal & Informational
+
+Labels a skill will rarely need to act on directly, but may see on an issue
+and should recognize.
+
+- **`fabrik:locked:<user>`** — Held while a specific Fabrik instance is
+  actively processing this issue; prevents other instances (or other
+  worker slots) from racing on the same item. Released when the stage
+  invocation ends, whatever the outcome.
+- **`fabrik:editing`** — Held for the duration of comment processing;
+  prevents a fresh stage dispatch from racing an in-flight comment reply.
+- **`stage:<name>:in_progress`** — Informational: shows which stage is
+  currently running on the item. Mirrors `fabrik:locked:<user>`'s
+  lifecycle.
+- **`stage:<name>:complete`** — Marks a stage as finished. Never removed
+  in the ordinary case (exception: `stage:Validate:complete` is stripped
+  if the linked PR's HEAD SHA changes after completion, since the
+  mergeability determination it certified no longer applies). Prevents
+  re-invocation of that stage and drives catch-up advancement to the next
+  one.
+- **`stage:<name>:failed`** — Applied after a stage exhausts its retry
+  budget; always paired with `fabrik:paused`. Cleared only when the user
+  manually removes `fabrik:paused` (signaling they've intervened).
+- **`fabrik:sub-issue`** — Applied to a child issue created by Plan's
+  `FABRIK_SPAWN_CHILD_*` decomposition mechanism. Purely informational —
+  carries no gating semantics of its own.
+- **`fabrik:children-spawned`** — Applied to the *parent* issue once all
+  of its declared sub-issues have been created, board-placed, and linked
+  as `blockedBy` dependencies. Acts as an idempotency guard — while
+  present, the pre-Implement spawn step is a no-op. Remove manually (and
+  close any orphaned children) to force a fresh spawn.
+- **`fabrik:claude-limit`** — Set when a Claude invocation exits because
+  the account's usage limit was hit (detected structurally from the CLI's
+  own result payload, never from output text). The stage attempt still
+  counts toward the normal dispatch cooldown, but not against
+  `max_retries` — the stage never actually ran. Cleared on the issue's
+  next invocation that isn't itself a usage-limit exit, or account-wide
+  once the suspension lifts. Distinct from GitHub's own API rate limiting.
+
+## Notes for skill authors
+
+- A label's *presence* on an issue is authoritative for engine behavior;
+  don't infer state from label *absence* plus board column alone — several
+  gate labels (the `awaiting-*` family) are retried independently of
+  column position.
+- When in doubt about a label not covered here, or about current, precise
+  semantics, treat this file as a starting point and defer to
+  `docs/state-machine.md` (fabrik source) or ask the operator — don't
+  guess at gating behavior.

--- a/plugin/fabrik-workflows/README.md
+++ b/plugin/fabrik-workflows/README.md
@@ -37,6 +37,12 @@ The skills contain:
 - **What NOT to do** (scope boundaries between stages)
 - **Common pitfalls** to avoid
 
+## Fabrik Labels
+
+Each skill documents the labels it reads or writes on a normal run in its own
+"Labels You Interact With" section. [`LABELS.md`](./LABELS.md) is the
+long-tail reference covering the rest of Fabrik's label protocol.
+
 ## Fabrik Markers
 
 Skills reference these markers that the Fabrik engine processes:

--- a/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
@@ -71,6 +71,13 @@ gh issue view <number> --json comments \
 
 Then update the relevant checkbox in the comment body.
 
+## Labels You Interact With
+
+- **`fabrik:extend-turns`** — if present, this and future comment-processing invocations get a pre-granted 2× turn budget.
+- **`fabrik:paused`** — repeated non-advancing comment-processing invocations can trip a circuit breaker that applies this label; you don't set it yourself, but it's why comment processing might stop being dispatched.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Completion
 
 Do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Implement returns control to the engine without advancing the pipeline. The Implement stage continues with the remaining tasks after the comment is processed.

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -214,6 +214,15 @@ Out-of-scope work in the same Fabrik run belongs to a sibling issue's worktree, 
 
 > Note: Hard tool-restriction enforcement of these guardrails is tracked in [handarbeit/fabrik#761](https://github.com/handarbeit/fabrik/issues/761). Until that ships, this section is the authoritative behavioral requirement. Follow it exactly.
 
+## Labels You Interact With
+
+- **`fabrik:extend-turns`** — if present, you've been pre-granted a 2× turn budget for this invocation; relevant if you're pacing work against "If You Hit the Turn Limit" concerns elsewhere in this skill.
+- **`base:<branch>`** — if present, your worktree was forked from and targets `<branch>` instead of the repository default; this is why your PR base isn't the default branch.
+- **`fabrik:unrestricted`** — if present, you were launched with `--dangerously-skip-permissions` instead of the default tool allowlist; explains why tools beyond the normal default set are available.
+- **`fabrik:children-spawned` / `fabrik:sub-issue`** — applied by the engine's pre-Implement step, before your first invocation, if the Plan stage declared sub-issue decomposition. You don't act on these; they're already-settled state by the time you start.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Engine Context
 
 **Before you run**: The engine has created a worktree on branch `fabrik/issue-<N>`, rebased onto main (on first run) or left as-is (on retry to preserve your context). A draft PR may have been created.

--- a/plugin/fabrik-workflows/skills/fabrik-plan-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-plan-comment/SKILL.md
@@ -39,6 +39,13 @@ Your output should be the full updated Plan stage content: implementation approa
 
 Do **not** use `FABRIK_ISSUE_UPDATE` markers — plan content lives in the stage comment, not the issue body. The issue body is the spec and is not updated by Plan comment processing.
 
+## Labels You Interact With
+
+- **`fabrik:paused` + `fabrik:awaiting-input`** — the engine cleared these to invoke you (a human comment is what resumes a blocked-on-input issue). You don't set or remove them yourself.
+- **`fabrik:children-spawned` / `fabrik:sub-issue`** — if the plan already declared sub-issue decomposition, these may already be applied by the time you're invoked; you don't act on them directly, but revising `FABRIK_SPAWN_CHILD_*` blocks in your output is still expected per the parent skill's decomposition rules.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Completion
 
 When all feedback has been incorporated, open questions resolved, and the plan is concrete and complete enough for implementation to begin, signal completion:

--- a/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
@@ -247,6 +247,14 @@ Example:
 
 Plans typically complete in a single pass. If the spec and research are solid, there shouldn't be open questions. If there are, something was missed upstream — flag it clearly.
 
+## Labels You Interact With
+
+- **`fabrik:paused` + `fabrik:awaiting-input`** — applied by the engine when you emit `FABRIK_BLOCKED_ON_INPUT`; cleared automatically when the user comments. You never set or remove these yourself.
+- **`fabrik:awaiting-done`** — applied by the engine the instant you emit `FABRIK_STAGE_COMPLETE` + `FABRIK_NO_WORK_NEEDED` (see "No Work Needed" above); it's the durable record of that decision until the Done move and issue close both succeed.
+- **`fabrik:children-spawned` / `fabrik:sub-issue`** — engine-applied consequences of the `FABRIK_SPAWN_CHILD_*` blocks you emit (see "Sub-issue Decomposition" above): `children-spawned` goes on this (parent) issue once all children are created and linked; `sub-issue` goes on each new child.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Engine Context
 
 **Before you run**: The engine has created a worktree and rebased onto main. You're in a read-only stage.

--- a/plugin/fabrik-workflows/skills/fabrik-research-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-research-comment/SKILL.md
@@ -37,6 +37,12 @@ Your output should be the full updated Research stage content: all findings, dec
 
 Do **not** use `FABRIK_ISSUE_UPDATE` markers — research findings live in the stage comment, not the issue body. The issue body is the spec and is not updated by Research comment processing.
 
+## Labels You Interact With
+
+- **`fabrik:paused` + `fabrik:awaiting-input`** — the engine cleared these to invoke you (a human comment is what resumes a blocked-on-input issue). You don't set or remove them yourself.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Completion
 
 When all open questions are resolved and the research findings are complete and sufficient for the Plan stage to proceed, signal completion:

--- a/plugin/fabrik-workflows/skills/fabrik-research/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-research/SKILL.md
@@ -120,6 +120,13 @@ The `### Repositories` section is **mandatory** in every Research output. It lis
 5. Incorporate answers and update findings
 6. When you have a thorough understanding and all questions are resolved, signal completion
 
+## Labels You Interact With
+
+- **`fabrik:paused` + `fabrik:awaiting-input`** — applied by the engine when you emit `FABRIK_BLOCKED_ON_INPUT`; cleared automatically when the user comments. You never set or remove these yourself.
+- **`model:opus`** — you don't apply this label directly, but the Complexity Assessment below has you *recommend* it as an open question when the issue warrants a more capable model for Implement/Review.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Engine Context
 
 **Before you run**: The engine has created a worktree and rebased onto main. You're in a read-only stage — your worktree will be stashed/restored.

--- a/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
@@ -108,6 +108,13 @@ Use bracketed or descriptive numbering instead:
 
 The same rule applies any time you number something in output that posts to a GitHub comment — threads, files, findings, or list items.
 
+## Labels You Interact With
+
+- **`fabrik:awaiting-review`** — the review-gate label; may already be present if you're processing a comment from a reviewer rather than a user decision on findings. You don't act on it directly.
+- **`fabrik:bot-reprompted`** — may be present if the engine already re-prompted an unresponsive bot reviewer this gate cycle; informational only from this skill's perspective.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Completion
 
 Do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Review returns control to the engine without advancing the pipeline. The Review stage continues until all findings are resolved and the main Review workflow signals completion.

--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -220,6 +220,15 @@ So: prefer making steady, committed progress over racing to finish inside one sl
 
   **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.
 
+## Labels You Interact With
+
+- **`fabrik:awaiting-review`** — applied by the engine when `wait_for_reviews: true` and outstanding PR reviewer requests remain after you signal completion; cleared once all reviewers respond or the wait times out.
+- **`review-authority:<mode>`** (`advisory`/`authoritative`) — if present, overrides this stage's configured `review_authority` for this issue: `authoritative` additionally requires no outstanding CHANGES_REQUESTED and satisfied approvals before the gate clears, beyond the `advisory` default of "reviewers responded, whatever they said."
+- **`expected-reviewers:<mode>`** (`none`/`declared`) / the stage's `expected_reviewers` config — declares self-submitting bot reviewers (Copilot, Gemini, CodeRabbit-style) that never appear in GitHub's formal requested-reviewer list but are still expected to respond before the gate clears.
+- **`fabrik:bot-reprompted`** — applied by the engine's bot-reviewer re-prompt ladder if every outstanding reviewer is a bot and the wait timeout elapses once; you don't act on it directly, but its presence means a re-prompt already happened this gate cycle.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Engine Context
 
 **Before you run**: Worktree exists with the implementation commits. The engine rebases onto main on first run.

--- a/plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-specify-comment/SKILL.md
@@ -67,6 +67,12 @@ FABRIK_ISSUE_UPDATE_END
 
 Include the ENTIRE body — not just changed sections.
 
+## Labels You Interact With
+
+- **`fabrik:paused` + `fabrik:awaiting-input`** — the engine cleared these to invoke you (a human comment is what resumes a blocked-on-input issue). You don't set or remove them yourself.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Completion
 
 When all questions are resolved and the spec is clear and complete, signal completion:

--- a/plugin/fabrik-workflows/skills/fabrik-specify/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-specify/SKILL.md
@@ -90,6 +90,13 @@ Anything that could complicate or block this work.
 4. Incorporate answers, remove resolved questions, surface follow-ups if needed
 5. When all questions are resolved and the spec is clear, signal completion
 
+## Labels You Interact With
+
+- **`fabrik:paused` + `fabrik:awaiting-input`** — applied by the engine when you emit `FABRIK_BLOCKED_ON_INPUT`; cleared automatically when the user comments. You never set or remove these yourself.
+- **`fabrik:cruise` / `fabrik:yolo`** — the only way this stage auto-advances despite its default `auto_advance: false`. Their presence doesn't change what you do; it's why completion sometimes proceeds immediately instead of waiting for a human to approve the spec.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Engine Context
 
 **Before you run**: The engine has created a worktree and rebased onto main. You're in a read-only stage — the worktree will be stashed/restored around your invocation.

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -55,6 +55,13 @@ After making any code changes:
 2. Commit with a clear message
 3. Push to the remote branch
 
+## Labels You Interact With
+
+- **`fabrik:awaiting-ci`** — may be present if you're processing a comment during an active CI-fix cycle; relevant to any "re-run checks" request in the user's comment.
+- **`fabrik:rebase-needed`** — may be present if a mergeability conflict is what's being discussed; resolving it clears the label on the next successful rebase, same as in the main Validate flow.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Completion
 
 By default, do NOT output `FABRIK_STAGE_COMPLETE`. Comment processing in Validate returns control to the engine without advancing the pipeline.

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -281,6 +281,16 @@ So: prefer making steady, committed progress over racing to finish inside one sl
 
   **Exception — review thread resolution**: Resolving a PR review thread via `gh api GraphQL` (e.g., the `resolveReviewThread` mutation) is permitted. Only *comment creation* is prohibited, not *thread resolution*.
 
+## Labels You Interact With
+
+- **`fabrik:awaiting-ci`** — applied by the engine the instant you emit `FABRIK_STAGE_COMPLETE` (since `wait_for_ci: true` by default here); `stage:Validate:complete` is deliberately withheld until CI actually passes. Also re-applied on a confirmed CI failure to drive the CI-fix re-invocation described below.
+- **`fabrik:rebase-needed`** — exactly the condition the Pre-Completion Gate's mergeability check (Step 2 above) exists to catch: the engine applies this if the PR stops being cleanly mergeable against its base and re-dispatches you to resolve it.
+- **`fabrik:awaiting-review` / `review-authority:<mode>` / `expected-reviewers:<mode>` / `fabrik:bot-reprompted`** — the same review-gate labels Review interacts with; Validate shares `wait_for_reviews: true` with Review by default, so the gate can still be active here.
+- **`fabrik:auto-merge-enabled` / `fabrik:yolo` / `fabrik:cruise`** — drive what happens after you emit `FABRIK_STAGE_COMPLETE`: `yolo` (non-cruise) triggers GitHub-native auto-merge and applies `fabrik:auto-merge-enabled`; `cruise` stops the pipeline at Validate completion without merging, even if `yolo` is also present.
+- **`fabrik:revalidate`** — the operator recovery path for a stuck Validate item: forces re-entry into this stage by stripping completion/gate labels and re-dispatching. You don't act on it directly; it's why you might be invoked again on an issue you'd already completed.
+
+See `../../LABELS.md` for the full label reference.
+
 ## Engine Context
 
 **Before you run**: Worktree exists with implementation + review commits.

--- a/plugin/labels_drift_test.go
+++ b/plugin/labels_drift_test.go
@@ -1,0 +1,130 @@
+package plugin
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestLabelsMdCoversStateMachineLabels guards against LABELS.md (and the 12
+// per-stage SKILL.md hot-subset sections) silently falling behind
+// docs/state-machine.md's §1.4 label table — the canonical, exhaustive
+// source LABELS.md is condensed from (ADR-1339, #1339 Requirement 6).
+//
+// This is a NAME-PRESENCE check, not a semantic-equivalence check: it
+// verifies every label identifier in §1.4 is mentioned somewhere in the
+// shipped plugin docs, not that its documented behavior still matches.
+// A label whose semantics changed in state-machine.md without a name
+// change will not be caught here. See ADR-1339 for why a byte-exact
+// regenerate-and-diff (the docs-drift.yml pattern) doesn't transfer to a
+// ~40:1 curated condensation.
+//
+// docs/state-machine.md is read from the source tree (it is fabrik source,
+// never embedded). LABELS.md and the SKILL.md files are read from
+// plugin.FabrikPlugin (the embed), not the source tree, so this test also
+// fails if the //go:embed directive for LABELS.md is ever dropped.
+func TestLabelsMdCoversStateMachineLabels(t *testing.T) {
+	labels, err := extractStateMachineLabels("../docs/state-machine.md")
+	if err != nil {
+		t.Fatalf("extracting labels from docs/state-machine.md: %v", err)
+	}
+	if len(labels) < 20 {
+		t.Fatalf("expected at least 20 labels extracted from state-machine.md §1.4, got %d: %v", len(labels), labels)
+	}
+
+	var corpus strings.Builder
+	labelsMd, err := FabrikPlugin.ReadFile("fabrik-workflows/LABELS.md")
+	if err != nil {
+		t.Fatalf("reading LABELS.md from embed: %v", err)
+	}
+	corpus.Write(labelsMd)
+
+	skillDirs, err := FabrikPlugin.ReadDir("fabrik-workflows/skills")
+	if err != nil {
+		t.Fatalf("reading skills dir from embed: %v", err)
+	}
+	for _, d := range skillDirs {
+		if !d.IsDir() {
+			continue
+		}
+		content, err := FabrikPlugin.ReadFile("fabrik-workflows/skills/" + d.Name() + "/SKILL.md")
+		if err != nil {
+			t.Fatalf("reading %s/SKILL.md from embed: %v", d.Name(), err)
+		}
+		corpus.Write(content)
+	}
+
+	corpusText := corpus.String()
+	var missing []string
+	for _, label := range labels {
+		if !labelMatcher(label).MatchString(corpusText) {
+			missing = append(missing, label)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("labels present in docs/state-machine.md §1.4 but absent from LABELS.md + all SKILL.md files: %v\n"+
+			"Add these to LABELS.md (and, if hot for a stage, that stage's SKILL.md) or confirm they were intentionally renamed/removed.", missing)
+	}
+}
+
+var (
+	labelCellRe        = regexp.MustCompile("^\\|\\s*`([^`]+)`")
+	labelPlaceholderRe = regexp.MustCompile(`<[^>]+>`)
+)
+
+// labelMatcher builds a regexp that matches a label identifier as it may
+// appear in consumer docs, tolerating a different placeholder spelling for
+// any <placeholder> segment (state-machine.md uses <user>/<X>, LABELS.md and
+// the SKILL.md files use <user>/<name>/<mode> — the segment name itself
+// isn't the contract, its position in the label is). A label with no
+// placeholder matches as a literal substring.
+func labelMatcher(label string) *regexp.Regexp {
+	parts := labelPlaceholderRe.Split(label, -1)
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = regexp.QuoteMeta(p)
+	}
+	pattern := strings.Join(quoted, `<?[A-Za-z0-9_.-]+>?`)
+	return regexp.MustCompile(pattern)
+}
+
+// extractStateMachineLabels parses the §1.4 "Label Semantics Reference" table
+// in docs/state-machine.md and returns each row's raw label identifier
+// (placeholders like <user> or <X> left intact — labelMatcher handles them).
+func extractStateMachineLabels(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	inSection := false
+	var labels []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "### 1.4 Label Semantics Reference") {
+			inSection = true
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		m := labelCellRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		labels = append(labels, m[1])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return labels, nil
+}

--- a/plugin/refresh_test.go
+++ b/plugin/refresh_test.go
@@ -7,6 +7,21 @@ import (
 	"testing"
 )
 
+// TestFabrikPlugin_EmbedsLabelsMd is the direct assertion for #1339 AC1:
+// LABELS.md must be present in the built binary's embed FS, asserted
+// against plugin.FabrikPlugin itself (not the source tree, which
+// TestRunInit_WritesPluginFiles-style tests would only indirectly cover).
+func TestFabrikPlugin_EmbedsLabelsMd(t *testing.T) {
+	content, err := FabrikPlugin.ReadFile("fabrik-workflows/LABELS.md")
+	if err != nil {
+		t.Fatalf("LABELS.md not present in FabrikPlugin embed: %v", err)
+	}
+	const minNonTrivialBytes = 1024
+	if len(content) < minNonTrivialBytes {
+		t.Errorf("LABELS.md embed content suspiciously small: %d bytes (want at least %d)", len(content), minNonTrivialBytes)
+	}
+}
+
 func TestComputeEmbeddedVersion_Deterministic(t *testing.T) {
 	v1 := ComputeEmbeddedVersion()
 	v2 := ComputeEmbeddedVersion()


### PR DESCRIPTION
Closes #1339

## What this does

Adds a new `plugin/fabrik-workflows/LABELS.md` (long-tail label reference, 12.4 KB — under the ~15 KB target) plus a "Labels You Interact With" hot-subset section in each of the 12 `plugin/fabrik-workflows/skills/*/SKILL.md` files, so consumer projects get Fabrik's label-protocol knowledge through the plugin itself instead of relying on a copy of the dev repo's `CLAUDE.md`.

## Key changes

- `plugin/embed.go`: new `//go:embed fabrik-workflows/LABELS.md` directive.
- `plugin/fabrik-workflows/LABELS.md`: condensed, lifecycle-grouped (Pause & Block / Gates / Operator Overrides / Engine-Internal) reference derived from `docs/state-machine.md` §1.4.
- All 12 skill files (6 stage + 6 comment-reviewer) get a "Labels You Interact With" section documenting only the labels that stage actually reads/writes on a normal run, each linking to `../../LABELS.md`.
- `plugin/fabrik-workflows/README.md`: one-line pointer to `LABELS.md`.
- `plugin/labels_drift_test.go`: a name-presence drift guard — extracts every label identifier from `docs/state-machine.md` §1.4's table and asserts each appears somewhere across `LABELS.md` + all 12 `SKILL.md` files (read from the embed, so it also catches a dropped `//go:embed` directive). This is a deliberately weaker guarantee than a byte-exact regenerate-and-diff (name presence, not semantic equivalence) — the tradeoff is documented in `adrs/1339-labels-md-drift-detection.md`, in the test's own comment, and in `LABELS.md`'s closing notes.
- `plugin/refresh_test.go`: explicit assertion that `LABELS.md` is present and non-trivial in `FabrikPlugin` (AC1).
- `cmd/upgrade_test.go`: new `TestRunUpgrade_DeliversLabelsMdToExistingInstall` covering AC3 — an already-populated `.fabrik/plugin/` (simulating a pre-#1339 install missing `LABELS.md`) receives it via the default (non-`--force`) `fabrik upgrade` path, not just fresh `fabrik init`.
- `adrs/1339-labels-md-drift-detection.md`: records the drift-detection design decision per Requirement 6.

## Manual end-to-end verification

Built the binary and ran both paths against scratch directories independent of the automated tests:
- `fabrik init` in an empty scratch dir → `.fabrik/plugin/LABELS.md` present, byte-identical to the embed (AC2).
- Simulated an already-populated `.fabrik/plugin/` predating `LABELS.md` (copied a full init, deleted `LABELS.md`, seeded `.installed-version` from the resulting disk state), then ran `fabrik upgrade` (default path) → `LABELS.md` appeared, byte-identical to the embed (AC3).

## How to test

```
go build -o fabrik .
go test ./...
go test -race ./cmd/... ./plugin/...
go vet ./...
```

Note: `TestExecute_ConfigYAMLApplied` in `cmd` fails in this sandbox due to real outbound GitHub API calls (no network mocking available here) — confirmed pre-existing on the branch's base commit, unrelated to this change.