### PR TITLE
test(e2e): serialize TestMergeTrainRunawayGuardPausesBatch against TestCrossRepoSpawn

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -394,6 +394,15 @@ timeout instead of skipping. Only run in the `on` leg of the two-mode gate.
     generates only ~7–10, so the test would time out. A cap of 6 sits above
     Alpha's bisect-scenario max (~4 trials) with comfortable margin. Wall-clock:
     ~10–20 min; ~6 trials × 2 required checks ≈ 12 Actions runs.
+    `TestMergeTrainRunawayGuardPausesBatch` intentionally does not call
+    `t.Parallel()` — it deliberately induces a repo-wide fault on
+    `fabrik-test-beta`, and `TestCrossRepoSpawn` is the only other scenario
+    that drives real work on that same repo. Running them concurrently let the
+    induced fault pause `TestCrossRepoSpawn`'s in-flight child issue as
+    collateral damage in the 0.0.77 validation gate (issue #1395); dropping
+    `t.Parallel()` here guarantees the runaway scenario completes before
+    `TestCrossRepoSpawn` starts real work, mirroring the same idiom
+    `TestMergeTrainRestartSafety` already uses below.
 
 ### Additional prerequisites for `TestReviewAuthority*` scenarios
 
@@ -894,7 +903,7 @@ the `Queued` column is absent, so it only runs in the gate's `on` leg.
 | `TestMergeTrainHappyPathLanding` | ADR-059 internal train: 3 clean Queued members → one integration PR → all advance Queued→Done, PRs closed, no O(N²) per-member retests | Train-only (on) | 10–25 min | low (no Claude) |
 | `TestMergeTrainBisectionEjectsPoisoner` | ADR-059 D4: red combined batch → halving bisection isolates the poison member → ejected → survivors land. Needs the `train-poison-guard` required check | Train-only (on) | 20–40 min | low–moderate |
 | `TestMergeTrainRestartSafety` | ADR-059 D5 / #960: after a landing, a restart with the historical merged integration PR present does NOT stall the next batch (reconstruct proceeds fresh). **Not parallel** — restarts the bed | Train-only (on) | 25–50 min | low |
-| `TestMergeTrainRunawayGuardPausesBatch` | ADR-059 D8 (#964/#965): persistently-red 4-member batch trips the runaway guard at cap=6, pauses all Queued members, no member reaches Done. Runs on RepoBeta for counter isolation | Train-only (on) | 10–20 min | low (no Claude) |
+| `TestMergeTrainRunawayGuardPausesBatch` | ADR-059 D8 (#964/#965): persistently-red 4-member batch trips the runaway guard at cap=6, pauses all Queued members, no member reaches Done. Runs on RepoBeta for counter isolation. **Not parallel** — induces a repo-wide fault on RepoBeta that would collide with `TestCrossRepoSpawn`'s use of the same repo (#1395) | Train-only (on) | 10–20 min | low (no Claude) |
 
 Approximate single-mode suite total: ~685 min wall-clock, $10.30–30 in Claude
 tokens. A full two-mode gate run is roughly double this, minus the

--- a/tests/e2e/mergetrain_runaway_test.go
+++ b/tests/e2e/mergetrain_runaway_test.go
@@ -30,10 +30,21 @@ import (
 // FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW=6 in the bed .env).
 // Skips cleanly if either prerequisite is absent.
 //
+// NOT t.Parallel(): it deliberately induces a repo-wide fault on RepoBeta
+// (fabrik-test-beta), and TestCrossRepoSpawn is the only other scenario that
+// drives real work on that same repo — running concurrently would let this
+// test's induced fault pause TestCrossRepoSpawn's in-flight child issue as
+// collateral damage (exactly what happened in the 0.0.77 validation gate,
+// issue #1395). Mirrors the same serialization idiom TestMergeTrainRestartSafety
+// already uses (see its doc comment): Go runs non-parallel tests to completion
+// before resuming parallel ones, so this test always finishes — guard tripped,
+// all 4 members paused — before TestCrossRepoSpawn starts real work. The test
+// body and assertions below are unchanged; only the scheduling annotation was
+// removed.
+//
 // Wall-clock: ~10–20 min (~6 trials × 2 required checks ≈ 12 Actions runs).
 // Cost: low (no Claude invocations).
 func TestMergeTrainRunawayGuardPausesBatch(t *testing.T) {
-	t.Parallel()
 	env := LoadEnv(t)
 	AssertFabrikRunning(t, env)
 	requireTrainBed(t, env)


### PR DESCRIPTION
Closes #1395

## What this does

`TestMergeTrainRunawayGuardPausesBatch` deliberately induces a repo-wide fault on `fabrik-test-beta` (persistently-red trials tripping the merge-train runaway guard). `TestCrossRepoSpawn` is the only other e2e scenario that drives real work on that same repo. Running them concurrently let the guard's repo-wide pause collateral-damage `TestCrossRepoSpawn`'s in-flight child issue, as observed in the 0.0.77 validation gate leg 2 (`handarbeit/fabrik-test-beta#216`, paused mid-flight by a guard it had nothing to do with).

## Key change

Drops `t.Parallel()` from `TestMergeTrainRunawayGuardPausesBatch`, mirroring the exact precedent `TestMergeTrainRestartSafety` already established in this same file set for an analogous reason ("this scenario perturbs shared state another scenario depends on"). Go runs all non-parallel top-level tests to completion, in declaration order, before any parallel test resumes past its own `t.Parallel()` call — so this guarantees the runaway scenario always finishes (guard tripped, all 4 poison members paused) before `TestCrossRepoSpawn` starts real work against beta.

The engine's runaway guard itself is untouched — this is scheduling-only. The test's assertions (guard-tripped comment, `fabrik:paused`/`fabrik:awaiting-input` labels, no member reaching Done) are byte-for-byte unchanged; only the doc comment gained an explanatory paragraph and the `t.Parallel()` call was removed.

## Files changed

- `tests/e2e/mergetrain_runaway_test.go` — removed `t.Parallel()`, added explanatory doc comment
- `tests/e2e/README.md` — noted the constraint next to the existing `FABRIK_MAX_TRAIN_TRIALS_PER_WINDOW=6` prerequisite (#20), and added a "Not parallel" annotation to the scenario table row, matching `TestMergeTrainRestartSafety`'s existing style

## How to test

Automated verification available in this sandboxed worktree (no live test-bed access):
```
go build -tags=e2e ./tests/e2e/...
go vet -tags=e2e ./tests/e2e/...
go build ./... && go vet ./... && go test ./...
```
All clean. (One pre-existing, unrelated flake — `TestExecute_ConfigYAMLApplied` in `cmd/`, a network/SIGINT-timing issue — reproduces identically on `main` before this change; confirmed via `git stash`.)

**Live confirmation of AC1/AC2 requires a real e2e run against the live test bed** (real GitHub repos, real Actions runs) — not something this pipeline's sandboxed stages can execute. Run post-merge:
```
E2E_TRAIN_MODE=on scripts/e2e/run.sh -run 'TestCrossRepoSpawn|TestMergeTrainRunawayGuardPausesBatch'
```
Confirm both scenarios pass, and that the "runaway guard tripped" comment is still observed on the runaway scenario's members (AC2 — a green suite alone is not evidence the guard still fires).