### PR TITLE
test(e2e): give every marker-writing scenario its own file to stop parallel merge conflicts

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -213,6 +213,58 @@ A repo-wide search (`grep -rn "🏭" tests/e2e/*.go`) found every call site in
 No other `tests/e2e/*.go` file references the `🏭` emoji or a
 `"🏭 **Fabrik —"` literal.
 
+### Marker-path convention (#1394)
+
+Multiple scenarios run in parallel against the same repo. Early on, several of
+them instructed the agent to append its marker to the *same* file —
+`README.md` on `fabrik-test-alpha`. When two such PRs landed close together,
+the second could pick up a merge conflict on the shared trailing lines and
+fail in its own harness code (e.g. `MergePR`), before any engine assertion
+ever ran — a flake, not a regression.
+
+Every scenario that writes a marker file (other than the deliberate exception
+below) must instead target its own dedicated, fixed path under
+`e2e/markers/`, so parallel scenarios can never collide on the same file:
+
+- **`markerPaths`** (`harness.go`) is the single source of truth: a map from
+  test-function name to its unique `e2e/markers/<scenario>.md` path.
+  `markerPath(name string) string` is the accessor — it panics on an unknown
+  name so a typo'd lookup fails loudly at test setup rather than silently
+  producing an empty path in an issue body.
+- **`TestMarkerPathsAreUnique`** (`marker_paths_test.go`) statically enumerates
+  `markerPaths` and fails on any duplicate or empty value. It requires no live
+  bed:
+
+  ```
+  go test -tags e2e -run TestMarkerPathsAreUnique -v ./tests/e2e/
+  ```
+
+- Paths are **fixed per scenario**, not derived from a per-run timestamp. This
+  differs from the merge-train members' `uniqueMemberPath` (`e2e/train/<name>-<issue>.txt`),
+  which needs a fresh path every run because a landed batch merges member
+  files into `main` and a fixed path would collide with the existing blob's
+  SHA on the next run's Contents-API PUT. These marker files are instead
+  edited through a normal agent git commit in a worktree — a real diff, not a
+  raw Contents-API PUT — so a fixed path across runs is fine, and it's what
+  lets `TestMarkerPathsAreUnique` enumerate the set statically instead of
+  needing to execute the tests to discover the paths.
+- `TestPausedMergedPRRecovery`'s 3 sequential sub-variants deliberately share
+  one path: they run strictly sequentially (`t.Run`, no `t.Parallel` between
+  them) and each variant's PR merges before the next is filed, so there is no
+  concurrent write to race.
+
+**Deliberate exception — `TestConvergenceRace`:** this scenario is absent from
+`markerPaths` on purpose. Its entire premise (see its own top-of-file comment)
+is that two yolo issues insert at the *same* anchor line of the *same*
+`README.md`, so that whichever PR merges first forces the other into a
+genuine `mergeable=CONFLICTING` state that Fabrik must resolve via a single
+rebase reinvoke. Giving it a unique path would eliminate the exact condition
+it exists to provoke. Any new scenario whose behavior genuinely depends on a
+shared file should be documented as such here, rather than left to race.
+
+When adding a new marker-writing scenario, add an entry to `markerPaths`
+before wiring up the issue body template — see "Adding a scenario" below.
+
 ### `TestNoWorkNeeded` discriminator verification (#1355)
 
 `TestNoWorkNeeded` used to assert only `WaitForIssueClosed` (plus a
@@ -956,7 +1008,12 @@ Every escape-from-release regression earns a new scenario in this table.
    the test bed (`t.Cleanup` is your friend).
 4. Document what regression the scenario protects against. Reference the
    originating issue or PR.
-5. **Assert on something that can only be produced by the engine, on the
+5. **If the scenario writes a marker file, give it its own path — do not
+   append to `README.md`.** Add an entry to `markerPaths` (`harness.go`) and
+   read it via `markerPath("Test...")` when building the issue body. See the
+   "Marker-path convention (#1394)" section above; `TestMarkerPathsAreUnique`
+   will fail the build if the new path collides with an existing one.
+6. **Assert on something that can only be produced by the engine, on the
    specific path under test** (handarbeit/fabrik#1355). A scenario that
    passes just as easily against a broken engine as a working one is worse
    than no scenario at all — it looks like coverage but proves nothing, and

--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -68,7 +68,8 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 	marker := fmt.Sprintf("auto-merge-yolo-%s", stamp)
-	body := fmt.Sprintf(autoMergeBodyTemplate, "`", "`", "```", marker, "```")
+	path := markerPath("TestYoloAutoMergeLabel")
+	body := fmt.Sprintf(autoMergeBodyTemplate, "`", path, "`", "```", marker, "```")
 
 	logStart := LogOffset(t, env)
 	num := FileIssue(t, env, env.RepoAlpha,
@@ -143,16 +144,16 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 	})
 }
 
-// autoMergeBodyTemplate is the issue body for TestYoloAutoMergeLabel. The five
-// %s placeholders are: backtick, backtick, codefence, marker, codefence
-// (Go raw strings can't contain backticks).
+// autoMergeBodyTemplate is the issue body for TestYoloAutoMergeLabel. The six
+// %s placeholders are: backtick, marker path, backtick, codefence, marker,
+// codefence (Go raw strings can't contain backticks).
 const autoMergeBodyTemplate = `## Goal
 
 End-to-end verification of the GitHub native auto-merge path for yolo issues (#829).
 
 ## Trivial change
 
-Append a single HTML comment line to %sREADME.md%s at the very end of the file:
+Append a single HTML comment line to %s%s%s at the very end of the file (create the file first if it doesn't already exist):
 
 %s
 <!-- %s -->

--- a/tests/e2e/basebranch_test.go
+++ b/tests/e2e/basebranch_test.go
@@ -62,7 +62,8 @@ func TestBaseBranchPipeline(t *testing.T) {
 	ensureLabelExists(t, env, env.RepoAlpha, baseLabel)
 
 	marker := fmt.Sprintf("base-branch-pipeline-%s", stamp)
-	body := fmt.Sprintf(baseBranchPipelineBodyTemplate, "`", "`", "```", marker, "```", branchName)
+	path := markerPath("TestBaseBranchPipeline")
+	body := fmt.Sprintf(baseBranchPipelineBodyTemplate, "`", path, "`", "```", marker, "```", branchName)
 
 	num := FileIssue(t, env, env.RepoAlpha,
 		fmt.Sprintf("e2e base-branch pipeline (%s)", stamp),
@@ -140,8 +141,8 @@ func ensureLabelExists(t *testing.T, env *Env, repo, label string) {
 }
 
 // baseBranchPipelineBodyTemplate is the issue body for TestBaseBranchPipeline.
-// The six %s placeholders are: backtick, backtick, codefence, marker,
-// codefence, branch name (Go raw strings can't contain backticks).
+// The seven %s placeholders are: backtick, marker path, backtick, codefence,
+// marker, codefence, branch name (Go raw strings can't contain backticks).
 const baseBranchPipelineBodyTemplate = `## Goal
 
 End-to-end verification of the base:<branch> (non-default base branch)
@@ -151,7 +152,7 @@ fixes.
 
 ## Trivial change
 
-Append a single HTML comment line to %sREADME.md%s at the very end of the file:
+Append a single HTML comment line to %s%s%s at the very end of the file (create the file first if it doesn't already exist):
 
 %s
 <!-- %s -->

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -43,8 +43,10 @@ func TestCIFixReinvoke(t *testing.T) {
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 	title := fmt.Sprintf("e2e ci-fix-reinvoke (%s)", stamp)
+	path := markerPath("TestCIFixReinvoke")
+	body := fmt.Sprintf(ciFixReinvokeBody, path, path)
 
-	num := FileIssue(t, env, env.RepoAlpha, title, ciFixReinvokeBody, "fabrik:yolo")
+	num := FileIssue(t, env, env.RepoAlpha, title, body, "fabrik:yolo")
 	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
 	SetIssueStatus(t, env, itemID, "Specify")
 	t.Logf("filed %s#%d", env.RepoAlpha, num)
@@ -277,8 +279,10 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 	title := fmt.Sprintf("e2e ci-fix-cycle-limit (%s)", stamp)
+	path := markerPath("TestCIFixReinvokeCycleLimit")
+	body := fmt.Sprintf(ciFixCycleLimitBody, path, path)
 
-	num := FileIssue(t, env, env.RepoAlpha, title, ciFixCycleLimitBody, "fabrik:yolo")
+	num := FileIssue(t, env, env.RepoAlpha, title, body, "fabrik:yolo")
 	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
 	SetIssueStatus(t, env, itemID, "Specify")
 	t.Logf("filed %s#%d", env.RepoAlpha, num)
@@ -368,12 +372,16 @@ func TestCIFixReinvokeCycleLimit(t *testing.T) {
 	AssertPRDidNotTouchWorkflows(t, env, env.RepoAlpha, prNumber)
 }
 
-// ciFixReinvokeBody is the issue body for TestCIFixReinvoke. The PR body must
-// contain "ci-fix-sentinel-required" so the test-alpha CI workflow triggers the
-// ci-fix-sentinel check. That check FAILS until a file named SENTINEL_FIX
-// (at the repo root) contains the line "ci-fix-satisfied" — the only sanctioned
-// way to satisfy it. Claude must create that file ONLY on the CI-fix reinvoke,
-// producing the failure → reinvoke → recovery sequence the test exercises.
+// ciFixReinvokeBody is the issue body template for TestCIFixReinvoke. Both %s
+// placeholders are the scenario's unique marker file path (see markerPath in
+// harness.go, #1394), repeated verbatim.
+//
+// The PR body must contain "ci-fix-sentinel-required" so the test-alpha CI
+// workflow triggers the ci-fix-sentinel check. That check
+// FAILS until a file named SENTINEL_FIX (at the repo root) contains the line
+// "ci-fix-satisfied" — the only sanctioned way to satisfy it. Claude must
+// create that file ONLY on the CI-fix reinvoke, producing the failure →
+// reinvoke → recovery sequence the test exercises.
 //
 // The SENTINEL_FIX mechanism is deliberately the sole satisfaction path and the
 // workflow is off-limits (see hard constraints) so the agent cannot satisfy or
@@ -385,9 +393,9 @@ End-to-end regression test for the Fabrik CI-fix reinvoke loop (handarbeit/fabri
 
 ## The change
 
-On the **initial Implement commit**, add exactly one new HTML comment to
-README.md, on its own line, immediately after the line containing
-"# fabrik-test-alpha":
+On the **initial Implement commit**, add exactly one new HTML comment as a new
+line at the end of ` + "`%s`" + ` (create the file first if it doesn't already
+exist):
 
     <!-- ci-fix-reinvoke-initial -->
 
@@ -424,14 +432,16 @@ ci-fix-sentinel-required
 
 ## Scope
 
-README.md on the initial commit; a new SENTINEL_FIX file on the CI-fix reinvoke.
+` + "`%s`" + ` on the initial commit; a new SENTINEL_FIX file on the CI-fix reinvoke.
 No other files. No decomposition. One commit on the initial push, one CI-fix
 commit.
 `
 
-// ciFixCycleLimitBody is the issue body for TestCIFixReinvokeCycleLimit. The
-// PR body must contain "ci-fix-sentinel-unfixable" so the test-alpha CI
-// workflow runs a permanently-failing sentinel check regardless of content.
+// ciFixCycleLimitBody is the issue body template for TestCIFixReinvokeCycleLimit.
+// Both %s placeholders are the scenario's unique marker file path (see
+// markerPath in harness.go, #1394), repeated verbatim. The PR body must
+// contain "ci-fix-sentinel-unfixable" so the test-alpha CI workflow runs a
+// permanently-failing sentinel check regardless of content.
 //
 // The sentinel cannot be satisfied by any commit content, so this fixture's
 // job is not to fix CI — it is to guarantee a NEW commit on every single
@@ -454,8 +464,8 @@ commit on every single CI-fix reinvoke.
 
 ## The change
 
-On the initial commit, add exactly one new HTML comment to README.md, on its
-own line, immediately after the line containing "# fabrik-test-alpha":
+On the initial commit, add exactly one new HTML comment as a new line at the
+end of ` + "`%s`" + ` (create the file first if it doesn't already exist):
 
     <!-- ci-fix-cycle-limit-test -->
 
@@ -502,6 +512,6 @@ ci-fix-sentinel-unfixable
 
 ## Scope
 
-README.md and ` + "`.ci-fix-attempts.log`" + ` only. Minimal change per commit. No
+` + "`%s`" + ` and ` + "`.ci-fix-attempts.log`" + ` only. Minimal change per commit. No
 decomposition.
 `

--- a/tests/e2e/conjunctive_ci_review_gate_test.go
+++ b/tests/e2e/conjunctive_ci_review_gate_test.go
@@ -124,8 +124,10 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 	title := fmt.Sprintf("e2e conjunctive-ci-review-gate (%s)", stamp)
+	path := markerPath("TestConjunctiveCIReviewGate")
+	body := fmt.Sprintf(conjunctiveCIReviewGateBody, path, path)
 
-	num := FileIssue(t, env, env.RepoAlpha, title, conjunctiveCIReviewGateBody, "fabrik:yolo")
+	num := FileIssue(t, env, env.RepoAlpha, title, body, "fabrik:yolo")
 	itemID := AddIssueToProject(t, env, env.RepoAlpha, num)
 	SetIssueStatus(t, env, itemID, "Specify")
 	t.Logf("filed %s#%d — waiting for Implement to complete", env.RepoAlpha, num)
@@ -295,8 +297,10 @@ func TestConjunctiveCIReviewGate(t *testing.T) {
 	}
 }
 
-// conjunctiveCIReviewGateBody is the issue body for TestConjunctiveCIReviewGate.
-// Claude makes a minimal change to README.md and includes "slow-ci-required"
+// conjunctiveCIReviewGateBody is the issue body template for
+// TestConjunctiveCIReviewGate. Both %s placeholders are the scenario's unique
+// marker file path (see markerPath in harness.go, #1394), repeated verbatim.
+// Claude makes a minimal change to that file and includes "slow-ci-required"
 // in the PR body to trigger the ~10-minute slow-gate required CI check, creating
 // a wide CI-await window for the conjunctive gate test.
 const conjunctiveCIReviewGateBody = `## Goal
@@ -307,8 +311,9 @@ review gate must both be satisfied before Validate advances the issue.
 
 ## The change
 
-Add exactly one new HTML comment to README.md, on its own line, immediately
-after the line containing "# fabrik-test-alpha". The comment must be EXACTLY:
+Add exactly one new HTML comment as a new line at the end of ` + "`%s`" + `
+(create the file first if it doesn't already exist). The comment must be
+EXACTLY:
 
     <!-- conjunctive-ci-review-gate-test -->
 
@@ -328,6 +333,6 @@ behaviour. Do NOT include ci-fix-sentinel-required in the PR body.
 
 ## Scope
 
-Single file (README.md). Minimal one-line change. No decomposition.
+Single file (` + "`%s`" + `). Minimal one-line change. No decomposition.
 Plan and Implement should be a one-commit change.
 `

--- a/tests/e2e/cruise_test.go
+++ b/tests/e2e/cruise_test.go
@@ -41,7 +41,8 @@ func TestCruiseFullPipeline(t *testing.T) {
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 	marker := fmt.Sprintf("cruise-pipeline-%s", stamp)
-	body := fmt.Sprintf(cruiseBodyTemplate, "`", "`", "```", marker, "```")
+	path := markerPath("TestCruiseFullPipeline")
+	body := fmt.Sprintf(cruiseBodyTemplate, "`", path, "`", "```", marker, "```")
 
 	num := FileIssue(t, env, env.RepoAlpha,
 		fmt.Sprintf("e2e cruise full pipeline (%s)", stamp),
@@ -110,16 +111,16 @@ func TestCruiseFullPipeline(t *testing.T) {
 	t.Logf("%s#%d closed after human merge — R5 verified (full cruise contract confirmed)", env.RepoAlpha, num)
 }
 
-// cruiseBodyTemplate is the issue body for TestCruiseFullPipeline. The five
-// %s placeholders are: backtick, backtick, codefence, marker, codefence
-// (Go raw strings can't contain backticks).
+// cruiseBodyTemplate is the issue body for TestCruiseFullPipeline. The six
+// %s placeholders are: backtick, marker path, backtick, codefence, marker,
+// codefence (Go raw strings can't contain backticks).
 const cruiseBodyTemplate = `## Goal
 
 End-to-end verification of the fabrik:cruise pipeline contract (#898).
 
 ## Trivial change
 
-Append a single HTML comment line to %sREADME.md%s at the very end of the file:
+Append a single HTML comment line to %s%s%s at the very end of the file (create the file first if it doesn't already exist):
 
 %s
 <!-- %s -->

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -30,6 +30,51 @@ const (
 	defaultProjectOwner  = "handarbeit"
 )
 
+// markerPaths is the single source of truth for every non-train scenario's
+// marker file target: one fixed, distinct e2e/markers/<scenario>.md path per
+// writer test function, so parallel scenarios can never conflict on a shared
+// file (#1394). Unlike the merge-train members' uniqueMemberPath (which needs
+// per-run uniqueness because a landed batch merges files into main and a
+// fixed path would collide with the existing blob's SHA on the Contents API),
+// these files are edited through a normal agent git commit in a worktree — a
+// real diff, not a raw Contents-API PUT — so a fixed path across runs is
+// fine, and it's what lets TestMarkerPathsAreUnique enumerate the set
+// statically (AC1) rather than needing to execute the tests to know the
+// paths.
+//
+// TestPausedMergedPRRecovery's 3 sub-variants deliberately share one path:
+// they run strictly sequentially (t.Run, no t.Parallel between them) and each
+// variant's PR merges before the next is filed, so there is no concurrent
+// write to race.
+//
+// TestConvergenceRace is deliberately absent from this map. Its entire
+// premise (documented in convergence_race_test.go's own top-of-file comment)
+// is that its two issues collide on the same anchor line of the shared
+// README.md, forcing a genuine merge conflict that Fabrik must resolve via a
+// rebase reinvoke — giving it a unique path would eliminate the exact
+// condition it exists to provoke (R4).
+var markerPaths = map[string]string{
+	"TestSmokeSingleRepoFullPipeline": "e2e/markers/smoke-full-pipeline.md",
+	"TestYoloAutoMergeLabel":          "e2e/markers/auto-merge-yolo.md",
+	"TestPausedMergedPRRecovery":      "e2e/markers/paused-merged-pr-recovery.md",
+	"TestBaseBranchPipeline":          "e2e/markers/base-branch-pipeline.md",
+	"TestCruiseFullPipeline":          "e2e/markers/cruise-full-pipeline.md",
+	"TestCIFixReinvoke":               "e2e/markers/ci-fix-reinvoke.md",
+	"TestCIFixReinvokeCycleLimit":     "e2e/markers/ci-fix-reinvoke-cycle-limit.md",
+	"TestConjunctiveCIReviewGate":     "e2e/markers/conjunctive-ci-review-gate.md",
+}
+
+// markerPath returns the unique marker file path for the named scenario.
+// Panics on an unknown name so a typo'd lookup fails loudly at test setup
+// rather than silently producing an empty path in an issue body.
+func markerPath(name string) string {
+	path, ok := markerPaths[name]
+	if !ok {
+		panic(fmt.Sprintf("markerPath: no entry for %q — add it to markerPaths in harness.go", name))
+	}
+	return path
+}
+
 // Env carries the resolved test-bed paths and identifiers. Constructed by
 // LoadEnv from environment variables (with sensible defaults).
 type Env struct {

--- a/tests/e2e/marker_paths_test.go
+++ b/tests/e2e/marker_paths_test.go
@@ -1,0 +1,27 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+// TestMarkerPathsAreUnique statically enumerates markerPaths and fails on any
+// duplicate or empty value (handarbeit/fabrik#1394 AC1). It requires no live
+// bed:
+//
+//	go test -tags e2e -run TestMarkerPathsAreUnique -v ./tests/e2e/
+//
+// TestConvergenceRace is deliberately absent from markerPaths — see the
+// comment above the map in harness.go — so its intentional collision on
+// README.md is not itself a bug this test should ever flag.
+func TestMarkerPathsAreUnique(t *testing.T) {
+	seen := make(map[string]string, len(markerPaths))
+	for scenario, path := range markerPaths {
+		if path == "" {
+			t.Fatalf("markerPaths[%q] is empty", scenario)
+		}
+		if other, ok := seen[path]; ok {
+			t.Fatalf("marker path %q is used by both %q and %q — each scenario must have a unique path", path, other, scenario)
+		}
+		seen[path] = scenario
+	}
+}

--- a/tests/e2e/paused_merged_pr_recovery_test.go
+++ b/tests/e2e/paused_merged_pr_recovery_test.go
@@ -55,7 +55,14 @@ func TestPausedMergedPRRecovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			stamp := time.Now().UTC().Format("20060102-150405")
 			marker := fmt.Sprintf("paused-merged-pr-%s-%s", tc.name, stamp)
-			body := fmt.Sprintf(pausedMergedPRBodyTemplate, "`", "`", "```", marker, "```")
+			// All 3 sub-variants share one marker file (markerPath is keyed by
+			// the parent test function, not the sub-test name): they run
+			// strictly sequentially (no t.Parallel inside t.Run, per R6/the
+			// comment above), and each variant's PR merges (step 7 below)
+			// before the next variant is filed, so there is no concurrent
+			// write to race.
+			path := markerPath("TestPausedMergedPRRecovery")
+			body := fmt.Sprintf(pausedMergedPRBodyTemplate, "`", path, "`", "```", marker, "```")
 
 			// File WITHOUT an auto-advance label. With global yolo off and
 			// auto_advance unset (nil, not true) on Research..Validate, the engine
@@ -155,8 +162,8 @@ func TestPausedMergedPRRecovery(t *testing.T) {
 }
 
 // pausedMergedPRBodyTemplate is the issue body for TestPausedMergedPRRecovery.
-// The five %s placeholders are: backtick, backtick, codefence, marker, codefence
-// (Go raw strings can't contain backticks).
+// The six %s placeholders are: backtick, marker path, backtick, codefence,
+// marker, codefence (Go raw strings can't contain backticks).
 const pausedMergedPRBodyTemplate = `## Goal
 
 End-to-end regression guard for the #874 bug class (paused item + merged PR
@@ -164,7 +171,7 @@ recovery via the settle-owner, ADR-056 D2).
 
 ## Trivial change
 
-Append a single HTML comment line to %sREADME.md%s at the very end of the file:
+Append a single HTML comment line to %s%s%s at the very end of the file (create the file first if it doesn't already exist):
 
 %s
 <!-- %s -->

--- a/tests/e2e/paused_merged_pr_recovery_test.go
+++ b/tests/e2e/paused_merged_pr_recovery_test.go
@@ -45,7 +45,7 @@ func TestPausedMergedPRRecovery(t *testing.T) {
 		name      string
 		gateLabel string
 	}{
-		{"awaiting-ci", "fabrik:awaiting-ci"},       // R1
+		{"awaiting-ci", "fabrik:awaiting-ci"},         // R1
 		{"awaiting-review", "fabrik:awaiting-review"}, // R2
 		{"no-gate-label", ""},                         // R3 (control)
 	}

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -59,6 +59,7 @@ func TestSmokeSingleRepoFullPipeline(t *testing.T) {
 
 	stamp := time.Now().UTC().Format("20060102-150405")
 	marker := fmt.Sprintf("smoke-full-pipeline-%s", stamp)
+	path := markerPath("TestSmokeSingleRepoFullPipeline")
 	num := FileIssue(t, env, env.RepoAlpha,
 		fmt.Sprintf("e2e smoke full-pipeline (%s)", stamp),
 		`## Goal
@@ -67,7 +68,7 @@ End-to-end single-repo pipeline smoke. Verify Fabrik can take an issue from Spec
 
 ## Trivial change
 
-Append a single comment line to `+"`README.md`"+` at the very end of the file:
+Append a single comment line to `+"`"+path+"`"+` at the very end of the file (create the file first if it doesn't already exist):
 
 `+"```"+`
 <!-- `+marker+` -->


### PR DESCRIPTION
Closes #1394

## What this does

Multiple e2e scenarios ran in parallel and all appended their marker to the same file (`README.md` on `fabrik-test-alpha`). When two landed close together, the second could hit a merge conflict on the shared trailing lines and fail in harness code (`MergePR`) before any engine assertion ran — a flake, not a regression (see #1394 for the incident).

This gives every marker-writing scenario a unique, fixed file path so parallel scenarios can no longer collide.

## Key changes

- **`tests/e2e/harness.go`**: new `markerPaths` map (single source of truth: test-function name → `e2e/markers/<scenario>.md`) and a `markerPath(name string) string` accessor that panics on an unknown key.
- **`tests/e2e/marker_paths_test.go`** (new): `TestMarkerPathsAreUnique` statically enumerates `markerPaths` and fails on any duplicate or empty value (AC1) — runnable without a live bed via `go test -tags e2e -run TestMarkerPathsAreUnique ./tests/e2e/`.
- **7 scenario files** (`smoke_test.go`, `auto_merge_test.go`, `paused_merged_pr_recovery_test.go`, `basebranch_test.go`, `cruise_test.go`, `ci_fix_reinvoke_test.go`, `conjunctive_ci_review_gate_test.go`): each issue-body template now targets its own `markerPath(...)` instead of `README.md`. The two anchor-style templates (`ci_fix_reinvoke_test.go` ×2, `conjunctive_ci_review_gate_test.go`) are normalized to "append at end, create-if-absent" — no assertion in these three depends on line position, and a brand-new file has no anchor line to insert after anyway. `TestPausedMergedPRRecovery`'s 3 sub-variants intentionally share one path since they run strictly sequentially.
- **`tests/e2e/README.md`**: new "Marker-path convention (#1394)" section documenting the pattern, plus an addition to the "Adding a scenario" checklist.
- `TestConvergenceRace` is deliberately **excluded** — its entire premise is two issues colliding on the same anchor line of the same `README.md` to force a genuine merge conflict Fabrik must resolve via rebase reinvoke. Giving it a unique path would break the exact condition it exists to test.

## Non-goals

No change to `MergePR`, to any scenario's assertions, to `-parallel`/`E2E_PARALLEL`, or to `TestConvergenceRace`.

## How to test

- `go test -tags e2e -run TestMarkerPathsAreUnique -v ./tests/e2e/` — static AC1 guard, no live bed needed.
- `go build -o fabrik .`, `go vet ./...`, `gofmt -l tests/e2e/` — all clean.
- `grep -n "README.md" tests/e2e/*.go` — confirms the only remaining hits are `convergence_race_test.go` (intentional), `no_work_needed_test.go` (read-only check, out of scope), and doc-comment references to the local `tests/e2e/README.md` file.
- Live-bed verification of AC2 (`TestPausedMergedPRRecovery` passing under `train-mode=on` in a full parallel gate) cannot be run from within this pipeline stage's sandbox — flagged as a manual follow-up validation run, per the same boundary documented in `tests/e2e/README.md`'s `#1355` section.