### PR TITLE
docs: fix inverted cruise/yolo precedence in fabrik supervisor skill

### DIFF
--- a/plugin/fabrik/skills/fabrik/SKILL.md
+++ b/plugin/fabrik/skills/fabrik/SKILL.md
@@ -72,7 +72,7 @@ Fabrik **uses labels as durable state**. The user **also** uses some labels to s
 |---|---|
 | `fabrik:paused` | You want to halt processing immediately. Add to pause, remove to resume. |
 | `fabrik:yolo` | Auto-advance through every stage **and** auto-merge the PR at Validate. Trust-the-pipeline mode. |
-| `fabrik:cruise` | Like `fabrik:yolo` but **stops at Validate** — no auto-merge, no Done. Good when you want a human to gate the merge. (`fabrik:yolo` wins if both are present.) |
+| `fabrik:cruise` | Like `fabrik:yolo` but **stops at Validate** — no auto-merge, no Done. Good when you want a human to gate the merge. (`fabrik:cruise` wins if both are present — the pipeline stops at Validate.) |
 | `fabrik:extend-turns` | The worker is making progress but ran out of `max_turns`. Pre-grants 2× budget for the next invocation; auto-removed on success. Safety valve. |
 | `fabrik:unrestricted` | Stage needs tools outside the default allowlist (e.g. `deno`, `bun`). **Removes all tool restrictions** — use sparingly. |
 | `model:opus` / `model:sonnet` | Override the model for this issue. |


### PR DESCRIPTION
Closes #1389

## What this does

Fixes an inverted precedence claim in `plugin/fabrik/skills/fabrik/SKILL.md`'s labels table.

## The bug

The `fabrik:cruise` row's parenthetical said "`fabrik:yolo` wins if both are present" — this is backwards. The actual, code-enforced behavior (per `engine/stages.go`'s end-of-Validate guards, which test the raw `fabrik:cruise` label directly and force `shouldAdvance = false` regardless of yolo) is that **`fabrik:cruise` wins**: when both labels are present, the pipeline stops at Validate with no auto-merge and no advance to Done.

This is safety-relevant because it concerns whether a PR gets auto-merged — a reader of this doc could otherwise be misled into expecting an unintended auto-merge on a both-labelled issue.

## Key changes

- `plugin/fabrik/skills/fabrik/SKILL.md`: corrected the `fabrik:cruise` row's parenthetical to state cruise wins over yolo, matching every other doc in the repo (`README.md`, `docs/USER_GUIDE.md`, `docs/state-machine.md`, `docs/llms-full.txt`, `plugin/fabrik-workflows/LABELS.md`, `adrs/050-convergence-budget-and-native-automerge.md`) and the existing unit tests (`TestHandleStageComplete_BothCruiseAndYolo_CruiseWins`, `TestCruiseCatchUp_BothCruiseAndYolo_CruiseWins`).

No other line in the file changed, and no code, tests, or `docs/llms-full.txt` regen are needed — this skill file is not one of the four canonical `docs/` sources that bundle regenerates from.

## How to test

`git diff` on the commit shows a single-line change (the parenthetical only); `go build ./...` and `go vet ./...` pass clean.