### PR TITLE
fix(engine): suppress ScheduleWakeup and Workflow via --disallowedTools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,14 @@ allowed_tools:                  # Optional: REPLACES the default tool set (not a
                                 # Bash(pnpm:*), Bash(make:*), Bash(cargo:*), Bash(python:*), Bash(pip:*),
                                 # Bash(uv:*), Bash(pytest:*), Bash(ls:*), Bash(cat:*), Bash(rm:*), Bash(cp:*),
                                 # Bash(mv:*), Bash(mkdir:*), Bash(find:*).
+                                # IMPORTANT: allowed_tools is a call-time PERMISSION filter, not an
+                                # AVAILABILITY filter — a tool absent from this list is still offered to
+                                # the model and, under --permission-mode dontAsk, may still be invoked
+                                # (see #1372). It cannot make a harness tool disappear. The only mechanism
+                                # that does is `--disallowedTools`, which Fabrik emits unconditionally
+                                # (both invocation paths) for `ScheduleWakeup` and `Workflow` — harness
+                                # tools whose contract is cross-turn resumption that a headless stage
+                                # cannot deliver. See ADR-1365.
 post_to_pr: true                # Post output to linked PR instead of issue
 create_draft_pr: true           # Create draft PR before stage runs
 mark_pr_ready_on_complete: true # Mark PR ready when stage completes

--- a/adrs/1365-suppress-cross-turn-tools.md
+++ b/adrs/1365-suppress-cross-turn-tools.md
@@ -1,0 +1,121 @@
+# ADR 1365: Suppress Cross-Turn Resumption Tools via `--disallowedTools`
+
+**Date**: 2026-08-08
+**Status**: Accepted
+**Issue**: #1365 — `--allowedTools` cannot withhold `ScheduleWakeup`/`Workflow` from headless stage workers, causing stalls and, for `Workflow`, wasted spend
+
+## Context
+
+Fabrik's headless stage workers are offered the full Claude Code harness tool set, including
+`ScheduleWakeup` and `Workflow` — both of which promise **cross-turn resumption**: a wakeup fired
+after a delay, or a `<task-notification>` delivered after a background workflow completes. Neither
+promise can be kept in a headless Fabrik stage. There is no interactive session listening for a
+timer or a notification; the turn simply ends, the stage exits without `FABRIK_STAGE_COMPLETE`,
+retries, and — because the reasoning that led there is deterministic — re-derives the identical
+stall on the next attempt until the issue exhausts its retries and pauses.
+
+Field evidence from a downstream repo (`verveguy/liminis-context-graph`, `.fabrik/logs/`) recorded
+**75 real `ScheduleWakeup` invocations**, delays 120s–1500s, with confirmed casualties across
+multiple issues. See #1345 for the full breakdown.
+
+### `--allowedTools` was the obvious fix, and does not work
+
+`defaultAllowedTools` (`engine/claude.go`) governs `--allowedTools`, and it seemed reasonable to
+assume that simply never listing `ScheduleWakeup`/`Workflow` there would keep them out of a stage
+worker's hands. Empirical testing against the live `claude -p` CLI, using Fabrik's exact flags
+(`--permission-mode dontAsk`, `--allowedTools Read --allowedTools Grep`), disproved this:
+
+```
+Read Bash Edit Glob Grep ReportFindings ScheduleWakeup Skill ToolSearch Workflow Write Agent
+SCHEDULEWAKEUP=YES
+```
+
+`Bash`, `Edit`, `Write`, and `Agent` were all offered and callable despite being absent from the
+two-entry allowlist. **`--allowedTools` is a call-time permission filter, not an availability
+filter** — it can only be checked against once a call is already attempted, and (see the related,
+independently-discovered #1372) that check is not even reliably enforced under `dontAsk` mode.
+Either way, the tool is still present in the schema offered to the model, and a stage worker not
+constrained by an intact permission check can still invoke it.
+
+### `--disallowedTools` does work
+
+The same probe, with `--disallowedTools ScheduleWakeup` added, returned `SCHEDULEWAKEUP=NO` — the
+tool was absent from `system.init.tools` entirely. This was independently re-verified during
+Research for #1365 against `--dangerously-skip-permissions` as well (the `fabrik:unrestricted`
+path), confirming the exclusion holds on both invocation paths. `--disallowedTools` is a
+**construction-time exclusion**: the tool is removed from the schema handed to the model, so there
+is no permission check to reason around or bypass — the model never sees it.
+
+## Decision
+
+Add a named, commented package-level var, `disallowedTools` (`engine/claude.go`, alongside
+`defaultAllowedTools`), and emit `--disallowedTools <tool>` once per entry, unconditionally, in
+`buildClaudeArgs` — placed immediately after the `unrestricted`/`dontAsk` branch and before any
+other flag, so it is structurally impossible for a future edit inside that branch to accidentally
+scope it to one path:
+
+```go
+var disallowedTools = []string{
+    "ScheduleWakeup", // cross-turn resumption; no scheduler exists in a headless stage
+    "Workflow",       // cross-turn resumption + background spend against session budget
+}
+```
+
+Only `ScheduleWakeup` and `Workflow` are suppressed. `Agent` is explicitly excluded (see FR-3
+below), and `Bash(run_in_background)` cannot be addressed by this mechanism at all (see FR-4).
+
+### Why `Workflow` specifically, and why it's worse than `ScheduleWakeup`
+
+`Workflow` returns immediately with a task ID and promises a `<task-notification>` on completion,
+after potentially spawning dozens of subagents against the session's own token budget. Its failure
+mode is therefore the stall *and* the spend — tokens consumed by subagents whose result is never
+seen, on top of the same dead-end retry loop `ScheduleWakeup` produces.
+
+### Why `Agent` is not suppressed (FR-3)
+
+`Agent`/`Task` (the harness's user-facing name differs from `defaultAllowedTools`'s existing
+`"Task"` entry — see Risks) completes synchronously within the parent turn. A subagent invocation
+blocks until it returns; there is no cross-turn promise being made, so it presents none of the
+failure mode this ADR addresses. Subagents are legitimately useful to stage workers and removing
+them would be a regression, not a fix. If `Agent` is later found reachable in some background mode
+from a stage, that is a distinct problem requiring separate investigation — not an extension of
+this suppression list.
+
+### Why `Bash(run_in_background)` is out of scope (FR-4)
+
+`--disallowedTools` operates on whole tool names. `Bash` cannot be partially disallowed by argument
+shape — suppressing it to block `run_in_background` would remove `Bash` entirely, which every stage
+depends on for `git`, `gh`, build tooling, and more. This gap is tracked by a sibling stage-prompt
+guidance issue and is deliberately not closed here; this ADR's mechanism structurally cannot reach
+it.
+
+### Relationship to #1372
+
+#1372 independently found that `--allowedTools` under `dontAsk` does not reliably enforce *any*
+restriction — a non-allowlisted `Bash` command can execute, and the worktree boundary
+(`applyWorktreeBoundary`, ADR-049) can be breached. That finding is about the *allow*-list's
+call-time enforcement gap. It does not undermine this ADR's fix: `--disallowedTools` sidesteps that
+failure mode entirely because there is no call-time check to bypass in the first place — the tool
+was never in the offered schema. The two issues address different mechanisms and neither issue's
+resolution depends on the other's.
+
+## Consequences
+
+- Every headless Fabrik stage invocation, on both the `--permission-mode dontAsk` and
+  `--dangerously-skip-permissions` (`fabrik:unrestricted`) paths, no longer offers `ScheduleWakeup`
+  or `Workflow` to the model. The corresponding class of stall (and, for `Workflow`, wasted spend)
+  is eliminated at the source rather than mitigated after the fact.
+- `--allowedTools`/`stage.AllowedTools`/`applyWorktreeBoundary` are untouched — this is a purely
+  additive, independent flag emission with no interaction with existing tool-restriction logic.
+- A future contributor extending tool restrictions should reach for `--disallowedTools` (a named
+  var, following this pattern) rather than assuming `--allowedTools` omission is sufficient — that
+  assumption is exactly what made this bug invisible for as long as it was.
+- `Bash(run_in_background)` remains a live gap, tracked separately. Do not treat this ADR as having
+  closed it.
+
+## Related
+
+- #1345 — original diagnosis and the 75-invocation field evidence.
+- #1372 — related but distinct `--allowedTools`/worktree-boundary enforcement gap under `dontAsk`;
+  not fixed by, and does not undermine, this change.
+- ADR-049 — worktree boundary enforcement via `--allowedTools` path-scoping; unaffected by this ADR.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2314,7 +2314,11 @@ If the named branch does not exist on the remote, Fabrik falls back to the repos
 
 ## 7. Permissions
 
-Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In this mode Claude does not prompt for tool permissions — tools not in the allowed set are silently denied rather than triggering an interactive prompt. This ensures Fabrik works correctly in headless mode and shared environments regardless of the user's `~/.claude/settings.json`. Fabrik does not require users to pre-configure permissions in their Claude Code settings.
+Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In this mode Claude does not prompt for tool permissions interactively. This ensures Fabrik works correctly in headless mode and shared environments regardless of the user's `~/.claude/settings.json`. Fabrik does not require users to pre-configure permissions in their Claude Code settings.
+
+**`allowed_tools` is a call-time permission filter, not an availability filter.** A tool absent from the allowed set is still offered to the model in its tool schema; under `--permission-mode dontAsk`, absence from the allowed list is not a guarantee the tool call is rejected either (see the Worktree Boundary Enforcement caveat below and #1372). The only mechanism that removes a tool from what the model is even offered is `--disallowedTools`, a separate, construction-time exclusion.
+
+**`ScheduleWakeup` and `Workflow` are unconditionally suppressed via `--disallowedTools`** on every invocation, regardless of stage config, `allowed_tools`, or whether `fabrik:unrestricted` is set. Both tools promise cross-turn resumption — a scheduled wakeup or a completion notification delivered after the current turn ends — that a headless Fabrik stage cannot honor: there is no running session to receive it. Without suppression, a stage worker calls one of these tools, the turn ends, the stage exits without `FABRIK_STAGE_COMPLETE`, and the next retry deterministically re-derives the identical stall (`Workflow` additionally risks spending session budget on background subagents that never report back). See ADR-1365.
 
 **Default allowed-tool set** (used when a stage does not specify `allowed_tools`):
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2312,7 +2312,11 @@ If the named branch does not exist on the remote, Fabrik falls back to the repos
 
 ## 7. Permissions
 
-Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In this mode Claude does not prompt for tool permissions — tools not in the allowed set are silently denied rather than triggering an interactive prompt. This ensures Fabrik works correctly in headless mode and shared environments regardless of the user's `~/.claude/settings.json`. Fabrik does not require users to pre-configure permissions in their Claude Code settings.
+Fabrik passes `--permission-mode dontAsk` to every Claude Code invocation. In this mode Claude does not prompt for tool permissions interactively. This ensures Fabrik works correctly in headless mode and shared environments regardless of the user's `~/.claude/settings.json`. Fabrik does not require users to pre-configure permissions in their Claude Code settings.
+
+**`allowed_tools` is a call-time permission filter, not an availability filter.** A tool absent from the allowed set is still offered to the model in its tool schema; under `--permission-mode dontAsk`, absence from the allowed list is not a guarantee the tool call is rejected either (see the Worktree Boundary Enforcement caveat below and #1372). The only mechanism that removes a tool from what the model is even offered is `--disallowedTools`, a separate, construction-time exclusion.
+
+**`ScheduleWakeup` and `Workflow` are unconditionally suppressed via `--disallowedTools`** on every invocation, regardless of stage config, `allowed_tools`, or whether `fabrik:unrestricted` is set. Both tools promise cross-turn resumption — a scheduled wakeup or a completion notification delivered after the current turn ends — that a headless Fabrik stage cannot honor: there is no running session to receive it. Without suppression, a stage worker calls one of these tools, the turn ends, the stage exits without `FABRIK_STAGE_COMPLETE`, and the next retry deterministically re-derives the identical stall (`Workflow` additionally risks spending session budget on background subagents that never report back). See ADR-1365.
 
 **Default allowed-tool set** (used when a stage does not specify `allowed_tools`):
 
@@ -7357,12 +7361,15 @@ Context files are available in .fabrik-context/
 --plugin-dir <absolute-path-to-.fabrik/plugin>
 --output-format json
 --verbose
+--disallowedTools <tool> ...  (always: ScheduleWakeup, Workflow — see below)
 --resume <sessionID>          (if retry)
 --model <override>            (if label or stage config)
 --max-turns <N>               (if configured)
 --allowedTools <tool> ...     (if restricted)
 --name <sentinel>             (if claude supports --name; probed once at startup)
 ```
+
+`--disallowedTools` is emitted unconditionally, outside the `--dangerously-skip-permissions`/`--permission-mode dontAsk` branch, so it applies on both invocation paths — it is a construction-time exclusion from the tool schema Claude is offered, not a call-time permission check like `--allowedTools`. `ScheduleWakeup` and `Workflow` are suppressed because both promise cross-turn resumption a headless stage cannot deliver (see `disallowedTools` in `engine/claude.go` and ADR-1365). `Agent` is deliberately not suppressed — subagents complete within the parent turn.
 
 ### Worker Session Naming (`--name`)
 

--- a/docs/stage-lifecycle.md
+++ b/docs/stage-lifecycle.md
@@ -280,12 +280,15 @@ Context files are available in .fabrik-context/
 --plugin-dir <absolute-path-to-.fabrik/plugin>
 --output-format json
 --verbose
+--disallowedTools <tool> ...  (always: ScheduleWakeup, Workflow — see below)
 --resume <sessionID>          (if retry)
 --model <override>            (if label or stage config)
 --max-turns <N>               (if configured)
 --allowedTools <tool> ...     (if restricted)
 --name <sentinel>             (if claude supports --name; probed once at startup)
 ```
+
+`--disallowedTools` is emitted unconditionally, outside the `--dangerously-skip-permissions`/`--permission-mode dontAsk` branch, so it applies on both invocation paths — it is a construction-time exclusion from the tool schema Claude is offered, not a call-time permission check like `--allowedTools`. `ScheduleWakeup` and `Workflow` are suppressed because both promise cross-turn resumption a headless stage cannot deliver (see `disallowedTools` in `engine/claude.go` and ADR-1365). `Agent` is deliberately not suppressed — subagents complete within the parent turn.
 
 ### Worker Session Naming (`--name`)
 

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -120,6 +120,26 @@ var defaultAllowedTools = []string{
 	"Bash(ls:*)", "Bash(cat:*)", "Bash(rm:*)", "Bash(cp:*)", "Bash(mv:*)", "Bash(mkdir:*)", "Bash(find:*)",
 }
 
+// disallowedTools lists harness tools that must never reach a headless Fabrik
+// stage worker, regardless of stage config or the unrestricted/dontAsk split.
+// Unlike --allowedTools (a call-time permission filter that does not prevent a
+// tool from being offered or invoked — see #1372 and #1365), --disallowedTools
+// is a construction-time exclusion: the tool is absent from the schema Claude
+// is given, so there is no permission check to reason around or bypass.
+var disallowedTools = []string{
+	// ScheduleWakeup promises cross-turn resumption via a scheduled wakeup.
+	// A headless Fabrik stage has no scheduler to deliver that wakeup: the
+	// turn ends, the stage exits without FABRIK_STAGE_COMPLETE, and the next
+	// retry re-derives the identical stall. See #1345, #1365.
+	"ScheduleWakeup",
+	// Workflow promises a <task-notification> on completion after spawning
+	// background subagents against the session budget. It is more damaging
+	// than ScheduleWakeup: nothing ever delivers the notification in a
+	// headless stage, so the failure mode is the stall plus the spend. See
+	// #1345, #1365.
+	"Workflow",
+}
+
 // CheckBlockedOnInput reports whether output contains the FABRIK_BLOCKED_ON_INPUT marker.
 func CheckBlockedOnInput(output string) bool {
 	return blockedOnInputRE.MatchString(output)
@@ -966,6 +986,13 @@ func buildClaudeArgs(stage *stages.Stage, resumeSessionID string, modelOverride 
 		args = append(args, "--dangerously-skip-permissions")
 	} else {
 		args = append(args, "--permission-mode", "dontAsk")
+	}
+
+	// Applies unconditionally on both invocation paths above: --disallowedTools
+	// is a construction-time exclusion, not a permission-mode behavior, so it
+	// must not live inside the unrestricted branch. See disallowedTools doc.
+	for _, tool := range disallowedTools {
+		args = append(args, "--disallowedTools", tool)
 	}
 
 	if claudePluginDir != "" {

--- a/engine/invoke_claude_test.go
+++ b/engine/invoke_claude_test.go
@@ -375,6 +375,32 @@ func TestBuildClaudeArgs_ResumeArg(t *testing.T) {
 	})
 }
 
+func TestBuildClaudeArgs_DisallowedTools(t *testing.T) {
+	stage := &stages.Stage{Name: "Plan", Prompt: "plan"}
+
+	assertDisallowed := func(t *testing.T, args []string, tool string) {
+		t.Helper()
+		for i, a := range args {
+			if a == "--disallowedTools" && i+1 < len(args) && args[i+1] == tool {
+				return
+			}
+		}
+		t.Fatalf("expected --disallowedTools %s in args, got %v", tool, args)
+	}
+
+	t.Run("dontAsk path", func(t *testing.T) {
+		args := buildClaudeArgs(stage, "", "", 0, false, "", "")
+		assertDisallowed(t, args, "ScheduleWakeup")
+		assertDisallowed(t, args, "Workflow")
+	})
+
+	t.Run("dangerously-skip-permissions path", func(t *testing.T) {
+		args := buildClaudeArgs(stage, "", "", 0, true, "", "")
+		assertDisallowed(t, args, "ScheduleWakeup")
+		assertDisallowed(t, args, "Workflow")
+	})
+}
+
 func TestInvokeClaude_WithResume_WhitespaceOnlySessionFile(t *testing.T) {
 	t.Chdir(t.TempDir())
 	binDir := t.TempDir()


### PR DESCRIPTION
Closes #1365

## What this does

Adds a named `disallowedTools` package-level var in `engine/claude.go` (`ScheduleWakeup`, `Workflow`) and emits `--disallowedTools <tool>` for each entry unconditionally in `buildClaudeArgs`, placed outside the `unrestricted`/`dontAsk` if/else so it applies to **both** invocation paths.

## Why

`--allowedTools` is a call-time permission filter, not an availability filter — empirical testing (documented in the issue and independently re-verified in Research) showed tools absent from a 2-entry allowlist (`Bash`, `Edit`, `Write`, `Agent`) still executed. `ScheduleWakeup` and `Workflow` both promise cross-turn resumption a headless Fabrik stage worker cannot deliver: the turn ends, the stage exits without `FABRIK_STAGE_COMPLETE`, and the retry deterministically re-derives the identical stall. `--disallowedTools` is a construction-time exclusion — the tool never appears in the schema offered to the model — verified empirically to work on both the `dontAsk` and `--dangerously-skip-permissions` paths.

`Agent` is deliberately **not** suppressed (subagents complete within the parent turn, no cross-turn promise). `Bash(run_in_background)` is explicitly out of scope — it can't be suppressed without removing `Bash` entirely; tracked by a sibling stage-prompt guidance issue.

## Key changes

- `engine/claude.go` — `disallowedTools` var + unconditional emission in `buildClaudeArgs`
- `engine/invoke_claude_test.go` — `TestBuildClaudeArgs_DisallowedTools`, asserting both tools are suppressed on both invocation paths
- `CLAUDE.md`, `docs/USER_GUIDE.md`, `docs/stage-lifecycle.md` — corrected the "silently denied" framing that implied `--allowedTools` controls availability, and documented the new suppression
- `docs/llms-full.txt` — regenerated
- `adrs/1365-suppress-cross-turn-tools.md` — new ADR recording the decision, empirical verification, and why `Agent`/`Bash(run_in_background)` are out of scope

## How to test

```
go build ./...
go vet ./...
go test -race -timeout 5m ./engine/...
```

All pass. `TestBuildClaudeArgs_DisallowedTools` specifically covers both the `--permission-mode dontAsk` and `--dangerously-skip-permissions` code paths per FR-2.