### PR TITLE
pruefer: wire Logf to a rotating log file at .pruefer/pruefer.log

### DIFF
--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -109,7 +109,7 @@ The TUI is purely observational — it never changes which PRs get reviewed, whe
 
 ## Logging
 
-Pruefer writes every daemon log line — poll cycles, review outcomes, warnings, auth events — to a timestamped, mutex-serialized log file at `.pruefer/pruefer.log` by default, so an incident is diagnosable from the daemon's own durable record instead of requiring reconstruction from the GitHub API. Set `log_file` (or `--log-file` / `PRUEFER_LOG_FILE`) to write elsewhere, or to an empty value to disable file logging entirely and fall back to stderr-only, matching Pruefer's behavior before this feature existed.
+Pruefer writes every daemon log line — poll cycles, review outcomes, warnings, auth events — to a timestamped, mutex-serialized log file at `.pruefer/pruefer.log` by default, so an incident is diagnosable from the daemon's own durable record instead of requiring reconstruction from the GitHub API. Set `log_file` (or `--log-file` / `PRUEFER_LOG_FILE`) to write elsewhere, or to an empty value to disable file logging entirely.
 
 Each line looks like:
 
@@ -117,8 +117,8 @@ Each line looks like:
 2026-08-08T18:12:03Z [pr#103 warn] listing open PRs for verveguy/zusammen: context deadline exceeded — skipping this repo this cycle
 ```
 
-- **With the TUI running** (the default on a real terminal), stderr output would corrupt the bubbletea display, so the log file is the sole destination.
-- **In plain daemon mode** (`-notui`, or no TTY attached), logging is additive: every line is written to both stderr and the log file, so an operator watching the terminal keeps seeing exactly what they see today.
+- **With the TUI running** (the default on a real terminal), stderr output would corrupt the bubbletea display, so the log file is the sole destination. If `log_file` is disabled (or the log file can't be opened) while the TUI is running, log lines are discarded rather than written raw to stderr — the same corruption concern, just with no file to fall back to.
+- **In plain daemon mode** (`-notui`, or no TTY attached), logging is additive: every line is written to both stderr and the log file, so an operator watching the terminal keeps seeing exactly what they see today. With `log_file` disabled in plain mode, output stays on stderr only, matching Pruefer's behavior before this feature existed.
 
 The log file is append-only across restarts — it is never truncated on daemon startup, unlike Fabrik engine's own `fabrik.log` — so a restart doesn't erase the history an incident investigation needs. Growth is bounded by size-triggered rotation: once the file reaches 10 MB it's renamed to `pruefer.log.1` (existing numbered backups shift up, `pruefer.log.3` is dropped), and a fresh file is opened. Up to 3 rotated backups are retained.
 

--- a/cmd/pruefer/README.md
+++ b/cmd/pruefer/README.md
@@ -107,6 +107,21 @@ Keyboard: `q` or `ctrl+c` to quit, `tab` to switch panes, `↑`/`↓` or `j`/`k`
 
 The TUI is purely observational — it never changes which PRs get reviewed, when, or how. Running with `-notui` disables it entirely and falls back to Pruefer's existing structured `logf`-based console output, with **identical review behavior** either way. Use `-notui` (or `PRUEFER_TUI=0` / `tui: false` in the YAML config) when running under systemd, tmux with no attached TTY, or any other non-interactive environment.
 
+## Logging
+
+Pruefer writes every daemon log line — poll cycles, review outcomes, warnings, auth events — to a timestamped, mutex-serialized log file at `.pruefer/pruefer.log` by default, so an incident is diagnosable from the daemon's own durable record instead of requiring reconstruction from the GitHub API. Set `log_file` (or `--log-file` / `PRUEFER_LOG_FILE`) to write elsewhere, or to an empty value to disable file logging entirely and fall back to stderr-only, matching Pruefer's behavior before this feature existed.
+
+Each line looks like:
+
+```
+2026-08-08T18:12:03Z [pr#103 warn] listing open PRs for verveguy/zusammen: context deadline exceeded — skipping this repo this cycle
+```
+
+- **With the TUI running** (the default on a real terminal), stderr output would corrupt the bubbletea display, so the log file is the sole destination.
+- **In plain daemon mode** (`-notui`, or no TTY attached), logging is additive: every line is written to both stderr and the log file, so an operator watching the terminal keeps seeing exactly what they see today.
+
+The log file is append-only across restarts — it is never truncated on daemon startup, unlike Fabrik engine's own `fabrik.log` — so a restart doesn't erase the history an incident investigation needs. Growth is bounded by size-triggered rotation: once the file reaches 10 MB it's renamed to `pruefer.log.1` (existing numbered backups shift up, `pruefer.log.3` is dropped), and a fresh file is opened. Up to 3 rotated backups are retained.
+
 ## On-demand re-review
 
 Comment `/pruefer review` on any watched PR to force a fresh review of the current head, even if that SHA was already reviewed. Pruefer acknowledges the command with a 👀 reaction when it picks it up and a 🚀 reaction once the review has been submitted — the same idempotency convention Fabrik uses for its own comment processing.
@@ -158,6 +173,7 @@ Precedence, highest to lowest: **flag > environment variable > YAML config file 
 | `--github-app-installation-id` | `PRUEFER_GITHUB_APP_INSTALLATION_ID` | `github_app_installation_id` | `0` (derive from `watched_repos`) | Legacy pin: set to force every watched repo through one specific installation, regardless of owner |
 | `--config` | `PRUEFER_CONFIG` | — | `.pruefer/config.yaml` | Path to the YAML config file itself |
 | `-notui` | `PRUEFER_TUI` | `tui` | `true` | Set `-notui` / `PRUEFER_TUI=0` / `tui: false` to disable the interactive TUI and fall back to console logging. The TUI is further gated on a real terminal being detected on both stdin and stdout, regardless of this setting. |
+| `--log-file` | `PRUEFER_LOG_FILE` | `log_file` | `.pruefer/pruefer.log` | Path daemon log lines are written to, resolved against the process's working directory (same convention as `github_app_private_key_path`). An explicitly empty value (`--log-file ""`, `PRUEFER_LOG_FILE=`, or `log_file: ""`) disables file logging entirely. See [Logging](#logging). |
 
 Draft PRs are always skipped — there is no configuration flag to include them in V1.
 

--- a/pruefer/config.go
+++ b/pruefer/config.go
@@ -26,6 +26,7 @@ const (
 	DefaultMaxDiffBytes   = 500_000 // 500 KB
 	DefaultConfigPath     = ".pruefer/config.yaml"
 	DefaultPrivateKeyPath = ".pruefer/app-private-key.pem"
+	DefaultLogPath        = ".pruefer/pruefer.log"
 )
 
 // Config holds Pruefer's fully-resolved runtime configuration, after
@@ -64,6 +65,13 @@ type Config struct {
 	// gates this on a real terminal being detected (see tui_run.go's useTUI).
 	TUI bool
 
+	// LogFile is the path Pruefer's daemon log lines are written to, resolved
+	// relative to the process cwd (the same way DefaultConfigPath and
+	// AppPrivateKeyPath are resolved). Defaults to DefaultLogPath. An
+	// explicitly empty value (YAML `log_file: ""`, PRUEFER_LOG_FILE=, or
+	// --log-file "") disables file logging entirely.
+	LogFile string
+
 	AppID             int64
 	AppPrivateKeyPath string
 	// AppInstallationID is a legacy pin/escape hatch: when set (non-zero),
@@ -94,6 +102,7 @@ type yamlConfig struct {
 	AppPrivateKeyPath       string   `yaml:"github_app_private_key_path"`
 	AppInstallationID       *int64   `yaml:"github_app_installation_id"`
 	TUI                     *bool    `yaml:"tui"`
+	LogFile                 *string  `yaml:"log_file"`
 }
 
 // loadYAMLConfig reads path, returning a zero-value yamlConfig (no error) if
@@ -131,6 +140,7 @@ type flagValues struct {
 	appInstallationID       int64
 	configPath              string
 	noTUI                   bool
+	logFile                 string
 }
 
 // LoadConfig resolves Pruefer's configuration from, in increasing priority:
@@ -158,6 +168,7 @@ func LoadConfig(args []string) (Config, error) {
 	fs.Int64Var(&fv.appInstallationID, "github-app-installation-id", 0, "GitHub App installation ID (0 = auto-discover)")
 	fs.StringVar(&fv.configPath, "config", DefaultConfigPath, "Path to Pruefer's YAML config file")
 	fs.BoolVar(&fv.noTUI, "notui", false, "Disable the interactive TUI dashboard (default: enabled when a real terminal is detected)")
+	fs.StringVar(&fv.logFile, "log-file", "", "Path to write daemon log lines to (empty disables file logging; default .pruefer/pruefer.log)")
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err
 	}
@@ -189,6 +200,7 @@ func LoadConfig(args []string) (Config, error) {
 		ExcludedLabels:    yc.ExcludedLabels,
 		AppPrivateKeyPath: DefaultPrivateKeyPath,
 		TUI:               true,
+		LogFile:           DefaultLogPath,
 	}
 	if yc.RequestChangesThreshold != "" {
 		cfg.RequestChangesThreshold = Severity(yc.RequestChangesThreshold)
@@ -222,6 +234,9 @@ func LoadConfig(args []string) (Config, error) {
 	}
 	if yc.AppInstallationID != nil {
 		cfg.AppInstallationID = *yc.AppInstallationID
+	}
+	if yc.LogFile != nil {
+		cfg.LogFile = *yc.LogFile
 	}
 
 	applyEnv(&cfg)
@@ -270,6 +285,9 @@ func LoadConfig(args []string) (Config, error) {
 	}
 	if explicit["notui"] {
 		cfg.TUI = !fv.noTUI
+	}
+	if explicit["log-file"] {
+		cfg.LogFile = fv.logFile
 	}
 
 	if cfg.RequestChangesThreshold != "" && !validSeverity(cfg.RequestChangesThreshold) {
@@ -340,6 +358,13 @@ func applyEnv(cfg *Config) {
 		if b, err := strconv.ParseBool(v); err == nil {
 			cfg.TUI = b
 		}
+	}
+	// Unlike every other PRUEFER_* var above, an explicitly empty
+	// PRUEFER_LOG_FILE must be distinguished from "unset" (R2: empty
+	// disables file logging entirely). os.LookupEnv, not the v != "" idiom
+	// used above, is what makes that distinction possible.
+	if v, ok := os.LookupEnv("PRUEFER_LOG_FILE"); ok {
+		cfg.LogFile = v
 	}
 }
 

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -56,34 +56,37 @@ func TestLoadConfig_DefaultsWhenNothingSet(t *testing.T) {
 
 func TestLoadConfig_LogFilePrecedence(t *testing.T) {
 	dir := t.TempDir()
+	custom := filepath.Join(t.TempDir(), "custom.log")
+	fromEnv := filepath.Join(t.TempDir(), "env.log")
+	fromFlag := filepath.Join(t.TempDir(), "flag.log")
 
 	// YAML override.
-	path := writeYAMLConfig(t, dir, `log_file: /tmp/custom.log`)
+	path := writeYAMLConfig(t, dir, "log_file: "+custom)
 	cfg, err := LoadConfig([]string{"-config", path})
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.LogFile != "/tmp/custom.log" {
-		t.Errorf("LogFile = %q, want /tmp/custom.log (from YAML)", cfg.LogFile)
+	if cfg.LogFile != custom {
+		t.Errorf("LogFile = %q, want %q (from YAML)", cfg.LogFile, custom)
 	}
 
 	// Env overrides YAML.
-	t.Setenv("PRUEFER_LOG_FILE", "/tmp/env.log")
+	t.Setenv("PRUEFER_LOG_FILE", fromEnv)
 	cfg, err = LoadConfig([]string{"-config", path})
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.LogFile != "/tmp/env.log" {
-		t.Errorf("LogFile = %q, want /tmp/env.log (env should override YAML)", cfg.LogFile)
+	if cfg.LogFile != fromEnv {
+		t.Errorf("LogFile = %q, want %q (env should override YAML)", cfg.LogFile, fromEnv)
 	}
 
 	// Flag overrides env.
-	cfg, err = LoadConfig([]string{"-config", path, "-log-file", "/tmp/flag.log"})
+	cfg, err = LoadConfig([]string{"-config", path, "-log-file", fromFlag})
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.LogFile != "/tmp/flag.log" {
-		t.Errorf("LogFile = %q, want /tmp/flag.log (flag should override env)", cfg.LogFile)
+	if cfg.LogFile != fromFlag {
+		t.Errorf("LogFile = %q, want %q (flag should override env)", cfg.LogFile, fromFlag)
 	}
 }
 
@@ -101,7 +104,7 @@ func TestLoadConfig_LogFileYAMLExplicitEmptyDisables(t *testing.T) {
 
 func TestLoadConfig_LogFileEnvExplicitEmptyDisables(t *testing.T) {
 	dir := t.TempDir()
-	path := writeYAMLConfig(t, dir, `log_file: /tmp/custom.log`)
+	path := writeYAMLConfig(t, dir, "log_file: "+filepath.Join(t.TempDir(), "custom.log"))
 	t.Setenv("PRUEFER_LOG_FILE", "")
 
 	cfg, err := LoadConfig([]string{"-config", path})
@@ -115,7 +118,7 @@ func TestLoadConfig_LogFileEnvExplicitEmptyDisables(t *testing.T) {
 
 func TestLoadConfig_LogFileFlagExplicitEmptyDisables(t *testing.T) {
 	dir := t.TempDir()
-	path := writeYAMLConfig(t, dir, `log_file: /tmp/custom.log`)
+	path := writeYAMLConfig(t, dir, "log_file: "+filepath.Join(t.TempDir(), "custom.log"))
 
 	cfg, err := LoadConfig([]string{"-config", path, "-log-file", ""})
 	if err != nil {

--- a/pruefer/config_test.go
+++ b/pruefer/config_test.go
@@ -49,6 +49,81 @@ func TestLoadConfig_DefaultsWhenNothingSet(t *testing.T) {
 	if !cfg.TUI {
 		t.Errorf("TUI = false, want true (default on)")
 	}
+	if cfg.LogFile != DefaultLogPath {
+		t.Errorf("LogFile = %q, want %q", cfg.LogFile, DefaultLogPath)
+	}
+}
+
+func TestLoadConfig_LogFilePrecedence(t *testing.T) {
+	dir := t.TempDir()
+
+	// YAML override.
+	path := writeYAMLConfig(t, dir, `log_file: /tmp/custom.log`)
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LogFile != "/tmp/custom.log" {
+		t.Errorf("LogFile = %q, want /tmp/custom.log (from YAML)", cfg.LogFile)
+	}
+
+	// Env overrides YAML.
+	t.Setenv("PRUEFER_LOG_FILE", "/tmp/env.log")
+	cfg, err = LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LogFile != "/tmp/env.log" {
+		t.Errorf("LogFile = %q, want /tmp/env.log (env should override YAML)", cfg.LogFile)
+	}
+
+	// Flag overrides env.
+	cfg, err = LoadConfig([]string{"-config", path, "-log-file", "/tmp/flag.log"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LogFile != "/tmp/flag.log" {
+		t.Errorf("LogFile = %q, want /tmp/flag.log (flag should override env)", cfg.LogFile)
+	}
+}
+
+func TestLoadConfig_LogFileYAMLExplicitEmptyDisables(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `log_file: ""`)
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LogFile != "" {
+		t.Errorf("LogFile = %q, want empty (YAML log_file: \"\" should disable file logging)", cfg.LogFile)
+	}
+}
+
+func TestLoadConfig_LogFileEnvExplicitEmptyDisables(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `log_file: /tmp/custom.log`)
+	t.Setenv("PRUEFER_LOG_FILE", "")
+
+	cfg, err := LoadConfig([]string{"-config", path})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LogFile != "" {
+		t.Errorf("LogFile = %q, want empty (PRUEFER_LOG_FILE= should disable file logging, overriding YAML)", cfg.LogFile)
+	}
+}
+
+func TestLoadConfig_LogFileFlagExplicitEmptyDisables(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAMLConfig(t, dir, `log_file: /tmp/custom.log`)
+
+	cfg, err := LoadConfig([]string{"-config", path, "-log-file", ""})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.LogFile != "" {
+		t.Errorf("LogFile = %q, want empty (-log-file \"\" should disable file logging, overriding YAML)", cfg.LogFile)
+	}
 }
 
 func TestLoadConfig_TUIPrecedence(t *testing.T) {

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -68,6 +68,51 @@ func (d *Daemon) emit(ev ptui.Event) {
 	}
 }
 
+// NewDaemon is the sole production construction path for Daemon: it builds
+// the Daemon and, when cfg.LogFile is non-empty, opens a rotating file
+// logger and assigns it to the package-level pruefer.Logf hook so every
+// logf call in this package routes to a timestamped, mutex-serialized log
+// file instead of stderr (issue #1428, R1/R2). The returned close function
+// closes the log file and clears Logf; callers should defer it.
+//
+// Deliberately NOT called from Daemon's own methods (Run/poll) — daemon_test.go
+// builds Daemon{} literals directly and calls Run/poll without going through
+// NewDaemon, relying on Logf staying nil in that path (R1: "Logf staying nil
+// in tests must remain true"). Execute is the only production caller.
+//
+// In TUI mode (per useTUI(cfg)), stderr output would corrupt the bubbletea
+// display, so the file is the sole destination; in plain daemon mode,
+// logging is additive — lines are teed to both stderr and the file (R5).
+//
+// A log-file open failure is non-fatal: it's logged as a warning to stderr
+// and Logf is left nil (falling back to stderr for every line), mirroring
+// engine/poll.go's own non-fatal fabrik.log open-failure handling.
+func NewDaemon(cfg Config, clients map[string]GitHubLister, claude ClaudeInvoker, clone CloneFunc, botLogin string) (*Daemon, func() error) {
+	d := &Daemon{
+		Clients:  clients,
+		Claude:   claude,
+		Clone:    clone,
+		Config:   cfg,
+		BotLogin: botLogin,
+	}
+
+	closeLog := func() error { return nil }
+	if cfg.LogFile != "" {
+		fl, err := newFileLogger(cfg.LogFile, logRotateMaxBytes, logRotateBackups, !useTUI(cfg))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pruefer: could not open log file %s: %v (falling back to stderr)\n", cfg.LogFile, err)
+		} else {
+			Logf = fl.Logf
+			closeLog = func() error {
+				Logf = nil
+				return fl.Close()
+			}
+		}
+	}
+
+	return d, closeLog
+}
+
 func (d *Daemon) lockPath() string {
 	dir := d.FabrikDir
 	if dir == "" {

--- a/pruefer/daemon.go
+++ b/pruefer/daemon.go
@@ -85,8 +85,13 @@ func (d *Daemon) emit(ev ptui.Event) {
 // logging is additive — lines are teed to both stderr and the file (R5).
 //
 // A log-file open failure is non-fatal: it's logged as a warning to stderr
-// and Logf is left nil (falling back to stderr for every line), mirroring
-// engine/poll.go's own non-fatal fabrik.log open-failure handling.
+// and, outside TUI mode, Logf is left nil (falling back to stderr for every
+// line), mirroring engine/poll.go's own non-fatal fabrik.log open-failure
+// handling. In TUI mode, an open failure or an explicitly empty cfg.LogFile
+// both leave nothing routing pruefer/log.go's raw fmt.Fprintf(os.Stderr, ...)
+// fallback out of the way of the bubbletea display, so Logf is instead
+// assigned a discard function — the same corruption R5 wires the file-only
+// path to avoid, just for the case where there is no file to write to.
 func NewDaemon(cfg Config, clients map[string]GitHubLister, claude ClaudeInvoker, clone CloneFunc, botLogin string) (*Daemon, func() error) {
 	d := &Daemon{
 		Clients:  clients,
@@ -96,11 +101,27 @@ func NewDaemon(cfg Config, clients map[string]GitHubLister, claude ClaudeInvoker
 		BotLogin: botLogin,
 	}
 
+	return d, wireLogf(cfg, useTUI(cfg))
+}
+
+// wireLogf assigns the package-level Logf hook according to cfg.LogFile and
+// tui (the caller's already-computed useTUI(cfg) result — split out as a
+// parameter purely so this decision table is unit-testable without a real
+// terminal, which useTUI itself requires). Returns the close function
+// NewDaemon should defer.
+func wireLogf(cfg Config, tui bool) func() error {
+	discardLog := func(int, string, string, ...any) {}
 	closeLog := func() error { return nil }
-	if cfg.LogFile != "" {
-		fl, err := newFileLogger(cfg.LogFile, logRotateMaxBytes, logRotateBackups, !useTUI(cfg))
+
+	switch {
+	case cfg.LogFile != "":
+		fl, err := newFileLogger(cfg.LogFile, logRotateMaxBytes, logRotateBackups, !tui)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "pruefer: could not open log file %s: %v (falling back to stderr)\n", cfg.LogFile, err)
+			if tui {
+				Logf = discardLog
+				closeLog = func() error { Logf = nil; return nil }
+			}
 		} else {
 			Logf = fl.Logf
 			closeLog = func() error {
@@ -108,9 +129,13 @@ func NewDaemon(cfg Config, clients map[string]GitHubLister, claude ClaudeInvoker
 				return fl.Close()
 			}
 		}
+	case tui:
+		// File logging explicitly disabled (log_file "") but TUI is active.
+		Logf = discardLog
+		closeLog = func() error { Logf = nil; return nil }
 	}
 
-	return d, closeLog
+	return closeLog
 }
 
 func (d *Daemon) lockPath() string {

--- a/pruefer/execute.go
+++ b/pruefer/execute.go
@@ -61,13 +61,8 @@ func Execute() error {
 		clients[owner] = client
 	}
 
-	daemon := &Daemon{
-		Clients:  clients,
-		Claude:   &RealClaudeInvoker{},
-		Clone:    CloneForReview,
-		Config:   cfg,
-		BotLogin: authSet.BotLogin,
-	}
+	daemon, closeLog := NewDaemon(cfg, clients, &RealClaudeInvoker{}, CloneForReview, authSet.BotLogin)
+	defer closeLog()
 
 	if useTUI(cfg) {
 		return runTUI(ctx, daemon)

--- a/pruefer/logfile.go
+++ b/pruefer/logfile.go
@@ -49,7 +49,9 @@ func newFileLogger(path string, maxBytes int64, backups int, tee bool) (*fileLog
 	}
 	info, err := f.Stat()
 	if err != nil {
-		f.Close()
+		if cerr := f.Close(); cerr != nil {
+			return nil, fmt.Errorf("stat log file %s: %w (also failed to close: %v)", path, err, cerr)
+		}
 		return nil, fmt.Errorf("stat log file %s: %w", path, err)
 	}
 	return &fileLogger{

--- a/pruefer/logfile.go
+++ b/pruefer/logfile.go
@@ -78,7 +78,10 @@ func (fl *fileLogger) Logf(prNumber int, tag, format string, args ...any) {
 	defer fl.mu.Unlock()
 
 	if fl.maxBytes > 0 && fl.size+int64(len(line)) > fl.maxBytes {
-		if err := fl.rotateLocked(); err != nil {
+		if err := fl.rotateLocked(); err != nil && fl.tee {
+			// Gated on fl.tee, matching every other stderr write in this
+			// method — in TUI mode (tee=false) a raw stderr write here would
+			// corrupt the bubbletea display exactly as R5 exists to prevent.
 			fmt.Fprintf(os.Stderr, "pruefer: log rotation failed for %s: %v\n", fl.path, err)
 		}
 	}
@@ -95,11 +98,19 @@ func (fl *fileLogger) Logf(prNumber int, tag, format string, args ...any) {
 // dropping the oldest beyond fl.backups), renames the current file to
 // path.1, and reopens a fresh empty file at path. Must be called with fl.mu
 // held.
+//
+// Backup shifting happens before fl.file is closed, since it touches only
+// the numbered *.N siblings, never fl.path itself — a failure there leaves
+// fl.file untouched and still perfectly usable. Only the final rename of
+// fl.path itself requires the file to already be closed (required for
+// Windows rename semantics, which forbids renaming an open file). If that
+// step — or the reopen after it — fails, fl.file is always left reopened
+// and appendable with fl.size resynced via Stat: without this, a caller
+// that left fl.file closed on error would silently drop every subsequent
+// WriteString forever (its error is deliberately ignored in Logf), and with
+// fl.size never advancing, every future call would re-attempt — and re-fail
+// — the same already-closed Close(), for the rest of the process's life.
 func (fl *fileLogger) rotateLocked() error {
-	if err := fl.file.Close(); err != nil {
-		return fmt.Errorf("closing %s before rotation: %w", fl.path, err)
-	}
-
 	oldest := fmt.Sprintf("%s.%d", fl.path, fl.backups)
 	if err := os.Remove(oldest); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing oldest backup %s: %w", oldest, err)
@@ -111,20 +122,41 @@ func (fl *fileLogger) rotateLocked() error {
 			return fmt.Errorf("renaming %s to %s: %w", src, dst, err)
 		}
 	}
+
+	if err := fl.file.Close(); err != nil {
+		return fmt.Errorf("closing %s before rotation: %w", fl.path, err)
+	}
+
+	var rotateErr error
 	if fl.backups >= 1 {
 		dst := fmt.Sprintf("%s.1", fl.path)
 		if err := os.Rename(fl.path, dst); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("renaming %s to %s: %w", fl.path, dst, err)
+			rotateErr = fmt.Errorf("renaming %s to %s: %w", fl.path, dst, err)
 		}
 	} else if err := os.Remove(fl.path); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing %s: %w", fl.path, err)
+		rotateErr = fmt.Errorf("removing %s: %w", fl.path, err)
 	}
 
 	f, err := os.OpenFile(fl.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
+		// fl.file is left as the prior (closed) handle here — there is no
+		// file left to reopen it to, so there is nothing to recover into.
 		return fmt.Errorf("reopening %s after rotation: %w", fl.path, err)
 	}
 	fl.file = f
+
+	if rotateErr != nil {
+		// The rename/remove of fl.path itself failed, so the reopened
+		// handle points at the still-oversized, unrotated file rather than
+		// a fresh one — resync fl.size to its real size (instead of
+		// resetting to 0) so the next call correctly re-attempts rotation
+		// rather than assuming it already succeeded.
+		if info, statErr := f.Stat(); statErr == nil {
+			fl.size = info.Size()
+		}
+		return rotateErr
+	}
+
 	fl.size = 0
 	return nil
 }

--- a/pruefer/logfile.go
+++ b/pruefer/logfile.go
@@ -1,0 +1,136 @@
+package pruefer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Defaults for pruefer.log's size-triggered rotation. The only concrete data
+// point on record (an operator-created pruefer.out.log reaching 2.1 MB under
+// nohup) makes 10 MB comfortable headroom; these are unexported constants
+// rather than new config keys since R2 (issue #1428) mandates only log_file
+// itself.
+const (
+	logRotateMaxBytes = 10 * 1024 * 1024 // 10 MB
+	logRotateBackups  = 3
+)
+
+// fileLogger is a mutex-serialized, size-rotating writer that backs
+// pruefer.Logf, mirroring engine.Engine's logFile/logMu pattern. A single
+// mutex spans the rotation check, the rotation itself, the file write, and
+// the optional stderr tee, so a rotation triggered mid-write by one
+// goroutine can never interleave with another goroutine's write (R4).
+type fileLogger struct {
+	mu       sync.Mutex
+	path     string
+	file     *os.File
+	size     int64
+	maxBytes int64
+	backups  int
+	tee      bool
+}
+
+// newFileLogger opens (creating and appending to, never truncating — a
+// daemon restart must not erase the history an incident investigation
+// needs) the log file at path, creating its parent directory if necessary.
+// tee controls whether every write is also copied to os.Stderr (R5: additive
+// in plain daemon mode, file-only in TUI mode since stderr output would
+// corrupt the bubbletea display).
+func newFileLogger(path string, maxBytes int64, backups int, tee bool) (*fileLogger, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("creating log directory for %s: %w", path, err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("opening log file %s: %w", path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("stat log file %s: %w", path, err)
+	}
+	return &fileLogger{
+		path:     path,
+		file:     f,
+		size:     info.Size(),
+		maxBytes: maxBytes,
+		backups:  backups,
+		tee:      tee,
+	}, nil
+}
+
+// Logf formats and writes a single log line, matching engine's timestamped
+// format: an RFC3339 UTC timestamp, then the exact "[pr#%d %s] "+format
+// construction pruefer/log.go's stderr fallback already produces (zero
+// wording drift versus today's output — Out-of-scope forbids changing tags
+// or wording). Suitable for direct assignment to the package-level Logf hook.
+func (fl *fileLogger) Logf(prNumber int, tag, format string, args ...any) {
+	msg := fmt.Sprintf("[pr#%d %s] "+format, append([]any{prNumber, tag}, args...)...)
+	ts := time.Now().UTC().Format(time.RFC3339)
+	line := ts + " " + msg
+
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+
+	if fl.maxBytes > 0 && fl.size+int64(len(line)) > fl.maxBytes {
+		if err := fl.rotateLocked(); err != nil {
+			fmt.Fprintf(os.Stderr, "pruefer: log rotation failed for %s: %v\n", fl.path, err)
+		}
+	}
+
+	if n, err := fl.file.WriteString(line); err == nil {
+		fl.size += int64(n)
+	}
+	if fl.tee {
+		os.Stderr.WriteString(line)
+	}
+}
+
+// rotateLocked shifts existing numbered backups (path.1 -> path.2, ...,
+// dropping the oldest beyond fl.backups), renames the current file to
+// path.1, and reopens a fresh empty file at path. Must be called with fl.mu
+// held.
+func (fl *fileLogger) rotateLocked() error {
+	if err := fl.file.Close(); err != nil {
+		return fmt.Errorf("closing %s before rotation: %w", fl.path, err)
+	}
+
+	oldest := fmt.Sprintf("%s.%d", fl.path, fl.backups)
+	if err := os.Remove(oldest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing oldest backup %s: %w", oldest, err)
+	}
+	for i := fl.backups - 1; i >= 1; i-- {
+		src := fmt.Sprintf("%s.%d", fl.path, i)
+		dst := fmt.Sprintf("%s.%d", fl.path, i+1)
+		if err := os.Rename(src, dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("renaming %s to %s: %w", src, dst, err)
+		}
+	}
+	if fl.backups >= 1 {
+		dst := fmt.Sprintf("%s.1", fl.path)
+		if err := os.Rename(fl.path, dst); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("renaming %s to %s: %w", fl.path, dst, err)
+		}
+	} else if err := os.Remove(fl.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing %s: %w", fl.path, err)
+	}
+
+	f, err := os.OpenFile(fl.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return fmt.Errorf("reopening %s after rotation: %w", fl.path, err)
+	}
+	fl.file = f
+	fl.size = 0
+	return nil
+}
+
+// Close closes the underlying file. Safe to call once during daemon
+// shutdown.
+func (fl *fileLogger) Close() error {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	return fl.file.Close()
+}

--- a/pruefer/logfile.go
+++ b/pruefer/logfile.go
@@ -101,12 +101,12 @@ func (fl *fileLogger) Logf(prNumber int, tag, format string, args ...any) {
 //
 // Backup shifting happens before fl.file is closed, since it touches only
 // the numbered *.N siblings, never fl.path itself — a failure there leaves
-// fl.file untouched and still perfectly usable. Only the final rename of
-// fl.path itself requires the file to already be closed (required for
-// Windows rename semantics, which forbids renaming an open file). If that
-// step — or the reopen after it — fails, fl.file is always left reopened
-// and appendable with fl.size resynced via Stat: without this, a caller
-// that left fl.file closed on error would silently drop every subsequent
+// fl.file untouched and still perfectly usable. Every failure from the
+// Close() below onward — closing fl.file, renaming/removing fl.path itself,
+// or the reopen after it — always leaves fl.file reopened and appendable
+// with fl.size resynced via Stat: without this, a caller that left fl.file
+// closed (or worse, left it as a handle that already failed to close, which
+// must not be used further) on error would silently drop every subsequent
 // WriteString forever (its error is deliberately ignored in Logf), and with
 // fl.size never advancing, every future call would re-attempt — and re-fail
 // — the same already-closed Close(), for the rest of the process's life.
@@ -124,7 +124,18 @@ func (fl *fileLogger) rotateLocked() error {
 	}
 
 	if err := fl.file.Close(); err != nil {
-		return fmt.Errorf("closing %s before rotation: %w", fl.path, err)
+		// fl.path hasn't been touched yet at this point (the rename below is
+		// what rotates it), so reopening it in place — the same recovery the
+		// later failure paths use — gives back a live, appendable handle
+		// instead of leaving fl.file as one that already failed to close.
+		closeErr := fmt.Errorf("closing %s before rotation: %w", fl.path, err)
+		if f, reopenErr := os.OpenFile(fl.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600); reopenErr == nil {
+			fl.file = f
+			if info, statErr := f.Stat(); statErr == nil {
+				fl.size = info.Size()
+			}
+		}
+		return closeErr
 	}
 
 	var rotateErr error

--- a/pruefer/logfile_test.go
+++ b/pruefer/logfile_test.go
@@ -1,0 +1,127 @@
+package pruefer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// timestampAndScopeRe matches an RFC3339 UTC timestamp followed by pruefer's
+// existing "[pr#<N> <tag>] " scoping (AC3).
+var timestampAndScopeRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \[pr#\d+ \w+\] `)
+
+func TestFileLogger_LineHasTimestampAndScoping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pruefer.log")
+
+	fl, err := newFileLogger(path, logRotateMaxBytes, logRotateBackups, false)
+	if err != nil {
+		t.Fatalf("newFileLogger: %v", err)
+	}
+	defer fl.Close()
+
+	fl.Logf(103, "warn", "diff fetch failed: %v\n", "boom")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	line := strings.TrimRight(string(data), "\n")
+	if !timestampAndScopeRe.MatchString(line) {
+		t.Errorf("line %q does not match timestamp+scoping pattern %s", line, timestampAndScopeRe.String())
+	}
+	if !strings.Contains(line, "[pr#103 warn]") {
+		t.Errorf("line %q missing exact [pr#103 warn] scoping", line)
+	}
+	if !strings.HasSuffix(line, "diff fetch failed: boom") {
+		t.Errorf("line %q missing expected message body", line)
+	}
+}
+
+func TestFileLogger_ConcurrentWritesProduceUninterleavedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pruefer.log")
+
+	fl, err := newFileLogger(path, logRotateMaxBytes, logRotateBackups, false)
+	if err != nil {
+		t.Fatalf("newFileLogger: %v", err)
+	}
+	defer fl.Close()
+
+	const goroutines = 20
+	const perGoroutine = 25
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		g := g
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				fl.Logf(g, "select", "worker %d iteration %d\n", g, i)
+			}
+		}()
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != goroutines*perGoroutine {
+		t.Fatalf("got %d lines, want %d (a mismatch indicates interleaved/corrupted writes)", len(lines), goroutines*perGoroutine)
+	}
+	lineRe := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \[pr#\d+ select\] worker \d+ iteration \d+$`)
+	for _, line := range lines {
+		if !lineRe.MatchString(line) {
+			t.Errorf("corrupted or interleaved line: %q", line)
+		}
+	}
+}
+
+func TestFileLogger_RotatesAtBoundAndRetainsBoundedCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pruefer.log")
+
+	const maxBytes = 200
+	const backups = 3
+	fl, err := newFileLogger(path, maxBytes, backups, false)
+	if err != nil {
+		t.Fatalf("newFileLogger: %v", err)
+	}
+	defer fl.Close()
+
+	// Each line is comfortably over 40 bytes; writing 60 lines guarantees
+	// several rotations past the configured backup count.
+	for i := 0; i < 60; i++ {
+		fl.Logf(1, "select", "synthetic oversized line to force rotation number %d\n", i)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("main log file %s missing: %v", path, err)
+	}
+	for i := 1; i <= backups; i++ {
+		backupPath := fmt.Sprintf("%s.%d", path, i)
+		if _, err := os.Stat(backupPath); err != nil {
+			t.Errorf("expected backup %s to exist: %v", backupPath, err)
+		}
+	}
+	beyond := fmt.Sprintf("%s.%d", path, backups+1)
+	if _, err := os.Stat(beyond); !os.IsNotExist(err) {
+		t.Errorf("expected no backup beyond retained count at %s, stat err = %v", beyond, err)
+	}
+
+	// Sanity: the main file itself never exceeds maxBytes by more than one
+	// line's worth (rotation is checked before each write, not after).
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if info.Size() > maxBytes*2 {
+		t.Errorf("main log file size %d unexpectedly large for maxBytes %d", info.Size(), maxBytes)
+	}
+}

--- a/pruefer/logging_test.go
+++ b/pruefer/logging_test.go
@@ -1,0 +1,116 @@
+package pruefer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// resetLogf ensures the package-level Logf hook is restored to nil after a
+// test that assigns it, so global-state leakage can't affect other tests in
+// this package (Logf is a package-level var, not test-scoped).
+func resetLogf(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { Logf = nil })
+}
+
+func TestNewDaemon_AssignsNonNilLogf(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	dir := t.TempDir()
+	cfg := Config{LogFile: filepath.Join(dir, "pruefer.log")}
+
+	_, closeLog := NewDaemon(cfg, nil, nil, nil, "bot")
+	defer closeLog()
+
+	if Logf == nil {
+		t.Fatal("NewDaemon did not assign pruefer.Logf; want a non-nil function")
+	}
+}
+
+func TestNewDaemon_DefaultPathResolvedAgainstCwd(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	dir := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	cfg := Config{LogFile: DefaultLogPath}
+	_, closeLog := NewDaemon(cfg, nil, nil, nil, "bot")
+	defer closeLog()
+
+	Logf(0, "poll", "hello\n")
+
+	wantPath := filepath.Join(dir, DefaultLogPath)
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("expected log file at %s (default path resolved against cwd): %v", wantPath, err)
+	}
+}
+
+func TestNewDaemon_ExplicitPathOverride(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "custom-subdir", "override.log")
+	cfg := Config{LogFile: logPath}
+
+	_, closeLog := NewDaemon(cfg, nil, nil, nil, "bot")
+	defer closeLog()
+
+	Logf(0, "poll", "hello\n")
+
+	if _, err := os.Stat(logPath); err != nil {
+		t.Errorf("expected log file at explicit override path %s: %v", logPath, err)
+	}
+}
+
+func TestNewDaemon_EmptyLogFileDisablesFileLogging(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	cfg := Config{LogFile: ""}
+	_, closeLog := NewDaemon(cfg, nil, nil, nil, "bot")
+	defer closeLog()
+
+	if Logf != nil {
+		t.Error("NewDaemon assigned pruefer.Logf despite an empty LogFile; want it left nil (file logging disabled)")
+	}
+}
+
+func TestLogf_FallsBackToStderrWhenLogfIsNil(t *testing.T) {
+	// No Daemon/NewDaemon involved at all — this is AC5's "package used
+	// without a Daemon" scenario. Logf must be nil for this test to be
+	// meaningful; guard against leakage from a prior test.
+	if Logf != nil {
+		t.Fatal("Logf is unexpectedly non-nil at start of test — a prior test leaked global state")
+	}
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	logf(103, "warn", "diff fetch failed: %v\n", "boom")
+
+	w.Close()
+	os.Stderr = origStderr
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	got := string(buf[:n])
+
+	if got != "[pr#103 warn] diff fetch failed: boom\n" {
+		t.Errorf("stderr output = %q, want the unmodified stderr-fallback format", got)
+	}
+}

--- a/pruefer/logging_test.go
+++ b/pruefer/logging_test.go
@@ -86,6 +86,68 @@ func TestNewDaemon_EmptyLogFileDisablesFileLogging(t *testing.T) {
 	}
 }
 
+func TestWireLogf_EmptyLogFileWithTUIDiscardsInsteadOfNil(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	// tui=true is passed directly (rather than exercised via NewDaemon's own
+	// useTUI(cfg) call) because useTUI requires a real terminal, which a
+	// unit test doesn't have.
+	closeLog := wireLogf(Config{LogFile: ""}, true)
+	defer closeLog()
+
+	if Logf == nil {
+		t.Fatal("wireLogf(LogFile=\"\", tui=true) left Logf nil; want a discard function assigned so log.go's raw stderr fallback never corrupts the TUI")
+	}
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	Logf(103, "warn", "diff fetch failed: %v\n", "boom")
+
+	w.Close()
+	os.Stderr = origStderr
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	if n != 0 {
+		t.Errorf("expected no stderr output from the discard Logf in TUI mode, got %q", string(buf[:n]))
+	}
+}
+
+func TestWireLogf_LogFileOpenFailureWithTUIDiscardsInsteadOfNil(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	// A path with a NUL byte is guaranteed to fail os.OpenFile on every
+	// platform, forcing newFileLogger's error branch without relying on
+	// filesystem permissions (which behave inconsistently across CI
+	// environments, e.g. root-owned runners bypassing 0000 dirs).
+	badPath := "bad\x00path.log"
+	closeLog := wireLogf(Config{LogFile: badPath}, true)
+	defer closeLog()
+
+	if Logf == nil {
+		t.Fatal("wireLogf with an unopenable LogFile and tui=true left Logf nil; want a discard function assigned so log.go's raw stderr fallback never corrupts the TUI")
+	}
+}
+
+func TestWireLogf_EmptyLogFileWithoutTUILeavesLogfNil(t *testing.T) {
+	resetLogf(t)
+	Logf = nil
+
+	closeLog := wireLogf(Config{LogFile: ""}, false)
+	defer closeLog()
+
+	if Logf != nil {
+		t.Error("wireLogf(LogFile=\"\", tui=false) assigned Logf; want it left nil (plain mode keeps the existing stderr-fallback behavior)")
+	}
+}
+
 func TestLogf_FallsBackToStderrWhenLogfIsNil(t *testing.T) {
 	// No Daemon/NewDaemon involved at all — this is AC5's "package used
 	// without a Daemon" scenario. Logf must be nil for this test to be


### PR DESCRIPTION
Closes #1428

## What this does

Wires `pruefer.Logf` — a package-level hook that was declared but never assigned — so Pruefer's daemon log lines land in a durable, timestamped log file instead of only ever going to a terminal's stderr scrollback.

## Key changes

- **`pruefer/config.go`**: New `Config.LogFile` (default `.pruefer/pruefer.log`), following the standard flag (`--log-file`) > env (`PRUEFER_LOG_FILE`) > YAML (`log_file`) > default precedence chain. `PRUEFER_LOG_FILE` is read via `os.LookupEnv` (not the package's usual `v != ""` idiom) so an explicitly empty value can distinguish "disable file logging" from "unset."
- **`pruefer/logfile.go`** (new): `fileLogger`, a mutex-serialized, size-rotating writer. A single mutex spans the rotation check, rotation, the write, and the optional stderr tee, so concurrent goroutines (poll dispatches reviews across a concurrency-capped semaphore) can never interleave or corrupt a line. Rotates at 10 MB, retaining 3 numbered backups. Opens append-only (never truncates) so a daemon restart doesn't erase the history an incident investigation needs.
- **`pruefer/daemon.go`**: New `NewDaemon` constructor — the sole production construction path. It opens the file logger (when `LogFile` is set) and assigns `pruefer.Logf`, teeing to stderr in plain daemon mode and going file-only in TUI mode (stderr would corrupt the bubbletea display). Deliberately *not* invoked from `Daemon.Run`/`poll`, so `daemon_test.go`'s existing hand-built `Daemon{}` literals keep `Logf` nil exactly as before — no existing tests needed to change.
- **`pruefer/execute.go`**: Now calls `NewDaemon` and defers the returned close function.
- **`cmd/pruefer/README.md`**: New "Logging" section plus a Configuration reference table row for `log_file`.

Lines reuse the exact existing `[pr#%d %s]` formatting Pruefer's stderr fallback already produces, with an RFC3339 UTC timestamp prepended — no wording or tag changes.

## Test plan

- `pruefer/config_test.go`: default/YAML/env/flag precedence for `log_file`, including explicit-empty-disables at each layer.
- `pruefer/logfile_test.go`: timestamp+scoping regex match, concurrent-writer race test (`go test -race`), rotation-at-bound test with a synthetic small `maxBytes`.
- `pruefer/logging_test.go`: `NewDaemon` assigns a non-nil `Logf`; default/override/disabled path resolution; `Logf` stays nil and `logf` falls back to stderr byte-for-byte when `NewDaemon` is never called.
- Every new test was manually neutralized (production change reverted) and confirmed to fail before being restored — see the diff history for details.
- `go build ./...`, `go vet ./...`, and `go test -race ./...` are clean. One pre-existing, unrelated flake (`cmd.TestExecute_ConfigYAMLApplied`, a SIGINT-timing test in the main fabrik CLI) reproduces identically on a clean `origin/main` checkout and is untouched by this change.