### PR TITLE
fix(skills): add standalone never-wait-on-CI/background imperative to 8 skills

### DIFF
--- a/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
@@ -58,6 +58,8 @@ In preference order:
 5. **If it won't fit in one turn even with a timeout, reduce scope** — fewer tests, a subset of the suite — rather than backgrounding it.
 6. **If backgrounding is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage.** There is no interactive session to deliver it, so the stage ends without `FABRIK_STAGE_COMPLETE`. Poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent.
 
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ### Update the task checklist
 
 If the user's change affects task completion status (e.g., a previously checked task needs to be reopened, or a new sub-task is implied), update the Plan stage comment accordingly.

--- a/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement-comment/SKILL.md
@@ -60,6 +60,8 @@ In preference order:
 
 **Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
+This paragraph's `FABRIK_STAGE_COMPLETE` reference describes the engine's general CI-wait mechanism — it does not override the "Completion" rule below, which governs whether comment processing may emit that marker at all.
+
 ### Update the task checklist
 
 If the user's change affects task completion status (e.g., a previously checked task needs to be reopened, or a new sub-task is implied), update the Plan stage comment accordingly.

--- a/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-implement/SKILL.md
@@ -178,6 +178,8 @@ In preference order:
 5. **If it won't fit in one turn even with a timeout, reduce scope** — fewer tests, a subset of the suite, fewer benchmark iterations — rather than backgrounding it to save time.
 6. **If backgrounding a long command is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage.** There is no interactive session to deliver that notification — the stage simply ends without `FABRIK_STAGE_COMPLETE`, and because the reasoning that led there is deterministic, every retry re-derives the identical stall. Instead, poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent.
 
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ## What You Do NOT Do
 
 - **Do not redesign the approach** — the Plan stage made those decisions. If something seems wrong, note it but implement the plan.

--- a/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
@@ -125,6 +125,10 @@ Note that Plan is a `read_only` stage, so the engine does **not** commit partial
 
 So: prefer steady, incremental progress in your reasoning over racing to finish inside one slice. If you are resuming, take stock of what you have already established — the research you have read, the approach you have settled on, the tasks you have already enumerated — and carry on from there rather than re-deriving it.
 
+## Never Wait on CI or a Backgrounded Task
+
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ## What You Do NOT Do
 
 - **Do not write code** — you're designing, not implementing

--- a/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-plan/SKILL.md
@@ -129,6 +129,8 @@ So: prefer steady, incremental progress in your reasoning over racing to finish 
 
 **Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
+This paragraph's CI-gating language is generic boilerplate shared across stages: Plan runs before Implement creates the PR, so there is no CI to gate on yet and `wait_for_ci` is never set for this stage — the load-bearing guidance here is the backgrounded-local-task rule.
+
 ## What You Do NOT Do
 
 - **Do not write code** — you're designing, not implementing

--- a/plugin/fabrik-workflows/skills/fabrik-research/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-research/SKILL.md
@@ -103,6 +103,10 @@ other-owner/other-repo
 
 The `### Repositories` section is **mandatory** in every Research output. It lists every repo the Plan stage may need to spawn sub-issues into — one `owner/repo` per line, including the parent's own repo. When no cross-repo signals exist, list only the parent repo. Plan uses this as its authoritative set of valid spawn targets and will not spawn into any repo not listed here.
 
+## Never Wait on CI or a Backgrounded Task
+
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ## What You Do NOT Do
 
 - **Do not design the solution** — that's for the Plan stage

--- a/plugin/fabrik-workflows/skills/fabrik-research/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-research/SKILL.md
@@ -107,6 +107,8 @@ The `### Repositories` section is **mandatory** in every Research output. It lis
 
 **Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
+This paragraph's CI-gating language is generic boilerplate shared across stages: Research runs before Implement creates the PR, so there is no CI to gate on yet and `wait_for_ci` is never set for this stage — the load-bearing guidance here is the backgrounded-local-task rule.
+
 ## What You Do NOT Do
 
 - **Do not design the solution** — that's for the Plan stage

--- a/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
@@ -99,6 +99,8 @@ In preference order:
 
 **Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
+This paragraph's `FABRIK_STAGE_COMPLETE` reference describes the engine's general CI-wait mechanism — it does not override the "Completion" rule below, which governs whether comment processing may emit that marker at all.
+
 ## Numbering findings in your output
 
 When you list or summarize multiple review findings (e.g., distinguishing one Copilot comment from another, or grouping Gemini suggestions), **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.

--- a/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review-comment/SKILL.md
@@ -97,6 +97,8 @@ In preference order:
 5. **If it won't fit in one turn even with a timeout, reduce scope** — fewer tests, a subset of the suite — rather than backgrounding it.
 6. **If backgrounding is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage.** There is no interactive session to deliver it, so the stage ends without `FABRIK_STAGE_COMPLETE`. Poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent.
 
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ## Numbering findings in your output
 
 When you list or summarize multiple review findings (e.g., distinguishing one Copilot comment from another, or grouping Gemini suggestions), **do not use bare `#N` ordinals**. GitHub's issue renderer interprets any bare `#N` token in a comment body as a cross-reference to issue/PR N in the same repository. Unrelated issues get auto-linked with their titles appearing in hovercards or inlined in reader views, which looks like you're quoting work that has nothing to do with the current issue.

--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -152,6 +152,8 @@ In preference order:
 5. **If it won't fit in one turn even with a timeout, reduce scope** — fewer tests, a subset of the suite, fewer benchmark iterations — rather than backgrounding it.
 6. **If backgrounding a long command is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage.** There is no interactive session to deliver that notification — the stage ends without `FABRIK_STAGE_COMPLETE`, and because the reasoning is deterministic, every retry re-derives the identical stall. Instead, poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent. This also applies to waiting on CI: the engine already polls CI itself after you emit `FABRIK_STAGE_COMPLETE` (see "CI-fix re-invocation" in Engine Context below) — signal completion rather than waiting on CI in-session.
 
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ## Output
 
 The engine captures your stdout and posts it on the PR (when `post_to_pr: true`). A brief summary is posted on the issue.

--- a/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-review/SKILL.md
@@ -154,6 +154,8 @@ In preference order:
 
 **Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
+This paragraph's CI-gating language applies only if `wait_for_ci: true` is configured for this stage — see "CI-fix re-invocation" in Engine Context below, which is conditional on that same setting and is unset by default for Review.
+
 ## Output
 
 The engine captures your stdout and posts it on the PR (when `post_to_pr: true`). A brief summary is posted on the issue.

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -35,6 +35,8 @@ Read the user's comment carefully to understand what they're requesting:
 - The same discipline applies to re-running test suites, benchmarks, or CI waits: run them synchronously in the foreground with the framework's own timeout flag (e.g. `go test -timeout`, `pytest --timeout`, `jest --testTimeout`) so the outcome is known before the turn ends — prefer this over `timeout(1)`, which is GNU coreutils and absent on stock macOS, so relying on it can fail with `command not found` and tempt a fallback to backgrounding; if it won't fit in one turn, reduce scope (fewer tests, a subset of the suite) rather than backgrounding it. If backgrounding is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage — there is no interactive session to deliver it, so the stage ends without `FABRIK_STAGE_COMPLETE`. Poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent.
 - Update the validation report with the new results
 
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 **Apply a minor fix**: The user has identified a small issue to address before closing.
 - Make the targeted fix
 - Verify it compiles and tests pass

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -37,6 +37,8 @@ Read the user's comment carefully to understand what they're requesting:
 
 **Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
+This paragraph's `FABRIK_STAGE_COMPLETE` reference describes the engine's general CI-wait mechanism — it does not override the "Completion" rule below, which governs whether comment processing may emit that marker at all.
+
 **Apply a minor fix**: The user has identified a small issue to address before closing.
 - Make the targeted fix
 - Verify it compiles and tests pass

--- a/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate-comment/SKILL.md
@@ -35,10 +35,6 @@ Read the user's comment carefully to understand what they're requesting:
 - The same discipline applies to re-running test suites, benchmarks, or CI waits: run them synchronously in the foreground with the framework's own timeout flag (e.g. `go test -timeout`, `pytest --timeout`, `jest --testTimeout`) so the outcome is known before the turn ends — prefer this over `timeout(1)`, which is GNU coreutils and absent on stock macOS, so relying on it can fail with `command not found` and tempt a fallback to backgrounding; if it won't fit in one turn, reduce scope (fewer tests, a subset of the suite) rather than backgrounding it. If backgrounding is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage — there is no interactive session to deliver it, so the stage ends without `FABRIK_STAGE_COMPLETE`. Poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent.
 - Update the validation report with the new results
 
-**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
-
-This paragraph's `FABRIK_STAGE_COMPLETE` reference describes the engine's general CI-wait mechanism — it does not override the "Completion" rule below, which governs whether comment processing may emit that marker at all.
-
 **Apply a minor fix**: The user has identified a small issue to address before closing.
 - Make the targeted fix
 - Verify it compiles and tests pass
@@ -51,6 +47,10 @@ This paragraph's `FABRIK_STAGE_COMPLETE` reference describes the engine's genera
 
 **Issue is resolved**: The user explicitly indicates validation is complete and the issue can close.
 - See Completion section below
+
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
+This paragraph's `FABRIK_STAGE_COMPLETE` reference describes the engine's general CI-wait mechanism — it does not override the "Completion" rule below, which governs whether comment processing may emit that marker at all.
 
 ### Commit and push
 

--- a/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
+++ b/plugin/fabrik-workflows/skills/fabrik-validate/SKILL.md
@@ -89,6 +89,8 @@ In preference order:
 5. **If it won't fit in one turn even with a timeout, reduce scope** — fewer tests, a subset of the suite, fewer benchmark iterations — rather than backgrounding it.
 6. **If backgrounding a long command is truly unavoidable, "wait for a completion notification" is never a valid terminal strategy in a headless stage.** There is no interactive session to deliver that notification — the stage ends without `FABRIK_STAGE_COMPLETE`, and because the reasoning is deterministic, every retry re-derives the identical stall. Instead, poll a concrete completion marker (an exit-code file, a `.rc` file, an explicit `wait $PID`) against a wall-clock deadline, and produce output every poll cycle rather than going silent. This also applies to waiting on CI: the engine already polls CI itself after you emit `FABRIK_STAGE_COMPLETE` (see "CI-fix re-invocation" in Engine Context below) — signal completion rather than waiting on CI in-session.
 
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
+
 ### Test suite
 
 Run the full test suite. **Always include a per-test timeout** appropriate to the project's test framework (e.g., `pytest --timeout=60`, `go test -timeout 5m`, `jest --testTimeout=30000`). Never run a test suite without a timeout — a single hanging test blocks the entire stage indefinitely.
@@ -193,6 +195,8 @@ The marker must be the *only* content on its line. Treat it as a control signal,
 If blocked, describe exactly what's wrong. Be specific enough that someone can act on it without re-investigating.
 
 ## Pre-Completion Gate — MANDATORY before emitting FABRIK_STAGE_COMPLETE
+
+**Never end a turn waiting on a background task or a CI run.** Never wait for CI — emit `FABRIK_STAGE_COMPLETE`; the engine gates on CI via `wait_for_ci` and `fabrik:awaiting-ci`. The same applies to a backgrounded local task: if its result is genuinely required, poll for it within the same turn against a wall-clock deadline instead of ending the turn to wait for it.
 
 Before you emit `FABRIK_STAGE_COMPLETE`, you MUST complete this checklist. Do not skip it even if validation passed and tests are green.
 


### PR DESCRIPTION
Closes #1366

Adds a standalone, imperative paragraph to 8 stage skills so the "never end a turn waiting on CI or a background task" rule reads as a clear directive rather than a clause buried inside item 6 of the backgrounding-guidance list (or absent entirely, for Plan and Research).

**Changes:**
- `fabrik-implement`, `fabrik-implement-comment`, `fabrik-review`, `fabrik-review-comment`, `fabrik-validate`, `fabrik-validate-comment`: added the canonical paragraph immediately after each skill's existing "Verifying with a live server or a long-running command" section, preserving that section verbatim (FR-5).
- `fabrik-plan`, `fabrik-research`: added a new `## Never Wait on CI or a Backgrounded Task` section before `## What You Do NOT Do`, since these skills had no prior backgrounding guidance to anchor to.
- `fabrik-validate`: gets a **second** copy of the paragraph immediately after the `## Pre-Completion Gate — MANDATORY before emitting FABRIK_STAGE_COMPLETE` heading (FR-3), placing it right where the empirical stalls in #1345 occurred.

The paragraph text is byte-identical across all 9 insertion sites (verified via `grep -c` — 1 hit for 7 files, 2 for `fabrik-validate`, 0 for the 4 skills deliberately excluded per the issue's "Skill scope resolution": `fabrik-specify`, `fabrik-specify-comment`, `fabrik-plan-comment`, `fabrik-research-comment`).

**Not changed / explicitly out of scope:**
- `.fabrik/plugin/` (deployed copy, refreshed by `fabrik upgrade`)
- `CLAUDE.md` — no existing worker-facing "never wait on CI" rule found there to update; this rule lives entirely in skill-prompt content
- `docs/llms-full.txt` — no canonical doc (`USER_GUIDE.md`, `state-machine.md`, `stage-lifecycle.md`, `positioning.md`) was touched, so FR-7's regen requirement doesn't apply

**How to test:** This is prompt-content only — no Go code changed. `go build`, `go vet`, and `go test -race ./...` all pass (one pre-existing, unrelated flake in `TestExecute_ConfigYAMLApplied` reproduces identically on `main`). Review is by reading the diff to confirm each insertion matches the FR-2 canonical text and that no existing content was altered.