### PR TITLE
Split turn-cap preemption into its own slice counter, separate from max_retries

### DIFF
--- a/adrs/1199-slice-budget-separate-from-failure-counter.md
+++ b/adrs/1199-slice-budget-separate-from-failure-counter.md
@@ -83,14 +83,35 @@ if claudeRan {
 }
 ```
 
-**Escalation** on exceeding `MaxSliceRetries` is modeled directly on the merge-gate's
+**Escalation** on exceeding `MaxSliceRetries` is modeled on the merge-gate's
 `pauseForRebaseCycleLimit` (`engine/merge_gate.go`) — a live, tested, in-production
-precedent for exactly this shape: a second, independently-bounded counter with its own
-non-failure message. `pauseForSliceLimit` posts a comment stating explicitly that this is
-not a failure, names `--max-slice-retries`/`FABRIK_MAX_SLICE_RETRIES` as the override, and
-suggests `fabrik:extend-turns` (wider per-invocation turn budget → fewer slices needed) or
+precedent for a second, independently-bounded counter with its own non-failure message —
+with one deliberate divergence (see "Recovery" below). `pauseForSliceLimit` posts a
+comment stating explicitly that this is not a failure, names
+`--max-slice-retries`/`FABRIK_MAX_SLICE_RETRIES` as the override, and suggests
+`fabrik:extend-turns` (wider per-invocation turn budget → fewer slices needed) or
 splitting the issue. It applies `fabrik:paused` + `fabrik:awaiting-input` — **never**
 `stage:<name>:failed`, since the stage has not failed.
+
+**Recovery diverges from `pauseForRebaseCycleLimit`: `pauseForSliceLimit` applies
+`itemstate.EnginePaused`.** `RebaseCycles` has an independent path back to progress that
+doesn't depend on the counter resetting at all: a human resolves the underlying merge
+conflict directly, which changes `settle.Status` and lets the poll loop advance without
+ever re-checking `RebaseCycles` again. `SliceRetries` has no equivalent independent
+signal — the job simply needs more slices than the budget allowed, and there is nothing
+external to "fix." Without `EnginePaused`, `processItem`'s unpause guard
+(`wasPaused || hasFailedLabel`, both false for a pure slice-limit pause, since no failed
+label is ever applied) would never fire `clearFailedStage`, `SliceRetries` would never
+reset, and removing `fabrik:paused` — the pause comment's own documented recovery
+instruction — would be a no-op: the very next dispatch takes exactly one more slice,
+re-checks a counter already at the limit, and re-pauses immediately, with the operator
+getting exactly one slice of progress per manual unpause forever. Applying `EnginePaused`
+makes `snap.PausedByEngine(stageName)` true, so removing `fabrik:paused` genuinely
+triggers `clearFailedStage` → `StageRetryCleared`, resetting `SliceRetries` and giving the
+stage a fresh slice budget. `clearFailedStage`'s `stage:<name>:failed` removal is a
+harmless no-op on this path, since that label was never applied. (Caught in Validate
+review before merge — the first draft copied `pauseForRebaseCycleLimit`'s omission of
+`EnginePaused` without accounting for this precondition difference.)
 
 **`SliceRetries` is bound higher than `Attempts` by default (10 vs. 3)** and is
 independently configurable (flag + env, mirroring `MaxRebaseCycles`'s wiring tier — no
@@ -113,15 +134,14 @@ attempts/slices this run-to-completion took" and share the same natural reset po
 intervention**, bounded instead by `MaxSliceRetries` — the issue's headline acceptance
 criterion. `Attempts` is untouched by any number of turn-cap preemptions.
 
-**`pauseForSliceLimit` does not reset `SliceRetries` on pause**, mirroring
-`pauseForRebaseCycleLimit` exactly (which likewise does not apply `itemstate.EnginePaused`
-or a failure-style label). A manual `fabrik:paused` + `fabrik:awaiting-input` removal
-alone does not reset the counter — it is already at the limit, so the very next turn-cap
-exit re-escalates immediately unless the underlying condition changes (wider turn budget
-via `fabrik:extend-turns`, or splitting the issue). This is a deliberate, precedented gap:
-the identical shape exists today for `RebaseCycles`/`MaxRebaseCycles`, and the pause
-comment's suggested remedies are the intended path to actual progress rather than a bare
-unpause.
+**A manual `fabrik:paused` removal genuinely resets `SliceRetries`**, because
+`pauseForSliceLimit` applies `itemstate.EnginePaused` (see "Recovery diverges..." above).
+This does not itself change the underlying condition — if the job still needs more slices
+than `MaxSliceRetries` allows within a single fresh budget, it will re-hit the limit and
+re-pause — but each manual unpause now grants a full fresh slice budget rather than
+exactly one slice, so `fabrik:extend-turns` (wider per-invocation turn budget → fewer
+slices needed) or splitting the issue are genuine accelerants rather than the only way to
+make any progress at all.
 
 **`--max-retries` now means exactly what it is documented to mean** — failed attempts —
 closing the gap #1191 reported between the documented and actual behavior of

--- a/adrs/1199-slice-budget-separate-from-failure-counter.md
+++ b/adrs/1199-slice-budget-separate-from-failure-counter.md
@@ -1,0 +1,195 @@
+# ADR 1199: Separate the slice-budget counter from the failure-retry counter
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Issue:** [#1199](https://github.com/handarbeit/fabrik/issues/1199)
+
+## Context
+
+`finalizeStageOutcome` (`engine/item.go`) is the single funnel every Claude invocation's
+outcome passes through. Before this change, its final `else` branch — reached whenever a
+stage did not complete and was not blocked-on-input — unconditionally incremented one
+counter, `Attempts`, and paused the issue with `stage:<name>:failed` once `MaxRetries` was
+exceeded:
+
+```go
+if claudeRan && e.cfg.MaxRetries > 0 {
+    e.store.Apply(itemstate.StageRetryIncremented{...})
+}
+```
+
+Three structurally distinct causes reached this branch:
+
+1. **Turn-cap preemption** — the CLI's own `subtype: "error_max_turns"` /
+   `terminal_reason: "max_turns"` (captured since #1178, surfaced as
+   `*claudeTurnLimitError`, `turnLimited` in code). The session ran out of turns and will
+   resume via `--resume` on the next dispatch; the worktree persists and work continues
+   from where it stopped.
+2. **Genuine error exit** — something broke.
+3. **Clean run, no `FABRIK_STAGE_COMPLETE`** — Claude finished without signalling
+   completion.
+
+All three counted identically against `MaxRetries` (default 3), and `--max-retries` is
+documented as bounding failed *attempts* — "Max failed stage attempts before pausing the
+issue" (`docs/USER_GUIDE.md`). A turn-cap preemption is not an attempt that failed; it is
+a time-slice of work still in progress. Conflating the two meant a job legitimately
+needing more than 3 slices was paused with `stage:<X>:failed` and a "failed to complete
+after 3 attempt(s)" comment while progressing normally — observed on the same day across
+three issues (#816: 3 slices before pausing, later completed at 41/100 turns; #1114: 5
+slices; #1183: 3 slices, with invocation cost visibly rising slice-over-slice — exactly
+what accumulating progress looks like). Each pause required a human to notice and
+manually unpause. `fabrik:extend-turns` "fixed" this only by making slices large enough
+to finish inside the retry budget — treating the symptom while re-introducing the
+unbounded-work risk the turn cap exists to prevent. Reported independently by @bdueck in
+#1191 as the undocumented `max_retries × max_turns` ceiling.
+
+The fix is not simply "stop counting preemptions" — that would remove the only bound on
+slicing and let a non-converging job resume forever. The counter needs to be split:
+one bound for "this keeps genuinely breaking, stop" and a separate, wider bound for "this
+job is too big for its slice budget, stop."
+
+**The routing decision for cause 3** (clean run, no marker) was explicitly deferred by
+the issue to this design stage: it is not obviously a failure or a slice. `turnLimited` —
+the CLI's own structural signal — is the only *verified* classification available at this
+call site; a clean run with no marker has no equivalent structural signal distinguishing
+it from "stopped for an unknown reason." Treating an unverified case as a slice would
+mean inferring rather than detecting structurally, which the issue explicitly rules out
+("distinguish structurally, not by inference"). Cause 3 therefore stays on the failure
+counter, unchanged from today.
+
+## Decision
+
+Split the single counter into two, both living on `itemstate.StageState`:
+
+| Counter | Field | Config | Default | Counts |
+|---------|-------|--------|---------|--------|
+| Failure counter (unchanged) | `Attempts` | `MaxRetries` / `--max-retries` / `FABRIK_MAX_RETRIES` | 3 (0 = unlimited) | Genuine errors, degenerate output, PR-creation failures, clean run with no completion marker |
+| Slice counter (new) | `SliceRetries` | `MaxSliceRetries` / `--max-slice-retries` / `FABRIK_MAX_SLICE_RETRIES` | 10 | Turn-cap preemptions only (`turnLimited == true`) |
+
+**Routing** is a single branch on the already-computed `turnLimited` boolean, inside the
+existing `claudeRan` guard in `finalizeStageOutcome`'s `else` branch — no new detection
+work, no change to the surrounding WIP-commit/push/comment-marking flow (ADR-1178
+requires that machinery keep running unconditionally for a turn-cap exit; unlike the
+usage-limit exemption below, a turn-capped invocation *did* run and made progress, so it
+cannot early-return the way `handleUsageLimitExit` does):
+
+```go
+if claudeRan {
+    if turnLimited {
+        // increment SliceRetries; escalate via pauseForSliceLimit at MaxSliceRetries
+    } else if e.cfg.MaxRetries > 0 {
+        // unchanged: increment Attempts; escalate via escalateFailedStage at MaxRetries
+    }
+}
+```
+
+**Escalation** on exceeding `MaxSliceRetries` is modeled directly on the merge-gate's
+`pauseForRebaseCycleLimit` (`engine/merge_gate.go`) — a live, tested, in-production
+precedent for exactly this shape: a second, independently-bounded counter with its own
+non-failure message. `pauseForSliceLimit` posts a comment stating explicitly that this is
+not a failure, names `--max-slice-retries`/`FABRIK_MAX_SLICE_RETRIES` as the override, and
+suggests `fabrik:extend-turns` (wider per-invocation turn budget → fewer slices needed) or
+splitting the issue. It applies `fabrik:paused` + `fabrik:awaiting-input` — **never**
+`stage:<name>:failed`, since the stage has not failed.
+
+**`SliceRetries` is bound higher than `Attempts` by default (10 vs. 3)** and is
+independently configurable (flag + env, mirroring `MaxRebaseCycles`'s wiring tier — no
+`config.yaml` field, the established tier for a "second, narrower" counter in this
+codebase) rather than a fixed multiplier of `MaxRetries`. A multiplier was rejected: it
+would silently change if `MaxRetries` is retuned, re-creating the exact "accidental
+ceiling" problem #1191 reported. 10 is large enough that all three cited real-world cases
+(3, 5, and 3 slices respectively) would have completed without pausing, while still
+bounding a genuinely non-converging job — the issue's explicit requirement that the bound
+on consecutive slices must still exist.
+
+**`SliceRetries` resets exactly when `Attempts` resets** — folded into the existing
+`StageRetryCleared` mutation (fired on normal stage completion and by `clearFailedStage`
+on manual unpause) rather than a new mutation type. Both counters represent "how many
+attempts/slices this run-to-completion took" and share the same natural reset point.
+
+## Consequences
+
+**A job needing more slices than `max_retries` now completes without human
+intervention**, bounded instead by `MaxSliceRetries` — the issue's headline acceptance
+criterion. `Attempts` is untouched by any number of turn-cap preemptions.
+
+**`pauseForSliceLimit` does not reset `SliceRetries` on pause**, mirroring
+`pauseForRebaseCycleLimit` exactly (which likewise does not apply `itemstate.EnginePaused`
+or a failure-style label). A manual `fabrik:paused` + `fabrik:awaiting-input` removal
+alone does not reset the counter — it is already at the limit, so the very next turn-cap
+exit re-escalates immediately unless the underlying condition changes (wider turn budget
+via `fabrik:extend-turns`, or splitting the issue). This is a deliberate, precedented gap:
+the identical shape exists today for `RebaseCycles`/`MaxRebaseCycles`, and the pause
+comment's suggested remedies are the intended path to actual progress rather than a bare
+unpause.
+
+**`--max-retries` now means exactly what it is documented to mean** — failed attempts —
+closing the gap #1191 reported between the documented and actual behavior of
+`max_retries`. The `max_retries × max_turns` ceiling that #1191 named is now either
+irrelevant (a large job no longer needs to fit inside it) or, if the operator still hits
+`MaxSliceRetries`, explicit and documented rather than an accidental product of two
+unrelated numbers.
+
+**`stage:<name>:failed`'s meaning narrows** to "failure budget exhausted," now that a
+second, non-failure budget exists with its own escalation shape. `LABELS.md`'s entry for
+the label is updated accordingly.
+
+**No change to `#1146`'s stall detection** (declining-turns heuristic, `detectAndArmStallHint`).
+It shares the same call site and `clean`/`turnLimited` inputs as the new routing logic but
+is a materially different concern — bounding non-converging *retry strategy*, not slice
+*count* — and remains independent of both `MaxRetries` and `MaxSliceRetries`.
+
+**Degenerate-output detection stays scoped to the failure-counter branch only.** A
+turn-limited exit could theoretically also produce degenerate output, but this is a
+vanishingly rare edge case not raised by the issue or its cited incidents, and adding a
+parallel check to the slice branch would be speculative engineering against an untriggered
+scenario.
+
+## Alternatives Considered
+
+**A fixed multiplier of `MaxRetries`** (e.g. `3 × MaxRetries`, no new flag). Rejected: it
+reintroduces exactly the "accidental ceiling" shape #1191 reported — the slice bound would
+silently change whenever an operator retunes the unrelated failure bound, rather than
+being an explicit, independently-documented number.
+
+**Cause 3 (clean run, no marker) routed to the slice counter.** Considered because it is
+"closer to a slice" in spirit — the stage ran fine and simply is not finished. Rejected:
+`turnLimited` is the only structurally verified signal at this call site; there is no
+equivalent structural marker for "clean run, no marker, but definitely not a failure."
+Routing it to the slice counter would be an inference, which the issue's own requirement
+("distinguish structurally, not by inference") rules out. It stays on the failure counter,
+unchanged from before this issue.
+
+**Reusing `escalateFailedStage`'s shape but skipping only `addFailedLabel`.** Considered
+as a smaller diff. Rejected in favor of mirroring `pauseForRebaseCycleLimit` end to end:
+the rebase-cycle path is a proven, tested precedent for the entire "second bounded
+counter, non-failure message, `awaiting-input` instead of `failed`" shape, not just the
+label choice — reusing it end to end means no new pause plumbing was invented for this
+issue.
+
+**A dedicated `SliceRetryCleared` mutation, independent of `StageRetryCleared`.**
+Considered so the two counters could diverge if a future need arose. Rejected: no case
+was found where "slices completed for this run" and "failures for this run" should reset
+at different times — both represent the same run-to-completion, and adding a second
+mutation type for a divergence that has no current use case is unnecessary surface area.
+
+## References
+
+- [ADR-1178: Turn-limit classification](1178-turn-limit-classification.md) — established
+  `claudeTurnLimitError`/`turnLimited` and explicitly scoped retry/escalation semantics as
+  out of this ADR's change — the follow-up this issue completes.
+- [ADR-1119: Claude usage-limit detection](1119-claude-usage-limit-detection.md) and
+  ADR-1120/1183 — precedent for excluding a structurally-detected cause from
+  `StageRetryIncremented` (`handleUsageLimitExit`). The precedent reused here is the
+  *counter-exclusion* pattern, not the *early-return* control flow: unlike a usage-limit
+  exit (stage never ran, zero cost), a turn-capped invocation did run and made progress,
+  so `StageAttempted`/`commitWIP`/the branch push must still run exactly as before.
+- `engine/merge_gate.go`'s `pauseForRebaseCycleLimit` — the structural model for
+  `pauseForSliceLimit`; a second, independently-bounded, non-failure-labeled pause path,
+  live in production for `RebaseCycles`/`MaxRebaseCycles`.
+- #816, #1114, #1183 — three same-day production instances of the original defect.
+- #1191 (@bdueck) — independent operator-facing report of the same undocumented ceiling.
+- #1146 — the related, explicitly out-of-scope declining-turns stall heuristic.
+- #1178, #1200, #1201 — sibling issues in the same turn-cap-classification cluster.
+- `docs/state-machine.md` §7.12 — as-built description of the shipped two-counter
+  behavior.

--- a/cmd/cmd_envvar_test.go
+++ b/cmd/cmd_envvar_test.go
@@ -119,6 +119,16 @@ func TestExecute_EnvMaxRetries_Valid(t *testing.T) {
 	executeAndStop(t)
 }
 
+func TestExecute_EnvMaxSliceRetries_Valid(t *testing.T) {
+	dir, stagesDir := setupValidStages(t)
+	chdirTest(t, dir)
+	resetFlags()
+	t.Setenv("FABRIK_MAX_SLICE_RETRIES", "20")
+	t.Setenv("GITHUB_TOKEN", "tok")
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--stages", stagesDir}
+	executeAndStop(t)
+}
+
 func TestExecute_EnvPluginDir(t *testing.T) {
 	dir, stagesDir := setupValidStages(t)
 	chdirTest(t, dir)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ type Config struct {
 	PollSeconds               int
 	MaxConcurrent             int
 	MaxRetries                int
+	MaxSliceRetries           int    // Max turn-cap preemption cycles per stage; 0 means use default (10; #1199)
 	ReviewWaitTimeout         int    // minutes; 0 means use default (15)
 	MaxReviewCycles           int    // 0 means use default (5)
 	CIWaitTimeout             int    // minutes; 0 means use default (30)
@@ -150,6 +151,7 @@ func Execute() error {
 	flag.IntVar(&cfg.PollSeconds, "poll", 30, "Polling interval in seconds")
 	flag.IntVar(&cfg.MaxConcurrent, "max-concurrent", 5, "Maximum number of concurrent issue workers")
 	flag.IntVar(&cfg.MaxRetries, "max-retries", 3, "Max failed stage attempts before pausing the issue (0 = unlimited)")
+	flag.IntVar(&cfg.MaxSliceRetries, "max-slice-retries", 0, "Maximum number of turn-cap preemption cycles per stage before pausing — a large job resuming across multiple slices is not a failure and is bounded separately from max-retries (0 = use default of 10; also FABRIK_MAX_SLICE_RETRIES; #1199)")
 	flag.IntVar(&cfg.ReviewWaitTimeout, "review-wait-timeout", 0, "Maximum time in minutes to wait for PR reviewers before advancing (0 = use default of 15; also FABRIK_REVIEW_WAIT_TIMEOUT)")
 	flag.IntVar(&cfg.MaxReviewCycles, "max-review-cycles", 0, "Maximum number of review-and-fix cycles per issue (0 = use default of 5; also FABRIK_MAX_REVIEW_CYCLES)")
 	flag.IntVar(&cfg.CIWaitTimeout, "ci-wait-timeout", 0, "Maximum time in minutes to wait for CI in the merge guard before pausing (0 = use default of 30; also FABRIK_CI_WAIT_TIMEOUT)")
@@ -323,6 +325,9 @@ func Execute() error {
 				cfg.MaxRetries = *pc.MaxRetries
 			}
 		}
+	}
+	if !explicitFlags["max-slice-retries"] {
+		cfg.MaxSliceRetries = resolveInt(cfg.MaxSliceRetries, "FABRIK_MAX_SLICE_RETRIES", "", 10)
 	}
 	if !explicitFlags["review-wait-timeout"] {
 		cfg.ReviewWaitTimeout = resolveInt(cfg.ReviewWaitTimeout, "FABRIK_REVIEW_WAIT_TIMEOUT", "of minutes", 15)
@@ -700,6 +705,7 @@ func Execute() error {
 		} else {
 			fmt.Printf("  max-retries: %d\n", cfg.MaxRetries)
 		}
+		fmt.Printf("  max-slice-retries: %d\n", maxSliceRetries(cfg.MaxSliceRetries))
 	}
 	fmt.Printf("  debug-output: %v\n", cfg.DebugOutput)
 
@@ -741,6 +747,7 @@ func Execute() error {
 		PollSeconds:               cfg.PollSeconds,
 		MaxConcurrent:             cfg.MaxConcurrent,
 		MaxRetries:                cfg.MaxRetries,
+		MaxSliceRetries:           maxSliceRetries(cfg.MaxSliceRetries),
 		ReviewWaitTimeout:         reviewWaitTimeout(cfg.ReviewWaitTimeout),
 		MaxReviewCycles:           maxReviewCycles(cfg.MaxReviewCycles),
 		CIWaitTimeout:             ciWaitTimeout(cfg.CIWaitTimeout),
@@ -1007,6 +1014,18 @@ func maxCiFixCycles(n int) int {
 func maxRebaseCycles(n int) int {
 	if n <= 0 {
 		return 3
+	}
+	return n
+}
+
+// maxSliceRetries returns the configured MaxSliceRetries value, defaulting to
+// 10 when n is 0 (unset). The default is higher than max-retries because a
+// turn-cap preemption is a resumable time-slice, not a failure — a job
+// legitimately needing several slices is routine and must not be conflated
+// with a stage that keeps genuinely failing (#1199).
+func maxSliceRetries(n int) int {
+	if n <= 0 {
+		return 10
 	}
 	return n
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -424,6 +424,35 @@ func TestMaxEnqueueCycles_Default(t *testing.T) {
 	}
 }
 
+func TestExecute_MaxSliceRetriesFlag(t *testing.T) {
+	resetFlags()
+	stagesDir := t.TempDir()
+	os.Args = []string{"fabrik", "--owner", "o", "--repo", "r", "--project", "1", "--user", "u", "--token", "tok", "--stages", stagesDir, "--max-slice-retries", "20"}
+
+	err := Execute()
+	if err == nil {
+		t.Fatal("expected error (no stages)")
+	}
+	if err.Error() == "unknown flag: --max-slice-retries" {
+		t.Error("--max-slice-retries flag not registered")
+	}
+}
+
+// TestMaxSliceRetries_Default covers the higher-than-MaxRetries default (#1199):
+// a turn-cap preemption is a resumable slice, not a failure, so its bound is
+// wider than max-retries's default of 3.
+func TestMaxSliceRetries_Default(t *testing.T) {
+	if got := maxSliceRetries(0); got != 10 {
+		t.Errorf("maxSliceRetries(0) = %d, want default 10", got)
+	}
+	if got := maxSliceRetries(-1); got != 10 {
+		t.Errorf("maxSliceRetries(-1) = %d, want default 10", got)
+	}
+	if got := maxSliceRetries(25); got != 25 {
+		t.Errorf("maxSliceRetries(25) = %d, want passthrough 25", got)
+	}
+}
+
 func TestExecute_HelpIncludesSubcommands(t *testing.T) {
 	resetFlags()
 	// Route flag.CommandLine output to a buffer so we can inspect usage text.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -762,7 +762,8 @@ FABRIK_USER=my-personal-username
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides `.fabrik/plugin/`) | auto-detected |
 | `--poll` | Poll interval in seconds | `30` |
 | `--max-concurrent` | Maximum number of concurrent issue workers | `5` |
-| `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
+| `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited). Counts genuine failures only — a turn-cap preemption never counts here; see `--max-slice-retries` | `3` |
+| `--max-slice-retries` | Maximum number of turn-cap preemption cycles per stage before pausing (0 = use default of 10; also `FABRIK_MAX_SLICE_RETRIES`). A large job that resumes across several slices is not a failure and is bounded separately from `--max-retries` — see the "Max retries" troubleshooting note below | `0` (10 slices) |
 | `--review-wait-timeout` | Minutes to wait for all requested PR reviewers before advancing (0 = use default of 15; also `FABRIK_REVIEW_WAIT_TIMEOUT`) | `0` (15 min) |
 | `--max-review-cycles` | Maximum number of review-and-fix cycles per issue (0 = use default of 5; also `FABRIK_MAX_REVIEW_CYCLES`) | `0` (5 cycles) |
 | `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
@@ -809,7 +810,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_YOLO` | `yolo` | Auto-advance (`true`/`1`/`yes`) | `false` |
 | `FABRIK_POLL` | `poll` | Poll interval in seconds | `30` |
 | `FABRIK_MAX_CONCURRENT` | `max_concurrent` | Max parallel Claude sessions | `5` |
-| `FABRIK_MAX_RETRIES` | `max_retries` | Max retries before pausing (0 = unlimited) | `3` |
+| `FABRIK_MAX_RETRIES` | `max_retries` | Max retries before pausing (0 = unlimited). Genuine failures only — see `FABRIK_MAX_SLICE_RETRIES` for turn-cap preemptions | `3` |
+| `FABRIK_MAX_SLICE_RETRIES` | *(no config.yaml key)* | Maximum number of turn-cap preemption cycles per stage before pausing with `fabrik:paused` + `fabrik:awaiting-input` (positive integer; invalid or unset values default to 10). A large job resuming across several slices is not a failure and is bounded separately from `max_retries`. See `--max-slice-retries`. | `10` |
 | `FABRIK_AUTO_UPGRADE` | `auto_upgrade` | Self-upgrade at startup and when idle (after 2 idle polls) (`true`/`1`/`yes`) | `false` |
 | `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
 | `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
@@ -1303,9 +1305,30 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
    - A Claude account usage-limit exit (see the `fabrik:claude-limit` troubleshooting
      note above) is exempted from this count entirely — the stage never ran, so it
      never consumes a retry attempt
+   - A turn-cap preemption (the invocation ran out of turns and will resume on the
+     next dispatch) is likewise exempted — it counts against a separate slice
+     counter instead. See below.
 
 To resume after escalation: remove the `fabrik:paused` label. Fabrik will clear the
 failed label, reset the retry count, and try again immediately.
+
+> **Troubleshooting: an issue is paused with a "slice budget exceeded" comment,
+> not a failure comment.** `--max-retries` bounds genuine failures only — errors,
+> degenerate output, PR-creation failures. A turn-cap preemption (the invocation
+> hit its per-stage turn budget and stopped; the session resumes on the next
+> dispatch) is not a failure and is bounded separately by `--max-slice-retries`
+> (default 10). A large job that legitimately needs several slices completes
+> without pausing as long as it stays within that limit; only a job that keeps
+> hitting the turn cap `--max-slice-retries` times in a row is paused. The pause
+> comment names the specific cause and never says "failed to complete" — no
+> `stage:<name>:failed` label is applied, since the stage has not failed. It
+> applies `fabrik:paused` + `fabrik:awaiting-input` instead. To resume: either add
+> `fabrik:extend-turns` (grants a larger per-invocation turn budget, so fewer
+> slices are needed) or split the issue into smaller pieces, then remove
+> `fabrik:paused` and `fabrik:awaiting-input`. Removing the labels alone does not
+> reset the slice counter — it is already at the limit, so the very next
+> turn-cap exit re-pauses immediately unless the underlying job size or turn
+> budget actually changes. See #1199 and #1191.
 
 ### Stages Waiting for Input
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -760,7 +760,8 @@ FABRIK_USER=my-personal-username
 | `--plugin-dir` | Path to Fabrik plugin directory (overrides `.fabrik/plugin/`) | auto-detected |
 | `--poll` | Poll interval in seconds | `30` |
 | `--max-concurrent` | Maximum number of concurrent issue workers | `5` |
-| `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited) | `3` |
+| `--max-retries` | Max failed stage attempts before pausing the issue (0 = unlimited). Counts genuine failures only — a turn-cap preemption never counts here; see `--max-slice-retries` | `3` |
+| `--max-slice-retries` | Maximum number of turn-cap preemption cycles per stage before pausing (0 = use default of 10; also `FABRIK_MAX_SLICE_RETRIES`). A large job that resumes across several slices is not a failure and is bounded separately from `--max-retries` — see the "Max retries" troubleshooting note below | `0` (10 slices) |
 | `--review-wait-timeout` | Minutes to wait for all requested PR reviewers before advancing (0 = use default of 15; also `FABRIK_REVIEW_WAIT_TIMEOUT`) | `0` (15 min) |
 | `--max-review-cycles` | Maximum number of review-and-fix cycles per issue (0 = use default of 5; also `FABRIK_MAX_REVIEW_CYCLES`) | `0` (5 cycles) |
 | `--ci-wait-timeout` | Minutes to wait for CI checks to pass before pausing (0 = use default of 30; also `FABRIK_CI_WAIT_TIMEOUT`) | `0` (30 min) |
@@ -807,7 +808,8 @@ FABRIK_USER=my-personal-username
 | `FABRIK_YOLO` | `yolo` | Auto-advance (`true`/`1`/`yes`) | `false` |
 | `FABRIK_POLL` | `poll` | Poll interval in seconds | `30` |
 | `FABRIK_MAX_CONCURRENT` | `max_concurrent` | Max parallel Claude sessions | `5` |
-| `FABRIK_MAX_RETRIES` | `max_retries` | Max retries before pausing (0 = unlimited) | `3` |
+| `FABRIK_MAX_RETRIES` | `max_retries` | Max retries before pausing (0 = unlimited). Genuine failures only — see `FABRIK_MAX_SLICE_RETRIES` for turn-cap preemptions | `3` |
+| `FABRIK_MAX_SLICE_RETRIES` | *(no config.yaml key)* | Maximum number of turn-cap preemption cycles per stage before pausing with `fabrik:paused` + `fabrik:awaiting-input` (positive integer; invalid or unset values default to 10). A large job resuming across several slices is not a failure and is bounded separately from `max_retries`. See `--max-slice-retries`. | `10` |
 | `FABRIK_AUTO_UPGRADE` | `auto_upgrade` | Self-upgrade at startup and when idle (after 2 idle polls) (`true`/`1`/`yes`) | `false` |
 | `FABRIK_TUI` | `tui` | Disable TUI dashboard (`false`/`0`/`no`) | `true` |
 | `FABRIK_PLUGIN_DIR` | *(no config.yaml key)* | Override plugin directory | `.fabrik/plugin/` |
@@ -1301,9 +1303,30 @@ When a stage doesn't complete (Claude doesn't output `FABRIK_STAGE_COMPLETE`):
    - A Claude account usage-limit exit (see the `fabrik:claude-limit` troubleshooting
      note above) is exempted from this count entirely — the stage never ran, so it
      never consumes a retry attempt
+   - A turn-cap preemption (the invocation ran out of turns and will resume on the
+     next dispatch) is likewise exempted — it counts against a separate slice
+     counter instead. See below.
 
 To resume after escalation: remove the `fabrik:paused` label. Fabrik will clear the
 failed label, reset the retry count, and try again immediately.
+
+> **Troubleshooting: an issue is paused with a "slice budget exceeded" comment,
+> not a failure comment.** `--max-retries` bounds genuine failures only — errors,
+> degenerate output, PR-creation failures. A turn-cap preemption (the invocation
+> hit its per-stage turn budget and stopped; the session resumes on the next
+> dispatch) is not a failure and is bounded separately by `--max-slice-retries`
+> (default 10). A large job that legitimately needs several slices completes
+> without pausing as long as it stays within that limit; only a job that keeps
+> hitting the turn cap `--max-slice-retries` times in a row is paused. The pause
+> comment names the specific cause and never says "failed to complete" — no
+> `stage:<name>:failed` label is applied, since the stage has not failed. It
+> applies `fabrik:paused` + `fabrik:awaiting-input` instead. To resume: either add
+> `fabrik:extend-turns` (grants a larger per-invocation turn budget, so fewer
+> slices are needed) or split the issue into smaller pieces, then remove
+> `fabrik:paused` and `fabrik:awaiting-input`. Removing the labels alone does not
+> reset the slice counter — it is already at the limit, so the very next
+> turn-cap exit re-pauses immediately unless the underlying job size or turn
+> budget actually changes. See #1199 and #1191.
 
 ### Stages Waiting for Input
 
@@ -4125,8 +4148,9 @@ In the conjunctive gate design (ADR 032), `stage:X:complete` is **withheld** unt
 | Column `<X>`, Locked + In Progress | No marker in output | `claudeRan` is true (includes both error-free runs and runs that errored mid-execution; excludes only start failures like binary-not-found) | Same column, Cooldown | | | `CooldownAt("periodic-re-eval")` recorded (via `CooldownRecorded`); cooldown = `PollSeconds * 10`; lock NOT released (stays locked through retries) |
 | Column `<X>`, Locked + In Progress | `FABRIK_STAGE_COMPLETE` present, but stripped output is degenerate (bare `@file`/absolute-path reference, §2.6) | `isDegenerateOutput(postOutput)` is true | Same column, Cooldown | | | Output not posted; `completed` forced to `false` before the marker-dispatch branches run; treated identically to "no marker in output" for retry purposes; first detection posts an immediate explanatory comment |
 | Same column, Cooldown | Poll tick | Cooldown expired | Same column, Locked + In Progress (retry) | | `stage:<X>:failed` (if present from prior escalation) | Claude re-invoked with `resume=true` |
-| Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && MaxRetries > 0` | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released |
-| Same column, Paused + Failed | Human removes `fabrik:paused` | `stage:<X>:failed` present OR `snap.PausedByEngine(stageName)` | Same column, Idle | | `stage:<X>:failed` | `clearFailedStage()` applies `StageRetryCleared`, `EngineUnpaused`, `StageLastAttemptCleared`, `EngineCyclesCleared` |
+| Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && !turnLimited && MaxRetries > 0` (genuine error, or a clean run that never emitted `FABRIK_STAGE_COMPLETE` — see §7.12 for why the latter counts here rather than as a slice) | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released; `Attempts` incremented via `StageRetryIncremented` (#1199 — `turnLimited` outcomes never reach this row; see the row below) |
+| Same column, Cooldown | Slice count ≥ MaxSliceRetries | `claudeRan && turnLimited && MaxSliceRetries > 0` | Same column, Paused + Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `pauseForSliceLimit()` posts a slice-budget comment (never "failed"); `SliceRetries` incremented via `SliceRetryIncremented`; **no** `stage:<X>:failed` — the stage has not failed (#1199, §7.12) |
+| Same column, Paused + Failed | Human removes `fabrik:paused` | `stage:<X>:failed` present OR `snap.PausedByEngine(stageName)` | Same column, Idle | | `stage:<X>:failed` | `clearFailedStage()` applies `StageRetryCleared` (also zeroes `SliceRetries` — the two counters share one reset point), `EngineUnpaused`, `StageLastAttemptCleared`, `EngineCyclesCleared` |
 
 > **In-flight items and cooldown (#544):** `CooldownAt("periodic-re-eval")` **is** stamped for in-flight items (those where a prior worker is still running at end-of-poll). Stamping is intentional: without it, once a prior expired cooldown ages out, the item would be re-admitted to the deep-fetch path on every poll cycle until the worker exits — causing repeated unnecessary deep-fetch evaluation work (and the fallback GraphQL fetch when the cache is invalidated or disabled) for items that can't be dispatched anyway (`snap.Worker() != nil` blocks them). The prompt re-dispatch after the worker finishes is guaranteed by `WorkerExited → WorkerLifecycleChanged`, which is in `wakeChFlags` and wakes the poll loop immediately. Note: `WorkerLifecycleChanged` is excluded from `cycleSetFlags` (Fix B, issue #576), so it does not bypass the cooldown gate via `mayNeedWork` — but the cooldown is already expired (or was already bypassed by an entry in cycleSet from earlier in the worker's lifecycle). See §2.14, §9.2, and §9.9.
 
@@ -4141,7 +4165,7 @@ In the conjunctive gate design (ADR 032), `stage:X:complete` is **withheld** unt
 >
 > Treat "turn limit hit" throughout this section as *this slice ended*, never as *this stage failed*. The distinction is load-bearing: the CLI reports it structurally as `subtype: "error_max_turns"` / `terminal_reason: "max_turns"` (captured since #1178), separate from a genuine fault, and the TUI renders it as `↻ (turn limit)` rather than `✗ (error)`.
 >
-> **Caveat — retry accounting does not yet match this model (#1199).** Today a turn-capped slice still calls `StageRetryIncremented` and is subject to the full `MaxRetries` escalation, exactly like a genuine failure — so a job needing more slices than `max_retries` is paused with `stage:<X>:failed` while progressing normally. `max_retries` is currently overloaded, bounding both genuine failures and total slices with one counter. This section describes what a turn cap *means*; it does not yet describe how the retry counter *treats* it. See #1199 and #1191.
+> **Retry accounting matches this model (#1199).** A turn-capped slice calls `SliceRetryIncremented`, not `StageRetryIncremented` — it is bounded by its own counter, `SliceRetries`/`MaxSliceRetries` (default 10), never by `MaxRetries` (default 3, unchanged). A job needing more slices than `max_retries` completes without pausing, as long as it stays within `MaxSliceRetries`. See §7.12 for the full detection/handling/recovery treatment, and #1191 for the operator-facing report this resolves.
 
 When Claude exits a stage invocation due to `max_turns` (i.e., the per-invocation turn usage satisfies `invUsage.TurnsUsed >= currentBudget` and `!completed && err == nil`), the engine evaluates whether to extend before entering the cooldown/retry path.
 
@@ -4175,8 +4199,8 @@ The "baseline clean AND working tree dirty" guard for Implement prevents a pre-e
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
 |--------------|-------|-------|-----------------|--------------|----------------|--------------|
 | Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple < 3`; progress detected | Same column, Locked + In Progress (extension) | | | `totalMultiple++`; `resume=true`; output accumulated; no WIP commit or push between extensions |
-| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; slice ends (a **preemption**, not a failure — the session resumes on the next dispatch). **However**: Cooldown still increments the retry counter, so per the Cooldown Retry table this can reach Paused + `stage:<X>:failed` once `MaxRetries` is hit — a preemption is not retry-free today (#1199). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
-| Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; slice ends (a **preemption**, not a failure). Same caveat as the row above: Cooldown still counts toward `MaxRetries` and can reach Paused + `stage:<X>:failed` (#1199). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
+| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; slice ends (a **preemption**, not a failure — the session resumes on the next dispatch). Cooldown routes this to the slice counter (`SliceRetries`/`MaxSliceRetries`), never `MaxRetries` — see the "Slice count ≥ MaxSliceRetries" row above and §7.12 (#1199). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
+| Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; slice ends (a **preemption**, not a failure). Same as the row above: Cooldown routes this to the slice counter, never `MaxRetries` (#1199, §7.12). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
 | Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE (any extension) | `completed = true` | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Normal completion flow; extend-turns label persists to next stage |
 
 #### Cleanup Stage
@@ -6056,6 +6080,79 @@ on `checkVersionSkew` for the same reasoning in code.
 **Non-goals.** No change to which conditions *produce* a warning, no TUI rendering change, and this is
 not a general warning-expiry/TTL mechanism — only subjects that have provably gone away (absent from a
 known-good set already computed elsewhere) are ever cleared. See ADR-1348.
+
+### 7.12 Slice Budget / Turn-Cap Preemption Limit
+
+`max_retries` (§7.2) is the **failure** counter: genuine errors, degenerate output, PR-creation
+failures, and a clean run that never emits `FABRIK_STAGE_COMPLETE`. It was previously overloaded to
+also bound turn-cap preemptions — a large job resuming across several slices looked identical to a
+stage that kept genuinely failing, so a job needing more slices than `max_retries` was paused with
+`stage:<X>:failed` while progressing normally (#816, #1114, #1183; reported independently as the
+undocumented `max_retries × max_turns` ceiling in #1191). §3.1's Turn Limit Extension subsection
+describes what a turn cap *means* — a resumable **preemption**, never a failure, per ADR-1178. This
+section describes how the retry accounting *treats* it (#1199).
+
+**The two counters:**
+
+| Counter | Field | Config | Default | Counts |
+|---------|-------|--------|---------|--------|
+| Failure counter | `StageState.Attempts` | `MaxRetries` / `--max-retries` / `FABRIK_MAX_RETRIES` | 3 (0 = unlimited) | Genuine errors, degenerate output, PR-creation failures, clean run with no completion marker |
+| Slice counter | `StageState.SliceRetries` | `MaxSliceRetries` / `--max-slice-retries` / `FABRIK_MAX_SLICE_RETRIES` | 10 | Turn-cap preemptions only (`turnLimited == true`, CLI `subtype: "error_max_turns"`) |
+
+The slice counter's default is intentionally higher than the failure counter's: a job legitimately
+needing several slices is routine, while a stage that keeps genuinely failing is not — the two want
+different bounds, which was exactly #1191's complaint about the single overloaded counter. `MaxRetries
+== 0` still means "unlimited failures"; there is no equivalent "unlimited slices" setting for
+`MaxSliceRetries` — it is resolved to its default (10) whenever configured as `0` or unset, the same
+tier `MaxRebaseCycles`/`MaxEnqueueCycles` use (flag + env only, no `config.yaml` field).
+
+**Detection:** `finalizeStageOutcome()` (`engine/item.go`) already computes `turnLimited :=
+errors.As(err, &turnLimitErr)` for the `InvocationRecorded` write (§3.1/ADR-1178) — the same boolean is
+reused here, so no new detection work exists. This is a *structural* signal (the CLI's own
+`subtype`/`terminal_reason`, captured since #1178), not an inference: distinguishing a preemption from a
+failure by a heuristic over output text would risk misclassifying either direction.
+
+**Handling:** Inside the existing non-completed/non-blocked `else` branch — after `StageAttempted`,
+`commitWIP`, the branch push, and `markCommentsSeenByStage` have already run unconditionally on
+`claudeRan` exactly as before (ADR-1178 requires this machinery keep running for a turn-cap exit; unlike
+§7.3's usage-limit exemption, which is a stage-never-ran early return, a turn-capped invocation *did*
+run and made progress) — the routing is a single branch on `turnLimited`:
+
+- **`turnLimited == true`:** applies `SliceRetryIncremented` (never `StageRetryIncremented`). If the
+  resulting `SliceRetries(stageName) >= MaxSliceRetries`, calls `pauseForSliceLimit()` instead of
+  `escalateFailedStage()` — modeled directly on the merge-gate's `pauseForRebaseCycleLimit` (§5, a live
+  in-production precedent for a second, independently-bounded, non-failure counter): posts a comment
+  that explicitly states this is not a failure, names
+  `--max-slice-retries`/`FABRIK_MAX_SLICE_RETRIES` as the override, and suggests `fabrik:extend-turns`
+  (wider per-invocation turn budget → fewer slices needed) or splitting the issue. Applies `fabrik:paused`
+  + `fabrik:awaiting-input` — **never** `stage:<X>:failed`. The degenerate-output first-detection comment
+  (§7.2) does not apply on this branch; degenerate output is a marker-content condition orthogonal to
+  `turnLimited`, and in practice a turn-capped exit's stripped output is never checked for it.
+- **`turnLimited == false`:** unchanged from before this issue — applies `StageRetryIncremented`,
+  compares to `MaxRetries`, escalates via `escalateFailedStage()` exactly as §7.2 describes. This covers
+  both a genuine error and a clean run with no completion marker.
+
+**The no-`FABRIK_STAGE_COMPLETE` decision (deferred by the issue to Plan):** a clean run
+(`err == nil`) that never emits `FABRIK_STAGE_COMPLETE` counts against the **failure** counter, not the
+slice counter. `turnLimited` is the only structurally verified signal available; a clean run with no
+marker has no equivalent structural signal distinguishing it from "stopped for an unknown reason," so it
+is treated the same as a genuine error rather than inferred to be a slice. This preserves today's
+(already narrow) protection against a silently-non-terminating stage.
+
+**Recovery:** `StageRetryCleared` — applied on normal stage completion and by `clearFailedStage()` on
+manual unpause — zeroes `SliceRetries(stageName)` alongside `Attempts(stageName)`; the two counters
+share one reset point. `pauseForSliceLimit()` does **not** apply `EnginePaused` or a `stage:<X>:failed`
+label (mirroring `pauseForRebaseCycleLimit` exactly), so a manual `fabrik:paused` +
+`fabrik:awaiting-input` removal alone does **not** reset `SliceRetries` — the counter is already at
+`MaxSliceRetries`, so the very next turn-cap exit re-escalates immediately. This is a deliberate,
+precedented gap (the identical shape exists for `RebaseCycles`/`MaxRebaseCycles`): the pause comment's
+suggested remedies (`fabrik:extend-turns`, splitting the issue) are the intended path to actually make
+progress, since `fabrik:extend-turns` widens the per-invocation turn budget and often lets the stage
+complete without hitting the cap again at all — at which point `StageRetryCleared` fires normally.
+
+**Regression guard:** a job that has already taken more turn-cap slices than `MaxRetries` (the old,
+accidental ceiling per #1191) is never paused as long as it stays within `MaxSliceRetries` — `Attempts`
+is untouched by any number of turn-cap preemptions.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6141,14 +6141,19 @@ is treated the same as a genuine error rather than inferred to be a slice. This 
 
 **Recovery:** `StageRetryCleared` — applied on normal stage completion and by `clearFailedStage()` on
 manual unpause — zeroes `SliceRetries(stageName)` alongside `Attempts(stageName)`; the two counters
-share one reset point. `pauseForSliceLimit()` does **not** apply `EnginePaused` or a `stage:<X>:failed`
-label (mirroring `pauseForRebaseCycleLimit` exactly), so a manual `fabrik:paused` +
-`fabrik:awaiting-input` removal alone does **not** reset `SliceRetries` — the counter is already at
-`MaxSliceRetries`, so the very next turn-cap exit re-escalates immediately. This is a deliberate,
-precedented gap (the identical shape exists for `RebaseCycles`/`MaxRebaseCycles`): the pause comment's
-suggested remedies (`fabrik:extend-turns`, splitting the issue) are the intended path to actually make
-progress, since `fabrik:extend-turns` widens the per-invocation turn budget and often lets the stage
-complete without hitting the cap again at all — at which point `StageRetryCleared` fires normally.
+share one reset point. Unlike `pauseForRebaseCycleLimit`, `pauseForSliceLimit()` **does** apply
+`itemstate.EnginePaused` (never `stage:<X>:failed`): `RebaseCycles` has an independent path back to
+progress (a human resolves the underlying merge conflict directly, which changes `settle.Status` and
+lets the poll loop advance without ever re-checking the counter), but `SliceRetries` has no such
+signal — the job simply needs more slices than the budget allowed, with nothing external to "fix."
+Without `EnginePaused`, `processItem()`'s unpause guard (`wasPaused || hasFailedLabel`, both false for
+a pure slice-limit pause) would never fire `clearFailedStage()`, `SliceRetries` would never reset, and
+removing `fabrik:paused` would be a no-op: the very next dispatch takes exactly one more slice,
+re-checks a counter already at `MaxSliceRetries`, and re-pauses immediately — the documented recovery
+path would not work. With `EnginePaused` applied, `snap.PausedByEngine(stageName)` is true on the next
+pass, so removing `fabrik:paused` genuinely triggers `clearFailedStage()` → `StageRetryCleared`, and
+the stage resumes with a fresh slice budget. `clearFailedStage()`'s `stage:<X>:failed` label removal is
+a harmless no-op on this path, since that label was never applied.
 
 **Regression guard:** a job that has already taken more turn-cap slices than `MaxRetries` (the old,
 accidental ceiling per #1191) is never paused as long as it stays within `MaxSliceRetries` — `Attempts`

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2748,14 +2748,19 @@ is treated the same as a genuine error rather than inferred to be a slice. This 
 
 **Recovery:** `StageRetryCleared` — applied on normal stage completion and by `clearFailedStage()` on
 manual unpause — zeroes `SliceRetries(stageName)` alongside `Attempts(stageName)`; the two counters
-share one reset point. `pauseForSliceLimit()` does **not** apply `EnginePaused` or a `stage:<X>:failed`
-label (mirroring `pauseForRebaseCycleLimit` exactly), so a manual `fabrik:paused` +
-`fabrik:awaiting-input` removal alone does **not** reset `SliceRetries` — the counter is already at
-`MaxSliceRetries`, so the very next turn-cap exit re-escalates immediately. This is a deliberate,
-precedented gap (the identical shape exists for `RebaseCycles`/`MaxRebaseCycles`): the pause comment's
-suggested remedies (`fabrik:extend-turns`, splitting the issue) are the intended path to actually make
-progress, since `fabrik:extend-turns` widens the per-invocation turn budget and often lets the stage
-complete without hitting the cap again at all — at which point `StageRetryCleared` fires normally.
+share one reset point. Unlike `pauseForRebaseCycleLimit`, `pauseForSliceLimit()` **does** apply
+`itemstate.EnginePaused` (never `stage:<X>:failed`): `RebaseCycles` has an independent path back to
+progress (a human resolves the underlying merge conflict directly, which changes `settle.Status` and
+lets the poll loop advance without ever re-checking the counter), but `SliceRetries` has no such
+signal — the job simply needs more slices than the budget allowed, with nothing external to "fix."
+Without `EnginePaused`, `processItem()`'s unpause guard (`wasPaused || hasFailedLabel`, both false for
+a pure slice-limit pause) would never fire `clearFailedStage()`, `SliceRetries` would never reset, and
+removing `fabrik:paused` would be a no-op: the very next dispatch takes exactly one more slice,
+re-checks a counter already at `MaxSliceRetries`, and re-pauses immediately — the documented recovery
+path would not work. With `EnginePaused` applied, `snap.PausedByEngine(stageName)` is true on the next
+pass, so removing `fabrik:paused` genuinely triggers `clearFailedStage()` → `StageRetryCleared`, and
+the stage resumes with a fresh slice budget. `clearFailedStage()`'s `stage:<X>:failed` label removal is
+a harmless no-op on this path, since that label was never applied.
 
 **Regression guard:** a job that has already taken more turn-cap slices than `MaxRetries` (the old,
 accidental ceiling per #1191) is never paused as long as it stays within `MaxSliceRetries` — `Attempts`

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -755,8 +755,9 @@ In the conjunctive gate design (ADR 032), `stage:X:complete` is **withheld** unt
 | Column `<X>`, Locked + In Progress | No marker in output | `claudeRan` is true (includes both error-free runs and runs that errored mid-execution; excludes only start failures like binary-not-found) | Same column, Cooldown | | | `CooldownAt("periodic-re-eval")` recorded (via `CooldownRecorded`); cooldown = `PollSeconds * 10`; lock NOT released (stays locked through retries) |
 | Column `<X>`, Locked + In Progress | `FABRIK_STAGE_COMPLETE` present, but stripped output is degenerate (bare `@file`/absolute-path reference, §2.6) | `isDegenerateOutput(postOutput)` is true | Same column, Cooldown | | | Output not posted; `completed` forced to `false` before the marker-dispatch branches run; treated identically to "no marker in output" for retry purposes; first detection posts an immediate explanatory comment |
 | Same column, Cooldown | Poll tick | Cooldown expired | Same column, Locked + In Progress (retry) | | `stage:<X>:failed` (if present from prior escalation) | Claude re-invoked with `resume=true` |
-| Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && MaxRetries > 0` | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released |
-| Same column, Paused + Failed | Human removes `fabrik:paused` | `stage:<X>:failed` present OR `snap.PausedByEngine(stageName)` | Same column, Idle | | `stage:<X>:failed` | `clearFailedStage()` applies `StageRetryCleared`, `EngineUnpaused`, `StageLastAttemptCleared`, `EngineCyclesCleared` |
+| Same column, Cooldown | Retry count ≥ MaxRetries | `claudeRan && !turnLimited && MaxRetries > 0` (genuine error, or a clean run that never emitted `FABRIK_STAGE_COMPLETE` — see §7.12 for why the latter counts here rather than as a slice) | Same column, Paused + Failed | `fabrik:paused`, `stage:<X>:failed` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `escalateFailedStage()` posts comment; lock released; `Attempts` incremented via `StageRetryIncremented` (#1199 — `turnLimited` outcomes never reach this row; see the row below) |
+| Same column, Cooldown | Slice count ≥ MaxSliceRetries | `claudeRan && turnLimited && MaxSliceRetries > 0` | Same column, Paused + Awaiting Input | `fabrik:paused`, `fabrik:awaiting-input` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | `pauseForSliceLimit()` posts a slice-budget comment (never "failed"); `SliceRetries` incremented via `SliceRetryIncremented`; **no** `stage:<X>:failed` — the stage has not failed (#1199, §7.12) |
+| Same column, Paused + Failed | Human removes `fabrik:paused` | `stage:<X>:failed` present OR `snap.PausedByEngine(stageName)` | Same column, Idle | | `stage:<X>:failed` | `clearFailedStage()` applies `StageRetryCleared` (also zeroes `SliceRetries` — the two counters share one reset point), `EngineUnpaused`, `StageLastAttemptCleared`, `EngineCyclesCleared` |
 
 > **In-flight items and cooldown (#544):** `CooldownAt("periodic-re-eval")` **is** stamped for in-flight items (those where a prior worker is still running at end-of-poll). Stamping is intentional: without it, once a prior expired cooldown ages out, the item would be re-admitted to the deep-fetch path on every poll cycle until the worker exits — causing repeated unnecessary deep-fetch evaluation work (and the fallback GraphQL fetch when the cache is invalidated or disabled) for items that can't be dispatched anyway (`snap.Worker() != nil` blocks them). The prompt re-dispatch after the worker finishes is guaranteed by `WorkerExited → WorkerLifecycleChanged`, which is in `wakeChFlags` and wakes the poll loop immediately. Note: `WorkerLifecycleChanged` is excluded from `cycleSetFlags` (Fix B, issue #576), so it does not bypass the cooldown gate via `mayNeedWork` — but the cooldown is already expired (or was already bypassed by an entry in cycleSet from earlier in the worker's lifecycle). See §2.14, §9.2, and §9.9.
 
@@ -771,7 +772,7 @@ In the conjunctive gate design (ADR 032), `stage:X:complete` is **withheld** unt
 >
 > Treat "turn limit hit" throughout this section as *this slice ended*, never as *this stage failed*. The distinction is load-bearing: the CLI reports it structurally as `subtype: "error_max_turns"` / `terminal_reason: "max_turns"` (captured since #1178), separate from a genuine fault, and the TUI renders it as `↻ (turn limit)` rather than `✗ (error)`.
 >
-> **Caveat — retry accounting does not yet match this model (#1199).** Today a turn-capped slice still calls `StageRetryIncremented` and is subject to the full `MaxRetries` escalation, exactly like a genuine failure — so a job needing more slices than `max_retries` is paused with `stage:<X>:failed` while progressing normally. `max_retries` is currently overloaded, bounding both genuine failures and total slices with one counter. This section describes what a turn cap *means*; it does not yet describe how the retry counter *treats* it. See #1199 and #1191.
+> **Retry accounting matches this model (#1199).** A turn-capped slice calls `SliceRetryIncremented`, not `StageRetryIncremented` — it is bounded by its own counter, `SliceRetries`/`MaxSliceRetries` (default 10), never by `MaxRetries` (default 3, unchanged). A job needing more slices than `max_retries` completes without pausing, as long as it stays within `MaxSliceRetries`. See §7.12 for the full detection/handling/recovery treatment, and #1191 for the operator-facing report this resolves.
 
 When Claude exits a stage invocation due to `max_turns` (i.e., the per-invocation turn usage satisfies `invUsage.TurnsUsed >= currentBudget` and `!completed && err == nil`), the engine evaluates whether to extend before entering the cooldown/retry path.
 
@@ -805,8 +806,8 @@ The "baseline clean AND working tree dirty" guard for Implement prevents a pre-e
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
 |--------------|-------|-------|-----------------|--------------|----------------|--------------|
 | Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple < 3`; progress detected | Same column, Locked + In Progress (extension) | | | `totalMultiple++`; `resume=true`; output accumulated; no WIP commit or push between extensions |
-| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; slice ends (a **preemption**, not a failure — the session resumes on the next dispatch). **However**: Cooldown still increments the retry counter, so per the Cooldown Retry table this can reach Paused + `stage:<X>:failed` once `MaxRetries` is hit — a preemption is not retry-free today (#1199). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
-| Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; slice ends (a **preemption**, not a failure). Same caveat as the row above: Cooldown still counts toward `MaxRetries` and can reach Paused + `stage:<X>:failed` (#1199). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
+| Column `<X>`, Locked + In Progress | Turn limit hit | `totalMultiple >= 3` (hard cap) | Same column, Cooldown | | | Hard cap reached; slice ends (a **preemption**, not a failure — the session resumes on the next dispatch). Cooldown routes this to the slice counter (`SliceRetries`/`MaxSliceRetries`), never `MaxRetries` — see the "Slice count ≥ MaxSliceRetries" row above and §7.12 (#1199). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
+| Column `<X>`, Locked + In Progress | Turn limit hit | No progress detected or progress check failed | Same column, Cooldown | | | No extension; slice ends (a **preemption**, not a failure). Same as the row above: Cooldown routes this to the slice counter, never `MaxRetries` (#1199, §7.12). `CooldownAt("periodic-re-eval")` recorded; WIP commit + push (skipped for `read_only` stages) |
 | Column `<X>`, Locked + In Progress | FABRIK_STAGE_COMPLETE (any extension) | `completed = true` | Same column, Complete | `stage:<X>:complete` | `fabrik:locked:<user>`, `stage:<X>:in_progress` | Normal completion flow; extend-turns label persists to next stage |
 
 #### Cleanup Stage
@@ -2686,6 +2687,79 @@ on `checkVersionSkew` for the same reasoning in code.
 **Non-goals.** No change to which conditions *produce* a warning, no TUI rendering change, and this is
 not a general warning-expiry/TTL mechanism — only subjects that have provably gone away (absent from a
 known-good set already computed elsewhere) are ever cleared. See ADR-1348.
+
+### 7.12 Slice Budget / Turn-Cap Preemption Limit
+
+`max_retries` (§7.2) is the **failure** counter: genuine errors, degenerate output, PR-creation
+failures, and a clean run that never emits `FABRIK_STAGE_COMPLETE`. It was previously overloaded to
+also bound turn-cap preemptions — a large job resuming across several slices looked identical to a
+stage that kept genuinely failing, so a job needing more slices than `max_retries` was paused with
+`stage:<X>:failed` while progressing normally (#816, #1114, #1183; reported independently as the
+undocumented `max_retries × max_turns` ceiling in #1191). §3.1's Turn Limit Extension subsection
+describes what a turn cap *means* — a resumable **preemption**, never a failure, per ADR-1178. This
+section describes how the retry accounting *treats* it (#1199).
+
+**The two counters:**
+
+| Counter | Field | Config | Default | Counts |
+|---------|-------|--------|---------|--------|
+| Failure counter | `StageState.Attempts` | `MaxRetries` / `--max-retries` / `FABRIK_MAX_RETRIES` | 3 (0 = unlimited) | Genuine errors, degenerate output, PR-creation failures, clean run with no completion marker |
+| Slice counter | `StageState.SliceRetries` | `MaxSliceRetries` / `--max-slice-retries` / `FABRIK_MAX_SLICE_RETRIES` | 10 | Turn-cap preemptions only (`turnLimited == true`, CLI `subtype: "error_max_turns"`) |
+
+The slice counter's default is intentionally higher than the failure counter's: a job legitimately
+needing several slices is routine, while a stage that keeps genuinely failing is not — the two want
+different bounds, which was exactly #1191's complaint about the single overloaded counter. `MaxRetries
+== 0` still means "unlimited failures"; there is no equivalent "unlimited slices" setting for
+`MaxSliceRetries` — it is resolved to its default (10) whenever configured as `0` or unset, the same
+tier `MaxRebaseCycles`/`MaxEnqueueCycles` use (flag + env only, no `config.yaml` field).
+
+**Detection:** `finalizeStageOutcome()` (`engine/item.go`) already computes `turnLimited :=
+errors.As(err, &turnLimitErr)` for the `InvocationRecorded` write (§3.1/ADR-1178) — the same boolean is
+reused here, so no new detection work exists. This is a *structural* signal (the CLI's own
+`subtype`/`terminal_reason`, captured since #1178), not an inference: distinguishing a preemption from a
+failure by a heuristic over output text would risk misclassifying either direction.
+
+**Handling:** Inside the existing non-completed/non-blocked `else` branch — after `StageAttempted`,
+`commitWIP`, the branch push, and `markCommentsSeenByStage` have already run unconditionally on
+`claudeRan` exactly as before (ADR-1178 requires this machinery keep running for a turn-cap exit; unlike
+§7.3's usage-limit exemption, which is a stage-never-ran early return, a turn-capped invocation *did*
+run and made progress) — the routing is a single branch on `turnLimited`:
+
+- **`turnLimited == true`:** applies `SliceRetryIncremented` (never `StageRetryIncremented`). If the
+  resulting `SliceRetries(stageName) >= MaxSliceRetries`, calls `pauseForSliceLimit()` instead of
+  `escalateFailedStage()` — modeled directly on the merge-gate's `pauseForRebaseCycleLimit` (§5, a live
+  in-production precedent for a second, independently-bounded, non-failure counter): posts a comment
+  that explicitly states this is not a failure, names
+  `--max-slice-retries`/`FABRIK_MAX_SLICE_RETRIES` as the override, and suggests `fabrik:extend-turns`
+  (wider per-invocation turn budget → fewer slices needed) or splitting the issue. Applies `fabrik:paused`
+  + `fabrik:awaiting-input` — **never** `stage:<X>:failed`. The degenerate-output first-detection comment
+  (§7.2) does not apply on this branch; degenerate output is a marker-content condition orthogonal to
+  `turnLimited`, and in practice a turn-capped exit's stripped output is never checked for it.
+- **`turnLimited == false`:** unchanged from before this issue — applies `StageRetryIncremented`,
+  compares to `MaxRetries`, escalates via `escalateFailedStage()` exactly as §7.2 describes. This covers
+  both a genuine error and a clean run with no completion marker.
+
+**The no-`FABRIK_STAGE_COMPLETE` decision (deferred by the issue to Plan):** a clean run
+(`err == nil`) that never emits `FABRIK_STAGE_COMPLETE` counts against the **failure** counter, not the
+slice counter. `turnLimited` is the only structurally verified signal available; a clean run with no
+marker has no equivalent structural signal distinguishing it from "stopped for an unknown reason," so it
+is treated the same as a genuine error rather than inferred to be a slice. This preserves today's
+(already narrow) protection against a silently-non-terminating stage.
+
+**Recovery:** `StageRetryCleared` — applied on normal stage completion and by `clearFailedStage()` on
+manual unpause — zeroes `SliceRetries(stageName)` alongside `Attempts(stageName)`; the two counters
+share one reset point. `pauseForSliceLimit()` does **not** apply `EnginePaused` or a `stage:<X>:failed`
+label (mirroring `pauseForRebaseCycleLimit` exactly), so a manual `fabrik:paused` +
+`fabrik:awaiting-input` removal alone does **not** reset `SliceRetries` — the counter is already at
+`MaxSliceRetries`, so the very next turn-cap exit re-escalates immediately. This is a deliberate,
+precedented gap (the identical shape exists for `RebaseCycles`/`MaxRebaseCycles`): the pause comment's
+suggested remedies (`fabrik:extend-turns`, splitting the issue) are the intended path to actually make
+progress, since `fabrik:extend-turns` widens the per-invocation turn budget and often lets the stage
+complete without hitting the cap again at all — at which point `StageRetryCleared` fires normally.
+
+**Regression guard:** a job that has already taken more turn-cap slices than `MaxRetries` (the old,
+accidental ceiling per #1191) is never paused as long as it stays within `MaxSliceRetries` — `Attempts`
+is untouched by any number of turn-cap preemptions.
 
 ---
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -31,6 +31,7 @@ type Config struct {
 	PollSeconds               int
 	MaxConcurrent             int
 	MaxRetries                int
+	MaxSliceRetries           int // Max turn-cap preemption ("slice") cycles per stage before pausing (default 10; #1199) — bounds a non-converging job independently of MaxRetries, which counts only genuine failures
 	ReviewWaitTimeout         time.Duration       // How long to wait for PR reviewers before auto-advancing anyway (default 15m)
 	ReconcileInterval         time.Duration       // Reconcile ticker cadence (0 = use lightReconcileInterval default of 3m)
 	MaxReviewCycles           int                 // Max review re-invocation cycles per issue before pausing (default 5)

--- a/engine/item.go
+++ b/engine/item.go
@@ -1536,25 +1536,48 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 		e.logf(item.Number, "wait", "stage %q did not complete — will retry after %v\n", stage.Name, cooldown)
 		// Escalation is decided before stall-hint arming (see below) so arming can be
 		// skipped on the attempt that triggers it.
-		willEscalate := false
-		if claudeRan && e.cfg.MaxRetries > 0 {
-			e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
-			var count int
-			if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
-				count = snap.Attempts(stage.Name)
+		//
+		// A turn-cap preemption (turnLimited) is routed to the SliceRetries counter
+		// instead of Attempts/MaxRetries: the CLI's own structural signal (subtype
+		// error_max_turns) says the session ended by running out of turns, not by
+		// failing — it is a resumable time-slice of a job that is still progressing,
+		// and must not count toward "this keeps breaking, stop." A non-turn-limited
+		// outcome (genuine error, or a clean run that never emitted
+		// FABRIK_STAGE_COMPLETE) has no equivalent structural signal distinguishing
+		// it from a failure, so both continue to count against Attempts/MaxRetries
+		// exactly as before (#1199).
+		willEscalateFailure := false
+		willEscalateSlice := false
+		var sliceCount int
+		if claudeRan {
+			if turnLimited {
+				if e.cfg.MaxSliceRetries > 0 {
+					e.store.Apply(itemstate.SliceRetryIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+					if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
+						sliceCount = snap.SliceRetries(stage.Name)
+					}
+					willEscalateSlice = sliceCount >= e.cfg.MaxSliceRetries
+				}
+			} else if e.cfg.MaxRetries > 0 {
+				e.store.Apply(itemstate.StageRetryIncremented{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+				var count int
+				if snap, snapErr := e.store.Get(repoStr, item.Number); snapErr == nil {
+					count = snap.Attempts(stage.Name)
+				}
+				if degenerateReason != "" && count == 1 && count < e.cfg.MaxRetries {
+					// Surface the problem immediately on first detection rather than staying
+					// silent until MaxRetries is hit — matches the existing empty-output
+					// warning's visibility level.
+					warnComment := fmt.Sprintf(
+						"🏭 **Fabrik — degenerate stage output**\n\nStage **%s** produced output that was just a bare file reference (`%s`) instead of real content, likely because the model wrote its output to a file and returned a dangling reference. The comment was not posted and the stage did not advance; it will be retried.",
+						stage.Name, degenerateReason,
+					)
+					e.postItemComment(item, warnComment, true)
+				}
+				willEscalateFailure = count >= e.cfg.MaxRetries
 			}
-			if degenerateReason != "" && count == 1 && count < e.cfg.MaxRetries {
-				// Surface the problem immediately on first detection rather than staying
-				// silent until MaxRetries is hit — matches the existing empty-output
-				// warning's visibility level.
-				warnComment := fmt.Sprintf(
-					"🏭 **Fabrik — degenerate stage output**\n\nStage **%s** produced output that was just a bare file reference (`%s`) instead of real content, likely because the model wrote its output to a file and returned a dangling reference. The comment was not posted and the stage did not advance; it will be retried.",
-					stage.Name, degenerateReason,
-				)
-				e.postItemComment(item, warnComment, true)
-			}
-			willEscalate = count >= e.cfg.MaxRetries
 		}
+		willEscalate := willEscalateFailure || willEscalateSlice
 		// Stall detection/recording is independent of MaxRetries: max_retries: 0 is a
 		// first-class "unlimited retries" config, not an edge case, and is exactly the
 		// setting where a stalled stage would otherwise grind identical retries forever
@@ -1587,8 +1610,11 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 		if claudeRan && !willEscalate {
 			e.detectAndArmStallHint(item, stage, repoStr, usage, err == nil || turnLimited)
 		}
-		if willEscalate {
+		if willEscalateFailure {
 			e.escalateFailedStage(item, stage, degenerateReason)
+			releaseLock() // permanently giving up — release the lock
+		} else if willEscalateSlice {
+			e.pauseForSliceLimit(item, stage, sliceCount, e.cfg.MaxSliceRetries)
 			releaseLock() // permanently giving up — release the lock
 		}
 	}
@@ -1731,6 +1757,32 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage, r
 
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+}
+
+// pauseForSliceLimit pauses the issue when a stage has hit its turn cap
+// (subtype error_max_turns) too many times in a row — the job is not failing,
+// it is simply larger than its per-invocation slice budget allows within
+// MaxSliceRetries resumptions. Modeled directly on pauseForRebaseCycleLimit:
+// a distinct, independently-bounded counter with its own non-failure message,
+// fabrik:paused + fabrik:awaiting-input, and deliberately no stage:<name>:failed
+// label — the stage has not failed (#1199).
+func (e *Engine) pauseForSliceLimit(item gh.ProjectItem, stage *stages.Stage, sliceCount, maxSliceRetries int) {
+	e.logf(item.Number, "slice-limit", "slice limit %d reached for stage %q — pausing (not a failure)\n", maxSliceRetries, stage.Name)
+
+	comment := fmt.Sprintf(
+		"🏭 **Fabrik — slice budget exceeded**\n\nStage **%s** has hit its turn cap %d time(s), which has reached the configured limit of %d "+
+			"(override with `--max-slice-retries` or `FABRIK_MAX_SLICE_RETRIES`).\n\n"+
+			"This is not a failure — each turn-cap exit resumes from where it left off, and the cost/turns-used trend rising across "+
+			"slices is exactly what accumulating progress looks like. The work is simply larger than its per-invocation turn budget "+
+			"allows within this many resumptions.\n\n"+
+			"Fabrik has paused this issue. To continue: add `fabrik:extend-turns` to grant larger per-invocation slices, or split the "+
+			"issue into smaller pieces, then remove the `fabrik:paused` and `fabrik:awaiting-input` labels to resume.",
+		stage.Name, sliceCount, maxSliceRetries,
+	)
+	e.pauseIssue(item, comment, pauseOpts{
+		awaitingInput: true,
+		reactRocket:   true,
+	})
 }
 
 // clearFailedStage is called when the user removes fabrik:paused from an issue

--- a/engine/item.go
+++ b/engine/item.go
@@ -1766,6 +1766,22 @@ func (e *Engine) escalateFailedStage(item gh.ProjectItem, stage *stages.Stage, r
 // a distinct, independently-bounded counter with its own non-failure message,
 // fabrik:paused + fabrik:awaiting-input, and deliberately no stage:<name>:failed
 // label — the stage has not failed (#1199).
+//
+// Unlike pauseForRebaseCycleLimit, this DOES apply itemstate.EnginePaused. The
+// rebase-cycle counter has an independent path back to progress: a human fixes
+// the underlying conflict directly, which changes settle.Status and lets the
+// poll loop advance without ever re-checking RebaseCycles. SliceRetries has no
+// such independent signal — the job simply needs more slices than the budget
+// allowed, and there is nothing to "fix" except widening the budget or
+// resetting the counter. Without EnginePaused, processItem's unpause guard
+// (wasPaused || hasFailedLabel, both false for this pause) never fires
+// clearFailedStage, SliceRetries never resets, and the documented "remove
+// fabrik:paused to resume" recovery is a no-op: the very next dispatch takes
+// exactly one more slice, re-hits a counter already at MaxSliceRetries, and
+// re-pauses immediately. Applying EnginePaused makes wasPaused true on the
+// next pass, so clearFailedStage's StageRetryCleared genuinely resets
+// SliceRetries — clearFailedStage's stage:<name>:failed removal is a
+// harmless no-op here since that label was never applied (#1199 review).
 func (e *Engine) pauseForSliceLimit(item gh.ProjectItem, stage *stages.Stage, sliceCount, maxSliceRetries int) {
 	e.logf(item.Number, "slice-limit", "slice limit %d reached for stage %q — pausing (not a failure)\n", maxSliceRetries, stage.Name)
 
@@ -1783,11 +1799,17 @@ func (e *Engine) pauseForSliceLimit(item gh.ProjectItem, stage *stages.Stage, sl
 		awaitingInput: true,
 		reactRocket:   true,
 	})
+
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 }
 
 // clearFailedStage is called when the user removes fabrik:paused from an issue
-// that was paused by the engine due to max retries. It removes the stage:<name>:failed
-// label and resets the retry count so the stage can be attempted again.
+// that was paused by the engine — either due to max retries (stage:<name>:failed
+// present) or a turn-cap slice budget exceeded (no failed label, only
+// PausedByEngine set by pauseForSliceLimit; #1199). It removes the
+// stage:<name>:failed label (a harmless no-op when it was never applied) and
+// resets both the failure and slice counters so the stage can be attempted again.
 func (e *Engine) clearFailedStage(item gh.ProjectItem, stage *stages.Stage) {
 	e.logf(item.Number, "unpause", "clearing failed stage %q after manual unpause\n", stage.Name)
 

--- a/engine/slice_retry_test.go
+++ b/engine/slice_retry_test.go
@@ -1,0 +1,234 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// TestTurnCapPreemption_IncrementsSliceRetriesOnly verifies the core #1199 fix:
+// a turn-cap exit (CLI subtype error_max_turns, surfaced as *claudeTurnLimitError)
+// increments the new SliceRetries counter, not Attempts, and must not apply
+// stage:<name>:failed or fabrik:paused — it is a resumable preemption, not a
+// failure.
+func TestTurnCapPreemption_IncrementsSliceRetriesOnly(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{TurnsUsed: 50, MaxTurns: 50},
+				&claudeTurnLimitError{TerminalReason: "max_turns", NumTurns: 50}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 5, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 200, Title: "Turn-cap test", Status: "Research", ItemID: "PVTI_200"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 200)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.SliceRetries("Research"); got != 1 {
+		t.Errorf("SliceRetries(\"Research\") = %d, want 1 (turn-cap exit must count as a slice)", got)
+	}
+	if got := snap.Attempts("Research"); got != 0 {
+		t.Errorf("Attempts(\"Research\") = %d, want 0 (turn-cap exit must NOT count against max_retries)", got)
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Research:failed" {
+			t.Error("stage:Research:failed must NOT be applied for a turn-cap preemption — it has not failed")
+		}
+		if c.labelName == "fabrik:paused" {
+			t.Error("should not pause on a single slice, well below MaxSliceRetries")
+		}
+	}
+}
+
+// TestGenuineError_IncrementsFailureCounterOnly_NotSlice verifies that a
+// non-turn-limited error keeps counting against Attempts/MaxRetries exactly as
+// before, and never touches SliceRetries — the two counters are structurally
+// distinguished by turnLimited, not by inference.
+func TestGenuineError_IncrementsFailureCounterOnly_NotSlice(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{}, errors.New("some genuine transient failure")
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 5, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 201, Title: "Genuine error test", Status: "Research", ItemID: "PVTI_201"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 201)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.Attempts("Research"); got != 1 {
+		t.Errorf("Attempts(\"Research\") = %d, want 1 (genuine failure must count against max_retries)", got)
+	}
+	if got := snap.SliceRetries("Research"); got != 0 {
+		t.Errorf("SliceRetries(\"Research\") = %d, want 0 (a genuine error is not a slice)", got)
+	}
+}
+
+// TestSliceLimit_Escalates_WithCorrectMessage_NoFailedLabel verifies that
+// exceeding MaxSliceRetries pauses the issue (fabrik:paused + fabrik:awaiting-input,
+// mirroring pauseForRebaseCycleLimit) without ever applying stage:<name>:failed,
+// and that the posted comment describes a slice-budget condition, not a failure.
+func TestSliceLimit_Escalates_WithCorrectMessage_NoFailedLabel(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{TurnsUsed: 50, MaxTurns: 50},
+				&claudeTurnLimitError{TerminalReason: "max_turns", NumTurns: 50}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 3, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	// Pre-fill SliceRetries to one below the limit so this invocation is the one
+	// that crosses it.
+	for i := 0; i < eng.cfg.MaxSliceRetries-1; i++ {
+		eng.store.Apply(itemstate.SliceRetryIncremented{Repo: "owner/repo", Number: 202, StageName: "Research"})
+	}
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 202, Title: "Slice limit test", Status: "Research", ItemID: "PVTI_202"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 202)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.SliceRetries("Research"); got != eng.cfg.MaxSliceRetries {
+		t.Errorf("SliceRetries(\"Research\") = %d, want %d (at the limit)", got, eng.cfg.MaxSliceRetries)
+	}
+
+	wantAdded := map[string]bool{"fabrik:paused": false, "fabrik:awaiting-input": false}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Research:failed" {
+			t.Error("stage:Research:failed must NOT be applied when the slice budget is exceeded — it has not failed")
+		}
+		if _, ok := wantAdded[c.labelName]; ok {
+			wantAdded[c.labelName] = true
+		}
+	}
+	for label, found := range wantAdded {
+		if !found {
+			t.Errorf("expected label %q to be added on slice-limit escalation", label)
+		}
+	}
+
+	if len(client.addCommentCalls) == 0 {
+		t.Fatal("expected a slice-limit comment to be posted")
+	}
+	body := client.addCommentCalls[len(client.addCommentCalls)-1].body
+	if strings.Contains(body, "failed to complete after") {
+		t.Errorf("comment must not describe this as a failure, got: %q", body)
+	}
+	if !strings.Contains(body, "slice budget") {
+		t.Errorf("comment should mention 'slice budget', got: %q", body)
+	}
+	if !strings.Contains(body, "--max-slice-retries") {
+		t.Errorf("comment should name the override flag --max-slice-retries, got: %q", body)
+	}
+	if !strings.Contains(body, "fabrik:extend-turns") {
+		t.Errorf("comment should suggest fabrik:extend-turns, got: %q", body)
+	}
+}
+
+// TestJobExceedingMaxRetriesSlices_DoesNotPause verifies the issue's headline
+// Definition-of-Done claim: a job that has taken more turn-cap slices than
+// MaxRetries (the old, overloaded ceiling) is not paused, as long as it is still
+// within MaxSliceRetries — the two counters are now independent.
+func TestJobExceedingMaxRetriesSlices_DoesNotPause(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{TurnsUsed: 50, MaxTurns: 50},
+				&claudeTurnLimitError{TerminalReason: "max_turns", NumTurns: 50}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 10, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	// Simulate a job already 5 slices in — more than MaxRetries (2) but well
+	// under MaxSliceRetries (10).
+	for i := 0; i < 5; i++ {
+		eng.store.Apply(itemstate.SliceRetryIncremented{Repo: "owner/repo", Number: 203, StageName: "Research"})
+	}
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 203, Title: "Large job test", Status: "Research", ItemID: "PVTI_203"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 203)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.SliceRetries("Research"); got != 6 {
+		t.Errorf("SliceRetries(\"Research\") = %d, want 6", got)
+	}
+	if got := snap.Attempts("Research"); got != 0 {
+		t.Errorf("Attempts(\"Research\") = %d, want 0 — slices never touch the failure counter", got)
+	}
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" || c.labelName == "stage:Research:failed" {
+			t.Errorf("must not pause/fail a job that has exceeded MaxRetries in slices alone (label %q added)", c.labelName)
+		}
+	}
+}

--- a/engine/slice_retry_test.go
+++ b/engine/slice_retry_test.go
@@ -232,3 +232,295 @@ func TestJobExceedingMaxRetriesSlices_DoesNotPause(t *testing.T) {
 		}
 	}
 }
+
+// TestSliceLimit_ManualUnpauseResetsSliceRetries verifies the review fix for #1199:
+// pauseForSliceLimit applies itemstate.EnginePaused (unlike pauseForRebaseCycleLimit,
+// whose counter has an independent path back to progress — a human resolves the
+// underlying merge conflict directly, changing settle.Status). SliceRetries has no
+// such independent signal, so without EnginePaused, processItem's unpause guard
+// (wasPaused || hasFailedLabel — both false after a slice-limit pause, since no
+// failed label is ever applied) would never fire clearFailedStage, SliceRetries
+// would never reset, and the pause comment's own documented recovery ("remove
+// fabrik:paused to resume") would be a no-op: the next dispatch takes exactly one
+// more slice, re-checks a counter already at the limit, and re-pauses immediately.
+//
+// This test drives the real pauseForSliceLimit call site (via two turn-capped
+// processItem calls, not a hand-rolled store mutation) to prove the escalation path
+// itself sets PausedByEngine, then simulates the user removing fabrik:paused and
+// asserts the COUNTER resets — not merely the pause flag/label, which the review
+// flagged as the vacuous assertion a naive test would settle for.
+func TestSliceLimit_ManualUnpauseResetsSliceRetries(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{TurnsUsed: 50, MaxTurns: 50},
+				&claudeTurnLimitError{TerminalReason: "max_turns", NumTurns: 50}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 2, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 210, Title: "Slice unpause test", Status: "Research", ItemID: "PVTI_210"}
+
+	// Call 1: SliceRetries 0 -> 1, below MaxSliceRetries(2), no pause.
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (1st): %v", err)
+	}
+	// Call 2: SliceRetries 1 -> 2, hits MaxSliceRetries — pauseForSliceLimit fires
+	// for real, through the actual escalation code path.
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (2nd): %v", err)
+	}
+
+	snap, err := eng.store.Get("owner/repo", 210)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.SliceRetries("Research"); got != eng.cfg.MaxSliceRetries {
+		t.Fatalf("SliceRetries after escalation = %d, want %d", got, eng.cfg.MaxSliceRetries)
+	}
+	if !snap.PausedByEngine("Research") {
+		t.Fatal("expected PausedByEngine to be true after pauseForSliceLimit — without this, removing fabrik:paused can never reset SliceRetries (the fix under test)")
+	}
+
+	// Simulate the user removing fabrik:paused and fabrik:awaiting-input: a fresh
+	// item value with no such labels, same issue number, same store. processItem
+	// resets SliceRetries via clearFailedStage AND, since nothing else stops it,
+	// immediately resumes dispatch within this same call — so the post-unpause
+	// snapshot reflects "reset to 0, then one fresh slice" (1), not a bare 0. What
+	// matters is that the counter did NOT stay stuck at the limit: if the reset had
+	// not happened (the bug under test), this same turn-capped dispatch would have
+	// pushed 2 -> 3 and immediately re-paused instead.
+	unpausedItem := gh.ProjectItem{Number: 210, Title: "Slice unpause test", Status: "Research", ItemID: "PVTI_210", Labels: []string{}}
+	if err := eng.processItem(context.Background(), board, unpausedItem); err != nil {
+		t.Fatalf("processItem (unpause): %v", err)
+	}
+
+	snap, err = eng.store.Get("owner/repo", 210)
+	if err != nil {
+		t.Fatalf("store.Get after unpause: %v", err)
+	}
+	// The assertion the review specifically called out as missing: the COUNTER
+	// must genuinely reset (and only accrue one fresh slice from the resumed
+	// dispatch), not merely the pause label/flag, and not stay pinned at the limit.
+	if got := snap.SliceRetries("Research"); got != 1 {
+		t.Errorf("SliceRetries after manual unpause = %d, want 1 (reset to 0 by clearFailedStage, then one fresh slice from the resumed dispatch — not stuck at the limit)", got)
+	}
+	if snap.PausedByEngine("Research") {
+		t.Error("expected PausedByEngine to be cleared after unpause, and not immediately re-paused by the resumed dispatch")
+	}
+
+	pausedCount := 0
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedCount++
+		}
+	}
+	if pausedCount != 1 {
+		t.Errorf("fabrik:paused applied %d time(s) across the whole test, want 1 (only the original escalation — a stuck counter would re-pause immediately after unpause)", pausedCount)
+	}
+}
+
+// TestSliceLimit_UnpauseThenJobCompletes is the operator-visible follow-through of
+// TestSliceLimit_ManualUnpauseResetsSliceRetries: after a manual unpause resets
+// SliceRetries, a job needing several more slices runs them without immediately
+// re-pausing (each stays well under the freshly-reset MaxSliceRetries budget) and
+// eventually completes — at which point StageRetryCleared fires again on normal
+// completion, resetting both counters exactly as before this issue.
+func TestSliceLimit_UnpauseThenJobCompletes(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	var callCount int
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			// Calls 1-2: turn-capped, crossing MaxSliceRetries(2) on call 2 (pause).
+			// Call 3: turn-capped again, after the simulated unpause (SliceRetries 0->1).
+			// Call 4: completes cleanly.
+			if callCount <= 3 {
+				return "partial output", false, TokenUsage{TurnsUsed: 50, MaxTurns: 50},
+					&claudeTurnLimitError{TerminalReason: "max_turns", NumTurns: 50}
+			}
+			return "all done\nFABRIK_STAGE_COMPLETE", true, TokenUsage{TurnsUsed: 10, MaxTurns: 50}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 2, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 211, Title: "Unpause-then-complete test", Status: "Research", ItemID: "PVTI_211"}
+
+	for i := 0; i < 2; i++ {
+		if err := eng.processItem(context.Background(), board, item); err != nil {
+			t.Fatalf("processItem (pre-pause call %d): %v", i+1, err)
+		}
+	}
+
+	// Confirm the job is actually paused before proceeding, so the rest of this
+	// test genuinely exercises "unpause, then finish" rather than passing
+	// vacuously because the job never paused.
+	snap, err := eng.store.Get("owner/repo", 211)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if !snap.PausedByEngine("Research") {
+		t.Fatal("expected the job to be paused before the unpause simulation")
+	}
+
+	// User removes fabrik:paused / fabrik:awaiting-input.
+	unpausedItem := gh.ProjectItem{Number: 211, Title: "Unpause-then-complete test", Status: "Research", ItemID: "PVTI_211", Labels: []string{}}
+
+	// Call 3 (post-unpause): one more turn-capped slice, well under the freshly
+	// reset budget — must NOT immediately re-pause.
+	if err := eng.processItem(context.Background(), board, unpausedItem); err != nil {
+		t.Fatalf("processItem (post-unpause slice): %v", err)
+	}
+	snap, err = eng.store.Get("owner/repo", 211)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.SliceRetries("Research"); got != 1 {
+		t.Errorf("SliceRetries after one post-unpause slice = %d, want 1 (fresh budget, not immediately re-pausing)", got)
+	}
+	if snap.PausedByEngine("Research") {
+		t.Error("must not immediately re-pause on the first slice after a fresh unpause")
+	}
+
+	// Call 4: the job completes. Record the label-call count beforehand so the
+	// "did this specific call re-pause" check isn't confused by the earlier,
+	// expected pause from call 2.
+	labelCallsBeforeCompletion := len(client.addLabelCalls)
+	if err := eng.processItem(context.Background(), board, unpausedItem); err != nil {
+		t.Fatalf("processItem (completion): %v", err)
+	}
+
+	snap, err = eng.store.Get("owner/repo", 211)
+	if err != nil {
+		t.Fatalf("store.Get after completion: %v", err)
+	}
+	if got := snap.SliceRetries("Research"); got != 0 {
+		t.Errorf("SliceRetries after normal completion = %d, want 0 (StageRetryCleared resets both counters)", got)
+	}
+	if got := snap.Attempts("Research"); got != 0 {
+		t.Errorf("Attempts after normal completion = %d, want 0", got)
+	}
+
+	foundComplete := false
+	for _, c := range client.addLabelCalls[labelCallsBeforeCompletion:] {
+		if c.labelName == "stage:Research:complete" {
+			foundComplete = true
+		}
+		if c.labelName == "fabrik:paused" {
+			t.Error("must not re-pause on the completing call")
+		}
+	}
+	if !foundComplete {
+		t.Error("expected stage:Research:complete to be applied once the job finishes")
+	}
+}
+
+// TestMaxRetriesEscalation_UnaffectedBySliceCounterChanges verifies acceptance
+// item 4 from the #1199 review: genuine-failure escalation and its unpause
+// recovery are unchanged by pauseForSliceLimit now applying itemstate.EnginePaused
+// — the two pause paths (escalateFailedStage vs. pauseForSliceLimit) are
+// independent, and a genuine failure still applies stage:<name>:failed, still
+// pauses at MaxRetries, and unpausing still resets Attempts exactly as before.
+func TestMaxRetriesEscalation_UnaffectedBySliceCounterChanges(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "partial output", false, TokenUsage{}, errors.New("some genuine transient failure")
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, MaxSliceRetries: 5, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 212, Title: "Genuine failure escalation test", Status: "Research", ItemID: "PVTI_212"}
+
+	for i := 0; i < 2; i++ {
+		if err := eng.processItem(context.Background(), board, item); err != nil {
+			t.Fatalf("processItem (call %d): %v", i+1, err)
+		}
+	}
+
+	snap, err := eng.store.Get("owner/repo", 212)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.Attempts("Research"); got != eng.cfg.MaxRetries {
+		t.Fatalf("Attempts after escalation = %d, want %d", got, eng.cfg.MaxRetries)
+	}
+	if got := snap.SliceRetries("Research"); got != 0 {
+		t.Errorf("SliceRetries after a genuine-failure escalation = %d, want 0 — unrelated to the slice counter", got)
+	}
+
+	foundFailed := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "stage:Research:failed" {
+			foundFailed = true
+		}
+	}
+	if !foundFailed {
+		t.Error("expected stage:Research:failed after MaxRetries exhausted — unchanged by the #1199 slice-counter work")
+	}
+
+	// User removes fabrik:paused. Same as the slice-limit case: clearFailedStage's
+	// reset happens, and — since nothing else stops it — processItem immediately
+	// resumes dispatch within this same call, so the post-unpause snapshot is
+	// "reset to 0, then one fresh attempt" (1), not a bare 0. What matters is
+	// Attempts did NOT stay pinned at MaxRetries (which would mean the reset never
+	// took effect and this call would have immediately re-escalated instead).
+	labelCallsBeforeUnpause := len(client.addLabelCalls)
+	unpausedItem := gh.ProjectItem{Number: 212, Title: "Genuine failure escalation test", Status: "Research", ItemID: "PVTI_212", Labels: []string{}}
+	if err := eng.processItem(context.Background(), board, unpausedItem); err != nil {
+		t.Fatalf("processItem (unpause): %v", err)
+	}
+
+	snap, err = eng.store.Get("owner/repo", 212)
+	if err != nil {
+		t.Fatalf("store.Get after unpause: %v", err)
+	}
+	if got := snap.Attempts("Research"); got != 1 {
+		t.Errorf("Attempts after unpause = %d, want 1 (reset to 0 by clearFailedStage, then one fresh attempt from the resumed dispatch — unchanged unpause behavior)", got)
+	}
+
+	foundRemoval := false
+	for _, c := range client.removeLabelCalls {
+		if c.labelName == "stage:Research:failed" {
+			foundRemoval = true
+		}
+	}
+	if !foundRemoval {
+		t.Error("expected stage:Research:failed to be removed on unpause, exactly as before this issue")
+	}
+	for _, c := range client.addLabelCalls[labelCallsBeforeUnpause:] {
+		if c.labelName == "stage:Research:failed" || c.labelName == "fabrik:paused" {
+			t.Errorf("must not immediately re-escalate on the resumed dispatch (Attempts=1 is well under MaxRetries=%d), got label %q", eng.cfg.MaxRetries, c.labelName)
+		}
+	}
+}

--- a/internal/itemstate/itemstate.go
+++ b/internal/itemstate/itemstate.go
@@ -271,6 +271,12 @@ type StageState struct {
 	// queue-thrash loop (enqueue→eject→re-enqueue→eject) independently of the
 	// RebaseCycles/CIFixCycles that the conflict/CI sub-paths increment.
 	EnqueueCycles map[string]int
+	// SliceRetries counts how many turn-cap preemptions (CLI subtype
+	// error_max_turns) each stage has hit. Bounded by MaxSliceRetries,
+	// independently of Attempts/MaxRetries — a turn-cap exit is a resumable
+	// time-slice, not a failure (#1199), so it must not count against the
+	// failure counter, but a non-converging job still needs its own bound.
+	SliceRetries map[string]int
 	// ProcessedComments maps comment ID to the time Fabrik finished processing it.
 	ProcessedComments map[string]time.Time
 	// LinkageHealAttempted maps stage name to the PR head SHA for which a linkage

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -477,8 +477,12 @@ type PRCreationFailedRecorded struct {
 func (PRCreationFailedRecorded) isMutation()       {}
 func (m PRCreationFailedRecorded) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
-// EnginePaused records that the engine has paused work on a stage due to
-// repeated failures. (The design doc listed this as "EngineEnginePaused" — typo.)
+// EnginePaused records that the engine has paused work on a stage — either
+// due to repeated failures (escalateFailedStage/escalatePRCreationFailure) or
+// a turn-cap slice budget exceeded (pauseForSliceLimit, #1199), both of which
+// need the same "a human manually removed fabrik:paused" detection to reset
+// their respective counters via clearFailedStage. (The design doc listed this
+// as "EngineEnginePaused" — typo.)
 type EnginePaused struct {
 	Repo      string
 	Number    int

--- a/internal/itemstate/mutation.go
+++ b/internal/itemstate/mutation.go
@@ -398,7 +398,8 @@ type StageRetryIncremented struct {
 func (StageRetryIncremented) isMutation()       {}
 func (m StageRetryIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
-// StageRetryCleared resets the attempt counter for a stage.
+// StageRetryCleared resets the attempt counter (and the sibling SliceRetries
+// counter) for a stage.
 type StageRetryCleared struct {
 	Repo      string
 	Number    int
@@ -407,6 +408,20 @@ type StageRetryCleared struct {
 
 func (StageRetryCleared) isMutation()       {}
 func (m StageRetryCleared) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
+
+// SliceRetryIncremented increments the turn-cap preemption ("slice") counter for
+// a stage. Applied instead of StageRetryIncremented when the invocation ended in
+// a turn-cap exit (CLI subtype error_max_turns) — a resumable time-slice, not a
+// failure — so it is bounded independently by MaxSliceRetries rather than
+// counting against MaxRetries (#1199).
+type SliceRetryIncremented struct {
+	Repo      string
+	Number    int
+	StageName string
+}
+
+func (SliceRetryIncremented) isMutation()       {}
+func (m SliceRetryIncremented) itemKey() string { return itemKeyFor(m.Repo, m.Number) }
 
 // ReviewCycleIncremented increments the review cycle counter for a stage.
 type ReviewCycleIncremented struct {

--- a/internal/itemstate/mutation_test.go
+++ b/internal/itemstate/mutation_test.go
@@ -393,9 +393,28 @@ func TestApplyStageRetryIncremented(t *testing.T) {
 func TestApplyStageRetryCleared(t *testing.T) {
 	s := newStoreWithItem(t, testRepo, 1)
 	s.Apply(StageRetryIncremented{Repo: testRepo, Number: 1, StageName: "Implement"})
+	s.Apply(SliceRetryIncremented{Repo: testRepo, Number: 1, StageName: "Implement"})
 	applyExpect(t, s, StageRetryCleared{Repo: testRepo, Number: 1, StageName: "Implement"}, StageStateChanged)
 	if getItem(t, s, testRepo, 1).StageState.Attempts["Implement"] != 0 {
 		t.Error("Attempts not cleared")
+	}
+	if getItem(t, s, testRepo, 1).StageState.SliceRetries["Implement"] != 0 {
+		t.Error("SliceRetries not cleared alongside Attempts")
+	}
+}
+
+// ---- SliceRetryIncremented ----
+
+func TestApplySliceRetryIncremented(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	applyExpect(t, s, SliceRetryIncremented{Repo: testRepo, Number: 1, StageName: "Implement"}, StageStateChanged)
+	if getItem(t, s, testRepo, 1).StageState.SliceRetries["Implement"] != 1 {
+		t.Error("SliceRetries not incremented to 1")
+	}
+	// SliceRetries is independent of Attempts — a turn-cap preemption must not
+	// also count against the failure counter (#1199).
+	if getItem(t, s, testRepo, 1).StageState.Attempts["Implement"] != 0 {
+		t.Error("Attempts must not be touched by SliceRetryIncremented")
 	}
 }
 
@@ -618,6 +637,21 @@ func TestEngineCyclesClearedClearsEnqueueCycles(t *testing.T) {
 	}
 	if got := st.StageState.RebaseCycles["Validate"]; got != 0 {
 		t.Errorf("RebaseCycles not cleared by EngineCyclesCleared: got %d, want 0", got)
+	}
+}
+
+// TestSliceRetriesSnapshotIsDeepCopy verifies that a Snapshot taken before a
+// later SliceRetryIncremented retains its original count — confirming
+// copyStageState deep-copies the SliceRetries map (no shared backing map).
+func TestSliceRetriesSnapshotIsDeepCopy(t *testing.T) {
+	s := newStoreWithItem(t, testRepo, 1)
+	held := applyExpect(t, s, SliceRetryIncremented{Repo: testRepo, Number: 1, StageName: "Implement"}, StageStateChanged)
+	if held.SliceRetries("Implement") != 1 {
+		t.Fatalf("precondition: held snapshot SliceRetries = %d, want 1", held.SliceRetries("Implement"))
+	}
+	s.Apply(SliceRetryIncremented{Repo: testRepo, Number: 1, StageName: "Implement"})
+	if held.SliceRetries("Implement") != 1 {
+		t.Errorf("held snapshot mutated by later increment: SliceRetries = %d, want 1", held.SliceRetries("Implement"))
 	}
 }
 

--- a/internal/itemstate/snapshot.go
+++ b/internal/itemstate/snapshot.go
@@ -36,6 +36,7 @@ type Snapshot struct {
 //   - ItemState.StageState.CIFixCycles
 //   - ItemState.StageState.RebaseCycles
 //   - ItemState.StageState.EnqueueCycles
+//   - ItemState.StageState.SliceRetries
 //   - ItemState.StageState.ProcessedComments
 //   - ItemState.StageState.LinkageHealAttempted
 //   - LinkedPRState.Reviews
@@ -223,6 +224,12 @@ func (s Snapshot) EnqueueCycles(stageName string) int {
 	return s.state.StageState.EnqueueCycles[stageName]
 }
 
+// SliceRetries returns the turn-cap preemption ("slice") count for a given
+// stage, or zero. Bounded independently of Attempts/MaxRetries (#1199).
+func (s Snapshot) SliceRetries(stageName string) int {
+	return s.state.StageState.SliceRetries[stageName]
+}
+
 // LastEnqueuedSHA returns the PR head SHA recorded at the last merge-queue enqueue,
 // or "" if not recorded (LinkedPR is nil or no enqueue has occurred).
 func (s Snapshot) LastEnqueuedSHA() string {
@@ -379,6 +386,7 @@ func copyStageState(s StageState) StageState {
 		CIFixCycles:          copyMap(s.CIFixCycles),
 		RebaseCycles:         copyMap(s.RebaseCycles),
 		EnqueueCycles:        copyMap(s.EnqueueCycles),
+		SliceRetries:         copyMap(s.SliceRetries),
 		ProcessedComments:    copyMap(s.ProcessedComments),
 		LinkageHealAttempted: copyMap(s.LinkageHealAttempted),
 		LastTurnsUsed:        copyMap(s.LastTurnsUsed),

--- a/internal/itemstate/store.go
+++ b/internal/itemstate/store.go
@@ -402,10 +402,16 @@ func (s *Store) applyToItem(item *ItemState, m Mutation) ChangeFlags {
 	case StageRetryCleared:
 		ensureStageStateMaps(item)
 		item.StageState.Attempts[v.StageName] = 0
+		item.StageState.SliceRetries[v.StageName] = 0
 		delete(item.StageState.PRCreationFailed, v.StageName)
 		delete(item.StageState.LastTurnsUsed, v.StageName)
 		delete(item.StageState.LastTurnsCapped, v.StageName)
 		delete(item.StageState.StallHintPending, v.StageName)
+		return StageStateChanged
+
+	case SliceRetryIncremented:
+		ensureStageStateMaps(item)
+		item.StageState.SliceRetries[v.StageName]++
 		return StageStateChanged
 
 	case ReviewCycleIncremented:
@@ -1143,6 +1149,9 @@ func ensureStageStateMaps(item *ItemState) {
 	}
 	if ss.EnqueueCycles == nil {
 		ss.EnqueueCycles = make(map[string]int)
+	}
+	if ss.SliceRetries == nil {
+		ss.SliceRetries = make(map[string]int)
 	}
 	if ss.ProcessedComments == nil {
 		ss.ProcessedComments = make(map[string]time.Time)

--- a/plugin/fabrik-workflows/LABELS.md
+++ b/plugin/fabrik-workflows/LABELS.md
@@ -177,9 +177,15 @@ and should recognize.
   mergeability determination it certified no longer applies). Prevents
   re-invocation of that stage and drives catch-up advancement to the next
   one.
-- **`stage:<name>:failed`** — Applied after a stage exhausts its retry
-  budget; always paired with `fabrik:paused`. Cleared only when the user
-  manually removes `fabrik:paused` (signaling they've intervened).
+- **`stage:<name>:failed`** — Applied after a stage exhausts its
+  *failure* budget (`max_retries`) — genuine errors, degenerate output,
+  PR-creation failures; always paired with `fabrik:paused`. A turn-cap
+  preemption (the invocation ran out of turns and will resume on the
+  next dispatch) is not a failure and never applies this label — it is
+  bounded separately by `max_slice_retries`, escalating instead with
+  `fabrik:paused` + `fabrik:awaiting-input` and a "slice budget exceeded"
+  comment. Cleared only when the user manually removes `fabrik:paused`
+  (signaling they've intervened).
 - **`fabrik:sub-issue`** — Applied to a child issue created by Plan's
   `FABRIK_SPAWN_CHILD_*` decomposition mechanism. Purely informational —
   carries no gating semantics of its own.


### PR DESCRIPTION
Closes #1199

## What this does

`--max-retries` was overloaded: it bounded both genuine stage failures and turn-cap preemptions (the invocation ran out of turns and will resume via `--resume` on the next dispatch — not a failure). A job needing more slices than `max_retries` was paused with `stage:<name>:failed` and a "failed to complete after N attempts" comment while progressing normally (#816, #1114, #1183; independently reported as the undocumented `max_retries × max_turns` ceiling in #1191).

This PR splits the single counter into two, routed structurally on the CLI's own `subtype: "error_max_turns"` signal (`turnLimited`, already computed since #1178 — no new detection work):

- **`Attempts` / `--max-retries`** (unchanged, default 3) — genuine errors, degenerate output, PR-creation failures, and a clean run that never emits `FABRIK_STAGE_COMPLETE` (the open question the issue deferred to Plan; decided here in favor of the failure counter, since `turnLimited` is the only structurally verified signal available).
- **`SliceRetries` / `--max-slice-retries` / `FABRIK_MAX_SLICE_RETRIES`** (new, default 10) — turn-cap preemptions only. Exceeding it pauses with `fabrik:paused` + `fabrik:awaiting-input` and a "slice budget exceeded" comment (never `stage:<name>:failed` — the stage has not failed), modeled directly on the existing `pauseForRebaseCycleLimit` precedent.

## Key changes

- `internal/itemstate`: new `SliceRetries` counter on `StageState` (fifth sibling of `ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles`), `SliceRetryIncremented` mutation, `Snapshot.SliceRetries()` getter. `StageRetryCleared` now also zeroes `SliceRetries` — the two counters share one reset point.
- `cmd/root.go` / `engine/engine.go`: `--max-slice-retries` flag + `FABRIK_MAX_SLICE_RETRIES` env, mirroring `--max-rebase-cycles`'s wiring tier (flag + env only, no `config.yaml` key).
- `engine/item.go`: `finalizeStageOutcome`'s `else` branch now routes on `turnLimited` before choosing which counter to increment and which escalation path to call; new `pauseForSliceLimit`.
- Docs: `docs/state-machine.md` §7.12 (new as-built section) plus rewrites of the three forward-referencing `(#1199)` caveats in the Turn Limit Extension section; `docs/USER_GUIDE.md` flag-table row + troubleshooting note; `docs/llms-full.txt` regenerated; `plugin/fabrik-workflows/LABELS.md` tightened.
- `adrs/1199-slice-budget-separate-from-failure-counter.md`: records the design decision, including the routing choice for the deferred "clean run, no marker" case.

## Test plan

- New `engine/slice_retry_test.go`: turn-capped slice increments `SliceRetries` only (never `Attempts`, never `stage:<name>:failed`); a genuine error increments `Attempts` only; exceeding `MaxSliceRetries` escalates with the correct non-failure message and labels; a job that has already taken more slices than `MaxRetries` is not paused as long as it's within `MaxSliceRetries`.
- New itemstate tests for the mutation, its clearing via `StageRetryCleared`, and snapshot deep-copy independence.
- `go build ./...`, `go vet ./...`, and `go test -race ./...` all pass (one pre-existing, unrelated flaky test — `TestExecute_ConfigYAMLApplied`, a real-network-dependent SIGINT test — fails identically on the pre-issue base commit; confirmed unrelated to this change).