### PR TITLE
fix: exempt transient api_error exits from max_retries

### DIFF
--- a/adrs/1458-transient-api-error-exemption.md
+++ b/adrs/1458-transient-api-error-exemption.md
@@ -1,0 +1,166 @@
+# ADR 1458: Transient `api_error` Exit Exemption from `max_retries`
+
+**Date**: 2026-08-09
+**Status**: Accepted
+**Issue**: #1458 — A transient `api_error` exit is charged against `max_retries` and pauses the issue, though the stage never ran
+
+## Context
+
+A Claude invocation that exits with `terminal_reason="api_error"` never ran the stage — the CLI's own
+result object records 0-1 turns and `$0.0000` cost — yet before this change it was charged against
+`max_retries` exactly like a genuine stage failure, and three of them paused the issue. Observed live on
+2026-08-08, 21:19–21:32 UTC: eight such exits across two issues (#1408, #1208), every one at 1 turn and
+`$0.0000`. #1408 was paused with `stage:Validate:failed` on a PR that was `MERGEABLE`/`CLEAN` with all
+six checks green, and stayed paused for roughly an hour with a dependent chain blocked behind it. No
+Claude invocation ran anywhere on the board for ~50 minutes, because both active lane heads were paused.
+Nothing was wrong with either issue's work — the transient was Anthropic-side.
+
+`engine/claude.go`'s structural classification (ADR-1183) recognized exactly one `terminal_reason`
+value, `"blocking_limit"` (a genuine account usage limit). Everything else, including `api_error`, fell
+through a diagnostic-only log line to the generic error path, reaching `StageRetryIncremented` and, at
+`MaxRetries`, `stage:<name>:failed` + `fabrik:paused`.
+
+This issue is explicitly modeled on ADR-1119's precedent (`StageAttempted`-without-
+`StageRetryIncremented`), which #1119 established for a genuine usage-limit exit and which
+`apiKeyHelperDetectedError`/`handleAPIKeyHelperDetected` (R13) later reused for a second, unrelated
+condition. The ask was not to loosen classification generally — ADR-1183's structural-only discipline
+(never output prose) had to be preserved — but to add one further narrow structural signal from the
+CLI's own result object.
+
+## Decision
+
+### A new, distinct sentinel type — not a reuse of `claudeUsageLimitError`
+
+The naive reading of the issue ("add one further structural `terminal_reason` match alongside the
+existing check") would add `"api_error"` as a second value inside `classifyUsageLimitExit` and route it
+through the existing `claudeUsageLimitError` type. This was rejected: `claudeUsageLimitError` is not an
+inert marker. By Go *type*, via `errors.As`, it is the trigger for two additional behaviors bundled at
+three call sites:
+
+1. Account-wide suspension activation (`activateClaudeSuspension`, in both
+   `runInvocationWithExtension` and `runCommentExtensionLoop`).
+2. Exclusion from the comment-processing circuit breaker's count (`processComments`).
+
+Both are correct only for a genuine account-wide usage limit. An `api_error` is per-invocation and
+transient — it says nothing about the account as a whole. Reusing the type would have silently
+suspended Claude dispatch account-wide on every transient API blip (directly regressing the ADR-1183
+incident this repository already paid for once, in spirit if not in mechanism) and would have exempted
+the comment-triggered dispatch path from its only existing bound (the circuit breaker), converting a
+bounded 3-strike pause into a potentially unbounded fast retry loop — exactly the failure mode
+`api_error`'s own observed shape (#1208: five exits in 31 seconds) demonstrates is reachable.
+
+`claudeAPIErrorExit` is therefore a new sentinel type, structurally parallel to the existing
+`claudeTurnLimitError`/`apiKeyHelperDetectedError` precedents:
+
+```go
+const apiErrorTerminalReason = "api_error"
+
+type claudeAPIErrorExit struct {
+    TerminalReason string
+    NumTurns       int
+    CostUSD        float64
+}
+```
+
+`classifyAPIErrorExit(resp claudeResponse, usage TokenUsage)` mirrors `classifyUsageLimitExit` exactly:
+structural-only (`resp.TerminalReason == "api_error"`, never output prose), reusing the same conjunctive
+`usage.TurnsUsed > 0 && usage.CostUSD > 0` exclusion. `interpretClaudeResult` (`engine/claude.go`) checks
+this immediately after the `classifyUsageLimitExit` branch and before the pre-existing diagnostic-only
+unmatched-`terminal_reason` log line, so an `api_error` exit that fails the guard (real turns and real
+cost) still falls through to that log line unchanged — the same behavior it had before this issue.
+
+Being a distinct type means the two `errors.As(&claudeUsageLimitError{})` checks in `item.go`/
+`comments.go` simply never match a `*claudeAPIErrorExit` — zero changes needed at either call site. This
+is a structural guarantee, not a conditional added at each site that could be forgotten in a future
+edit.
+
+### Handling: a fifth, more minimal "did not run" shape
+
+`finalizeStageOutcome()` (`engine/item.go`) gains one more `errors.As` branch, alongside the existing
+`claudeUsageLimitError`/`apiKeyHelperDetectedError` branches, routing to `handleAPIErrorExit`. It applies
+`itemstate.StageAttempted` (so the normal dispatch cooldown applies) but never `StageRetryIncremented` —
+the same split every prior "did not run" handler uses. Unlike `handleUsageLimitExit` and
+`handleAPIKeyHelperDetected`, it applies **no label and posts no comment** — R4's explicit requirement,
+and a shape none of the four existing "did not run"/boundary handlers matched exactly. The condition
+self-resolves on the next invocation; a label here would be indistinguishable from the orphaned-durable-
+state leak ADR-1183's own sweep exists to clean up, and a comment for a self-healing, per-invocation
+transient is noise (the same "comment when a human must act, log when the engine self-heals" rule #1414
+established for a sibling condition).
+
+### `engine/comments.go` is deliberately untouched
+
+The comment-triggered dispatch path has no `LastAttemptAt`-based cooldown at all — that mechanism only
+exists in `itemNeedsWork`'s stage-dispatch fallthrough, which the comment path bypasses entirely (a new
+comment dispatches unconditionally once detected). Its only existing bound is the comment-processing
+circuit breaker (`checkCommentBreaker`, #1089, default 10 invocations/30 min). Because
+`claudeAPIErrorExit` is a distinct type from `claudeUsageLimitError`, it automatically falls through to
+the same `checkCommentBreaker(item, "")` call every other unclassified error already reaches — no code
+change was needed, and none was made. This is also the answer to R6 for the comment-triggered path:
+unlike a genuine usage-limit hit (deliberately exempt from the breaker, since it says nothing about a
+specific issue's comment thread), an `api_error` should count toward "no forward progress" accounting —
+counting it is a feature, not an oversight, cheap insurance against an unusually long-lived transient. It
+is the direct explanation for #1208's 31-second/5-invocation burst: comment-triggered redispatch, not
+the 5-minute-cadence stage-dispatch cooldown that bounds #1408's pattern.
+
+## Rationale
+
+### Why reuse `classifyUsageLimitExit`'s exact exclusion guard despite unverified `CostUSD`?
+
+R5 asked whether the observed 1-turn/`$0.0000` `api_error` exits' `CostUSD` is exactly zero or a small
+value the `%.4f` log format rounds down — this could not be empirically verified: no raw NDJSON/result-
+object sample of a real `api_error` exit exists anywhere in this repository (`grep -rl "api_error"`
+across all `.go` files returned nothing prior to this change). The guard is reused unchanged rather than
+dropped, because it is directionally safe regardless of the true value: if a future `api_error` exit
+follows genuine billed work (many turns, real cost), the guard excludes it and it falls through
+unchanged to the pre-existing generic-failure path — no regression, no silent over-classification of a
+real failure. If cost is genuinely zero, as the observed shape strongly suggests, the guard passes and
+the fix activates. Dropping the guard entirely was considered and rejected: it would remove the belt-
+and-suspenders protection that is the direct lesson of this codebase's own #1184/#1183 history, for no
+evidenced benefit. The pre-existing diagnostic-only log line remains reachable for an `api_error` that
+fails the guard, so a future occurrence stays observable and the guard can be revisited with real
+captured data.
+
+### Why not a config flag or a shared "did-not-run" umbrella type instead of a new struct?
+
+A single umbrella type covering usage-limit, apiKeyHelper, and api_error conditions was considered and
+rejected: the three conditions differ in exactly the two behaviors (suspension, breaker exemption) this
+decision hinges on keeping *out* of the `api_error` path. A shared type would need a discriminant field
+and conditional logic at every call site that currently just checks a type — reintroducing the coupling
+risk this ADR's whole design avoids. Small, distinct sentinel types matching the existing
+`claudeTurnLimitError`/`apiKeyHelperDetectedError` precedent keep each condition's blast radius exactly
+as narrow as it needs to be, verified by the compiler (a call site either handles the type or it falls
+through) rather than by a runtime conditional someone has to remember to add.
+
+## Consequences
+
+**Positive:**
+- A transient `api_error` exit no longer consumes `max_retries` budget; a genuinely transient failure
+  that happens to follow one still has the full budget available (mirrors ADR-1119's regression guard).
+- No account-wide suspension is ever triggered by a per-invocation transient — avoiding a new false-
+  positive class in the same family ADR-1183 already paid to eliminate once.
+- The comment-triggered dispatch path gains a correct, non-invasive bound (the existing circuit breaker)
+  without inventing a new mechanism.
+
+**Negative / Trade-offs:**
+- No new label means no durable operator-visible signal that an issue has recently hit `api_error`
+  exits — by design (R4), but it does mean a human reviewing an issue's label history sees no trace of
+  a self-healed episode, only the log line.
+- The exclusion guard's `CostUSD > 0` behavior remains unverified against a real captured sample; if a
+  future occurrence shows nonzero cost, the guard silently stops matching and this fix becomes inert for
+  that shape until revisited (mitigated by the diagnostic log line staying reachable).
+- Like ADR-1119's usage-limit exemption, there is no ceiling on retries for this condition — an
+  unusually persistent or misdetected `api_error` condition on the stage-dispatch path retries every
+  cooldown window indefinitely rather than ever escalating for human review. Bounded on the comment-
+  dispatch path only by the existing circuit breaker.
+
+## Explicitly Out of Scope
+
+Other unmatched `terminal_reason` values (e.g. `rapid_refill_breaker`) — added only when observed in the
+wild with evidence, per the same discipline that kept this list at one entry (`blocking_limit`) until
+this issue. Retry/backoff policy for genuine stage failures. The account-wide suspension mechanism
+itself (ADR-1120), untouched by this change.
+
+**References:** ADR-1119 (the `StageAttempted`-without-`StageRetryIncremented` precedent this mirrors),
+ADR-1183 (why classification is structural-only), ADR-1120 (the account-wide suspension this
+deliberately does not touch), ADR-1199 (confirmed unrelated — a different budget, `SliceRetryIncremented`,
+for turn-cap preemption where the stage *did* run).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5904,6 +5904,64 @@ limitation per ADR-1119 and ADR-1120. Cross-process coordination between multipl
 sharing one account is also out of scope: the suspension is per-process, so a fleet of instances will
 each discover the limit once.
 
+### 7.3a Transient `api_error` Exemption
+
+A Claude invocation that exits with `resp.TerminalReason == "api_error"` (the `apiErrorTerminalReason`
+constant) is, like §7.3's usage-limit exit, a condition where the stage never ran — but unlike a usage
+limit, it is per-invocation and self-resolving, not account-wide. Observed live on 2026-08-08 (#1458):
+eight such exits across two issues, each at 1 turn and `$0.0000`, with three consecutive hits on #1408
+incorrectly consuming its entire `MaxRetries` budget and pausing a PR that was otherwise mergeable and
+green.
+
+**Detection:** `classifyAPIErrorExit(resp claudeResponse, usage TokenUsage)` (`engine/claude.go`)
+mirrors `classifyUsageLimitExit` exactly — structural-only (`resp.TerminalReason == "api_error"`, never
+output prose), with the same conjunctive `usage.TurnsUsed > 0 && usage.CostUSD > 0` exclusion carried
+over unchanged (a real `api_error` sample's `CostUSD` could not be empirically captured during Research,
+so the guard is reused rather than dropped or re-derived — see ADR-1458). `interpretClaudeResult`
+checks this immediately after the `classifyUsageLimitExit` branch and before the diagnostic-only
+unmatched-`terminal_reason` log line, returning a `*claudeAPIErrorExit{TerminalReason, NumTurns,
+CostUSD}` sentinel in place of the generic error wrapper.
+
+**Handling — deliberately a distinct type, not a reuse of `claudeUsageLimitError`:** `claudeUsageLimitError`
+is the trigger, by Go type via `errors.As`, for two behaviors beyond `handleUsageLimitExit` itself:
+`activateClaudeSuspension` (account-wide, in both `runInvocationWithExtension` and
+`runCommentExtensionLoop`) and the comment-processing circuit breaker bypass (`processComments`). Both
+are correct only for a genuine account-wide usage limit — an `api_error` says nothing about the account
+as a whole, so `claudeAPIErrorExit` is a separate sentinel type that simply never matches either
+`errors.As(&claudeUsageLimitError{})` check, avoiding both behaviors by construction rather than by an
+added conditional. `finalizeStageOutcome()` detects it via its own `errors.As` branch (alongside the
+usage-limit and apiKeyHelper branches) and routes to `handleAPIErrorExit()`, which:
+
+1. Applies `itemstate.StageAttempted` — the normal dispatch cooldown (`PollSeconds * 10`) applies on the
+   stage-dispatch path, exactly as for a usage-limit exit. Deliberately does **not** call
+   `StageRetryIncremented` — the stage never ran, so this does not count against `MaxRetries`.
+2. Logs only. Unlike `handleUsageLimitExit`/`handleAPIKeyHelperDetected`, posts **no comment** and
+   applies **no label** — a fifth, more minimal "did not run" shape. The condition is per-invocation and
+   self-resolving on the next attempt; a durable label here would be indistinguishable from the
+   orphaned-durable-state leak ADR-1183's sweep exists to clean up, and a comment for a self-healing
+   event is noise (see #1414's "comment when a human must act, log when the engine self-heals").
+3. Releases the lock and returns — no `stage:<name>:failed`, no `fabrik:paused`, no account-wide
+   suspension.
+
+**The comment-triggered dispatch path (`engine/comments.go`) is deliberately unmodified.** That path has
+no `LastAttemptAt`-based cooldown at all (§7.3's cooldown only exists in `itemNeedsWork`'s stage-dispatch
+fallthrough); its only bound is the comment-processing circuit breaker (`checkCommentBreaker`, #1089,
+default 10 invocations/30 min). Because `claudeAPIErrorExit` is a distinct type from
+`claudeUsageLimitError`, it automatically falls through to the same `checkCommentBreaker(item, "")` call
+every other unclassified error already reaches — unlike a genuine usage-limit hit, which
+`processComments` deliberately exempts from the breaker. Counting an `api_error` toward the breaker is
+correct here: it says nothing account-wide that would justify exempting an issue's comment thread from
+"no forward progress" accounting, and the breaker is the only mechanism that bounds this path (the
+5-invocations-in-31-seconds burst observed on #1208 came from comment-triggered redispatch, not the
+5-minute-cadence stage-dispatch cooldown).
+
+**Regression guard:** an `api_error` exit followed by a genuine failure leaves the full `MaxRetries`
+budget available for the genuine failure, exactly as §7.3 describes for a usage-limit exit. A genuine
+stage failure with no matching `TerminalReason` is entirely unaffected by this section — it still counts
+against `MaxRetries` and still escalates via `escalateFailedStage()` (§7.2) at the limit.
+
+See ADR-1458 and #1458.
+
 ### 7.4 Multi-Instance Lock Protocol
 
 Per [ADR-007](../adrs/007-label-based-locking.md):

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2511,6 +2511,64 @@ limitation per ADR-1119 and ADR-1120. Cross-process coordination between multipl
 sharing one account is also out of scope: the suspension is per-process, so a fleet of instances will
 each discover the limit once.
 
+### 7.3a Transient `api_error` Exemption
+
+A Claude invocation that exits with `resp.TerminalReason == "api_error"` (the `apiErrorTerminalReason`
+constant) is, like §7.3's usage-limit exit, a condition where the stage never ran — but unlike a usage
+limit, it is per-invocation and self-resolving, not account-wide. Observed live on 2026-08-08 (#1458):
+eight such exits across two issues, each at 1 turn and `$0.0000`, with three consecutive hits on #1408
+incorrectly consuming its entire `MaxRetries` budget and pausing a PR that was otherwise mergeable and
+green.
+
+**Detection:** `classifyAPIErrorExit(resp claudeResponse, usage TokenUsage)` (`engine/claude.go`)
+mirrors `classifyUsageLimitExit` exactly — structural-only (`resp.TerminalReason == "api_error"`, never
+output prose), with the same conjunctive `usage.TurnsUsed > 0 && usage.CostUSD > 0` exclusion carried
+over unchanged (a real `api_error` sample's `CostUSD` could not be empirically captured during Research,
+so the guard is reused rather than dropped or re-derived — see ADR-1458). `interpretClaudeResult`
+checks this immediately after the `classifyUsageLimitExit` branch and before the diagnostic-only
+unmatched-`terminal_reason` log line, returning a `*claudeAPIErrorExit{TerminalReason, NumTurns,
+CostUSD}` sentinel in place of the generic error wrapper.
+
+**Handling — deliberately a distinct type, not a reuse of `claudeUsageLimitError`:** `claudeUsageLimitError`
+is the trigger, by Go type via `errors.As`, for two behaviors beyond `handleUsageLimitExit` itself:
+`activateClaudeSuspension` (account-wide, in both `runInvocationWithExtension` and
+`runCommentExtensionLoop`) and the comment-processing circuit breaker bypass (`processComments`). Both
+are correct only for a genuine account-wide usage limit — an `api_error` says nothing about the account
+as a whole, so `claudeAPIErrorExit` is a separate sentinel type that simply never matches either
+`errors.As(&claudeUsageLimitError{})` check, avoiding both behaviors by construction rather than by an
+added conditional. `finalizeStageOutcome()` detects it via its own `errors.As` branch (alongside the
+usage-limit and apiKeyHelper branches) and routes to `handleAPIErrorExit()`, which:
+
+1. Applies `itemstate.StageAttempted` — the normal dispatch cooldown (`PollSeconds * 10`) applies on the
+   stage-dispatch path, exactly as for a usage-limit exit. Deliberately does **not** call
+   `StageRetryIncremented` — the stage never ran, so this does not count against `MaxRetries`.
+2. Logs only. Unlike `handleUsageLimitExit`/`handleAPIKeyHelperDetected`, posts **no comment** and
+   applies **no label** — a fifth, more minimal "did not run" shape. The condition is per-invocation and
+   self-resolving on the next attempt; a durable label here would be indistinguishable from the
+   orphaned-durable-state leak ADR-1183's sweep exists to clean up, and a comment for a self-healing
+   event is noise (see #1414's "comment when a human must act, log when the engine self-heals").
+3. Releases the lock and returns — no `stage:<name>:failed`, no `fabrik:paused`, no account-wide
+   suspension.
+
+**The comment-triggered dispatch path (`engine/comments.go`) is deliberately unmodified.** That path has
+no `LastAttemptAt`-based cooldown at all (§7.3's cooldown only exists in `itemNeedsWork`'s stage-dispatch
+fallthrough); its only bound is the comment-processing circuit breaker (`checkCommentBreaker`, #1089,
+default 10 invocations/30 min). Because `claudeAPIErrorExit` is a distinct type from
+`claudeUsageLimitError`, it automatically falls through to the same `checkCommentBreaker(item, "")` call
+every other unclassified error already reaches — unlike a genuine usage-limit hit, which
+`processComments` deliberately exempts from the breaker. Counting an `api_error` toward the breaker is
+correct here: it says nothing account-wide that would justify exempting an issue's comment thread from
+"no forward progress" accounting, and the breaker is the only mechanism that bounds this path (the
+5-invocations-in-31-seconds burst observed on #1208 came from comment-triggered redispatch, not the
+5-minute-cadence stage-dispatch cooldown).
+
+**Regression guard:** an `api_error` exit followed by a genuine failure leaves the full `MaxRetries`
+budget available for the genuine failure, exactly as §7.3 describes for a usage-limit exit. A genuine
+stage failure with no matching `TerminalReason` is entirely unaffected by this section — it still counts
+against `MaxRetries` and still escalates via `escalateFailedStage()` (§7.2) at the limit.
+
+See ADR-1458 and #1458.
+
 ### 7.4 Multi-Instance Lock Protocol
 
 Per [ADR-007](../adrs/007-label-based-locking.md):

--- a/engine/api_error_exit_test.go
+++ b/engine/api_error_exit_test.go
@@ -1,0 +1,185 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/stages"
+)
+
+// TestAPIErrorExit_ExemptFromRetryNoLabelNoComment is the core
+// acceptance-criteria test (#1458 Acceptance 1): an api_error exit must not
+// increment the retry count, and — unlike claudeUsageLimitError/
+// apiKeyHelperDetectedError — must apply no label at all and post no
+// comment (R4's "fifth, more minimal shape"). Assert on the counter itself,
+// not just on the absence of a pause, per the issue's explicit instruction
+// that "not paused" alone is vacuous.
+func TestAPIErrorExit_ExemptFromRetryNoLabelNoComment(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "", false, TokenUsage{TurnsUsed: 1, CostUSD: 0},
+				&claudeAPIErrorExit{TerminalReason: "api_error", NumTurns: 1, CostUSD: 0}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 300, Title: "api_error test", Status: "Research", ItemID: "PVTI_300"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	// Retry count must be 0 — the stage never ran.
+	snap, err := eng.store.Get("owner/repo", 300)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.Attempts("Research"); got != 0 {
+		t.Errorf("Attempts(\"Research\") = %d, want 0 (api_error must not count against max_retries)", got)
+	}
+	// LastAttemptAt must be set — the dispatch cooldown must apply so the
+	// item doesn't retry on the very next poll.
+	if snap.LastAttemptAt("Research").IsZero() {
+		t.Error("LastAttemptAt(\"Research\") is zero, want set (cooldown must apply)")
+	}
+
+	// fabrik:locked:<user> and stage:<name>:in_progress are pre-invocation
+	// dispatch bookkeeping applied before Claude ever runs — unrelated to
+	// R4's "no durable condition-specific label" claim. What R4 forbids is
+	// any label describing the api_error condition itself (the
+	// fabrik:claude-limit/fabrik:api-key-helper-detected shape).
+	for _, c := range client.addLabelCalls {
+		switch c.labelName {
+		case "fabrik:locked:testuser", "stage:Research:in_progress":
+			continue
+		default:
+			t.Errorf("expected no condition-specific label for an api_error exit (R4), got %q", c.labelName)
+		}
+	}
+	if len(client.addCommentCalls) != 0 {
+		t.Errorf("expected zero comments posted for an api_error exit (R4), got %d", len(client.addCommentCalls))
+	}
+}
+
+// TestAPIErrorExit_ThreeConsecutiveThenSuccess_CompletesNormally is the
+// end-to-end #1408 scenario (#1458 Acceptance 2): three consecutive
+// api_error exits must not apply stage:<name>:failed or fabrik:paused, and a
+// subsequent successful invocation must complete the stage normally.
+func TestAPIErrorExit_ThreeConsecutiveThenSuccess_CompletesNormally(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	callCount := 0
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			callCount++
+			if callCount <= 3 {
+				return "", false, TokenUsage{TurnsUsed: 1, CostUSD: 0},
+					&claudeAPIErrorExit{TerminalReason: "api_error", NumTurns: 1, CostUSD: 0}
+			}
+			return "done\nFABRIK_STAGE_COMPLETE\n", true, TokenUsage{}, nil
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 301, Title: "Three api_error then success", Status: "Research", ItemID: "PVTI_301"}
+
+	for i := 0; i < 3; i++ {
+		if err := eng.processItem(context.Background(), board, item); err != nil {
+			t.Fatalf("processItem (api_error call %d): %v", i+1, err)
+		}
+	}
+
+	snap, err := eng.store.Get("owner/repo", 301)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got := snap.Attempts("Research"); got != 0 {
+		t.Errorf("Attempts(\"Research\") = %d, want 0 after 3 api_error exits (max_retries=2 would otherwise have paused the issue)", got)
+	}
+
+	// Fourth call: a genuine successful invocation.
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem (success call): %v", err)
+	}
+
+	var sawFailedLabel, sawPausedLabel, sawCompleteLabel bool
+	for _, c := range client.addLabelCalls {
+		switch c.labelName {
+		case "stage:Research:failed":
+			sawFailedLabel = true
+		case "fabrik:paused":
+			sawPausedLabel = true
+		case "stage:Research:complete":
+			sawCompleteLabel = true
+		}
+	}
+	if sawFailedLabel {
+		t.Error("stage:Research:failed must NOT be applied — three api_error exits never charged against max_retries")
+	}
+	if sawPausedLabel {
+		t.Error("fabrik:paused must NOT be applied — three api_error exits never charged against max_retries")
+	}
+	if !sawCompleteLabel {
+		t.Error("expected stage:Research:complete to be added once the successful invocation lands")
+	}
+	if callCount != 4 {
+		t.Errorf("expected exactly 4 Claude invocations, got %d", callCount)
+	}
+}
+
+// TestAPIErrorExit_DoesNotActivateAccountWideSuspension verifies #1458
+// Acceptance 4: unlike claudeUsageLimitError, an api_error exit is
+// per-invocation/transient and must never touch claudeSuspendedUntilTime or
+// any account-wide suspension state.
+func TestAPIErrorExit_DoesNotActivateAccountWideSuspension(t *testing.T) {
+	skipIfNoGit(t)
+	repoDir := initBareRepo(t)
+	wm := NewWorktreeManager(repoDir)
+
+	client := &mockGitHubClient{}
+	claude := &mockClaudeInvoker{
+		invokeFn: func(stage *stages.Stage, issue gh.ProjectItem, newComments []gh.Comment, resume bool, workDir string, opts InvokeOptions) (string, bool, TokenUsage, error) {
+			return "", false, TokenUsage{TurnsUsed: 1, CostUSD: 0},
+				&claudeAPIErrorExit{TerminalReason: "api_error", NumTurns: 1, CostUSD: 0}
+		},
+	}
+
+	eng := NewWithDeps(
+		Config{Owner: "owner", Repo: "repo", ProjectNum: 1, User: "testuser", Token: "token",
+			MaxRetries: 2, Stages: testStages()},
+		client, claude, wm,
+	)
+
+	board := &gh.ProjectBoard{ProjectID: "PVT_1"}
+	item := gh.ProjectItem{Number: 302, Title: "No account-wide suspension", Status: "Research", ItemID: "PVTI_302"}
+
+	if err := eng.processItem(context.Background(), board, item); err != nil {
+		t.Fatalf("processItem: %v", err)
+	}
+
+	if _, suspended := eng.claudeSuspendedUntilTime(time.Now()); suspended {
+		t.Error("api_error exit must NOT activate the account-wide Claude suspension")
+	}
+}

--- a/engine/claude.go
+++ b/engine/claude.go
@@ -80,6 +80,64 @@ func (e *claudeTurnLimitError) Error() string {
 	return fmt.Sprintf("claude exited: turn limit reached (num_turns=%d)", e.NumTurns)
 }
 
+// apiErrorTerminalReason is the CLI's structural terminal_reason value for a
+// transient Anthropic-side API error — observed live on 2026-08-08 (#1458) as
+// eight exits across two issues, each at 1 turn and $0.0000. Unlike
+// usageLimitTerminalReason, this is per-invocation and self-resolving: it
+// says nothing about the account as a whole, so it must never trigger
+// activateClaudeSuspension (see claudeAPIErrorExit's doc comment and #1458 R3).
+const apiErrorTerminalReason = "api_error"
+
+// claudeAPIErrorExit signals that a Claude invocation exited because of a
+// transient Anthropic-side API error, not because the stage genuinely
+// failed. The stage never ran, so this condition must be excluded from
+// max_retries — see handleAPIErrorExit in item.go, which is the sole
+// consumer (via errors.As).
+//
+// Deliberately a distinct type from claudeUsageLimitError, not a second
+// value recognized by classifyUsageLimitExit itself: claudeUsageLimitError
+// is also the trigger, by Go type, for two behaviors that must NOT apply
+// here — activateClaudeSuspension (item.go/comments.go, forbidden by R3,
+// since an api_error is per-invocation, not account-wide) and the
+// comment-processing circuit breaker bypass (comments.go, forbidden by R6's
+// spirit, since exempting api_error from the breaker would leave the
+// comment-triggered dispatch path with no bound at all). Being a distinct
+// type means neither errors.As(&claudeUsageLimitError{}) check ever matches
+// a *claudeAPIErrorExit, so both call sites need no changes. See ADR-1458.
+type claudeAPIErrorExit struct {
+	// TerminalReason is the CLI's own terminal_reason field, for logging.
+	TerminalReason string
+	// NumTurns is the CLI-reported turn count at exit, for logging.
+	NumTurns int
+	// CostUSD is the CLI-reported cost at exit, for logging.
+	CostUSD float64
+}
+
+func (e *claudeAPIErrorExit) Error() string {
+	return fmt.Sprintf("claude exited: transient api_error (terminal_reason=%q, num_turns=%d, cost=$%.4f)", e.TerminalReason, e.NumTurns, e.CostUSD)
+}
+
+// classifyAPIErrorExit determines whether a Claude invocation exited on a
+// transient Anthropic-side API error, using only the CLI's own structured
+// result object (resp) — never text the assistant itself wrote, per the same
+// structural-only discipline #1183 established for classifyUsageLimitExit.
+//
+// resp.TerminalReason == "api_error" is the CLI's structural signal. usage is
+// kept as the same belt-and-suspenders exclusion gate classifyUsageLimitExit
+// uses: an invocation that consumed turns and incurred real cost is never
+// classified as a did-not-run exit, regardless of what TerminalReason says
+// (#1458 R5 could not empirically verify CostUSD on a real api_error sample,
+// so this guard is reused unchanged rather than dropped — see ADR-1458).
+func classifyAPIErrorExit(resp claudeResponse, usage TokenUsage) (msg string, detected bool) {
+	if resp.TerminalReason != apiErrorTerminalReason {
+		return "", false
+	}
+	if usage.TurnsUsed > 0 && usage.CostUSD > 0 {
+		return "", false
+	}
+	return fmt.Sprintf("terminal_reason=%q", resp.TerminalReason), true
+}
+
 // classifyUsageLimitExit determines whether a Claude invocation exited on a
 // genuine account usage-limit condition, using only the CLI's own structured
 // result object (resp) — never text the assistant itself wrote. This
@@ -1336,6 +1394,9 @@ func interpretClaudeResult(ctx context.Context, issueNumber int, rawOutput []byt
 			if msg, detected := classifyUsageLimitExit(resp, usage); detected {
 				claudeLog(issueNumber, "claude-limit", "usage-limit exit detected (turns=%d, cost=$%.4f): %s\n", usage.TurnsUsed, usage.CostUSD, msg)
 				return text, false, usage, &claudeUsageLimitError{Message: msg}
+			} else if _, detected := classifyAPIErrorExit(resp, usage); detected {
+				claudeLog(issueNumber, "claude", "api_error exit detected (turns=%d, cost=$%.4f) — stage did not run, not charged against max_retries\n", usage.TurnsUsed, usage.CostUSD)
+				return text, false, usage, &claudeAPIErrorExit{TerminalReason: resp.TerminalReason, NumTurns: resp.NumTurns, CostUSD: resp.CostUSD}
 			} else if resp.TerminalReason != "" && resp.TerminalReason != usageLimitTerminalReason {
 				// Diagnostic-only: records any other non-empty terminal_reason
 				// seen on an error exit (e.g. "rapid_refill_breaker"), so a

--- a/engine/claude_api_error_test.go
+++ b/engine/claude_api_error_test.go
@@ -1,0 +1,202 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestClassifyAPIErrorExit covers structural detection from the CLI's own
+// result object (claudeResponse.TerminalReason) — never from output prose,
+// mirroring the discipline TestClassifyUsageLimitExit exercises for
+// "blocking_limit". See #1458.
+func TestClassifyAPIErrorExit(t *testing.T) {
+	tests := []struct {
+		name         string
+		resp         claudeResponse
+		usage        TokenUsage
+		wantDetected bool
+	}{
+		{
+			name:         "api_error with zero turns and zero cost detects",
+			resp:         claudeResponse{TerminalReason: "api_error"},
+			usage:        TokenUsage{},
+			wantDetected: true,
+		},
+		{
+			// Observed live #1458 shape: 1 turn, $0.0000 — TurnsUsed>0 alone
+			// does not exclude; the guard is conjunctive (both must be
+			// nonzero to exclude).
+			name:         "api_error with one turn and zero cost detects",
+			resp:         claudeResponse{TerminalReason: "api_error"},
+			usage:        TokenUsage{TurnsUsed: 1, CostUSD: 0},
+			wantDetected: true,
+		},
+		{
+			// Belt-and-suspenders exclusion reused unchanged from
+			// classifyUsageLimitExit (#1458 R5): real progress (turns and
+			// cost both nonzero) is never classified as a did-not-run exit,
+			// regardless of terminal_reason.
+			name:         "api_error with TurnsUsed>0 && CostUSD>0 does not detect",
+			resp:         claudeResponse{TerminalReason: "api_error"},
+			usage:        TokenUsage{TurnsUsed: 51, CostUSD: 2.2766},
+			wantDetected: false,
+		},
+		{
+			name:         "blocking_limit does not detect as api_error",
+			resp:         claudeResponse{TerminalReason: "blocking_limit"},
+			usage:        TokenUsage{},
+			wantDetected: false,
+		},
+		{
+			name:         "empty terminal_reason does not detect",
+			resp:         claudeResponse{TerminalReason: ""},
+			usage:        TokenUsage{},
+			wantDetected: false,
+		},
+		{
+			name:         "unrelated terminal_reason does not detect",
+			resp:         claudeResponse{TerminalReason: "rapid_refill_breaker"},
+			usage:        TokenUsage{},
+			wantDetected: false,
+		},
+		{
+			// The exclusion is conjunctive: cost without turns (or vice
+			// versa) is not evidence the invocation ran, so detection stands.
+			name:         "cost recorded but zero turns still detects",
+			resp:         claudeResponse{TerminalReason: "api_error"},
+			usage:        TokenUsage{TurnsUsed: 0, CostUSD: 0.01},
+			wantDetected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, detected := classifyAPIErrorExit(tt.resp, tt.usage)
+			if detected != tt.wantDetected {
+				t.Fatalf("detected = %v, want %v (msg=%q)", detected, tt.wantDetected, msg)
+			}
+			if detected && msg == "" {
+				t.Errorf("expected non-empty msg when detected")
+			}
+		})
+	}
+}
+
+// TestInterpretClaudeResult_APIErrorExit_ReturnsSentinelError verifies that
+// interpretClaudeResult, when Claude exits non-zero with terminal_reason
+// "api_error" and no FABRIK_STAGE_COMPLETE marker, returns a
+// *claudeAPIErrorExit via errors.As rather than the generic "claude exited
+// with error" wrapper or a *claudeUsageLimitError — this is the seam
+// finalizeStageOutcome classifies on.
+func TestInterpretClaudeResult_APIErrorExit_ReturnsSentinelError(t *testing.T) {
+	raw := []byte(`{"result":"","session_id":"sid-1","terminal_reason":"api_error","is_error":true,"num_turns":1,"total_cost_usd":0}`)
+	text, completed, usage, err := interpretClaudeResult(context.Background(), 1, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var apiErr *claudeAPIErrorExit
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("errors.As(err, *claudeAPIErrorExit) = false; err = %v", err)
+	}
+	var limitErr *claudeUsageLimitError
+	if errors.As(err, &limitErr) {
+		t.Fatalf("api_error exit must not also be classified as claudeUsageLimitError")
+	}
+	if apiErr.TerminalReason != "api_error" {
+		t.Errorf("TerminalReason = %q, want %q", apiErr.TerminalReason, "api_error")
+	}
+	if apiErr.NumTurns != 1 {
+		t.Errorf("NumTurns = %d, want 1", apiErr.NumTurns)
+	}
+	if usage.TurnsUsed != 1 {
+		t.Errorf("usage.TurnsUsed = %d, want 1", usage.TurnsUsed)
+	}
+	if completed {
+		t.Errorf("expected completed=false for an api_error exit")
+	}
+	_ = text
+}
+
+// TestInterpretClaudeResult_APIErrorExit_MarkerTakesPrecedence verifies that
+// a genuine stage completion (FABRIK_STAGE_COMPLETE present) is never
+// misclassified as an api_error exit, even when the structural
+// terminal_reason field is also present — the marker check runs first in
+// interpretClaudeResult and returns before api_error detection is reached.
+func TestInterpretClaudeResult_APIErrorExit_MarkerTakesPrecedence(t *testing.T) {
+	raw := []byte(`{"result":"work done\nFABRIK_STAGE_COMPLETE","terminal_reason":"api_error"}`)
+	_, completed, _, err := interpretClaudeResult(context.Background(), 1, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+
+	if err == nil {
+		t.Fatalf("expected error (non-zero exit)")
+	}
+	var apiErr *claudeAPIErrorExit
+	if errors.As(err, &apiErr) {
+		t.Fatalf("expected marker-completion to take precedence, got claudeAPIErrorExit")
+	}
+	if !completed {
+		t.Errorf("expected completed=true (marker present)")
+	}
+}
+
+// TestInterpretClaudeResult_APIErrorExit_UnparseableJSON_NotClassified
+// verifies that when JSON parsing fails (ok == false), there is no
+// structured result object to trust, so the invocation is never classified
+// as an api_error exit by any means — it falls through to the generic
+// error/timeout handling paths. Mirrors #1183 Requirement 2, applied to the
+// new classifier (#1458 Acceptance 6).
+func TestInterpretClaudeResult_APIErrorExit_UnparseableJSON_NotClassified(t *testing.T) {
+	raw := []byte("not valid json, but mentions api_error anyway")
+	_, completed, _, err := interpretClaudeResult(context.Background(), 1, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+
+	if err == nil {
+		t.Fatalf("expected error (non-zero exit)")
+	}
+	var apiErr *claudeAPIErrorExit
+	if errors.As(err, &apiErr) {
+		t.Fatalf("unparseable JSON must never be classified as an api_error exit, got claudeAPIErrorExit")
+	}
+	if completed {
+		t.Errorf("expected completed=false")
+	}
+	if !strings.Contains(err.Error(), "claude exited with error") {
+		t.Errorf("expected generic error, got %v", err)
+	}
+}
+
+// TestInterpretClaudeResult_APIErrorWithRealProgress_NotClassified is the
+// full-pipeline regression for the guard-exclusion path (#1458 R5/R1): a raw
+// payload carrying both nonzero num_turns and nonzero total_cost_usd must
+// not be classified as an api_error exit, even when terminal_reason is
+// "api_error" — the exclusion gate only fires if tokenUsageFromResponse
+// actually populates TurnsUsed/CostUSD from the JSON, so this asserts on the
+// parsed usage rather than hand-supplied values (mirrors
+// TestInterpretClaudeResult_TurnCappedQuotingMessage_NotUsageLimit's
+// pipeline-level shape).
+func TestInterpretClaudeResult_APIErrorWithRealProgress_NotClassified(t *testing.T) {
+	raw := []byte(`{"terminal_reason":"api_error","is_error":true,` +
+		`"num_turns":12,"total_cost_usd":0.4321,` +
+		`"result":"partial work before a transient API error",` +
+		`"errors":["transient API error"]}`)
+
+	_, completed, usage, err := interpretClaudeResult(context.Background(), 1, raw, errors.New("exit status 1"), false, t.TempDir()+"/sess", t.TempDir())
+
+	// Guard the wiring the exclusion depends on: if these are zero, the gate is
+	// inert and the assertion below would pass for the wrong reason.
+	if usage.TurnsUsed == 0 || usage.CostUSD == 0 {
+		t.Fatalf("usage not parsed from raw payload: TurnsUsed=%d CostUSD=%v — exclusion gate would be inert", usage.TurnsUsed, usage.CostUSD)
+	}
+
+	var apiErr *claudeAPIErrorExit
+	if errors.As(err, &apiErr) {
+		t.Fatalf("an api_error exit with real progress (turns=%d, cost=$%v) was classified as a did-not-run exit", usage.TurnsUsed, usage.CostUSD)
+	}
+	if completed {
+		t.Errorf("expected completed=false")
+	}
+	if !strings.Contains(err.Error(), "claude exited with error") {
+		t.Errorf("expected generic error for excluded api_error exit, got %v", err)
+	}
+}

--- a/engine/item.go
+++ b/engine/item.go
@@ -1230,6 +1230,15 @@ func (e *Engine) finalizeStageOutcome(p stageOutcomeParams) {
 			e.handleAPIKeyHelperDetected(p, apiKeyErr)
 			return
 		}
+
+		// A transient Anthropic-side api_error exit is likewise not a stage
+		// failure — the stage never ran. See claudeAPIErrorExit in claude.go
+		// and #1458.
+		var apiErrExit *claudeAPIErrorExit
+		if errors.As(err, &apiErrExit) {
+			e.handleAPIErrorExit(p, apiErrExit)
+			return
+		}
 	}
 
 	// A Claude turn-limit exit (CLI subtype error_max_turns) is not a genuine
@@ -2618,6 +2627,39 @@ func (e *Engine) handleAPIKeyHelperDetected(p stageOutcomeParams, apiKeyErr *api
 		e.postItemComment(item, comment, false)
 		e.addLabel(item, "fabrik:api-key-helper-detected")
 	}
+
+	p.release()
+}
+
+// handleAPIErrorExit is called by finalizeStageOutcome when a Claude
+// invocation exited on a transient Anthropic-side API error (see
+// claudeAPIErrorExit in claude.go, #1458), not because the stage genuinely
+// failed. Structurally the same "StageAttempted, never StageRetryIncremented"
+// split as handleUsageLimitExit/handleAPIKeyHelperDetected, but deliberately
+// a fifth, more minimal shape (#1458 R4): no durable label, no issue
+// comment. The condition is per-invocation and self-resolving on the next
+// attempt, so a label would be indistinguishable from the orphaned-durable-
+// state leak ADR-1183's sweep exists to clean up, and a comment for a
+// self-healing event is noise — log only. The dispatch cooldown that
+// StageAttempted activates (via LastAttemptAt) is the mechanism that bounds
+// the stage-dispatch retry loop (#1458 R6); see ADR-1458 for why the
+// comment-triggered dispatch path is bounded differently (the existing
+// comment-processing circuit breaker, not this handler).
+func (e *Engine) handleAPIErrorExit(p stageOutcomeParams, apiErr *claudeAPIErrorExit) {
+	item := p.item
+	stage := p.stage
+	repoStr := p.repoStr
+
+	e.logf(item.Number, "claude", "stage %q did not run — transient api_error (num_turns=%d, cost=$%.4f); not charged against max_retries\n", stage.Name, apiErr.NumTurns, apiErr.CostUSD)
+
+	// Record StageAttempted so the normal dispatch cooldown applies — the
+	// stage never ran, so StageRetryIncremented is deliberately never called.
+	e.store.Apply(itemstate.StageAttempted{
+		Repo:      repoStr,
+		Number:    item.Number,
+		StageName: stage.Name,
+		At:        time.Now(),
+	})
 
 	p.release()
 }


### PR DESCRIPTION
Closes #1458

## Summary

A Claude invocation exiting with `terminal_reason="api_error"` never ran the stage, but was previously charged against `max_retries` like a genuine failure — three such exits paused the issue even when nothing was wrong with the work. Observed live on 2026-08-08: eight such exits across two issues (#1408, #1208), all at 1 turn and `$0.0000`; #1408 was paused with a mergeable, all-green PR blocked behind it, and no Claude invocation ran anywhere on the board for ~50 minutes.

## Changes

- **`engine/claude.go`**: new `claudeAPIErrorExit` sentinel type and `classifyAPIErrorExit` classifier, structurally parallel to the existing `blocking_limit` usage-limit detector — `terminal_reason == "api_error"` from the CLI's own parsed result object only, never output prose. Wired into `interpretClaudeResult`'s cascade right after the usage-limit branch.
- **`engine/item.go`**: new `handleAPIErrorExit` routed from `finalizeStageOutcome` via `errors.As`. Records `StageAttempted` (so the normal dispatch cooldown applies) but never `StageRetryIncremented` — no `stage:<name>:failed`, no `fabrik:paused`, and (unlike the usage-limit/apiKeyHelper handlers) **no label and no comment** — a smaller, log-only "did not run" shape, since the condition is per-invocation and self-resolving.
- **`engine/comments.go`**: deliberately untouched. Because `claudeAPIErrorExit` is a distinct Go type from `claudeUsageLimitError`, it never triggers the account-wide Claude suspension and never bypasses the comment-processing circuit breaker — both of which are appropriate only for a genuine account-wide usage limit, not a transient per-invocation error.
- **`docs/state-machine.md`** (+regenerated `docs/llms-full.txt`): new §7.3a documenting the exemption and contrasting it with §7.3's usage-limit handling.
- **`adrs/1458-transient-api-error-exemption.md`**: records why a distinct sentinel type was used instead of reusing `claudeUsageLimitError`, why the exclusion guard is kept despite an unverified `CostUSD` sample, and why the comment path needed no change.

## Why a new sentinel type instead of just adding `"api_error"` to the existing usage-limit check?

`claudeUsageLimitError` isn't inert — by Go type, it also triggers account-wide Claude suspension and exempts the invocation from the comment-processing circuit breaker. Both are correct only for a genuine account-wide usage limit. Reusing it for `api_error` would have suspended Claude dispatch account-wide on a transient per-issue blip, and would have left the comment-triggered dispatch path with no bound at all — converting a bounded 3-strike pause into a potentially unbounded fast retry loop (the exact shape #1208's 5-exits-in-31-seconds burst showed is reachable). A distinct type avoids both by construction: the existing `errors.As(&claudeUsageLimitError{})` checks simply never match it.

## Acceptance criteria verification

1. ✅ `TestAPIErrorExit_ExemptFromRetryNoLabelNoComment` asserts `snap.Attempts("Research") == 0` directly (not just "not paused").
2. ✅ `TestAPIErrorExit_ThreeConsecutiveThenSuccess_CompletesNormally` — three `api_error` exits (with `MaxRetries: 2`, which would otherwise have paused after 3) then a successful invocation completes normally.
3. ✅ **Verified manually**: stubbed `classifyAPIErrorExit` to always return `false`, confirming `TestClassifyAPIErrorExit`'s zero-cost cases and `TestInterpretClaudeResult_APIErrorExit_ReturnsSentinelError` go red, then restored the fix (clean revert, verified with `git diff`). Note: the item-level `TestAPIErrorExit_*` tests mock the `ClaudeInvoker` to return the sentinel directly (per this repo's testing convention — mock at the interface boundary, not a fake binary), so they exercise the routing half (R2) independent of the classification half (R1); the classification-level tests in `claude_api_error_test.go` are what catch a classifier regression, and they did.
4. ✅ `TestAPIErrorExit_DoesNotActivateAccountWideSuspension` asserts `claudeSuspendedUntilTime` is unaffected.
5. ✅ `TestGenuineStageFailure_StillCountsAgainstRetries` (pre-existing) already covers this — a plain error with no `terminal_reason` matches no sentinel type.
6. ✅ `TestInterpretClaudeResult_APIErrorExit_UnparseableJSON_NotClassified`.
7. ✅ `go build`, `go vet ./...` clean. `go test -race ./...`: 3843 passed, 1 unrelated pre-existing failure (`TestExecute_ConfigYAMLApplied` in `cmd/`, a SIGINT-timing test — confirmed failing identically on `origin/main` before this branch's changes, via a throwaway worktree).

## Test plan

- [x] `go build -o fabrik .`
- [x] `go vet ./...`
- [x] `go test -race ./...` (3843 passed; 1 pre-existing unrelated failure confirmed on `origin/main`)
- [x] Manual Acceptance-3 neutralization check (see above)