### PR TITLE
fix: make review/CI-fix/rebase/enqueue cycle-limit pauses actually resumable

### DIFF
--- a/adrs/1460-resumable-engine-pauses.md
+++ b/adrs/1460-resumable-engine-pauses.md
@@ -1,0 +1,285 @@
+# ADR 1460: Resumable Engine Pauses — a Reset Trigger for Cycle-Limit Counters
+
+**Date**: 2026-08-08
+**Status**: Accepted
+**Issue**: #1460 — every pause comment Fabrik posts says "remove `fabrik:paused` to resume," but for
+four cycle-limit pause sites this was false: the triggering counter was never reset, so the item
+re-paused within seconds of the label being removed.
+
+## Context
+
+Every `pauseIssue` call site tells the operator, in the pause comment itself, to remove
+`fabrik:paused` to resume. For genuine stage failures (`escalateFailedStage`, `escalatePRCreationFailure`,
+`handleBoundaryViolation`, `escalateSettle`) that promise has always been honest: each of these applies
+`itemstate.EnginePaused`, which routes the item through `processItem`'s unpause gate
+(`engine/item.go`):
+
+```go
+wasPaused = snap.PausedByEngine(stage.Name)   // requires itemstate.EnginePaused to have been Applied
+if wasPaused || hasFailedLabel {              // hasFailedLabel requires stage:<name>:failed
+    e.clearFailedStage(item, stage)
+}
+```
+
+`clearFailedStage` is the sole caller of `EngineCyclesCleared`, the only mutation that zeroes
+`ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles` for a stage. Four sites —
+`pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`,
+`pauseForEnqueueCycleLimit` — pause on exactly this shape (`cycleCount >= maxCycles`) but never applied
+`itemstate.EnginePaused`, so `wasPaused` was never true for them and `clearFailedStage` never fired.
+Because nothing else zeroes these counters, `cycleCount >= maxCycles` remained true forever once
+tripped: the very next time the item was evaluated after a human removed `fabrik:paused`, it
+re-evaluated the identical `>=` check and re-paused — reproduced live on #1208, five seconds from
+unpause to re-pause, byte-identical repost comment.
+
+PR #1445 (issue #1408, merged a few hours before this issue was filed) had already fixed the
+comment-repost half of this shape for `pauseForCITimeout`/`pauseForCIFixCycleLimit`
+([ADR-1408](1408-ci-gate-pause-comment-reuse-on-resume.md)) — `hasCIGatePauseComment` +
+`reapplyCIGatePauseLabels` stop a re-pause from spamming a duplicate comment. It deliberately did not
+touch counter reset (out of scope for #1408); `pauseForCIFixCycleLimit` remained a one-way door after
+that merge, confirmed by reading the current code before this issue's Specify stage ran.
+
+### The suggested fix's premise was wrong
+
+The issue body's own suggested R2 approach — "apply `itemstate.EnginePaused`, making `wasPaused` true
+so `clearFailedStage` fires on unpause" via `processItem`'s existing gate — assumed that gate is
+reachable for these four sites. It is not. All four pauses fire from the Phase 1 catch-up handler
+chain (`catchUpPhase1Handlers`, `engine/catch_up_handlers.go` — `handleReviewGate` for review,
+`handleMergeAndCIGates`/`handleAutoMergeConvergence` for CI-fix/rebase/enqueue), which only runs for
+items that are **already stage-complete** (or carrying `fabrik:awaiting-ci`) with no new comment.
+`itemNeedsWork` (`engine/item.go`) returns `false` for such an item — "already completed this stage,"
+no new comment — so `processItem` is never dispatched for it after a label-only unpause.
+`processItem`'s own unpause gate is structurally unreachable for these four sites.
+
+The actual re-evaluation point is the catch-up loop's admission in `poll.go` and the identical loop
+`settleAwaitingCIScan` runs in `ci_settle.go` — both skip an item outright while `fabrik:paused` is
+present, then re-run the same `catchUpPhase1Handlers` chain the moment it's removed. Before this fix,
+that chain contained no reset logic at all — which is exactly what #1208's live repro shows: no
+comment was ever involved in the resume attempt, only a label removal, and the item was re-evaluated
+by the catch-up loop, not by `processItem`.
+
+## Decision
+
+### R2 — apply `itemstate.EnginePaused`, but add a second, additive reset trigger
+
+Reuse `itemstate.EnginePaused` directly (not a neutral marker — see "Alternatives Considered"). Each
+of the four confirmed sites now applies it in **both** branches (fresh pause and the R4
+reapply-existing-comment branch — see below for why both matter).
+
+That alone is insufficient, per the reachability finding above. The actual fix is a new Phase 1
+handler, `handleEngineUnpause`, **prepended first** in `catchUpPhase1Handlers`:
+
+```go
+func (e *Engine) handleEngineUnpause(pctx *phase1Ctx) bool {
+	repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
+	snap, err := e.store.Get(repoStr, pctx.item.Number)
+	if err != nil || !snap.PausedByEngine(pctx.stage.Name) {
+		return false
+	}
+	e.clearFailedStage(pctx.item, pctx.stage)
+	return false
+}
+```
+
+It reuses `clearFailedStage` as-is — no new reset implementation, keeping one reset path for both the
+pre-completion (`processItem`) and post-completion (`catchUpPhase1Handlers`) resume cases.
+`PausedByEngine` being true here means: the item reached this handler chain (so `fabrik:paused` is
+currently absent, per both entry points' admission filters) while still carrying a stale
+`EnginePaused` record from before the label was removed — precisely "a human unpaused a cycle-limit
+pause." It always returns `false` (never claims), so the rest of the chain evaluates the just-reset
+counters in the *same* pass — a genuine resume converges in one poll, not two, satisfying AC2
+immediately.
+
+Placement is load-bearing: `handleEngineUnpause` must run **unconditionally, before any handler that
+might claim/short-circuit the item**, so the reset always lands before that pass's own cycle-limit
+checks read the (freshly zeroed) counters. `escalateFailedStage`/`escalatePRCreationFailure`/
+`handleBoundaryViolation`-paused items are never stage-complete when paused, so they never reach the
+catch-up loop at all — `processItem`'s gate remains their sole, unchanged resume path (AC5).
+`escalateSettle` is untouched: out of scope, and it uses a synthetic `retryStage` string that doesn't
+intersect with either gate.
+
+**Why EnginePaused is applied on the reapply branch too, not just the fresh-pause branch:** a resume
+clears `PausedByEngine` via `handleEngineUnpause`. If the underlying condition recurs (CI keeps
+failing, the conflict keeps recurring, the queue keeps thrashing) and the counter climbs back to the
+limit a *second* time, the pause function runs again — but `hasPauseComment` still matches the old
+comment, so it takes the reapply branch. If that branch didn't re-apply `EnginePaused`, the *next*
+resume attempt would be a no-op again. Both branches must re-arm it uniformly.
+
+### The `Attempts`-reset side effect (accepted, not a defect)
+
+`clearFailedStage`'s full reset sequence — remove `stage:<name>:failed` (harmless no-op; these four
+sites never apply it) → `StageRetryCleared` → `EngineUnpaused` → `StageLastAttemptCleared` →
+`EngineCyclesCleared` → `resetCommentBreaker` — also zeroes `Attempts(stage.Name)` via
+`StageRetryCleared`, the counter `MaxRetries`/`escalateFailedStage` uses. A stage can accumulate
+`Attempts` from genuine incomplete/errored invocations independently of its cycle counter. Unpausing a
+review-cycle-limited (etc.) item therefore also gives that stage's `MaxRetries` budget a clean slate.
+
+This is accepted as deliberate — "a human unpause is 'try again,' clean slate" — consistent with the
+same reset already applying identically to `escalateFailedStage`/`escalatePRCreationFailure` (AC5's
+own baseline) and to `pauseForSliceLimit` (#1199, landed on `main` ahead of this issue via a review
+finding on PR #1447 — see "Relationship to `pauseForSliceLimit`" below). There is no "unchanged"
+`Attempts` baseline to preserve for the four newly-fixed sites — they were broken before this fix — so
+this is a net-new, intentional behavior, not a regression.
+
+### R4 — reuse, generalize, and correctly scope PR #1445's no-repost pattern
+
+`hasCIGatePauseComment`/`reapplyCIGatePauseLabels` (`engine/ci.go`) are generalized into
+`engine/mutate.go` as `hasPauseComment(item, fragments...) bool` and `reapplyPauseLabels(item)` —
+identical bodies, parameterized on the caller's own stable message fragment(s) instead of hardcoding
+CI's two. `hasCIGatePauseComment` now delegates to the shared helper; no behavior change for the CI
+case.
+
+Each of the three newly-fixed sites gets its own fragment constant/function and reapply branch,
+mirroring the CI pair exactly:
+
+| Site | Stable fragment matched |
+|---|---|
+| `pauseForReviewCycleLimit` | `"The stage **%s** has been re-invoked to address PR review feedback"` |
+| `pauseForRebaseCycleLimit` | `"The stage **%s** has been re-invoked to rebase onto the base branch"` |
+| `pauseForEnqueueCycleLimit` | `"has been re-enqueued into GitHub's merge queue"` (deliberately omits the stage name — the original sentence puts it earlier: *"The linked PR for stage **%s** has been re-enqueued..."*) |
+| `pauseForCIFixCycleLimit` | unchanged — `"The stage **%s** has been re-invoked to fix CI failures"` (from #1445) |
+
+All four functions now return `(escalated bool)` — `true` when a fresh pause comment was posted,
+`false` when an existing episode's pause was merely reapplied — matching `pauseForCITimeout`'s
+existing shape from #1445. Every call site discards the return value as a bare statement (Go permits
+this; no signature changes were needed at any of the six call sites across the four functions),
+matching the existing precedent at `merge_gate.go` and `catch_up_handlers.go` for the CI case.
+
+Given R2 zeroes the counter on every genuine resume, this reapply branch rarely fires post-fix for the
+three newly-covered sites — once resumed, the counter reads 0, so `cycleCount >= maxCycles` is false
+and the item just proceeds normally instead of re-pausing. Its remaining purpose is defense-in-depth:
+the same same-poll double-call race [ADR-1408](1408-ci-gate-pause-comment-reuse-on-resume.md)
+documents for CI, and the second-episode-after-a-successful-resume case described above.
+
+**Inherited, unscoped-by-time caveat (unchanged, out of scope to fix):** `hasPauseComment`'s match
+scans the issue's *entire* comment history for the fragment, not just "this episode." A stage that was
+cycle-limit-paused once, resumed successfully, and later hits the same limit again for an unrelated
+reason will match the old comment and silently relabel instead of posting a fresh one. This is
+identical to `hasCIGatePauseComment`'s pre-existing, already-accepted behavior (documented in its own
+comment) — the issue's scope explicitly asks to reuse the pattern, not fix this characteristic.
+
+### `pauseForEnqueueCycleLimit`'s doc comment correction
+
+Before this fix, the function's doc comment asserted: *"The EnqueueCycles counter is cleared by
+`clearFailedStage` (`EngineCyclesCleared`) when the user unpauses."* This was never true — the
+function never applied `itemstate.EnginePaused`, so `wasPaused` was never true for it via
+`processItem`'s gate, and (before `handleEngineUnpause` existed) nothing else called
+`clearFailedStage` for it either. The comment is corrected to describe the actual, now-true mechanism
+(`handleEngineUnpause`).
+
+## R3 — Classification of Every `pauseIssue`/Cycle-Limit Site
+
+Every site identified in the issue's root-cause sweep, re-verified against the current codebase (not
+assumed from the original report):
+
+| Site | Classification | Mechanism |
+|---|---|---|
+| `escalateFailedStage` | Already correct | Applies `EnginePaused`; resumed via `processItem`'s gate (unreachable-by-catch-up-loop items only, since not yet stage-complete) |
+| `escalatePRCreationFailure` | Already correct | Same as above |
+| `handleBoundaryViolation` | Already correct | Same as above |
+| `escalateSettle` | Already correct | Applies `EnginePaused` keyed on a synthetic `retryStage` string; out of scope, untouched |
+| `pauseForSliceLimit` | Already correct (fixed on `main` ahead of this issue) | Applies `EnginePaused`; resumed via `processItem`'s gate — reachable for it because a slice-limit pause fires *mid-stage*, before `stage:<name>:complete`, unlike the four confirmed sites here. See "Relationship to `pauseForSliceLimit`" below. |
+| **`pauseForReviewCycleLimit`** | **Confirmed defective → fixed (R2)** | `ReviewCycles`; now applies `EnginePaused`, resumed via `handleEngineUnpause` |
+| **`pauseForCIFixCycleLimit`** | **Confirmed defective → fixed (R2)** | `CIFixCycles`; now applies `EnginePaused`, resumed via `handleEngineUnpause` (R4 no-repost already existed from #1445) |
+| **`pauseForRebaseCycleLimit`** | **Confirmed defective → fixed (R2)** | `RebaseCycles`; now applies `EnginePaused`, resumed via `handleEngineUnpause` |
+| **`pauseForEnqueueCycleLimit`** | **Confirmed defective → fixed (R2)** | `EnqueueCycles`; now applies `EnginePaused`, resumed via `handleEngineUnpause`; doc comment corrected |
+| `pauseForReviewTimeout` | Independently resets | `checkAwaitingReviewTimeout` calls `removeAwaitingReviewLabel` (strips `fabrik:awaiting-review` + `fabrik:bot-reprompted`) *before* pausing — its own timing anchor is gone by the time the pause fires. No counter. |
+| `pauseForCITimeout` | Condition-driven, no counter | Anchored to `fabrik:awaiting-ci`'s label-applied-at (external CI-completion state, not an attempt budget). Already has R4's reapply-without-repost from #1445. Re-pausing on resume while CI is genuinely still unresolved is correct, not a defect — there is no "give it another try" budget for an external wait condition. |
+| `pauseForConvergenceFailed` | Independently resets | `pauseOpts{removeAutoMerge: true}` strips `fabrik:auto-merge-enabled`, its own anchor label (`ConvergenceBudget` is measured from that label's applied-at). Resume naturally starts a fresh budget once `attemptMergeOnValidate` reapplies the label. |
+| `pauseForMergeGroupStall` | Independently resets | Same `removeAutoMerge: true` mechanism, explicitly documented in its own doc comment as resetting the convergence flow so the stall check doesn't immediately re-fire on resume. |
+| `pauseForPRClosedNotMerged` | Condition-driven, no counter | Removes all three gate labels (`fabrik:awaiting-ci`, `fabrik:awaiting-review`, `fabrik:rebase-needed`) itself; resuming requires a GitHub-side state change (reopen/replace the PR), not a counter reset. |
+| `pauseForRequiredNeverRunningCheck` | Condition-driven, no counter | Removes `fabrik:awaiting-ci`; resuming re-derives check-run presence live from GitHub on every call. |
+| `handleBrokenReviewLinkage` | Condition-driven, no counter | Re-fetches `FetchLinkedPR`/`FetchPRClosingIssues` live on every call (`item.LinkedPRNumber != 0` short-circuits at the top when linkage is already fine); resolves itself once a human fixes the PR body/branch. No counter, no anchor. |
+| `checkAutoMergeConvergence`'s direct pause ("auto-merge disabled by user") | Independently resets | Also uses `pauseOpts{removeAutoMerge: true}` — same mechanism as `pauseForConvergenceFailed`/`pauseForMergeGroupStall`. |
+| `pauseForBrokenLinkage` | Condition-driven, no counter | No cycle counter; resolves once the PR is created/relinked. |
+| `tripCommentBreaker` | Independently resets | The comment-breaker counter is windowed (time-based), so it self-expires — not gated by `fabrik:paused` removal at all. |
+| `checkDependencies` | Independently resets | Cleared when the blocking issues close; no counter, live-derived every call. |
+| `ensureRepoReady`, `postSpawnCloneError`, `spawnChildren` | Condition-driven, no counter | Each resolves once the underlying external condition (clone succeeds, spawn retried) changes; no stuck counter. |
+
+None of the 8 originally-unclassified sites needed R2's treatment. Each was re-verified by reading
+its current implementation (not taken on faith from Research's read) — every one either strips its own
+timing anchor before or as part of pausing, or has no counter/anchor at all and re-derives its
+condition live on every call.
+
+## Relationship to `pauseForSliceLimit` (#1199, R5)
+
+#1199/PR #1447 (`pauseForSliceLimit`, the turn-cap/slice-budget pause) landed on `main` *ahead of* this
+issue, via a review finding on that PR: *"a slice-limit pause was unrecoverable... `SliceRetries`
+stayed pinned at `MaxSliceRetries`."* Its fix applies `itemstate.EnginePaused` — the same mechanism
+this ADR formalizes — but reaches resumability differently: a slice-limit pause fires **mid-stage**,
+before `stage:<name>:complete` is ever applied, so the item is *not* yet stage-complete when paused,
+and `processItem`'s own existing gate remains reachable and sufficient for it (it never needs
+`handleEngineUnpause`). This is the same distinction that keeps `escalateFailedStage` et al. off the
+catch-up-loop path: whether a pause happens *before* or *after* stage completion determines which of
+the two resume gates (`processItem`'s vs. `handleEngineUnpause`'s) actually reaches it.
+
+`pauseForSliceLimit` independently adopted the `EnginePaused` mechanism this issue's R2 also uses,
+which satisfies R5's coordination requirement retroactively — no further change to that function is
+needed here. It is listed in the R3 table above as "already correct" for completeness.
+
+## The Two Resume Gates
+
+Post-fix, "remove `fabrik:paused` to resume" is honest for every reachable pause, via exactly one of
+two paths depending on *when* the pause fires relative to stage completion:
+
+1. **Pre-completion pauses** (stage not yet marked `stage:<name>:complete`) — `escalateFailedStage`,
+   `escalatePRCreationFailure`, `handleBoundaryViolation`, `pauseForSliceLimit` — resume via
+   `processItem`'s own `wasPaused || hasFailedLabel` gate (`engine/item.go`), unchanged by this issue.
+2. **Post-completion pauses** (stage already complete, or in the `fabrik:awaiting-ci` window) — the
+   four confirmed sites this issue fixes — resume via `handleEngineUnpause`, the new Phase 1 handler
+   in `catchUpPhase1Handlers`.
+
+`escalateSettle` is a structurally separate third case (settle-scan retry, synthetic stage key), left
+untouched and out of scope.
+
+## Alternatives Considered
+
+**A neutral marker instead of reusing `itemstate.EnginePaused`.** Would require a new `Mutation` type
+(e.g. `EngineCounterPaused`), a second field in `StageState`, a second checked condition at both
+resume gates, and a variant of `clearFailedStage` that skips `stage:<name>:failed` removal/
+`StageRetryCleared`/`resetCommentBreaker`. This avoids the `Attempts`-reset side effect but is
+materially more code across `itemstate` and `engine`, and introduces a second reset implementation to
+keep in sync with the first. Rejected: the `Attempts`-reset side effect is accepted as intentional
+(see above), and one reset path is easier to reason about and test than two.
+
+**Relying solely on `processItem`'s existing gate**, as the issue body's own suggested R2 approach
+assumed. Rejected because it is provably unreachable for all four confirmed sites — see "The
+suggested fix's premise was wrong" above. This is the single most important correction this ADR
+records versus the issue's own suggested implementation.
+
+## Consequences
+
+**Positive:**
+- Every pause comment's "remove `fabrik:paused` to resume" instruction is now honest for all four
+  previously-defective sites, closing the exact defect #1208 demonstrated live.
+- One reset implementation (`clearFailedStage`) serves both resume gates — no duplicated reset logic.
+- `handleEngineUnpause`'s placement and always-`false` return let a genuine resume converge in a
+  single poll pass (reset, then re-evaluate with the fresh counter, in the same call).
+- R4's no-repost pattern is now uniform across all four cycle-limit-pause domains (review, rebase,
+  enqueue, CI-fix), sharing one implementation in `mutate.go` instead of four near-duplicates.
+- `escalateFailedStage`/`escalatePRCreationFailure`/`handleBoundaryViolation`'s existing, correct
+  behavior is provably unaffected — none of the three functions, nor `clearFailedStage`, nor
+  `processItem`'s gate were modified; they are structurally unreachable by `handleEngineUnpause`
+  (never stage-complete when paused).
+
+**Negative / Trade-offs:**
+- A manual unpause of a cycle-limit-paused stage also resets that stage's unrelated `Attempts`/
+  `MaxRetries` counter (the accepted side effect described above) — a behavior change from "broken"
+  (no reset at all) to "broader reset than the issue narrowly asked for," not a regression from any
+  prior correct behavior.
+- `hasPauseComment`'s fragment matching remains unscoped by time, inherited unchanged from
+  `hasCIGatePauseComment` — a second, unrelated cycle-limit episode long after a successful resume
+  will silently relabel instead of posting a fresh comment. Pre-existing, accepted, and explicitly out
+  of scope to fix here.
+- `handleEngineUnpause` adds one more unconditional handler to every Phase 1 catch-up pass (one
+  `store.Get` per stage-complete-or-awaiting-ci item, per poll) — negligible cost, no additional
+  GitHub API calls (store-only read).
+
+## References
+
+[ADR-1408: CI-Gate Pause Comment Reuse on Resume](1408-ci-gate-pause-comment-reuse-on-resume.md) (the
+direct R4 precedent this issue generalizes), [ADR-1270: Awaiting-CI Settle Scan](1270-awaiting-ci-settle-scan.md)
+(establishes the `catchUpPhase1Handlers`-shared-loop pattern `handleEngineUnpause` also runs inside),
+[ADR-1199: Separate the slice-budget counter from the failure-retry counter](1199-slice-budget-separate-from-failure-counter.md)
+(the sibling pause site that independently adopted `EnginePaused`, satisfying R5), issue #1208 (the
+live reproduction that prompted this issue), `docs/state-machine.md` §6.2 and the "Resumable Engine
+Pauses" section (as-built documentation of both resume gates).

--- a/adrs/1460-resumable-engine-pauses.md
+++ b/adrs/1460-resumable-engine-pauses.md
@@ -231,6 +231,40 @@ two paths depending on *when* the pause fires relative to stage completion:
 `escalateSettle` is a structurally separate third case (settle-scan retry, synthetic stage key), left
 untouched and out of scope.
 
+## Restart Durability
+
+A review comment on the implementing PR raised a plausible-sounding concern: `handleEngineUnpause`
+detects a stale pause purely via `snap.PausedByEngine(stage.Name)`, which is in-memory-only and "does
+not survive restart" per its own doc comment (`internal/itemstate/snapshot.go`) — so if the engine
+restarts while an item is genuinely cycle-limit-paused, wouldn't that flag come back `false`, leaving
+`handleEngineUnpause` unable to detect the stale pause, while the *durable* cycle counter stays pinned
+at the limit? That would reproduce this issue's exact bug via a restart instead of a missing
+`EnginePaused` apply.
+
+The premise doesn't hold: `ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles` are **not**
+durable either — they live in the same in-memory `StageState` map structure as `PausedByEngine`, in
+the same `itemstate.Store`, which `NewStore(nil)` (`engine/engine.go`) always constructs with empty
+maps at process start; nothing in this codebase serializes or rehydrates `itemstate.Store` from any
+prior process. There is no persistence layer for any of `StageState`'s fields — the "in-memory only,
+does not survive restart" language on `PausedByEngine`'s and `PRCreationFailed`'s doc comments happens
+to call this out explicitly, but it applies uniformly to every field in `StageState`, cycle counters
+included; those two doc comments are not marking an exception.
+
+Concretely: a restart wipes `PausedByEngine` *and* the triggering cycle counter for that stage
+together, in the same moment (a fresh `ItemState` for that key, or the whole `items` map starting
+empty). There is no interleaving in which one resets while the other survives — both are gone, or
+neither is (trivially, since the process either restarted or it didn't). Tracing the actual sequence:
+a restart before a human removes `fabrik:paused` leaves the label in place (durable, on GitHub) while
+the in-memory counter and flag both silently zero; when the label is later removed, the item reaches
+`handleEngineUnpause` with `PausedByEngine` already `false` — a no-op, exactly as the comment
+predicts — but the cycle-limit check downstream reads the *also-already-zeroed* counter, so it doesn't
+re-pause either. The net effect of a restart is indistinguishable from an early, free `handleEngineUnpause`
+having already fired for every paused item — never the split-brain (flag lost, counter retained) the
+comment described. This is unchanged by, and not specific to, this issue's fix: it is a pre-existing
+property of every `EnginePaused`-gated site, including the four already-correct ones
+(`escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation`) and `pauseForSliceLimit`
+(#1199), none of which persist `Attempts`/`SliceRetries` across a restart either.
+
 ## Alternatives Considered
 
 **A neutral marker instead of reusing `itemstate.EnginePaused`.** Would require a new `Mutation` type

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4076,6 +4076,8 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Same column, Paused | Human removes `fabrik:paused` | — | Same column, Idle | | | Engine processes item on next poll |
 | Same column, Paused | New human comment | Not a bot login (`github.IsBotLogin`, `humanNewComments()`) | Same column, Idle → comment processing | | `fabrik:paused` | Unpause; `clearFailedStage()` also called (clears any failed label + resets retries); falls through to `processComments()`. A bot-authored comment does not match this guard and leaves the item Paused (#1083). |
 
+> **This table covers `processItem`'s own unpause gate** — reachable only for a pause that fires *before* the stage is marked `stage:<X>:complete` (`escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation`, `pauseForSliceLimit`). A pause that fires *after* the stage is already complete (the four cycle-limit pause sites: review, CI-fix, rebase, enqueue — see §7.2 "Resumable Engine Pauses") is resumed by a different mechanism, `handleEngineUnpause` in the catch-up loop's Phase 1 handler chain (§6.2, Handler 0) — `processItem` is never dispatched for a stage-complete item with no new comment, so its gate above is structurally unreachable for those four sites. See ADR-1460.
+
 #### Lock Conflict (Multi-Instance)
 
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
@@ -4829,6 +4831,8 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 **Phase 1 — unconditional, ordered handler list (`catchUpPhase1Handlers`):**
 
 Phase 1 is implemented as an explicit ordered slice of named handler methods (`catchUpPhase1Handlers` in `engine/catch_up_handlers.go`). Each handler returns `true` to claim the item — Phase 2 is skipped for this item this cycle — or `false` to pass through to the next handler. **Ordering is structurally enforced by slice position** (ADR-056 D3); a future reorder requires a deliberate code change and triggers a test failure, rather than occurring as an accidental side effect of a `continue` insertion.
+
+**Handler 0: `handleEngineUnpause`** (#1460 — numbered 0, not renumbering Handlers 1-4 below, to avoid an invasive cross-reference cascade) — runs first, unconditionally, ahead of every other Phase 1 handler. It is the actual resume trigger for the four cycle-limit pause sites (`pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `pauseForEnqueueCycleLimit`; see §7.2 "Resumable Engine Pauses"): checks `snap.PausedByEngine(stage.Name)`; if true — meaning the item reached this handler chain (so `fabrik:paused` is currently absent, per both the main catch-up loop's and `settleAwaitingCIScan`'s admission filters) while still carrying a stale `itemstate.EnginePaused` record from before the label was removed — it calls `clearFailedStage()`, the same reset `processItem`'s own unpause gate already uses (zeroing `ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles`, clearing `Attempts`, resetting `LastAttemptAt`, and resetting the comment circuit breaker). Always returns `false` — it only resets state, never claims — so the rest of the chain evaluates the just-reset counters in the *same* pass, letting a genuine resume converge in one poll rather than two. See ADR-1460 for why this handler exists at all (`processItem`'s pre-existing unpause gate is structurally unreachable for these four sites — they only ever fire post-stage-completion, where `itemNeedsWork` never re-dispatches `processItem`).
 
 **Handler 1: `handleDependencies`** — thin wrapper around `checkDependencies()`. If the item has unresolved blocking dependencies, claims the item (returns true); otherwise passes through. `checkDependencies`'s own bool return **is** the Phase 1 claim signal directly (no translation layer, unlike the review/CI gates below) — so its cycle-detection branch (a bounded BFS finds the item is itself a transitive blocker of one of its own blockers) also returns `true` when it pauses the issue via `pauseIssue` (ADR-1223), rather than reusing the `false` value returned for "no open dependencies." Before this fix the cycle-detection pause fell through unclaimed, the same overloaded-return bug present in the review/CI gates.
 
@@ -5731,6 +5735,30 @@ When a stage fails `MaxRetries` times (default: configurable, 0 disables):
 - Removes `stage:<X>:failed`
 - Resets retry count (`StageRetryCleared`), engine-paused flag (`EngineUnpaused`), cooldown (`StageLastAttemptCleared`), and review cycle count (`EngineCyclesCleared`)
 
+#### 7.2.1 Resumable Engine Pauses (ADR-1460)
+
+**The invariant:** every pause comment Fabrik posts ends with "remove `fabrik:paused` to resume" — this must actually be true for every pause site, not just stage-failure escalation. Before #1460, four pause sites violated it: `pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `pauseForEnqueueCycleLimit` never applied `itemstate.EnginePaused`, so removing `fabrik:paused` was a no-op — the triggering cycle counter (`ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles`) stayed pinned at its limit and the item re-paused on its very next evaluation (reproduced live on #1208: five seconds from unpause to re-pause, byte-identical repost comment, no comment involved in the resume attempt at all).
+
+**Two resume gates, chosen by *when* the pause fires relative to stage completion:**
+
+1. **Pre-completion pauses** (stage not yet `stage:<X>:complete`) — `escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation` (§7.2 above), `pauseForSliceLimit` (§7.12) — resume via `processItem()`'s own `wasPaused || hasFailedLabel` gate, described above. Unchanged by #1460.
+2. **Post-completion pauses** (stage already `stage:<X>:complete`, or in the `fabrik:awaiting-ci` window) — the four cycle-limit sites — resume via **`handleEngineUnpause`**, a Phase 1 catch-up-loop handler (§6.2, Handler 0) added by #1460. `processItem()` is never dispatched for a stage-complete item with no new comment (`itemNeedsWork` returns false), so gate 1 above is structurally unreachable for these four sites — this was the flaw in the issue's own originally-suggested fix. `handleEngineUnpause` runs first, unconditionally, in every Phase 1 pass: if `snap.PausedByEngine(stage.Name)` is true while the item is here at all (meaning `fabrik:paused` is currently absent, per the catch-up loop's own admission filter), it calls the identical `clearFailedStage()` reset gate 1 uses, then lets the rest of the chain re-evaluate the just-reset counter in the same pass.
+
+All four now-fixed sites apply `itemstate.EnginePaused` in both their fresh-pause branch and their reapply-existing-comment branch (see below) — the reapply branch must re-arm it too, or a *second* cycle-limit episode after a successful first resume would itself become a fresh one-way door.
+
+**No-repost on re-pause (R4):** reusing the pattern from ADR-1408 (`pauseForCITimeout`/`pauseForCIFixCycleLimit`), each of the four sites checks `hasPauseComment(item, <its own stable message fragment>)` before posting — a `mutate.go`-shared helper generalized from ADR-1408's CI-specific `hasCIGatePauseComment`. If a matching comment already exists for the episode, the labels are reapplied (`reapplyPauseLabels`) without a duplicate post.
+
+**Classification of every pause/counter site (full detail in ADR-1460):**
+
+| Category | Sites |
+|---|---|
+| Already correct (applies `EnginePaused`, resumes via gate 1) | `escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation`, `escalateSettle` (synthetic stage key, out of scope), `pauseForSliceLimit` (§7.12 — mid-stage, gate 1 reachable) |
+| Fixed by #1460 (applies `EnginePaused`, resumes via gate 2 / `handleEngineUnpause`) | `pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `pauseForEnqueueCycleLimit` |
+| Independently resets (no fix needed) | `pauseForReviewTimeout` (strips its own `fabrik:awaiting-review` anchor before pausing), `pauseForConvergenceFailed` / `pauseForMergeGroupStall` / `checkAutoMergeConvergence`'s "auto-merge disabled" branch (all strip `fabrik:auto-merge-enabled`, their shared anchor), `tripCommentBreaker` (self-expiring window), `checkDependencies` (live-derived) |
+| Condition-driven, no counter (no fix needed) | `pauseForCITimeout` (anchored to external `fabrik:awaiting-ci` state, not an attempt budget — re-pausing while CI is genuinely still unresolved is correct), `pauseForPRClosedNotMerged`, `pauseForRequiredNeverRunningCheck`, `handleBrokenReviewLinkage`, `pauseForBrokenLinkage`, `ensureRepoReady`/`postSpawnCloneError`/`spawnChildren` |
+
+**Accepted side effect:** `clearFailedStage()`'s reset (reused unmodified by `handleEngineUnpause`) also zeroes `Attempts(stage.Name)` — the unrelated `MaxRetries` failure counter — via `StageRetryCleared`. A manual unpause of a cycle-limit-paused item therefore also gives that stage's failure budget a clean slate. This is deliberate ("a human unpause is 'try again'"), consistent with the same reset already applying to `escalateFailedStage`/`escalatePRCreationFailure`, and is a net-new intentional behavior for the four newly-fixed sites (they had no working "unchanged" baseline to preserve — they were broken before #1460).
+
 ### 7.3 Claude Usage-Limit Exemption
 
 When a Claude invocation exits because the account's usage limit was hit (e.g. `You've hit your
@@ -6250,19 +6278,22 @@ is treated the same as a genuine error rather than inferred to be a slice. This 
 
 **Recovery:** `StageRetryCleared` — applied on normal stage completion and by `clearFailedStage()` on
 manual unpause — zeroes `SliceRetries(stageName)` alongside `Attempts(stageName)`; the two counters
-share one reset point. Unlike `pauseForRebaseCycleLimit`, `pauseForSliceLimit()` **does** apply
-`itemstate.EnginePaused` (never `stage:<X>:failed`): `RebaseCycles` has an independent path back to
-progress (a human resolves the underlying merge conflict directly, which changes `settle.Status` and
-lets the poll loop advance without ever re-checking the counter), but `SliceRetries` has no such
-signal — the job simply needs more slices than the budget allowed, with nothing external to "fix."
-Without `EnginePaused`, `processItem()`'s unpause guard (`wasPaused || hasFailedLabel`, both false for
-a pure slice-limit pause) would never fire `clearFailedStage()`, `SliceRetries` would never reset, and
-removing `fabrik:paused` would be a no-op: the very next dispatch takes exactly one more slice,
-re-checks a counter already at `MaxSliceRetries`, and re-pauses immediately — the documented recovery
-path would not work. With `EnginePaused` applied, `snap.PausedByEngine(stageName)` is true on the next
-pass, so removing `fabrik:paused` genuinely triggers `clearFailedStage()` → `StageRetryCleared`, and
-the stage resumes with a fresh slice budget. `clearFailedStage()`'s `stage:<X>:failed` label removal is
-a harmless no-op on this path, since that label was never applied.
+share one reset point. `pauseForSliceLimit()` applies `itemstate.EnginePaused` (never
+`stage:<X>:failed`), and — unlike the four cycle-limit sites #1460 fixes (§7.2.1) — resumes via
+`processItem()`'s own gate directly, not via `handleEngineUnpause`: a slice-limit pause fires
+**mid-stage**, before `stage:<X>:complete` is ever applied, so the item is not yet stage-complete when
+paused and `processItem()`'s gate remains reachable. Without `EnginePaused`, `processItem()`'s unpause
+guard (`wasPaused || hasFailedLabel`, both false for a pure slice-limit pause) would never fire
+`clearFailedStage()`, `SliceRetries` would never reset, and removing `fabrik:paused` would be a no-op:
+the very next dispatch takes exactly one more slice, re-checks a counter already at `MaxSliceRetries`,
+and re-pauses immediately — the documented recovery path would not work. With `EnginePaused` applied,
+`snap.PausedByEngine(stageName)` is true on the next pass, so removing `fabrik:paused` genuinely
+triggers `clearFailedStage()` → `StageRetryCleared`, and the stage resumes with a fresh slice budget.
+`clearFailedStage()`'s `stage:<X>:failed` label removal is a harmless no-op on this path, since that
+label was never applied. (This section previously contrasted with `pauseForRebaseCycleLimit`, which at
+the time did not apply `EnginePaused` either — #1460 fixed that site too, via the separate
+`handleEngineUnpause` resume path described in §7.2.1, since a rebase-cycle-limit pause fires
+post-completion, unlike this section's mid-stage slice-limit pause.)
 
 **Regression guard:** a job that has already taken more turn-cap slices than `MaxRetries` (the old,
 accidental ceiling per #1191) is never paused as long as it stays within `MaxSliceRetries` — `Attempts`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5759,6 +5759,8 @@ All four now-fixed sites apply `itemstate.EnginePaused` in both their fresh-paus
 
 **Accepted side effect:** `clearFailedStage()`'s reset (reused unmodified by `handleEngineUnpause`) also zeroes `Attempts(stage.Name)` — the unrelated `MaxRetries` failure counter — via `StageRetryCleared`. A manual unpause of a cycle-limit-paused item therefore also gives that stage's failure budget a clean slate. This is deliberate ("a human unpause is 'try again'"), consistent with the same reset already applying to `escalateFailedStage`/`escalatePRCreationFailure`, and is a net-new intentional behavior for the four newly-fixed sites (they had no working "unchanged" baseline to preserve — they were broken before #1460).
 
+**Restart durability:** `handleEngineUnpause` reads `PausedByEngine`, which is in-memory-only (does not survive an engine restart — `internal/itemstate/snapshot.go`). This is not a gap: `ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles` live in the same in-memory `StageState`, constructed empty by `NewStore(nil)` on every process start with no persistence layer for any `StageState` field — so a restart clears the pause flag *and* the triggering counter together, never one without the other. A restart before a human unpauses an item is equivalent to `handleEngineUnpause` having already fired for free (both read back as zero); there is no interleaving that reproduces this section's defect via a restart. See ADR-1460's "Restart Durability" section.
+
 ### 7.3 Claude Usage-Limit Exemption
 
 When a Claude invocation exits because the account's usage limit was hit (e.g. `You've hit your

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2366,6 +2366,8 @@ All four now-fixed sites apply `itemstate.EnginePaused` in both their fresh-paus
 
 **Accepted side effect:** `clearFailedStage()`'s reset (reused unmodified by `handleEngineUnpause`) also zeroes `Attempts(stage.Name)` — the unrelated `MaxRetries` failure counter — via `StageRetryCleared`. A manual unpause of a cycle-limit-paused item therefore also gives that stage's failure budget a clean slate. This is deliberate ("a human unpause is 'try again'"), consistent with the same reset already applying to `escalateFailedStage`/`escalatePRCreationFailure`, and is a net-new intentional behavior for the four newly-fixed sites (they had no working "unchanged" baseline to preserve — they were broken before #1460).
 
+**Restart durability:** `handleEngineUnpause` reads `PausedByEngine`, which is in-memory-only (does not survive an engine restart — `internal/itemstate/snapshot.go`). This is not a gap: `ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles` live in the same in-memory `StageState`, constructed empty by `NewStore(nil)` on every process start with no persistence layer for any `StageState` field — so a restart clears the pause flag *and* the triggering counter together, never one without the other. A restart before a human unpauses an item is equivalent to `handleEngineUnpause` having already fired for free (both read back as zero); there is no interleaving that reproduces this section's defect via a restart. See ADR-1460's "Restart Durability" section.
+
 ### 7.3 Claude Usage-Limit Exemption
 
 When a Claude invocation exits because the account's usage limit was hit (e.g. `You've hit your

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -683,6 +683,8 @@ This table shows the normal flow when an issue progresses through the pipeline w
 | Same column, Paused | Human removes `fabrik:paused` | — | Same column, Idle | | | Engine processes item on next poll |
 | Same column, Paused | New human comment | Not a bot login (`github.IsBotLogin`, `humanNewComments()`) | Same column, Idle → comment processing | | `fabrik:paused` | Unpause; `clearFailedStage()` also called (clears any failed label + resets retries); falls through to `processComments()`. A bot-authored comment does not match this guard and leaves the item Paused (#1083). |
 
+> **This table covers `processItem`'s own unpause gate** — reachable only for a pause that fires *before* the stage is marked `stage:<X>:complete` (`escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation`, `pauseForSliceLimit`). A pause that fires *after* the stage is already complete (the four cycle-limit pause sites: review, CI-fix, rebase, enqueue — see §7.2 "Resumable Engine Pauses") is resumed by a different mechanism, `handleEngineUnpause` in the catch-up loop's Phase 1 handler chain (§6.2, Handler 0) — `processItem` is never dispatched for a stage-complete item with no new comment, so its gate above is structurally unreachable for those four sites. See ADR-1460.
+
 #### Lock Conflict (Multi-Instance)
 
 | Current State | Event | Guard | Resulting State | Labels Added | Labels Removed | Side Effects |
@@ -1436,6 +1438,8 @@ The catch-up loop in `poll()` is split into two phases for every non-paused non-
 **Phase 1 — unconditional, ordered handler list (`catchUpPhase1Handlers`):**
 
 Phase 1 is implemented as an explicit ordered slice of named handler methods (`catchUpPhase1Handlers` in `engine/catch_up_handlers.go`). Each handler returns `true` to claim the item — Phase 2 is skipped for this item this cycle — or `false` to pass through to the next handler. **Ordering is structurally enforced by slice position** (ADR-056 D3); a future reorder requires a deliberate code change and triggers a test failure, rather than occurring as an accidental side effect of a `continue` insertion.
+
+**Handler 0: `handleEngineUnpause`** (#1460 — numbered 0, not renumbering Handlers 1-4 below, to avoid an invasive cross-reference cascade) — runs first, unconditionally, ahead of every other Phase 1 handler. It is the actual resume trigger for the four cycle-limit pause sites (`pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `pauseForEnqueueCycleLimit`; see §7.2 "Resumable Engine Pauses"): checks `snap.PausedByEngine(stage.Name)`; if true — meaning the item reached this handler chain (so `fabrik:paused` is currently absent, per both the main catch-up loop's and `settleAwaitingCIScan`'s admission filters) while still carrying a stale `itemstate.EnginePaused` record from before the label was removed — it calls `clearFailedStage()`, the same reset `processItem`'s own unpause gate already uses (zeroing `ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles`, clearing `Attempts`, resetting `LastAttemptAt`, and resetting the comment circuit breaker). Always returns `false` — it only resets state, never claims — so the rest of the chain evaluates the just-reset counters in the *same* pass, letting a genuine resume converge in one poll rather than two. See ADR-1460 for why this handler exists at all (`processItem`'s pre-existing unpause gate is structurally unreachable for these four sites — they only ever fire post-stage-completion, where `itemNeedsWork` never re-dispatches `processItem`).
 
 **Handler 1: `handleDependencies`** — thin wrapper around `checkDependencies()`. If the item has unresolved blocking dependencies, claims the item (returns true); otherwise passes through. `checkDependencies`'s own bool return **is** the Phase 1 claim signal directly (no translation layer, unlike the review/CI gates below) — so its cycle-detection branch (a bounded BFS finds the item is itself a transitive blocker of one of its own blockers) also returns `true` when it pauses the issue via `pauseIssue` (ADR-1223), rather than reusing the `false` value returned for "no open dependencies." Before this fix the cycle-detection pause fell through unclaimed, the same overloaded-return bug present in the review/CI gates.
 
@@ -2338,6 +2342,30 @@ When a stage fails `MaxRetries` times (default: configurable, 0 disables):
 - Removes `stage:<X>:failed`
 - Resets retry count (`StageRetryCleared`), engine-paused flag (`EngineUnpaused`), cooldown (`StageLastAttemptCleared`), and review cycle count (`EngineCyclesCleared`)
 
+#### 7.2.1 Resumable Engine Pauses (ADR-1460)
+
+**The invariant:** every pause comment Fabrik posts ends with "remove `fabrik:paused` to resume" — this must actually be true for every pause site, not just stage-failure escalation. Before #1460, four pause sites violated it: `pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `pauseForEnqueueCycleLimit` never applied `itemstate.EnginePaused`, so removing `fabrik:paused` was a no-op — the triggering cycle counter (`ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles`) stayed pinned at its limit and the item re-paused on its very next evaluation (reproduced live on #1208: five seconds from unpause to re-pause, byte-identical repost comment, no comment involved in the resume attempt at all).
+
+**Two resume gates, chosen by *when* the pause fires relative to stage completion:**
+
+1. **Pre-completion pauses** (stage not yet `stage:<X>:complete`) — `escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation` (§7.2 above), `pauseForSliceLimit` (§7.12) — resume via `processItem()`'s own `wasPaused || hasFailedLabel` gate, described above. Unchanged by #1460.
+2. **Post-completion pauses** (stage already `stage:<X>:complete`, or in the `fabrik:awaiting-ci` window) — the four cycle-limit sites — resume via **`handleEngineUnpause`**, a Phase 1 catch-up-loop handler (§6.2, Handler 0) added by #1460. `processItem()` is never dispatched for a stage-complete item with no new comment (`itemNeedsWork` returns false), so gate 1 above is structurally unreachable for these four sites — this was the flaw in the issue's own originally-suggested fix. `handleEngineUnpause` runs first, unconditionally, in every Phase 1 pass: if `snap.PausedByEngine(stage.Name)` is true while the item is here at all (meaning `fabrik:paused` is currently absent, per the catch-up loop's own admission filter), it calls the identical `clearFailedStage()` reset gate 1 uses, then lets the rest of the chain re-evaluate the just-reset counter in the same pass.
+
+All four now-fixed sites apply `itemstate.EnginePaused` in both their fresh-pause branch and their reapply-existing-comment branch (see below) — the reapply branch must re-arm it too, or a *second* cycle-limit episode after a successful first resume would itself become a fresh one-way door.
+
+**No-repost on re-pause (R4):** reusing the pattern from ADR-1408 (`pauseForCITimeout`/`pauseForCIFixCycleLimit`), each of the four sites checks `hasPauseComment(item, <its own stable message fragment>)` before posting — a `mutate.go`-shared helper generalized from ADR-1408's CI-specific `hasCIGatePauseComment`. If a matching comment already exists for the episode, the labels are reapplied (`reapplyPauseLabels`) without a duplicate post.
+
+**Classification of every pause/counter site (full detail in ADR-1460):**
+
+| Category | Sites |
+|---|---|
+| Already correct (applies `EnginePaused`, resumes via gate 1) | `escalateFailedStage`, `escalatePRCreationFailure`, `handleBoundaryViolation`, `escalateSettle` (synthetic stage key, out of scope), `pauseForSliceLimit` (§7.12 — mid-stage, gate 1 reachable) |
+| Fixed by #1460 (applies `EnginePaused`, resumes via gate 2 / `handleEngineUnpause`) | `pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, `pauseForEnqueueCycleLimit` |
+| Independently resets (no fix needed) | `pauseForReviewTimeout` (strips its own `fabrik:awaiting-review` anchor before pausing), `pauseForConvergenceFailed` / `pauseForMergeGroupStall` / `checkAutoMergeConvergence`'s "auto-merge disabled" branch (all strip `fabrik:auto-merge-enabled`, their shared anchor), `tripCommentBreaker` (self-expiring window), `checkDependencies` (live-derived) |
+| Condition-driven, no counter (no fix needed) | `pauseForCITimeout` (anchored to external `fabrik:awaiting-ci` state, not an attempt budget — re-pausing while CI is genuinely still unresolved is correct), `pauseForPRClosedNotMerged`, `pauseForRequiredNeverRunningCheck`, `handleBrokenReviewLinkage`, `pauseForBrokenLinkage`, `ensureRepoReady`/`postSpawnCloneError`/`spawnChildren` |
+
+**Accepted side effect:** `clearFailedStage()`'s reset (reused unmodified by `handleEngineUnpause`) also zeroes `Attempts(stage.Name)` — the unrelated `MaxRetries` failure counter — via `StageRetryCleared`. A manual unpause of a cycle-limit-paused item therefore also gives that stage's failure budget a clean slate. This is deliberate ("a human unpause is 'try again'"), consistent with the same reset already applying to `escalateFailedStage`/`escalatePRCreationFailure`, and is a net-new intentional behavior for the four newly-fixed sites (they had no working "unchanged" baseline to preserve — they were broken before #1460).
+
 ### 7.3 Claude Usage-Limit Exemption
 
 When a Claude invocation exits because the account's usage limit was hit (e.g. `You've hit your
@@ -2857,19 +2885,22 @@ is treated the same as a genuine error rather than inferred to be a slice. This 
 
 **Recovery:** `StageRetryCleared` — applied on normal stage completion and by `clearFailedStage()` on
 manual unpause — zeroes `SliceRetries(stageName)` alongside `Attempts(stageName)`; the two counters
-share one reset point. Unlike `pauseForRebaseCycleLimit`, `pauseForSliceLimit()` **does** apply
-`itemstate.EnginePaused` (never `stage:<X>:failed`): `RebaseCycles` has an independent path back to
-progress (a human resolves the underlying merge conflict directly, which changes `settle.Status` and
-lets the poll loop advance without ever re-checking the counter), but `SliceRetries` has no such
-signal — the job simply needs more slices than the budget allowed, with nothing external to "fix."
-Without `EnginePaused`, `processItem()`'s unpause guard (`wasPaused || hasFailedLabel`, both false for
-a pure slice-limit pause) would never fire `clearFailedStage()`, `SliceRetries` would never reset, and
-removing `fabrik:paused` would be a no-op: the very next dispatch takes exactly one more slice,
-re-checks a counter already at `MaxSliceRetries`, and re-pauses immediately — the documented recovery
-path would not work. With `EnginePaused` applied, `snap.PausedByEngine(stageName)` is true on the next
-pass, so removing `fabrik:paused` genuinely triggers `clearFailedStage()` → `StageRetryCleared`, and
-the stage resumes with a fresh slice budget. `clearFailedStage()`'s `stage:<X>:failed` label removal is
-a harmless no-op on this path, since that label was never applied.
+share one reset point. `pauseForSliceLimit()` applies `itemstate.EnginePaused` (never
+`stage:<X>:failed`), and — unlike the four cycle-limit sites #1460 fixes (§7.2.1) — resumes via
+`processItem()`'s own gate directly, not via `handleEngineUnpause`: a slice-limit pause fires
+**mid-stage**, before `stage:<X>:complete` is ever applied, so the item is not yet stage-complete when
+paused and `processItem()`'s gate remains reachable. Without `EnginePaused`, `processItem()`'s unpause
+guard (`wasPaused || hasFailedLabel`, both false for a pure slice-limit pause) would never fire
+`clearFailedStage()`, `SliceRetries` would never reset, and removing `fabrik:paused` would be a no-op:
+the very next dispatch takes exactly one more slice, re-checks a counter already at `MaxSliceRetries`,
+and re-pauses immediately — the documented recovery path would not work. With `EnginePaused` applied,
+`snap.PausedByEngine(stageName)` is true on the next pass, so removing `fabrik:paused` genuinely
+triggers `clearFailedStage()` → `StageRetryCleared`, and the stage resumes with a fresh slice budget.
+`clearFailedStage()`'s `stage:<X>:failed` label removal is a harmless no-op on this path, since that
+label was never applied. (This section previously contrasted with `pauseForRebaseCycleLimit`, which at
+the time did not apply `EnginePaused` either — #1460 fixed that site too, via the separate
+`handleEngineUnpause` resume path described in §7.2.1, since a rebase-cycle-limit pause fires
+post-completion, unlike this section's mid-stage slice-limit pause.)
 
 **Regression guard:** a job that has already taken more turn-cap slices than `MaxRetries` (the old,
 accidental ceiling per #1191) is never paused as long as it stays within `MaxSliceRetries` — `Attempts`

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -53,10 +53,64 @@ type catchUpHandler struct {
 //     (GitHub owns the merge decision)
 //   - mergeAndCIGates: merge-conflict gate runs before the CI gate (ADR-028)
 var catchUpPhase1Handlers = []catchUpHandler{
+	{name: "engineUnpause", run: (*Engine).handleEngineUnpause},
 	{name: "dependencies", run: (*Engine).handleDependencies},
 	{name: "reviewGate", run: (*Engine).handleReviewGate},
 	{name: "autoMergeConvergence", run: (*Engine).handleAutoMergeConvergence},
 	{name: "mergeAndCIGates", run: (*Engine).handleMergeAndCIGates},
+}
+
+// handleEngineUnpause is the actual resume trigger for the four cycle-limit
+// pause sites (pauseForReviewCycleLimit, pauseForCIFixCycleLimit,
+// pauseForRebaseCycleLimit, pauseForEnqueueCycleLimit — #1460 R2). It must run
+// first, unconditionally, ahead of every other Phase 1 handler, so a
+// just-reset counter is what the rest of this same pass evaluates.
+//
+// Why this can't live in processItem's existing wasPaused-gate instead
+// (engine/item.go, around the clearFailedStage call): that gate is reachable
+// only when processItem itself is dispatched for the item, and itemNeedsWork
+// returns false the moment stage:<name>:complete is already present and there
+// is no new comment — which is exactly the state all four cycle-limit pause
+// sites leave the item in. They fire from this very handler chain
+// (handleReviewGate / handleMergeAndCIGates), which — per poll.go's
+// deepFetchCandidates loop and settleAwaitingCIScan's identical loop — is
+// only reached for items that are NOT currently paused (both entry points
+// skip fabrik:paused items outright) but ARE already stage-complete. So the
+// instant a human removes fabrik:paused, the item re-enters this chain
+// directly; processItem is never invoked for it, and its unpause gate is
+// unreachable. Without a reset trigger inside this chain, the freshly
+// unpaused item hits the same stuck cycleCount >= maxCycles check on its very
+// next pass and re-pauses immediately (confirmed live on #1208: five seconds
+// from unpause to re-pause, with no comment involved).
+//
+// PausedByEngine being true here means: this item reached the handler chain
+// (so fabrik:paused is currently absent, per both admission filters above)
+// while still carrying a stale EnginePaused record from before the label was
+// removed. That is precisely "a human unpaused a cycle-limit-paused item" —
+// clearFailedStage is safe to reuse as-is: it removes stage:<name>:failed (a
+// harmless no-op, since these four sites never apply it), clears
+// PausedByEngine, resets LastAttemptAt, zeroes ReviewCycles/CIFixCycles/
+// RebaseCycles/EnqueueCycles via EngineCyclesCleared, and resets the comment
+// circuit breaker — the identical reset already used by
+// escalateFailedStage/escalatePRCreationFailure/handleBoundaryViolation via
+// processItem's gate, and by pauseForSliceLimit via that same gate (a
+// different call path — slice-limit pauses mid-stage, before completion, so
+// processItem's gate remains reachable for it; see pauseForSliceLimit's doc
+// comment).
+//
+// Always returns false: this handler only resets state, it never claims the
+// item — the rest of the chain (including the cycle-limit checks that would
+// otherwise re-pause) must still run in the same pass so a genuine resume
+// converges in one poll (AC2), not two.
+func (e *Engine) handleEngineUnpause(pctx *phase1Ctx) bool {
+	repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
+	snap, err := e.store.Get(repoStr, pctx.item.Number)
+	if err != nil || !snap.PausedByEngine(pctx.stage.Name) {
+		return false
+	}
+	e.logf(pctx.item.Number, "unpause", "stale engine-pause record found for stage %q with fabrik:paused absent — clearing (#1460)\n", pctx.stage.Name)
+	e.clearFailedStage(pctx.item, pctx.stage)
+	return false
 }
 
 // handleDependencies claims the item when it has unresolved blocking

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -121,6 +121,32 @@ var catchUpPhase1Handlers = []catchUpHandler{
 // after its stage is already marked complete, it would be picked up here too
 // — which is the intended, general behavior (any stale EnginePaused record on
 // a stage-complete item should reset), not a defect to guard against.
+//
+// This safety argument is enforced by convention (every current applier's own
+// call-site ordering), not by a compile-time or runtime assertion — nothing
+// stops a future EnginePaused applier from being added after a stage's
+// completion point. That gap is deliberately not closed here: the reset
+// behavior in that case is still correct by design (see the paragraph above),
+// so there is nothing to guard against, only a scenario to keep verified.
+// TestHandleEngineUnpause_PausedByEngine_ResetsAndReturnsFalse exercises
+// exactly that shape directly (EnginePaused applied to a stage that is
+// simultaneously stage:<name>:complete) and asserts the reset still lands
+// cleanly, regardless of which applier produced the record. A future site
+// that violates today's "pause before completion" convention would still
+// pass through this handler correctly — this doc note exists so the next
+// person adding an EnginePaused applier sees this discussion rather than
+// rediscovering it (#1460 review finding).
+//
+// Cost note (#1460 review finding): this handler adds one unconditional
+// e.store.Get per stage-complete-or-awaiting-ci item, per poll pass, ahead of
+// every other Phase 1 handler. store.Get's fast path (the overwhelming
+// majority of calls, since these items are already tracked) is an in-memory
+// RLock + map lookup + snapshot copy — no GitHub API call — and every
+// downstream handler in this same chain (handleReviewGate, handleMergeAndCIGates,
+// etc.) already performs its own store.Get calls per item per pass, so this is
+// not a new class of cost, just one more instance of an existing pattern.
+// Accounted for explicitly in ADR-1460's Consequences/Negative section, not an
+// oversight.
 func (e *Engine) handleEngineUnpause(pctx *phase1Ctx) bool {
 	repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
 	snap, err := e.store.Get(repoStr, pctx.item.Number)

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -102,6 +102,25 @@ var catchUpPhase1Handlers = []catchUpHandler{
 // item — the rest of the chain (including the cycle-limit checks that would
 // otherwise re-pause) must still run in the same pass so a genuine resume
 // converges in one poll (AC2), not two.
+//
+// Scope note (#1460 review finding): the check below is `snap.PausedByEngine`
+// for the item's current stage, not specifically one of the four named sites
+// — it fires for *any* stage whose EnginePaused record is stale when the item
+// reaches this chain, including escalateFailedStage/escalatePRCreationFailure/
+// handleBoundaryViolation/pauseForSliceLimit's own EnginePaused applications.
+// This is currently safe, not merely idempotent-by-luck: every one of those
+// other appliers pauses strictly *before* stage:<name>:complete is set for
+// that stage (mid-invocation, on a non-terminal Claude exit), and this chain
+// is reachable only for items that are already stage-complete (or carrying
+// fabrik:awaiting-ci) — see the reachability argument above. So a stage
+// paused by one of those sites can never simultaneously be in the
+// stage-complete-or-awaiting-ci state this chain requires; by the time such a
+// stage does reach stage:<name>:complete, processItem's own gate has already
+// cleared its EnginePaused record on the resuming dispatch, well before this
+// chain would ever see it. If a future pause site ever applies EnginePaused
+// after its stage is already marked complete, it would be picked up here too
+// — which is the intended, general behavior (any stale EnginePaused record on
+// a stage-complete item should reset), not a defect to guard against.
 func (e *Engine) handleEngineUnpause(pctx *phase1Ctx) bool {
 	repoStr := itemOwnerRepoString(pctx.item, e.defaultRepo())
 	snap, err := e.store.Get(repoStr, pctx.item.Number)

--- a/engine/catch_up_handlers.go
+++ b/engine/catch_up_handlers.go
@@ -165,6 +165,9 @@ func (e *Engine) handleReviewGate(pctx *phase1Ctx) bool {
 			},
 			func() { e.dispatchReviewReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage, syntheticComments) },
 			func(cycleCount int) {
+				// escalated return value intentionally discarded — this claim
+				// (dispatchWithCycleLimit always returns true) is correct whether the
+				// call posted a fresh pause or reused an existing one (#1460 R4).
 				e.pauseForReviewCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, e.cfg.MaxReviewCycles)
 			},
 		)
@@ -292,6 +295,8 @@ func (e *Engine) handleMergeAndCIGates(pctx *phase1Ctx) bool {
 			},
 			func() { e.dispatchRebaseReinvoke(pctx.ctx, pctx.board, pctx.item, pctx.stage) },
 			func(cycleCount int) {
+				// escalated return value intentionally discarded — same reasoning as
+				// the review-reinvoke pause callback above (#1460 R4).
 				e.pauseForRebaseCycleLimit(pctx.board, pctx.item, pctx.stage, cycleCount, e.cfg.MaxRebaseCycles)
 			},
 		)

--- a/engine/catch_up_handlers_test.go
+++ b/engine/catch_up_handlers_test.go
@@ -16,11 +16,15 @@ import (
 // TestCatchUpPhase1HandlersOrder asserts the handler precedence order by name.
 // A future reorder of catchUpPhase1Handlers is a test failure, not a silent
 // behavioral change — this directly implements the ADR-056 D3 "ordering as data"
-// invariant. ADR-028 requires merge gate before CI gate; both are inside
-// handleMergeAndCIGates (position 3), which follows handleAutoMergeConvergence
-// (position 2) so that auto-merge items bypass settlePRMergeState entirely.
+// invariant. engineUnpause (position 0, #1460 R2) must run first and
+// unconditionally so a just-reset cycle counter is what every other handler in
+// the same pass evaluates. ADR-028 requires merge gate before CI gate; both are
+// inside handleMergeAndCIGates (position 4), which follows
+// handleAutoMergeConvergence (position 3) so that auto-merge items bypass
+// settlePRMergeState entirely.
 func TestCatchUpPhase1HandlersOrder(t *testing.T) {
 	want := []string{
+		"engineUnpause",
 		"dependencies",
 		"reviewGate",
 		"autoMergeConvergence",
@@ -1505,5 +1509,99 @@ func TestDispatchRebaseReinvoke_BotNoticeInReviewThread_ExcludedFromInvocation(t
 	}
 	if seenComments[0].ID != "rebase-synthetic" {
 		t.Errorf("expected synthetic rebase comment to survive, got %q", seenComments[0].ID)
+	}
+}
+
+// ---- handleEngineUnpause tests (#1460 R2) ----
+
+// runPhase1Chain drives pctx through the full ordered catchUpPhase1Handlers
+// list, mirroring the exact loop poll.go's main catch-up loop and
+// settleAwaitingCIScan both run (ci_settle.go). AC1/AC2 tests for the four
+// confirmed cycle-limit sites must go through this — not call
+// clearFailedStage directly — since the defect (and the fix) lives in
+// whether the real chain reaches and resets the stuck counter, not in
+// clearFailedStage's own correctness (already covered by
+// TestClearFailedStage_ReviewCycleCount_ResetsOnlyCurrentStage).
+func runPhase1Chain(eng *Engine, pctx *phase1Ctx) (claimed bool) {
+	for _, h := range catchUpPhase1Handlers {
+		if h.run(eng, pctx) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHandleEngineUnpause_PausedByEngine_ResetsAndReturnsFalse verifies the
+// core reset behavior: when the store carries a stale EnginePaused record for
+// the stage (the item reached this handler chain — meaning fabrik:paused is
+// currently absent per poll.go's/ci_settle.go's admission filters — while
+// still marked paused-by-engine from before), handleEngineUnpause fires
+// clearFailedStage (zeroing ReviewCycles/CIFixCycles/RebaseCycles/
+// EnqueueCycles and clearing PausedByEngine) and always returns false so the
+// rest of the chain still runs this same pass.
+func TestHandleEngineUnpause_PausedByEngine_ResetsAndReturnsFalse(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := []*stages.Stage{{Name: "Implement", Order: 1, Prompt: "implement"}}
+	eng := testEngineWithStages(t, client, stgs)
+
+	item := gh.ProjectItem{Number: 20, Repo: "owner/repo", Labels: []string{"stage:Implement:complete"}}
+	stage := stgs[0]
+	pctx := &phase1Ctx{ctx: context.Background(), board: &gh.ProjectBoard{}, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+
+	eng.store.Apply(itemstate.EnginePaused{Repo: "owner/repo", Number: 20, StageName: "Implement"})
+	for i := 0; i < 3; i++ {
+		eng.store.Apply(itemstate.ReviewCycleIncremented{Repo: "owner/repo", Number: 20, StageName: "Implement"})
+		eng.store.Apply(itemstate.CIFixCycleIncremented{Repo: "owner/repo", Number: 20, StageName: "Implement"})
+		eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: "owner/repo", Number: 20, StageName: "Implement"})
+		eng.store.Apply(itemstate.EnqueueCycleIncremented{Repo: "owner/repo", Number: 20, StageName: "Implement"})
+	}
+
+	got := eng.handleEngineUnpause(pctx)
+
+	if got {
+		t.Error("handleEngineUnpause must always return false — it resets state but never claims the item")
+	}
+	snap, _ := eng.store.Get("owner/repo", 20)
+	if snap.PausedByEngine("Implement") {
+		t.Error("PausedByEngine(Implement) must be cleared after handleEngineUnpause")
+	}
+	if got := snap.ReviewCycles("Implement"); got != 0 {
+		t.Errorf("ReviewCycles(Implement) = %d; want 0", got)
+	}
+	if got := snap.CIFixCycles("Implement"); got != 0 {
+		t.Errorf("CIFixCycles(Implement) = %d; want 0", got)
+	}
+	if got := snap.RebaseCycles("Implement"); got != 0 {
+		t.Errorf("RebaseCycles(Implement) = %d; want 0", got)
+	}
+	if got := snap.EnqueueCycles("Implement"); got != 0 {
+		t.Errorf("EnqueueCycles(Implement) = %d; want 0", got)
+	}
+}
+
+// TestHandleEngineUnpause_NotPaused_NoOp verifies the common steady-state
+// case (no store entry, or PausedByEngine false) is a true no-op: no store
+// mutation, no clearFailedStage side effects, always returns false.
+func TestHandleEngineUnpause_NotPaused_NoOp(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := []*stages.Stage{{Name: "Implement", Order: 1, Prompt: "implement"}}
+	eng := testEngineWithStages(t, client, stgs)
+
+	item := gh.ProjectItem{Number: 21, Repo: "owner/repo", Labels: []string{"stage:Implement:complete"}}
+	stage := stgs[0]
+	pctx := &phase1Ctx{ctx: context.Background(), board: &gh.ProjectBoard{}, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+
+	// No store entry at all for issue 21 — snap lookup errors, PausedByEngine
+	// defaults false either way.
+	got := eng.handleEngineUnpause(pctx)
+	if got {
+		t.Error("handleEngineUnpause must return false when the item was never engine-paused")
+	}
+
+	client.mu.Lock()
+	labelCalls := len(client.addLabelCalls) + len(client.removeLabelCalls)
+	client.mu.Unlock()
+	if labelCalls != 0 {
+		t.Errorf("expected no label mutations for a never-paused item, got %d", labelCalls)
 	}
 }

--- a/engine/ci.go
+++ b/engine/ci.go
@@ -451,25 +451,7 @@ func (e *Engine) dispatchCIFixReinvoke(ctx context.Context, board *gh.ProjectBoa
 func hasCIGatePauseComment(item gh.ProjectItem, stage *stages.Stage) bool {
 	timeoutWant := fmt.Sprintf("The CI gate for stage **%s** timed out", stage.Name)
 	cycleWant := fmt.Sprintf("The stage **%s** has been re-invoked to fix CI failures", stage.Name)
-	for _, c := range item.Comments {
-		if strings.Contains(c.Body, timeoutWant) || strings.Contains(c.Body, cycleWant) {
-			return true
-		}
-	}
-	return false
-}
-
-// reapplyCIGatePauseLabels re-applies fabrik:paused + fabrik:awaiting-input
-// without posting a new comment. Used by pauseForCITimeout/
-// pauseForCIFixCycleLimit (issue #1408) when hasCIGatePauseComment finds an
-// existing pause comment for this episode: a human resuming the item removes
-// only fabrik:paused, never the comment, so a still-blocked item must be
-// re-escalated (labels reapplied) without spamming a duplicate comment.
-// applyLabelAdd's underlying AddLabelToIssue call is idempotent, so this is
-// safe to call even in the (should-be-rare) case the labels are still present.
-func (e *Engine) reapplyCIGatePauseLabels(item gh.ProjectItem) {
-	e.applyLabelAdd(item, "fabrik:paused", false)
-	e.applyLabelAdd(item, "fabrik:awaiting-input", false)
+	return hasPauseComment(item, timeoutWant, cycleWant)
 }
 
 // pauseForCITimeout pauses the issue when the CI wait timeout in the catch-up
@@ -489,7 +471,7 @@ func (e *Engine) reapplyCIGatePauseLabels(item gh.ProjectItem) {
 func (e *Engine) pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage) (escalated bool) {
 	if hasCIGatePauseComment(item, stage) {
 		e.logf(item.Number, "ci-timeout", "CI-gate pause comment already exists for this episode — reapplying pause without reposting\n")
-		e.reapplyCIGatePauseLabels(item)
+		e.reapplyPauseLabels(item)
 		return false
 	}
 	e.logf(item.Number, "ci-timeout", "CI wait timeout elapsed — pausing for human intervention\n")
@@ -511,12 +493,25 @@ func (e *Engine) pauseForCITimeout(board *gh.ProjectBoard, item gh.ProjectItem, 
 // for the reapply-without-repost behavior on an existing episode (issue
 // #1408) — identical shape, applied here for R5.
 //
+// Applies itemstate.EnginePaused (#1460 R2) in both branches — the fresh
+// pause AND the reapply-existing-comment branch. This is one of the four
+// confirmed one-way-door sites: CIFixCycles has no reset path other than
+// clearFailedStage's EngineCyclesCleared, and clearFailedStage only fires
+// when PausedByEngine is true. It must be (re-)applied even on the reapply
+// branch: a resume clears PausedByEngine via handleEngineUnpause, so if CI
+// keeps failing and the counter climbs back to the limit a second time, this
+// function is called again (reapply branch, since the old comment still
+// matches) and must re-arm PausedByEngine or the next resume would be a
+// no-op.
+//
 // Returns escalated: true when a fresh pause comment was posted, false when
 // an existing episode's pause was merely reapplied.
 func (e *Engine) pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) (escalated bool) {
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	if hasCIGatePauseComment(item, stage) {
 		e.logf(item.Number, "ci-cycles", "CI-gate pause comment already exists for this episode — reapplying pause without reposting\n")
-		e.reapplyCIGatePauseLabels(item)
+		e.reapplyPauseLabels(item)
+		e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 		return false
 	}
 	e.logf(item.Number, "ci-cycles", "CI-fix cycle limit %d reached — pausing for human intervention\n", maxCycles)
@@ -533,6 +528,7 @@ func (e *Engine) pauseForCIFixCycleLimit(board *gh.ProjectBoard, item gh.Project
 		awaitingInput: true,
 		reactRocket:   true,
 	})
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
 	return true
 }
 

--- a/engine/ci_settle_test.go
+++ b/engine/ci_settle_test.go
@@ -927,6 +927,112 @@ func TestSettleAwaitingCIScan_ResumedAtCycleLimit_StillFailing_ReEscalates(t *te
 	}
 }
 
+// ---- #1460 R2/AC1/AC2: pauseForCIFixCycleLimit resumability ----
+
+// TestCIFixCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles is the
+// AC1/AC2 regression for #1460's confirmed site #2: PR #1445/ADR-1408 fixed
+// only the comment-repost half (R4) of this site — it never applied
+// itemstate.EnginePaused, so removing fabrik:paused was (and, without this
+// fix, still would be) a no-op: CIFixCycles stayed pinned at the limit and
+// the very next catch-up pass re-paused immediately.
+//
+// Uses ciFailureSettleClient(), the same fixture
+// TestSettleAwaitingCIScan_ResumedAtCycleLimit_StillFailing_ReEscalates uses
+// for the "still failing, re-escalate without reposting" (R4) case — that
+// test's fixture never applies itemstate.EnginePaused itself (it seeds
+// CIFixCycles directly), so it remains a valid, unaffected regression test
+// for the case where the item was never actually paused through the real
+// code path. This test instead drives the pause itself through the real
+// handleMergeAndCIGates -> dispatchWithCycleLimit -> pauseForCIFixCycleLimit
+// path via runPhase1Chain, mirroring the review/rebase/enqueue-cycle-limit
+// tests.
+//
+// AC3: reverting pauseForCIFixCycleLimit's two itemstate.EnginePaused apply
+// lines turns this test red at the Step 1 PausedByEngine assertion (verified
+// by hand).
+func TestCIFixCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testing.T) {
+	client := ciFailureSettleClient() // classifies ciFailure on every call — CI never resolves
+	eng := testEngineWithStages(t, client, ciSettleWaitForCIStages())
+	eng.cfg.MaxCiFixCycles = 2
+	stage := eng.cfg.Stages[0] // "Validate", WaitForCI: true
+	board := &gh.ProjectBoard{}
+	const repo = "owner/repo"
+	const number = 60
+
+	// Step 1: drive a REAL pause through the actual code path. CIFixCycles
+	// pre-set to exactly the limit; ciFailureSettleClient keeps CI classified
+	// as failing on every call, so handleMergeAndCIGates's dispatchWithCycleLimit
+	// reaches the pause branch and calls the real pauseForCIFixCycleLimit.
+	for i := 0; i < eng.cfg.MaxCiFixCycles; i++ {
+		eng.store.Apply(itemstate.CIFixCycleIncremented{Repo: repo, Number: number, StageName: "Validate"})
+	}
+	item := gh.ProjectItem{Number: number, Repo: repo, Labels: []string{"fabrik:awaiting-ci"}}
+	pctx := &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: false, advancedItems: make(map[string]bool)}
+	claimed := runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected the cycle-limit pause branch to claim the item")
+	}
+
+	client.mu.Lock()
+	pausedApplied := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedApplied = true
+		}
+	}
+	client.mu.Unlock()
+	if !pausedApplied {
+		t.Fatal("expected fabrik:paused to be applied by the real cycle-limit pause")
+	}
+	snap, _ := eng.store.Get(repo, number)
+	if !snap.PausedByEngine("Validate") {
+		t.Fatal("R2: pauseForCIFixCycleLimit must apply itemstate.EnginePaused so wasPaused becomes true on resume — PausedByEngine(Validate) is false after the real pause")
+	}
+
+	// Step 2 (AC1): simulate the operator removing fabrik:paused and run
+	// another pass. CI is still (perpetually, per this fixture) failing, so
+	// this same pass's own dispatch fires right after the reset — the
+	// counter reading 1 (not the still-stuck 2) is itself proof the reset
+	// landed.
+	item.Labels = []string{"fabrik:awaiting-ci"}
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: false, advancedItems: make(map[string]bool)}
+	runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+
+	snap, _ = eng.store.Get(repo, number)
+	if snap.PausedByEngine("Validate") {
+		t.Error("PausedByEngine(Validate) must be cleared after the reset pass")
+	}
+	if got := snap.CIFixCycles("Validate"); got != 1 {
+		t.Fatalf("AC1: CIFixCycles(Validate) after unpause = %d; want 1 — the counter must have reset to 0 before this pass's own dispatch incremented it, not stayed pinned at the limit", got)
+	}
+
+	// Step 3 (AC2): confirm a further cycle proceeds without re-pausing
+	// (baseline excludes Step 1's legitimate pause).
+	client.mu.Lock()
+	baseline := len(client.addLabelCalls)
+	client.mu.Unlock()
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: false, advancedItems: make(map[string]bool)}
+	claimed = runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected a second ci-fix reinvoke to claim the item")
+	}
+	snap, _ = eng.store.Get(repo, number)
+	if got := snap.CIFixCycles("Validate"); got != 2 {
+		t.Errorf("AC2: CIFixCycles(Validate) = %d; want 2 — a genuinely reset counter must permit more than one further cycle before re-hitting the limit", got)
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	for _, c := range client.addLabelCalls[baseline:] {
+		if c.labelName == "fabrik:paused" {
+			t.Errorf("AC2: fabrik:paused must not be re-added — CIFixCycles(2) has not yet reached MaxCiFixCycles(%d) again", eng.cfg.MaxCiFixCycles)
+		}
+	}
+}
+
 // TestSettleAwaitingCIScan_StaleCachedPendingCheckRuns_EndToEnd is the full
 // end-to-end regression test for #1303's confirmed root cause, reproducing the
 // exact field incident shape through the REAL boardcache.CacheImpl (not a mock

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -585,26 +585,57 @@ func summarizeCIRuns(runs []gh.CheckRun) string {
 	return fmt.Sprintf("✅ %d passed", passed)
 }
 
+// rebaseCyclePauseFragment is the stable prose fragment identifying a
+// pauseForRebaseCycleLimit pause comment, matched by hasPauseComment (#1460 R4).
+func rebaseCyclePauseFragment(stage *stages.Stage) string {
+	return fmt.Sprintf("The stage **%s** has been re-invoked to rebase onto the base branch", stage.Name)
+}
+
 // pauseForRebaseCycleLimit pauses the issue when rebase re-invocations have
 // been attempted too many times — usually a signal that the conflict needs
-// human judgment.
-func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
+// human judgment — unless a pause comment for this episode already exists
+// (#1408/#1460 R4), in which case it reapplies the pause labels only, reusing
+// the existing comment rather than reposting.
+//
+// Applies itemstate.EnginePaused (#1460 R2) in both branches — the fresh
+// pause AND the reapply-existing-comment branch — so wasPaused becomes true
+// and the new handleEngineUnpause Phase 1 handler fires clearFailedStage on
+// resume, actually resetting RebaseCycles. Without this, removing
+// fabrik:paused was a no-op: RebaseCycles stayed pinned at the limit and the
+// item re-paused on its very next catch-up pass. Re-applying on the reapply
+// branch matters too: a resume clears PausedByEngine, so if the conflict
+// keeps recurring and the counter climbs back to the limit a second time,
+// this function runs again on the reapply branch (the old comment still
+// matches) and must re-arm PausedByEngine or the next resume would be a no-op.
+//
+// Returns escalated: true when a fresh pause comment was posted, false when
+// an existing episode's pause was merely reapplied.
+func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) (escalated bool) {
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	if hasPauseComment(item, rebaseCyclePauseFragment(stage)) {
+		e.logf(item.Number, "rebase-cycles", "rebase-cycle pause comment already exists for this episode — reapplying pause without reposting\n")
+		e.reapplyPauseLabels(item)
+		e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		return false
+	}
 	e.logf(item.Number, "rebase-cycles", "rebase cycle limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
-		"🏭 **Fabrik — rebase cycle limit reached**\n\nThe stage **%s** has been re-invoked to rebase onto the base branch %d time(s), "+
+		"🏭 **Fabrik — rebase cycle limit reached**\n\n%s %d time(s), "+
 			"which has reached the configured limit of %d (override with `--max-rebase-cycles` or `FABRIK_MAX_REBASE_CYCLES`).\n\n"+
 			"GitHub still reports the PR as not mergeable. This usually means the conflict requires human judgment "+
 			"(for example: two PRs picked the same ADR number or migration slot, or a semantic overlap that cannot be "+
 			"resolved by automated rebase).\n\n"+
 			"Fabrik has paused this issue. Resolve the conflict manually, then remove the `fabrik:paused` and "+
 			"`fabrik:rebase-needed` labels to resume.",
-		stage.Name, cycleCount, maxCycles,
+		rebaseCyclePauseFragment(stage), cycleCount, maxCycles,
 	)
 	e.pauseIssue(item, msg, pauseOpts{
 		awaitingInput: true,
 		reactRocket:   true,
 	})
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+	return true
 }
 
 // advanceConvergedPRToDone removes the convergence labels and advances a merged
@@ -681,6 +712,8 @@ func (e *Engine) reEnqueueOrPause(board *gh.ProjectBoard, item gh.ProjectItem, s
 	}
 	maxCycles := e.cfg.MaxEnqueueCycles
 	if cycleCount >= maxCycles {
+		// escalated return value intentionally discarded — same reasoning as
+		// the identical pauseForCIFixCycleLimit call above (#1460 R4).
 		e.pauseForEnqueueCycleLimit(board, item, stage, cycleCount, maxCycles)
 		return
 	}
@@ -703,27 +736,62 @@ func (e *Engine) reEnqueueOrPause(board *gh.ProjectBoard, item gh.ProjectItem, s
 	e.store.Apply(itemstate.PREnqueueRecorded{Repo: repoStr, Number: item.Number, SHA: pr.HeadSHA})
 }
 
+// enqueueCyclePauseFragment is the stable prose fragment identifying a
+// pauseForEnqueueCycleLimit pause comment, matched by hasPauseComment (#1460
+// R4). Unlike the review/rebase fragments, this one deliberately omits the
+// stage name — the original message text puts it earlier in the sentence
+// ("The linked PR for stage **%s** has been re-enqueued...").
+const enqueueCyclePauseFragment = "has been re-enqueued into GitHub's merge queue"
+
 // pauseForEnqueueCycleLimit pauses the issue when merge-queue re-enqueue trips
 // have been attempted too many times — a queue-thrash loop (enqueue → eject →
 // re-enqueue → eject) that no single sub-path cap (rebase / CI-fix) would catch.
 // Mirrors pauseForRebaseCycleLimit: structured comment naming --max-enqueue-cycles,
-// fabrik:paused + fabrik:awaiting-input (write-through). The EnqueueCycles counter
-// is cleared by clearFailedStage (EngineCyclesCleared) when the user unpauses.
-func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
+// fabrik:paused + fabrik:awaiting-input (write-through) — unless a pause
+// comment for this episode already exists (#1408/#1460 R4), in which case it
+// reapplies the pause labels only, reusing the existing comment rather than
+// reposting.
+//
+// Applies itemstate.EnginePaused (#1460 R2) in both branches — the fresh
+// pause AND the reapply-existing-comment branch — so wasPaused becomes true
+// and the new handleEngineUnpause Phase 1 handler fires clearFailedStage on
+// resume, actually resetting EnqueueCycles. (This doc comment previously
+// claimed "the EnqueueCycles counter is cleared by clearFailedStage
+// (EngineCyclesCleared) when the user unpauses" — that was false: this
+// function never applied EnginePaused, so wasPaused was never true and
+// clearFailedStage never fired via processItem's gate. #1460 corrects this.)
+// Re-applying on the reapply branch matters too: a resume clears
+// PausedByEngine, so if the queue-thrash recurs and the counter climbs back
+// to the limit a second time, this function runs again on the reapply branch
+// (the old comment still matches) and must re-arm PausedByEngine or the next
+// resume would be a no-op.
+//
+// Returns escalated: true when a fresh pause comment was posted, false when
+// an existing episode's pause was merely reapplied.
+func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) (escalated bool) {
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	if hasPauseComment(item, enqueueCyclePauseFragment) {
+		e.logf(item.Number, "enqueue-cycles", "enqueue-cycle pause comment already exists for this episode — reapplying pause without reposting\n")
+		e.reapplyPauseLabels(item)
+		e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		return false
+	}
 	e.logf(item.Number, "enqueue-cycles", "merge-queue re-enqueue limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
-		"🏭 **Fabrik — merge-queue re-enqueue limit reached**\n\nThe linked PR for stage **%s** has been re-enqueued into GitHub's merge queue %d time(s), "+
+		"🏭 **Fabrik — merge-queue re-enqueue limit reached**\n\nThe linked PR for stage **%s** %s %d time(s), "+
 			"which has reached the configured limit of %d (override with `--max-enqueue-cycles` or `FABRIK_MAX_ENQUEUE_CYCLES`).\n\n"+
 			"The PR keeps being ejected from the merge queue and re-enqueued without merging. This usually means the merge group repeatedly fails to build or test "+
 			"against the current base — for example a flaky required check, a missing `merge_group` CI trigger, or a persistent semantic conflict with other queued PRs.\n\n"+
 			"Fabrik has paused this issue. Investigate the merge-queue failures, then remove the `fabrik:paused` label to resume.",
-		stage.Name, cycleCount, maxCycles,
+		stage.Name, enqueueCyclePauseFragment, cycleCount, maxCycles,
 	)
 	e.pauseIssue(item, msg, pauseOpts{
 		awaitingInput: true,
 		reactRocket:   true,
 	})
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+	return true
 }
 
 // pauseForMergeGroupStall pauses the issue when the linked PR has been in the

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -753,10 +753,14 @@ func (e *Engine) reEnqueueOrPause(board *gh.ProjectBoard, item gh.ProjectItem, s
 
 // enqueueCyclePauseFragment is the stable prose fragment identifying a
 // pauseForEnqueueCycleLimit pause comment, matched by hasPauseComment (#1460
-// R4). Unlike the review/rebase fragments, this one deliberately omits the
-// stage name — the original message text puts it earlier in the sentence
-// ("The linked PR for stage **%s** has been re-enqueued...").
-const enqueueCyclePauseFragment = "has been re-enqueued into GitHub's merge queue"
+// R4). Scoped by stage name, matching reviewCyclePauseFragment/
+// rebaseCyclePauseFragment — a prior version of this fragment was a bare,
+// stage-unscoped const, which would have matched a comment from *any* stage
+// the item passed through, not just the current one, once this pause is ever
+// reached from more than one stage (review finding on #1460's own PR).
+func enqueueCyclePauseFragment(stage *stages.Stage) string {
+	return fmt.Sprintf("The linked PR for stage **%s** has been re-enqueued into GitHub's merge queue", stage.Name)
+}
 
 // pauseForEnqueueCycleLimit pauses the issue when merge-queue re-enqueue trips
 // have been attempted too many times — a queue-thrash loop (enqueue → eject →
@@ -785,7 +789,7 @@ const enqueueCyclePauseFragment = "has been re-enqueued into GitHub's merge queu
 // an existing episode's pause was merely reapplied.
 func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) (escalated bool) {
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
-	if hasPauseComment(item, enqueueCyclePauseFragment) {
+	if hasPauseComment(item, enqueueCyclePauseFragment(stage)) {
 		e.logf(item.Number, "enqueue-cycles", "enqueue-cycle pause comment already exists for this episode — reapplying pause without reposting\n")
 		e.reapplyPauseLabels(item)
 		e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
@@ -794,12 +798,12 @@ func (e *Engine) pauseForEnqueueCycleLimit(_ *gh.ProjectBoard, item gh.ProjectIt
 	e.logf(item.Number, "enqueue-cycles", "merge-queue re-enqueue limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
-		"🏭 **Fabrik — merge-queue re-enqueue limit reached**\n\nThe linked PR for stage **%s** %s %d time(s), "+
+		"🏭 **Fabrik — merge-queue re-enqueue limit reached**\n\n%s %d time(s), "+
 			"which has reached the configured limit of %d (override with `--max-enqueue-cycles` or `FABRIK_MAX_ENQUEUE_CYCLES`).\n\n"+
 			"The PR keeps being ejected from the merge queue and re-enqueued without merging. This usually means the merge group repeatedly fails to build or test "+
 			"against the current base — for example a flaky required check, a missing `merge_group` CI trigger, or a persistent semantic conflict with other queued PRs.\n\n"+
 			"Fabrik has paused this issue. Investigate the merge-queue failures, then remove the `fabrik:paused` label to resume.",
-		stage.Name, enqueueCyclePauseFragment, cycleCount, maxCycles,
+		enqueueCyclePauseFragment(stage), cycleCount, maxCycles,
 	)
 	e.pauseIssue(item, msg, pauseOpts{
 		awaitingInput: true,

--- a/engine/merge_gate.go
+++ b/engine/merge_gate.go
@@ -610,6 +610,21 @@ func rebaseCyclePauseFragment(stage *stages.Stage) string {
 //
 // Returns escalated: true when a fresh pause comment was posted, false when
 // an existing episode's pause was merely reapplied.
+//
+// The pause message also asks the operator to remove fabrik:rebase-needed
+// alongside fabrik:paused (#1460 review finding: clearFailedStage, run by
+// handleEngineUnpause on resume, never touches fabrik:rebase-needed — it only
+// knows about EnginePaused/cycle-counter state, not this gate's own label).
+// Confirmed harmless either way: checkMergeabilityGate recomputes
+// fabrik:rebase-needed from GitHub's live mergeability on every catch-up
+// pass, independent of what clearFailedStage did — if the conflict is
+// resolved it clears the label itself (removeRebaseNeededLabel), and if the
+// conflict persists it re-applies the label (idempotent) and a fresh rebase
+// reinvoke is exactly what should happen against the just-reset RebaseCycles.
+// So a stale fabrik:rebase-needed left behind by a manual unpause self-heals
+// on the very next observation and never blocks or misleads the gate either
+// way; the message's instruction to remove it is a courtesy, not a
+// requirement.
 func (e *Engine) pauseForRebaseCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) (escalated bool) {
 	repoStr := itemOwnerRepoString(item, e.defaultRepo())
 	if hasPauseComment(item, rebaseCyclePauseFragment(stage)) {

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -1549,3 +1549,124 @@ func TestReenableAutoMergeAfterRebase_NotInConvergenceFlow_NoOp(t *testing.T) {
 		t.Errorf("MergePR must not be called without fabrik:auto-merge-enabled, got %d call(s)", len(client.mergePRCalls))
 	}
 }
+
+// ---- #1460 R2/AC1/AC2: pauseForRebaseCycleLimit resumability ----
+
+// TestRebaseCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles is the
+// AC1/AC2 regression for #1460's confirmed site #3: before this fix,
+// pauseForRebaseCycleLimit never applied itemstate.EnginePaused, so removing
+// fabrik:paused was a no-op — RebaseCycles stayed pinned at the limit.
+//
+// Drives through the real catchUpPhase1Handlers chain (runPhase1Chain), and
+// drives the pause itself through the real dispatchWithCycleLimit ->
+// pauseForRebaseCycleLimit path (RebaseCycles pre-set to the limit, PR
+// genuinely classified PRMergeConflicting via the mock client, so
+// handleMergeAndCIGates's checkMergeabilityGate reaches the pause branch for
+// real) rather than seeding itemstate.EnginePaused directly — see the review
+// site's identical test for why that distinction matters.
+//
+// AC3: reverting pauseForRebaseCycleLimit's two itemstate.EnginePaused apply
+// lines turns this test red at the Step 1 PausedByEngine assertion (verified
+// by hand).
+func TestRebaseCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testing.T) {
+	notMergeable := false
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 77, State: "open", HeadSHA: "cafebabe"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return &notMergeable, "dirty", nil // PRMergeConflicting
+		},
+		addCommentFn:         func(_, _ string, _ int, _ string) (int, error) { return 1, nil },
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	waitForCI := true
+	stgs := []*stages.Stage{{Name: "Validate", Order: 1, Prompt: "validate", WaitForCI: &waitForCI}}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxRebaseCycles = 2
+	stage := stgs[0]
+	board := &gh.ProjectBoard{}
+	const repo = "owner/repo"
+	const number = 40
+
+	// Step 1: drive a REAL pause through the actual code path. RebaseCycles
+	// pre-set to exactly the limit; the mock client makes settlePRMergeState
+	// classify PRMergeConflicting on every call, so checkMergeabilityGate's
+	// dispatchWithCycleLimit reaches the pause branch and calls the real
+	// pauseForRebaseCycleLimit.
+	for i := 0; i < eng.cfg.MaxRebaseCycles; i++ {
+		eng.store.Apply(itemstate.RebaseCycleIncremented{Repo: repo, Number: number, StageName: "Validate"})
+	}
+	item := gh.ProjectItem{Number: number, Repo: repo, Labels: []string{"stage:Validate:complete"}}
+	pctx := &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+	claimed := runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected the cycle-limit pause branch to claim the item")
+	}
+
+	client.mu.Lock()
+	pausedApplied := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedApplied = true
+		}
+	}
+	client.mu.Unlock()
+	if !pausedApplied {
+		t.Fatal("expected fabrik:paused to be applied by the real cycle-limit pause")
+	}
+	snap, _ := eng.store.Get(repo, number)
+	if !snap.PausedByEngine("Validate") {
+		t.Fatal("R2: pauseForRebaseCycleLimit must apply itemstate.EnginePaused so wasPaused becomes true on resume — PausedByEngine(Validate) is false after the real pause")
+	}
+
+	// Step 2 (AC1): simulate the operator removing fabrik:paused (label set no
+	// longer carries it) and run another pass — checkMergeabilityGate will
+	// re-claim the item again once the reset lands (RebaseCycles resets to 0
+	// first, in the same pass, ahead of the cycle-limit check), so this
+	// asserts the RESET happened by reading the counter right after.
+	item.Labels = []string{"stage:Validate:complete"}
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+	runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+
+	snap, _ = eng.store.Get(repo, number)
+	if snap.PausedByEngine("Validate") {
+		t.Error("PausedByEngine(Validate) must be cleared after the reset pass")
+	}
+	// Note: unlike the review site, this pass's own dispatchWithCycleLimit
+	// call also fires (the mock keeps returning PRMergeConflicting every
+	// call, so there is always "actionable" work) — RebaseCycles is reset to
+	// 0 by handleEngineUnpause and then immediately incremented to 1 by this
+	// same pass's dispatch. That increment is itself proof of the reset: a
+	// still-stuck counter would have re-hit cycleCount(2) >= maxCycles(2) and
+	// paused again instead.
+	if got := snap.RebaseCycles("Validate"); got != 1 {
+		t.Fatalf("AC1: RebaseCycles(Validate) after unpause = %d; want 1 — the counter must have reset to 0 before this pass's own dispatch incremented it, not stayed pinned at the limit", got)
+	}
+
+	// Step 3 (AC2): confirm at least one further cycle proceeds without
+	// re-pausing (baseline excludes Step 1's legitimate pause).
+	client.mu.Lock()
+	baseline := len(client.addLabelCalls)
+	client.mu.Unlock()
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+	claimed = runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected a second rebase-reinvoke dispatch to claim the item")
+	}
+	snap, _ = eng.store.Get(repo, number)
+	if got := snap.RebaseCycles("Validate"); got != 2 {
+		t.Errorf("AC2: RebaseCycles(Validate) = %d; want 2 — a genuinely reset counter must permit more than one further cycle before re-hitting the limit", got)
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	for _, c := range client.addLabelCalls[baseline:] {
+		if c.labelName == "fabrik:paused" {
+			t.Errorf("AC2: fabrik:paused must not be re-added — RebaseCycles(2) has not yet reached MaxRebaseCycles(%d) again", eng.cfg.MaxRebaseCycles)
+		}
+	}
+}

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -1796,3 +1796,89 @@ func TestEnqueueCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testin
 		}
 	}
 }
+
+// TestPauseForRebaseCycleLimit_ExistingComment_NoRepost is the AC4 regression
+// for #1460's confirmed site #3: when a pause comment for this episode
+// already exists, pauseForRebaseCycleLimit must reapply fabrik:paused +
+// fabrik:awaiting-input (re-arming itemstate.EnginePaused too) without
+// posting a duplicate comment.
+func TestPauseForRebaseCycleLimit_ExistingComment_NoRepost(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(t, client)
+	stage := &stages.Stage{Name: "Validate"}
+	item := gh.ProjectItem{
+		Number: 41, Repo: "owner/repo",
+		Comments: []gh.Comment{
+			{ID: "C1", Body: "🏭 **Fabrik — rebase cycle limit reached**\n\nThe stage **Validate** has been re-invoked to rebase onto the base branch 2 time(s), " +
+				"which has reached the configured limit of 2 (override with `--max-rebase-cycles` or `FABRIK_MAX_REBASE_CYCLES`)."},
+		},
+	}
+
+	escalated := eng.pauseForRebaseCycleLimit(&gh.ProjectBoard{}, item, stage, 2, 2)
+
+	if escalated {
+		t.Error("expected escalated=false when an existing pause comment is reused")
+	}
+	if len(client.addCommentCalls) != 0 {
+		t.Errorf("AC4: expected no new comment posted when one already exists for this episode, got %d", len(client.addCommentCalls))
+	}
+	pausedApplied, awaitingInputApplied := false, false
+	for _, c := range client.addLabelCalls {
+		switch c.labelName {
+		case "fabrik:paused":
+			pausedApplied = true
+		case "fabrik:awaiting-input":
+			awaitingInputApplied = true
+		}
+	}
+	if !pausedApplied || !awaitingInputApplied {
+		t.Errorf("expected fabrik:paused and fabrik:awaiting-input to be reapplied, got paused=%v awaitingInput=%v", pausedApplied, awaitingInputApplied)
+	}
+	snap, _ := eng.store.Get("owner/repo", 41)
+	if !snap.PausedByEngine("Validate") {
+		t.Error("R2: expected itemstate.EnginePaused to be (re-)applied even on the reapply branch")
+	}
+}
+
+// TestPauseForEnqueueCycleLimit_ExistingComment_NoRepost is the AC4
+// regression for #1460's confirmed site #4: when a pause comment for this
+// episode already exists, pauseForEnqueueCycleLimit must reapply
+// fabrik:paused + fabrik:awaiting-input (re-arming itemstate.EnginePaused
+// too) without posting a duplicate comment.
+func TestPauseForEnqueueCycleLimit_ExistingComment_NoRepost(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineForMerge(t, client)
+	stage := &stages.Stage{Name: "Validate"}
+	item := gh.ProjectItem{
+		Number: 51, Repo: "owner/repo",
+		Comments: []gh.Comment{
+			{ID: "C1", Body: "🏭 **Fabrik — merge-queue re-enqueue limit reached**\n\nThe linked PR for stage **Validate** has been re-enqueued into GitHub's merge queue 2 time(s), " +
+				"which has reached the configured limit of 2 (override with `--max-enqueue-cycles` or `FABRIK_MAX_ENQUEUE_CYCLES`)."},
+		},
+	}
+
+	escalated := eng.pauseForEnqueueCycleLimit(&gh.ProjectBoard{}, item, stage, 2, 2)
+
+	if escalated {
+		t.Error("expected escalated=false when an existing pause comment is reused")
+	}
+	if len(client.addCommentCalls) != 0 {
+		t.Errorf("AC4: expected no new comment posted when one already exists for this episode, got %d", len(client.addCommentCalls))
+	}
+	pausedApplied, awaitingInputApplied := false, false
+	for _, c := range client.addLabelCalls {
+		switch c.labelName {
+		case "fabrik:paused":
+			pausedApplied = true
+		case "fabrik:awaiting-input":
+			awaitingInputApplied = true
+		}
+	}
+	if !pausedApplied || !awaitingInputApplied {
+		t.Errorf("expected fabrik:paused and fabrik:awaiting-input to be reapplied, got paused=%v awaitingInput=%v", pausedApplied, awaitingInputApplied)
+	}
+	snap, _ := eng.store.Get("owner/repo", 51)
+	if !snap.PausedByEngine("Validate") {
+		t.Error("R2: expected itemstate.EnginePaused to be (re-)applied even on the reapply branch")
+	}
+}

--- a/engine/merge_gate_test.go
+++ b/engine/merge_gate_test.go
@@ -1670,3 +1670,129 @@ func TestRebaseCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testing
 		}
 	}
 }
+
+// ---- #1460 R2/AC1/AC2: pauseForEnqueueCycleLimit resumability ----
+
+// TestEnqueueCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles is the
+// AC1/AC2 regression for #1460's confirmed site #4: before this fix,
+// pauseForEnqueueCycleLimit never applied itemstate.EnginePaused (its own doc
+// comment falsely claimed the counter was already cleared by
+// clearFailedStage — #1460 also corrects that comment), so removing
+// fabrik:paused was a no-op — EnqueueCycles stayed pinned at the limit.
+//
+// Reaches pauseForEnqueueCycleLimit via the real leftQueue ejection-recovery
+// ladder: handleAutoMergeConvergence (chain handler) -> checkAutoMergeConvergence
+// -> reEnqueueOrPause -> pauseForEnqueueCycleLimit, driven through
+// runPhase1Chain exactly as poll.go/ci_settle.go do (priorInQueue:true on the
+// phase1Ctx simulates "in the merge queue last poll, ejected now" — the
+// leftQueue edge that TestCheckAutoMergeConvergence_LeftQueue_CleanAtCap_Pauses
+// exercises via a direct call; this test goes through the full chain instead
+// so handleEngineUnpause's reset is genuinely exercised).
+//
+// AC3: reverting pauseForEnqueueCycleLimit's two itemstate.EnginePaused apply
+// lines turns this test red at the Step 1 PausedByEngine assertion (verified
+// by hand).
+func TestEnqueueCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testing.T) {
+	mergeableTrue := true
+	client := &mockGitHubClient{
+		fetchLinkedPRFn: func(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+			return &gh.PRDetails{Number: 88, State: "open", AutoMergeEnabled: false, HeadSHA: "cafe1234"}, nil
+		},
+		fetchPRMergeableFieldsFn: func(owner, repo string, prNumber int) (*bool, string, error) {
+			return &mergeableTrue, "clean", nil // PRMergeReady (ADR-033 shortcut)
+		},
+		addCommentFn:         func(_, _ string, _ int, _ string) (int, error) { return 1, nil },
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	stgs := []*stages.Stage{{Name: "Validate", Order: 1, Prompt: "validate"}}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxEnqueueCycles = 2
+	stage := stgs[0]
+	board := &gh.ProjectBoard{}
+	const repo = "owner/repo"
+	const number = 50
+
+	// Step 1: drive a REAL pause. EnqueueCycles pre-set to the limit; the mock
+	// client makes settlePRMergeState classify PRMergeReady on every call, and
+	// priorInQueue:true simulates the leftQueue ejection edge every pass, so
+	// reEnqueueOrPause's cycle-limit check reaches the real
+	// pauseForEnqueueCycleLimit.
+	for i := 0; i < eng.cfg.MaxEnqueueCycles; i++ {
+		eng.store.Apply(itemstate.EnqueueCycleIncremented{Repo: repo, Number: number, StageName: "Validate"})
+	}
+	item := gh.ProjectItem{
+		Number: number, Repo: repo,
+		Labels:                      []string{"stage:Validate:complete", "fabrik:auto-merge-enabled"},
+		LinkedPRIsMergeQueueEnabled: true,
+	}
+	pctx := &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool), priorInQueue: true}
+	claimed := runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected the cycle-limit pause branch to claim the item")
+	}
+
+	client.mu.Lock()
+	pausedApplied := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedApplied = true
+		}
+	}
+	client.mu.Unlock()
+	if !pausedApplied {
+		t.Fatal("expected fabrik:paused to be applied by the real cycle-limit pause")
+	}
+	snap, _ := eng.store.Get(repo, number)
+	if !snap.PausedByEngine("Validate") {
+		t.Fatal("R2: pauseForEnqueueCycleLimit must apply itemstate.EnginePaused so wasPaused becomes true on resume — PausedByEngine(Validate) is false after the real pause")
+	}
+
+	// Step 2 (AC1): simulate the operator removing fabrik:paused and run
+	// another pass. As with the rebase site, the mock keeps returning
+	// "actionable" (leftQueue) state every call, so this same pass's own
+	// dispatch fires right after the reset — the counter reading 1 (not the
+	// still-stuck 2) is itself proof the reset landed.
+	item.Labels = []string{"stage:Validate:complete", "fabrik:auto-merge-enabled"}
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool), priorInQueue: true}
+	runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+
+	snap, _ = eng.store.Get(repo, number)
+	if snap.PausedByEngine("Validate") {
+		t.Error("PausedByEngine(Validate) must be cleared after the reset pass")
+	}
+	if got := snap.EnqueueCycles("Validate"); got != 1 {
+		t.Fatalf("AC1: EnqueueCycles(Validate) after unpause = %d; want 1 — the counter must have reset to 0 before this pass's own re-enqueue incremented it, not stayed pinned at the limit", got)
+	}
+	if len(client.enqueuePullRequestCalls) != 1 {
+		t.Fatalf("expected exactly 1 re-enqueue call after the reset, got %d", len(client.enqueuePullRequestCalls))
+	}
+
+	// Step 3 (AC2): confirm a further cycle proceeds without re-pausing
+	// (baseline excludes Step 1's legitimate pause).
+	client.mu.Lock()
+	baseline := len(client.addLabelCalls)
+	client.mu.Unlock()
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool), priorInQueue: true}
+	claimed = runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected a second re-enqueue to claim the item")
+	}
+	snap, _ = eng.store.Get(repo, number)
+	if got := snap.EnqueueCycles("Validate"); got != 2 {
+		t.Errorf("AC2: EnqueueCycles(Validate) = %d; want 2 — a genuinely reset counter must permit more than one further cycle before re-hitting the limit", got)
+	}
+	if len(client.enqueuePullRequestCalls) != 2 {
+		t.Errorf("expected a second re-enqueue call, got %d total", len(client.enqueuePullRequestCalls))
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	for _, c := range client.addLabelCalls[baseline:] {
+		if c.labelName == "fabrik:paused" {
+			t.Errorf("AC2: fabrik:paused must not be re-added — EnqueueCycles(2) has not yet reached MaxEnqueueCycles(%d) again", eng.cfg.MaxEnqueueCycles)
+		}
+	}
+}

--- a/engine/mutate.go
+++ b/engine/mutate.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/handarbeit/fabrik/boardcache"
@@ -293,4 +294,41 @@ func (e *Engine) pauseIssue(item gh.ProjectItem, comment string, opts pauseOpts)
 	if opts.removeAutoMerge {
 		e.applyLabelRemove(item, "fabrik:auto-merge-enabled", opts.labelEcho)
 	}
+}
+
+// hasPauseComment reports whether item already carries a comment matching any
+// of the given stable prose fragments — the shared primitive behind each
+// pause domain's own hasXPauseComment wrapper (CI gate, review cycle, rebase
+// cycle, enqueue cycle). The match is unscoped by time — it scans the issue's
+// entire comment history, not just "this poll" — so it identifies a single
+// pause *episode* rather than a single call. That's what lets a pauseFor*
+// function tell a genuine same-poll duplicate call apart from a later
+// re-escalation of the same unresolved episode after a human resumed the item
+// by removing fabrik:paused (issue #1408) — both hit this same check, but
+// only the caller-side context decides which one it is. Mirrors
+// hasSkippedComment's precedent (no_work_needed_settle.go): match on a stable
+// prose fragment rather than the full message, since counters/values embedded
+// in the message can differ between posts of the "same" episode.
+func hasPauseComment(item gh.ProjectItem, fragments ...string) bool {
+	for _, c := range item.Comments {
+		for _, frag := range fragments {
+			if strings.Contains(c.Body, frag) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// reapplyPauseLabels re-applies fabrik:paused + fabrik:awaiting-input without
+// posting a new comment. Used by a pauseFor* function's reapply branch (issue
+// #1408) when hasPauseComment finds an existing pause comment for this
+// episode: a human resuming the item removes only fabrik:paused, never the
+// comment, so a still-blocked item must be re-escalated (labels reapplied)
+// without spamming a duplicate comment. applyLabelAdd's underlying
+// AddLabelToIssue call is idempotent, so this is safe to call even in the
+// (should-be-rare) case the labels are still present.
+func (e *Engine) reapplyPauseLabels(item gh.ProjectItem) {
+	e.applyLabelAdd(item, "fabrik:paused", false)
+	e.applyLabelAdd(item, "fabrik:awaiting-input", false)
 }

--- a/engine/process_item_test.go
+++ b/engine/process_item_test.go
@@ -1038,6 +1038,84 @@ func TestProcessItem_ResetsOnUnpause(t *testing.T) {
 	}
 }
 
+// TestEscalateFailedStage_ClearFailedStage_ResetsAttempts is the AC5
+// regression for #1460: escalateFailedStage/clearFailedStage are untouched by
+// this issue's fix (the four cycle-limit sites are fixed via a separate,
+// additive handler — handleEngineUnpause — in catchUpPhase1Handlers, which a
+// stage-not-yet-complete item like this one never reaches; escalateFailedStage
+// itself is only ever reached from processItem's own unchanged gate). This
+// drives the REAL escalateFailedStage and REAL clearFailedStage (not
+// simulated store state), confirming stage:<name>:failed is applied then
+// removed, PausedByEngine is set then cleared, and — the part AC5 explicitly
+// calls out — Attempts(stage) is reset to 0 on unpause, exactly as before
+// this issue's change.
+//
+// Calls clearFailedStage directly (mirroring
+// TestClearFailedStage_ReviewCycleCount_ResetsOnlyCurrentStage's existing
+// precedent) rather than driving a full processItem pass: a full pass would
+// immediately re-dispatch the now-eligible stage, and that dispatch's own
+// StageRetryIncremented would confound the very assertion this test makes
+// (Attempts == 0 right after the reset, not after a subsequent attempt).
+// TestProcessItem_ResetsOnUnpause already covers that processItem's gate
+// itself still fires clearFailedStage correctly end-to-end.
+func TestEscalateFailedStage_ClearFailedStage_ResetsAttempts(t *testing.T) {
+	client := &mockGitHubClient{}
+	eng := testEngineWithStages(t, client, testStages())
+	eng.cfg.MaxRetries = 3
+
+	stage := &stages.Stage{Name: "Research", Order: 1}
+	item := gh.ProjectItem{Number: 12, Title: "Escalate test", Status: "Research", ItemID: "PVTI_12", Repo: "owner/repo"}
+
+	// Drive the real escalation: 3 failed attempts, then escalateFailedStage
+	// (mirrors what item.go's own MaxRetries check does at the call site).
+	for i := 0; i < eng.cfg.MaxRetries; i++ {
+		eng.store.Apply(itemstate.StageRetryIncremented{Repo: "owner/repo", Number: 12, StageName: "Research"})
+	}
+	eng.escalateFailedStage(item, stage, "")
+
+	snap, _ := eng.store.Get("owner/repo", 12)
+	if snap.Attempts("Research") != eng.cfg.MaxRetries {
+		t.Fatalf("Attempts(Research) after escalation = %d; want %d (unchanged from escalation)", snap.Attempts("Research"), eng.cfg.MaxRetries)
+	}
+	if !snap.PausedByEngine("Research") {
+		t.Fatal("expected PausedByEngine(Research) to be true after escalateFailedStage — this is the pre-existing, unchanged mechanism AC5 protects")
+	}
+	pausedApplied, failedApplied := false, false
+	for _, c := range client.addLabelCalls {
+		switch c.labelName {
+		case "fabrik:paused":
+			pausedApplied = true
+		case "stage:Research:failed":
+			failedApplied = true
+		}
+	}
+	if !pausedApplied || !failedApplied {
+		t.Fatalf("expected both fabrik:paused and stage:Research:failed to be applied by escalateFailedStage, got paused=%v failed=%v", pausedApplied, failedApplied)
+	}
+
+	// Simulate the operator investigating and removing fabrik:paused, then
+	// the real clearFailedStage reset that processItem's gate would trigger.
+	item.Labels = []string{"stage:Research:failed"}
+	eng.clearFailedStage(item, stage)
+
+	foundRemoval := false
+	for _, call := range client.removeLabelCalls {
+		if call.labelName == "stage:Research:failed" {
+			foundRemoval = true
+		}
+	}
+	if !foundRemoval {
+		t.Error("expected stage:Research:failed to be removed on unpause — AC5 regression")
+	}
+	snap, _ = eng.store.Get("owner/repo", 12)
+	if snap.Attempts("Research") != 0 {
+		t.Errorf("AC5: Attempts(Research) after unpause = %d; want 0 — escalateFailedStage's unpause behavior must be byte-for-byte unchanged by this issue's fix", snap.Attempts("Research"))
+	}
+	if snap.PausedByEngine("Research") {
+		t.Error("expected PausedByEngine(Research) to be cleared after unpause")
+	}
+}
+
 func TestProcessItem_UnlimitedWhenMaxRetriesZero(t *testing.T) {
 	skipIfNoGit(t)
 	repoDir := initBareRepo(t)

--- a/engine/reviews.go
+++ b/engine/reviews.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/itemstate"
 	"github.com/handarbeit/fabrik/stages"
 )
 
@@ -1666,24 +1667,56 @@ func (e *Engine) dispatchReviewReinvoke(ctx context.Context, board *gh.ProjectBo
 	})
 }
 
+// reviewCyclePauseFragment is the stable prose fragment identifying a
+// pauseForReviewCycleLimit pause comment, matched by hasPauseComment (#1460 R4).
+func reviewCyclePauseFragment(stage *stages.Stage) string {
+	return fmt.Sprintf("The stage **%s** has been re-invoked to address PR review feedback", stage.Name)
+}
+
 // pauseForReviewCycleLimit pauses the issue when the maximum review re-invocation
 // cycle count is reached. It applies fabrik:paused + fabrik:awaiting-input and
-// posts an explanatory comment.
-func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) {
+// posts an explanatory comment — unless a pause comment for this episode
+// already exists (#1408/#1460 R4), in which case it reapplies the pause
+// labels only, reusing the existing comment rather than reposting.
+//
+// Applies itemstate.EnginePaused (#1460 R2) in both branches — the fresh
+// pause AND the reapply-existing-comment branch — so wasPaused becomes true
+// and the new handleEngineUnpause Phase 1 handler fires clearFailedStage on
+// resume, actually resetting ReviewCycles. Without this, removing
+// fabrik:paused was a no-op: ReviewCycles stayed pinned at the limit and the
+// item re-paused on its very next catch-up pass (confirmed live on #1208).
+// Re-applying on the reapply branch matters too: a resume clears
+// PausedByEngine, so if review feedback keeps arriving and the counter climbs
+// back to the limit a second time, this function runs again on the reapply
+// branch (the old comment still matches) and must re-arm PausedByEngine or
+// the next resume would be a no-op.
+//
+// Returns escalated: true when a fresh pause comment was posted, false when
+// an existing episode's pause was merely reapplied.
+func (e *Engine) pauseForReviewCycleLimit(board *gh.ProjectBoard, item gh.ProjectItem, stage *stages.Stage, cycleCount, maxCycles int) (escalated bool) {
+	repoStr := itemOwnerRepoString(item, e.defaultRepo())
+	if hasPauseComment(item, reviewCyclePauseFragment(stage)) {
+		e.logf(item.Number, "review-cycles", "review-cycle pause comment already exists for this episode — reapplying pause without reposting\n")
+		e.reapplyPauseLabels(item)
+		e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+		return false
+	}
 	e.logf(item.Number, "review-cycles", "review cycle limit %d reached — pausing for human intervention\n", maxCycles)
 
 	msg := fmt.Sprintf(
-		"🏭 **Fabrik — review cycle limit reached**\n\nThe stage **%s** has been re-invoked to address PR review feedback %d time(s), "+
+		"🏭 **Fabrik — review cycle limit reached**\n\n%s %d time(s), "+
 			"which has reached the maximum configured limit (`FABRIK_MAX_REVIEW_CYCLES=%d`).\n\n"+
 			"This usually means a reviewer (bot or human) is repeatedly requesting changes after each fix. "+
 			"Fabrik has paused this issue for human review. Once the review situation is resolved, "+
 			"remove the `fabrik:paused` label to resume.",
-		stage.Name, cycleCount, maxCycles,
+		reviewCyclePauseFragment(stage), cycleCount, maxCycles,
 	)
 	e.pauseIssue(item, msg, pauseOpts{
 		awaitingInput: true,
 		reactRocket:   true,
 	})
+	e.store.Apply(itemstate.EnginePaused{Repo: repoStr, Number: item.Number, StageName: stage.Name})
+	return true
 }
 
 // botMentionHandle maps copilot-* logins to "copilot" — GitHub's canonical mention surface for the reviewer bot.

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -3682,3 +3682,133 @@ func TestCheckReviewGate_DefaultBranch_DoesNotCallRESTReviewFetch(t *testing.T) 
 		t.Errorf("expected no REST review-fetch calls on a default-branch item, got reviews=%d requests=%d", restReviewCalls, restRequestCalls)
 	}
 }
+
+// ---- #1460 R2/AC1/AC2: pauseForReviewCycleLimit resumability ----
+
+// TestReviewCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles is the
+// AC1/AC2 regression for #1460's confirmed site #1: before this fix,
+// pauseForReviewCycleLimit never applied itemstate.EnginePaused, so removing
+// fabrik:paused was a no-op — ReviewCycles stayed pinned at the limit and the
+// very next catch-up pass re-paused immediately (reproduced live on #1208).
+//
+// Drives through the real catchUpPhase1Handlers chain (runPhase1Chain, not
+// clearFailedStage directly), and — critically — drives the pause itself
+// through the real dispatchWithCycleLimit/pauseForReviewCycleLimit call
+// (cycleCount pre-set to exactly the limit, with actionable feedback present
+// so the gate actually reaches the pause branch) rather than seeding
+// itemstate.EnginePaused directly in the test. Seeding it directly would
+// validate handleEngineUnpause's own reset logic (already covered by
+// TestHandleEngineUnpause_PausedByEngine_ResetsAndReturnsFalse) but prove
+// nothing about whether pauseForReviewCycleLimit itself applies EnginePaused
+// — the actual R2 fix.
+//
+// AC3: reverting pauseForReviewCycleLimit's two itemstate.EnginePaused apply
+// lines back to their pre-fix (absent) form turns this test red: Step 1's
+// PausedByEngine assertion fails immediately (confirmed by neutralizing both
+// lines and re-running — see PR description).
+func TestReviewCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testing.T) {
+	client := &mockGitHubClient{
+		addCommentFn:         func(_, _ string, _ int, _ string) (int, error) { return 1, nil },
+		addCommentReactionFn: func(_, _ string, _ int, _ string) error { return nil },
+	}
+	stgs := []*stages.Stage{{Name: "Implement", Order: 1, Prompt: "implement"}}
+	eng := testEngineWithStages(t, client, stgs)
+	eng.cfg.MaxReviewCycles = 2
+	stage := stgs[0]
+	board := &gh.ProjectBoard{}
+	const repo = "owner/repo"
+	const number = 30
+
+	// Step 1: drive a REAL pause through the actual code path. ReviewCycles
+	// pre-set to exactly the limit, with actionable feedback present, so
+	// handleReviewGate's dispatchWithCycleLimit reaches the pause branch
+	// (cycleCount >= maxCycles) and calls the real pauseForReviewCycleLimit.
+	for i := 0; i < eng.cfg.MaxReviewCycles; i++ {
+		eng.store.Apply(itemstate.ReviewCycleIncremented{Repo: repo, Number: number, StageName: "Implement"})
+	}
+	item := gh.ProjectItem{
+		Number: number, Repo: repo, Labels: []string{"stage:Implement:complete"},
+		LinkedPRReviewThreadComments: []gh.Comment{
+			{ID: "PRRC_initial", DatabaseID: 199, Author: "copilot", Body: "fix this", ReviewThreadID: "RT_initial"},
+		},
+	}
+	pctx := &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+	claimed := runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+	if !claimed {
+		t.Fatal("expected the cycle-limit pause branch to claim the item")
+	}
+
+	client.mu.Lock()
+	pausedApplied := false
+	for _, c := range client.addLabelCalls {
+		if c.labelName == "fabrik:paused" {
+			pausedApplied = true
+		}
+	}
+	client.mu.Unlock()
+	if !pausedApplied {
+		t.Fatal("expected fabrik:paused to be applied by the real cycle-limit pause")
+	}
+	snap, _ := eng.store.Get(repo, number)
+	if !snap.PausedByEngine("Implement") {
+		t.Fatal("R2: pauseForReviewCycleLimit must apply itemstate.EnginePaused so wasPaused becomes true on resume — PausedByEngine(Implement) is false after the real pause")
+	}
+
+	// Step 2 (AC1): simulate the operator removing fabrik:paused (the item's
+	// own label set no longer carries it) and run a pass with nothing new
+	// actionable — isolates the reset itself from any same-pass re-dispatch.
+	item.Labels = []string{"stage:Implement:complete"}
+	item.LinkedPRReviewThreadComments = nil
+	pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+	runPhase1Chain(eng, pctx)
+	eng.wg.Wait()
+
+	snap, _ = eng.store.Get(repo, number)
+	if got := snap.ReviewCycles("Implement"); got != 0 {
+		t.Fatalf("AC1: ReviewCycles(Implement) after unpause = %d; want 0 — the counter must actually reset, not just the label go away", got)
+	}
+	if snap.PausedByEngine("Implement") {
+		t.Error("PausedByEngine(Implement) must be cleared after the reset pass")
+	}
+
+	// Step 3 (AC2): the item must now perform more than one subsequent cycle
+	// without re-pausing. Feed fresh actionable review feedback across two
+	// more passes (distinct comment/thread IDs per pass, simulating new
+	// reviewer activity each time — buildReviewThreadComments excludes an
+	// already-processed comment ID, so reusing one ID would silently stop
+	// being "actionable" rather than proving anything about the cycle limit)
+	// and confirm ReviewCycles climbs while fabrik:paused is never re-added.
+	// baseline records the addLabelCalls count so far (Step 1's genuine pause
+	// legitimately added fabrik:paused once — only re-additions AFTER the
+	// reset are the regression this checks for).
+	client.mu.Lock()
+	baseline := len(client.addLabelCalls)
+	client.mu.Unlock()
+	for cycle := 1; cycle <= 2; cycle++ {
+		item.LinkedPRReviewThreadComments = []gh.Comment{
+			{
+				ID: fmt.Sprintf("PRRC_cycle_%d", cycle), DatabaseID: 200 + cycle,
+				Author: "copilot", Body: "fix this", ReviewThreadID: fmt.Sprintf("RT_cycle_%d", cycle),
+			},
+		}
+		pctx = &phase1Ctx{ctx: context.Background(), board: board, item: item, stage: stage, hasComplete: true, advancedItems: make(map[string]bool)}
+		claimed := runPhase1Chain(eng, pctx)
+		eng.wg.Wait()
+		if !claimed {
+			t.Fatalf("cycle %d: expected the review-reinvoke dispatch to claim the item", cycle)
+		}
+		snap, _ = eng.store.Get(repo, number)
+		if got := snap.ReviewCycles("Implement"); got != cycle {
+			t.Errorf("cycle %d: ReviewCycles(Implement) = %d; want %d — a genuinely reset counter must permit more than one further cycle", cycle, got, cycle)
+		}
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	for _, c := range client.addLabelCalls[baseline:] {
+		if c.labelName == "fabrik:paused" {
+			t.Errorf("AC2: fabrik:paused must not be re-added across 2 subsequent cycles, both well below MaxReviewCycles=%d", eng.cfg.MaxReviewCycles)
+		}
+	}
+}

--- a/engine/reviews_test.go
+++ b/engine/reviews_test.go
@@ -3812,3 +3812,51 @@ func TestReviewCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles(t *testing
 		}
 	}
 }
+
+// TestPauseForReviewCycleLimit_ExistingComment_NoRepost is the AC4 regression
+// for #1460's confirmed site #1: when a pause comment for this episode
+// already exists (hasPauseComment matches the stable review-cycle-limit
+// fragment), pauseForReviewCycleLimit must reapply fabrik:paused +
+// fabrik:awaiting-input (and re-arm itemstate.EnginePaused — R2 must fire on
+// the reapply branch too, not just the fresh-pause branch) without posting a
+// duplicate comment. Mirrors
+// TestSettleAwaitingCIScan_RaceWithMainLoop_CycleLimitPause_NoDuplicateComment's
+// assertion style for the CI-gate precedent this reuses (PR #1445/ADR-1408).
+func TestPauseForReviewCycleLimit_ExistingComment_NoRepost(t *testing.T) {
+	client := &mockGitHubClient{}
+	stgs := []*stages.Stage{{Name: "Implement", Order: 1, Prompt: "implement"}}
+	eng := testEngineWithStages(t, client, stgs)
+	stage := stgs[0]
+	item := gh.ProjectItem{
+		Number: 31, Repo: "owner/repo",
+		Comments: []gh.Comment{
+			{ID: "C1", Body: "🏭 **Fabrik — review cycle limit reached**\n\nThe stage **Implement** has been re-invoked to address " +
+				"PR review feedback 3 time(s), which has reached the maximum configured limit (`FABRIK_MAX_REVIEW_CYCLES=3`)."},
+		},
+	}
+
+	escalated := eng.pauseForReviewCycleLimit(&gh.ProjectBoard{}, item, stage, 3, 3)
+
+	if escalated {
+		t.Error("expected escalated=false when an existing pause comment is reused")
+	}
+	if len(client.addCommentCalls) != 0 {
+		t.Errorf("AC4: expected no new comment posted when one already exists for this episode, got %d", len(client.addCommentCalls))
+	}
+	pausedApplied, awaitingInputApplied := false, false
+	for _, c := range client.addLabelCalls {
+		switch c.labelName {
+		case "fabrik:paused":
+			pausedApplied = true
+		case "fabrik:awaiting-input":
+			awaitingInputApplied = true
+		}
+	}
+	if !pausedApplied || !awaitingInputApplied {
+		t.Errorf("expected fabrik:paused and fabrik:awaiting-input to be reapplied, got paused=%v awaitingInput=%v", pausedApplied, awaitingInputApplied)
+	}
+	snap, _ := eng.store.Get("owner/repo", 31)
+	if !snap.PausedByEngine("Implement") {
+		t.Error("R2: expected itemstate.EnginePaused to be (re-)applied even on the reapply branch — otherwise a second unpause after this episode would be a no-op")
+	}
+}


### PR DESCRIPTION
Closes #1460

## Summary

`fabrik:paused` is documented everywhere as "remove this label to resume" — for four cycle-limit pause sites that was false. `pauseForReviewCycleLimit`, `pauseForCIFixCycleLimit`, `pauseForRebaseCycleLimit`, and `pauseForEnqueueCycleLimit` never applied `itemstate.EnginePaused`, so their triggering counter (`ReviewCycles`/`CIFixCycles`/`RebaseCycles`/`EnqueueCycles`) was never reset on unpause. The item re-paused on its very next evaluation — reproduced live on #1208 (5 seconds, unpause → byte-identical repost → re-pause).

## Root cause correction vs. the issue's suggested fix

The issue body suggested simply applying `itemstate.EnginePaused` so `processItem`'s existing `wasPaused` gate would fire `clearFailedStage`. That gate is **structurally unreachable** for all four sites: they only ever fire *after* `stage:<name>:complete`, where `itemNeedsWork` never re-dispatches `processItem`. The actual re-evaluation point is the Phase 1 catch-up handler chain (`catchUpPhase1Handlers`), which contained no reset logic at all — exactly matching #1208's repro (no comment involved, just a label removal).

## Fix

1. **R2** — all four functions now apply `itemstate.EnginePaused` in both their fresh-pause and reapply-existing-comment branches.
2. **R2, the actual reset trigger** — a new Phase 1 handler, `handleEngineUnpause`, prepended first in `catchUpPhase1Handlers`. Detects a stale `EnginePaused` record (item reached the chain, meaning the label is gone) and calls the existing `clearFailedStage`, letting the rest of the chain re-evaluate the freshly-reset counter in the same pass.
3. **R4** — generalized PR #1445's `hasCIGatePauseComment`/`reapplyCIGatePauseLabels` into shared `hasPauseComment`/`reapplyPauseLabels` (`engine/mutate.go`), applied to all four sites so a re-pause never reposts an identical comment.
4. Corrected `pauseForEnqueueCycleLimit`'s doc comment, which falsely claimed the counter was already cleared by `clearFailedStage`.
5. **R3** — re-verified all 8 previously-unclassified pause sites against current code; none need this fix (each independently resets its own anchor or is purely condition-driven). Full classification table in the new ADR.
6. **R5** — `pauseForSliceLimit` (#1199) landed on `main` ahead of this issue and independently adopted the same `EnginePaused` mechanism; documented the relationship in the ADR (no code change needed there).

## AC3 — neutralization proof (verified by hand for each site, not left as a claim)

Reverting either of a site's two `itemstate.EnginePaused` applies back to nothing turns that site's resumability test red:

| Site | Line(s) reverted | Test that goes red |
|---|---|---|
| `pauseForReviewCycleLimit` | both `e.store.Apply(itemstate.EnginePaused{...})` calls in `engine/reviews.go` | `TestReviewCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles` |
| `pauseForRebaseCycleLimit` | both calls in `engine/merge_gate.go` | `TestRebaseCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles` |
| `pauseForEnqueueCycleLimit` | both calls in `engine/merge_gate.go` | `TestEnqueueCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles` |
| `pauseForCIFixCycleLimit` | both calls in `engine/ci.go` | `TestCIFixCycleLimit_UnpauseResetsCounterAndAllowsMultipleCycles` |

Each test drives the pause through the *real* dispatch path (not simulated `EnginePaused` seeding), so neutralizing the fix fails at the `PausedByEngine` assertion immediately after the genuine pause — not at a downstream, easier-to-miss assertion.

## Testing

- 4 new resumability tests (AC1/AC2/AC3), one per confirmed site, driven through the real `catchUpPhase1Handlers` chain via a new `runPhase1Chain` test helper.
- 3 new no-repost tests (AC4) for review/rebase/enqueue (CI-fix's AC4 was already covered by an existing PR #1445 test).
- New `TestEscalateFailedStage_ClearFailedStage_ResetsAttempts` (AC5): confirms `escalateFailedStage`/`clearFailedStage` are byte-for-byte unaffected.
- AC6 (independent-reset sites unchanged): covered by pre-existing, unmodified tests (`TestPauseForConvergenceFailed_PostsComment_AppliesLabels`, `TestCheckDependencies_AllDepsClosed_RemovesBlockedLabel`), both still green.
- `handleEngineUnpause` direct unit tests + updated `TestCatchUpPhase1HandlersOrder`.
- `go vet ./...` clean, `go test -race ./...` green **except** `TestExecute_ConfigYAMLApplied` (`cmd` package) — a pre-existing, network-dependent SIGINT-timing test unrelated to this change (predates this branch, untouched files, fails identically on `main`; consistently reproduces the same way regardless of these changes — environment network latency against real `api.github.com`, not a regression).

## Docs

- New ADR `adrs/1460-resumable-engine-pauses.md`: full mechanism writeup, the `processItem`-unreachability finding, the accepted `Attempts`-reset side effect, and the complete 12-site R3 classification table.
- `docs/state-machine.md`: new §7.2.1 "Resumable Engine Pauses", a "Handler 0: `handleEngineUnpause`" paragraph in §6.2, a scoping note on the §3.2 pause/unpause table, and a correction to §7.12's now-stale claim about `pauseForRebaseCycleLimit`.
- `docs/llms-full.txt` regenerated.

## Out of scope (unchanged)

No pause *policy* changes — same conditions, same thresholds. `pauseForSliceLimit` itself not touched (already fixed independently, see R5 note above).