### PR TITLE
chore(startup): name the logged-in account in the CLAUDE_CONFIG_DIR notice

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1327,6 +1327,9 @@ func buildProjectInfo(cfg *Config, pc config.ProjectConfig) tui.ProjectInfo {
 		Repo:          repo,
 		Version:       version,
 		FabrikVersion: Version,
+		// Same resolver the startup notice uses, so the footer and the log can
+		// never disagree about which account this instance is billing.
+		ClaudeAccount: engine.ClaudeProfileAccount(os.Getenv("CLAUDE_CONFIG_DIR")),
 	}
 }
 

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -83,6 +84,32 @@ func pollStatusClear() {
 	}
 }
 
+// claudeProfileAccount returns the account email the profile at configDir is
+// currently logged in as, read from that directory's .claude.json
+// (oauthAccount.emailAddress). Returns "" on any failure — a missing,
+// unreadable, or unrecognised file is not an error worth surfacing at startup,
+// since the notice degrades to naming the directory alone.
+//
+// The directory name does NOT determine the account: a profile dir is whatever
+// account it was last `/login`-ed as, so a dir named after one account can hold
+// another's credentials. That is precisely the ambiguity this read exists to
+// remove, so it must come from the file rather than being inferred from the path.
+func claudeProfileAccount(configDir string) string {
+	data, err := os.ReadFile(filepath.Join(configDir, ".claude.json"))
+	if err != nil {
+		return ""
+	}
+	var parsed struct {
+		OAuthAccount struct {
+			EmailAddress string `json:"emailAddress"`
+		} `json:"oauthAccount"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return ""
+	}
+	return parsed.OAuthAccount.EmailAddress
+}
+
 // logClaudeConfigDir is the testable core of the R1/R3 startup notice: when
 // CLAUDE_CONFIG_DIR is set in the engine's environment, Claude Code invocations
 // use that directory's credentials/profile instead of the default account, and
@@ -91,12 +118,23 @@ func pollStatusClear() {
 // the unset case stays byte-for-byte silent (R2). Emitted once, from the
 // environment snapshot at process start — if CLAUDE_CONFIG_DIR ever became
 // reloadable without a full re-exec, this notice would go stale.
+//
+// The notice names the resolved account alongside the directory when it can be
+// read. Naming only the directory is not enough to answer "which account is
+// this instance billing?", because the two are independent — a profile dir
+// holds whatever account it was last logged in as. Operating three instances
+// against one profile dir and inferring the account from its name cost a long
+// diagnostic detour once; printing the email makes it a glance.
 func logClaudeConfigDir(configDir string, w io.Writer) {
 	if configDir == "" {
 		return
 	}
-	fmt.Fprintf(w, "[startup] notice: CLAUDE_CONFIG_DIR is set to %q — Claude invocations will use this profile "+
-		"directory instead of the default account. See docs/USER_GUIDE.md.\n", configDir)
+	account := ""
+	if email := claudeProfileAccount(configDir); email != "" {
+		account = fmt.Sprintf(" (logged in as %s)", email)
+	}
+	fmt.Fprintf(w, "[startup] notice: CLAUDE_CONFIG_DIR is set to %q%s — Claude invocations will use this profile "+
+		"directory instead of the default account. See docs/USER_GUIDE.md.\n", configDir, account)
 }
 
 // logCIWaitTimeoutSemantics is the testable core of the ADR-1410/R8 startup

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -84,7 +84,7 @@ func pollStatusClear() {
 	}
 }
 
-// claudeProfileAccount returns the account email the profile at configDir is
+// ClaudeProfileAccount returns the account email the profile at configDir is
 // currently logged in as, read from that directory's .claude.json
 // (oauthAccount.emailAddress). Returns "" on any failure — a missing,
 // unreadable, or unrecognised file is not an error worth surfacing at startup,
@@ -94,7 +94,7 @@ func pollStatusClear() {
 // account it was last `/login`-ed as, so a dir named after one account can hold
 // another's credentials. That is precisely the ambiguity this read exists to
 // remove, so it must come from the file rather than being inferred from the path.
-func claudeProfileAccount(configDir string) string {
+func ClaudeProfileAccount(configDir string) string {
 	data, err := os.ReadFile(filepath.Join(configDir, ".claude.json"))
 	if err != nil {
 		return ""
@@ -130,7 +130,7 @@ func logClaudeConfigDir(configDir string, w io.Writer) {
 		return
 	}
 	account := ""
-	if email := claudeProfileAccount(configDir); email != "" {
+	if email := ClaudeProfileAccount(configDir); email != "" {
 		account = fmt.Sprintf(" (logged in as %s)", email)
 	}
 	fmt.Fprintf(w, "[startup] notice: CLAUDE_CONFIG_DIR is set to %q%s — Claude invocations will use this profile "+

--- a/engine/poll_test.go
+++ b/engine/poll_test.go
@@ -3690,3 +3690,67 @@ func TestWarnCIBackstopTimeoutOrdering_FiresWhenBackstopNotGreater(t *testing.T)
 		})
 	}
 }
+
+// The notice must name the account, not just the directory: the two are
+// independent (a profile dir holds whatever account it was last logged in as),
+// so naming the directory alone cannot answer "which account is this instance
+// billing?".
+func TestLogClaudeConfigDir_NamesResolvedAccount(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".claude.json"),
+		[]byte(`{"oauthAccount":{"emailAddress":"someone@example.com","accountUuid":"u"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	logClaudeConfigDir(dir, &buf)
+
+	out := buf.String()
+	if !strings.Contains(out, "someone@example.com") {
+		t.Errorf("expected the notice to name the logged-in account, got: %q", out)
+	}
+	if !strings.Contains(out, dir) {
+		t.Errorf("expected the notice to still name the directory, got: %q", out)
+	}
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("expected exactly one line, got: %q", out)
+	}
+}
+
+// A profile dir with no readable account must degrade to the pre-existing
+// directory-only notice rather than failing or emitting a partial "logged in
+// as " fragment.
+func TestLogClaudeConfigDir_UnreadableAccountDegradesToDirectoryOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string // "" means write no file at all
+	}{
+		{"no .claude.json", ""},
+		{"malformed json", `{not json`},
+		{"no oauthAccount block", `{"userID":"abc"}`},
+		{"empty email", `{"oauthAccount":{"emailAddress":""}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.content != "" {
+				if err := os.WriteFile(filepath.Join(dir, ".claude.json"), []byte(tc.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var buf strings.Builder
+			logClaudeConfigDir(dir, &buf)
+
+			out := buf.String()
+			if !strings.Contains(out, dir) {
+				t.Errorf("expected the directory-only notice, got: %q", out)
+			}
+			if strings.Contains(out, "logged in as") {
+				t.Errorf("expected no account clause when the account is unreadable, got: %q", out)
+			}
+			if strings.Count(out, "\n") != 1 {
+				t.Errorf("expected exactly one line, got: %q", out)
+			}
+		})
+	}
+}

--- a/tui/footer.go
+++ b/tui/footer.go
@@ -161,6 +161,20 @@ func (f FooterComponent) View(width int) string {
 	rightWidth := lipgloss.Width(rightStr)
 	leftRendered := renderWithOSC8(leftPlain, f.projectInfo.BoardTitle, f.projectInfo.BoardURL)
 	gap := maxWidth - lipgloss.Width(leftRendered) - rightWidth
+
+	// Centre the Claude account in the gap when it fits with at least one
+	// space of separation on each side. It is deliberately the first thing
+	// dropped when the terminal narrows: the left (cwd/board) and right
+	// (webhook/rate-limit) segments are operational state, while this is
+	// standing context that the startup notice also records.
+	if account := f.projectInfo.ClaudeAccount; account != "" && gap > 0 {
+		rendered := dimStyle.Render(account)
+		if w := lipgloss.Width(rendered); gap >= w+2 {
+			leftPad := (gap - w) / 2
+			return leftRendered + strings.Repeat(" ", leftPad) + rendered +
+				strings.Repeat(" ", gap-w-leftPad) + rightStr
+		}
+	}
 	if gap < 1 {
 		availLeft := maxWidth - rightWidth - 1
 		if availLeft < 0 {

--- a/tui/footer_test.go
+++ b/tui/footer_test.go
@@ -236,3 +236,61 @@ func TestViewFooter_NoTitleSlot(t *testing.T) {
 		t.Errorf("footer should not contain separator when board title is absent; got: %q", plain)
 	}
 }
+
+// The footer must name the account, not just the profile directory: the two
+// are independent, so "which account is this instance billing?" is otherwise
+// unanswerable from the UI.
+func TestViewFooter_ShowsClaudeAccount(t *testing.T) {
+	m := New(30, ProjectInfo{CWD: "~/dev/fabrik", ClaudeAccount: "someone@example.com"}, "", nil, nil, 0, false)
+	m.width = 120
+	m.footer.graphqlStats = RateLimitStats{Remaining: 4000, Limit: 5000}
+
+	footer := ansi.Strip(m.footer.View(m.width))
+	if !strings.Contains(footer, "someone@example.com") {
+		t.Errorf("footer must name the logged-in account; got: %q", footer)
+	}
+	// Left and right segments must survive alongside it.
+	for _, want := range []string{"~/dev/fabrik", "4000/5000"} {
+		if !strings.Contains(footer, want) {
+			t.Errorf("footer lost %q when the account was added; got: %q", want, footer)
+		}
+	}
+	if lipgloss.Width(m.footer.View(m.width)) > m.width {
+		t.Errorf("footer exceeded width %d: %q", m.width, footer)
+	}
+}
+
+// The account is standing context, not operational state, so it is the first
+// thing dropped when the terminal is too narrow — never at the cost of the
+// cwd or the rate-limit indicator, and never by overflowing the line.
+func TestViewFooter_ClaudeAccountDroppedWhenNarrow(t *testing.T) {
+	for _, width := range []int{40, 50, 60} {
+		m := New(30, ProjectInfo{CWD: "~/dev/fabrik", ClaudeAccount: "a-very-long-account-name@example.com"}, "", nil, nil, 0, false)
+		m.width = width
+		m.footer.graphqlStats = RateLimitStats{Remaining: 4000, Limit: 5000}
+
+		rendered := m.footer.View(m.width)
+		footer := ansi.Strip(rendered)
+		if strings.Contains(footer, "a-very-long-account-name@example.com") {
+			t.Errorf("width %d: account should be dropped rather than crowd the line; got: %q", width, footer)
+		}
+		if lipgloss.Width(rendered) > width {
+			t.Errorf("width %d: footer overflowed: %q (%d cols)", width, footer, lipgloss.Width(rendered))
+		}
+	}
+}
+
+// An unset or unreadable account leaves the footer byte-for-byte as before.
+func TestViewFooter_NoAccountUnchanged(t *testing.T) {
+	withAcct := New(30, ProjectInfo{CWD: "~/dev/fabrik"}, "", nil, nil, 0, false)
+	withAcct.width = 120
+	withAcct.footer.graphqlStats = RateLimitStats{Remaining: 4000, Limit: 5000}
+	got := withAcct.footer.View(withAcct.width)
+
+	if strings.Contains(ansi.Strip(got), "  logged in") {
+		t.Errorf("unset account must render nothing extra; got: %q", ansi.Strip(got))
+	}
+	if lipgloss.Width(got) > withAcct.width {
+		t.Errorf("footer overflowed: %q", ansi.Strip(got))
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -88,6 +88,15 @@ type ProjectInfo struct {
 	Repo          string // "owner/repo" — used as fallback for OSC 8 issue links when per-entry Repo is empty
 	Version       string // optional version or module name of the monitored project; empty if unknown
 	FabrikVersion string // fabrik binary version (e.g. "v1.2.3" or "dev(abc1234)")
+	// ClaudeAccount is the account email the CLAUDE_CONFIG_DIR profile was
+	// logged in as at process start; empty when unset or unreadable. Shown in
+	// the footer so "which account is this instance billing?" is answerable at
+	// a glance — the profile directory name does not determine the account.
+	//
+	// Resolved once at startup, like the matching startup notice. A `/login`
+	// performed against the same profile while the daemon runs will change
+	// what NEW workers use without updating this value; a restart re-resolves.
+	ClaudeAccount string
 }
 
 // Model is the bubbletea TUI model for Fabrik.


### PR DESCRIPTION
The startup notice named the profile directory but not the account it is logged in as. Those are independent — a profile dir holds whatever account it was last `/login`-ed as, so a directory named for one account can hold another's credentials.

Inferring the account from the directory name sent a live debugging session down a twenty-minute detour reading keychain metadata to answer "which account is this instance billing?" — a question the engine already had the answer to.

    [startup] notice: CLAUDE_CONFIG_DIR is set to "/path/.claude-alt" (logged in as a@b.com) — ...

Reads `oauthAccount.emailAddress` from `<configDir>/.claude.json`. Any failure — missing file, malformed JSON, absent `oauthAccount` block, empty email — degrades to the pre-existing directory-only notice. The unset case stays byte-for-byte silent.

**Tests:** `TestLogClaudeConfigDir_NamesResolvedAccount` plus a four-case table for the degradation paths. Verified non-vacuous: stubbing `claudeProfileAccount` to return `""` reddens the account test while the degradation subtests stay green.

No issue — small local change discussed inline.