### PR TITLE
Add source-checkout staleness reporting independent of the idle-upgrade gate (#1464)

### DIFF
--- a/adrs/1464-source-checkout-staleness-reporting.md
+++ b/adrs/1464-source-checkout-staleness-reporting.md
@@ -149,7 +149,12 @@ automating it is a follow-up once #1393 exists.
 **Negative / Trade-offs:**
 - A new `git fetch` every ~15 minutes on a source-checkout daemon, independent of idle state —
   bounded network/CPU cost, justified in the issue by the incident's own severity (a full working
-  day of silent staleness) against a fetch's low per-call cost.
+  day of silent staleness) against a fetch's low per-call cost. The ~15-minute figure is a poll
+  count (`stalenessCheckPollInterval` = 30), not a wall-clock duration — it only holds at the
+  default 30s `--poll`. An operator running a much shorter `--poll` gets a proportionally shorter
+  wall-clock interval and proportionally more frequent fetches; this is an accepted consequence of
+  reusing the same poll-count convention `idleUpgradeThreshold` already uses, not a separate
+  wall-clock ticker.
 - Two structurally similar "is the on-disk/remote code newer than what's running" checks now
   exist (`checkVersionSkew` for the local disk/process split, `checkSourceStaleness` for the
   local/origin split) with slightly different triggers and messaging — an operator needs to read

--- a/adrs/1464-source-checkout-staleness-reporting.md
+++ b/adrs/1464-source-checkout-staleness-reporting.md
@@ -1,0 +1,178 @@
+# ADR 1464: Source-checkout staleness reporting, independent of the idle-upgrade gate
+
+**Date**: 2026-08-09
+**Status**: Accepted
+**Issue**: #1464 — a busy source-checkout daemon runs arbitrarily stale code with no signal
+
+## Context
+
+On 2026-08-08 the primary dev instance of this repo's own Fabrik daemon started at 08:31 and
+was still running `8a5ef0f` at 23:50 — 75 commits and ~15 hours behind `origin/main`, across ten
+merges, with `--auto-upgrade` enabled the entire time. Every fix that landed that day was live
+on `main` and absent from the running engine, and #1428's merge-train ejection diagnostics were
+opaque at 18:59 specifically because #1420's fix to them had merged at 18:40 and simply wasn't
+running. Nothing in the TUI, the startup output, or `fabrik.log` said so; the staleness was found
+only by reading the binary's SHA by hand.
+
+The root cause: `checkAndUpgrade` (`engine/upgrade.go`) — the function that actually rebuilds and
+`syscall.Exec`s a dev build onto current code — is reachable from exactly two places: once at
+startup, and once after `idleUpgradeThreshold` (2) *consecutive fully-idle* polls
+(`engine/poll.go`). `idleCount` resets to 0 on any in-flight worker, including a repo-scoped
+merge-train worker (`Store.HasInFlightWorker()`), and that reset is correct — `syscall.Exec`
+would kill whatever Claude invocation is currently running. But it means a continuously busy
+board (dispatching work, or with a merge-train worker in flight, on literally every poll) never
+reaches the idle branch at all, and the only other trigger is a restart that never happens on its
+own. Detecting staleness and acting on it were gated behind the same condition, even though only
+the latter has a real safety reason to require idleness.
+
+`internal/selfupgrade.CheckAndRebuildDev` (ADR-1196) already computes the comparison this issue
+needs — running binary's embedded SHA vs. local `HEAD`, then local vs. `origin/<base>` — but only
+as an inline step interleaved with the `git pull`/`go build`/`syscall.Exec` side effects that
+follow it. There was no way to ask "how stale am I?" without also risking "and now rebuild."
+
+## Decision
+
+Split *detecting* staleness from *acting* on it, and give detection its own, always-reachable
+call site. The existing idle-gated exec path (`checkAndUpgrade`, `idleUpgradeThreshold`,
+`checkVersionSkew`) is untouched — this is purely additive.
+
+### Extract the comparison: `selfupgrade.CompareDevBuild`
+
+`internal/selfupgrade/devbuild.go` gains `CompareDevBuild(cfg DevBuildConfig) (DevBuildStatus,
+error)`, containing exactly the read-only steps `CheckAndRebuildDev` used to run inline before
+deciding to act: the `IsSourceCheckout` gate, resolving local `HEAD`, the SHA-mismatch shortcut
+(skips the network fetch entirely when the running binary's embedded SHA already doesn't match
+local `HEAD`), and — only when that shortcut doesn't fire — `git fetch` + resolving
+`origin/<base>` + the `merge-base --is-ancestor` check. It additionally computes two things the
+original inline code never needed: `CommitsBehind` (`git rev-list --count HEAD..origin/<base>`)
+and `LocalCommitTime` (`git log -1 --format=%cI HEAD`, no extra network call) — R2's "commit count
+and age of the running build."
+
+`CompareDevBuild` structurally never calls `git pull`, `go build`, or `execFn` — there is no
+branch, flag, or code path inside it that reaches any of the three. `CheckAndRebuildDev` is
+rewritten to call `CompareDevBuild` for its decision (`ShaMismatch`/`RemoteAhead`/`NeedsRebuild`)
+and only then proceeds to pull/build/exec exactly as before. This is the single source of truth
+R4 asks for: there is no second, independently-written comparison for the staleness warning to
+disagree with, because there is no other comparison. `devbuild_test.go`'s existing suite passes
+unchanged against the refactor (the same regression-guard technique ADR-1196 used for its own
+extraction), plus new tests exercise `CompareDevBuild` directly — including an explicit assertion
+that a rebuild-eligible fixture still leaves the on-disk executable's bytes untouched and never
+calls the `PostBuildHook`/`execFn` seams (the AC6 "structurally unreachable, not just
+unreached-this-run" bar the issue's acceptance criteria set).
+
+### New engine call site, deliberately outside the idle gate
+
+`engine/staleness.go` adds `checkSourceStaleness()` and its poll-count gate,
+`maybeCheckSourceStaleness()`. The gate is a flat poll counter
+(`stalenessCheckPollInterval = 30`, ≈15 minutes at the default 30s `--poll` interval, firing on
+the very first poll too — free startup coverage) with no idleness precondition at all. It's
+called from `poll()` before the `if dispatched == 0 { ... idleCount ... }` block — never nested
+inside it — which is what makes it reachable on a board that dispatches work every single cycle.
+
+Applicability mirrors `checkAndUpgrade`'s existing fork: `e.cfg.Version` must start with `"dev"`,
+then `CompareDevBuild`'s own `IsSourceCheckout` gate applies. A release build never calls into
+`selfupgrade` for this check at all — zero git subprocesses, satisfying R6/AC5 by construction
+rather than by an extra guard.
+
+### Poll-count gate, not a ticker goroutine
+
+Two scheduling idioms already coexist in this codebase: a dedicated background ticker goroutine
+(`reconcileLoop`, `runWorktreeJanitor`), and an in-`poll()` `time.Time`/counter gate (the Layer 2
+`lastProjectUpdatedAt` check). This issue's acceptance criteria need a fixture that drives many
+poll cycles deterministically without real or mocked wall-clock waiting — a synchronous in-poll
+counter is directly driveable by calling `poll()` N times in a test, which a ticker goroutine is
+not. No new `Config`/CLI flag: `idleUpgradeThreshold` is precedent for a hardcoded const covering
+the same class of decision, and R4 only asks that an interval be chosen and stated, not that it
+be operator-tunable.
+
+### Single fixed warning key, no stale-sweep needed
+
+The warning is recorded under one fixed key, `"source_staleness"` — unlike
+`allow_auto_merge`/`stage_drift` (one entry per board repo/configured stage, a set that shrinks),
+there is exactly one source checkout per Fabrik process. Every throttled evaluation re-derives
+the comparison from scratch and either records or clears the same key, so the `Clear` branch is
+reachable on every single evaluation — the same reasoning `checkVersionSkew`'s own doc comment
+already makes for its per-executable-path key (#1074). No `ClearMissing`-style sweep is needed;
+see `docs/state-machine.md` §7.11 for the parallel writeup.
+
+### Preserve the SHA-mismatch shortcut for the reporting use case too
+
+`CompareDevBuild` keeps `CheckAndRebuildDev`'s existing behavior of skipping the network fetch
+when the running binary's embedded SHA doesn't prefix local `HEAD` — an already-tested case
+(`TestCheckAndRebuildDev_SHAMismatchTriggersRebuildWithoutFetch`). This means that rare edge case
+(a human committed locally without the daemon rebuilding) reports "rebuild pending" without an
+origin-relative commit count, rather than forcing an extra fetch purely to enrich a report. This
+is acceptable because it isn't the incident's failure mode: on a running dev daemon, local `HEAD`
+only ever advances via `CheckAndRebuildDev`'s own `git pull`, so in the ordinary "origin moved on,
+nobody restarted" scenario the SHA still matches and the full fetch-and-count path runs.
+
+### `kill -HUP` is a real fix only when `--auto-upgrade` is enabled
+
+A SIGHUP re-execs the running binary in place (`performSighupRestart` → `syscall.Exec`), which
+re-enters `main()` and re-runs the startup-time `checkAndUpgrade()` call. For a dev build, that
+call does pull/rebuild/re-exec if stale — so `kill -HUP` transitively fixes staleness, but only
+because the startup call itself is gated on `e.cfg.AutoUpgrade`. When `--auto-upgrade` is
+disabled, that startup call never runs either, so a SIGHUP just re-execs the same stale binary.
+`checkSourceStaleness` therefore branches its `FixAction`/`FixParams` on `AutoUpgrade`: a
+`shell_command` fix (`kill -HUP <pid>`) only when it's enabled; when it's disabled, `FixAction` is
+left empty and the `Detail` text spells out the manual `git pull && go build` + restart steps
+instead. Offering `kill -HUP` unconditionally would be actively misleading for a real, common
+configuration, not just unhelpful.
+
+## Deliberately not in scope: automatic upgrade on a busy board
+
+The obvious alternative — detect that `main` moved, drain in-flight workers, upgrade — was
+considered and rejected for now, for reasons stated in the issue: it depends on #1393 (clean-stop
+shutdown; today's drain path cancels the root context, killing Claude subprocesses mid-run), it
+self-triggers on Fabrik's own merges (a ten-merge day becomes ten restarts, each paying a cold
+board-bootstrap cache), and in-memory merge-train state does not survive a re-exec. A warning gets
+the operator the same decision at none of that cost; if it proves to always be answered "yes,"
+automating it is a follow-up once #1393 exists.
+
+## Consequences
+
+**Positive:**
+- Closes the exact incident: a source-checkout daemon that dispatches work every poll now
+  surfaces "N commits / H hours behind origin/main" via the TUI Warnings panel, startup output,
+  and `fabrik.log` — the sentence that would have caught the 2026-08-08 incident.
+- The staleness warning and the real upgrade decision share one comparison function
+  (`CompareDevBuild`), so they cannot silently diverge — the exact risk ADR-1196 already flagged
+  once for the extraction-vs-duplication choice, one layer deeper this time (extracting the
+  comparison *within* `devbuild.go`, not just across a package boundary).
+- Zero behavior change to the existing idle-gated exec path: `idleUpgradeThreshold`,
+  `checkAndUpgrade`, and `checkVersionSkew` are untouched, verified by the existing test suite
+  passing unchanged.
+- `CompareDevBuild` is independently useful: any future caller that wants a read-only "is this
+  dev checkout stale" answer (e.g. a `fabrik status` subcommand) can call it directly without
+  risking a rebuild.
+
+**Negative / Trade-offs:**
+- A new `git fetch` every ~15 minutes on a source-checkout daemon, independent of idle state —
+  bounded network/CPU cost, justified in the issue by the incident's own severity (a full working
+  day of silent staleness) against a fetch's low per-call cost.
+- Two structurally similar "is the on-disk/remote code newer than what's running" checks now
+  exist (`checkVersionSkew` for the local disk/process split, `checkSourceStaleness` for the
+  local/origin split) with slightly different triggers and messaging — an operator needs to read
+  both entries to understand the full picture, though they're independent hypotheses about the
+  same underlying symptom class ("what's running isn't what's meant to be running") and don't
+  overlap in practice.
+- The staleness check's own poll-count gate is a hardcoded constant, not configurable — acceptable
+  per R4's explicit framing ("pick an interval... state it"), but a future operator wanting a
+  tighter or looser cadence would need a code change, not a flag.
+
+## Related Work
+
+- `adrs/1196-extract-self-upgrade-package.md` — the prior extraction of `CheckAndRebuildDev`
+  itself into `internal/selfupgrade`, and the "extraction over duplication" rationale this issue
+  continues one layer deeper.
+- `engine/upgrade.go` — `checkAndUpgrade`/`checkVersionSkew`, both untouched by this issue; the
+  idle-gated exec path this issue's detection is deliberately decoupled from.
+- `engine/staleness.go` — the new call site.
+- `internal/selfupgrade/devbuild.go` — `CompareDevBuild`, the extracted comparison.
+- `docs/state-machine.md` §7.11 (Stale Warning Sweep) and §9.2 (Worker In-Flight Guard) — the
+  as-built documentation of the warning's no-sweep-needed reasoning and its deliberate exclusion
+  from the idle+no-in-flight gate.
+- #1074/#1348 — prior work establishing `checkVersionSkew` and the `warnings/` lifecycle this
+  issue reuses.
+- #1393 — clean-stop shutdown; prerequisite for any future automatic-upgrade-on-busy-board
+  follow-up, explicitly out of scope here.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -361,8 +361,8 @@ None of these affect correctness — they may just show a `github.com`-shaped li
 
 The `--auto-upgrade` flag enables Fabrik to upgrade itself automatically. It checks for a newer version in two places:
 
-- **At startup** — once before the first poll, so boards that are always busy still receive upgrades promptly. The check fires after the exclusive file lock is acquired, so concurrent Fabrik instances never race on the upgrade check.
-- **After 2 consecutive idle polls** — as a belt-and-suspenders check for long-running instances.
+- **At startup** — once before the first poll. The check fires after the exclusive file lock is acquired, so concurrent Fabrik instances never race on the upgrade check.
+- **After 2 consecutive idle polls** — the only other trigger. Because upgrading a dev build re-execs the process (`syscall.Exec`), this check requires true idleness — no workers in flight, including merge-train workers — so an in-progress Claude invocation is never killed mid-run. A board that is *continuously* busy (dispatching work, or with a merge-train worker in flight, every single poll) never reaches this check, and therefore never upgrades on its own — see "Staleness reporting on a busy board" below for how that gap is surfaced instead of going unnoticed.
 
 For release builds, Fabrik queries the GitHub Releases API at each check point. If a newer version is found, it downloads the new binary, replaces the running executable, runs `fabrik upgrade` to refresh plugin skills, and re-execs itself. Version comparison ignores any pre-release/build/pseudo-version suffix (`-...`/`+...`) on the running version's version string — so a `go install ...@main` or branch install (which reports a pseudo-version like `v0.0.72-0.20260716173320-6198e8102f90+dirty` in `--version`) still upgrades correctly when a newer clean release tag is published; before this fix such a suffixed version silently compared as "already up to date" and the daemon would never upgrade (#1074). On macOS, the freshly-downloaded binary is best-effort re-signed (`xattr -cr` + `codesign --force --sign -`) before the re-exec, working around an Apple Silicon quirk where a binary materialized via a fresh file write (rather than built in place) can otherwise be killed on exec.
 
@@ -383,6 +383,27 @@ local `HEAD`:
 After rebuilding, Fabrik runs `fabrik upgrade` (non-interactive, silent — see below)
 and re-execs the new binary. This keeps dev builds current with the same hands-off
 experience as release binaries.
+
+**Staleness reporting on a busy board:** the two upgrade-check points above both
+require true idleness before a dev build can rebuild and re-exec (upgrading kills
+in-flight workers). A board that dispatches work every poll — or has a merge-train
+worker running continuously — never reaches either one, so the daemon can end up
+running arbitrarily stale code indefinitely with no signal that anything is wrong.
+To close that gap, dev-build source checkouts get a separate, report-only staleness
+check that runs independently of idleness: every 30 polls (~15 minutes at the
+default 30s `--poll` interval, including once on the very first poll), Fabrik
+compares the running binary's commit against `origin/main` — the same comparison
+the upgrade path itself uses, so the two can never disagree — and, if it's behind,
+records a warning naming the running SHA, how many commits behind it is, and the
+age of the running commit (e.g. "75 commits behind origin/main" was the exact
+signal that would have caught the incident this feature was built to prevent).
+The warning surfaces in the TUI Warnings panel, in the startup/poll log output,
+and in `fabrik.log`; it clears itself on the next check once the daemon is
+restarted onto current code. This check **never** runs `git pull`, `go build`, or
+re-execs — it only reports. Applies to dev-build source checkouts only (the same
+`handarbeit/fabrik`-remote gate the upgrade path itself uses); release-binary
+installs and non-source-checkout directories see no change and trigger no `git
+fetch`.
 
 > **Plugin-skills upgrade: automatic vs. standalone behavior**: The plugin-skills check
 > runs in two contexts with different behavior.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -359,8 +359,8 @@ None of these affect correctness — they may just show a `github.com`-shaped li
 
 The `--auto-upgrade` flag enables Fabrik to upgrade itself automatically. It checks for a newer version in two places:
 
-- **At startup** — once before the first poll, so boards that are always busy still receive upgrades promptly. The check fires after the exclusive file lock is acquired, so concurrent Fabrik instances never race on the upgrade check.
-- **After 2 consecutive idle polls** — as a belt-and-suspenders check for long-running instances.
+- **At startup** — once before the first poll. The check fires after the exclusive file lock is acquired, so concurrent Fabrik instances never race on the upgrade check.
+- **After 2 consecutive idle polls** — the only other trigger. Because upgrading a dev build re-execs the process (`syscall.Exec`), this check requires true idleness — no workers in flight, including merge-train workers — so an in-progress Claude invocation is never killed mid-run. A board that is *continuously* busy (dispatching work, or with a merge-train worker in flight, every single poll) never reaches this check, and therefore never upgrades on its own — see "Staleness reporting on a busy board" below for how that gap is surfaced instead of going unnoticed.
 
 For release builds, Fabrik queries the GitHub Releases API at each check point. If a newer version is found, it downloads the new binary, replaces the running executable, runs `fabrik upgrade` to refresh plugin skills, and re-execs itself. Version comparison ignores any pre-release/build/pseudo-version suffix (`-...`/`+...`) on the running version's version string — so a `go install ...@main` or branch install (which reports a pseudo-version like `v0.0.72-0.20260716173320-6198e8102f90+dirty` in `--version`) still upgrades correctly when a newer clean release tag is published; before this fix such a suffixed version silently compared as "already up to date" and the daemon would never upgrade (#1074). On macOS, the freshly-downloaded binary is best-effort re-signed (`xattr -cr` + `codesign --force --sign -`) before the re-exec, working around an Apple Silicon quirk where a binary materialized via a fresh file write (rather than built in place) can otherwise be killed on exec.
 
@@ -381,6 +381,27 @@ local `HEAD`:
 After rebuilding, Fabrik runs `fabrik upgrade` (non-interactive, silent — see below)
 and re-execs the new binary. This keeps dev builds current with the same hands-off
 experience as release binaries.
+
+**Staleness reporting on a busy board:** the two upgrade-check points above both
+require true idleness before a dev build can rebuild and re-exec (upgrading kills
+in-flight workers). A board that dispatches work every poll — or has a merge-train
+worker running continuously — never reaches either one, so the daemon can end up
+running arbitrarily stale code indefinitely with no signal that anything is wrong.
+To close that gap, dev-build source checkouts get a separate, report-only staleness
+check that runs independently of idleness: every 30 polls (~15 minutes at the
+default 30s `--poll` interval, including once on the very first poll), Fabrik
+compares the running binary's commit against `origin/main` — the same comparison
+the upgrade path itself uses, so the two can never disagree — and, if it's behind,
+records a warning naming the running SHA, how many commits behind it is, and the
+age of the running commit (e.g. "75 commits behind origin/main" was the exact
+signal that would have caught the incident this feature was built to prevent).
+The warning surfaces in the TUI Warnings panel, in the startup/poll log output,
+and in `fabrik.log`; it clears itself on the next check once the daemon is
+restarted onto current code. This check **never** runs `git pull`, `go build`, or
+re-execs — it only reports. Applies to dev-build source checkouts only (the same
+`handarbeit/fabrik`-remote gate the upgrade path itself uses); release-binary
+installs and non-source-checkout directories see no change and trigger no `git
+fetch`.
 
 > **Plugin-skills upgrade: automatic vs. standalone behavior**: The plugin-skills check
 > runs in two contexts with different behavior.
@@ -6186,6 +6207,17 @@ a configured stage name is. Its `Clear` branch (`diskVersion == running`) is the
 single evaluation, so the warning can never outlive the condition that produced it — see the doc comment
 on `checkVersionSkew` for the same reasoning in code.
 
+**`source_staleness`: no sweep needed, by construction — same reasoning as `version_skew`.**
+`checkSourceStaleness` (`engine/staleness.go`, #1464) uses a single fixed key
+(`"source_staleness"`) rather than a per-subject key, because there is exactly one source
+checkout per Fabrik process — unlike `allow_auto_merge`/`stage_drift` (one entry per board
+repo/configured stage, a set that shrinks as repos leave the board or stages are removed).
+Every throttled evaluation (§9.2 below) re-derives the comparison from scratch via
+`selfupgrade.CompareDevBuild` and either records or clears the same key, so its `Clear` branch
+is reachable on every single evaluation the same way `checkVersionSkew`'s is — the warning
+cannot outlive the condition that produced it, and there is no "subject went away" case to sweep
+for.
+
 **Non-goals.** No change to which conditions *produce* a warning, no TUI rendering change, and this is
 not a general warning-expiry/TTL mechanism — only subjects that have provably gone away (absent from a
 known-good set already computed elsewhere) are ever cleared. See ADR-1348.
@@ -6338,6 +6370,30 @@ The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is a
 - **Idempotent:** the `WorkerExited` mutation handler (`internal/itemstate/store.go`) returns 0 changes when `item.Worker == nil`, so a redundant defer (e.g. an inner `defer WorkerExited` inside `processItem` firing in addition to the goroutine-top defer) does not produce spurious observer notifications.
 
 **Version-skew watchdog (#1074):** Piggybacked on the same idle+no-in-flight gate described above, `Engine.checkVersionSkew()` (`engine/upgrade.go`) runs immediately before `checkAndUpgrade()` whenever `AutoUpgrade` is enabled and `idleUpgradeThreshold` is reached — no new counter or threshold. It resolves the on-disk executable path (`versionSkewExecutableFn` → `os.Executable` + `filepath.EvalSymlinks` — engine's own private seam, distinct from `internal/selfupgrade`'s `executableFn` used by `PerformReleaseUpgrade`/`CheckAndRebuildDev` since ADR-1196 moved the self-upgrade trigger logic to its own package), spawns `<exe> --version` with a 5s timeout, and compares the trimmed output to `e.cfg.Version`. A mismatch is a general "the code on disk has moved on from what's running" signal — it catches a `SemverGreater` bug, a `syscall.Exec` failure after a successful binary replace, or an externally-replaced binary (e.g. a fleet sharing `~/go/bin/fabrik`) uniformly, without needing a dedicated warning per cause. The mismatch is recorded as a persistent `warnings.Entry` (`Type: "version_skew"`, keyed by the resolved executable path, `FixAction: "shell_command"` suggesting `kill -HUP <pid>`) via the same `warnings.Record`/`warnings.Clear` pattern as `checkAllowAutoMerge` (ADR-052), so it survives process restarts and surfaces in the TUI Warnings panel. A matching version clears any existing entry for that key. All failures resolving the path or running the subprocess are logged and non-fatal — the check is simply skipped for that poll.
+
+**Source-checkout staleness reporting (#1464): deliberately *not* piggybacked on the idle
+gate.** Unlike the version-skew watchdog above, `Engine.checkSourceStaleness()`
+(`engine/staleness.go`) does **not** run inside the idle+no-in-flight branch — it is called
+unconditionally from `poll()`, before the `dispatched == 0` check, throttled internally by
+its own poll-count gate (`maybeCheckSourceStaleness`, every `stalenessCheckPollInterval` = 30
+polls, ≈15 minutes at the default 30s `--poll` interval, firing on the very first poll too).
+This is the fix for the gap the version-skew watchdog and `checkAndUpgrade` both share: both
+require `idleUpgradeThreshold` consecutive fully-idle polls to ever run, so a board that
+dispatches work (or has a merge-train worker in flight) on every single poll never reaches
+either one — the daemon can run arbitrarily stale code indefinitely with no signal. Since
+`checkSourceStaleness` only *reports* (via `selfupgrade.CompareDevBuild`, which never calls
+`git pull`, `go build`, or `execFn` — see its doc comment), it has no in-flight-worker
+precondition to honor: there's nothing here that would kill a live Claude invocation, unlike
+`checkAndUpgrade`'s `syscall.Exec`. `CompareDevBuild` is the same comparison
+`selfupgrade.CheckAndRebuildDev` uses to decide whether to actually rebuild, so the staleness
+warning and the real upgrade decision are structurally unable to disagree. Applicability
+mirrors `checkAndUpgrade`'s own fork (`e.cfg.Version` must start with `"dev"`, then
+`CompareDevBuild`'s own `IsSourceCheckout` gate) — a release build never calls into
+`selfupgrade` for this check at all, so it never runs a `git fetch`. Recorded via the same
+`warnings.Record`/`warnings.Clear` pattern as `version_skew`, under the single fixed key
+`"source_staleness"` (§7.11 above); the `FixAction` differs depending on `e.cfg.AutoUpgrade`,
+since `kill -HUP` only self-heals staleness when the startup-time `checkAndUpgrade()` call that
+a SIGHUP re-exec re-triggers is itself enabled.
 
 **Safe-point-gating race (investigated for #1074, none found):** the concern was whether a webhook-triggered concurrent poll could dispatch a new worker while a synchronous `checkReleaseUpgrade()` download+exec is in flight on another poll cycle. It cannot: `Engine.Run()`'s single `for { select {...} }` loop is the only caller of `doPollCycle()`; webhook wakes are delivered through `e.wakeCh` and consumed serially by that same loop, so `checkAndUpgrade()` (and its `syscall.Exec`) always runs synchronously on the main goroutine between poll cycles — never concurrently with worker dispatch from a different cycle. The in-flight check at the top of this section (`Store.HasInFlightWorker()`, covering both `snap.Worker() != nil` over `e.store.All()` and the repo-scoped merge-train registry) already detects workers dispatched by any prior poll cycle regardless of which cycle started them, so no additional guard was needed. This also covers the same-cycle case: `dispatchMergeTrainWorker` calls `Store.EnterRepoWorker` synchronously before returning, so the very poll cycle that just launched a merge-train worker (which `dispatchCandidates` does not count in its `dispatched` return value) no longer misreports itself as idle.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -2793,6 +2793,17 @@ a configured stage name is. Its `Clear` branch (`diskVersion == running`) is the
 single evaluation, so the warning can never outlive the condition that produced it — see the doc comment
 on `checkVersionSkew` for the same reasoning in code.
 
+**`source_staleness`: no sweep needed, by construction — same reasoning as `version_skew`.**
+`checkSourceStaleness` (`engine/staleness.go`, #1464) uses a single fixed key
+(`"source_staleness"`) rather than a per-subject key, because there is exactly one source
+checkout per Fabrik process — unlike `allow_auto_merge`/`stage_drift` (one entry per board
+repo/configured stage, a set that shrinks as repos leave the board or stages are removed).
+Every throttled evaluation (§9.2 below) re-derives the comparison from scratch via
+`selfupgrade.CompareDevBuild` and either records or clears the same key, so its `Clear` branch
+is reachable on every single evaluation the same way `checkVersionSkew`'s is — the warning
+cannot outlive the condition that produced it, and there is no "subject went away" case to sweep
+for.
+
 **Non-goals.** No change to which conditions *produce* a warning, no TUI rendering change, and this is
 not a general warning-expiry/TTL mechanism — only subjects that have provably gone away (absent from a
 known-good set already computed elsewhere) are ever cleared. See ADR-1348.
@@ -2945,6 +2956,30 @@ The dispatch loop uses `snap.Worker() != nil` to detect whether a goroutine is a
 - **Idempotent:** the `WorkerExited` mutation handler (`internal/itemstate/store.go`) returns 0 changes when `item.Worker == nil`, so a redundant defer (e.g. an inner `defer WorkerExited` inside `processItem` firing in addition to the goroutine-top defer) does not produce spurious observer notifications.
 
 **Version-skew watchdog (#1074):** Piggybacked on the same idle+no-in-flight gate described above, `Engine.checkVersionSkew()` (`engine/upgrade.go`) runs immediately before `checkAndUpgrade()` whenever `AutoUpgrade` is enabled and `idleUpgradeThreshold` is reached — no new counter or threshold. It resolves the on-disk executable path (`versionSkewExecutableFn` → `os.Executable` + `filepath.EvalSymlinks` — engine's own private seam, distinct from `internal/selfupgrade`'s `executableFn` used by `PerformReleaseUpgrade`/`CheckAndRebuildDev` since ADR-1196 moved the self-upgrade trigger logic to its own package), spawns `<exe> --version` with a 5s timeout, and compares the trimmed output to `e.cfg.Version`. A mismatch is a general "the code on disk has moved on from what's running" signal — it catches a `SemverGreater` bug, a `syscall.Exec` failure after a successful binary replace, or an externally-replaced binary (e.g. a fleet sharing `~/go/bin/fabrik`) uniformly, without needing a dedicated warning per cause. The mismatch is recorded as a persistent `warnings.Entry` (`Type: "version_skew"`, keyed by the resolved executable path, `FixAction: "shell_command"` suggesting `kill -HUP <pid>`) via the same `warnings.Record`/`warnings.Clear` pattern as `checkAllowAutoMerge` (ADR-052), so it survives process restarts and surfaces in the TUI Warnings panel. A matching version clears any existing entry for that key. All failures resolving the path or running the subprocess are logged and non-fatal — the check is simply skipped for that poll.
+
+**Source-checkout staleness reporting (#1464): deliberately *not* piggybacked on the idle
+gate.** Unlike the version-skew watchdog above, `Engine.checkSourceStaleness()`
+(`engine/staleness.go`) does **not** run inside the idle+no-in-flight branch — it is called
+unconditionally from `poll()`, before the `dispatched == 0` check, throttled internally by
+its own poll-count gate (`maybeCheckSourceStaleness`, every `stalenessCheckPollInterval` = 30
+polls, ≈15 minutes at the default 30s `--poll` interval, firing on the very first poll too).
+This is the fix for the gap the version-skew watchdog and `checkAndUpgrade` both share: both
+require `idleUpgradeThreshold` consecutive fully-idle polls to ever run, so a board that
+dispatches work (or has a merge-train worker in flight) on every single poll never reaches
+either one — the daemon can run arbitrarily stale code indefinitely with no signal. Since
+`checkSourceStaleness` only *reports* (via `selfupgrade.CompareDevBuild`, which never calls
+`git pull`, `go build`, or `execFn` — see its doc comment), it has no in-flight-worker
+precondition to honor: there's nothing here that would kill a live Claude invocation, unlike
+`checkAndUpgrade`'s `syscall.Exec`. `CompareDevBuild` is the same comparison
+`selfupgrade.CheckAndRebuildDev` uses to decide whether to actually rebuild, so the staleness
+warning and the real upgrade decision are structurally unable to disagree. Applicability
+mirrors `checkAndUpgrade`'s own fork (`e.cfg.Version` must start with `"dev"`, then
+`CompareDevBuild`'s own `IsSourceCheckout` gate) — a release build never calls into
+`selfupgrade` for this check at all, so it never runs a `git fetch`. Recorded via the same
+`warnings.Record`/`warnings.Clear` pattern as `version_skew`, under the single fixed key
+`"source_staleness"` (§7.11 above); the `FixAction` differs depending on `e.cfg.AutoUpgrade`,
+since `kill -HUP` only self-heals staleness when the startup-time `checkAndUpgrade()` call that
+a SIGHUP re-exec re-triggers is itself enabled.
 
 **Safe-point-gating race (investigated for #1074, none found):** the concern was whether a webhook-triggered concurrent poll could dispatch a new worker while a synchronous `checkReleaseUpgrade()` download+exec is in flight on another poll cycle. It cannot: `Engine.Run()`'s single `for { select {...} }` loop is the only caller of `doPollCycle()`; webhook wakes are delivered through `e.wakeCh` and consumed serially by that same loop, so `checkAndUpgrade()` (and its `syscall.Exec`) always runs synchronously on the main goroutine between poll cycles — never concurrently with worker dispatch from a different cycle. The in-flight check at the top of this section (`Store.HasInFlightWorker()`, covering both `snap.Worker() != nil` over `e.store.All()` and the repo-scoped merge-train registry) already detects workers dispatched by any prior poll cycle regardless of which cycle started them, so no additional guard was needed. This also covers the same-cycle case: `dispatchMergeTrainWorker` calls `Store.EnterRepoWorker` synchronously before returning, so the very poll cycle that just launched a merge-train worker (which `dispatchCandidates` does not count in its `dispatched` return value) no longer misreports itself as idle.
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/handarbeit/fabrik/boardcache"
 	gh "github.com/handarbeit/fabrik/github"
 	"github.com/handarbeit/fabrik/internal/itemstate"
+	"github.com/handarbeit/fabrik/internal/selfupgrade"
 	"github.com/handarbeit/fabrik/stages"
 	"github.com/handarbeit/fabrik/tui"
 )
@@ -108,6 +109,11 @@ type Engine struct {
 	repoAccess                  map[string]gh.RepoAccess // key: "owner/repo"; resolveRepoAccess's cache — single source of truth for seeding, the allow_auto_merge check, and itemMayNeedWork's dispatch gate (ADR-1347)
 	idleCount                   int                      // consecutive idle polls; triggers self-upgrade at threshold
 	idleStart                   time.Time                // when consecutive idle polls began; zero value = not idle
+	pollsUntilStalenessCheck    int                      // countdown to next checkSourceStaleness; 0 fires on next poll (#1464)
+	// stalenessCompareFn overrides selfupgrade.CompareDevBuild when non-nil.
+	// Used by tests to inject a synthetic DevBuildStatus without real git
+	// subprocesses. Production leaves this nil.
+	stalenessCompareFn func(selfupgrade.DevBuildConfig) (selfupgrade.DevBuildStatus, error)
 	lastProjectUpdatedAt        time.Time                // last seen project.updatedAt from FetchProjectUpdatedAt gate; zero = not yet checked
 	wakeCh                      chan struct{}            // TUI sends on this to wake the poll loop immediately; nil if no TUI
 	stopCh                      chan tui.StopRequest     // TUI sends on this to stop a specific in-flight issue; nil if no TUI

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -1305,6 +1305,17 @@ func (e *Engine) poll(ctx context.Context) (pollResult, error) {
 			tokens.CostUSD, tokens.InputTokens, tokens.OutputTokens, tokens.CacheReadTokens, tokens.CacheCreationTokens)
 	}
 
+	// Source-checkout staleness check (#1464): reports (never acts on) how far
+	// a dev-build daemon's running binary is behind origin/main, via the
+	// warnings/ lifecycle. Runs unconditionally every poll (throttled
+	// internally to once per stalenessCheckPollInterval polls) — deliberately
+	// outside the dispatched==0 block below, so it stays reachable on a board
+	// that dispatches work every single cycle and never reaches idleCount's
+	// threshold. This is purely additive: it never touches idleCount,
+	// checkAndUpgrade, or checkVersionSkew, all of which remain gated exactly
+	// as before.
+	e.maybeCheckSourceStaleness()
+
 	if dispatched == 0 {
 		// Check whether any workers from a previous poll cycle — or a merge-train
 		// worker, which registers repo-scoped rather than per-item liveness — are

--- a/engine/staleness.go
+++ b/engine/staleness.go
@@ -132,12 +132,21 @@ func stalenessWarningContent(status selfupgrade.DevBuildStatus, autoUpgrade bool
 
 	var behind string
 	switch {
-	case status.RemoteAhead:
+	case status.RemoteAhead && status.CommitsBehind > 0:
 		behind = fmt.Sprintf("%d commit", status.CommitsBehind)
 		if status.CommitsBehind != 1 {
 			behind += "s"
 		}
 		behind += " behind origin/main"
+	case status.RemoteAhead:
+		// RemoteAhead is only true when localRef is a proper ancestor of
+		// remoteRef, which always means at least one commit is behind — a
+		// CommitsBehind of 0 here can only mean gitRevListCount itself failed
+		// (left at its zero value; see the field's doc comment), not a
+		// genuine zero. Fall back to generic phrasing rather than rendering
+		// the self-contradictory "0 commits behind" alongside a warning that
+		// a rebuild is needed.
+		behind = "running an older commit than origin/main"
 	default:
 		// ShaMismatch: a local commit exists that the running binary predates.
 		// The SHA-mismatch shortcut skips the fetch, so there's no origin-relative

--- a/engine/staleness.go
+++ b/engine/staleness.go
@@ -18,6 +18,14 @@ import (
 // cycle's GitHub-adjacent traffic. Unlike idleUpgradeThreshold (consecutive
 // *idle* polls), this is a flat poll count with no idleness precondition —
 // that's what makes it reachable on a continuously busy board (R1).
+//
+// This is a poll count, not a wall-clock duration: the ≈15 minute figure
+// only holds at the default 30s --poll. An operator running with a much
+// shorter --poll gets a proportionally shorter wall-clock interval (and a
+// proportionally higher steady-state git-fetch frequency on a busy board);
+// a much longer --poll stretches it out. No behavior compensates for this —
+// the constant is poll-count-relative by design (see maybeCheckSourceStaleness),
+// matching idleUpgradeThreshold's own poll-count convention.
 const stalenessCheckPollInterval = 30
 
 // sourceStalenessWarningKey is the single fixed warnings/ key for the

--- a/engine/staleness.go
+++ b/engine/staleness.go
@@ -40,7 +40,12 @@ func (e *Engine) maybeCheckSourceStaleness() {
 		e.pollsUntilStalenessCheck--
 		return
 	}
-	e.pollsUntilStalenessCheck = stalenessCheckPollInterval
+	// stalenessCheckPollInterval-1, not stalenessCheckPollInterval: this call
+	// itself is the first of the next interval's calls, so only
+	// stalenessCheckPollInterval-1 more decrementing calls remain before the
+	// next fire. Setting it to the full interval would make the actual gap
+	// between fires stalenessCheckPollInterval+1 calls.
+	e.pollsUntilStalenessCheck = stalenessCheckPollInterval - 1
 	e.checkSourceStaleness()
 }
 

--- a/engine/staleness.go
+++ b/engine/staleness.go
@@ -1,0 +1,170 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/handarbeit/fabrik/internal/selfupgrade"
+	"github.com/handarbeit/fabrik/warnings"
+)
+
+// stalenessCheckPollInterval is how many poll() calls elapse between
+// source-checkout staleness checks (R4). 30 polls at the default 30s --poll
+// interval is ≈15 minutes — frequent enough that a busy board notices
+// staleness well within a working day, infrequent enough that the git fetch
+// it requires (network I/O) never becomes a meaningful fraction of a poll
+// cycle's GitHub-adjacent traffic. Unlike idleUpgradeThreshold (consecutive
+// *idle* polls), this is a flat poll count with no idleness precondition —
+// that's what makes it reachable on a continuously busy board (R1).
+const stalenessCheckPollInterval = 30
+
+// sourceStalenessWarningKey is the single fixed warnings/ key for the
+// source-checkout staleness notice. Unlike allow_auto_merge/version_skew
+// (keyed per-repo/per-exe), there is exactly one source checkout per Fabrik
+// process, so one fixed key is sufficient — no ClearMissing sweep is needed
+// because checkSourceStaleness's Clear branch is reachable on every
+// throttled evaluation (see its doc comment), the same reasoning
+// checkVersionSkew already documents for its own key.
+const sourceStalenessWarningKey = "source_staleness"
+
+// maybeCheckSourceStaleness is the poll-count gate for checkSourceStaleness:
+// it fires on the very first call (covering "check at startup" for free) and
+// every stalenessCheckPollInterval calls thereafter. Called unconditionally
+// from poll()'s per-poll settle-scan section — never nested inside the
+// dispatched==0/idleCount block that gates the actual upgrade-exec path, so
+// it stays reachable on a board that never goes idle (R1).
+func (e *Engine) maybeCheckSourceStaleness() {
+	if e.pollsUntilStalenessCheck > 0 {
+		e.pollsUntilStalenessCheck--
+		return
+	}
+	e.pollsUntilStalenessCheck = stalenessCheckPollInterval
+	e.checkSourceStaleness()
+}
+
+// checkSourceStaleness reports (never acts on) how far the running dev build
+// is behind origin/main, via selfupgrade.CompareDevBuild — the same
+// comparison CheckAndRebuildDev uses to decide whether to rebuild, so this
+// warning and the actual upgrade decision can never disagree (R4). It never
+// calls git pull, go build, or exec: CompareDevBuild structurally stops
+// before any of those, and checkSourceStaleness does nothing beyond read its
+// result.
+//
+// Applicability mirrors checkAndUpgrade's own fork: only dev builds
+// (Version starts with "dev") reach selfupgrade at all — a release build
+// never calls into this package for this check, so it never runs a git
+// fetch (R6). CompareDevBuild's own IsSourceCheckout gate then covers the
+// remaining "is this actually the fabrik source tree" case.
+//
+// Uses the single fixed key sourceStalenessWarningKey: there is exactly one
+// source checkout per Fabrik process, so (mirroring checkVersionSkew's
+// documented reasoning) the Clear branch below is reachable on every
+// throttled evaluation — the warning can never outlive the condition that
+// produced it, and needs no separate stale-sweep.
+func (e *Engine) checkSourceStaleness() {
+	if !strings.HasPrefix(e.cfg.Version, "dev") {
+		return
+	}
+
+	compare := e.stalenessCompareFn
+	if compare == nil {
+		compare = selfupgrade.CompareDevBuild
+	}
+
+	logf := func(format string, args ...any) {
+		e.logf(0, "upgrade", format, args...)
+	}
+
+	status, err := compare(selfupgrade.DevBuildConfig{
+		Dir:            e.fabrikDir,
+		Version:        e.cfg.Version,
+		BaseBranch:     "main",
+		ExpectedRemote: fabrikOwner + "/" + fabrikRepo,
+		Logf:           logf,
+	})
+	if err != nil {
+		logf("staleness check: %v\n", err)
+		return
+	}
+	if !status.Applicable {
+		return
+	}
+
+	if !status.NeedsRebuild {
+		_ = warnings.Clear(sourceStalenessWarningKey)
+		return
+	}
+
+	title, detail, fixAction, fixParams := stalenessWarningContent(status, e.cfg.AutoUpgrade)
+	logf("WARNING: %s\n", title)
+	_ = warnings.Record(warnings.Entry{
+		Key:       sourceStalenessWarningKey,
+		Type:      "source_staleness",
+		Title:     title,
+		Detail:    detail,
+		FixAction: fixAction,
+		FixParams: fixParams,
+	})
+}
+
+// stalenessWarningContent builds the Title/Detail/FixAction/FixParams for a
+// stale-build warning. The fix action is conditional on AutoUpgrade: a
+// SIGHUP re-execs the running binary in place (performSighupRestart), which
+// re-enters main() and re-runs the startup-time checkAndUpgrade() call — for
+// a dev build, that call pulls/rebuilds/re-execs onto current code, so
+// "kill -HUP" is a genuine one-shot fix only when AutoUpgrade is enabled.
+// When it's disabled, that startup check never runs either, so a SIGHUP just
+// re-execs the same stale binary — offering it as a fix action there would
+// be actively misleading, so FixAction/FixParams are left empty and the
+// Detail spells out the manual steps instead.
+func stalenessWarningContent(status selfupgrade.DevBuildStatus, autoUpgrade bool) (title, detail, fixAction string, fixParams map[string]string) {
+	sha := status.LocalRef
+	if len(sha) > 7 {
+		sha = sha[:7]
+	}
+
+	var behind string
+	switch {
+	case status.RemoteAhead:
+		behind = fmt.Sprintf("%d commit", status.CommitsBehind)
+		if status.CommitsBehind != 1 {
+			behind += "s"
+		}
+		behind += " behind origin/main"
+	default:
+		// ShaMismatch: a local commit exists that the running binary predates.
+		// The SHA-mismatch shortcut skips the fetch, so there's no origin-relative
+		// commit count to report — see CompareDevBuild's doc comment.
+		behind = "running an older commit than the local checkout's HEAD"
+	}
+
+	var age string
+	if !status.LocalCommitTime.IsZero() {
+		age = fmt.Sprintf(", %s old", roundedSince(status.LocalCommitTime))
+	}
+
+	title = fmt.Sprintf("Running binary is %s", behind)
+
+	var fix string
+	if autoUpgrade {
+		fix = fmt.Sprintf("Fix: kill -HUP %d — auto-upgrade is enabled, so restarting re-execs onto the pending build automatically.", os.Getpid())
+		fixAction = "shell_command"
+		fixParams = map[string]string{"cmd": fmt.Sprintf("kill -HUP %d", os.Getpid())}
+	} else {
+		fix = "Fix: auto-upgrade is disabled. Pull and rebuild manually (git pull && go build), then restart — kill -HUP alone re-execs the same stale binary, it does not pick up the new commits."
+	}
+
+	detail = fmt.Sprintf(
+		"The running binary was built from %s%s. It is %s. %s",
+		sha, age, behind, fix,
+	)
+	return title, detail, fixAction, fixParams
+}
+
+// roundedSince renders time.Since(t) at minute granularity for a
+// human-readable "how old is this" detail (e.g. "15h32m0s" -> "15h32m").
+func roundedSince(t time.Time) string {
+	return time.Since(t).Round(time.Minute).String()
+}

--- a/engine/staleness_test.go
+++ b/engine/staleness_test.go
@@ -1,0 +1,298 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+	"github.com/handarbeit/fabrik/internal/selfupgrade"
+	"github.com/handarbeit/fabrik/warnings"
+)
+
+// TestMaybeCheckSourceStaleness_ReachableWhileBusy is the AC1 fixture: a
+// merge-train worker is permanently in flight (the exact "continuously busy
+// board" shape from the incident — dispatched stays 0 every poll, but so does
+// idleCount, since HasInFlightWorker() is true the whole time). It asserts
+// the source_staleness warning is still recorded after enough real eng.poll()
+// cycles to cross stalenessCheckPollInterval — proving the new check does not
+// share idleUpgradeThreshold's gate.
+//
+// AC2 companion (not automatable without two code revisions in one test):
+// moving the e.maybeCheckSourceStaleness() call site in poll.go inside the
+// `if dispatched == 0 { ... idleCount ... }` block turns this test red, since
+// idleCount never reaches idleUpgradeThreshold in this fixture. Verified
+// manually during implementation; stated here per the acceptance criteria.
+func TestMaybeCheckSourceStaleness_ReachableWhileBusy(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	defer func() { warnings.WarningsPathOverride = "" }()
+
+	client := &mockGitHubClient{
+		fetchProjectBoardFn: func(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+			return &gh.ProjectBoard{ProjectID: "PVT_1", Items: nil}, nil
+		},
+	}
+	eng := NewWithDeps(Config{
+		Owner:         "owner",
+		Repo:          "repo",
+		ProjectNum:    1,
+		User:          "testuser",
+		Token:         "token",
+		MaxConcurrent: 5,
+		AutoUpgrade:   true,
+		Version:       "dev(8a5ef0f1234567890abcdef1234567890abcdef)",
+		Stages:        testStages(),
+	}, client, &mockClaudeInvoker{}, NewWorktreeManager(t.TempDir()))
+
+	// A merge-train worker that never exits — the board is permanently busy.
+	eng.store.EnterRepoWorker("owner/repo")
+
+	commitTime := time.Now().Add(-15 * time.Hour)
+	compareCalls := 0
+	eng.stalenessCompareFn = func(selfupgrade.DevBuildConfig) (selfupgrade.DevBuildStatus, error) {
+		compareCalls++
+		return selfupgrade.DevBuildStatus{
+			Applicable:      true,
+			LocalRef:        "8a5ef0f1234567890abcdef1234567890abcdef",
+			LocalCommitTime: commitTime,
+			RemoteAhead:     true,
+			CommitsBehind:   75,
+			NeedsRebuild:    true,
+		}, nil
+	}
+
+	for i := 0; i < stalenessCheckPollInterval; i++ {
+		if _, err := eng.poll(context.Background()); err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+	}
+
+	if eng.idleCount != 0 {
+		t.Fatalf("idleCount = %d, want 0 — fixture must never go idle for this test to prove anything", eng.idleCount)
+	}
+	if compareCalls != 1 {
+		t.Fatalf("stalenessCompareFn called %d times over %d polls, want exactly 1 (fires on poll #1, next fire is %d polls later)", compareCalls, stalenessCheckPollInterval, stalenessCheckPollInterval)
+	}
+
+	entries, err := warnings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *warnings.Entry
+	for i := range entries {
+		if entries[i].Key == sourceStalenessWarningKey {
+			found = &entries[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a %q warning to be recorded while workers stayed continuously in flight; entries: %+v", sourceStalenessWarningKey, entries)
+	}
+	if !strings.Contains(found.Detail, "75 commit") {
+		t.Errorf("Detail = %q, want it to name the commits-behind count", found.Detail)
+	}
+	if !strings.Contains(found.Detail, "8a5ef0f") {
+		t.Errorf("Detail = %q, want it to name the running SHA", found.Detail)
+	}
+	if !strings.Contains(found.Detail, "15h") {
+		t.Errorf("Detail = %q, want it to name the commit age", found.Detail)
+	}
+}
+
+// TestCheckSourceStaleness_ClearsOnUpToDate verifies R5's self-clearing
+// behavior: a pre-existing warning is removed once the comparison reports
+// the checkout is current.
+func TestCheckSourceStaleness_ClearsOnUpToDate(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	defer func() { warnings.WarningsPathOverride = "" }()
+
+	if err := warnings.Record(warnings.Entry{
+		Key:   sourceStalenessWarningKey,
+		Type:  "source_staleness",
+		Title: "stale from a previous check",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.Version = "dev(abc1234)"
+	eng.stalenessCompareFn = func(selfupgrade.DevBuildConfig) (selfupgrade.DevBuildStatus, error) {
+		return selfupgrade.DevBuildStatus{Applicable: true, NeedsRebuild: false}, nil
+	}
+
+	eng.checkSourceStaleness()
+
+	entries, err := warnings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Key == sourceStalenessWarningKey {
+			t.Fatalf("expected %q to be cleared once up to date, still present: %+v", sourceStalenessWarningKey, e)
+		}
+	}
+}
+
+// TestCheckSourceStaleness_FreshCheckUpToDateRecordsNothing simulates a
+// daemon restart (a brand new Engine, a fresh warnings file) whose first
+// staleness check finds the checkout already current — nothing should be
+// recorded. Combined with TestCheckSourceStaleness_ClearsOnUpToDate, this
+// covers R5's "clears itself when the daemon is restarted onto current code"
+// even when the old process's warning entry never made it to disk before
+// the restart.
+func TestCheckSourceStaleness_FreshCheckUpToDateRecordsNothing(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	defer func() { warnings.WarningsPathOverride = "" }()
+
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.Version = "dev(abc1234)"
+	eng.stalenessCompareFn = func(selfupgrade.DevBuildConfig) (selfupgrade.DevBuildStatus, error) {
+		return selfupgrade.DevBuildStatus{Applicable: true, NeedsRebuild: false}, nil
+	}
+
+	// pollsUntilStalenessCheck's zero value fires immediately — the "check at
+	// startup" behavior a restart relies on.
+	eng.maybeCheckSourceStaleness()
+
+	entries, err := warnings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no warnings recorded for an up-to-date fresh check, got: %+v", entries)
+	}
+}
+
+// TestCheckSourceStaleness_NonDevVersionSkipsEntirely is the AC5 case: a
+// release build never calls into the comparator at all — no git fetch, no
+// warning, regardless of what the comparator would have returned.
+func TestCheckSourceStaleness_NonDevVersionSkipsEntirely(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	defer func() { warnings.WarningsPathOverride = "" }()
+
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.Version = "v1.2.3" // release build, not "dev(...)"
+
+	called := false
+	eng.stalenessCompareFn = func(selfupgrade.DevBuildConfig) (selfupgrade.DevBuildStatus, error) {
+		called = true
+		return selfupgrade.DevBuildStatus{}, nil
+	}
+
+	eng.checkSourceStaleness()
+
+	if called {
+		t.Error("expected the comparator (and therefore any git fetch) to never be invoked for a release version")
+	}
+	entries, err := warnings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no warnings for a release version, got: %+v", entries)
+	}
+}
+
+// TestCheckSourceStaleness_RealCompareDevBuild drives checkSourceStaleness
+// through the real, un-stubbed selfupgrade.CompareDevBuild against an actual
+// git checkout that is genuinely two commits behind its origin — proving the
+// engine call site is wired to the real comparator (not just its own test
+// seam) and that going through it end-to-end never touches go build/exec:
+// the checkout's placeholder files are asserted unchanged afterward.
+func TestCheckSourceStaleness_RealCompareDevBuild(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	defer func() { warnings.WarningsPathOverride = "" }()
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	// The origin remote's URL must contain "handarbeit/fabrik" to satisfy
+	// IsSourceCheckout — using that literal path segment on local disk lets a
+	// real (non-network) git remote clear the same substring gate production
+	// traffic does.
+	originDir := filepath.Join(t.TempDir(), "handarbeit", "fabrik")
+	if err := os.MkdirAll(originDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(originDir, "go.mod"), []byte("module staletest\n\ngo 1.21\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(originDir, "init", "-b", "main")
+	runGit(originDir, "config", "user.email", "test@test.com")
+	runGit(originDir, "config", "user.name", "Test")
+	runGit(originDir, "add", "-A")
+	runGit(originDir, "commit", "-m", "initial")
+
+	localDir := t.TempDir()
+	runGit(localDir, "clone", originDir, ".")
+	runGit(localDir, "config", "user.email", "test@test.com")
+	runGit(localDir, "config", "user.name", "Test")
+
+	localSHACmd := exec.Command("git", "rev-parse", "HEAD")
+	localSHACmd.Dir = localDir
+	out, err := localSHACmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	localSHA := strings.TrimSpace(string(out))
+
+	runGit(originDir, "commit", "--allow-empty", "-m", "second")
+	runGit(originDir, "commit", "--allow-empty", "-m", "third")
+
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.fabrikDir = localDir
+	eng.cfg.Version = "dev(" + localSHA[:7] + ")"
+	eng.cfg.AutoUpgrade = true
+	// stalenessCompareFn left nil — production defaults to the real
+	// selfupgrade.CompareDevBuild.
+
+	goModBefore, err := os.ReadFile(filepath.Join(localDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eng.checkSourceStaleness()
+
+	goModAfter, err := os.ReadFile(filepath.Join(localDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(goModBefore) != string(goModAfter) {
+		t.Error("checkSourceStaleness modified checkout files — it must never build")
+	}
+
+	entries, err := warnings.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *warnings.Entry
+	for i := range entries {
+		if entries[i].Key == sourceStalenessWarningKey {
+			found = &entries[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a %q warning for a checkout 2 commits behind origin, entries: %+v", sourceStalenessWarningKey, entries)
+	}
+	if !strings.Contains(found.Detail, "2 commits") {
+		t.Errorf("Detail = %q, want it to name the commits-behind count (2)", found.Detail)
+	}
+	if !strings.Contains(found.Detail, localSHA[:7]) {
+		t.Errorf("Detail = %q, want it to name the running SHA (%s)", found.Detail, localSHA[:7])
+	}
+	if found.FixAction != "shell_command" {
+		t.Errorf("FixAction = %q, want %q since AutoUpgrade is enabled", found.FixAction, "shell_command")
+	}
+}

--- a/engine/staleness_test.go
+++ b/engine/staleness_test.go
@@ -234,6 +234,33 @@ func TestCheckSourceStaleness_NonDevVersionSkipsEntirely(t *testing.T) {
 	}
 }
 
+// TestStalenessWarningContent_RemoteAheadZeroCommitsBehindFallsBack covers a
+// Pruefer review finding: RemoteAhead can only be true when localRef is a
+// proper ancestor of remoteRef, which always means at least one commit is
+// behind — so a CommitsBehind of 0 here can only mean gitRevListCount itself
+// failed (left at its zero value), not a genuine zero. The message must not
+// render the self-contradictory "0 commits behind origin/main" alongside a
+// warning that a rebuild is needed; it should fall back to generic phrasing
+// instead.
+func TestStalenessWarningContent_RemoteAheadZeroCommitsBehindFallsBack(t *testing.T) {
+	status := selfupgrade.DevBuildStatus{
+		Applicable:    true,
+		LocalRef:      "8a5ef0f1234567890abcdef1234567890abcdef",
+		RemoteAhead:   true,
+		CommitsBehind: 0, // gitRevListCount failed
+		NeedsRebuild:  true,
+	}
+
+	title, detail, _, _ := stalenessWarningContent(status, true)
+
+	if strings.Contains(title, "0 commit") || strings.Contains(detail, "0 commit") {
+		t.Errorf("title/detail must not claim 0 commits behind when the count is unknown; title=%q detail=%q", title, detail)
+	}
+	if !strings.Contains(title, "older commit than origin/main") {
+		t.Errorf("title = %q, want generic fallback phrasing", title)
+	}
+}
+
 // TestCheckSourceStaleness_RealCompareDevBuild drives checkSourceStaleness
 // through the real, un-stubbed selfupgrade.CompareDevBuild against an actual
 // git checkout that is genuinely two commits behind its origin — proving the

--- a/engine/staleness_test.go
+++ b/engine/staleness_test.go
@@ -102,6 +102,44 @@ func TestMaybeCheckSourceStaleness_ReachableWhileBusy(t *testing.T) {
 	}
 }
 
+// TestMaybeCheckSourceStaleness_FiresExactlyEveryInterval pins the gate's
+// exact cadence: it must fire on call 1 (startup coverage) and again exactly
+// stalenessCheckPollInterval calls later — not stalenessCheckPollInterval+1,
+// which was the off-by-one a prior version of this gate had (the reset value
+// left after a fire needs to be stalenessCheckPollInterval-1, since the fire
+// call itself already counts as the first call of the next interval).
+func TestMaybeCheckSourceStaleness_FiresExactlyEveryInterval(t *testing.T) {
+	warnings.WarningsPathOverride = filepath.Join(t.TempDir(), "warnings.json")
+	defer func() { warnings.WarningsPathOverride = "" }()
+
+	eng := testEngine(t, &mockGitHubClient{}, &mockClaudeInvoker{})
+	eng.cfg.Version = "dev(abc1234)"
+	eng.stalenessCompareFn = func(selfupgrade.DevBuildConfig) (selfupgrade.DevBuildStatus, error) {
+		return selfupgrade.DevBuildStatus{Applicable: true, NeedsRebuild: false}, nil
+	}
+
+	var fireCalls []int
+	for call := 1; call <= 2*stalenessCheckPollInterval+1; call++ {
+		before := eng.pollsUntilStalenessCheck
+		eng.maybeCheckSourceStaleness()
+		// A fire is distinguishable from a decrement by the gate resetting
+		// the counter instead of decrementing it by exactly one.
+		if before == 0 {
+			fireCalls = append(fireCalls, call)
+		}
+	}
+
+	want := []int{1, 1 + stalenessCheckPollInterval, 1 + 2*stalenessCheckPollInterval}
+	if len(fireCalls) != len(want) {
+		t.Fatalf("fired on calls %v, want %v", fireCalls, want)
+	}
+	for i, w := range want {
+		if fireCalls[i] != w {
+			t.Errorf("fire %d happened on call %d, want call %d (gap between fires must be exactly stalenessCheckPollInterval=%d calls)", i, fireCalls[i], w, stalenessCheckPollInterval)
+		}
+	}
+}
+
 // TestCheckSourceStaleness_ClearsOnUpToDate verifies R5's self-clearing
 // behavior: a pre-existing warning is removed once the comparison reports
 // the checkout is current.

--- a/internal/selfupgrade/devbuild.go
+++ b/internal/selfupgrade/devbuild.go
@@ -1,10 +1,13 @@
 package selfupgrade
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // DevBuildConfig bundles the caller-supplied identity, source location, and
@@ -43,71 +46,164 @@ func (cfg DevBuildConfig) statusClear() {
 	}
 }
 
-// CheckAndRebuildDev implements the dev-build self-upgrade path: compare the
-// running binary's embedded SHA (and, failing that, the local checkout's
-// remote) against upstream, rebuild from source with `go build`, run the
-// optional PostBuildHook, and re-exec. Requires cfg.Dir to be a git source
-// checkout matching cfg.ExpectedRemote (IsSourceCheckout) — a dev-mode daemon
-// can only self-upgrade when run from its own source tree. All failures are
-// logged via cfg.Logf and non-fatal: the function simply returns without
-// upgrading.
-func CheckAndRebuildDev(cfg DevBuildConfig) {
+// DevBuildStatus is the result of comparing a dev build's running SHA and
+// local git checkout against its upstream branch — the read-only comparison
+// CheckAndRebuildDev performs before deciding whether to act. Computed by
+// CompareDevBuild, which never calls `git pull`, `go build`, or execFn; only
+// CheckAndRebuildDev's own code (downstream of CompareDevBuild) does that.
+type DevBuildStatus struct {
+	// Applicable is false when Dir is not a source checkout matching
+	// ExpectedRemote (IsSourceCheckout) — every other field is zero-valued.
+	Applicable bool
+
+	// LocalRef is the resolved SHA of local HEAD.
+	LocalRef string
+
+	// LocalCommitTime is the commit timestamp of LocalRef — how old the code
+	// actually running is. Left zero if it could not be determined; this is
+	// non-fatal since it's an incidental reporting detail, not the applicability
+	// or rebuild-need decision.
+	LocalCommitTime time.Time
+
+	// BinarySHA is the SHA embedded in the running version string
+	// ("dev(<sha>)"), or "" if Version isn't in that form.
+	BinarySHA string
+
+	// ShaMismatch is true when BinarySHA is non-empty and does not prefix
+	// LocalRef — the running binary predates the checkout's own HEAD. When
+	// true, the remote comparison below is skipped entirely (no git fetch),
+	// mirroring CheckAndRebuildDev's pre-extraction no-fetch shortcut;
+	// RemoteRef, RemoteAhead, and CommitsBehind are left zero-valued.
+	ShaMismatch bool
+
+	// RemoteRef is the resolved SHA of origin/BaseBranch, populated only when
+	// the remote comparison ran (i.e. ShaMismatch is false and the fetch
+	// succeeded).
+	RemoteRef string
+
+	// RemoteAhead is true when RemoteRef is a descendant of LocalRef (origin
+	// has commits the checkout doesn't) — as opposed to LocalRef being ahead
+	// of or diverged from RemoteRef, in which case nothing is pulled.
+	RemoteAhead bool
+
+	// CommitsBehind is the number of commits LocalRef is behind RemoteRef.
+	// Only meaningful when RemoteAhead is true; left 0 when the count itself
+	// could not be computed (non-fatal, same reasoning as LocalCommitTime).
+	CommitsBehind int
+
+	// NeedsRebuild is true when either ShaMismatch or RemoteAhead is true —
+	// i.e. CheckAndRebuildDev would proceed to pull/build/exec.
+	NeedsRebuild bool
+}
+
+// CompareDevBuild performs the read-only comparison CheckAndRebuildDev needs
+// to decide whether a dev-build source checkout is stale: local HEAD vs. the
+// running binary's embedded SHA, and (when that alone is inconclusive) local
+// HEAD vs. origin/BaseBranch after a `git fetch`. It never mutates the
+// checkout beyond that fetch, and never calls `git pull`, `go build`, or
+// execFn — CheckAndRebuildDev is the only caller that takes those actions,
+// based on the DevBuildStatus this returns. This split lets a caller that
+// only wants to *report* staleness (e.g. a busy-board warning, see #1464) do
+// so without any risk of triggering a rebuild.
+//
+// A non-nil error means the comparison could not be completed (HEAD or
+// origin/BaseBranch unresolvable, or the fetch itself failed); the returned
+// status is the partial result up to that point.
+func CompareDevBuild(cfg DevBuildConfig) (DevBuildStatus, error) {
+	var status DevBuildStatus
 	if !IsSourceCheckout(cfg.Dir, cfg.ExpectedRemote) {
-		return
+		return status, nil
 	}
+	status.Applicable = true
 
 	// Check local HEAD first — detects local commits that haven't been pushed.
 	localRef, err := gitRevParse(cfg.Dir, "HEAD")
 	if err != nil {
-		cfg.Logf("could not resolve HEAD: %v\n", err)
-		return
+		return status, fmt.Errorf("could not resolve HEAD: %w", err)
 	}
-	binarySHA := extractBinarySHA(cfg.Version)
-	needsRebuild := binarySHA != "" && !strings.HasPrefix(localRef, binarySHA)
-	if needsRebuild {
-		cfg.Logf("binary built from %s but HEAD is %s — rebuilding\n", binarySHA, localRef[:7])
+	status.LocalRef = localRef
+	if t, terr := gitCommitTime(cfg.Dir, localRef); terr == nil {
+		status.LocalCommitTime = t
+	}
+
+	status.BinarySHA = extractBinarySHA(cfg.Version)
+	status.ShaMismatch = status.BinarySHA != "" && !strings.HasPrefix(localRef, status.BinarySHA)
+	if status.ShaMismatch {
+		status.NeedsRebuild = true
+		return status, nil
 	}
 
 	// Also check remote for new upstream commits.
-	if !needsRebuild {
-		cfg.status("[upgrade] checking origin/%s ...", cfg.BaseBranch)
+	cfg.status("[upgrade] checking origin/%s ...", cfg.BaseBranch)
 
-		fetchCmd := exec.Command("git", "fetch", "origin", cfg.BaseBranch)
-		fetchCmd.Dir = cfg.Dir
-		if out, err := fetchCmd.CombinedOutput(); err != nil {
-			cfg.Logf("git fetch failed: %v\n%s\n", err, out)
-			return
-		}
+	fetchCmd := exec.Command("git", "fetch", "origin", cfg.BaseBranch)
+	fetchCmd.Dir = cfg.Dir
+	if out, ferr := fetchCmd.CombinedOutput(); ferr != nil {
+		return status, fmt.Errorf("git fetch failed: %w\n%s", ferr, out)
+	}
 
-		remoteRef, err := gitRevParse(cfg.Dir, "origin/"+cfg.BaseBranch)
-		if err != nil {
-			cfg.Logf("could not resolve origin/%s: %v\n", cfg.BaseBranch, err)
-			return
-		}
-		if localRef == remoteRef {
-			cfg.statusClear()
-			return // up to date
-		}
-		// Only pull if remote is ahead of local. If local is ahead (unpushed
-		// commits), we already checked the binary SHA against local HEAD above.
-		mergeBaseCmd := exec.Command("git", "merge-base", "--is-ancestor", localRef, remoteRef)
-		mergeBaseCmd.Dir = cfg.Dir
-		if err := mergeBaseCmd.Run(); err != nil {
-			// localRef is not an ancestor of remoteRef — local is ahead or diverged.
-			// Either way, nothing to pull. The binary SHA check above already
-			// handled whether a rebuild is needed.
-			cfg.statusClear()
-			return
-		}
-		needsRebuild = true
+	remoteRef, err := gitRevParse(cfg.Dir, "origin/"+cfg.BaseBranch)
+	if err != nil {
+		return status, fmt.Errorf("could not resolve origin/%s: %w", cfg.BaseBranch, err)
+	}
+	status.RemoteRef = remoteRef
+	if localRef == remoteRef {
+		cfg.statusClear()
+		return status, nil // up to date
+	}
+	// Only "remote ahead" if remote is ahead of local. If local is ahead
+	// (unpushed commits) or diverged, we already checked the binary SHA
+	// against local HEAD above.
+	mergeBaseCmd := exec.Command("git", "merge-base", "--is-ancestor", localRef, remoteRef)
+	mergeBaseCmd.Dir = cfg.Dir
+	if merr := mergeBaseCmd.Run(); merr != nil {
+		// localRef is not an ancestor of remoteRef — local is ahead or diverged.
+		// Either way, nothing to pull. The binary SHA check above already
+		// handled whether a rebuild is needed.
+		cfg.statusClear()
+		return status, nil
+	}
+
+	status.RemoteAhead = true
+	status.NeedsRebuild = true
+	if count, cerr := gitRevListCount(cfg.Dir, localRef, remoteRef); cerr == nil {
+		status.CommitsBehind = count
+	}
+	return status, nil
+}
+
+// CheckAndRebuildDev implements the dev-build self-upgrade path: compare the
+// running binary's embedded SHA (and, failing that, the local checkout's
+// remote) against upstream via CompareDevBuild, rebuild from source with
+// `go build`, run the optional PostBuildHook, and re-exec. Requires cfg.Dir
+// to be a git source checkout matching cfg.ExpectedRemote (IsSourceCheckout)
+// — a dev-mode daemon can only self-upgrade when run from its own source
+// tree. All failures are logged via cfg.Logf and non-fatal: the function
+// simply returns without upgrading.
+func CheckAndRebuildDev(cfg DevBuildConfig) {
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		cfg.Logf("%v\n", err)
+		return
+	}
+	if !status.Applicable {
+		return
+	}
+
+	switch {
+	case status.ShaMismatch:
+		cfg.Logf("binary built from %s but HEAD is %s — rebuilding\n", status.BinarySHA, status.LocalRef[:7])
+	case status.RemoteAhead:
 		cfg.Logf("new commits on origin/%s — pulling\n", cfg.BaseBranch)
-
 		pullCmd := exec.Command("git", "pull", "--ff-only", "origin", cfg.BaseBranch)
 		pullCmd.Dir = cfg.Dir
 		if out, err := pullCmd.CombinedOutput(); err != nil {
 			cfg.Logf("git pull --ff-only failed (local changes?): %v\n%s\n", err, out)
 			return
 		}
+	default:
+		// Up to date, or local ahead of/diverged from remote — nothing to do.
+		return
 	}
 
 	exe, err := executableFn()
@@ -176,4 +272,33 @@ func gitRevParse(dir, ref string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// gitRevListCount returns the number of commits reachable from "to" but not
+// from "from" in the git checkout at dir — i.e. `git rev-list --count
+// from..to`.
+func gitRevListCount(dir, from, to string) (int, error) {
+	cmd := exec.Command("git", "rev-list", "--count", from+".."+to)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("parsing rev-list count: %w", err)
+	}
+	return n, nil
+}
+
+// gitCommitTime returns the commit timestamp of ref in the git checkout at
+// dir.
+func gitCommitTime(dir, ref string) (time.Time, error) {
+	cmd := exec.Command("git", "log", "-1", "--format=%cI", ref)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Parse(time.RFC3339, strings.TrimSpace(string(out)))
 }

--- a/internal/selfupgrade/devbuild_test.go
+++ b/internal/selfupgrade/devbuild_test.go
@@ -1,6 +1,7 @@
 package selfupgrade
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -284,6 +285,213 @@ func TestCheckAndRebuildDev_LocalAheadDoesNotPull(t *testing.T) {
 	}
 	if *execCalled {
 		t.Errorf("expected no re-exec when local is ahead of origin, logs: %v", *logs)
+	}
+}
+
+// initOriginAndClone creates a bare-ish origin source checkout and a clone of
+// it, both wired the way CompareDevBuild/CheckAndRebuildDev expect (git user
+// configured, ExpectedRemote resolvable to originDir). Returns both dirs.
+func initOriginAndClone(t *testing.T) (originDir, localDir string) {
+	t.Helper()
+	originDir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(originDir, "go.mod"), []byte("module selfupgradetest\n\ngo 1.21\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(originDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, originDir, "init", "-b", "main")
+	runGit(t, originDir, "config", "user.email", "test@test.com")
+	runGit(t, originDir, "config", "user.name", "Test")
+	runGit(t, originDir, "add", "-A")
+	runGit(t, originDir, "commit", "-m", "initial")
+
+	localDir = t.TempDir()
+	runGit(t, localDir, "clone", originDir, ".")
+	runGit(t, localDir, "config", "user.email", "test@test.com")
+	runGit(t, localDir, "config", "user.name", "Test")
+	return originDir, localDir
+}
+
+// TestCompareDevBuild_NotSourceCheckout verifies that a directory that isn't
+// a git checkout of the expected remote reports Applicable=false and takes no
+// action.
+func TestCompareDevBuild_NotSourceCheckout(t *testing.T) {
+	skipIfNoGit(t)
+	dir := t.TempDir() // no git init at all
+
+	cfg, _, _, _ := testDevBuildConfig(t, dir, "dev(abc1234)", "handarbeit/fabrik")
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		t.Fatalf("CompareDevBuild returned error: %v", err)
+	}
+	if status.Applicable {
+		t.Error("expected Applicable=false for a non-source-checkout directory")
+	}
+	if status.NeedsRebuild {
+		t.Error("expected NeedsRebuild=false for a non-source-checkout directory")
+	}
+}
+
+// TestCompareDevBuild_ShaMismatchSkipsFetch verifies that when the running
+// binary's embedded SHA doesn't match local HEAD, CompareDevBuild reports
+// NeedsRebuild without ever calling `git fetch` against origin — origin is
+// deliberately unreachable, so RemoteRef staying empty is proof no fetch ran
+// (a fetch attempt would otherwise surface as an error here).
+func TestCompareDevBuild_ShaMismatchSkipsFetch(t *testing.T) {
+	skipIfNoGit(t)
+	dir := initDevSourceCheckout(t, "handarbeit/fabrik")
+
+	cfg, _, _, logs := testDevBuildConfig(t, dir, "dev(0000000)", "handarbeit/fabrik")
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		t.Fatalf("CompareDevBuild returned error: %v, logs: %v", err, *logs)
+	}
+	if !status.Applicable {
+		t.Fatal("expected Applicable=true")
+	}
+	if !status.ShaMismatch {
+		t.Error("expected ShaMismatch=true")
+	}
+	if !status.NeedsRebuild {
+		t.Error("expected NeedsRebuild=true")
+	}
+	if status.RemoteRef != "" {
+		t.Errorf("expected no fetch to have run (RemoteRef empty), got %q", status.RemoteRef)
+	}
+	if status.CommitsBehind != 0 {
+		t.Errorf("expected CommitsBehind=0 when the SHA-mismatch shortcut fires, got %d", status.CommitsBehind)
+	}
+}
+
+// TestCompareDevBuild_RemoteAhead verifies the remote-ahead field values:
+// CommitsBehind, RemoteRef, and LocalCommitTime are all populated correctly
+// when origin has new commits.
+func TestCompareDevBuild_RemoteAhead(t *testing.T) {
+	skipIfNoGit(t)
+	originDir, localDir := initOriginAndClone(t)
+
+	runGit(t, originDir, "commit", "--allow-empty", "-m", "second")
+	runGit(t, originDir, "commit", "--allow-empty", "-m", "third")
+
+	// Version is not a "dev(...)" string, so extractBinarySHA returns "" and
+	// the SHA-mismatch shortcut never fires — forcing the remote-check path.
+	cfg, _, _, logs := testDevBuildConfig(t, localDir, "", originDir)
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		t.Fatalf("CompareDevBuild returned error: %v, logs: %v", err, *logs)
+	}
+	if status.ShaMismatch {
+		t.Error("expected ShaMismatch=false")
+	}
+	if !status.RemoteAhead {
+		t.Error("expected RemoteAhead=true")
+	}
+	if !status.NeedsRebuild {
+		t.Error("expected NeedsRebuild=true")
+	}
+	if status.CommitsBehind != 2 {
+		t.Errorf("CommitsBehind = %d, want 2", status.CommitsBehind)
+	}
+	remoteHead, err := gitRevParse(originDir, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.RemoteRef != remoteHead {
+		t.Errorf("RemoteRef = %q, want %q", status.RemoteRef, remoteHead)
+	}
+	if status.LocalCommitTime.IsZero() {
+		t.Error("expected LocalCommitTime to be populated")
+	}
+}
+
+// TestCompareDevBuild_UpToDate verifies that a checkout whose local HEAD
+// matches origin/BaseBranch reports NeedsRebuild=false.
+func TestCompareDevBuild_UpToDate(t *testing.T) {
+	skipIfNoGit(t)
+	originDir, localDir := initOriginAndClone(t)
+
+	cfg, _, _, logs := testDevBuildConfig(t, localDir, "", originDir)
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		t.Fatalf("CompareDevBuild returned error: %v, logs: %v", err, *logs)
+	}
+	if !status.Applicable {
+		t.Error("expected Applicable=true")
+	}
+	if status.NeedsRebuild {
+		t.Error("expected NeedsRebuild=false when up to date")
+	}
+	if status.RemoteRef == "" {
+		t.Error("expected RemoteRef to be resolved by the fetch")
+	}
+}
+
+// TestCompareDevBuild_LocalAheadNoRebuild verifies that a checkout with
+// unpushed local commits (ahead of origin) reports NeedsRebuild=false — an
+// unpushed local commit must never be flagged for rebuild.
+func TestCompareDevBuild_LocalAheadNoRebuild(t *testing.T) {
+	skipIfNoGit(t)
+	originDir, localDir := initOriginAndClone(t)
+	runGit(t, localDir, "commit", "--allow-empty", "-m", "local-only")
+
+	cfg, _, _, logs := testDevBuildConfig(t, localDir, "", originDir)
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		t.Fatalf("CompareDevBuild returned error: %v, logs: %v", err, *logs)
+	}
+	if status.RemoteAhead {
+		t.Error("expected RemoteAhead=false when local is ahead of origin")
+	}
+	if status.NeedsRebuild {
+		t.Error("expected NeedsRebuild=false when local is ahead of origin")
+	}
+}
+
+// TestCompareDevBuild_NeverBuildsOrExecs is the AC6 assertion: run
+// CompareDevBuild against a fixture that is unambiguously rebuild-eligible
+// (remote ahead, NeedsRebuild=true — the exact condition that would make
+// CheckAndRebuildDev pull/build/exec) and confirm none of PostBuildHook,
+// execFn, or an on-disk binary rewrite happened. The executable's bytes are
+// compared before/after since `go build -o` would rewrite them; unchanged
+// bytes plus untriggered hooks together prove no build or exec occurred, not
+// just that this particular run happened not to need one.
+func TestCompareDevBuild_NeverBuildsOrExecs(t *testing.T) {
+	skipIfNoGit(t)
+	originDir, localDir := initOriginAndClone(t)
+	runGit(t, originDir, "commit", "--allow-empty", "-m", "second")
+
+	cfg, postBuildCalled, execCalled, logs := testDevBuildConfig(t, localDir, "", originDir)
+
+	exePath, err := executableFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(exePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := CompareDevBuild(cfg)
+	if err != nil {
+		t.Fatalf("CompareDevBuild returned error: %v, logs: %v", err, *logs)
+	}
+	if !status.NeedsRebuild {
+		t.Fatal("fixture must be rebuild-eligible for this test to prove anything")
+	}
+
+	after, err := os.ReadFile(exePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("CompareDevBuild modified the executable on disk — it must never build")
+	}
+	if *postBuildCalled {
+		t.Error("CompareDevBuild called PostBuildHook — it must never build/exec")
+	}
+	if *execCalled {
+		t.Error("CompareDevBuild called execFn — it must never exec")
 	}
 }
 


### PR DESCRIPTION
Closes #1464

## Summary

A busy source-checkout daemon could run arbitrarily stale code indefinitely with no signal, because *detecting* staleness was gated behind the same `idleUpgradeThreshold` (2 consecutive idle polls) as *acting* on it (`git pull` + `go build` + `syscall.Exec`). This PR splits detection from action: detection now runs unconditionally every poll (throttled to once per 30 polls, ~15 min at the default 30s `--poll` interval), while the existing idle-gated exec path is completely untouched.

## Key changes

- **`internal/selfupgrade.CompareDevBuild`** (new, extracted from `CheckAndRebuildDev`): performs the read-only SHA-vs-HEAD-vs-`origin/<base>` comparison, plus two new computations — `CommitsBehind` (`git rev-list --count`) and `LocalCommitTime` (`git log -1 --format=%cI`). Structurally never calls `git pull`, `go build`, or `execFn` — no code path reaches them. `CheckAndRebuildDev` now calls this function for its own decision, so the staleness warning and the real upgrade decision share one comparison and can never disagree.
- **`engine/staleness.go`** (new): `checkSourceStaleness()` + its poll-count gate `maybeCheckSourceStaleness()`. Called from `poll()` *before* the `dispatched == 0` / `idleCount` block — never nested inside it — which is what makes it reachable on a continuously busy board. Gated on `e.cfg.Version` having a `"dev"` prefix (mirroring `checkAndUpgrade`'s own fork) plus `CompareDevBuild`'s own `IsSourceCheckout` check, so release builds never touch this code at all (no `git fetch`).
- Reports via the existing `warnings/` package under a single fixed key (`source_staleness`) — self-clears on the next check once current, no stale-sweep needed (same reasoning `checkVersionSkew` already documents for its own key). Surfaces in the TUI Warnings panel (automatic, zero new TUI code), startup output, and `fabrik.log` via the existing `e.logf` routing.
- The warning names the running SHA, commits-behind count, and commit age, and its fix advice is conditional on `--auto-upgrade`: `kill -HUP <pid>` is only offered as a genuine fix when auto-upgrade is enabled (since a SIGHUP re-exec only rebuilds via the startup-time `checkAndUpgrade()` call when that flag is set); otherwise the message spells out manual `git pull && go build` steps.
- `docs/USER_GUIDE.md`: corrected the false "boards that are always busy still receive upgrades promptly" claim and documented the new staleness-reporting behavior in the same section.
- `docs/state-machine.md`: added the `source_staleness` no-sweep-needed reasoning and the deliberate "not gated on idle+no-in-flight" writeup.
- `adrs/1464-source-checkout-staleness-reporting.md` (new): documents the extraction, scheduling, and warning-lifecycle decisions.

## Testing

- `engine/staleness_test.go`: AC1 fixture keeps a merge-train worker permanently in flight across 30 `poll()` calls (`idleCount` never leaves 0) and asserts the warning is still recorded, naming the SHA/commits-behind/age. A companion end-to-end test drives the real (un-stubbed) `selfupgrade.CompareDevBuild` against an actual local git checkout genuinely 2 commits behind, and asserts no file in the checkout is touched.
- **AC2 verified manually during this review**: temporarily moved the `maybeCheckSourceStaleness()` call site inside the `idleCount >= idleUpgradeThreshold` branch (the historical, insufficient-for-a-busy-board location) and confirmed the AC1 test goes red (`stalenessCompareFn called 0 times over 30 polls`), then reverted — confirming the new call site is the load-bearing fix, not incidental.
- `internal/selfupgrade/devbuild_test.go`: existing suite passes unchanged (regression guard for the extraction), plus new tests for `CompareDevBuild` covering not-a-source-checkout, SHA-mismatch (no-fetch shortcut preserved), remote-ahead, up-to-date, and local-ahead/diverged cases, with an explicit "never builds or execs" assertion.
- `go build ./...`, `go vet ./...` clean. `go test -race ./internal/selfupgrade/... ./engine/...` green (2357 tests). Full `go test -race ./...` is green except one pre-existing, unrelated flaky test (`TestExecute_ConfigYAMLApplied` in `cmd/`, a real-network-dependent SIGINT-shutdown-timing test) — confirmed to fail identically on `origin/main` with none of this branch's changes applied.
- `docs/llms-full.txt` regenerated; no drift.

## How to test

```
go build ./... && go vet ./...
go test -race ./internal/selfupgrade/... ./engine/...
```