### PR TITLE
test(e2e): make bed reviewer honest and add fail-fast diagnosis for dropped reviews

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -102,6 +102,11 @@ E2E_POLL_INTERVAL=15s scripts/e2e/run.sh -run TestCruiseFullPipeline
 Shortening it is safe for a single scenario in isolation, where budget is not a
 constraint; leave it at the default for a full parallel run.
 
+`WaitForIssueClosedWithReviewCheck` (#1396) adds one `gh pr view --json
+isDraft,createdAt,reviews` call (also ~1 pt) per poll cycle, on the 7 call
+sites that adopt it, only until a review lands or the fail-fast check fires
+— a bounded addition well inside the ~2x headroom above.
+
 If you hit the limit anyway, check the reset time and wait it out:
 
 ```bash
@@ -508,16 +513,21 @@ scenarios below therefore assert the gate *clears* (`fabrik:awaiting-review` dis
     *interprets* the label on an issue it already carries, not the GitHub label object
     itself — the object must exist before any of these scenarios can even file their
     seed issue.
-23. **Why the bed reviewer (`claude-review.yml`) stays COMMENT-only, and is not used
-    for verdict assertions here**: `.github/workflows/claude-review.yml` submits
-    `gh pr review --comment` in both its agent path and its fallback path — it can
-    never produce `APPROVE` or `CHANGES_REQUESTED`, so it cannot exercise authoritative
-    mode's blocking or clearing paths. Switching it to a real reviewer bot (e.g. pruefer)
-    was explicitly rejected for issue #1258: non-determinism (verdict depends on Claude's
-    severity classification of a synthetic diff), latency (pruefer polls, default 120s,
-    vs. an Action firing on PR-open), cost (a real Claude invocation per test PR), and
-    coupling (Fabrik's release gate depending on pruefer's health). All verdict assertions
-    in `TestReviewAuthority*` instead use `SubmitPRReview` + `FABRIK_REVIEWER_TOKEN` —
+23. **Why the bed's real reviewer (Pruefer, as of #1396 — see "Reviewer topology"
+    below) is not used for verdict assertions here**: this is narrower than it
+    once was. Before #1396, the bed's incidental reviewer was `claude-review.yml`,
+    which submits `gh pr review --comment` in both its agent path and its fallback
+    path — it could never produce `APPROVE` or `CHANGES_REQUESTED`, so it could not
+    exercise authoritative mode's blocking or clearing paths at all. #1396 disabled
+    that workflow and made Pruefer the bed's real reviewer, and Pruefer *can* submit
+    APPROVE/REQUEST_CHANGES verdicts — but using it as the deterministic verdict
+    source for `TestReviewAuthority*`'s assertions was explicitly rejected for issue
+    #1258, and #1396 does not reopen that rejection: non-determinism (verdict
+    depends on Claude's severity classification of a synthetic diff), latency
+    (Pruefer polls, default 120s, vs. an Action firing on PR-open), cost (a real
+    Claude invocation per test PR), and coupling (Fabrik's release gate depending
+    on Pruefer's health) all still apply. All verdict assertions in
+    `TestReviewAuthority*` instead use `SubmitPRReview` + `FABRIK_REVIEWER_TOKEN` —
     deterministic, harness-posted formal reviews from a non-author identity.
 24. **`TestReviewAuthorityReinvokesOnChangesRequested`'s wall-clock is dominated by one
     real Claude invocation** (the review-reinvoke itself addressing the harness's
@@ -639,14 +649,57 @@ is a documented, accepted e2e gap.
     "declared but unrequested" — would be falsified by requesting a reviewer via
     `RequestPRReviewer`, so unlike `TestReviewAuthority*` these scenarios can't
     win the race deterministically that way. Opening the member
-    PR as a draft instead removes the race altogether: `claude-review.yml`
-    guards its review job with `if: github.event.pull_request.draft == false`
-    and triggers only on `opened`/`ready_for_review`, so a draft PR that is
-    never marked ready is permanently invisible to it — there is no incidental
-    bot review to land before the engine's first gate evaluation, or before
-    these scenarios' own bounded-window assertions. This requires no additional
-    bed setup; it is purely a change in how the harness constructs the member
-    PR.
+    PR as a draft instead removes the race altogether: Pruefer (the bed's real
+    reviewer as of #1396 — see "Reviewer topology" below; formerly
+    `claude-review.yml`, disabled) only lists "open, non-draft PRs" each poll
+    (`cmd/pruefer/README.md`), so a draft PR that is never marked ready is
+    permanently invisible to it — there is no incidental bot review to land
+    before the engine's first gate evaluation, or before these scenarios' own
+    bounded-window assertions. This requires no additional bed setup; it is
+    purely a change in how the harness constructs the member PR.
+
+### Reviewer topology (#1396)
+
+Every scenario that drives a PR through the organic Review gate depends on
+some external actor actually submitting a review. As of #1396, the bed's
+reviewer topology is:
+
+- **Pruefer (`handarbeit-pruefer`) is the present, real reviewer.** Once
+  `.pruefer/config.yaml`'s `watched_repos` includes `fabrik-test-alpha` and
+  `fabrik-test-beta` (an operator action against Pruefer's own deployment,
+  not a file in this repo — `.gitignore` excludes `.pruefer/` wholesale),
+  Pruefer polls both test repos like every other repo it watches (default
+  `poll_interval_seconds: 120`, `concurrency_cap: 3`) and reviews open,
+  non-draft PRs. The bed's `expected_reviewers: [handarbeit-pruefer]`
+  declaration in `review.yaml`/`validate.yaml` names this identity — no bed
+  stage-YAML change was needed, since the identity was already correct, only
+  previously unreachable.
+- **`e2e-synthetic-declared-reviewer` is the deliberately absent reviewer.**
+  Reachable per-issue via the `expected-reviewers:declared` label (ADR-1283,
+  see prerequisite #26), it never posts a review by construction
+  (`engine/reviews.go:523`) — used by scenarios that need a declared-but-
+  never-responding reviewer (`TestExpectedReviewersDeclaredWaitsAndReprompts`
+  and friends), independent of Pruefer's own presence or health.
+- **`claude-review.yml` is disabled, not deleted, on both test repos**
+  (`gh workflow disable`, the same mechanism used to retire it on
+  `handarbeit/fabrik` when Pruefer took over there). The file itself is
+  untouched — its trigger set (`opened`/`ready_for_review`, deliberately
+  excluding `synchronize` per #1078) is preserved for the record, but the
+  workflow no longer runs and no longer participates in the bed's reviewer
+  topology.
+- **Gemini does not participate in this topology at all.** It was considered
+  as the deliberately-absent reviewer and rejected: Gemini is *usually*
+  silent on the bed but not reliably so, which would make a scenario's
+  verdict a function of a third party's uptime rather than a deterministic
+  property (see the issue's discussion for the full reasoning).
+- **A dropped Pruefer review-dispatch still presents as a review-timeout
+  pause** — same failure signature the Problem section of #1396 describes
+  for the (now-retired) `claude-review.yml` case. `WaitForIssueClosedWithReviewCheck`
+  (see prerequisite/harness discussion above) exists to catch this faster and
+  more legibly than running out the full close-timeout, but it does not
+  change the underlying risk: Pruefer going silent (dispatch dropped,
+  daemon down, etc.) is still a single point of failure for every scenario
+  that depends on an organic review landing.
 
 ## Running
 

--- a/tests/e2e/auto_merge_test.go
+++ b/tests/e2e/auto_merge_test.go
@@ -128,7 +128,7 @@ func TestYoloAutoMergeLabel(t *testing.T) {
 		// of auto-merge being enabled — so we don't poll for the transient
 		// fabrik:auto-merge-enabled label here. We let the issue close and then
 		// audit the timeline.
-		WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
+		WaitForIssueClosedWithReviewCheck(t, env, env.RepoAlpha, num, 45*time.Minute)
 		t.Logf("%s#%d closed — checking the auto-merge path was taken", env.RepoAlpha, num)
 
 		// Race-free verification that auto-merge enablement happened: scan the

--- a/tests/e2e/ci_fix_reinvoke_test.go
+++ b/tests/e2e/ci_fix_reinvoke_test.go
@@ -132,7 +132,7 @@ func TestCIFixReinvoke(t *testing.T) {
 	}
 
 	// Issue must close (Validate completes and yolo auto-merges the PR).
-	WaitForIssueClosed(t, env, env.RepoAlpha, num, 30*time.Minute)
+	WaitForIssueClosedWithReviewCheck(t, env, env.RepoAlpha, num, 30*time.Minute)
 	AssertLabelWasApplied(t, env, env.RepoAlpha, num, "stage:Validate:complete")
 	t.Logf("%s#%d closed with stage:Validate:complete", env.RepoAlpha, num)
 

--- a/tests/e2e/convergence_race_test.go
+++ b/tests/e2e/convergence_race_test.go
@@ -113,7 +113,7 @@ func TestConvergenceRace(t *testing.T) {
 		closeWg.Add(1)
 		go func(num int) {
 			defer closeWg.Done()
-			WaitForIssueClosed(t, env, env.RepoAlpha, num, 90*time.Minute)
+			WaitForIssueClosedWithReviewCheck(t, env, env.RepoAlpha, num, 90*time.Minute)
 			t.Logf("%s#%d closed", env.RepoAlpha, num)
 		}(num)
 	}

--- a/tests/e2e/cross_repo_spawn_test.go
+++ b/tests/e2e/cross_repo_spawn_test.go
@@ -86,11 +86,11 @@ func TestCrossRepoSpawn(t *testing.T) {
 	SetIssueStatus(t, env, childItemID, "Specify")
 
 	// Wait for child to close (its PR merges).
-	WaitForIssueClosed(t, env, env.RepoBeta, child, 45*time.Minute)
+	WaitForIssueClosedWithReviewCheck(t, env, env.RepoBeta, child, 45*time.Minute)
 	t.Logf("child closed — parent should resume")
 
 	// Parent unblocks, runs Implement → Review → Validate → closes.
-	WaitForIssueClosed(t, env, env.RepoAlpha, parent, 30*time.Minute)
+	WaitForIssueClosedWithReviewCheck(t, env, env.RepoAlpha, parent, 30*time.Minute)
 	t.Logf("parent closed — cross-repo flow complete")
 
 	// fabrik:children-spawned only proves Plan emitted a spawn block — it

--- a/tests/e2e/cruise_test.go
+++ b/tests/e2e/cruise_test.go
@@ -107,7 +107,7 @@ func TestCruiseFullPipeline(t *testing.T) {
 	// R5: after the human merge, the engine detects the terminal PR state,
 	// advances the board to Done, and the issue closes (via GitHub's
 	// Closes #N auto-close on merge).
-	WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
+	WaitForIssueClosedWithReviewCheck(t, env, env.RepoAlpha, num, 45*time.Minute)
 	t.Logf("%s#%d closed after human merge — R5 verified (full cruise contract confirmed)", env.RepoAlpha, num)
 }
 

--- a/tests/e2e/expected_reviewers_test.go
+++ b/tests/e2e/expected_reviewers_test.go
@@ -13,9 +13,10 @@ import (
 // This file covers ADR-1283's expected_reviewers (declared unrequested
 // reviewers for the review gate) end-to-end (issue #1298), using
 // deterministic harness-posted verdicts (SubmitPRReview +
-// FABRIK_REVIEWER_TOKEN) — never the bed's COMMENT-only claude-review.yml
-// bot — for every verdict assertion. This is the direct #1258 precedent
-// applied to a second, list-shaped stage-config field.
+// FABRIK_REVIEWER_TOKEN) — never the bed's real reviewer (Pruefer, as of
+// #1396; formerly claude-review.yml, now disabled) — for every verdict
+// assertion. This is the direct #1258 precedent applied to a second,
+// list-shaped stage-config field.
 //
 // Mechanism: all scenarios seed a member PR directly via the GitHub API
 // (seedReviewGateItem -> CreateMemberPR, zero Claude cost) against the bed's
@@ -72,11 +73,10 @@ import (
 // requested", "declared but unrequested") would be falsified by
 // RequestPRReviewer, so unlike the review_authority_test.go fix they can't
 // use a genuinely outstanding reviewer to make the wait deterministic.
-// Opening the member PR as a draft keeps the bed's claude-review.yml bot
-// from ever reviewing it (its job is guarded by
-// `if: github.event.pull_request.draft == false`, triggering only on
-// opened/ready_for_review), removing the incidental review entirely rather
-// than racing it.
+// Opening the member PR as a draft keeps the bed's real reviewer (Pruefer,
+// as of #1396) from ever reviewing it — it only lists open, non-draft PRs
+// each poll (cmd/pruefer/README.md) — removing the incidental review
+// entirely rather than racing it.
 const (
 	expectedReviewersNoneLabel     = "expected-reviewers:none"
 	expectedReviewersDeclaredLabel = "expected-reviewers:declared"
@@ -137,14 +137,14 @@ func TestExpectedReviewersFastAdvance(t *testing.T) {
 // Uses seedReviewGateItemDraft (#1312): this scenario's entire mechanism
 // depends on nothing being reviewed until the Phase 1/2 timeouts fire, but
 // expected_reviewers is not consulted by checkReviewGate's outer clearing
-// branch — an incidental bot COMMENT review would clear the gate in advisory
+// branch — an incidental bot review would clear the gate in advisory
 // mode before Phase 1 can ever be reached, silently preventing the
 // re-prompt ladder (this test's actual subject) from engaging at all.
 // RequestPRReviewer isn't an option here either: a genuinely outstanding
 // *requested* reviewer routes to the mixed/human pause path instead of the
 // bot ladder (reviewGateAllBots). The draft PR is never marked ready for
-// the duration of this test, so the bed's claude-review.yml never reviews
-// it and there is no incidental review to race.
+// the duration of this test, so the bed's real reviewer (Pruefer, as of
+// #1396) never reviews it and there is no incidental review to race.
 //
 // Wall-clock (worst case): ~2xFABRIK_REVIEW_WAIT_TIMEOUT + buffer — see
 // README for a recommended bed value.
@@ -203,9 +203,9 @@ func TestExpectedReviewersDeclaredWaitsAndReprompts(t *testing.T) {
 // Uses seedReviewGateItemDraft (#1312): the property under test is "nothing
 // requested, nothing reviewed yet" — RequestPRReviewer would falsify that
 // premise, so it can't be used to make the wait deterministic the way the
-// TestReviewAuthority* scenarios do. A draft PR means the bed's
-// claude-review.yml bot never reviews it, so there is no incidental review
-// to race against the engine's first gate evaluation.
+// TestReviewAuthority* scenarios do. A draft PR means the bed's real
+// reviewer (Pruefer, as of #1396) never reviews it, so there is no
+// incidental review to race against the engine's first gate evaluation.
 //
 // Wall-clock: ~2-5 min.
 func TestExpectedReviewersUndeclaredRegressionGuard(t *testing.T) {

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -482,7 +482,27 @@ func tryPRReviewState(env *Env, repo string, prNumber int) (isDraft bool, create
 // poll observed isDraft==true (a real draft→ready transition happened
 // in-window), or to the PR's createdAt if it was never seen as a draft
 // (opened ready from the start; the ~poll-interval error this introduces is
-// negligible against a 10-minute window).
+// negligible against a 10-minute window). If a later poll observes
+// isDraft==true again (a PR re-drafted after going ready — unusual but
+// possible), readyAt resets to zero so the zero-review clock doesn't keep
+// running through a period the PR genuinely wasn't reviewable.
+//
+// Once a review is observed (reviewCount > 0), the PR-review-state poll is
+// skipped for the remainder of the wait — reviewFailFastDue can never fire
+// again once a review exists, so there's no reason to keep paying the extra
+// `gh pr view` call every cycle (see tests/e2e/README.md's GraphQL-budget
+// note, which assumes exactly this bound).
+//
+// Contract for callers: this helper only trusts readyAt's createdAt fallback
+// to be within poll-interval error of "actually ready" if the wait begins at
+// or near PR creation (true of all current call sites — either no PR exists
+// yet, or, per the "opt-in" note below, a review has already organically
+// landed via the Review stage's own gate before this helper is ever called).
+// A future call site that invokes this well after a long-idle, never-drafted,
+// still-unreviewed PR was created would see readyAt anchored to that stale
+// createdAt and could fail on its very first poll — that's a real risk for a
+// hypothetical caller, not a mitigated one; verify it doesn't apply before
+// adopting this helper at a new site.
 //
 // Not wired into every WaitForIssueClosed call site — see the Plan stage's
 // "Opt-in helper, not a default-on change" decision (handarbeit/fabrik#1396):
@@ -496,6 +516,7 @@ func WaitForIssueClosedWithReviewCheck(t *testing.T, env *Env, repo string, issu
 	deadline := time.Now().Add(timeout)
 	var sawDraft bool
 	var readyAt time.Time
+	var reviewLanded bool
 	for time.Now().Before(deadline) {
 		state, err := tryIssueState(env, repo, issueNumber)
 		if err != nil {
@@ -504,21 +525,26 @@ func WaitForIssueClosedWithReviewCheck(t *testing.T, env *Env, repo string, issu
 			return
 		}
 
-		if prNumber, prErr := tryLinkedPRNumber(env, repo, issueNumber); prErr == nil {
-			if isDraft, createdAt, reviewCount, rsErr := tryPRReviewState(env, repo, prNumber); rsErr == nil {
-				if isDraft {
-					sawDraft = true
-				} else if readyAt.IsZero() {
-					if sawDraft {
-						readyAt = time.Now()
-					} else {
-						readyAt = createdAt
+		if !reviewLanded {
+			if prNumber, prErr := tryLinkedPRNumber(env, repo, issueNumber); prErr == nil {
+				if isDraft, createdAt, reviewCount, rsErr := tryPRReviewState(env, repo, prNumber); rsErr == nil {
+					if isDraft {
+						sawDraft = true
+						readyAt = time.Time{}
+					} else if readyAt.IsZero() {
+						if sawDraft {
+							readyAt = time.Now()
+						} else {
+							readyAt = createdAt
+						}
 					}
-				}
-				if reviewFailFastDue(readyAt, reviewCount, time.Now(), reviewFailFastWindow()) {
-					t.Fatalf("%s#%d: PR #%d has been ready for review for over %s with zero reviews — "+
-						"likely a dropped bot-review dispatch, not a Fabrik engine defect (see handarbeit/fabrik#1396)",
-						repo, issueNumber, prNumber, reviewFailFastWindow())
+					if reviewCount > 0 {
+						reviewLanded = true
+					} else if reviewFailFastDue(readyAt, reviewCount, time.Now(), reviewFailFastWindow()) {
+						t.Fatalf("%s#%d: PR #%d has been ready for review for over %s with zero reviews — "+
+							"likely a dropped bot-review dispatch, not a Fabrik engine defect (see handarbeit/fabrik#1396)",
+							repo, issueNumber, prNumber, reviewFailFastWindow())
+					}
 				}
 			}
 		}

--- a/tests/e2e/harness.go
+++ b/tests/e2e/harness.go
@@ -398,6 +398,137 @@ func WaitForIssueClosed(t *testing.T, env *Env, repo string, issueNumber int, ti
 	t.Fatalf("timed out waiting for %s#%d to close (last observed: %q)", repo, issueNumber, state)
 }
 
+// defaultReviewFailFastWindow is how long a linked PR may sit ready-for-review
+// with zero reviews before WaitForIssueClosedWithReviewCheck fails fast,
+// rather than running out the full close-timeout (handarbeit/fabrik#1396).
+//
+// Pruefer (the bed's real reviewer once .pruefer/config.yaml's watched_repos
+// includes the test repos — see tests/e2e/README.md "Reviewer topology")
+// polls every 120s with a concurrency_cap of 3 across its watched repos. 10
+// minutes is ~5x that cadence — comfortable headroom for a busy-but-healthy
+// Pruefer — while still catching a genuinely dropped review-dispatch well
+// before the engine's own first ReviewWaitTimeout window (15 min default)
+// completes, let alone the ~45-minute wall-clock the issue's Problem section
+// observed.
+//
+// Override with E2E_REVIEW_FAILFAST_WINDOW (any time.ParseDuration value),
+// mirroring E2E_POLL_INTERVAL's tuning convention, if real-world flakiness
+// data says the bound needs adjusting.
+const defaultReviewFailFastWindow = 10 * time.Minute
+
+func reviewFailFastWindow() time.Duration {
+	if s := os.Getenv("E2E_REVIEW_FAILFAST_WINDOW"); s != "" {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultReviewFailFastWindow
+}
+
+// reviewFailFastDue is the pure decision behind the fail-fast check: given
+// when the PR became ready for review (readyAt, zero if not yet ready or
+// unknown), how many reviews it currently has, the current time, and the
+// configured window, should the wait fail now?
+//
+// Deliberately author- and state-agnostic (any review counts, including
+// DISMISSED) — this is a test-side diagnostic, not a reimplementation of
+// engine/reviews.go's hasReviews gate-clearing semantics (R2 requires the
+// engine's clearing rule stay untouched).
+func reviewFailFastDue(readyAt time.Time, reviewCount int, now time.Time, window time.Duration) bool {
+	if readyAt.IsZero() {
+		return false
+	}
+	if reviewCount > 0 {
+		return false
+	}
+	return now.Sub(readyAt) >= window
+}
+
+// tryPRReviewState is the non-fatal read behind WaitForIssueClosedWithReviewCheck's
+// fail-fast check: draft state, creation time, and review count for a PR, in
+// one gh call. Returns an error on any gh/JSON failure so callers can treat
+// it like the other try* helpers — log and retry, never fail the whole wait
+// on one transient blip.
+func tryPRReviewState(env *Env, repo string, prNumber int) (isDraft bool, createdAt time.Time, reviewCount int, err error) {
+	out, err := ghOutput(env, "pr", "view", fmt.Sprint(prNumber), "-R", repo,
+		"--json", "isDraft,createdAt,reviews")
+	if err != nil {
+		return false, time.Time{}, 0, err
+	}
+	var parsed struct {
+		IsDraft   bool              `json:"isDraft"`
+		CreatedAt time.Time         `json:"createdAt"`
+		Reviews   []json.RawMessage `json:"reviews"`
+	}
+	if uerr := json.Unmarshal([]byte(out), &parsed); uerr != nil {
+		return false, time.Time{}, 0, fmt.Errorf("parse PR review state for %s PR #%d: %w", repo, prNumber, uerr)
+	}
+	return parsed.IsDraft, parsed.CreatedAt, len(parsed.Reviews), nil
+}
+
+// WaitForIssueClosedWithReviewCheck is WaitForIssueClosed plus a bounded
+// fail-fast check on the linked PR's review state (handarbeit/fabrik#1396,
+// R3/R4). If the PR has been ready-for-review (not draft) for
+// reviewFailFastWindow() with zero reviews, it fails immediately with a
+// message that names that specific cause — distinguishable from the generic
+// close-timeout below — rather than running out the full timeout waiting on
+// a review that (per the issue's Problem section) may never come because a
+// bot-review dispatch was dropped.
+//
+// The draft→ready transition is self-observed across polls rather than read
+// from GitHub's readyForReviewAt field: that field isn't in this gh CLI's
+// supported --json fields for `pr view` (verified during Plan). The first
+// poll that observes isDraft==false anchors readyAt — to "now" if an earlier
+// poll observed isDraft==true (a real draft→ready transition happened
+// in-window), or to the PR's createdAt if it was never seen as a draft
+// (opened ready from the start; the ~poll-interval error this introduces is
+// negligible against a 10-minute window).
+//
+// Not wired into every WaitForIssueClosed call site — see the Plan stage's
+// "Opt-in helper, not a default-on change" decision (handarbeit/fabrik#1396):
+// only scenarios that drive a real, unreviewed PR through the organic Review
+// gate benefit: sites that submit their own review before waiting, or that
+// never create an organically-reviewed PR at all (FABRIK_NO_WORK_NEEDED,
+// merge-train Queued members, externally-force-merged PRs), would never
+// trigger the check or would trigger it spuriously.
+func WaitForIssueClosedWithReviewCheck(t *testing.T, env *Env, repo string, issueNumber int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var sawDraft bool
+	var readyAt time.Time
+	for time.Now().Before(deadline) {
+		state, err := tryIssueState(env, repo, issueNumber)
+		if err != nil {
+			t.Logf("WaitForIssueClosedWithReviewCheck: transient gh error on %s#%d: %v (will retry)", repo, issueNumber, err)
+		} else if state == "CLOSED" {
+			return
+		}
+
+		if prNumber, prErr := tryLinkedPRNumber(env, repo, issueNumber); prErr == nil {
+			if isDraft, createdAt, reviewCount, rsErr := tryPRReviewState(env, repo, prNumber); rsErr == nil {
+				if isDraft {
+					sawDraft = true
+				} else if readyAt.IsZero() {
+					if sawDraft {
+						readyAt = time.Now()
+					} else {
+						readyAt = createdAt
+					}
+				}
+				if reviewFailFastDue(readyAt, reviewCount, time.Now(), reviewFailFastWindow()) {
+					t.Fatalf("%s#%d: PR #%d has been ready for review for over %s with zero reviews — "+
+						"likely a dropped bot-review dispatch, not a Fabrik engine defect (see handarbeit/fabrik#1396)",
+						repo, issueNumber, prNumber, reviewFailFastWindow())
+				}
+			}
+		}
+
+		pollSleep(pollBase())
+	}
+	state, _ := tryIssueState(env, repo, issueNumber)
+	t.Fatalf("timed out waiting for %s#%d to close (last observed: %q)", repo, issueNumber, state)
+}
+
 // WaitForLabelAbsent polls until the named label is no longer on the issue.
 // Tolerant of transient gh errors — see WaitForIssueClosed for rationale.
 func WaitForLabelAbsent(t *testing.T, env *Env, repo string, issueNumber int, label string, timeout time.Duration) {

--- a/tests/e2e/mergetrain_helpers.go
+++ b/tests/e2e/mergetrain_helpers.go
@@ -89,11 +89,12 @@ func CreateMemberPR(t *testing.T, env *Env, repo, baseBranch, branch, path, cont
 }
 
 // CreateMemberPRDraft is CreateMemberPR, but opens the PR as a draft. The bed's
-// claude-review.yml review workflow guards its job with
-// `if: github.event.pull_request.draft == false` and only triggers on
-// opened/ready_for_review — a draft PR that is never marked ready is therefore
-// permanently invisible to it. Scenarios whose property under test is "nothing
-// has reviewed this PR yet" (e.g. expected_reviewers's declared-but-unrequested
+// real reviewer (Pruefer, as of #1396 — see tests/e2e/README.md's "Reviewer
+// topology"; formerly claude-review.yml, now disabled) only lists open,
+// non-draft PRs each poll (cmd/pruefer/README.md) — a draft PR that is never
+// marked ready is therefore permanently invisible to it. Scenarios whose
+// property under test is "nothing has reviewed this PR yet" (e.g.
+// expected_reviewers's declared-but-unrequested
 // and undeclared-nothing-requested cases) use this instead of CreateMemberPR to
 // avoid racing that bot's incidental review against the engine's first gate
 // evaluation (see #1312).

--- a/tests/e2e/review_authority_helpers.go
+++ b/tests/e2e/review_authority_helpers.go
@@ -34,20 +34,21 @@ import (
 // construction precedent as TestPausedMergedPRRecovery's R5. extraLabels are
 // applied at file time (e.g. "fabrik:yolo" for the composition scenario).
 //
-// The member PR is opened ready (non-draft), so the bed's claude-review.yml
-// bot will typically review it within ~60-100s. Scenarios that submit their
-// own deliberate verdict must not treat the bot's incidental review as proof
-// the gate engaged — see the file-level "Determinism" note below and #1312.
+// The member PR is opened ready (non-draft), so the bed's real reviewer
+// (Pruefer, as of #1396 — see tests/e2e/README.md's "Reviewer topology";
+// formerly claude-review.yml, now disabled) will typically review it within
+// its poll cadence. Scenarios that submit their own deliberate verdict must
+// not treat the bot's incidental review as proof the gate engaged — see the
+// file-level "Determinism" note below and #1312.
 func seedReviewGateItem(t *testing.T, env *Env, repo, baseBranch, column, marker string, extraLabels ...string) (issueNum, prNum int, itemID string) {
 	t.Helper()
 	return seedReviewGateItemImpl(t, env, repo, baseBranch, column, marker, false, extraLabels...)
 }
 
 // seedReviewGateItemDraft is seedReviewGateItem, but opens the member PR as a
-// draft (via CreateMemberPRDraft) so the bed's claude-review.yml bot never
-// reviews it — its job is guarded by
-// `if: github.event.pull_request.draft == false` and only triggers on
-// opened/ready_for_review. Use this when the property under test is "nothing
+// draft (via CreateMemberPRDraft) so the bed's real reviewer (Pruefer, as of
+// #1396) never reviews it — it only lists open, non-draft PRs each poll
+// (cmd/pruefer/README.md). Use this when the property under test is "nothing
 // has reviewed this PR" (e.g. expected_reviewers's declared-but-unrequested
 // and undeclared-nothing-requested scenarios): with a real (non-draft) PR, an
 // incidental bot review can satisfy checkReviewGate's

--- a/tests/e2e/review_authority_test.go
+++ b/tests/e2e/review_authority_test.go
@@ -11,8 +11,9 @@ import (
 
 // This file covers ADR-1250's review_authority: authoritative mode
 // end-to-end (issue #1258), using deterministic harness-posted verdicts
-// (SubmitPRReview + FABRIK_REVIEWER_TOKEN) — never the bed's COMMENT-only
-// claude-review.yml bot — for every verdict assertion.
+// (SubmitPRReview + FABRIK_REVIEWER_TOKEN) — never the bed's real reviewer
+// (Pruefer, as of #1396; formerly claude-review.yml, now disabled) — for
+// every verdict assertion.
 //
 // Mechanism: all scenarios seed a member PR directly via the GitHub API
 // (CreateMemberPR, zero Claude cost) against the bed's existing Review
@@ -61,13 +62,14 @@ import (
 // ADR-1258's original "no RequestPRReviewer call is needed" rationale — that
 // reasoning covered checkReviewGate's outer clearing condition
 // (len(outstanding)==0 && hasReviews) in isolation, but didn't account for
-// the bed's own claude-review.yml bot satisfying that same condition with an
-// incidental COMMENT review before the engine's first gate evaluation, which
-// is exactly what #1312 reports. YoloDoesNotBypassBlock's two
-// fabrik:awaiting-review waits need no such fix: both occur after this
-// test's own genuine REQUEST_CHANGES review is already submitted, and once a
-// genuine CHANGES_REQUESTED review exists, an unrelated incidental bot
-// COMMENT landing before or after it can never satisfy the outer clearing
+// the bed's own incidental reviewer (formerly claude-review.yml, now
+// Pruefer as of #1396) satisfying that same condition with an incidental
+// review before the engine's first gate evaluation, which is exactly what
+// #1312 reports. YoloDoesNotBypassBlock's two fabrik:awaiting-review waits
+// need no such fix: both occur after this test's own genuine
+// REQUEST_CHANGES review is already submitted, and once a genuine
+// CHANGES_REQUESTED review exists, an unrelated incidental bot review
+// landing before or after it can never satisfy the outer clearing
 // condition on its own — the wait is already deterministic. See
 // adrs/1258-e2e-review-authority-coverage.md's Revision section.
 //
@@ -128,8 +130,8 @@ func TestReviewAuthorityReinvokesOnChangesRequested(t *testing.T) {
 
 	// Request the reviewer so outstanding is genuinely non-empty by
 	// construction, before confirming the gate's pre-verdict block. Without
-	// this, the bed's claude-review.yml bot can land its own incidental
-	// COMMENT review before the engine's first gate evaluation; that alone
+	// this, the bed's real reviewer (Pruefer, as of #1396) can land its own
+	// incidental review before the engine's first gate evaluation; that alone
 	// satisfies checkReviewGate's outer len(outstanding)==0 && hasReviews
 	// clearing branch, which never applies fabrik:awaiting-review — the wait
 	// below would then time out against genuinely correct engine behavior
@@ -276,9 +278,9 @@ func TestReviewAuthorityClearsOnApproval(t *testing.T) {
 
 	// Request the reviewer so outstanding is genuinely non-empty by
 	// construction, before confirming the gate engages. Without this, the
-	// bed's claude-review.yml bot can land its own incidental COMMENT review
-	// before the engine's first gate evaluation and before this test's own
-	// APPROVE — that alone satisfies checkReviewGate's outer
+	// bed's real reviewer (Pruefer, as of #1396) can land its own incidental
+	// review before the engine's first gate evaluation and before this test's
+	// own APPROVE — that alone satisfies checkReviewGate's outer
 	// len(outstanding)==0 && hasReviews clearing branch, which never applies
 	// fabrik:awaiting-review. The wait below would then time out against
 	// genuinely correct engine behavior (#1312) instead of proving the gate
@@ -412,9 +414,9 @@ func TestReviewAuthorityAdvisoryRegressionGuard(t *testing.T) {
 
 	// Request the reviewer so outstanding is genuinely non-empty by
 	// construction, before confirming the gate engages. Without this, the
-	// bed's claude-review.yml bot can land its own incidental COMMENT review
-	// before the engine's first gate evaluation and before this test's own
-	// REQUEST_CHANGES — that alone satisfies checkReviewGate's outer
+	// bed's real reviewer (Pruefer, as of #1396) can land its own incidental
+	// review before the engine's first gate evaluation and before this test's
+	// own REQUEST_CHANGES — that alone satisfies checkReviewGate's outer
 	// len(outstanding)==0 && hasReviews clearing branch, which never applies
 	// fabrik:awaiting-review. The wait below would then time out against
 	// genuinely correct engine behavior (#1312) instead of proving the gate

--- a/tests/e2e/review_failfast_test.go
+++ b/tests/e2e/review_failfast_test.go
@@ -1,0 +1,97 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReviewFailFastDecision unit-tests reviewFailFastDue's boundary
+// conditions (handarbeit/fabrik#1396, R3/R4). It requires no live bed:
+//
+//	go test -tags e2e -run TestReviewFailFastDecision -v ./tests/e2e/
+func TestReviewFailFastDecision(t *testing.T) {
+	window := 10 * time.Minute
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		readyAt     time.Time
+		reviewCount int
+		now         time.Time
+		want        bool
+	}{
+		{
+			name:        "not yet ready (zero readyAt) never fires, however long",
+			readyAt:     time.Time{},
+			reviewCount: 0,
+			now:         now,
+			want:        false,
+		},
+		{
+			name:        "ready but has a review never fires, however long",
+			readyAt:     now.Add(-24 * time.Hour),
+			reviewCount: 1,
+			now:         now,
+			want:        false,
+		},
+		{
+			name:        "ready with a DISMISSED-or-any review still never fires (author/state agnostic)",
+			readyAt:     now.Add(-24 * time.Hour),
+			reviewCount: 3,
+			now:         now,
+			want:        false,
+		},
+		{
+			name:        "just before the window elapses does not fire",
+			readyAt:     now.Add(-window + time.Second),
+			reviewCount: 0,
+			now:         now,
+			want:        false,
+		},
+		{
+			name:        "exactly at the window fires (>=)",
+			readyAt:     now.Add(-window),
+			reviewCount: 0,
+			now:         now,
+			want:        true,
+		},
+		{
+			name:        "past the window with zero reviews fires",
+			readyAt:     now.Add(-window - time.Minute),
+			reviewCount: 0,
+			now:         now,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reviewFailFastDue(tt.readyAt, tt.reviewCount, tt.now, window)
+			if got != tt.want {
+				t.Errorf("reviewFailFastDue(readyAt=%v, reviewCount=%d, now=%v, window=%v) = %v, want %v",
+					tt.readyAt, tt.reviewCount, tt.now, window, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReviewFailFastWindowDefault confirms the documented default and the
+// E2E_REVIEW_FAILFAST_WINDOW override, mirroring pollBase()'s own test
+// convention (t.Setenv auto-restores).
+func TestReviewFailFastWindowDefault(t *testing.T) {
+	if got := reviewFailFastWindow(); got != defaultReviewFailFastWindow {
+		t.Errorf("reviewFailFastWindow() = %v, want default %v", got, defaultReviewFailFastWindow)
+	}
+
+	t.Setenv("E2E_REVIEW_FAILFAST_WINDOW", "5m")
+	if got := reviewFailFastWindow(); got != 5*time.Minute {
+		t.Errorf("reviewFailFastWindow() with override = %v, want 5m", got)
+	}
+
+	t.Setenv("E2E_REVIEW_FAILFAST_WINDOW", "not-a-duration")
+	if got := reviewFailFastWindow(); got != defaultReviewFailFastWindow {
+		t.Errorf("reviewFailFastWindow() with invalid override = %v, want default %v", got, defaultReviewFailFastWindow)
+	}
+}

--- a/tests/e2e/smoke_test.go
+++ b/tests/e2e/smoke_test.go
@@ -86,6 +86,6 @@ Single repo only — no cross-repo work. The Plan stage should NOT decompose.`,
 	t.Logf("filed %s#%d at Status=Specify, marker=%s", env.RepoAlpha, num, marker)
 
 	// Full pipeline can take up to ~30 min depending on Claude latency.
-	WaitForIssueClosed(t, env, env.RepoAlpha, num, 45*time.Minute)
+	WaitForIssueClosedWithReviewCheck(t, env, env.RepoAlpha, num, 45*time.Minute)
 	t.Logf("%s#%d closed — full single-repo pipeline verified", env.RepoAlpha, num)
 }


### PR DESCRIPTION
Closes #1396

## What this does

Two related fixes for the e2e suite's Review-gate dependency (#1396):

**R3/R4 — fail fast with an accurate message.** Adds `WaitForIssueClosedWithReviewCheck` to `tests/e2e/harness.go`: it polls exactly like `WaitForIssueClosed`, but tracks the linked PR's draft→ready transition and review count. If the PR has been ready for review for 10 minutes (tunable via `E2E_REVIEW_FAILFAST_WINDOW`) with zero reviews, it fails immediately with a message naming that specific cause — instead of running out the full ~45-minute close-timeout on a review that may never come because a bot-dispatch was dropped.

Wired into the 7 `WaitForIssueClosed` call sites that drive a real, organically-reviewed PR through Review end-to-end (`smoke_test.go`, `auto_merge_test.go`, `ci_fix_reinvoke_test.go`, `cruise_test.go`, `cross_repo_spawn_test.go` ×2, `convergence_race_test.go`). The other 6 sites either pre-submit their own review, create no PR at all, or never traverse the per-issue Review gate — wiring the check in there would be dead code or a signature mismatch.

**R6 — document the reviewer topology.** `tests/e2e/README.md` gets a new "Reviewer topology" section: Pruefer becomes the bed's present, real reviewer once `.pruefer/config.yaml`'s `watched_repos` includes the test repos; `e2e-synthetic-declared-reviewer` is the deliberately-absent reviewer; `claude-review.yml` is disabled (not deleted) on both test repos; Gemini doesn't participate. Corrects two existing README items (#23, #29) and four Go files' comments that previously named `claude-review.yml` as the bed's incidental reviewer, without reopening ADR-1258's separate rejection of Pruefer as a deterministic verdict source for `TestReviewAuthority*`.

**R2 — engine unchanged.** No change to `engine/reviews.go`'s gate-clearing semantics. `reviewFailFastDue`'s review-count check is deliberately author/state-agnostic — a test-side diagnostic, not a reimplementation of the gate.

**R1 — operator actions (not part of this diff):**
- `.pruefer/config.yaml`'s `watched_repos` needs `handarbeit/fabrik-test-alpha` and `handarbeit/fabrik-test-beta` added. This file is gitignored (`.gitignore:35`) and not tracked anywhere in this repo — it lives on Pruefer's deployment host.
- `gh workflow disable claude-review.yml` needs to run against both test repos (same mechanism used to retire it on `handarbeit/fabrik`). No file in either test repo's checkout is touched.
- AC1 ("demonstrate with a real PR") is a manual, post-merge verification step against live infrastructure — not something this PR's CI can assert.

## Key decisions

- 10-minute fail-fast bound: ~5x Pruefer's 120s poll cadence, well below the engine's own 15-min `ReviewWaitTimeout`, so a genuinely dropped dispatch is caught before the engine's own re-prompt ladder even finishes its first stage.
- Draft→ready detection is self-observed (`isDraft` diffed across polls), not read from GitHub's `readyForReviewAt` — that field isn't in this repo's `gh` CLI's supported `pr view --json` fields.
- No engine change, no new ADR — this is entirely e2e-harness/test-README scope.

## How to test

```bash
go build ./... && go vet ./...
go test -tags e2e -run 'TestMarkerPathsAreUnique|TestReviewFailFastDecision|TestReviewFailFastWindowDefault' -v ./tests/e2e/
go test ./...
```

All pass locally (3849 unit tests, plus the new network-free e2e logic tests). The 7 adopting scenarios themselves require a live bed and aren't run here.