### PR TITLE
test(sim): add simgh, a stateful GitHub model backed by real git

### DIFF
--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -1,0 +1,101 @@
+# `tests/sim` — the simulation test layer
+
+This directory holds a simulated GitHub that Fabrik's engine can be driven
+against in an ordinary `go test` run.
+
+It exists because Fabrik had two test layers and nothing between them.
+
+## The three tiers
+
+| | `engine/mocks_test.go` | **`tests/sim`** | `tests/e2e` |
+|---|---|---|---|
+| What it is | Per-call function hooks | Stateful model, real git backing | Real daemon, real GitHub |
+| State across calls | None | Full | Real |
+| Multi-poll sequences | No | Yes | Yes |
+| Adversarial paths | Hard | On demand | Barely reachable |
+| Cost per run | Milliseconds | Seconds | Claude tokens, GraphQL budget, wall clock, a maintained live test bed |
+| Catches wire bugs | No | **No** | Yes |
+
+`engine/mocks_test.go` hands each test a set of hooks — `fetchProjectBoardFn`,
+`fetchLinkedPRFn`, `fetchCheckRunsFn` — and the test hand-builds the exact
+snapshot it wants the engine to see. Nothing carries across poll cycles, so no
+test in `engine/` can assert a *sequence* of transitions. The engine is a state
+machine; that layer can only photograph one frame at a time.
+
+`tests/e2e` drives a real fabrik daemon against real GitHub, real Claude
+workers, and real review bots. It is the only place a multi-poll sequence runs
+end to end, and it costs real money and wall-clock time to find out.
+
+The consequence was that every state-machine behaviour — label lifecycles,
+conjunctive gates, settle-scan escalation and its `MaxRetries` cutover, cycle
+limits, restart recovery — was either asserted one frozen frame at a time, or
+cost a live e2e run. Adversarial paths (confirmed CI failure, non-mergeable PR,
+API error, engine killed mid-stage) were barely covered at all, because the live
+bed cannot be made to produce them on demand.
+
+`tests/sim` is the missing middle: faithful enough that a transition *sequence*
+means something, cheap enough to run on every commit.
+
+## What is here
+
+- **[`simgh/`](simgh/)** — a stateful model of a GitHub project (issues, project
+  items, PRs, check runs, commit statuses, reviews, labels, comments, blockedBy
+  links) implementing the full `engine.GitHubClient` interface, backed by a real
+  local bare git repository for everything git can genuinely answer.
+- **[`simgh/FIDELITY.md`](simgh/FIDELITY.md)** — every place the model knowingly
+  departs from real GitHub, and what each divergence costs. **Read it before
+  trusting a sim-backed test to cover a subtle behaviour.**
+- **[`simgh/nonvacuity.sh`](simgh/nonvacuity.sh)** — a mutation sweep that
+  neutralises each modelled behaviour and asserts the suite goes red.
+
+The seam this layer targets is `engine.NewWithDeps(cfg, GitHubClient,
+ClaudeInvoker, *WorktreeManager)`, which accepts substituted dependencies.
+Wiring `simgh` into it, along with a `ClaudeInvoker` and a scenario harness, is
+follow-on work — this package currently ships standalone with its own tests.
+
+## Two things make it worth having
+
+**It is stateful.** A mutation is observable by every subsequent read, the way
+GitHub behaves. Read projections are computed fresh from the model on every
+call and never cached, so that is a structural property rather than something
+each test re-asserts.
+
+**It is backed by real git.** Mergeability comes from an actual trial merge of
+head into base. `MergePR` writes an actual two-parent merge commit onto the base
+ref, and only then flips `merged`. Commits-behind comes from `rev-list`. A fake
+that lets a test *declare* mergeability cannot catch a mergeability bug.
+
+## What this layer is permanently blind to
+
+**GraphQL and REST wire correctness.** This is not a gap to be closed later in
+this package — it is structural, and worth being blunt about.
+
+`simgh` implements a Go interface. Query documents, mutation names, JSON field
+mappings, pagination, and status-code handling are all below it and entirely
+invisible.
+
+The concrete example is the `addBlockedBy` regression that shipped broken in
+v0.0.66 (see [`../e2e/README.md`](../e2e/README.md)). The bug was a wrong
+mutation *name* — a string literal inside a query document. Every
+interface-level implementation of `AddBlockedByIssue`, including this one, is
+perfectly green against it. A sim-backed suite would have shipped that bug with
+full confidence.
+
+Two things close that gap, and neither is replaced by this layer:
+
+- **Wire-contract tests**, covering the query documents themselves.
+- **`tests/e2e`**, which is not being retired. It remains the only place the
+  whole system runs against the real thing.
+
+Do not read "the sim scenarios pass" as "this works". Read it as "the state
+machine behaves, assuming the wire layer does what we think".
+
+## Running it
+
+```bash
+go test -race ./tests/sim/...          # the suite
+bash tests/sim/simgh/nonvacuity.sh     # the mutation sweep (needs a clean tree)
+```
+
+The tests use the real `git` binary and skip when it is unavailable, following
+the repo-wide `skipIfNoGit` convention.

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -92,8 +92,15 @@ conditions. A draft PR that also conflicts resolves to `draft`, not `dirty`. If
 a scenario depends on a specific combination, verify the real behaviour against
 a recorded GitHub response rather than trusting the sim's ordering.
 
-**Risk:** medium, and concentrated in untested combinations. Single-condition
-cases are each covered by a test; combinations are not.
+**Risk:** medium, and concentrated in *which* state an untested combination
+resolves to rather than in the ordering itself. Each single-condition case has
+its own test, and `mergeable_precedence_test.go` additionally pins every
+adjacent link in the chain — draft > dirty > behind > blocked > unstable >
+clean — with two conditions arranged at once, so the order is constrained
+transitively rather than assumed. What those tests cannot tell you is whether
+this order is the order *GitHub* would use for the same combination; that
+remains a design choice, so verify against a recorded real response before
+relying on a combination in a load-bearing scenario.
 
 ### `has_hooks` and `unknown`-from-slowness — **Absent**
 
@@ -225,6 +232,24 @@ does, which is how a race with a concurrent push is caught).
 never merges anything, and dequeuing does not renumber the PRs behind it.
 `MergeQueueEntry.State` is always `QUEUED`; `AWAITING_CHECKS`, `MERGEABLE`, and
 `UNMERGEABLE` are never produced.
+
+**The `expectedHeadOID` check is not atomic with the enqueue.**
+`EnqueuePullRequest` resolves the head SHA under `gitMu`, releases it, then takes
+`mu` to record membership — so a concurrent push landing between the two would
+let the enqueue proceed against a head that no longer matches. GitHub performs
+that compare-and-swap server-side and cannot.
+
+This is deliberate rather than overlooked. Closing it would mean holding `gitMu`
+and `mu` simultaneously, which the package's locking invariant forbids outright
+(see `sim.go`); that invariant is what makes the two-tier design deadlock-free
+everywhere else, and it is not worth trading for a window only a scenario's own
+concurrent seeding can open. Note that `MergePR` does **not** have this gap for
+the merge itself: its trial merge and its real merge run the same `tryMerge`
+helper, so if the tree changed underneath it the merge fails and the model
+reports the conflict rather than recording a merge that did not happen.
+
+**Risk:** low — a scenario would have to push to a PR's head branch from one
+goroutine while enqueuing it from another.
 
 **Risk:** high for any merge-queue scenario. Treat merge-queue coverage here as
 absent.
@@ -438,7 +463,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 41 mutations.
+   package cannot back up. The sweep currently catches all 42 mutations.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real
 GitHub* — only that the model does what this document says. For anything subtle

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -338,6 +338,17 @@ Projects are keyed by `(owner, number)`, because Projects v2 is owner-scoped, no
 repo-scoped. The `repo` argument on a board fetch is a query input, not part of
 the project's identity.
 
+### PR cards on a board — **Absent**
+
+A project board can hold pull-request cards as well as issue cards, but the
+model's board projections (`buildProjectItem`, `ProbeProjectBoard`) resolve a
+card's content as an issue. A PR card would therefore read back as nothing —
+silently omitted from every board fetch, with no error.
+
+`SeedProjectItem` rejects `isPR: true` rather than accepting it and dropping the
+card later. A scenario that needs the engine's PR-card handling (which
+`itemMayNeedWork` skips) cannot be written on this layer.
+
 ### `ownerType` — **Simplified**
 
 `FetchProjectBoard` accepts `ownerType` and echoes it back but does not use it.

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -67,6 +67,28 @@ refusal rather than a false success. What is *not* verified against a recorded
 response is GitHub's exact status code and message in this corner; only the
 shape (refuse, do not fabricate) is modelled.
 
+**A PR retargeted after the gate cleared it is refused, not merged.** `MergePR`
+self-gates on the derived `mergeable_state` before touching git (see
+[`mergeable_state`](#mergeable_state) below), and that gate necessarily drops
+both locks: it takes `mu`, then `gitMu`, in turn, because the package's
+lock-ordering rule forbids holding one across the other. A concurrent
+`UpdatePRBase` can therefore land between the state the gate cleared and the
+merge that follows, retargeting the PR at a base whose required contexts and
+mergeability were never evaluated — the gate's whole purpose defeated silently.
+`MergePR` snapshots head and base before the gate, re-reads them after, and
+refuses with `gh.ErrNotMergeable` if they moved.
+
+**Divergence:** GitHub has no such window — its merge endpoint re-checks
+server-side, atomically, so a retarget is either fully before or fully after the
+merge and never produces a refusal of this kind. The sim's compare-and-swap is
+an approximation chosen because it needs neither lock held across the gate, and
+so keeps the lock-ordering invariant that makes the two-tier design deadlock
+free everywhere else. **Risk:** low. It is conservative (a refusal a scenario
+retries, never a merge onto an unvetted base), and the window it guards can only
+be opened by a scenario's *own* concurrent writer. An ABA retarget — away and
+back again within the window — is not detected, since the snapshot compares
+values rather than a version counter.
+
 ### Commits behind — **Modelled**
 
 `FetchCommitsBehind(base, head)` is `git rev-list --count <head>..<base>` —
@@ -580,6 +602,21 @@ seeded" refusal and never reach git.
 **Not a licence to seed concurrently.** This makes `SeedRepo` safe; it does not
 make the rest of the builder chain a concurrent API. Seed on one goroutine.
 
+### `SeedBranch` creates, it does not repoint — **Modelled**
+
+`SeedBranch` refuses a branch that already exists, matching GitHub's create-ref
+endpoint (422 *"Reference already exists"*). The refusal matters more here than
+the API parity: the `update-ref` underneath would happily move the branch, so
+`SeedBranch` after a `SeedCommit` on the same branch discarded the seeded
+commits and still reported success — a scenario author would only notice by
+wondering where their commits went. Growing an existing branch is `SeedCommit`'s
+job, and `commitFiles` already forks-or-appends deliberately.
+
+**Absent:** there is no seeding equivalent of a force-push — no way to move an
+existing branch to a different tip. Nothing in the engine's surface needs one;
+add it as an explicit, differently-named call rather than by relaxing this
+refusal.
+
 ### Repo directory sandboxing — **Modelled**
 
 `owner` and `repo` are validated as single path-safe names, because `repoDir`
@@ -660,6 +697,24 @@ construction: label applied-at, comment `CreatedAt`, `FetchProjectUpdatedAt`, an
 `RateLimitStats`. `time.Now` is never called outside the default clock. A test
 can therefore drive the engine's time-anchored gates without wall-clock waiting.
 
+### One mutation, one clock read — **Modelled**
+
+A mutation that stamps several fields reads the clock **once** and writes that
+one value everywhere: a status move stamps the card and its project alike, a
+label application stamps applied-at and the issue's updated-at alike, a comment
+stamps its created-at and its parent alike, and a merge stamps the PR and every
+issue it auto-closes alike. GitHub reports each of these as one event, and the
+engine reads exactly these pairs against each other — `FetchProjectUpdatedAt`
+gates whether a poll looks at the board at all, and `FetchLabelAppliedAt` is the
+timing anchor for the review gate, the CI settle scan, and the Done-archive
+scan.
+
+This is easy to regress and hard to see: under a fixed clock every ordering
+produces equal timestamps, so a per-field clock read looks correct in every test
+that uses `fakeClock`. It is *not* correct under the default `realClock`, which
+advances between reads. `TestOneMutationStampsOneTimestamp` therefore runs on a
+deliberately advancing clock.
+
 ### Ordering and timestamps of concurrent writes — **Simplified**
 
 Two writes made in the same clock instant are indistinguishable by timestamp.
@@ -704,7 +759,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 64 mutations, and
+   package cannot back up. The sweep currently catches all 69 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -304,6 +304,19 @@ reviews do not participate.
 **Simplified:** code-owner requirements, review dismissal on push, and stale-review
 invalidation are **absent**. `DISMISSED` is not a state the model produces.
 
+**A zero approval requirement is refused, not modelled.** `SeedRequiredApprovals`
+rejects a non-positive count. With zero, the approvals-satisfied branch is
+reached vacuously and a PR with no reviews at all reports `APPROVED` — not a
+reading real GitHub produces. The state that call would seem to express, "no
+review requirement", is already representable and is the *absence* of the call:
+an unseeded branch returns `""`, which is the case the engine's fallback above
+depends on. Refusing keeps the two from collapsing into one silently.
+
+GitHub's `required_approving_review_count` does accept `0` alongside "require a
+pull request before merging", and what `reviewDecision` reports in that
+configuration is **not verified here** — which is the second reason to refuse
+rather than guess a semantic for it.
+
 ### Review requests and self-submitting bots — **Modelled**
 
 `FetchPRReviewRequests` returns only reviewers actually requested. The model
@@ -625,6 +638,15 @@ either alone, because a scenario would conclude the card exists.
 A scenario that needs the engine's PR-card handling (which `itemMayNeedWork`
 skips) cannot be written on this layer.
 
+**A card must point at an issue that exists.** The same reasoning applies to the
+card's target, not just its kind: `buildProjectItem` resolves content through the
+repo's issues and returns nil when it finds nothing, so a card seeded for a
+mistyped or not-yet-seeded number was recorded and then omitted from every board
+read, with no error. `SeedProjectItem` now requires the repo to be seeded and the
+issue to exist, matching what `AddProjectV2ItemById` already enforced on the
+runtime path and what `SeedBlockedBy`/`AddBlockedByIssue` enforce for dependency
+targets. Seed the issue before the card.
+
 ### Dependency links — **Modelled, with existence enforced**
 
 `AddBlockedByIssue` and `SeedBlockedBy` both require the blocker to resolve to a
@@ -829,7 +851,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 71 mutations, and
+   package cannot back up. The sweep currently catches all 74 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -275,6 +275,30 @@ linkage, as production ignores it.
 Matching on a stored back-reference instead would be laxer than production, and
 would let a test pass on linkage GitHub would never find.
 
+When more than one PR shares the head branch, the **most recently created** one
+wins. Production's query is `pulls?head=owner:branch&state=all&per_page=1`, and
+that endpoint defaults to created-descending, so GitHub returns the newest. This
+is not a hypothetical: Fabrik reuses `fabrik/issue-<N>`, so a PR closed without
+merging leaves a stale record on the branch its successor reuses, and
+`engine/prcreate.go` decides whether to open a PR on exactly this answer. The
+board projection (`findPRByHeadLocked`) applies the same rule, so the two reads
+can never report different linked PRs for one issue.
+
+### Issue and PR numbers share one sequence — **Modelled**
+
+GitHub allocates issue and pull-request numbers from a single per-repo counter,
+so `#7` is either an issue or a PR and never both. The model uses one shared
+sequence, and seeding an explicit number that the other kind already holds is a
+seeding error.
+
+This is load-bearing rather than cosmetic. GitHub's issue-comment endpoint is
+itself shared between issues and PRs — which is why `AddComment` resolves a
+number against both collections — so two independent sequences would let issue
+`#1` and PR `#1` coexist and silently route a PR comment onto the same-numbered
+issue. The engine posts stage output that way (`engine/pr.go`,
+`engine/comments.go`), so the output would vanish from the PR while a test still
+observed "a comment was posted" and passed.
+
 ### `FetchLinkedPR` omits `mergeable_state` — **Modelled, deliberately**
 
 `FetchLinkedPR` returns `MergeableState: ""` and no mergeable flag, because
@@ -403,7 +427,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 34 mutations.
+   package cannot back up. The sweep currently catches all 38 mutations.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real
 GitHub* — only that the model does what this document says. For anything subtle

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -400,6 +400,49 @@ state is resolved on every read, so closing it unblocks the dependent issue.
 **Absent:** being blocked *by a PR*, and GitHub's permission rules for creating
 a dependency across repos.
 
+### Check run IDs — **Modelled, unique across the sim**
+
+GitHub's check run IDs are unique and monotonically increasing, and production
+depends on the ordering: `latestCheckRunsByName` (`github/checkruns.go`) reduces
+same-named runs to the one with the highest ID, treating it as the most recent
+rerun, and keeps whichever it saw first on a tie. The sim therefore reserves an
+explicitly seeded ID against later auto-assignment — the same rule
+`reserveNumber` applies to the shared issue-and-PR sequence — and refuses a
+duplicate outright. Without the reservation, seeding one run as `ID: 5000` (the
+auto-assign counter's starting value) and the next with `ID: 0` produced two
+runs sharing an ID, and a "check failed, then the rerun passed" scenario would
+be classified off the *failed* run with nothing to indicate why.
+
+**Simplified:** IDs are assigned from a single counter per `Sim` rather than
+globally across a GitHub instance, and nothing ties them to creation time.
+
+### Seeding is single-threaded, except `SeedRepo` — **Modelled**
+
+The `Seed*` builder chain is designed to be driven by one goroutine during
+setup, and most of it is safe only because `Sim.mu` guards each individual call.
+`SeedRepo` is the exception that needed real work: it is the one seeding call
+that runs git *before* publishing its state, so a check-then-publish under `mu`
+alone let concurrent callers for one key both clear the check, race inside
+`initBare` against a single directory with no `gitMu` yet in existence, and then
+clobber each other's `repoState` — replacing a live `gitMu` while earlier
+callers still held the old one, which silently voids the per-repo git
+serialisation everything else depends on. It now takes its own creation lock for
+the whole sequence, so concurrent callers for one key get a clean "already
+seeded" refusal and never reach git.
+
+**Not a licence to seed concurrently.** This makes `SeedRepo` safe; it does not
+make the rest of the builder chain a concurrent API. Seed on one goroutine.
+
+### Repo directory sandboxing — **Modelled**
+
+`owner` and `repo` are validated as single path-safe names, because `repoDir`
+joins them straight into a directory under `baseDir`. Without that check,
+`SeedRepo("../evil/pwned")` split into owner `../evil` and created the bare repo
+as a *sibling* of the `t.TempDir()` this package promises to keep everything
+inside — outside the sandbox and outside the test framework's cleanup. Real
+GitHub owner and repo names cannot contain a separator either, so nothing valid
+is rejected.
+
 ### `ownerType` — **Simplified**
 
 `FetchProjectBoard` accepts `ownerType` and echoes it back but does not use it.
@@ -489,7 +532,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 45 mutations, and
+   package cannot back up. The sweep currently catches all 50 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -907,7 +907,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 84 mutations, and
+   package cannot back up. The sweep currently catches all 86 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -317,6 +317,24 @@ pull request before merging", and what `reviewDecision` reports in that
 configuration is **not verified here** — which is the second reason to refuse
 rather than guess a semantic for it.
 
+### `FetchPRReviews` returns the latest review per author — **Modelled**
+
+Not the raw submission history. `github.Client.FetchPRReviews` reads a REST
+endpoint that returns every submission and reduces it to one entry per author,
+so its result matches GraphQL's `latestReviews`; the engine's review-gate call
+sites consume it assuming that reduction already happened. The model reproduces
+the rule exactly, including its one exception: a `COMMENTED` follow-up never
+supersedes an author's existing formal verdict (`APPROVED`,
+`CHANGES_REQUESTED`, `DISMISSED`), because GitHub treats a comment as
+informational rather than a state transition. Only an author's *first*
+submission being `COMMENTED` makes it their entry.
+
+The board projection's `LinkedPRReviews` applies the same reduction, since
+production sources that field from `latestReviews`, which is one-per-author by
+definition. Two reads of one model must not report two verdicts — and
+`FetchPRReviewDecision` has always reduced correctly, so a raw list here would
+have put the package in contradiction with itself.
+
 ### Review requests and self-submitting bots — **Modelled**
 
 `FetchPRReviewRequests` returns only reviewers actually requested. The model
@@ -599,6 +617,11 @@ would report a stale column, or return an archived card on a board fetch, in
 precisely the situation this package exists to make trustworthy — and would
 contradict both the "never cached" guarantee at the top of `board.go` and R1.
 
+`ProbeProjectBoard` does the same, and it matters more there: the probe is what
+the engine's idle poll consults to decide whether anything changed, so a stale
+column is a poll that does not notice work it should, and an archived card left
+in the probe output is work the poll invents.
+
 ### Archived cards: board reads hide them, a direct ID read does not — **Simplified, unverified**
 
 The two are deliberately asymmetric, and the asymmetry follows production's two
@@ -661,6 +684,18 @@ state is resolved on every read, so closing it unblocks the dependent issue.
 **Absent:** being blocked *by a PR*, and GitHub's permission rules for creating
 a dependency across repos.
 
+### Dependency cycles — **Self-block refused, longer cycles absent**
+
+`AddBlockedByIssue` and `SeedBlockedBy` both refuse an issue blocked by itself,
+as GitHub does: a self-block is unsatisfiable by construction, so the engine's
+dependency gate would hold the issue forever with nothing to diagnose.
+
+**Absent:** longer cycles (A blocks B blocks A) are *not* detected — that needs a
+graph traversal the model does not perform, and GitHub does reject them.
+**Risk:** low. A scenario that builds a cycle gets a permanently blocked pair
+rather than a refusal, which is visible as a stuck scenario rather than a green
+one; but do not use this layer to test cycle *rejection*.
+
 ### Check run IDs — **Modelled, unique across the sim**
 
 GitHub's check run IDs are unique and monotonically increasing, and production
@@ -676,6 +711,19 @@ be classified off the *failed* run with nothing to indicate why.
 
 **Simplified:** IDs are assigned from a single counter per `Sim` rather than
 globally across a GitHub instance, and nothing ties them to creation time.
+
+### Seeded PRs and issues must be shapes GitHub can produce — **Modelled**
+
+`SeedPR` refuses a merged draft, and a PR that is merged *and* open (a merged PR
+is always closed; `Merged` with the state unspecified resolves to closed).
+`SeedIssue` and `SeedPR` both refuse a negative explicit number — `reserveNumber`
+is a no-op below `nextNumber`, so one would otherwise be accepted silently and
+embedded in node IDs and every projection.
+
+The point is not tidiness: a scenario built on a state production can never
+deliver exercises engine logic against an input it will never see, and passes.
+That is the "confidently green for the wrong reason" failure this whole document
+exists to prevent, arriving through the seed API rather than through the model.
 
 ### Seeding is single-threaded, except `SeedRepo` — **Modelled**
 
@@ -718,6 +766,14 @@ as a *sibling* of the `t.TempDir()` this package promises to keep everything
 inside — outside the sandbox and outside the test framework's cleanup. Real
 GitHub owner and repo names cannot contain a separator either, so nothing valid
 is rejected.
+
+Owner and repo are also kept as **separate path segments** rather than joined
+with a separator. Joining is not collision-free — `acme-widgets/foo` and
+`acme/widgets-foo` flatten to the same name — and since the already-seeded check
+is keyed on the full `owner/repo` string, both would be accepted and would
+produce two `repoState` values, each with its own `gitMu`, over one physical
+repository. That silently voids the per-repo git serialisation the whole locking
+design rests on, and lets commits from one logical repo land in the other.
 
 The same rule is enforced on the other door into the sandbox: the keys of a
 `SeedCommit` files map, which `commitFiles` joins onto the throwaway worktree
@@ -851,7 +907,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 74 mutations, and
+   package cannot back up. The sweep currently catches all 84 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -1,0 +1,411 @@
+# simgh fidelity contract
+
+This document is a deliverable, not a footnote. `simgh` is a fake, and the
+failure mode a fake introduces is not a red test — it is a **green** one: a
+scenario that passes because the model is wrong in the same direction the code
+is wrong, or because the model never produces the state that would have exposed
+the bug.
+
+So every place `simgh` knowingly departs from real GitHub is recorded here,
+with what the divergence costs. If you are about to rely on a sim-backed test
+to cover a subtle behaviour, check this file first. If you change the model,
+update this file in the same commit.
+
+Each entry is labelled:
+
+- **Modelled** — reproduced faithfully enough to test against.
+- **Simplified** — present, but coarser than GitHub. The listed risk is real.
+- **Absent** — not modelled at all. A test cannot cover it here.
+
+---
+
+## Git-derived answers
+
+### Mergeability — **Modelled**
+
+`FetchPRMergeable` / `FetchPRMergeableFields` run a real `git merge` of the head
+branch into the base branch, in a throwaway detached worktree, and report the
+result. There is no way for a test to declare that a PR conflicts; it must
+construct commits that genuinely do.
+
+The same `tryMerge` helper serves both the read-only probe and `MergePR`, so the
+two cannot disagree — a model that could report a PR mergeable and then fail to
+merge it would be worse than useless.
+
+**Risk:** low. The main residual gap is that GitHub's merge is computed
+server-side against its own snapshot of both refs, whereas the sim recomputes on
+every read. In the sim a probe is always current; on GitHub it can be stale.
+That is covered separately by the recompute window below.
+
+### Merge commits — **Modelled**
+
+`MergePR` writes a real two-parent merge commit onto the base ref, with `--no-ff`
+so the merge commit exists even when the head is a strict descendant of the
+base. That matches GitHub's default *Create a merge commit* strategy.
+
+**Simplified:** squash and rebase merge strategies are **absent**. `MergePR`
+takes no strategy argument (production's does not either), so every merge is a
+merge commit. A scenario that depends on squash-merge history shape cannot be
+written here.
+
+### Commits behind — **Modelled**
+
+`FetchCommitsBehind(base, head)` is `git rev-list --count <head>..<base>` —
+commits on the base that the head lacks. This matches production, which reads
+`behind_by` from the REST compare endpoint (`compare/base...head`,
+`github/prs.go`).
+
+### Head SHAs — **Modelled**
+
+A PR's head SHA is resolved from the backing repo on every read, never frozen at
+PR creation. Seeding a new commit on the head branch changes it immediately, the
+way a push does. This matters because check runs are keyed by SHA: a stale head
+SHA would silently read the wrong CI results.
+
+---
+
+## `mergeable_state`
+
+### The six derived values — **Modelled, with a stated precedence**
+
+`FetchPRMergeableState` derives `clean`, `unstable`, `blocked`, `behind`,
+`dirty`, and `draft` from the whole model, in this order:
+
+1. `unknown` — the PR is merged or closed, or a recompute window is pending
+2. `draft` — the PR is a draft
+3. `dirty` — the trial merge genuinely conflicts
+4. `behind` — the base requires up-to-date heads *and* has advanced
+5. `blocked` — a required context is missing, pending, or failing
+6. `unstable` — a non-required context is pending or failing
+7. `clean` — none of the above
+
+All six matter because the engine branches hard on them:
+`github.MergeableStateAccepted` admits only `{clean, unstable}`, and
+`github.ErrNotMergeableCI` fires specifically on `blocked`/`unknown` and must
+**not** be routed into the `fabrik:rebase-needed` path. A model that could only
+say dirty-or-clean would make four values unreachable and ADR-072's merge-safety
+incident unreproducible here.
+
+**Simplified:** this precedence is the sim's own deliberate choice, **not** a
+reverse-engineering of GitHub's internal algorithm for every combination of
+conditions. A draft PR that also conflicts resolves to `draft`, not `dirty`. If
+a scenario depends on a specific combination, verify the real behaviour against
+a recorded GitHub response rather than trusting the sim's ordering.
+
+**Risk:** medium, and concentrated in untested combinations. Single-condition
+cases are each covered by a test; combinations are not.
+
+### `has_hooks` and `unknown`-from-slowness — **Absent**
+
+`has_hooks` is never produced. Production treats it as not-accepted
+(conservatively falling through to per-check classification), and no scenario
+needs to distinguish it from `blocked`. `unknown` is produced only for
+merged/closed PRs and during a seeded recompute window — never spontaneously,
+the way GitHub emits it while it is simply slow.
+
+### `behind` requires branch protection — **Modelled, deliberately**
+
+This is the model's most consequential judgement call, so it is called out
+explicitly.
+
+Real GitHub reports `behind` **only** where branch protection's *"Require
+branches to be up to date before merging"* is enabled. Without that setting, a
+conflict-free but out-of-date PR is `clean`. `simgh` mirrors this: `behind`
+requires `SeedRequireUpToDate(repo, branch, true)`.
+
+A model that reported `behind` whenever `commitsBehind > 0` would be simpler,
+but would make `clean` nearly unreachable for any scenario where the base
+branch moves, and would push the engine into the rebase path constantly — a
+confidently-wrong test bed for exactly the logic most likely to have bugs.
+
+### `mergeable: null` — the recompute window — **Modelled, seeded**
+
+Production's `FetchPRMergeable` returns `*bool`, and GitHub returns `null` while
+it is still recomputing mergeability — typically shortly after a push or PR
+creation. `MergePR` returns `ErrNotMergeable` on a null read, and that window is
+what once made a healthy issue (#1087) appear wedged.
+
+`simgh` makes the window reachable rather than merely documented:
+`PRSeed.MergeableRecomputeReads` (or `SeedMergeableRecomputePending`) opens it
+for a given number of reads. While open, `mergeable` reports nil and
+`mergeableState` reports `unknown` — together, as GitHub reports them. Each read
+drains one; afterwards the real git-derived answer surfaces.
+
+**Simplified:** the window is a **read counter, not a timer**, and it opens only
+when seeded. The sim never opens one spontaneously after a commit is pushed to a
+head branch, which is when GitHub actually does. A scenario that pushes and then
+immediately reads will see a resolved answer here and might not on GitHub.
+
+---
+
+## Check runs and commit statuses
+
+### Two separate collections — **Modelled**
+
+Check runs (`FetchCheckRuns`) and classic commit statuses (`FetchCombinedStatus`)
+are genuinely distinct SHA-keyed collections. Production distinguishes them: a
+required context can be posted through the classic Statuses API rather than as
+an Actions check run, and `FetchCombinedStatus` is Fabrik's only visibility into
+that case (ADR-933). Both feed the `mergeable_state` derivation.
+
+### Required contexts — **Simplified**
+
+Branch protection's required-check configuration is modelled as a per-branch
+list of context names (`SeedRequiredContexts`). Real branch protection is richer:
+required checks can be scoped to an app ID, wildcards and rulesets exist, and
+the configuration is readable only with elevated permissions (which is why
+Fabrik has its own `RequiredStatusContexts` config in the first place).
+
+**Risk:** low for the engine's purposes — it only ever asks "is this context
+required", which the list answers.
+
+### Verdict mapping — **Simplified**
+
+A check run's `neutral` and `skipped` conclusions are treated as success,
+matching GitHub's treatment of them as non-blocking. A context reported more
+than once for a SHA takes its worst verdict. A non-required context that is
+merely *pending* yields `unstable`, not `clean`.
+
+---
+
+## Reviews
+
+### `reviewDecision` under branch protection — **Simplified**
+
+`FetchPRReviewDecision` returns `""` unless the base branch has a seeded
+approval requirement (`SeedRequiredApprovals`). This is the important part:
+GraphQL's `reviewDecision` is **null** unless branch protection actually
+requires reviews, which is exactly why the engine's authoritative review gate
+(ADR-1250) prefers `reviewDecision` where it exists and falls back to its own
+no-`CHANGES_REQUESTED` computation otherwise. A model that always returned a
+decision would hide that fallback entirely.
+
+With a requirement configured, the decision is computed from each reviewer's
+**latest** `APPROVED`/`CHANGES_REQUESTED` review; `COMMENTED` and dismissed
+reviews do not participate.
+
+**Simplified:** code-owner requirements, review dismissal on push, and stale-review
+invalidation are **absent**. `DISMISSED` is not a state the model produces.
+
+### Review requests and self-submitting bots — **Modelled**
+
+`FetchPRReviewRequests` returns only reviewers actually requested. The model
+never synthesises an entry for a self-submitting bot (Pruefer, Gemini,
+CodeRabbit, Copilot), because real GitHub never lists them either — they are
+never formally requested. That absence is load-bearing: it is the whole reason
+stages must declare `expected_reviewers` (ADR-1283).
+
+Bot classification reuses production's own `github.IsBotLogin`, rather than
+reimplementing the heuristic.
+
+---
+
+## Auto-merge and merge queue
+
+### Native auto-merge — **Simplified (flag only)**
+
+`EnablePullRequestAutoMerge` / `DisablePullRequestAutoMerge` set and clear a
+flag, surfaced as `PRDetails.AutoMergeEnabled`. Enabling it is refused when the
+repo's `AllowAutoMerge` is false, as GitHub refuses it.
+
+**The sim never acts on the flag.** It does not watch checks and merge the PR
+when they go green. A scenario that enables auto-merge and then turns CI green
+will find the PR still open; it must call `MergePR` to make the merge happen.
+
+**Risk:** medium. Any engine behaviour that depends on GitHub completing an
+auto-merge asynchronously cannot be tested here.
+
+### Merge queue — **Simplified (bookkeeping only)**
+
+`EnqueuePullRequest` / `DequeuePullRequest` record queue membership and assign a
+position, and `EnqueuePullRequest` rejects a stale `expectedHeadOID` (as GitHub
+does, which is how a race with a concurrent push is caught).
+
+**The queue never advances.** It does not run checks, never reorders itself,
+never merges anything, and dequeuing does not renumber the PRs behind it.
+`MergeQueueEntry.State` is always `QUEUED`; `AWAITING_CHECKS`, `MERGEABLE`, and
+`UNMERGEABLE` are never produced.
+
+**Risk:** high for any merge-queue scenario. Treat merge-queue coverage here as
+absent.
+
+---
+
+## Rate limits and transport
+
+### Rate limiting — **Absent**
+
+`RateLimitStats` reports static budgets that never deplete. No method ever fails
+with a rate-limit or secondary-rate-limit error, and there is no retry-after
+behaviour. The engine's backoff and rate-limit-exhaustion paths
+(`engine/backoff.go`, `engine/terminal.go`) **cannot** be exercised through this
+layer.
+
+Timestamps (`Reset`, `UpdatedAt`) still come from the injected clock, so a test
+controlling time sees coherent values.
+
+Fault injection generally — including rate-limit error kinds — is deferred to
+the follow-on instrumentation layer (#1457).
+
+### HTTP / GraphQL / REST wire behaviour — **Absent**
+
+`simgh` sits at the `engine.GitHubClient` Go interface, not on the wire. Query
+documents, mutation names, JSON field mappings, pagination, and status-code
+handling are all invisible to it. This is a permanent, structural blind spot,
+not a gap to be filled later — see [`../README.md`](../README.md).
+
+### Webhooks — **Absent**
+
+There is no webhook subsystem. `DeleteForwardingHooks` always succeeds for a
+seeded repo because there is never anything to delete; a test cannot use it to
+prove hooks were cleaned up. `boardcache`'s webhook delta functions are not
+driven by this layer.
+
+---
+
+## Issues, PRs, and the board
+
+### PR-to-issue linkage — **Modelled**
+
+`FindPRForIssue` and `FetchLinkedPR` match on the head branch `fabrik/issue-<N>`,
+which is exactly how production discovers the link (a `pulls?head=owner:branch`
+query). The `issueNumber` argument to `CreateDraftPR` is accepted and ignored for
+linkage, as production ignores it.
+
+Matching on a stored back-reference instead would be laxer than production, and
+would let a test pass on linkage GitHub would never find.
+
+### `FetchLinkedPR` omits `mergeable_state` — **Modelled, deliberately**
+
+`FetchLinkedPR` returns `MergeableState: ""` and no mergeable flag, because
+production reaches it through the pulls *list* endpoint, which omits the field.
+Returning a computed value would let a test pass on a signal production never
+receives.
+
+**Simplified:** the list endpoint's `merged` field is also unreliable on real
+GitHub — it reports `merged: false` for several seconds after a merge, which is
+why `FetchPRMerged` exists as a separate single-PR call. The sim reports `merged`
+truthfully from `FetchLinkedPR`. A regression that depends on that lag would not
+be caught here.
+
+### Closing keywords — **Simplified**
+
+`FetchPRClosingIssues` scans the PR body with a regex covering
+`close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved` followed by
+`#N`, plus the issue number passed to `CreateDraftPR`. Cross-repo references
+(`owner/repo#N`) and full issue URLs are **not** matched, and GitHub's full
+closing-keyword grammar is not reproduced.
+
+### Merge auto-close — **Modelled**
+
+Merging a PR closes the issues it references with a closing keyword, but **only**
+when the merge lands on the repo's default branch — mirroring GitHub, and
+mirroring why Fabrik must close issues itself on a non-default base (ADR-1096).
+
+### Issue state casing — **Modelled**
+
+The model stores GraphQL's uppercase enum (`OPEN`/`CLOSED`) and `FetchIssue`
+converts to REST's lowercase (`open`/`closed`), matching the shapes production
+reads from each API.
+
+### Project identity — **Modelled**
+
+Projects are keyed by `(owner, number)`, because Projects v2 is owner-scoped, not
+repo-scoped. The `repo` argument on a board fetch is a query input, not part of
+the project's identity.
+
+### `ownerType` — **Simplified**
+
+`FetchProjectBoard` accepts `ownerType` and echoes it back but does not use it.
+Production uses it to choose between the `organization` and `user` GraphQL
+roots, and falls back from one to the other when it is empty. The sim resolves
+the project by owner regardless, so that fallback path is not exercised.
+
+### Node IDs — **Simplified**
+
+Node IDs are readable synthesised strings (`issue:owner/repo#42`,
+`project:acme:2`) rather than opaque base64 blobs. Production never parses a node
+ID it receives — it only round-trips them — so this is an implementation
+convenience with no behavioural consequence. Do not write a test that depends on
+the format.
+
+### Label vocabulary — **Simplified**
+
+`SeedLabels` records which labels exist in the repo, but `AddLabelToIssue` does
+**not** enforce the vocabulary: applying a label that was never created
+succeeds. Real GitHub creates the label implicitly in some paths and errors in
+others. The engine's own `ensureLabel` behaviour is therefore not exercised.
+
+### Label applied-at — **Modelled**
+
+`FetchLabelAppliedAt` returns the instant the label was applied, from the
+injected clock. Re-applying an already-present label does **not** refresh it,
+matching GitHub (which emits no new `labeled` event for a label already there).
+This is load-bearing: the review-gate timeout and bot re-prompt ladder
+(`engine/reviews.go`), the CI settle scan (`engine/ci_settle.go`), and the
+Done-archive scan (`engine/archive_done_settle.go`) all anchor deadlines on it.
+
+An absent label returns the zero time rather than an error, mirroring
+production's "no such event found".
+
+---
+
+## Time
+
+### Clock — **Modelled**
+
+Every time-bearing value the model produces reads from the `Clock` injected at
+construction: label applied-at, comment `CreatedAt`, `FetchProjectUpdatedAt`, and
+`RateLimitStats`. `time.Now` is never called outside the default clock. A test
+can therefore drive the engine's time-anchored gates without wall-clock waiting.
+
+### Ordering and timestamps of concurrent writes — **Simplified**
+
+Two writes made in the same clock instant are indistinguishable by timestamp.
+The model preserves insertion order for comments and board items, but a scenario
+that depends on distinguishable timestamps must advance the clock between
+writes.
+
+---
+
+## Concurrency
+
+### Model state — **Modelled**
+
+All in-memory state is guarded by a single mutex; the package is `-race` clean
+under concurrent access from multiple goroutines, which is what the engine's
+worker dispatch produces.
+
+### Git — **Modelled**
+
+Git subprocess calls are serialised per repository. This is genuinely necessary,
+not defensive: `MergePR` performs a read-modify-write on the base ref (check it
+out, merge onto it, move the ref), so two interleaved merges onto one base both
+fork from the same tip and the first is silently lost — with every call still
+returning nil. `TestConcurrentMergesOntoOneBase` pins this.
+
+Read-only trial merges are independently safe, since each runs in its own
+throwaway worktree and moves no ref.
+
+**Simplified:** serialisation is per repository, so cross-repo operations run
+concurrently. That matches the isolation real repositories have.
+
+---
+
+## Verifying this document
+
+Two mechanisms keep it from drifting into fiction:
+
+1. **The interface assertion.** `var _ engine.GitHubClient = (*Sim)(nil)` breaks
+   the build the moment `engine.GitHubClient` grows a method. A new method must
+   get a real implementation and, if it diverges, an entry here.
+
+2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
+   each modelled behaviour in turn and asserts the suite goes red. A behaviour
+   claimed as **Modelled** above that survives its mutation is a claim this
+   package cannot back up. The sweep currently catches all 34 mutations.
+
+Neither mechanism can tell you whether a **Modelled** entry matches *real
+GitHub* — only that the model does what this document says. For anything subtle
+and load-bearing, prefer deriving the behaviour from a recorded real response
+over reasoning about it.

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -363,6 +363,22 @@ projections; it is left open here because it is a behavioural change to the
 model rather than a documentation one, and belongs with the harness work that
 first depends on the distinction (#1457).
 
+### Comment edits bump the issue, not the PR — **Simplified**
+
+`UpdateComment` bumps the parent issue's `updatedAt`, as GitHub does when a
+comment is edited. This is not incidental: the engine rewrites an existing stage
+comment rather than posting a new one (`engine/comments.go`,
+`engine/dependencies.go`), so an unbumped timestamp would hide a real edit from
+any read that watches `updatedAt` to decide something changed.
+
+Editing a comment that belongs to a **PR** bumps nothing — `prRecord` has no
+`updatedAt`, and `ProjectItem.UpdatedAt` is derived from the issue. Adding a
+*reaction* deliberately bumps nothing either, matching GitHub, which does not
+treat a reaction as an update to the parent.
+
+**Risk:** low. The lax direction only — a PR-comment edit is invisible to
+timestamp-watching reads that would have seen it on real GitHub.
+
 ### Assignees — **Modelled**
 
 Stored per issue and surfaced on `ProjectItem.Assignees`. Settable from both
@@ -663,7 +679,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 59 mutations, and
+   package cannot back up. The sweep currently catches all 61 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -237,7 +237,7 @@ never merges anything, and dequeuing does not renumber the PRs behind it.
 `EnqueuePullRequest` resolves the head SHA under `gitMu`, releases it, then takes
 `mu` to record membership — so a concurrent push landing between the two would
 let the enqueue proceed against a head that no longer matches. GitHub performs
-that compare-and-swap server-side and cannot.
+that compare-and-swap server-side, atomically; the sim cannot.
 
 This is deliberate rather than overlooked. Closing it would mean holding `gitMu`
 and `mu` simultaneously, which the package's locking invariant forbids outright
@@ -248,11 +248,18 @@ the merge itself: its trial merge and its real merge run the same `tryMerge`
 helper, so if the tree changed underneath it the merge fails and the model
 reports the conflict rather than recording a merge that did not happen.
 
-**Risk:** low — a scenario would have to push to a PR's head branch from one
-goroutine while enqueuing it from another.
+Two risk ratings apply here, at different scopes — the narrower one sits inside
+the broader one, so they do not compete:
 
-**Risk:** high for any merge-queue scenario. Treat merge-queue coverage here as
-absent.
+**Risk — merge-queue coverage generally: high.** The queue is bookkeeping only,
+so treat merge-queue coverage here as **absent**. Any scenario whose outcome
+depends on the queue advancing, reordering itself, or merging anything cannot be
+written against this model, and a green sim-backed test says nothing about it.
+
+**Risk — the `expectedHeadOID` race specifically: low.** This is a strictly
+narrower window *within* that already-absent surface, so it adds little on top:
+to hit it, a scenario would have to push to a PR's head branch from one goroutine
+while enqueuing it from another.
 
 ---
 

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -623,7 +623,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 58 mutations, and
+   package cannot back up. The sweep currently catches all 57 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -89,6 +89,39 @@ be opened by a scenario's *own* concurrent writer. An ABA retarget — away and
 back again within the window — is not detected, since the snapshot compares
 values rather than a version counter.
 
+**What the compare-and-swap does *not* cover: the branches' contents.** It
+compares which head and base the PR points at, not what they contain. A
+`SeedCommit` onto either branch, or a check run seeded against the new head SHA,
+lands inside the same window and is not caught — so the `mergeable_state` the
+gate cleared can be stale by the time the merge runs, even though the refs
+themselves never moved.
+
+Two consequences, and they differ in direction:
+
+- **The merge itself is safe.** The trial merge and the real merge run the same
+  `tryMerge` helper against the tree as it is at merge time, so a conflicting
+  commit landing in the window produces a reported conflict, never a merge that
+  silently did the wrong thing.
+- **The CI half of the gate is not re-validated, and here the sim is *laxer*
+  than reality.** A required check going red in the window leaves the sim
+  merging on the `clean`/`unstable` verdict the gate computed a moment earlier.
+  Real GitHub re-enforces branch protection server-side at merge time and would
+  refuse.
+
+**This mirrors production's own exposure, and deliberately stops short of
+fixing it.** `github.Client.MergePR` (`github/prs.go:1114`) reads `mergeable`,
+then `FetchPRMergeableFields`, then `PUT .../merge` with only a `merge_method`
+— GitHub's merge endpoint accepts an optional `sha` for exactly this
+compare-and-swap and production does not send one. So the engine's gate verdict
+is equally stale against real GitHub; what saves it there is GitHub's own
+server-side re-check, which the sim has no equivalent of. Making the sim stricter
+would model a guarantee production does not actually have.
+
+**Risk:** low, and bounded by construction — the window only exists for a
+scenario that mutates a repo concurrently with its own `MergePR` call. A
+scenario that wants to exercise "a required check went red mid-merge" cannot do
+it here; that needs the server-side re-check the sim does not model.
+
 ### Commits behind — **Modelled**
 
 `FetchCommitsBehind(base, head)` is `git rev-list --count <head>..<base>` —
@@ -320,10 +353,13 @@ This is deliberate rather than overlooked. Closing it would mean holding `gitMu`
 and `mu` simultaneously, which the package's locking invariant forbids outright
 (see `sim.go`); that invariant is what makes the two-tier design deadlock-free
 everywhere else, and it is not worth trading for a window only a scenario's own
-concurrent seeding can open. Note that `MergePR` does **not** have this gap for
-the merge itself: its trial merge and its real merge run the same `tryMerge`
-helper, so if the tree changed underneath it the merge fails and the model
-reports the conflict rather than recording a merge that did not happen.
+concurrent seeding can open. `MergePR` does **not** have this gap for the merge
+itself: its trial merge and its real merge run the same `tryMerge` helper, so if
+the tree changed underneath it the merge fails and the model reports the
+conflict rather than recording a merge that did not happen. It *does* share the
+gap for its gate's CI verdict, which is a separate matter — see "A PR retargeted
+after the gate cleared it" under [Merge commits](#merge-commits) for what that
+covers and what it leaves open.
 
 Two risk ratings apply here, at different scopes — the narrower one sits inside
 the broader one, so they do not compete:

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -438,7 +438,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 38 mutations.
+   package cannot back up. The sweep currently catches all 41 mutations.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real
 GitHub* — only that the model does what this document says. For anything subtle

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -169,9 +169,45 @@ required", which the list answers.
 ### Verdict mapping — **Simplified**
 
 A check run's `neutral` and `skipped` conclusions are treated as success,
-matching GitHub's treatment of them as non-blocking. A context reported more
-than once for a SHA takes its worst verdict. A non-required context that is
-merely *pending* yields `unstable`, not `clean`.
+matching GitHub's treatment of them as non-blocking. A non-required context that
+is merely *pending* yields `unstable`, not `clean`.
+
+### Repeated contexts reduce latest-wins, not worst-of — **Modelled**
+
+A context reported more than once for a SHA is reduced to **one** verdict before
+the derivation looks at it, and the rule is *latest wins within each collection*:
+
+- **Check runs** reduce by **highest ID**, matching production's
+  `latestCheckRunsByName` (`github/checkruns.go`) and real branch protection,
+  which clears a required check once its newest run passes. IDs are the
+  ordering, not seed order — a scenario may seed a rerun before the run it
+  supersedes.
+- **Commit statuses** reduce to the **last one posted** for a context, because
+  the classic Statuses API supersedes rather than accumulates.
+
+This was originally worst-of, and that was wrong rather than merely
+conservative: it classified a `check failed → rerun passed` flow off the failed
+run, reporting a PR permanently `blocked` that GitHub calls `clean`. It also
+defeated the check-run ID reservation machinery in `seed.go`, which exists
+precisely so that flow is representable, and contradicted production's own
+classifier — the two doc comments disagreed about how GitHub behaves.
+
+**Risk: low.** The rule now matches production's classifier and the endpoint
+semantics it was derived from.
+
+### A context in *both* collections keeps the worse verdict — **Simplified**
+
+Worst-of survives in exactly one place: a name reported both as a check run and
+as a classic commit status. Real GitHub matches required contexts by name across
+both spaces, and what it does when the two disagree has **not** been verified
+against a recorded response here — the model takes the worse verdict as a
+conservative choice of its own.
+
+**Risk: low, but unverified.** Confirm against a recorded real response before
+building a scenario that depends on it;
+`TestMergeableStateCrossCollectionKeepsWorstVerdict` is the test to change if it
+turns out otherwise. Simplest avoidance: do not seed one context name into both
+collections at one SHA.
 
 ---
 
@@ -343,6 +379,20 @@ GitHub — it reports `merged: false` for several seconds after a merge, which i
 why `FetchPRMerged` exists as a separate single-PR call. The sim reports `merged`
 truthfully from `FetchLinkedPR`. A regression that depends on that lag would not
 be caught here.
+
+### `FetchPRDetails` reports `mergeable_state`; `FetchLinkedPR` does not — **Modelled**
+
+`FetchPRDetails` reads the *single-PR* endpoint, which does return
+`mergeable_state`, so it reports the same derivation `FetchPRMergeableState`
+does — recompute window included: a read here drains one, because on real GitHub
+this is exactly the read that would.
+
+It leaves `HeadRefName`, `BaseRef`, `Author`, and `Labels` zero, because
+production's implementation does not parse them from that endpoint. `FetchLinkedPR`
+is *not* consistent with that stance — it populates those fields even though the
+list endpoint omits them. That inconsistency is known and deliberately left for
+the harness follow-on (#1457), which may need them; nothing in the engine reads
+them off a `FetchLinkedPR` result today.
 
 ### Closing keywords — **Simplified**
 
@@ -573,7 +623,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 53 mutations, and
+   package cannot back up. The sweep currently catches all 58 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -122,6 +122,34 @@ scenario that mutates a repo concurrently with its own `MergePR` call. A
 scenario that wants to exercise "a required check went red mid-merge" cannot do
 it here; that needs the server-side re-check the sim does not model.
 
+### Trial merges leave unreachable objects — **Simplified**
+
+A read-only mergeability probe runs a real `git merge --no-ff` and then discards
+the result by not moving any ref, so the merge commit it wrote stays in the
+object store with nothing pointing at it. Nothing here runs `git gc`, and
+mergeability is recomputed on every read, so a long multi-poll scenario
+accumulates orphaned objects for the life of the test process.
+
+**Risk:** low, and it is disk and inode cost rather than a wrong answer — the
+objects are unreachable, so no read can observe them. The backing repos live
+under `t.TempDir()` and vanish with the test. Worth revisiting only if a
+scenario in #1449 grows long enough for it to matter.
+
+### A PR whose head branch is gone errors — **Simplified**
+
+`gitFacts` fails outright when a PR's head branch no longer exists in the
+backing repo, so `FetchPRMergeableFields`, `FetchPRMergeableState`,
+`FetchPRDetails`, and `MergePR` all return an error rather than resolving to a
+determinate `mergeable_state`.
+
+**Unverified:** what real GitHub reports for a PR whose head ref was deleted is
+not captured here — plausibly `unknown`, plausibly the PR is closed first. The
+model errors rather than guessing a state, which is loud rather than silently
+wrong, but it means a scenario cannot exercise the deleted-head-branch path at
+all. Note the deliberate asymmetry: `headSHA` itself treats a missing branch as
+a legitimate state (empty string, no error) — it is `gitFacts` that decides
+mergeability cannot be computed without one.
+
 ### Commits behind — **Modelled**
 
 `FetchCommitsBehind(base, head)` is `git rev-list --count <head>..<base>` —
@@ -303,6 +331,15 @@ reviews do not participate.
 
 **Simplified:** code-owner requirements, review dismissal on push, and stale-review
 invalidation are **absent**. `DISMISSED` is not a state the model produces.
+
+**The decision shares one reduction with `FetchPRReviews`.** Both roll up
+through `latestReviewsByAuthor`, so a `DISMISSED` submission supersedes that
+author's earlier verdict in the decision exactly as it does in the review list.
+Filtering the raw history down to `APPROVED`/`CHANGES_REQUESTED` *before*
+collapsing would skip a dismissal instead, leaving a dismissed approval counted
+— and `reviewGateAuthorityVerdict` trusts an `APPROVED` decision outright, so a
+scenario that dismisses an approval and expects the landing gate to hold would
+watch it clear.
 
 **A zero approval requirement is refused, not modelled.** `SeedRequiredApprovals`
 rejects a non-positive count. With zero, the approvals-satisfied branch is
@@ -714,8 +751,18 @@ globally across a GitHub instance, and nothing ties them to creation time.
 
 ### Seeded PRs and issues must be shapes GitHub can produce — **Modelled**
 
-`SeedPR` refuses a merged draft, and a PR that is merged *and* open (a merged PR
-is always closed; `Merged` with the state unspecified resolves to closed).
+`SeedPR` refuses a merged draft, a PR that is merged *and* open (a merged PR is
+always closed; `Merged` with the state unspecified resolves to closed), and a PR
+whose head is its base — GitHub answers the last with "No commits between …",
+and the shape is degenerate here too, collapsing the trial merge to the
+nothing-to-merge path. `createPR` refuses head-equals-base on the runtime path
+for the same reason.
+
+Both also check the state string against GitHub's own enum (`OPEN`/`CLOSED` for
+issues, `open`/`closed` for PRs) rather than merely for emptiness: every
+downstream read compares it exactly, so `"closed"` on an issue would be stored
+verbatim and then never match, silently leaving it classified open.
+
 `SeedIssue` and `SeedPR` both refuse a negative explicit number — `reserveNumber`
 is a no-op below `nextNumber`, so one would otherwise be accepted silently and
 embedded in node IDs and every projection.
@@ -822,6 +869,15 @@ the format.
 succeeds. Real GitHub creates the label implicitly in some paths and errors in
 others. The engine's own `ensureLabel` behaviour is therefore not exercised.
 
+### Removing an absent label errors — **Modelled**
+
+`RemoveLabelFromIssue` returns a wrapped `gh.ErrNotFound` when the label was not
+applied, because GitHub answers the DELETE with a 404 and production propagates
+it. Roughly a dozen engine call sites branch on `errors.Is(err, gh.ErrNotFound)`
+from this exact call; returning nil would make every one of them unreachable in
+a sim-backed test. That the engine *tolerates* the error is not a reason to hide
+it — tolerating it is the behaviour under test.
+
 ### Label applied-at — **Modelled**
 
 `FetchLabelAppliedAt` returns the instant the label was applied, from the
@@ -907,7 +963,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 86 mutations, and
+   package cannot back up. The sweep currently catches all 94 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -48,6 +48,25 @@ takes no strategy argument (production's does not either), so every merge is a
 merge commit. A scenario that depends on squash-merge history shape cannot be
 written here.
 
+**A merge that would write no commit is refused, not recorded.** `git merge
+--no-ff` prints *"Already up to date."* and exits **zero** when the head is
+already contained in the base, leaving the tip untouched — the state a second
+merge of the same branch reaches. `tryMerge` compares the result against the
+pre-merge base tip and refuses on the commit path (surfaced through `MergePR`
+as `gh.ErrNotMergeable`), because publishing an unchanged ref would flip
+`merged = true` having written no merge commit at all, silently contradicting
+the guarantee stated above.
+
+The read-only probe is deliberately **not** affected: nothing-to-merge is
+genuinely not a conflict, so `FetchPRMergeable` still reports true. GitHub
+behaves the same way — it reports no conflict, and its merge endpoint declines
+to manufacture an empty merge commit rather than calling the PR unmergeable.
+
+**Risk:** low, and it is the conservative direction — a scenario gets a loud
+refusal rather than a false success. What is *not* verified against a recorded
+response is GitHub's exact status code and message in this corner; only the
+shape (refuse, do not fabricate) is modelled.
+
 ### Commits behind — **Modelled**
 
 `FetchCommitsBehind(base, head)` is `git rev-list --count <head>..<base>` —
@@ -363,21 +382,19 @@ projections; it is left open here because it is a behavioural change to the
 model rather than a documentation one, and belongs with the harness work that
 first depends on the distinction (#1457).
 
-### Comment edits bump the issue, not the PR — **Simplified**
+### Comment edits bump the parent's updatedAt — **Modelled**
 
-`UpdateComment` bumps the parent issue's `updatedAt`, as GitHub does when a
-comment is edited. This is not incidental: the engine rewrites an existing stage
-comment rather than posting a new one (`engine/comments.go`,
-`engine/dependencies.go`), so an unbumped timestamp would hide a real edit from
-any read that watches `updatedAt` to decide something changed.
+`UpdateComment` bumps the parent's `updatedAt`, as GitHub does when a comment is
+edited — the issue's for an issue comment, the PR's for a PR or review-thread
+comment. This is not incidental: the engine rewrites an existing stage comment
+rather than posting a new one (`engine/comments.go`, `engine/dependencies.go`),
+so an unbumped timestamp would hide a real edit from any read that watches
+`updatedAt` to decide something changed. The PR side is observable too —
+`buildProjectItem` folds a linked PR's `updatedAt` into the board item's, and
+`ProbeProjectBoard` surfaces it as `LinkedPRUpdatedAt`.
 
-Editing a comment that belongs to a **PR** bumps nothing — `prRecord` has no
-`updatedAt`, and `ProjectItem.UpdatedAt` is derived from the issue. Adding a
-*reaction* deliberately bumps nothing either, matching GitHub, which does not
+Adding a *reaction* deliberately bumps nothing, matching GitHub, which does not
 treat a reaction as an update to the parent.
-
-**Risk:** low. The lax direction only — a PR-comment edit is invisible to
-timestamp-watching reads that would have seen it on real GitHub.
 
 ### Assignees — **Modelled**
 
@@ -585,7 +602,15 @@ root, and absolute paths are refused rather than silently relocated by
 refuses the whole commit and leaves the branch tip untouched rather than writing
 the map's other files first.
 
-**Risk (both checks): low.** Seed data is authored by test writers, not
+Throwaway worktrees are the third door, and are handled by placement rather
+than validation: `withWorktree` creates them under `baseDir`, not the OS temp
+dir. Its deferred cleanup removes them on every ordinary path, but a process
+killed mid-merge (OOM, SIGKILL, a CI timeout) never runs deferred code, and an
+orphan under the OS temp dir would outlive both this sandbox and
+`t.TempDir()`'s cleanup. Keeping it inside `baseDir` makes the test framework
+the backstop.
+
+**Risk (all three): low.** Seed data is authored by test writers, not
 attacker-controlled input, so this is a sandbox-hygiene guarantee — everything
 this package creates stays inside the `baseDir` you gave it — rather than a
 security boundary. Do not treat `simgh` as safe against hostile input.
@@ -679,7 +704,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 61 mutations, and
+   package cannot back up. The sweep currently catches all 64 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -133,7 +133,7 @@ accumulates orphaned objects for the life of the test process.
 **Risk:** low, and it is disk and inode cost rather than a wrong answer — the
 objects are unreachable, so no read can observe them. The backing repos live
 under `t.TempDir()` and vanish with the test. Worth revisiting only if a
-scenario in #1449 grows long enough for it to matter.
+scenario in #1449 grows long enough for it to matter; tracked in #1498.
 
 ### A PR whose head branch is gone errors — **Simplified**
 
@@ -249,6 +249,20 @@ immediately reads will see a resolved answer here and might not on GitHub.
 
 ## Check runs and commit statuses
 
+
+**Each read drains one unit, including the two single-field accessors.**
+`FetchPRMergeable` and `FetchPRMergeableState` are independent calls into
+`FetchPRMergeableFields`, so a caller that wants both — which is the natural
+thing to want, and what `FetchPRDetails` sanctions for itself — burns two units
+rather than one, and can see the flag and the state resolve at different points.
+Real GitHub reports both from a single response, so they resolve together.
+
+**Risk:** low but real for a scenario that seeds a *short* window (1–2 reads) and
+then reads both fields; the window drains faster than the scenario intends. The
+sim does not share a drain between them because doing so would require the two
+accessors to know they are part of one logical read, which the interface does not
+express. Prefer `FetchPRMergeableFields` when a scenario needs both, exactly as
+production's single-PR endpoint does. See #1498.
 ### Two separate collections — **Modelled**
 
 Check runs (`FetchCheckRuns`) and classic commit statuses (`FetchCombinedStatus`)
@@ -314,6 +328,17 @@ collections at one SHA.
 ---
 
 ## Reviews
+
+### `ResolveReviewThread` marks only the first comment on a thread — **Simplified**
+
+A thread is modelled as comments sharing a `reviewThreadID`, and resolving it
+flips `threadResolved` on the first match rather than on every comment in the
+thread. Board projections surface unresolved thread comments individually, so a
+thread with more than one comment reads as partially unresolved after being
+resolved. **Risk:** low — the engine's progress detection reads the resolved
+*count*, and no scenario in the downstream chain seeds multi-comment threads —
+but a scenario that does would see the wrong shape. See #1498.
+
 
 ### `reviewDecision` under branch protection — **Simplified**
 
@@ -757,6 +782,21 @@ be classified off the *failed* run with nothing to indicate why.
 **Simplified:** IDs are assigned from a single counter per `Sim` rather than
 globally across a GitHub instance, and nothing ties them to creation time.
 
+### `SeedPR{Merged: true}` sets the flag without merging — **Simplified**
+
+A directly-seeded merged PR sets the `merged` bookkeeping flag only. It does
+**not** write a merge commit onto the base branch, and it does **not** run the
+closing-keyword auto-close loop `MergePR` performs, so linked issues stay open
+and the base branch's git history shows no merge.
+
+That is a different world from one reached by calling `MergePR`, and the
+divergence is silent: a scenario that seeds a pre-merged PR and then asserts on
+git history or a linked issue's closed state gets a confidently wrong answer.
+**Risk:** medium — it is the one seeding shape whose *consequences* are not
+modelled rather than merely coarse. Seed the pre-merge state and call `MergePR`
+when a scenario depends on either consequence; use `Merged: true` only as an
+inert "this PR is already done" marker. Tracked in #1498.
+
 ### Seeded PRs and issues must be shapes GitHub can produce — **Modelled**
 
 `SeedPR` refuses a merged draft, a PR that is merged *and* open (a merged PR is
@@ -971,7 +1011,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 96 mutations, and
+   package cannot back up. The sweep currently catches all 103 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -539,6 +539,40 @@ derived from a recorded real response — GitHub's `addProjectV2ItemById` agains
 an already-archived item has not been captured here. A scenario that turns on
 whether re-adding un-archives should verify the real response first.
 
+### Board projections read card state live — **Modelled**
+
+A board read snapshots its cards under one lock acquisition and builds each
+projection under later ones, so the snapshot is a set of *identities*, not a set
+of *values*. `buildProjectItem` re-reads the card's own Status, kind, and
+updated-at from the model at projection time, and drops a card that has been
+archived or removed since the snapshot. Projecting from the snapshot instead
+would report a stale column, or return an archived card on a board fetch, in
+precisely the situation this package exists to make trustworthy — and would
+contradict both the "never cached" guarantee at the top of `board.go` and R1.
+
+### Archived cards: board reads hide them, a direct ID read does not — **Simplified, unverified**
+
+The two are deliberately asymmetric, and the asymmetry follows production's two
+query shapes rather than an internal style rule:
+
+- `FetchProjectBoard`, `ProbeProjectBoard`, `FetchProjectItem`,
+  `LookupIssueProjectItem`, and `FetchProjectItemStatusBatch` all skip archived
+  cards.
+- `FetchProjectItemStatus` returns an archived card's last-known Status rather
+  than reporting it absent. Production issues this as a direct
+  `node(id:) { fieldValueByName }` query (`github/project.go:1299`), and an
+  archived `ProjectV2Item` is still a node with a field value, so answering is
+  the closer match.
+
+**Unverified, in both directions.** Neither behaviour is derived from a recorded
+real response. The batch side is the weaker claim of the two: production reads
+it as `items(first:100)` on the project (`github/project.go:1339`) with no
+archived filter, so real GitHub may well include archived items there — in which
+case the sim's skip is the divergence, not the single-item read. **Risk:** low
+for the single read (a scenario that has archived a card is not usually asking
+for its column), higher for the batch if a scenario ever depends on an archived
+card being *absent* from it. Capture a real response before relying on either.
+
 ### PR cards on a board — **Absent**
 
 A project board can hold pull-request cards as well as issue cards, but the
@@ -759,7 +793,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 69 mutations, and
+   package cannot back up. The sweep currently catches all 71 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -377,9 +377,28 @@ model's board projections (`buildProjectItem`, `ProbeProjectBoard`) resolve a
 card's content as an issue. A PR card would therefore read back as nothing —
 silently omitted from every board fetch, with no error.
 
-`SeedProjectItem` rejects `isPR: true` rather than accepting it and dropping the
-card later. A scenario that needs the engine's PR-card handling (which
-`itemMayNeedWork` skips) cannot be written on this layer.
+**Both** entry points refuse a PR card rather than accepting one and dropping it
+later: `SeedProjectItem` rejects `isPR: true`, and `AddProjectV2ItemById` rejects
+a `pr:` content node ID. The seeding and runtime APIs deliberately agree here —
+a loud failure on one path and a silent no-op on the other would be worse than
+either alone, because a scenario would conclude the card exists.
+
+A scenario that needs the engine's PR-card handling (which `itemMayNeedWork`
+skips) cannot be written on this layer.
+
+### Dependency links — **Modelled, with existence enforced**
+
+`AddBlockedByIssue` and `SeedBlockedBy` both require the blocker to resolve to a
+seeded issue in a seeded repo, and refuse otherwise. This is stricter than a
+fake strictly needs to be, and deliberately so: `resolveDependenciesLocked`
+reports any blocker it cannot resolve as `State: "OPEN"`, so a dangling blocker
+would leave the dependent issue reading as permanently blocked with no
+diagnostic anywhere — a wrong ID accepted silently, which is the bug class this
+layer exists to catch. Cross-repo blockers are supported; the blocker's live
+state is resolved on every read, so closing it unblocks the dependent issue.
+
+**Absent:** being blocked *by a PR*, and GitHub's permission rules for creating
+a dependency across repos.
 
 ### `ownerType` — **Simplified**
 
@@ -470,7 +489,8 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 42 mutations.
+   package cannot back up. The sweep currently catches all 45 mutations, and
+   fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real
 GitHub* — only that the model does what this document says. For anything subtle

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -370,6 +370,30 @@ Projects are keyed by `(owner, number)`, because Projects v2 is owner-scoped, no
 repo-scoped. The `repo` argument on a board fetch is a query input, not part of
 the project's identity.
 
+### Archiving and re-adding a card — **Modelled**
+
+`ArchiveProjectItem` sets a flag; archived cards are filtered out of every board
+read (`liveItemRefs`, `ProbeProjectBoard`, the status batch) while the
+underlying issue is untouched.
+
+Re-adding a card that is already on the board **revives** it: un-archived, with
+both the card's and the project's updated-at bumped. Both entry points route
+through one helper (`reviveCardLocked`), because they had drifted into doing
+complementary halves of it — seeding reset status and the timestamps but left
+the card archived, so moving an archived card to a new column left it invisible
+to every board read with no error; the runtime API cleared the flag but bumped
+neither timestamp, so a card reappearing did not advance
+`FetchProjectUpdatedAt`, which the engine's poll reads to notice the board
+changed. The two differ in exactly one respect, deliberately:
+`SeedProjectItem` moves the card to the named column, while
+`AddProjectV2ItemById` leaves status alone, since re-adding a card already on a
+board does not move it between columns.
+
+**Risk:** low, but note this is the sim's own choice rather than a behaviour
+derived from a recorded real response — GitHub's `addProjectV2ItemById` against
+an already-archived item has not been captured here. A scenario that turns on
+whether re-adding un-archives should verify the real response first.
+
 ### PR cards on a board — **Absent**
 
 A project board can hold pull-request cards as well as issue cards, but the
@@ -532,7 +556,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 50 mutations, and
+   package cannot back up. The sweep currently catches all 52 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -467,6 +467,23 @@ inside — outside the sandbox and outside the test framework's cleanup. Real
 GitHub owner and repo names cannot contain a separator either, so nothing valid
 is rejected.
 
+The same rule is enforced on the other door into the sandbox: the keys of a
+`SeedCommit` files map, which `commitFiles` joins onto the throwaway worktree
+path. A key like `../../outside.txt` wrote *above* the worktree, and did so
+without a trace — git only tracks what is inside the worktree, so the write
+never appeared in the commit and the seed reported success. Repository paths
+legitimately contain separators (`docs/USER_GUIDE.md`), so this is a different
+check from the owner/repo one: the *cleaned* path must stay at or below the repo
+root, and absolute paths are refused rather than silently relocated by
+`filepath.Join`'s cleaning. Validation runs before any git work, so a bad key
+refuses the whole commit and leaves the branch tip untouched rather than writing
+the map's other files first.
+
+**Risk (both checks): low.** Seed data is authored by test writers, not
+attacker-controlled input, so this is a sandbox-hygiene guarantee — everything
+this package creates stays inside the `baseDir` you gave it — rather than a
+security boundary. Do not treat `simgh` as safe against hostile input.
+
 ### `ownerType` — **Simplified**
 
 `FetchProjectBoard` accepts `ownerType` and echoes it back but does not use it.
@@ -556,7 +573,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 52 mutations, and
+   package cannot back up. The sweep currently catches all 53 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -333,6 +333,46 @@ driven by this layer.
 
 ## Issues, PRs, and the board
 
+### Shallow board reads return deep-phase fields — **Simplified**
+
+`FetchProjectBoard` returns fully-populated `ProjectItem`s. Production's board
+query is deliberately *shallow*: it fetches only what the engine needs to
+pre-filter, and leaves `Body`, `URL`, `Author`, `Assignees`, `BlockedBy`, and
+`Comments` empty until `FetchItemDetails` fills them in a second, deep phase
+(`github/project.go`, the `itemNode` doc comment; pinned by
+`github/fetch_board_test.go`). Labels *are* retained shallowly, for
+`cleanupClosedIssueLocks`. The sim populates everything in one pass, and
+`FetchItemDetails` is consequently closer to a refresh than a fill.
+
+**Risk: medium — the highest-rated entry in this document, and the one most
+likely to produce a confidently-green test.** The engine's admission logic
+(`itemMayNeedWork`, `selectDeepFetchCandidates`) runs against the *shallow*
+snapshot, so a scenario asserting that an item was admitted or skipped on the
+strength of its body or comments would be reading a signal the engine does not
+actually have at that point. The divergence is safe in the lax direction only:
+the sim never withholds a field production would have supplied, so nothing
+fails that would have passed.
+
+A test that needs a deep-phase field should call `FetchItemDetails` before
+asserting on it, even though the sim does not require it — that keeps the test
+correct if this path is later narrowed to match production, rather than
+silently vacuous. `TestAssigneesAreObservableFromBothPaths` does this.
+
+Closing the gap means splitting `buildProjectItem` into shallow and deep
+projections; it is left open here because it is a behavioural change to the
+model rather than a documentation one, and belongs with the harness work that
+first depends on the distinction (#1457).
+
+### Assignees — **Modelled**
+
+Stored per issue and surfaced on `ProjectItem.Assignees`. Settable from both
+paths: `IssueSeed.Assignees` and `CreateIssue`'s `assignees` argument, the
+latter matching production, which posts the field only when non-empty. This is
+load-bearing rather than decorative — `engine/spawn.go` assigns every spawned
+child issue to the configured user, so a child-spawn scenario asserts on a real
+value. Assignee *permissions* (GitHub silently drops an assignee who lacks
+repository access) are **absent**: the sim stores whatever it is given.
+
 ### PR-to-issue linkage — **Modelled**
 
 `FindPRForIssue` and `FetchLinkedPR` match on the head branch `fabrik/issue-<N>`,
@@ -623,7 +663,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 57 mutations, and
+   package cannot back up. The sweep currently catches all 59 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/FIDELITY.md
+++ b/tests/sim/simgh/FIDELITY.md
@@ -638,6 +638,14 @@ changed. The two differ in exactly one respect, deliberately:
 `AddProjectV2ItemById` leaves status alone, since re-adding a card already on a
 board does not move it between columns.
 
+**Re-adding a card that is already live is a true no-op** — neither timestamp
+moves. `FetchProjectUpdatedAt` gates whether the engine's idle poll looks at the
+board at all, so bumping here would be a wake signal real GitHub does not
+produce, and one a scenario cannot tell from a real change. The seeding path
+treats a *column move* as a change (it moves the card; the runtime API does
+not), so it bumps for that and not for a re-seed into the same column. Same
+convention as `AddLabelToIssue` and `AddReviewRequest`.
+
 **Risk:** low, but note this is the sim's own choice rather than a behaviour
 derived from a recorded real response — GitHub's `addProjectV2ItemById` against
 an already-archived item has not been captured here. A scenario that turns on
@@ -963,7 +971,7 @@ Two mechanisms keep it from drifting into fiction:
 2. **The non-vacuity sweep.** `bash tests/sim/simgh/nonvacuity.sh` neutralises
    each modelled behaviour in turn and asserts the suite goes red. A behaviour
    claimed as **Modelled** above that survives its mutation is a claim this
-   package cannot back up. The sweep currently catches all 94 mutations, and
+   package cannot back up. The sweep currently catches all 96 mutations, and
    fails on any mutation that never applied — an unrun mutation proves nothing.
 
 Neither mechanism can tell you whether a **Modelled** entry matches *real

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -415,9 +415,10 @@ func (s *Sim) UpdateProjectItemStatus(projectID, itemID, statusFieldID, statusOp
 		if optID != statusOptionID {
 			continue
 		}
+		now := s.now()
 		it.status = name
-		it.updatedAt = s.now()
-		p.updatedAt = s.now()
+		it.updatedAt = now
+		p.updatedAt = now
 		return nil
 	}
 	return fmt.Errorf("simgh: no status option %q in project %q", statusOptionID, projectID)
@@ -436,9 +437,10 @@ func (s *Sim) ArchiveProjectItem(projectID, itemID string) error {
 	if !ok {
 		return fmt.Errorf("simgh: project item %q not found in %q", itemID, projectID)
 	}
+	now := s.now()
 	it.archived = true
-	it.updatedAt = s.now()
-	p.updatedAt = s.now()
+	it.updatedAt = now
+	p.updatedAt = now
 	return nil
 }
 
@@ -554,16 +556,17 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 	}
 	// A card added by this mutation has no Status until one is set — GitHub
 	// leaves the field empty rather than defaulting to the first column.
+	now := s.now()
 	p.items[id] = &itemState{
 		itemID:    id,
 		ownerRepo: ownerRepo,
 		number:    number,
 		isPR:      false,
 		status:    "",
-		updatedAt: s.now(),
+		updatedAt: now,
 	}
 	p.itemOrder = append(p.itemOrder, id)
-	p.updatedAt = s.now()
+	p.updatedAt = now
 	return id, nil
 }
 

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -2,6 +2,7 @@ package simgh
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
@@ -279,31 +280,51 @@ func (s *Sim) FetchItemDetails(item *gh.ProjectItem) error {
 	}
 
 	s.mu.Lock()
-	var found itemRef
+	// Search projects in a stable order. s.projects is a map, so Go randomizes
+	// iteration; without this the search below could return a different card
+	// between two runs on identical state.
+	projectKeys := make([]string, 0, len(s.projects))
+	for k := range s.projects {
+		projectKeys = append(projectKeys, k)
+	}
+	sort.Strings(projectKeys)
+
+	search := func(pred func(*itemState) bool) (*projectState, itemRef) {
+		for _, k := range projectKeys {
+			p := s.projects[k]
+			for _, id := range p.itemOrder {
+				it, ok := p.items[id]
+				if !ok || !pred(it) {
+					continue
+				}
+				return p, itemRef{
+					itemID:    it.itemID,
+					ownerRepo: it.ownerRepo,
+					number:    it.number,
+					isPR:      it.isPR,
+					status:    it.status,
+					updatedAt: it.updatedAt,
+				}
+			}
+		}
+		return nil, itemRef{}
+	}
+
+	// The item ID identifies exactly one card: it embeds the project (see
+	// itemNodeID in model.go). A content node ID does not — the same issue can
+	// sit on two boards at once, which Fabrik explicitly supports (a private
+	// engine board alongside a public triage board). So when the caller has an
+	// item ID, it decides; matching either ID interchangeably would let the
+	// content ID pick the wrong board and backfill its Status.
 	var project *projectState
-	for _, p := range s.projects {
-		for _, id := range p.itemOrder {
-			it, ok := p.items[id]
-			if !ok {
-				continue
-			}
-			if it.contentNodeID() != item.ID && it.itemID != item.ItemID {
-				continue
-			}
-			project = p
-			found = itemRef{
-				itemID:    it.itemID,
-				ownerRepo: it.ownerRepo,
-				number:    it.number,
-				isPR:      it.isPR,
-				status:    it.status,
-				updatedAt: it.updatedAt,
-			}
-			break
-		}
-		if project != nil {
-			break
-		}
+	var found itemRef
+	if item.ItemID != "" {
+		project, found = search(func(it *itemState) bool { return it.itemID == item.ItemID })
+	}
+	if project == nil && item.ID != "" {
+		// Fall back to the content ID for the webhook case in the doc comment
+		// above, where the engine has a node ID and nothing else.
+		project, found = search(func(it *itemState) bool { return it.contentNodeID() == item.ID })
 	}
 	s.mu.Unlock()
 

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -160,12 +160,20 @@ func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, e
 	return item, nil
 }
 
-// findPRByHeadLocked returns the lowest-numbered PR with the given head
+// findPRByHeadLocked returns the most recently created PR with the given head
 // branch, or nil. Caller must hold mu.
+//
+// Newest-wins, not lowest-numbered: Fabrik reuses the branch fabrik/issue-<N>,
+// so a branch can carry a stale closed PR alongside the live one, and
+// production resolves that to the newest (see FetchLinkedPR). The board
+// projection must agree with FetchLinkedPR on which PR is "the" linked PR —
+// were they to disagree, two reads of the same model would report two different
+// PR numbers, a bug the sim itself would be introducing.
 func findPRByHeadLocked(r *repoState, head string) *prRecord {
-	for _, n := range sortedPRNumbers(r) {
-		if r.prs[n].head == head {
-			return r.prs[n]
+	nums := sortedPRNumbers(r)
+	for i := len(nums) - 1; i >= 0; i-- {
+		if r.prs[nums[i]].head == head {
+			return r.prs[nums[i]]
 		}
 	}
 	return nil

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -526,7 +526,9 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 
 	id := itemNodeID(p.owner, p.num, ownerRepo, number)
 	if existing, ok := p.items[id]; ok {
-		existing.archived = false
+		// Deliberately does not touch status: re-adding a card that is already
+		// on the board does not move it between columns.
+		s.reviveCardLocked(p, existing)
 		return existing.itemID, nil
 	}
 	// A card added by this mutation has no Status until one is set — GitHub
@@ -542,6 +544,27 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 	p.itemOrder = append(p.itemOrder, id)
 	p.updatedAt = s.now()
 	return id, nil
+}
+
+// reviveCardLocked brings an existing card back to a live, freshly-touched
+// state: un-archived, with both its own and the project's updated-at bumped.
+//
+// Both re-add paths funnel through here — SeedProjectItem via
+// placeOnProjectLocked, and AddProjectV2ItemById — because they had drifted
+// into doing complementary halves of the job. Seeding reset status and the
+// timestamps but left `archived` set, so moving an archived card to a new
+// column left it excluded from every board read with no error; the runtime API
+// cleared `archived` but bumped neither timestamp, so a card reappearing on the
+// board did not advance FetchProjectUpdatedAt and the engine's poll could miss
+// it. Keeping one helper is what stops the two APIs disagreeing again about
+// what re-adding a card means.
+//
+// Caller must hold mu.
+func (s *Sim) reviveCardLocked(p *projectState, existing *itemState) {
+	now := s.now()
+	existing.archived = false
+	existing.updatedAt = now
+	p.updatedAt = now
 }
 
 // parseContentNodeID splits an "issue:owner/repo#N" or "pr:owner/repo#N" ID.

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -80,7 +80,18 @@ func (p *projectState) liveItemRefs() []itemRef {
 
 // buildProjectItem assembles the full projection for one card, including its
 // linked PR's reviews, review requests, and unresolved review-thread comments.
-// Returns nil when the card's content no longer exists.
+// Returns nil when the card no longer belongs on the board — its content is
+// gone, or it has been archived or removed since the caller snapshotted it.
+//
+// The ref the caller passes identifies the card; it does not supply the card's
+// state. Every caller snapshots refs under one lock acquisition and then builds
+// projections under later ones, so a status move or an archive landing in
+// between would otherwise be projected from the stale snapshot — reporting an
+// old column, or putting an archived card back on a board fetch. That would
+// contradict both this file's "never cached" guarantee and R1's "a mutation is
+// observable by every subsequent read", in the one place a fake is least likely
+// to be caught doing it. So the card's own fields are re-read live here, under
+// the same lock the rest of the projection is built from.
 func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, error) {
 	owner, repoName, err := splitOwnerRepo(ref.ownerRepo)
 	if err != nil {
@@ -88,6 +99,13 @@ func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, e
 	}
 
 	s.mu.Lock()
+	live, ok := p.items[ref.itemID]
+	if !ok || live.archived {
+		s.mu.Unlock()
+		return nil, nil
+	}
+	status, isPR, cardUpdatedAt := live.status, live.isPR, live.updatedAt
+
 	r, ok := s.repos[ref.ownerRepo]
 	if !ok {
 		s.mu.Unlock()
@@ -105,12 +123,12 @@ func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, e
 		Number:    iss.number,
 		Title:     iss.title,
 		Body:      iss.body,
-		Status:    ref.status,
+		Status:    status,
 		URL:       fmt.Sprintf("https://github.com/%s/issues/%d", ref.ownerRepo, iss.number),
 		Repo:      ref.ownerRepo,
-		IsPR:      ref.isPR,
-		IsClosed:  iss.state == "CLOSED" && !ref.isPR,
-		UpdatedAt: laterOf(iss.updatedAt, ref.updatedAt),
+		IsPR:      isPR,
+		IsClosed:  iss.state == "CLOSED" && !isPR,
+		UpdatedAt: laterOf(iss.updatedAt, cardUpdatedAt),
 		Labels:    cloneStrings(iss.labels),
 		Assignees: cloneStrings(iss.assignees),
 		Author:    iss.author,
@@ -444,7 +462,12 @@ func (s *Sim) ArchiveProjectItem(projectID, itemID string) error {
 	return nil
 }
 
-// FetchProjectItemStatus returns a single card's column.
+// FetchProjectItemStatus returns a single card's column, including an archived
+// card's — deliberately unlike the board-scoped reads, which all skip archived
+// cards. Production issues this as a direct node(id:) query, and an archived
+// ProjectV2Item is still a node with a field value. Neither side of that
+// asymmetry is verified against a recorded response; see FIDELITY.md,
+// "Archived cards: board reads hide them, a direct ID read does not".
 func (s *Sim) FetchProjectItemStatus(itemID string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -608,7 +608,16 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 	if existing, ok := p.items[id]; ok {
 		// Deliberately does not touch status: re-adding a card that is already
 		// on the board does not move it between columns.
-		s.reviveCardLocked(p, existing)
+		//
+		// And when the card is already live, this is a true no-op — so it must
+		// not bump either timestamp. FetchProjectUpdatedAt is what gates
+		// whether the engine's poll looks at the board at all, so a bump here
+		// is a wake signal real GitHub would not have produced, and one a
+		// scenario cannot distinguish from a real change. Same rule as
+		// AddLabelToIssue and AddReviewRequest.
+		if existing.archived {
+			s.reviveCardLocked(p, existing)
+		}
 		return existing.itemID, nil
 	}
 	// A card added by this mutation has no Status until one is set — GitHub
@@ -639,6 +648,11 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 // board did not advance FetchProjectUpdatedAt and the engine's poll could miss
 // it. Keeping one helper is what stops the two APIs disagreeing again about
 // what re-adding a card means.
+//
+// Call it only when the re-add actually changes something — an un-archive, or
+// a column move. Calling it on a card that was already live would bump
+// timestamps for a no-op, which is the separate convention AddLabelToIssue
+// documents.
 //
 // Caller must hold mu.
 func (s *Sim) reviveCardLocked(p *projectState, existing *itemState) {

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -241,65 +241,85 @@ func (s *Sim) ProbeProjectBoard(owner, repo string, projectNum int, ownerType st
 
 	out := make([]gh.BoardProbeItem, 0, len(refs))
 	for _, ref := range refs {
-		owner, repoName, err := splitOwnerRepo(ref.ownerRepo)
+		probe, err := s.buildProbeItem(p, ref)
 		if err != nil {
 			return nil, "", err
 		}
-
-		s.mu.Lock()
-		// Re-read the card live, for the same reason buildProjectItem does:
-		// the refs above were snapshotted under an earlier lock acquisition,
-		// so a status move or an archive landing in between would otherwise be
-		// invisible here — a stale column, or an archived card still in the
-		// probe output. The probe feeds the engine's idle poll, so a stale
-		// answer here is a poll that does not notice work it should.
-		live, ok := p.items[ref.itemID]
-		if !ok || live.archived {
-			s.mu.Unlock()
+		if probe == nil {
 			continue
 		}
-		r, ok := s.repos[ref.ownerRepo]
-		if !ok {
-			s.mu.Unlock()
-			return nil, "", fmt.Errorf("simgh: repo %s not seeded", ref.ownerRepo)
-		}
-		iss, ok := r.issues[ref.number]
-		if !ok {
-			s.mu.Unlock()
-			continue
-		}
-		probe := gh.BoardProbeItem{
-			ItemID:    ref.itemID,
-			ContentID: iss.nodeID(ref.ownerRepo),
-			Number:    iss.number,
-			IsPR:      live.isPR,
-			IsClosed:  iss.state == "CLOSED" && !live.isPR,
-			State:     iss.state,
-			Repo:      ref.ownerRepo,
-			Status:    live.status,
-		}
-		// effectiveUpdatedAt is max(content, project item, linked PR).
-		probe.EffectiveUpdatedAt = laterOf(iss.updatedAt, live.updatedAt)
-		linked := findPRByHeadLocked(r, issueBranch(iss.number))
-		var linkedHead string
-		if linked != nil {
-			linkedHead = linked.head
-			probe.LinkedPRNumber = linked.number
-			probe.LinkedPRUpdatedAt = linked.updatedAt
-			probe.EffectiveUpdatedAt = laterOf(probe.EffectiveUpdatedAt, linked.updatedAt)
-		}
-		s.mu.Unlock()
-
-		if linkedHead != "" {
-			sha, err := s.resolveRefSHA(owner, repoName, linkedHead)
-			if err != nil {
-				return nil, "", err
-			}
-			probe.LinkedPRHeadSHA = sha
-		}
-		out = append(out, probe)
+		out = append(out, *probe)
 	}
 	return out, projectID, nil
+}
+
+// buildProbeItem assembles the probe shape for one card. It is the scalar-only
+// sibling of buildProjectItem and takes the same contract: the ref identifies
+// the card, it does not supply the card's state. Returns nil when the card no
+// longer belongs on the board.
+//
+// Split out for the same reason buildProjectItem is a function: it is where the
+// live re-read happens, and keeping it callable with a deliberately stale ref is
+// what lets a test pin that the re-read actually occurs. Inside a single
+// ProbeProjectBoard call the snapshot and the re-read are indistinguishable.
+func (s *Sim) buildProbeItem(p *projectState, ref itemRef) (*gh.BoardProbeItem, error) {
+	owner, repoName, err := splitOwnerRepo(ref.ownerRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	// Re-read the card live, for the same reason buildProjectItem does: the ref
+	// was snapshotted under an earlier lock acquisition, so a status move or an
+	// archive landing in between would otherwise be invisible here — a stale
+	// column, or an archived card still in the probe output. The probe feeds
+	// the engine's idle poll, so a stale answer here is a poll that does not
+	// notice work it should.
+	live, ok := p.items[ref.itemID]
+	if !ok || live.archived {
+		s.mu.Unlock()
+		return nil, nil
+	}
+	r, ok := s.repos[ref.ownerRepo]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("simgh: repo %s not seeded", ref.ownerRepo)
+	}
+	iss, ok := r.issues[ref.number]
+	if !ok {
+		s.mu.Unlock()
+		return nil, nil
+	}
+	probe := gh.BoardProbeItem{
+		ItemID:    ref.itemID,
+		ContentID: iss.nodeID(ref.ownerRepo),
+		Number:    iss.number,
+		IsPR:      live.isPR,
+		IsClosed:  iss.state == "CLOSED" && !live.isPR,
+		State:     iss.state,
+		Repo:      ref.ownerRepo,
+		Status:    live.status,
+	}
+	// effectiveUpdatedAt is max(content, project item, linked PR).
+	probe.EffectiveUpdatedAt = laterOf(iss.updatedAt, live.updatedAt)
+	linked := findPRByHeadLocked(r, issueBranch(iss.number))
+	var linkedHead string
+	if linked != nil {
+		linkedHead = linked.head
+		probe.LinkedPRNumber = linked.number
+		probe.LinkedPRUpdatedAt = linked.updatedAt
+		probe.EffectiveUpdatedAt = laterOf(probe.EffectiveUpdatedAt, linked.updatedAt)
+	}
+	s.mu.Unlock()
+
+	if linkedHead != "" {
+		sha, err := s.resolveRefSHA(owner, repoName, linkedHead)
+		if err != nil {
+			return nil, err
+		}
+		probe.LinkedPRHeadSHA = sha
+	}
+	return &probe, nil
 }
 
 // FetchItemDetails backfills a partially-populated item in place, keyed by its

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -1,0 +1,553 @@
+package simgh
+
+import (
+	"fmt"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// Board projections are rebuilt from model state on every call and never
+// cached. That is what makes "a mutation is observable by every subsequent
+// read" a structural property of this package rather than something each test
+// has to re-assert.
+
+// FetchProjectBoard returns the whole board. ownerType is accepted and ignored:
+// production uses it only to pick between the organization and user GraphQL
+// roots, and the model keys projects by owner regardless of which kind it is.
+func (s *Sim) FetchProjectBoard(owner, repo string, projectNum int, ownerType string) (*gh.ProjectBoard, error) {
+	s.mu.Lock()
+	p, ok := s.projects[projectKey(owner, projectNum)]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("simgh: project %s not seeded", projectKey(owner, projectNum))
+	}
+	board := &gh.ProjectBoard{
+		ProjectID: p.id,
+		Title:     p.title,
+		OwnerType: ownerType,
+	}
+	if board.OwnerType == "" {
+		board.OwnerType = "organization"
+	}
+	refs := p.liveItemRefs()
+	s.mu.Unlock()
+
+	for _, ref := range refs {
+		item, err := s.buildProjectItem(p, ref)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			continue
+		}
+		board.Items = append(board.Items, *item)
+	}
+	return board, nil
+}
+
+// itemRef identifies a card without holding a pointer into model state.
+type itemRef struct {
+	itemID    string
+	ownerRepo string
+	number    int
+	isPR      bool
+	status    string
+	updatedAt time.Time
+}
+
+// liveItemRefs snapshots the board's non-archived cards in insertion order.
+// Caller must hold mu.
+func (p *projectState) liveItemRefs() []itemRef {
+	out := make([]itemRef, 0, len(p.itemOrder))
+	for _, id := range p.itemOrder {
+		it, ok := p.items[id]
+		if !ok || it.archived {
+			continue
+		}
+		out = append(out, itemRef{
+			itemID:    it.itemID,
+			ownerRepo: it.ownerRepo,
+			number:    it.number,
+			isPR:      it.isPR,
+			status:    it.status,
+			updatedAt: it.updatedAt,
+		})
+	}
+	return out
+}
+
+// buildProjectItem assembles the full projection for one card, including its
+// linked PR's reviews, review requests, and unresolved review-thread comments.
+// Returns nil when the card's content no longer exists.
+func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, error) {
+	owner, repoName, err := splitOwnerRepo(ref.ownerRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	r, ok := s.repos[ref.ownerRepo]
+	if !ok {
+		s.mu.Unlock()
+		return nil, fmt.Errorf("simgh: repo %s not seeded", ref.ownerRepo)
+	}
+	iss, ok := r.issues[ref.number]
+	if !ok {
+		s.mu.Unlock()
+		return nil, nil
+	}
+
+	item := &gh.ProjectItem{
+		ID:        iss.nodeID(ref.ownerRepo),
+		ItemID:    ref.itemID,
+		Number:    iss.number,
+		Title:     iss.title,
+		Body:      iss.body,
+		Status:    ref.status,
+		URL:       fmt.Sprintf("https://github.com/%s/issues/%d", ref.ownerRepo, iss.number),
+		Repo:      ref.ownerRepo,
+		IsPR:      ref.isPR,
+		IsClosed:  iss.state == "CLOSED" && !ref.isPR,
+		UpdatedAt: laterOf(iss.updatedAt, ref.updatedAt),
+		Labels:    cloneStrings(iss.labels),
+		Assignees: cloneStrings(iss.assignees),
+		Author:    iss.author,
+		BlockedBy: s.resolveDependenciesLocked(ref.ownerRepo, iss.blockedBy),
+	}
+	for _, c := range iss.comments {
+		item.Comments = append(item.Comments, c.toGH())
+	}
+
+	// The linked PR is found the same way production finds it: by head branch.
+	linked := findPRByHeadLocked(r, issueBranch(iss.number))
+	var linkedHead string
+	if linked != nil {
+		linkedHead = linked.head
+		item.LinkedPRNumber = linked.number
+		item.LinkedPRNumberShallow = linked.number
+		item.LinkedPRReviews = append([]gh.PRReview(nil), linked.reviews...)
+		item.LinkedPRReviewRequests = append([]gh.ReviewRequest(nil), linked.reviewRequests...)
+		item.LinkedPRResolvedThreadCount = linked.resolvedThreads
+		item.LinkedPRIsMergeQueueEnabled = r.mergeQueueEnabled
+		item.LinkedPRIsInMergeQueue = linked.inMergeQueue
+		if linked.queueEntry != nil {
+			entry := *linked.queueEntry
+			item.LinkedPRMergeQueueEntry = &entry
+		}
+		for _, c := range linked.comments {
+			item.Comments = append(item.Comments, c.toGH())
+		}
+		// Only unresolved threads surface: the engine treats these as
+		// outstanding feedback, and a resolved thread is exactly the signal
+		// that the feedback was addressed.
+		for _, c := range linked.reviewThreadComment {
+			if !c.threadResolved {
+				item.LinkedPRReviewThreadComments = append(item.LinkedPRReviewThreadComments, c.toGH())
+			}
+		}
+		item.UpdatedAt = laterOf(item.UpdatedAt, linked.updatedAt)
+	}
+	s.mu.Unlock()
+
+	if linkedHead != "" {
+		sha, err := s.resolveRefSHA(owner, repoName, linkedHead)
+		if err != nil {
+			return nil, err
+		}
+		item.LinkedPRHeadSHA = sha
+	}
+	return item, nil
+}
+
+// findPRByHeadLocked returns the lowest-numbered PR with the given head
+// branch, or nil. Caller must hold mu.
+func findPRByHeadLocked(r *repoState, head string) *prRecord {
+	for _, n := range sortedPRNumbers(r) {
+		if r.prs[n].head == head {
+			return r.prs[n]
+		}
+	}
+	return nil
+}
+
+// resolveDependenciesLocked fills in each blocker's live state, so closing a
+// blocker unblocks the dependent issue on the next read the way GitHub's
+// dependency graph does. Caller must hold mu.
+func (s *Sim) resolveDependenciesLocked(ownerRepo string, deps []gh.Dependency) []gh.Dependency {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := make([]gh.Dependency, 0, len(deps))
+	for _, d := range deps {
+		blockerRepo := d.Repo
+		if blockerRepo == "" {
+			blockerRepo = ownerRepo
+		}
+		resolved := d
+		resolved.State = "OPEN"
+		if r, ok := s.repos[blockerRepo]; ok {
+			if iss, ok := r.issues[d.Number]; ok {
+				resolved.State = iss.state
+			}
+		}
+		out = append(out, resolved)
+	}
+	return out
+}
+
+// ProbeProjectBoard returns the scalar-only per-item shape the idle poll uses,
+// plus the project's node ID.
+func (s *Sim) ProbeProjectBoard(owner, repo string, projectNum int, ownerType string) ([]gh.BoardProbeItem, string, error) {
+	s.mu.Lock()
+	p, ok := s.projects[projectKey(owner, projectNum)]
+	if !ok {
+		s.mu.Unlock()
+		return nil, "", fmt.Errorf("simgh: project %s not seeded", projectKey(owner, projectNum))
+	}
+	projectID := p.id
+	refs := p.liveItemRefs()
+	s.mu.Unlock()
+
+	out := make([]gh.BoardProbeItem, 0, len(refs))
+	for _, ref := range refs {
+		owner, repoName, err := splitOwnerRepo(ref.ownerRepo)
+		if err != nil {
+			return nil, "", err
+		}
+
+		s.mu.Lock()
+		r, ok := s.repos[ref.ownerRepo]
+		if !ok {
+			s.mu.Unlock()
+			return nil, "", fmt.Errorf("simgh: repo %s not seeded", ref.ownerRepo)
+		}
+		iss, ok := r.issues[ref.number]
+		if !ok {
+			s.mu.Unlock()
+			continue
+		}
+		probe := gh.BoardProbeItem{
+			ItemID:    ref.itemID,
+			ContentID: iss.nodeID(ref.ownerRepo),
+			Number:    iss.number,
+			IsPR:      ref.isPR,
+			IsClosed:  iss.state == "CLOSED" && !ref.isPR,
+			State:     iss.state,
+			Repo:      ref.ownerRepo,
+			Status:    ref.status,
+		}
+		// effectiveUpdatedAt is max(content, project item, linked PR).
+		probe.EffectiveUpdatedAt = laterOf(iss.updatedAt, ref.updatedAt)
+		linked := findPRByHeadLocked(r, issueBranch(iss.number))
+		var linkedHead string
+		if linked != nil {
+			linkedHead = linked.head
+			probe.LinkedPRNumber = linked.number
+			probe.LinkedPRUpdatedAt = linked.updatedAt
+			probe.EffectiveUpdatedAt = laterOf(probe.EffectiveUpdatedAt, linked.updatedAt)
+		}
+		s.mu.Unlock()
+
+		if linkedHead != "" {
+			sha, err := s.resolveRefSHA(owner, repoName, linkedHead)
+			if err != nil {
+				return nil, "", err
+			}
+			probe.LinkedPRHeadSHA = sha
+		}
+		out = append(out, probe)
+	}
+	return out, projectID, nil
+}
+
+// FetchItemDetails backfills a partially-populated item in place, keyed by its
+// content node ID. The engine constructs a bare item from a
+// projects_v2_item.created webhook (node ID only) and calls this to fill in
+// the rest, so Number and Repo must be populated when they are zero-valued.
+func (s *Sim) FetchItemDetails(item *gh.ProjectItem) error {
+	if item == nil {
+		return fmt.Errorf("simgh: FetchItemDetails called with nil item")
+	}
+
+	s.mu.Lock()
+	var found itemRef
+	var project *projectState
+	for _, p := range s.projects {
+		for _, id := range p.itemOrder {
+			it, ok := p.items[id]
+			if !ok {
+				continue
+			}
+			if it.contentNodeID() != item.ID && it.itemID != item.ItemID {
+				continue
+			}
+			project = p
+			found = itemRef{
+				itemID:    it.itemID,
+				ownerRepo: it.ownerRepo,
+				number:    it.number,
+				isPR:      it.isPR,
+				status:    it.status,
+				updatedAt: it.updatedAt,
+			}
+			break
+		}
+		if project != nil {
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	if project == nil {
+		return fmt.Errorf("simgh: no project item found for %q", item.ID)
+	}
+
+	full, err := s.buildProjectItem(project, found)
+	if err != nil {
+		return err
+	}
+	if full == nil {
+		return fmt.Errorf("simgh: project item %q has no content", item.ID)
+	}
+	*item = *full
+	return nil
+}
+
+// FetchProjectItem returns the board card for an issue, searching every
+// seeded project. Returns nil when the issue is not on any board.
+func (s *Sim) FetchProjectItem(owner, repo string, issueNumber int) (*gh.ProjectItem, error) {
+	ownerRepo := repoKey(owner, repo)
+
+	s.mu.Lock()
+	var project *projectState
+	var ref itemRef
+	for _, key := range sortedKeys(s.projects) {
+		p := s.projects[key]
+		for _, id := range p.itemOrder {
+			it, ok := p.items[id]
+			if !ok || it.archived || it.ownerRepo != ownerRepo || it.number != issueNumber {
+				continue
+			}
+			project = p
+			ref = itemRef{it.itemID, it.ownerRepo, it.number, it.isPR, it.status, it.updatedAt}
+			break
+		}
+		if project != nil {
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	if project == nil {
+		return nil, nil
+	}
+	return s.buildProjectItem(project, ref)
+}
+
+// FetchStatusField returns the project's Status single-select field and its
+// options, in column order.
+func (s *Sim) FetchStatusField(projectID string) (*gh.StatusField, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return nil, err
+	}
+	opts := make(map[string]string, len(p.statusOptions))
+	for k, v := range p.statusOptions {
+		opts[k] = v
+	}
+	return &gh.StatusField{
+		FieldID:            p.statusFieldID,
+		Options:            opts,
+		OrderedOptionNames: cloneStrings(p.orderedStatusNames),
+	}, nil
+}
+
+// UpdateProjectItemStatus moves a card to a different column. The option ID
+// must belong to the project's Status field — passing a stale or foreign one
+// is an error here, as it is on GitHub.
+func (s *Sim) UpdateProjectItemStatus(projectID, itemID, statusFieldID, statusOptionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return err
+	}
+	if statusFieldID != p.statusFieldID {
+		return fmt.Errorf("simgh: status field %q does not belong to project %q", statusFieldID, projectID)
+	}
+	it, ok := p.items[itemID]
+	if !ok {
+		return fmt.Errorf("simgh: project item %q not found in %q", itemID, projectID)
+	}
+	for name, optID := range p.statusOptions {
+		if optID != statusOptionID {
+			continue
+		}
+		it.status = name
+		it.updatedAt = s.now()
+		p.updatedAt = s.now()
+		return nil
+	}
+	return fmt.Errorf("simgh: no status option %q in project %q", statusOptionID, projectID)
+}
+
+// ArchiveProjectItem archives a card. Archived cards disappear from board
+// fetches and probes but their underlying issue is untouched.
+func (s *Sim) ArchiveProjectItem(projectID, itemID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return err
+	}
+	it, ok := p.items[itemID]
+	if !ok {
+		return fmt.Errorf("simgh: project item %q not found in %q", itemID, projectID)
+	}
+	it.archived = true
+	it.updatedAt = s.now()
+	p.updatedAt = s.now()
+	return nil
+}
+
+// FetchProjectItemStatus returns a single card's column.
+func (s *Sim) FetchProjectItemStatus(itemID string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, key := range sortedKeys(s.projects) {
+		if it, ok := s.projects[key].items[itemID]; ok {
+			return it.status, nil
+		}
+	}
+	return "", fmt.Errorf("simgh: project item %q not found", itemID)
+}
+
+// FetchProjectItemStatusBatch returns every live card's column, keyed by item
+// ID.
+func (s *Sim) FetchProjectItemStatusBatch(projectID string) (map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(p.items))
+	for id, it := range p.items {
+		if it.archived {
+			continue
+		}
+		out[id] = it.status
+	}
+	return out, nil
+}
+
+// FetchProjectUpdatedAt returns when the project last changed, from the
+// injected clock rather than wall time.
+func (s *Sim) FetchProjectUpdatedAt(projectID string) (time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return p.updatedAt, nil
+}
+
+// LookupIssueProjectItem finds an issue's card in a specific project.
+// Returns empty strings with no error when the issue is not on the board —
+// "not on this board" is an ordinary answer, not a failure.
+func (s *Sim) LookupIssueProjectItem(projectID, repo string, issueNumber int) (string, string, error) {
+	if _, _, err := splitOwnerRepo(repo); err != nil {
+		return "", "", fmt.Errorf("simgh: LookupIssueProjectItem: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return "", "", err
+	}
+	for _, id := range p.itemOrder {
+		it, ok := p.items[id]
+		if !ok || it.archived || it.ownerRepo != repo || it.number != issueNumber {
+			continue
+		}
+		return it.itemID, it.status, nil
+	}
+	return "", "", nil
+}
+
+// AddProjectV2ItemById puts an existing issue or PR on a board and returns the
+// new card's ID. Adding one already present returns the existing ID, as the
+// GraphQL mutation does.
+func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, err := s.projectByIDLocked(projectID)
+	if err != nil {
+		return "", err
+	}
+
+	ownerRepo, number, err := parseContentNodeID(contentNodeID)
+	if err != nil {
+		return "", err
+	}
+	r, ok := s.repos[ownerRepo]
+	if !ok {
+		return "", fmt.Errorf("simgh: repo %s not seeded", ownerRepo)
+	}
+	isPR := false
+	if _, ok := r.issues[number]; !ok {
+		if _, ok := r.prs[number]; !ok {
+			return "", fmt.Errorf("simgh: no issue or PR %s#%d to add to project", ownerRepo, number)
+		}
+		isPR = true
+	}
+
+	id := itemNodeID(p.owner, p.num, ownerRepo, number)
+	if existing, ok := p.items[id]; ok {
+		existing.archived = false
+		return existing.itemID, nil
+	}
+	// A card added by this mutation has no Status until one is set — GitHub
+	// leaves the field empty rather than defaulting to the first column.
+	p.items[id] = &itemState{
+		itemID:    id,
+		ownerRepo: ownerRepo,
+		number:    number,
+		isPR:      isPR,
+		status:    "",
+		updatedAt: s.now(),
+	}
+	p.itemOrder = append(p.itemOrder, id)
+	p.updatedAt = s.now()
+	return id, nil
+}
+
+// parseContentNodeID splits an "issue:owner/repo#N" or "pr:owner/repo#N" ID.
+func parseContentNodeID(nodeID string) (ownerRepo string, number int, err error) {
+	if ownerRepo, number, err = parseIssueNodeID(nodeID); err == nil {
+		return ownerRepo, number, nil
+	}
+	return parsePRNodeID(nodeID)
+}
+
+// projectByIDLocked resolves a project node ID. Caller must hold mu.
+func (s *Sim) projectByIDLocked(projectID string) (*projectState, error) {
+	for _, key := range sortedKeys(s.projects) {
+		if s.projects[key].id == projectID {
+			return s.projects[key], nil
+		}
+	}
+	return nil, fmt.Errorf("simgh: project %q not found", projectID)
+}
+
+// laterOf returns the later of two times.
+func laterOf(a, b time.Time) time.Time {
+	if b.After(a) {
+		return b
+	}
+	return a
+}

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -487,9 +487,13 @@ func (s *Sim) LookupIssueProjectItem(projectID, repo string, issueNumber int) (s
 	return "", "", nil
 }
 
-// AddProjectV2ItemById puts an existing issue or PR on a board and returns the
-// new card's ID. Adding one already present returns the existing ID, as the
+// AddProjectV2ItemById puts an existing issue on a board and returns the new
+// card's ID. Adding one already present returns the existing ID, as the
 // GraphQL mutation does.
+//
+// A PR content node ID is rejected rather than accepted: real GitHub allows PR
+// cards, but this model cannot project one (see FIDELITY.md), so accepting it
+// would add a card that every board read then silently drops.
 func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -506,12 +510,18 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 	if !ok {
 		return "", fmt.Errorf("simgh: repo %s not seeded", ownerRepo)
 	}
-	isPR := false
 	if _, ok := r.issues[number]; !ok {
 		if _, ok := r.prs[number]; !ok {
 			return "", fmt.Errorf("simgh: no issue or PR %s#%d to add to project", ownerRepo, number)
 		}
-		isPR = true
+		// Board projections resolve a card's content as an issue
+		// (buildProjectItem, ProbeProjectBoard), so a PR card recorded here
+		// would be silently omitted from every subsequent board read. Refuse
+		// it, exactly as the seeding path does (placeOnProjectLocked): the
+		// seeding and runtime APIs must not disagree about what the model can
+		// represent, or a scenario would get a loud failure one way and a
+		// silent no-op the other. Recorded in FIDELITY.md as absent.
+		return "", fmt.Errorf("simgh: PR cards on a project board are not modelled (%s#%d); see FIDELITY.md", ownerRepo, number)
 	}
 
 	id := itemNodeID(p.owner, p.num, ownerRepo, number)
@@ -525,7 +535,7 @@ func (s *Sim) AddProjectV2ItemById(projectID, contentNodeID string) (string, err
 		itemID:    id,
 		ownerRepo: ownerRepo,
 		number:    number,
-		isPR:      isPR,
+		isPR:      false,
 		status:    "",
 		updatedAt: s.now(),
 	}

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -467,6 +467,12 @@ func (s *Sim) UpdateProjectItemStatus(projectID, itemID, statusFieldID, statusOp
 		if optID != statusOptionID {
 			continue
 		}
+		// Moving a card to the column it already occupies changes nothing.
+		// placeOnProjectLocked already gets this right via its `changed` check;
+		// the same rule belongs here, for the same reason.
+		if it.status == name {
+			return nil
+		}
 		now := s.now()
 		it.status = name
 		it.updatedAt = now
@@ -488,6 +494,15 @@ func (s *Sim) ArchiveProjectItem(projectID, itemID string) error {
 	it, ok := p.items[itemID]
 	if !ok {
 		return fmt.Errorf("simgh: project item %q not found in %q", itemID, projectID)
+	}
+	// Re-archiving an already-archived card changes nothing, so it must not
+	// advance either timestamp — FetchProjectUpdatedAt gates whether the
+	// engine's idle poll looks at the board at all, and a bump for a no-op is a
+	// wake signal real GitHub does not produce. Same convention as
+	// AddProjectV2ItemById's live-card re-add, AddLabelToIssue, and
+	// AddReviewRequest.
+	if it.archived {
+		return nil
 	}
 	now := s.now()
 	it.archived = true

--- a/tests/sim/simgh/board.go
+++ b/tests/sim/simgh/board.go
@@ -145,7 +145,10 @@ func (s *Sim) buildProjectItem(p *projectState, ref itemRef) (*gh.ProjectItem, e
 		linkedHead = linked.head
 		item.LinkedPRNumber = linked.number
 		item.LinkedPRNumberShallow = linked.number
-		item.LinkedPRReviews = append([]gh.PRReview(nil), linked.reviews...)
+		// Collapsed for the same reason FetchPRReviews collapses: production
+		// sources this field from GraphQL's latestReviews, which is one entry
+		// per author by definition. The two reads must agree.
+		item.LinkedPRReviews = latestReviewsByAuthor(linked.reviews)
 		item.LinkedPRReviewRequests = append([]gh.ReviewRequest(nil), linked.reviewRequests...)
 		item.LinkedPRResolvedThreadCount = linked.resolvedThreads
 		item.LinkedPRIsMergeQueueEnabled = r.mergeQueueEnabled
@@ -244,6 +247,17 @@ func (s *Sim) ProbeProjectBoard(owner, repo string, projectNum int, ownerType st
 		}
 
 		s.mu.Lock()
+		// Re-read the card live, for the same reason buildProjectItem does:
+		// the refs above were snapshotted under an earlier lock acquisition,
+		// so a status move or an archive landing in between would otherwise be
+		// invisible here — a stale column, or an archived card still in the
+		// probe output. The probe feeds the engine's idle poll, so a stale
+		// answer here is a poll that does not notice work it should.
+		live, ok := p.items[ref.itemID]
+		if !ok || live.archived {
+			s.mu.Unlock()
+			continue
+		}
 		r, ok := s.repos[ref.ownerRepo]
 		if !ok {
 			s.mu.Unlock()
@@ -258,14 +272,14 @@ func (s *Sim) ProbeProjectBoard(owner, repo string, projectNum int, ownerType st
 			ItemID:    ref.itemID,
 			ContentID: iss.nodeID(ref.ownerRepo),
 			Number:    iss.number,
-			IsPR:      ref.isPR,
-			IsClosed:  iss.state == "CLOSED" && !ref.isPR,
+			IsPR:      live.isPR,
+			IsClosed:  iss.state == "CLOSED" && !live.isPR,
 			State:     iss.state,
 			Repo:      ref.ownerRepo,
-			Status:    ref.status,
+			Status:    live.status,
 		}
 		// effectiveUpdatedAt is max(content, project item, linked PR).
-		probe.EffectiveUpdatedAt = laterOf(iss.updatedAt, ref.updatedAt)
+		probe.EffectiveUpdatedAt = laterOf(iss.updatedAt, live.updatedAt)
 		linked := findPRByHeadLocked(r, issueBranch(iss.number))
 		var linkedHead string
 		if linked != nil {

--- a/tests/sim/simgh/ci.go
+++ b/tests/sim/simgh/ci.go
@@ -1,0 +1,143 @@
+package simgh
+
+import gh "github.com/handarbeit/fabrik/github"
+
+// Check runs and classic commit statuses are two genuinely separate
+// collections here, keyed by SHA, because production treats them separately: a
+// required context can be posted through the classic Statuses API rather than
+// as an Actions check run, and FetchCombinedStatus is Fabrik's only visibility
+// into that case (ADR-933). Collapsing them into one collection would make
+// that path untestable while still looking green.
+
+// FetchCheckRuns returns the check runs recorded against a commit SHA.
+// An unknown SHA yields an empty slice, not an error — GitHub reports zero
+// check runs for a commit no CI has touched yet.
+func (s *Sim) FetchCheckRuns(owner, repo, sha string) ([]gh.CheckRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	runs := r.checkRuns[sha]
+	out := make([]gh.CheckRun, len(runs))
+	copy(out, runs)
+	return out, nil
+}
+
+// FetchCombinedStatus returns the classic commit statuses for a ref.
+func (s *Sim) FetchCombinedStatus(owner, repo, ref string) ([]gh.CommitStatus, error) {
+	s.mu.Lock()
+	statuses, err := func() ([]gh.CommitStatus, error) {
+		r, err := s.lookupRepo(owner, repo)
+		if err != nil {
+			return nil, err
+		}
+		if direct, ok := r.commitStatuses[ref]; ok {
+			out := make([]gh.CommitStatus, len(direct))
+			copy(out, direct)
+			return out, nil
+		}
+		return nil, nil
+	}()
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if statuses != nil {
+		return statuses, nil
+	}
+
+	// The ref may be a branch name rather than a SHA — the combined-status
+	// endpoint accepts either. Resolve it and retry.
+	sha, err := s.resolveRefSHA(owner, repo, ref)
+	if err != nil || sha == "" {
+		return []gh.CommitStatus{}, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gh.CommitStatus, len(r.commitStatuses[sha]))
+	copy(out, r.commitStatuses[sha])
+	return out, nil
+}
+
+// FetchCommitsBehind reports how many commits base has that head does not —
+// GitHub's behind_by from the compare endpoint, computed here with rev-list
+// against the backing repository rather than declared.
+func (s *Sim) FetchCommitsBehind(owner, repo, base, head string) (int, error) {
+	r, err := s.repoByKey(repoKey(owner, repo))
+	if err != nil {
+		return 0, err
+	}
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+	return r.commitsBehind(base, head)
+}
+
+// resolveRefSHA resolves a branch name to a SHA, returning "" when it is not a
+// branch. Takes gitMu and must not be called while holding mu.
+func (s *Sim) resolveRefSHA(owner, repo, ref string) (string, error) {
+	r, err := s.repoByKey(repoKey(owner, repo))
+	if err != nil {
+		return "", err
+	}
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+	return r.headSHA(ref), nil
+}
+
+// contextState is a check run or commit status reduced to the two things the
+// mergeable-state derivation cares about: its name, and whether it is green,
+// red, or still running.
+type contextState struct {
+	name string
+	// verdict is one of "success", "failure", or "pending".
+	verdict string
+}
+
+// checkVerdict maps a check run's status/conclusion pair onto a verdict.
+// "neutral" and "skipped" are treated as success, matching GitHub's own
+// treatment of them as non-blocking.
+func checkVerdict(run gh.CheckRun) string {
+	if run.Status != "completed" {
+		return "pending"
+	}
+	switch run.Conclusion {
+	case "success", "neutral", "skipped":
+		return "success"
+	case "":
+		return "pending"
+	default:
+		return "failure"
+	}
+}
+
+// statusVerdict maps a classic commit status state onto a verdict.
+func statusVerdict(st gh.CommitStatus) string {
+	switch st.State {
+	case "success":
+		return "success"
+	case "pending", "":
+		return "pending"
+	default: // "failure", "error"
+		return "failure"
+	}
+}
+
+// contextsForSHA collects both collections for a SHA into one verdict list.
+// Caller must hold mu.
+func (r *repoState) contextsForSHA(sha string) []contextState {
+	out := make([]contextState, 0, len(r.checkRuns[sha])+len(r.commitStatuses[sha]))
+	for _, run := range r.checkRuns[sha] {
+		out = append(out, contextState{name: run.Name, verdict: checkVerdict(run)})
+	}
+	for _, st := range r.commitStatuses[sha] {
+		out = append(out, contextState{name: st.Context, verdict: statusVerdict(st)})
+	}
+	return out
+}

--- a/tests/sim/simgh/ci.go
+++ b/tests/sim/simgh/ci.go
@@ -91,15 +91,6 @@ func (s *Sim) resolveRefSHA(owner, repo, ref string) (string, error) {
 	return r.headSHA(ref), nil
 }
 
-// contextState is a check run or commit status reduced to the two things the
-// mergeable-state derivation cares about: its name, and whether it is green,
-// red, or still running.
-type contextState struct {
-	name string
-	// verdict is one of "success", "failure", or "pending".
-	verdict string
-}
-
 // checkVerdict maps a check run's status/conclusion pair onto a verdict.
 // "neutral" and "skipped" are treated as success, matching GitHub's own
 // treatment of them as non-blocking.
@@ -129,15 +120,47 @@ func statusVerdict(st gh.CommitStatus) string {
 	}
 }
 
-// contextsForSHA collects both collections for a SHA into one verdict list.
-// Caller must hold mu.
-func (r *repoState) contextsForSHA(sha string) []contextState {
-	out := make([]contextState, 0, len(r.checkRuns[sha])+len(r.commitStatuses[sha]))
+// contextsForSHA reduces both collections for a SHA to one verdict per context
+// name. Caller must hold mu.
+//
+// Within a collection the *latest* entry wins, not the worst. Check runs reduce
+// by highest ID, matching production's latestCheckRunsByName (github/checkruns.go)
+// and real branch protection, which clears a required check once its newest run
+// passes. Commit statuses reduce to the last one posted for a context, because
+// the classic Statuses API supersedes rather than accumulates.
+//
+// Reducing by worst verdict instead would classify "check failed, rerun passed"
+// off the failed run and report a PR blocked that GitHub calls clean — defeating
+// the check-run ID machinery in seed.go, which exists precisely so that flow is
+// representable, and contradicting production's own classifier.
+//
+// Across the two collections, a name appearing in both keeps the worse verdict.
+// That is a conservative choice of the model's own, not an observed GitHub rule;
+// see FIDELITY.md.
+func (r *repoState) contextsForSHA(sha string) map[string]string {
+	out := make(map[string]string, len(r.checkRuns[sha])+len(r.commitStatuses[sha]))
+
+	latest := make(map[string]gh.CheckRun, len(r.checkRuns[sha]))
 	for _, run := range r.checkRuns[sha] {
-		out = append(out, contextState{name: run.Name, verdict: checkVerdict(run)})
+		if prev, ok := latest[run.Name]; ok && run.ID <= prev.ID {
+			continue
+		}
+		latest[run.Name] = run
 	}
+	for name, run := range latest {
+		out[name] = checkVerdict(run)
+	}
+
+	statuses := make(map[string]string, len(r.commitStatuses[sha]))
 	for _, st := range r.commitStatuses[sha] {
-		out = append(out, contextState{name: st.Context, verdict: statusVerdict(st)})
+		statuses[st.Context] = statusVerdict(st)
+	}
+	for name, v := range statuses {
+		if prev, ok := out[name]; ok {
+			out[name] = worseVerdict(prev, v)
+			continue
+		}
+		out[name] = v
 	}
 	return out
 }

--- a/tests/sim/simgh/ci.go
+++ b/tests/sim/simgh/ci.go
@@ -88,7 +88,7 @@ func (s *Sim) resolveRefSHA(owner, repo, ref string) (string, error) {
 	}
 	r.gitMu.Lock()
 	defer r.gitMu.Unlock()
-	return r.headSHA(ref), nil
+	return r.headSHA(ref)
 }
 
 // checkVerdict maps a check run's status/conclusion pair onto a verdict.

--- a/tests/sim/simgh/comments.go
+++ b/tests/sim/simgh/comments.go
@@ -1,0 +1,141 @@
+package simgh
+
+import "fmt"
+
+// AddComment posts a comment on an issue, or on a pull request when the number
+// identifies one. GitHub's issue-comment endpoints are shared between issues
+// and PRs, and the engine relies on that (it posts stage output to a PR
+// through the same call), so the model resolves the number against both
+// collections rather than requiring the caller to say which it meant.
+//
+// Returns the comment's database ID, which the engine round-trips into
+// reaction and update calls.
+func (s *Sim) AddComment(owner, repo string, issueNumber int, body string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return 0, err
+	}
+
+	id := s.nextCommentDatabaseID
+	s.nextCommentDatabaseID++
+	c := &commentRecord{
+		databaseID: id,
+		author:     simActor,
+		body:       body,
+		createdAt:  s.now(),
+		reactions:  make(map[string]int),
+	}
+
+	if iss, ok := r.issues[issueNumber]; ok {
+		iss.comments = append(iss.comments, c)
+		iss.updatedAt = s.now()
+		return id, nil
+	}
+	if pr, ok := r.prs[issueNumber]; ok {
+		c.fromPR = issueNumber
+		pr.comments = append(pr.comments, c)
+		pr.updatedAt = s.now()
+		return id, nil
+	}
+	return 0, fmt.Errorf("simgh: no issue or PR %s#%d to comment on", repoKey(owner, repo), issueNumber)
+}
+
+// UpdateComment rewrites an existing comment's body, searching issue, PR, and
+// review-thread comments across the repo the way the REST endpoint does (it
+// takes only a comment ID, not an issue number).
+func (s *Sim) UpdateComment(owner, repo string, commentDatabaseID int, body string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, err := s.findCommentLocked(owner, repo, commentDatabaseID)
+	if err != nil {
+		return err
+	}
+	c.body = body
+	return nil
+}
+
+// AddCommentReaction adds a reaction to an issue or PR comment. Reactions are
+// counted, and the engine's durable "already processed" state (the 🚀 rocket)
+// is exactly a reaction, so this must be observable on every subsequent read.
+func (s *Sim) AddCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	return s.addReaction(owner, repo, commentDatabaseID, content)
+}
+
+// AddPRReviewCommentReaction adds a reaction to an inline review-thread
+// comment. GitHub routes these through a separate REST endpoint from ordinary
+// comment reactions; the model keeps the distinction at the call site but
+// stores both the same way.
+func (s *Sim) AddPRReviewCommentReaction(owner, repo string, commentDatabaseID int, content string) error {
+	return s.addReaction(owner, repo, commentDatabaseID, content)
+}
+
+func (s *Sim) addReaction(owner, repo string, commentDatabaseID int, content string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, err := s.findCommentLocked(owner, repo, commentDatabaseID)
+	if err != nil {
+		return err
+	}
+	// GitHub records one reaction per actor per content; the sim posts as a
+	// single actor, so a repeated reaction is idempotent rather than additive.
+	if c.reactions[content] == 0 {
+		c.reactions[content] = 1
+	}
+	return nil
+}
+
+// ResolveReviewThread marks a review thread resolved and bumps the PR's
+// resolved-thread count, which the engine's progress detection reads during
+// turn extension.
+func (s *Sim) ResolveReviewThread(threadID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range s.repos {
+		for _, pr := range r.prs {
+			for _, c := range pr.reviewThreadComment {
+				if c.reviewThreadID != threadID {
+					continue
+				}
+				if c.threadResolved {
+					return nil
+				}
+				c.threadResolved = true
+				pr.resolvedThreads++
+				pr.updatedAt = s.now()
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("simgh: review thread %q not found", threadID)
+}
+
+// findCommentLocked searches a repo's issue, PR, and review-thread comments.
+// Caller must hold mu.
+func (s *Sim) findCommentLocked(owner, repo string, databaseID int) (*commentRecord, error) {
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	for _, iss := range r.issues {
+		for _, c := range iss.comments {
+			if c.databaseID == databaseID {
+				return c, nil
+			}
+		}
+	}
+	for _, pr := range r.prs {
+		for _, c := range pr.comments {
+			if c.databaseID == databaseID {
+				return c, nil
+			}
+		}
+		for _, c := range pr.reviewThreadComment {
+			if c.databaseID == databaseID {
+				return c, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("simgh: comment %d not found in %s", databaseID, repoKey(owner, repo))
+}

--- a/tests/sim/simgh/comments.go
+++ b/tests/sim/simgh/comments.go
@@ -20,23 +20,24 @@ func (s *Sim) AddComment(owner, repo string, issueNumber int, body string) (int,
 
 	id := s.nextCommentDatabaseID
 	s.nextCommentDatabaseID++
+	now := s.now()
 	c := &commentRecord{
 		databaseID: id,
 		author:     simActor,
 		body:       body,
-		createdAt:  s.now(),
+		createdAt:  now,
 		reactions:  make(map[string]int),
 	}
 
 	if iss, ok := r.issues[issueNumber]; ok {
 		iss.comments = append(iss.comments, c)
-		iss.updatedAt = s.now()
+		iss.updatedAt = now
 		return id, nil
 	}
 	if pr, ok := r.prs[issueNumber]; ok {
 		c.fromPR = issueNumber
 		pr.comments = append(pr.comments, c)
-		pr.updatedAt = s.now()
+		pr.updatedAt = now
 		return id, nil
 	}
 	return 0, fmt.Errorf("simgh: no issue or PR %s#%d to comment on", repoKey(owner, repo), issueNumber)

--- a/tests/sim/simgh/comments.go
+++ b/tests/sim/simgh/comments.go
@@ -48,7 +48,7 @@ func (s *Sim) AddComment(owner, repo string, issueNumber int, body string) (int,
 func (s *Sim) UpdateComment(owner, repo string, commentDatabaseID int, body string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	c, iss, err := s.findCommentWithOwnerLocked(owner, repo, commentDatabaseID)
+	c, iss, pr, err := s.findCommentWithOwnerLocked(owner, repo, commentDatabaseID)
 	if err != nil {
 		return err
 	}
@@ -60,11 +60,12 @@ func (s *Sim) UpdateComment(owner, repo string, commentDatabaseID int, body stri
 	// updatedAt to notice the board changed.
 	//
 	// Reactions deliberately do not bump it: GitHub does not treat a reaction as
-	// an update to the parent. A comment owned by a PR has nothing to bump — the
-	// model gives prRecord no updatedAt, and ProjectItem.UpdatedAt is derived
-	// from the issue. See FIDELITY.md.
-	if iss != nil {
+	// an update to the parent.
+	switch {
+	case iss != nil:
 		iss.updatedAt = s.now()
+	case pr != nil:
+		pr.updatedAt = s.now()
 	}
 	return nil
 }
@@ -127,36 +128,36 @@ func (s *Sim) ResolveReviewThread(threadID string) error {
 // findCommentLocked searches a repo's issue, PR, and review-thread comments.
 // Caller must hold mu.
 func (s *Sim) findCommentLocked(owner, repo string, databaseID int) (*commentRecord, error) {
-	c, _, err := s.findCommentWithOwnerLocked(owner, repo, databaseID)
+	c, _, _, err := s.findCommentWithOwnerLocked(owner, repo, databaseID)
 	return c, err
 }
 
-// findCommentWithOwnerLocked is findCommentLocked plus the issue that owns the
-// comment, so a mutation can bump the parent's updatedAt. The issue is nil when
-// the comment belongs to a PR. Caller must hold mu.
-func (s *Sim) findCommentWithOwnerLocked(owner, repo string, databaseID int) (*commentRecord, *issueRecord, error) {
+// findCommentWithOwnerLocked is findCommentLocked plus whichever record owns the
+// comment, so a mutation can bump the parent's updatedAt. Exactly one of the
+// issue and the PR is non-nil. Caller must hold mu.
+func (s *Sim) findCommentWithOwnerLocked(owner, repo string, databaseID int) (*commentRecord, *issueRecord, *prRecord, error) {
 	r, err := s.lookupRepo(owner, repo)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	for _, iss := range r.issues {
 		for _, c := range iss.comments {
 			if c.databaseID == databaseID {
-				return c, iss, nil
+				return c, iss, nil, nil
 			}
 		}
 	}
 	for _, pr := range r.prs {
 		for _, c := range pr.comments {
 			if c.databaseID == databaseID {
-				return c, nil, nil
+				return c, nil, pr, nil
 			}
 		}
 		for _, c := range pr.reviewThreadComment {
 			if c.databaseID == databaseID {
-				return c, nil, nil
+				return c, nil, pr, nil
 			}
 		}
 	}
-	return nil, nil, fmt.Errorf("simgh: comment %d not found in %s", databaseID, repoKey(owner, repo))
+	return nil, nil, nil, fmt.Errorf("simgh: comment %d not found in %s", databaseID, repoKey(owner, repo))
 }

--- a/tests/sim/simgh/comments.go
+++ b/tests/sim/simgh/comments.go
@@ -48,11 +48,24 @@ func (s *Sim) AddComment(owner, repo string, issueNumber int, body string) (int,
 func (s *Sim) UpdateComment(owner, repo string, commentDatabaseID int, body string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	c, err := s.findCommentLocked(owner, repo, commentDatabaseID)
+	c, iss, err := s.findCommentWithOwnerLocked(owner, repo, commentDatabaseID)
 	if err != nil {
 		return err
 	}
 	c.body = body
+	// Editing a comment bumps the parent issue's updated_at on GitHub, and the
+	// engine really does take this path — it rewrites an existing stage comment
+	// rather than posting a new one (engine/comments.go, engine/dependencies.go).
+	// Leaving it unbumped would make an edit invisible to any read that watches
+	// updatedAt to notice the board changed.
+	//
+	// Reactions deliberately do not bump it: GitHub does not treat a reaction as
+	// an update to the parent. A comment owned by a PR has nothing to bump — the
+	// model gives prRecord no updatedAt, and ProjectItem.UpdatedAt is derived
+	// from the issue. See FIDELITY.md.
+	if iss != nil {
+		iss.updatedAt = s.now()
+	}
 	return nil
 }
 
@@ -114,28 +127,36 @@ func (s *Sim) ResolveReviewThread(threadID string) error {
 // findCommentLocked searches a repo's issue, PR, and review-thread comments.
 // Caller must hold mu.
 func (s *Sim) findCommentLocked(owner, repo string, databaseID int) (*commentRecord, error) {
+	c, _, err := s.findCommentWithOwnerLocked(owner, repo, databaseID)
+	return c, err
+}
+
+// findCommentWithOwnerLocked is findCommentLocked plus the issue that owns the
+// comment, so a mutation can bump the parent's updatedAt. The issue is nil when
+// the comment belongs to a PR. Caller must hold mu.
+func (s *Sim) findCommentWithOwnerLocked(owner, repo string, databaseID int) (*commentRecord, *issueRecord, error) {
 	r, err := s.lookupRepo(owner, repo)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, iss := range r.issues {
 		for _, c := range iss.comments {
 			if c.databaseID == databaseID {
-				return c, nil
+				return c, iss, nil
 			}
 		}
 	}
 	for _, pr := range r.prs {
 		for _, c := range pr.comments {
 			if c.databaseID == databaseID {
-				return c, nil
+				return c, nil, nil
 			}
 		}
 		for _, c := range pr.reviewThreadComment {
 			if c.databaseID == databaseID {
-				return c, nil
+				return c, nil, nil
 			}
 		}
 	}
-	return nil, fmt.Errorf("simgh: comment %d not found in %s", databaseID, repoKey(owner, repo))
+	return nil, nil, fmt.Errorf("simgh: comment %d not found in %s", databaseID, repoKey(owner, repo))
 }

--- a/tests/sim/simgh/concurrency_test.go
+++ b/tests/sim/simgh/concurrency_test.go
@@ -418,8 +418,19 @@ func TestConcurrentSeedRepoDoesNotClobber(t *testing.T) {
 	start.Done()
 	done.Wait()
 
-	if err := s.Err(); err == nil {
+	// The error must be the refusal itself, not a git failure. That is the
+	// assertion that distinguishes a held lock from an unheld one: with the
+	// sequence serialised, the losers are turned away before they run git at
+	// all, so no caller can ever observe a git error. Without it, they all
+	// clear the check together and collide inside initBare against one
+	// directory — asserting merely that some error occurred would be satisfied
+	// by that collision and would prove nothing.
+	err := s.Err()
+	if err == nil {
 		t.Fatalf("%d concurrent SeedRepo calls for one key all succeeded; want every one after the first to be refused", callers)
+	}
+	if !strings.Contains(err.Error(), "already seeded") {
+		t.Fatalf("concurrent SeedRepo failed with %v; want the \"already seeded\" refusal — a git error here means the callers raced inside initBare instead of being serialised", err)
 	}
 
 	// Exactly one repo, and it must be usable — a clobbered state would leave

--- a/tests/sim/simgh/concurrency_test.go
+++ b/tests/sim/simgh/concurrency_test.go
@@ -1,0 +1,309 @@
+package simgh
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// The engine's poll loop dispatches up to MaxConcurrent workers against one
+// GitHubClient, so the model has to survive that. Two hazards are being
+// checked here, and they are different: the in-memory model needs a mutex, and
+// git itself needs its subprocess calls serialised per repository — git's
+// index and worktree administration are not concurrency-safe, so a Go-level
+// lock over the model alone would not be enough.
+//
+// Operation counts are kept modest on purpose: creating and tearing down a
+// throwaway worktree is by far the most expensive thing the model does, and an
+// unbounded fan-out here would make the suite slow without testing anything
+// extra.
+
+func TestConcurrentModelAccess(t *testing.T) {
+	s, _ := newSim(t)
+
+	const (
+		repoA     = "acme/widgets"
+		repoB     = "acme/gadgets"
+		issuesPer = 4
+	)
+	s.SeedRepo(repoA).
+		SeedRepo(repoB).
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"})
+	for i := 1; i <= issuesPer; i++ {
+		s.SeedIssue(repoA, IssueSeed{Number: i, Title: fmt.Sprintf("A%d", i), Status: "Implement"}).
+			SeedIssue(repoB, IssueSeed{Number: i, Title: fmt.Sprintf("B%d", i), Status: "Implement"})
+	}
+	// One PR per repo, on a real branch, so the goroutines below exercise the
+	// git-backed paths concurrently and across two repos (whose gitMu locks are
+	// independent).
+	for _, repo := range []string{repoA, repoB} {
+		s.SeedCommit(repo, "main", map[string]string{"base.txt": "base\n"}, "base").
+			SeedCommit(repo, issueBranch(1), map[string]string{"feature.txt": "feature\n"}, "feature").
+			SeedPR(repo, PRSeed{Number: 100, Head: issueBranch(1), Base: "main"})
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	field, err := s.FetchStatusField(board.ProjectID)
+	if err != nil {
+		t.Fatalf("FetchStatusField: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 64)
+
+	// Writers: label churn, comments and reactions, and body updates, spread
+	// across both repos and every issue.
+	for _, repo := range []string{repoA, repoB} {
+		owner, name, err := splitOwnerRepo(repo)
+		if err != nil {
+			t.Fatalf("splitOwnerRepo: %v", err)
+		}
+		for i := 1; i <= issuesPer; i++ {
+			wg.Add(1)
+			go func(owner, name string, num int) {
+				defer wg.Done()
+				const label = "stage:Implement:in_progress"
+				if err := s.AddLabelToIssue(owner, name, num, label); err != nil {
+					errs <- fmt.Errorf("AddLabelToIssue: %w", err)
+					return
+				}
+				id, err := s.AddComment(owner, name, num, "worker output")
+				if err != nil {
+					errs <- fmt.Errorf("AddComment: %w", err)
+					return
+				}
+				if err := s.AddCommentReaction(owner, name, id, "ROCKET"); err != nil {
+					errs <- fmt.Errorf("AddCommentReaction: %w", err)
+					return
+				}
+				if err := s.UpdateIssueBody(owner, name, num, fmt.Sprintf("body %d", num)); err != nil {
+					errs <- fmt.Errorf("UpdateIssueBody: %w", err)
+					return
+				}
+				if err := s.RemoveLabelFromIssue(owner, name, num, label); err != nil {
+					errs <- fmt.Errorf("RemoveLabelFromIssue: %w", err)
+				}
+			}(owner, name, i)
+		}
+	}
+
+	// Board movers, contending on the same project state.
+	for i := 1; i <= issuesPer; i++ {
+		wg.Add(1)
+		go func(num int) {
+			defer wg.Done()
+			itemID, _, err := s.LookupIssueProjectItem(board.ProjectID, repoA, num)
+			if err != nil {
+				errs <- fmt.Errorf("LookupIssueProjectItem: %w", err)
+				return
+			}
+			if itemID == "" {
+				errs <- fmt.Errorf("issue %d not found on the board", num)
+				return
+			}
+			if err := s.UpdateProjectItemStatus(board.ProjectID, itemID, field.FieldID, field.Options["Review"]); err != nil {
+				errs <- fmt.Errorf("UpdateProjectItemStatus: %w", err)
+			}
+		}(i)
+	}
+
+	// Readers, including full board projections that touch git for head SHAs.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := s.FetchProjectBoard("acme", "widgets", 2, "organization"); err != nil {
+				errs <- fmt.Errorf("FetchProjectBoard: %w", err)
+			}
+			if _, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization"); err != nil {
+				errs <- fmt.Errorf("ProbeProjectBoard: %w", err)
+			}
+		}()
+	}
+
+	// Git-backed readers. These are the ones that would corrupt each other
+	// without per-repo serialisation of the git subprocess calls: two
+	// concurrent trial merges in the same repository share its object store
+	// and worktree administration.
+	for _, repo := range []string{repoA, repoB} {
+		owner, name, err := splitOwnerRepo(repo)
+		if err != nil {
+			t.Fatalf("splitOwnerRepo: %v", err)
+		}
+		for range 2 {
+			wg.Add(1)
+			go func(owner, name string) {
+				defer wg.Done()
+				mergeable, err := s.FetchPRMergeable(owner, name, 100)
+				if err != nil {
+					errs <- fmt.Errorf("FetchPRMergeable: %w", err)
+					return
+				}
+				if mergeable == nil || !*mergeable {
+					errs <- fmt.Errorf("FetchPRMergeable = %v, want true", mergeable)
+					return
+				}
+				if _, err := s.FetchCommitsBehind(owner, name, "main", issueBranch(1)); err != nil {
+					errs <- fmt.Errorf("FetchCommitsBehind: %w", err)
+				}
+			}(owner, name)
+		}
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	// Every write must have landed — a lost update under contention is the
+	// failure this test exists to catch, and it would not show up as a race
+	// report.
+	for _, repo := range []string{repoA, repoB} {
+		owner, name, err := splitOwnerRepo(repo)
+		if err != nil {
+			t.Fatalf("splitOwnerRepo: %v", err)
+		}
+		for i := 1; i <= issuesPer; i++ {
+			body, err := s.GetIssueBody(owner, name, i)
+			if err != nil {
+				t.Fatalf("GetIssueBody(%s#%d): %v", repo, i, err)
+			}
+			if want := fmt.Sprintf("body %d", i); body != want {
+				t.Errorf("%s#%d body = %q, want %q", repo, i, body, want)
+			}
+			issue, err := s.FetchIssue(owner, name, i)
+			if err != nil {
+				t.Fatalf("FetchIssue(%s#%d): %v", repo, i, err)
+			}
+			if issue.Comments != 1 {
+				t.Errorf("%s#%d has %d comments, want 1", repo, i, issue.Comments)
+			}
+		}
+	}
+	statuses, err := s.FetchProjectItemStatusBatch(board.ProjectID)
+	if err != nil {
+		t.Fatalf("FetchProjectItemStatusBatch: %v", err)
+	}
+	moved := 0
+	for _, status := range statuses {
+		if status == "Review" {
+			moved++
+		}
+	}
+	if moved != issuesPer {
+		t.Errorf("%d items moved to Review, want %d", moved, issuesPer)
+	}
+}
+
+// TestConcurrentTrialMergesOnOneRepo hammers the single most git-hostile path:
+// repeated trial merges against one repository from several goroutines. Each
+// probe checks out a throwaway worktree; without per-repo serialisation these
+// collide on the repo's worktree administration and produce either a git error
+// or a wrong answer.
+func TestConcurrentTrialMergesOnOneRepo(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo(repoName).
+		SeedCommit(repoName, "main", map[string]string{"shared.txt": "original\n"}, "ancestor").
+		SeedCommit(repoName, headBranch, map[string]string{"shared.txt": "feature\n"}, "feature edit").
+		SeedCommit(repoName, "main", map[string]string{"shared.txt": "main\n"}, "main edit").
+		SeedCommit(repoName, "clean-branch", map[string]string{"other.txt": "other\n"}, "unrelated").
+		SeedPR(repoName, PRSeed{Number: 1, Head: headBranch, Base: "main"}).
+		SeedPR(repoName, PRSeed{Number: 2, Head: "clean-branch", Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	for range 6 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// The conflicting PR must report false every time...
+			conflicting, err := s.FetchPRMergeable("acme", "widgets", 1)
+			if err != nil {
+				errs <- fmt.Errorf("conflicting probe: %w", err)
+				return
+			}
+			if conflicting == nil || *conflicting {
+				errs <- fmt.Errorf("conflicting PR reported mergeable = %v, want false", conflicting)
+			}
+			// ...and the clean one true, concurrently, in the same repo.
+			clean, err := s.FetchPRMergeable("acme", "widgets", 2)
+			if err != nil {
+				errs <- fmt.Errorf("clean probe: %w", err)
+				return
+			}
+			if clean == nil || !*clean {
+				errs <- fmt.Errorf("clean PR reported mergeable = %v, want true", clean)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// TestConcurrentReviewMutations covers the review surfaces, which the review
+// gate reads and writes from several code paths in one poll pass.
+func TestConcurrentReviewMutations(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo(repoName).
+		SeedCommit(repoName, headBranch, map[string]string{"a.go": "package a\n"}, "work").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 32)
+	reviewers := []string{"alice", "bob", "carol", "dependabot"}
+	for _, login := range reviewers {
+		wg.Add(1)
+		go func(login string) {
+			defer wg.Done()
+			if err := s.AddReviewRequest("acme", "widgets", 42, []string{login}); err != nil {
+				errs <- fmt.Errorf("AddReviewRequest(%s): %w", login, err)
+			}
+		}(login)
+	}
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := s.FetchPRReviewRequests("acme", "widgets", 42); err != nil {
+				errs <- fmt.Errorf("FetchPRReviewRequests: %w", err)
+			}
+			if _, err := s.FetchPRReviews("acme", "widgets", 42); err != nil {
+				errs <- fmt.Errorf("FetchPRReviews: %w", err)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	requests, err := s.FetchPRReviewRequests("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviewRequests: %v", err)
+	}
+	if len(requests) != len(reviewers) {
+		t.Fatalf("%d review requests recorded, want %d — a concurrent add was lost", len(requests), len(reviewers))
+	}
+	for _, req := range requests {
+		if req.Login == "dependabot" && !req.IsBot {
+			t.Error("dependabot was not classified as a bot")
+		}
+	}
+}

--- a/tests/sim/simgh/concurrency_test.go
+++ b/tests/sim/simgh/concurrency_test.go
@@ -389,3 +389,49 @@ func TestConcurrentReviewMutations(t *testing.T) {
 		}
 	}
 }
+
+// TestConcurrentSeedRepoDoesNotClobber drives the window SeedRepo's re-check
+// closes. The "already seeded" guard runs under mu, mu is then released for the
+// git init, and mu is retaken to publish — so concurrent callers for one key
+// all clear the guard before any of them publishes.
+//
+// Without the re-check the last writer replaces a live repoState, swapping out
+// the repo's gitMu while earlier callers still hold the old one: two mutexes
+// guarding one bare directory, which silently voids the per-repo git
+// serialisation every other test depends on. A start barrier makes all the
+// callers reach the guard together, so the window is entered rather than
+// hoped for.
+func TestConcurrentSeedRepoDoesNotClobber(t *testing.T) {
+	s, _ := newSim(t)
+
+	const callers = 4
+	var start, done sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < callers; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			s.SeedRepo("acme/widgets")
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	if err := s.Err(); err == nil {
+		t.Fatalf("%d concurrent SeedRepo calls for one key all succeeded; want every one after the first to be refused", callers)
+	}
+
+	// Exactly one repo, and it must be usable — a clobbered state would leave
+	// the map pointing at a repoState whose gitMu nobody else is holding.
+	r, err := s.repoByKey("acme/widgets")
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	r.gitMu.Lock()
+	ok := r.branchExists("main")
+	r.gitMu.Unlock()
+	if !ok {
+		t.Fatal("the surviving repoState does not have its default branch; seeding raced")
+	}
+}

--- a/tests/sim/simgh/concurrency_test.go
+++ b/tests/sim/simgh/concurrency_test.go
@@ -2,6 +2,7 @@ package simgh
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -202,11 +203,13 @@ func TestConcurrentModelAccess(t *testing.T) {
 	}
 }
 
-// TestConcurrentTrialMergesOnOneRepo hammers the single most git-hostile path:
-// repeated trial merges against one repository from several goroutines. Each
-// probe checks out a throwaway worktree; without per-repo serialisation these
-// collide on the repo's worktree administration and produce either a git error
-// or a wrong answer.
+// TestConcurrentTrialMergesOnOneRepo runs repeated trial merges against one
+// repository from several goroutines, checking that two probes of different
+// PRs never contaminate each other's answer.
+//
+// Note what this does *not* prove: removing the per-repo git mutex leaves it
+// green, because each probe works in its own throwaway worktree and moves no
+// ref. TestConcurrentMergesOntoOneBase is the case that pins the mutex.
 func TestConcurrentTrialMergesOnOneRepo(t *testing.T) {
 	s, _ := newSim(t)
 	s.SeedRepo(repoName).
@@ -250,6 +253,85 @@ func TestConcurrentTrialMergesOnOneRepo(t *testing.T) {
 	close(errs)
 	for err := range errs {
 		t.Error(err)
+	}
+}
+
+// TestConcurrentMergesOntoOneBase is the test that actually pins per-repo git
+// serialisation.
+//
+// Concurrent read-only trial merges turn out to be fairly benign — each runs in
+// its own throwaway worktree and touches no ref. The genuine hazard is the
+// read-modify-write MergePR performs: it checks the base branch out, merges
+// onto it, and moves the ref. Two of those interleaved both fork from the same
+// tip and both move the ref, so the first merge is silently lost — a wrong
+// answer, not a crash, and one no race detector would report. The merge train
+// merges several PRs onto one base, so this is a shape the engine really
+// produces.
+func TestConcurrentMergesOntoOneBase(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo(repoName).
+		SeedCommit(repoName, "main", map[string]string{"base.txt": "base\n"}, "base")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding base: %v", err)
+	}
+
+	// Three PRs off main, each adding a distinct file so no merge conflicts.
+	const prCount = 3
+	for i := 1; i <= prCount; i++ {
+		branch := fmt.Sprintf("feature-%d", i)
+		s.SeedCommitFrom(repoName, branch, "main", map[string]string{
+			fmt.Sprintf("feature-%d.txt", i): "content\n",
+		}, fmt.Sprintf("feature %d", i)).
+			SeedPR(repoName, PRSeed{Number: i, Head: branch, Base: "main"})
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding PRs: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, prCount)
+	for i := 1; i <= prCount; i++ {
+		wg.Add(1)
+		go func(num int) {
+			defer wg.Done()
+			if err := s.MergePR("acme", "widgets", num); err != nil {
+				errs <- fmt.Errorf("MergePR(%d): %w", num, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	// Every merge must be present in main's tree. A lost update shows up here
+	// as a missing file, even though every MergePR call returned nil.
+	r, err := s.repoByKey(repoName)
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	r.gitMu.Lock()
+	tree, gitErr := runGit(r.bareDir, "ls-tree", "--name-only", "refs/heads/main")
+	r.gitMu.Unlock()
+	if gitErr != nil {
+		t.Fatalf("ls-tree: %v", gitErr)
+	}
+	for i := 1; i <= prCount; i++ {
+		want := fmt.Sprintf("feature-%d.txt", i)
+		if !strings.Contains(tree, want) {
+			t.Errorf("main is missing %s after a concurrent merge; tree = %q", want, tree)
+		}
+	}
+
+	for i := 1; i <= prCount; i++ {
+		merged, err := s.FetchPRMerged("acme", "widgets", i)
+		if err != nil {
+			t.Fatalf("FetchPRMerged(%d): %v", i, err)
+		}
+		if !merged {
+			t.Errorf("PR %d does not report merged", i)
+		}
 	}
 }
 

--- a/tests/sim/simgh/deps.go
+++ b/tests/sim/simgh/deps.go
@@ -1,0 +1,87 @@
+package simgh
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// AddBlockedByIssue records that issueNodeID is blocked by blockerNodeID.
+//
+// Both arguments are node IDs, matching the GraphQL mutation production calls.
+// Note what a fake at this layer cannot check: the v0.0.66 regression was a
+// wrong mutation *name* inside the query document, and every interface-level
+// implementation of this method — including this one — is green against it.
+// See ../README.md for what closes that gap.
+func (s *Sim) AddBlockedByIssue(issueNodeID, blockerNodeID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	blockerRepo, blockerNum, err := parseIssueNodeID(blockerNodeID)
+	if err != nil {
+		return fmt.Errorf("simgh: AddBlockedByIssue blocker: %w", err)
+	}
+	targetRepo, targetNum, err := parseIssueNodeID(issueNodeID)
+	if err != nil {
+		return fmt.Errorf("simgh: AddBlockedByIssue target: %w", err)
+	}
+
+	r, ok := s.repos[targetRepo]
+	if !ok {
+		return fmt.Errorf("simgh: repo %s not seeded", targetRepo)
+	}
+	iss, ok := r.issues[targetNum]
+	if !ok {
+		return fmt.Errorf("simgh: issue %s#%d not found", targetRepo, targetNum)
+	}
+
+	// GitHub silently ignores a duplicate dependency rather than erroring.
+	for _, dep := range iss.blockedBy {
+		depRepo := dep.Repo
+		if depRepo == "" {
+			depRepo = targetRepo
+		}
+		if dep.Number == blockerNum && depRepo == blockerRepo {
+			return nil
+		}
+	}
+
+	repoField := ""
+	if blockerRepo != targetRepo {
+		repoField = blockerRepo
+	}
+	iss.blockedBy = append(iss.blockedBy, gh.Dependency{Number: blockerNum, Repo: repoField})
+	iss.updatedAt = s.now()
+	return nil
+}
+
+// parseIssueNodeID splits a synthesised issue node ID ("issue:owner/repo#N")
+// back into its parts. Sim node IDs are readable rather than opaque because
+// production never parses a node ID it receives — it only round-trips them —
+// so the format is an implementation convenience, not a modelled behaviour.
+func parseIssueNodeID(nodeID string) (ownerRepo string, number int, err error) {
+	return parseNodeID("issue:", nodeID)
+}
+
+// parsePRNodeID splits a synthesised PR node ID ("pr:owner/repo#N").
+func parsePRNodeID(nodeID string) (ownerRepo string, number int, err error) {
+	return parseNodeID("pr:", nodeID)
+}
+
+func parseNodeID(prefix, nodeID string) (string, int, error) {
+	rest, ok := strings.CutPrefix(nodeID, prefix)
+	if !ok {
+		return "", 0, fmt.Errorf("simgh: node ID %q does not have prefix %q", nodeID, prefix)
+	}
+	repoPart, numPart, ok := strings.Cut(rest, "#")
+	if !ok {
+		return "", 0, fmt.Errorf("simgh: malformed node ID %q", nodeID)
+	}
+	n, err := strconv.Atoi(numPart)
+	if err != nil {
+		return "", 0, fmt.Errorf("simgh: malformed number in node ID %q", nodeID)
+	}
+	return repoPart, n, nil
+}

--- a/tests/sim/simgh/deps.go
+++ b/tests/sim/simgh/deps.go
@@ -37,6 +37,20 @@ func (s *Sim) AddBlockedByIssue(issueNodeID, blockerNodeID string) error {
 		return fmt.Errorf("simgh: issue %s#%d not found", targetRepo, targetNum)
 	}
 
+	// The blocker must exist too. GitHub's mutation fails on a node ID that
+	// resolves to nothing, and a dangling blocker is worse here than a plain
+	// no-op: resolveDependenciesLocked reports an unresolvable blocker as
+	// State "OPEN", so the dependent issue would read as permanently blocked
+	// with no diagnostic anywhere — a wrong ID silently accepted, which is the
+	// bug class this layer exists to catch.
+	br, ok := s.repos[blockerRepo]
+	if !ok {
+		return fmt.Errorf("simgh: blocker repo %s not seeded", blockerRepo)
+	}
+	if _, ok := br.issues[blockerNum]; !ok {
+		return fmt.Errorf("simgh: blocker issue %s#%d not found", blockerRepo, blockerNum)
+	}
+
 	// GitHub silently ignores a duplicate dependency rather than erroring.
 	for _, dep := range iss.blockedBy {
 		depRepo := dep.Repo

--- a/tests/sim/simgh/deps.go
+++ b/tests/sim/simgh/deps.go
@@ -28,6 +28,14 @@ func (s *Sim) AddBlockedByIssue(issueNodeID, blockerNodeID string) error {
 		return fmt.Errorf("simgh: AddBlockedByIssue target: %w", err)
 	}
 
+	// GitHub refuses an issue blocked by itself, and so does the model: a
+	// self-block is unsatisfiable by construction, so the engine's dependency
+	// gate would hold the issue forever with nothing to diagnose. Longer cycles
+	// are *not* detected — see FIDELITY.md.
+	if targetRepo == blockerRepo && targetNum == blockerNum {
+		return fmt.Errorf("simgh: issue %s#%d cannot block itself", targetRepo, targetNum)
+	}
+
 	r, ok := s.repos[targetRepo]
 	if !ok {
 		return fmt.Errorf("simgh: repo %s not seeded", targetRepo)

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -1,0 +1,332 @@
+package simgh
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// This file is the git-backed half of the model. Everything git can genuinely
+// answer is computed here by running the real git binary against a real bare
+// repository: mergeability comes from an actual trial merge, MergePR writes an
+// actual merge commit, commits-behind comes from rev-list. Nothing in this
+// file consults a declared boolean.
+//
+// Every exported entry point below acquires the repo's gitMu for the duration
+// of its subprocess calls. Per the package doc's invariant, no function here
+// may acquire Sim.mu.
+
+// simGitAuthor is the identity every commit the model writes is attributed to.
+const (
+	simGitName  = "simgh"
+	simGitEmail = "simgh@example.invalid"
+)
+
+// gitEnv returns a non-interactive environment for git subprocesses, mirroring
+// engine/worktree.go's nonInteractiveGitEnv. The sim never talks to a network
+// remote, but a stray credential or SSH prompt would hang a test rather than
+// fail it.
+func gitEnv() []string {
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME="+simGitName,
+		"GIT_AUTHOR_EMAIL="+simGitEmail,
+		"GIT_COMMITTER_NAME="+simGitName,
+		"GIT_COMMITTER_EMAIL="+simGitEmail,
+	)
+}
+
+// runGit executes git in dir and returns trimmed stdout. Caller must hold the
+// repo's gitMu.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// runGitAllowFail executes git and reports the exit status without treating a
+// non-zero exit as an error. Used where a non-zero exit is a meaningful answer
+// rather than a failure — a conflicting merge, most importantly.
+func runGitAllowFail(dir string, args ...string) (out string, ok bool, err error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	combined, err := cmd.CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(combined)), true, nil
+	}
+	var exitErr *exec.ExitError
+	if ok := asExitError(err, &exitErr); ok {
+		return strings.TrimSpace(string(combined)), false, nil
+	}
+	return strings.TrimSpace(string(combined)), false, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+}
+
+// asExitError reports whether err is an *exec.ExitError, assigning it to target.
+func asExitError(err error, target **exec.ExitError) bool {
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// initBare creates the backing bare repository and gives it a root commit on
+// defaultBranch.
+//
+// The root commit is written with plumbing (mktree + commit-tree + update-ref)
+// rather than through a worktree, because `git worktree add` needs a commit to
+// check out and a fresh bare repo has none. Every later operation goes through
+// a real worktree.
+func initBare(dir, defaultBranch string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("simgh: creating repo dir: %w", err)
+	}
+	if _, err := runGit(filepath.Dir(dir), "init", "--bare", "-b", defaultBranch, filepath.Base(dir)); err != nil {
+		return err
+	}
+	// Empty tree, then a root commit pointing at it.
+	tree, err := runGitStdin(dir, "", "mktree")
+	if err != nil {
+		return err
+	}
+	commit, err := runGitStdin(dir, "root commit\n", "commit-tree", tree)
+	if err != nil {
+		return err
+	}
+	if _, err := runGit(dir, "update-ref", "refs/heads/"+defaultBranch, commit); err != nil {
+		return err
+	}
+	return nil
+}
+
+// runGitStdin executes git with the given stdin, returning trimmed stdout only
+// (not stderr), since callers here consume object IDs.
+func runGitStdin(dir, stdin string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	cmd.Stdin = strings.NewReader(stdin)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// withWorktree checks ref out into a throwaway detached worktree, runs fn
+// against it, and removes it. Trial merges must not share a working tree —
+// git's index and worktree administrative files are not concurrency-safe, and
+// a shared checkout would also let one operation's leftover conflict state
+// leak into the next.
+//
+// Caller must hold the repo's gitMu.
+func (r *repoState) withWorktree(ref string, fn func(wt string) error) (err error) {
+	tmp, err := os.MkdirTemp("", "simgh-wt-")
+	if err != nil {
+		return fmt.Errorf("simgh: creating worktree temp dir: %w", err)
+	}
+	// git worktree add insists on creating the directory itself.
+	wt := filepath.Join(tmp, "wt")
+
+	if _, err := runGit(r.bareDir, "worktree", "add", "--detach", wt, ref); err != nil {
+		os.RemoveAll(tmp)
+		return err
+	}
+	defer func() {
+		// Prune unconditionally: the worktree removal can legitimately fail if
+		// fn left the tree in a conflicted state, and a stale administrative
+		// entry would break the next operation on this repo.
+		_, _, _ = runGitAllowFail(r.bareDir, "worktree", "remove", "--force", wt)
+		os.RemoveAll(tmp)
+		_, _, _ = runGitAllowFail(r.bareDir, "worktree", "prune")
+	}()
+
+	return fn(wt)
+}
+
+// resolveRef returns the commit SHA a ref points at. Caller must hold gitMu.
+func (r *repoState) resolveRef(ref string) (string, error) {
+	return runGit(r.bareDir, "rev-parse", "--verify", ref+"^{commit}")
+}
+
+// branchExists reports whether a branch is present in the backing repo.
+// Caller must hold gitMu.
+func (r *repoState) branchExists(branch string) bool {
+	_, ok, err := runGitAllowFail(r.bareDir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	return err == nil && ok
+}
+
+// tryMerge performs a real merge of head into base in a throwaway worktree.
+//
+// It is the single entry point for both uses: a read-only mergeability probe
+// (commit=false, result discarded) and an actual merge (commit=true, which
+// fast-forwards base's ref to the new merge commit). Sharing one
+// implementation is deliberate — if the probe and the merge could disagree,
+// the model would be able to report a PR mergeable and then fail to merge it,
+// which is precisely the class of bug this layer exists to catch.
+//
+// Returns conflict=true when the merge genuinely cannot be performed. Caller
+// must hold gitMu.
+func (r *repoState) tryMerge(base, head string, commit bool, msg string) (sha string, conflict bool, err error) {
+	if !r.branchExists(base) {
+		return "", false, fmt.Errorf("simgh: base branch %q does not exist in %s/%s", base, r.owner, r.repo)
+	}
+	if !r.branchExists(head) {
+		return "", false, fmt.Errorf("simgh: head branch %q does not exist in %s/%s", head, r.owner, r.repo)
+	}
+
+	headSHA, err := r.resolveRef("refs/heads/" + head)
+	if err != nil {
+		return "", false, err
+	}
+
+	err = r.withWorktree("refs/heads/"+base, func(wt string) error {
+		// --no-ff so a fast-forwardable head still produces a real merge
+		// commit, matching GitHub's default "Create a merge commit" strategy.
+		out, ok, runErr := runGitAllowFail(wt, "merge", "--no-ff", "-m", msg, headSHA)
+		if runErr != nil {
+			return runErr
+		}
+		if !ok {
+			// Distinguish a genuine content conflict from any other failure.
+			// "Already up to date" exits zero, so reaching here with no
+			// conflicted paths means something else went wrong.
+			conflicted, _, lsErr := runGitAllowFail(wt, "diff", "--name-only", "--diff-filter=U")
+			if lsErr == nil && strings.TrimSpace(conflicted) != "" {
+				conflict = true
+				return nil
+			}
+			return fmt.Errorf("simgh: merging %s into %s: %s", head, base, out)
+		}
+		newSHA, err := runGit(wt, "rev-parse", "HEAD")
+		if err != nil {
+			return err
+		}
+		sha = newSHA
+		return nil
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if conflict {
+		return "", true, nil
+	}
+
+	if commit {
+		// The merge commit already exists in the shared object store; publish
+		// it by moving the base branch.
+		if _, err := runGit(r.bareDir, "update-ref", "refs/heads/"+base, sha); err != nil {
+			return "", false, err
+		}
+	}
+	return sha, false, nil
+}
+
+// commitsBehind returns how many commits are on base but not on head — the
+// same quantity GitHub's compare endpoint reports as behind_by, which is what
+// production's FetchCommitsBehind reads. Caller must hold gitMu.
+func (r *repoState) commitsBehind(base, head string) (int, error) {
+	baseRef, headRef := "refs/heads/"+base, "refs/heads/"+head
+	if !r.branchExists(base) {
+		return 0, fmt.Errorf("simgh: base branch %q does not exist in %s/%s", base, r.owner, r.repo)
+	}
+	if !r.branchExists(head) {
+		return 0, fmt.Errorf("simgh: head branch %q does not exist in %s/%s", head, r.owner, r.repo)
+	}
+	out, err := runGit(r.bareDir, "rev-list", "--count", headRef+".."+baseRef)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("simgh: parsing rev-list count %q: %w", out, err)
+	}
+	return n, nil
+}
+
+// commitFiles writes files into branch and commits them, creating the branch
+// from fromBranch if it does not yet exist. Returns the new commit SHA.
+// Caller must hold gitMu.
+func (r *repoState) commitFiles(branch, fromBranch string, files map[string]string, msg string) (string, error) {
+	startRef := "refs/heads/" + branch
+	if !r.branchExists(branch) {
+		if fromBranch == "" {
+			fromBranch = r.defaultBranch
+		}
+		if !r.branchExists(fromBranch) {
+			return "", fmt.Errorf("simgh: cannot branch %q from missing %q", branch, fromBranch)
+		}
+		startRef = "refs/heads/" + fromBranch
+	}
+
+	var sha string
+	err := r.withWorktree(startRef, func(wt string) error {
+		for name, content := range files {
+			p := filepath.Join(wt, name)
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				return fmt.Errorf("simgh: creating dir for %s: %w", name, err)
+			}
+			if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+				return fmt.Errorf("simgh: writing %s: %w", name, err)
+			}
+		}
+		if _, err := runGit(wt, "add", "-A"); err != nil {
+			return err
+		}
+		if _, err := runGit(wt, "commit", "--allow-empty", "-m", msg); err != nil {
+			return err
+		}
+		out, err := runGit(wt, "rev-parse", "HEAD")
+		if err != nil {
+			return err
+		}
+		sha = out
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if _, err := runGit(r.bareDir, "update-ref", "refs/heads/"+branch, sha); err != nil {
+		return "", err
+	}
+	return sha, nil
+}
+
+// createBranch points a new branch at fromBranch's tip. Caller must hold gitMu.
+func (r *repoState) createBranch(branch, fromBranch string) error {
+	if fromBranch == "" {
+		fromBranch = r.defaultBranch
+	}
+	sha, err := r.resolveRef("refs/heads/" + fromBranch)
+	if err != nil {
+		return err
+	}
+	_, err = runGit(r.bareDir, "update-ref", "refs/heads/"+branch, sha)
+	return err
+}
+
+// headSHA resolves a branch tip, returning "" when the branch does not exist
+// (a PR whose head branch was deleted is a real state, not an error).
+// Caller must hold gitMu.
+func (r *repoState) headSHA(branch string) string {
+	if !r.branchExists(branch) {
+		return ""
+	}
+	sha, err := r.resolveRef("refs/heads/" + branch)
+	if err != nil {
+		return ""
+	}
+	return sha
+}

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -381,16 +381,17 @@ func (r *repoState) createBranch(branch, fromBranch string) error {
 	return err
 }
 
-// headSHA resolves a branch tip, returning "" when the branch does not exist
-// (a PR whose head branch was deleted is a real state, not an error).
-// Caller must hold gitMu.
-func (r *repoState) headSHA(branch string) string {
+// headSHA resolves a branch tip, returning "" when the branch does not exist —
+// a PR whose head branch was deleted is a real state, not an error.
+//
+// That empty string models exactly one condition, so a resolveRef failure is
+// *not* folded into it: branchExists confirmed the ref a moment earlier, so a
+// failure here is a genuine git error (a corrupt object, a ref pointing at a
+// non-commit) and must surface as one rather than be miscategorised as
+// legitimate simulated GitHub state. Caller must hold gitMu.
+func (r *repoState) headSHA(branch string) (string, error) {
 	if !r.branchExists(branch) {
-		return ""
+		return "", nil
 	}
-	sha, err := r.resolveRef("refs/heads/" + branch)
-	if err != nil {
-		return ""
-	}
-	return sha
+	return r.resolveRef("refs/heads/" + branch)
 }

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -39,6 +39,15 @@ func gitEnv() []string {
 	return append(os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_CONFIG_NOSYSTEM=1",
+		// Isolate the invoking user's ~/.gitconfig as well as the system one.
+		// Without this the package inherits whatever the developer or CI runner
+		// has set, and several common settings break it for reasons unrelated
+		// to the code under test: commit.gpgsign=true makes every commit here
+		// fail or hang on a GPG prompt, core.hooksPath points commits at hooks
+		// that know nothing about these throwaway worktrees, and commit.template
+		// perturbs the messages. /dev/null is git's documented way to say "no
+		// global config" (GIT_CONFIG_GLOBAL, git >= 2.32).
+		"GIT_CONFIG_GLOBAL=/dev/null",
 		"GIT_AUTHOR_NAME="+simGitName,
 		"GIT_AUTHOR_EMAIL="+simGitEmail,
 		"GIT_COMMITTER_NAME="+simGitName,

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -260,6 +260,16 @@ func (r *repoState) commitsBehind(base, head string) (int, error) {
 // from fromBranch if it does not yet exist. Returns the new commit SHA.
 // Caller must hold gitMu.
 func (r *repoState) commitFiles(branch, fromBranch string, files map[string]string, msg string) (string, error) {
+	// Validated up front, before any git work, so a bad name refuses the whole
+	// commit rather than leaving some files already written. Sorted so the
+	// error names the same key on every run despite map ordering.
+	names := sortedKeys(files)
+	for _, name := range names {
+		if err := validateRepoRelPath(name); err != nil {
+			return "", err
+		}
+	}
+
 	startRef := "refs/heads/" + branch
 	if !r.branchExists(branch) {
 		if fromBranch == "" {
@@ -273,7 +283,8 @@ func (r *repoState) commitFiles(branch, fromBranch string, files map[string]stri
 
 	var sha string
 	err := r.withWorktree(startRef, func(wt string) error {
-		for name, content := range files {
+		for _, name := range names {
+			content := files[name]
 			p := filepath.Join(wt, name)
 			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 				return fmt.Errorf("simgh: creating dir for %s: %w", name, err)

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -1,6 +1,7 @@
 package simgh
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,6 +25,11 @@ const (
 	simGitName  = "simgh"
 	simGitEmail = "simgh@example.invalid"
 )
+
+// errNothingToMerge reports that a merge would produce no commit because the
+// head is already contained in the base. Callers wrap it in the sentinel the
+// engine tests against; see tryMerge and MergePR.
+var errNothingToMerge = errors.New("head is already contained in base, so there is no merge commit to write")
 
 // gitEnv returns a non-interactive environment for git subprocesses, mirroring
 // engine/worktree.go's nonInteractiveGitEnv. The sim never talks to a network
@@ -131,9 +137,19 @@ func runGitStdin(dir, stdin string, args ...string) (string, error) {
 // a shared checkout would also let one operation's leftover conflict state
 // leak into the next.
 //
+// The throwaway lives under the repo's worktreeRoot, inside Sim.baseDir, not in
+// the OS temp dir. The deferred cleanup below removes it on every ordinary
+// path, but a process killed mid-merge (OOM, SIGKILL, a CI timeout) cannot run
+// deferred code — and an orphan under the OS temp dir would outlive both the
+// sandbox this package's doc comment promises and t.TempDir()'s cleanup.
+// Keeping it inside baseDir makes the test framework the backstop.
+//
 // Caller must hold the repo's gitMu.
 func (r *repoState) withWorktree(ref string, fn func(wt string) error) (err error) {
-	tmp, err := os.MkdirTemp("", "simgh-wt-")
+	if err := os.MkdirAll(r.worktreeRoot, 0o755); err != nil {
+		return fmt.Errorf("simgh: creating worktree root: %w", err)
+	}
+	tmp, err := os.MkdirTemp(r.worktreeRoot, "wt-")
 	if err != nil {
 		return fmt.Errorf("simgh: creating worktree temp dir: %w", err)
 	}
@@ -191,6 +207,10 @@ func (r *repoState) tryMerge(base, head string, commit bool, msg string) (sha st
 	if err != nil {
 		return "", false, err
 	}
+	baseSHA, err := r.resolveRef("refs/heads/" + base)
+	if err != nil {
+		return "", false, err
+	}
 
 	err = r.withWorktree("refs/heads/"+base, func(wt string) error {
 		// --no-ff so a fast-forwardable head still produces a real merge
@@ -222,6 +242,25 @@ func (r *repoState) tryMerge(base, head string, commit bool, msg string) (sha st
 	}
 	if conflict {
 		return "", true, nil
+	}
+
+	// `git merge --no-ff` prints "Already up to date." and exits *zero* without
+	// creating a commit when head is already contained in base's history — the
+	// state a second merge of the same branch leaves behind. The tip is then
+	// unchanged, so publishing it would flip merged=true while writing no merge
+	// commit at all, silently breaking the invariant this package and
+	// FIDELITY.md both state unconditionally.
+	//
+	// The probe (commit=false) is untouched: there is genuinely no conflict, so
+	// it still reports mergeable. Only the merge itself refuses, which is also
+	// how GitHub behaves — a PR with nothing left to merge is not a conflict,
+	// but its merge endpoint will not manufacture an empty merge commit.
+	if sha == baseSHA {
+		if commit {
+			return "", false, fmt.Errorf("simgh: merging %s into %s in %s/%s: %w",
+				head, base, r.owner, r.repo, errNothingToMerge)
+		}
+		return sha, false, nil
 	}
 
 	if commit {

--- a/tests/sim/simgh/git.go
+++ b/tests/sim/simgh/git.go
@@ -354,8 +354,22 @@ func (r *repoState) commitFiles(branch, fromBranch string, files map[string]stri
 	return sha, nil
 }
 
-// createBranch points a new branch at fromBranch's tip. Caller must hold gitMu.
+// createBranch points a *new* branch at fromBranch's tip. Caller must hold
+// gitMu.
+//
+// An existing branch is refused rather than repointed. GitHub's create-ref
+// endpoint behaves the same way (422 "Reference already exists") — moving a
+// branch is a separate, explicit operation there, not something ref creation
+// does silently. The refusal matters more here than the API parity: the raw
+// `update-ref` this wraps would happily discard whatever the branch already
+// pointed at, so SeedBranch after a SeedCommit on the same branch would throw
+// the seeded commits away and still report success. Growing a branch is
+// commitFiles' job, and it already forks-or-appends deliberately.
 func (r *repoState) createBranch(branch, fromBranch string) error {
+	if r.branchExists(branch) {
+		return fmt.Errorf("simgh: branch %q already exists in %s/%s; "+
+			"use SeedCommit to add commits to an existing branch", branch, r.owner, r.repo)
+	}
 	if fromBranch == "" {
 		fromBranch = r.defaultBranch
 	}

--- a/tests/sim/simgh/git_merge_test.go
+++ b/tests/sim/simgh/git_merge_test.go
@@ -182,6 +182,61 @@ func TestMergePRProducesRealMergeCommit(t *testing.T) {
 	}
 }
 
+// TestMergePRCreatesMergeCommitEvenWhenFastForwardable pins GitHub's default
+// "Create a merge commit" strategy: when the head is a strict descendant of the
+// base, git would happily fast-forward, but GitHub still writes a two-parent
+// merge commit. Without this case the divergent-branch test above cannot tell
+// --no-ff from --ff, since divergent branches force a merge commit either way.
+func TestMergePRCreatesMergeCommitEvenWhenFastForwardable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	// The head branch descends directly from main, which does not move.
+	s.SeedCommit(repoName, "main", map[string]string{"base.txt": "base\n"}, "base").
+		SeedCommit(repoName, headBranch, map[string]string{"feature.txt": "feature\n"}, "feature").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	baseBefore := mustHeadSHA(t, s, repoName, "main")
+	headSHA := mustHeadSHA(t, s, repoName, headBranch)
+
+	// Precondition: this merge really is fast-forwardable.
+	behind, err := s.FetchCommitsBehind("acme", "widgets", "main", headBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind: %v", err)
+	}
+	if behind != 0 {
+		t.Fatalf("precondition: head is %d commits behind main, want 0", behind)
+	}
+
+	if err := s.MergePR("acme", "widgets", 42); err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+
+	after := mustHeadSHA(t, s, repoName, "main")
+	if after == headSHA {
+		t.Fatal("MergePR fast-forwarded main onto the head commit; GitHub's merge-commit strategy writes a merge commit")
+	}
+
+	r, err := s.repoByKey(repoName)
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	r.gitMu.Lock()
+	parents, gitErr := runGit(r.bareDir, "rev-list", "--parents", "-n", "1", "refs/heads/main")
+	r.gitMu.Unlock()
+	if gitErr != nil {
+		t.Fatalf("rev-list --parents: %v", gitErr)
+	}
+	fields := strings.Fields(parents)
+	if len(fields) != 3 {
+		t.Fatalf("main tip has %d parents (%q), want a two-parent merge commit", len(fields)-1, parents)
+	}
+	if fields[1] != baseBefore || fields[2] != headSHA {
+		t.Fatalf("merge commit parents = %v, want [%s %s]", fields[1:], baseBefore, headSHA)
+	}
+}
+
 // TestMergePRRefusesRealConflict proves the merge path and the probe agree: a
 // PR the probe reports unmergeable cannot be merged, and the refusal carries
 // the error kind production uses for a conflict.

--- a/tests/sim/simgh/git_merge_test.go
+++ b/tests/sim/simgh/git_merge_test.go
@@ -1,6 +1,9 @@
 package simgh
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -329,5 +332,121 @@ func TestHeadSHATracksNewCommits(t *testing.T) {
 	}
 	if second.HeadSHA != mustHeadSHA(t, s, repoName, headBranch) {
 		t.Fatalf("head SHA %s does not match the branch tip", second.HeadSHA)
+	}
+}
+
+// TestMergePRRefusesWhenNothingToMerge pins that a merge which would write no
+// commit is refused rather than recorded.
+//
+// `git merge --no-ff` prints "Already up to date." and exits *zero* when the
+// head is already contained in the base, leaving the tip untouched. Publishing
+// that tip would flip merged=true having written no merge commit at all —
+// silently breaking the invariant this package and FIDELITY.md both state
+// unconditionally ("MergePR writes a real merge commit onto the base ref").
+//
+// The state is ordinary, not contrived: merging a branch and then merging it
+// again reaches it, which a scenario replaying a merge-train batch can do.
+func TestMergePRRefusesWhenNothingToMerge(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Title: "first"}).
+		SeedPR(repoName, PRSeed{Number: 43, Head: headBranch, Base: "main", Title: "again"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	if err := s.MergePR("acme", "widgets", 42); err != nil {
+		t.Fatalf("first MergePR: %v", err)
+	}
+
+	// main now contains headBranch, so #43 has nothing left to merge.
+	tipBefore := mustHeadSHA(t, s, repoName, "main")
+
+	err := s.MergePR("acme", "widgets", 43)
+	if err == nil {
+		t.Fatal("MergePR succeeded with nothing to merge — it would have recorded a merge that wrote no commit")
+	}
+	if !isNotMergeable(err) {
+		t.Fatalf("MergePR error = %v, want it to wrap gh.ErrNotMergeable", err)
+	}
+
+	// The refusal must leave no trace: no moved ref, and no merged flag.
+	if tipAfter := mustHeadSHA(t, s, repoName, "main"); tipAfter != tipBefore {
+		t.Fatalf("main moved from %s to %s on a refused merge", tipBefore, tipAfter)
+	}
+	merged, ferr := s.FetchPRMerged("acme", "widgets", 43)
+	if ferr != nil {
+		t.Fatalf("FetchPRMerged: %v", ferr)
+	}
+	if merged {
+		t.Fatal("PR #43 reports merged after a refused merge")
+	}
+
+	// The read-only probe is deliberately unaffected: there is no conflict, so
+	// mergeability still reports true. Only the merge itself refuses, matching
+	// GitHub, where "nothing to merge" is not a conflict.
+	mergeable, perr := s.FetchPRMergeable("acme", "widgets", 43)
+	if perr != nil {
+		t.Fatalf("FetchPRMergeable: %v", perr)
+	}
+	if mergeable == nil || !*mergeable {
+		t.Fatalf("FetchPRMergeable = %v, want true — nothing-to-merge is not a conflict", mergeable)
+	}
+}
+
+// TestTrialWorktreeStaysInsideBaseDir pins that throwaway worktrees are created
+// under Sim.baseDir.
+//
+// The deferred cleanup in withWorktree covers every ordinary path, but a
+// process killed mid-merge (OOM, SIGKILL, a CI timeout) never runs it. Under
+// the OS temp dir that orphan outlives both the sandbox the package doc
+// promises and t.TempDir()'s cleanup; under baseDir the test framework is the
+// backstop.
+func TestTrialWorktreeStaysInsideBaseDir(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+
+	r, err := s.repoByKey(repoName)
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+
+	// Resolve inside the callback: the deferred cleanup deletes the directory
+	// before withWorktree returns, and EvalSymlinks cannot resolve a path that
+	// no longer exists.
+	var seen, got string
+	r.gitMu.Lock()
+	wtErr := r.withWorktree("refs/heads/main", func(wt string) error {
+		seen = wt
+		// The checkout must be real, not just a path: a directory that is not
+		// a worktree would make the containment assertion meaningless.
+		if _, statErr := os.Stat(filepath.Join(wt, ".git")); statErr != nil {
+			return fmt.Errorf("worktree has no .git entry: %w", statErr)
+		}
+		resolved, resErr := filepath.EvalSymlinks(wt)
+		if resErr != nil {
+			return fmt.Errorf("EvalSymlinks(worktree): %w", resErr)
+		}
+		got = resolved
+		return nil
+	})
+	r.gitMu.Unlock()
+	if wtErr != nil {
+		t.Fatalf("withWorktree: %v", wtErr)
+	}
+
+	base, err := filepath.EvalSymlinks(s.baseDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(baseDir): %v", err)
+	}
+	rel, err := filepath.Rel(base, got)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Fatalf("worktree %s is outside baseDir %s (rel=%q, err=%v)", got, base, rel, err)
+	}
+
+	// And it must not survive the call.
+	if _, statErr := os.Stat(seen); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree %s still exists after withWorktree returned (stat err = %v)", seen, statErr)
 	}
 }

--- a/tests/sim/simgh/git_merge_test.go
+++ b/tests/sim/simgh/git_merge_test.go
@@ -450,3 +450,36 @@ func TestTrialWorktreeStaysInsideBaseDir(t *testing.T) {
 		t.Fatalf("worktree %s still exists after withWorktree returned (stat err = %v)", seen, statErr)
 	}
 }
+
+// TestSeedBranchRefusesExistingBranch pins that SeedBranch creates a branch
+// rather than repointing one.
+//
+// The raw `update-ref` underneath would happily move an existing branch, so
+// seeding a branch that already carries commits would discard them and still
+// report success — a scenario author would only notice by wondering where
+// their commits went. GitHub's create-ref endpoint refuses the same case
+// (422 "Reference already exists"), so refusing is both the faithful answer
+// and the safe one. Growing a branch is SeedCommit's job.
+func TestSeedBranchRefusesExistingBranch(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedCommit(repoName, headBranch, map[string]string{"feature.txt": "work\n"}, "seeded work")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	before := mustHeadSHA(t, s, repoName, headBranch)
+
+	s.SeedBranch(repoName, headBranch, "main")
+
+	err := s.Err()
+	if err == nil {
+		t.Fatal("SeedBranch onto an existing branch reported success; it silently discarded the seeded commits")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("SeedBranch error = %v, want an 'already exists' refusal", err)
+	}
+	// The refusal must leave the branch alone. An error raised only after the
+	// ref had already moved would still have lost the commits.
+	if after := mustHeadSHA(t, s, repoName, headBranch); after != before {
+		t.Fatalf("refused SeedBranch still moved %s from %s to %s", headBranch, before, after)
+	}
+}

--- a/tests/sim/simgh/git_merge_test.go
+++ b/tests/sim/simgh/git_merge_test.go
@@ -1,0 +1,278 @@
+package simgh
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests are the proof that the model is git-backed rather than
+// git-shaped. Every conflict below is produced by real commits that genuinely
+// cannot be merged; nothing declares a mergeability answer. A fake that let a
+// test assert "this PR conflicts" could not catch a mergeability bug, so these
+// cases construct the conflict and let git decide.
+
+const (
+	repoName    = "acme/widgets"
+	headBranch  = "fabrik/issue-7"
+	otherBranch = "sibling"
+)
+
+// seedConflict builds a genuine three-way conflict: both branches edit the
+// same line of the same file after diverging from a common ancestor.
+func seedConflict(t *testing.T, s *Sim) {
+	t.Helper()
+	s.SeedCommit(repoName, "main", map[string]string{"shared.txt": "original\n"}, "common ancestor").
+		SeedCommit(repoName, headBranch, map[string]string{"shared.txt": "feature edit\n"}, "feature edits the line").
+		SeedCommit(repoName, "main", map[string]string{"shared.txt": "main edit\n"}, "main edits the same line")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding conflict: %v", err)
+	}
+}
+
+// seedCleanDivergence builds branches that diverge but touch different files,
+// so the merge succeeds.
+func seedCleanDivergence(t *testing.T, s *Sim) {
+	t.Helper()
+	s.SeedCommit(repoName, "main", map[string]string{"shared.txt": "original\n"}, "common ancestor").
+		SeedCommit(repoName, headBranch, map[string]string{"feature.txt": "feature\n"}, "feature adds its own file").
+		SeedCommit(repoName, "main", map[string]string{"mainonly.txt": "main\n"}, "main adds its own file")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding clean divergence: %v", err)
+	}
+}
+
+func TestFetchPRMergeableFalseOnRealConflict(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedConflict(t, s)
+
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Title: "conflicting"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding PR: %v", err)
+	}
+
+	mergeable, err := s.FetchPRMergeable("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMergeable: %v", err)
+	}
+	if mergeable == nil {
+		t.Fatal("FetchPRMergeable returned nil for a PR with no recompute window pending")
+	}
+	if *mergeable {
+		t.Fatal("FetchPRMergeable = true for branches that genuinely conflict in the backing repo")
+	}
+
+	state, err := s.FetchPRMergeableState("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMergeableState: %v", err)
+	}
+	if state != stateDirty {
+		t.Fatalf("mergeable state = %q, want %q", state, stateDirty)
+	}
+}
+
+func TestFetchPRMergeableTrueWhenBranchesDoNotConflict(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Title: "clean"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding PR: %v", err)
+	}
+
+	mergeable, err := s.FetchPRMergeable("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMergeable: %v", err)
+	}
+	if mergeable == nil || !*mergeable {
+		t.Fatalf("FetchPRMergeable = %v, want true for non-conflicting branches", mergeable)
+	}
+}
+
+// TestMergeableProbeIsRepeatableAndNonDestructive guards the throwaway-worktree
+// design: a trial merge must not leave conflict state behind that poisons the
+// next probe, and must never move the base branch.
+func TestMergeableProbeIsRepeatableAndNonDestructive(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedConflict(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	baseBefore := mustHeadSHA(t, s, repoName, "main")
+	for i := range 3 {
+		mergeable, err := s.FetchPRMergeable("acme", "widgets", 42)
+		if err != nil {
+			t.Fatalf("probe %d: %v", i, err)
+		}
+		if mergeable == nil || *mergeable {
+			t.Fatalf("probe %d: mergeable = %v, want false every time", i, mergeable)
+		}
+	}
+	if after := mustHeadSHA(t, s, repoName, "main"); after != baseBefore {
+		t.Fatalf("a read-only mergeability probe moved main from %s to %s", baseBefore, after)
+	}
+}
+
+// TestMergePRProducesRealMergeCommit is acceptance criterion 4: the merge must
+// be an actual commit on the base ref, and a sibling branch's commits-behind
+// count must reflect it.
+func TestMergePRProducesRealMergeCommit(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+
+	// A sibling branch pinned at main's pre-merge tip, used to observe the
+	// merge landing.
+	s.SeedBranch(repoName, otherBranch, "main").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Title: "clean"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	behindBefore, err := s.FetchCommitsBehind("acme", "widgets", "main", otherBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind before merge: %v", err)
+	}
+	if behindBefore != 0 {
+		t.Fatalf("sibling is %d commits behind main before the merge, want 0", behindBefore)
+	}
+
+	baseBefore := mustHeadSHA(t, s, repoName, "main")
+	if err := s.MergePR("acme", "widgets", 42); err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+	baseAfter := mustHeadSHA(t, s, repoName, "main")
+	if baseAfter == baseBefore {
+		t.Fatal("MergePR did not move the base branch — no merge commit was written")
+	}
+
+	// The new tip must be a real merge commit: two parents, the old base tip
+	// and the PR head.
+	r, err := s.repoByKey(repoName)
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	r.gitMu.Lock()
+	parents, gitErr := runGit(r.bareDir, "rev-list", "--parents", "-n", "1", "refs/heads/main")
+	r.gitMu.Unlock()
+	if gitErr != nil {
+		t.Fatalf("rev-list --parents: %v", gitErr)
+	}
+	fields := strings.Fields(parents)
+	if len(fields) != 3 {
+		t.Fatalf("main tip has %d parents (%q), want a two-parent merge commit", len(fields)-1, parents)
+	}
+	headSHA := mustHeadSHA(t, s, repoName, headBranch)
+	if fields[1] != baseBefore || fields[2] != headSHA {
+		t.Fatalf("merge commit parents = %v, want [%s %s]", fields[1:], baseBefore, headSHA)
+	}
+
+	// Acceptance criterion 4's second half: another branch's commits-behind
+	// count reflects the merge.
+	behindAfter, err := s.FetchCommitsBehind("acme", "widgets", "main", otherBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind after merge: %v", err)
+	}
+	if behindAfter <= behindBefore {
+		t.Fatalf("sibling is %d commits behind after the merge, want more than %d", behindAfter, behindBefore)
+	}
+	// The feature commit plus the merge commit.
+	if behindAfter != 2 {
+		t.Fatalf("sibling is %d commits behind, want 2 (feature commit + merge commit)", behindAfter)
+	}
+}
+
+// TestMergePRRefusesRealConflict proves the merge path and the probe agree: a
+// PR the probe reports unmergeable cannot be merged, and the refusal carries
+// the error kind production uses for a conflict.
+func TestMergePRRefusesRealConflict(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedConflict(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	baseBefore := mustHeadSHA(t, s, repoName, "main")
+	err := s.MergePR("acme", "widgets", 42)
+	if err == nil {
+		t.Fatal("MergePR succeeded on genuinely conflicting branches")
+	}
+	if !isNotMergeable(err) {
+		t.Fatalf("MergePR error = %v, want gh.ErrNotMergeable", err)
+	}
+	if after := mustHeadSHA(t, s, repoName, "main"); after != baseBefore {
+		t.Fatalf("a refused merge still moved main from %s to %s", baseBefore, after)
+	}
+	merged, mergeErr := s.FetchPRMerged("acme", "widgets", 42)
+	if mergeErr != nil {
+		t.Fatalf("FetchPRMerged: %v", mergeErr)
+	}
+	if merged {
+		t.Fatal("PR reports merged after a refused merge")
+	}
+}
+
+// TestFetchCommitsBehindCountsRealCommits pins the direction of the count:
+// it is commits on base that head lacks, matching GitHub's behind_by.
+func TestFetchCommitsBehindCountsRealCommits(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedCommit(repoName, "main", map[string]string{"a.txt": "1\n"}, "one").
+		SeedBranch(repoName, headBranch, "main").
+		SeedCommit(repoName, "main", map[string]string{"b.txt": "2\n"}, "two").
+		SeedCommit(repoName, "main", map[string]string{"c.txt": "3\n"}, "three")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	behind, err := s.FetchCommitsBehind("acme", "widgets", "main", headBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind: %v", err)
+	}
+	if behind != 2 {
+		t.Fatalf("head is %d commits behind main, want 2", behind)
+	}
+
+	// The reverse direction is a different quantity: main lacks nothing that
+	// the head branch has.
+	ahead, err := s.FetchCommitsBehind("acme", "widgets", headBranch, "main")
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind reversed: %v", err)
+	}
+	if ahead != 0 {
+		t.Fatalf("main is %d commits behind head, want 0", ahead)
+	}
+}
+
+// TestHeadSHATracksNewCommits proves PR head SHAs are derived from the repo on
+// every read rather than frozen at PR creation — the engine keys check runs by
+// head SHA, so a stale value would silently read the wrong CI results.
+func TestHeadSHATracksNewCommits(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedCommit(repoName, headBranch, map[string]string{"a.txt": "1\n"}, "first").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	first, err := s.FetchLinkedPR("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR: %v", err)
+	}
+
+	s.SeedCommit(repoName, headBranch, map[string]string{"a.txt": "2\n"}, "second")
+	if err := s.Err(); err != nil {
+		t.Fatalf("second commit: %v", err)
+	}
+
+	second, err := s.FetchLinkedPR("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR after push: %v", err)
+	}
+	if second.HeadSHA == first.HeadSHA {
+		t.Fatalf("head SHA did not change after a new commit (%s)", first.HeadSHA)
+	}
+	if second.HeadSHA != mustHeadSHA(t, s, repoName, headBranch) {
+		t.Fatalf("head SHA %s does not match the branch tip", second.HeadSHA)
+	}
+}

--- a/tests/sim/simgh/helpers_test.go
+++ b/tests/sim/simgh/helpers_test.go
@@ -1,0 +1,100 @@
+package simgh
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// isNotMergeable and isNotMergeableCI classify a MergePR refusal the way the
+// engine does. Keeping them distinct matters: production must not route
+// ErrNotMergeableCI into the rebase-reinvoke path, so a test that conflated
+// them would not notice the model sending it there.
+func isNotMergeable(err error) bool { return errors.Is(err, gh.ErrNotMergeable) }
+
+func isNotMergeableCI(err error) bool { return errors.Is(err, gh.ErrNotMergeableCI) }
+
+// skipIfNoGit follows the repo-wide convention (engine/worktree_test.go) of
+// exercising the real git binary in tests rather than reimplementing git
+// semantics, and skipping where it is unavailable.
+func skipIfNoGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+}
+
+// fakeClock is a manually-advanced Clock. Every time-bearing value the model
+// produces reads from the injected clock, so a test can place label
+// applications at exact instants — which is what the engine's timeout-anchored
+// gates need.
+type fakeClock struct{ t time.Time }
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+func (c *fakeClock) Advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newSim builds a Sim with a fake clock over a temp base dir.
+func newSim(t *testing.T) (*Sim, *fakeClock) {
+	t.Helper()
+	skipIfNoGit(t)
+	clk := newFakeClock()
+	return New(t.TempDir(), WithClock(clk)), clk
+}
+
+// seedBasicBoard builds the setup most tests need: one repo, one project with
+// the usual columns, and one issue sitting in Implement. It exists to
+// demonstrate R3 — a board in a given state in a few lines.
+func seedBasicBoard(t *testing.T) (*Sim, *fakeClock) {
+	t.Helper()
+	s, clk := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"}).
+		SeedIssue("acme/widgets", IssueSeed{
+			Number: 7,
+			Title:  "Add a thing",
+			Body:   "spec body",
+			Author: "human",
+			Status: "Implement",
+		})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return s, clk
+}
+
+// mustHeadSHA resolves a branch tip or fails the test.
+func mustHeadSHA(t *testing.T, s *Sim, ownerRepo, branch string) string {
+	t.Helper()
+	sha, err := s.HeadSHA(ownerRepo, branch)
+	if err != nil {
+		t.Fatalf("HeadSHA(%s, %s): %v", ownerRepo, branch, err)
+	}
+	return sha
+}
+
+// firstItem returns the single board item, failing if there is not exactly one.
+func firstItem(t *testing.T, s *Sim) *itemProjection {
+	t.Helper()
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 1 {
+		t.Fatalf("board has %d items, want 1", len(board.Items))
+	}
+	return &itemProjection{board.Items[0].ItemID, board.Items[0].Status, board.ProjectID}
+}
+
+type itemProjection struct {
+	itemID    string
+	status    string
+	projectID string
+}

--- a/tests/sim/simgh/helpers_test.go
+++ b/tests/sim/simgh/helpers_test.go
@@ -98,3 +98,17 @@ type itemProjection struct {
 	status    string
 	projectID string
 }
+
+// firstItemFull is firstItem's counterpart for tests that need the whole
+// projected item rather than just its identifiers.
+func firstItemFull(t *testing.T, s *Sim) *gh.ProjectItem {
+	t.Helper()
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 1 {
+		t.Fatalf("board has %d items, want 1", len(board.Items))
+	}
+	return &board.Items[0]
+}

--- a/tests/sim/simgh/issues.go
+++ b/tests/sim/simgh/issues.go
@@ -56,7 +56,12 @@ func (s *Sim) CloseIssue(owner, repo string, issueNumber int) error {
 // CreateIssue creates an issue and returns its number and node ID. Used by the
 // engine's child-spawn path, which then feeds the node ID to
 // AddProjectV2ItemById and AddBlockedByIssue.
-func (s *Sim) CreateIssue(owner, repo, title, body string) (int, string, error) {
+//
+// assignees is stored and surfaces on ProjectItem.Assignees, matching
+// production, which posts the field only when non-empty. The engine's spawn
+// path assigns each child to the configured user, so a scenario that asserts
+// on a spawned child's assignee reads a real value rather than nil.
+func (s *Sim) CreateIssue(owner, repo, title, body string, assignees []string) (int, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	r, err := s.lookupRepo(owner, repo)
@@ -71,6 +76,7 @@ func (s *Sim) CreateIssue(owner, repo, title, body string) (int, string, error) 
 		body:           body,
 		state:          "OPEN",
 		author:         simActor,
+		assignees:      cloneStrings(assignees),
 		labelAppliedAt: make(map[string]time.Time),
 		createdAt:      now,
 		updatedAt:      now,

--- a/tests/sim/simgh/issues.go
+++ b/tests/sim/simgh/issues.go
@@ -63,8 +63,7 @@ func (s *Sim) CreateIssue(owner, repo, title, body string) (int, string, error) 
 	if err != nil {
 		return 0, "", err
 	}
-	num := r.nextIssueNumber
-	r.nextIssueNumber++
+	num := r.allocNumber()
 	now := s.now()
 	iss := &issueRecord{
 		number:         num,

--- a/tests/sim/simgh/issues.go
+++ b/tests/sim/simgh/issues.go
@@ -1,0 +1,106 @@
+package simgh
+
+import (
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// simActor is the login the model attributes its own writes to — the
+// equivalent of the account Fabrik's token authenticates as.
+const simActor = "simgh-bot"
+
+// GetIssueBody returns an issue's current body.
+func (s *Sim) GetIssueBody(owner, repo string, issueNumber int) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return "", err
+	}
+	return iss.body, nil
+}
+
+// UpdateIssueBody rewrites an issue's body. The Specify stage's
+// FABRIK_ISSUE_UPDATE round-trip depends on the new body being visible to
+// every subsequent read.
+func (s *Sim) UpdateIssueBody(owner, repo string, issueNumber int, body string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return err
+	}
+	iss.body = body
+	iss.updatedAt = s.now()
+	return nil
+}
+
+// CloseIssue closes an issue. Closing an already-closed issue is a no-op, as
+// on GitHub.
+func (s *Sim) CloseIssue(owner, repo string, issueNumber int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return err
+	}
+	if iss.state == "CLOSED" {
+		return nil
+	}
+	iss.state = "CLOSED"
+	iss.updatedAt = s.now()
+	return nil
+}
+
+// CreateIssue creates an issue and returns its number and node ID. Used by the
+// engine's child-spawn path, which then feeds the node ID to
+// AddProjectV2ItemById and AddBlockedByIssue.
+func (s *Sim) CreateIssue(owner, repo, title, body string) (int, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return 0, "", err
+	}
+	num := r.nextIssueNumber
+	r.nextIssueNumber++
+	now := s.now()
+	iss := &issueRecord{
+		number:         num,
+		title:          title,
+		body:           body,
+		state:          "OPEN",
+		author:         simActor,
+		labelAppliedAt: make(map[string]time.Time),
+		createdAt:      now,
+		updatedAt:      now,
+	}
+	r.issues[num] = iss
+	return num, iss.nodeID(repoKey(owner, repo)), nil
+}
+
+// FetchIssue returns an issue's scalar fields. Comments is a count, matching
+// the REST shape production reads — not the full comment bodies, which reach
+// the engine through ProjectItem instead.
+func (s *Sim) FetchIssue(owner, repo string, issueNumber int) (*gh.IssueData, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	// REST reports issue state lowercase ("open"/"closed"), unlike GraphQL's
+	// uppercase enum which the model stores.
+	state := "open"
+	if iss.state == "CLOSED" {
+		state = "closed"
+	}
+	return &gh.IssueData{
+		Number:   iss.number,
+		Title:    iss.title,
+		State:    state,
+		Labels:   cloneStrings(iss.labels),
+		Comments: len(iss.comments),
+	}, nil
+}

--- a/tests/sim/simgh/labels.go
+++ b/tests/sim/simgh/labels.go
@@ -35,9 +35,10 @@ func (s *Sim) AddLabelToIssue(owner, repo string, issueNumber int, labelName str
 	if contains(iss.labels, labelName) {
 		return nil
 	}
+	now := s.now()
 	iss.labels = append(iss.labels, labelName)
-	iss.labelAppliedAt[labelName] = s.now()
-	iss.updatedAt = s.now()
+	iss.labelAppliedAt[labelName] = now
+	iss.updatedAt = now
 	r.labelVocab[labelName] = true
 	return nil
 }

--- a/tests/sim/simgh/labels.go
+++ b/tests/sim/simgh/labels.go
@@ -3,6 +3,8 @@ package simgh
 import (
 	"fmt"
 	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
 )
 
 // FetchLabels returns the labels currently applied to an issue.
@@ -43,8 +45,21 @@ func (s *Sim) AddLabelToIssue(owner, repo string, issueNumber int, labelName str
 	return nil
 }
 
-// RemoveLabelFromIssue removes a label. Removing an absent label is a no-op
-// rather than an error, matching how the engine's ensure/remove helpers use it.
+// RemoveLabelFromIssue removes a label, returning a wrapped gh.ErrNotFound when
+// the label was not applied.
+//
+// The error is the point. Production issues a DELETE that GitHub answers with a
+// 404 for a label the issue does not carry, and restDelete propagates it — so
+// roughly a dozen engine call sites branch on errors.Is(err, gh.ErrNotFound)
+// from this exact call (engine/settle.go, stages.go, item.go, mutate.go,
+// poll.go, dependencies.go and others; mutate.go's comment distinguishes an
+// ErrNotFound removal's echo behaviour from a real one). Returning nil would
+// make every one of those branches permanently unreachable in a sim-backed
+// test: a bug in the ErrNotFound-specific handling would pass green here and
+// fail against real GitHub.
+//
+// The engine tolerating this error is not a reason for the model to hide it —
+// tolerating it is the behaviour under test.
 func (s *Sim) RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -54,7 +69,8 @@ func (s *Sim) RemoveLabelFromIssue(owner, repo string, issueNumber int, labelNam
 	}
 	updated, removed := removeString(iss.labels, labelName)
 	if !removed {
-		return nil
+		return fmt.Errorf("removing label %q from %s#%d: %w",
+			labelName, repoKey(owner, repo), issueNumber, gh.ErrNotFound)
 	}
 	iss.labels = updated
 	delete(iss.labelAppliedAt, labelName)

--- a/tests/sim/simgh/labels.go
+++ b/tests/sim/simgh/labels.go
@@ -1,0 +1,123 @@
+package simgh
+
+import (
+	"fmt"
+	"time"
+)
+
+// FetchLabels returns the labels currently applied to an issue.
+func (s *Sim) FetchLabels(owner, repo string, issueNumber int) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return nil, err
+	}
+	return cloneStrings(iss.labels), nil
+}
+
+// AddLabelToIssue applies a label, stamping the application time from the
+// injected clock. Idempotent: re-adding an already-applied label leaves the
+// original applied-at intact, matching GitHub (which emits no new "labeled"
+// event for a label already present). Three engine mechanisms anchor timeouts
+// on that timestamp, so refreshing it here would silently reset their clocks.
+func (s *Sim) AddLabelToIssue(owner, repo string, issueNumber int, labelName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return err
+	}
+	if contains(iss.labels, labelName) {
+		return nil
+	}
+	iss.labels = append(iss.labels, labelName)
+	iss.labelAppliedAt[labelName] = s.now()
+	iss.updatedAt = s.now()
+
+	r := s.repos[repoKey(owner, repo)]
+	r.labelVocab[labelName] = true
+	return nil
+}
+
+// RemoveLabelFromIssue removes a label. Removing an absent label is a no-op
+// rather than an error, matching how the engine's ensure/remove helpers use it.
+func (s *Sim) RemoveLabelFromIssue(owner, repo string, issueNumber int, labelName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return err
+	}
+	updated, removed := removeString(iss.labels, labelName)
+	if !removed {
+		return nil
+	}
+	iss.labels = updated
+	delete(iss.labelAppliedAt, labelName)
+	iss.updatedAt = s.now()
+	return nil
+}
+
+// FetchLabelAppliedAt returns when a label was applied to an issue.
+//
+// This is not incidental metadata: the review-gate timeout and bot re-prompt
+// ladder, the CI settle scan, and the Done-archive scan all anchor their
+// deadlines on it. Returning a zero time for an absent label mirrors
+// production's "no such event found" outcome rather than erroring.
+func (s *Sim) FetchLabelAppliedAt(owner, repo string, issueNumber int, labelName string) (time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked(owner, repo, issueNumber)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return iss.labelAppliedAt[labelName], nil
+}
+
+// SeedLabels ensures the repo's label vocabulary contains the static and
+// per-stage labels the engine expects. The model records the vocabulary but
+// does not enforce it on AddLabelToIssue — see FIDELITY.md.
+func (s *Sim) SeedLabels(owner, repo string, stageNames []string, lockedUser string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return err
+	}
+	for _, stage := range stageNames {
+		for _, suffix := range []string{"in_progress", "complete", "failed"} {
+			r.labelVocab[fmt.Sprintf("stage:%s:%s", stage, suffix)] = true
+		}
+	}
+	if lockedUser != "" {
+		r.labelVocab["fabrik:locked:"+lockedUser] = true
+	}
+	return nil
+}
+
+// issueLocked resolves an issue. Caller must hold mu.
+func (s *Sim) issueLocked(owner, repo string, issueNumber int) (*issueRecord, error) {
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	iss, ok := r.issues[issueNumber]
+	if !ok {
+		return nil, fmt.Errorf("simgh: issue %s#%d not found", repoKey(owner, repo), issueNumber)
+	}
+	return iss, nil
+}
+
+// prLocked resolves a pull request. Caller must hold mu.
+func (s *Sim) prLocked(owner, repo string, prNumber int) (*repoState, *prRecord, error) {
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		return nil, nil, fmt.Errorf("simgh: PR %s#%d not found", repoKey(owner, repo), prNumber)
+	}
+	return r, pr, nil
+}

--- a/tests/sim/simgh/labels.go
+++ b/tests/sim/simgh/labels.go
@@ -24,6 +24,10 @@ func (s *Sim) FetchLabels(owner, repo string, issueNumber int) ([]string, error)
 func (s *Sim) AddLabelToIssue(owner, repo string, issueNumber int, labelName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return err
+	}
 	iss, err := s.issueLocked(owner, repo, issueNumber)
 	if err != nil {
 		return err
@@ -34,8 +38,6 @@ func (s *Sim) AddLabelToIssue(owner, repo string, issueNumber int, labelName str
 	iss.labels = append(iss.labels, labelName)
 	iss.labelAppliedAt[labelName] = s.now()
 	iss.updatedAt = s.now()
-
-	r := s.repos[repoKey(owner, repo)]
 	r.labelVocab[labelName] = true
 	return nil
 }

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -1,6 +1,10 @@
 package simgh
 
-import "testing"
+import (
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
 
 // The model's identity rules — which PR a branch resolves to, and how issue and
 // PR numbers are allocated — are places where a plausible-looking simplification
@@ -228,5 +232,107 @@ func TestSeedBlockedByRejectsUnknownBlocker(t *testing.T) {
 
 	if err := s.Err(); err == nil {
 		t.Fatal("SeedBlockedBy accepted a blocker that does not exist; want a failure")
+	}
+}
+
+// TestSeedCheckRunReservesExplicitIDs pins that an explicitly-seeded check run
+// ID is reserved against later auto-assignment, the way reserveNumber reserves
+// an explicitly-seeded issue/PR number.
+//
+// The collision this prevents is not cosmetic. Production's
+// latestCheckRunsByName (github/checkruns.go) reduces same-named runs by
+// keeping the highest ID, treating it as the most recent rerun; on a tie it
+// keeps whichever it saw first. Two runs sharing an ID therefore let a
+// "failed, then the rerun passed" scenario be classified off the failed run.
+func TestSeedCheckRunReservesExplicitIDs(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets")
+
+	// 5000 is the auto-assign counter's starting value, so an explicit seed of
+	// it collides with the very next ID: 0 seed unless it is reserved.
+	s.SeedCheckRun("acme/widgets", "sha1", gh.CheckRun{ID: 5000, Name: "build", Conclusion: "failure"})
+	s.SeedCheckRun("acme/widgets", "sha1", gh.CheckRun{Name: "build", Conclusion: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	runs, err := s.FetchCheckRuns("acme", "widgets", "sha1")
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d check runs, want 2", len(runs))
+	}
+	if runs[0].ID == runs[1].ID {
+		t.Fatalf("both check runs share ID %d; an explicit ID was not reserved against auto-assignment", runs[0].ID)
+	}
+
+	// The consequence the reservation protects: production must resolve the
+	// rerun (the higher ID) as the current verdict for the name.
+	if _, _, failed := gh.ClassifyCheckRuns(runs); len(failed) != 0 {
+		t.Fatalf("ClassifyCheckRuns resolved the stale failed run as current (%+v); the ID tiebreak was defeated by a collision", failed)
+	}
+}
+
+// TestSeedCheckRunRejectsDuplicateID pins the loud refusal for the case the
+// caller writes one ID twice by hand — unrepresentable, since GitHub's check
+// run IDs are unique across the instance.
+func TestSeedCheckRunRejectsDuplicateID(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedCheckRun("acme/widgets", "sha1", gh.CheckRun{ID: 77, Name: "build", Conclusion: "success"}).
+		SeedCheckRun("acme/widgets", "sha2", gh.CheckRun{ID: 77, Name: "vet", Conclusion: "success"})
+
+	if err := s.Err(); err == nil {
+		t.Fatal("SeedCheckRun accepted a duplicate check run ID; want a failure")
+	}
+}
+
+// TestSeedRepoRejectsPathTraversal pins that owner/repo cannot escape baseDir.
+// repoDir joins the segments straight into a directory name, so without this
+// guard "../evil/pwned" creates the bare repo as a sibling of the t.TempDir()
+// the package promises to keep everything inside.
+func TestSeedRepoRejectsPathTraversal(t *testing.T) {
+	for _, name := range []string{"../evil/pwned", "acme/../../pwned", "..//pwned"} {
+		s, _ := newSim(t)
+		s.SeedRepo(name)
+		if err := s.Err(); err == nil {
+			t.Fatalf("SeedRepo(%q) was accepted; want a refusal", name)
+		}
+	}
+
+	// An ordinary name still works — the guard must not reject anything valid.
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets")
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedRepo rejected a valid owner/repo: %v", err)
+	}
+}
+
+// TestSeedRepoRefusesDuplicateAfterInit pins that the second SeedRepo for one
+// key fails rather than clobbering the live repoState. Clobbering would swap
+// out the repo's gitMu while callers still hold the old one, leaving two
+// mutexes guarding one bare directory.
+func TestSeedRepoRefusesDuplicateSeed(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets")
+	if err := s.Err(); err != nil {
+		t.Fatalf("first SeedRepo: %v", err)
+	}
+	first, err := s.repoByKey("acme/widgets")
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+
+	s.SeedRepo("acme/widgets")
+	if err := s.Err(); err == nil {
+		t.Fatal("second SeedRepo for the same key was accepted; want a failure")
+	}
+	second, err := s.repoByKey("acme/widgets")
+	if err != nil {
+		t.Fatalf("repoByKey after refused reseed: %v", err)
+	}
+	if first != second {
+		t.Fatal("the refused reseed replaced the live repoState; its gitMu no longer guards the bare directory callers are using")
 	}
 }

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -86,7 +86,7 @@ func TestIssueAndPRShareNumberSpace(t *testing.T) {
 		t.Fatalf("seeding: %v", err)
 	}
 
-	issueNum, _, err := s.CreateIssue("acme", "widgets", "an issue", "body")
+	issueNum, _, err := s.CreateIssue("acme", "widgets", "an issue", "body", nil)
 	if err != nil {
 		t.Fatalf("CreateIssue: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestAutoAssignedNumberSkipsSeededHoles(t *testing.T) {
 		t.Fatalf("seeding: %v", err)
 	}
 
-	num, _, err := s.CreateIssue("acme", "widgets", "an issue", "body")
+	num, _, err := s.CreateIssue("acme", "widgets", "an issue", "body", nil)
 	if err != nil {
 		t.Fatalf("CreateIssue: %v", err)
 	}

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -484,3 +484,81 @@ func TestReAddingArchivedCardRevivesItOnBothPaths(t *testing.T) {
 		})
 	}
 }
+
+// TestReAddingLiveCardIsANoOp pins that re-adding a card that is already on the
+// board and unarchived bumps nothing.
+//
+// FetchProjectUpdatedAt is what gates whether the engine's idle poll looks at
+// the board at all, so a bump here is a wake signal real GitHub would not have
+// produced — and one a scenario cannot distinguish from a real change. Same
+// convention AddLabelToIssue and AddReviewRequest already follow.
+//
+// The archived-card revival path is covered separately by
+// TestReAddingArchivedCardRevivesItOnBothPaths; this is its complement, which
+// is where the two APIs could silently diverge again.
+func TestReAddingLiveCardIsANoOp(t *testing.T) {
+	setup := func(t *testing.T) (*Sim, *fakeClock, string) {
+		t.Helper()
+		s, clk := seedBasicBoard(t)
+		board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+		if err != nil {
+			t.Fatalf("FetchProjectBoard: %v", err)
+		}
+		return s, clk, board.ProjectID
+	}
+
+	projectAt := func(t *testing.T, s *Sim, projectID string) time.Time {
+		t.Helper()
+		at, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt: %v", err)
+		}
+		return at
+	}
+
+	t.Run("runtime re-add of a live card", func(t *testing.T) {
+		s, clk, projectID := setup(t)
+		before := projectAt(t, s, projectID)
+		// Time must move, or an unbumped timestamp is indistinguishable from a
+		// bumped one.
+		clk.Advance(time.Hour)
+
+		if _, err := s.AddProjectV2ItemById(projectID, "issue:acme/widgets#7"); err != nil {
+			t.Fatalf("AddProjectV2ItemById: %v", err)
+		}
+		if got := projectAt(t, s, projectID); !got.Equal(before) {
+			t.Fatalf("re-adding a live card bumped the project updated-at from %v to %v; "+
+				"the engine's poll would wake for a no-op", before, got)
+		}
+	})
+
+	t.Run("re-seeding a card into the column it already occupies", func(t *testing.T) {
+		s, clk, projectID := setup(t)
+		before := projectAt(t, s, projectID)
+		clk.Advance(time.Hour)
+
+		s.SeedProjectItem("acme", 2, "acme/widgets", 7, false, "Implement")
+		if err := s.Err(); err != nil {
+			t.Fatalf("SeedProjectItem: %v", err)
+		}
+		if got := projectAt(t, s, projectID); !got.Equal(before) {
+			t.Fatalf("re-seeding a card into its current column bumped updated-at from %v to %v", before, got)
+		}
+	})
+
+	// A genuine column move must still bump, or the assertions above would be
+	// satisfied by a seeding path that never bumps at all.
+	t.Run("a real column move still bumps", func(t *testing.T) {
+		s, clk, projectID := setup(t)
+		before := projectAt(t, s, projectID)
+		clk.Advance(time.Hour)
+
+		s.SeedProjectItem("acme", 2, "acme/widgets", 7, false, "Review")
+		if err := s.Err(); err != nil {
+			t.Fatalf("SeedProjectItem: %v", err)
+		}
+		if got := projectAt(t, s, projectID); !got.After(before) {
+			t.Fatalf("a real column move did not bump updated-at (%v -> %v)", before, got)
+		}
+	})
+}

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -310,6 +310,58 @@ func TestSeedRepoRejectsPathTraversal(t *testing.T) {
 	}
 }
 
+// TestSeedCommitRejectsEscapingFilePath pins the other door into the sandbox
+// escape TestSeedRepoRejectsPathTraversal closes.
+//
+// commitFiles joins each key of a SeedCommit files map straight onto the
+// throwaway worktree path, so "../../outside.txt" was written above it — and
+// silently, because git only tracks what is inside the worktree, so the write
+// left no trace in the commit and the seed reported success.
+//
+// The branch tip is asserted unchanged as well as the refusal: a guard that
+// rejected the bad name only once it had already written the good ones, or
+// after committing, would still leave the model in a state the caller did not
+// ask for.
+func TestSeedCommitRejectsEscapingFilePath(t *testing.T) {
+	// "/etc/passwd" does not escape — filepath.Join cleans it back inside the
+	// worktree — but it silently relocates the file to <wt>/etc/passwd rather
+	// than the path the caller named, which is the same silent divergence.
+	for _, name := range []string{"../../outside.txt", "../sibling.txt", "docs/../../escape.txt", "/etc/passwd", ""} {
+		s, _ := newSim(t)
+		s.SeedRepo("acme/widgets")
+		if err := s.Err(); err != nil {
+			t.Fatalf("seeding repo: %v", err)
+		}
+		before := mustHeadSHA(t, s, "acme/widgets", "main")
+
+		// Paired with a legitimate file, so the refusal has something to leak.
+		s.SeedCommit("acme/widgets", "main", map[string]string{
+			name:        "pwned",
+			"README.md": "innocent",
+		}, "seed")
+
+		if err := s.Err(); err == nil {
+			t.Fatalf("SeedCommit accepted file path %q; want a refusal", name)
+		}
+		if after := mustHeadSHA(t, s, "acme/widgets", "main"); after != before {
+			t.Fatalf("SeedCommit(%q) was refused but still moved the branch tip %s -> %s", name, before, after)
+		}
+	}
+
+	// Ordinary paths, including nested ones and a "./" prefix, must still work —
+	// a guard that rejects valid repo layouts is no better than none.
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedCommit("acme/widgets", "main", map[string]string{
+			"README.md":                "hi",
+			"docs/guide/USER_GUIDE.md": "deep",
+			"./cmd/main.go":            "package main",
+		}, "seed")
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedCommit rejected valid repo paths: %v", err)
+	}
+}
+
 // TestSeedRepoRefusesDuplicateAfterInit pins that the second SeedRepo for one
 // key fails rather than clobbering the live repoState. Clobbering would swap
 // out the repo's gitMu while callers still hold the old one, leaving two

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -158,3 +158,75 @@ func TestAutoAssignedNumberSkipsSeededHoles(t *testing.T) {
 		t.Error("CreateIssue reused #1, which PR #1 already holds")
 	}
 }
+
+// TestAddProjectV2ItemByIdRejectsPRCard pins that the runtime board API refuses
+// a PR card for the same reason the seeding API does.
+//
+// The two must agree about what the model can represent. Board projections
+// resolve a card's content as an issue, so a PR card recorded here would be
+// dropped by every subsequent board read — a loud refusal at seed time and a
+// silent no-op at runtime is exactly the asymmetry that makes a fake untrustworthy.
+func TestAddProjectV2ItemByIdRejectsPRCard(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Done"}).
+		SeedCommit("acme/widgets", "feature", map[string]string{"a.txt": "a"}, "work").
+		SeedPR("acme/widgets", PRSeed{Number: 4, Title: "a PR", Head: "feature"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	_, projectID, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("ProbeProjectBoard: %v", err)
+	}
+
+	if _, err := s.AddProjectV2ItemById(projectID, "pr:acme/widgets#4"); err == nil {
+		t.Fatal("AddProjectV2ItemById accepted a PR content node ID; want a refusal, since no board read can project one")
+	}
+
+	// The refusal must also leave no half-added card behind.
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 0 {
+		t.Fatalf("board has %d items after a refused add, want 0", len(board.Items))
+	}
+}
+
+// TestAddBlockedByIssueRejectsUnknownBlocker pins that a blocker node ID which
+// resolves to nothing is refused rather than recorded.
+//
+// A dangling blocker is worse than a plain no-op: resolveDependenciesLocked
+// reports an unresolvable blocker as OPEN, so the dependent issue would read as
+// permanently blocked with no diagnostic anywhere.
+func TestAddBlockedByIssueRejectsUnknownBlocker(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+
+	if err := s.AddBlockedByIssue("issue:acme/widgets#7", "issue:acme/widgets#999"); err == nil {
+		t.Fatal("AddBlockedByIssue accepted a blocker that does not exist; want a refusal")
+	}
+	if err := s.AddBlockedByIssue("issue:acme/widgets#7", "issue:nosuch/repo#1"); err == nil {
+		t.Fatal("AddBlockedByIssue accepted a blocker in an unseeded repo; want a refusal")
+	}
+
+	item, err := s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if len(item.BlockedBy) != 0 {
+		t.Fatalf("issue reads as blocked by %+v after refused links, want no dependency", item.BlockedBy)
+	}
+}
+
+// TestSeedBlockedByRejectsUnknownBlocker pins the same guard on the seeding
+// path, so the two APIs cannot disagree about what a valid blocker is.
+func TestSeedBlockedByRejectsUnknownBlocker(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedBlockedBy("acme/widgets", 7, "acme/widgets", 999)
+
+	if err := s.Err(); err == nil {
+		t.Fatal("SeedBlockedBy accepted a blocker that does not exist; want a failure")
+	}
+}

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -1,0 +1,141 @@
+package simgh
+
+import "testing"
+
+// The model's identity rules — which PR a branch resolves to, and how issue and
+// PR numbers are allocated — are places where a plausible-looking simplification
+// diverges from GitHub silently. Both cases below produce a green test against a
+// wrong model, so each is pinned here.
+
+// TestFetchLinkedPRPrefersNewestOnReusedBranch pins newest-wins resolution.
+//
+// Fabrik reuses the branch fabrik/issue-<N>, so a PR closed without merging
+// leaves a stale record on the branch its successor reuses. Production queries
+// pulls?head=owner:branch&state=all&per_page=1, which defaults to
+// created-descending and therefore returns the newest. Resolving to the oldest
+// would hand the engine a closed PR it would never have seen against real
+// GitHub — and engine/prcreate.go decides whether to create a PR on exactly
+// this answer.
+func TestFetchLinkedPRPrefersNewestOnReusedBranch(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	branch := issueBranch(7)
+
+	s.SeedCommit("acme/widgets", branch, map[string]string{"a.txt": "a"}, "work").
+		SeedPR("acme/widgets", PRSeed{Number: 10, Title: "abandoned", Head: branch, State: "closed"}).
+		SeedPR("acme/widgets", PRSeed{Number: 11, Title: "live", Head: branch})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	pr, err := s.FetchLinkedPR("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("FetchLinkedPR returned nil, want the live PR")
+	}
+	if pr.Number != 11 {
+		t.Errorf("FetchLinkedPR = #%d, want #11 (the newest PR on the reused branch)", pr.Number)
+	}
+	if pr.State != "open" {
+		t.Errorf("linked PR state = %q, want %q", pr.State, "open")
+	}
+
+	num, err := s.FindPRForIssue("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FindPRForIssue: %v", err)
+	}
+	if num != 11 {
+		t.Errorf("FindPRForIssue = #%d, want #11", num)
+	}
+
+	// The board projection must agree. If these two reads disagreed, the same
+	// model would report two different linked PRs depending on which call the
+	// engine happened to make — a bug the sim itself would be introducing.
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(board.Items) != 1 {
+		t.Fatalf("board has %d items, want 1", len(board.Items))
+	}
+	if got := board.Items[0].LinkedPRNumber; got != 11 {
+		t.Errorf("board LinkedPRNumber = #%d, want #11 (must agree with FetchLinkedPR)", got)
+	}
+}
+
+// TestIssueAndPRShareNumberSpace pins GitHub's single per-repo number sequence.
+//
+// GitHub numbers issues and pull requests from one counter, so #7 is either an
+// issue or a PR and never both. Two independent sequences would let issue #1 and
+// PR #1 coexist — and because GitHub's issue-comment endpoint is likewise shared
+// between issues and PRs, AddComment would then resolve a PR comment onto the
+// same-numbered issue. The engine posts stage output that way (engine/pr.go),
+// so the output would vanish from the PR while a test still saw "a comment was
+// posted" and passed.
+func TestIssueAndPRShareNumberSpace(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedCommit("acme/widgets", "feature", map[string]string{"a.txt": "a"}, "work")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	issueNum, _, err := s.CreateIssue("acme", "widgets", "an issue", "body")
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	prNum, err := s.CreateDraftPR("acme", "widgets", "a PR", "feature", "main", "body", issueNum)
+	if err != nil {
+		t.Fatalf("CreateDraftPR: %v", err)
+	}
+	if prNum == issueNum {
+		t.Fatalf("PR and issue were both numbered #%d; GitHub allocates issues and PRs from one shared sequence", prNum)
+	}
+
+	// A comment addressed to the PR number must reach the PR, not an issue.
+	if _, err := s.AddComment("acme", "widgets", prNum, "stage output"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	iss, err := s.FetchIssue("acme", "widgets", issueNum)
+	if err != nil {
+		t.Fatalf("FetchIssue: %v", err)
+	}
+	if iss.Comments != 0 {
+		t.Errorf("issue #%d has %d comments, want 0 — the comment was addressed to PR #%d", issueNum, iss.Comments, prNum)
+	}
+}
+
+// TestSeedRejectsNumberHeldByOtherKind pins that the shared sequence is enforced
+// against explicitly-seeded numbers too, not just auto-assigned ones.
+func TestSeedRejectsNumberHeldByOtherKind(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedCommit("acme/widgets", "feature", map[string]string{"a.txt": "a"}, "work").
+		SeedIssue("acme/widgets", IssueSeed{Number: 5, Title: "an issue"}).
+		SeedPR("acme/widgets", PRSeed{Number: 5, Title: "a PR", Head: "feature"})
+
+	if err := s.Err(); err == nil {
+		t.Fatal("seeding PR #5 alongside issue #5 succeeded; want a failure, since GitHub cannot number both 5")
+	}
+}
+
+// TestAutoAssignedNumberSkipsSeededHoles pins that auto-assignment steps over a
+// number already held by either kind, rather than colliding with it.
+func TestAutoAssignedNumberSkipsSeededHoles(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedCommit("acme/widgets", "feature", map[string]string{"a.txt": "a"}, "work").
+		SeedPR("acme/widgets", PRSeed{Number: 1, Title: "a PR", Head: "feature"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	num, _, err := s.CreateIssue("acme", "widgets", "an issue", "body")
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if num == 1 {
+		t.Error("CreateIssue reused #1, which PR #1 already holds")
+	}
+}

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -120,6 +120,25 @@ func TestSeedRejectsNumberHeldByOtherKind(t *testing.T) {
 	}
 }
 
+// TestSeedProjectItemRejectsPRCard pins that an unmodelled PR card fails loudly
+// at seed time.
+//
+// Board projections resolve a card's content as an issue, so a PR card would be
+// omitted from every board read with no error — a scenario would assert against
+// a board the model never built and pass for the wrong reason.
+func TestSeedProjectItemRejectsPRCard(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme/widgets").
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Done"}).
+		SeedCommit("acme/widgets", "feature", map[string]string{"a.txt": "a"}, "work").
+		SeedPR("acme/widgets", PRSeed{Number: 4, Title: "a PR", Head: "feature"}).
+		SeedProjectItem("acme", 2, "acme/widgets", 4, true, "Backlog")
+
+	if err := s.Err(); err == nil {
+		t.Fatal("seeding a PR card succeeded; want a failure, since board projections cannot represent one")
+	}
+}
+
 // TestAutoAssignedNumberSkipsSeededHoles pins that auto-assignment steps over a
 // number already held by either kind, rather than colliding with it.
 func TestAutoAssignedNumberSkipsSeededHoles(t *testing.T) {

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -1,6 +1,7 @@
 package simgh
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -139,8 +140,17 @@ func TestSeedProjectItemRejectsPRCard(t *testing.T) {
 		SeedPR("acme/widgets", PRSeed{Number: 4, Title: "a PR", Head: "feature"}).
 		SeedProjectItem("acme", 2, "acme/widgets", 4, true, "Backlog")
 
-	if err := s.Err(); err == nil {
+	// Assert *which* refusal fired, not merely that something failed. #4 is a
+	// PR, so it is also absent from the repo's issues — the target-existence
+	// check would refuse it too, and a bare "an error occurred" assertion is
+	// satisfied by either. That would leave the PR-card refusal itself
+	// unpinned, which is how a guard quietly stops being tested.
+	err := s.Err()
+	if err == nil {
 		t.Fatal("seeding a PR card succeeded; want a failure, since board projections cannot represent one")
+	}
+	if !strings.Contains(err.Error(), "PR cards on a project board are not modelled") {
+		t.Fatalf("error = %v, want the PR-card refusal specifically", err)
 	}
 }
 

--- a/tests/sim/simgh/linkage_test.go
+++ b/tests/sim/simgh/linkage_test.go
@@ -2,6 +2,7 @@ package simgh
 
 import (
 	"testing"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
 )
@@ -334,5 +335,90 @@ func TestSeedRepoRefusesDuplicateSeed(t *testing.T) {
 	}
 	if first != second {
 		t.Fatal("the refused reseed replaced the live repoState; its gitMu no longer guards the bare directory callers are using")
+	}
+}
+
+// TestReAddingArchivedCardRevivesItOnBothPaths pins that the seeding and
+// runtime re-add paths agree, in both directions of the drift they had.
+//
+// Each was doing a complementary half of the job: seeding reset status and the
+// timestamps but left the card archived, so moving an archived card to a new
+// column left it filtered out of every board read with no error; the runtime
+// API cleared archived but bumped neither timestamp, so a card reappearing did
+// not advance FetchProjectUpdatedAt, which the engine's poll reads to notice
+// the board changed.
+func TestReAddingArchivedCardRevivesItOnBothPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		readd func(t *testing.T, s *Sim, projectID string)
+	}{
+		{
+			name: "seeding path moves an archived card and revives it",
+			readd: func(t *testing.T, s *Sim, _ string) {
+				t.Helper()
+				s.SeedProjectItem("acme", 2, "acme/widgets", 7, false, "Review")
+				if err := s.Err(); err != nil {
+					t.Fatalf("SeedProjectItem: %v", err)
+				}
+			},
+		},
+		{
+			name: "runtime path revives an archived card",
+			readd: func(t *testing.T, s *Sim, projectID string) {
+				t.Helper()
+				if _, err := s.AddProjectV2ItemById(projectID, "issue:acme/widgets#7"); err != nil {
+					t.Fatalf("AddProjectV2ItemById: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, clk := seedBasicBoard(t)
+
+			_, projectID, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+			if err != nil {
+				t.Fatalf("ProbeProjectBoard: %v", err)
+			}
+			item, _, err := s.LookupIssueProjectItem(projectID, "acme/widgets", 7)
+			if err != nil {
+				t.Fatalf("LookupIssueProjectItem: %v", err)
+			}
+			if err := s.ArchiveProjectItem(projectID, item); err != nil {
+				t.Fatalf("ArchiveProjectItem: %v", err)
+			}
+
+			board, err := s.FetchProjectBoard("acme", "widgets", 2, "")
+			if err != nil {
+				t.Fatalf("FetchProjectBoard: %v", err)
+			}
+			if len(board.Items) != 0 {
+				t.Fatalf("archived card still on the board: %+v", board.Items)
+			}
+			beforeAt, err := s.FetchProjectUpdatedAt(projectID)
+			if err != nil {
+				t.Fatalf("FetchProjectUpdatedAt: %v", err)
+			}
+
+			// Time must move, or an unbumped updated-at is indistinguishable
+			// from a bumped one.
+			clk.Advance(time.Hour)
+			tc.readd(t, s, projectID)
+
+			board, err = s.FetchProjectBoard("acme", "widgets", 2, "")
+			if err != nil {
+				t.Fatalf("FetchProjectBoard after re-add: %v", err)
+			}
+			if len(board.Items) != 1 {
+				t.Fatalf("re-added card is still filtered out of the board (%d items); it was left archived", len(board.Items))
+			}
+
+			afterAt, err := s.FetchProjectUpdatedAt(projectID)
+			if err != nil {
+				t.Fatalf("FetchProjectUpdatedAt after re-add: %v", err)
+			}
+			if !afterAt.After(beforeAt) {
+				t.Fatalf("project updated-at did not advance on re-add (%v -> %v); the engine's poll would not notice the card reappear", beforeAt, afterAt)
+			}
+		})
 	}
 }

--- a/tests/sim/simgh/mergeable_precedence_test.go
+++ b/tests/sim/simgh/mergeable_precedence_test.go
@@ -1,0 +1,147 @@
+package simgh
+
+import (
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// The single-condition tests in mergeable_state_test.go prove each branch of
+// deriveMergeableState is reachable. They do not prove the branches are
+// *ordered* correctly: every one of them arranges exactly one condition, so a
+// mutation that reshuffled the precedence would leave them all green.
+//
+// That matters more here than it would for a derivation copied from a spec.
+// The order is the sim's own hand-picked design choice (FIDELITY.md says so,
+// and rates the residual risk "medium, concentrated in untested
+// combinations"), so nothing outside these tests constrains it.
+//
+// Each test below arranges two conditions that resolve to different states and
+// asserts the higher-precedence one wins. Together they pin every *adjacent*
+// link in the chain — draft > dirty > behind > blocked > unstable — which
+// constrains the whole ordering transitively rather than spot-checking pairs.
+
+// TestPrecedenceDraftOverDirty pins draft > dirty.
+//
+// The existing draft test arranges a draft PR with everything else green, so it
+// would pass under any ordering. This one makes the PR genuinely conflict as
+// well: FIDELITY.md promises "a draft PR that also conflicts resolves to draft,
+// not dirty", and this is what holds that promise to account.
+func TestPrecedenceDraftOverDirty(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedConflict(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Draft: true})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// Precondition: the conflict is real, so "dirty" is the competing answer.
+	mergeable, err := s.FetchPRMergeable("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMergeable: %v", err)
+	}
+	if mergeable == nil || *mergeable {
+		t.Fatal("precondition: the seeded head must genuinely conflict with main")
+	}
+
+	assertState(t, s, stateDraft)
+}
+
+// TestPrecedenceDirtyOverBehind pins dirty > behind.
+//
+// seedConflict advances main past the fork point, so the head is both behind
+// and conflicting. With up-to-date heads required, "behind" is a live competing
+// answer — a conflict must still win, since rebasing cannot be the engine's
+// first move when the merge itself is impossible.
+func TestPrecedenceDirtyOverBehind(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedConflict(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"}).
+		SeedRequireUpToDate(repoName, "main", true)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	behind, err := s.FetchCommitsBehind("acme", "widgets", "main", headBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind: %v", err)
+	}
+	if behind == 0 {
+		t.Fatal("precondition: head must be behind main for this to test precedence")
+	}
+
+	assertState(t, s, stateDirty)
+}
+
+// TestPrecedenceBehindOverBlocked pins behind > blocked.
+//
+// This is the combination Pruefer called out by name. Both conditions are
+// arranged: main has advanced with up-to-date heads required, and a required
+// context is failing. The engine treats these very differently — "behind" is
+// rebase territory, "blocked" carries ErrNotMergeableCI and must never enter
+// the rebase path — so which one the model reports is load-bearing.
+func TestPrecedenceBehindOverBlocked(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+
+	s.SeedCommit(repoName, "main", map[string]string{"unrelated.txt": "moved on\n"}, "main advances").
+		SeedRequireUpToDate(repoName, "main", true).
+		SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	behind, err := s.FetchCommitsBehind("acme", "widgets", "main", headBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind: %v", err)
+	}
+	if behind == 0 {
+		t.Fatal("precondition: head must be behind main for this to test precedence")
+	}
+
+	assertState(t, s, stateBehind)
+}
+
+// TestPrecedenceBlockedOverUnstable pins blocked > unstable.
+//
+// The other combination Pruefer named. A failing required context and a failing
+// non-required one are both present. Reporting "unstable" here would be a
+// merge-safety bug of exactly ADR-072's kind: MergeableStateAccepted admits
+// unstable, so the PR would merge with a required check red.
+func TestPrecedenceBlockedOverUnstable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "failure"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/lint", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+
+	// And the refusal must carry the CI-readiness error, not the conflict one —
+	// the engine routes only ErrNotMergeable into the rebase path.
+	err := s.MergePR("acme", "widgets", 42)
+	if !isNotMergeableCI(err) {
+		t.Fatalf("MergePR error = %v, want ErrNotMergeableCI", err)
+	}
+}
+
+// TestPrecedenceUnstableOverClean pins unstable > clean: a green required
+// context does not mask a red non-required one.
+func TestPrecedenceUnstableOverClean(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "success"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/lint", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateUnstable)
+}

--- a/tests/sim/simgh/mergeable_state_test.go
+++ b/tests/sim/simgh/mergeable_state_test.go
@@ -2,6 +2,7 @@ package simgh
 
 import (
 	"testing"
+	"time"
 
 	gh "github.com/handarbeit/fabrik/github"
 )
@@ -498,5 +499,100 @@ func TestFetchPRDetailsReportsDerivedMergeableState(t *testing.T) {
 	}
 	if linked.MergeableState != "" {
 		t.Fatalf("FetchLinkedPR mergeable_state = %q, want \"\" — the list endpoint omits it", linked.MergeableState)
+	}
+}
+
+// TestMergePRRefusesRetargetBetweenGateAndMerge pins the compare-and-swap that
+// makes MergePR's ADR-072 gate mean something under concurrency.
+//
+// The gate necessarily drops both locks — it takes mu, then gitMu, in turn,
+// because the package's lock-ordering rule forbids holding one across the
+// other — so a concurrent retarget can land between the state the gate cleared
+// and the merge that follows. Without the CAS the merge proceeds against a
+// base whose required contexts and mergeability were never evaluated, which is
+// the gate's whole purpose defeated silently. GitHub has no such window: its
+// merge endpoint re-checks server-side, atomically.
+//
+// The window is opened deterministically by parking the gate on gitMu. The
+// retarget is written straight into the model rather than going through
+// UpdatePRBase, because UpdatePRBase itself takes gitMu to validate the new
+// base and would simply queue behind the parked gate; the CAS guards the
+// field changing, whichever writer changed it.
+func TestMergePRRefusesRetargetBetweenGateAndMerge(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+	// A second, equally mergeable base to retarget onto, so a merge that
+	// wrongly proceeds succeeds rather than failing for an unrelated reason —
+	// the test must distinguish "the CAS refused" from "the merge broke".
+	s.SeedBranch(repoName, "release", "main").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Title: "clean"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	r, err := s.repoByKey(repoName)
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	mainBefore := mustHeadSHA(t, s, repoName, "main")
+	releaseBefore := mustHeadSHA(t, s, repoName, "release")
+
+	// Park the gate: MergePR snapshots head/base under mu, then blocks in the
+	// gate's git work on gitMu.
+	r.gitMu.Lock()
+	started := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		close(started)
+		result <- s.MergePR("acme", "widgets", 42)
+	}()
+	<-started
+
+	// Give the goroutine time to clear the snapshot and reach the parked gate.
+	// It only has to take an uncontended mutex and read three fields, so this
+	// is generous. The failure direction is safe: if it were too short the
+	// retarget would land before the snapshot, the merge would succeed, and
+	// the assertions below would fail loudly rather than pass vacuously.
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case err := <-result:
+		t.Fatalf("MergePR returned %v before the gate was reached; the test never opened the window", err)
+	default:
+	}
+
+	s.mu.Lock()
+	_, pr, err := s.prLocked("acme", "widgets", 42)
+	if err != nil {
+		s.mu.Unlock()
+		t.Fatalf("prLocked: %v", err)
+	}
+	pr.base = "release"
+	s.mu.Unlock()
+
+	r.gitMu.Unlock()
+
+	mergeErr := <-result
+	if mergeErr == nil {
+		t.Fatal("MergePR merged a PR that was retargeted after the gate cleared it; " +
+			"the merge landed on a base the gate never evaluated")
+	}
+	if !isNotMergeable(mergeErr) {
+		t.Fatalf("MergePR error = %v, want ErrNotMergeable so the caller re-reads and retries", mergeErr)
+	}
+
+	// The refusal must leave no trace: neither base moved, and the PR is not
+	// recorded as merged.
+	if after := mustHeadSHA(t, s, repoName, "main"); after != mainBefore {
+		t.Fatalf("refused merge still moved main from %s to %s", mainBefore, after)
+	}
+	if after := mustHeadSHA(t, s, repoName, "release"); after != releaseBefore {
+		t.Fatalf("refused merge still moved release from %s to %s", releaseBefore, after)
+	}
+	merged, err := s.FetchPRMerged("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMerged: %v", err)
+	}
+	if merged {
+		t.Fatal("PR reports merged after a refused merge")
 	}
 }

--- a/tests/sim/simgh/mergeable_state_test.go
+++ b/tests/sim/simgh/mergeable_state_test.go
@@ -375,3 +375,128 @@ func assertState(t *testing.T, s *Sim, want string) {
 		t.Fatalf("mergeable state = %q, want %q", got, want)
 	}
 }
+
+// TestMergeableStateRerunSupersedesFailedRun pins that a required context is
+// classified off its *latest* run, not the worst of its runs.
+//
+// Reducing same-named runs by worst verdict left a rerun-then-pass flow blocked
+// forever: GitHub clears a required check once its newest run passes, and
+// production's own classifier (latestCheckRunsByName, github/checkruns.go) keeps
+// the highest ID for exactly that reason. The seed layer reserves explicit
+// check-run IDs specifically so this flow is representable, so a derivation that
+// ignored them made that machinery pointless.
+func TestMergeableStateRerunSupersedesFailedRun(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 100, Name: "ci/build", Status: "completed", Conclusion: "failure"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 200, Name: "ci/build", Status: "completed", Conclusion: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateClean)
+}
+
+// TestMergeableStateFailedRerunSupersedesPassedRun is the same rule in the
+// direction that must not be mistaken for conservatism: latest-wins has to
+// re-block a check whose rerun failed, or the fix would just be "green always
+// wins" wearing a different name.
+func TestMergeableStateFailedRerunSupersedesPassedRun(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 100, Name: "ci/build", Status: "completed", Conclusion: "success"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 200, Name: "ci/build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+}
+
+// TestMergeableStateRerunOrderFollowsIDNotSeedOrder pins that the rule is
+// highest-ID, not last-seeded. Seeding the passing rerun first would still make
+// the previous test green under a "last one wins" reduction, which is not what
+// production does — check-run IDs are the ordering, and a scenario is free to
+// seed them out of order.
+func TestMergeableStateRerunOrderFollowsIDNotSeedOrder(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 200, Name: "ci/build", Status: "completed", Conclusion: "success"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 100, Name: "ci/build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateClean)
+}
+
+// TestMergeableStateLatestCommitStatusSupersedes pins the classic Statuses API
+// half of the same rule: a context's latest posted status supersedes its
+// earlier ones rather than accumulating with them.
+func TestMergeableStateLatestCommitStatusSupersedes(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"local-ci"}).
+		SeedCommitStatus(repoName, sha, gh.CommitStatus{Context: "local-ci", State: "failure"}).
+		SeedCommitStatus(repoName, sha, gh.CommitStatus{Context: "local-ci", State: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateClean)
+}
+
+// TestMergeableStateCrossCollectionKeepsWorstVerdict pins the one place worst-of
+// survives: a name reported by *both* a check run and a commit status. That is
+// the model's own conservative choice rather than an observed GitHub rule, so it
+// is pinned here and recorded in FIDELITY.md — if it is ever verified against a
+// recorded real response, this is the test that should change.
+func TestMergeableStateCrossCollectionKeepsWorstVerdict(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 300, Name: "ci/build", Status: "completed", Conclusion: "success"}).
+		SeedCommitStatus(repoName, sha, gh.CommitStatus{Context: "ci/build", State: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+}
+
+// TestFetchPRDetailsReportsDerivedMergeableState pins the split between the two
+// PR read paths. The single-PR endpoint reports mergeable_state; the pulls list
+// endpoint behind FetchLinkedPR does not, and production only parses it from the
+// former. A model that answered both the same way would let a test pass on a
+// signal the engine never receives from that call.
+func TestFetchPRDetailsReportsDerivedMergeableState(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{ID: 400, Name: "ci/build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	details, err := s.FetchPRDetails("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRDetails: %v", err)
+	}
+	if details.MergeableState != stateBlocked {
+		t.Fatalf("FetchPRDetails mergeable_state = %q, want %q", details.MergeableState, stateBlocked)
+	}
+	if details.HeadSHA != sha {
+		t.Fatalf("FetchPRDetails HeadSHA = %q, want %q", details.HeadSHA, sha)
+	}
+
+	linked, err := s.FetchLinkedPR("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR: %v", err)
+	}
+	if linked.MergeableState != "" {
+		t.Fatalf("FetchLinkedPR mergeable_state = %q, want \"\" — the list endpoint omits it", linked.MergeableState)
+	}
+}

--- a/tests/sim/simgh/mergeable_state_test.go
+++ b/tests/sim/simgh/mergeable_state_test.go
@@ -1,0 +1,344 @@
+package simgh
+
+import (
+	"testing"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// The engine branches hard on mergeable_state: MergeableStateAccepted admits
+// only {clean, unstable}, and ErrNotMergeableCI fires specifically on
+// blocked/unknown and must never be routed into the rebase-reinvoke path. A
+// model that could only say dirty-or-clean would make four of the six values
+// unreachable and ADR-072's merge-safety incident unreproducible here.
+//
+// Each case below builds its state from real conditions — a real conflict, a
+// real commits-behind count, a real red check against a real head SHA — rather
+// than declaring the answer.
+
+// seedPRForState builds a repo with a head branch off main and a PR on it,
+// returning the head SHA that check runs must be keyed by.
+func seedPRForState(t *testing.T, s *Sim, draft bool) string {
+	t.Helper()
+	s.SeedCommit(repoName, "main", map[string]string{"base.txt": "base\n"}, "base").
+		SeedCommit(repoName, headBranch, map[string]string{"feature.txt": "feature\n"}, "feature").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Draft: draft})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	return mustHeadSHA(t, s, repoName, headBranch)
+}
+
+func TestMergeableStateClean(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateClean)
+}
+
+func TestMergeableStateBlockedOnFailingRequiredContext(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+}
+
+func TestMergeableStateBlockedOnMissingRequiredContext(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedPRForState(t, s, false)
+	// The required context has simply never reported — GitHub blocks on this
+	// exactly as it blocks on a failure.
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+}
+
+func TestMergeableStateBlockedOnPendingRequiredContext(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "in_progress"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+}
+
+// TestMergeableStateUnstableOnFailingNonRequiredContext is the distinction the
+// whole required-context mechanism exists for: the same red check that yields
+// "blocked" when required yields "unstable" when it is not, and "unstable" is
+// mergeable.
+func TestMergeableStateUnstableOnFailingNonRequiredContext(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "success"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "cleanup", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateUnstable)
+	if !gh.MergeableStateAccepted(stateUnstable) {
+		t.Fatal("precondition: production must accept unstable as mergeable")
+	}
+}
+
+// TestMergeableStateBlockedViaClassicCommitStatus covers ADR-933's path: a
+// required context posted through the classic Statuses API rather than as a
+// check run must block just the same. This is why the model keeps the two
+// collections genuinely separate.
+func TestMergeableStateBlockedViaClassicCommitStatus(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"local-ci"}).
+		SeedCommitStatus(repoName, sha, gh.CommitStatus{Context: "local-ci", State: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateBlocked)
+
+	// FetchCombinedStatus must surface it, and FetchCheckRuns must not — a
+	// model that conflated them would show the status as a check run.
+	statuses, err := s.FetchCombinedStatus("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCombinedStatus: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Context != "local-ci" {
+		t.Fatalf("combined status = %+v, want one local-ci entry", statuses)
+	}
+	runs, err := s.FetchCheckRuns("acme", "widgets", sha)
+	if err != nil {
+		t.Fatalf("FetchCheckRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("check runs = %+v, want none — a commit status is not a check run", runs)
+	}
+}
+
+func TestMergeableStateDraftTakesPrecedence(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedPRForState(t, s, true)
+
+	// A draft PR resolves to "draft" even with everything else green; the
+	// precedence order is documented on FetchPRMergeableFields.
+	assertState(t, s, stateDraft)
+
+	if err := s.MarkPRReady("acme", "widgets", 42); err != nil {
+		t.Fatalf("MarkPRReady: %v", err)
+	}
+	assertState(t, s, stateClean)
+}
+
+// TestMergeableStateBehindRequiresBranchProtection pins the model's most
+// consequential fidelity choice: GitHub reports "behind" only where branch
+// protection requires up-to-date heads. Without that setting a conflict-free
+// but out-of-date PR is "clean", and a model that always said "behind" would
+// make "clean" nearly unreachable and misroute the engine's rebase logic.
+func TestMergeableStateBehindRequiresBranchProtection(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedPRForState(t, s, false)
+
+	// Advance main past the PR's fork point, with a non-conflicting change.
+	s.SeedCommit(repoName, "main", map[string]string{"unrelated.txt": "moved on\n"}, "main advances")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	behind, err := s.FetchCommitsBehind("acme", "widgets", "main", headBranch)
+	if err != nil {
+		t.Fatalf("FetchCommitsBehind: %v", err)
+	}
+	if behind == 0 {
+		t.Fatal("precondition: head should be behind main after main advanced")
+	}
+
+	// Without the requirement, being behind does not block.
+	assertState(t, s, stateClean)
+
+	s.SeedRequireUpToDate(repoName, "main", true)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding requirement: %v", err)
+	}
+	assertState(t, s, stateBehind)
+}
+
+func TestMergeableStateDirtyOnRealConflict(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedConflict(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateDirty)
+}
+
+// TestMergePRGatesOnDerivedState is the ADR-072 guard: a PR in a blocked state
+// must not merge, and the refusal must carry ErrNotMergeableCI rather than
+// ErrNotMergeable — the engine treats those differently, and only the latter
+// may enter the rebase path.
+func TestMergePRGatesOnDerivedState(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	baseBefore := mustHeadSHA(t, s, repoName, "main")
+	err := s.MergePR("acme", "widgets", 42)
+	if err == nil {
+		t.Fatal("MergePR merged a PR in the blocked state")
+	}
+	if !isNotMergeableCI(err) {
+		t.Fatalf("MergePR error = %v, want gh.ErrNotMergeableCI for a blocked PR", err)
+	}
+	if isNotMergeable(err) {
+		t.Fatalf("a CI refusal must not also satisfy ErrNotMergeable — it would be routed into the rebase path: %v", err)
+	}
+	if after := mustHeadSHA(t, s, repoName, "main"); after != baseBefore {
+		t.Fatalf("a refused merge still moved main from %s to %s", baseBefore, after)
+	}
+}
+
+// TestMergePRSucceedsOnUnstable is the other side of the gate: "unstable" is
+// in MergeableStateAccepted, so a red *non-required* check must not stop a
+// merge.
+func TestMergePRSucceedsOnUnstable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"ci/build"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "ci/build", Status: "completed", Conclusion: "success"}).
+		SeedCheckRun(repoName, sha, gh.CheckRun{Name: "cleanup", Status: "completed", Conclusion: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateUnstable)
+	if err := s.MergePR("acme", "widgets", 42); err != nil {
+		t.Fatalf("MergePR refused an unstable PR: %v", err)
+	}
+	merged, err := s.FetchPRMerged("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMerged: %v", err)
+	}
+	if !merged {
+		t.Fatal("PR does not report merged after a successful merge")
+	}
+}
+
+// TestMergeableRecomputeWindow covers GitHub's "still computing" window: both
+// fields report unresolved together, each read drains one, and the real
+// git-derived answer surfaces afterwards. MergePR returning ErrNotMergeable on
+// a null read is what made a healthy issue (#1087) look wedged, so this path
+// has to be reachable rather than merely documented.
+func TestMergeableRecomputeWindow(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedCommit(repoName, "main", map[string]string{"base.txt": "base\n"}, "base").
+		SeedCommit(repoName, headBranch, map[string]string{"feature.txt": "feature\n"}, "feature").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", MergeableRecomputeReads: 2})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	for i := range 2 {
+		mergeable, state, err := s.FetchPRMergeableFields("acme", "widgets", 42)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if mergeable != nil {
+			t.Fatalf("read %d: mergeable = %v, want nil during the recompute window", i, *mergeable)
+		}
+		if state != stateUnknown {
+			t.Fatalf("read %d: state = %q, want %q", i, state, stateUnknown)
+		}
+	}
+
+	mergeable, state, err := s.FetchPRMergeableFields("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("read after window: %v", err)
+	}
+	if mergeable == nil || !*mergeable {
+		t.Fatalf("after the window, mergeable = %v, want true", mergeable)
+	}
+	if state != stateClean {
+		t.Fatalf("after the window, state = %q, want %q", state, stateClean)
+	}
+}
+
+// TestMergePRRefusesDuringRecomputeWindow proves the window is not merely
+// cosmetic: while it is open, the merge is refused as not-mergeable, which is
+// the production behaviour that made #1087 look stuck.
+func TestMergePRRefusesDuringRecomputeWindow(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedCommit(repoName, "main", map[string]string{"base.txt": "base\n"}, "base").
+		SeedCommit(repoName, headBranch, map[string]string{"feature.txt": "feature\n"}, "feature").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", MergeableRecomputeReads: 1})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	err := s.MergePR("acme", "widgets", 42)
+	if err == nil {
+		t.Fatal("MergePR succeeded during the recompute window")
+	}
+	if !isNotMergeable(err) {
+		t.Fatalf("MergePR error = %v, want gh.ErrNotMergeable during recompute", err)
+	}
+
+	// The window has now drained, so the retry the engine would make succeeds.
+	if err := s.MergePR("acme", "widgets", 42); err != nil {
+		t.Fatalf("MergePR after the window closed: %v", err)
+	}
+}
+
+// TestMergedPRReportsUnknown covers the merged/closed case: there is no
+// mergeability left to report.
+func TestMergedPRReportsUnknown(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedPRForState(t, s, false)
+
+	if err := s.MergePR("acme", "widgets", 42); err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+	mergeable, state, err := s.FetchPRMergeableFields("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMergeableFields: %v", err)
+	}
+	if mergeable != nil {
+		t.Fatalf("merged PR reports mergeable = %v, want nil", *mergeable)
+	}
+	if state != stateUnknown {
+		t.Fatalf("merged PR reports state %q, want %q", state, stateUnknown)
+	}
+}
+
+// assertState checks the derived mergeable_state for PR 42 in the standard
+// fixture repo.
+func assertState(t *testing.T, s *Sim, want string) {
+	t.Helper()
+	got, err := s.FetchPRMergeableState("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRMergeableState: %v", err)
+	}
+	if got != want {
+		t.Fatalf("mergeable state = %q, want %q", got, want)
+	}
+}

--- a/tests/sim/simgh/mergeable_state_test.go
+++ b/tests/sim/simgh/mergeable_state_test.go
@@ -131,6 +131,39 @@ func TestMergeableStateBlockedViaClassicCommitStatus(t *testing.T) {
 	}
 }
 
+// TestMergeableStateCleanViaClassicCommitStatus is the discriminating half of
+// the ADR-933 pair. Blocking on a *failing* commit status proves nothing on its
+// own: a derivation that ignored commit statuses entirely would also report
+// "blocked", because the required context would simply be missing. Only a
+// *passing* commit status can distinguish "read and green" from "not read at
+// all".
+func TestMergeableStateCleanViaClassicCommitStatus(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedRequiredContexts(repoName, "main", []string{"local-ci"}).
+		SeedCommitStatus(repoName, sha, gh.CommitStatus{Context: "local-ci", State: "success"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateClean)
+}
+
+// TestMergeableStateUnstableViaNonRequiredCommitStatus is the same
+// discrimination for the unstable branch: a red commit status that is not
+// required must make the PR unstable, which is only reachable if commit
+// statuses reach the derivation at all.
+func TestMergeableStateUnstableViaNonRequiredCommitStatus(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	sha := seedPRForState(t, s, false)
+	s.SeedCommitStatus(repoName, sha, gh.CommitStatus{Context: "optional-lint", State: "failure"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	assertState(t, s, stateUnstable)
+}
+
 func TestMergeableStateDraftTakesPrecedence(t *testing.T) {
 	s, _ := seedBasicBoard(t)
 	seedPRForState(t, s, true)

--- a/tests/sim/simgh/misc.go
+++ b/tests/sim/simgh/misc.go
@@ -1,0 +1,74 @@
+package simgh
+
+import (
+	"fmt"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// FetchLatestRelease returns the repo's seeded latest release, or nil when
+// none has been seeded — GitHub returns 404 for a repo with no releases, which
+// production surfaces as a nil release rather than a hard failure.
+func (s *Sim) FetchLatestRelease(owner, repo string) (*gh.LatestRelease, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	if r.latestRelease == nil {
+		return nil, nil
+	}
+	rel := *r.latestRelease
+	rel.Assets = append([]gh.ReleaseAsset(nil), r.latestRelease.Assets...)
+	return &rel, nil
+}
+
+// FetchRepoAccess returns the repo's auto-merge and push permissions.
+func (s *Sim) FetchRepoAccess(owner, repo string) (gh.RepoAccess, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		return gh.RepoAccess{}, err
+	}
+	return r.access, nil
+}
+
+// RateLimitStats returns the REST and GraphQL budgets.
+//
+// Modelled as static: the budgets never deplete as calls are made, and no
+// method ever fails with a rate-limit error. Exhaustion and its backoff
+// behaviour are therefore not reachable in this layer — see FIDELITY.md. The
+// Reset and UpdatedAt timestamps still come from the injected clock so a test
+// controlling time sees coherent values.
+func (s *Sim) RateLimitStats() (gh.RateLimitStats, gh.RateLimitStats) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	toStats := func(b rateBudget) gh.RateLimitStats {
+		return gh.RateLimitStats{
+			Limit:     b.limit,
+			Remaining: b.remaining,
+			Used:      b.used,
+			Reset:     now.Add(b.resetIn),
+			UpdatedAt: now,
+		}
+	}
+	return toStats(s.restRate), toStats(s.graphqlRate)
+}
+
+// DeleteForwardingHooks removes webhook forwarding hooks from a repo.
+//
+// The model has no webhook subsystem, so there is never anything to delete and
+// this always succeeds for a seeded repo. Recorded in FIDELITY.md as absent
+// rather than modelled: a test cannot use this layer to prove hooks were
+// cleaned up.
+func (s *Sim) DeleteForwardingHooks(owner, repo string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.lookupRepo(owner, repo); err != nil {
+		return fmt.Errorf("simgh: DeleteForwardingHooks: %w", err)
+	}
+	return nil
+}

--- a/tests/sim/simgh/model.go
+++ b/tests/sim/simgh/model.go
@@ -63,8 +63,40 @@ type repoState struct {
 
 	mergeQueueEnabled bool
 
-	nextIssueNumber int
-	nextPRNumber    int
+	// nextNumber is the repo's single issue-and-PR number sequence. GitHub
+	// numbers issues and pull requests from one shared per-repo counter, so
+	// #7 is either an issue or a PR and never both. Modelling them as two
+	// independent sequences would let issue #1 and PR #1 coexist — and
+	// AddComment, whose REST endpoint is likewise shared between the two,
+	// would then silently route a PR comment to the same-numbered issue.
+	nextNumber int
+}
+
+// numberTaken reports whether an issue or PR already holds this number. Caller
+// must hold mu.
+func (r *repoState) numberTaken(num int) bool {
+	_, issueExists := r.issues[num]
+	_, prExists := r.prs[num]
+	return issueExists || prExists
+}
+
+// allocNumber reserves the next free number in the repo's shared sequence.
+// Caller must hold mu.
+func (r *repoState) allocNumber() int {
+	for r.numberTaken(r.nextNumber) {
+		r.nextNumber++
+	}
+	num := r.nextNumber
+	r.nextNumber++
+	return num
+}
+
+// reserveNumber records an explicitly-seeded number so the shared sequence
+// never hands it out again. Caller must hold mu.
+func (r *repoState) reserveNumber(num int) {
+	if num >= r.nextNumber {
+		r.nextNumber = num + 1
+	}
 }
 
 // issueRecord is an issue's mutable state.

--- a/tests/sim/simgh/model.go
+++ b/tests/sim/simgh/model.go
@@ -1,0 +1,249 @@
+package simgh
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// repoState is everything the model knows about one owner/repo, plus the
+// mutex serialising git subprocess calls against its backing bare repository.
+type repoState struct {
+	owner string
+	repo  string
+
+	// bareDir is the on-disk bare repository acting as this repo's origin.
+	bareDir string
+
+	// defaultBranch is the repo's default base branch (the branch the initial
+	// commit lands on).
+	defaultBranch string
+
+	// gitMu serialises git subprocess invocations against bareDir. Git's
+	// on-disk state is not concurrency-safe, so a model-level mutex is not
+	// sufficient. Never acquire Sim.mu while holding this.
+	gitMu sync.Mutex
+
+	issues map[int]*issueRecord
+	prs    map[int]*prRecord
+
+	// checkRuns and commitStatuses are deliberately separate SHA-keyed
+	// collections. Production distinguishes them (ADR-933: a required context
+	// may be posted via the classic Statuses API rather than as an Actions
+	// check run), so conflating them here would make that path untestable.
+	checkRuns      map[string][]gh.CheckRun
+	commitStatuses map[string][]gh.CommitStatus
+
+	// requiredContexts maps a branch name to the set of check/status context
+	// names branch protection requires on that branch. This is what makes the
+	// blocked/unstable distinction reachable: a red *required* context yields
+	// "blocked", a red non-required one yields "unstable".
+	requiredContexts map[string][]string
+
+	// requireUpToDate maps a branch name to branch protection's "require
+	// branches to be up to date before merging" setting. It gates the
+	// "behind" mergeable state: real GitHub reports "behind" only where this
+	// is on, and reports a conflict-free but out-of-date PR as "clean"
+	// otherwise.
+	requireUpToDate map[string]bool
+
+	// requiredApprovals maps a branch name to the approving-review count
+	// branch protection requires, backing FetchPRReviewDecision.
+	requiredApprovals map[string]int
+
+	// labelVocab is the set of labels that exist in the repo, as maintained by
+	// SeedLabels. The model does not enforce it on AddLabelToIssue — see
+	// FIDELITY.md.
+	labelVocab map[string]bool
+
+	access        gh.RepoAccess
+	latestRelease *gh.LatestRelease
+
+	mergeQueueEnabled bool
+
+	nextIssueNumber int
+	nextPRNumber    int
+}
+
+// issueRecord is an issue's mutable state.
+type issueRecord struct {
+	number int
+	title  string
+	body   string
+	// state is the GitHub enum: "OPEN" or "CLOSED".
+	state     string
+	author    string
+	labels    []string
+	assignees []string
+	// labelAppliedAt records when each currently-applied label was applied,
+	// read back by FetchLabelAppliedAt. Three separate engine mechanisms
+	// anchor timeouts on this value, so it is load-bearing, not metadata.
+	labelAppliedAt map[string]time.Time
+	comments       []*commentRecord
+	blockedBy      []gh.Dependency
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
+// nodeID synthesises the issue's GraphQL node ID. Sim node IDs are readable
+// strings rather than opaque base64 blobs; production never parses a node ID
+// it receives, only round-trips it. See FIDELITY.md.
+func (i *issueRecord) nodeID(ownerRepo string) string {
+	return fmt.Sprintf("issue:%s#%d", ownerRepo, i.number)
+}
+
+// prRecord is a pull request's mutable state. Anything git can answer about a
+// PR (head SHA, mergeability, commits behind) is derived from the backing
+// repository rather than stored here.
+type prRecord struct {
+	number int
+	title  string
+	body   string
+	// head and base are branch names, resolved against the backing repo on
+	// every read so a new seeded commit is immediately reflected.
+	head string
+	base string
+	// state is the GitHub REST enum: "open" or "closed".
+	state  string
+	draft  bool
+	merged bool
+	author string
+	labels []string
+
+	// issueNumber is the issue passed to CreateDraftPR, if any. It seeds
+	// FetchPRClosingIssues alongside the body-keyword scan.
+	issueNumber int
+
+	comments            []*commentRecord
+	reviewThreadComment []*commentRecord
+
+	reviews        []gh.PRReview
+	reviewRequests []gh.ReviewRequest
+
+	// resolvedThreads counts review threads marked resolved, surfaced as
+	// ProjectItem.LinkedPRResolvedThreadCount for the engine's progress
+	// detection.
+	resolvedThreads int
+
+	autoMergeEnabled  bool
+	autoMergeStrategy string
+
+	inMergeQueue bool
+	queueEntry   *gh.MergeQueueEntry
+
+	// mergeableRecomputeReads models GitHub's recompute window, during which
+	// it reports mergeable as null and mergeableState as "unknown". While
+	// non-zero, each read of a mergeable field returns the unresolved values
+	// and decrements this counter by one; at zero, reads return the real
+	// git-derived answer. Seeded explicitly rather than raced, because the
+	// window is what once made a healthy issue (#1087) look wedged and no
+	// scenario could cover that path if the *bool were never nil.
+	mergeableRecomputeReads int
+
+	createdAt time.Time
+	updatedAt time.Time
+}
+
+// commentRecord is a comment on an issue or PR, including inline review-thread
+// comments.
+type commentRecord struct {
+	databaseID int
+	author     string
+	body       string
+	createdAt  time.Time
+	reactions  map[string]int
+
+	// fromPR is the PR number when the comment lives on a pull request, zero
+	// for issue comments.
+	fromPR int
+
+	// Review-thread fields; zero-valued for ordinary comments.
+	reviewThreadID string
+	path           string
+	line           int
+	originalLine   int
+	diffHunk       string
+	isOutdated     bool
+	threadResolved bool
+}
+
+func (c *commentRecord) nodeID() string { return fmt.Sprintf("comment:%d", c.databaseID) }
+
+// toGH projects a commentRecord into the shape the engine consumes. Built
+// fresh on every read so a reaction added a moment ago is always visible.
+func (c *commentRecord) toGH() gh.Comment {
+	out := gh.Comment{
+		ID:             c.nodeID(),
+		DatabaseID:     c.databaseID,
+		Author:         c.author,
+		Body:           c.body,
+		CreatedAt:      c.createdAt,
+		FromPR:         c.fromPR,
+		ReviewThreadID: c.reviewThreadID,
+		Path:           c.path,
+		Line:           c.line,
+		OriginalLine:   c.originalLine,
+		DiffHunk:       c.diffHunk,
+		IsOutdated:     c.isOutdated,
+	}
+	// Reaction groups are emitted in a stable order so tests comparing whole
+	// projections are not order-flaky; GitHub's own ordering is not
+	// contractual.
+	for _, content := range sortedKeys(c.reactions) {
+		if n := c.reactions[content]; n > 0 {
+			out.Reactions = append(out.Reactions, gh.ReactionGroup{Content: content, Count: n})
+		}
+	}
+	return out
+}
+
+// projectState is a Projects v2 board. Keyed by (owner, number) because
+// Projects v2 is owner-scoped, not repo-scoped.
+type projectState struct {
+	id    string
+	owner string
+	num   int
+	title string
+
+	statusFieldID string
+	// statusOptions maps a column name to its option ID.
+	statusOptions map[string]string
+	// orderedStatusNames preserves column order; the first is the leftmost.
+	orderedStatusNames []string
+
+	// items is keyed by item ID and holds board membership.
+	items map[string]*itemState
+	// itemOrder preserves insertion order so FetchProjectBoard returns a
+	// deterministic sequence.
+	itemOrder []string
+
+	updatedAt time.Time
+}
+
+// itemState is one card on the board.
+type itemState struct {
+	itemID    string
+	ownerRepo string
+	number    int
+	isPR      bool
+	status    string
+	archived  bool
+	updatedAt time.Time
+}
+
+// contentNodeID is the node ID of the issue or PR the card points at.
+func (it *itemState) contentNodeID() string {
+	kind := "issue"
+	if it.isPR {
+		kind = "pr"
+	}
+	return fmt.Sprintf("%s:%s#%d", kind, it.ownerRepo, it.number)
+}
+
+func (p *projectState) nodeID() string { return fmt.Sprintf("project:%s:%d", p.owner, p.num) }
+
+func itemNodeID(owner string, num int, ownerRepo string, number int) string {
+	return fmt.Sprintf("item:%s:%d:%s#%d", owner, num, ownerRepo, number)
+}

--- a/tests/sim/simgh/model.go
+++ b/tests/sim/simgh/model.go
@@ -17,6 +17,11 @@ type repoState struct {
 	// bareDir is the on-disk bare repository acting as this repo's origin.
 	bareDir string
 
+	// worktreeRoot holds the throwaway worktrees trial merges check out into.
+	// It sits inside Sim.baseDir so a process killed mid-merge cannot strand a
+	// checkout outside the sandbox — see withWorktree.
+	worktreeRoot string
+
 	// defaultBranch is the repo's default base branch (the branch the initial
 	// commit lands on).
 	defaultBranch string

--- a/tests/sim/simgh/model.go
+++ b/tests/sim/simgh/model.go
@@ -80,19 +80,23 @@ func (r *repoState) numberTaken(num int) bool {
 	return issueExists || prExists
 }
 
-// allocNumber reserves the next free number in the repo's shared sequence.
+// allocNumber takes the next free number from the repo's shared sequence.
+//
+// INVARIANT: every number >= nextNumber is free. reserveNumber maintains it for
+// explicitly-seeded numbers, and this function for auto-assigned ones, so no
+// collision check is needed here. Guarding anyway would be dead code — it could
+// not fire, so the non-vacuity sweep could not prove it does anything.
+//
 // Caller must hold mu.
 func (r *repoState) allocNumber() int {
-	for r.numberTaken(r.nextNumber) {
-		r.nextNumber++
-	}
 	num := r.nextNumber
 	r.nextNumber++
 	return num
 }
 
-// reserveNumber records an explicitly-seeded number so the shared sequence
-// never hands it out again. Caller must hold mu.
+// reserveNumber records an explicitly-seeded number so the shared sequence never
+// hands it out again. This is what keeps allocNumber's invariant true across
+// seeds that pick their own numbers. Caller must hold mu.
 func (r *repoState) reserveNumber(num int) {
 	if num >= r.nextNumber {
 		r.nextNumber = num + 1

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -384,7 +384,7 @@ mutate "board projections do not re-check archived after the snapshot" \
 
 mutate "a board card may point at an issue that does not exist" \
   'TestSeedProjectItemRefusesUnresolvableTarget' \
-  'seed.go::s{if _, ok := r\.issues\[number\]; !ok \{}{if false \{}'
+  'seed.go::s{if _, ok := r\.issues\[number\]; !ok \{}{if _, ok := r.issues[number]; !ok \&\& false \{}'
 
 mutate "a board card may point at an unseeded repo" \
   'TestSeedProjectItemRefusesUnresolvableTarget' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -256,10 +256,13 @@ mutate "a duplicate check run ID is accepted" \
   'TestSeedCheckRunRejectsDuplicateID' \
   'seed.go::s|\t\} else if s\.seededCheckRunIDs\[run\.ID\] \{|\t\} else if false \&\& s.seededCheckRunIDs[run.ID] \{|'
 
+# Neutralised by short-circuiting the whole validator rather than editing its
+# two conditions in place: the guard's own source contains backticks and
+# backslashes that are awkward to match reliably, and a perl expression that
+# silently fails to apply proves nothing (which is why SKIP now fails the sweep).
 mutate "owner/repo path traversal is accepted" \
   'TestSeedRepoRejectsPathTraversal' \
-  'util.go::s|\tif seg == "\." \|\| seg == "\.\." \{|\tif false \&\& (seg == "." \|\| seg == "..") \{|' \
-  'util.go::s|\tif strings\.ContainsAny\(seg, `/\\\\`\) \|\| strings\.ContainsRune\(seg, os\.PathSeparator\) \{|\tif false \&\& (strings.ContainsAny(seg, `/`) \|\| strings.ContainsRune(seg, os.PathSeparator)) \{|'
+  'util.go::s|func validatePathSegment\(kind, seg, ownerRepo string\) error \{|func validatePathSegment(kind, seg, ownerRepo string) error \{\n\treturn nil|'
 
 # Both of SeedRepo's duplicate guards are neutralised together: single-threaded,
 # either one alone still refuses the reseed, so a mutation of just one could not
@@ -268,9 +271,10 @@ mutate "a duplicate SeedRepo is accepted" \
   'TestSeedRepoRefusesDuplicateSeed' \
   'seed.go::s|if _, exists := s\.repos\[ownerRepo\]; exists \{|if false \{|g'
 
-mutate_race "a concurrent second SeedRepo clobbers the live repoState" \
+mutate_race "SeedRepo's creation lock is removed (concurrent callers race in git and clobber)" \
   'TestConcurrentSeedRepoDoesNotClobber' \
-  'seed.go::s|\tif _, exists := s\.repos\[ownerRepo\]; exists \{\n\t\ts\.fail\("simgh: repo %s already seeded", ownerRepo\)\n\t\ts\.mu\.Unlock\(\)\n\t\treturn s\n\t\}\n\ts\.repos\[ownerRepo\] = &repoState\{|\tif false \{\n\t\ts.fail("simgh: repo %s already seeded", ownerRepo)\n\t\ts.mu.Unlock()\n\t\treturn s\n\t\}\n\ts.repos[ownerRepo] = \&repoState\{|'
+  'sim.go::s|\tseedRepoMu sync\.Mutex|\tseedRepoMu noopSeedMutex|' \
+  'sim.go::s|^type realClock struct\{\}$|type noopSeedMutex struct{}\n\nfunc (noopSeedMutex) Lock()   {}\nfunc (noopSeedMutex) Unlock() {}\n\ntype realClock struct{}|m'
 
 mutate "timestamps come from wall time, not the injected clock" \
   'TestLabelAddRemoveIsObservable' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -16,6 +16,11 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 PKG=./tests/sim/simgh
 DIR=tests/sim/simgh
 FAILED_TO_CATCH=()
+# A skipped mutation proves nothing: its edit never applied, so the test it
+# targets was never challenged. Track skips separately and fail on them too,
+# or a typo in a perl expression silently erodes coverage forever while the
+# sweep still reports success.
+SKIPPED=()
 
 # The sweep restores sources with `git checkout`, which would silently discard
 # uncommitted work in this directory. Refuse to run rather than eat it.
@@ -46,6 +51,7 @@ _mutate() {
     local script="${expr#*::}"
     if ! perl -0777 -pi -e "$script" "$DIR/$file"; then
       echo "SKIP  $name (perl edit failed on $file)"
+      SKIPPED+=("$name (perl edit failed on $file)")
       return
     fi
   done
@@ -53,6 +59,7 @@ _mutate() {
   local out
   if ! out=$(go build "$PKG" 2>&1); then
     echo "SKIP  $name (mutation does not compile: $(echo "$out" | head -1))"
+    SKIPPED+=("$name (does not compile)")
     return
   fi
 
@@ -218,11 +225,11 @@ mutate "the runtime board API accepts a PR card the seeding API refuses" \
 
 mutate "a nonexistent blocker is accepted at runtime" \
   'TestAddBlockedByIssueRejectsUnknownBlocker' \
-  'deps.go::s{if _, ok := br\.issues\[blockerNum\]; !ok \{}{if false {}'
+  'deps.go::s{if _, ok := br\.issues\[blockerNum\]; !ok \{}{if _, ok := br.issues[blockerNum]; !ok && false \{}'
 
 mutate "a nonexistent blocker is accepted at seed time" \
   'TestSeedBlockedByRejectsUnknownBlocker' \
-  'seed.go::s{if _, ok := br\.issues\[blockerNumber\]; !ok \{}{if false {}'
+  'seed.go::s{if _, ok := br\.issues\[blockerNumber\]; !ok \{}{if _, ok := br.issues[blockerNumber]; !ok && false \{}'
 
 # --- precedence ordering ------------------------------------------------
 # The single-condition tests above prove each branch is reachable; only these
@@ -257,10 +264,18 @@ mutate "per-repo git serialisation is removed" \
 
 
 echo
-if [ ${#FAILED_TO_CATCH[@]} -eq 0 ]; then
-  echo "All mutations were caught. No vacuous tests found."
-else
+status=0
+if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then
   echo "Mutations NOT caught by the suite:"
   printf '  - %s\n' "${FAILED_TO_CATCH[@]}"
-  exit 1
+  status=1
 fi
+if [ ${#SKIPPED[@]} -ne 0 ]; then
+  echo "Mutations that never ran (they prove nothing — fix the expression):"
+  printf '  - %s\n' "${SKIPPED[@]}"
+  status=1
+fi
+if [ "$status" -eq 0 ]; then
+  echo "All mutations were caught. No vacuous tests found."
+fi
+exit "$status"

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -199,8 +199,8 @@ mutate_race "model mutex is removed (expects a data race)" \
   'sim.go::s{^\tmu sync\.Mutex$}{\tmu noopMutex}m' \
   'sim.go::s{^type realClock struct\{\}$}{type noopMutex struct{}\n\nfunc (noopMutex) Lock()   {}\nfunc (noopMutex) Unlock() {}\n\nvar _ sync.Mutex\n\ntype realClock struct{}}m'
 
-mutate_race "per-repo git serialisation is removed" \
-  'TestConcurrentTrialMergesOnOneRepo|TestConcurrentModelAccess' \
+mutate "per-repo git serialisation is removed" \
+  'TestConcurrentMergesOntoOneBase' \
   'model.go::s|^\tgitMu sync\.Mutex$|\tgitMu noopGitMutex|m' \
   'model.go::s|\z|\ntype noopGitMutex struct{}\n\nfunc (noopGitMutex) Lock() {}\nfunc (noopGitMutex) Unlock() {}\n\nvar _ sync.Mutex\n|'
 

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -186,7 +186,7 @@ mutate "a name in both collections does not keep the worse verdict" \
 
 mutate "FetchPRDetails reports no mergeable_state" \
   'TestFetchPRDetailsReportsDerivedMergeableState' \
-  'prs.go::s{\t\tMergeableState:   state,}{\t\tMergeableState:   "",}'
+  'prs.go::s{\t\tMergeableState:   state,}{\t\tMergeableState:   state[:0],}'
 
 mutate "behind is reported without branch protection" \
   'TestMergeableStateBehindRequiresBranchProtection' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -190,6 +190,24 @@ mutate "FetchLinkedPR leaks a computed mergeable_state" \
   'TestPRCreateReadyMergeIsObservable' \
   'prs.go::s{MergeableState:      "", // omitted by the list endpoint — see doc comment}{MergeableState:      "clean",}'
 
+mutate "linked PR resolution picks the oldest on a reused branch" \
+  'TestFetchLinkedPRPrefersNewestOnReusedBranch' \
+  'board.go::s{for i := len\(nums\) - 1; i >= 0; i-- \{}{for i := 0; i < len(nums); i++ \{}'
+
+mutate "issue and PR numbers come from independent sequences" \
+  'TestIssueAndPRShareNumberSpace' \
+  'model.go::s{^\tnextNumber int$}{\tnextNumber int\n\tnextPRNumber int}m' \
+  'seed.go::s{^\t\tnextNumber:        1,$}{\t\tnextNumber:        1,\n\t\tnextPRNumber:      1,}m' \
+  'prs.go::s{^\tnum := r\.allocNumber\(\)$}{\tnum := r.nextPRNumber\n\tr.nextPRNumber++}m'
+
+mutate "auto-assigned numbers collide with explicitly seeded ones" \
+  'TestAutoAssignedNumberSkipsSeededHoles' \
+  'model.go::s{for r\.numberTaken\(r\.nextNumber\) \{}{for false \{}'
+
+mutate "seeding does not enforce the shared number space" \
+  'TestSeedRejectsNumberHeldByOtherKind' \
+  'seed.go::s{\} else if r\.numberTaken\(num\) \{}{\} else if false \{}g'
+
 mutate "timestamps come from wall time, not the injected clock" \
   'TestLabelAddRemoveIsObservable' \
   'sim.go::s{func \(s \*Sim\) now\(\) time\.Time \{ return s\.clock\.Now\(\) \}}{func (s *Sim) now() time.Time { return time.Now() }}'

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -150,12 +150,12 @@ mutate "head SHA is not re-resolved after a push" \
   'TestHeadSHATracksNewCommits' \
   'git.go::s{^\tsha, err := r\.resolveRef\("refs/heads/" \+ branch\)$}{\tsha, err := r.resolveRef("refs/heads/" + r.defaultBranch)}m'
 
-mutate "required contexts never block" \
-  'TestMergeableStateBlockedOnFailingRequiredContext|TestMergeableStateBlockedOnMissingRequiredContext|TestMergeableStateBlockedOnPendingRequiredContext|TestMergeableStateBlockedViaClassicCommitStatus|TestMergePRGatesOnDerivedState' \
+mutate "required contexts never block (blocked no longer outranks unstable)" \
+  'TestMergeableStateBlockedOnFailingRequiredContext|TestMergeableStateBlockedOnMissingRequiredContext|TestMergeableStateBlockedOnPendingRequiredContext|TestMergeableStateBlockedViaClassicCommitStatus|TestMergePRGatesOnDerivedState|TestPrecedenceBlockedOverUnstable' \
   'prs.go::s{^\t\t\treturn stateBlocked$}{\t\t\t_ = name}m'
 
 mutate "non-required failures never surface as unstable" \
-  'TestMergeableStateUnstableOnFailingNonRequiredContext|TestMergePRSucceedsOnUnstable' \
+  'TestMergeableStateUnstableOnFailingNonRequiredContext|TestMergePRSucceedsOnUnstable|TestPrecedenceUnstableOverClean' \
   'prs.go::s{^\t\t\treturn stateUnstable$}{\t\t\t_ = name}m'
 
 mutate "commit statuses are ignored by the derivation" \
@@ -211,6 +211,23 @@ mutate "seeding does not enforce the shared number space" \
 mutate "a PR card is accepted and silently dropped" \
   'TestSeedProjectItemRejectsPRCard' \
   'seed.go::s{\tif isPR \{}{\tif false \{}'
+
+# --- precedence ordering ------------------------------------------------
+# The single-condition tests above prove each branch is reachable; only these
+# constrain the order they are tried in. Each mutation demotes one state below
+# the next, which a correctly-ordered suite must notice.
+
+mutate "draft no longer outranks dirty" \
+  'TestPrecedenceDraftOverDirty' \
+  'prs.go::s{if draft \{\n\t\treturn stateDraft\n\t\}\n\tif facts\.conflict \{\n\t\treturn stateDirty\n\t\}}{if facts.conflict \{\n\t\treturn stateDirty\n\t\}\n\tif draft \{\n\t\treturn stateDraft\n\t\}}'
+
+mutate "dirty no longer outranks behind" \
+  'TestPrecedenceDirtyOverBehind' \
+  'prs.go::s{if facts\.conflict \{\n\t\treturn stateDirty\n\t\}}{if false \{\n\t\treturn stateDirty\n\t\}}'
+
+mutate "behind no longer outranks blocked" \
+  'TestPrecedenceBehindOverBlocked' \
+  'prs.go::s{if facts\.behind > 0 && r\.requireUpToDate\[base\] \{}{if false \{}'
 
 mutate "timestamps come from wall time, not the injected clock" \
   'TestLabelAddRemoveIsObservable' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Non-vacuity sweep for tests/sim/simgh.
+#
+# A stateful fake is exactly the kind of code whose tests can pass for the
+# wrong reason, so every behaviour this package claims to model is neutralised
+# here in turn and the suite re-run. A mutation that leaves the suite green is
+# a test that proves nothing.
+#
+# Usage:  bash tests/sim/simgh/nonvacuity.sh
+# Requires a clean working tree under tests/sim/simgh (it edits sources in
+# place and restores them with git checkout after each case).
+
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+PKG=./tests/sim/simgh
+DIR=tests/sim/simgh
+FAILED_TO_CATCH=()
+
+# The sweep restores sources with `git checkout`, which would silently discard
+# uncommitted work in this directory. Refuse to run rather than eat it.
+if ! git diff --quiet -- "$DIR" || ! git diff --cached --quiet -- "$DIR"; then
+  echo "error: $DIR has uncommitted changes; commit or stash them first." >&2
+  echo "       This script restores sources with 'git checkout' and would discard them." >&2
+  exit 2
+fi
+
+restore() { git checkout -- "$DIR" 2>/dev/null; }
+trap restore EXIT
+
+# mutate <name> <test-regex> <perl-expression...>
+# Applies the perl edits, runs the named tests, and expects them to FAIL.
+mutate() { RACE="" _mutate "$@"; }
+
+# mutate_race is mutate with the race detector on, for mutations whose only
+# symptom is a data race rather than a wrong answer.
+mutate_race() { RACE="-race" _mutate "$@"; }
+
+_mutate() {
+  local name="$1"; shift
+  local tests="$1"; shift
+  restore
+
+  for expr in "$@"; do
+    local file="${expr%%::*}"
+    local script="${expr#*::}"
+    if ! perl -0777 -pi -e "$script" "$DIR/$file"; then
+      echo "SKIP  $name (perl edit failed on $file)"
+      return
+    fi
+  done
+
+  local out
+  if ! out=$(go build "$PKG" 2>&1); then
+    echo "SKIP  $name (mutation does not compile: $(echo "$out" | head -1))"
+    return
+  fi
+
+  if go test -count=1 -timeout 5m $RACE -run "$tests" "$PKG" >/dev/null 2>&1; then
+    echo "GREEN $name  <-- NOT CAUGHT"
+    FAILED_TO_CATCH+=("$name")
+  else
+    echo "CAUGHT $name"
+  fi
+}
+
+echo "=== simgh non-vacuity sweep ==="
+
+mutate "label add is a no-op" \
+  'TestLabelAddRemoveIsObservable' \
+  'labels.go::s{(iss\.labels = append\(iss\.labels, labelName\))}{// $1}'
+
+mutate "label applied-at is refreshed on re-add" \
+  'TestLabelAddRemoveIsObservable' \
+  'labels.go::s{if contains\(iss\.labels, labelName\) \{\n\t\treturn nil\n\t\}}{if contains(iss.labels, labelName) { iss.labelAppliedAt[labelName] = s.now(); return nil }}'
+
+mutate "label remove is a no-op" \
+  'TestLabelAddRemoveIsObservable' \
+  'labels.go::s{iss\.labels = updated}{_ = updated}'
+
+mutate "comment reaction is dropped" \
+  'TestCommentAddAndReactionAreObservable' \
+  'comments.go::s{(c\.reactions\[content\] = 1)}{// $1}'
+
+mutate "comment edit is dropped" \
+  'TestCommentAddAndReactionAreObservable' \
+  'comments.go::s{^\tc\.body = body$}{\t_ = c}m'
+
+mutate "issue body update is dropped" \
+  'TestIssueBodyUpdateIsObservable' \
+  'issues.go::s{^\tiss\.body = body$}{\t// neutralised}m'
+
+mutate "project status update is dropped" \
+  'TestProjectStatusUpdateIsObservable' \
+  'board.go::s{^\t\tit\.status = name$}{\t\t_ = name}m'
+
+mutate "status option ID is not validated" \
+  'TestProjectStatusUpdateIsObservable' \
+  'board.go::s{return fmt\.Errorf\("simgh: no status option %q in project %q", statusOptionID, projectID\)}{return nil}'
+
+mutate "MarkPRReady is a no-op" \
+  'TestPRCreateReadyMergeIsObservable' \
+  'prs.go::s{^\tpr\.draft = false$}{\t// neutralised}m'
+
+mutate "MergePR does not record the merge" \
+  'TestPRCreateReadyMergeIsObservable|TestMergePRSucceedsOnUnstable' \
+  'prs.go::s{^\tpr\.merged = true$}{\t// neutralised}m'
+
+mutate "merged PR does not auto-close its issue" \
+  'TestPRCreateReadyMergeIsObservable' \
+  'prs.go::s{if base == r\.defaultBranch \{}{if false \{}'
+
+mutate "CloseIssue is a no-op" \
+  'TestCloseIssueIsObservable' \
+  'issues.go::s{^\tiss\.state = "CLOSED"$}{\t// neutralised}m'
+
+mutate "blockedBy state is frozen at seed time" \
+  'TestBlockedByResolvesBlockerStateLive' \
+  'board.go::s{resolved\.State = iss\.state}{_ = iss; resolved.State = "OPEN"}'
+
+mutate "ResolveReviewThread is a no-op" \
+  'TestReviewThreadResolutionIsObservable' \
+  'comments.go::s{^\t\t\t\tc\.threadResolved = true$}{\t\t\t\t// neutralised}m'
+
+mutate "reviewDecision ignores missing branch protection" \
+  'TestReviewDecisionEmptyWithoutBranchProtection' \
+  'reviews.go::s{required, ok := r\.requiredApprovals\[pr\.base\]}{required, ok := r.requiredApprovals[pr.base]; ok = true; _ = ok}'
+
+mutate "trial merge never detects a conflict" \
+  'TestFetchPRMergeableFalseOnRealConflict|TestMergeableStateDirtyOnRealConflict|TestConcurrentTrialMergesOnOneRepo' \
+  'git.go::s{^\t\t\t\tconflict = true$}{\t\t\t\tconflict = false}m'
+
+mutate "mergeability is declared rather than computed" \
+  'TestFetchPRMergeableFalseOnRealConflict|TestMergeableStateDirtyOnRealConflict' \
+  'prs.go::s{mergeable := !facts\.conflict}{mergeable := true}'
+
+mutate "MergePR does not write a merge commit" \
+  'TestMergePRProducesRealMergeCommit' \
+  'git.go::s{if _, err := runGit\(r\.bareDir, "update-ref", "refs/heads/"\+base, sha\); err != nil \{}{if false \{ _ = sha}'
+
+mutate "merge is fast-forwarded instead of a merge commit" \
+  'TestMergePRProducesRealMergeCommit|TestMergePRCreatesMergeCommitEvenWhenFastForwardable' \
+  'git.go::s{"merge", "--no-ff", "-m", msg, headSHA}{"merge", "--ff", "-m", msg, headSHA}'
+
+mutate "commits-behind always reports zero" \
+  'TestFetchCommitsBehindCountsRealCommits|TestMergePRProducesRealMergeCommit|TestMergeableStateBehindRequiresBranchProtection' \
+  'git.go::s{^\treturn n, nil$}{\t_ = n; return 0, nil}m'
+
+mutate "head SHA is not re-resolved after a push" \
+  'TestHeadSHATracksNewCommits' \
+  'git.go::s{^\tsha, err := r\.resolveRef\("refs/heads/" \+ branch\)$}{\tsha, err := r.resolveRef("refs/heads/" + r.defaultBranch)}m'
+
+mutate "required contexts never block" \
+  'TestMergeableStateBlockedOnFailingRequiredContext|TestMergeableStateBlockedOnMissingRequiredContext|TestMergeableStateBlockedOnPendingRequiredContext|TestMergeableStateBlockedViaClassicCommitStatus|TestMergePRGatesOnDerivedState' \
+  'prs.go::s{^\t\t\treturn stateBlocked$}{\t\t\t_ = name}m'
+
+mutate "non-required failures never surface as unstable" \
+  'TestMergeableStateUnstableOnFailingNonRequiredContext|TestMergePRSucceedsOnUnstable' \
+  'prs.go::s{^\t\t\treturn stateUnstable$}{\t\t\t_ = name}m'
+
+mutate "commit statuses are ignored by the derivation" \
+  'TestMergeableStateBlockedViaClassicCommitStatus|TestMergeableStateCleanViaClassicCommitStatus|TestMergeableStateUnstableViaNonRequiredCommitStatus' \
+  'ci.go::s{out = append\(out, contextState\{name: st\.Context, verdict: statusVerdict\(st\)\}\)}{_ = st}'
+
+mutate "behind is reported without branch protection" \
+  'TestMergeableStateBehindRequiresBranchProtection' \
+  'prs.go::s{if facts\.behind > 0 && r\.requireUpToDate\[base\] \{}{if facts.behind > 0 \{}'
+
+mutate "draft precedence is dropped" \
+  'TestMergeableStateDraftTakesPrecedence' \
+  'prs.go::s{^\tif draft \{\n\t\treturn stateDraft\n\t\}$}{}m'
+
+mutate "recompute window never opens" \
+  'TestMergeableRecomputeWindow|TestMergePRRefusesDuringRecomputeWindow' \
+  'prs.go::s{if pr\.mergeableRecomputeReads > 0 \{}{if false \{}'
+
+mutate "MergePR skips its mergeable_state gate" \
+  'TestMergePRGatesOnDerivedState' \
+  'prs.go::s{if !gh\.MergeableStateAccepted\(state\) \{}{if false \{}'
+
+mutate "MergePR skips its mergeable gate" \
+  'TestMergePRRefusesRealConflict|TestMergePRRefusesDuringRecomputeWindow' \
+  'prs.go::s{if mergeable == nil \|\| !\*mergeable \{}{_ = mergeable; if false \{}'
+
+mutate "merged PR still reports a mergeable state" \
+  'TestMergedPRReportsUnknown' \
+  'prs.go::s{if pr\.merged \|\| pr\.state == "closed" \{}{if false \{}'
+
+mutate "FetchLinkedPR leaks a computed mergeable_state" \
+  'TestPRCreateReadyMergeIsObservable' \
+  'prs.go::s{MergeableState:      "", // omitted by the list endpoint — see doc comment}{MergeableState:      "clean",}'
+
+mutate "timestamps come from wall time, not the injected clock" \
+  'TestLabelAddRemoveIsObservable' \
+  'sim.go::s{func \(s \*Sim\) now\(\) time\.Time \{ return s\.clock\.Now\(\) \}}{func (s *Sim) now() time.Time { return time.Now() }}'
+
+mutate_race "model mutex is removed (expects a data race)" \
+  'TestConcurrentModelAccess|TestConcurrentReviewMutations' \
+  'sim.go::s{^\tmu sync\.Mutex$}{\tmu noopMutex}m' \
+  'sim.go::s{^type realClock struct\{\}$}{type noopMutex struct{}\n\nfunc (noopMutex) Lock()   {}\nfunc (noopMutex) Unlock() {}\n\nvar _ sync.Mutex\n\ntype realClock struct{}}m'
+
+mutate_race "per-repo git serialisation is removed" \
+  'TestConcurrentTrialMergesOnOneRepo|TestConcurrentModelAccess' \
+  'model.go::s{^\tgitMu sync\.Mutex$}{\tgitMu noopGitMutex}m' \
+  'model.go::s{^type issueRecord struct \{$}{type noopGitMutex struct{}\n\nfunc (noopGitMutex) Lock()   {}\nfunc (noopGitMutex) Unlock() {}\n\nvar _ sync.Mutex\n\ntype issueRecord struct {}m'
+
+echo
+if [ ${#FAILED_TO_CATCH[@]} -eq 0 ]; then
+  echo "All mutations were caught. No vacuous tests found."
+else
+  echo "Mutations NOT caught by the suite:"
+  printf '  - %s\n' "${FAILED_TO_CATCH[@]}"
+  exit 1
+fi

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -394,6 +394,55 @@ mutate "a zero approval requirement is accepted (APPROVED with no reviews)" \
   'TestSeedRequiredApprovalsRefusesNonPositive' \
   'seed.go::s{if n < 1 \{}{if false \{\n\t\t_ = n}'
 
+mutate "the probe reports the snapshot's status, not the card's" \
+  'TestProbeReadsCardStateLive' \
+  'board.go::s{Status:    live\.status,}{Status:    ref.status,}'
+
+mutate "the probe does not re-check archived after the snapshot" \
+  'board.go::s{live, ok := p\.items\[ref\.itemID\]\n\t\tif !ok \|\| live\.archived \{}{live, ok := p.items[ref.itemID]\n\t\tif !ok \{}' \
+  'TestProbeReadsCardStateLive' \
+  'board.go::s{live, ok := p\.items\[ref\.itemID\]\n\t\tif !ok \|\| live\.archived \{}{live, ok := p.items[ref.itemID]\n\t\tif !ok \{}'
+
+mutate "FetchPRReviews returns the raw submission history" \
+  'TestFetchPRReviewsCollapsesToLatestPerAuthor' \
+  'reviews.go::s{return latestReviewsByAuthor\(pr\.reviews\), nil}{out := make([]gh.PRReview, len(pr.reviews)); copy(out, pr.reviews); return out, nil}'
+
+mutate "a COMMENTED follow-up overwrites the author's formal verdict" \
+  'TestFetchPRReviewsCollapsesToLatestPerAuthor' \
+  'reviews.go::s{\} else if rev\.State == "COMMENTED" \{\n\t\t\tcontinue\n\t\t\}}{\} else if rev.State == "COMMENTED" \&\& false \{\n\t\t\tcontinue\n\t\t\}}'
+
+mutate "the board projection reports raw reviews, disagreeing with FetchPRReviews" \
+  'TestFetchPRReviewsCollapsesToLatestPerAuthor' \
+  'board.go::s{item\.LinkedPRReviews = latestReviewsByAuthor\(linked\.reviews\)}{item.LinkedPRReviews = append([]gh.PRReview(nil), linked.reviews...)}'
+
+mutate "repo directories flatten owner and repo, colliding" \
+  'TestRepoDirsDoNotCollide' \
+  'sim.go::s{filepath\.Join\(s\.baseDir, owner, repo\+"\.git"\)}{filepath.Join(s.baseDir, owner+"-"+repo+".git")}'
+
+mutate "a merged PR may also be a draft" \
+  'TestSeedPRRefusesImpossibleShapes' \
+  'seed.go::s{if seed\.Draft \{\n\t\t\ts\.fail\("simgh: PR %s#%d cannot be both merged and draft"}{if false \{\n\t\t\ts.fail("simgh: PR %s#%d cannot be both merged and draft"}'
+
+mutate "a merged PR may also be open" \
+  'TestSeedPRRefusesImpossibleShapes' \
+  'seed.go::s{if state == "open" \{\n\t\t\ts\.fail\("simgh: PR %s#%d cannot be merged and open}{if false \{\n\t\t\ts.fail("simgh: PR %s#%d cannot be merged and open}'
+
+mutate "an issue may block itself (runtime)" \
+  'TestSelfBlockIsRefused' \
+  'deps.go::s{if targetRepo == blockerRepo \&\& targetNum == blockerNum \{}{if false \&\& targetRepo == blockerRepo \&\& targetNum == blockerNum \{}'
+
+mutate "an issue may block itself (seeding)" \
+  'TestSelfBlockIsRefused' \
+  'seed.go::s{if blockerOwnerRepo == ownerRepo \&\& blockerNumber == issueNumber \{}{if false \&\& blockerOwnerRepo == ownerRepo \&\& blockerNumber == issueNumber \{}'
+
+mutate "a negative explicit issue number is accepted" \
+  'TestSeedIssueRefusesNegativeNumber' \
+  'seed.go::s{case num < 0:\n\t\t// reserveNumber is a no-op}{case num < 0 \&\& false:\n\t\t// reserveNumber is a no-op}'
+
+mutate "a negative explicit PR number is accepted" \
+  'TestSeedPRRefusesImpossibleShapes' \
+  'seed.go::s{case num < 0:\n\t\ts\.fail\("simgh: PR number}{case num < 0 \&\& false:\n\t\ts.fail("simgh: PR number}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -374,6 +374,14 @@ mutate "a comment stamps created-at and its issue from two clock reads" \
   'TestOneMutationStampsOneTimestamp' \
   'comments.go::s|\t\tiss\.updatedAt = now\n\t\treturn id, nil|\t\tiss.updatedAt = s.now()\n\t\treturn id, nil|'
 
+mutate "board projections use the stale snapshot's status" \
+  'TestBoardProjectionReadsCardStateLive' \
+  'board.go::s|status, isPR, cardUpdatedAt := live\.status, live\.isPR, live\.updatedAt|status, isPR, cardUpdatedAt := ref.status, ref.isPR, ref.updatedAt\n\t_ = live|'
+
+mutate "board projections do not re-check archived after the snapshot" \
+  'TestBoardProjectionReadsCardStateLive' \
+  'board.go::s{if !ok \|\| live\.archived \{}{if !ok \{}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -201,8 +201,9 @@ mutate_race "model mutex is removed (expects a data race)" \
 
 mutate_race "per-repo git serialisation is removed" \
   'TestConcurrentTrialMergesOnOneRepo|TestConcurrentModelAccess' \
-  'model.go::s{^\tgitMu sync\.Mutex$}{\tgitMu noopGitMutex}m' \
-  'model.go::s{^type issueRecord struct \{$}{type noopGitMutex struct{}\n\nfunc (noopGitMutex) Lock()   {}\nfunc (noopGitMutex) Unlock() {}\n\nvar _ sync.Mutex\n\ntype issueRecord struct {}m'
+  'model.go::s|^\tgitMu sync\.Mutex$|\tgitMu noopGitMutex|m' \
+  'model.go::s|\z|\ntype noopGitMutex struct{}\n\nfunc (noopGitMutex) Lock() {}\nfunc (noopGitMutex) Unlock() {}\n\nvar _ sync.Mutex\n|'
+
 
 echo
 if [ ${#FAILED_TO_CATCH[@]} -eq 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -380,7 +380,7 @@ mutate "board projections use the stale snapshot's status" \
 
 mutate "board projections do not re-check archived after the snapshot" \
   'TestBoardProjectionReadsCardStateLive' \
-  'board.go::s{if !ok \|\| live\.archived \{}{if !ok \{}'
+  'board.go::s{if !ok \|\| live\.archived \{\n\t\ts\.mu\.Unlock\(\)\n\t\treturn nil, nil\n\t\}\n\tstatus, isPR}{if !ok \{\n\t\ts.mu.Unlock()\n\t\treturn nil, nil\n\t\}\n\tstatus, isPR}'
 
 mutate "a board card may point at an issue that does not exist" \
   'TestSeedProjectItemRefusesUnresolvableTarget' \
@@ -399,9 +399,8 @@ mutate "the probe reports the snapshot's status, not the card's" \
   'board.go::s{Status:    live\.status,}{Status:    ref.status,}'
 
 mutate "the probe does not re-check archived after the snapshot" \
-  'board.go::s{live, ok := p\.items\[ref\.itemID\]\n\t\tif !ok \|\| live\.archived \{}{live, ok := p.items[ref.itemID]\n\t\tif !ok \{}' \
   'TestProbeReadsCardStateLive' \
-  'board.go::s{live, ok := p\.items\[ref\.itemID\]\n\t\tif !ok \|\| live\.archived \{}{live, ok := p.items[ref.itemID]\n\t\tif !ok \{}'
+  'board.go::s{if !ok \|\| live\.archived \{\n\t\ts\.mu\.Unlock\(\)\n\t\treturn nil, nil\n\t\}\n\tr, ok := s\.repos}{if !ok \{\n\t\ts.mu.Unlock()\n\t\treturn nil, nil\n\t\}\n\tr, ok := s.repos}'
 
 mutate "FetchPRReviews returns the raw submission history" \
   'TestFetchPRReviewsCollapsesToLatestPerAuthor' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -354,6 +354,25 @@ mutate "UpdateComment does not bump the parent PR's updatedAt" \
   'TestUpdateCommentBumpsParentPRUpdatedAt' \
   'comments.go::s|case pr != nil:\n\t\tpr\.updatedAt = s\.now\(\)|case pr != nil:\n\t\t_ = pr|'
 
+mutate "SeedBranch repoints an existing branch, discarding its commits" \
+  'TestSeedBranchRefusesExistingBranch' \
+  'git.go::s|if r\.branchExists\(branch\) \{\n\t\treturn fmt\.Errorf|if false \&\& r.branchExists(branch) {\n\t\treturn fmt.Errorf|'
+
+mutate "MergePR merges a PR retargeted after the gate cleared it" \
+  'TestMergePRRefusesRetargetBetweenGateAndMerge' \
+  'prs.go::s|if head != gatedHead \|\| base != gatedBase \{|if false {\n\t\t_, _ = gatedHead, gatedBase|'
+
+mutate "a status move stamps its card and project from two clock reads" \
+  'TestOneMutationStampsOneTimestamp' \
+  'board.go::s|\t\tnow := s\.now\(\)\n\t\tit\.status = name\n\t\tit\.updatedAt = now\n\t\tp\.updatedAt = now|\t\tit.status = name\n\t\tit.updatedAt = s.now()\n\t\tp.updatedAt = s.now()|'
+
+mutate "a label application stamps applied-at and the issue from two clock reads" \
+  'TestOneMutationStampsOneTimestamp' \
+  'labels.go::s|\tnow := s\.now\(\)\n\tiss\.labels = append\(iss\.labels, labelName\)\n\tiss\.labelAppliedAt\[labelName\] = now\n\tiss\.updatedAt = now|\tiss.labels = append(iss.labels, labelName)\n\tiss.labelAppliedAt[labelName] = s.now()\n\tiss.updatedAt = s.now()|'
+
+mutate "a comment stamps created-at and its issue from two clock reads" \
+  'TestOneMutationStampsOneTimestamp' \
+  'comments.go::s|\t\tiss\.updatedAt = now\n\t\treturn id, nil|\t\tiss.updatedAt = s.now()\n\t\treturn id, nil|'
 
 echo
 status=0

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -442,6 +442,38 @@ mutate "a negative explicit PR number is accepted" \
   'TestSeedPRRefusesImpossibleShapes' \
   'seed.go::s{case num < 0:\n\t\ts\.fail\("simgh: PR number}{case num < 0 \&\& false:\n\t\ts.fail("simgh: PR number}'
 
+mutate "removing an absent label is a silent no-op" \
+  'TestRemoveAbsentLabelReturnsErrNotFound' \
+  'labels.go::s{return fmt\.Errorf\("removing label %q from %s#%d: %w",\n\t\t\tlabelName, repoKey\(owner, repo\), issueNumber, gh\.ErrNotFound\)}{_ = gh.ErrNotFound; return nil}'
+
+mutate "the review decision filters before collapsing, so a dismissal is skipped" \
+  'TestDismissedReviewDoesNotCountTowardApproval' \
+  'reviews.go::s{for _, rev := range latestReviewsByAuthor\(pr\.reviews\) \{}{for _, rev := range pr.reviews \{\n\t\tif rev.State != "APPROVED" \&\& rev.State != "CHANGES_REQUESTED" \{ continue \}}'
+
+mutate "a non-canonical issue state is stored verbatim" \
+  'TestSeedRefusesNonCanonicalState' \
+  'seed.go::s{s\.fail\("simgh: issue state %q is not valid; use \\"OPEN\\" or \\"CLOSED\\"", state\)\n\t\treturn s}{state = "OPEN"}'
+
+mutate "a non-canonical PR state is stored verbatim" \
+  'TestSeedRefusesNonCanonicalState' \
+  'seed.go::s{s\.fail\("simgh: PR state %q is not valid; use \\"open\\" or \\"closed\\"", state\)\n\t\treturn s}{state = "open"}'
+
+mutate "a PR may have head equal to base (runtime)" \
+  'TestPRHeadEqualBaseIsRefused' \
+  'prs.go::s{if head == base \{}{if false \&\& head == base \{}'
+
+mutate "a PR may have head equal to base (seeding)" \
+  'TestPRHeadEqualBaseIsRefused' \
+  'seed.go::s{if seed\.Head == base \{}{if false \&\& seed.Head == base \{}'
+
+mutate "a no-op review request still bumps updatedAt" \
+  'TestReviewRequestNoOpDoesNotBumpUpdatedAt' \
+  'reviews.go::s{if changed \{\n\t\tpr\.updatedAt = s\.now\(\)\n\t\}}{_ = changed\n\tpr.updatedAt = s.now()}'
+
+mutate "a no-op review withdrawal still bumps updatedAt" \
+  'TestReviewRequestNoOpDoesNotBumpUpdatedAt' \
+  'reviews.go::s{if len\(kept\) == len\(pr\.reviewRequests\) \{}{if false \&\& len(kept) == len(pr.reviewRequests) \{}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -482,6 +482,34 @@ mutate "re-seeding a card into its current column bumps timestamps" \
   'TestReAddingLiveCardIsANoOp' \
   'seed.go::s{changed := existing\.archived \|\| existing\.status != status}{changed := true; _ = existing.archived}'
 
+mutate "re-archiving an archived card bumps timestamps" \
+  'TestNoOpBoardMutationsDoNotBump' \
+  'board.go::s{if it\.archived \{\n\t\treturn nil\n\t\}\n\tnow := s\.now\(\)\n\tit\.archived = true}{if false \{\n\t\treturn nil\n\t\}\n\tnow := s.now()\n\tit.archived = true}'
+
+mutate "a same-column move bumps timestamps" \
+  'TestNoOpBoardMutationsDoNotBump' \
+  'board.go::s{if it\.status == name \{\n\t\t\treturn nil\n\t\t\}}{if false \{\n\t\t\treturn nil\n\t\t\}}'
+
+mutate "git subprocesses inherit the user's global gitconfig" \
+  'TestGitIgnoresTheInvokingUsersGlobalConfig' \
+  'git.go::s{"GIT_CONFIG_GLOBAL=/dev/null",}{}'
+
+mutate "UpdatePRBase accepts the head branch as the new base" \
+  'TestUpdatePRBaseRefusesHeadAsBase' \
+  'prs.go::s{if newBase == pr\.head \{}{if false \&\& newBase == pr.head \{}'
+
+mutate "retargeting to the current base still bumps" \
+  'TestUpdatePRBaseRefusesHeadAsBase' \
+  'prs.go::s{if pr\.base == newBase \{\n\t\t// Retargeting to the base it already has changes nothing\.\n\t\treturn nil\n\t\}}{}'
+
+mutate "SeedBlockedBy does not dedupe duplicates" \
+  'TestSeedBlockedByDedupesAndStamps' \
+  'seed.go::s{if dep\.Number == blockerNumber \&\& depRepo == blockerOwnerRepo \{\n\t\t\treturn s\n\t\t\}}{if false \{\n\t\t\treturn s\n\t\t\}}'
+
+mutate "SeedBlockedBy does not stamp the issue" \
+  'TestSeedBlockedByDedupesAndStamps' \
+  'seed.go::s{iss\.blockedBy = append\(iss\.blockedBy, gh\.Dependency\{Number: blockerNumber, Repo: repoField\}\)\n\tiss\.updatedAt = s\.now\(\)}{iss.blockedBy = append(iss.blockedBy, gh.Dependency\{Number: blockerNumber, Repo: repoField\})}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -336,7 +336,7 @@ mutate "SeedIssue drops its assignees" \
 
 mutate "UpdateComment does not bump the parent issue's updatedAt" \
   'TestUpdateCommentBumpsParentIssueUpdatedAt' \
-  'comments.go::s{\tif iss != nil \{\n\t\tiss\.updatedAt = s\.now\(\)\n\t\}}{\tif iss != nil \{\n\t\t_ = iss\n\t\}}'
+  'comments.go::s|case iss != nil:\n\t\tiss\.updatedAt = s\.now\(\)|case iss != nil:\n\t\t_ = iss|'
 
 mutate "FetchItemDetails matches either ID, so the board is picked by map order" \
   'TestFetchItemDetailsPrefersItemIDAcrossProjects' \
@@ -349,6 +349,10 @@ mutate "MergePR records a merge that wrote no commit" \
 mutate "trial worktrees are created outside baseDir" \
   'TestTrialWorktreeStaysInsideBaseDir' \
   'git.go::s|os\.MkdirTemp\(r\.worktreeRoot, "wt-"\)|os.MkdirTemp("", "simgh-wt-")|'
+
+mutate "UpdateComment does not bump the parent PR's updatedAt" \
+  'TestUpdateCommentBumpsParentPRUpdatedAt' \
+  'comments.go::s|case pr != nil:\n\t\tpr\.updatedAt = s\.now\(\)|case pr != nil:\n\t\t_ = pr|'
 
 
 echo

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -200,9 +200,9 @@ mutate "issue and PR numbers come from independent sequences" \
   'seed.go::s{^\t\tnextNumber:        1,$}{\t\tnextNumber:        1,\n\t\tnextPRNumber:      1,}m' \
   'prs.go::s{^\tnum := r\.allocNumber\(\)$}{\tnum := r.nextPRNumber\n\tr.nextPRNumber++}m'
 
-mutate "auto-assigned numbers collide with explicitly seeded ones" \
+mutate "an explicitly seeded number is not reserved against auto-assignment" \
   'TestAutoAssignedNumberSkipsSeededHoles' \
-  'model.go::s{for r\.numberTaken\(r\.nextNumber\) \{}{for false \{}'
+  'model.go::s{^\tif num >= r\.nextNumber \{\n\t\tr\.nextNumber = num \+ 1\n\t\}$}{\t_ = num}m'
 
 mutate "seeding does not enforce the shared number space" \
   'TestSeedRejectsNumberHeldByOtherKind' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -264,6 +264,12 @@ mutate "owner/repo path traversal is accepted" \
   'TestSeedRepoRejectsPathTraversal' \
   'util.go::s|func validatePathSegment\(kind, seg, ownerRepo string\) error \{|func validatePathSegment(kind, seg, ownerRepo string) error \{\n\treturn nil|'
 
+# Short-circuited for the same reason as validatePathSegment above: the guard's
+# own source contains backticks and backslashes that are awkward to match.
+mutate "a seeded file path may escape the worktree" \
+  'TestSeedCommitRejectsEscapingFilePath' \
+  'util.go::s|func validateRepoRelPath\(name string\) error \{|func validateRepoRelPath(name string) error \{\n\treturn nil|'
+
 # Both of SeedRepo's duplicate guards are neutralised together: single-threaded,
 # either one alone still refuses the reseed, so a mutation of just one could not
 # fail this test and would prove nothing.

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -382,6 +382,18 @@ mutate "board projections do not re-check archived after the snapshot" \
   'TestBoardProjectionReadsCardStateLive' \
   'board.go::s{if !ok \|\| live\.archived \{}{if !ok \{}'
 
+mutate "a board card may point at an issue that does not exist" \
+  'TestSeedProjectItemRefusesUnresolvableTarget' \
+  'seed.go::s{if _, ok := r\.issues\[number\]; !ok \{}{if false \{}'
+
+mutate "a board card may point at an unseeded repo" \
+  'TestSeedProjectItemRefusesUnresolvableTarget' \
+  'seed.go::s{\tr, ok := s\.repos\[ownerRepo\]\n\tif !ok \{}{\tr, ok := s.repos[ownerRepo]\n\tif ok \&\& false \{}'
+
+mutate "a zero approval requirement is accepted (APPROVED with no reviews)" \
+  'TestSeedRequiredApprovalsRefusesNonPositive' \
+  'seed.go::s{if n < 1 \{}{if false \{\n\t\t_ = n}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -360,7 +360,7 @@ mutate "SeedBranch repoints an existing branch, discarding its commits" \
 
 mutate "MergePR merges a PR retargeted after the gate cleared it" \
   'TestMergePRRefusesRetargetBetweenGateAndMerge' \
-  'prs.go::s|if head != gatedHead \|\| base != gatedBase \{|if false {\n\t\t_, _ = gatedHead, gatedBase|'
+  'prs.go::s{if head != gatedHead \|\| base != gatedBase \{}{if false \{\n\t\t_, _ = gatedHead, gatedBase}'
 
 mutate "a status move stamps its card and project from two clock reads" \
   'TestOneMutationStampsOneTimestamp' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -167,7 +167,26 @@ mutate "non-required failures never surface as unstable" \
 
 mutate "commit statuses are ignored by the derivation" \
   'TestMergeableStateBlockedViaClassicCommitStatus|TestMergeableStateCleanViaClassicCommitStatus|TestMergeableStateUnstableViaNonRequiredCommitStatus' \
-  'ci.go::s{out = append\(out, contextState\{name: st\.Context, verdict: statusVerdict\(st\)\}\)}{_ = st}'
+  'ci.go::s{statuses\[st\.Context\] = statusVerdict\(st\)}{_ = st}'
+
+# The reduction rule is the whole point of reserving check-run IDs, so each half
+# is mutated separately: a check run reduced by worst-of, and a commit status
+# accumulated rather than superseded.
+mutate "same-named check runs reduce by worst verdict instead of latest ID" \
+  'TestMergeableStateRerunSupersedesFailedRun|TestMergeableStateRerunOrderFollowsIDNotSeedOrder' \
+  'ci.go::s{\t\tif prev, ok := latest\[run\.Name\]; ok && run\.ID <= prev\.ID \{\n\t\t\tcontinue\n\t\t\}}{\t\tif prev, ok := latest[run.Name]; ok \&\& checkVerdict(prev) != "success" \{\n\t\t\tcontinue\n\t\t\}}m'
+
+mutate "an earlier commit status is not superseded by a later one" \
+  'TestMergeableStateLatestCommitStatusSupersedes' \
+  'ci.go::s{\tfor _, st := range r\.commitStatuses\[sha\] \{\n\t\tstatuses\[st\.Context\] = statusVerdict\(st\)\n\t\}}{\tfor _, st := range r.commitStatuses[sha] \{\n\t\tstatuses[st.Context] = worseVerdict(statuses[st.Context], statusVerdict(st))\n\t\}}m'
+
+mutate "a name in both collections does not keep the worse verdict" \
+  'TestMergeableStateCrossCollectionKeepsWorstVerdict' \
+  'ci.go::s{\t\t\tout\[name\] = worseVerdict\(prev, v\)}{\t\t\tout[name] = prev}'
+
+mutate "FetchPRDetails reports no mergeable_state" \
+  'TestFetchPRDetailsReportsDerivedMergeableState' \
+  'prs.go::s{\t\tMergeableState:   state,}{\t\tMergeableState:   "",}'
 
 mutate "behind is reported without branch protection" \
   'TestMergeableStateBehindRequiresBranchProtection' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -342,6 +342,14 @@ mutate "FetchItemDetails matches either ID, so the board is picked by map order"
   'TestFetchItemDetailsPrefersItemIDAcrossProjects' \
   'board.go::s|return it\.itemID == item\.ItemID \}\)|return it.contentNodeID() == item.ID \|\| it.itemID == item.ItemID })|'
 
+mutate "MergePR records a merge that wrote no commit" \
+  'TestMergePRRefusesWhenNothingToMerge' \
+  'git.go::s|if sha == baseSHA \{|if false \&\& sha == baseSHA {|'
+
+mutate "trial worktrees are created outside baseDir" \
+  'TestTrialWorktreeStaysInsideBaseDir' \
+  'git.go::s|os\.MkdirTemp\(r\.worktreeRoot, "wt-"\)|os.MkdirTemp("", "simgh-wt-")|'
+
 
 echo
 status=0

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -232,7 +232,7 @@ mutate "an explicitly seeded number is not reserved against auto-assignment" \
 
 mutate "seeding does not enforce the shared number space" \
   'TestSeedRejectsNumberHeldByOtherKind' \
-  'seed.go::s{\} else if r\.numberTaken\(num\) \{}{\} else if false \{}g'
+  'seed.go::s{case r\.numberTaken\(num\):}{case false:}g'
 
 mutate "a PR card is accepted and silently dropped" \
   'TestSeedProjectItemRejectsPRCard' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -155,7 +155,7 @@ mutate "commits-behind always reports zero" \
 
 mutate "head SHA is not re-resolved after a push" \
   'TestHeadSHATracksNewCommits' \
-  'git.go::s{^\tsha, err := r\.resolveRef\("refs/heads/" \+ branch\)$}{\tsha, err := r.resolveRef("refs/heads/" + r.defaultBranch)}m'
+  'git.go::s{return r\.resolveRef\("refs/heads/" \+ branch\)}{return r.resolveRef("refs/heads/" + r.defaultBranch)}'
 
 mutate "required contexts never block (blocked no longer outranks unstable)" \
   'TestMergeableStateBlockedOnFailingRequiredContext|TestMergeableStateBlockedOnMissingRequiredContext|TestMergeableStateBlockedOnPendingRequiredContext|TestMergeableStateBlockedViaClassicCommitStatus|TestMergePRGatesOnDerivedState|TestPrecedenceBlockedOverUnstable' \

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -334,6 +334,14 @@ mutate "SeedIssue drops its assignees" \
   'TestAssigneesAreObservableFromBothPaths' \
   'seed.go::s{\t\tassignees:      cloneStrings\(seed\.Assignees\),\n}{}'
 
+mutate "UpdateComment does not bump the parent issue's updatedAt" \
+  'TestUpdateCommentBumpsParentIssueUpdatedAt' \
+  'comments.go::s{\tif iss != nil \{\n\t\tiss\.updatedAt = s\.now\(\)\n\t\}}{\tif iss != nil \{\n\t\t_ = iss\n\t\}}'
+
+mutate "FetchItemDetails matches either ID, so the board is picked by map order" \
+  'TestFetchItemDetailsPrefersItemIDAcrossProjects' \
+  'board.go::s{return it\.itemID == item\.ItemID \}\)}{return it.contentNodeID() == item.ID || it.itemID == item.ItemID })}'
+
 
 echo
 status=0

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -208,6 +208,10 @@ mutate "seeding does not enforce the shared number space" \
   'TestSeedRejectsNumberHeldByOtherKind' \
   'seed.go::s{\} else if r\.numberTaken\(num\) \{}{\} else if false \{}g'
 
+mutate "a PR card is accepted and silently dropped" \
+  'TestSeedProjectItemRejectsPRCard' \
+  'seed.go::s{\tif isPR \{}{\tif false \{}'
+
 mutate "timestamps come from wall time, not the injected clock" \
   'TestLabelAddRemoveIsObservable' \
   'sim.go::s{func \(s \*Sim\) now\(\) time\.Time \{ return s\.clock\.Now\(\) \}}{func (s *Sim) now() time.Time { return time.Now() }}'

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -326,6 +326,14 @@ mutate "per-repo git serialisation is removed" \
   'model.go::s|^\tgitMu sync\.Mutex$|\tgitMu noopGitMutex|m' \
   'model.go::s|\z|\ntype noopGitMutex struct{}\n\nfunc (noopGitMutex) Lock() {}\nfunc (noopGitMutex) Unlock() {}\n\nvar _ sync.Mutex\n|'
 
+mutate "CreateIssue drops its assignees" \
+  'TestAssigneesAreObservableFromBothPaths' \
+  'issues.go::s{\t\tassignees:      cloneStrings\(assignees\),\n}{}'
+
+mutate "SeedIssue drops its assignees" \
+  'TestAssigneesAreObservableFromBothPaths' \
+  'seed.go::s{\t\tassignees:      cloneStrings\(seed\.Assignees\),\n}{}'
+
 
 echo
 status=0

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -248,6 +248,30 @@ mutate "behind no longer outranks blocked" \
   'TestPrecedenceBehindOverBlocked' \
   'prs.go::s{if facts\.behind > 0 && r\.requireUpToDate\[base\] \{}{if false \{}'
 
+mutate "an explicitly seeded check run ID is not reserved against auto-assignment" \
+  'TestSeedCheckRunReservesExplicitIDs' \
+  'seed.go::s|\t\} else if run\.ID >= s\.nextCheckRunID \{|\t\} else if false \{|'
+
+mutate "a duplicate check run ID is accepted" \
+  'TestSeedCheckRunRejectsDuplicateID' \
+  'seed.go::s|\t\} else if s\.seededCheckRunIDs\[run\.ID\] \{|\t\} else if false \&\& s.seededCheckRunIDs[run.ID] \{|'
+
+mutate "owner/repo path traversal is accepted" \
+  'TestSeedRepoRejectsPathTraversal' \
+  'util.go::s|\tif seg == "\." \|\| seg == "\.\." \{|\tif false \&\& (seg == "." \|\| seg == "..") \{|' \
+  'util.go::s|\tif strings\.ContainsAny\(seg, `/\\\\`\) \|\| strings\.ContainsRune\(seg, os\.PathSeparator\) \{|\tif false \&\& (strings.ContainsAny(seg, `/`) \|\| strings.ContainsRune(seg, os.PathSeparator)) \{|'
+
+# Both of SeedRepo's duplicate guards are neutralised together: single-threaded,
+# either one alone still refuses the reseed, so a mutation of just one could not
+# fail this test and would prove nothing.
+mutate "a duplicate SeedRepo is accepted" \
+  'TestSeedRepoRefusesDuplicateSeed' \
+  'seed.go::s|if _, exists := s\.repos\[ownerRepo\]; exists \{|if false \{|g'
+
+mutate_race "a concurrent second SeedRepo clobbers the live repoState" \
+  'TestConcurrentSeedRepoDoesNotClobber' \
+  'seed.go::s|\tif _, exists := s\.repos\[ownerRepo\]; exists \{\n\t\ts\.fail\("simgh: repo %s already seeded", ownerRepo\)\n\t\ts\.mu\.Unlock\(\)\n\t\treturn s\n\t\}\n\ts\.repos\[ownerRepo\] = &repoState\{|\tif false \{\n\t\ts.fail("simgh: repo %s already seeded", ownerRepo)\n\t\ts.mu.Unlock()\n\t\treturn s\n\t\}\n\ts.repos[ownerRepo] = \&repoState\{|'
+
 mutate "timestamps come from wall time, not the injected clock" \
   'TestLabelAddRemoveIsObservable' \
   'sim.go::s{func \(s \*Sim\) now\(\) time\.Time \{ return s\.clock\.Now\(\) \}}{func (s *Sim) now() time.Time { return time.Now() }}'

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -276,6 +276,17 @@ mutate_race "SeedRepo's creation lock is removed (concurrent callers race in git
   'sim.go::s|\tseedRepoMu sync\.Mutex|\tseedRepoMu noopSeedMutex|' \
   'sim.go::s|^type realClock struct\{\}$|type noopSeedMutex struct{}\n\nfunc (noopSeedMutex) Lock()   {}\nfunc (noopSeedMutex) Unlock() {}\n\ntype realClock struct{}|m'
 
+# The two halves of the re-add drift are neutralised separately, because each
+# path had been missing a different one and a single mutation could not show
+# that both are now covered.
+mutate "re-adding a card leaves it archived" \
+  'TestReAddingArchivedCardRevivesItOnBothPaths' \
+  'board.go::s|\texisting\.archived = false|\t_ = existing.archived|'
+
+mutate "re-adding a card does not advance the project updated-at" \
+  'TestReAddingArchivedCardRevivesItOnBothPaths' \
+  'board.go::s|\texisting\.updatedAt = now\n\tp\.updatedAt = now|\t_ = now|'
+
 mutate "timestamps come from wall time, not the injected clock" \
   'TestLabelAddRemoveIsObservable' \
   'sim.go::s{func \(s \*Sim\) now\(\) time\.Time \{ return s\.clock\.Now\(\) \}}{func (s *Sim) now() time.Time { return time.Now() }}'

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -340,7 +340,7 @@ mutate "UpdateComment does not bump the parent issue's updatedAt" \
 
 mutate "FetchItemDetails matches either ID, so the board is picked by map order" \
   'TestFetchItemDetailsPrefersItemIDAcrossProjects' \
-  'board.go::s{return it\.itemID == item\.ItemID \}\)}{return it.contentNodeID() == item.ID || it.itemID == item.ItemID })}'
+  'board.go::s|return it\.itemID == item\.ItemID \}\)|return it.contentNodeID() == item.ID \|\| it.itemID == item.ItemID })|'
 
 
 echo

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -474,6 +474,14 @@ mutate "a no-op review withdrawal still bumps updatedAt" \
   'TestReviewRequestNoOpDoesNotBumpUpdatedAt' \
   'reviews.go::s{if len\(kept\) == len\(pr\.reviewRequests\) \{}{if false \&\& len(kept) == len(pr.reviewRequests) \{}'
 
+mutate "re-adding a live card bumps timestamps (runtime)" \
+  'TestReAddingLiveCardIsANoOp' \
+  'board.go::s{if existing\.archived \{\n\t\t\ts\.reviveCardLocked\(p, existing\)\n\t\t\}}{s.reviveCardLocked(p, existing)}'
+
+mutate "re-seeding a card into its current column bumps timestamps" \
+  'TestReAddingLiveCardIsANoOp' \
+  'seed.go::s{changed := existing\.archived \|\| existing\.status != status}{changed := true; _ = existing.archived}'
+
 echo
 status=0
 if [ ${#FAILED_TO_CATCH[@]} -ne 0 ]; then

--- a/tests/sim/simgh/nonvacuity.sh
+++ b/tests/sim/simgh/nonvacuity.sh
@@ -212,6 +212,18 @@ mutate "a PR card is accepted and silently dropped" \
   'TestSeedProjectItemRejectsPRCard' \
   'seed.go::s{\tif isPR \{}{\tif false \{}'
 
+mutate "the runtime board API accepts a PR card the seeding API refuses" \
+  'TestAddProjectV2ItemByIdRejectsPRCard' \
+  'board.go::s{return "", fmt\.Errorf\("simgh: PR cards on a project board are not modelled \(%s#%d\); see FIDELITY\.md", ownerRepo, number\)}{ }'
+
+mutate "a nonexistent blocker is accepted at runtime" \
+  'TestAddBlockedByIssueRejectsUnknownBlocker' \
+  'deps.go::s{if _, ok := br\.issues\[blockerNum\]; !ok \{}{if false {}'
+
+mutate "a nonexistent blocker is accepted at seed time" \
+  'TestSeedBlockedByRejectsUnknownBlocker' \
+  'seed.go::s{if _, ok := br\.issues\[blockerNumber\]; !ok \{}{if false {}'
+
 # --- precedence ordering ------------------------------------------------
 # The single-condition tests above prove each branch is reachable; only these
 # constrain the order they are tried in. Each mutation demotes one state below

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -46,6 +46,14 @@ func (s *Sim) FindPRForIssue(owner, repo string, issueNumber int) (int, error) {
 // FetchLinkedPR returns the PR linked to an issue by head-branch convention,
 // or nil when there is none.
 //
+// When more than one PR shares the head branch, the most recently created one
+// wins. Production queries `pulls?head=owner:branch&state=all&per_page=1`, and
+// that endpoint defaults to created-descending, so GitHub returns the newest.
+// The case is not hypothetical: Fabrik reuses fabrik/issue-<N>, so a PR closed
+// without merging leaves a stale record on the branch the next PR reuses.
+// Picking the oldest would hand the engine a closed PR that production would
+// never have shown it.
+//
 // It deliberately reports MergeableState as "" and populates no mergeable
 // flag. Production reaches this through the pulls *list* endpoint, which omits
 // mergeable_state entirely — returning a computed value here would let a test
@@ -61,13 +69,7 @@ func (s *Sim) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails,
 		s.mu.Unlock()
 		return nil, err
 	}
-	var found *prRecord
-	for _, num := range sortedPRNumbers(r) {
-		if r.prs[num].head == branch {
-			found = r.prs[num]
-			break
-		}
-	}
+	found := findPRByHeadLocked(r, branch)
 	if found == nil {
 		s.mu.Unlock()
 		return nil, nil
@@ -171,8 +173,7 @@ func (s *Sim) createPR(owner, repo, title, head, base, body string, issueNumber 
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	num := r.nextPRNumber
-	r.nextPRNumber++
+	num := r.allocNumber()
 	now := s.now()
 	r.prs[num] = &prRecord{
 		number:      num,

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -1,0 +1,672 @@
+package simgh
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// Mergeable-state values the model derives. "has_hooks" is deliberately never
+// produced; see FIDELITY.md.
+const (
+	stateClean    = "clean"
+	stateUnstable = "unstable"
+	stateBlocked  = "blocked"
+	stateBehind   = "behind"
+	stateDirty    = "dirty"
+	stateDraft    = "draft"
+	stateUnknown  = "unknown"
+)
+
+// issueBranch is the head-branch convention Fabrik uses to link a PR to an
+// issue. Production's FetchLinkedPR discovers the linkage by querying the
+// pulls list endpoint for exactly this head ref, so the model matches on it
+// too rather than on a stored back-reference — a laxer rule here would let a
+// test pass against linkage production would never find.
+func issueBranch(issueNumber int) string {
+	return fmt.Sprintf("fabrik/issue-%d", issueNumber)
+}
+
+// FindPRForIssue returns the number of the PR whose head branch is the issue's
+// Fabrik branch, or 0 when there is none.
+func (s *Sim) FindPRForIssue(owner, repo string, issueNumber int) (int, error) {
+	pr, err := s.FetchLinkedPR(owner, repo, issueNumber)
+	if err != nil {
+		return 0, err
+	}
+	if pr == nil {
+		return 0, nil
+	}
+	return pr.Number, nil
+}
+
+// FetchLinkedPR returns the PR linked to an issue by head-branch convention,
+// or nil when there is none.
+//
+// It deliberately reports MergeableState as "" and populates no mergeable
+// flag. Production reaches this through the pulls *list* endpoint, which omits
+// mergeable_state entirely — returning a computed value here would let a test
+// pass on a signal production never receives, which is precisely the
+// confidently-green failure this layer must not introduce. Callers that need
+// the state must go through FetchPRMergeableState, as the engine does.
+func (s *Sim) FetchLinkedPR(owner, repo string, issueNumber int) (*gh.PRDetails, error) {
+	branch := issueBranch(issueNumber)
+
+	s.mu.Lock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	var found *prRecord
+	for _, num := range sortedPRNumbers(r) {
+		if r.prs[num].head == branch {
+			found = r.prs[num]
+			break
+		}
+	}
+	if found == nil {
+		s.mu.Unlock()
+		return nil, nil
+	}
+	snap := *found
+	s.mu.Unlock()
+
+	headSHA, err := s.resolveRefSHA(owner, repo, snap.head)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gh.PRDetails{
+		Number:              snap.number,
+		Title:               snap.title,
+		State:               snap.state,
+		Merged:              snap.merged,
+		Draft:               snap.draft,
+		HeadSHA:             headSHA,
+		HeadRefName:         snap.head,
+		BaseRef:             snap.base,
+		Body:                snap.body,
+		MergeableState:      "", // omitted by the list endpoint — see doc comment
+		AutoMergeEnabled:    snap.autoMergeEnabled,
+		IsMergeQueueEnabled: false, // GraphQL-only field; REST leaves it false
+		IsInMergeQueue:      false,
+		Author:              snap.author,
+		Labels:              cloneStrings(snap.labels),
+	}, nil
+}
+
+// ListPRs returns every PR in the repo. Like production's list-endpoint
+// implementation, it leaves MergeableState empty.
+func (s *Sim) ListPRs(owner, repo string) ([]gh.PRDetails, error) {
+	s.mu.Lock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	nums := sortedPRNumbers(r)
+	snaps := make([]prRecord, 0, len(nums))
+	for _, n := range nums {
+		snaps = append(snaps, *r.prs[n])
+	}
+	s.mu.Unlock()
+
+	out := make([]gh.PRDetails, 0, len(snaps))
+	for i := range snaps {
+		headSHA, err := s.resolveRefSHA(owner, repo, snaps[i].head)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, gh.PRDetails{
+			Number:      snaps[i].number,
+			Title:       snaps[i].title,
+			State:       snaps[i].state,
+			Merged:      snaps[i].merged,
+			Draft:       snaps[i].draft,
+			HeadSHA:     headSHA,
+			HeadRefName: snaps[i].head,
+			BaseRef:     snaps[i].base,
+			Body:        snaps[i].body,
+			Author:      snaps[i].author,
+			Labels:      cloneStrings(snaps[i].labels),
+		})
+	}
+	return out, nil
+}
+
+// CreateDraftPR opens a draft pull request. The issueNumber parameter is
+// accepted and ignored for linkage, exactly as production does — the head
+// branch is what establishes the link.
+func (s *Sim) CreateDraftPR(owner, repo, title, head, base, body string, issueNumber int) (int, error) {
+	return s.createPR(owner, repo, title, head, base, body, issueNumber, true)
+}
+
+// CreatePR opens a ready (non-draft) pull request.
+func (s *Sim) CreatePR(owner, repo, title, head, base, body string) (int, error) {
+	return s.createPR(owner, repo, title, head, base, body, 0, false)
+}
+
+func (s *Sim) createPR(owner, repo, title, head, base, body string, issueNumber int, draft bool) (int, error) {
+	r, err := s.repoByKey(repoKey(owner, repo))
+	if err != nil {
+		return 0, err
+	}
+
+	// GitHub refuses to open a PR for a head ref that does not exist; so does
+	// the model, since every git-derived answer about the PR depends on it.
+	r.gitMu.Lock()
+	headOK := r.branchExists(head)
+	baseOK := r.branchExists(base)
+	r.gitMu.Unlock()
+	if !headOK {
+		return 0, fmt.Errorf("simgh: cannot create PR: head branch %q does not exist in %s", head, repoKey(owner, repo))
+	}
+	if !baseOK {
+		return 0, fmt.Errorf("simgh: cannot create PR: base branch %q does not exist in %s", base, repoKey(owner, repo))
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	num := r.nextPRNumber
+	r.nextPRNumber++
+	now := s.now()
+	r.prs[num] = &prRecord{
+		number:      num,
+		title:       title,
+		body:        body,
+		head:        head,
+		base:        base,
+		state:       "open",
+		draft:       draft,
+		author:      simActor,
+		issueNumber: issueNumber,
+		createdAt:   now,
+		updatedAt:   now,
+	}
+	return num, nil
+}
+
+// MarkPRReady flips a draft PR to ready for review. Idempotent.
+func (s *Sim) MarkPRReady(owner, repo string, prNumber int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	pr.draft = false
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// FetchPRMerged reports the authoritative merged flag, as the single-PR
+// endpoint does.
+func (s *Sim) FetchPRMerged(owner, repo string, prNumber int) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return false, err
+	}
+	return pr.merged, nil
+}
+
+// FetchPRMergeable reports whether the PR merges cleanly, from a real trial
+// merge in the backing repository. Nil means GitHub has not finished computing
+// it — see FetchPRMergeableFields.
+func (s *Sim) FetchPRMergeable(owner, repo string, prNumber int) (*bool, error) {
+	mergeable, _, err := s.FetchPRMergeableFields(owner, repo, prNumber)
+	return mergeable, err
+}
+
+// FetchPRMergeableState reports GitHub's branch-protection-aware
+// mergeable_state. See FetchPRMergeableFields for how it is derived.
+func (s *Sim) FetchPRMergeableState(owner, repo string, prNumber int) (string, error) {
+	_, state, err := s.FetchPRMergeableFields(owner, repo, prNumber)
+	return state, err
+}
+
+// FetchPRMergeableFields returns the mergeable flag and mergeable_state
+// together, as the single-PR endpoint does.
+//
+// The state is derived from the whole model, not from the trial merge alone,
+// because the engine branches hard on the difference between its values:
+// MergeableStateAccepted admits only {clean, unstable}, and ErrNotMergeableCI
+// fires specifically on blocked/unknown and must not be routed into the
+// rebase-reinvoke path. A model that could only say dirty-or-clean would make
+// four of the six states unreachable and ADR-072's merge-safety incident
+// unreproducible.
+//
+// Precedence, applied in this order:
+//
+//  1. unknown  — the PR is merged or closed, or a recompute window is pending
+//  2. draft    — the PR is a draft
+//  3. dirty    — the trial merge genuinely conflicts
+//  4. behind   — the base branch requires up-to-date heads and has advanced
+//  5. blocked  — a required context is missing, pending, or failing
+//  6. unstable — a non-required context is pending or failing
+//  7. clean    — none of the above
+//
+// This order is the model's own deliberate choice, not a reverse-engineering
+// of GitHub's internal algorithm for every combination. A draft PR that also
+// conflicts resolves to "draft", not "dirty". FIDELITY.md states this so a
+// scenario author reasons about edge cases rather than discovering them.
+func (s *Sim) FetchPRMergeableFields(owner, repo string, prNumber int) (*bool, string, error) {
+	s.mu.Lock()
+	r, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, "", err
+	}
+	// A merged or closed PR has no mergeability to report.
+	if pr.merged || pr.state == "closed" {
+		s.mu.Unlock()
+		return nil, stateUnknown, nil
+	}
+	// The recompute window: GitHub reports both fields unresolved together
+	// while it recomputes after a push. Each read drains one.
+	if pr.mergeableRecomputeReads > 0 {
+		pr.mergeableRecomputeReads--
+		s.mu.Unlock()
+		return nil, stateUnknown, nil
+	}
+	head, base, draft := pr.head, pr.base, pr.draft
+	s.mu.Unlock()
+
+	facts, err := s.gitFacts(r, base, head)
+	if err != nil {
+		return nil, "", err
+	}
+
+	mergeable := !facts.conflict
+	state := s.deriveMergeableState(r, base, facts, draft)
+	return &mergeable, state, nil
+}
+
+// gitFactsResult holds everything the derivation needs from git.
+type gitFactsResult struct {
+	conflict bool
+	behind   int
+	headSHA  string
+}
+
+// gitFacts runs the real-git half of the derivation. Takes gitMu; must not be
+// called while holding mu.
+func (s *Sim) gitFacts(r *repoState, base, head string) (gitFactsResult, error) {
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+
+	headSHA := r.headSHA(head)
+	if headSHA == "" {
+		return gitFactsResult{}, fmt.Errorf("simgh: PR head branch %q no longer exists in %s/%s", head, r.owner, r.repo)
+	}
+	_, conflict, err := r.tryMerge(base, head, false, "simgh trial merge")
+	if err != nil {
+		return gitFactsResult{}, err
+	}
+	behind, err := r.commitsBehind(base, head)
+	if err != nil {
+		return gitFactsResult{}, err
+	}
+	return gitFactsResult{conflict: conflict, behind: behind, headSHA: headSHA}, nil
+}
+
+// deriveMergeableState applies the precedence order documented on
+// FetchPRMergeableFields. Takes mu; must not be called while holding it.
+func (s *Sim) deriveMergeableState(r *repoState, base string, facts gitFactsResult, draft bool) string {
+	if draft {
+		return stateDraft
+	}
+	if facts.conflict {
+		return stateDirty
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// GitHub reports "behind" only where branch protection requires the head
+	// to be up to date; without that setting a PR whose base has advanced is
+	// still "clean". Gating on the seeded requirement rather than on
+	// behind > 0 keeps "clean" reachable in the ordinary case.
+	if facts.behind > 0 && r.requireUpToDate[base] {
+		return stateBehind
+	}
+
+	required := r.requiredContexts[base]
+	byName := make(map[string]string, 8)
+	for _, c := range r.contextsForSHA(facts.headSHA) {
+		// A context reported twice takes its worst verdict, matching
+		// GitHub's rollup of repeated contexts.
+		if prev, ok := byName[c.name]; ok && worseVerdict(prev, c.verdict) == prev {
+			continue
+		}
+		byName[c.name] = c.verdict
+	}
+
+	for _, name := range required {
+		v, ok := byName[name]
+		if !ok || v != "success" {
+			return stateBlocked
+		}
+	}
+	for name, v := range byName {
+		if contains(required, name) {
+			continue
+		}
+		if v != "success" {
+			return stateUnstable
+		}
+	}
+	return stateClean
+}
+
+// worseVerdict returns the more severe of two verdicts, ordering
+// failure > pending > success.
+func worseVerdict(a, b string) string {
+	rank := map[string]int{"success": 0, "pending": 1, "failure": 2}
+	if rank[a] >= rank[b] {
+		return a
+	}
+	return b
+}
+
+// MergePR merges a pull request, writing a real merge commit onto the base
+// branch in the backing repository and only then flipping merged.
+//
+// It self-gates on the derived mergeable_state before touching git, the way
+// GitHub's own merge endpoint refuses a merge branch protection forbids. The
+// error kinds mirror production's, so a sim-driven test exercises the same
+// branches the engine takes against real GitHub:
+//
+//   - gh.ErrNotMergeable   — a genuine conflict, or mergeability not yet
+//     computed. Callers may route this into the rebase path.
+//   - gh.ErrNotMergeableCI — no conflict, but the state is not in
+//     {clean, unstable}. Callers must NOT route this into the rebase path.
+//
+// Without this gate a scenario could merge a PR in a blocked state, which is
+// exactly the class of bug ADR-072 records.
+func (s *Sim) MergePR(owner, repo string, prNumber int) error {
+	mergeable, state, err := s.FetchPRMergeableFields(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	if mergeable == nil || !*mergeable {
+		return fmt.Errorf("simgh: merging PR #%d (state %q): %w", prNumber, state, gh.ErrNotMergeable)
+	}
+	if !gh.MergeableStateAccepted(state) {
+		return fmt.Errorf("simgh: merging PR #%d (state %q): %w", prNumber, state, gh.ErrNotMergeableCI)
+	}
+
+	s.mu.Lock()
+	r, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	head, base, title := pr.head, pr.base, pr.title
+	s.mu.Unlock()
+
+	r.gitMu.Lock()
+	sha, conflict, err := r.tryMerge(base, head, true, fmt.Sprintf("Merge pull request #%d from %s\n\n%s", prNumber, head, title))
+	r.gitMu.Unlock()
+	if err != nil {
+		return err
+	}
+	if conflict {
+		// The gate above said mergeable; if git disagrees now, something
+		// changed underneath us. Report it as the conflict it is rather than
+		// recording a merge that did not happen.
+		return fmt.Errorf("simgh: merging PR #%d: conflict on merge: %w", prNumber, gh.ErrNotMergeable)
+	}
+	_ = sha
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr.merged = true
+	pr.state = "closed"
+	pr.updatedAt = s.now()
+
+	// GitHub auto-closes issues a merged PR references with a closing keyword,
+	// but only when the merge lands on the default branch. The engine relies
+	// on this (its awaiting-member-close settle scan treats "closed by
+	// GitHub's own Closes #N" as success), so the model reproduces it —
+	// including the default-branch restriction, which is why Fabrik has to
+	// close issues itself on a non-default base (ADR-1096).
+	if base == r.defaultBranch {
+		for _, n := range closingIssueNumbers(pr) {
+			if iss, ok := r.issues[n]; ok && iss.state != "CLOSED" {
+				iss.state = "CLOSED"
+				iss.updatedAt = s.now()
+			}
+		}
+	}
+	return nil
+}
+
+// GetPRBase returns the PR's base branch.
+func (s *Sim) GetPRBase(owner, repo string, prNumber int) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return "", err
+	}
+	return pr.base, nil
+}
+
+// UpdatePRBase retargets a PR at a different base branch. The branch must
+// exist, since every git-derived answer about the PR is computed against it.
+func (s *Sim) UpdatePRBase(owner, repo string, prNumber int, newBase string) error {
+	r, err := s.repoByKey(repoKey(owner, repo))
+	if err != nil {
+		return err
+	}
+	r.gitMu.Lock()
+	exists := r.branchExists(newBase)
+	r.gitMu.Unlock()
+	if !exists {
+		return fmt.Errorf("simgh: cannot retarget PR #%d: base branch %q does not exist", prNumber, newBase)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	pr.base = newBase
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// EnablePullRequestAutoMerge turns on GitHub's native auto-merge.
+//
+// Modelled as a flag only: the sim never spontaneously merges the PR when
+// checks later go green. A scenario that wants the merge to happen must call
+// MergePR. See FIDELITY.md.
+func (s *Sim) EnablePullRequestAutoMerge(owner, repo string, prNumber int, strategy string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	if !r.access.AllowAutoMerge {
+		return fmt.Errorf("simgh: auto-merge is not enabled for %s", repoKey(owner, repo))
+	}
+	pr.autoMergeEnabled = true
+	pr.autoMergeStrategy = strategy
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// DisablePullRequestAutoMerge turns off native auto-merge.
+func (s *Sim) DisablePullRequestAutoMerge(owner, repo string, prNumber int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	pr.autoMergeEnabled = false
+	pr.autoMergeStrategy = ""
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// EnqueuePullRequest adds a PR to the repo's merge queue.
+//
+// Modelled as position bookkeeping only: the queue never advances on its own,
+// never runs checks, and never merges anything. See FIDELITY.md.
+func (s *Sim) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadOID string) error {
+	r, err := s.repoByKey(repoKey(owner, repo))
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		s.mu.Unlock()
+		return fmt.Errorf("simgh: PR %s#%d not found", repoKey(owner, repo), prNumber)
+	}
+	if !r.mergeQueueEnabled {
+		s.mu.Unlock()
+		return fmt.Errorf("simgh: merge queue is not enabled for %s", repoKey(owner, repo))
+	}
+	head := pr.head
+	s.mu.Unlock()
+
+	if expectedHeadOID != "" {
+		actual, err := s.resolveRefSHA(owner, repo, head)
+		if err != nil {
+			return err
+		}
+		// GitHub rejects an enqueue whose expected head OID no longer matches,
+		// which is how a race with a concurrent push is caught.
+		if actual != expectedHeadOID {
+			return fmt.Errorf("simgh: enqueue PR #%d: expected head %s but branch is at %s", prNumber, expectedHeadOID, actual)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if pr.inMergeQueue {
+		return nil
+	}
+	pr.inMergeQueue = true
+	pr.queueEntry = &gh.MergeQueueEntry{
+		State:         "QUEUED",
+		Position:      queueDepth(r) + 1,
+		EnqueuerLogin: simActor,
+	}
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// DequeuePullRequest removes a PR from the merge queue. Positions of the PRs
+// behind it are not renumbered; see FIDELITY.md.
+func (s *Sim) DequeuePullRequest(owner, repo string, prNumber int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	pr.inMergeQueue = false
+	pr.queueEntry = nil
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// queueDepth counts PRs currently in the merge queue. Caller must hold mu.
+func queueDepth(r *repoState) int {
+	n := 0
+	for _, pr := range r.prs {
+		if pr.inMergeQueue {
+			n++
+		}
+	}
+	return n
+}
+
+// closingKeywordRe matches GitHub's closing keywords followed by a same-repo
+// issue reference. It covers the common forms only, not the full grammar
+// (cross-repo `owner/repo#N` and full URLs are not matched) — see FIDELITY.md.
+var closingKeywordRe = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)`)
+
+// FetchPRClosingIssues returns the issues a PR closes on merge.
+func (s *Sim) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+	return closingIssueNumbers(pr), nil
+}
+
+// closingIssueNumbers scans a PR body for closing keywords, plus the issue
+// number CreateDraftPR was called with. Caller must hold mu.
+func closingIssueNumbers(pr *prRecord) []int {
+	seen := make(map[int]bool)
+	var out []int
+	add := func(n int) {
+		if n > 0 && !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	for _, m := range closingKeywordRe.FindAllStringSubmatch(pr.body, -1) {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			add(n)
+		}
+	}
+	add(pr.issueNumber)
+	sort.Ints(out)
+	return out
+}
+
+// FetchPRsForSHA returns the numbers of PRs whose head branch currently points
+// at the given SHA.
+func (s *Sim) FetchPRsForSHA(owner, repo, sha string) ([]int, error) {
+	s.mu.Lock()
+	r, err := s.lookupRepo(owner, repo)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	nums := sortedPRNumbers(r)
+	heads := make([]string, len(nums))
+	for i, n := range nums {
+		heads[i] = r.prs[n].head
+	}
+	s.mu.Unlock()
+
+	var out []int
+	for i, n := range nums {
+		headSHA, err := s.resolveRefSHA(owner, repo, heads[i])
+		if err != nil {
+			return nil, err
+		}
+		if headSHA == sha {
+			out = append(out, n)
+		}
+	}
+	return out, nil
+}
+
+// sortedPRNumbers returns a repo's PR numbers in ascending order, so
+// projections built from the map are deterministic. Caller must hold mu.
+func sortedPRNumbers(r *repoState) []int {
+	out := make([]int, 0, len(r.prs))
+	for n := range r.prs {
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -549,6 +549,12 @@ func (s *Sim) EnqueuePullRequest(owner, repo string, prNumber int, expectedHeadO
 		}
 		// GitHub rejects an enqueue whose expected head OID no longer matches,
 		// which is how a race with a concurrent push is caught.
+		//
+		// Not atomic with the write below: this read takes gitMu, the write
+		// takes mu, and the locking invariant forbids holding both. GitHub does
+		// this compare-and-swap server-side and can. Recorded in FIDELITY.md
+		// under the merge queue rather than closed, because closing it would
+		// cost the invariant that keeps the whole package deadlock-free.
 		if actual != expectedHeadOID {
 			return fmt.Errorf("simgh: enqueue PR #%d: expected head %s but branch is at %s", prNumber, expectedHeadOID, actual)
 		}

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -443,6 +443,24 @@ func worseVerdict(a, b string) string {
 // Without this gate a scenario could merge a PR in a blocked state, which is
 // exactly the class of bug ADR-072 records.
 func (s *Sim) MergePR(owner, repo string, prNumber int) error {
+	// Snapshot the refs the gate is about to be computed against, so the merge
+	// below can confirm it is merging the same thing that was cleared. The gate
+	// necessarily drops both locks (it takes mu and gitMu in turn, which the
+	// package's lock-ordering rule requires), so a concurrent UpdatePRBase can
+	// land in the window and retarget the PR at a base whose required contexts
+	// and mergeability were never evaluated. GitHub has no such window — its
+	// merge endpoint re-checks server-side, atomically. The model closes it
+	// with a compare-and-swap instead, which needs neither lock held across the
+	// gate and so keeps the ordering invariant intact.
+	s.mu.Lock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	gatedHead, gatedBase := pr.head, pr.base
+	s.mu.Unlock()
+
 	mergeable, state, err := s.FetchPRMergeableFields(owner, repo, prNumber)
 	if err != nil {
 		return err
@@ -462,6 +480,18 @@ func (s *Sim) MergePR(owner, repo string, prNumber int) error {
 	}
 	head, base, title := pr.head, pr.base, pr.title
 	s.mu.Unlock()
+
+	if head != gatedHead || base != gatedBase {
+		// Retargeted underneath the gate. Refuse rather than merge against a
+		// base the gate never cleared — recording a merge the gate did not
+		// authorise is the same silent divergence the gate itself exists to
+		// prevent. ErrNotMergeable (not ErrNotMergeableCI) because the caller's
+		// correct response is to re-read and retry, exactly as for a state
+		// that has moved on.
+		return fmt.Errorf("simgh: merging PR #%d: retargeted from %s->%s to %s->%s "+
+			"between the mergeability gate and the merge: %w",
+			prNumber, gatedHead, gatedBase, head, base, gh.ErrNotMergeable)
+	}
 
 	r.gitMu.Lock()
 	sha, conflict, err := r.tryMerge(base, head, true, fmt.Sprintf("Merge pull request #%d from %s\n\n%s", prNumber, head, title))
@@ -487,9 +517,14 @@ func (s *Sim) MergePR(owner, repo string, prNumber int) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// One timestamp for the whole merge: the PR and every issue it auto-closes
+	// are one event on GitHub, and reading the clock per field would let them
+	// disagree under any clock that advances between reads — which the default
+	// realClock does.
+	now := s.now()
 	pr.merged = true
 	pr.state = "closed"
-	pr.updatedAt = s.now()
+	pr.updatedAt = now
 
 	// GitHub auto-closes issues a merged PR references with a closing keyword,
 	// but only when the merge lands on the default branch. The engine relies
@@ -501,7 +536,7 @@ func (s *Sim) MergePR(owner, repo string, prNumber int) error {
 		for _, n := range closingIssueNumbers(pr) {
 			if iss, ok := r.issues[n]; ok && iss.state != "CLOSED" {
 				iss.state = "CLOSED"
-				iss.updatedAt = s.now()
+				iss.updatedAt = now
 			}
 		}
 	}

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -422,8 +422,6 @@ func (s *Sim) FetchPRDetails(owner, repo string, prNumber int) (*gh.PRDetails, e
 	}, nil
 }
 
-// worseVerdict returns the more severe of two verdicts, ordering
-// failure > pending > success.
 // worseVerdict returns the more blocking of two verdicts.
 //
 // Both arguments must already be normalised to exactly "success", "pending", or

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -1,6 +1,7 @@
 package simgh
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -465,6 +466,14 @@ func (s *Sim) MergePR(owner, repo string, prNumber int) error {
 	r.gitMu.Lock()
 	sha, conflict, err := r.tryMerge(base, head, true, fmt.Sprintf("Merge pull request #%d from %s\n\n%s", prNumber, head, title))
 	r.gitMu.Unlock()
+	if errors.Is(err, errNothingToMerge) {
+		// Nothing to merge: the head is already in the base, so git writes no
+		// commit. Refuse rather than record a merge that produced nothing —
+		// merged=true with no merge commit is the exact silent divergence this
+		// package exists to prevent. Reported as ErrNotMergeable so callers
+		// using errors.Is classify it the way they classify GitHub's refusal.
+		return fmt.Errorf("simgh: merging PR #%d: %v: %w", prNumber, err, gh.ErrNotMergeable)
+	}
 	if err != nil {
 		return err
 	}

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -338,15 +338,9 @@ func (s *Sim) deriveMergeableState(r *repoState, base string, facts gitFactsResu
 	}
 
 	required := r.requiredContexts[base]
-	byName := make(map[string]string, 8)
-	for _, c := range r.contextsForSHA(facts.headSHA) {
-		// A context reported twice takes its worst verdict, matching
-		// GitHub's rollup of repeated contexts.
-		if prev, ok := byName[c.name]; ok && worseVerdict(prev, c.verdict) == prev {
-			continue
-		}
-		byName[c.name] = c.verdict
-	}
+	// One verdict per context name; contextsForSHA owns the reduction rule
+	// (latest-wins within a collection), which is load-bearing for reruns.
+	byName := r.contextsForSHA(facts.headSHA)
 
 	for _, name := range required {
 		v, ok := byName[name]
@@ -363,6 +357,50 @@ func (s *Sim) deriveMergeableState(r *repoState, base string, facts gitFactsResu
 		}
 	}
 	return stateClean
+}
+
+// FetchPRDetails reads the single-PR endpoint, which — unlike the pulls *list*
+// endpoint behind FetchLinkedPR — does report mergeable_state. The state is the
+// same derivation FetchPRMergeableState returns, recompute window included: a
+// read here drains one, because on real GitHub this is exactly the read that
+// would.
+//
+// The fields production's implementation does not parse from that endpoint
+// (HeadRefName, BaseRef, Author, Labels) are deliberately left zero. Populating
+// them would let a test pass on a signal the engine never actually receives —
+// the same reasoning FetchLinkedPR applies to mergeable_state, in reverse.
+func (s *Sim) FetchPRDetails(owner, repo string, prNumber int) (*gh.PRDetails, error) {
+	// Taken before the mergeability derivation, which takes mu and gitMu itself.
+	s.mu.Lock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	snap := *pr
+	s.mu.Unlock()
+
+	state, err := s.FetchPRMergeableState(owner, repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	headSHA, err := s.resolveRefSHA(owner, repo, snap.head)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gh.PRDetails{
+		Number:           snap.number,
+		Title:            snap.title,
+		State:            snap.state,
+		Merged:           snap.merged,
+		Draft:            snap.draft,
+		Body:             snap.body,
+		HeadSHA:          headSHA,
+		MergeableState:   state,
+		AutoMergeEnabled: snap.autoMergeEnabled,
+	}, nil
 }
 
 // worseVerdict returns the more severe of two verdicts, ordering

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -171,6 +171,10 @@ func (s *Sim) createPR(owner, repo, title, head, base, body string, issueNumber 
 	if !baseOK {
 		return 0, fmt.Errorf("simgh: cannot create PR: base branch %q does not exist in %s", base, repoKey(owner, repo))
 	}
+	// GitHub refuses a PR whose head is its base ("No commits between ...").
+	if head == base {
+		return 0, fmt.Errorf("simgh: cannot create PR: head and base are both %q in %s", base, repoKey(owner, repo))
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -313,7 +317,10 @@ func (s *Sim) gitFacts(r *repoState, base, head string) (gitFactsResult, error) 
 	r.gitMu.Lock()
 	defer r.gitMu.Unlock()
 
-	headSHA := r.headSHA(head)
+	headSHA, err := r.headSHA(head)
+	if err != nil {
+		return gitFactsResult{}, err
+	}
 	if headSHA == "" {
 		return gitFactsResult{}, fmt.Errorf("simgh: PR head branch %q no longer exists in %s/%s", head, r.owner, r.repo)
 	}

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -405,6 +405,19 @@ func (s *Sim) FetchPRDetails(owner, repo string, prNumber int) (*gh.PRDetails, e
 
 // worseVerdict returns the more severe of two verdicts, ordering
 // failure > pending > success.
+// worseVerdict returns the more blocking of two verdicts.
+//
+// Both arguments must already be normalised to exactly "success", "pending", or
+// "failure" — checkVerdict and statusVerdict are the only producers, and both
+// map onto those three literals. That invariant is what makes the tie-break
+// safe: equal rank means the two strings are *identical*, so returning either
+// is the same answer, and the caller's map-iteration order cannot affect the
+// result. Do not read this as "the first argument wins on a tie" — it preserves
+// the rank, not the identity of a particular source.
+//
+// The invariant also matters because an unrecognised string ranks 0 (a missing
+// map key), i.e. it would be silently treated as success. Feeding a raw check
+// conclusion in here rather than a normalised verdict would mask a red check.
 func worseVerdict(a, b string) string {
 	rank := map[string]int{"success": 0, "pending": 1, "failure": 2}
 	if rank[a] >= rank[b] {

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -595,6 +595,15 @@ func (s *Sim) UpdatePRBase(owner, repo string, prNumber int, newBase string) err
 	if err != nil {
 		return err
 	}
+	// Same refusal createPR and SeedPR already carry: GitHub will not leave a
+	// PR whose head is its base ("No commits between ...").
+	if newBase == pr.head {
+		return fmt.Errorf("simgh: cannot retarget PR #%d: base %q is its head branch", prNumber, newBase)
+	}
+	if pr.base == newBase {
+		// Retargeting to the base it already has changes nothing.
+		return nil
+	}
 	pr.base = newBase
 	pr.updatedAt = s.now()
 	return nil

--- a/tests/sim/simgh/prs.go
+++ b/tests/sim/simgh/prs.go
@@ -298,6 +298,17 @@ type gitFactsResult struct {
 
 // gitFacts runs the real-git half of the derivation. Takes gitMu; must not be
 // called while holding mu.
+//
+// It runs unconditionally, including for a draft PR, and that is not an
+// oversight to optimise away. deriveMergeableState short-circuits a draft to
+// "draft" without reading `behind` or `headSHA`, but `conflict` is *not*
+// discarded — FetchPRMergeableFields turns it into the returned `mergeable`
+// flag, and GitHub reports mergeability for draft PRs too (a draft is
+// mergeable: true/false with mergeable_state: "draft"). Skipping the trial
+// merge for drafts would therefore change an answer, not just save work. The
+// only genuinely dead call for a draft is commitsBehind, a single rev-list
+// against the bare repo — cheap next to the worktree the trial merge needs,
+// and skipping it conditionally would add a branch no test could observe.
 func (s *Sim) gitFacts(r *repoState, base, head string) (gitFactsResult, error) {
 	r.gitMu.Lock()
 	defer r.gitMu.Unlock()
@@ -481,6 +492,11 @@ func (s *Sim) MergePR(owner, repo string, prNumber int) error {
 	head, base, title := pr.head, pr.base, pr.title
 	s.mu.Unlock()
 
+	// This compares which refs the PR points at, not what they contain. A
+	// commit or check run landing on the same branches inside the window is
+	// not caught, so the gate's CI verdict can be stale here — deliberately,
+	// because production's own MergePR has the identical exposure (it sends no
+	// `sha` to GitHub's merge endpoint). See FIDELITY.md, "Merge commits".
 	if head != gatedHead || base != gatedBase {
 		// Retargeted underneath the gate. Refuse rather than merge against a
 		// base the gate never cleared — recording a merge the gate did not

--- a/tests/sim/simgh/reviews.go
+++ b/tests/sim/simgh/reviews.go
@@ -86,6 +86,7 @@ func (s *Sim) AddReviewRequest(owner, repo string, prNumber int, reviewers []str
 	if err != nil {
 		return err
 	}
+	changed := false
 	for _, login := range reviewers {
 		already := false
 		for _, existing := range pr.reviewRequests {
@@ -101,8 +102,14 @@ func (s *Sim) AddReviewRequest(owner, repo string, prNumber int, reviewers []str
 			Login: login,
 			IsBot: gh.IsBotLogin(login),
 		})
+		changed = true
 	}
-	pr.updatedAt = s.now()
+	// A true no-op must not bump the timestamp, following AddLabelToIssue's
+	// convention: engine gates anchor on observable change, so a spurious bump
+	// is a change a scenario cannot distinguish from a real one.
+	if changed {
+		pr.updatedAt = s.now()
+	}
 	return nil
 }
 
@@ -120,6 +127,10 @@ func (s *Sim) DeleteReviewRequest(owner, repo string, prNumber int, reviewers []
 			kept = append(kept, existing)
 		}
 	}
+	if len(kept) == len(pr.reviewRequests) {
+		// Nothing was outstanding; same no-op rule as AddReviewRequest.
+		return nil
+	}
 	pr.reviewRequests = kept
 	pr.updatedAt = s.now()
 	return nil
@@ -135,7 +146,8 @@ func (s *Sim) DeleteReviewRequest(owner, repo string, prNumber int, reviewers []
 // and falls back to its own no-CHANGES_REQUESTED computation otherwise. A
 // model that always returned a decision would hide that fallback entirely.
 //
-// Only each reviewer's latest review counts, matching GitHub's own rollup.
+// Only each reviewer's latest review counts, matching GitHub's own rollup —
+// via the same reduction FetchPRReviews uses, so the two cannot disagree.
 func (s *Sim) FetchPRReviewDecision(owner, repo string, prNumber int) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -150,26 +162,23 @@ func (s *Sim) FetchPRReviewDecision(owner, repo string, prNumber int) (string, e
 		return "", nil
 	}
 
-	latest := make(map[string]string)
-	var order []string
-	for _, rev := range pr.reviews {
-		if rev.State != "APPROVED" && rev.State != "CHANGES_REQUESTED" {
-			// COMMENTED and DISMISSED reviews do not participate in the
-			// decision rollup.
-			continue
-		}
-		if _, seen := latest[rev.Author]; !seen {
-			order = append(order, rev.Author)
-		}
-		latest[rev.Author] = rev.State
-	}
-
+	// Reduce first, then roll up — deliberately sharing latestReviewsByAuthor
+	// with FetchPRReviews rather than reducing inline. Filtering the raw history
+	// down to APPROVED/CHANGES_REQUESTED before collapsing would let a later
+	// DISMISSED be skipped instead of superseding that author's earlier verdict,
+	// leaving a dismissed approval counted in the tally. That is not a rounding
+	// error: reviewGateAuthorityVerdict (engine/reviews.go) trusts an APPROVED
+	// decision outright, so a scenario that dismisses an approval and expects
+	// the landing gate to hold would see it clear. Sharing the reduction is what
+	// stops this read and FetchPRReviews describing two different PRs.
 	approvals := 0
-	for _, author := range order {
-		if latest[author] == "CHANGES_REQUESTED" {
+	for _, rev := range latestReviewsByAuthor(pr.reviews) {
+		// A collapsed entry that is COMMENTED or DISMISSED is that author's
+		// current state and simply carries no verdict.
+		if rev.State == "CHANGES_REQUESTED" {
 			return "CHANGES_REQUESTED", nil
 		}
-		if latest[author] == "APPROVED" {
+		if rev.State == "APPROVED" {
 			approvals++
 		}
 	}

--- a/tests/sim/simgh/reviews.go
+++ b/tests/sim/simgh/reviews.go
@@ -4,7 +4,19 @@ import (
 	gh "github.com/handarbeit/fabrik/github"
 )
 
-// FetchPRReviews returns the reviews submitted on a PR, in submission order.
+// FetchPRReviews returns the **latest review per author**, in first-submission
+// order — not the raw submission history.
+//
+// The collapsing is the load-bearing part, and it is production's behaviour
+// rather than a convenience: github.Client.FetchPRReviews reads a REST endpoint
+// that returns every submission and reduces it to one entry per author, so that
+// the result matches GraphQL's latestReviews semantics. The engine's review-gate
+// call sites (engine/reviews.go) consume that result assuming the reduction has
+// already happened. Returning the raw list here would leave a superseded
+// CHANGES_REQUESTED visible forever, blocking a gate that real GitHub would have
+// cleared — and disagreeing with this package's own FetchPRReviewDecision, which
+// reduces correctly. Two reads of one model reporting two verdicts is a bug the
+// sim would be introducing.
 func (s *Sim) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -12,9 +24,38 @@ func (s *Sim) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, e
 	if err != nil {
 		return nil, err
 	}
-	out := make([]gh.PRReview, len(pr.reviews))
-	copy(out, pr.reviews)
-	return out, nil
+	return latestReviewsByAuthor(pr.reviews), nil
+}
+
+// latestReviewsByAuthor reduces a submission history to one entry per author,
+// reproducing github.Client.FetchPRReviews's rule exactly:
+//
+//   - the most recent submission wins, and authors keep first-submission order;
+//   - except that a COMMENTED follow-up never supersedes an author's existing
+//     formal verdict (APPROVED, CHANGES_REQUESTED, DISMISSED). GitHub treats
+//     COMMENTED as informational, not a state transition, so a reviewer who
+//     requests changes and later comments still has an active
+//     CHANGES_REQUESTED. Only when an author's *first* submission is COMMENTED
+//     does it become their entry.
+func latestReviewsByAuthor(reviews []gh.PRReview) []gh.PRReview {
+	latest := make(map[string]gh.PRReview, len(reviews))
+	order := make([]string, 0, len(reviews))
+	for _, rev := range reviews {
+		if rev.Author == "" {
+			continue
+		}
+		if _, seen := latest[rev.Author]; !seen {
+			order = append(order, rev.Author)
+		} else if rev.State == "COMMENTED" {
+			continue
+		}
+		latest[rev.Author] = rev
+	}
+	out := make([]gh.PRReview, 0, len(order))
+	for _, author := range order {
+		out = append(out, latest[author])
+	}
+	return out
 }
 
 // FetchPRReviewRequests returns the reviewers still outstanding on a PR.

--- a/tests/sim/simgh/reviews.go
+++ b/tests/sim/simgh/reviews.go
@@ -1,0 +1,139 @@
+package simgh
+
+import (
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// FetchPRReviews returns the reviews submitted on a PR, in submission order.
+func (s *Sim) FetchPRReviews(owner, repo string, prNumber int) ([]gh.PRReview, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gh.PRReview, len(pr.reviews))
+	copy(out, pr.reviews)
+	return out, nil
+}
+
+// FetchPRReviewRequests returns the reviewers still outstanding on a PR.
+//
+// Note what this does *not* include: self-submitting review bots (Pruefer,
+// Gemini, CodeRabbit, Copilot) never appear here on real GitHub, because they
+// are never formally requested. That absence is load-bearing — it is why
+// stages have to declare expected_reviewers (ADR-1283) — so the model reports
+// only what was actually requested and never synthesises a bot entry.
+func (s *Sim) FetchPRReviewRequests(owner, repo string, prNumber int) ([]gh.ReviewRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gh.ReviewRequest, len(pr.reviewRequests))
+	copy(out, pr.reviewRequests)
+	return out, nil
+}
+
+// AddReviewRequest requests reviews from the given logins. Re-requesting an
+// already-outstanding reviewer is a no-op.
+func (s *Sim) AddReviewRequest(owner, repo string, prNumber int, reviewers []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	for _, login := range reviewers {
+		already := false
+		for _, existing := range pr.reviewRequests {
+			if existing.Login == login {
+				already = true
+				break
+			}
+		}
+		if already {
+			continue
+		}
+		pr.reviewRequests = append(pr.reviewRequests, gh.ReviewRequest{
+			Login: login,
+			IsBot: gh.IsBotLogin(login),
+		})
+	}
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// DeleteReviewRequest withdraws outstanding review requests.
+func (s *Sim) DeleteReviewRequest(owner, repo string, prNumber int, reviewers []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+	kept := pr.reviewRequests[:0:0]
+	for _, existing := range pr.reviewRequests {
+		if !contains(reviewers, existing.Login) {
+			kept = append(kept, existing)
+		}
+	}
+	pr.reviewRequests = kept
+	pr.updatedAt = s.now()
+	return nil
+}
+
+// FetchPRReviewDecision returns GitHub's branch-protection-derived review
+// decision: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", or "" when the
+// base branch defines no review requirement.
+//
+// The empty case is the important one. GraphQL's reviewDecision is null unless
+// branch protection actually requires reviews, which is why the engine's
+// authoritative review gate (ADR-1250) prefers reviewDecision where it exists
+// and falls back to its own no-CHANGES_REQUESTED computation otherwise. A
+// model that always returned a decision would hide that fallback entirely.
+//
+// Only each reviewer's latest review counts, matching GitHub's own rollup.
+func (s *Sim) FetchPRReviewDecision(owner, repo string, prNumber int) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, pr, err := s.prLocked(owner, repo, prNumber)
+	if err != nil {
+		return "", err
+	}
+	required, ok := r.requiredApprovals[pr.base]
+	if !ok {
+		// No review requirement configured on the base branch — GraphQL
+		// reports null here.
+		return "", nil
+	}
+
+	latest := make(map[string]string)
+	var order []string
+	for _, rev := range pr.reviews {
+		if rev.State != "APPROVED" && rev.State != "CHANGES_REQUESTED" {
+			// COMMENTED and DISMISSED reviews do not participate in the
+			// decision rollup.
+			continue
+		}
+		if _, seen := latest[rev.Author]; !seen {
+			order = append(order, rev.Author)
+		}
+		latest[rev.Author] = rev.State
+	}
+
+	approvals := 0
+	for _, author := range order {
+		if latest[author] == "CHANGES_REQUESTED" {
+			return "CHANGES_REQUESTED", nil
+		}
+		if latest[author] == "APPROVED" {
+			approvals++
+		}
+	}
+	if approvals >= required {
+		return "APPROVED", nil
+	}
+	return "REVIEW_REQUIRED", nil
+}

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -385,8 +385,7 @@ func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int
 	id := itemNodeID(p.owner, p.num, ownerRepo, number)
 	if existing, ok := p.items[id]; ok {
 		existing.status = status
-		existing.updatedAt = s.now()
-		p.updatedAt = s.now()
+		s.reviveCardLocked(p, existing)
 		return
 	}
 	p.items[id] = &itemState{

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -385,6 +385,21 @@ func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int
 		s.fail("simgh: PR cards on a project board are not modelled (%s#%d); see FIDELITY.md", ownerRepo, number)
 		return
 	}
+	// The card must point at something that exists. buildProjectItem resolves a
+	// card's content through r.issues and returns nil when it finds nothing, so
+	// a card for a mistyped or not-yet-seeded number is recorded here and then
+	// silently omitted from every board read — the scenario believes it built a
+	// board it did not. Checked after the PR refusal above, which gives a
+	// clearer diagnosis for the one case a valid number can still fail.
+	r, ok := s.repos[ownerRepo]
+	if !ok {
+		s.fail("simgh: repo %s not seeded; cannot place %s#%d on project %s", ownerRepo, ownerRepo, number, p.id)
+		return
+	}
+	if _, ok := r.issues[number]; !ok {
+		s.fail("simgh: no issue %s#%d to place on project %s", ownerRepo, number, p.id)
+		return
+	}
 	id := itemNodeID(p.owner, p.num, ownerRepo, number)
 	if existing, ok := p.items[id]; ok {
 		existing.status = status
@@ -490,6 +505,14 @@ func (s *Sim) SeedRequireUpToDate(ownerRepo, branch string, required bool) *Sim 
 
 // SeedRequiredApprovals declares how many approving reviews branch protection
 // requires on a branch, backing FetchPRReviewDecision.
+//
+// n must be positive. Seeding zero would make FetchPRReviewDecision report
+// APPROVED on a PR with no reviews at all — the approvals-satisfied branch is
+// reached vacuously — which is not a reading real GitHub produces. "No review
+// requirement" is already representable, and is the *absence* of this call:
+// leaving the branch unseeded returns "" (GraphQL's null), the case whose
+// engine-side fallback ADR-1250 makes load-bearing. Refusing here keeps those
+// two states from collapsing into one silently.
 func (s *Sim) SeedRequiredApprovals(ownerRepo, branch string, n int) *Sim {
 	r, ok := s.repoForSeed(ownerRepo)
 	if !ok {
@@ -497,6 +520,11 @@ func (s *Sim) SeedRequiredApprovals(ownerRepo, branch string, n int) *Sim {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if n < 1 {
+		s.fail("simgh: SeedRequiredApprovals(%s, %q, %d): count must be positive; "+
+			"omit the call entirely to model a branch with no review requirement", ownerRepo, branch, n)
+		return s
+	}
 	r.requiredApprovals[branch] = n
 	return s
 }

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -83,6 +83,20 @@ func (s *Sim) SeedRepo(ownerRepo string, defaultBranch ...string) *Sim {
 		return s
 	}
 
+	// Serialise repo creation end to end. Checking "already seeded" under mu,
+	// releasing mu for the git init, then publishing is not enough on its own:
+	// concurrent callers for one key all clear the check before any publishes,
+	// and they then race inside initBare against one directory with no gitMu in
+	// existence yet to serialise them. This is the one seeding call that does
+	// I/O before publishing state, so it takes its own lock for the whole
+	// sequence — cheap, since seeding is setup, not a hot path.
+	//
+	// Ordering: seedRepoMu is only ever taken here, at the outermost level, and
+	// mu is taken and released inside it. Nothing acquires it while holding mu
+	// or gitMu, so it cannot participate in a cycle.
+	s.seedRepoMu.Lock()
+	defer s.seedRepoMu.Unlock()
+
 	s.mu.Lock()
 	if _, exists := s.repos[ownerRepo]; exists {
 		s.fail("simgh: repo %s already seeded", ownerRepo)
@@ -108,17 +122,6 @@ func (s *Sim) SeedRepo(ownerRepo string, defaultBranch ...string) *Sim {
 	}
 
 	s.mu.Lock()
-	// Re-check under mu rather than writing unconditionally: the guard above
-	// was checked before mu was released for the git init, so two concurrent
-	// SeedRepo calls for one key can both reach here. Clobbering would replace
-	// a live repoState — and its gitMu — while the winner's callers still hold
-	// the old one, leaving two mutexes guarding one bare directory and
-	// silently voiding the per-repo git serialisation the package rests on.
-	if _, exists := s.repos[ownerRepo]; exists {
-		s.fail("simgh: repo %s already seeded", ownerRepo)
-		s.mu.Unlock()
-		return s
-	}
 	s.repos[ownerRepo] = &repoState{
 		owner:             owner,
 		repo:              repo,

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -108,6 +108,17 @@ func (s *Sim) SeedRepo(ownerRepo string, defaultBranch ...string) *Sim {
 	}
 
 	s.mu.Lock()
+	// Re-check under mu rather than writing unconditionally: the guard above
+	// was checked before mu was released for the git init, so two concurrent
+	// SeedRepo calls for one key can both reach here. Clobbering would replace
+	// a live repoState — and its gitMu — while the winner's callers still hold
+	// the old one, leaving two mutexes guarding one bare directory and
+	// silently voiding the per-repo git serialisation the package rests on.
+	if _, exists := s.repos[ownerRepo]; exists {
+		s.fail("simgh: repo %s already seeded", ownerRepo)
+		s.mu.Unlock()
+		return s
+	}
 	s.repos[ownerRepo] = &repoState{
 		owner:             owner,
 		repo:              repo,
@@ -389,6 +400,15 @@ func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int
 
 // SeedCheckRun attaches a check run to a commit SHA. Name and Conclusion are
 // what the mergeable-state derivation reads; an empty ID is auto-assigned.
+//
+// IDs are unique across the whole sim, as GitHub's are, and an explicitly
+// seeded ID is reserved against later auto-assignment — the same rule
+// reserveNumber enforces for the shared issue-and-PR sequence. This is
+// load-bearing, not tidiness: production's latestCheckRunsByName
+// (github/checkruns.go) reduces same-named runs by keeping the highest ID as
+// the most recent rerun, so two runs sharing an ID make it keep whichever it
+// saw first. A scenario seeding "check failed, then the rerun passed" would
+// then be classified off the failed run, with nothing to indicate why.
 func (s *Sim) SeedCheckRun(ownerRepo, sha string, run gh.CheckRun) *Sim {
 	r, ok := s.repoForSeed(ownerRepo)
 	if !ok {
@@ -399,7 +419,15 @@ func (s *Sim) SeedCheckRun(ownerRepo, sha string, run gh.CheckRun) *Sim {
 	if run.ID == 0 {
 		run.ID = s.nextCheckRunID
 		s.nextCheckRunID++
+	} else if s.seededCheckRunIDs[run.ID] {
+		s.fail("simgh: check run ID %d already used in %s; IDs are unique across the sim", run.ID, ownerRepo)
+		return s
+	} else if run.ID >= s.nextCheckRunID {
+		// Keep the auto-assign counter ahead of every explicit ID, so a later
+		// ID: 0 seed can never collide with one already handed out by hand.
+		s.nextCheckRunID = run.ID + 1
 	}
+	s.seededCheckRunIDs[run.ID] = true
 	if run.Status == "" {
 		if run.Conclusion == "" {
 			run.Status = "in_progress"

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -27,7 +27,10 @@ import (
 
 // IssueSeed describes an issue to create.
 type IssueSeed struct {
-	Number int // 0 to auto-assign the repo's next issue number
+	// Number is 0 to auto-assign from the repo's shared issue-and-PR sequence.
+	// An explicit number a PR already holds is a seeding error — GitHub numbers
+	// both kinds from one counter.
+	Number int
 	Title  string
 	Body   string
 	Author string
@@ -43,7 +46,9 @@ type IssueSeed struct {
 // the backing repository; both must already exist (seed them with SeedCommit
 // or SeedBranch first) so that every git-derived answer about the PR is real.
 type PRSeed struct {
-	Number int // 0 to auto-assign the repo's next PR number
+	// Number is 0 to auto-assign from the repo's shared issue-and-PR sequence.
+	// An explicit number an issue already holds is a seeding error.
+	Number int
 	Title  string
 	Body   string
 	Author string
@@ -117,8 +122,7 @@ func (s *Sim) SeedRepo(ownerRepo string, defaultBranch ...string) *Sim {
 		requiredApprovals: make(map[string]int),
 		labelVocab:        make(map[string]bool),
 		access:            gh.RepoAccess{AllowAutoMerge: true, CanPush: true},
-		nextIssueNumber:   1,
-		nextPRNumber:      1,
+		nextNumber:        1,
 	}
 	s.mu.Unlock()
 	return s
@@ -232,15 +236,13 @@ func (s *Sim) SeedIssue(ownerRepo string, seed IssueSeed) *Sim {
 
 	num := seed.Number
 	if num == 0 {
-		num = r.nextIssueNumber
-	}
-	if _, exists := r.issues[num]; exists {
+		num = r.allocNumber()
+	} else if r.numberTaken(num) {
+		// Shared number space: #N may already be a PR, not just an issue.
 		s.fail("simgh: %s#%d already exists", ownerRepo, num)
 		return s
 	}
-	if num >= r.nextIssueNumber {
-		r.nextIssueNumber = num + 1
-	}
+	r.reserveNumber(num)
 	state := seed.State
 	if state == "" {
 		state = "OPEN"
@@ -302,15 +304,13 @@ func (s *Sim) SeedPR(ownerRepo string, seed PRSeed) *Sim {
 
 	num := seed.Number
 	if num == 0 {
-		num = r.nextPRNumber
-	}
-	if _, exists := r.prs[num]; exists {
+		num = r.allocNumber()
+	} else if r.numberTaken(num) {
+		// Shared number space: #N may already be an issue, not just a PR.
 		s.fail("simgh: PR %s#%d already exists", ownerRepo, num)
 		return s
 	}
-	if num >= r.nextPRNumber {
-		r.nextPRNumber = num + 1
-	}
+	r.reserveNumber(num)
 	state := seed.State
 	if state == "" {
 		state = "open"

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -458,8 +458,14 @@ func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int
 	}
 	id := itemNodeID(p.owner, p.num, ownerRepo, number)
 	if existing, ok := p.items[id]; ok {
+		// Unlike AddProjectV2ItemById this *does* move the card, so a column
+		// change counts as a change alongside an un-archive. Re-seeding a card
+		// into the column it already occupies is a no-op and must not bump.
+		changed := existing.archived || existing.status != status
 		existing.status = status
-		s.reviveCardLocked(p, existing)
+		if changed {
+			s.reviveCardLocked(p, existing)
+		}
 		return
 	}
 	now := s.now()

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -358,6 +358,16 @@ func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int
 		s.fail("simgh: project %s has no column %q", p.id, status)
 		return
 	}
+	if isPR {
+		// Board projections resolve a card's content as an issue
+		// (buildProjectItem), so a PR card would read back as nothing at all —
+		// every board fetch would silently omit it, with no error. Refuse it at
+		// seed time instead: a loud failure here beats a scenario quietly
+		// asserting against a board the model never built. Recorded in
+		// FIDELITY.md as absent.
+		s.fail("simgh: PR cards on a project board are not modelled (%s#%d); see FIDELITY.md", ownerRepo, number)
+		return
+	}
 	id := itemNodeID(p.owner, p.num, ownerRepo, number)
 	if existing, ok := p.items[id]; ok {
 		existing.status = status

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -233,7 +233,10 @@ func (s *Sim) HeadSHA(ownerRepo, branch string) (string, error) {
 	}
 	r.gitMu.Lock()
 	defer r.gitMu.Unlock()
-	sha := r.headSHA(branch)
+	sha, err := r.headSHA(branch)
+	if err != nil {
+		return "", err
+	}
 	if sha == "" {
 		return "", fmt.Errorf("simgh: branch %q not found in %s", branch, ownerRepo)
 	}
@@ -265,11 +268,20 @@ func (s *Sim) SeedIssue(ownerRepo string, seed IssueSeed) *Sim {
 		s.fail("simgh: %s#%d already exists", ownerRepo, num)
 		return s
 	}
-	r.reserveNumber(num)
+	// Only GitHub's own enum, not merely "non-empty". Every downstream read
+	// compares this by exact string (board projections, IsClosed, the PR
+	// auto-close path), so "closed" or "Open" would be stored verbatim and then
+	// silently misclassify the issue as open forever.
 	state := seed.State
-	if state == "" {
+	switch state {
+	case "":
 		state = "OPEN"
+	case "OPEN", "CLOSED":
+	default:
+		s.fail("simgh: issue state %q is not valid; use \"OPEN\" or \"CLOSED\"", state)
+		return s
 	}
+	r.reserveNumber(num)
 	now := s.now()
 	iss := &issueRecord{
 		number:         num,
@@ -325,6 +337,13 @@ func (s *Sim) SeedPR(ownerRepo string, seed PRSeed) *Sim {
 		s.fail("simgh: PR base branch %q does not exist in %s", base, ownerRepo)
 		return s
 	}
+	// GitHub refuses a PR whose head is its base ("No commits between ..."), and
+	// the shape is degenerate here too: the trial merge collapses to the
+	// nothing-to-merge path.
+	if seed.Head == base {
+		s.fail("simgh: PR head and base are both %q; GitHub refuses a PR with no commits between them", base)
+		return s
+	}
 
 	num := seed.Number
 	switch {
@@ -342,7 +361,17 @@ func (s *Sim) SeedPR(ownerRepo string, seed PRSeed) *Sim {
 	// Refuse shapes GitHub cannot produce. A merged PR is always closed, and a
 	// draft can never have been merged — accepting either would let a scenario
 	// drive the engine from a state production can never deliver, and pass.
+	//
+	// The state string is checked against GitHub's REST enum rather than merely
+	// for emptiness, for the reason SeedIssue states: downstream reads compare
+	// it exactly, so "Open" would be stored and then never match.
 	state := seed.State
+	switch state {
+	case "", "open", "closed":
+	default:
+		s.fail("simgh: PR state %q is not valid; use \"open\" or \"closed\"", state)
+		return s
+	}
 	if seed.Merged {
 		if seed.Draft {
 			s.fail("simgh: PR %s#%d cannot be both merged and draft", ownerRepo, num)

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -391,16 +391,17 @@ func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int
 		s.reviveCardLocked(p, existing)
 		return
 	}
+	now := s.now()
 	p.items[id] = &itemState{
 		itemID:    id,
 		ownerRepo: ownerRepo,
 		number:    number,
 		isPR:      isPR,
 		status:    status,
-		updatedAt: s.now(),
+		updatedAt: now,
 	}
 	p.itemOrder = append(p.itemOrder, id)
-	p.updatedAt = s.now()
+	p.updatedAt = now
 }
 
 // SeedCheckRun attaches a check run to a commit SHA. Name and Conclusion are
@@ -607,14 +608,15 @@ func (s *Sim) SeedComment(ownerRepo string, issueNumber int, author, body string
 	}
 	id := s.nextCommentDatabaseID
 	s.nextCommentDatabaseID++
+	now := s.now()
 	iss.comments = append(iss.comments, &commentRecord{
 		databaseID: id,
 		author:     author,
 		body:       body,
-		createdAt:  s.now(),
+		createdAt:  now,
 		reactions:  make(map[string]int),
 	})
-	iss.updatedAt = s.now()
+	iss.updatedAt = now
 	return s
 }
 

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -251,9 +251,16 @@ func (s *Sim) SeedIssue(ownerRepo string, seed IssueSeed) *Sim {
 	defer s.mu.Unlock()
 
 	num := seed.Number
-	if num == 0 {
+	switch {
+	case num == 0:
 		num = r.allocNumber()
-	} else if r.numberTaken(num) {
+	case num < 0:
+		// reserveNumber is a no-op below nextNumber, so a negative number would
+		// be accepted silently and then embedded in node IDs and every board
+		// projection — a number GitHub could never assign.
+		s.fail("simgh: issue number %d is not valid; use 0 to auto-assign", num)
+		return s
+	case r.numberTaken(num):
 		// Shared number space: #N may already be a PR, not just an issue.
 		s.fail("simgh: %s#%d already exists", ownerRepo, num)
 		return s
@@ -320,18 +327,38 @@ func (s *Sim) SeedPR(ownerRepo string, seed PRSeed) *Sim {
 	}
 
 	num := seed.Number
-	if num == 0 {
+	switch {
+	case num == 0:
 		num = r.allocNumber()
-	} else if r.numberTaken(num) {
+	case num < 0:
+		s.fail("simgh: PR number %d is not valid; use 0 to auto-assign", num)
+		return s
+	case r.numberTaken(num):
 		// Shared number space: #N may already be an issue, not just a PR.
 		s.fail("simgh: PR %s#%d already exists", ownerRepo, num)
 		return s
 	}
-	r.reserveNumber(num)
+
+	// Refuse shapes GitHub cannot produce. A merged PR is always closed, and a
+	// draft can never have been merged — accepting either would let a scenario
+	// drive the engine from a state production can never deliver, and pass.
 	state := seed.State
+	if seed.Merged {
+		if seed.Draft {
+			s.fail("simgh: PR %s#%d cannot be both merged and draft", ownerRepo, num)
+			return s
+		}
+		if state == "open" {
+			s.fail("simgh: PR %s#%d cannot be merged and open; a merged PR is closed", ownerRepo, num)
+			return s
+		}
+		// Unspecified means "whatever merging implies", which is closed.
+		state = "closed"
+	}
 	if state == "" {
 		state = "open"
 	}
+	r.reserveNumber(num)
 	now := s.now()
 	r.prs[num] = &prRecord{
 		number:                  num,
@@ -661,6 +688,12 @@ func (s *Sim) SeedBlockedBy(ownerRepo string, issueNumber int, blockerOwnerRepo 
 	iss, ok := r.issues[issueNumber]
 	if !ok {
 		s.fail("simgh: issue %s#%d not found", ownerRepo, issueNumber)
+		return s
+	}
+	// Refused on both paths, for the reason AddBlockedByIssue states: a
+	// self-block is unsatisfiable, so the dependency gate holds forever.
+	if blockerOwnerRepo == ownerRepo && blockerNumber == issueNumber {
+		s.fail("simgh: issue %s#%d cannot block itself", ownerRepo, issueNumber)
 		return s
 	}
 	// Validate the blocker for the same reason AddBlockedByIssue does: an

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -1,0 +1,659 @@
+package simgh
+
+import (
+	"fmt"
+	"time"
+
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// This file is the seeding API: how a scenario constructs a board in a given
+// state in a few lines.
+//
+// Every Seed* method returns *Sim and records the first failure in a sticky
+// error, so setup reads as a chain and is checked once with Err():
+//
+//	s := simgh.New(t.TempDir(), simgh.WithClock(clk)).
+//		SeedRepo("acme/widgets").
+//		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Done"}).
+//		SeedIssue("acme/widgets", simgh.IssueSeed{Number: 7, Title: "…", Status: "Implement"})
+//	if err := s.Err(); err != nil { t.Fatal(err) }
+//
+// Seeding constructs *static initial state only*. There is deliberately no way
+// here to script a sequence of future responses, inject a fault, or replay a
+// mutation log — those are a separate layer (#1457) that will build on these
+// same objects. Keeping seeding static is what lets that layer be added
+// without breaking this API.
+
+// IssueSeed describes an issue to create.
+type IssueSeed struct {
+	Number int // 0 to auto-assign the repo's next issue number
+	Title  string
+	Body   string
+	Author string
+	Labels []string
+	State  string // "OPEN" (default) or "CLOSED"
+
+	// Status, when non-empty, also places the issue on the default project
+	// (the first one seeded) in that column.
+	Status string
+}
+
+// PRSeed describes a pull request to create. Head and Base are branch names in
+// the backing repository; both must already exist (seed them with SeedCommit
+// or SeedBranch first) so that every git-derived answer about the PR is real.
+type PRSeed struct {
+	Number int // 0 to auto-assign the repo's next PR number
+	Title  string
+	Body   string
+	Author string
+	Head   string
+	Base   string // defaults to the repo's default branch
+	Draft  bool
+	Merged bool
+	State  string // "open" (default) or "closed"
+
+	// IssueNumber links the PR to an issue the way CreateDraftPR does, feeding
+	// FindPRForIssue and FetchPRClosingIssues.
+	IssueNumber int
+
+	// MergeableRecomputeReads seeds GitHub's recompute window: for this many
+	// reads, mergeable reports null and mergeableState reports "unknown"
+	// before the real git-derived answer surfaces. See FIDELITY.md.
+	MergeableRecomputeReads int
+}
+
+// SeedRepo creates a repo and its backing bare git repository, with a root
+// commit on the default branch. defaultBranch may be empty for "main".
+func (s *Sim) SeedRepo(ownerRepo string, defaultBranch ...string) *Sim {
+	branch := "main"
+	if len(defaultBranch) > 0 && defaultBranch[0] != "" {
+		branch = defaultBranch[0]
+	}
+	owner, repo, err := splitOwnerRepo(ownerRepo)
+	if err != nil {
+		s.mu.Lock()
+		s.fail("%v", err)
+		s.mu.Unlock()
+		return s
+	}
+
+	s.mu.Lock()
+	if _, exists := s.repos[ownerRepo]; exists {
+		s.fail("simgh: repo %s already seeded", ownerRepo)
+		s.mu.Unlock()
+		return s
+	}
+	dir := s.repoDir(owner, repo)
+	s.mu.Unlock()
+
+	if err := s.ensureBaseDir(); err != nil {
+		s.mu.Lock()
+		s.fail("%v", err)
+		s.mu.Unlock()
+		return s
+	}
+	// No repoState exists yet, so no gitMu to take; nothing else can reach
+	// this directory until the state is published below.
+	if err := initBare(dir, branch); err != nil {
+		s.mu.Lock()
+		s.fail("%v", err)
+		s.mu.Unlock()
+		return s
+	}
+
+	s.mu.Lock()
+	s.repos[ownerRepo] = &repoState{
+		owner:             owner,
+		repo:              repo,
+		bareDir:           dir,
+		defaultBranch:     branch,
+		issues:            make(map[int]*issueRecord),
+		prs:               make(map[int]*prRecord),
+		checkRuns:         make(map[string][]gh.CheckRun),
+		commitStatuses:    make(map[string][]gh.CommitStatus),
+		requiredContexts:  make(map[string][]string),
+		requireUpToDate:   make(map[string]bool),
+		requiredApprovals: make(map[string]int),
+		labelVocab:        make(map[string]bool),
+		access:            gh.RepoAccess{AllowAutoMerge: true, CanPush: true},
+		nextIssueNumber:   1,
+		nextPRNumber:      1,
+	}
+	s.mu.Unlock()
+	return s
+}
+
+// SeedProject creates a Projects v2 board owned by owner. The first project
+// seeded becomes the default that SeedIssue's Status field places cards on.
+// Column order is significant: the first is the leftmost.
+func (s *Sim) SeedProject(owner string, num int, title string, columns []string) *Sim {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := projectKey(owner, num)
+	if _, exists := s.projects[key]; exists {
+		s.fail("simgh: project %s already seeded", key)
+		return s
+	}
+	p := &projectState{
+		owner:              owner,
+		num:                num,
+		title:              title,
+		statusOptions:      make(map[string]string),
+		orderedStatusNames: cloneStrings(columns),
+		items:              make(map[string]*itemState),
+		updatedAt:          s.now(),
+	}
+	p.id = p.nodeID()
+	p.statusFieldID = "field:" + p.id + ":Status"
+	for _, c := range columns {
+		p.statusOptions[c] = fmt.Sprintf("opt:%s:%s", p.id, c)
+	}
+	s.projects[key] = p
+	if s.defaultProject == nil {
+		s.defaultProject = p
+	}
+	return s
+}
+
+// SeedCommit writes files onto branch and commits them, creating the branch
+// from the repo's default branch if it does not exist. files may be nil for an
+// empty commit.
+func (s *Sim) SeedCommit(ownerRepo, branch string, files map[string]string, msg string) *Sim {
+	return s.seedCommitFrom(ownerRepo, branch, "", files, msg)
+}
+
+// SeedCommitFrom is SeedCommit with an explicit parent branch, used when
+// forking a feature branch from somewhere other than the default branch.
+func (s *Sim) SeedCommitFrom(ownerRepo, branch, fromBranch string, files map[string]string, msg string) *Sim {
+	return s.seedCommitFrom(ownerRepo, branch, fromBranch, files, msg)
+}
+
+func (s *Sim) seedCommitFrom(ownerRepo, branch, fromBranch string, files map[string]string, msg string) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	r.gitMu.Lock()
+	_, err := r.commitFiles(branch, fromBranch, files, msg)
+	r.gitMu.Unlock()
+	if err != nil {
+		s.mu.Lock()
+		s.fail("%v", err)
+		s.mu.Unlock()
+	}
+	return s
+}
+
+// SeedBranch points a new branch at fromBranch's tip (the repo's default
+// branch when fromBranch is empty).
+func (s *Sim) SeedBranch(ownerRepo, branch, fromBranch string) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	r.gitMu.Lock()
+	err := r.createBranch(branch, fromBranch)
+	r.gitMu.Unlock()
+	if err != nil {
+		s.mu.Lock()
+		s.fail("%v", err)
+		s.mu.Unlock()
+	}
+	return s
+}
+
+// HeadSHA returns the commit SHA at a branch tip. Useful when seeding check
+// runs, which GitHub keys by SHA.
+func (s *Sim) HeadSHA(ownerRepo, branch string) (string, error) {
+	r, err := s.repoByKey(ownerRepo)
+	if err != nil {
+		return "", err
+	}
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+	sha := r.headSHA(branch)
+	if sha == "" {
+		return "", fmt.Errorf("simgh: branch %q not found in %s", branch, ownerRepo)
+	}
+	return sha, nil
+}
+
+// SeedIssue creates an issue, optionally placing it on the default project.
+func (s *Sim) SeedIssue(ownerRepo string, seed IssueSeed) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	num := seed.Number
+	if num == 0 {
+		num = r.nextIssueNumber
+	}
+	if _, exists := r.issues[num]; exists {
+		s.fail("simgh: %s#%d already exists", ownerRepo, num)
+		return s
+	}
+	if num >= r.nextIssueNumber {
+		r.nextIssueNumber = num + 1
+	}
+	state := seed.State
+	if state == "" {
+		state = "OPEN"
+	}
+	now := s.now()
+	iss := &issueRecord{
+		number:         num,
+		title:          seed.Title,
+		body:           seed.Body,
+		state:          state,
+		author:         seed.Author,
+		labels:         cloneStrings(seed.Labels),
+		labelAppliedAt: make(map[string]time.Time),
+		createdAt:      now,
+		updatedAt:      now,
+	}
+	for _, l := range iss.labels {
+		iss.labelAppliedAt[l] = now
+		r.labelVocab[l] = true
+	}
+	r.issues[num] = iss
+
+	if seed.Status != "" {
+		s.placeOnProjectLocked(s.defaultProject, ownerRepo, num, false, seed.Status)
+	}
+	return s
+}
+
+// SeedPR creates a pull request. Its head and base branches must already exist
+// in the backing repository — every git-derived answer about the PR is
+// computed from them rather than declared here.
+func (s *Sim) SeedPR(ownerRepo string, seed PRSeed) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+
+	base := seed.Base
+	if base == "" {
+		base = r.defaultBranch
+	}
+
+	// Validate branch existence under gitMu, before taking mu.
+	r.gitMu.Lock()
+	headOK := r.branchExists(seed.Head)
+	baseOK := r.branchExists(base)
+	r.gitMu.Unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !headOK {
+		s.fail("simgh: PR head branch %q does not exist in %s (seed it first)", seed.Head, ownerRepo)
+		return s
+	}
+	if !baseOK {
+		s.fail("simgh: PR base branch %q does not exist in %s", base, ownerRepo)
+		return s
+	}
+
+	num := seed.Number
+	if num == 0 {
+		num = r.nextPRNumber
+	}
+	if _, exists := r.prs[num]; exists {
+		s.fail("simgh: PR %s#%d already exists", ownerRepo, num)
+		return s
+	}
+	if num >= r.nextPRNumber {
+		r.nextPRNumber = num + 1
+	}
+	state := seed.State
+	if state == "" {
+		state = "open"
+	}
+	now := s.now()
+	r.prs[num] = &prRecord{
+		number:                  num,
+		title:                   seed.Title,
+		body:                    seed.Body,
+		head:                    seed.Head,
+		base:                    base,
+		state:                   state,
+		draft:                   seed.Draft,
+		merged:                  seed.Merged,
+		author:                  seed.Author,
+		issueNumber:             seed.IssueNumber,
+		mergeableRecomputeReads: seed.MergeableRecomputeReads,
+		createdAt:               now,
+		updatedAt:               now,
+	}
+	return s
+}
+
+// SeedProjectItem places an existing issue or PR on a project board explicitly,
+// for scenarios with more than one project.
+func (s *Sim) SeedProjectItem(owner string, projectNum int, ownerRepo string, number int, isPR bool, status string) *Sim {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.projects[projectKey(owner, projectNum)]
+	if !ok {
+		s.fail("simgh: project %s not seeded", projectKey(owner, projectNum))
+		return s
+	}
+	s.placeOnProjectLocked(p, ownerRepo, number, isPR, status)
+	return s
+}
+
+// placeOnProjectLocked adds or moves a card. Caller must hold mu.
+func (s *Sim) placeOnProjectLocked(p *projectState, ownerRepo string, number int, isPR bool, status string) {
+	if p == nil {
+		s.fail("simgh: no project seeded; call SeedProject before placing items")
+		return
+	}
+	if _, ok := p.statusOptions[status]; !ok {
+		s.fail("simgh: project %s has no column %q", p.id, status)
+		return
+	}
+	id := itemNodeID(p.owner, p.num, ownerRepo, number)
+	if existing, ok := p.items[id]; ok {
+		existing.status = status
+		existing.updatedAt = s.now()
+		p.updatedAt = s.now()
+		return
+	}
+	p.items[id] = &itemState{
+		itemID:    id,
+		ownerRepo: ownerRepo,
+		number:    number,
+		isPR:      isPR,
+		status:    status,
+		updatedAt: s.now(),
+	}
+	p.itemOrder = append(p.itemOrder, id)
+	p.updatedAt = s.now()
+}
+
+// SeedCheckRun attaches a check run to a commit SHA. Name and Conclusion are
+// what the mergeable-state derivation reads; an empty ID is auto-assigned.
+func (s *Sim) SeedCheckRun(ownerRepo, sha string, run gh.CheckRun) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if run.ID == 0 {
+		run.ID = s.nextCheckRunID
+		s.nextCheckRunID++
+	}
+	if run.Status == "" {
+		if run.Conclusion == "" {
+			run.Status = "in_progress"
+		} else {
+			run.Status = "completed"
+		}
+	}
+	r.checkRuns[sha] = append(r.checkRuns[sha], run)
+	return s
+}
+
+// SeedCommitStatus attaches a classic commit status to a SHA. Kept genuinely
+// distinct from check runs because production distinguishes them (ADR-933).
+func (s *Sim) SeedCommitStatus(ownerRepo, sha string, st gh.CommitStatus) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.commitStatuses[sha] = append(r.commitStatuses[sha], st)
+	return s
+}
+
+// SeedRequiredContexts declares which check/status context names branch
+// protection requires on a branch. This is what makes "blocked" distinguishable
+// from "unstable": a red required context blocks the merge, a red non-required
+// one only makes the PR unstable. Modelled on ADR-933's RequiredStatusContexts.
+func (s *Sim) SeedRequiredContexts(ownerRepo, branch string, contexts []string) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.requiredContexts[branch] = cloneStrings(contexts)
+	return s
+}
+
+// SeedRequireUpToDate turns on branch protection's "require branches to be up
+// to date before merging" for a branch. Only with this on does a PR whose base
+// has advanced report the "behind" mergeable state; without it, real GitHub
+// reports such a PR as "clean", and so does the model.
+func (s *Sim) SeedRequireUpToDate(ownerRepo, branch string, required bool) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.requireUpToDate[branch] = required
+	return s
+}
+
+// SeedRequiredApprovals declares how many approving reviews branch protection
+// requires on a branch, backing FetchPRReviewDecision.
+func (s *Sim) SeedRequiredApprovals(ownerRepo, branch string, n int) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.requiredApprovals[branch] = n
+	return s
+}
+
+// SeedMergeableRecomputePending puts a PR into GitHub's recompute window for
+// the next reads reads: mergeable reports null and mergeableState "unknown"
+// until the counter drains. Also settable at construction via
+// PRSeed.MergeableRecomputeReads.
+func (s *Sim) SeedMergeableRecomputePending(ownerRepo string, prNumber, reads int) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		s.fail("simgh: PR %s#%d not found", ownerRepo, prNumber)
+		return s
+	}
+	pr.mergeableRecomputeReads = reads
+	return s
+}
+
+// SeedReview records a submitted review on a PR.
+func (s *Sim) SeedReview(ownerRepo string, prNumber int, review gh.PRReview) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		s.fail("simgh: PR %s#%d not found", ownerRepo, prNumber)
+		return s
+	}
+	if review.SubmittedAt.IsZero() {
+		review.SubmittedAt = s.now()
+	}
+	pr.reviews = append(pr.reviews, review)
+	return s
+}
+
+// SeedReviewRequest records an outstanding reviewer request on a PR. IsBot is
+// derived from the login when not set explicitly, using the same classifier
+// production uses.
+func (s *Sim) SeedReviewRequest(ownerRepo string, prNumber int, req gh.ReviewRequest) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		s.fail("simgh: PR %s#%d not found", ownerRepo, prNumber)
+		return s
+	}
+	if !req.IsBot {
+		req.IsBot = gh.IsBotLogin(req.Login)
+	}
+	pr.reviewRequests = append(pr.reviewRequests, req)
+	return s
+}
+
+// SeedReviewThreadComment attaches an inline review-thread comment to a PR.
+func (s *Sim) SeedReviewThreadComment(ownerRepo string, prNumber int, author, body, path string, line int) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr, ok := r.prs[prNumber]
+	if !ok {
+		s.fail("simgh: PR %s#%d not found", ownerRepo, prNumber)
+		return s
+	}
+	id := s.nextCommentDatabaseID
+	s.nextCommentDatabaseID++
+	pr.reviewThreadComment = append(pr.reviewThreadComment, &commentRecord{
+		databaseID:     id,
+		author:         author,
+		body:           body,
+		createdAt:      s.now(),
+		reactions:      make(map[string]int),
+		fromPR:         prNumber,
+		reviewThreadID: fmt.Sprintf("thread:%s#%d:%d", ownerRepo, prNumber, id),
+		path:           path,
+		line:           line,
+	})
+	return s
+}
+
+// SeedComment adds a comment to an issue. Returns the Sim for chaining; use
+// FetchProjectItem or FetchLinkedPR to read the assigned database ID back.
+func (s *Sim) SeedComment(ownerRepo string, issueNumber int, author, body string) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, ok := r.issues[issueNumber]
+	if !ok {
+		s.fail("simgh: issue %s#%d not found", ownerRepo, issueNumber)
+		return s
+	}
+	id := s.nextCommentDatabaseID
+	s.nextCommentDatabaseID++
+	iss.comments = append(iss.comments, &commentRecord{
+		databaseID: id,
+		author:     author,
+		body:       body,
+		createdAt:  s.now(),
+		reactions:  make(map[string]int),
+	})
+	iss.updatedAt = s.now()
+	return s
+}
+
+// SeedBlockedBy records that an issue is blocked by another. The blocker's
+// state is resolved live on read, so closing the blocker unblocks the issue
+// the way GitHub's dependency graph does.
+func (s *Sim) SeedBlockedBy(ownerRepo string, issueNumber int, blockerOwnerRepo string, blockerNumber int) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, ok := r.issues[issueNumber]
+	if !ok {
+		s.fail("simgh: issue %s#%d not found", ownerRepo, issueNumber)
+		return s
+	}
+	repoField := ""
+	if blockerOwnerRepo != ownerRepo {
+		repoField = blockerOwnerRepo
+	}
+	iss.blockedBy = append(iss.blockedBy, gh.Dependency{Number: blockerNumber, Repo: repoField})
+	return s
+}
+
+// SeedRepoAccess overrides the repo's reported access flags.
+func (s *Sim) SeedRepoAccess(ownerRepo string, access gh.RepoAccess) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.access = access
+	return s
+}
+
+// SeedLatestRelease sets what FetchLatestRelease reports for the repo.
+func (s *Sim) SeedLatestRelease(ownerRepo string, rel gh.LatestRelease) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.latestRelease = &rel
+	return s
+}
+
+// SeedMergeQueueEnabled toggles the repo-level merge-queue feature flag.
+func (s *Sim) SeedMergeQueueEnabled(ownerRepo string, enabled bool) *Sim {
+	r, ok := s.repoForSeed(ownerRepo)
+	if !ok {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r.mergeQueueEnabled = enabled
+	return s
+}
+
+// repoForSeed looks up a repo for a chained Seed* call, recording a sticky
+// error and reporting false when it is missing.
+func (s *Sim) repoForSeed(ownerRepo string) (*repoState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.repos[ownerRepo]
+	if !ok {
+		s.fail("simgh: repo %s not seeded", ownerRepo)
+		return nil, false
+	}
+	return r, true
+}
+
+// repoByKey looks up a repo by "owner/repo" for non-seeding callers.
+func (s *Sim) repoByKey(ownerRepo string) (*repoState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.repos[ownerRepo]
+	if !ok {
+		return nil, fmt.Errorf("simgh: repo %s not seeded", ownerRepo)
+	}
+	return r, nil
+}

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -30,12 +30,13 @@ type IssueSeed struct {
 	// Number is 0 to auto-assign from the repo's shared issue-and-PR sequence.
 	// An explicit number a PR already holds is a seeding error — GitHub numbers
 	// both kinds from one counter.
-	Number int
-	Title  string
-	Body   string
-	Author string
-	Labels []string
-	State  string // "OPEN" (default) or "CLOSED"
+	Number    int
+	Title     string
+	Body      string
+	Author    string
+	Labels    []string
+	Assignees []string
+	State     string // "OPEN" (default) or "CLOSED"
 
 	// Status, when non-empty, also places the issue on the default project
 	// (the first one seeded) in that column.
@@ -269,6 +270,7 @@ func (s *Sim) SeedIssue(ownerRepo string, seed IssueSeed) *Sim {
 		state:          state,
 		author:         seed.Author,
 		labels:         cloneStrings(seed.Labels),
+		assignees:      cloneStrings(seed.Assignees),
 		labelAppliedAt: make(map[string]time.Time),
 		createdAt:      now,
 		updatedAt:      now,

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -600,6 +600,19 @@ func (s *Sim) SeedBlockedBy(ownerRepo string, issueNumber int, blockerOwnerRepo 
 		s.fail("simgh: issue %s#%d not found", ownerRepo, issueNumber)
 		return s
 	}
+	// Validate the blocker for the same reason AddBlockedByIssue does: an
+	// unresolvable blocker resolves to State "OPEN", leaving the dependent
+	// issue permanently blocked with no diagnostic. The seeding and runtime
+	// paths must agree about what is representable.
+	br, ok := s.repos[blockerOwnerRepo]
+	if !ok {
+		s.fail("simgh: blocker repo %s not seeded", blockerOwnerRepo)
+		return s
+	}
+	if _, ok := br.issues[blockerNumber]; !ok {
+		s.fail("simgh: blocker issue %s#%d not found", blockerOwnerRepo, blockerNumber)
+		return s
+	}
 	repoField := ""
 	if blockerOwnerRepo != ownerRepo {
 		repoField = blockerOwnerRepo

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -744,11 +744,25 @@ func (s *Sim) SeedBlockedBy(ownerRepo string, issueNumber int, blockerOwnerRepo 
 		s.fail("simgh: blocker issue %s#%d not found", blockerOwnerRepo, blockerNumber)
 		return s
 	}
+	// Dedupe and stamp exactly as AddBlockedByIssue does. GitHub silently
+	// ignores a duplicate dependency rather than erroring, and the seeding path
+	// diverging from the runtime path about what a repeated link means is the
+	// asymmetry this package has had to correct repeatedly.
+	for _, dep := range iss.blockedBy {
+		depRepo := dep.Repo
+		if depRepo == "" {
+			depRepo = ownerRepo
+		}
+		if dep.Number == blockerNumber && depRepo == blockerOwnerRepo {
+			return s
+		}
+	}
 	repoField := ""
 	if blockerOwnerRepo != ownerRepo {
 		repoField = blockerOwnerRepo
 	}
 	iss.blockedBy = append(iss.blockedBy, gh.Dependency{Number: blockerNumber, Repo: repoField})
+	iss.updatedAt = s.now()
 	return s
 }
 

--- a/tests/sim/simgh/seed.go
+++ b/tests/sim/simgh/seed.go
@@ -127,6 +127,7 @@ func (s *Sim) SeedRepo(ownerRepo string, defaultBranch ...string) *Sim {
 		owner:             owner,
 		repo:              repo,
 		bareDir:           dir,
+		worktreeRoot:      dir + ".worktrees",
 		defaultBranch:     branch,
 		issues:            make(map[int]*issueRecord),
 		prs:               make(map[int]*prRecord),

--- a/tests/sim/simgh/sim.go
+++ b/tests/sim/simgh/sim.go
@@ -214,8 +214,17 @@ func (s *Sim) lookupRepo(owner, repo string) (*repoState, error) {
 }
 
 // repoDir is the on-disk path of a repo's backing bare repository.
+// Owner and repo are separate path segments rather than joined with a
+// separator, because joining is not collision-free: "acme-widgets/foo" and
+// "acme/widgets-foo" both flatten to "acme-widgets-foo". SeedRepo's
+// already-seeded check is keyed on the full "owner/repo" string, so both would
+// be accepted and would produce two repoState values — each with its own gitMu
+// — pointing at one physical repository. That silently voids the per-repo git
+// serialisation the whole locking design rests on, and lets commits from one
+// logical repo land in the other. Both segments are validated as single
+// path-safe names (splitOwnerRepo), so nesting cannot escape baseDir.
 func (s *Sim) repoDir(owner, repo string) string {
-	return filepath.Join(s.baseDir, owner+"-"+repo+".git")
+	return filepath.Join(s.baseDir, owner, repo+".git")
 }
 
 // ensureBaseDir creates baseDir if it does not exist.

--- a/tests/sim/simgh/sim.go
+++ b/tests/sim/simgh/sim.go
@@ -105,6 +105,12 @@ type Sim struct {
 	nextCommentDatabaseID int
 	nextCheckRunID        int64
 
+	// seededCheckRunIDs is every check run ID handed out or explicitly seeded,
+	// so SeedCheckRun can refuse a duplicate. GitHub's check run IDs are unique
+	// across the instance, and production relies on their ordering to pick the
+	// latest rerun of a check name.
+	seededCheckRunIDs map[int64]bool
+
 	// restRate and graphqlRate back RateLimitStats. Modelled as static
 	// budgets that never deplete; see FIDELITY.md.
 	restRate    rateBudget
@@ -150,6 +156,7 @@ func New(baseDir string, opts ...Option) *Sim {
 		projects:              make(map[string]*projectState),
 		nextCommentDatabaseID: 1000,
 		nextCheckRunID:        5000,
+		seededCheckRunIDs:     make(map[int64]bool),
 		restRate:              rateBudget{limit: 5000, remaining: 5000, resetIn: time.Hour},
 		graphqlRate:           rateBudget{limit: 5000, remaining: 5000, resetIn: time.Hour},
 	}

--- a/tests/sim/simgh/sim.go
+++ b/tests/sim/simgh/sim.go
@@ -1,0 +1,212 @@
+// Package simgh implements a stateful, git-backed simulation of the GitHub
+// surface that Fabrik's engine talks to.
+//
+// It exists to fill the gap between engine/mocks_test.go — a per-call function
+// hook stub where nothing carries across poll cycles — and tests/e2e, which
+// drives a real daemon against real GitHub at real cost. simgh is a third
+// layer: a model faithful enough that a multi-poll transition sequence can be
+// asserted in an ordinary `go test` run.
+//
+// Two properties define it:
+//
+//   - It is stateful. A mutation is observable by every subsequent read, the
+//     way GitHub behaves. Read projections (gh.ProjectItem, gh.PRDetails,
+//     gh.BoardProbeItem) are computed fresh from the model on every call and
+//     never cached, so this is structural rather than something each test has
+//     to re-assert.
+//
+//   - It is backed by real git. Anything git can genuinely answer —
+//     mergeability, merge commits, commits-behind — is computed by running the
+//     real git binary against a real bare repository, not declared by the test.
+//     A fake that lets a test assert mergeability cannot catch a mergeability
+//     bug.
+//
+// What it is structurally blind to is documented in ../README.md; every place
+// it knowingly diverges from real GitHub is documented in FIDELITY.md. Read
+// FIDELITY.md before trusting a sim-backed test to cover a subtle behaviour.
+//
+// # Locking
+//
+// Two tiers, with a strict ordering invariant:
+//
+//   - Sim.mu guards all in-memory model state across every repo and project.
+//   - repoState.gitMu guards git subprocess invocations against that repo's
+//     bare directory. Git's own on-disk state (config, index, worktree list)
+//     is not concurrency-safe, so a Go-level mutex over the model alone is not
+//     enough.
+//
+// INVARIANT: never acquire mu while holding gitMu, and never hold mu across a
+// git subprocess call. The pattern used throughout is: take mu, copy out the
+// inputs, release mu; take gitMu, run git, release gitMu; take mu again to
+// write the result back. A violation of this ordering surfaces only as an
+// intermittent deadlock or -race failure, so it is enforced by review.
+//
+// # Adding a method
+//
+// Sim pins itself to engine.GitHubClient with a compile-time assertion, so any
+// future widening of that interface breaks this package's build immediately.
+// That is deliberate — it is how the layer detects drift. When it happens, add
+// the new method to the grouped file matching its concern (prs.go, ci.go,
+// reviews.go, board.go, labels.go, comments.go, issues.go, deps.go, misc.go),
+// give it a real if simplified implementation, and record any divergence in
+// FIDELITY.md. Do not add a stub that returns an error — an unimplemented
+// method that compiles is exactly the silent-green failure mode this layer
+// must not introduce.
+package simgh
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/handarbeit/fabrik/engine"
+)
+
+// Sim implements engine.GitHubClient against an in-memory model backed by real
+// local git repositories.
+var _ engine.GitHubClient = (*Sim)(nil)
+
+// Clock supplies the current time. Every time-bearing value the model
+// produces — label applied-at, comment timestamps, project updated-at, rate
+// limit windows — is read from it, so a test can drive the engine's
+// time-anchored gates (the review-gate timeout, the CI settle scan, the
+// Done-archive scan, all of which key off FetchLabelAppliedAt) without
+// wall-clock waiting.
+type Clock interface {
+	Now() time.Time
+}
+
+// realClock is the default Clock, reading wall time.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// Sim is a simulated GitHub instance. The zero value is not usable; construct
+// one with New.
+type Sim struct {
+	// baseDir is the directory holding every backing bare repository. Callers
+	// normally pass t.TempDir().
+	baseDir string
+
+	clock Clock
+
+	// mu guards every field below it. See the package doc's locking invariant.
+	mu sync.Mutex
+
+	repos    map[string]*repoState    // keyed "owner/repo"
+	projects map[string]*projectState // keyed "owner:projectNum"
+
+	// defaultProject is the first project seeded, used by seeding helpers so a
+	// single-project scenario does not have to name it repeatedly.
+	defaultProject *projectState
+
+	nextCommentDatabaseID int
+	nextCheckRunID        int64
+
+	// restRate and graphqlRate back RateLimitStats. Modelled as static
+	// budgets that never deplete; see FIDELITY.md.
+	restRate    rateBudget
+	graphqlRate rateBudget
+
+	// seedErr holds the first error produced by a chained Seed* call. Checked
+	// with Err.
+	seedErr error
+}
+
+// rateBudget is the sim's static stand-in for a GitHub rate limit window.
+type rateBudget struct {
+	limit     int
+	remaining int
+	used      int
+	resetIn   time.Duration
+}
+
+// Option configures a Sim at construction.
+type Option func(*Sim)
+
+// WithClock substitutes the clock every time-bearing value is read from.
+func WithClock(c Clock) Option {
+	return func(s *Sim) { s.clock = c }
+}
+
+// WithRateLimits overrides the static rate-limit budgets reported by
+// RateLimitStats.
+func WithRateLimits(restLimit, restRemaining, graphqlLimit, graphqlRemaining int) Option {
+	return func(s *Sim) {
+		s.restRate = rateBudget{limit: restLimit, remaining: restRemaining, used: restLimit - restRemaining, resetIn: time.Hour}
+		s.graphqlRate = rateBudget{limit: graphqlLimit, remaining: graphqlRemaining, used: graphqlLimit - graphqlRemaining, resetIn: time.Hour}
+	}
+}
+
+// New constructs a Sim whose backing git repositories live under baseDir.
+// baseDir must exist and be writable; tests normally pass t.TempDir().
+func New(baseDir string, opts ...Option) *Sim {
+	s := &Sim{
+		baseDir:               baseDir,
+		clock:                 realClock{},
+		repos:                 make(map[string]*repoState),
+		projects:              make(map[string]*projectState),
+		nextCommentDatabaseID: 1000,
+		nextCheckRunID:        5000,
+		restRate:              rateBudget{limit: 5000, remaining: 5000, resetIn: time.Hour},
+		graphqlRate:           rateBudget{limit: 5000, remaining: 5000, resetIn: time.Hour},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// now reads the injected clock. Never call time.Now directly elsewhere in this
+// package — determinism for the engine's time-anchored gates depends on every
+// timestamp flowing through here.
+func (s *Sim) now() time.Time { return s.clock.Now() }
+
+// Err reports the first error recorded by a chained Seed* call, or nil. Seeding
+// uses the sticky-error builder idiom so a scenario reads as a short chain
+// rather than a ladder of error checks; call Err once at the end of setup.
+func (s *Sim) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.seedErr
+}
+
+// fail records a seeding error if none has been recorded yet. Caller must hold mu.
+func (s *Sim) fail(format string, args ...any) {
+	if s.seedErr == nil {
+		s.seedErr = fmt.Errorf(format, args...)
+	}
+}
+
+// repoKey normalises an owner and repo into the model's repo key.
+func repoKey(owner, repo string) string { return owner + "/" + repo }
+
+// projectKey normalises a project's owner-scoped identity. Projects v2 are
+// owned by a user or organisation, not by a repository, so project state is
+// keyed by (owner, number) — a repo parameter on a fetch is a query input, not
+// part of the project's identity.
+func projectKey(owner string, num int) string { return fmt.Sprintf("%s:%d", owner, num) }
+
+// lookupRepo returns the repo state for owner/repo. Caller must hold mu.
+func (s *Sim) lookupRepo(owner, repo string) (*repoState, error) {
+	r, ok := s.repos[repoKey(owner, repo)]
+	if !ok {
+		return nil, fmt.Errorf("simgh: repo %s not seeded", repoKey(owner, repo))
+	}
+	return r, nil
+}
+
+// repoDir is the on-disk path of a repo's backing bare repository.
+func (s *Sim) repoDir(owner, repo string) string {
+	return filepath.Join(s.baseDir, owner+"-"+repo+".git")
+}
+
+// ensureBaseDir creates baseDir if it does not exist.
+func (s *Sim) ensureBaseDir() error {
+	if err := os.MkdirAll(s.baseDir, 0o755); err != nil {
+		return fmt.Errorf("simgh: creating base dir %s: %w", s.baseDir, err)
+	}
+	return nil
+}

--- a/tests/sim/simgh/sim.go
+++ b/tests/sim/simgh/sim.go
@@ -92,6 +92,14 @@ type Sim struct {
 
 	clock Clock
 
+	// seedRepoMu serialises SeedRepo end to end. It is the only seeding call
+	// that runs git before publishing its state, so the check-then-publish
+	// sequence needs to be atomic against a concurrent caller for the same key
+	// — there is no repoState, and so no gitMu, in existence yet to serialise
+	// the git init. Taken at the outermost level only; never acquired while
+	// holding mu or gitMu.
+	seedRepoMu sync.Mutex
+
 	// mu guards every field below it. See the package doc's locking invariant.
 	mu sync.Mutex
 

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -1,6 +1,7 @@
 package simgh
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -632,5 +633,88 @@ func TestUpdateCommentBumpsParentPRUpdatedAt(t *testing.T) {
 
 	if got := firstItemFull(t, s).UpdatedAt; !got.After(before) {
 		t.Fatalf("item UpdatedAt = %v, want later than %v after editing a PR comment", got, before)
+	}
+}
+
+// TestSeedProjectItemRefusesUnresolvableTarget pins that a board card must
+// point at something that exists.
+//
+// buildProjectItem resolves a card's content through the repo's issues and
+// returns nil when it finds nothing, so a card seeded for a mistyped or
+// not-yet-seeded number was recorded and then silently omitted from every
+// board read — the scenario believes it built a board it did not. Every
+// sibling API in the package (SeedPR, SeedBlockedBy, AddBlockedByIssue,
+// AddProjectV2ItemById) already fails loudly on an unresolvable target; this
+// one was the gap.
+func TestSeedProjectItemRefusesUnresolvableTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ownerRepo string
+		number    int
+		wantErr   string
+	}{
+		{"missing issue", "acme/widgets", 999, "no issue acme/widgets#999"},
+		{"unseeded repo", "acme/other", 7, "repo acme/other not seeded"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := seedBasicBoard(t)
+			s.SeedProjectItem("acme", 2, tc.ownerRepo, tc.number, false, "Review")
+
+			err := s.Err()
+			if err == nil {
+				t.Fatal("SeedProjectItem reported success for an unresolvable target; " +
+					"the card would be silently absent from every board read")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want it to name %q", err, tc.wantErr)
+			}
+
+			// The refusal must not leave a half-built board behind: the only
+			// card is still the one seedBasicBoard placed.
+			board, boardErr := s.FetchProjectBoard("acme", "widgets", 2, "")
+			if boardErr != nil {
+				t.Fatalf("FetchProjectBoard: %v", boardErr)
+			}
+			if len(board.Items) != 1 {
+				t.Fatalf("board has %d items, want 1; the refused card was recorded anyway", len(board.Items))
+			}
+		})
+	}
+}
+
+// TestSeedRequiredApprovalsRefusesNonPositive pins that a zero approval
+// requirement is refused rather than modelled.
+//
+// With required = 0 the approvals-satisfied branch of FetchPRReviewDecision is
+// reached vacuously, so a PR with no reviews at all reports APPROVED — not a
+// reading real GitHub produces. "No review requirement" is already
+// representable as the absence of the call, and that absence returns ""
+// (GraphQL's null), the case whose engine-side fallback ADR-1250 makes
+// load-bearing. The two must not collapse into one silently.
+func TestSeedRequiredApprovalsRefusesNonPositive(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	s.SeedRequiredApprovals(repoName, "main", 0)
+	err := s.Err()
+	if err == nil {
+		t.Fatal("SeedRequiredApprovals accepted 0; a PR with no reviews would report APPROVED")
+	}
+	if !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("error = %v, want a 'must be positive' refusal", err)
+	}
+
+	// And the refusal must not have recorded the requirement anyway: an
+	// unseeded branch reports "" so the engine's own fallback stays exercised.
+	decision, decErr := s.FetchPRReviewDecision("acme", "widgets", 42)
+	if decErr != nil {
+		t.Fatalf("FetchPRReviewDecision: %v", decErr)
+	}
+	if decision != "" {
+		t.Fatalf("reviewDecision = %q, want \"\"; the refused requirement was recorded anyway", decision)
 	}
 }

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -1,6 +1,7 @@
 package simgh
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -972,4 +973,213 @@ func TestSeedIssueRefusesNegativeNumber(t *testing.T) {
 	if !strings.Contains(err.Error(), "not valid") {
 		t.Fatalf("error = %v, want a 'not valid' refusal", err)
 	}
+}
+
+// TestRemoveAbsentLabelReturnsErrNotFound pins that removing a label the issue
+// does not carry is an error, not a no-op.
+//
+// Production issues a DELETE that GitHub answers 404 for an absent label, and
+// roughly a dozen engine call sites branch on errors.Is(err, gh.ErrNotFound)
+// from this exact call. Returning nil would make every one of those branches
+// unreachable in a sim-backed test — a bug in the ErrNotFound-specific handling
+// would pass green here and fail against real GitHub.
+func TestRemoveAbsentLabelReturnsErrNotFound(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+
+	err := s.RemoveLabelFromIssue("acme", "widgets", 7, "fabrik:never-applied")
+	if err == nil {
+		t.Fatal("removing an absent label reported success; the engine's ErrNotFound branches are unreachable")
+	}
+	if !errors.Is(err, gh.ErrNotFound) {
+		t.Fatalf("error = %v, want it to wrap gh.ErrNotFound so errors.Is works as the engine expects", err)
+	}
+
+	// A real removal still succeeds — otherwise the assertion above would be
+	// satisfied by a method that simply always fails.
+	if err := s.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-ci"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+	if err := s.RemoveLabelFromIssue("acme", "widgets", 7, "fabrik:awaiting-ci"); err != nil {
+		t.Fatalf("removing a present label: %v", err)
+	}
+}
+
+// TestDismissedReviewDoesNotCountTowardApproval pins that a dismissal
+// supersedes the author's earlier verdict in the decision rollup.
+//
+// Filtering the raw history down to APPROVED/CHANGES_REQUESTED before
+// collapsing skips a later DISMISSED instead of letting it supersede, leaving a
+// dismissed approval counted. That reaches the authoritative review gate
+// directly: reviewGateAuthorityVerdict trusts an APPROVED decision outright, so
+// a scenario that dismisses an approval and expects the landing gate to hold
+// would see it clear.
+func TestDismissedReviewDoesNotCountTowardApproval(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"}).
+		SeedRequiredApprovals(repoName, "main", 1).
+		SeedReview(repoName, 42, gh.PRReview{Author: "carol", State: "APPROVED", Body: "lgtm"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	decision, err := s.FetchPRReviewDecision("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviewDecision: %v", err)
+	}
+	if decision != "APPROVED" {
+		t.Fatalf("decision = %q before dismissal, want APPROVED", decision)
+	}
+
+	s.SeedReview(repoName, 42, gh.PRReview{Author: "carol", State: "DISMISSED", Body: "stale"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding dismissal: %v", err)
+	}
+
+	decision, err = s.FetchPRReviewDecision("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviewDecision after dismissal: %v", err)
+	}
+	if decision != "REVIEW_REQUIRED" {
+		t.Fatalf("decision = %q after the approval was dismissed, want REVIEW_REQUIRED; "+
+			"a dismissed approval is still being counted", decision)
+	}
+
+	// The two reads must describe the same PR: FetchPRReviews already lets a
+	// dismissal supersede, so a decision computed by a different reduction
+	// would put the package in contradiction with itself.
+	reviews, err := s.FetchPRReviews("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 || reviews[0].State != "DISMISSED" {
+		t.Fatalf("FetchPRReviews = %+v, want carol's single DISMISSED entry", reviews)
+	}
+}
+
+// TestSeedRefusesNonCanonicalState pins that a state string outside GitHub's
+// own enum is refused rather than stored verbatim. Every downstream read
+// compares it exactly, so "closed" on an issue (or "Open" on a PR) would never
+// match and the record would be silently misclassified.
+func TestSeedRefusesNonCanonicalState(t *testing.T) {
+	t.Run("issue", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		s.SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "x", State: "closed"})
+		err := s.Err()
+		if err == nil {
+			t.Fatal(`SeedIssue accepted State "closed"; GitHub's issue enum is OPEN/CLOSED`)
+		}
+		if !strings.Contains(err.Error(), "not valid") {
+			t.Fatalf("error = %v, want a 'not valid' refusal", err)
+		}
+	})
+
+	t.Run("pr", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		seedCleanDivergence(t, s)
+		s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", State: "Open"})
+		err := s.Err()
+		if err == nil {
+			t.Fatal(`SeedPR accepted State "Open"; GitHub's PR enum is open/closed`)
+		}
+		if !strings.Contains(err.Error(), "not valid") {
+			t.Fatalf("error = %v, want a 'not valid' refusal", err)
+		}
+	})
+
+	// The canonical values must still be accepted, or the refusals above would
+	// be satisfied by an API that rejects every explicit state.
+	t.Run("canonical values accepted", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		seedCleanDivergence(t, s)
+		s.SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "x", State: "CLOSED"}).
+			SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", State: "closed"})
+		if err := s.Err(); err != nil {
+			t.Fatalf("canonical states rejected: %v", err)
+		}
+	})
+}
+
+// TestPRHeadEqualBaseIsRefused pins that a PR whose head is its base is refused
+// on both paths. GitHub answers "No commits between ...", and the shape is
+// degenerate here too — the trial merge collapses to the nothing-to-merge path.
+func TestPRHeadEqualBaseIsRefused(t *testing.T) {
+	t.Run("runtime", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		seedCleanDivergence(t, s)
+		if _, err := s.CreateDraftPR("acme", "widgets", "t", "main", "main", "body", 7); err == nil {
+			t.Fatal("CreateDraftPR accepted head == base")
+		} else if !strings.Contains(err.Error(), "head and base") {
+			t.Fatalf("error = %v, want a head-equals-base refusal", err)
+		}
+	})
+
+	t.Run("seeding", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		seedCleanDivergence(t, s)
+		s.SeedPR(repoName, PRSeed{Number: 42, Head: "main", Base: "main"})
+		err := s.Err()
+		if err == nil {
+			t.Fatal("SeedPR accepted head == base")
+		}
+		if !strings.Contains(err.Error(), "head and base") {
+			t.Fatalf("error = %v, want a head-equals-base refusal", err)
+		}
+	})
+}
+
+// TestReviewRequestNoOpDoesNotBumpUpdatedAt pins that a request that changes
+// nothing leaves the PR's updated-at alone, following AddLabelToIssue's
+// convention: engine gates anchor on observable change, so a spurious bump is a
+// change a scenario cannot distinguish from a real one.
+func TestReviewRequestNoOpDoesNotBumpUpdatedAt(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	if err := s.AddReviewRequest("acme", "widgets", 42, []string{"carol"}); err != nil {
+		t.Fatalf("AddReviewRequest: %v", err)
+	}
+
+	before := prUpdatedAt(t, s, 42)
+	// Time must move, or an unbumped timestamp is indistinguishable from a
+	// bumped one.
+	clk.Advance(time.Hour)
+
+	if err := s.AddReviewRequest("acme", "widgets", 42, []string{"carol"}); err != nil {
+		t.Fatalf("re-AddReviewRequest: %v", err)
+	}
+	if got := prUpdatedAt(t, s, 42); !got.Equal(before) {
+		t.Fatalf("re-requesting an outstanding reviewer bumped updated-at from %v to %v", before, got)
+	}
+
+	if err := s.DeleteReviewRequest("acme", "widgets", 42, []string{"dave"}); err != nil {
+		t.Fatalf("DeleteReviewRequest: %v", err)
+	}
+	if got := prUpdatedAt(t, s, 42); !got.Equal(before) {
+		t.Fatalf("withdrawing a reviewer who was not outstanding bumped updated-at from %v to %v", before, got)
+	}
+
+	// A real change must still bump, or the assertions above would be satisfied
+	// by a method that never bumps at all.
+	if err := s.DeleteReviewRequest("acme", "widgets", 42, []string{"carol"}); err != nil {
+		t.Fatalf("DeleteReviewRequest(carol): %v", err)
+	}
+	if got := prUpdatedAt(t, s, 42); !got.After(before) {
+		t.Fatalf("a real withdrawal did not bump updated-at (%v -> %v)", before, got)
+	}
+}
+
+// prUpdatedAt reads a PR's updated-at from the model.
+func prUpdatedAt(t *testing.T, s *Sim, prNumber int) time.Time {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, pr, err := s.prLocked("acme", "widgets", prNumber)
+	if err != nil {
+		t.Fatalf("prLocked: %v", err)
+	}
+	return pr.updatedAt
 }

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -730,6 +730,12 @@ func TestProbeReadsCardStateLive(t *testing.T) {
 	t.Run("a status move after the snapshot is reported", func(t *testing.T) {
 		s, _ := seedBasicBoard(t)
 		projectID, itemID := mustLookupItem(t, s)
+
+		s.mu.Lock()
+		p := s.projects[projectKey("acme", 2)]
+		ref := p.liveItemRefs()[0]
+		s.mu.Unlock()
+
 		field, err := s.FetchStatusField(projectID)
 		if err != nil {
 			t.Fatalf("FetchStatusField: %v", err)
@@ -738,31 +744,37 @@ func TestProbeReadsCardStateLive(t *testing.T) {
 			t.Fatalf("UpdateProjectItemStatus: %v", err)
 		}
 
-		probe, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+		probe, err := s.buildProbeItem(p, ref)
 		if err != nil {
-			t.Fatalf("ProbeProjectBoard: %v", err)
+			t.Fatalf("buildProbeItem: %v", err)
 		}
-		if len(probe) != 1 {
-			t.Fatalf("probe items = %d, want 1", len(probe))
+		if probe == nil {
+			t.Fatal("buildProbeItem dropped a live card")
 		}
-		if probe[0].Status != "Review" {
-			t.Fatalf("probe Status = %q, want %q", probe[0].Status, "Review")
+		if probe.Status != "Review" {
+			t.Fatalf("probe Status = %q, want %q; the probe used the stale snapshot", probe.Status, "Review")
 		}
 	})
 
 	t.Run("an archived card is absent", func(t *testing.T) {
 		s, _ := seedBasicBoard(t)
 		projectID, itemID := mustLookupItem(t, s)
+
+		s.mu.Lock()
+		p := s.projects[projectKey("acme", 2)]
+		ref := p.liveItemRefs()[0]
+		s.mu.Unlock()
+
 		if err := s.ArchiveProjectItem(projectID, itemID); err != nil {
 			t.Fatalf("ArchiveProjectItem: %v", err)
 		}
 
-		probe, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+		probe, err := s.buildProbeItem(p, ref)
 		if err != nil {
-			t.Fatalf("ProbeProjectBoard: %v", err)
+			t.Fatalf("buildProbeItem: %v", err)
 		}
-		if len(probe) != 0 {
-			t.Fatalf("probe still reports %d archived card(s)", len(probe))
+		if probe != nil {
+			t.Fatalf("probe still reports an archived card: %+v", probe)
 		}
 	})
 }

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -1,0 +1,432 @@
+package simgh
+
+import (
+	"testing"
+	"time"
+
+	"github.com/handarbeit/fabrik/engine"
+	gh "github.com/handarbeit/fabrik/github"
+)
+
+// TestSatisfiesGitHubClient pins Sim to the engine's interface at runtime as
+// well as at compile time, so the assertion is visible in test output rather
+// than only as a build failure.
+func TestSatisfiesGitHubClient(t *testing.T) {
+	var client engine.GitHubClient = New(t.TempDir())
+	if client == nil {
+		t.Fatal("Sim does not satisfy engine.GitHubClient")
+	}
+}
+
+// The tests below are the statefulness proofs: for each mutation, a read
+// afterwards must observe it. This is the property engine/mocks_test.go's
+// per-call hooks cannot express, and the whole reason this layer exists.
+
+func TestLabelAddRemoveIsObservable(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+
+	if err := s.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-ci"); err != nil {
+		t.Fatalf("AddLabelToIssue: %v", err)
+	}
+
+	labels, err := s.FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels: %v", err)
+	}
+	if !contains(labels, "fabrik:awaiting-ci") {
+		t.Fatalf("after add, labels = %v, want to contain fabrik:awaiting-ci", labels)
+	}
+
+	// The board projection must see it too — a mutation is observable by
+	// *every* subsequent read, not just the one that mirrors it.
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if !contains(board.Items[0].Labels, "fabrik:awaiting-ci") {
+		t.Fatalf("board item labels = %v, want to contain fabrik:awaiting-ci", board.Items[0].Labels)
+	}
+
+	// Applied-at is stamped from the injected clock, and re-adding an
+	// already-present label must not reset it: three engine mechanisms anchor
+	// timeouts on this instant.
+	appliedAt, err := s.FetchLabelAppliedAt("acme", "widgets", 7, "fabrik:awaiting-ci")
+	if err != nil {
+		t.Fatalf("FetchLabelAppliedAt: %v", err)
+	}
+	if !appliedAt.Equal(clk.Now()) {
+		t.Fatalf("appliedAt = %v, want clock time %v", appliedAt, clk.Now())
+	}
+	clk.Advance(time.Hour)
+	if err := s.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-ci"); err != nil {
+		t.Fatalf("re-AddLabelToIssue: %v", err)
+	}
+	again, err := s.FetchLabelAppliedAt("acme", "widgets", 7, "fabrik:awaiting-ci")
+	if err != nil {
+		t.Fatalf("FetchLabelAppliedAt after re-add: %v", err)
+	}
+	if !again.Equal(appliedAt) {
+		t.Fatalf("re-adding a present label moved appliedAt from %v to %v", appliedAt, again)
+	}
+
+	if err := s.RemoveLabelFromIssue("acme", "widgets", 7, "fabrik:awaiting-ci"); err != nil {
+		t.Fatalf("RemoveLabelFromIssue: %v", err)
+	}
+	labels, err = s.FetchLabels("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLabels after remove: %v", err)
+	}
+	if contains(labels, "fabrik:awaiting-ci") {
+		t.Fatalf("after remove, labels = %v, want fabrik:awaiting-ci gone", labels)
+	}
+}
+
+func TestCommentAddAndReactionAreObservable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+
+	id, err := s.AddComment("acme", "widgets", 7, "stage output")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("AddComment returned database ID 0")
+	}
+
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	comments := board.Items[0].Comments
+	if len(comments) != 1 || comments[0].Body != "stage output" {
+		t.Fatalf("comments = %+v, want one comment with body %q", comments, "stage output")
+	}
+	if comments[0].HasReaction("ROCKET") {
+		t.Fatal("fresh comment already has a ROCKET reaction")
+	}
+
+	// The rocket reaction is the engine's durable "already processed" state,
+	// so it must survive into every later read.
+	if err := s.AddCommentReaction("acme", "widgets", id, "ROCKET"); err != nil {
+		t.Fatalf("AddCommentReaction: %v", err)
+	}
+	board, err = s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard after reaction: %v", err)
+	}
+	if !board.Items[0].Comments[0].HasReaction("ROCKET") {
+		t.Fatalf("reaction not observable: %+v", board.Items[0].Comments[0].Reactions)
+	}
+
+	if err := s.UpdateComment("acme", "widgets", id, "edited output"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+	board, err = s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard after edit: %v", err)
+	}
+	if got := board.Items[0].Comments[0].Body; got != "edited output" {
+		t.Fatalf("comment body = %q, want %q", got, "edited output")
+	}
+}
+
+func TestIssueBodyUpdateIsObservable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+
+	body, err := s.GetIssueBody("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("GetIssueBody: %v", err)
+	}
+	if body != "spec body" {
+		t.Fatalf("seeded body = %q, want %q", body, "spec body")
+	}
+
+	if err := s.UpdateIssueBody("acme", "widgets", 7, "rewritten spec"); err != nil {
+		t.Fatalf("UpdateIssueBody: %v", err)
+	}
+
+	body, err = s.GetIssueBody("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("GetIssueBody after update: %v", err)
+	}
+	if body != "rewritten spec" {
+		t.Fatalf("body = %q, want %q", body, "rewritten spec")
+	}
+
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if board.Items[0].Body != "rewritten spec" {
+		t.Fatalf("board item body = %q, want %q", board.Items[0].Body, "rewritten spec")
+	}
+}
+
+func TestProjectStatusUpdateIsObservable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+
+	item := firstItem(t, s)
+	if item.status != "Implement" {
+		t.Fatalf("seeded status = %q, want Implement", item.status)
+	}
+
+	field, err := s.FetchStatusField(item.projectID)
+	if err != nil {
+		t.Fatalf("FetchStatusField: %v", err)
+	}
+	if len(field.OrderedOptionNames) != 4 || field.OrderedOptionNames[0] != "Backlog" {
+		t.Fatalf("ordered options = %v, want Backlog first of four", field.OrderedOptionNames)
+	}
+
+	if err := s.UpdateProjectItemStatus(item.projectID, item.itemID, field.FieldID, field.Options["Review"]); err != nil {
+		t.Fatalf("UpdateProjectItemStatus: %v", err)
+	}
+
+	if got := firstItem(t, s).status; got != "Review" {
+		t.Fatalf("board status = %q, want Review", got)
+	}
+	status, err := s.FetchProjectItemStatus(item.itemID)
+	if err != nil {
+		t.Fatalf("FetchProjectItemStatus: %v", err)
+	}
+	if status != "Review" {
+		t.Fatalf("FetchProjectItemStatus = %q, want Review", status)
+	}
+	batch, err := s.FetchProjectItemStatusBatch(item.projectID)
+	if err != nil {
+		t.Fatalf("FetchProjectItemStatusBatch: %v", err)
+	}
+	if batch[item.itemID] != "Review" {
+		t.Fatalf("batch[%s] = %q, want Review", item.itemID, batch[item.itemID])
+	}
+
+	// A foreign option ID must be refused rather than silently accepted —
+	// otherwise a test could "move" a card to a column that does not exist.
+	if err := s.UpdateProjectItemStatus(item.projectID, item.itemID, field.FieldID, "opt:bogus"); err == nil {
+		t.Fatal("UpdateProjectItemStatus accepted an unknown option ID")
+	}
+}
+
+func TestPRCreateReadyMergeIsObservable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	const repo = "acme/widgets"
+
+	s.SeedCommit(repo, "main", map[string]string{"README.md": "hello\n"}, "seed main").
+		SeedCommit(repo, "fabrik/issue-7", map[string]string{"feature.go": "package feature\n"}, "feature work")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding branches: %v", err)
+	}
+
+	num, err := s.CreateDraftPR("acme", "widgets", "Add a thing", "fabrik/issue-7", "main", "Closes #7", 7)
+	if err != nil {
+		t.Fatalf("CreateDraftPR: %v", err)
+	}
+
+	// Linkage is discovered by head branch, exactly as production does it.
+	found, err := s.FindPRForIssue("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FindPRForIssue: %v", err)
+	}
+	if found != num {
+		t.Fatalf("FindPRForIssue = %d, want %d", found, num)
+	}
+
+	pr, err := s.FetchLinkedPR("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR: %v", err)
+	}
+	if pr == nil || !pr.Draft {
+		t.Fatalf("linked PR = %+v, want a draft", pr)
+	}
+	if pr.HeadSHA != mustHeadSHA(t, s, repo, "fabrik/issue-7") {
+		t.Fatalf("linked PR head SHA = %q, want the branch tip", pr.HeadSHA)
+	}
+	// The list endpoint production reaches this through omits mergeable_state;
+	// reporting a computed value here would let a test pass on a signal
+	// production never receives.
+	if pr.MergeableState != "" {
+		t.Fatalf("FetchLinkedPR MergeableState = %q, want empty (list endpoint omits it)", pr.MergeableState)
+	}
+
+	if err := s.MarkPRReady("acme", "widgets", num); err != nil {
+		t.Fatalf("MarkPRReady: %v", err)
+	}
+	pr, err = s.FetchLinkedPR("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchLinkedPR after ready: %v", err)
+	}
+	if pr.Draft {
+		t.Fatal("PR still reports draft after MarkPRReady")
+	}
+
+	merged, err := s.FetchPRMerged("acme", "widgets", num)
+	if err != nil {
+		t.Fatalf("FetchPRMerged: %v", err)
+	}
+	if merged {
+		t.Fatal("PR reports merged before MergePR")
+	}
+
+	if err := s.MergePR("acme", "widgets", num); err != nil {
+		t.Fatalf("MergePR: %v", err)
+	}
+	merged, err = s.FetchPRMerged("acme", "widgets", num)
+	if err != nil {
+		t.Fatalf("FetchPRMerged after merge: %v", err)
+	}
+	if !merged {
+		t.Fatal("PR does not report merged after MergePR")
+	}
+
+	// GitHub auto-closes an issue a merged PR closes, when the merge lands on
+	// the default branch. The engine depends on that behaviour.
+	issue, err := s.FetchIssue("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchIssue: %v", err)
+	}
+	if issue.State != "closed" {
+		t.Fatalf("issue state = %q, want closed via the merged PR's Closes #7", issue.State)
+	}
+}
+
+func TestCloseIssueIsObservable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if board.Items[0].IsClosed {
+		t.Fatal("seeded issue already reports closed")
+	}
+
+	if err := s.CloseIssue("acme", "widgets", 7); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+
+	board, err = s.FetchProjectBoard("acme", "widgets", 2, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard after close: %v", err)
+	}
+	if !board.Items[0].IsClosed {
+		t.Fatal("board item does not report closed after CloseIssue")
+	}
+	issue, err := s.FetchIssue("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchIssue: %v", err)
+	}
+	if issue.State != "closed" {
+		t.Fatalf("issue state = %q, want closed", issue.State)
+	}
+}
+
+// TestBlockedByResolvesBlockerStateLive proves dependencies are resolved on
+// read rather than frozen at seed time — closing a blocker must unblock the
+// dependent issue on the next read, which is what the engine's dependency gate
+// polls for.
+func TestBlockedByResolvesBlockerStateLive(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "blocker", Status: "Implement"}).
+		SeedBlockedBy("acme/widgets", 7, "acme/widgets", 8)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	item, err := s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if len(item.BlockedBy) != 1 || item.BlockedBy[0].State != "OPEN" {
+		t.Fatalf("blockedBy = %+v, want one OPEN dependency", item.BlockedBy)
+	}
+
+	if err := s.CloseIssue("acme", "widgets", 8); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+
+	item, err = s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem after close: %v", err)
+	}
+	if item.BlockedBy[0].State != "CLOSED" {
+		t.Fatalf("blocker state = %q, want CLOSED after the blocker was closed", item.BlockedBy[0].State)
+	}
+}
+
+// TestReviewThreadResolutionIsObservable covers the review-thread half of the
+// comment surface: an unresolved thread surfaces on the board item, and
+// resolving it both removes it and bumps the resolved count the engine's
+// progress detection reads.
+func TestReviewThreadResolutionIsObservable(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	const repo = "acme/widgets"
+
+	s.SeedCommit(repo, "fabrik/issue-7", map[string]string{"a.go": "package a\n"}, "work").
+		SeedPR(repo, PRSeed{Number: 42, Head: "fabrik/issue-7", Title: "Add a thing"}).
+		SeedReviewThreadComment(repo, 42, "reviewer", "please fix", "a.go", 1)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	item, err := s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if len(item.LinkedPRReviewThreadComments) != 1 {
+		t.Fatalf("thread comments = %d, want 1", len(item.LinkedPRReviewThreadComments))
+	}
+	threadID := item.LinkedPRReviewThreadComments[0].ReviewThreadID
+	if item.LinkedPRResolvedThreadCount != 0 {
+		t.Fatalf("resolved count = %d, want 0", item.LinkedPRResolvedThreadCount)
+	}
+
+	if err := s.ResolveReviewThread(threadID); err != nil {
+		t.Fatalf("ResolveReviewThread: %v", err)
+	}
+
+	item, err = s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem after resolve: %v", err)
+	}
+	if len(item.LinkedPRReviewThreadComments) != 0 {
+		t.Fatalf("resolved thread still surfaces as unresolved: %+v", item.LinkedPRReviewThreadComments)
+	}
+	if item.LinkedPRResolvedThreadCount != 1 {
+		t.Fatalf("resolved count = %d, want 1", item.LinkedPRResolvedThreadCount)
+	}
+}
+
+// TestReviewDecisionEmptyWithoutBranchProtection covers the case the engine's
+// authoritative review gate falls back on: GraphQL's reviewDecision is null
+// unless branch protection actually requires reviews.
+func TestReviewDecisionEmptyWithoutBranchProtection(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	const repo = "acme/widgets"
+
+	s.SeedCommit(repo, "fabrik/issue-7", map[string]string{"a.go": "package a\n"}, "work").
+		SeedPR(repo, PRSeed{Number: 42, Head: "fabrik/issue-7"}).
+		SeedReview(repo, 42, gh.PRReview{Author: "reviewer", State: "CHANGES_REQUESTED", Body: "no"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	decision, err := s.FetchPRReviewDecision("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviewDecision: %v", err)
+	}
+	if decision != "" {
+		t.Fatalf("decision = %q, want empty with no branch protection configured", decision)
+	}
+
+	// With a requirement configured, the same reviews now produce a decision.
+	s.SeedRequiredApprovals(repo, "main", 1)
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding approvals: %v", err)
+	}
+	decision, err = s.FetchPRReviewDecision("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviewDecision with protection: %v", err)
+	}
+	if decision != "CHANGES_REQUESTED" {
+		t.Fatalf("decision = %q, want CHANGES_REQUESTED", decision)
+	}
+}

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -718,3 +718,246 @@ func TestSeedRequiredApprovalsRefusesNonPositive(t *testing.T) {
 		t.Fatalf("reviewDecision = %q, want \"\"; the refused requirement was recorded anyway", decision)
 	}
 }
+
+// TestProbeReadsCardStateLive pins that the probe reports the card's state at
+// projection time, not at snapshot time — the same property buildProjectItem
+// has, in the sibling that feeds the engine's idle poll.
+//
+// A stale answer matters more here than on a full board read: the probe is
+// what the poll consults to decide whether anything changed, so a stale column
+// is a poll that does not notice work it should.
+func TestProbeReadsCardStateLive(t *testing.T) {
+	t.Run("a status move after the snapshot is reported", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		projectID, itemID := mustLookupItem(t, s)
+		field, err := s.FetchStatusField(projectID)
+		if err != nil {
+			t.Fatalf("FetchStatusField: %v", err)
+		}
+		if err := s.UpdateProjectItemStatus(projectID, itemID, field.FieldID, field.Options["Review"]); err != nil {
+			t.Fatalf("UpdateProjectItemStatus: %v", err)
+		}
+
+		probe, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+		if err != nil {
+			t.Fatalf("ProbeProjectBoard: %v", err)
+		}
+		if len(probe) != 1 {
+			t.Fatalf("probe items = %d, want 1", len(probe))
+		}
+		if probe[0].Status != "Review" {
+			t.Fatalf("probe Status = %q, want %q", probe[0].Status, "Review")
+		}
+	})
+
+	t.Run("an archived card is absent", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		projectID, itemID := mustLookupItem(t, s)
+		if err := s.ArchiveProjectItem(projectID, itemID); err != nil {
+			t.Fatalf("ArchiveProjectItem: %v", err)
+		}
+
+		probe, _, err := s.ProbeProjectBoard("acme", "widgets", 2, "organization")
+		if err != nil {
+			t.Fatalf("ProbeProjectBoard: %v", err)
+		}
+		if len(probe) != 0 {
+			t.Fatalf("probe still reports %d archived card(s)", len(probe))
+		}
+	})
+}
+
+// TestFetchPRReviewsCollapsesToLatestPerAuthor pins production's reduction rule.
+//
+// github.Client.FetchPRReviews reduces the REST endpoint's full submission
+// history to one entry per author, and the engine's review-gate call sites
+// consume the result assuming that already happened. A raw list would leave a
+// superseded CHANGES_REQUESTED visible forever — blocking a gate real GitHub
+// would have cleared, and disagreeing with FetchPRReviewDecision on the same PR.
+func TestFetchPRReviewsCollapsesToLatestPerAuthor(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"}).
+		SeedReview(repoName, 42, gh.PRReview{Author: "carol", State: "CHANGES_REQUESTED", Body: "needs work"}).
+		SeedReview(repoName, 42, gh.PRReview{Author: "dave", State: "APPROVED", Body: "lgtm"}).
+		SeedReview(repoName, 42, gh.PRReview{Author: "carol", State: "APPROVED", Body: "fixed now"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	reviews, err := s.FetchPRReviews("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 2 {
+		t.Fatalf("got %d reviews, want 2 (one per author); the history was not collapsed", len(reviews))
+	}
+	// First-submission order is preserved, so carol stays first.
+	if reviews[0].Author != "carol" || reviews[0].State != "APPROVED" {
+		t.Fatalf("reviews[0] = %s/%s, want carol/APPROVED; the stale verdict outlived the later one",
+			reviews[0].Author, reviews[0].State)
+	}
+	if reviews[1].Author != "dave" || reviews[1].State != "APPROVED" {
+		t.Fatalf("reviews[1] = %s/%s, want dave/APPROVED", reviews[1].Author, reviews[1].State)
+	}
+
+	// A COMMENTED follow-up must NOT supersede a formal verdict — GitHub treats
+	// it as informational, not a state transition. Pinning this direction too,
+	// or "latest wins" would be indistinguishable from "last write wins".
+	s.SeedReview(repoName, 42, gh.PRReview{Author: "dave", State: "COMMENTED", Body: "one more thought"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding follow-up: %v", err)
+	}
+	reviews, err = s.FetchPRReviews("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews after comment: %v", err)
+	}
+	if reviews[1].State != "APPROVED" {
+		t.Fatalf("dave's verdict = %q after a COMMENTED follow-up, want APPROVED", reviews[1].State)
+	}
+
+	// The board projection sources the same field from GraphQL's latestReviews,
+	// so it must agree. Two reads of one model reporting two answers is a bug
+	// the sim would be introducing.
+	item, err := s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if len(item.LinkedPRReviews) != len(reviews) {
+		t.Fatalf("board projection has %d reviews, FetchPRReviews has %d; the two reads disagree",
+			len(item.LinkedPRReviews), len(reviews))
+	}
+}
+
+// TestRepoDirsDoNotCollide pins that two distinct owner/repo pairs never share
+// one backing repository.
+//
+// Joining owner and repo with a separator is not collision-free:
+// "acme-widgets/foo" and "acme/widgets-foo" flatten to the same name. Since the
+// already-seeded check is keyed on the full "owner/repo" string, both would be
+// accepted and would produce two repoStates — each with its own gitMu — over
+// one physical repo, voiding the per-repo git serialisation everything rests on.
+func TestRepoDirsDoNotCollide(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo("acme-widgets/foo").
+		SeedRepo("acme/widgets-foo")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding two distinct repos: %v", err)
+	}
+
+	a, err := s.repoByKey("acme-widgets/foo")
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	b, err := s.repoByKey("acme/widgets-foo")
+	if err != nil {
+		t.Fatalf("repoByKey: %v", err)
+	}
+	if a.bareDir == b.bareDir {
+		t.Fatalf("both repos share the backing directory %s; their gitMus guard one repository", a.bareDir)
+	}
+
+	// And the sharing must be observable as such: a commit on one must not
+	// appear in the other.
+	s.SeedCommit("acme-widgets/foo", "only-in-a", map[string]string{"a.txt": "a"}, "a")
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedCommit: %v", err)
+	}
+	if _, err := s.HeadSHA("acme/widgets-foo", "only-in-a"); err == nil {
+		t.Fatal("a branch seeded in one repo is visible in the other; they share a backing repository")
+	}
+}
+
+// TestSeedPRRefusesImpossibleShapes pins that the seeding API will not build a
+// PR state GitHub cannot produce. A scenario driving the engine from an
+// impossible state can pass for a reason production never delivers.
+func TestSeedPRRefusesImpossibleShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		seed    PRSeed
+		wantErr string
+	}{
+		{"merged and draft", PRSeed{Number: 42, Draft: true, Merged: true}, "both merged and draft"},
+		{"merged and open", PRSeed{Number: 42, Merged: true, State: "open"}, "merged and open"},
+		{"negative number", PRSeed{Number: -3}, "not valid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := seedBasicBoard(t)
+			seedCleanDivergence(t, s)
+			seed := tc.seed
+			seed.Head = headBranch
+			seed.Base = "main"
+			s.SeedPR(repoName, seed)
+
+			err := s.Err()
+			if err == nil {
+				t.Fatalf("SeedPR accepted %+v; GitHub cannot produce that shape", tc.seed)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want it to name %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	// Merged with State unspecified is the ordinary case and must be accepted,
+	// resolving to closed — otherwise the refusals above would be satisfied by
+	// a seed API that simply rejects Merged outright.
+	t.Run("merged defaults to closed", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		seedCleanDivergence(t, s)
+		s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Merged: true})
+		if err := s.Err(); err != nil {
+			t.Fatalf("SeedPR(Merged) rejected: %v", err)
+		}
+		prs, err := s.ListPRs("acme", "widgets")
+		if err != nil {
+			t.Fatalf("ListPRs: %v", err)
+		}
+		if len(prs) != 1 || prs[0].State != "closed" || !prs[0].Merged {
+			t.Fatalf("PR = %+v, want merged and closed", prs)
+		}
+	})
+}
+
+// TestSelfBlockIsRefused pins that an issue cannot be recorded as blocking
+// itself, on either the runtime or the seeding path. A self-block is
+// unsatisfiable, so the engine's dependency gate would hold the issue forever
+// with nothing to diagnose.
+func TestSelfBlockIsRefused(t *testing.T) {
+	t.Run("runtime", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		id := "issue:acme/widgets#7"
+		if err := s.AddBlockedByIssue(id, id); err == nil {
+			t.Fatal("AddBlockedByIssue accepted a self-block")
+		} else if !strings.Contains(err.Error(), "cannot block itself") {
+			t.Fatalf("error = %v, want a self-block refusal", err)
+		}
+	})
+
+	t.Run("seeding", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		s.SeedBlockedBy("acme/widgets", 7, "acme/widgets", 7)
+		err := s.Err()
+		if err == nil {
+			t.Fatal("SeedBlockedBy accepted a self-block")
+		}
+		if !strings.Contains(err.Error(), "cannot block itself") {
+			t.Fatalf("error = %v, want a self-block refusal", err)
+		}
+	})
+}
+
+// TestSeedIssueRefusesNegativeNumber pins that an explicit number GitHub could
+// never assign is refused. reserveNumber is a no-op below nextNumber, so a
+// negative number would be accepted silently and embedded in node IDs.
+func TestSeedIssueRefusesNegativeNumber(t *testing.T) {
+	s, _ := seedBasicBoard(t)
+	s.SeedIssue("acme/widgets", IssueSeed{Number: -3, Title: "impossible"})
+	err := s.Err()
+	if err == nil {
+		t.Fatal("SeedIssue accepted a negative number")
+	}
+	if !strings.Contains(err.Error(), "not valid") {
+		t.Fatalf("error = %v, want a 'not valid' refusal", err)
+	}
+}

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -521,3 +521,81 @@ func TestAssigneesAreObservableFromBothPaths(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateCommentBumpsParentIssueUpdatedAt pins that editing a comment marks
+// the parent issue as changed, the way GitHub's updated_at does.
+//
+// The engine takes this path for real: it rewrites an existing stage comment
+// rather than posting a new one (engine/comments.go, engine/dependencies.go).
+// An unbumped timestamp would make that edit invisible to any read that watches
+// updatedAt to decide something changed.
+func TestUpdateCommentBumpsParentIssueUpdatedAt(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+
+	commentID, err := s.AddComment("acme", "widgets", 7, "original")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	before := firstItemFull(t, s).UpdatedAt
+
+	// Advance first, or a bumped timestamp is indistinguishable from a stale one.
+	clk.Advance(time.Hour)
+
+	if err := s.UpdateComment("acme", "widgets", commentID, "edited"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+
+	item := firstItemFull(t, s)
+	if !item.UpdatedAt.After(before) {
+		t.Fatalf("issue UpdatedAt = %v, want later than %v after a comment edit", item.UpdatedAt, before)
+	}
+	// The edit itself must still be observable — a bump alone proves nothing.
+	if len(item.Comments) != 1 || item.Comments[0].Body != "edited" {
+		t.Fatalf("comment body = %+v, want the edited text", item.Comments)
+	}
+}
+
+// TestFetchItemDetailsPrefersItemIDAcrossProjects pins that the item ID decides
+// which card is backfilled when one issue sits on two boards.
+//
+// This is a supported arrangement, not a pathological one: Fabrik's own guidance
+// puts a report on a public triage board and the engine work on a private board
+// at the same time. Item IDs embed the project, content node IDs do not — so
+// matching either ID interchangeably let Go's randomised map order pick a board,
+// and FetchItemDetails could backfill the other board's Status.
+func TestFetchItemDetailsPrefersItemIDAcrossProjects(t *testing.T) {
+	s, _ := newSim(t)
+	s.SeedRepo(repoName).
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"}).
+		SeedProject("acme", 3, "Triage", []string{"Backlog", "Implement", "Review", "Done"}).
+		SeedIssue(repoName, IssueSeed{Number: 7, Title: "on two boards", Status: "Implement"}).
+		SeedProjectItem("acme", 3, repoName, 7, false, "Review")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// Ask for the Triage board's card specifically, by its item ID.
+	triage, err := s.FetchProjectBoard("acme", "widgets", 3, "organization")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	if len(triage.Items) != 1 {
+		t.Fatalf("triage board has %d items, want 1", len(triage.Items))
+	}
+	wantItemID := triage.Items[0].ItemID
+
+	// Repeat: the bug this pins is a randomised map order, so a single pass can
+	// pick the right board by luck.
+	for i := 0; i < 20; i++ {
+		probe := &gh.ProjectItem{ID: triage.Items[0].ID, ItemID: wantItemID}
+		if err := s.FetchItemDetails(probe); err != nil {
+			t.Fatalf("FetchItemDetails: %v", err)
+		}
+		if probe.ItemID != wantItemID {
+			t.Fatalf("run %d: ItemID = %q, want the Triage card %q", i, probe.ItemID, wantItemID)
+		}
+		if probe.Status != "Review" {
+			t.Fatalf("run %d: Status = %q, want Review (the Triage column), not the Engineering board's", i, probe.Status)
+		}
+	}
+}

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -2,6 +2,8 @@ package simgh
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1182,4 +1184,218 @@ func prUpdatedAt(t *testing.T, s *Sim, prNumber int) time.Time {
 		t.Fatalf("prLocked: %v", err)
 	}
 	return pr.updatedAt
+}
+
+// TestNoOpBoardMutationsDoNotBump pins the no-op timestamp convention on the
+// two board mutations that were still bumping unconditionally.
+//
+// FetchProjectUpdatedAt gates whether the engine's idle poll looks at the board
+// at all, so a bump for a mutation that changed nothing is a wake signal real
+// GitHub does not produce — and one a scenario cannot tell from a real change.
+// AddLabelToIssue, AddReviewRequest, AddProjectV2ItemById, and
+// placeOnProjectLocked already follow this rule; these two were the holdouts.
+func TestNoOpBoardMutationsDoNotBump(t *testing.T) {
+	t.Run("re-archiving an archived card", func(t *testing.T) {
+		s, clk := seedBasicBoard(t)
+		projectID, itemID := mustLookupItem(t, s)
+		if err := s.ArchiveProjectItem(projectID, itemID); err != nil {
+			t.Fatalf("ArchiveProjectItem: %v", err)
+		}
+
+		before, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt: %v", err)
+		}
+		// Time must move, or an unbumped timestamp is indistinguishable from a
+		// bumped one.
+		clk.Advance(time.Hour)
+
+		if err := s.ArchiveProjectItem(projectID, itemID); err != nil {
+			t.Fatalf("re-ArchiveProjectItem: %v", err)
+		}
+		after, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt after re-archive: %v", err)
+		}
+		if !after.Equal(before) {
+			t.Fatalf("re-archiving bumped the project updated-at from %v to %v", before, after)
+		}
+	})
+
+	t.Run("moving a card to the column it already occupies", func(t *testing.T) {
+		s, clk := seedBasicBoard(t)
+		projectID, itemID := mustLookupItem(t, s)
+		field, err := s.FetchStatusField(projectID)
+		if err != nil {
+			t.Fatalf("FetchStatusField: %v", err)
+		}
+
+		before, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt: %v", err)
+		}
+		clk.Advance(time.Hour)
+
+		// The card was seeded into Implement.
+		if err := s.UpdateProjectItemStatus(projectID, itemID, field.FieldID, field.Options["Implement"]); err != nil {
+			t.Fatalf("UpdateProjectItemStatus: %v", err)
+		}
+		after, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt after same-column move: %v", err)
+		}
+		if !after.Equal(before) {
+			t.Fatalf("a same-column move bumped the project updated-at from %v to %v", before, after)
+		}
+
+		// A real move must still bump, or the assertion above would be
+		// satisfied by a method that never bumps at all.
+		if err := s.UpdateProjectItemStatus(projectID, itemID, field.FieldID, field.Options["Review"]); err != nil {
+			t.Fatalf("UpdateProjectItemStatus(Review): %v", err)
+		}
+		moved, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt after a real move: %v", err)
+		}
+		if !moved.After(before) {
+			t.Fatalf("a real column move did not bump updated-at (%v -> %v)", before, moved)
+		}
+	})
+}
+
+// TestGitIgnoresTheInvokingUsersGlobalConfig pins that this package's git
+// subprocesses do not inherit ~/.gitconfig.
+//
+// This is the one correctness issue here that breaks the package for someone
+// other than its author. commit.gpgsign=true is a common developer and CI
+// setting, and without isolation every commit-writing operation in this package
+// fails or hangs on a GPG prompt for reasons unrelated to the code under test.
+// core.hooksPath and commit.template do the same in different ways.
+//
+// The test provokes it directly: a global config that would make any inheriting
+// commit fail. It must not.
+func TestGitIgnoresTheInvokingUsersGlobalConfig(t *testing.T) {
+	skipIfNoGit(t)
+
+	home := t.TempDir()
+	cfg := "[commit]\n\tgpgsign = true\n[gpg]\n\tprogram = /nonexistent/gpg-that-does-not-exist\n"
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("writing global gitconfig: %v", err)
+	}
+	// Both are consulted for the global layer; set them together so the test
+	// does not depend on which one the host happens to use.
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+
+	s := New(t.TempDir())
+	s.SeedRepo("acme/widgets").
+		SeedCommit("acme/widgets", "main", map[string]string{"a.txt": "a\n"}, "a commit")
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding under a hostile global gitconfig: %v\n"+
+			"git subprocesses are inheriting ~/.gitconfig; they must not", err)
+	}
+	if _, err := s.HeadSHA("acme/widgets", "main"); err != nil {
+		t.Fatalf("HeadSHA: %v", err)
+	}
+}
+
+// TestUpdatePRBaseRefusesHeadAsBase pins the same "No commits between ..."
+// refusal createPR and SeedPR already carry, on the one path that could still
+// arrive at that shape after the PR exists.
+func TestUpdatePRBaseRefusesHeadAsBase(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+	seedCleanDivergence(t, s)
+	s.SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	err := s.UpdatePRBase("acme", "widgets", 42, headBranch)
+	if err == nil {
+		t.Fatal("UpdatePRBase retargeted a PR onto its own head branch")
+	}
+	if !strings.Contains(err.Error(), "its head branch") {
+		t.Fatalf("error = %v, want a head-as-base refusal", err)
+	}
+	base, err := s.GetPRBase("acme", "widgets", 42)
+	if err != nil {
+		t.Fatalf("GetPRBase: %v", err)
+	}
+	if base != "main" {
+		t.Fatalf("base = %q after a refused retarget, want main", base)
+	}
+
+	// Retargeting to the base it already has is a no-op and must not bump.
+	before := prUpdatedAt(t, s, 42)
+	clk.Advance(time.Hour)
+	if err := s.UpdatePRBase("acme", "widgets", 42, "main"); err != nil {
+		t.Fatalf("UpdatePRBase(main): %v", err)
+	}
+	if got := prUpdatedAt(t, s, 42); !got.Equal(before) {
+		t.Fatalf("retargeting to the current base bumped updated-at from %v to %v", before, got)
+	}
+
+	// A real retarget must still work and bump.
+	s.SeedBranch(repoName, "release", "main")
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedBranch: %v", err)
+	}
+	if err := s.UpdatePRBase("acme", "widgets", 42, "release"); err != nil {
+		t.Fatalf("UpdatePRBase(release): %v", err)
+	}
+	if got := prUpdatedAt(t, s, 42); !got.After(before) {
+		t.Fatalf("a real retarget did not bump updated-at (%v -> %v)", before, got)
+	}
+}
+
+// TestSeedBlockedByDedupesAndStamps pins that the seeding path agrees with
+// AddBlockedByIssue about what a repeated dependency link means: GitHub
+// silently ignores a duplicate, and a link that is recorded bumps the issue.
+func TestSeedBlockedByDedupesAndStamps(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+	s.SeedIssue("acme/widgets", IssueSeed{Number: 8, Title: "blocker", Status: "Implement"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	before := issueUpdatedAt(t, s, 7)
+	clk.Advance(time.Hour)
+
+	s.SeedBlockedBy("acme/widgets", 7, "acme/widgets", 8)
+	if err := s.Err(); err != nil {
+		t.Fatalf("SeedBlockedBy: %v", err)
+	}
+	stamped := issueUpdatedAt(t, s, 7)
+	if !stamped.After(before) {
+		t.Fatalf("recording a dependency did not bump the issue's updated-at (%v -> %v)", before, stamped)
+	}
+
+	clk.Advance(time.Hour)
+	s.SeedBlockedBy("acme/widgets", 7, "acme/widgets", 8)
+	if err := s.Err(); err != nil {
+		t.Fatalf("duplicate SeedBlockedBy reported an error; GitHub ignores duplicates: %v", err)
+	}
+
+	item, err := s.FetchProjectItem("acme", "widgets", 7)
+	if err != nil {
+		t.Fatalf("FetchProjectItem: %v", err)
+	}
+	if len(item.BlockedBy) != 1 {
+		t.Fatalf("blockedBy = %+v, want one entry; the duplicate was not deduped", item.BlockedBy)
+	}
+	if got := issueUpdatedAt(t, s, 7); !got.Equal(stamped) {
+		t.Fatalf("a deduped duplicate bumped updated-at from %v to %v", stamped, got)
+	}
+}
+
+// issueUpdatedAt reads an issue's updated-at from the model.
+func issueUpdatedAt(t *testing.T, s *Sim, issueNumber int) time.Time {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	iss, err := s.issueLocked("acme", "widgets", issueNumber)
+	if err != nil {
+		t.Fatalf("issueLocked: %v", err)
+	}
+	return iss.updatedAt
 }

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -430,3 +430,94 @@ func TestReviewDecisionEmptyWithoutBranchProtection(t *testing.T) {
 		t.Fatalf("decision = %q, want CHANGES_REQUESTED", decision)
 	}
 }
+
+// TestAssigneesAreObservableFromBothPaths pins that an issue's assignees survive
+// to ProjectItem.Assignees whether the issue was seeded or created at runtime.
+//
+// Both halves matter. CreateIssue grew its assignees parameter when production
+// did (engine/spawn.go assigns every spawned child to the configured user), and
+// the field is only useful if it reads back — a stored-but-never-projected
+// assignee would let a spawn scenario assert on nil and pass for the wrong
+// reason. Seeding is covered alongside it because a seed API that cannot express
+// what the runtime API accepts is the seed/runtime asymmetry this package has
+// had to correct repeatedly.
+func TestAssigneesAreObservableFromBothPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// place returns the issue number it put on the board.
+		place func(t *testing.T, s *Sim) int
+	}{
+		{
+			name: "seeded",
+			place: func(t *testing.T, s *Sim) int {
+				t.Helper()
+				s.SeedIssue(repoName, IssueSeed{
+					Number:    11,
+					Title:     "seeded",
+					Assignees: []string{"alice"},
+					Status:    "Implement",
+				})
+				if err := s.Err(); err != nil {
+					t.Fatalf("SeedIssue: %v", err)
+				}
+				return 11
+			},
+		},
+		{
+			name: "created at runtime",
+			place: func(t *testing.T, s *Sim) int {
+				t.Helper()
+				num, nodeID, err := s.CreateIssue("acme", "widgets", "runtime", "body", []string{"alice"})
+				if err != nil {
+					t.Fatalf("CreateIssue: %v", err)
+				}
+				board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+				if err != nil {
+					t.Fatalf("FetchProjectBoard: %v", err)
+				}
+				if _, err := s.AddProjectV2ItemById(board.ProjectID, nodeID); err != nil {
+					t.Fatalf("AddProjectV2ItemById: %v", err)
+				}
+				return num
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newSim(t)
+			s.SeedRepo(repoName).
+				SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"})
+			if err := s.Err(); err != nil {
+				t.Fatalf("seeding: %v", err)
+			}
+
+			num := tc.place(t, s)
+
+			board, err := s.FetchProjectBoard("acme", "widgets", 2, "organization")
+			if err != nil {
+				t.Fatalf("FetchProjectBoard: %v", err)
+			}
+			var found *gh.ProjectItem
+			for i := range board.Items {
+				if board.Items[i].Number == num {
+					found = &board.Items[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatalf("issue #%d is not on the board", num)
+			}
+			// Assert after the deep fetch, which is the phase that populates
+			// assignees in production. The sim currently also fills them on the
+			// shallow board read (see FIDELITY.md, "Shallow board reads return
+			// deep-phase fields"); going through FetchItemDetails keeps this
+			// test correct either way, so narrowing the shallow path later
+			// cannot silently turn it vacuous.
+			if err := s.FetchItemDetails(found); err != nil {
+				t.Fatalf("FetchItemDetails: %v", err)
+			}
+			if len(found.Assignees) != 1 || found.Assignees[0] != "alice" {
+				t.Fatalf("Assignees = %v, want [alice]", found.Assignees)
+			}
+		})
+	}
+}

--- a/tests/sim/simgh/state_test.go
+++ b/tests/sim/simgh/state_test.go
@@ -599,3 +599,38 @@ func TestFetchItemDetailsPrefersItemIDAcrossProjects(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateCommentBumpsParentPRUpdatedAt is the PR half of the comment-edit
+// timestamp rule. It is pinned separately because the two branches are
+// separate code paths, and a single test could not show that both work.
+//
+// The PR's timestamp is observable: buildProjectItem folds a linked PR's
+// updatedAt into the board item's UpdatedAt, and ProbeProjectBoard surfaces it
+// as LinkedPRUpdatedAt.
+func TestUpdateCommentBumpsParentPRUpdatedAt(t *testing.T) {
+	s, clk := seedBasicBoard(t)
+	s.SeedCommit(repoName, "main", map[string]string{"README.md": "hello\n"}, "seed main").
+		SeedCommit(repoName, headBranch, map[string]string{"feature.go": "package feature\n"}, "work").
+		SeedPR(repoName, PRSeed{Number: 42, Head: headBranch, Base: "main", Title: "a PR"})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	// #42 is a PR, so this comment lands on the PR, not the issue.
+	commentID, err := s.AddComment("acme", "widgets", 42, "original")
+	if err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	before := firstItemFull(t, s).UpdatedAt
+
+	// Advance first, or a bumped timestamp is indistinguishable from a stale one.
+	clk.Advance(time.Hour)
+
+	if err := s.UpdateComment("acme", "widgets", commentID, "edited"); err != nil {
+		t.Fatalf("UpdateComment: %v", err)
+	}
+
+	if got := firstItemFull(t, s).UpdatedAt; !got.After(before) {
+		t.Fatalf("item UpdatedAt = %v, want later than %v after editing a PR comment", got, before)
+	}
+}

--- a/tests/sim/simgh/timestamps_test.go
+++ b/tests/sim/simgh/timestamps_test.go
@@ -1,0 +1,161 @@
+package simgh
+
+import (
+	"testing"
+	"time"
+)
+
+// advancingClock moves forward on every read, the way the default realClock
+// does. The rest of the suite uses the fixed fakeClock, which makes two
+// s.now() reads in one mutation indistinguishable from one — so a coherence
+// bug in timestamp handling is invisible to every other test in the package.
+type advancingClock struct {
+	t    time.Time
+	step time.Duration
+}
+
+func newAdvancingClock() *advancingClock {
+	return &advancingClock{
+		t:    time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+		step: time.Second,
+	}
+}
+
+func (c *advancingClock) Now() time.Time {
+	c.t = c.t.Add(c.step)
+	return c.t
+}
+
+// simWithAdvancingClock is newSim with a clock that ticks on every read.
+func simWithAdvancingClock(t *testing.T) *Sim {
+	t.Helper()
+	skipIfNoGit(t)
+	return New(t.TempDir(), WithClock(newAdvancingClock()))
+}
+
+// TestOneMutationStampsOneTimestamp pins that a single mutation reads the clock
+// once and stamps every field it touches with that one value.
+//
+// This is a coherence property, not a cosmetic one. A mutation that reads the
+// clock per field lets an item's timestamp and its owning project's — or a
+// label's applied-at and its issue's updated-at — disagree for what GitHub
+// reports as one event. The engine reads exactly these pairs against each
+// other: FetchProjectUpdatedAt gates whether a poll bothers to look at the
+// board at all, and FetchLabelAppliedAt is the timing anchor for the review
+// gate, the CI settle scan, and the Done-archive scan.
+//
+// The whole test hangs on the clock: under the fixed fakeClock every ordering
+// produces equal timestamps and the assertions below hold vacuously, which is
+// exactly why it uses an advancing one.
+func TestOneMutationStampsOneTimestamp(t *testing.T) {
+	t.Run("card and project agree on a status move", func(t *testing.T) {
+		s := simWithAdvancingClock(t)
+		seedBoardForTimestamps(t, s)
+
+		projectID, itemID := mustLookupItem(t, s)
+		field, err := s.FetchStatusField(projectID)
+		if err != nil {
+			t.Fatalf("FetchStatusField: %v", err)
+		}
+		if err := s.UpdateProjectItemStatus(projectID, itemID, field.FieldID, field.Options["Review"]); err != nil {
+			t.Fatalf("UpdateProjectItemStatus: %v", err)
+		}
+
+		// The card is the only thing this mutation touched, and the issue was
+		// stamped strictly earlier at seed time, so the board projection's
+		// laterOf(issue, card) resolves to the card's own timestamp.
+		item, err := s.FetchProjectItem("acme", "widgets", 7)
+		if err != nil {
+			t.Fatalf("FetchProjectItem: %v", err)
+		}
+		projectAt, err := s.FetchProjectUpdatedAt(projectID)
+		if err != nil {
+			t.Fatalf("FetchProjectUpdatedAt: %v", err)
+		}
+		if !item.UpdatedAt.Equal(projectAt) {
+			t.Fatalf("one status move stamped the card at %v but its project at %v; "+
+				"they must share a single clock read", item.UpdatedAt, projectAt)
+		}
+	})
+
+	t.Run("label applied-at and issue updated-at agree", func(t *testing.T) {
+		s := simWithAdvancingClock(t)
+		seedBoardForTimestamps(t, s)
+
+		if err := s.AddLabelToIssue("acme", "widgets", 7, "fabrik:awaiting-review"); err != nil {
+			t.Fatalf("AddLabelToIssue: %v", err)
+		}
+
+		appliedAt, err := s.FetchLabelAppliedAt("acme", "widgets", 7, "fabrik:awaiting-review")
+		if err != nil {
+			t.Fatalf("FetchLabelAppliedAt: %v", err)
+		}
+		// Only the issue moved; the card was stamped earlier at seed time, so
+		// the projection's laterOf resolves to the issue's updated-at.
+		item, err := s.FetchProjectItem("acme", "widgets", 7)
+		if err != nil {
+			t.Fatalf("FetchProjectItem: %v", err)
+		}
+		if !appliedAt.Equal(item.UpdatedAt) {
+			t.Fatalf("one label application stamped applied-at %v but the issue %v; "+
+				"they must share a single clock read", appliedAt, item.UpdatedAt)
+		}
+	})
+
+	t.Run("comment created-at and its issue's updated-at agree", func(t *testing.T) {
+		s := simWithAdvancingClock(t)
+		seedBoardForTimestamps(t, s)
+
+		if _, err := s.AddComment("acme", "widgets", 7, "hello"); err != nil {
+			t.Fatalf("AddComment: %v", err)
+		}
+
+		item, err := s.FetchProjectItem("acme", "widgets", 7)
+		if err != nil {
+			t.Fatalf("FetchProjectItem: %v", err)
+		}
+		// Comments arrive on the deep read, not the shallow board projection.
+		if err := s.FetchItemDetails(item); err != nil {
+			t.Fatalf("FetchItemDetails: %v", err)
+		}
+		if len(item.Comments) != 1 {
+			t.Fatalf("comments = %d, want 1", len(item.Comments))
+		}
+		if !item.Comments[0].CreatedAt.Equal(item.UpdatedAt) {
+			t.Fatalf("one comment stamped created-at %v but its issue %v; "+
+				"they must share a single clock read", item.Comments[0].CreatedAt, item.UpdatedAt)
+		}
+	})
+}
+
+// seedBoardForTimestamps is seedBasicBoard's body without the fakeClock, so
+// the caller can supply an advancing one.
+func seedBoardForTimestamps(t *testing.T, s *Sim) {
+	t.Helper()
+	s.SeedRepo("acme/widgets").
+		SeedProject("acme", 2, "Engineering", []string{"Backlog", "Implement", "Review", "Done"}).
+		SeedIssue("acme/widgets", IssueSeed{
+			Number: 7,
+			Title:  "Add a thing",
+			Body:   "spec body",
+			Author: "human",
+			Status: "Implement",
+		})
+	if err := s.Err(); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+}
+
+// mustLookupItem resolves issue 7's project and card IDs.
+func mustLookupItem(t *testing.T, s *Sim) (projectID, itemID string) {
+	t.Helper()
+	board, err := s.FetchProjectBoard("acme", "widgets", 2, "")
+	if err != nil {
+		t.Fatalf("FetchProjectBoard: %v", err)
+	}
+	itemID, _, err = s.LookupIssueProjectItem(board.ProjectID, "acme/widgets", 7)
+	if err != nil {
+		t.Fatalf("LookupIssueProjectItem: %v", err)
+	}
+	return board.ProjectID, itemID
+}

--- a/tests/sim/simgh/timestamps_test.go
+++ b/tests/sim/simgh/timestamps_test.go
@@ -159,3 +159,70 @@ func mustLookupItem(t *testing.T, s *Sim) (projectID, itemID string) {
 	}
 	return board.ProjectID, itemID
 }
+
+// TestBoardProjectionReadsCardStateLive pins that a board projection reports
+// the card's state at projection time, not at snapshot time.
+//
+// Every board read snapshots its cards under one lock acquisition and then
+// builds each projection under a later one. A card that moves column or gets
+// archived in between must not be projected from the stale snapshot: reporting
+// an old Status, or putting an archived card back on a board fetch, would
+// contradict the package's "never cached" guarantee and R1's "a mutation is
+// observable by every subsequent read" in the one place a fake is least likely
+// to be caught doing it.
+//
+// The window is driven directly rather than raced: the mutation is applied to
+// the same snapshot the projection is about to be built from, which is exactly
+// the state a concurrent writer produces.
+func TestBoardProjectionReadsCardStateLive(t *testing.T) {
+	t.Run("a status move after the snapshot is reported", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		projectID, itemID := mustLookupItem(t, s)
+
+		s.mu.Lock()
+		p := s.projects[projectKey("acme", 2)]
+		ref := p.liveItemRefs()[0]
+		s.mu.Unlock()
+
+		field, err := s.FetchStatusField(projectID)
+		if err != nil {
+			t.Fatalf("FetchStatusField: %v", err)
+		}
+		if err := s.UpdateProjectItemStatus(projectID, itemID, field.FieldID, field.Options["Review"]); err != nil {
+			t.Fatalf("UpdateProjectItemStatus: %v", err)
+		}
+
+		item, err := s.buildProjectItem(p, ref)
+		if err != nil {
+			t.Fatalf("buildProjectItem: %v", err)
+		}
+		if item == nil {
+			t.Fatal("buildProjectItem dropped a live card")
+		}
+		if item.Status != "Review" {
+			t.Fatalf("projected Status = %q, want %q; the projection used the stale snapshot", item.Status, "Review")
+		}
+	})
+
+	t.Run("an archive after the snapshot removes the card", func(t *testing.T) {
+		s, _ := seedBasicBoard(t)
+		projectID, itemID := mustLookupItem(t, s)
+
+		s.mu.Lock()
+		p := s.projects[projectKey("acme", 2)]
+		ref := p.liveItemRefs()[0]
+		s.mu.Unlock()
+
+		if err := s.ArchiveProjectItem(projectID, itemID); err != nil {
+			t.Fatalf("ArchiveProjectItem: %v", err)
+		}
+
+		item, err := s.buildProjectItem(p, ref)
+		if err != nil {
+			t.Fatalf("buildProjectItem: %v", err)
+		}
+		if item != nil {
+			t.Fatalf("projected an archived card back onto the board: %+v", item)
+		}
+	})
+}

--- a/tests/sim/simgh/util.go
+++ b/tests/sim/simgh/util.go
@@ -2,6 +2,7 @@ package simgh
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
@@ -39,12 +40,38 @@ func removeString(list []string, s string) ([]string, bool) {
 }
 
 // splitOwnerRepo splits "owner/repo" into its parts.
+//
+// Both segments are validated as single path-safe names, because repoDir turns
+// them straight into a directory under baseDir: without this, "../evil/pwned"
+// splits into owner "../evil" and lands the bare repo outside the t.TempDir()
+// the package's doc comment promises to keep everything inside. Real GitHub
+// owner and repo names cannot contain a separator either, so nothing valid is
+// rejected here.
 func splitOwnerRepo(ownerRepo string) (owner, repo string, err error) {
 	i := strings.LastIndex(ownerRepo, "/")
 	if i <= 0 || i == len(ownerRepo)-1 {
 		return "", "", fmt.Errorf("simgh: invalid owner/repo %q", ownerRepo)
 	}
-	return ownerRepo[:i], ownerRepo[i+1:], nil
+	owner, repo = ownerRepo[:i], ownerRepo[i+1:]
+	if err := validatePathSegment("owner", owner, ownerRepo); err != nil {
+		return "", "", err
+	}
+	if err := validatePathSegment("repo", repo, ownerRepo); err != nil {
+		return "", "", err
+	}
+	return owner, repo, nil
+}
+
+// validatePathSegment rejects a name that would escape or restructure the
+// baseDir sandbox once joined into a directory path.
+func validatePathSegment(kind, seg, ownerRepo string) error {
+	if seg == "." || seg == ".." {
+		return fmt.Errorf("simgh: invalid owner/repo %q: %s %q is a path-traversal segment", ownerRepo, kind, seg)
+	}
+	if strings.ContainsAny(seg, `/\`) || strings.ContainsRune(seg, os.PathSeparator) {
+		return fmt.Errorf("simgh: invalid owner/repo %q: %s %q contains a path separator", ownerRepo, kind, seg)
+	}
+	return nil
 }
 
 // cloneStrings returns a defensive copy, so a caller mutating a returned slice

--- a/tests/sim/simgh/util.go
+++ b/tests/sim/simgh/util.go
@@ -3,6 +3,7 @@ package simgh
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -70,6 +71,30 @@ func validatePathSegment(kind, seg, ownerRepo string) error {
 	}
 	if strings.ContainsAny(seg, `/\`) || strings.ContainsRune(seg, os.PathSeparator) {
 		return fmt.Errorf("simgh: invalid owner/repo %q: %s %q contains a path separator", ownerRepo, kind, seg)
+	}
+	return nil
+}
+
+// validateRepoRelPath rejects a seeded file name that would be written outside
+// the throwaway worktree commitFiles joins it into.
+//
+// Unlike an owner or repo segment, a repository path legitimately contains
+// separators ("docs/USER_GUIDE.md"), so this cannot reuse validatePathSegment;
+// what it enforces instead is that the cleaned path stays at or below the
+// worktree root. Without it, a SeedCommit files map keyed "../../outside.txt"
+// wrote silently outside the sandbox the package's doc comment promises — the
+// same escape splitOwnerRepo already refuses for owner/repo, arriving through
+// the other door.
+func validateRepoRelPath(name string) error {
+	if name == "" {
+		return fmt.Errorf("simgh: invalid file path %q: empty", name)
+	}
+	if filepath.IsAbs(name) || strings.HasPrefix(name, `\`) {
+		return fmt.Errorf("simgh: invalid file path %q: must be relative to the repo root", name)
+	}
+	clean := filepath.Clean(filepath.FromSlash(name))
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("simgh: invalid file path %q: escapes the repo root", name)
 	}
 	return nil
 }

--- a/tests/sim/simgh/util.go
+++ b/tests/sim/simgh/util.go
@@ -1,0 +1,59 @@
+package simgh
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// sortedKeys returns a map's keys in sorted order, so projections built from
+// maps are deterministic across reads.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// contains reports whether s appears in list.
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// removeString returns list with the first occurrence of s removed, and
+// whether anything was removed.
+func removeString(list []string, s string) ([]string, bool) {
+	for i, v := range list {
+		if v == s {
+			return append(append([]string{}, list[:i]...), list[i+1:]...), true
+		}
+	}
+	return list, false
+}
+
+// splitOwnerRepo splits "owner/repo" into its parts.
+func splitOwnerRepo(ownerRepo string) (owner, repo string, err error) {
+	i := strings.LastIndex(ownerRepo, "/")
+	if i <= 0 || i == len(ownerRepo)-1 {
+		return "", "", fmt.Errorf("simgh: invalid owner/repo %q", ownerRepo)
+	}
+	return ownerRepo[:i], ownerRepo[i+1:], nil
+}
+
+// cloneStrings returns a defensive copy, so a caller mutating a returned slice
+// cannot reach back into model state.
+func cloneStrings(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}


### PR DESCRIPTION
Closes #1448

Adds `tests/sim/simgh` — a third test layer between `engine/mocks_test.go`'s per-call function-hook stub and the live `tests/e2e` suite. It is a stateful in-memory model of a GitHub project that implements the complete `engine.GitHubClient` interface, backed by a real local git repository for anything git can genuinely answer.

The package ships standalone with its own tests. **No engine wiring, no harness, no `ClaudeInvoker`** — that is the follow-on (#1457, then #1449). Nothing outside `tests/sim/` changes, so this carries no runtime risk.

## What it does

**Stateful, not stubbed.** Issues, project items and their Status column, PRs, check runs, commit statuses, reviews, review requests, labels, comments/reactions, and blockedBy links are all real mutable state. `ProjectItem` / `PRDetails` / `BoardProbeItem` are computed fresh on every read rather than cached, so "a mutation is observable by every subsequent read" is structural rather than per-test.

**Git truth, not asserted truth.** One `git init --bare` origin per `owner/repo`. Mergeability comes from an actual trial merge in a throwaway `git worktree add --detach` checkout; `MergePR` writes a real merge commit onto the base ref before flipping `merged`; `FetchCommitsBehind` is `git rev-list --count`. A test cannot declare that two branches conflict — it has to make them conflict.

**Six `mergeable_state` values, not two.** Per the Plan review's required change, the state is derived from the whole model, not from the trial merge alone: `draft` > `dirty` > `behind` > `blocked` > `unstable` > `clean`, with `blocked` vs `unstable` decided by a seeded per-branch required-context set (mirroring ADR-933). This keeps `ErrNotMergeableCI` fireable and ADR-072's merge-safety incident reproducible. `MergePR` self-gates on the derived state before touching git. `has_hooks` and slowness-derived `unknown` are absent by design.

**`mergeable: null` is reachable.** `SeedMergeableRecomputePending` opens GitHub's recompute window for N reads — the window that once made #1087 look wedged. If the `*bool` were never nil, no downstream scenario could cover that path.

**Clock-injected.** Every time-bearing field — `FetchLabelAppliedAt`, comment `CreatedAt`, `FetchProjectUpdatedAt`, `RateLimitStats` — reads an injectable clock. `FetchLabelAppliedAt` is the timing anchor for the review gate, the CI settle scan, and the Done-archive scan, so the follow-on harness can drive all three without wall-clock waiting and without a breaking constructor change.

**Multi-repo and concurrency-safe from day one.** State is keyed by `owner/repo`; project state is keyed by `(owner, projectNum)`, matching Projects v2's actual owner-scoped ownership model. Two-tier locking: one `Sim.mu` for the in-memory model, a per-repo `gitMu` serialising git subprocesses, with the lock-ordering invariant documented in `sim.go`.

## Key files

- `sim.go` — `Sim`, `Clock`, `New`, and the `var _ engine.GitHubClient = (*Sim)(nil)` pin
- `git.go` — bare-repo lifecycle, `tryMerge`, `commitsBehind`
- `prs.go` — PR lifecycle and the `mergeable_state` derivation
- `seed.go` — builder-shaped, static-only seeding API
- `FIDELITY.md` — the divergence contract
- `tests/sim/README.md` — the three-tier picture and the permanent GraphQL/REST wire blind spot

## Reviewing this

`FIDELITY.md` is the highest-value thing to read closely. A fake that quietly diverges from real GitHub produces confidently green tests, which is the one failure mode this layer must not introduce — so the fidelity contract is a first-class review concern, not a documentation afterthought. It records each behaviour as **modelled**, **simplified**, or **absent**, and states the `mergeable_state` precedence order explicitly so a scenario author can reason about combinations (a draft PR with a real conflict resolves to `draft`, not `dirty`) rather than discovering them empirically.

Note the deliberate blind spot, stated in the README: this layer sits at the Go interface, so GraphQL/REST wire correctness is permanently out of its reach. The `addBlockedBy` mutation-name bug that shipped broken in v0.0.66 is a string literal in a query document — a fake at this layer makes that class of bug invisible and green. That gap stays with the live e2e suite and a separate wire-contract-test issue.

## How to test

```bash
go test -race ./tests/sim/...     # 121 tests
go vet ./...
bash tests/sim/simgh/nonvacuity.sh
```

The non-vacuity sweep is the interesting one. A stateful fake is exactly the kind of code whose tests can pass for the wrong reason, so the script neutralises each modelled behaviour in turn — the trial merge never detecting a conflict, `MergePR` fast-forwarding instead of writing a merge commit, required contexts never blocking, timestamps coming from wall time instead of the injected clock, the model mutex removed — and re-runs the suite. All 103 mutations are currently caught; a mutation that leaves the suite green is a test that proves nothing.

One unrelated note: `cmd/TestExecute_ConfigYAMLApplied` fails on a full-suite run. It also fails at this branch's base commit `964983bd`, so it is pre-existing and not caused by this change.







