### PR TITLE
test(merge-train): real-subprocess wall-time coverage for extend-turns override

### DIFF
--- a/adrs/1206-scale-max-wall-time-with-extend-turns-budget.md
+++ b/adrs/1206-scale-max-wall-time-with-extend-turns-budget.md
@@ -144,23 +144,37 @@ initially inherited was wrong, not just unverified: `resolveConflictWithClaude` 
 its pre-grant as `holdingStg.MaxTurns * 2` — scaled off `stage.MaxTurns`, not
 `commentMaxTurns(holdingStg)`, the base `scaledWallTime` actually divides by inside
 `InvokeClaudeForComments` (`limit` vs. `commentMaxTurns(stage)`). Whenever a stage's
-`comment_max_turns` differs from its `max_turns` — true of every stage YAML in this repo,
-which sets `max_turns: 100` and `comment_max_turns: 50` — the two bases disagreed and the
-multiplier came out to 4x (`30m` → `120m`) instead of the intended 2x, weakening the
-runaway bound for merge-train conflict resolution beyond what this issue set out to fix.
-This was a pre-existing mismatch in `merge_train.go`'s own turn-budget sizing that
-predated this issue (not part of this issue's original diff), but leaving a 4x-scaled
-deadline live on `main` as a side effect of centralizing the scaling here was judged not
-acceptable to defer, so the fix was folded into this issue rather than left solely to the
-follow-up: `resolveConflictWithClaude` now computes its pre-grant via
-`mergeTrainMaxTurnsOverride(holdingStg, extendTurns)` (`engine/merge_train.go`), which
-bases it on `commentMaxTurns(holdingStg) * 2` — the same base `scaledWallTime` divides
-by — with direct unit coverage
-(`TestMergeTrainMaxTurnsOverride_UsesCommentMaxTurnsBase`,
-`engine/merge_train_test.go`). [#1472](https://github.com/handarbeit/fabrik/issues/1472)
-remains open only to add real-subprocess wall-time coverage for this path (mirroring the
-`engine/grandchild_test.go` tests added for `item.go`/`comments.go`), which is out of this
-issue's explicit test-coverage scope; the correctness fix itself landed here.
+`comment_max_turns` differs from its `max_turns`, the two bases disagreed and the
+multiplier came out to 4x (`30m` → `120m`) instead of the intended 2x. This mismatch was
+real and worth fixing regardless of whether any repo's config currently trips it — the
+numerator and denominator were genuinely different bases — so it was folded into this
+issue rather than left solely to the follow-up: `resolveConflictWithClaude` now computes
+its pre-grant via `mergeTrainMaxTurnsOverride(holdingStg, extendTurns)`
+(`engine/merge_train.go`), which bases it on `commentMaxTurns(holdingStg) * 2` — the same
+base `scaledWallTime` divides by — with direct unit coverage
+(`TestMergeTrainMaxTurnsOverride_UsesCommentMaxTurnsBase`, `engine/merge_train_test.go`)
+and real-subprocess wall-time coverage against a non-degenerate holding-stage fixture
+(`TestInvokeClaudeForComments_MergeTrainOverrideScalesWallTime`,
+`engine/grandchild_test.go`, added by [#1472](https://github.com/handarbeit/fabrik/issues/1472)).
+
+**Important correction, made after this ADR first landed:** the *bug* described above was
+never live on this repo, and the "`max_turns: 100`/`comment_max_turns: 50`, true of every
+stage YAML in this repo" framing this section originally used was wrong in a way that
+mattered. `resolveConflictWithClaude` reads the *holding stage* passed in by
+`assembleTrialBranch` (`e.holdingStg`), not a pipeline stage — on this repo that is
+`Queued`, and `.fabrik/stages/queued.yaml` is three lines: `name`, `order`,
+`holding_stage: true`. It sets none of `max_turns`, `comment_max_turns`, or
+`max_wall_time`. With `holdingStg.MaxTurns == 0`, the pre-fix guard
+(`holdingStg.MaxTurns > 0`) was false, so no turn-budget pre-grant was ever applied on
+this path; and with `stage.MaxWallTime == 0`, `scaledWallTime`'s `base <= 0` guard
+short-circuited before any scaling happened. So the ratio was never actually 4x here:
+this code path was inert both before and after this issue, and merge-train conflict
+resolution ran uncapped (not at a live 4x deadline) the whole time — nothing regressed
+in production as a result of the original mismatch. The mismatch was still real and
+worth fixing (any holding-stage config that *does* set these three fields, with the two
+turn fields differing, would trip it), which is why the fix above was kept; it just never
+fired against this repo's own config. See #1472's discussion thread for the fuller
+account of this correction.
 
 ## Consequences
 
@@ -194,6 +208,8 @@ issue's explicit test-coverage scope; the correctness fix itself landed here.
 - PR #1201 — the `60m` workaround this issue's config change reverts.
 - [#1472](https://github.com/handarbeit/fabrik/issues/1472) — originally filed to fix
   `engine/merge_train.go`'s turn-budget/wall-time scaling multiplier; the correctness fix
-  landed in this issue instead (see above), and #1472 was narrowed to the remaining
-  real-subprocess test-coverage gap. Found by `handarbeit-pruefer[bot]` reviewing PR
-  #1467.
+  landed in this issue instead (see above). #1472 added the real-subprocess wall-time
+  coverage for this path (`TestInvokeClaudeForComments_MergeTrainOverrideScalesWallTime`,
+  `engine/grandchild_test.go`) and corrected this section's original "weakened the
+  runaway bound in production" framing to the latent/inert-on-this-repo account above.
+  Found by `handarbeit-pruefer[bot]` reviewing PR #1467.

--- a/engine/grandchild_test.go
+++ b/engine/grandchild_test.go
@@ -499,6 +499,92 @@ func TestInvokeClaudeForComments_ExtendTurnsStillKilledAtScaledDeadline(t *testi
 	}
 }
 
+// TestInvokeClaudeForComments_MergeTrainOverrideScalesWallTime verifies #1472's
+// non-degenerate case: mergeTrainMaxTurnsOverride (engine/merge_train.go) derives
+// resolveConflictWithClaude's fabrik:extend-turns pre-grant from
+// commentMaxTurns(holdingStg), not holdingStg.MaxTurns. Unlike the ExtendTurns*
+// siblings above (whose fixture stages leave CommentMaxTurns unset, so it falls back
+// to MaxTurns and the old-buggy/new-fixed formulas coincide — exactly the vacuity
+// trap #1472 warns about), this fixture sets MaxTurns:100 and CommentMaxTurns:50 to
+// different values, mirroring this repo's real pipeline-stage convention. It also
+// calls the real mergeTrainMaxTurnsOverride function rather than hand-computing
+// opts.MaxTurnsOverride, so it fails if that function regresses to scale off
+// holdingStg.MaxTurns again:
+//   - fixed:  commentMaxTurns(holdingStg)*2 = 50*2 = 100 -> scaledWallTime(800ms,100,50)  = 1600ms (correct 2x)
+//   - buggy:  holdingStg.MaxTurns*2         = 100*2 = 200 -> scaledWallTime(800ms,200,50) = 3200ms (the old 4x bug)
+//
+// The [1400ms, 2500ms] bracket sits around the correct ~1600-1900ms (with kill-grace
+// overhead) observed elapsed time while excluding the buggy ~3200-3500ms case with
+// wide margin on both sides.
+func TestInvokeClaudeForComments_MergeTrainOverrideScalesWallTime(t *testing.T) {
+	t.Chdir(t.TempDir())
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"sleep 60\n"
+	if err := os.WriteFile(fakeClaude, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	origDelay := claudeWaitDelay
+	claudeWaitDelay = 1 * time.Second
+	defer func() { claudeWaitDelay = origDelay }()
+
+	origSigInt := claudeKillGraceSigInt
+	origSigTerm := claudeKillGraceSigTerm
+	claudeKillGraceSigInt = 100 * time.Millisecond
+	claudeKillGraceSigTerm = 100 * time.Millisecond
+	defer func() {
+		claudeKillGraceSigInt = origSigInt
+		claudeKillGraceSigTerm = origSigTerm
+	}()
+
+	// Mirrors .fabrik/stages' real pipeline-stage convention (max_turns: 100 /
+	// comment_max_turns: 50) rather than this repo's queued.yaml (a bare holding
+	// stage with none of these fields set, on which the bug is inert — see #1472).
+	holdingStg := &stages.Stage{
+		Name:            "Queued",
+		HoldingStage:    true,
+		MaxTurns:        100,
+		CommentMaxTurns: 50,
+		MaxWallTime:     800 * time.Millisecond,
+	}
+	issue := gh.ProjectItem{Number: 99, Title: "MergeTrainOverrideScalesWallTime"}
+	comments := []gh.Comment{{Author: "user", Body: "conflict comment", CreatedAt: time.Now()}}
+	opts := InvokeOptions{MaxTurnsOverride: mergeTrainMaxTurnsOverride(holdingStg, true)}
+
+	workDir := t.TempDir()
+	start := time.Now()
+	type result struct {
+		completed bool
+		err       error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		_, completed, _, err := InvokeClaudeForComments(context.Background(), holdingStg, issue, comments, workDir, opts)
+		ch <- result{completed, err}
+	}()
+
+	select {
+	case res := <-ch:
+		elapsed := time.Since(start)
+		if res.completed {
+			t.Errorf("expected completed=false (no FABRIK_STAGE_COMPLETE)")
+		}
+		if elapsed < 1400*time.Millisecond {
+			t.Errorf("killed too early (elapsed=%v) — correct scaled deadline (~1600ms) was not honored", elapsed)
+		}
+		if elapsed > 2500*time.Millisecond {
+			t.Errorf("killed too late (elapsed=%v) — deadline may have used the old buggy 4x multiplier (~3200ms)", elapsed)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("InvokeClaudeForComments did not return within 15s after max_wall_time kill")
+	}
+}
+
 // TestKillProcGroupGraceful_StructuredLog (SC-1) verifies that the kill escalation
 // sequence emits structured log lines for each signal sent to the process group,
 // with the correct signal name and reason code (max_wall_time in this case).


### PR DESCRIPTION
Closes #1472

## What this does

The `fabrik:extend-turns` multiplier-base fix (`mergeTrainMaxTurnsOverride`, `engine/merge_train.go`) already landed in #1206/PR #1467. This PR adds the real-subprocess wall-time test coverage that was called out as remaining scope, and corrects ADR-1206's description of the original bug's severity.

## Key changes

- **`engine/grandchild_test.go`**: adds `TestInvokeClaudeForComments_MergeTrainOverrideScalesWallTime`. Unlike the existing `TestInvokeClaudeForComments_ExtendTurns*` sibling tests — whose fixture stages leave `CommentMaxTurns` unset, so it falls back to `MaxTurns` and the old-buggy/new-fixed formulas coincide — this test uses a holding-stage fixture with `MaxTurns: 100` / `CommentMaxTurns: 50` (differing values, mirroring this repo's real pipeline-stage convention) and calls the real `mergeTrainMaxTurnsOverride` function rather than hand-computing the override. A `[1400ms, 2500ms]` kill-timing bracket distinguishes the correct ~1600ms scaled deadline from the old buggy ~3200ms one.
- **`adrs/1206-scale-max-wall-time-with-extend-turns-budget.md`**: corrects the `engine/merge_train.go` coverage section, which originally described the multiplier mismatch as live and "weakening the runaway bound ... beyond what this issue set out to fix." In fact `resolveConflictWithClaude` reads the *holding stage* (`Queued` on this repo), and `.fabrik/stages/queued.yaml` sets none of `max_turns`/`comment_max_turns`/`max_wall_time` — so the bug was inert here both before and after #1206 (no pre-grant applied, no scaling applied, uncapped conflict resolution throughout, nothing regressed in production).

## How to test

```
go test -race -run TestInvokeClaudeForComments_MergeTrainOverrideScalesWallTime -v ./engine/...
go test -race ./engine/...
go build ./... && go vet ./...
```

Non-vacuity was verified manually during implementation: temporarily reverting `mergeTrainMaxTurnsOverride` to scale off `holdingStg.MaxTurns` (the old bug) makes the new test fail with `elapsed=3.3s`, well outside the `[1400ms, 2500ms]` bracket — confirming the test actually distinguishes correct from buggy behavior rather than passing vacuously.

No user-facing behavior change — test coverage and ADR-text correction only. No `docs/llms-full.txt` regen required (ADRs are excluded from that bundle).