### PR TITLE
fix(pruefer): re-review loop at unchanged head — COMMENTED reviews now correctly supersede in FetchPRReviews

### DIFF
--- a/github/prs.go
+++ b/github/prs.go
@@ -62,8 +62,14 @@ func (c *Client) FetchPRClosingIssues(owner, repo string, prNumber int) ([]int, 
 // reviewDecision computation treats COMMENTED as informational, not a state
 // transition, so a reviewer who requests changes and later leaves a comment-only
 // follow-up (without re-approving or dismissing) still has an active
-// CHANGES_REQUESTED verdict. Only when an author's *first* submission is
-// COMMENTED (no verdict established yet) does it become their collapsed entry.
+// CHANGES_REQUESTED verdict. Only when an author's *stored* entry is itself
+// COMMENTED (no verdict established yet) does a later COMMENTED submission
+// supersede it — so a comment-only reviewer's collapsed entry tracks their
+// latest submission, not just their first. States outside COMMENTED and the
+// three formal verdicts (e.g. PENDING, which is visible only to the token
+// that created it and may reflect an incomplete submission) are enumerated
+// explicitly as never eligible to establish or overwrite a collapsed entry —
+// first-seen or not — rather than being treated as a verdict by omission.
 // Returns nil, nil on 404.
 func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, error) {
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews?per_page=100", c.baseURL, owner, repo, prNumber)
@@ -89,10 +95,17 @@ func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, e
 		if r.User == nil || r.User.Login == "" {
 			continue
 		}
-		_, seen := latestByAuthor[r.User.Login]
+		if !canEstablishOrSupersedeReview(r.State) {
+			// PENDING (or any other state outside COMMENTED and the three
+			// formal verdicts) never establishes or overwrites a collapsed
+			// entry — a private/incomplete submission must not pin an
+			// author's review, first-seen or not.
+			continue
+		}
+		stored, seen := latestByAuthor[r.User.Login]
 		if !seen {
 			order = append(order, r.User.Login)
-		} else if r.State == "COMMENTED" {
+		} else if r.State == "COMMENTED" && isFormalReviewVerdict(stored.State) {
 			// A comment-only follow-up does not overwrite the author's
 			// existing formal verdict.
 			continue
@@ -114,6 +127,27 @@ func (c *Client) FetchPRReviews(owner, repo string, prNumber int) ([]PRReview, e
 		out = append(out, latestByAuthor[author])
 	}
 	return out, nil
+}
+
+// isFormalReviewVerdict reports whether state is one of GitHub's three
+// formal review verdicts — the states a COMMENTED follow-up must never
+// overwrite.
+func isFormalReviewVerdict(state string) bool {
+	switch state {
+	case "APPROVED", "CHANGES_REQUESTED", "DISMISSED":
+		return true
+	}
+	return false
+}
+
+// canEstablishOrSupersedeReview reports whether an incoming submission's
+// state is ever eligible to become or replace an author's collapsed entry.
+// Only COMMENTED and the three formal verdicts qualify; every other state
+// (PENDING, or any state GitHub introduces in the future) is excluded
+// unconditionally, so it can neither establish a first entry nor silently
+// pin an author's collapsed review at a later submission.
+func canEstablishOrSupersedeReview(state string) bool {
+	return state == "COMMENTED" || isFormalReviewVerdict(state)
 }
 
 // FetchPRReviewDecision returns GitHub's computed review-decision verdict for a

--- a/github/prs_test.go
+++ b/github/prs_test.go
@@ -1222,6 +1222,188 @@ func TestFetchPRReviews_CommentedFollowUpDoesNotOverwriteVerdict(t *testing.T) {
 	}
 }
 
+// TestFetchPRReviews_SecondCommentedSupersedesFirst covers the production
+// shape that caused the re-review loop on handarbeit/fabrik#1477: a
+// comment-only reviewer (Pruefer never approves — see
+// pruefer/claude.go's "never approve" policy) submits COMMENTED multiple
+// times across separate pushes. Since neither submission is a formal
+// verdict, the later one must win — AC1.
+func TestFetchPRReviews_SecondCommentedSupersedesFirst(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 1, "user": map[string]string{"login": "handarbeit-pruefer[bot]"}, "state": "COMMENTED", "body": "first pass", "commit_id": "667bd208"},
+			{"id": 2, "user": map[string]string{"login": "handarbeit-pruefer[bot]"}, "state": "COMMENTED", "body": "second pass", "commit_id": "a08167a2"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	reviews, err := c.FetchPRReviews("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 collapsed review, got %d: %+v", len(reviews), reviews)
+	}
+	if got := reviews[0].DatabaseID; got != 2 {
+		t.Errorf("collapsed review DatabaseID = %d, want 2 (the later COMMENTED submission)", got)
+	}
+	if got := reviews[0].CommitID; got != "a08167a2" {
+		t.Errorf("collapsed review CommitID = %q, want %q (the later submission's head)", got, "a08167a2")
+	}
+}
+
+// TestFetchPRReviews_CommentedNeverSupersedesVerdict pins AC2 in all three
+// verdict directions — a COMMENTED follow-up must not overwrite APPROVED,
+// CHANGES_REQUESTED, or DISMISSED. The pre-existing suite only covered
+// CHANGES_REQUESTED; this closes the other two so a "latest always wins"
+// implementation (AC6) cannot pass here by accident.
+func TestFetchPRReviews_CommentedNeverSupersedesVerdict(t *testing.T) {
+	for _, verdict := range []string{"APPROVED", "CHANGES_REQUESTED", "DISMISSED"} {
+		t.Run(verdict, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode([]map[string]interface{}{
+					{"id": 1, "user": map[string]string{"login": "alice"}, "state": verdict, "body": "verdict"},
+					{"id": 2, "user": map[string]string{"login": "alice"}, "state": "COMMENTED", "body": "follow-up"},
+				})
+			}))
+			defer srv.Close()
+
+			c := NewClientWithBaseURL("token", srv.URL)
+			reviews, err := c.FetchPRReviews("owner", "repo", 42)
+			if err != nil {
+				t.Fatalf("FetchPRReviews: %v", err)
+			}
+			if len(reviews) != 1 {
+				t.Fatalf("expected 1 collapsed review, got %d: %+v", len(reviews), reviews)
+			}
+			if got := reviews[0].State; got != verdict {
+				t.Errorf("collapsed review state = %q, want %q (COMMENTED follow-up must not overwrite it)", got, verdict)
+			}
+			if got := reviews[0].DatabaseID; got != 1 {
+				t.Errorf("collapsed review DatabaseID = %d, want 1 (the %s submission)", got, verdict)
+			}
+		})
+	}
+}
+
+// TestFetchPRReviews_PendingDoesNotSupersede covers AC7: a PENDING
+// submission between two real submissions from the same author must never
+// become — or overwrite — the collapsed entry. PENDING reviews are visible
+// only to the token that created them and may reflect an incomplete
+// submission (the suspected mechanism behind the "second failure mode" in
+// the issue, where a stray PENDING entry silently pinned an author to the
+// head and suppressed all future reviews).
+func TestFetchPRReviews_PendingDoesNotSupersede(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 1, "user": map[string]string{"login": "alice"}, "state": "COMMENTED", "body": "first", "commit_id": "aaa"},
+			{"id": 2, "user": map[string]string{"login": "alice"}, "state": "PENDING", "body": "", "commit_id": "bbb"},
+			{"id": 3, "user": map[string]string{"login": "alice"}, "state": "COMMENTED", "body": "second", "commit_id": "ccc"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	reviews, err := c.FetchPRReviews("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 collapsed review, got %d: %+v", len(reviews), reviews)
+	}
+	// The PENDING entry (id 2) must be invisible: alice's collapsed entry
+	// must be the later real COMMENTED submission (id 3), not pinned to the
+	// stray PENDING one that sits between them.
+	if got := reviews[0].DatabaseID; got != 3 {
+		t.Errorf("collapsed review DatabaseID = %d, want 3 (the later COMMENTED submission; PENDING must not pin the entry)", got)
+	}
+	if got := reviews[0].State; got != "COMMENTED" {
+		t.Errorf("collapsed review state = %q, want COMMENTED", got)
+	}
+	if got := reviews[0].CommitID; got != "ccc" {
+		t.Errorf("collapsed review CommitID = %q, want %q", got, "ccc")
+	}
+}
+
+// TestFetchPRReviews_PendingOnlyAuthorOmitted covers the other half of AC7:
+// an author whose only submission is PENDING must produce no collapsed
+// entry at all — PENDING is never eligible to establish an entry, not even
+// as a first-seen fallback.
+func TestFetchPRReviews_PendingOnlyAuthorOmitted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 1, "user": map[string]string{"login": "alice"}, "state": "PENDING", "body": ""},
+			{"id": 2, "user": map[string]string{"login": "bob"}, "state": "COMMENTED", "body": "note"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBaseURL("token", srv.URL)
+	reviews, err := c.FetchPRReviews("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 collapsed review (alice's PENDING-only submission must be omitted), got %d: %+v", len(reviews), reviews)
+	}
+	if reviews[0].Author != "bob" {
+		t.Errorf("collapsed review author = %q, want bob (alice's PENDING-only entry must not appear)", reviews[0].Author)
+	}
+}
+
+// TestFetchPRReviews_NaiveLatestWinsFailsVerdictPinning demonstrates AC6's
+// non-vacuity requirement directly: a naive "the most recent submission
+// always wins, regardless of state" collapsing rule — which would fix the
+// re-review loop (bug #1) — reintroduces the opposite regression, letting a
+// COMMENTED follow-up silently erase a formal verdict. This proves
+// TestFetchPRReviews_CommentedNeverSupersedesVerdict is not trivially
+// satisfied by any fix that merely stops re-reviewing.
+func TestFetchPRReviews_NaiveLatestWinsFailsVerdictPinning(t *testing.T) {
+	raw := []struct {
+		Author string
+		State  string
+	}{
+		{"alice", "CHANGES_REQUESTED"},
+		{"alice", "COMMENTED"},
+	}
+	// naiveLatestWins mirrors a "latest submission always wins" collapsing
+	// rule: no state-based skip at all, just last-write-wins per author.
+	naiveLatestWins := make(map[string]string, len(raw))
+	for _, r := range raw {
+		naiveLatestWins[r.Author] = r.State
+	}
+	if got := naiveLatestWins["alice"]; got == "CHANGES_REQUESTED" {
+		t.Fatal("naive latest-wins unexpectedly preserved the verdict — this test is supposed to demonstrate the naive fix's failure")
+	}
+	if got := naiveLatestWins["alice"]; got != "COMMENTED" {
+		t.Fatalf("naive latest-wins state = %q, want COMMENTED (demonstrating the regression a naive fix introduces)", got)
+	}
+	// The actual fix, exercised via the real code path, must not have this
+	// failure: re-run the CHANGES_REQUESTED-pinning case through the real
+	// client and confirm it survives.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 1, "user": map[string]string{"login": "alice"}, "state": "CHANGES_REQUESTED", "body": "please fix"},
+			{"id": 2, "user": map[string]string{"login": "alice"}, "state": "COMMENTED", "body": "still waiting"},
+		})
+	}))
+	defer srv.Close()
+	c := NewClientWithBaseURL("token", srv.URL)
+	reviews, err := c.FetchPRReviews("owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("FetchPRReviews: %v", err)
+	}
+	if len(reviews) != 1 || reviews[0].State != "CHANGES_REQUESTED" {
+		t.Fatalf("real fix must preserve the verdict where the naive latest-wins rule above did not; got %+v", reviews)
+	}
+}
+
 func TestFetchPRReviews_NotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(404)

--- a/pruefer/select.go
+++ b/pruefer/select.go
@@ -73,7 +73,26 @@ func Eligible(in EligibilityInput) (bool, SkipReason) {
 	if len(in.ExcludedPaths) > 0 && allPathsExcluded(in.ChangedPaths, in.ExcludedPaths) {
 		return false, SkipExcludedPath
 	}
-	if !in.ForceReview && alreadyReviewedAtHead(in.ExistingReviews, in.BotLogin, in.PR.HeadSHA) {
+	matched, foundSHA := alreadyReviewedAtHead(in.ExistingReviews, in.BotLogin, in.PR.HeadSHA)
+	// Defense-in-depth (R3): this decision depends entirely on FetchPRReviews
+	// having correctly collapsed the bot's review history to its true latest
+	// submission — a defect there (as in #1496) produces no error and no
+	// distinguishing symptom other than silent misbehavior. Logging both the
+	// compared SHA and the found SHA on every check, not just on skip, means
+	// a future regression of that kind is visible in pruefer.log even though
+	// this code has no independent way to verify FetchPRReviews's output.
+	found := foundSHA
+	if found == "" {
+		found = "(none)"
+	}
+	outcome := "proceeding"
+	if matched && !in.ForceReview {
+		outcome = "skipping"
+	} else if matched && in.ForceReview {
+		outcome = "proceeding (force review)"
+	}
+	logf(in.PR.Number, "select", "head-SHA check for %s: compared=%s found=%s outcome=%s\n", in.BotLogin, in.PR.HeadSHA, found, outcome)
+	if !in.ForceReview && matched {
 		return false, SkipAlreadyReviewed
 	}
 	return true, ""
@@ -134,17 +153,23 @@ func matchGlobParts(pat, name []string) bool {
 }
 
 // alreadyReviewedAtHead reports whether reviews contains a review authored
-// by botLogin whose CommitID matches headSHA exactly.
-func alreadyReviewedAtHead(reviews []gh.PRReview, botLogin, headSHA string) bool {
+// by botLogin whose CommitID matches headSHA exactly, and returns the bot's
+// found CommitID (the SHA of its collapsed entry, "" if the bot has no
+// entry at all) for logging — so a caller can tell a healthy skip (found
+// really does equal compared) apart from an anomalous one after the fact.
+func alreadyReviewedAtHead(reviews []gh.PRReview, botLogin, headSHA string) (matched bool, foundSHA string) {
 	if botLogin == "" || headSHA == "" {
-		return false
+		return false, ""
 	}
 	for _, r := range reviews {
-		if strings.EqualFold(r.Author, botLogin) && r.CommitID == headSHA {
-			return true
+		if strings.EqualFold(r.Author, botLogin) {
+			foundSHA = r.CommitID
+			if r.CommitID == headSHA {
+				return true, foundSHA
+			}
 		}
 	}
-	return false
+	return false, foundSHA
 }
 
 // diffGitHeaderRE matches a unified diff's per-file header line:

--- a/pruefer/select_test.go
+++ b/pruefer/select_test.go
@@ -1,6 +1,8 @@
 package pruefer
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	gh "github.com/handarbeit/fabrik/github"
@@ -190,6 +192,26 @@ func TestEligible(t *testing.T) {
 			},
 			wantOK: true,
 		},
+		{
+			// AC3 / #1496: the exact production shape (Pruefer never
+			// approves — every one of its reviews is COMMENTED) that the
+			// prior single-review-per-author fixtures never covered. Its
+			// most recent submission's CommitID matches the current head,
+			// so it must be skipped even though earlier submissions target
+			// stale SHAs.
+			name: "comment-only reviewer with multiple submissions is skipped when the most recent matches head",
+			in: EligibilityInput{
+				PR:       gh.PRDetails{Author: "alice", HeadSHA: "a08167a2"},
+				BotLogin: "handarbeit-pruefer[bot]",
+				ExistingReviews: []gh.PRReview{
+					{Author: "handarbeit-pruefer[bot]", State: "COMMENTED", CommitID: "667bd208"},
+					{Author: "handarbeit-pruefer[bot]", State: "COMMENTED", CommitID: "4b333a27"},
+					{Author: "handarbeit-pruefer[bot]", State: "COMMENTED", CommitID: "a08167a2"},
+				},
+			},
+			wantOK:     false,
+			wantReason: SkipAlreadyReviewed,
+		},
 	}
 
 	for _, tt := range tests {
@@ -202,6 +224,77 @@ func TestEligible(t *testing.T) {
 				t.Errorf("Eligible() reason = %q, want %q", reason, tt.wantReason)
 			}
 		})
+	}
+}
+
+// TestEligible_LogsComparedAndFoundSHA demonstrates R3/AC5: the head-SHA
+// check must log both the SHA it compared against and the SHA it found,
+// distinctly, so a healthy skip and a wrongly-pinned skip (the failure mode
+// that went unnoticed for three weeks in #1496 — both previously produced
+// the identical "already reviewed at this head SHA" line) can be told apart
+// from pruefer.log output after the fact.
+func TestEligible_LogsComparedAndFoundSHA(t *testing.T) {
+	resetLogf(t)
+	var lines []string
+	Logf = func(prNumber int, tag, format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+
+	ok, reason := Eligible(EligibilityInput{
+		PR:       gh.PRDetails{Author: "alice", HeadSHA: "a08167a2"},
+		BotLogin: "handarbeit-pruefer[bot]",
+		ExistingReviews: []gh.PRReview{
+			{Author: "handarbeit-pruefer[bot]", State: "COMMENTED", CommitID: "a08167a2"},
+		},
+	})
+	if ok || reason != SkipAlreadyReviewed {
+		t.Fatalf("Eligible() = (%v, %q), want (false, %q)", ok, reason, SkipAlreadyReviewed)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line from the head-SHA check, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "compared=a08167a2") {
+		t.Errorf("log line %q does not record the compared (head) SHA", lines[0])
+	}
+	if !strings.Contains(lines[0], "found=a08167a2") {
+		t.Errorf("log line %q does not record the found (bot's collapsed) SHA", lines[0])
+	}
+	if !strings.Contains(lines[0], "skipping") {
+		t.Errorf("log line %q does not record the skip outcome", lines[0])
+	}
+}
+
+// TestEligible_LogsDistinguishesCompareFromFound covers the anomalous case
+// directly: a proceed decision where the bot's found SHA differs from the
+// compared head SHA must still log both values distinctly, not just the
+// binary outcome — this is what would have surfaced the #1496 bug (the
+// found SHA stuck at the bot's first review while the compared SHA kept
+// advancing) had it existed at the time.
+func TestEligible_LogsDistinguishesCompareFromFound(t *testing.T) {
+	resetLogf(t)
+	var lines []string
+	Logf = func(prNumber int, tag, format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+
+	ok, _ := Eligible(EligibilityInput{
+		PR:       gh.PRDetails{Author: "alice", HeadSHA: "new-sha"},
+		BotLogin: "handarbeit-pruefer[bot]",
+		ExistingReviews: []gh.PRReview{
+			{Author: "handarbeit-pruefer[bot]", State: "COMMENTED", CommitID: "stale-sha"},
+		},
+	})
+	if !ok {
+		t.Fatal("Eligible() = false, want true (head SHA advanced past the bot's found entry)")
+	}
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly 1 log line, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "compared=new-sha") || !strings.Contains(lines[0], "found=stale-sha") {
+		t.Errorf("log line %q must record compared and found as distinct values", lines[0])
+	}
+	if !strings.Contains(lines[0], "proceeding") {
+		t.Errorf("log line %q does not record the proceed outcome", lines[0])
 	}
 }
 


### PR DESCRIPTION
Closes #1496

## What this does

Fixes a supersession bug in `gh.FetchPRReviews` (`github/prs.go`) that caused Pruefer to re-review the same unchanged PR head indefinitely, and adds a defense-in-depth guard in Pruefer itself so a future regression of this kind is visible in `pruefer.log` rather than silent.

## Root cause (R1)

`FetchPRReviews` collapses the REST API's full per-author review history to one entry per author. The old condition tested only whether the **incoming** submission's state was `"COMMENTED"` — not whether the **stored** entry was a formal verdict:

```go
} else if r.State == "COMMENTED" {
    continue // always skips, regardless of what's already stored
}
```

This produced two bugs:
1. **The loop**: since Pruefer's policy is to never approve, every one of its reviews is `COMMENTED`. A second `COMMENTED` review always hit this branch and was discarded — the collapsed entry stayed pinned to the *first* review forever, so `alreadyReviewedAtHead` could never match a new head SHA.
2. **Silent suppression**: the `else` branch unconditionally overwrote on *any* non-`COMMENTED` incoming state, including `PENDING` — a review state that's private to the token that created it and may reflect an incomplete submission. A stray `PENDING` entry could silently pin an author's collapsed review at the head, suppressing all future reviews with no error or symptom.

The fix tests the **stored** entry's state and enumerates which states are ever eligible to establish or supersede a collapsed entry (`COMMENTED` plus the three formal verdicts — `APPROVED`, `CHANGES_REQUESTED`, `DISMISSED`); `PENDING` and any other state is excluded unconditionally, first-seen or not.

## R2 — consumer analysis

All four `engine/reviews.go` consumers of `FetchPRReviews`'s output were checked against the change:

- **`reviewGateOutstanding`** (`engine/reviews.go:394`) — unaffected in the common case (any non-`DISMISSED` entry sets `hasReviews=true` regardless of which entry is returned), **except** the stray-`PENDING` scenario: previously a `PENDING` pin made `hasReviews` read `true` on a PR nothing had genuinely reviewed (`PENDING != DISMISSED`); after the fix, a `PENDING`-only author correctly contributes nothing.
- **`reviewGateAuthorityVerdict`** (`engine/reviews.go:631`) — previously a `PENDING` pin could make an author's collapsed state read as non-`CHANGES_REQUESTED` even when their real last formal verdict *was* `CHANGES_REQUESTED`, wrongly clearing the authoritative-mode gate. The fix closes this.
- **`declaredReviewersOutstanding`** (`engine/reviews.go:1817`, called at `:202`/`:1420`) — matches by author identity, not state; a `PENDING`-pinned author would still "match" today, so the practical effect of this bug here was minor.
- **`buildReviewBodyCommentsFromReviews`** (`engine/reviews.go:1276`) — the most consequential: once an author's collapsed entry pinned to a non-`COMMENTED` state (e.g. a stray `PENDING`), every subsequent real `COMMENTED` review body from that author was silently discarded forever, because the old incoming-state check fired regardless of what was stored. This could starve the engine's own review-reinvoke path of Pruefer's actual findings — the fix restores it.
- **`FetchPRReviewDecision`** (`github/prs.go:134`) — **does not share this defect**. It's a pure GraphQL passthrough of GitHub's own server-computed `reviewDecision` field with no client-side collapsing logic at all. No code change was needed or made here.

## R3 — Pruefer defense-in-depth (independent of the upstream fix)

The SHA guard being silently dead for three weeks in production produced no error and no distinguishing log line — a healthy skip and a wrongly-pinned skip both emitted the identical `"already reviewed at this head SHA"` message. `alreadyReviewedAtHead` (`pruefer/select.go`) now also returns the bot's found `CommitID`, and `Eligible` logs both the **compared** (PR head) and **found** (bot's collapsed entry) SHAs on every check that reaches this decision point — not just on skip — so a future recurrence is visible in `pruefer.log` directly:

```
head-SHA check for handarbeit-pruefer[bot]: compared=a08167a2 found=a08167a2 outcome=skipping
head-SHA check for handarbeit-pruefer[bot]: compared=new-head-sha found=old-stale-sha outcome=proceeding
```

Demonstrated via a manual run against a real `pruefer.log` file (`NewDaemon`-wired logger), and pinned with two automated tests capturing `Logf` output.

## Test coverage (R4)

- `github/prs_test.go`: second `COMMENTED` supersedes first (AC1); `COMMENTED` after `APPROVED`/`CHANGES_REQUESTED`/`DISMISSED` does not supersede in all three directions (AC2); a `PENDING` entry between two real submissions does not supersede, and a `PENDING`-only author produces no entry (AC7).
- **Non-vacuity (AC6)**: manually reverted the fix and confirmed 3 of the 4 new positive-assertion tests fail against the pre-fix code — the loop bug and the `PENDING`-suppression bug are both demonstrated, not just asserted. A separate test also shows a naive "latest submission always wins" rule fails the verdict-pinning case directly.
- `pruefer/select_test.go`: a fixture matching the exact production shape from `#1477` — a comment-only reviewer with multiple `COMMENTED` submissions whose most recent matches the head SHA (AC3) — plus two tests pinning the compared/found log distinction (AC5).
- The two pre-existing `github/prs_test.go` tests pass unchanged.

## Out of scope (flagged, not touched)

- `tests/sim/simgh/reviews.go`'s `latestReviewsByAuthor` intentionally mirrors the *pre-fix* collapsing behavior and now diverges from production. Per the issue's scope, updating it is left as a follow-up rather than done here.
- Confirming the `PENDING`-review hypothesis itself (root cause of the "second failure mode" on `#1477`) — Research could not confirm or deny it without the Pruefer App's installation token; R1's enumerated-states fix is the correct defensive rule regardless.

## How to test

```
go build ./...
go vet ./...
go test -race ./github/... ./pruefer/...
```

All pass. Full-repo `go test -race ./...` also passes except two pre-existing, unrelated failures — `cmd.TestExecute_ConfigYAMLApplied` (a SIGINT-timing test) and `engine.TestInvokeClaude_FabrikEnvVarsInjected`/its `FABRIK_PR absent` subtest (sensitive to an ambient `NVM_INC` env var on this host) — both confirmed to fail identically on `main` before this branch's changes, in packages this PR's diff never touches (`cmd/`, `engine/`).
